### PR TITLE
fix: add VitePress config with GitHub Pages base path support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,9 +34,7 @@ jobs:
 
       - name: Build documentation
         working-directory: docs-site
-        run: bun run build
-        env:
-          ONLINE_MODE: "true"
+        run: bun run build:gh-pages
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,12 +159,18 @@ tasks:
       - '{{.BUN}} run build:offline'
 
   docs:build:online:
-    desc: Build documentation for online deployment (GitHub Pages)
+    desc: Build documentation for online deployment
     dir: docs-site
     env:
       ONLINE_MODE: 'true'
     cmds:
       - '{{.BUN}} run build'
+
+  docs:build:gh-pages:
+    desc: Build documentation for GitHub Pages deployment
+    dir: docs-site
+    cmds:
+      - '{{.BUN}} run build:gh-pages'
 
   docs:preview:
     desc: Preview built documentation

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -5,7 +5,8 @@ dist/
 
 # dependencies
 node_modules/
-.vitepress/
+.vitepress/cache/
+.vitepress/dist/
 
 # logs
 npm-debug.log*

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,0 +1,87 @@
+import { defineConfig } from 'vitepress'
+import { withMermaid } from 'vitepress-plugin-mermaid'
+
+const isGitHubPages = process.env['GITHUB_PAGES'] === 'true'
+
+export default withMermaid(
+  defineConfig({
+    title: 'Diagrammer',
+    description: 'High-performance diagramming and whiteboard application',
+    base: isGitHubPages ? '/diagrammer/' : '/',
+
+    head: [
+      ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
+    ],
+
+    themeConfig: {
+      logo: '/logo.svg',
+
+      nav: [
+        { text: 'Getting Started', link: '/getting-started/introduction' },
+        { text: 'Guide', link: '/guide/canvas-navigation' },
+        { text: 'Developer', link: '/developer/architecture' },
+      ],
+
+      sidebar: {
+        '/getting-started/': [
+          {
+            text: 'Getting Started',
+            items: [
+              { text: 'Introduction', link: '/getting-started/introduction' },
+              { text: 'Installation', link: '/getting-started/installation' },
+              { text: 'Quick Start', link: '/getting-started/quick-start' },
+              { text: 'Interface Tour', link: '/getting-started/interface-tour' },
+            ],
+          },
+        ],
+        '/guide/': [
+          {
+            text: 'User Guide',
+            items: [
+              { text: 'Canvas & Navigation', link: '/guide/canvas-navigation' },
+              { text: 'Drawing Tools', link: '/guide/drawing-tools' },
+              { text: 'Connectors', link: '/guide/connectors' },
+              { text: 'Shape Libraries', link: '/guide/shape-libraries' },
+              { text: 'Styling & Themes', link: '/guide/styling' },
+              { text: 'Multi-Page Documents', link: '/guide/multi-page-documents' },
+              { text: 'Rich Text & Notes', link: '/guide/rich-text-editor' },
+              { text: 'Embedded Files', link: '/guide/embedded-files' },
+              { text: 'Export & Import', link: '/guide/export-import' },
+              { text: 'Whiteboard & Ideas', link: '/guide/whiteboard' },
+              { text: 'Collaboration', link: '/guide/collaboration' },
+              { text: 'Keyboard Shortcuts', link: '/guide/keyboard-shortcuts' },
+              { text: 'Settings', link: '/guide/settings' },
+            ],
+          },
+        ],
+        '/developer/': [
+          {
+            text: 'Developer Guide',
+            items: [
+              { text: 'Architecture Overview', link: '/developer/architecture' },
+              { text: 'Project Setup', link: '/developer/project-setup' },
+              { text: 'Core Systems', link: '/developer/core-systems' },
+              { text: 'State Management', link: '/developer/state-management' },
+              { text: 'Creating Custom Shapes', link: '/developer/creating-shapes' },
+              { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
+              { text: 'Shape Properties', link: '/developer/shape-properties' },
+              { text: 'Plugin Development', link: '/developer/plugin-development' },
+              { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
+              { text: 'Utility Modules', link: '/developer/utilities' },
+              { text: 'Contributing', link: '/developer/contributing' },
+              { text: 'Roadmap', link: '/developer/roadmap' },
+            ],
+          },
+        ],
+      },
+
+      socialLinks: [
+        { icon: 'github', link: 'https://github.com/QR-Madness/diagrammer' },
+      ],
+
+      search: {
+        provider: 'local',
+      },
+    },
+  })
+)

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "cross-env ONLINE_MODE=true vitepress dev",
     "build": "cross-env ONLINE_MODE=true vitepress build",
+    "build:gh-pages": "cross-env ONLINE_MODE=true GITHUB_PAGES=true vitepress build",
     "build:offline": "vitepress build",
     "preview": "cross-env ONLINE_MODE=true vitepress preview"
   },


### PR DESCRIPTION
The docs site was missing a .vitepress/config.mts entirely, causing VitePress to use base: '/' by default. On GitHub Pages at /diagrammer/, all assets, links, and images would 404.

Changes:
- Create .vitepress/config.mts with GITHUB_PAGES env var support
- Set base: '/diagrammer/' when GITHUB_PAGES=true
- Add full site config: nav, sidebar, mermaid, search, social links
- Add build:gh-pages script to package.json
- Update docs.yml workflow to use build:gh-pages
- Add docs:build:gh-pages task to Taskfile.yml
- Fix .gitignore to track config but ignore cache/dist