### PR TITLE
fix(editor): preserve blob references on offline-queued saves (JP-127, client half)

### DIFF
--- a/src/store/persistenceStore.offlineRelaySave.test.ts
+++ b/src/store/persistenceStore.offlineRelaySave.test.ts
@@ -88,6 +88,36 @@ describe('saveDocumentPdfSettings — offline relay edit durability (JP-106)', (
     expect(syncManagerMock.queueSave).toHaveBeenCalledTimes(1);
   });
 
+  it('pins collected blob references onto the cached + queued snapshot (JP-127)', () => {
+    // The data-loss case: a doc references a blob (FileShape.blobRef) but its
+    // GC list (`blobReferences`) is empty/stale. Pre-fix the offline-queued
+    // snapshot kept that empty list, so on reconnect the replay saved a
+    // ref-less doc → the relay released the ACL → the blob was orphaned + GC'd.
+    useRelayDocumentStore.setState({ authenticated: true });
+    useConnectionStore.setState({
+      status: 'disconnected',
+      host: { address: 'localhost:9876', url: 'http://localhost:9876' },
+    });
+    const doc = makeRelayDoc('relay-doc-asset');
+    doc.pages = {
+      p1: { id: 'p1', name: 'P1', shapes: { s1: { id: 's1', type: 'file', blobRef: 'hash-abc' } } },
+    } as unknown as DiagramDocument['pages'];
+    doc.pageOrder = ['p1'];
+    doc.activePageId = 'p1';
+    expect(doc.blobReferences).toBeUndefined();
+    saveDocumentToStorage(doc);
+
+    const ok = saveDocumentPdfSettings('relay-doc-asset', pdfSettings);
+
+    expect(ok).toBe(true);
+    expect(syncManagerMock.queueSave).toHaveBeenCalledTimes(1);
+    const queuedCalls = syncManagerMock.queueSave.mock.calls as unknown as Array<[DiagramDocument, string]>;
+    expect(queuedCalls[0]?.[0]?.blobReferences).toContain('hash-abc');
+    // The cached snapshot carries them too (same reconciled doc).
+    const cachedCalls = cacheMock.put.mock.calls as unknown as Array<[DiagramDocument, string]>;
+    expect(cachedCalls[0]?.[0]?.blobReferences).toContain('hash-abc');
+  });
+
   it('queues on a COLD BOOT before any connection (authenticated=false) — JP-106 follow-up', () => {
     // The reboot data-loss case: edits made offline before the relay session
     // exists this boot. `relayDocumentStore.authenticated` is not persisted,

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -33,6 +33,7 @@ import { isRemoteDocument, isCachedDocument } from '../types/DocumentRegistry';
 import { useCollaborationStore } from '../collaboration';
 import { useWhiteboardStore } from './whiteboardStore';
 import { blobStorage } from '../storage/BlobStorage';
+import { collectBlobReferences } from '../storage/AssetBundler';
 import { extractRichTextBlobIds, extractShapeBlobIds } from '../utils/richTextBlobExtractor';
 import { withAutoSaveSuppressed, flushAutoSaveNow } from './autoSaveGuard';
 import { VersionConflictError } from '../api/relayClient';
@@ -89,6 +90,12 @@ function resolveHomeRelayId(docId: string): string | undefined {
  */
 function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
   if (!doc.isRelayDocument) return;
+  // JP-127 (data safety): pin the reconciled blob reference set onto the doc up
+  // front so the cached + offline-queued snapshot — and any reconnect replay of
+  // it — can never persist a ref-less version. A replayed save that dropped a
+  // ref made the relay release the ACL and GC the bytes (orphaned the asset).
+  // saveToHost recomputes the same set; this guarantees the *queued* copy matches.
+  doc = { ...doc, blobReferences: collectBlobReferences(doc) };
   const relayStore = useRelayDocumentStore.getState();
 
   const home = resolveHomeRelayId(doc.id);


### PR DESCRIPTION
**Data loss fix.** Files added to a relay doc vanished on restart/reconnect.

**Mechanism (confirmed from relay logs):** on reconnect the editor replayed a queued doc save whose `blobReferences` omitted a just-added asset → the relay's JP-120 ref-diff released the blob ACL → the bytes were orphaned and GC'd. The queued/cached snapshot was captured *before* `saveToHost` reconciled the references (it computes them internally and never wrote them back to the queued copy).

```
21:56 Saved blob f983f0… + doc yRqn… v19 (references it)
22:09 Client reconnects, joins → doc yRqn… v20 saved WITHOUT the ref → "released blob ACL f983f0…"
```

**Fix:** `pushRelaySaveOrQueue` now pins `collectBlobReferences(doc)` onto the doc up front, so the cached + offline-queued copy — and any reconnect replay of it — always carries the full reference set. `saveToHost` already recomputes the same set; this just guarantees the *queued* copy matches.

**Test:** new regression in `persistenceStore.offlineRelaySave.test.ts` — a doc with a `FileShape.blobRef` but an empty GC list now queues (and caches) with the ref present. `bun typecheck` + suite green.

Client half of **JP-127**. A relay-side **GC grace** (defense-in-depth: defer byte reclaim after the last ACL releases) follows as a separate PR for isolated review.

Relates: JP-120 (blob GC), JP-118, JP-125, JP-126.

Assisted-by: Opus 4.8
