### PR TITLE
feat(relay): enforce free-tier storage quota (507) + concurrent-editor cap (JP-81)

### DIFF
--- a/relay/docs/api/token-format.md
+++ b/relay/docs/api/token-format.md
@@ -65,6 +65,20 @@ Other algorithms are not accepted. In particular:
 - `role` — one of `owner`, `member`, `viewer`. Relay enforces role on document operations.
 - `region` — region code the workspace is bound to (e.g. `yyz`, `ord`, `nrt`, `fra`). The relay refuses connections whose `region` does not match the relay's configured `region`.
 
+Each entry may also carry two **optional** per-workspace limit fields. When
+present they are authoritative; when absent the relay falls back to its
+`[tenancy.limits]` config (see [Per-workspace limits](#per-workspace-limits)).
+The relay enforces the raw numbers — it has no notion of plans or tiers.
+
+- `quota_bytes` — integer storage-byte quota for the workspace. New blob
+  uploads / document saves past this return **HTTP 507**.
+- `editor_limit` — integer cap on concurrent **editor** (role `owner`/`member`)
+  connections. Viewers are never counted against it.
+
+```json
+{ "id": "ws_01H...", "role": "owner", "region": "yyz", "quota_bytes": 262144000, "editor_limit": 2 }
+```
+
 Single-workspace deployments may still ship a one-entry `wsp` array — the shape is fixed.
 
 ### Optional claims
@@ -130,10 +144,34 @@ The `[tenancy.limits]` block configures per-workspace traffic limits, enforced f
 | -- | -- |
 | `writes_per_sec` | Token-bucket refill rate. Applies to WS CRDT sync frames and MCP write tools. Over-quota WS frames are silently dropped with an `ERR_RATE_LIMIT` reply; over-quota MCP calls return HTTP `429` with `Retry-After`. |
 | `writes_burst` | Token-bucket capacity. Short spikes up to this size pass through without throttling. |
-| `max_ws_connections_per_workspace` | Authenticated WS connection cap per workspace. The Nth + 1 connect fails with `ERR_WORKSPACE_CONNECTION_LIMIT` on the `AUTH_RESPONSE`. |
+| `max_ws_connections_per_workspace` | Authenticated WS connection cap per workspace (editors + viewers — the total-connection safety ceiling that also guards pure-viewer flooding). The Nth + 1 connect fails with `ERR_WORKSPACE_CONNECTION_LIMIT` on the `AUTH_RESPONSE`. |
 | `max_ws_payload_bytes` | Per-frame payload size cap. Pathologically large WS frames are rejected before dispatch; the connection is dropped. |
+| `storage_quota_bytes` | Per-workspace storage-byte quota. `0` = unlimited. Fallback for the JWT `quota_bytes` claim. |
+| `max_editors_per_workspace` | Per-workspace concurrent-**editor** cap. `0` = unlimited. Fallback for the JWT `editor_limit` claim. |
 
-Defaults match the project's Free-Tier reference values; self-hosters can override any field.
+Defaults match the project's Free-Tier reference values; self-hosters can override any field. `storage_quota_bytes` and `max_editors_per_workspace` default to `0` (unlimited) so a self-host deploy is unconstrained out of the box.
+
+### Effective limit resolution
+
+For `quota_bytes` / `editor_limit`, the **effective limit is the JWT claim value if present, else the config fallback**. A resolved `0` (from either source) means unlimited. This lets a control plane mint absolute per-workspace numbers in the token while self-hosters rely on `[tenancy.limits]`.
+
+### Storage enforcement (`507`)
+
+Storage is a *level* read live from disk (full-size-per-grant attribution) — no persisted counter. A blob upload (`POST /api/blobs/:hash`) or document save (`PUT /api/docs/:id`) returns **HTTP 507 Insufficient Storage** when the projected workspace total would exceed the effective `quota_bytes`. A re-upload of an already-stored hash adds 0 (dedup) and is never refused. Existing data stays **readable** when over quota (`GET` is unaffected) — only new writes are refused.
+
+### Editor cap (`ERR_EDITOR_LIMIT`)
+
+When a workspace has an effective `editor_limit`, the Nth + 1 **editor** (role `owner`/`member`) WS connection is refused at auth with `ERR_EDITOR_LIMIT` on the `AUTH_RESPONSE`. **Viewers (role `viewer`) are never refused on this axis.** The total-connection ceiling above still applies to everyone.
+
+## Usage endpoint
+
+`GET /api/v1/usage` returns the **calling token's own** workspace usage and effective limits (JSON, camelCase). The workspace is resolved from the validated JWT exactly like `/api/docs`, so a caller can never read another workspace's numbers. `null` quota/limit means unlimited.
+
+```json
+{ "storageBytes": 12345678, "storageQuota": 262144000, "activeEditors": 1, "editorLimit": 2 }
+```
+
+The response carries counts only — no document ids and no content.
 
 ## Token lifetime guidance
 

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -28,7 +28,7 @@ use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
     PermissionError,
 };
-use crate::server::protocol::{DocEventType, DocId, WorkspaceId};
+use crate::server::protocol::{ClaimLimits, DocEventType, DocId, WorkspaceId};
 use crate::server::ServerState;
 
 /// Resolve the workspace this request is authenticated to, and apply
@@ -39,8 +39,8 @@ use crate::server::ServerState;
 fn resolve_workspace(
     state: &Arc<ServerState>,
     claims: &OidcClaims,
-) -> Result<(WorkspaceId, WorkspaceRole), axum::response::Response> {
-    let (ws, role) = match WorkspaceId::from_oidc_array(claims, None, state.relay_region()) {
+) -> Result<(WorkspaceId, WorkspaceRole, ClaimLimits), axum::response::Response> {
+    let (ws, role, limits) = match WorkspaceId::from_oidc_array(claims, None, state.relay_region()) {
         Ok(v) => v,
         Err(_) => {
             return Err((StatusCode::FORBIDDEN, ApiError::body("forbidden")).into_response());
@@ -49,7 +49,7 @@ fn resolve_workspace(
     if state.check_tenancy(&ws).is_err() {
         return Err((StatusCode::FORBIDDEN, ApiError::body("forbidden")).into_response());
     }
-    Ok((ws, role))
+    Ok((ws, role, limits))
 }
 
 /// Stringified role value used by the permissions layer.
@@ -92,6 +92,7 @@ fn parse_doc_path(id: String) -> Result<DocId, axum::response::Response> {
 pub fn routes() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/api/v1/internal/revoke", post(revoke_handler))
+        .route("/api/v1/usage", get(usage_handler))
         .route("/api/docs", get(list_docs_handler))
         .route("/api/docs/:id", get(get_doc_handler))
         .route("/api/docs/:id", put(save_doc_handler))
@@ -141,6 +142,19 @@ struct ShareRequest {
 struct TransferRequest {
     new_owner_id: String,
     new_owner_name: String,
+}
+
+/// Workspace-scoped usage + effective limits, consumed by the
+/// `docushark-web` account portal (JP-82). `null` quota/limit means
+/// unlimited. Serialized camelCase to match the rest of the relay's REST
+/// JSON. Privacy: counts only — no doc ids, no content (JP-81).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageResponse {
+    storage_bytes: u64,
+    storage_quota: Option<u64>,
+    active_editors: u32,
+    editor_limit: Option<u32>,
 }
 
 #[derive(Serialize)]
@@ -217,12 +231,41 @@ async fn list_docs_handler(
         Ok(c) => c,
         Err(resp) => return resp,
     };
-    let (ws, _role) = match resolve_workspace(&state, &claims) {
+    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
     let docs = state.doc_store().list_documents(&ws);
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
+}
+
+/// `GET /api/v1/usage` — the caller's own workspace usage + effective
+/// limits (JP-81). Workspace is resolved from the validated JWT exactly
+/// like `/api/docs`, so a caller can only ever see their own numbers.
+async fn usage_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+    let effective = state.resolve_limits(limits);
+    let counts = state.workspace_conn_for(&ws).await;
+    (
+        StatusCode::OK,
+        Json(UsageResponse {
+            storage_bytes: state.blob_store().get_workspace_size(&ws),
+            storage_quota: effective.quota_bytes,
+            active_editors: counts.editors,
+            editor_limit: effective.editor_limit,
+        }),
+    )
+        .into_response()
 }
 
 async fn get_doc_handler(
@@ -238,7 +281,7 @@ async fn get_doc_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, role) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
@@ -274,7 +317,7 @@ async fn save_doc_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, role) = match resolve_workspace(&state, &claims) {
+    let (ws, role, limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
@@ -301,6 +344,20 @@ async fn save_doc_handler(
             Some(role_str(role)),
         ) {
             return permission_error_response(&e);
+        }
+    }
+
+    // Storage backpressure (JP-81): once a workspace is at/over its storage
+    // quota, refuse *new* writes with 507 — existing data stays readable
+    // (GET is unaffected). Doc JSON references blobs (not base64) so its own
+    // metered delta is ~0; the precise per-byte clamp lives on blob upload.
+    if let Some(quota) = state.resolve_limits(limits).quota_bytes {
+        if state.blob_store().get_workspace_size(&ws) >= quota {
+            return (
+                StatusCode::INSUFFICIENT_STORAGE,
+                ApiError::body("storage quota exceeded"),
+            )
+                .into_response();
         }
     }
 
@@ -353,7 +410,7 @@ async fn delete_doc_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, role) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
@@ -396,7 +453,7 @@ async fn share_doc_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, role) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
@@ -435,7 +492,7 @@ async fn transfer_doc_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, role) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };

--- a/relay/src/auth/jwt.rs
+++ b/relay/src/auth/jwt.rs
@@ -30,6 +30,17 @@ pub struct WorkspaceClaim {
     pub id: String,
     pub role: WorkspaceRole,
     pub region: String,
+    /// Per-workspace storage byte quota (single-meter free-tier model).
+    /// Minted by the control plane from the workspace's tier. Absent on
+    /// self-host / legacy tokens — the relay then falls back to
+    /// `[tenancy.limits]`. The relay enforces the raw number; it never
+    /// resolves tiers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quota_bytes: Option<u64>,
+    /// Per-workspace concurrent-editor hard cap (viewers are uncapped).
+    /// Same minting/fallback story as `quota_bytes`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub editor_limit: Option<u32>,
 }
 
 /// Claim shape published in `relay/docs/api/token-format.md`. Optional
@@ -160,6 +171,31 @@ mod tests {
 
     fn empty_jwks() -> JwksCache {
         JwksCache::new("test://unused".to_string())
+    }
+
+    #[test]
+    fn workspace_claim_limit_fields_round_trip() {
+        // JP-81: optional `quota_bytes` / `editor_limit` parse when present.
+        let with: WorkspaceClaim = serde_json::from_value(json!({
+            "id": "ws_1", "role": "owner", "region": "yyz",
+            "quota_bytes": 262144000u64, "editor_limit": 2
+        }))
+        .unwrap();
+        assert_eq!(with.quota_bytes, Some(262_144_000));
+        assert_eq!(with.editor_limit, Some(2));
+
+        // Absent fields default to None (legacy / self-host tokens parse).
+        let without: WorkspaceClaim = serde_json::from_value(json!({
+            "id": "ws_1", "role": "member", "region": "yyz"
+        }))
+        .unwrap();
+        assert_eq!(without.quota_bytes, None);
+        assert_eq!(without.editor_limit, None);
+
+        // None is omitted on the wire (skip_serializing_if).
+        let serialized = serde_json::to_value(&without).unwrap();
+        assert!(serialized.get("quota_bytes").is_none());
+        assert!(serialized.get("editor_limit").is_none());
     }
 
     #[tokio::test]

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -50,6 +50,23 @@ pub const DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE: u32 = 25;
 /// per-frame size cap closes the same blast-radius concern.
 pub const DEFAULT_MAX_WS_PAYLOAD_BYTES: usize = 262_144; // 256 KiB
 
+// ---- JP-81: single-meter free-tier enforcement fallbacks ----
+//
+// These are the *fallback* limits applied when a JWT `wsp[]` claim omits
+// `quota_bytes` / `editor_limit` (self-host, `dedicated` mode, or a legacy
+// token). The effective limit is always "claim value if present, else this
+// config default." `0` means **unlimited / disabled** — the safe-by-default
+// self-host story; DocuShark Cloud injects real per-tier numbers via the
+// claim (or per-pod config). The relay enforces raw numbers and never knows
+// tiers.
+
+/// Default per-workspace storage byte quota fallback. `0` = unlimited.
+pub const DEFAULT_STORAGE_QUOTA_BYTES: u64 = 0;
+/// Default per-workspace concurrent-editor cap fallback. `0` = unlimited.
+/// Distinct from `max_ws_connections_per_workspace` (the total-connection
+/// safety ceiling that also guards pure-viewer flooding).
+pub const DEFAULT_MAX_EDITORS_PER_WORKSPACE: u32 = 0;
+
 /// Network exposure for the sync listener.
 ///
 /// `Localhost` binds only to 127.0.0.1; `Lan` binds 0.0.0.0 (the
@@ -229,6 +246,13 @@ pub struct LimitsConfig {
     pub max_ws_connections_per_workspace: u32,
     /// Cap on a single WS frame's payload size (bytes).
     pub max_ws_payload_bytes: usize,
+    /// Fallback per-workspace storage byte quota (JP-81), used when the
+    /// JWT claim omits `quota_bytes`. `0` = unlimited.
+    pub storage_quota_bytes: u64,
+    /// Fallback per-workspace concurrent-editor cap (JP-81), used when the
+    /// JWT claim omits `editor_limit`. `0` = unlimited. Viewers are never
+    /// counted here; the total-connection ceiling above still applies.
+    pub max_editors_per_workspace: u32,
 }
 
 impl Default for LimitsConfig {
@@ -238,6 +262,8 @@ impl Default for LimitsConfig {
             writes_burst: DEFAULT_WRITES_BURST,
             max_ws_connections_per_workspace: DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE,
             max_ws_payload_bytes: DEFAULT_MAX_WS_PAYLOAD_BYTES,
+            storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
+            max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
         }
     }
 }
@@ -381,6 +407,18 @@ impl RelayConfig {
         if let Some(v) = get("RELAY_TENANCY_WORKSPACE") {
             self.tenancy.workspace_id = Some(v);
         }
+        if let Some(v) = get("RELAY_STORAGE_QUOTA_BYTES") {
+            self.tenancy.limits.storage_quota_bytes = v
+                .parse()
+                .map_err(|_| anyhow::anyhow!("RELAY_STORAGE_QUOTA_BYTES must be a u64 (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_MAX_EDITORS_PER_WORKSPACE") {
+            self.tenancy.limits.max_editors_per_workspace = v
+                .parse()
+                .map_err(|_| {
+                    anyhow::anyhow!("RELAY_MAX_EDITORS_PER_WORKSPACE must be a u32 (got {v:?})")
+                })?;
+        }
         Ok(())
     }
 
@@ -516,6 +554,37 @@ mod tests {
             .is_err());
         assert!(cfg
             .apply_env_overrides(env_getter(&[("RELAY_NETWORK_MODE", "wan")]))
+            .is_err());
+    }
+
+    #[test]
+    fn limits_defaults_are_unlimited() {
+        // JP-81: a self-host deploy is unconstrained out of the box.
+        let cfg = LimitsConfig::default();
+        assert_eq!(cfg.storage_quota_bytes, 0);
+        assert_eq!(cfg.max_editors_per_workspace, 0);
+    }
+
+    #[test]
+    fn env_overlay_sets_storage_and_editor_limits() {
+        let mut cfg = RelayConfig::default();
+        cfg.apply_env_overrides(env_getter(&[
+            ("RELAY_STORAGE_QUOTA_BYTES", "262144000"),
+            ("RELAY_MAX_EDITORS_PER_WORKSPACE", "2"),
+        ]))
+        .expect("overlay applies");
+        assert_eq!(cfg.tenancy.limits.storage_quota_bytes, 262_144_000);
+        assert_eq!(cfg.tenancy.limits.max_editors_per_workspace, 2);
+    }
+
+    #[test]
+    fn env_overlay_rejects_bad_limit_values() {
+        let mut cfg = RelayConfig::default();
+        assert!(cfg
+            .apply_env_overrides(env_getter(&[("RELAY_STORAGE_QUOTA_BYTES", "lots")]))
+            .is_err());
+        assert!(cfg
+            .apply_env_overrides(env_getter(&[("RELAY_MAX_EDITORS_PER_WORKSPACE", "-1")]))
             .is_err());
     }
 

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -203,7 +203,7 @@ async fn authenticate(
         });
     }
     if let Ok(claims) = auth.validate(presented).await {
-        if let Ok((ws, _role)) = WorkspaceId::from_oidc_array(&claims, None, relay_region) {
+        if let Ok((ws, _role, _limits)) = WorkspaceId::from_oidc_array(&claims, None, relay_region) {
             return Some(AuthOutcome { workspace: ws });
         }
     }

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -53,6 +53,39 @@ pub struct BlobAcl {
     pub uploaded_at: u64,
 }
 
+/// Failure modes of [`BlobStore::save_blob_with_quota`]. The HTTP layer
+/// maps `QuotaExceeded` to **507 Insufficient Storage** (JP-81), a hash
+/// mismatch to 400, and IO to 500.
+#[derive(Debug)]
+pub enum SaveBlobError {
+    /// The uploaded bytes don't hash to the claimed `:hash`.
+    HashMismatch { expected: String, actual: String },
+    /// Granting this new `(ws, hash)` would push the workspace's
+    /// full-size-per-grant total past its storage quota. A re-upload of
+    /// an already-granted hash never produces this (dedup adds 0).
+    QuotaExceeded { used: u64, quota: u64, incoming: u64 },
+    /// Filesystem / index-persistence failure.
+    Io(String),
+}
+
+impl std::fmt::Display for SaveBlobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Keep the "Hash mismatch" wording — the REST layer and tests
+            // match on it.
+            SaveBlobError::HashMismatch { expected, actual } => {
+                write!(f, "Hash mismatch: expected {}, got {}", expected, actual)
+            }
+            SaveBlobError::QuotaExceeded { used, quota, incoming } => write!(
+                f,
+                "storage quota exceeded: {} used + {} incoming > {} quota",
+                used, incoming, quota
+            ),
+            SaveBlobError::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
 /// Content-addressed blob storage with per-`(workspace, hash)` ACLs.
 pub struct BlobStore {
     /// Directory for storing blobs
@@ -274,6 +307,9 @@ impl BlobStore {
     /// deduplicated; the ACL row is `(ws, hash)`-scoped so two workspaces
     /// that upload identical bytes share the storage but neither can
     /// see the other's upload metadata without independently re-granting.
+    /// Save a blob without quota enforcement (the legacy contract).
+    /// Equivalent to [`Self::save_blob_with_quota`] with no quota. Kept for
+    /// callers/tests that don't enforce storage limits.
     pub fn save_blob(
         &self,
         ws: &WorkspaceId,
@@ -282,12 +318,55 @@ impl BlobStore {
         mime_type: &str,
         user_id: &str,
     ) -> Result<BlobMetadata, String> {
+        self.save_blob_with_quota(ws, expected_hash, data, mime_type, user_id, None)
+            .map_err(|e| e.to_string())
+    }
+
+    /// Save a blob with hash verification, optional per-workspace storage
+    /// quota enforcement, and an ACL grant to the uploading workspace.
+    ///
+    /// `quota_bytes = Some(q)` refuses the upload with
+    /// [`SaveBlobError::QuotaExceeded`] when granting a **new** `(ws, hash)`
+    /// would push the workspace's full-size-per-grant total past `q`. A
+    /// re-upload of an already-granted hash adds 0 (dedup) and is never
+    /// refused; existing data therefore stays readable when a workspace is
+    /// over quota — only new writes are refused (JP-81). `None` = unlimited.
+    ///
+    /// The quota check runs before any disk write so a refused upload writes
+    /// nothing. It reads `acls` then `index` (matching `get_workspace_size`'s
+    /// lock order); a small over-grant under concurrent *new* uploads is
+    /// accepted for simplicity, consistent with the metering tolerance.
+    pub fn save_blob_with_quota(
+        &self,
+        ws: &WorkspaceId,
+        expected_hash: &str,
+        data: &[u8],
+        mime_type: &str,
+        user_id: &str,
+        quota_bytes: Option<u64>,
+    ) -> Result<BlobMetadata, SaveBlobError> {
         let actual_hash = Self::compute_hash(data);
         if actual_hash != expected_hash {
-            return Err(format!(
-                "Hash mismatch: expected {}, got {}",
-                expected_hash, actual_hash
-            ));
+            return Err(SaveBlobError::HashMismatch {
+                expected: expected_hash.to_string(),
+                actual: actual_hash,
+            });
+        }
+
+        if let Some(quota) = quota_bytes {
+            // Only a *new* grant counts toward the workspace total; a
+            // re-upload of an already-granted hash adds 0.
+            if !self.has_acl(ws, &actual_hash) {
+                let incoming = data.len() as u64;
+                let used = self.get_workspace_size(ws);
+                if used.saturating_add(incoming) > quota {
+                    return Err(SaveBlobError::QuotaExceeded {
+                        used,
+                        quota,
+                        incoming,
+                    });
+                }
+            }
         }
 
         // If the bytes are already on disk, skip the rewrite — but
@@ -297,10 +376,10 @@ impl BlobStore {
         if !bytes_exist {
             if let Some(parent) = blob_path.parent() {
                 std::fs::create_dir_all(parent)
-                    .map_err(|e| format!("Failed to create directories: {}", e))?;
+                    .map_err(|e| SaveBlobError::Io(format!("Failed to create directories: {}", e)))?;
             }
             std::fs::write(&blob_path, data)
-                .map_err(|e| format!("Failed to write blob: {}", e))?;
+                .map_err(|e| SaveBlobError::Io(format!("Failed to write blob: {}", e)))?;
         } else {
             log::debug!("Blob {} bytes already on disk, deduped", actual_hash);
         }
@@ -320,7 +399,7 @@ impl BlobStore {
 
         let metadata_changed;
         {
-            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            let mut index = self.index.write().map_err(|e| SaveBlobError::Io(e.to_string()))?;
             // Keep the original metadata if the blob was already known —
             // we only need to ensure presence, not overwrite uploader.
             metadata_changed = !index.contains_key(&actual_hash);
@@ -328,12 +407,12 @@ impl BlobStore {
         }
         let acl_changed;
         {
-            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            let mut acls = self.acls.write().map_err(|e| SaveBlobError::Io(e.to_string()))?;
             acl_changed = acls.insert((ws.clone(), actual_hash.clone()));
         }
 
         if metadata_changed {
-            self.save_index()?;
+            self.save_index().map_err(SaveBlobError::Io)?;
             log::info!(
                 "Saved blob: {}/{} ({} bytes, {})",
                 ws.as_str(),
@@ -343,7 +422,7 @@ impl BlobStore {
             );
         }
         if acl_changed {
-            self.save_acls()?;
+            self.save_acls().map_err(SaveBlobError::Io)?;
         }
 
         // Return the canonical (possibly pre-existing) metadata.
@@ -663,5 +742,73 @@ mod tests {
             let loaded = store.load_blob(&ws, &hash).unwrap();
             assert_eq!(loaded, data);
         }
+    }
+
+    // ---- JP-81: per-workspace storage quota (507) ----
+
+    #[test]
+    fn quota_allows_under_and_rejects_over() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let a = b"0123456789"; // 10 bytes
+        let a_hash = BlobStore::compute_hash(a);
+        store.save_blob_with_quota(&ws, &a_hash, a, "text/plain", "u", Some(25)).unwrap();
+
+        let b = b"abcdefghij"; // 10 bytes, distinct content → 20 total
+        let b_hash = BlobStore::compute_hash(b);
+        store.save_blob_with_quota(&ws, &b_hash, b, "text/plain", "u", Some(25)).unwrap();
+
+        // A third distinct 10-byte blob would be 30 > 25 → refused.
+        let c = b"klmnopqrst";
+        let c_hash = BlobStore::compute_hash(c);
+        let err = store
+            .save_blob_with_quota(&ws, &c_hash, c, "text/plain", "u", Some(25))
+            .unwrap_err();
+        assert!(matches!(err, SaveBlobError::QuotaExceeded { .. }));
+        // The refused upload granted no ACL → workspace size stays at 20.
+        assert_eq!(store.get_workspace_size(&ws), 20);
+    }
+
+    #[test]
+    fn quota_dedup_reupload_of_granted_hash_adds_zero() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let data = b"0123456789"; // 10 bytes
+        let hash = BlobStore::compute_hash(data);
+
+        // Quota exactly 10: the first upload fits.
+        store.save_blob_with_quota(&ws, &hash, data, "text/plain", "u", Some(10)).unwrap();
+        // Re-upload of the already-granted hash adds 0 → still OK at quota.
+        store.save_blob_with_quota(&ws, &hash, data, "text/plain", "u", Some(10)).unwrap();
+        assert_eq!(store.get_workspace_size(&ws), 10);
+    }
+
+    #[test]
+    fn quota_is_per_workspace_isolated() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let alpha = WorkspaceId::from_configured("alpha").unwrap();
+        let beta = WorkspaceId::from_configured("beta").unwrap();
+
+        let data = b"0123456789"; // 10 bytes
+        let hash = BlobStore::compute_hash(data);
+        // Alpha fills its 10-byte quota.
+        store.save_blob_with_quota(&alpha, &hash, data, "text/plain", "a", Some(10)).unwrap();
+        // Alpha is full: a new distinct blob is refused.
+        let data2 = b"xyz";
+        let hash2 = BlobStore::compute_hash(data2);
+        assert!(matches!(
+            store
+                .save_blob_with_quota(&alpha, &hash2, data2, "text/plain", "a", Some(10))
+                .unwrap_err(),
+            SaveBlobError::QuotaExceeded { .. }
+        ));
+        // Beta is unaffected — it can still grant the shared hash (deduped
+        // bytes, fresh ACL) within its own 10-byte quota.
+        store.save_blob_with_quota(&beta, &hash, data, "text/plain", "b", Some(10)).unwrap();
+        assert_eq!(store.get_workspace_size(&beta), 10);
     }
 }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tower_http::cors::{Any, CorsLayer};
 
-use blobs::BlobStore;
+use blobs::{BlobStore, SaveBlobError};
 use documents::DocumentStore;
 use governor::{
     clock::DefaultClock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter,
@@ -200,7 +200,12 @@ pub(crate) enum TenancyError {
 /// Per-workspace connection-cap failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorkspaceLimitError {
+    /// The total-connection safety ceiling (`max_ws_connections_per_workspace`,
+    /// editors + viewers) is full. Guards pure-viewer flooding.
     CapExceeded,
+    /// The per-workspace concurrent-**editor** cap (JP-81) is full. Viewers
+    /// are never rejected on this axis.
+    EditorCapExceeded,
 }
 
 /// Per-workspace live connection counts, split by whether the connection
@@ -220,6 +225,16 @@ impl WorkspaceConnCounts {
     fn total(&self) -> u32 {
         self.editors.saturating_add(self.viewers)
     }
+}
+
+/// Effective per-workspace limits after applying the claim-else-config
+/// fallback (JP-81). `None` means **unlimited** — either nothing was
+/// minted on the claim and the config fallback is `0`, or the resolved
+/// value is `0`. Built by [`ServerState::resolve_limits`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct EffectiveLimits {
+    pub quota_bytes: Option<u64>,
+    pub editor_limit: Option<u32>,
 }
 
 /// Shared state for the WebSocket server
@@ -363,13 +378,20 @@ impl ServerState {
     }
 
     /// Try to register a new authenticated WS connection for the
-    /// given workspace. Returns `Err(WorkspaceLimitError::CapExceeded)`
-    /// if the per-workspace cap would be exceeded. Increment is atomic
-    /// with the check under the write lock.
+    /// given workspace. Returns:
+    /// - `Err(CapExceeded)` if the total-connection safety ceiling
+    ///   (`max_ws_connections_per_workspace`, editors + viewers) is full;
+    /// - `Err(EditorCapExceeded)` if the connection is an **editor** and
+    ///   the per-workspace editor cap (`editor_limit`, JP-81) is full —
+    ///   viewers are never rejected on this axis;
+    /// both checks and the increment are atomic under the write lock.
+    /// `editor_limit` is the *effective* limit (claim else config);
+    /// `None` = unlimited.
     pub(crate) async fn try_register_workspace_connection(
         &self,
         ws: &WorkspaceId,
         is_editor: bool,
+        editor_limit: Option<u32>,
     ) -> Result<(), WorkspaceLimitError> {
         let cap = self.tenancy.limits.max_ws_connections_per_workspace;
         let mut counts = self.workspace_client_counts.write().await;
@@ -378,11 +400,32 @@ impl ServerState {
             return Err(WorkspaceLimitError::CapExceeded);
         }
         if is_editor {
+            if let Some(limit) = editor_limit {
+                if entry.editors >= limit {
+                    return Err(WorkspaceLimitError::EditorCapExceeded);
+                }
+            }
             entry.editors += 1;
         } else {
             entry.viewers += 1;
         }
         Ok(())
+    }
+
+    /// Resolve the *effective* per-workspace limits for a request: the
+    /// value minted on the JWT `wsp[]` claim if present, else the
+    /// `[tenancy.limits]` config fallback. A resolved `0` (from either
+    /// source) normalises to `None` = **unlimited** — the safe-by-default
+    /// self-host story. The relay enforces raw numbers; tier resolution
+    /// lives in the control plane (JP-81).
+    pub(crate) fn resolve_limits(&self, claim: ClaimLimits) -> EffectiveLimits {
+        let cfg = &self.tenancy.limits;
+        let quota = claim.quota_bytes.unwrap_or(cfg.storage_quota_bytes);
+        let editors = claim.editor_limit.unwrap_or(cfg.max_editors_per_workspace);
+        EffectiveLimits {
+            quota_bytes: (quota != 0).then_some(quota),
+            editor_limit: (editors != 0).then_some(editors),
+        }
     }
 
     /// Mirror of `try_register_workspace_connection` used on clean
@@ -449,6 +492,18 @@ impl ServerState {
     /// split), for the metering debug log.
     pub(crate) async fn workspace_conn_snapshot(&self) -> HashMap<WorkspaceId, WorkspaceConnCounts> {
         self.workspace_client_counts.read().await.clone()
+    }
+
+    /// Live editor/viewer counts for a single workspace (zero if the
+    /// workspace has no connections). Backs the `GET /api/v1/usage`
+    /// `active_editors` field (JP-81).
+    pub(crate) async fn workspace_conn_for(&self, ws: &WorkspaceId) -> WorkspaceConnCounts {
+        self.workspace_client_counts
+            .read()
+            .await
+            .get(ws)
+            .copied()
+            .unwrap_or_default()
     }
 
     fn next_client_id(&self) -> u64 {
@@ -1114,17 +1169,18 @@ fn resolve_blob_workspace(
     state: &Arc<ServerState>,
     claims: &OidcClaims,
     requested: Option<&str>,
-) -> Result<WorkspaceId, axum::response::Response> {
-    let (ws, _role) = match WorkspaceId::from_oidc_array(claims, requested, state.relay_region()) {
-        Ok(v) => v,
-        Err(_) => {
-            return Err((StatusCode::FORBIDDEN, "forbidden".to_string()).into_response());
-        }
-    };
+) -> Result<(WorkspaceId, ClaimLimits), axum::response::Response> {
+    let (ws, _role, limits) =
+        match WorkspaceId::from_oidc_array(claims, requested, state.relay_region()) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err((StatusCode::FORBIDDEN, "forbidden".to_string()).into_response());
+            }
+        };
     if state.check_tenancy(&ws).is_err() {
         return Err((StatusCode::FORBIDDEN, "forbidden".to_string()).into_response());
     }
-    Ok(ws)
+    Ok((ws, limits))
 }
 
 /// Upload a blob (POST /api/blobs/:hash)
@@ -1139,7 +1195,7 @@ async fn blob_upload_handler(
         Ok(c) => c,
         Err((status, msg)) => return (status, msg).into_response(),
     };
-    let ws = match resolve_blob_workspace(&state, &claims, None) {
+    let (ws, claim_limits) = match resolve_blob_workspace(&state, &claims, None) {
         Ok(w) => w,
         Err(resp) => return resp,
     };
@@ -1151,8 +1207,14 @@ async fn blob_upload_handler(
         .unwrap_or("application/octet-stream")
         .to_string();
 
-    // Save blob with hash verification — grants ACL to the uploading workspace.
-    match state.blob_store.save_blob(&ws, &hash, &body, &mime_type, &claims.sub) {
+    // Save blob with hash verification + per-workspace storage quota (JP-81)
+    // — grants ACL to the uploading workspace. Quota = claim value else
+    // config fallback; `None` = unlimited.
+    let quota = state.resolve_limits(claim_limits).quota_bytes;
+    match state
+        .blob_store
+        .save_blob_with_quota(&ws, &hash, &body, &mime_type, &claims.sub, quota)
+    {
         Ok(metadata) => {
             let json = serde_json::json!({
                 "success": true,
@@ -1162,12 +1224,17 @@ async fn blob_upload_handler(
             });
             (StatusCode::OK, axum::Json(json)).into_response()
         }
-        Err(e) => {
-            if e.contains("Hash mismatch") {
-                (StatusCode::BAD_REQUEST, e).into_response()
-            } else {
-                (StatusCode::INTERNAL_SERVER_ERROR, e).into_response()
-            }
+        Err(e @ SaveBlobError::HashMismatch { .. }) => {
+            (StatusCode::BAD_REQUEST, e.to_string()).into_response()
+        }
+        Err(e @ SaveBlobError::QuotaExceeded { .. }) => {
+            // 507 Insufficient Storage: existing data stays readable; only
+            // this new write is refused.
+            log::info!("blob upload refused for {}: {}", ws.as_str(), e);
+            (StatusCode::INSUFFICIENT_STORAGE, e.to_string()).into_response()
+        }
+        Err(e @ SaveBlobError::Io(_)) => {
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }
 }
@@ -1183,7 +1250,7 @@ async fn blob_download_handler(
         Ok(c) => c,
         Err((status, msg)) => return (status, msg).into_response(),
     };
-    let ws = match resolve_blob_workspace(&state, &claims, None) {
+    let (ws, _claim_limits) = match resolve_blob_workspace(&state, &claims, None) {
         Ok(w) => w,
         Err(resp) => return resp,
     };
@@ -1231,7 +1298,7 @@ async fn blob_exists_handler(
         Ok(c) => c,
         Err((status, msg)) => return (status, msg).into_response(),
     };
-    let ws = match resolve_blob_workspace(&state, &claims, None) {
+    let (ws, _claim_limits) = match resolve_blob_workspace(&state, &claims, None) {
         Ok(w) => w,
         Err(resp) => return resp,
     };
@@ -1569,7 +1636,7 @@ async fn handle_auth(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
         }
     };
 
-    let (claim_ws, role) =
+    let (claim_ws, role, claim_limits) =
         match WorkspaceId::from_oidc_array(&claims, None, state.relay_region()) {
             Ok(v) => v,
             Err(e) => {
@@ -1590,29 +1657,30 @@ async fn handle_auth(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
     }
 
     // Editors (owner/member) can write and drive CRDT cost; viewers are
-    // read-only. The concurrency cap counts the total; the split is metered.
+    // read-only. The total-connection ceiling counts both; the editor cap
+    // (JP-81) bounds editors only — viewers stay free + uncapped.
     let is_editor = !matches!(role, WorkspaceRole::Viewer);
-    if let Err(WorkspaceLimitError::CapExceeded) =
-        state.try_register_workspace_connection(&claim_ws, is_editor).await
+    let editor_limit = state.resolve_limits(claim_limits).editor_limit;
+    match state
+        .try_register_workspace_connection(&claim_ws, is_editor, editor_limit)
+        .await
     {
-        log::warn!(
-            "ws auth rejected: workspace cap exceeded client_id={} workspace_id={}",
-            client_id,
-            claim_ws.as_str()
-        );
-        send_auth_response(
-            client_id,
-            false,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some("ERR_WORKSPACE_CONNECTION_LIMIT"),
-            state,
-        )
-        .await;
-        return;
+        Ok(()) => {}
+        Err(e) => {
+            let code = match e {
+                WorkspaceLimitError::CapExceeded => "ERR_WORKSPACE_CONNECTION_LIMIT",
+                WorkspaceLimitError::EditorCapExceeded => "ERR_EDITOR_LIMIT",
+            };
+            log::warn!(
+                "ws auth rejected: {} client_id={} workspace_id={}",
+                code,
+                client_id,
+                claim_ws.as_str()
+            );
+            send_auth_response(client_id, false, None, None, None, None, None, Some(code), state)
+                .await;
+            return;
+        }
     }
 
     let role_str = format!("{:?}", role).to_lowercase();
@@ -2152,14 +2220,14 @@ mod tests {
         .await;
         let ws = WorkspaceId::single_tenant();
         // Cap applies to the total regardless of editor/viewer mix.
-        assert!(state.try_register_workspace_connection(&ws, true).await.is_ok());
-        assert!(state.try_register_workspace_connection(&ws, false).await.is_ok());
+        assert!(state.try_register_workspace_connection(&ws, true, None).await.is_ok());
+        assert!(state.try_register_workspace_connection(&ws, false, None).await.is_ok());
         assert_eq!(
-            state.try_register_workspace_connection(&ws, true).await,
+            state.try_register_workspace_connection(&ws, true, None).await,
             Err(WorkspaceLimitError::CapExceeded)
         );
         state.release_workspace_connection(&ws, false).await;
-        assert!(state.try_register_workspace_connection(&ws, true).await.is_ok());
+        assert!(state.try_register_workspace_connection(&ws, true, None).await.is_ok());
     }
 
     /// The editor/viewer split is tracked independently and balances on
@@ -2178,10 +2246,10 @@ mod tests {
         let alpha = WorkspaceId::from_configured("alpha").unwrap();
         let beta = WorkspaceId::from_configured("beta").unwrap();
 
-        state.try_register_workspace_connection(&alpha, true).await.unwrap();
-        state.try_register_workspace_connection(&alpha, true).await.unwrap();
-        state.try_register_workspace_connection(&alpha, false).await.unwrap();
-        state.try_register_workspace_connection(&beta, false).await.unwrap();
+        state.try_register_workspace_connection(&alpha, true, None).await.unwrap();
+        state.try_register_workspace_connection(&alpha, true, None).await.unwrap();
+        state.try_register_workspace_connection(&alpha, false, None).await.unwrap();
+        state.try_register_workspace_connection(&beta, false, None).await.unwrap();
 
         assert_eq!(state.active_editor_count().await, 2);
         assert_eq!(state.active_viewer_count().await, 2);
@@ -2193,6 +2261,99 @@ mod tests {
 
         state.release_workspace_connection(&alpha, true).await;
         assert_eq!(state.active_editor_count().await, 1);
+    }
+
+    /// JP-81: the concurrent-editor cap refuses the Nth + 1 *editor* while
+    /// viewers stay uncapped; releasing an editor frees a slot.
+    #[tokio::test]
+    async fn editor_cap_rejects_extra_editors_but_not_viewers() {
+        let limits = LimitsConfig {
+            max_ws_connections_per_workspace: 100,
+            ..LimitsConfig::default()
+        };
+        let state = test_server_state(TenancyConfig {
+            limits,
+            ..TenancyConfig::default()
+        })
+        .await;
+        let ws = WorkspaceId::single_tenant();
+        let editor_limit = Some(2);
+
+        assert!(state.try_register_workspace_connection(&ws, true, editor_limit).await.is_ok());
+        assert!(state.try_register_workspace_connection(&ws, true, editor_limit).await.is_ok());
+        assert_eq!(
+            state.try_register_workspace_connection(&ws, true, editor_limit).await,
+            Err(WorkspaceLimitError::EditorCapExceeded)
+        );
+        // Viewers are never refused on the editor axis.
+        assert!(state.try_register_workspace_connection(&ws, false, editor_limit).await.is_ok());
+        assert!(state.try_register_workspace_connection(&ws, false, editor_limit).await.is_ok());
+        // Releasing an editor makes room for one more.
+        state.release_workspace_connection(&ws, true).await;
+        assert!(state.try_register_workspace_connection(&ws, true, editor_limit).await.is_ok());
+    }
+
+    /// JP-81: `editor_limit = None` is unlimited (only the total-connection
+    /// ceiling applies).
+    #[tokio::test]
+    async fn editor_cap_none_is_unlimited() {
+        let limits = LimitsConfig {
+            max_ws_connections_per_workspace: 100,
+            ..LimitsConfig::default()
+        };
+        let state = test_server_state(TenancyConfig {
+            limits,
+            ..TenancyConfig::default()
+        })
+        .await;
+        let ws = WorkspaceId::single_tenant();
+        for _ in 0..20 {
+            state.try_register_workspace_connection(&ws, true, None).await.unwrap();
+        }
+        assert_eq!(state.active_editor_count().await, 20);
+    }
+
+    /// JP-81: effective limits prefer the JWT claim, fall back to config, and
+    /// normalise `0` → `None` (unlimited) from either source.
+    #[tokio::test]
+    async fn resolve_limits_claim_overrides_config_and_zero_is_unlimited() {
+        let limits = LimitsConfig {
+            storage_quota_bytes: 1000,
+            max_editors_per_workspace: 5,
+            ..LimitsConfig::default()
+        };
+        let state = test_server_state(TenancyConfig {
+            limits,
+            ..TenancyConfig::default()
+        })
+        .await;
+
+        // Claim absent → config fallback.
+        let eff = state.resolve_limits(ClaimLimits::default());
+        assert_eq!(eff.quota_bytes, Some(1000));
+        assert_eq!(eff.editor_limit, Some(5));
+
+        // Claim present → overrides config.
+        let eff = state.resolve_limits(ClaimLimits {
+            quota_bytes: Some(2048),
+            editor_limit: Some(3),
+        });
+        assert_eq!(eff.quota_bytes, Some(2048));
+        assert_eq!(eff.editor_limit, Some(3));
+
+        // Claim 0 → unlimited (overrides a non-zero config).
+        let eff = state.resolve_limits(ClaimLimits {
+            quota_bytes: Some(0),
+            editor_limit: Some(0),
+        });
+        assert_eq!(eff.quota_bytes, None);
+        assert_eq!(eff.editor_limit, None);
+
+        // Config 0 default + claim absent → unlimited.
+        let state2 = test_server_state(TenancyConfig::default()).await;
+        let eff = state2.resolve_limits(ClaimLimits::default());
+        assert_eq!(eff.quota_bytes, None);
+        assert_eq!(eff.editor_limit, None);
     }
 
 }

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -32,6 +32,18 @@ use crate::auth::{AuthError, OidcClaims, WorkspaceRole};
 #[serde(transparent)]
 pub struct WorkspaceId(String);
 
+/// Raw per-workspace limits carried (optionally) on the chosen `wsp[]`
+/// claim entry — surfaced alongside the resolved workspace by
+/// [`WorkspaceId::from_oidc_array`]. `None` means the token didn't mint
+/// the field; the caller resolves the config fallback
+/// (`ServerState::resolve_limits`). The relay never interprets tiers —
+/// these are raw numbers minted by the control plane (JP-81).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ClaimLimits {
+    pub quota_bytes: Option<u64>,
+    pub editor_limit: Option<u32>,
+}
+
 impl WorkspaceId {
     /// The legacy single-tenant constant (`"default"`). Used as the
     /// fallback when a JWT lacks a workspace claim, when `[tenancy]`
@@ -60,7 +72,7 @@ impl WorkspaceId {
         claims: &OidcClaims,
         requested: Option<&str>,
         relay_region: &str,
-    ) -> Result<(Self, WorkspaceRole), AuthError> {
+    ) -> Result<(Self, WorkspaceRole, ClaimLimits), AuthError> {
         if claims.wsp.is_empty() {
             return Err(AuthError::WorkspaceMismatch);
         }
@@ -84,7 +96,14 @@ impl WorkspaceId {
             return Err(AuthError::WorkspaceMismatch);
         }
 
-        Ok((Self(chosen.id.clone()), chosen.role))
+        Ok((
+            Self(chosen.id.clone()),
+            chosen.role,
+            ClaimLimits {
+                quota_bytes: chosen.quota_bytes,
+                editor_limit: chosen.editor_limit,
+            },
+        ))
     }
 
     pub fn as_str(&self) -> &str {

--- a/relay/src/test_support.rs
+++ b/relay/src/test_support.rs
@@ -109,6 +109,34 @@ impl OidcTestIssuer {
         region: &str,
         ttl_seconds: u64,
     ) -> String {
+        self.mint_full(sub, workspace, role, region, ttl_seconds, None, None)
+    }
+
+    /// Mint a token carrying per-workspace `quota_bytes` / `editor_limit`
+    /// claim fields (JP-81 free-tier enforcement). `None` for either omits
+    /// the field, exercising the config fallback path.
+    pub fn mint_with_limits(
+        &self,
+        sub: &str,
+        workspace: &str,
+        role: WorkspaceRole,
+        quota_bytes: Option<u64>,
+        editor_limit: Option<u32>,
+    ) -> String {
+        self.mint_full(sub, workspace, role, "default", 3600, quota_bytes, editor_limit)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mint_full(
+        &self,
+        sub: &str,
+        workspace: &str,
+        role: WorkspaceRole,
+        region: &str,
+        ttl_seconds: u64,
+        quota_bytes: Option<u64>,
+        editor_limit: Option<u32>,
+    ) -> String {
         let now = Utc::now().timestamp() as u64;
         let claims = OidcClaims {
             iss: TEST_ISSUER.to_string(),
@@ -121,6 +149,8 @@ impl OidcTestIssuer {
                 id: workspace.to_string(),
                 role,
                 region: region.to_string(),
+                quota_bytes,
+                editor_limit,
             }],
         };
         let mut header = Header::new(Algorithm::RS256);

--- a/relay/tests/free_tier_enforcement.rs
+++ b/relay/tests/free_tier_enforcement.rs
@@ -1,0 +1,148 @@
+//! JP-81 — free-tier enforcement, end-to-end over the real REST surface.
+//!
+//! Exercises the two user-facing halves of the single-meter model through
+//! HTTP against an in-process relay:
+//!
+//!   * `GET /api/v1/usage` reports the *calling* workspace's storage bytes
+//!     and effective limits, and never another workspace's numbers.
+//!   * `POST /api/blobs/:hash` returns **507** once a new grant would push
+//!     the workspace past its `quota_bytes`, while a dedup re-upload of an
+//!     already-stored hash is never refused.
+//!
+//! Limits are minted onto the JWT `wsp[]` claim via the test issuer
+//! (`mint_with_limits`), the same path DocuShark Cloud uses — so this
+//! validates the claim → effective-limit resolution too.
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+/// In-process relay in shared-tenancy mode. Returns the HTTP base and the
+/// issuer (kept alive so its JWKS endpoint keeps serving verification keys).
+async fn start_relay() -> (Arc<WebSocketServer>, String, OidcTestIssuer, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+
+    (server, http, issuer, tmp)
+}
+
+fn blob_hash(data: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(data);
+    hex::encode(h.finalize())
+}
+
+async fn upload_blob(http: &str, token: &str, data: &[u8]) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .post(format!("{http}/api/blobs/{}", blob_hash(data)))
+        .bearer_auth(token)
+        .body(data.to_vec())
+        .send()
+        .await
+        .expect("blob upload request")
+        .status()
+}
+
+async fn get_usage(http: &str, token: &str) -> Value {
+    reqwest::Client::new()
+        .get(format!("{http}/api/v1/usage"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("usage request")
+        .json()
+        .await
+        .expect("usage json")
+}
+
+#[tokio::test]
+async fn usage_reports_claim_limits_and_is_workspace_scoped() {
+    let (_server, http, issuer, _tmp) = start_relay().await;
+
+    // Two workspaces with *different* minted limits.
+    let alpha = issuer.mint_with_limits("user-a", "alpha", WorkspaceRole::Owner, Some(1_000_000), Some(2));
+    let beta = issuer.mint_with_limits("user-b", "beta", WorkspaceRole::Owner, Some(5_000), Some(9));
+
+    // Give alpha 11 bytes of stored blob.
+    assert_eq!(upload_blob(&http, &alpha, b"hello world").await, reqwest::StatusCode::OK);
+
+    let ua = get_usage(&http, &alpha).await;
+    assert_eq!(ua["storageBytes"], 11);
+    assert_eq!(ua["storageQuota"], 1_000_000);
+    assert_eq!(ua["editorLimit"], 2);
+    assert_eq!(ua["activeEditors"], 0); // no live WS editors
+
+    // Beta sees only its own numbers — alpha's 11 bytes are invisible.
+    let ub = get_usage(&http, &beta).await;
+    assert_eq!(ub["storageBytes"], 0);
+    assert_eq!(ub["storageQuota"], 5_000);
+    assert_eq!(ub["editorLimit"], 9);
+}
+
+#[tokio::test]
+async fn usage_omits_unlimited_quota_as_null() {
+    let (_server, http, issuer, _tmp) = start_relay().await;
+    // No limits minted + config default 0 → unlimited → null on the wire.
+    let token = issuer.mint_with_limits("user-c", "gamma", WorkspaceRole::Owner, None, None);
+    let usage = get_usage(&http, &token).await;
+    assert!(usage["storageQuota"].is_null());
+    assert!(usage["editorLimit"].is_null());
+    assert_eq!(usage["storageBytes"], 0);
+}
+
+#[tokio::test]
+async fn blob_upload_returns_507_over_quota_but_dedup_reupload_is_free() {
+    let (_server, http, issuer, _tmp) = start_relay().await;
+    // 15-byte quota.
+    let token = issuer.mint_with_limits("user-d", "delta", WorkspaceRole::Owner, Some(15), None);
+
+    let first = b"0123456789"; // 10 bytes → fits (10 <= 15)
+    assert_eq!(upload_blob(&http, &token, first).await, reqwest::StatusCode::OK);
+
+    // A second distinct 10-byte blob would be 20 > 15 → 507.
+    let second = b"abcdefghij";
+    assert_eq!(
+        upload_blob(&http, &token, second).await,
+        reqwest::StatusCode::INSUFFICIENT_STORAGE
+    );
+
+    // Re-uploading the already-granted hash adds 0 (dedup) → still OK,
+    // even though the workspace is at quota.
+    assert_eq!(upload_blob(&http, &token, first).await, reqwest::StatusCode::OK);
+
+    // Usage confirms only the first blob's bytes are counted.
+    let usage = get_usage(&http, &token).await;
+    assert_eq!(usage["storageBytes"], 10);
+    assert_eq!(usage["storageQuota"], 15);
+}


### PR DESCRIPTION
Enforces the single-meter free-tier model in the OSS relay: a per-workspace **storage byte quota** (HTTP 507) and a **concurrent-editor** hard cap (viewers uncapped). The relay stays a generic OIDC resource server — per-workspace limits arrive on the JWT `wsp[]` claim (control-plane minted), falling back to `[tenancy.limits]` config. **Effective = claim if present else config; resolved 0 = unlimited**, so self-host stays unconstrained.

Closes JP-81. Subsumes (and closes) JP-119 — its `/api/v1/usage` endpoint + isolation test ship here.

## Changes (OSS relay)
- **Claim fields:** optional `wsp[].quota_bytes` (u64) / `wsp[].editor_limit` (u32); `from_oidc_array` → `ClaimLimits`; `ServerState::resolve_limits` applies claim-else-config. New config knobs `storage_quota_bytes` / `max_editors_per_workspace` (default 0) + `RELAY_STORAGE_QUOTA_BYTES` / `RELAY_MAX_EDITORS_PER_WORKSPACE` env overlay.
- **Storage 507:** `BlobStore::save_blob_with_quota` refuses a *new* `(ws,hash)` grant past quota → `SaveBlobError::QuotaExceeded` → 507 at `POST /api/blobs/:hash` (dedup re-upload adds 0; existing data stays readable). `PUT /api/docs/:id` backpressures when already over.
- **Editor cap:** `try_register_workspace_connection` rejects the Nth+1 editor → `ERR_EDITOR_LIMIT`; viewers free; total-connection ceiling retained.
- **`GET /api/v1/usage`:** `{ storageBytes, storageQuota, activeEditors, editorLimit }`, workspace-scoped from the JWT (null = unlimited).
- **Docs:** `relay/docs/api/token-format.md` (claim fields, effective-limit resolution, 507 + editor cap, usage endpoint).

## Tests
Blob quota (under/over/dedup/per-workspace isolation), editor cap, effective-limit resolution, claim parse, env overlay, and an end-to-end `tests/free_tier_enforcement.rs` (usage isolation + 507). 127 lib unit tests + all relay integration suites green; `cargo check`/`cargo test --locked` clean.

## Out of scope (separate)
Claim minting in `docushark-web` auth-exchange (JP-78 area), JP-82 account-portal UI + mid-session grace, JP-120 blob orphan GC. Enabling/trusting enforcement in prod follows JP-109's live `/metrics` validation.

Assisted-by: Opus 4.8