### PR TITLE
fix(editor): reqwest-backed relay HTTP on desktop + tame upload timeout (JP-127)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-fs": "^2.5.0",
+        "@tauri-apps/plugin-http": "^2.5.9",
         "@tiptap/core": "^2.1.0",
         "@tiptap/extension-color": "^2.1.0",
         "@tiptap/extension-highlight": "^2.1.0",
@@ -458,6 +459,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NTpyQxkpzGmU6ceWBTY2xRIEaS0ZLbVx1HE1zTA3TY/pV3+cPoPPOs+7YScr4IMzXMtOw7tLw5LEXo5oIG3qaQ=="],
 
     "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.5.0", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ=="],
+
+    "@tauri-apps/plugin-http": ["@tauri-apps/plugin-http@2.5.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA=="],
 
     "@tiptap/core": ["@tiptap/core@2.27.1", "", { "peerDependencies": { "@tiptap/pm": "^2.7.0" } }, "sha512-nkerkl8syHj44ZzAB7oA2GPmmZINKBKCa79FuNvmGJrJ4qyZwlkDzszud23YteFZEytbc87kVd/fP76ROS6sLg=="],
 
@@ -1576,6 +1579,8 @@
     "@babel/preset-modules/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@tauri-apps/plugin-http/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "babel-plugin-polyfill-corejs2/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-fs": "^2.5.0",
+    "@tauri-apps/plugin-http": "^2.5.9",
     "@tiptap/core": "^2.1.0",
     "@tiptap/extension-color": "^2.1.0",
     "@tiptap/extension-highlight": "^2.1.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "foreign-types",
  "libc",
@@ -724,7 +724,7 @@ checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
  "bitflags 2.11.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "objc",
 ]
