### PR TITLE
Relay asset durability stack: blob store routing, immutable origin, blob:// canvas render (JP-118/117/121/122)

### DIFF
--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -12,9 +12,9 @@
  *   PUT    /api/docs/:id        Bearer + body
  *   DELETE /api/docs/:id        Bearer
  *   POST   /api/docs/:id/share  Bearer + body
- *   POST   /api/blobs/:hash     (no auth required by current relay)
- *   GET    /api/blobs/:hash     (no auth required)
- *   HEAD   /api/blobs/:hash     (no auth required)
+ *   POST   /api/blobs/:hash     Bearer + body
+ *   GET    /api/blobs/:hash     Bearer
+ *   HEAD   /api/blobs/:hash     Bearer
  */
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -11,6 +11,7 @@
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
 import type { RelayClient } from './relayClient';
+import { BlobSyncService, type BlobSyncResult } from '../collaboration/BlobSyncService';
 
 /** Share entry shape carried by the store's `updateDocumentShares`. */
 export interface DocumentProviderShareEntry {
@@ -25,7 +26,16 @@ export interface DocumentProviderShareEntry {
  * directional dependencies clean (store -> adapter, not the reverse).
  */
 export class RestDocumentProvider {
-  constructor(private readonly client: RelayClient) {}
+  /**
+   * Syncs relay-doc assets to/from the relay blob store. The `RelayClient`
+   * satisfies `BlobTransport` directly, so blob traffic reuses the same
+   * bearer token + 401 → refresh path as document CRUD (JP-118).
+   */
+  private readonly blobSync: BlobSyncService;
+
+  constructor(private readonly client: RelayClient) {
+    this.blobSync = new BlobSyncService({ transport: client });
+  }
 
   async listDocuments(): Promise<DocumentMetadata[]> {
     const { documents } = await this.client.listDocuments();
@@ -64,6 +74,23 @@ export class RestDocumentProvider {
   /** True when there's a JWT to send. Used by `SyncStateManager` to gate queue flushes. */
   isReady(): boolean {
     return this.client.getToken() !== undefined;
+  }
+
+  /**
+   * Upload the blobs a relay doc references to the blob store, before the
+   * doc save. Only blobs the relay is missing are sent (deduped server-side).
+   */
+  async uploadBlobs(hashes: string[]): Promise<BlobSyncResult> {
+    return this.blobSync.ensureBlobsUploaded(hashes);
+  }
+
+  /**
+   * Download into local IndexedDB any referenced blobs missing locally,
+   * after a relay doc load — so blob:// refs render and the doc stays
+   * viewable offline from the cache.
+   */
+  async downloadBlobs(hashes: string[]): Promise<BlobSyncResult> {
+    return this.blobSync.downloadMissingBlobs(hashes);
   }
 
   async transferDocumentOwnership(

--- a/src/collaboration/BlobSyncService.test.ts
+++ b/src/collaboration/BlobSyncService.test.ts
@@ -1,392 +1,231 @@
 /**
  * BlobSyncService Tests
  *
- * Tests for HTTP-based blob synchronization.
+ * Exercises the orchestration over an injected blob transport (the same
+ * shape the connected RelayClient satisfies). No fetch/token mocking — the
+ * service no longer owns transport or auth.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { BlobSyncService, type BlobSyncProgress } from './BlobSyncService';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  BlobSyncService,
+  type BlobTransport,
+  type BlobSyncProgress,
+} from './BlobSyncService';
+import type { BlobStorage } from '../storage/BlobStorage';
 
-// Mock BlobStorage
-vi.mock('../storage/BlobStorage', () => ({
-  BlobStorage: {
-    getInstance: () => ({
-      loadBlob: vi.fn(),
-      saveBlob: vi.fn(),
-      getBlobMetadata: vi.fn(),
+// jsdom's Blob has no arrayBuffer() (real browsers + Tauri webview do).
+// Polyfill via FileReader so the service's Blob→bytes read works under test.
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+  Blob.prototype.arrayBuffer = function (this: Blob): Promise<ArrayBuffer> {
+    return new Promise((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = () => resolve(fr.result as ArrayBuffer);
+      fr.onerror = () => reject(fr.error);
+      fr.readAsArrayBuffer(this);
+    });
+  };
+}
+
+/** A RelayError-shaped failure: carries a numeric `status` like the real client. */
+function httpError(status: number, message = `HTTP ${status}`): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+/** Minimal in-memory BlobStorage stand-in (only the methods the service uses). */
+function makeBlobStorage(seed: Record<string, Blob> = {}): {
+  store: Map<string, Blob>;
+  mock: BlobStorage;
+} {
+  const store = new Map<string, Blob>(Object.entries(seed));
+  const mock = {
+    loadBlob: vi.fn(async (id: string) => store.get(id) ?? null),
+    saveBlob: vi.fn(async (blob: Blob, name: string) => {
+      store.set(name, blob);
+      return name;
     }),
-  },
-}));
+  } as unknown as BlobStorage;
+  return { store, mock };
+}
+
+function makeTransport(overrides: Partial<BlobTransport> = {}): BlobTransport {
+  return {
+    blobExists: vi.fn(async () => false),
+    uploadBlob: vi.fn(async () => {}),
+    downloadBlob: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    ...overrides,
+  };
+}
+
+const fast = { maxRetries: 3, initialRetryDelay: 1, maxRetryDelay: 5 } as const;
 
 describe('BlobSyncService', () => {
-  let service: BlobSyncService;
-  let mockFetch: ReturnType<typeof vi.fn>;
-  let originalFetch: typeof fetch;
-  const testServerUrl = 'http://localhost:9876';
-  const testToken = 'test-jwt-token';
-
   beforeEach(() => {
-    // Reset mocks
     vi.clearAllMocks();
-
-    // Save original fetch
-    originalFetch = global.fetch;
-
-    // Mock fetch
-    mockFetch = vi.fn();
-    global.fetch = mockFetch as typeof fetch;
-
-    // Create service
-    service = new BlobSyncService({
-      serverUrl: testServerUrl,
-      token: testToken,
-    });
-  });
-
-  afterEach(() => {
-    // Restore original fetch
-    global.fetch = originalFetch;
-    vi.restoreAllMocks();
   });
 
   describe('checkBlobExists', () => {
-    it('returns exists: true when server returns 204', async () => {
-      mockFetch.mockResolvedValueOnce({
-        status: 204,
-        headers: new Headers({
-          'Content-Length': '1024',
-          'Content-Type': 'image/png',
-        }),
-      });
-
-      const result = await service.checkBlobExists('abc123');
-
-      expect(result.exists).toBe(true);
-      expect(result.size).toBe(1024);
-      expect(result.mimeType).toBe('image/png');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${testServerUrl}/api/blobs/abc123`,
-        {
-          method: 'HEAD',
-          headers: {
-            Authorization: `Bearer ${testToken}`,
-          },
-        }
-      );
-    });
-
-    it('returns exists: false when server returns 404', async () => {
-      mockFetch.mockResolvedValueOnce({
-        status: 404,
-        headers: new Headers(),
-      });
-
-      const result = await service.checkBlobExists('nonexistent');
-
-      expect(result.exists).toBe(false);
-    });
-
-    it('throws on 401 unauthorized', async () => {
-      mockFetch.mockResolvedValueOnce({
-        status: 401,
-        headers: new Headers(),
-      });
-
-      await expect(service.checkBlobExists('abc123')).rejects.toThrow(
-        'Unauthorized'
-      );
+    it('delegates to the transport', async () => {
+      const transport = makeTransport({ blobExists: vi.fn(async () => true) });
+      const svc = new BlobSyncService({ transport, ...fast });
+      expect(await svc.checkBlobExists('abc')).toBe(true);
+      expect(transport.blobExists).toHaveBeenCalledWith('abc');
     });
   });
 
   describe('uploadBlob', () => {
-    it('uploads blob successfully', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ success: true }),
-      });
-
-      const blob = new Blob(['test content'], { type: 'text/plain' });
-      await service.uploadBlob('abc123', blob);
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${testServerUrl}/api/blobs/abc123`,
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            Authorization: `Bearer ${testToken}`,
-            'Content-Type': 'text/plain',
-          }),
-          body: blob,
-        })
-      );
+    it('sends the blob bytes to the transport', async () => {
+      const transport = makeTransport();
+      const svc = new BlobSyncService({ transport, ...fast });
+      await svc.uploadBlob('abc', new Blob([new Uint8Array([9, 8, 7])]));
+      const [hash, data] = (transport.uploadBlob as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(hash).toBe('abc');
+      expect(Array.from(data as Uint8Array)).toEqual([9, 8, 7]);
     });
 
-    it('throws on hash mismatch (400)', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        text: () => Promise.resolve('Hash mismatch: expected abc, got xyz'),
+    it('propagates a hash-mismatch (4xx) without retrying', async () => {
+      const uploadBlob = vi.fn(async () => {
+        throw httpError(400, 'Hash mismatch');
       });
-
-      const blob = new Blob(['test content'], { type: 'text/plain' });
-      await expect(service.uploadBlob('abc123', blob)).rejects.toThrow(
-        'Hash mismatch'
-      );
-    });
-
-    it('throws on unauthorized (401)', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 401,
-        text: () => Promise.resolve('Unauthorized'),
-      });
-
-      const blob = new Blob(['test content'], { type: 'text/plain' });
-      await expect(service.uploadBlob('abc123', blob)).rejects.toThrow(
-        'Unauthorized'
-      );
+      const transport = makeTransport({ uploadBlob });
+      const svc = new BlobSyncService({ transport, ...fast });
+      await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow('Hash mismatch');
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('downloadBlob', () => {
-    it('downloads blob successfully', async () => {
-      const mockBlob = new Blob(['test content'], { type: 'text/plain' });
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        blob: () => Promise.resolve(mockBlob),
-      });
-
-      const result = await service.downloadBlob('abc123');
-
-      expect(result).toBeInstanceOf(Blob);
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${testServerUrl}/api/blobs/abc123`,
-        expect.objectContaining({
-          method: 'GET',
-          headers: expect.objectContaining({
-            Authorization: `Bearer ${testToken}`,
-          }),
-        })
-      );
+    it('returns a Blob and sniffs PNG bytes to a MIME type', async () => {
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const transport = makeTransport({ downloadBlob: vi.fn(async () => png) });
+      const svc = new BlobSyncService({ transport, ...fast });
+      const blob = await svc.downloadBlob('abc');
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.type).toBe('image/png');
     });
 
-    it('throws on 404 not found', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      });
-
-      await expect(service.downloadBlob('nonexistent')).rejects.toThrow(
-        'Blob not found'
-      );
+    it('returns an untyped Blob for unknown bytes', async () => {
+      const transport = makeTransport({ downloadBlob: vi.fn(async () => new Uint8Array([0, 1, 2])) });
+      const svc = new BlobSyncService({ transport, ...fast });
+      const blob = await svc.downloadBlob('abc');
+      expect(blob.type).toBe('');
     });
   });
 
-  describe('extractBlobReferences', () => {
-    it('extracts blobRef from FileShape', () => {
-      const doc = {
-        id: 'doc-1',
-        name: 'Test',
-        pages: {
-          'page-1': {
-            id: 'page-1',
-            name: 'Page 1',
-            shapes: {
-              'shape-1': {
-                id: 'shape-1',
-                type: 'file',
-                blobRef: 'hash1',
-                fileName: 'test.pdf',
-              },
-              'shape-2': {
-                id: 'shape-2',
-                type: 'rectangle',
-                // No blobRef
-              },
-              'shape-3': {
-                id: 'shape-3',
-                type: 'file',
-                blobRef: 'hash2',
-                fileName: 'test2.pdf',
-              },
-            },
-            shapeOrder: ['shape-1', 'shape-2', 'shape-3'],
-            createdAt: 0,
-            modifiedAt: 0,
-          },
-        },
-        pageOrder: ['page-1'],
-        activePageId: 'page-1',
-        createdAt: 0,
-        modifiedAt: 0,
-        version: 1,
-      };
+  describe('ensureBlobsUploaded', () => {
+    it('skips blobs already on the relay and uploads only the missing ones', async () => {
+      const { mock: blobStorage } = makeBlobStorage({
+        present: new Blob(['a']),
+        missing: new Blob(['b']),
+      });
+      const blobExists = vi.fn(async (hash: string) => hash === 'present');
+      const uploadBlob = vi.fn(async () => {});
+      const svc = new BlobSyncService({
+        transport: makeTransport({ blobExists, uploadBlob }),
+        blobStorage,
+        ...fast,
+      });
 
-      // @ts-expect-error - simplified document for testing
-      const hashes = service.extractBlobReferences(doc);
+      const result = await svc.ensureBlobsUploaded(['present', 'missing']);
 
-      expect(hashes).toHaveLength(2);
-      expect(hashes).toContain('hash1');
-      expect(hashes).toContain('hash2');
+      expect(result.total).toBe(2);
+      expect(result.success).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      expect((uploadBlob as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe('missing');
     });
 
-    it('returns empty array for document with no FileShapes', () => {
-      const doc = {
-        id: 'doc-1',
-        name: 'Test',
-        pages: {
-          'page-1': {
-            id: 'page-1',
-            name: 'Page 1',
-            shapes: {
-              'shape-1': {
-                id: 'shape-1',
-                type: 'rectangle',
-              },
-            },
-            shapeOrder: ['shape-1'],
-            createdAt: 0,
-            modifiedAt: 0,
-          },
-        },
-        pageOrder: ['page-1'],
-        activePageId: 'page-1',
-        createdAt: 0,
-        modifiedAt: 0,
-        version: 1,
-      };
+    it('records a failure when a referenced blob is absent locally', async () => {
+      const { mock: blobStorage } = makeBlobStorage(); // empty
+      const svc = new BlobSyncService({
+        transport: makeTransport({ blobExists: vi.fn(async () => false) }),
+        blobStorage,
+        ...fast,
+      });
 
-      // @ts-expect-error - simplified document for testing
-      const hashes = service.extractBlobReferences(doc);
+      const result = await svc.ensureBlobsUploaded(['gone']);
 
-      expect(hashes).toHaveLength(0);
+      expect(result.failed).toBe(1);
+      expect(result.errors.get('gone')).toMatch(/local storage/);
+    });
+  });
+
+  describe('downloadMissingBlobs', () => {
+    it('downloads and persists blobs missing locally; skips present ones', async () => {
+      const { store, mock: blobStorage } = makeBlobStorage({ here: new Blob(['x']) });
+      const downloadBlob = vi.fn(async () => new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]));
+      const svc = new BlobSyncService({
+        transport: makeTransport({ downloadBlob }),
+        blobStorage,
+        ...fast,
+      });
+
+      const result = await svc.downloadMissingBlobs(['here', 'fetchme']);
+
+      expect(result.success).toBe(2);
+      expect(downloadBlob).toHaveBeenCalledTimes(1);
+      expect(downloadBlob).toHaveBeenCalledWith('fetchme');
+      expect(store.has('fetchme')).toBe(true);
     });
   });
 
   describe('progress callback', () => {
-    it('calls onProgress during operations', async () => {
-      const progressCallbacks: BlobSyncProgress[] = [];
-      const serviceWithProgress = new BlobSyncService({
-        serverUrl: testServerUrl,
-        token: testToken,
-        onProgress: (p) => progressCallbacks.push({ ...p }),
+    it('reports checking then uploading phases', async () => {
+      const phases: BlobSyncProgress['phase'][] = [];
+      const { mock: blobStorage } = makeBlobStorage({ h1: new Blob(['x']) });
+      const svc = new BlobSyncService({
+        transport: makeTransport({ blobExists: vi.fn(async () => false) }),
+        blobStorage,
+        onProgress: (p) => phases.push(p.phase),
+        ...fast,
       });
 
-      // Mock check - blob doesn't exist
-      mockFetch.mockResolvedValueOnce({
-        status: 404,
-        headers: new Headers(),
-      });
+      await svc.ensureBlobsUploaded(['h1']);
 
-      // Mock upload success
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ success: true }),
-      });
-
-      // Mock BlobStorage
-      const { BlobStorage } = await import('../storage/BlobStorage');
-      const mockInstance = BlobStorage.getInstance();
-      (mockInstance.loadBlob as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-        new Blob(['test'], { type: 'text/plain' })
-      );
-
-      await serviceWithProgress.ensureBlobsUploaded(['hash1']);
-
-      // Should have progress for checking and uploading phases
-      expect(progressCallbacks.some((p) => p.phase === 'checking')).toBe(true);
-      expect(progressCallbacks.some((p) => p.phase === 'uploading')).toBe(true);
-    });
-  });
-
-  describe('setToken', () => {
-    it('updates the token', async () => {
-      service.setToken('new-token');
-
-      mockFetch.mockResolvedValueOnce({
-        status: 204,
-        headers: new Headers(),
-      });
-
-      await service.checkBlobExists('abc123');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer new-token',
-          }),
-        })
-      );
+      expect(phases).toContain('checking');
+      expect(phases).toContain('uploading');
     });
   });
 
   describe('retry logic', () => {
-    it('retries on 500 error', async () => {
-      // First call fails with 500
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        text: () => Promise.resolve('Internal Server Error'),
+    it('retries on a 5xx then succeeds', async () => {
+      let calls = 0;
+      const downloadBlob = vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw httpError(500);
+        return new Uint8Array([1]);
       });
+      const svc = new BlobSyncService({ transport: makeTransport({ downloadBlob }), ...fast });
 
-      // Second call succeeds
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        blob: () => Promise.resolve(new Blob(['test'])),
-      });
-
-      // Create service with short retry delay for testing
-      const fastService = new BlobSyncService({
-        serverUrl: testServerUrl,
-        token: testToken,
-        maxRetries: 3,
-        initialRetryDelay: 10, // Very short for testing
-      });
-
-      const result = await fastService.downloadBlob('abc123');
-
-      expect(result).toBeInstanceOf(Blob);
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const blob = await svc.downloadBlob('abc');
+      expect(blob).toBeInstanceOf(Blob);
+      expect(downloadBlob).toHaveBeenCalledTimes(2);
     });
 
-    it('does not retry on 400 client error', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        text: () => Promise.resolve('Bad Request'),
+    it('does not retry a 4xx', async () => {
+      const uploadBlob = vi.fn(async () => {
+        throw httpError(400);
       });
+      const svc = new BlobSyncService({ transport: makeTransport({ uploadBlob }), ...fast });
 
-      await expect(service.uploadBlob('abc123', new Blob(['test']))).rejects.toThrow();
-
-      // Should only be called once (no retry)
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow();
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe('URL handling', () => {
-    it('handles URL with trailing slash', () => {
-      const serviceWithSlash = new BlobSyncService({
-        serverUrl: 'http://localhost:9876/',
-        token: testToken,
+    it('retries network errors (no status) up to maxRetries then throws', async () => {
+      const downloadBlob = vi.fn(async () => {
+        throw new Error('network down');
+      });
+      const svc = new BlobSyncService({
+        transport: makeTransport({ downloadBlob }),
+        maxRetries: 2,
+        initialRetryDelay: 1,
+        maxRetryDelay: 5,
       });
 
-      mockFetch.mockResolvedValueOnce({
-        status: 204,
-        headers: new Headers(),
-      });
-
-      serviceWithSlash.checkBlobExists('abc123');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:9876/api/blobs/abc123',
-        expect.any(Object)
-      );
+      await expect(svc.downloadBlob('abc')).rejects.toThrow('network down');
+      // initial attempt + 2 retries
+      expect(downloadBlob).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/collaboration/BlobSyncService.test.ts
+++ b/src/collaboration/BlobSyncService.test.ts
@@ -130,6 +130,8 @@ describe('BlobSyncService', () => {
 
       expect(result.total).toBe(2);
       expect(result.success).toBe(2);
+      // Only the missing blob was actually sent; the present one was skipped.
+      expect(result.uploaded).toBe(1);
       expect(result.failed).toBe(0);
       expect(uploadBlob).toHaveBeenCalledTimes(1);
       expect((uploadBlob as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe('missing');

--- a/src/collaboration/BlobSyncService.ts
+++ b/src/collaboration/BlobSyncService.ts
@@ -68,8 +68,15 @@ export interface BlobSyncServiceOptions {
 export interface BlobSyncResult {
   /** Total blobs processed */
   total: number;
-  /** Blobs successfully synced */
+  /** Blobs successfully synced (uploaded + already-present) */
   success: number;
+  /**
+   * Blobs actually transferred over the wire — a subset of `success`. On
+   * upload, the rest were already on the relay (HEAD-gate skip); on download,
+   * the rest were already in local storage. Lets callers report honestly
+   * instead of claiming everything was (re)uploaded.
+   */
+  uploaded: number;
   /** Blobs that failed */
   failed: number;
   /** Error messages for failed blobs */
@@ -146,6 +153,7 @@ export class BlobSyncService {
     const result: BlobSyncResult = {
       total: hashes.length,
       success: 0,
+      uploaded: 0,
       failed: 0,
       errors: new Map(),
     };
@@ -203,6 +211,7 @@ export class BlobSyncService {
           // Upload to relay
           await this.uploadBlob(hash, blob);
           result.success++;
+          result.uploaded++;
         } catch (error) {
           result.failed++;
           result.errors.set(hash, error instanceof Error ? error.message : String(error));
@@ -223,6 +232,7 @@ export class BlobSyncService {
     const result: BlobSyncResult = {
       total: hashes.length,
       success: 0,
+      uploaded: 0,
       failed: 0,
       errors: new Map(),
     };
@@ -271,6 +281,7 @@ export class BlobSyncService {
           // content, so the local ID matches the relay hash (content-addressed).
           await this.blobStorage.saveBlob(blob, hash);
           result.success++;
+          result.uploaded++;
         } catch (error) {
           result.failed++;
           result.errors.set(hash, error instanceof Error ? error.message : String(error));
@@ -289,7 +300,7 @@ export class BlobSyncService {
     const blobHashes = collectBlobReferences(document);
 
     if (blobHashes.length === 0) {
-      return { total: 0, success: 0, failed: 0, errors: new Map() };
+      return { total: 0, success: 0, uploaded: 0, failed: 0, errors: new Map() };
     }
 
     const uploadResult = await this.ensureBlobsUploaded(blobHashes);
@@ -298,6 +309,7 @@ export class BlobSyncService {
     return {
       total: blobHashes.length,
       success: Math.max(uploadResult.success, downloadResult.success),
+      uploaded: uploadResult.uploaded + downloadResult.uploaded,
       failed: Math.min(uploadResult.failed, downloadResult.failed),
       errors: new Map([...uploadResult.errors, ...downloadResult.errors]),
     };

--- a/src/collaboration/BlobSyncService.ts
+++ b/src/collaboration/BlobSyncService.ts
@@ -1,22 +1,23 @@
 /**
  * Blob Sync Service
  *
- * HTTP-based blob synchronization for embedded files in collaborative documents.
- * Uploads blobs to server before document save, downloads missing blobs after
- * document load.
+ * HTTP-based blob synchronization for assets in relay documents. Uploads
+ * referenced blobs to the relay blob store before a document save, and
+ * downloads any missing blobs into local IndexedDB after a document load.
  *
- * Features:
- * - HTTP transport (separate from WebSocket document sync)
- * - Retry with exponential backoff
- * - Progress tracking
- * - Integration with local BlobStorage
+ * Transport is injected (`BlobTransport`) rather than owning its own
+ * `fetch` + JWT: the connected `RelayClient` already satisfies the
+ * interface, so blob traffic rides the same bearer token, 401 → refresh
+ * path, and base URL as document CRUD (see `collaborationStore` wiring).
+ * This service keeps the orchestration on top: check-then-act batching,
+ * retry with backoff, progress reporting, and `BlobStorage` integration.
  *
- * Phase 17.5 Collaboration Support
+ * Phase 17.5 Collaboration Support; transport seam added for JP-118.
  */
 
 import type { DiagramDocument } from '../types/Document';
-import type { Shape, FileShape } from '../shapes/Shape';
 import { BlobStorage } from '../storage/BlobStorage';
+import { collectBlobReferences } from '../storage/AssetBundler';
 
 // ============ Types ============
 
@@ -36,12 +37,21 @@ export interface BlobSyncProgress {
   bytesTotal?: number;
 }
 
+/**
+ * Low-level blob transport. The connected `RelayClient` implements this
+ * directly (`uploadBlob`/`downloadBlob`/`blobExists`), so auth + refresh
+ * are handled there; this service never touches tokens.
+ */
+export interface BlobTransport {
+  blobExists(hash: string): Promise<boolean>;
+  uploadBlob(hash: string, data: Uint8Array): Promise<void>;
+  downloadBlob(hash: string): Promise<Uint8Array>;
+}
+
 /** Options for BlobSyncService */
 export interface BlobSyncServiceOptions {
-  /** Server base URL (e.g., http://192.168.1.100:9876) - no trailing slash */
-  serverUrl: string;
-  /** JWT token for authentication */
-  token: string;
+  /** Blob transport (typically the connected RelayClient). */
+  transport: BlobTransport;
   /** Progress callback */
   onProgress?: ((progress: BlobSyncProgress) => void) | undefined;
   /** Max retry attempts (default: 5) */
@@ -50,13 +60,8 @@ export interface BlobSyncServiceOptions {
   initialRetryDelay?: number | undefined;
   /** Max retry delay in ms (default: 30000) */
   maxRetryDelay?: number | undefined;
-}
-
-/** Result of a blob existence check */
-interface BlobExistsResult {
-  exists: boolean;
-  size?: number | undefined;
-  mimeType?: string | undefined;
+  /** Override the BlobStorage instance (defaults to the singleton; for tests). */
+  blobStorage?: BlobStorage | undefined;
 }
 
 /** Result of a batch sync operation */
@@ -74,23 +79,17 @@ export interface BlobSyncResult {
 // ============ BlobSyncService ============
 
 /**
- * Service for synchronizing blobs between client and server via HTTP.
+ * Service for synchronizing blobs between client and relay over HTTP.
  *
  * Usage:
  * ```typescript
- * const service = new BlobSyncService({
- *   serverUrl: 'http://192.168.1.100:9876',
- *   token: 'jwt-token',
- *   onProgress: (p) => console.log(`${p.phase}: ${p.current}/${p.total}`),
- * });
- *
- * // Sync blobs for a document (upload missing to server, download missing locally)
- * await service.syncBlobsForDocument(document);
+ * const service = new BlobSyncService({ transport: relayClient });
+ * await service.ensureBlobsUploaded(hashes); // before doc save
+ * await service.downloadMissingBlobs(hashes); // after doc load
  * ```
  */
 export class BlobSyncService {
-  private serverUrl: string;
-  private token: string;
+  private transport: BlobTransport;
   private onProgress: ((progress: BlobSyncProgress) => void) | undefined;
   private maxRetries: number;
   private initialRetryDelay: number;
@@ -98,112 +97,50 @@ export class BlobSyncService {
   private blobStorage: BlobStorage;
 
   constructor(options: BlobSyncServiceOptions) {
-    this.serverUrl = options.serverUrl.replace(/\/$/, ''); // Remove trailing slash
-    this.token = options.token;
+    this.transport = options.transport;
     this.onProgress = options.onProgress ?? undefined;
     this.maxRetries = options.maxRetries ?? 5;
     this.initialRetryDelay = options.initialRetryDelay ?? 1000;
     this.maxRetryDelay = options.maxRetryDelay ?? 30000;
-    this.blobStorage = BlobStorage.getInstance();
+    this.blobStorage = options.blobStorage ?? BlobStorage.getInstance();
   }
 
   /**
-   * Update the JWT token (e.g., after refresh).
+   * Check if a blob exists on the relay.
    */
-  setToken(token: string): void {
-    this.token = token;
+  async checkBlobExists(hash: string): Promise<boolean> {
+    return this.withRetry(() => this.transport.blobExists(hash));
   }
 
   /**
-   * Check if a blob exists on the server.
-   */
-  async checkBlobExists(hash: string): Promise<BlobExistsResult> {
-    const url = `${this.serverUrl}/api/blobs/${hash}`;
-
-    const response = await fetch(url, {
-      method: 'HEAD',
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-      },
-    });
-
-    if (response.status === 204) {
-      return {
-        exists: true,
-        size: parseInt(response.headers.get('Content-Length') || '0', 10),
-        mimeType: response.headers.get('Content-Type') || undefined,
-      };
-    }
-
-    if (response.status === 404) {
-      return { exists: false };
-    }
-
-    if (response.status === 401) {
-      throw new Error('Unauthorized: Invalid or expired token');
-    }
-
-    throw new Error(`Unexpected response: ${response.status}`);
-  }
-
-  /**
-   * Upload a blob to the server.
+   * Upload a blob to the relay.
    */
   async uploadBlob(hash: string, blob: Blob): Promise<void> {
-    const url = `${this.serverUrl}/api/blobs/${hash}`;
-
-    const response = await this.fetchWithRetry(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        'Content-Type': blob.type || 'application/octet-stream',
-      },
-      body: blob,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      if (response.status === 400 && text.includes('Hash mismatch')) {
-        throw new Error(`Hash mismatch: blob content doesn't match hash ${hash}`);
-      }
-      if (response.status === 401) {
-        throw new Error('Unauthorized: Invalid or expired token');
-      }
-      throw new Error(`Upload failed: ${response.status} ${text}`);
-    }
+    const data = new Uint8Array(await blob.arrayBuffer());
+    await this.withRetry(() => this.transport.uploadBlob(hash, data));
   }
 
   /**
-   * Download a blob from the server.
+   * Download a blob from the relay. The relay does not round-trip a
+   * reliable MIME type (uploads are stored as octet-stream), so we sniff
+   * the common image/PDF signatures from the bytes to give the cached
+   * blob a sensible `type` for rendering and re-export.
    */
   async downloadBlob(hash: string): Promise<Blob> {
-    const url = `${this.serverUrl}/api/blobs/${hash}`;
-
-    const response = await this.fetchWithRetry(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-      },
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new Error(`Blob not found: ${hash}`);
-      }
-      if (response.status === 401) {
-        throw new Error('Unauthorized: Invalid or expired token');
-      }
-      throw new Error(`Download failed: ${response.status}`);
-    }
-
-    const blob = await response.blob();
-    return blob;
+    const data = await this.withRetry(() => this.transport.downloadBlob(hash));
+    const type = sniffMimeType(data);
+    // Copy into a fresh ArrayBuffer so the body is unambiguously a BlobPart
+    // (strict TS lib defs reject `Uint8Array<ArrayBufferLike>` directly).
+    const buffer = new ArrayBuffer(data.byteLength);
+    new Uint8Array(buffer).set(data);
+    return type ? new Blob([buffer], { type }) : new Blob([buffer]);
   }
 
   /**
-   * Ensure all blobs referenced by a document are uploaded to the server.
+   * Ensure all blobs referenced by a document are uploaded to the relay.
    *
-   * Call this before saving a document to ensure blobs are available.
+   * Call this before saving a relay document: a doc that references blobs
+   * the relay doesn't have would render broken for collaborators.
    */
   async ensureBlobsUploaded(hashes: string[]): Promise<BlobSyncResult> {
     const result: BlobSyncResult = {
@@ -229,14 +166,14 @@ export class BlobSyncService {
       });
 
       try {
-        const { exists } = await this.checkBlobExists(hash);
+        const exists = await this.checkBlobExists(hash);
         if (!exists) {
           toUpload.push(hash);
         } else {
           result.success++;
         }
-      } catch (error) {
-        // If check fails, try to upload anyway
+      } catch {
+        // If the existence check fails, try to upload anyway.
         toUpload.push(hash);
       }
     }
@@ -263,7 +200,7 @@ export class BlobSyncService {
             continue;
           }
 
-          // Upload to server
+          // Upload to relay
           await this.uploadBlob(hash, blob);
           result.success++;
         } catch (error) {
@@ -277,9 +214,10 @@ export class BlobSyncService {
   }
 
   /**
-   * Download missing blobs from the server to local storage.
+   * Download missing blobs from the relay into local storage.
    *
-   * Call this after loading a document to ensure all blobs are available locally.
+   * Call this after loading a relay document so blob:// references resolve
+   * for rendering and the doc stays viewable offline from the IndexedDB cache.
    */
   async downloadMissingBlobs(hashes: string[]): Promise<BlobSyncResult> {
     const result: BlobSyncResult = {
@@ -326,11 +264,11 @@ export class BlobSyncService {
         });
 
         try {
-          // Download from server
+          // Download from relay
           const blob = await this.downloadBlob(hash);
 
-          // Save to local storage
-          // The blob ID should match the hash since we're using content-addressed storage
+          // Save to local storage. BlobStorage recomputes the SHA-256 from
+          // content, so the local ID matches the relay hash (content-addressed).
           await this.blobStorage.saveBlob(blob, hash);
           result.success++;
         } catch (error) {
@@ -344,59 +282,25 @@ export class BlobSyncService {
   }
 
   /**
-   * Sync all blobs for a document.
-   *
-   * This is a convenience method that:
-   * 1. Extracts blob references from the document
-   * 2. Uploads any blobs that exist locally but not on server
-   * 3. Downloads any blobs that exist on server but not locally
+   * Sync all blobs for a document: upload local-only blobs to the relay,
+   * then download any the relay has but the client is missing.
    */
   async syncBlobsForDocument(document: DiagramDocument): Promise<BlobSyncResult> {
-    const blobHashes = this.extractBlobReferences(document);
+    const blobHashes = collectBlobReferences(document);
 
     if (blobHashes.length === 0) {
       return { total: 0, success: 0, failed: 0, errors: new Map() };
     }
 
-    // First upload local blobs to server
     const uploadResult = await this.ensureBlobsUploaded(blobHashes);
-
-    // Then download any missing from server
     const downloadResult = await this.downloadMissingBlobs(blobHashes);
 
-    // Combine results
     return {
       total: blobHashes.length,
       success: Math.max(uploadResult.success, downloadResult.success),
       failed: Math.min(uploadResult.failed, downloadResult.failed),
       errors: new Map([...uploadResult.errors, ...downloadResult.errors]),
     };
-  }
-
-  /**
-   * Extract blob references from a document.
-   * Scans all pages for FileShape.blobRef fields.
-   */
-  extractBlobReferences(document: DiagramDocument): string[] {
-    const hashes = new Set<string>();
-
-    // Scan all pages
-    for (const page of Object.values(document.pages)) {
-      for (const shape of Object.values(page.shapes)) {
-        if (this.isFileShape(shape) && shape.blobRef) {
-          hashes.add(shape.blobRef);
-        }
-      }
-    }
-
-    return Array.from(hashes);
-  }
-
-  /**
-   * Type guard for FileShape.
-   */
-  private isFileShape(shape: Shape): shape is FileShape {
-    return shape.type === 'file';
   }
 
   /**
@@ -407,38 +311,30 @@ export class BlobSyncService {
   }
 
   /**
-   * Fetch with retry and exponential backoff.
+   * Run a transport call with retry + exponential backoff. Retries on
+   * network errors and on transport errors carrying a 5xx / 429 `status`
+   * (duck-typed off `RelayError`); 4xx (other than 429) fail fast.
    */
-  private async fetchWithRetry(
-    url: string,
-    options: RequestInit,
-    attempt = 0
-  ): Promise<Response> {
+  private async withRetry<T>(fn: () => Promise<T>, attempt = 0): Promise<T> {
     try {
-      const response = await fetch(url, options);
-
-      // Don't retry client errors (4xx) except rate limiting
-      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-        return response;
-      }
-
-      // Retry server errors (5xx) and rate limiting
-      if (response.status >= 500 || response.status === 429) {
-        if (attempt < this.maxRetries) {
-          await this.delay(this.getRetryDelay(attempt));
-          return this.fetchWithRetry(url, options, attempt + 1);
-        }
-      }
-
-      return response;
+      return await fn();
     } catch (error) {
-      // Network errors - retry
-      if (attempt < this.maxRetries) {
+      if (this.shouldRetry(error) && attempt < this.maxRetries) {
         await this.delay(this.getRetryDelay(attempt));
-        return this.fetchWithRetry(url, options, attempt + 1);
+        return this.withRetry(fn, attempt + 1);
       }
       throw error;
     }
+  }
+
+  /** Retry transient failures only: network errors and 5xx / 429 responses. */
+  private shouldRetry(error: unknown): boolean {
+    const status = (error as { status?: unknown })?.status;
+    if (typeof status === 'number') {
+      return status >= 500 || status === 429;
+    }
+    // No status -> treat as a network/transport error and retry.
+    return true;
   }
 
   /**
@@ -458,4 +354,33 @@ export class BlobSyncService {
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+}
+
+/**
+ * Best-effort MIME sniff from leading magic bytes for the asset types the
+ * editor handles. Returns `undefined` when unknown (the blob is then stored
+ * untyped; `<img>` object URLs still decode by content). Kept tiny on
+ * purpose — full content-type round-tripping is out of scope for JP-118.
+ */
+function sniffMimeType(data: Uint8Array): string | undefined {
+  if (data.length >= 8 &&
+      data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+    return 'image/png';
+  }
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (data.length >= 6 && data[0] === 0x47 && data[1] === 0x49 && data[2] === 0x46) {
+    return 'image/gif';
+  }
+  if (data.length >= 12 &&
+      data[0] === 0x52 && data[1] === 0x49 && data[2] === 0x46 && data[3] === 0x46 &&
+      data[8] === 0x57 && data[9] === 0x45 && data[10] === 0x42 && data[11] === 0x50) {
+    return 'image/webp';
+  }
+  if (data.length >= 5 &&
+      data[0] === 0x25 && data[1] === 0x50 && data[2] === 0x44 && data[3] === 0x46) {
+    return 'application/pdf';
+  }
+  return undefined;
 }

--- a/src/collaboration/SyncStateManager.ts
+++ b/src/collaboration/SyncStateManager.ts
@@ -403,12 +403,17 @@ export class SyncStateManager {
     console.log('[SyncStateManager] Connection changed:', prevStatus, '->', status);
 
     if (status === 'authenticated' && prevStatus !== 'authenticated') {
-      // Connection restored
+      // Connection restored. Replay only the entries queued for the relay we
+      // actually reconnected to — never flush another relay's queue through
+      // this connection (JP-117).
       if (this.options.autoProcessOnReconnect && !this.queue.isEmpty()) {
-        console.log('[SyncStateManager] Connection restored, processing queue...');
-        this.processQueue().catch((e) => {
-          console.error('[SyncStateManager] Auto-process failed:', e);
-        });
+        const relayId = useConnectionStore.getState().host?.address;
+        if (relayId) {
+          console.log('[SyncStateManager] Connection restored, processing queue for host:', relayId);
+          this.processQueueForHost(relayId).catch((e) => {
+            console.error('[SyncStateManager] Auto-process failed:', e);
+          });
+        }
       }
     }
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -257,8 +257,15 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
           // provider's isReady() is still false and the auto-process bails.
           // We re-trigger here, after setAuthenticated, where isReady() holds.
           if (success) {
+            // Replay only this relay's queued entries — not another relay's
+            // (JP-117). `config.serverUrl` is the relay we just authenticated to.
+            const replayRelayId = useConnectionStore.getState().host?.address;
             void reattachAwaitingTeamDocument()
-              .then(() => getSyncStateManager().processQueue())
+              .then(() =>
+                replayRelayId
+                  ? getSyncStateManager().processQueueForHost(replayRelayId)
+                  : undefined,
+              )
               .then(() => syncCurrentDocToRelayOnConnect())
               .catch((e) => console.warn('[collab] on-connect relay sync failed:', e));
           }

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -5,6 +5,7 @@ import { shapeRegistry } from '../shapes/ShapeRegistry';
 import type { GroupShapeHandler } from '../shapes/Group';
 import { setLatexRenderCallback } from '../utils/textUtils';
 import { onIconLoad } from '../utils/iconCache';
+import { onThumbnailLoad } from '../shapes/FileShape';
 import { ContrastCache, isAutoColor } from './ContrastResolver';
 import { setRenderContext } from './RenderContext';
 import { getAdaptiveBudget } from '../platform/adaptiveBudget';
@@ -132,6 +133,7 @@ export class Renderer {
 
   // Cleanup callback for icon load subscription
   private unsubscribeIconLoad: (() => void) | null = null;
+  private unsubscribeThumbnailLoad: (() => void) | null = null;
 
   // Shape data for rendering
   private shapes: Record<string, Shape> = {};
@@ -176,6 +178,9 @@ export class Renderer {
 
     // Re-render when icons finish loading asynchronously
     this.unsubscribeIconLoad = onIconLoad(() => this.requestRender());
+
+    // Re-render when FileShape thumbnails resolve (blob:// → object URL) asynchronously
+    this.unsubscribeThumbnailLoad = onThumbnailLoad(() => this.requestRender());
   }
 
   /**
@@ -321,6 +326,8 @@ export class Renderer {
     this.toolOverlayCallback = null;
     this.unsubscribeIconLoad?.();
     this.unsubscribeIconLoad = null;
+    this.unsubscribeThumbnailLoad?.();
+    this.unsubscribeThumbnailLoad = null;
   }
 
   /**

--- a/src/shapes/FileShape.test.ts
+++ b/src/shapes/FileShape.test.ts
@@ -1,8 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
-import { fileShapeHandler } from './FileShape';
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import {
+  fileShapeHandler,
+  onThumbnailLoad,
+  resetFileThumbnailCaches,
+  isBlobMissing,
+} from './FileShape';
 import { FileShape, isFile, DEFAULT_FILE_SHAPE } from './Shape';
 import { Vec2 } from '../math/Vec2';
 import { shapeRegistry } from './ShapeRegistry';
+
+// JP-122: the blob:// thumbnail resolver loads bytes from BlobStorage. Mock the
+// singleton so tests control resolution without touching IndexedDB.
+const blobStorageMock = vi.hoisted(() => ({ loadBlob: vi.fn() }));
+vi.mock('../storage/BlobStorage', () => ({ blobStorage: blobStorageMock }));
 
 /**
  * Create a test file shape with default properties.
@@ -455,6 +465,155 @@ describe('FileShape Handler', () => {
       // File shape always uses rounded corners
       expect(ctx.arcTo).toHaveBeenCalled();
     });
+  });
+});
+
+describe('blob:// thumbnail resolution (JP-122)', () => {
+  const HASH = 'abc123hash';
+  const BLOB_THUMB = `blob://${HASH}`;
+
+  /** A minimal canvas context mock that records the calls we assert on. */
+  function makeCtx(): CanvasRenderingContext2D {
+    return {
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      arcTo: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      clip: vi.fn(),
+      rect: vi.fn(),
+      fillRect: vi.fn(),
+      fillText: vi.fn(),
+      measureText: vi.fn().mockReturnValue({ width: 30 }),
+      drawImage: vi.fn(),
+      globalAlpha: 1,
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 1,
+      textAlign: 'left',
+      textBaseline: 'top',
+      font: '',
+    } as unknown as CanvasRenderingContext2D;
+  }
+
+  /** Let the resolver's then/catch/finally microtask chain settle. */
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  beforeAll(() => {
+    // jsdom lacks object-URL APIs — stub them so the resolver can run.
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:objecturl/stub');
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  beforeEach(() => {
+    resetFileThumbnailCaches();
+    blobStorageMock.loadBlob.mockReset();
+    (globalThis.URL.createObjectURL as ReturnType<typeof vi.fn>).mockClear();
+    (globalThis.URL.revokeObjectURL as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('loads the blob, caches an object URL, and notifies on success', async () => {
+    blobStorageMock.loadBlob.mockResolvedValue(new Blob(['img'], { type: 'image/png' }));
+    const onLoad = vi.fn();
+    const unsub = onThumbnailLoad(onLoad);
+    const shape = createTestFile({ preview: { thumbnail: BLOB_THUMB } });
+
+    // First frame: not resolved yet — falls through (emoji), kicks off the load.
+    fileShapeHandler.render(makeCtx(), shape);
+    expect(blobStorageMock.loadBlob).toHaveBeenCalledWith(HASH);
+
+    await flush();
+
+    expect(globalThis.URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(onLoad).toHaveBeenCalled(); // renderer would redraw
+    expect(isBlobMissing(HASH)).toBe(false); // marked available
+    unsub();
+  });
+
+  it('does not re-load the same blob on subsequent renders', async () => {
+    blobStorageMock.loadBlob.mockResolvedValue(new Blob(['img'], { type: 'image/png' }));
+    const shape = createTestFile({ preview: { thumbnail: BLOB_THUMB } });
+
+    fileShapeHandler.render(makeCtx(), shape); // kicks off load
+    await flush();
+    fileShapeHandler.render(makeCtx(), shape); // object URL cached now
+    fileShapeHandler.render(makeCtx(), shape);
+
+    expect(blobStorageMock.loadBlob).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent loads while one is in flight', () => {
+    blobStorageMock.loadBlob.mockReturnValue(new Promise(() => {})); // never resolves
+    const shape = createTestFile({ preview: { thumbnail: BLOB_THUMB } });
+
+    fileShapeHandler.render(makeCtx(), shape);
+    fileShapeHandler.render(makeCtx(), shape);
+
+    expect(blobStorageMock.loadBlob).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks missing and draws the ⚠ overlay when the blob is absent', async () => {
+    blobStorageMock.loadBlob.mockResolvedValue(null);
+    const shape = createTestFile({
+      blobRef: HASH,
+      preview: { thumbnail: BLOB_THUMB },
+    });
+
+    fileShapeHandler.render(makeCtx(), shape);
+    await flush();
+
+    expect(isBlobMissing(HASH)).toBe(true);
+
+    // A render after the miss draws the warning glyph rather than throwing.
+    const ctx = makeCtx();
+    fileShapeHandler.render(ctx, shape);
+    const drewWarning = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls.some(
+      (call) => call[0] === '⚠'
+    );
+    expect(drewWarning).toBe(true);
+  });
+
+  it('marks missing when the load rejects (no throw)', async () => {
+    blobStorageMock.loadBlob.mockRejectedValue(new Error('idb down'));
+    const shape = createTestFile({ preview: { thumbnail: BLOB_THUMB } });
+
+    expect(() => fileShapeHandler.render(makeCtx(), shape)).not.toThrow();
+    await flush();
+
+    expect(isBlobMissing(HASH)).toBe(true);
+  });
+
+  it('passes regular data:/http URLs straight through without a blob load', () => {
+    const shape = createTestFile({
+      preview: { thumbnail: 'data:image/png;base64,AAAA' },
+    });
+
+    fileShapeHandler.render(makeCtx(), shape);
+
+    expect(blobStorageMock.loadBlob).not.toHaveBeenCalled();
+  });
+
+  it('resetFileThumbnailCaches revokes object URLs and forces a fresh load', async () => {
+    blobStorageMock.loadBlob.mockResolvedValue(new Blob(['img'], { type: 'image/png' }));
+    const shape = createTestFile({ preview: { thumbnail: BLOB_THUMB } });
+
+    fileShapeHandler.render(makeCtx(), shape);
+    await flush();
+    expect(globalThis.URL.createObjectURL).toHaveBeenCalledTimes(1);
+
+    resetFileThumbnailCaches();
+    expect(globalThis.URL.revokeObjectURL).toHaveBeenCalledWith('blob:objecturl/stub');
+    expect(isBlobMissing(HASH)).toBeUndefined(); // availability cleared
+
+    // After reset the next render re-resolves from storage.
+    fileShapeHandler.render(makeCtx(), shape);
+    expect(blobStorageMock.loadBlob).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/shapes/FileShape.ts
+++ b/src/shapes/FileShape.ts
@@ -11,13 +11,85 @@ import {
 } from './Shape';
 import { ShapeMetadata, createStandardProperties } from './ShapeMetadata';
 import { formatFileSize, getFileTypeIcon } from '../utils/fileUtils';
+import { blobStorage } from '../storage/BlobStorage';
 
-// Module-level thumbnail cache to avoid re-decoding base64 every frame
+/** DocuShark's custom blob reference scheme (NOT the browser's native `blob:`). */
+const BLOB_PREFIX = 'blob://';
+
+// Module-level thumbnail cache to avoid re-decoding every frame. Keyed by shape id.
 const thumbnailCache = new Map<string, HTMLImageElement>();
+
+// Resolved object URLs for `blob://<hash>` thumbnails, keyed by content hash.
+// Content-addressed, so an object URL is valid for that hash across shapes/docs;
+// revoked + cleared on document switch via resetFileThumbnailCaches().
+const blobObjectUrls = new Map<string, string>();
+
+// Hashes with an in-flight BlobStorage load, to dedupe concurrent resolves.
+const blobLoadsInFlight = new Set<string>();
 
 // Module-level cache tracking blob availability (populated by BlobStorage checks)
 // Maps blobRef -> boolean (true = exists, false = missing)
 const blobAvailabilityCache = new Map<string, boolean>();
+
+/**
+ * Callbacks fired when a thumbnail blob finishes resolving (or an <img> decodes).
+ * Mirrors iconCache.onIconLoad — the Renderer subscribes to trigger a redraw so
+ * the next frame can draw an image that wasn't ready on the frame that requested it.
+ */
+const thumbnailLoadCallbacks = new Set<() => void>();
+
+/**
+ * Register a callback invoked whenever a thumbnail finishes loading.
+ * Returns an unsubscribe function. Used to trigger canvas re-renders.
+ */
+export function onThumbnailLoad(callback: () => void): () => void {
+  thumbnailLoadCallbacks.add(callback);
+  return () => thumbnailLoadCallbacks.delete(callback);
+}
+
+/** Notify listeners that a thumbnail has loaded (or failed). */
+function notifyThumbnailLoad(): void {
+  for (const callback of thumbnailLoadCallbacks) {
+    callback();
+  }
+}
+
+/**
+ * Extract the content hash from a `blob://<hash>` thumbnail string, or null if
+ * the source is a regular (`data:`/`http(s):`) URL the browser can load directly.
+ */
+function blobHashFromThumbnail(thumbnail: string | undefined): string | null {
+  if (!thumbnail || !thumbnail.startsWith(BLOB_PREFIX)) return null;
+  return thumbnail.slice(BLOB_PREFIX.length);
+}
+
+/**
+ * Load a `blob://` thumbnail's bytes from IndexedDB and cache an object URL.
+ * Runs in the background; on completion notifies listeners so the canvas redraws.
+ * Marks blob availability so the missing-blob overlay can reflect the result.
+ */
+function resolveBlobThumbnail(hash: string): void {
+  if (blobObjectUrls.has(hash) || blobLoadsInFlight.has(hash)) return;
+  blobLoadsInFlight.add(hash);
+
+  void blobStorage
+    .loadBlob(hash)
+    .then((blob) => {
+      if (blob) {
+        blobObjectUrls.set(hash, URL.createObjectURL(blob));
+        markBlobAvailable(hash);
+      } else {
+        markBlobMissing(hash);
+      }
+    })
+    .catch(() => {
+      markBlobMissing(hash);
+    })
+    .finally(() => {
+      blobLoadsInFlight.delete(hash);
+      notifyThumbnailLoad();
+    });
+}
 
 /**
  * Mark a blob as available (exists in storage).
@@ -46,25 +118,67 @@ export function isBlobMissing(blobRef: string): boolean | undefined {
 }
 
 /**
- * Clear the blob availability cache (e.g., on document switch).
+ * Reset all FileShape thumbnail caches. Called on document switch: revokes the
+ * object URLs minted for `blob://` thumbnails (no leak), and drops the decoded
+ * <img> + blob-availability state so the newly opened doc re-resolves cleanly.
  */
-export function clearBlobAvailabilityCache(): void {
+export function resetFileThumbnailCaches(): void {
+  for (const url of blobObjectUrls.values()) {
+    URL.revokeObjectURL(url);
+  }
+  blobObjectUrls.clear();
+  blobLoadsInFlight.clear();
+  thumbnailCache.clear();
   blobAvailabilityCache.clear();
 }
 
 /**
+ * @deprecated Use {@link resetFileThumbnailCaches}. Retained as an alias so the
+ * blob-availability cache can still be cleared by name.
+ */
+export function clearBlobAvailabilityCache(): void {
+  resetFileThumbnailCaches();
+}
+
+/**
  * Retrieve (or create and cache) an HTMLImageElement for a file shape's thumbnail.
+ *
+ * Thumbnails arrive either as a directly-loadable URL (`data:`/`http(s):`, the
+ * locally-created case) or — after a relay doc round-trips through
+ * `extractAssetsFromBundle` — as DocuShark's custom `blob://<hash>` scheme, which
+ * the browser refuses to load. For the latter we resolve the hash to an object URL
+ * via IndexedDB in the background (returning null until ready), mirroring how
+ * TiptapEditor handles rich-text images.
  */
 function getThumbnailImage(shape: FileShape): HTMLImageElement | null {
-  if (!shape.preview?.thumbnail) return null;
+  const thumbnail = shape.preview?.thumbnail;
+  if (!thumbnail) return null;
+
+  // Resolve the effective, browser-loadable source.
+  let src: string;
+  const hash = blobHashFromThumbnail(thumbnail);
+  if (hash) {
+    const objectUrl = blobObjectUrls.get(hash);
+    if (!objectUrl) {
+      // Not resolved yet — kick off the load and let this frame fall through to
+      // the emoji/⚠ branch; the load notifies the renderer to redraw when done.
+      resolveBlobThumbnail(hash);
+      return null;
+    }
+    src = objectUrl;
+  } else {
+    src = thumbnail;
+  }
 
   const key = shape.id;
   const cached = thumbnailCache.get(key);
-  if (cached && cached.dataset['src'] === shape.preview.thumbnail) return cached;
+  if (cached && cached.dataset['src'] === src) return cached;
 
   const img = new Image();
-  img.dataset['src'] = shape.preview.thumbnail;
-  img.src = shape.preview.thumbnail;
+  img.dataset['src'] = src;
+  // Even data: thumbnails decode asynchronously — redraw once the bitmap is ready.
+  img.onload = notifyThumbnailLoad;
+  img.src = src;
   thumbnailCache.set(key, img);
   return img;
 }
@@ -285,9 +399,13 @@ export const fileShapeHandler: ShapeHandler<FileShape> = {
     }
 
     // --- Missing blob indicator ---
-    // Show warning overlay if blob is known to be missing
-    const blobMissing = shape.blobRef ? isBlobMissing(shape.blobRef) : false;
-    if (blobMissing === true) {
+    // Show warning overlay if the file blob OR its thumbnail blob is known to be
+    // missing. FileViewerModal marks the file `blobRef` when opened; the canvas
+    // thumbnail resolver marks the thumbnail hash when its load fails.
+    const thumbHash = blobHashFromThumbnail(shape.preview?.thumbnail);
+    const fileMissing = shape.blobRef ? isBlobMissing(shape.blobRef) === true : false;
+    const thumbMissing = thumbHash ? isBlobMissing(thumbHash) === true : false;
+    if (fileMissing || thumbMissing) {
       // Semi-transparent red overlay
       ctx.fillStyle = 'rgba(239, 68, 68, 0.15)';
       ctx.beginPath();

--- a/src/storage/AssetBundler.ts
+++ b/src/storage/AssetBundler.ts
@@ -382,6 +382,28 @@ export function hasBlobReferences(document: DiagramDocument): boolean {
 }
 
 /**
+ * Collect every blob hash a document references, walking the whole tree.
+ *
+ * This is the canonical extractor: it catches both rich-text image `src`
+ * (`blob://<hash>`) and `FileShape.blobRef` (raw hash, no prefix), then
+ * unions in the document's explicit `blobReferences` GC list. Use it to
+ * build the upload set on save and the download set on load — it sees
+ * strictly more than `hasBlobReferences` (which misses raw `blobRef`s).
+ */
+export function collectBlobReferences(document: DiagramDocument): string[] {
+  const blobIds = new Set<string>();
+  findBlobReferences(document, blobIds);
+
+  if (document.blobReferences) {
+    for (const id of document.blobReferences) {
+      blobIds.add(id);
+    }
+  }
+
+  return Array.from(blobIds);
+}
+
+/**
  * Estimate the size increase from bundling (data URLs are ~33% larger than binary).
  */
 export async function estimateBundleSize(document: DiagramDocument): Promise<number> {

--- a/src/storage/RelayDocumentCache.test.ts
+++ b/src/storage/RelayDocumentCache.test.ts
@@ -155,6 +155,19 @@ describe('RelayDocumentCache', () => {
       expect(cached).toBeNull();
     });
 
+    it('does not re-home a doc: a later put from another relay keeps the origin (JP-117)', async () => {
+      const doc = createTestDocument('doc-1');
+
+      await RelayDocumentCache.put(doc, 'relay-a');
+      // Caching the same doc again while connected to a different relay must
+      // NOT change its origin — origin is first-set, never clobbered.
+      await RelayDocumentCache.put(doc, 'relay-b');
+
+      expect(RelayDocumentCache.getMeta('doc-1')?.relayId).toBe('relay-a');
+      expect(RelayDocumentCache.getCachedIdsForHost('relay-a')).toContain('doc-1');
+      expect(RelayDocumentCache.getCachedIdsForHost('relay-b')).not.toContain('doc-1');
+    });
+
     it('stores metadata in localStorage', async () => {
       const doc = createTestDocument('doc-1', { serverVersion: 5 });
 

--- a/src/storage/RelayDocumentCache.ts
+++ b/src/storage/RelayDocumentCache.ts
@@ -288,11 +288,17 @@ export const RelayDocumentCache = {
     // Check if we need to evict
     await this.ensureSpace(size);
 
+    // JP-117: a doc's origin relay is first-set, never clobbered. If this doc
+    // is already cached, keep the relay it was first seen on — caching it again
+    // while connected to a different relay must not re-home it.
+    const originRelayId =
+      getCacheMeta().find((m) => m.id === document.id)?.relayId ?? relayId;
+
     const entry: CacheEntry = {
       id: document.id,
       cachedAt: Date.now(),
       size,
-      relayId,
+      relayId: originRelayId,
       document,
     };
     if (document.serverVersion !== undefined) {

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -27,6 +27,26 @@ import {
   toCachedDocument,
   toRemoteFromCached,
 } from '../types/DocumentRegistry';
+import { RelayDocumentCache } from '../storage/RelayDocumentCache';
+
+/**
+ * JP-117: resolve the relay a doc belongs to, first-set and never clobbered.
+ * A doc's origin is the relay it was first seen on; re-registering it from a
+ * different connected relay (a list fetch or broadcast while connected
+ * elsewhere) must not re-home it. Priority: an existing record's origin, then
+ * the durable cache (cold boot, registry empty), then — only for a genuine
+ * first sighting — the passed (connected) relay.
+ */
+function resolveOriginRelayId(
+  existing: DocumentRegistryEntry | undefined,
+  id: string,
+  passedRelayId: string,
+): string {
+  if (existing && (isRemoteDocument(existing.record) || isCachedDocument(existing.record))) {
+    return existing.record.relayId;
+  }
+  return RelayDocumentCache.getMeta(id)?.relayId ?? passedRelayId;
+}
 
 // ============ Types ============
 
@@ -210,23 +230,27 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
       },
 
       registerRemote: (metadata, relayId, permission, syncState = 'synced') => {
-        const record: RemoteDocument = toRemoteDocument(metadata, relayId, permission, syncState);
-        set((state) => ({
-          entries: {
-            ...state.entries,
-            [metadata.id]: {
-              record,
-              isLoading: false,
+        set((state) => {
+          const originRelayId = resolveOriginRelayId(state.entries[metadata.id], metadata.id, relayId);
+          const record: RemoteDocument = toRemoteDocument(metadata, originRelayId, permission, syncState);
+          return {
+            entries: {
+              ...state.entries,
+              [metadata.id]: {
+                record,
+                isLoading: false,
+              },
             },
-          },
-        }));
+          };
+        });
       },
 
       registerRemoteBatch: (documents, relayId, permission) => {
         set((state) => {
           const newEntries = { ...state.entries };
           for (const doc of documents) {
-            const record: RemoteDocument = toRemoteDocument(doc, relayId, permission, 'synced');
+            const originRelayId = resolveOriginRelayId(state.entries[doc.id], doc.id, relayId);
+            const record: RemoteDocument = toRemoteDocument(doc, originRelayId, permission, 'synced');
             newEntries[doc.id] = {
               record,
               isLoading: false,

--- a/src/store/pageStore.test.ts
+++ b/src/store/pageStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { usePageStore, getActivePageId, pageExists } from './pageStore';
 import { useDocumentStore } from './documentStore';
+import { useHistoryStore } from './historyStore';
 import { RectangleShape } from '../shapes/Shape';
 
 /**
@@ -34,6 +35,21 @@ describe('Page Store', () => {
   });
 
   describe('createPage', () => {
+    it('keeps historyStore.activePageId in lockstep when activating the first page', () => {
+      // Reproduce the new-doc desync: a previous doc leaves history pinned to
+      // its page; the consistency guard then refused edits on the fresh doc.
+      useHistoryStore.getState().setActivePage('stale-prev-doc-page');
+
+      // newDocument resets the page store first — history must clear in lockstep.
+      usePageStore.getState().reset();
+      expect(useHistoryStore.getState().activePageId).toBeNull();
+
+      // The new doc's first page becomes active; history follows it (not stale).
+      const pageId = usePageStore.getState().createPage('Page 1');
+      expect(usePageStore.getState().activePageId).toBe(pageId);
+      expect(useHistoryStore.getState().activePageId).toBe(pageId);
+    });
+
     it('creates a page with default name', () => {
       const pageId = usePageStore.getState().createPage();
 

--- a/src/store/pageStore.ts
+++ b/src/store/pageStore.ts
@@ -111,8 +111,14 @@ export const usePageStore = create<PageState & PageActions>()(
         }
       });
 
-      // Keep historyStore's pageStore-mirror in sync if we just activated this page.
+      // Keep historyStore in lockstep if we just activated this page. Both the
+      // history store's own activePageId AND its pageStore-mirror must move
+      // together — updating only the mirror (as before) left history pinned to
+      // the previous doc's page on a fresh doc (createPage activates page 1 but
+      // history.clear() doesn't realign activePageId), so the consistency guard
+      // then refused every edit on the new doc.
       if (get().activePageId === pageId) {
+        useHistoryStore.getState().setActivePage(pageId);
         registerPageStoreActiveId(pageId);
       }
 
@@ -394,6 +400,9 @@ export const usePageStore = create<PageState & PageActions>()(
         state.pageOrder = [];
         state.activePageId = null;
       });
+      // Lockstep with the mirror: clear history's active page too so there's
+      // no window where the two disagree (e.g. reset before re-init).
+      useHistoryStore.getState().setActivePage(null);
       registerPageStoreActiveId(null);
     },
 

--- a/src/store/persistenceStore.offlineRelaySave.test.ts
+++ b/src/store/persistenceStore.offlineRelaySave.test.ts
@@ -16,6 +16,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const cacheMock = vi.hoisted(() => ({
   put: vi.fn<[unknown, string], Promise<void>>(async () => {}),
+  // JP-117: save routing now resolves a doc's home relay, consulting the
+  // persistent cache as a fallback origin source. Default to no cached origin.
+  getMeta: vi.fn<[string], { relayId: string; cachedAt: number } | null>(() => null),
 }));
 vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
 

--- a/src/store/persistenceStore.relayRouting.test.ts
+++ b/src/store/persistenceStore.relayRouting.test.ts
@@ -1,0 +1,215 @@
+/**
+ * JP-117: relay saves must route to the document's *home* relay, not whatever
+ * relay happens to be connected.
+ *
+ * A doc belonging to relay A, edited while connected to relay B, must not be
+ * pushed to (or queued under) B — it's cached + queued under A and replays
+ * when next connected to A. Driven through `saveDocumentPdfSettings` (a
+ * read-modify-write that routes its relay push through `pushRelaySaveOrQueue`)
+ * and `syncCurrentDocToRelayOnConnect`, mirroring the JP-106 offline tests.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  put: vi.fn<[unknown, string], Promise<void>>(async () => {}),
+  getMeta: vi.fn<[string], { relayId: string; cachedAt: number } | null>(() => null),
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+
+const syncManagerMock = vi.hoisted(() => ({
+  queueSave: vi.fn<[unknown, string], { id: string }>(() => ({ id: 'op-1' })),
+  hasPendingChanges: vi.fn<[string], boolean>(() => false),
+  processQueueForHost: vi.fn(async () => []),
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => syncManagerMock,
+}));
+
+import {
+  saveDocumentToStorage,
+  saveDocumentPdfSettings,
+  syncCurrentDocToRelayOnConnect,
+  usePersistenceStore,
+} from './persistenceStore';
+import { useRelayDocumentStore } from './relayDocumentStore';
+import { useConnectionStore } from './connectionStore';
+import { useDocumentRegistry } from './documentRegistry';
+import type { DiagramDocument, DocumentMetadata } from '../types/Document';
+import type { PDFSettings } from '../types/PDFExport';
+
+const RELAY_A = 'relay-a:9876';
+const RELAY_B = 'relay-b:9876';
+const pdfSettings = { orientation: 'portrait' } as unknown as PDFSettings;
+
+function makeRelayDoc(id: string): DiagramDocument {
+  return {
+    id,
+    name: id,
+    pages: {},
+    pageOrder: [],
+    activePageId: '',
+    createdAt: 1,
+    modifiedAt: 1,
+    version: 1,
+    isRelayDocument: true,
+  };
+}
+
+function makeMeta(id: string): DocumentMetadata {
+  return {
+    id,
+    name: id,
+    pageCount: 1,
+    ownerId: 'owner-1',
+    ownerName: 'owner',
+    createdAt: 1,
+    modifiedAt: 1,
+    isRelayDocument: true,
+  };
+}
+
+/** Register a doc in the registry as belonging to `relayId` (sets its origin). */
+function registerHome(id: string, relayId: string): void {
+  useDocumentRegistry.getState().registerRemote(makeMeta(id), relayId, 'owner', 'synced');
+}
+
+function connectTo(relayId: string): void {
+  useConnectionStore.setState({
+    status: 'authenticated',
+    host: { address: relayId, url: `http://${relayId}` },
+  });
+}
+
+describe('JP-117 — relay save routing by origin relay', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    cacheMock.put.mockClear();
+    cacheMock.getMeta.mockReset();
+    cacheMock.getMeta.mockReturnValue(null);
+    syncManagerMock.queueSave.mockClear();
+    syncManagerMock.hasPendingChanges.mockReset();
+    syncManagerMock.hasPendingChanges.mockReturnValue(false);
+    useConnectionStore.getState().reset();
+    useDocumentRegistry.setState({ entries: {} } as never);
+    useRelayDocumentStore.setState({ authenticated: false });
+  });
+
+  it('A-doc edited while connected to B is NOT pushed to B, and queues under A', () => {
+    const saveToHost = vi.fn(async () => ({ newVersion: 1 }));
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    registerHome('doc-A', RELAY_A);
+    connectTo(RELAY_B); // connected to the wrong relay
+    saveDocumentToStorage(makeRelayDoc('doc-A'));
+
+    const ok = saveDocumentPdfSettings('doc-A', pdfSettings);
+
+    expect(ok).toBe(true);
+    // Never written to the connected (wrong) relay.
+    expect(saveToHost).not.toHaveBeenCalled();
+    // Cached + queued under the doc's HOME relay, not the connected one.
+    expect(syncManagerMock.queueSave).toHaveBeenCalledTimes(1);
+    expect(syncManagerMock.queueSave.mock.calls[0]?.[1]).toBe(RELAY_A);
+    expect(cacheMock.put).toHaveBeenCalledTimes(1);
+    expect(cacheMock.put.mock.calls[0]?.[1]).toBe(RELAY_A);
+  });
+
+  it('pushes immediately when the connected relay IS the doc home', () => {
+    const saveToHost = vi.fn(async () => ({ newVersion: 1 }));
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    registerHome('doc-A', RELAY_A);
+    connectTo(RELAY_A); // connected to the right relay
+    saveDocumentToStorage(makeRelayDoc('doc-A'));
+
+    const ok = saveDocumentPdfSettings('doc-A', pdfSettings);
+
+    expect(ok).toBe(true);
+    expect(saveToHost).toHaveBeenCalledTimes(1);
+    expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
+  });
+
+  it('cold boot (registry empty): resolves origin from the persistent cache and queues under it', () => {
+    // No registry record; the durable cache remembers the home relay.
+    cacheMock.getMeta.mockReturnValue({ relayId: RELAY_A, cachedAt: 1 });
+    useRelayDocumentStore.setState({ authenticated: false }); // cold boot, offline
+    useConnectionStore.setState({ status: 'disconnected' }); // no host
+    saveDocumentToStorage(makeRelayDoc('doc-cold'));
+
+    const ok = saveDocumentPdfSettings('doc-cold', pdfSettings);
+
+    expect(ok).toBe(true);
+    expect(syncManagerMock.queueSave).toHaveBeenCalledTimes(1);
+    expect(syncManagerMock.queueSave.mock.calls[0]?.[1]).toBe(RELAY_A);
+    expect(cacheMock.put.mock.calls[0]?.[1]).toBe(RELAY_A);
+  });
+
+  it('brand-new doc with no known origin pushes to the connected relay', () => {
+    const saveToHost = vi.fn(async () => ({ newVersion: 1 }));
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    // No registry record, no cache meta -> origin unknown -> treat connected as home.
+    connectTo(RELAY_B);
+    saveDocumentToStorage(makeRelayDoc('doc-new'));
+
+    const ok = saveDocumentPdfSettings('doc-new', pdfSettings);
+
+    expect(ok).toBe(true);
+    expect(saveToHost).toHaveBeenCalledTimes(1);
+    expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
+  });
+
+  it('registry never re-homes a doc: registering it from another relay keeps the origin', () => {
+    const registry = useDocumentRegistry.getState();
+    registry.registerRemote(makeMeta('doc-imm'), RELAY_A, 'owner', 'synced');
+    // Simulate fetchDocumentList while connected to B listing the same id.
+    registry.registerRemote(makeMeta('doc-imm'), RELAY_B, 'owner', 'synced');
+
+    const rec = useDocumentRegistry.getState().getRecord('doc-imm') as { relayId?: string };
+    expect(rec.relayId).toBe(RELAY_A);
+  });
+
+  it('registry cold-boot resolves origin from the durable cache, not the connected relay', () => {
+    // Registry empty for this id; the cache remembers it was first seen on A.
+    cacheMock.getMeta.mockImplementation((id: string) =>
+      id === 'doc-cold-reg' ? { relayId: RELAY_A, cachedAt: 1 } : null,
+    );
+    useDocumentRegistry.getState().registerRemote(makeMeta('doc-cold-reg'), RELAY_B, 'owner', 'synced');
+
+    const rec = useDocumentRegistry.getState().getRecord('doc-cold-reg') as { relayId?: string };
+    expect(rec.relayId).toBe(RELAY_A);
+  });
+
+  it('a flip attempt (register under B) does not leak a subsequent save to B', () => {
+    const saveToHost = vi.fn(async () => ({ newVersion: 1 }));
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    // Doc's home is A; then B's list tries to re-home it (the old bug).
+    useDocumentRegistry.getState().registerRemote(makeMeta('doc-flip'), RELAY_A, 'owner', 'synced');
+    useDocumentRegistry.getState().registerRemote(makeMeta('doc-flip'), RELAY_B, 'owner', 'synced');
+    connectTo(RELAY_B);
+    saveDocumentToStorage(makeRelayDoc('doc-flip'));
+
+    saveDocumentPdfSettings('doc-flip', pdfSettings);
+
+    expect(saveToHost).not.toHaveBeenCalled();
+    expect(syncManagerMock.queueSave.mock.calls[0]?.[1]).toBe(RELAY_A);
+  });
+
+  it('syncCurrentDocToRelayOnConnect does not push a doc whose home is a different relay', async () => {
+    const saveToHost = vi.fn(async () => ({ newVersion: 2 }));
+    usePersistenceStore.getState().newDocument('OnConnect');
+    const stored = makeRelayDoc('doc-conn');
+    stored.serverVersion = 5;
+    saveDocumentToStorage(stored);
+    registerHome('doc-conn', RELAY_A); // home is A
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    connectTo(RELAY_B); // connected to B
+    usePersistenceStore.setState({
+      currentDocumentId: 'doc-conn',
+      isDirty: true,
+      teamDocContentPending: false,
+    });
+
+    await syncCurrentDocToRelayOnConnect();
+
+    expect(saveToHost).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -36,6 +36,7 @@ import { blobStorage } from '../storage/BlobStorage';
 import { extractRichTextBlobIds, extractShapeBlobIds } from '../utils/richTextBlobExtractor';
 import { withAutoSaveSuppressed, flushAutoSaveNow } from './autoSaveGuard';
 import { VersionConflictError } from '../api/relayClient';
+import { resetFileThumbnailCaches } from '../shapes/FileShape';
 
 /**
  * Auto-save debounce time in milliseconds.
@@ -445,6 +446,11 @@ function createDocumentFromPageStore(
  * Load a DiagramDocument into the page store and rich text store.
  */
 function loadDocumentToPageStore(doc: DiagramDocument): void {
+  // Switching documents: drop the previous doc's FileShape thumbnail caches
+  // (revoking minted object URLs) so this doc re-resolves its blob:// thumbnails
+  // and never shows a stale image or a stale missing-blob overlay.
+  resetFileThumbnailCaches();
+
   // Suppress autosave subscribers while we replay the document into the
   // live stores — these writes are a load, not a user edit, and would
   // otherwise schedule a spurious push back to the relay on next debounce.

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -29,6 +29,7 @@ import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { useSessionStore } from './sessionStore';
 import { useHistoryStore } from './historyStore';
 import { useDocumentRegistry } from './documentRegistry';
+import { isRemoteDocument, isCachedDocument } from '../types/DocumentRegistry';
 import { useCollaborationStore } from '../collaboration';
 import { useWhiteboardStore } from './whiteboardStore';
 import { blobStorage } from '../storage/BlobStorage';
@@ -42,46 +43,86 @@ import { VersionConflictError } from '../api/relayClient';
 export const AUTO_SAVE_DEBOUNCE = 2000;
 
 /**
- * Push a relay document to the host, or — when we can't reach the relay —
- * durably cache it and queue the save for replay on reconnect instead of
- * dropping the edit. (JP-106: offline edits to relay docs were being lost
- * because the live `isRelayAuthenticated()` gate is false while offline, so
- * the save was never attempted and never queued.)
+ * Resolve the relay a document belongs to (its *home* relay), independent of
+ * whichever relay is currently connected. Origin is tracked on the document
+ * record (`RemoteDocument`/`CachedDocument.relayId`) and, durably, on the
+ * persistent cache entry. We consult both because the registry is in-memory
+ * and empty on a cold boot — the persistent cache is the only origin source
+ * for an offline edit made before any connection this boot (the JP-106 case).
  *
- * Gating: any `isRelayDocument` — such a doc always has a relay home, so
- * its edits must be durable even when made offline *before any connection
- * this boot* (the in-memory `relayDocumentStore.authenticated` flag is not
- * persisted, so it is `false` on a cold boot until auth completes; gating
- * on it dropped exactly these edits). When online we push immediately; a
- * connectivity failure falls back to cache+queue. When offline we skip the
- * doomed push and cache+queue directly so the queue replays on reconnect.
- * Genuine errors (auth, version conflict) are logged, not queued.
+ * Returns `undefined` when the doc has no known origin yet — a brand-new doc
+ * not registered or cached, which is being created on the connected relay.
+ */
+function resolveHomeRelayId(docId: string): string | undefined {
+  const record = useDocumentRegistry.getState().getRecord(docId);
+  if (record && (isRemoteDocument(record) || isCachedDocument(record))) {
+    return record.relayId;
+  }
+  return RelayDocumentCache.getMeta(docId)?.relayId ?? undefined;
+}
+
+/**
+ * Push a relay document to *its own* relay, or — when that relay isn't the
+ * one we're connected to, or we can't reach it — durably cache it and queue
+ * the save under the document's home relay for replay when we next connect
+ * there, instead of dropping the edit or writing it to the wrong relay.
+ *
+ * (JP-106: offline edits to relay docs were being lost because the live
+ * `isRelayAuthenticated()` gate is false while offline, so the save was never
+ * attempted and never queued. JP-117: saves ignored the doc's origin and went
+ * to whichever relay was connected — a cross-relay data-integrity/leak risk.)
+ *
+ * Gating: any `isRelayDocument` — such a doc always has a relay home, so its
+ * edits must be durable even when made offline *before any connection this
+ * boot* (the in-memory `relayDocumentStore.authenticated` flag is not
+ * persisted, so it is `false` on a cold boot until auth completes; gating on
+ * it dropped exactly these edits).
+ *
+ * Routing: the cache+queue are always tagged with the doc's home relay (its
+ * own `relayId`, falling back to the connected relay only for a brand-new doc
+ * with no origin yet). We push immediately only when the doc's home *is* the
+ * connected relay; if its home is a different relay we never push — we queue
+ * under home so it replays on the next connection there. When offline, or on a
+ * connectivity failure, we cache+queue directly. Genuine errors (auth, version
+ * conflict) are logged, not queued.
  */
 function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
   if (!doc.isRelayDocument) return;
   const relayStore = useRelayDocumentStore.getState();
 
-  const queueForReplay = (): void => {
-    const relayId = useConnectionStore.getState().host?.address ?? 'unknown';
-    void RelayDocumentCache.put(doc, relayId).catch((e) =>
-      console.error('[persistenceStore] Failed to cache offline relay edit:', e),
+  const home = resolveHomeRelayId(doc.id);
+  const connected = useConnectionStore.getState().host?.address;
+  // A brand-new doc with no origin yet is being created on the connected relay.
+  const homeRelayId = home ?? connected ?? 'unknown';
+
+  const queueForReplay = (reason: string): void => {
+    void RelayDocumentCache.put(doc, homeRelayId).catch((e) =>
+      console.error('[persistenceStore] Failed to cache relay edit:', e),
     );
-    getSyncStateManager().queueSave(doc, relayId);
+    getSyncStateManager().queueSave(doc, homeRelayId);
     console.warn(
-      `[persistenceStore] Offline — cached + queued relay save for replay (${context})`,
+      `[persistenceStore] ${reason} — cached + queued relay save under ${homeRelayId} for replay (${context})`,
     );
   };
 
+  // We're connected to a relay that isn't this doc's home: never push it to
+  // the connected relay. Queue under its home relay instead. (When there's no
+  // connected relay at all, this falls through to the offline branch below.)
+  if (connected !== undefined && home !== undefined && home !== connected) {
+    queueForReplay('Doc belongs to another relay');
+    return;
+  }
+
   if (!isRelayAuthenticated()) {
     // Offline: don't attempt a push the relay can't receive.
-    queueForReplay();
+    queueForReplay('Offline');
     return;
   }
 
   relayStore.saveToHost(doc).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('Not connected to host')) {
-      queueForReplay();
+      queueForReplay('Not connected');
     } else {
       console.error(
         `[persistenceStore] Failed to sync relay document to host (${context}):`,
@@ -1267,6 +1308,14 @@ export async function syncCurrentDocToRelayOnConnect(): Promise<void> {
 
   const existing = loadDocumentFromStorage(docId);
   if (!existing?.isRelayDocument) return;
+
+  // Only push the current doc to the relay we just connected to if that relay
+  // is the doc's home (JP-117). If it belongs elsewhere, leave it to the
+  // durable queue, which is tagged with — and only replays under — its home
+  // relay; pushing here would write it to the wrong relay.
+  const home = resolveHomeRelayId(docId);
+  const connected = useConnectionStore.getState().host?.address;
+  if (connected !== undefined && home !== undefined && home !== connected) return;
 
   const relayStore = useRelayDocumentStore.getState();
   if (!relayStore.authenticated) return;

--- a/src/store/relayDocumentStore.blobSync.test.ts
+++ b/src/store/relayDocumentStore.blobSync.test.ts
@@ -1,0 +1,189 @@
+/**
+ * JP-118 — relay-doc asset routing through the blob store.
+ *
+ * Asserts the store's save/load seams use the provider's blob-sync hooks:
+ *  - save uploads referenced blobs *before* the doc save, keeps blob://
+ *    refs (no base64), and aborts the save if an upload fails;
+ *  - load downloads referenced blobs (non-fatal on failure).
+ *
+ * IndexedDB-backed deps (RelayDocumentCache, SyncStateManager) are mocked
+ * so the test stays in-memory; AssetBundler runs for real (reference-mode
+ * bundling + hash collection are pure).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn(async () => null),
+  put: vi.fn(async () => {}),
+  getCachedIdsForHost: vi.fn(() => [] as string[]),
+  getMeta: vi.fn(() => null),
+  remove: vi.fn(async () => {}),
+}));
+
+vi.mock('../storage/RelayDocumentCache', () => ({
+  RelayDocumentCache: cacheMock,
+}));
+
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => ({ hasPendingChanges: () => false }),
+}));
+
+import { useRelayDocumentStore, type DocumentProvider } from './relayDocumentStore';
+import { useConnectionStore } from './connectionStore';
+import type { BlobSyncResult } from '../collaboration/BlobSyncService';
+import type { DiagramDocument } from '../types/Document';
+
+function ok(total: number): BlobSyncResult {
+  return { total, success: total, failed: 0, errors: new Map() };
+}
+
+/** A doc that references one blob (rich-text image + GC list). */
+function docWithBlob(id: string, hash: string, serverVersion?: number): DiagramDocument {
+  return {
+    id,
+    name: id,
+    pages: {
+      'page-1': {
+        id: 'page-1',
+        name: 'Page 1',
+        shapes: {},
+        shapeOrder: [],
+        createdAt: 0,
+        modifiedAt: 0,
+      },
+    },
+    pageOrder: ['page-1'],
+    activePageId: 'page-1',
+    richTextContent: `<img src="blob://${hash}">`,
+    blobReferences: [hash],
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 1,
+    ...(serverVersion !== undefined ? { serverVersion } : {}),
+  } as unknown as DiagramDocument;
+}
+
+/** Provider with blob-sync hooks and spyable save/get. */
+function makeProvider(over: Partial<DocumentProvider> = {}): DocumentProvider & {
+  saveDocument: ReturnType<typeof vi.fn>;
+  uploadBlobs: ReturnType<typeof vi.fn>;
+  downloadBlobs: ReturnType<typeof vi.fn>;
+  getDocument: ReturnType<typeof vi.fn>;
+} {
+  const p = {
+    listDocuments: vi.fn(async () => []),
+    getDocument: vi.fn(async () => {
+      throw new Error('not used');
+    }),
+    saveDocument: vi.fn(async () => ({ newVersion: 2 })),
+    deleteDocument: vi.fn(async () => {}),
+    uploadBlobs: vi.fn(async (hashes: string[]) => ok(hashes.length)),
+    downloadBlobs: vi.fn(async (hashes: string[]) => ok(hashes.length)),
+    ...over,
+  };
+  return p as never;
+}
+
+describe('relayDocumentStore — JP-118 blob routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheMock.get.mockResolvedValue(null);
+    useRelayDocumentStore.setState({ relayDocuments: {}, documentCache: {} });
+    useConnectionStore.setState({
+      host: { address: 'localhost:9876', url: 'http://localhost:9876' },
+    });
+  });
+
+  it('uploads referenced blobs before the save and keeps blob:// refs (no base64)', async () => {
+    const provider = makeProvider();
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await useRelayDocumentStore.getState().saveToHost(docWithBlob('doc-1', 'hashA'));
+
+    // Uploaded the referenced blob...
+    expect(provider.uploadBlobs).toHaveBeenCalledWith(['hashA']);
+    // ...before the doc save (upload call ordered before save call).
+    expect(provider.uploadBlobs.mock.invocationCallOrder[0]!).toBeLessThan(
+      provider.saveDocument.mock.invocationCallOrder[0]!,
+    );
+    // The saved doc carries the blob:// ref and no embedded base64.
+    const savedDoc = provider.saveDocument.mock.calls[0]![0] as DiagramDocument;
+    const json = JSON.stringify(savedDoc);
+    expect(json).toContain('blob://hashA');
+    expect(json).not.toContain('data:');
+    expect(json).not.toContain('base64');
+  });
+
+  it('aborts the save when a blob upload fails', async () => {
+    const provider = makeProvider({
+      uploadBlobs: vi.fn(async () => ({
+        total: 1,
+        success: 0,
+        failed: 1,
+        errors: new Map([['hashA', 'quota exceeded']]),
+      })),
+    });
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await expect(
+      useRelayDocumentStore.getState().saveToHost(docWithBlob('doc-2', 'hashA')),
+    ).rejects.toThrow(/upload .*asset/i);
+
+    expect(provider.saveDocument).not.toHaveBeenCalled();
+  });
+
+  it('saves a doc with no assets without calling uploadBlobs', async () => {
+    const provider = makeProvider();
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    const bare = {
+      id: 'doc-3',
+      name: 'doc-3',
+      pages: { 'p': { id: 'p', name: 'P', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['p'],
+      activePageId: 'p',
+      createdAt: 0,
+      modifiedAt: 0,
+      version: 1,
+    } as unknown as DiagramDocument;
+
+    await useRelayDocumentStore.getState().saveToHost(bare);
+
+    expect(provider.uploadBlobs).not.toHaveBeenCalled();
+    expect(provider.saveDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads referenced blobs on load', async () => {
+    const provider = makeProvider({
+      getDocument: vi.fn(async () => ({
+        document: docWithBlob('doc-4', 'hashB'),
+        serverVersion: 5,
+      })),
+    });
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    const doc = await useRelayDocumentStore.getState().loadRelayDocument('doc-4');
+
+    expect(provider.downloadBlobs).toHaveBeenCalledWith(['hashB']);
+    expect(doc.id).toBe('doc-4');
+  });
+
+  it('still returns the doc when a blob download fails (non-fatal)', async () => {
+    const provider = makeProvider({
+      getDocument: vi.fn(async () => ({ document: docWithBlob('doc-5', 'hashC') })),
+      downloadBlobs: vi.fn(async () => ({
+        total: 1,
+        success: 0,
+        failed: 1,
+        errors: new Map([['hashC', 'offline']]),
+      })),
+    });
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    const doc = await useRelayDocumentStore.getState().loadRelayDocument('doc-5');
+
+    expect(provider.downloadBlobs).toHaveBeenCalled();
+    expect(doc.id).toBe('doc-5');
+  });
+});

--- a/src/store/relayDocumentStore.blobSync.test.ts
+++ b/src/store/relayDocumentStore.blobSync.test.ts
@@ -35,7 +35,7 @@ import type { BlobSyncResult } from '../collaboration/BlobSyncService';
 import type { DiagramDocument } from '../types/Document';
 
 function ok(total: number): BlobSyncResult {
-  return { total, success: total, failed: 0, errors: new Map() };
+  return { total, success: total, uploaded: total, failed: 0, errors: new Map() };
 }
 
 /** A doc that references one blob (rich-text image + GC list). */
@@ -120,6 +120,7 @@ describe('relayDocumentStore — JP-118 blob routing', () => {
       uploadBlobs: vi.fn(async () => ({
         total: 1,
         success: 0,
+        uploaded: 0,
         failed: 1,
         errors: new Map([['hashA', 'quota exceeded']]),
       })),
@@ -175,6 +176,7 @@ describe('relayDocumentStore — JP-118 blob routing', () => {
       downloadBlobs: vi.fn(async () => ({
         total: 1,
         success: 0,
+        uploaded: 0,
         failed: 1,
         errors: new Map([['hashC', 'offline']]),
       })),

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -438,7 +438,10 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
             }
             const bundleResult = await bundleDocumentWithAssets(doc, { mode: 'reference' });
             docToSave = bundleResult.document;
-            console.log(`[relayDocumentStore] Uploaded ${uploadResult.success} asset(s); saving with blob:// refs`);
+            console.log(
+              `[relayDocumentStore] Assets for ${doc.id}: ${uploadResult.total} referenced, ` +
+                `${uploadResult.uploaded} uploaded (rest already present); saving with blob:// refs`,
+            );
           }
         } else if (hasBlobReferences(doc)) {
           // Legacy fallback (provider without blob sync): embed assets as

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -21,12 +21,14 @@ import { useUserStore } from './userStore';
 import type { Permission } from '../types/DocumentRegistry';
 import {
   bundleDocumentWithAssets,
+  collectBlobReferences,
   extractAssetsFromBundle,
   hasBlobReferences,
   hasEmbeddedAssets,
 } from '../storage/AssetBundler';
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
+import type { BlobSyncResult } from '../collaboration/BlobSyncService';
 
 /**
  * Calculate the effective permission for a user on a document.
@@ -107,6 +109,15 @@ export interface DocumentProvider {
     newOwnerId: string,
     newOwnerName: string
   ): Promise<void>;
+  /**
+   * Upload referenced blobs to the relay blob store before a doc save.
+   * Optional: when absent the store falls back to base64-embedding assets
+   * in the doc (legacy path). When present, assets are stored as deduped,
+   * metered blobs and the doc keeps blob:// references (JP-118).
+   */
+  uploadBlobs?(hashes: string[]): Promise<BlobSyncResult>;
+  /** Download referenced blobs missing locally after a doc load. */
+  downloadBlobs?(hashes: string[]): Promise<BlobSyncResult>;
 }
 
 /** Team document store actions */
@@ -327,9 +338,11 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           doc = { ...doc, serverVersion };
         }
 
-        // Extract embedded assets from the document if present
-        // This converts data: URLs to local blob:// references
         if (hasEmbeddedAssets(doc)) {
+          // Legacy embedded doc: convert base64 data URLs to local blob://
+          // references in IndexedDB. This is the lazy-migration read path —
+          // the next saveToHost uploads these to the blob store and drops the
+          // base64 (see JP-118).
           console.log('[relayDocumentStore] Extracting embedded assets from document:', docId);
           const assetResult = await extractAssetsFromBundle(doc);
           doc = assetResult.document;
@@ -338,6 +351,20 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
             doc = { ...doc, serverVersion };
           }
           console.log(`[relayDocumentStore] Extracted ${assetResult.assetCount} assets`);
+        } else if (docProvider.downloadBlobs) {
+          // Reference doc (JP-118): pull any referenced blobs we don't already
+          // have into local IndexedDB so blob:// refs render and the doc stays
+          // viewable offline from the cache. A missing blob is non-fatal — the
+          // doc still opens; that one asset just won't render.
+          const blobHashes = collectBlobReferences(doc);
+          if (blobHashes.length > 0) {
+            const dl = await docProvider.downloadBlobs(blobHashes);
+            if (dl.failed > 0) {
+              console.warn(
+                `[relayDocumentStore] ${dl.failed} of ${dl.total} asset(s) failed to download for ${docId}`,
+              );
+            }
+          }
         }
 
         // Cache the document in memory
@@ -388,10 +415,34 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       registry.setSyncState(doc.id, 'syncing');
 
       try {
-        // Bundle assets as base64 data URLs before sending
-        // This ensures other clients can access the assets
+        // Get referenced asset hashes (rich-text images + FileShape blobRefs +
+        // the explicit GC list) via the canonical whole-doc walk.
+        const blobHashes = collectBlobReferences(doc);
+
         let docToSave = doc;
-        if (hasBlobReferences(doc)) {
+        if (docProvider.uploadBlobs) {
+          // JP-118: route assets to the relay blob store. Upload any blobs the
+          // relay is missing *before* the doc save so collaborators never load
+          // a doc that references blobs the relay doesn't have, and the doc
+          // keeps lightweight blob:// refs (no base64 — the storage meter sees
+          // real bytes). Keep the doc's GC list accurate at the same time.
+          if (blobHashes.length > 0) {
+            doc = { ...doc, blobReferences: blobHashes };
+            console.log('[relayDocumentStore] Uploading assets to blob store for document:', doc.id);
+            const uploadResult = await docProvider.uploadBlobs(blobHashes);
+            if (uploadResult.failed > 0) {
+              const detail = Array.from(uploadResult.errors.values())[0] ?? 'unknown error';
+              throw new Error(
+                `Failed to upload ${uploadResult.failed} of ${uploadResult.total} asset(s) to the relay: ${detail}`,
+              );
+            }
+            const bundleResult = await bundleDocumentWithAssets(doc, { mode: 'reference' });
+            docToSave = bundleResult.document;
+            console.log(`[relayDocumentStore] Uploaded ${uploadResult.success} asset(s); saving with blob:// refs`);
+          }
+        } else if (hasBlobReferences(doc)) {
+          // Legacy fallback (provider without blob sync): embed assets as
+          // base64 data URLs so other clients can access them.
           console.log('[relayDocumentStore] Bundling assets for document:', doc.id);
           const bundleResult = await bundleDocumentWithAssets(doc);
           docToSave = bundleResult.document;


### PR DESCRIPTION
Stacked set of relay-document fixes for the Cloud MVP critical path. The branch
sits linearly on top of `master`; each commit is an independent fix that was
E2E-verified before landing.

## Commits

- **JP-118** — route relay-doc assets to the blob store. Relay docs were
  base64-bundling assets inline instead of using the content-addressed blob
  store, so `relay_storage_bytes_total` read 0 and the storage meter was blind.
  Assets now upload via the blob path; `collectBlobReferences` is the canonical
  hash extractor.
- **JP-117** — route relay saves to the doc's **immutable origin relay**. Saves
  followed whatever relay was connected; the registry + cache also re-stamped a
  doc's `relayId` on every list/load, flipping origins. Origin is now first-set,
  never clobbered (no-clobber `RelayDocumentCache.put` + registry); saves/queue
  replay route to the home relay.
- **JP-121** — keep `historyStore.activePageId` in lockstep when a new doc
  activates its first page (the consistency guard was refusing edits on fresh
  docs).
- **JP-122** — render `FileShape` `blob://` thumbnails on canvas. The renderer
  assigned DocuShark's custom `blob://` scheme straight to `img.src` (browser
  rejects it); now resolved to a cached object URL via `BlobStorage`, mirroring
  TiptapEditor's resolver, with an `onThumbnailLoad` redraw channel and
  doc-switch cache reset.

## Verification

- `tsc --noEmit` clean.
- Full suite: **1686 passing** (75 files) — all four verified together.
- Each fix independently E2E-verified against local + staging relays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)