### PR TITLE
fix(editor+relay): stop relay-doc upload stalls + data loss on restart (JP-127)

### DIFF
--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -713,12 +713,45 @@ impl BlobStore {
     /// the number of ACLs released. Only safe once `doc_refs` is fully
     /// seeded from the live documents.
     pub fn sweep_unreferenced(&self) -> usize {
+        let grace = self.gc_grace_secs.load(Ordering::Relaxed);
+        let grace_ms = grace.saturating_mul(1000);
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
         let acl_pairs: Vec<(WorkspaceId, String)> = match self.acls.read() {
             Ok(g) => g.iter().cloned().collect(),
             Err(_) => return 0,
         };
         let mut released = 0usize;
         for (ws, hash) in acl_pairs {
+            // JP-127: with a grace configured, never sweep-release a blob whose
+            // bytes were uploaded within the grace window. The sweep can't tell
+            // an abandoned upload from one whose owning doc-save is still in
+            // flight (bytes uploaded, save not yet landed — e.g. a stalled save
+            // at a relay restart). Releasing its ACL would 404 the asset before
+            // the save records the reference, which is the data-loss the user
+            // hit. A later sweep (post-grace) or the incremental ref-diff still
+            // reclaims it if it truly stays unreferenced.
+            if grace > 0 {
+                let recently_uploaded = self
+                    .index
+                    .read()
+                    .ok()
+                    .and_then(|idx| idx.get(&hash).map(|m| m.created_at))
+                    .map(|created| now_ms.saturating_sub(created) < grace_ms)
+                    .unwrap_or(false);
+                if recently_uploaded {
+                    log::info!(
+                        "sweep: skipping {}/{} — uploaded within {}s grace (in-flight save?)",
+                        ws.as_str(),
+                        hash,
+                        grace
+                    );
+                    continue;
+                }
+            }
             // release_acl_if_unreferenced re-checks the referenced condition
             // and GCs orphaned bytes; count only ACLs it actually removes.
             match self.release_acl_if_unreferenced(&ws, &hash) {
@@ -926,6 +959,33 @@ mod tests {
         // No grace → dropping the last reference reclaims the bytes at once.
         store.sync_doc_refs(&ws, "doc-1", HashSet::new()).unwrap();
         assert_eq!(store.get_blob_count(), 0);
+    }
+
+    // JP-127: a relay restart's startup sweep must NOT release the ACL of a
+    // freshly-uploaded blob whose owning doc-save hasn't landed yet (an
+    // in-flight / interrupted save). This was the data-loss the user hit:
+    // deploy a secret → relay restarts → sweep releases the just-uploaded
+    // blob's ACL → asset 404s before the save records its reference.
+    #[test]
+    fn sweep_skips_freshly_uploaded_unreferenced_blob_under_grace() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.set_gc_grace_secs(3600); // 1h grace
+        let ws = WorkspaceId::single_tenant();
+        let data = b"in-flight upload, doc save not landed yet";
+        let hash = BlobStore::compute_hash(data);
+
+        // Uploaded (ACL granted) but no doc references it yet.
+        store.save_blob(&ws, &hash, data, "application/octet-stream", "u1").unwrap();
+
+        // The startup sweep must leave the freshly-uploaded blob alone.
+        assert_eq!(store.sweep_unreferenced(), 0, "fresh upload must survive the sweep");
+        assert!(store.exists(&ws, &hash), "ACL must still grant access after the sweep");
+
+        // A subsequent doc-save that references it keeps it permanently.
+        store.sync_doc_refs(&ws, "doc-1", HashSet::from([hash.clone()])).unwrap();
+        assert!(store.exists(&ws, &hash));
+        assert_eq!(store.get_blob_count(), 1);
     }
 
     #[test]

--- a/src/api/relayClient.test.ts
+++ b/src/api/relayClient.test.ts
@@ -343,3 +343,56 @@ describe('RelayClient', () => {
     });
   });
 });
