### PR TITLE
feat(relay): blob refcount + orphan GC — release ACLs on doc delete, reclaim unreferenced bytes (JP-120)

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -9,6 +9,7 @@
 //! Mounted at `/api/...` by `server::mod::WebSocketServer::start`.
 //! See `routes()` for the full surface.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::{
@@ -50,6 +51,22 @@ fn resolve_workspace(
         return Err((StatusCode::FORBIDDEN, ApiError::body("forbidden")).into_response());
     }
     Ok((ws, role, limits))
+}
+
+/// Extract a document's referenced blob hashes from its `blobReferences`
+/// array (JP-120) — the canonical per-doc reference set the relay refcounts
+/// against. Bare SHA-256 hashes; a `blob://` prefix is stripped defensively
+/// in case a client ever sends the URI form.
+pub(crate) fn blob_refs_from_doc(doc: &Value) -> HashSet<String> {
+    doc.get("blobReferences")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.strip_prefix("blob://").unwrap_or(s).to_string())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Stringified role value used by the permissions layer.
@@ -361,6 +378,11 @@ async fn save_doc_handler(
         }
     }
 
+    // Capture the doc's referenced blob hashes before `document` is moved
+    // into the store — used to update the blob refcount after a successful
+    // save (JP-120).
+    let blob_refs = blob_refs_from_doc(&document);
+
     let outcome = match state
         .doc_store()
         .save_document_with_expected_version(&ws, document, query.expected_version)
@@ -385,6 +407,15 @@ async fn save_doc_handler(
                 DocEventType::Updated
             };
             state.emit_doc_event(&ws, &doc_id, event_type, Some(claims.sub.clone()));