@@ -770,8 +770,37 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -797,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -810,7 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -823,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -953,6 +982,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deranged"
@@ -1118,6 +1153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "docushark"
 version = "1.3.1-beta.1"
 dependencies = [
@@ -1130,6 +1174,7 @@ dependencies = [
  "tauri-plugin-devtools",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tokio",
@@ -1212,6 +1257,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1655,8 +1709,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1666,9 +1722,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1852,6 +1910,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,7 +2087,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2034,6 +2111,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2044,6 +2122,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2076,9 +2170,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2498,6 +2594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "local-ip-address"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,6 +2628,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3482,6 +3590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,6 +3616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,6 +3638,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3569,6 +3748,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,6 +3803,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3710,6 +3918,49 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3764,6 +4015,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3848,6 +4113,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4373,6 +4673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4432,6 +4738,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,7 +4779,7 @@ checksum = "6e06d52c379e63da659a483a958110bbde891695a0ecb53e48cc7786d5eda7bb"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
@@ -4536,7 +4863,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4705,6 +5032,30 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfba7d4ec72763f9d1fdf73c217747f01e2c84b08b87a8cacd2f94f35853f84d"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http 1.4.0",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
 ]
 
 [[package]]
@@ -5032,6 +5383,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5171,7 +5532,7 @@ dependencies = [
  "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -5508,6 +5869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5772,6 +6139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5825,6 +6202,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6010,6 +6396,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6693,6 +7090,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,10 @@ tauri-plugin-log = "2.8.0"
 tauri-plugin-fs = "2.5.0"
 tauri-plugin-dialog = "2.6.0"
 tauri-plugin-opener = "2.5.3"
+# JP-127: route relay REST/blob HTTP through this reqwest-backed client on
+# desktop. The webview's own fetch (WebKitGTK/libsoup) throttles large request
+# bodies to 15–80 KB/s; reqwest does not. See src/platform/relayFetch.tauri.ts.
+tauri-plugin-http = "2.5.0"
 
 # Tauri's async runtime — required even after the WS server moved
 # out, since Tauri itself uses tokio internally.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -47,6 +47,15 @@
     "dialog:allow-save",
     "dialog:allow-message",
     "dialog:allow-ask",
-    "dialog:allow-confirm"
+    "dialog:allow-confirm",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "https://*.fly.dev/*" },
+        { "url": "https://*.docushark.app/*" },
+        { "url": "http://localhost:*/*" },
+        { "url": "http://127.0.0.1:*/*" }
+      ]
+    }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,7 +272,10 @@ pub fn run() {
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_opener::init());
+        .plugin(tauri_plugin_opener::init())
+        // JP-127: reqwest-backed HTTP for relay REST/blob transfer (the webview's
+        // libsoup fetch throttles large uploads). Used via the relayFetch seam.
+        .plugin(tauri_plugin_http::init());
 
     #[cfg(debug_assertions)]
     {

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -29,9 +29,13 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 /**
  * Longer ceiling for blob transfers, which move large bodies (up to the relay
  * blob cap). `fetch` exposes no upload progress, so this is a total-time bound,
- * not an idle timeout; an aborted upload is queued + retried by the save layer.
+ * not an idle timeout; an aborted upload is queued (once) by the save layer.
+ * Generous so a legitimately slow link finishing a large upload isn't killed
+ * mid-flight and re-sent — ~150 MiB completes above ~260 KB/s within this bound
+ * (JP-127). A 504 from this timeout is *not* retried in-loop (see
+ * `BlobSyncService.shouldRetry`).
  */
-const BLOB_TRANSFER_TIMEOUT_MS = 300_000;
+const BLOB_TRANSFER_TIMEOUT_MS = 600_000;
 
 // ============ Types ============
 

--- a/src/collaboration/BlobSyncService.test.ts
+++ b/src/collaboration/BlobSyncService.test.ts
@@ -230,6 +230,19 @@ describe('BlobSyncService', () => {
       expect(uploadBlob).toHaveBeenCalledTimes(1);
     });
 
+    it('does NOT retry a 504 client-timeout — fails fast (JP-127)', async () => {
+      // relayClient surfaces its AbortController upload timeout as RelayError(504).
+      // Re-sending a large body 5× just multiplies a slow upload, so the service
+      // must fail fast and let the save layer queue one clean replay instead.
+      const uploadBlob = vi.fn(async () => {
+        throw httpError(504, 'Request timed out after 600000ms');
+      });
+      const svc = new BlobSyncService({ transport: makeTransport({ uploadBlob }), ...fast });
+
+      await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow();
+      expect(uploadBlob).toHaveBeenCalledTimes(1);
+    });
+
     it('retries network errors (no status) up to maxRetries then throws', async () => {
       const downloadBlob = vi.fn(async () => {
         throw new Error('network down');

--- a/src/collaboration/BlobSyncService.ts
+++ b/src/collaboration/BlobSyncService.ts
@@ -357,6 +357,11 @@ export class BlobSyncService {
   private shouldRetry(error: unknown): boolean {
     const status = (error as { status?: unknown })?.status;
     if (typeof status === 'number') {
+      // JP-127: a 504 here is the client-side upload timeout (relayClient's
+      // AbortController firing), not a real gateway timeout. Re-sending a large
+      // body up to 5× just multiplies an already-slow upload — fail fast and let
+      // the save layer queue it for a single clean replay instead.
+      if (status === 504) return false;
       return status >= 500 || status === 429;
     }
     // No status -> treat as a network/transport error and retry.

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -39,6 +39,7 @@ import type { DocEvent } from './protocol';
 import { isUnknownDocError } from './protocol';
 import { throttle } from '../utils/requestUtils';
 import { getAdaptiveBudget } from '../platform/adaptiveBudget';
+import { relayFetch } from '../platform/relayFetch';
 
 /** Convert a WS server URL to the matching REST origin for the same relay. */
 function wsUrlToHttpOrigin(wsUrl: string): string {
@@ -325,6 +326,11 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       relayClient = new RelayClient({
         baseUrl: restBaseUrl,
         ...(config.token !== undefined ? { token: config.token } : {}),
+        // JP-127: on desktop this routes through the reqwest-backed Tauri HTTP
+        // plugin (the webview's libsoup fetch throttles large uploads to
+        // 15–80 KB/s); on web it's the native fetch. Resolved lazily on first
+        // request, so construction stays synchronous.
+        fetchImpl: relayFetch,
         onUnauthorized: () => {
           // JP-100: try a silent token refresh first (no-op until a
           // TokenRefresher is registered — see tokenRefresh.ts). On success the

--- a/src/platform/relayFetch.tauri.ts
+++ b/src/platform/relayFetch.tauri.ts
@@ -1,0 +1,19 @@
+/**
+ * Tauri implementation of {@link relayFetch}. Routes relay HTTP through the
+ * reqwest-backed `@tauri-apps/plugin-http` `fetch` instead of the webview's own
+ * `fetch` (WebKitGTK/libsoup), which throttles large request bodies to
+ * 15–80 KB/s (JP-127). This module is only imported in the desktop build
+ * (gated by `__IS_TAURI__` in `./relayFetch`).
+ *
+ * Requires the `http:default` capability scoped to the relay origins in
+ * `src-tauri/capabilities/default.json`.
+ */
+
+import { fetch as tauriHttpFetch } from '@tauri-apps/plugin-http';
+
+export function createTauriRelayFetch(): typeof fetch {
+  // The plugin's fetch is web-fetch-compatible (method / headers / body /
+  // AbortSignal) but moves bytes through Rust/reqwest. Cast through `unknown`
+  // because its signature carries extra `ClientOptions` beyond the DOM `fetch`.
+  return tauriHttpFetch as unknown as typeof fetch;
+}

--- a/src/platform/relayFetch.ts
+++ b/src/platform/relayFetch.ts
@@ -1,0 +1,38 @@
+/**
+ * `platform.relayFetch` — the `fetch` used by `RelayClient` for relay REST +
+ * blob HTTP.
+ *
+ * Desktop routes through the reqwest-backed Tauri HTTP plugin because the
+ * webview's own `fetch` (WebKitGTK/libsoup) throttles large request bodies to
+ * 15–80 KB/s (JP-127); web/PWA uses the native `fetch`, which is fine. The
+ * `@tauri-apps/plugin-http` import lives in `./relayFetch.tauri` so it is
+ * tree-shaken out of the PWA bundle (the `__IS_TAURI__`-gated dynamic import,
+ * same pattern as `./opener`).
+ *
+ * The impl resolves asynchronously (dynamic import) but is exposed as a
+ * synchronous `fetch`-shaped function — it awaits + caches the platform impl on
+ * first call — so `RelayClient` (which takes a synchronous `fetchImpl`) and its
+ * `AbortController` timeout (JP-127) need no change.
+ */
+
+let cached: Promise<typeof fetch> | null = null;
+
+function resolveRelayFetch(): Promise<typeof fetch> {
+  if (!cached) {
+    // `__IS_TAURI__` is a build-time literal — the false branch (and its
+    // `@tauri-apps` import) is dead-code-eliminated from the PWA bundle.
+    cached = __IS_TAURI__
+      ? import('./relayFetch.tauri').then((m) => m.createTauriRelayFetch())
+      : import('./relayFetch.web').then((m) => m.createWebRelayFetch());
+  }
+  return cached;
+}
+
+/**
+ * A `fetch`-compatible function backed by the platform's preferred HTTP
+ * transport. Pass as `RelayClient`'s `fetchImpl`.
+ */
+export const relayFetch = ((
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => resolveRelayFetch().then((f) => f(input, init))) as unknown as typeof fetch;

--- a/src/platform/relayFetch.web.ts
+++ b/src/platform/relayFetch.web.ts
@@ -1,0 +1,8 @@
+/**
+ * Web implementation of {@link relayFetch}. The browser's native `fetch`
+ * handles large uploads fine, so this is just the platform `fetch`.
+ */
+
+export function createWebRelayFetch(): typeof fetch {
+  return globalThis.fetch.bind(globalThis) as typeof fetch;
+}


### PR DESCRIPTION
**Stacked on #26** (base = `developerjp/jp-127-upload-stall-and-data-loss`). Merge #26 first, or retarget to master after it lands.

## Why
With the data-loss fix (#26) holding, the remaining problem is **large-file upload throughput on the Tauri desktop app**. Confirmed by a same-machine PWA-vs-Tauri test: the **PWA is fast; the desktop app uploads at 15–80 KB/s** (a 50 MiB file = 10–60 min), because the webview's own `fetch` (WebKitGTK/libsoup) throttles large request bodies. My #26 timeout then fires on the crawling upload and `BlobSyncService` re-sends it 5× → a multi-minute loop.

## What
- **Desktop transport:** add `tauri-plugin-http` (reqwest-backed) + a `relayFetch` platform seam (`src/platform/relayFetch.{ts,tauri.ts,web.ts}`, mirroring `opener`). Desktop routes relay REST + blob transfer through the plugin's `fetch`; web/PWA uses native `fetch`. Wired as `RelayClient`'s `fetchImpl` in `collaborationStore` (resolved lazily so construction stays sync; the #26 `AbortController` timeout still works). `@tauri-apps` import stays under `src/platform/` (importBoundary invariant). `http:default` capability scoped to the relay origins.
- **Robustness (Fix C):** `BLOB_TRANSFER_TIMEOUT_MS` 300s → 600s (a legitimately slow large upload isn't killed mid-flight); `BlobSyncService.shouldRetry` no longer retries a **504** client-timeout — fail fast → the save layer queues one clean replay instead of re-sending megabytes.

## Not covered here
A **second, independent** failure mode shows in the Fly logs *during PWA testing*: `hyper error: user body write aborted … early end` + `http2 error … stream error` for large bodies — Fly's edge↔instance proxy choking on large **HTTP/2** request bodies (hits the PWA too; the PWA only wins by retry-brute-forcing). The fix is a **Fly service config change (force HTTP/1.1)** in the `docushark-web`/ops repo — tracked separately.

## Verification
- `bun run typecheck` + full suite **1698** green; `importBoundary.test.ts` green (tauri import confined to `src/platform/`); new `BlobSyncService` 504-no-retry test.
- `cargo check` (src-tauri) compiles with the new plugin (`reqwest`/`urlpattern`/`hyper-rustls` resolve).
- **On-device check needed:** re-measure desktop upload KB/s before/after (expect ≫1 MB/s) — can't be verified in CI.

Relates to JP-127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)