+
+describe('RelayClient — request timeout (JP-127)', () => {
+  it('aborts a stalled request and surfaces a 504 RelayError', async () => {
+    // A fetch that never resolves until its signal is aborted — mimics a hung
+    // upload with no server response. Pre-fix this hung forever, leaving a
+    // relay doc stuck "syncing".
+    const fetchImpl = ((_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('The operation was aborted.', 'AbortError')),
+        );
+      })) as unknown as typeof fetch;
+
+    const client = new RelayClient({
+      baseUrl: 'http://relay.test',
+      token: 't',
+      fetchImpl,
+      requestTimeoutMs: 20,
+    });
+
+    // blobExists only swallows a 404; the 504 timeout error propagates.
+    await expect(client.blobExists('abc')).rejects.toMatchObject({
+      name: 'RelayError',
+      status: 504,
+    });
+  });
+
+  it('passes through normally when fetch resolves before the timeout', async () => {
+    const fetchImpl = (async () =>
+      new Response(null, { status: 404, statusText: 'Not Found' })) as unknown as typeof fetch;
+    const client = new RelayClient({
+      baseUrl: 'http://relay.test',
+      token: 't',
+      fetchImpl,
+      requestTimeoutMs: 1000,
+    });
+    await expect(client.blobExists('abc')).resolves.toBe(false);
+  });
+
+  it('does not arm a timeout (no AbortSignal) when requestTimeoutMs is 0', async () => {
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      expect(init?.signal).toBeUndefined();
+      return new Response(null, { status: 404 });
+    }) as unknown as typeof fetch;
+    const client = new RelayClient({
+      baseUrl: 'http://relay.test',
+      token: 't',
+      fetchImpl,
+      requestTimeoutMs: 0,
+    });
+    await expect(client.blobExists('abc')).resolves.toBe(false);
+  });
+});

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -19,6 +19,20 @@
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
 
+/**
+ * Default per-request timeout. Bounds a stalled connection so a hung request
+ * surfaces as a (retryable) error instead of leaving a relay-doc save stuck
+ * "syncing" forever (JP-127). Generous — it's a hang ceiling, not a perf SLA.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+/**
+ * Longer ceiling for blob transfers, which move large bodies (up to the relay
+ * blob cap). `fetch` exposes no upload progress, so this is a total-time bound,
+ * not an idle timeout; an aborted upload is queued + retried by the save layer.
+ */
+const BLOB_TRANSFER_TIMEOUT_MS = 300_000;
+
 // ============ Types ============
 
 /**
@@ -85,6 +99,11 @@ export interface RelayClientOptions {
    * 401s (e.g. a failed `login()` — that already throws RelayError).
    */
   onUnauthorized?: () => void;
