### PR TITLE
fix(relay): configurable blob upload body limit, default 150 MiB (JP-125)

### DIFF
--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -50,6 +50,12 @@ pub const DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE: u32 = 25;
 /// per-frame size cap closes the same blast-radius concern.
 pub const DEFAULT_MAX_WS_PAYLOAD_BYTES: usize = 262_144; // 256 KiB
 
+/// Max body size for a single blob upload (`POST /api/blobs/:hash`). The
+/// per-workspace `storage_quota_bytes` is the real cap; this just bounds one
+/// request so the in-memory `Bytes` buffer can't grow unbounded. Without it,
+/// Axum's 2 MiB default silently 413s larger blobs (JP-125).
+pub const DEFAULT_MAX_BLOB_BYTES: usize = 157_286_400; // 150 MiB
+
 // ---- JP-81: single-meter free-tier enforcement fallbacks ----
 //
 // These are the *fallback* limits applied when a JWT `wsp[]` claim omits
@@ -246,6 +252,11 @@ pub struct LimitsConfig {
     pub max_ws_connections_per_workspace: u32,
     /// Cap on a single WS frame's payload size (bytes).
     pub max_ws_payload_bytes: usize,
+    /// Max body size for a single blob upload (`POST /api/blobs/:hash`), bytes.
+    /// Bounds in-memory buffering; the per-workspace storage quota is the real
+    /// cap. Without this the Axum default (2 MiB) silently 413s larger blobs
+    /// (JP-125).
+    pub max_blob_bytes: usize,
     /// Fallback per-workspace storage byte quota (JP-81), used when the
     /// JWT claim omits `quota_bytes`. `0` = unlimited.
     pub storage_quota_bytes: u64,
@@ -262,6 +273,7 @@ impl Default for LimitsConfig {
             writes_burst: DEFAULT_WRITES_BURST,
             max_ws_connections_per_workspace: DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE,
             max_ws_payload_bytes: DEFAULT_MAX_WS_PAYLOAD_BYTES,
+            max_blob_bytes: DEFAULT_MAX_BLOB_BYTES,
             storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
             max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
         }
@@ -418,6 +430,11 @@ impl RelayConfig {
                 .map_err(|_| {
                     anyhow::anyhow!("RELAY_MAX_EDITORS_PER_WORKSPACE must be a u32 (got {v:?})")
                 })?;
+        }
+        if let Some(v) = get("RELAY_MAX_BLOB_BYTES") {
+            self.tenancy.limits.max_blob_bytes = v
+                .parse()
+                .map_err(|_| anyhow::anyhow!("RELAY_MAX_BLOB_BYTES must be a usize (got {v:?})"))?;
         }
         Ok(())
     }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -22,7 +22,7 @@ use axum::{
     body::Body,
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        Path, Query, State,
+        DefaultBodyLimit, Path, Query, State,
     },
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
@@ -901,6 +901,8 @@ impl WebSocketServer {
         let rate_limit_rejections = self.rate_limit_rejections.clone();
         let metering_debug_log = self.metering_debug_log.load(Ordering::Relaxed);
         let tenancy = self.tenancy.read().await.clone();
+        // JP-125: bound the blob upload body (Axum's default is a silent 2 MiB).
+        let max_blob_bytes = tenancy.limits.max_blob_bytes;
         // Reuse the cached limiter so MCP and WS share one bucket.
         let write_limiter = self.build_write_limiter().await;
         #[cfg(debug_assertions)]
@@ -946,7 +948,10 @@ impl WebSocketServer {
             .route("/ws", get(ws_handler))
             .route("/health", get(health_handler))
             .route("/metrics", get(metrics_handler))
-            .route("/api/blobs/:hash", post(blob_upload_handler))
+            .route(
+                "/api/blobs/:hash",
+                post(blob_upload_handler).layer(DefaultBodyLimit::max(max_blob_bytes)),
+            )
             .route("/api/blobs/:hash", get(blob_download_handler))
             .route("/api/blobs/:hash", head(blob_exists_handler))
             .merge(crate::api::routes())

--- a/relay/tests/blob_upload_limit.rs
+++ b/relay/tests/blob_upload_limit.rs
@@ -1,0 +1,84 @@
+//! JP-125 — blob upload body limit. `POST /api/blobs/:hash` must honor
+//! `[tenancy.limits].max_blob_bytes`, not Axum's silent 2 MiB default (which
+//! 413'd any larger blob regardless of the workspace storage quota).
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{LimitsConfig, TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+/// In-process relay in shared-tenancy mode with an explicit `max_blob_bytes`.
+async fn start_relay(max_blob_bytes: usize) -> (Arc<WebSocketServer>, String, OidcTestIssuer, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            limits: LimitsConfig { max_blob_bytes, ..LimitsConfig::default() },
+        })
+        .await;
+    server
+        .set_config(ServerConfig { port: 0, network_mode: NetworkMode::Localhost, max_connections: 0 })
+        .await
+        .expect("set_config");
+
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+    (server, http, issuer, tmp)
+}
+
+fn blob_hash(data: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(data);
+    hex::encode(h.finalize())
+}
+
+async fn upload(http: &str, token: &str, data: &[u8]) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .post(format!("{http}/api/blobs/{}", blob_hash(data)))
+        .bearer_auth(token)
+        .body(data.to_vec())
+        .send()
+        .await
+        .expect("blob upload request")
+        .status()
+}
+
+#[tokio::test]
+async fn blob_upload_enforces_configured_max_not_axum_default() {
+    // Tiny cap so the test stays cheap; proves the *config* value gates the body.
+    let (_server, http, issuer, _tmp) = start_relay(1024).await;
+    let token = issuer.mint("user-a", "default", WorkspaceRole::Owner);
+
+    // Under the cap → accepted.
+    assert_eq!(upload(&http, &token, &vec![b'a'; 500]).await, reqwest::StatusCode::OK);
+
+    // Over the cap → 413 (not silently dropped, not the 2 MiB default).
+    assert_eq!(
+        upload(&http, &token, &vec![b'b'; 2048]).await,
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE
+    );
+}
+
+#[tokio::test]
+async fn blob_upload_allows_over_2mib_when_cap_is_higher() {
+    // The regression: a 3 MiB blob — which Axum's 2 MiB default would have
+    // 413'd — now succeeds because the cap is 8 MiB.
+    let (_server, http, issuer, _tmp) = start_relay(8 * 1024 * 1024).await;
+    let token = issuer.mint("user-b", "default", WorkspaceRole::Owner);
+
+    let three_mib = vec![b'c'; 3 * 1024 * 1024];
+    assert_eq!(upload(&http, &token, &three_mib).await, reqwest::StatusCode::OK);
+}


