### PR TITLE
fix: prevent Tiptap tab content corruption during page switches

### DIFF
--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -15,6 +15,8 @@ import { TiptapEditor } from './TiptapEditor';
 import { TiptapEditorProvider } from './TiptapEditorContext';
 import { RichTextTabBar } from './RichTextTabBar';
 import { useRichTextPagesStore, initializeRichTextPages } from '../store/richTextPagesStore';
+import { useRichTextStore } from '../store/richTextStore';
+import { RICH_TEXT_VERSION } from '../types/RichText';
 import './DocumentEditorPanel.css';
 
 export interface DocumentEditorPanelProps {
@@ -27,9 +29,10 @@ export interface DocumentEditorPanelProps {
 }
 
 export function DocumentEditorPanel({ onCollapse, isFullscreen, onToggleFullscreen }: DocumentEditorPanelProps) {
-  const { activePageId, pages, updatePageContent } = useRichTextPagesStore();
+  const { activePageId, updatePageContent } = useRichTextPagesStore();
   const lastActivePageRef = useRef<string | null>(null);
   const isLoadingRef = useRef(false);
+  const pendingLoadRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [editor, setEditor] = useState<Editor | null>(null);
   const editorRef = useRef<Editor | null>(null);
 
@@ -58,30 +61,44 @@ export function DocumentEditorPanel({ onCollapse, isFullscreen, onToggleFullscre
   useEffect(() => {
     if (!editor || !activePageId) return;
 
-    // If this is the first load or same page, skip
+    // Same page — nothing to do
     if (lastActivePageRef.current === activePageId) return;
 
-    // Save current page content before switching
+    // Cancel any in-flight load from a previous (now-superseded) switch
+    if (pendingLoadRef.current !== null) {
+      clearTimeout(pendingLoadRef.current);
+      pendingLoadRef.current = null;
+    }
+
+    // Save the page we are leaving (skip if we were already mid-load)
     if (lastActivePageRef.current && !isLoadingRef.current) {
       const currentContent = editor.getHTML();
       updatePageContent(lastActivePageRef.current, currentContent);
     }
 
-    // Load new page content
+    const targetPageId = activePageId;
     isLoadingRef.current = true;
-    const newPage = pages[activePageId];
-    if (newPage) {
-      // Use setTimeout to ensure editor is ready
-      setTimeout(() => {
-        if (editorRef.current) {
-          editorRef.current.commands.setContent(newPage.content || '<p></p>');
-        }
-        isLoadingRef.current = false;
-      }, 0);
-    }
+    lastActivePageRef.current = targetPageId;
 
-    lastActivePageRef.current = activePageId;
-  }, [activePageId, pages, updatePageContent, editor]);
+    pendingLoadRef.current = setTimeout(() => {
+      pendingLoadRef.current = null;
+
+      // Read the freshest page content from the store, not from a stale closure
+      const freshPage = useRichTextPagesStore.getState().pages[targetPageId];
+      if (editorRef.current) {
+        editorRef.current.commands.setContent(freshPage?.content ?? '<p></p>');
+        // Keep richTextStore in sync so TiptapEditor's content-watcher
+        // never sees a mismatch and overwrites the freshly-loaded page.
+        useRichTextStore.getState().loadContent({
+          content: editorRef.current.getJSON(),
+          version: RICH_TEXT_VERSION,
+        });
+      }
+      isLoadingRef.current = false;
+    }, 0);
+    // `pages` is intentionally excluded from deps — it is read imperatively
+    // inside the timeout to avoid stale closures and spurious re-runs.
+  }, [activePageId, updatePageContent, editor]);
 
   // Auto-save current page content periodically
   useEffect(() => {
@@ -99,6 +116,11 @@ export function DocumentEditorPanel({ onCollapse, isFullscreen, onToggleFullscre
   // Save on unmount
   useEffect(() => {
     return () => {
+      // Cancel any pending page load before unmounting
+      if (pendingLoadRef.current !== null) {
+        clearTimeout(pendingLoadRef.current);
+        pendingLoadRef.current = null;
+      }
       const pageId = useRichTextPagesStore.getState().activePageId;
       if (editorRef.current && pageId) {
         const content = editorRef.current.getHTML();


### PR DESCRIPTION
## Summary

Fixes a bug where cutting and pasting an embedded group in **Tab 1** (with multiple rich-text tabs open) could corrupt **Tab 2's content** — replacing it with Tab 1's HTML — or load stale content into the wrong tab after rapid tab switching.

---

## Root Cause Analysis

Five interacting bugs in `DocumentEditorPanel.tsx` and the dual-store architecture (`richTextStore` + `richTextPagesStore`) created the conditions for content corruption.

### Bug 1 — `pages` in page-switching effect dependency array (primary trigger)

```ts
// Before
}, [activePageId, pages, updatePageContent, editor]);
```

`pages` is an Immer-proxied object that produces a **new reference on every `updatePageContent` call** (every 5 s auto-save tick, plus on every switch). This caused the entire page-switching effect to re-run spuriously. If `lastActivePageRef` and `activePageId` were temporarily out of sync during a transition, the effect would save the current editor HTML to the **wrong page**.

### Bug 2 — `isLoadingRef` never reset when the target page is missing

The reset (`isLoadingRef.current = false`) lived inside the `if (newPage)` block. If `pages[activePageId]` was falsy, `isLoadingRef` stayed `true` permanently, **silently disabling the auto-save interval** for the rest of the session.

### Bug 3 — No timeout cancellation + stale closure during rapid switches

When the user switched Tab 1 → Tab 2 → Tab 1 before the first `setTimeout(fn, 0)` fired, two load callbacks queued up. The first would briefly load Tab 2's content into the editor while `isLoadingRef = false` and `activePageId = "tab1"` — a window where the 5-second interval could fire and write Tab 2's HTML to Tab 1. Additionally, `newPage.content` was captured in a closure at effect-run time; intervening `updatePageContent` calls meant stale content was loaded.

### Bug 4 — Dual-store race: `TiptapEditor.useEffect` overwrites freshly-loaded page (direct cause of reported symptom)

`DocumentEditorPanel` loads page content via `editor.commands.setContent(html)`. Tiptap's `setContent` defaults to `emitUpdate = false`, so `onUpdate` does **not** fire and `richTextStore` is **not** updated. `TiptapEditor.tsx` has a `useEffect([editor, content.content])` that calls `editor.commands.setContent(richTextStore.content.content)` whenever the two stores disagree.

**The race:** While Tab 2 was loaded (editor = Tab 2 JSON, `richTextStore` = stale Tab 1 JSON), an async `updateAttributes({ cachedImageUrl })` call fired by `EmbeddedGroupComponent` after `exportToPng` completed during the paste operation triggered a Zustand subscriber. This caused `TiptapEditor.useEffect` to run, detect the mismatch, and **overwrite the editor with Tab 1's stale JSON while Tab 2 was active** — exactly matching the reported symptom.

---

## Changes — `src/ui/DocumentEditorPanel.tsx`

| # | Fix |
|---|-----|
| 1 | Remove `pages` from the effect dependency array; read page content **imperatively** from `useRichTextPagesStore.getState().pages[targetPageId]` inside the timeout |
| 2 | Add `pendingLoadRef` to track in-flight timeouts; `clearTimeout` on every new switch so superseded callbacks never fire |
| 3 | `isLoadingRef` reset is now **unconditional** inside the timeout (no longer inside `if (newPage)`) |
| 4 | After loading new page content, call `useRichTextStore.getState().loadContent(editor.getJSON())` to keep both stores in agreement — preventing `TiptapEditor.useEffect` from detecting a false mismatch and overwriting the page |
| 5 | Pending timeout is cancelled on unmount |

---

## Testing

- Three-tab documents: rapid switching preserves all tab content
- Embedded group cut/paste on Tab 1 while Tab 2 and Tab 3 exist — no corruption
- Fast Tab1→Tab2→Tab1 switching: both tabs retain correct content
- TypeScript: `bun run typecheck` passes with zero errors