+  /**
+   * Per-request timeout in ms (default 120 000). `0` disables the timeout.
+   * Blob transfers use a longer internal ceiling regardless.
+   */
+  requestTimeoutMs?: number;
 }
 
 export class RelayClient {
@@ -92,6 +111,7 @@ export class RelayClient {
   private token: string | undefined;
   private fetchImpl: typeof fetch;
   private onUnauthorized: (() => void) | undefined;
+  private requestTimeoutMs: number;
 
   constructor(opts: RelayClientOptions) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
@@ -100,6 +120,7 @@ export class RelayClient {
     }
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.onUnauthorized = opts.onUnauthorized;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   }
 
   /** Update the bearer token after a fresh login. Pass undefined to log out. */
@@ -178,11 +199,14 @@ export class RelayClient {
     await this.requestRaw('POST', `/api/blobs/${encodeURIComponent(hash)}`, {
       body: buffer,
       contentType: 'application/octet-stream',
+      timeoutMs: BLOB_TRANSFER_TIMEOUT_MS,
     });
   }
 
   async downloadBlob(hash: string): Promise<Uint8Array> {
-    const res = await this.requestRaw('GET', `/api/blobs/${encodeURIComponent(hash)}`);
+    const res = await this.requestRaw('GET', `/api/blobs/${encodeURIComponent(hash)}`, {
+      timeoutMs: BLOB_TRANSFER_TIMEOUT_MS,
+    });
     return new Uint8Array(await res.arrayBuffer());
   }
 
@@ -201,7 +225,7 @@ export class RelayClient {
   private async requestJson<T>(
     method: string,
     path: string,
-    opts: { body?: unknown; auth?: boolean } = {},
+    opts: { body?: unknown; auth?: boolean; timeoutMs?: number } = {},
   ): Promise<T> {
     const headers: Record<string, string> = {
       Accept: 'application/json',
@@ -219,7 +243,7 @@ export class RelayClient {
       init.body = JSON.stringify(opts.body);
     }
     const wasAuthed = opts.auth !== false && this.token !== undefined;
-    const res = await this.fetchImpl(url, init);
+    const res = await this.fetchWithTimeout(url, init, opts.timeoutMs ?? this.requestTimeoutMs);
     if (!res.ok) {
       if (res.status === 401 && wasAuthed) {
         this.onUnauthorized?.();
@@ -236,7 +260,7 @@ export class RelayClient {
   private async requestRaw(
     method: string,
     path: string,
-    opts: { body?: BodyInit; contentType?: string } = {},
+    opts: { body?: BodyInit; contentType?: string; timeoutMs?: number } = {},
   ): Promise<Response> {
     const headers: Record<string, string> = {};
     if (opts.contentType !== undefined) {
@@ -252,7 +276,7 @@ export class RelayClient {
       init.body = opts.body;
     }
     const wasAuthed = this.token !== undefined;
-    const res = await this.fetchImpl(url, init);
+    const res = await this.fetchWithTimeout(url, init, opts.timeoutMs ?? this.requestTimeoutMs);
     if (!res.ok) {
       if (res.status === 401 && wasAuthed) {
         this.onUnauthorized?.();
@@ -260,6 +284,36 @@ export class RelayClient {
       throw await buildRelayError(res, url);
     }
     return res;
+  }
+
+  /**
+   * `fetch` with an abort-based timeout. A stalled request is aborted and
+   * surfaced as a 504 `RelayError` — numeric status, so `BlobSyncService`
+   * retries it and the save layer treats it as transient (queues for replay)
+   * instead of leaving the doc stuck "syncing" (JP-127). `timeoutMs <= 0`
+   * disables the timeout. The caller's `init` is spread so a future
+   * caller-supplied `signal` still works; none does today.
+   */
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    timeoutMs: number,
+  ): Promise<Response> {
+    if (timeoutMs <= 0) {
+      return this.fetchImpl(url, init);
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (err) {
+      if (controller.signal.aborted) {
+        throw new RelayError(504, url, `Request timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 

--- a/src/store/persistenceStore.offlineRelaySave.test.ts
+++ b/src/store/persistenceStore.offlineRelaySave.test.ts
@@ -25,6 +25,7 @@ vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock 
 const syncManagerMock = vi.hoisted(() => ({
   queueSave: vi.fn(() => ({ id: 'op-1' })),
   hasPendingChanges: vi.fn<[string], boolean>(() => false),
+  processQueueForHost: vi.fn(async () => []),
 }));
 vi.mock('../collaboration/SyncStateManager', () => ({
   getSyncStateManager: () => syncManagerMock,
@@ -148,6 +149,67 @@ describe('saveDocumentPdfSettings — offline relay edit durability (JP-106)', (
   });
 });
 
+describe('pushRelaySaveOrQueue — connected-save failure handling (JP-127)', () => {
+  // Drain the fire-and-forget `saveToHost(doc).catch(...)` microtask.
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    localStorage.clear();
+    cacheMock.put.mockClear();
+    syncManagerMock.queueSave.mockClear();
+    syncManagerMock.hasPendingChanges.mockReset();
+    syncManagerMock.hasPendingChanges.mockReturnValue(false);
+    useConnectionStore.getState().reset();
+    useRelayDocumentStore.setState({ authenticated: false });
+    // Connected + authenticated so the helper actually attempts saveToHost.
+    useConnectionStore.setState({
+      status: 'authenticated',
+      host: { address: 'localhost:9876', url: 'http://localhost:9876' },
+    });
+  });
+
+  it('queues for replay when a connected save fails transiently — not just "Not connected"', async () => {
+    // Pre-fix: any error other than the literal "Not connected to host" was
+    // logged and dropped, so the edit was lost and a later reattach rolled the
+    // doc back. A stalled/aborted upload or a 5xx must now be queued instead.
+    const saveToHost = vi.fn(async () => {
+      throw new Error('Failed to upload 1 of 1 asset(s) to the relay: network blip');
+    });
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    saveDocumentToStorage(makeRelayDoc('relay-transient'));
+
+    saveDocumentPdfSettings('relay-transient', pdfSettings);
+    await flush();
+
+    expect(saveToHost).toHaveBeenCalledTimes(1);
+    expect(syncManagerMock.queueSave).toHaveBeenCalledTimes(1);
+    expect(cacheMock.put).toHaveBeenCalledTimes(1);
+    expect(cacheMock.put.mock.calls[0]?.[1]).toBe('localhost:9876');
+  });
+
+  it('surfaces an over-quota (507) failure without queuing or silently dropping', async () => {
+    const err = Object.assign(
+      new Error('storage quota exceeded: 250 used + 10 incoming > 250 quota'),
+      { status: 507 },
+    );
+    const saveToHost = vi.fn(async () => {
+      throw err;
+    });
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    saveDocumentToStorage(makeRelayDoc('relay-quota'));
+    const errorSpy = vi.spyOn(useNotificationStore.getState(), 'error');
+
+    saveDocumentPdfSettings('relay-quota', pdfSettings);
+    await flush();
+
+    expect(errorSpy).toHaveBeenCalled();
+    // Terminal: a blind replay can't fix it, so don't queue — but the local
+    // copy is kept (not dropped), and reattach won't clobber it.
+    expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
 describe('saveDocument — defect-D guard narrowed to unhydrated parked docs (JP-106 follow-up)', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -192,6 +254,9 @@ describe('saveDocument — defect-D guard narrowed to unhydrated parked docs (JP
 describe('reattachAwaitingTeamDocument — no clobber of unsynced edits (JP-106 follow-up)', () => {
   beforeEach(() => {
     localStorage.clear();
+    cacheMock.put.mockClear();
+    syncManagerMock.queueSave.mockClear();
+    syncManagerMock.processQueueForHost.mockClear();
     syncManagerMock.hasPendingChanges.mockReset();
     syncManagerMock.hasPendingChanges.mockReturnValue(false);
     useConnectionStore.getState().reset();
@@ -229,6 +294,71 @@ describe('reattachAwaitingTeamDocument — no clobber of unsynced edits (JP-106 
     await reattachAwaitingTeamDocument();
 
     expect(loadRelayDocument).toHaveBeenCalledWith('doc-Y');
+  });
+
+  it('keeps a NEWER local copy and queues a replay instead of clobbering (JP-127)', async () => {
+    // The real data-loss path: a save failed/was-interrupted without ever
+    // queuing (hasPendingChanges=false), so the local copy is newer than the
+    // relay's and holds the unsynced edit (e.g. a just-added file). Reattach
+    // must keep it and queue a replay, not overwrite it with the stale relay copy.
+    const localNewer = makeRelayDoc('doc-newer');
+    localNewer.modifiedAt = 5000;
+    localNewer.blobReferences = [];
+    localNewer.pages = {
+      p1: { id: 'p1', name: 'P1', shapes: { s1: { id: 's1', type: 'file', blobRef: 'hash-keep' } } },
+    } as unknown as DiagramDocument['pages'];
+    saveDocumentToStorage(localNewer);
+
+    const relayOlder = makeRelayDoc('doc-newer');
+    relayOlder.modifiedAt = 1; // stale relay copy, pre-edit
+    const loadRelayDocument = vi.fn(async () => relayOlder);
+    useRelayDocumentStore.setState({ loadRelayDocument } as never);
+    useConnectionStore.setState({
+      status: 'authenticated',
+      host: { address: 'localhost:9876', url: 'http://localhost:9876' },
+    });
+    syncManagerMock.hasPendingChanges.mockReturnValue(false);
+    usePersistenceStore.setState({
+      currentDocumentId: 'doc-newer',
+      isAwaitingTeamLoad: true,
+      teamDocContentPending: false,
+    });
+
+    await reattachAwaitingTeamDocument();
+
+    expect(loadRelayDocument).toHaveBeenCalledWith('doc-newer');
+    // Kept local + queued for replay (not clobbered).
+    expect(syncManagerMock.queueSave).toHaveBeenCalledTimes(1);
+    const queued = syncManagerMock.queueSave.mock.calls as unknown as Array<[DiagramDocument, string]>;
+    expect(queued[0]?.[0]?.id).toBe('doc-newer');
+    expect(queued[0]?.[0]?.modifiedAt).toBe(5000);
+    // The queued snapshot carries the pinned blob ref so the replay can't orphan it.
+    expect(queued[0]?.[0]?.blobReferences).toContain('hash-keep');
+    expect(usePersistenceStore.getState().isAwaitingTeamLoad).toBe(false);
+  });
+
+  it('still overwrites when the relay copy is newer-or-equal (no unsynced local edit)', async () => {
+    const localOlder = makeRelayDoc('doc-older');
+    localOlder.modifiedAt = 1;
+    saveDocumentToStorage(localOlder);
+
+    const relayNewer = makeRelayDoc('doc-older');
+    relayNewer.modifiedAt = 9000; // server moved ahead
+    const loadRelayDocument = vi.fn(async () => relayNewer);
+    useRelayDocumentStore.setState({ loadRelayDocument } as never);
+    syncManagerMock.hasPendingChanges.mockReturnValue(false);
+    usePersistenceStore.setState({
+      currentDocumentId: 'doc-older',
+      isAwaitingTeamLoad: true,
+      teamDocContentPending: false,
+    });
+
+    await reattachAwaitingTeamDocument();
+
+    expect(loadRelayDocument).toHaveBeenCalledWith('doc-older');
+    // Relay copy wins → loaded into the editor, nothing queued.
+    expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
+    expect(usePersistenceStore.getState().currentDocumentName).toBe('doc-older');
   });
 });
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -129,14 +129,51 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
 
   relayStore.saveToHost(doc).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('Not connected to host')) {
-      queueForReplay('Not connected');
-    } else {
-      console.error(
-        `[persistenceStore] Failed to sync relay document to host (${context}):`,
-        err,
-      );
+    const status = (err as { status?: unknown }).status;
+
+    // Terminal failures (JP-127): a blind replay can't fix these, so don't
+    // queue — but never *silently* drop the edit. Surface it and keep the local
+    // copy (reattach's newer-local guard stops a later clobber).
+    if (err instanceof VersionConflictError) {
+      useNotificationStore
+        .getState()
+        .warning(
+          'This document changed on the relay while you were away — your local ' +
+            'edits were not pushed to avoid overwriting them. Reopen the document to merge.',
+        );
+      return;
     }
+    // The relay maps an over-quota upload to 507; its body carries the
+    // "storage quota exceeded" wording, which rides through the blob-upload
+    // error wrapper in `saveToHost` (the thrown Error has no `status`).
+    if (status === 507 || /quota exceeded/i.test(message)) {
+      useNotificationStore.getState().error(
+        'Save failed: the workspace is out of storage. Free up space and try again — ' +
+          'your local copy is kept and was not lost.',
+        { category: 'permanent' },
+      );
+      return;
+    }
+    if (status === 403) {
+      useNotificationStore.getState().error(
+        'Save failed: you don’t have permission to edit this document. Your local copy is kept.',
+        { category: 'permanent' },
+      );
+      return;
+    }
+
+    // Everything else is transient — network/timeout/abort, 5xx, 429, 401
+    // (replays after token refresh), and a stalled or failed blob upload. Cache
+    // + queue under the doc's home relay so the reconnect replay (which carries
+    // the pinned blob refs) re-saves the edit instead of dropping it. This is
+    // the path JP-127's ref-pinning was meant to protect: previously only a
+    // literal "Not connected to host" reached it, so any other failure silently
+    // lost the edit and a later reattach rolled the doc back.
+    queueForReplay(
+      message.includes('Not connected to host')
+        ? 'Not connected'
+        : `Transient save failure (${context})`,
+    );
   });
 }
 
@@ -1279,6 +1316,7 @@ export async function reattachAwaitingTeamDocument(): Promise<void> {
   const state = usePersistenceStore.getState();
   if (!state.isAwaitingTeamLoad || !state.currentDocumentId) return;
   const docId = state.currentDocumentId;
+  const hydrated = state.teamDocContentPending !== true;
 
   // If the locally-loaded copy has unsynced offline edits queued for replay,
   // do NOT overwrite the editor with the relay/server copy (JP-106): that
@@ -1286,13 +1324,49 @@ export async function reattachAwaitingTeamDocument(): Promise<void> {
   // page store *and* localStorage and the edits would flicker out and revert.
   // Keep the local edits — already hydrated and queued — and let the sync
   // queue push them to the relay. Just disengage the reattach hook.
-  if (state.teamDocContentPending !== true && getSyncStateManager().hasPendingChanges(docId)) {
+  if (hydrated && getSyncStateManager().hasPendingChanges(docId)) {
     usePersistenceStore.setState({ isAwaitingTeamLoad: false });
     return;
   }
 
   try {
     const doc = await useRelayDocumentStore.getState().loadRelayDocument(docId);
+
+    // JP-127: a save can fail or be interrupted (a stalled upload, a dropped
+    // non-"Not connected" error) without ever reaching the durable sync queue,
+    // so `hasPendingChanges` was false above. But the locally-stored copy is
+    // still *newer* than the relay's and holds the unsynced edit (e.g. a
+    // just-added file). Overwriting it with the older relay copy is exactly the
+    // rollback/data-loss the user hit. When local is newer, keep it and queue a
+    // replay (carrying pinned blob refs) instead of clobbering.
+    if (hydrated) {
+      const local = loadDocumentFromStorage(docId);
+      if (local?.isRelayDocument && local.modifiedAt > doc.modifiedAt) {
+        const connected = useConnectionStore.getState().host?.address;
+        const home = resolveHomeRelayId(docId) ?? connected ?? 'unknown';
+        const pinned: DiagramDocument = {
+          ...local,
+          blobReferences: collectBlobReferences(local),
+        };
+        void RelayDocumentCache.put(pinned, home).catch((e) =>
+          console.error('[persistence] Failed to re-cache newer local copy:', e),
+        );
+        getSyncStateManager().queueSave(pinned, home);
+        usePersistenceStore.setState({ isAwaitingTeamLoad: false });
+        console.warn(
+          `[persistence] Local copy of ${docId} is newer than the relay copy ` +
+            '(unsynced edit) — keeping it and queuing a replay instead of ' +
+            'overwriting with the older relay copy (JP-127).',
+        );
+        // Push promptly rather than waiting for the next reconnect; the
+        // host-queue processor is guarded against concurrent runs.
+        if (home === connected) {
+          void getSyncStateManager().processQueueForHost(home).catch(() => {});
+        }
+        return;
+      }
+    }
+
     usePersistenceStore.getState().loadRemoteDocument(doc);
   } catch (error) {
     console.warn('[persistence] Failed to reattach relay document on auth:', error);
@@ -1356,7 +1430,14 @@ export async function syncCurrentDocToRelayOnConnect(): Promise<void> {
         );
       return;
     }
-    console.warn('[persistence] on-connect relay sync failed:', err);
+    // Transient failure — don't drop the edit (JP-127). Cache + queue under the
+    // doc's home relay (pinning refs) so it replays instead of being lost; the
+    // doc also stays `isDirty` so it's retried on the next reconnect.
+    const homeRelay = home ?? connected ?? 'unknown';
+    const pinned: DiagramDocument = { ...doc, blobReferences: collectBlobReferences(doc) };
+    void RelayDocumentCache.put(pinned, homeRelay).catch(() => {});
+    getSyncStateManager().queueSave(pinned, homeRelay);
+    console.warn('[persistence] on-connect relay sync failed; queued for replay:', err);
   }
 }
 


### PR DESCRIPTION
## Why

After merging #24 (client pin-refs) + #25 (relay GC grace) and deploying with `RELAY_BLOB_GC_GRACE_SECS=600`, the **exact data-loss bug recurred**, plus a new symptom: large-file relay saves get stuck **"syncing"**, no upload traffic reaches the relay, no saves land, and on client restart the doc **rolls back to before the file was added** while the relay **releases the blob's ACL**.

Re-tracing the whole save/upload chain showed #24/#25 are correct but guard paths the real failure never traverses. There are four layered defects.

## Root-cause chain

- **A (trigger):** `relayClient.requestRaw` had **no timeout** → a stalled large upload hangs forever → `saveToHost` never reaches the doc save → doc stuck `syncing`.
- **B:** `pushRelaySaveOrQueue` only queued on the literal `"Not connected to host"`; **every other failure was logged and dropped** → no durable queue entry → JP-127's pin-refs (which only runs in the queue path) never engaged.
- **C:** `reattachAwaitingTeamDocument` kept local edits only when `hasPendingChanges` was true. After B that's false → it overwrote the newer local doc with the **stale relay copy** = the rollback.
- **D:** the relay startup sweep (`sweep_unreferenced`, fired on the secret-deploy restart) released the ACL of a just-uploaded blob whose doc-save hadn't landed; #25's grace deferred the *bytes* but not the *ACL*, so the asset 404'd.

## Fix (data-safety first)

1. **`relayClient`** — abort-based timeout (default 120s; 300s for blob transfers). A stall now surfaces a retryable **504**, never an infinite `syncing`.
2. **`persistenceStore.pushRelaySaveOrQueue`** — queue on **any transient** failure (network/timeout/abort, 5xx, 429, blob-upload failure); surface **terminal** ones (version conflict, **507 over-quota**, 403) with a notification and keep the local copy. Never silently drop. (`syncCurrentDocToRelayOnConnect` queues on transient too.)
3. **`persistenceStore.reattachAwaitingTeamDocument`** — when the local copy is **newer** than the relay's, keep it + queue a replay instead of clobbering.
4. **relay `sweep_unreferenced`** — with a GC grace set, **skip** releasing the ACL of a blob uploaded within the grace window (in-flight save). Leaves #25's incremental `orphaned_at` byte-deferral intact.

## Tests
- `relayClient.test.ts`: timeout → 504, passthrough, disabled (no signal).
- `persistenceStore.offlineRelaySave.test.ts`: transient failure queues; 507 notifies without queuing; reattach keeps newer-local (+ pinned ref) vs. overwrites when relay is newer.
- `blobs.rs`: `sweep_skips_freshly_uploaded_unreferenced_blob_under_grace`.
- Full suites green: **TS 1697**, relay all (incl. 21 blob tests).

## To verify on staging
Add a large CSV → if the upload stalls it now aborts + queues (no permanent `syncing`); restart the client → file **survives** (no rollback); restart the relay with grace set → the in-flight blob's ACL survives the sweep (no `released blob ACL` for the just-uploaded hash). Force a 507 → "out of storage" notice, local copy kept.

Supersedes the insufficient #24/#25 (kept — they're correct, just not the whole story). Relates to JP-127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)