### PR DESCRIPTION
**Fixes the 2 MB blob-upload cap** that 413'd large files regardless of the workspace storage quota.

**Root cause:** `blob_upload_handler` (`relay/src/server/mod.rs`) extracts `body: axum::body::Bytes` with no `DefaultBodyLimit` override → Axum's **2 MiB default** rejects any larger blob on every client. A 2 MB per-file cap on a 250 MB-quota store breaks the blob-heavy (Researcher) workflow and blocked live testing of the JP-81 storage 507.

**Fix:**
- `max_blob_bytes` on `[tenancy.limits]` (default **150 MiB**) + `RELAY_MAX_BLOB_BYTES` env overlay — same pattern as JP-81/JP-111.
- `DefaultBodyLimit::max(max_blob_bytes)` applied to the **blob upload route only** (GET/HEAD untouched; doc-save + other routes keep Axum's default).
- Bounded `max` rather than `disable()` — `Bytes` buffers the whole body in memory, so an unbounded limit risks OOM; streaming-to-disk for very large blobs is a separate improvement.

**Test:** `relay/tests/blob_upload_limit.rs` — a 3 MiB upload (413'd before) succeeds at an 8 MiB cap; over-cap → 413; config value gates it (not Axum's default). Full relay suite green `--locked`.

Closes JP-125. (The `libsoup-http2` desktop warning was a symptom of the mid-upload rejection; if very-large uploads still fail on Linux desktop after this, routing blob uploads through the Tauri Rust HTTP client is a tracked follow-up.)

Assisted-by: Opus 4.8