+            // Refresh the blob refcount; release+GC anything this doc dropped.
+            if let Err(e) = state.blob_store().sync_doc_refs(&ws, doc_id.as_str(), blob_refs) {
+                log::warn!(
+                    "blob doc-ref sync failed for {}/{}: {}",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+            }
             (
                 StatusCode::OK,
                 Json(SaveAck {
@@ -428,6 +459,16 @@ async fn delete_doc_handler(
     match state.doc_store().delete_document(&ws, &doc_id) {
         Ok(true) => {
             state.emit_doc_event(&ws, &doc_id, DocEventType::Deleted, Some(claims.sub.clone()));
+            // Release this doc's blob references; GC anything the workspace
+            // no longer references (JP-120).
+            if let Err(e) = state.blob_store().release_doc_refs(&ws, doc_id.as_str()) {
+                log::warn!(
+                    "blob doc-ref release failed for {}/{}: {}",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+            }
             (StatusCode::OK, Json(WriteAck { success: true })).into_response()
         }
         Ok(false) => (

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -53,6 +53,17 @@ pub struct BlobAcl {
     pub uploaded_at: u64,
 }
 
+/// One persisted row of the per-document blob-reference map (JP-120). The
+/// in-memory form is `(workspace, doc_id) -> {hash}`; this is its
+/// on-disk shape in `blob_refs.json` (a flat `Vec`, mirroring `BlobAcl`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocRefRow {
+    pub workspace: WorkspaceId,
+    pub doc_id: String,
+    pub hashes: Vec<String>,
+}
+
 /// Failure modes of [`BlobStore::save_blob_with_quota`]. The HTTP layer
 /// maps `QuotaExceeded` to **507 Insufficient Storage** (JP-81), a hash
 /// mismatch to 400, and IO to 500.
@@ -95,6 +106,14 @@ pub struct BlobStore {
     /// In-memory ACL set — `(workspace, hash)` is granted access.
     /// Persisted to `blob_acl.json` next to `blob_index.json`.
     acls: RwLock<HashSet<(WorkspaceId, String)>>,
+    /// Per-document blob-reference map (JP-120): `(workspace, doc_id)` →
+    /// the set of blob hashes that document references (its
+    /// `blobReferences`). The refcount that decides when a `(ws,hash)` ACL
+    /// can be released (no remaining doc in the workspace references it)
+    /// and when the underlying bytes can be reclaimed (no workspace holds
+    /// an ACL). Persisted to `blob_refs.json`. Keyed by doc-id `String` to
+    /// avoid a `DocId: Hash` dependency.
+    doc_refs: RwLock<HashMap<(WorkspaceId, String), HashSet<String>>>,
 }
 
 impl BlobStore {
@@ -111,11 +130,13 @@ impl BlobStore {
             blobs_dir: blobs_dir.clone(),
             index: RwLock::new(HashMap::new()),
             acls: RwLock::new(HashSet::new()),
+            doc_refs: RwLock::new(HashMap::new()),
         };
 
-        // Load existing index + ACLs.
+        // Load existing index + ACLs + per-doc references.
         store.load_index();
         store.load_acls_or_backfill();
+        store.load_doc_refs();
 
         store
     }
@@ -133,6 +154,14 @@ impl BlobStore {
             .parent()
             .map(|p| p.join("blob_acl.json"))
             .unwrap_or_else(|| self.blobs_dir.join("blob_acl.json"))
+    }
+
+    /// Path to the per-document blob-reference sidecar (JP-120).
+    fn refs_path(&self) -> PathBuf {
+        self.blobs_dir
+            .parent()
+            .map(|p| p.join("blob_refs.json"))
+            .unwrap_or_else(|| self.blobs_dir.join("blob_refs.json"))
     }
 
     /// Get the sharded path for a blob hash
@@ -249,6 +278,46 @@ impl BlobStore {
         let json = serde_json::to_string_pretty(&snapshot)
             .map_err(|e| format!("Serialize error: {}", e))?;
         std::fs::write(self.acl_path(), json)
+            .map_err(|e| format!("Write error: {}", e))?;
+        Ok(())
+    }
+
+    /// Load the per-document blob-reference map from disk (JP-120). Absent
+    /// sidecar = empty map; `ServerState` seeds it from existing docs at
+    /// startup, so a cold boot still ends up with a complete map.
+    fn load_doc_refs(&self) {
+        let path = self.refs_path();
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            if let Ok(rows) = serde_json::from_str::<Vec<DocRefRow>>(&data) {
+                if let Ok(mut current) = self.doc_refs.write() {
+                    current.clear();
+                    for row in rows {
+                        current.insert(
+                            (row.workspace, row.doc_id),
+                            row.hashes.into_iter().collect(),
+                        );
+                    }
+                    log::info!("Loaded blob doc-refs with {} entries", current.len());
+                }
+            }
+        }
+    }
+
+    /// Persist the per-document blob-reference map to disk (JP-120).
+    fn save_doc_refs(&self) -> Result<(), String> {
+        let snapshot: Vec<DocRefRow> = {
+            let refs = self.doc_refs.read().map_err(|e| e.to_string())?;
+            refs.iter()
+                .map(|((ws, doc_id), hashes)| DocRefRow {
+                    workspace: ws.clone(),
+                    doc_id: doc_id.clone(),
+                    hashes: hashes.iter().cloned().collect(),
+                })
+                .collect()
+        };
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| format!("Serialize error: {}", e))?;
+        std::fs::write(self.refs_path(), json)
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -556,6 +625,130 @@ impl BlobStore {
         }
         out
     }
+
+    // ---- JP-120: blob refcount + orphan GC ----
+
+    /// Record the blob hashes a document references (its `blobReferences`).
+    /// Called on each successful save. For any hash this doc *stops*
+    /// referencing, release the `(ws,hash)` ACL when no other doc in the
+    /// workspace still references it (and reclaim the bytes when the last
+    /// ACL across all workspaces is gone). Best-effort: persistence errors
+    /// surface to the caller but the save itself has already succeeded.
+    pub fn sync_doc_refs(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &str,
+        hashes: HashSet<String>,
+    ) -> Result<(), String> {
+        let dropped: Vec<String> = {
+            let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
+            let old = refs
+                .insert((ws.clone(), doc_id.to_string()), hashes.clone())
+                .unwrap_or_default();
+            old.difference(&hashes).cloned().collect()
+        };
+        self.save_doc_refs()?;
+        for h in dropped {
+            self.release_acl_if_unreferenced(ws, &h)?;
+        }
+        Ok(())
+    }
+
+    /// Drop all of a document's blob references (called on doc delete) and
+    /// release/GC anything the workspace no longer references.
+    pub fn release_doc_refs(&self, ws: &WorkspaceId, doc_id: &str) -> Result<(), String> {
+        let dropped: Vec<String> = {
+            let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
+            refs.remove(&(ws.clone(), doc_id.to_string()))
+                .map(|s| s.into_iter().collect())
+                .unwrap_or_default()
+        };
+        self.save_doc_refs()?;
+        for h in dropped {
+            self.release_acl_if_unreferenced(ws, &h)?;
+        }
+        Ok(())
+    }
+
+    /// Seed a document's references at startup without releasing anything
+    /// (JP-120 backfill). Makes `doc_refs` complete from a cold boot so the
+    /// meter is accurate and [`Self::sweep_unreferenced`] is safe.
+    pub fn seed_doc_refs(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &str,
+        hashes: HashSet<String>,
+    ) -> Result<(), String> {
+        {
+            let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
+            refs.insert((ws.clone(), doc_id.to_string()), hashes);
+        }
+        self.save_doc_refs()
+    }
+
+    /// Reclaim blobs that no document references (JP-120 startup sweep) —
+    /// catches the upload-then-abandon case the incremental path can't see.
+    /// For every `(ws,hash)` ACL with no referencing doc in that workspace,
+    /// release the ACL; bytes are GC'd once their last ACL is gone. Returns
+    /// the number of ACLs released. Only safe once `doc_refs` is fully
+    /// seeded from the live documents.
+    pub fn sweep_unreferenced(&self) -> usize {
+        let acl_pairs: Vec<(WorkspaceId, String)> = match self.acls.read() {
+            Ok(g) => g.iter().cloned().collect(),
+            Err(_) => return 0,
+        };
+        let mut released = 0usize;
+        for (ws, hash) in acl_pairs {
+            // release_acl_if_unreferenced re-checks the referenced condition
+            // and GCs orphaned bytes; count only ACLs it actually removes.
+            match self.release_acl_if_unreferenced(&ws, &hash) {
+                Ok(true) => released += 1,
+                Ok(false) => {}
+                Err(e) => log::warn!("sweep: release {}/{} failed: {}", ws.as_str(), hash, e),
+            }
+        }
+        released
+    }
+
+    /// Release the `(ws,hash)` ACL iff no document in `ws` still references
+    /// `hash`, then GC the bytes if no workspace holds an ACL. Returns
+    /// `true` if the ACL was removed.
+    fn release_acl_if_unreferenced(&self, ws: &WorkspaceId, hash: &str) -> Result<bool, String> {
+        let still_referenced = {
+            let refs = self.doc_refs.read().map_err(|e| e.to_string())?;
+            refs.iter()
+                .any(|((w, _doc), hs)| w == ws && hs.contains(hash))
+        };
+        if still_referenced {
+            return Ok(false);
+        }
+        let removed = {
+            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            acls.remove(&(ws.clone(), hash.to_string()))
+        };
+        if removed {
+            self.save_acls()?;
+            log::info!("released blob ACL {}/{}", ws.as_str(), hash);
+            self.gc_blob_if_orphaned(hash)?;
+        }
+        Ok(removed)
+    }
+
+    /// Reclaim a blob's bytes once no workspace holds an ACL for it.
+    /// Content-addressed bytes are shared across workspaces, so this only
+    /// fires when the *last* ACL for `hash` is gone. First caller of
+    /// [`Self::delete_blob`].
+    fn gc_blob_if_orphaned(&self, hash: &str) -> Result<(), String> {
+        let any_acl = {
+            let acls = self.acls.read().map_err(|e| e.to_string())?;
+            acls.iter().any(|(_ws, h)| h == hash)
+        };
+        if !any_acl {
+            self.delete_blob(hash)?;
+            log::info!("GC'd orphaned blob {}", hash);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -810,5 +1003,148 @@ mod tests {
         // bytes, fresh ACL) within its own 10-byte quota.
         store.save_blob_with_quota(&beta, &hash, data, "text/plain", "b", Some(10)).unwrap();
         assert_eq!(store.get_workspace_size(&beta), 10);
+    }
+
+    // ---- JP-120: refcount release + orphan GC ----
+
+    fn refs(hashes: &[&str]) -> HashSet<String> {
+        hashes.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn delete_doc_releases_acls_and_reclaims_bytes() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let a = b"0123456789"; // 10
+        let b = b"abcde"; // 5
+        let ha = BlobStore::compute_hash(a);
+        let hb = BlobStore::compute_hash(b);
+        store.save_blob(&ws, &ha, a, "text/plain", "u").unwrap();
+        store.save_blob(&ws, &hb, b, "text/plain", "u").unwrap();
+        store.sync_doc_refs(&ws, "doc1", refs(&[&ha, &hb])).unwrap();
+        assert_eq!(store.get_workspace_size(&ws), 15);
+        assert_eq!(store.get_blob_count(), 2);
+
+        // Deleting the only doc that referenced them releases both ACLs and,
+        // since no workspace holds an ACL anymore, reclaims the bytes.
+        store.release_doc_refs(&ws, "doc1").unwrap();
+        assert_eq!(store.get_workspace_size(&ws), 0);
+        assert_eq!(store.get_total_size(), 0);
+        assert_eq!(store.get_blob_count(), 0);
+        assert!(!store.exists(&ws, &ha));
+    }
+
+    #[test]
+    fn shared_blob_survives_until_last_workspace_drops() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let alpha = WorkspaceId::from_configured("alpha").unwrap();
+        let beta = WorkspaceId::from_configured("beta").unwrap();
+
+        let data = b"shared-bytes";
+        let h = BlobStore::compute_hash(data);
+        // Same bytes uploaded to two workspaces — deduped on disk, one ACL each.
+        store.save_blob(&alpha, &h, data, "text/plain", "a").unwrap();
+        store.save_blob(&beta, &h, data, "text/plain", "b").unwrap();
+        store.sync_doc_refs(&alpha, "docA", refs(&[&h])).unwrap();
+        store.sync_doc_refs(&beta, "docB", refs(&[&h])).unwrap();
+        assert_eq!(store.get_blob_count(), 1);
+
+        // Alpha drops its doc → alpha ACL released, but beta still holds one,
+        // so the bytes survive and beta can still read them.
+        store.release_doc_refs(&alpha, "docA").unwrap();
+        assert_eq!(store.get_workspace_size(&alpha), 0);
+        assert!(store.exists(&beta, &h));
+        assert_eq!(store.get_blob_count(), 1);
+
+        // Beta drops the last reference → last ACL gone → bytes reclaimed.
+        store.release_doc_refs(&beta, "docB").unwrap();
+        assert!(!store.exists(&beta, &h));
+        assert_eq!(store.get_blob_count(), 0);
+    }
+
+    #[test]
+    fn save_dropping_a_hash_releases_only_that_one() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let a = b"aaaa";
+        let b = b"bbbbbb";
+        let ha = BlobStore::compute_hash(a);
+        let hb = BlobStore::compute_hash(b);
+        store.save_blob(&ws, &ha, a, "text/plain", "u").unwrap();
+        store.save_blob(&ws, &hb, b, "text/plain", "u").unwrap();
+        store.sync_doc_refs(&ws, "doc1", refs(&[&ha, &hb])).unwrap();
+
+        // Re-save dropping hb → hb released + reclaimed; ha kept.
+        store.sync_doc_refs(&ws, "doc1", refs(&[&ha])).unwrap();
+        assert!(store.exists(&ws, &ha));
+        assert!(!store.exists(&ws, &hb));
+        assert_eq!(store.get_workspace_size(&ws), a.len() as u64);
+    }
+
+    #[test]
+    fn hash_referenced_by_another_doc_in_same_workspace_is_kept() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let data = b"two-docs-one-blob";
+        let h = BlobStore::compute_hash(data);
+        store.save_blob(&ws, &h, data, "text/plain", "u").unwrap();
+        store.sync_doc_refs(&ws, "docA", refs(&[&h])).unwrap();
+        store.sync_doc_refs(&ws, "docB", refs(&[&h])).unwrap();
+
+        // Deleting docA leaves docB still referencing the hash → ACL kept.
+        store.release_doc_refs(&ws, "docA").unwrap();
+        assert!(store.exists(&ws, &h));
+        assert_eq!(store.get_workspace_size(&ws), data.len() as u64);
+
+        // Deleting docB drops the last reference → released + reclaimed.
+        store.release_doc_refs(&ws, "docB").unwrap();
+        assert!(!store.exists(&ws, &h));
+        assert_eq!(store.get_blob_count(), 0);
+    }
+
+    #[test]
+    fn sweep_reclaims_unreferenced_uploads_but_keeps_referenced() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let orphan = b"never-saved-into-a-doc";
+        let kept = b"referenced";
+        let ho = BlobStore::compute_hash(orphan);
+        let hk = BlobStore::compute_hash(kept);
+        // Both uploaded (ACL granted); only `kept` is referenced by a doc.
+        store.save_blob(&ws, &ho, orphan, "text/plain", "u").unwrap();
+        store.save_blob(&ws, &hk, kept, "text/plain", "u").unwrap();
+        store.sync_doc_refs(&ws, "doc1", refs(&[&hk])).unwrap();
+
+        let reclaimed = store.sweep_unreferenced();
+        assert_eq!(reclaimed, 1);
+        assert!(!store.exists(&ws, &ho)); // orphan reclaimed
+        assert!(store.exists(&ws, &hk)); // referenced kept
+        assert_eq!(store.get_workspace_size(&ws), kept.len() as u64);
+    }
+
+    #[test]
+    fn doc_refs_persist_across_reload() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceId::single_tenant();
+        let data = b"persist-refs";
+        let h = BlobStore::compute_hash(data);
+        {
+            let store = BlobStore::new(dir.path().to_path_buf());
+            store.save_blob(&ws, &h, data, "text/plain", "u").unwrap();
+            store.sync_doc_refs(&ws, "doc1", refs(&[&h])).unwrap();
+        }
+        // New instance loads blob_refs.json — a later sweep must NOT reclaim
+        // the still-referenced blob.
+        {
+            let store = BlobStore::new(dir.path().to_path_buf());
+            assert_eq!(store.sweep_unreferenced(), 0);
+            assert!(store.exists(&ws, &h));
+        }
     }
 }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -494,6 +494,36 @@ impl ServerState {
         self.workspace_client_counts.read().await.clone()
     }
 
+    /// JP-120 startup step: seed the blob refcount from the documents
+    /// already on disk (so the per-workspace meter is accurate and the
+    /// sweep is safe), then reclaim blobs no document references. Keeps
+    /// `BlobStore` decoupled from `DocumentStore` — the cross-store wiring
+    /// lives here. Best-effort; logs but never fails startup.
+    pub(crate) fn backfill_and_sweep_blob_refs(&self) {
+        for ws in self.doc_store.known_workspaces() {
+            for meta in self.doc_store.list_documents(&ws) {
+                if let Ok(doc) = self.doc_store.get_document(&ws, &meta.id) {
+                    let hashes = crate::api::blob_refs_from_doc(&doc);
+                    if let Err(e) = self.blob_store.seed_doc_refs(&ws, meta.id.as_str(), hashes) {
+                        log::warn!(
+                            "blob doc-ref seed failed for {}/{}: {}",
+                            ws.as_str(),
+                            meta.id.as_str(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+        let reclaimed = self.blob_store.sweep_unreferenced();
+        if reclaimed > 0 {
+            log::info!(
+                "JP-120 startup sweep reclaimed {} unreferenced blob ACL(s)",
+                reclaimed
+            );
+        }
+    }
+
     /// Live editor/viewer counts for a single workspace (zero if the
     /// workspace has no connections). Backs the `GET /api/v1/usage`
     /// `active_editors` field (JP-81).
@@ -890,6 +920,11 @@ impl WebSocketServer {
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
         ));
+
+        // JP-120: seed the blob refcount from the documents already on disk,
+        // then sweep orphaned blobs. Done once at startup before serving.
+        server_state.backfill_and_sweep_blob_refs();
+
         *self.state.write().await = Some(server_state.clone());
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();

--- a/relay/tests/blob_gc.rs
+++ b/relay/tests/blob_gc.rs
@@ -1,0 +1,142 @@
+//! JP-120 — blob refcount + orphan GC, end-to-end over REST.
+//!
+//! Acceptance (from the issue): upload a blob, reference it from documents in
+//! two workspaces, delete one → that workspace's ACL is released and its
+//! `/api/v1/usage` storage drops, while the other workspace still reads the
+//! blob; delete the second → the last ACL is gone and the bytes are reclaimed
+//! (the blob 404s). Content-addressed bytes shared across workspaces survive
+//! until the last reference drops.
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+async fn start_relay() -> (Arc<WebSocketServer>, String, OidcTestIssuer, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+    (server, http, issuer, tmp)
+}
+
+fn blob_hash(data: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(data);
+    hex::encode(h.finalize())
+}
+
+async fn upload_blob(http: &str, token: &str, data: &[u8]) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .post(format!("{http}/api/blobs/{}", blob_hash(data)))
+        .bearer_auth(token)
+        .body(data.to_vec())
+        .send()
+        .await
+        .expect("upload")
+        .status()
+}
+
+async fn blob_status(http: &str, token: &str, hash: &str) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .get(format!("{http}/api/blobs/{hash}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("blob get")
+        .status()
+}
+
+async fn put_doc(http: &str, token: &str, doc_id: &str, blob_refs: &[&str]) -> reqwest::StatusCode {
+    let body = json!({ "id": doc_id, "blobReferences": blob_refs });
+    reqwest::Client::new()
+        .put(format!("{http}/api/docs/{doc_id}"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("put doc")
+        .status()
+}
+
+async fn delete_doc(http: &str, token: &str, doc_id: &str) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .delete(format!("{http}/api/docs/{doc_id}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("delete doc")
+        .status()
+}
+
+async fn usage_storage(http: &str, token: &str) -> u64 {
+    let v: Value = reqwest::Client::new()
+        .get(format!("{http}/api/v1/usage"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("usage")
+        .json()
+        .await
+        .expect("usage json");
+    v["storageBytes"].as_u64().expect("storageBytes")
+}
+
+#[tokio::test]
+async fn deleting_a_doc_releases_acls_and_shared_blob_survives_until_last_drop() {
+    let (_server, http, issuer, _tmp) = start_relay().await;
+    let alpha = issuer.mint("user-a", "alpha", WorkspaceRole::Owner);
+    let beta = issuer.mint("user-b", "beta", WorkspaceRole::Owner);
+
+    let data = b"shared image bytes";
+    let hash = blob_hash(data);
+
+    // Same bytes uploaded to both workspaces (deduped on disk, one ACL each),
+    // each referenced by a document in its workspace.
+    assert_eq!(upload_blob(&http, &alpha, data).await, reqwest::StatusCode::OK);
+    assert_eq!(upload_blob(&http, &beta, data).await, reqwest::StatusCode::OK);
+    assert_eq!(put_doc(&http, &alpha, "docalpha", &[&hash]).await, reqwest::StatusCode::OK);
+    assert_eq!(put_doc(&http, &beta, "docbeta", &[&hash]).await, reqwest::StatusCode::OK);
+
+    assert_eq!(usage_storage(&http, &alpha).await, data.len() as u64);
+    assert_eq!(usage_storage(&http, &beta).await, data.len() as u64);
+
+    // Delete alpha's doc → alpha's ACL released (usage 0, blob 404 for alpha),
+    // but beta still references it (blob still readable, bytes intact).
+    assert_eq!(delete_doc(&http, &alpha, "docalpha").await, reqwest::StatusCode::OK);
+    assert_eq!(usage_storage(&http, &alpha).await, 0);
+    assert_eq!(blob_status(&http, &alpha, &hash).await, reqwest::StatusCode::NOT_FOUND);
+    assert_eq!(blob_status(&http, &beta, &hash).await, reqwest::StatusCode::OK);
+    assert_eq!(usage_storage(&http, &beta).await, data.len() as u64);
+
+    // Delete beta's doc → last ACL gone → bytes reclaimed (404 for beta too).
+    assert_eq!(delete_doc(&http, &beta, "docbeta").await, reqwest::StatusCode::OK);
+    assert_eq!(usage_storage(&http, &beta).await, 0);
+    assert_eq!(blob_status(&http, &beta, &hash).await, reqwest::StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Adds the blob **reclamation** story the relay was missing: until now `save_blob` granted a `(ws,hash)` ACL on upload and *never* released it (and `delete_blob` had no callers), so deleting a doc or removing an image left the bytes counted against the workspace's metered storage forever and inflated `relay_storage_bytes_total`. This makes JP-81's quota enforcement honest over time.

Closes JP-120. Builds on JP-81 (#19, merged).

## Changes (OSS relay)
- **Per-document reference map** on `BlobStore`: `(workspace, doc_id) → {hash}`, persisted to a `blob_refs.json` sidecar, refcounted off the doc's canonical `blobReferences` (bare SHA-256 hashes the client already emits).
- **Incremental release + GC:** `sync_doc_refs` (save) / `release_doc_refs` (delete) release the `(ws,hash)` ACL once no doc in the workspace references the hash, then reclaim bytes via the now-wired `delete_blob` once the **last** ACL across all workspaces is gone. Content-addressed bytes shared across workspaces survive until the last reference drops. Per-workspace size + `relay_storage_bytes_total` drop automatically (they already derive from ACLs + index).
- **Startup sweep:** `ServerState::backfill_and_sweep_blob_refs` seeds the map from the docs on disk (accurate meter + safe sweep from a cold boot), then `sweep_unreferenced` reclaims upload-then-abandon orphans. **Sweep model = incremental + one-shot startup sweep; no background timer** (deferred).
- Hooks in `save_doc_handler` / `delete_doc_handler` (best-effort; the doc op has already succeeded).

## Tests
`blobs.rs` units (delete releases + reclaims; shared blob survives until last drop; save-that-drops-a-hash; same-ws second referer keeps it; sweep reclaims orphans but keeps referenced; refs persist across reload) + `tests/blob_gc.rs` integration (upload → reference in two workspaces → delete one → ACL released + `/api/v1/usage` drops while the other still reads it → delete the second → bytes reclaimed/404). 133 lib unit tests + all relay integration suites green; `cargo check`/`cargo test --locked` clean.

## Out of scope
Periodic/background sweep timer (deferred follow-up — the startup sweep + incremental path cover the acceptance).

Assisted-by: Opus 4.8