### PR TITLE
feat(editor): upload progress indicator for relay asset uploads (JP-126)

### DIFF
--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -11,7 +11,11 @@
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
 import type { RelayClient } from './relayClient';
-import { BlobSyncService, type BlobSyncResult } from '../collaboration/BlobSyncService';
+import {
+  BlobSyncService,
+  type BlobSyncProgress,
+  type BlobSyncResult,
+} from '../collaboration/BlobSyncService';
 
 /** Share entry shape carried by the store's `updateDocumentShares`. */
 export interface DocumentProviderShareEntry {
@@ -80,8 +84,11 @@ export class RestDocumentProvider {
    * Upload the blobs a relay doc references to the blob store, before the
    * doc save. Only blobs the relay is missing are sent (deduped server-side).
    */
-  async uploadBlobs(hashes: string[]): Promise<BlobSyncResult> {
-    return this.blobSync.ensureBlobsUploaded(hashes);
+  async uploadBlobs(
+    hashes: string[],
+    onProgress?: (progress: BlobSyncProgress) => void,
+  ): Promise<BlobSyncResult> {
+    return this.blobSync.ensureBlobsUploaded(hashes, onProgress);
   }
 
   /**

--- a/src/collaboration/BlobSyncService.test.ts
+++ b/src/collaboration/BlobSyncService.test.ts
@@ -187,6 +187,22 @@ describe('BlobSyncService', () => {
       expect(phases).toContain('checking');
       expect(phases).toContain('uploading');
     });
+
+    it('forwards a per-call onProgress with file counts (JP-126)', async () => {
+      const events: BlobSyncProgress[] = [];
+      const { mock: blobStorage } = makeBlobStorage({ h1: new Blob(['a']), h2: new Blob(['b']) });
+      const svc = new BlobSyncService({
+        transport: makeTransport({ blobExists: vi.fn(async () => false) }),
+        blobStorage,
+        ...fast,
+      });
+
+      await svc.ensureBlobsUploaded(['h1', 'h2'], (p) => events.push(p));
+
+      const uploading = events.filter((e) => e.phase === 'uploading');
+      expect(uploading.length).toBeGreaterThan(0);
+      expect(uploading[uploading.length - 1]).toMatchObject({ current: 2, total: 2 });
+    });
   });
 
   describe('retry logic', () => {

--- a/src/collaboration/BlobSyncService.ts
+++ b/src/collaboration/BlobSyncService.ts
@@ -98,6 +98,8 @@ export interface BlobSyncResult {
 export class BlobSyncService {
   private transport: BlobTransport;
   private onProgress: ((progress: BlobSyncProgress) => void) | undefined;
+  /** Per-call progress sink, set for the duration of one ensureBlobsUploaded. */
+  private callProgress: ((progress: BlobSyncProgress) => void) | undefined;
   private maxRetries: number;
   private initialRetryDelay: number;
   private maxRetryDelay: number;
@@ -149,7 +151,14 @@ export class BlobSyncService {
    * Call this before saving a relay document: a doc that references blobs
    * the relay doesn't have would render broken for collaborators.
    */
-  async ensureBlobsUploaded(hashes: string[]): Promise<BlobSyncResult> {
+  async ensureBlobsUploaded(
+    hashes: string[],
+    onProgress?: (progress: BlobSyncProgress) => void,
+  ): Promise<BlobSyncResult> {
+    // Per-call progress sink (file-count granularity), cleared before return.
+    // This method never throws (per-blob errors are recorded into `result`),
+    // so clearing at the two return points is sufficient (JP-126).
+    this.callProgress = onProgress;
     const result: BlobSyncResult = {
       total: hashes.length,
       success: 0,
@@ -158,7 +167,10 @@ export class BlobSyncService {
       errors: new Map(),
     };
 
-    if (hashes.length === 0) return result;
+    if (hashes.length === 0) {
+      this.callProgress = undefined;
+      return result;
+    }
 
     // First, check which blobs need uploading
     this.reportProgress({ phase: 'checking', current: 0, total: hashes.length });
@@ -219,6 +231,7 @@ export class BlobSyncService {
       }
     }
 
+    this.callProgress = undefined;
     return result;
   }
 
@@ -320,6 +333,7 @@ export class BlobSyncService {
    */
   private reportProgress(progress: BlobSyncProgress): void {
     this.onProgress?.(progress);
+    this.callProgress?.(progress);
   }
 
   /**

--- a/src/store/relayDocumentStore.blobSync.test.ts
+++ b/src/store/relayDocumentStore.blobSync.test.ts
@@ -101,8 +101,8 @@ describe('relayDocumentStore — JP-118 blob routing', () => {
 
     await useRelayDocumentStore.getState().saveToHost(docWithBlob('doc-1', 'hashA'));
 
-    // Uploaded the referenced blob...
-    expect(provider.uploadBlobs).toHaveBeenCalledWith(['hashA']);
+    // Uploaded the referenced blob (with a progress callback, JP-126)...
+    expect(provider.uploadBlobs).toHaveBeenCalledWith(['hashA'], expect.any(Function));
     // ...before the doc save (upload call ordered before save call).
     expect(provider.uploadBlobs.mock.invocationCallOrder[0]!).toBeLessThan(
       provider.saveDocument.mock.invocationCallOrder[0]!,

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -28,7 +28,8 @@ import {
 } from '../storage/AssetBundler';
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
-import type { BlobSyncResult } from '../collaboration/BlobSyncService';
+import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
+import { useUploadStatusStore } from './uploadStatusStore';
 
 /**
  * Calculate the effective permission for a user on a document.
@@ -115,7 +116,10 @@ export interface DocumentProvider {
    * in the doc (legacy path). When present, assets are stored as deduped,
    * metered blobs and the doc keeps blob:// references (JP-118).
    */
-  uploadBlobs?(hashes: string[]): Promise<BlobSyncResult>;
+  uploadBlobs?(
+    hashes: string[],
+    onProgress?: (progress: BlobSyncProgress) => void,
+  ): Promise<BlobSyncResult>;
   /** Download referenced blobs missing locally after a doc load. */
   downloadBlobs?(hashes: string[]): Promise<BlobSyncResult>;
 }
@@ -429,7 +433,13 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           if (blobHashes.length > 0) {
             doc = { ...doc, blobReferences: blobHashes };
             console.log('[relayDocumentStore] Uploading assets to blob store for document:', doc.id);
-            const uploadResult = await docProvider.uploadBlobs(blobHashes);
+            const uploadStatus = useUploadStatusStore.getState();
+            let uploadResult: BlobSyncResult;
+            try {
+              uploadResult = await docProvider.uploadBlobs(blobHashes, uploadStatus.report);
+            } finally {
+              uploadStatus.clear();
+            }
             if (uploadResult.failed > 0) {
               const detail = Array.from(uploadResult.errors.values())[0] ?? 'unknown error';
               throw new Error(

--- a/src/store/uploadStatusStore.test.ts
+++ b/src/store/uploadStatusStore.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUploadStatusStore } from './uploadStatusStore';
+
+describe('uploadStatusStore', () => {
+  beforeEach(() => useUploadStatusStore.getState().clear());
+
+  it('report sets active state from a progress event', () => {
+    useUploadStatusStore.getState().report({ phase: 'uploading', current: 2, total: 5 });
+    expect(useUploadStatusStore.getState()).toMatchObject({
+      active: true,
+      phase: 'uploading',
+      current: 2,
+      total: 5,
+    });
+  });
+
+  it('clear resets to idle', () => {
+    useUploadStatusStore.getState().report({ phase: 'uploading', current: 1, total: 3 });
+    useUploadStatusStore.getState().clear();
+    expect(useUploadStatusStore.getState()).toMatchObject({
+      active: false,
+      phase: null,
+      current: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/store/uploadStatusStore.ts
+++ b/src/store/uploadStatusStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import type { BlobSyncProgress } from '../collaboration/BlobSyncService';
+
+/**
+ * Transient UI state for relay asset uploads (JP-126). Fed by `BlobSyncService`
+ * progress events during `saveToHost`; read by `UploadIndicator`. File-count
+ * granularity — per-byte progress within a file is a follow-up (needs an XHR
+ * upload transport; `fetch` has no upload-progress events).
+ */
+interface UploadStatusState {
+  active: boolean;
+  phase: BlobSyncProgress['phase'] | null;
+  current: number;
+  total: number;
+  /** Record a progress event from the blob sync service. */
+  report: (progress: BlobSyncProgress) => void;
+  /** Reset to idle once a save's uploads finish. */
+  clear: () => void;
+}
+
+export const useUploadStatusStore = create<UploadStatusState>((set) => ({
+  active: false,
+  phase: null,
+  current: 0,
+  total: 0,
+  report: (progress) =>
+    set({
+      active: true,
+      phase: progress.phase,
+      current: progress.current,
+      total: progress.total,
+    }),
+  clear: () => set({ active: false, phase: null, current: 0, total: 0 }),
+}));

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -20,6 +20,7 @@ import { UnifiedToolbar } from './UnifiedToolbar';
 import { StatusBar } from './StatusBar';
 import { PresenceIndicators } from './PresenceIndicators';
 import { NotificationToast } from './NotificationToast';
+import { UploadIndicator } from './UploadIndicator';
 import { ErrorBoundary } from './ErrorBoundary';
 import { ConnectionStatusBanner } from './ConnectionStatusBanner';
 import { CommandPalette } from './CommandPalette';
@@ -455,6 +456,7 @@ function App() {
 
       {/* Toast notifications */}
       <NotificationToast />
+      <UploadIndicator />
     </div>
   );
 }

--- a/src/ui/UploadIndicator.tsx
+++ b/src/ui/UploadIndicator.tsx
@@ -1,0 +1,45 @@
+import { useUploadStatusStore } from '../store/uploadStatusStore';
+
+/**
+ * Minimal upload-progress indicator (JP-126). Visible while a save uploads
+ * referenced assets to the relay blob store; file-count granularity. Styling is
+ * intentionally bare — the comprehensive design is owned separately.
+ */
+export function UploadIndicator() {
+  const active = useUploadStatusStore((s) => s.active);
+  const phase = useUploadStatusStore((s) => s.phase);
+  const current = useUploadStatusStore((s) => s.current);
+  const total = useUploadStatusStore((s) => s.total);
+
+  if (!active || phase !== 'uploading' || total === 0) return null;
+  const pct = Math.min(100, Math.round((current / total) * 100));
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        bottom: 12,
+        right: 12,
+        zIndex: 9999,
+        minWidth: 180,
+        padding: '8px 12px',
+        borderRadius: 6,
+        background: 'rgba(20,20,20,0.92)',
+        color: '#fff',
+        fontSize: 12,
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div>
+        Uploading assets… {current} of {total}
+      </div>
+      <div style={{ height: 4, marginTop: 6, borderRadius: 2, background: '#444' }}>
+        <div
+          style={{ width: `${pct}%`, height: '100%', borderRadius: 2, background: '#4ea1ff' }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Surfaces save-time asset uploads to the relay blob store — previously silent, so large files looked like a hang.

**What:** `BlobSyncService` already emitted `onProgress` per asset but it was never wired to UI.
- `ensureBlobsUploaded` gains an optional per-call `onProgress`; `reportProgress` fans out to both the instance handler and the per-call sink (cleared before return — the method never throws).
- `DocumentProvider.uploadBlobs` + `RestDocumentProvider` thread it through.
- `relayDocumentStore.saveToHost` feeds a new `uploadStatusStore` (report, then `clear()` in a `finally`).
- `UploadIndicator`: minimal fixed indicator ("Uploading assets… N of M" + bar), mounted in `App`, hidden unless actively uploading. **Styling intentionally bare** — comprehensive design owned separately (Claude Design).

**Granularity:** file-count. Per-*byte* progress within a single file is a follow-up — `relayClient.uploadBlob` uses `fetch`, which has no upload-progress events; real % needs an XHR transport (the `BlobSyncProgress.bytesTransferred`/`bytesTotal` fields are already there for it). Matters most for single large files (the 150 MB JP-125 case).

**Tests:** per-call `onProgress` forwarding (counts) + `uploadStatusStore` report/clear; updated the blobSync save-ordering assertion for the new arg. Full suite **1689 green**, `tsc` clean.

Closes JP-126. Relates: JP-118 (blob sync routing), JP-125 (blob size cap).

Assisted-by: Opus 4.8
