### PR TITLE
feat(documents): relay-aware document browser + settings UI polish

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -105,6 +105,13 @@ describe('uiPreferencesStore — layout slice', () => {
   });
 });
 
+describe('uiPreferencesStore — document browser grouping', () => {
+  it('accepts the relay grouping mode', () => {
+    useUIPreferencesStore.getState().setDocumentBrowserGroupBy('relay');
+    expect(useUIPreferencesStore.getState().documentBrowserGroupBy).toBe('relay');
+  });
+});
+
 describe('layout presets', () => {
   it('every layout has an entry for every panel id', () => {
     for (const mode of ['relaxed', 'designer', 'technician', 'power'] as const) {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -23,7 +23,7 @@ export type DocumentBrowserSort =
   | 'name-asc'
   | 'name-desc'
   | 'created-desc';
-export type DocumentBrowserGroupBy = 'none' | 'group';
+export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
 
 /**
  * UI preferences state.

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -80,12 +80,20 @@
 }
 
 .document-card__type {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 10px;
   font-weight: 600;
   padding: 2px 6px;
   border-radius: 4px;
   text-transform: uppercase;
   letter-spacing: 0.3px;
+}
+
+.document-card__type svg,
+.document-card__relay svg {
+  flex-shrink: 0;
 }
 
 .document-card__type--local {
@@ -103,32 +111,9 @@
   background: rgba(245, 158, 11, 0.1);
 }
 
-.document-card__offline-badge {
-  font-size: 11px;
-  cursor: help;
-  opacity: 0.8;
-}
-
-.document-card__permission {
-  font-size: 10px;
-  color: var(--text-muted, #94a3b8);
-}
-
-.document-card__pages {
-  font-size: 11px;
-  color: var(--text-secondary, #64748b);
-}
-
 .document-card__date {
   font-size: 11px;
   color: var(--text-muted, #94a3b8);
-}
-
-/* Owner info */
-.document-card__owner {
-  font-size: 11px;
-  color: var(--text-secondary, #64748b);
-  margin-top: 4px;
 }
 
 /* Actions */
@@ -136,11 +121,23 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  flex-shrink: 0;
   opacity: 0;
   transition: opacity 0.15s ease;
 }
 
-.document-card:hover .document-card__actions {
+/* Compact / grid keep the hover-reveal; full mode shows them quietly always. */
+.document-card:hover .document-card__actions,
+.document-card:focus-within .document-card__actions {
+  opacity: 1;
+}
+
+.document-card--full .document-card__actions {
+  opacity: 0.7;
+}
+
+.document-card--full:hover .document-card__actions,
+.document-card--full:focus-within .document-card__actions {
   opacity: 1;
 }
 
@@ -148,24 +145,41 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
-  font-size: 12px;
+  width: 30px;
+  height: 30px;
   color: var(--text-secondary, #64748b);
   background: transparent;
-  border: none;
-  border-radius: 4px;
+  border: 1px solid transparent;
+  border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
+.document-card__action svg,
+.document-card__expand svg {
+  display: block;
+}
+
 .document-card__action:hover {
   background: var(--bg-secondary, #f1f5f9);
+  border-color: var(--border-color, #e2e8f0);
   color: var(--text-primary, #1e293b);
+}
+
+.document-card__action:focus-visible,
+.document-card__expand:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-color, #3b82f6);
+}
+
+.document-card__action:disabled {
+  cursor: progress;
+  opacity: 0.6;
 }
 
 .document-card__action--danger:hover {
   background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
   color: #ef4444;
 }
 
@@ -210,6 +224,110 @@
   background: var(--bg-tertiary, #e2e8f0);
 }
 
+/* Relay badge */
+.document-card__relay {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.document-card__relay--connected {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.1);
+}
+
+.document-card__relay--disconnected {
+  color: var(--text-muted, #94a3b8);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+/* Details toggle (chevron) */
+.document-card__expand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  width: 30px;
+  height: 30px;
+  margin-left: 4px;
+  color: var(--text-secondary, #64748b);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.document-card__expand:hover {
+  background: var(--bg-secondary, #f1f5f9);
+  border-color: var(--border-color, #e2e8f0);
+  color: var(--text-primary, #1e293b);
+}
+
+.document-card__chevron {
+  display: block;
+  transition: transform 0.15s ease;
+}
+
+.document-card__chevron--open {
+  transform: rotate(180deg);
+}
+
+/* Spinner for in-flight publish / move actions */
+@keyframes document-card-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.document-card__spin {
+  animation: document-card-spin 1s linear infinite;
+}
+
+/* Expandable details panel */
+.document-card__details {
+  margin: 10px 0 2px;
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 5px 14px;
+  background: var(--bg-secondary, #f8fafc);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  cursor: default;
+}
+
+.document-card__detail {
+  display: contents;
+}
+
+.document-card__detail dt {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted, #94a3b8);
+}
+
+.document-card__detail dd {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-secondary, #64748b);
+  word-break: break-word;
+}
+
+.document-card__detail--id dd {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+}
+
 /* Full mode */
 .document-card--full {
   padding: 14px 16px;
@@ -217,6 +335,15 @@
 
 .document-card--full .document-card__name {
   font-size: 14px;
+}
+
+.document-card--full .document-card__name-row {
+  margin-bottom: 10px;
+}
+
+.document-card--full .document-card__meta {
+  gap: 10px;
+  row-gap: 6px;
 }
 
 /* Compact mode adjustments */
@@ -292,7 +419,16 @@
 
 .document-card--grid .document-card__select {
   position: absolute;
+  top: 8px;
+  left: 8px;
   margin: 0;
+  z-index: 2;
+}
+
+/* Reserve room so the title never sits under the absolute checkbox. */
+.document-card--grid .document-card__name-row {
+  padding-left: 24px;
+  min-height: 22px;
 }
 
 .document-card--grid {
@@ -341,4 +477,23 @@
 :root[data-theme="dark"] .document-card__type--cached {
   color: #fbbf24;
   background: rgba(251, 191, 36, 0.15);
+}
+
+:root[data-theme="dark"] .document-card__relay--connected {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.15);
+}
+
+:root[data-theme="dark"] .document-card__relay--disconnected {
+  color: #94a3b8;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+:root[data-theme="dark"] .document-card__details {
+  background: var(--bg-tertiary, #334155);
+  border-color: var(--border-color, #334155);
+}
+
+:root[data-theme="dark"] .document-card__expand:hover {
+  background: var(--bg-tertiary, #334155);
 }

--- a/src/ui/DocumentCard.relay.test.ts
+++ b/src/ui/DocumentCard.relay.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the relay-labelling helpers used by the document browser to
+ * differentiate documents across relays (connected vs disconnected) and to
+ * bucket them under "By relay" grouping.
+ */
+
+import { formatRelayLabel, getRelayId } from './DocumentCard';
+import { relayKeyForRecord } from './settings/DocumentBrowser';
+import type {
+  LocalDocument,
+  RemoteDocument,
+  CachedDocument,
+} from '../types/DocumentRegistry';
+
+const base = { name: 'Doc', pageCount: 1, createdAt: 0, modifiedAt: 0 };
+
+const local: LocalDocument = { type: 'local', id: 'l1', ...base };
+
+const remote: RemoteDocument = {
+  type: 'remote',
+  id: 'r1',
+  ...base,
+  relayId: 'localhost:9876',
+  ownerId: 'u1',
+  ownerName: 'Alice',
+  permission: 'owner',
+  syncState: 'synced',
+  lastSyncedAt: 0,
+};
+
+const cached: CachedDocument = {
+  type: 'cached',
+  id: 'c1',
+  ...base,
+  relayId: 'office.example:9876',
+  originalDocId: 'r2',
+  cachedAt: 0,
+  pendingChanges: 0,
+  permission: 'editor',
+};
+
+const unknownRemote: RemoteDocument = { ...remote, id: 'r3', relayId: 'unknown' };
+
+describe('getRelayId', () => {
+  it('returns undefined for local documents', () => {
+    expect(getRelayId(local)).toBeUndefined();
+  });
+
+  it('returns the relayId for remote and cached documents', () => {
+    expect(getRelayId(remote)).toBe('localhost:9876');
+    expect(getRelayId(cached)).toBe('office.example:9876');
+  });
+});
+
+describe('formatRelayLabel', () => {
+  it('returns undefined for local documents (no relay badge)', () => {
+    expect(formatRelayLabel(local, 'localhost:9876')).toBeUndefined();
+  });
+
+  it('marks a document connected when its relayId matches the connected address', () => {
+    expect(formatRelayLabel(remote, 'localhost:9876')).toEqual({
+      host: 'localhost:9876',
+      status: 'connected',
+    });
+  });
+
+  it('marks a document disconnected when the relay differs', () => {
+    expect(formatRelayLabel(cached, 'localhost:9876')).toEqual({
+      host: 'office.example:9876',
+      status: 'disconnected',
+    });
+  });
+
+  it('marks a document disconnected when nothing is connected', () => {
+    expect(formatRelayLabel(remote, undefined)).toEqual({
+      host: 'localhost:9876',
+      status: 'disconnected',
+    });
+  });
+
+  it("treats 'unknown' relays as disconnected even if connected address is also 'unknown'", () => {
+    expect(formatRelayLabel(unknownRemote, 'unknown')).toEqual({
+      host: 'Unknown relay',
+      status: 'disconnected',
+    });
+  });
+});
+
+describe('relayKeyForRecord', () => {
+  it('buckets local documents under the local key', () => {
+    expect(relayKeyForRecord(local)).toBe('__local__');
+  });
+
+  it('buckets remote/cached documents under their relayId', () => {
+    expect(relayKeyForRecord(remote)).toBe('localhost:9876');
+    expect(relayKeyForRecord(cached)).toBe('office.example:9876');
+  });
+
+  it("buckets relayId-less remote docs under 'unknown'", () => {
+    expect(relayKeyForRecord({ ...remote, relayId: '' })).toBe('unknown');
+  });
+});

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -6,6 +6,21 @@
  */
 
 import { useState, useCallback, useEffect } from 'react';
+import {
+  Check,
+  ChevronDown,
+  Cloud,
+  CloudOff,
+  Download,
+  HardDrive,
+  Loader2,
+  Pencil,
+  Trash2,
+  Upload,
+  Users,
+  Wifi,
+  WifiOff,
+} from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
 import type { DocumentRecord, Permission } from '../types/DocumentRegistry';
 import './DocumentCard.css';
@@ -39,6 +54,8 @@ interface DocumentCardProps {
     | undefined;
   /** Optional group accent (used to surface group membership in the card). */
   groupAccent?: { name: string; color?: string | undefined } | undefined;
+  /** Address (host:port) of the currently-connected relay, for connected/disconnected badge state. */
+  connectedRelayAddress?: string | undefined;
   /** Display mode */
   mode?: 'compact' | 'full' | 'grid' | undefined;
 }
@@ -74,6 +91,18 @@ function getTypeLabel(type: DocumentRecord['type']): string {
   }
 }
 
+/** Leading icon for the document type badge. */
+function TypeIcon({ type }: { type: DocumentRecord['type'] }) {
+  switch (type) {
+    case 'local':
+      return <HardDrive size={12} aria-hidden="true" />;
+    case 'remote':
+      return <Cloud size={12} aria-hidden="true" />;
+    case 'cached':
+      return <CloudOff size={12} aria-hidden="true" />;
+  }
+}
+
 function getSyncState(record: DocumentRecord): ExtendedSyncState {
   switch (record.type) {
     case 'local':
@@ -96,6 +125,38 @@ function getPermissionLabel(permission: Permission): string {
   }
 }
 
+/** Relay host identifier (host:port) for records that belong to a relay. */
+export function getRelayId(record: DocumentRecord): string | undefined {
+  return record.type === 'remote' || record.type === 'cached' ? record.relayId : undefined;
+}
+
+/** Relay badge label + connected/disconnected state for a card. */
+export interface RelayLabel {
+  host: string;
+  status: 'connected' | 'disconnected';
+}
+
+/**
+ * Build the relay badge for a document, comparing its relayId against the
+ * currently-connected relay address. Returns undefined for local documents,
+ * which have no relay. A relayId of 'unknown' is always treated as
+ * disconnected and labelled accordingly.
+ */
+export function formatRelayLabel(
+  record: DocumentRecord,
+  connectedRelayAddress: string | undefined
+): RelayLabel | undefined {
+  const relayId = getRelayId(record);
+  if (!relayId) return undefined;
+  if (relayId === 'unknown') {
+    return { host: 'Unknown relay', status: 'disconnected' };
+  }
+  return {
+    host: relayId,
+    status: relayId === connectedRelayAddress ? 'connected' : 'disconnected',
+  };
+}
+
 export function DocumentCard({
   record,
   isActive = false,
@@ -110,6 +171,7 @@ export function DocumentCard({
   onMoveToPersonal,
   onSelectToggle,
   groupAccent,
+  connectedRelayAddress,
   mode = 'compact',
 }: DocumentCardProps) {
   const [isEditing, setIsEditing] = useState(false);
@@ -117,6 +179,7 @@ export function DocumentCard({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [isMovingToPersonal, setIsMovingToPersonal] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   // Sync editName when record.name changes externally
   useEffect(() => {
@@ -223,7 +286,8 @@ export function DocumentCard({
   }, []);
 
   const syncState = getSyncState(record);
-  const isRemoteOrCached = record.type === 'remote' || record.type === 'cached';
+  const relay = formatRelayLabel(record, connectedRelayAddress);
+  const showDetails = mode === 'full';
 
   const showCheckbox = Boolean(onSelectToggle) && (showSelectionCheckbox || isSelected);
 
@@ -241,7 +305,7 @@ export function DocumentCard({
           title={isSelected ? 'Deselect' : 'Select'}
           aria-pressed={isSelected}
         >
-          {isSelected ? '✓' : ''}
+          {isSelected ? <Check size={14} aria-hidden="true" /> : null}
         </button>
       )}
       <div className="document-card__content">
@@ -275,47 +339,131 @@ export function DocumentCard({
           )}
         </div>
 
-        {/* Metadata row */}
+        {/* Metadata row — lean: type, relay, sync, modified date.
+            Permission / pages / owner / full host live in the details panel. */}
         <div className="document-card__meta">
           {/* Type badge */}
           <span className={`document-card__type document-card__type--${record.type}`}>
+            <TypeIcon type={record.type} />
             {getTypeLabel(record.type)}
           </span>
 
-          {/* Offline available indicator (for team docs cached locally) */}
-          {record.type === 'remote' && isOfflineAvailable && (
-            <span 
-              className="document-card__offline-badge" 
-              title="Available offline - cached locally"
+          {/* Relay badge (which relay this doc belongs to + connection state) */}
+          {relay && (
+            <span
+              className={`document-card__relay document-card__relay--${relay.status}`}
+              title={
+                relay.status === 'connected'
+                  ? `Relay ${relay.host} — connected`
+                  : `Relay ${relay.host} — disconnected`
+              }
             >
-              📴
+              {relay.status === 'connected' ? (
+                <Wifi size={12} aria-hidden="true" />
+              ) : (
+                <WifiOff size={12} aria-hidden="true" />
+              )}
+              {relay.host}
             </span>
           )}
 
           {/* Sync status */}
-          <SyncStatusBadge state={syncState} size="small" />
-
-          {/* Permission (for remote/cached) */}
-          {isRemoteOrCached && (
-            <span className="document-card__permission">
-              {getPermissionLabel((record as { permission: Permission }).permission)}
-            </span>
-          )}
-
-          {/* Page count */}
-          <span className="document-card__pages">{record.pageCount} page{record.pageCount !== 1 ? 's' : ''}</span>
+          <SyncStatusBadge state={syncState} size="small" showLabel />
 
           {/* Modified time */}
           <span className="document-card__date">{formatDate(record.modifiedAt)}</span>
         </div>
 
-        {/* Owner info for remote docs */}
-        {mode === 'full' && record.type === 'remote' && (
-          <div className="document-card__owner">
-            Owner: {record.ownerName}
-          </div>
+        {/* Expandable details panel */}
+        {showDetails && isExpanded && (
+          <dl className="document-card__details" onClick={(e) => e.stopPropagation()}>
+            {relay && (
+              <div className="document-card__detail">
+                <dt>Relay</dt>
+                <dd>
+                  {relay.host} · {relay.status === 'connected' ? 'Connected' : 'Disconnected'}
+                </dd>
+              </div>
+            )}
+            {record.type === 'remote' && (
+              <>
+                <div className="document-card__detail">
+                  <dt>Owner</dt>
+                  <dd>{record.ownerName || '—'}</dd>
+                </div>
+                <div className="document-card__detail">
+                  <dt>Permission</dt>
+                  <dd>{getPermissionLabel(record.permission)}</dd>
+                </div>
+                <div className="document-card__detail">
+                  <dt>Last synced</dt>
+                  <dd>{formatDate(record.lastSyncedAt)}</dd>
+                </div>
+                <div className="document-card__detail">
+                  <dt>Offline available</dt>
+                  <dd>{isOfflineAvailable ? 'Yes' : 'No'}</dd>
+                </div>
+              </>
+            )}
+            {record.type === 'cached' && (
+              <>
+                <div className="document-card__detail">
+                  <dt>Permission</dt>
+                  <dd>{getPermissionLabel(record.permission)}</dd>
+                </div>
+                <div className="document-card__detail">
+                  <dt>Cached</dt>
+                  <dd>{formatDate(record.cachedAt)}</dd>
+                </div>
+                <div className="document-card__detail">
+                  <dt>Pending changes</dt>
+                  <dd>{record.pendingChanges}</dd>
+                </div>
+              </>
+            )}
+            <div className="document-card__detail">
+              <dt>Sync state</dt>
+              <dd>{syncState}</dd>
+            </div>
+            <div className="document-card__detail">
+              <dt>Pages</dt>
+              <dd>{record.pageCount}</dd>
+            </div>
+            <div className="document-card__detail">
+              <dt>Created</dt>
+              <dd>{formatDate(record.createdAt)}</dd>
+            </div>
+            <div className="document-card__detail">
+              <dt>Modified</dt>
+              <dd>{formatDate(record.modifiedAt)}</dd>
+            </div>
+            <div className="document-card__detail document-card__detail--id">
+              <dt>Document ID</dt>
+              <dd title={record.id}>{record.id}</dd>
+            </div>
+          </dl>
         )}
       </div>
+
+      {/* Details toggle (full mode only) — sibling of actions so it stays visible */}
+      {showDetails && (
+        <button
+          type="button"
+          className="document-card__expand"
+          aria-expanded={isExpanded}
+          title={isExpanded ? 'Hide details' : 'Show details'}
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsExpanded((v) => !v);
+          }}
+        >
+          <ChevronDown
+            className={`document-card__chevron ${isExpanded ? 'document-card__chevron--open' : ''}`}
+            size={16}
+            aria-hidden="true"
+          />
+        </button>
+      )}
 
       {/* Actions */}
       <div className="document-card__actions">
@@ -325,8 +473,13 @@ export function DocumentCard({
             onClick={handlePublish}
             disabled={isPublishing}
             title="Move to relay"
+            aria-label="Move to relay"
           >
-            {isPublishing ? '⏳' : '📤'}
+            {isPublishing ? (
+              <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
+            ) : (
+              <Upload size={16} aria-hidden="true" />
+            )}
           </button>
         )}
         {onMoveToPersonal && (
@@ -335,8 +488,13 @@ export function DocumentCard({
             onClick={handleMoveToPersonal}
             disabled={isMovingToPersonal}
             title="Move to personal"
+            aria-label="Move to personal"
           >
-            {isMovingToPersonal ? '⏳' : '📥'}
+            {isMovingToPersonal ? (
+              <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
+            ) : (
+              <Download size={16} aria-hidden="true" />
+            )}
           </button>
         )}
         {onEditPermissions && (
@@ -347,8 +505,9 @@ export function DocumentCard({
               onEditPermissions(record.id);
             }}
             title="Manage access"
+            aria-label="Manage access"
           >
-            👥
+            <Users size={16} aria-hidden="true" />
           </button>
         )}
         {onRename && (
@@ -360,8 +519,9 @@ export function DocumentCard({
               setIsEditing(true);
             }}
             title="Rename"
+            aria-label="Rename"
           >
-            ✎
+            <Pencil size={16} aria-hidden="true" />
           </button>
         )}
         {onDelete && !showDeleteConfirm && (
@@ -369,8 +529,9 @@ export function DocumentCard({
             className="document-card__action document-card__action--danger"
             onClick={handleDeleteClick}
             title="Delete"
+            aria-label="Delete"
           >
-            🗑
+            <Trash2 size={16} aria-hidden="true" />
           </button>
         )}
         {showDeleteConfirm && (

--- a/src/ui/SettingsModal.css
+++ b/src/ui/SettingsModal.css
@@ -284,6 +284,11 @@
   overflow: auto;
   padding: 24px;
   background: var(--bg-primary, #ffffff);
+  /* Flex column so a tab that opts into `flex: 1` (e.g. the document
+     browser) can fill the available height — including in fullscreen.
+     Natural-height tabs still scroll normally. */
+  display: flex;
+  flex-direction: column;
 }
 
 /* Settings Section - Shared pattern for all settings tabs */

--- a/src/ui/SyncStatusBadge.css
+++ b/src/ui/SyncStatusBadge.css
@@ -9,23 +9,23 @@
   white-space: nowrap;
 }
 
+/* Icon wrapper — holds a lucide SVG; inline-flex keeps it centered and
+   lets the spin animation rotate about the center. */
+.sync-status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Size variants */
 .sync-status--small {
   font-size: 10px;
   padding: 2px 4px;
 }
 
-.sync-status--small .sync-status-icon {
-  font-size: 10px;
-}
-
 .sync-status--medium {
   font-size: 12px;
   padding: 3px 6px;
-}
-
-.sync-status--medium .sync-status-icon {
-  font-size: 12px;
 }
 
 /* State variants */

--- a/src/ui/SyncStatusBadge.tsx
+++ b/src/ui/SyncStatusBadge.tsx
@@ -6,6 +6,15 @@
  */
 
 import { useMemo } from 'react';
+import {
+  AlertTriangle,
+  Check,
+  Circle,
+  Clock,
+  CloudOff,
+  RefreshCw,
+  type LucideIcon,
+} from 'lucide-react';
 import type { SyncState } from '../types/DocumentRegistry';
 import './SyncStatusBadge.css';
 
@@ -23,7 +32,7 @@ interface SyncStatusBadgeProps {
 }
 
 interface SyncStateConfig {
-  icon: string;
+  Icon: LucideIcon;
   label: string;
   className: string;
   title: string;
@@ -31,37 +40,37 @@ interface SyncStateConfig {
 
 const SYNC_STATE_CONFIGS: Record<ExtendedSyncState, SyncStateConfig> = {
   synced: {
-    icon: '✓',
+    Icon: Check,
     label: 'Synced',
     className: 'sync-status--synced',
     title: 'Document is synced with the host',
   },
   syncing: {
-    icon: '↻',
+    Icon: RefreshCw,
     label: 'Syncing',
     className: 'sync-status--syncing',
     title: 'Document is currently syncing',
   },
   pending: {
-    icon: '◐',
+    Icon: Clock,
     label: 'Pending',
     className: 'sync-status--pending',
     title: 'Document has pending changes waiting to sync',
   },
   error: {
-    icon: '✕',
+    Icon: AlertTriangle,
     label: 'Error',
     className: 'sync-status--error',
     title: 'Failed to sync document',
   },
   local: {
-    icon: '●',
+    Icon: Circle,
     label: 'Local',
     className: 'sync-status--local',
     title: 'Personal document (not synced)',
   },
   offline: {
-    icon: '◎',
+    Icon: CloudOff,
     label: 'Offline',
     className: 'sync-status--offline',
     title: 'Cached offline - changes will sync when reconnected',
@@ -75,13 +84,16 @@ export function SyncStatusBadge({
   className = '',
 }: SyncStatusBadgeProps) {
   const config = useMemo(() => SYNC_STATE_CONFIGS[state], [state]);
+  const { Icon } = config;
 
   return (
     <span
       className={`sync-status-badge sync-status--${size} ${config.className} ${className}`}
       title={config.title}
     >
-      <span className="sync-status-icon">{config.icon}</span>
+      <span className="sync-status-icon">
+        <Icon size={size === 'medium' ? 14 : 12} aria-hidden={true} />
+      </span>
       {showLabel && <span className="sync-status-label">{config.label}</span>}
     </span>
   );

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -66,7 +66,9 @@
 }
 
 .document-browser__action-icon {
-  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
 }
 
@@ -215,6 +217,20 @@
   max-height: 380px;
   overflow-y: auto;
   padding: var(--space-1) 0;
+}
+
+/* In the Settings modal, let the browser fill the content height (so the
+   list grows when fullscreen and stays balanced when not). Scoped to the
+   settings context so the sidebar/compact usage keeps its fixed height. */
+.settings-modal-content .document-browser {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.settings-modal-content .document-browser__list {
+  flex: 1 1 auto;
+  min-height: 160px;
+  max-height: none;
 }
 
 /* Empty state - Better visual styling */
@@ -374,6 +390,9 @@
 }
 
 .document-browser__new-group-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   margin-left: auto;
   font-size: 11px;
   font-weight: 600;
@@ -540,7 +559,7 @@
 }
 
 .document-browser__caret {
-  font-size: 10px;
+  flex-shrink: 0;
   color: var(--text-secondary, #64748b);
   transition: transform 0.15s ease;
 }
@@ -570,12 +589,37 @@
   border-radius: 8px;
 }
 
+/* Relay-section connection status pill */
+.document-browser__section-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.document-browser__section-status--connected {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+
+.document-browser__section-status--disconnected {
+  color: var(--text-muted, #94a3b8);
+  background: var(--bg-secondary, #f1f5f9);
+}
+
 .document-browser__section-menu-wrap {
   position: relative;
 }
 
 .document-browser__section-menu-btn {
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 22px;
   height: 22px;
   border: none;
@@ -627,9 +671,11 @@
 }
 
 .document-browser__swatch--clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--bg-primary, #ffffff);
   color: var(--text-secondary, #64748b);
-  font-size: 12px;
   line-height: 1;
 }
 
@@ -687,6 +733,16 @@
 }
 
 :root[data-theme="dark"] .document-browser__section-count {
+  background: var(--bg-tertiary, #1e293b);
+  color: var(--text-muted, #94a3b8);
+}
+
+:root[data-theme="dark"] .document-browser__section-status--connected {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.15);
+}
+
+:root[data-theme="dark"] .document-browser__section-status--disconnected {
   background: var(--bg-tertiary, #1e293b);
   color: var(--text-muted, #94a3b8);
 }

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -7,9 +7,24 @@
  */
 
 import { useState, useCallback, useMemo, useRef, useEffect, lazy, Suspense } from 'react';
+import {
+  ChevronDown,
+  Download,
+  FileText,
+  LayoutGrid,
+  List,
+  MoreHorizontal,
+  Plus,
+  RefreshCw,
+  Save,
+  Upload,
+  Wifi,
+  WifiOff,
+  X,
+} from 'lucide-react';
 import { useDocumentRegistry } from '../../store/documentRegistry';
 import { usePersistenceStore } from '../../store/persistenceStore';
-import { useIsRelayAuthenticated } from '../../store/connectionStore';
+import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
 import { useRelayDocumentStore } from '../../store/relayDocumentStore';
 import { useUserStore } from '../../store/userStore';
 import {
@@ -42,6 +57,15 @@ import './DocumentBrowser.css';
 
 type FilterMode = 'all' | 'local' | 'team' | 'cached';
 const UNGROUPED_KEY = '__ungrouped__';
+const LOCAL_RELAY_KEY = '__local__';
+const UNKNOWN_RELAY_KEY = 'unknown';
+
+/** Bucket key for a record under "By relay" grouping. */
+export function relayKeyForRecord(record: DocumentRecord): string {
+  if (record.type === 'local') return LOCAL_RELAY_KEY;
+  // remote | cached both carry relayId; relayDocumentStore uses 'unknown' fallback.
+  return record.relayId || UNKNOWN_RELAY_KEY;
+}
 
 interface DocumentBrowserProps {
   /** Compact mode for sidebar usage */
@@ -117,6 +141,10 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const loadRelayDocument = useRelayDocumentStore((s) => s.loadRelayDocument);
   const deleteFromHost = useRelayDocumentStore((s) => s.deleteFromHost);
   const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
+
+  // Currently-connected relay address (host:port) — drives per-card relay
+  // badges and the "By relay" section ordering.
+  const connectedRelayAddress = useConnectionStore((s) => s.host?.address);
 
   // User store
   const currentUser = useUserStore((s) => s.currentUser);
@@ -205,6 +233,47 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
     });
     return sections;
   }, [groupBy, documentList, assignments, groupsMap, groups]);
+
+  // Bucket documents by relay when "By relay" grouping is enabled. Separate
+  // code path from the user-defined group buckets above. Order: connected
+  // relay first, then other relays (alpha), then unknown, then Local last.
+  const relaySections = useMemo(() => {
+    if (groupBy !== 'relay') return null;
+    const buckets = new Map<string, DocumentRecord[]>();
+    for (const doc of documentList) {
+      const key = relayKeyForRecord(doc);
+      const arr = buckets.get(key);
+      if (arr) arr.push(doc);
+      else buckets.set(key, [doc]);
+    }
+    const relayKeys = [...buckets.keys()].filter(
+      (k) => k !== LOCAL_RELAY_KEY && k !== UNKNOWN_RELAY_KEY
+    );
+    relayKeys.sort((a, b) => {
+      if (a === connectedRelayAddress) return -1;
+      if (b === connectedRelayAddress) return 1;
+      return a.localeCompare(b);
+    });
+    const ordered: string[] = [...relayKeys];
+    if (buckets.has(UNKNOWN_RELAY_KEY)) ordered.push(UNKNOWN_RELAY_KEY);
+    if (buckets.has(LOCAL_RELAY_KEY)) ordered.push(LOCAL_RELAY_KEY);
+
+    return ordered.map((key) => {
+      const title =
+        key === LOCAL_RELAY_KEY
+          ? 'Personal / Local'
+          : key === UNKNOWN_RELAY_KEY
+            ? 'Unknown relay'
+            : key;
+      const status: 'connected' | 'disconnected' | undefined =
+        key === LOCAL_RELAY_KEY || key === UNKNOWN_RELAY_KEY
+          ? undefined
+          : key === connectedRelayAddress
+            ? 'connected'
+            : 'disconnected';
+      return { key, title, status, docs: buckets.get(key) ?? [] };
+    });
+  }, [groupBy, documentList, connectedRelayAddress]);
 
   // Count documents by type
   const documentCounts = useMemo(() => {
@@ -576,6 +645,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
           onPublishToTeam={canPublishToTeam(record, isInTeamMode, authenticated) ? handlePublishToTeam : undefined}
           onMoveToPersonal={canMoveToPersonal(record, authenticated, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
           groupAccent={accent}
+          connectedRelayAddress={connectedRelayAddress}
           mode={cardMode}
         />
       );
@@ -584,6 +654,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       assignments,
       groupsMap,
       groupBy,
+      connectedRelayAddress,
       currentDocumentId,
       selectedIds,
       showSelectionAffordance,
@@ -610,19 +681,33 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
           onClick={handleNewDocument}
           title="Create new document"
         >
-          <span className="document-browser__action-icon">+</span>
+          <span className="document-browser__action-icon">
+            <Plus size={18} aria-hidden="true" />
+          </span>
           New
         </button>
         <button className="document-browser__action" onClick={handleSave} title="Save current document">
+          <span className="document-browser__action-icon">
+            <Save size={18} aria-hidden="true" />
+          </span>
           Save
         </button>
         <button className="document-browser__action" onClick={handleImport} title="Import .docushark file">
+          <span className="document-browser__action-icon">
+            <Upload size={18} aria-hidden="true" />
+          </span>
           Import
         </button>
         <button className="document-browser__action" onClick={handleExport} title="Export as .docushark">
+          <span className="document-browser__action-icon">
+            <Download size={18} aria-hidden="true" />
+          </span>
           Export
         </button>
         <button className="document-browser__action" onClick={() => setPdfExportOpen(true)} title="Export as PDF">
+          <span className="document-browser__action-icon">
+            <FileText size={18} aria-hidden="true" />
+          </span>
           PDF
         </button>
       </div>
@@ -661,8 +746,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
             onClick={handleRefresh}
             disabled={isLoading}
             title="Refresh document list"
+            aria-label="Refresh document list"
           >
-            {isLoading ? '↻' : '⟳'}
+            <RefreshCw size={14} aria-hidden="true" />
           </button>
         </div>
       )}
@@ -733,6 +819,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               options={[
                 { value: 'none', label: 'No grouping' },
                 { value: 'group', label: 'By group' },
+                { value: 'relay', label: 'By relay' },
               ]}
             />
             <div className="document-browser__view-toggle" role="group" aria-label="View mode">
@@ -740,17 +827,19 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
                 className={`document-browser__view-btn ${view === 'list' ? 'document-browser__view-btn--active' : ''}`}
                 onClick={() => setView('list' as DocumentBrowserView)}
                 title="List view"
+                aria-label="List view"
                 aria-pressed={view === 'list'}
               >
-                ☰
+                <List size={16} aria-hidden="true" />
               </button>
               <button
                 className={`document-browser__view-btn ${view === 'grid' ? 'document-browser__view-btn--active' : ''}`}
                 onClick={() => setView('grid' as DocumentBrowserView)}
                 title="Grid view"
+                aria-label="Grid view"
                 aria-pressed={view === 'grid'}
               >
-                ⊞
+                <LayoutGrid size={16} aria-hidden="true" />
               </button>
             </div>
             <button
@@ -758,7 +847,8 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               onClick={handleCreateGroup}
               title="Create document group"
             >
-              + Group
+              <Plus size={13} aria-hidden="true" />
+              Group
             </button>
           </div>
         </div>
@@ -862,6 +952,23 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               />
             );
           })
+        ) : relaySections ? (
+          relaySections.map(({ key, title, status, docs }) => {
+            const collapsed = collapsedMap[key] === true;
+            return (
+              <GroupSection
+                key={key}
+                group={null}
+                titleOverride={title}
+                relayStatus={status}
+                docs={docs}
+                collapsed={collapsed}
+                onToggle={() => toggleCollapsed(key)}
+                view={view}
+                renderCard={renderCard}
+              />
+            );
+          })
         ) : (
           documentList.map((record) => renderCard(record))
         )}
@@ -918,12 +1025,16 @@ interface GroupSectionProps {
   view: DocumentBrowserView;
   onToggle: () => void;
   renderCard: (record: DocumentRecord) => React.ReactNode;
-  isMenuOpen: boolean;
-  onOpenMenu: () => void;
-  onCloseMenu: () => void;
-  onRename: (group: DocumentGroup) => void;
-  onDelete: (group: DocumentGroup) => void;
-  onRecolor: (group: DocumentGroup, color: string | undefined) => void;
+  // User-defined group menu props — only supplied for user-group sections.
+  isMenuOpen?: boolean | undefined;
+  onOpenMenu?: (() => void) | undefined;
+  onCloseMenu?: (() => void) | undefined;
+  onRename?: ((group: DocumentGroup) => void) | undefined;
+  onDelete?: ((group: DocumentGroup) => void) | undefined;
+  onRecolor?: ((group: DocumentGroup, color: string | undefined) => void) | undefined;
+  // Relay-section overrides (used by the "By relay" grouping path).
+  titleOverride?: string | undefined;
+  relayStatus?: 'connected' | 'disconnected' | undefined;
 }
 
 function GroupSection({
@@ -939,11 +1050,13 @@ function GroupSection({
   onRename,
   onDelete,
   onRecolor,
+  titleOverride,
+  relayStatus,
 }: GroupSectionProps) {
   const menuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!isMenuOpen) return;
+    if (!isMenuOpen || !onCloseMenu) return;
     const onDoc = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         onCloseMenu();
@@ -954,6 +1067,11 @@ function GroupSection({
   }, [isMenuOpen, onCloseMenu]);
 
   const isUngrouped = group === null;
+  // Show the group-actions menu only for real user-defined groups, never for
+  // the relay or ungrouped sections.
+  const showMenu = group !== null && titleOverride === undefined;
+  const showSwatch = !isUngrouped && titleOverride === undefined;
+  const title = titleOverride ?? (group !== null ? group.name : 'Ungrouped');
   return (
     <div className="document-browser__section">
       <div className="document-browser__section-header">
@@ -962,35 +1080,48 @@ function GroupSection({
           onClick={onToggle}
           aria-expanded={!collapsed}
         >
-          <span className={`document-browser__caret ${collapsed ? 'document-browser__caret--collapsed' : ''}`}>
-            ▾
-          </span>
-          {!isUngrouped && (
+          <ChevronDown
+            className={`document-browser__caret ${collapsed ? 'document-browser__caret--collapsed' : ''}`}
+            size={14}
+            aria-hidden="true"
+          />
+          {showSwatch && (
             <span
               className="document-browser__section-swatch"
               style={group?.color ? { background: group.color } : undefined}
             />
           )}
-          <span className="document-browser__section-title">
-            {isUngrouped ? 'Ungrouped' : group.name}
-          </span>
+          <span className="document-browser__section-title">{title}</span>
+          {relayStatus && (
+            <span
+              className={`document-browser__section-status document-browser__section-status--${relayStatus}`}
+            >
+              {relayStatus === 'connected' ? (
+                <Wifi size={11} aria-hidden="true" />
+              ) : (
+                <WifiOff size={11} aria-hidden="true" />
+              )}
+              {relayStatus === 'connected' ? 'Connected' : 'Disconnected'}
+            </span>
+          )}
           <span className="document-browser__section-count">{docs.length}</span>
         </button>
-        {!isUngrouped && (
+        {showMenu && group && (
           <div className="document-browser__section-menu-wrap" ref={menuRef}>
             <button
               className="document-browser__section-menu-btn"
               onClick={onOpenMenu}
               title="Group actions"
+              aria-label="Group actions"
               aria-haspopup="menu"
             >
-              ⋯
+              <MoreHorizontal size={16} aria-hidden="true" />
             </button>
             {isMenuOpen && (
               <div className="document-browser__section-menu" role="menu">
                 <button
                   className="document-browser__assign-item"
-                  onClick={() => onRename(group)}
+                  onClick={() => onRename?.(group)}
                 >
                   Rename…
                 </button>
@@ -1001,22 +1132,23 @@ function GroupSection({
                       key={color}
                       className="document-browser__swatch"
                       style={{ background: color }}
-                      onClick={() => onRecolor(group, color)}
+                      onClick={() => onRecolor?.(group, color)}
                       title={color}
                     />
                   ))}
                   <button
                     className="document-browser__swatch document-browser__swatch--clear"
-                    onClick={() => onRecolor(group, undefined)}
+                    onClick={() => onRecolor?.(group, undefined)}
                     title="Clear colour"
+                    aria-label="Clear colour"
                   >
-                    ×
+                    <X size={12} aria-hidden="true" />
                   </button>
                 </div>
                 <div className="document-browser__assign-sep" />
                 <button
                   className="document-browser__assign-item document-browser__assign-item--danger"
-                  onClick={() => onDelete(group)}
+                  onClick={() => onDelete?.(group)}
                 >
                   Delete group
                 </button>


### PR DESCRIPTION
Refines the **Settings → Documents** browser.

## Relay differentiation
A cached/offline document from a *disconnected* relay was visually indistinguishable from a live document on the currently-connected relay. Now:
- **Per-card relay badge** — shows the relay host with connected (green `Wifi`) / disconnected (muted `WifiOff`) state, comparing `record.relayId` against `useConnectionStore` `host.address`.
- **"By relay" grouping** — new option in the Group dropdown, reusing the existing `GroupSection` machinery (connected relay first → other relays → Unknown → Personal/Local last). Separate code path from user-defined groups.
- **Expandable details panel** — chevron reveals relay, owner, permission, created/modified, sync state, pending changes, offline availability, and document id.

## UI polish
- **Leaner card meta row** — permission / page count / owner / full host moved into the details panel (collapsed card = type, relay, sync, date).
- **Fills the settings height** — the document list now grows to fill the content area, including fullscreen (scoped to `.settings-modal-content`; sidebar/compact unaffected). Replaces the fixed `max-height: 380px`.
- **Visible, clickable action buttons** — full-mode actions are always visible, 30px hit targets, hover/`:focus-visible` styling.
- **Grid checkbox fix** — the absolute checkbox no longer overlaps the title (real offsets + reserved title padding).
- **Clean icons** — emoji/Unicode glyphs replaced with lucide line icons across `DocumentCard`, `DocumentBrowser`, and the shared `SyncStatusBadge`; state colors preserved, syncing/in-flight spin. Reuses the existing `lucide-react` dependency (no new lib).

## Tests
- New `src/ui/DocumentCard.relay.test.ts` — `formatRelayLabel` (local→undefined, connected/disconnected, `unknown` handling) + `relayKeyForRecord` bucketing.
- `uiPreferencesStore.test.ts` — round-trips the new `relay` grouping mode.
- `bun run typecheck` clean; full suite 1667/1667 pass.

_Left open for review (not merged)._