### PR TITLE
feat: direct-to-R2 presigned blob storage (relay-owned) [JP-87]

### DIFF
--- a/relay/.dockerignore
+++ b/relay/.dockerignore
@@ -1,0 +1,8 @@
+# Keep the build context small + free of local secrets/state. The Dockerfile
+# only COPYs Cargo.toml, Cargo.lock, src/, and tests/, but the context upload
+# (e.g. `fly deploy --remote-only`) otherwise ships everything here.
+/target/
+/data/
+/relay.toml
+/relay.local.toml
+*.local.toml

--- a/relay/.gitignore
+++ b/relay/.gitignore
@@ -4,4 +4,5 @@
 
 # Local config (created by `relay init`, never checked in)
 /relay.toml
+/relay.local.toml
 /data/

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -461,6 +462,7 @@ dependencies = [
  "futures-util",
  "governor",
  "hex",
+ "hmac",
  "jsonwebtoken",
  "local-ip-address",
  "log",
@@ -733,6 +735,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -64,6 +64,11 @@ local-ip-address = "0.6"
 # Cryptographic hashing for blob storage (Phase 17.5 — lifted)
 sha2 = "0.10"
 hex = "0.4"
+# HMAC-SHA256 for the S3/R2 SigV4 request signer (blob_backend/s3.rs). A
+# lightweight presign-only signer over the existing `reqwest`/`sha2` stack —
+# deliberately *not* `aws-sdk-s3` (keeps the relay's 1.77.2 MSRV + a small dep
+# tree; the relay only needs presign + HEAD + DELETE against R2).
+hmac = "0.12"
 
 # CSPRNG (used for nonces in the revocation push bearer compare, plus
 # test-side keypair generation).

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -181,21 +181,40 @@ paths:
     get:
       tags: [blobs]
       summary: Download a blob
+      description: |
+        On a filesystem backend the relay streams the bytes (200). On an
+        object-storage backend it ACL-checks the workspace and returns a 302
+        redirect to a short-lived presigned URL the client fetches directly.
       security:
         - bearerAuth: []
       responses:
         '200':
-          description: Blob bytes (content type per stored MIME).
+          description: Blob bytes (filesystem backend; content type per stored MIME).
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
+        '302':
+          description: |
+            Object-storage backend: redirect to a presigned GET URL. The URL
+            self-authenticates via its query string — clients must not forward
+            the `Authorization` bearer on the cross-origin redirect.
+          headers:
+            Location:
+              description: Presigned GET URL.
+              schema:
+                type: string
         '404':
           description: Not found.
     post:
       tags: [blobs]
-      summary: Upload a blob (hash in path must match content)
+      summary: Upload a blob through the relay (hash in path must match content)
+      description: |
+        Proxies the bytes through the relay. This is the upload path for the
+        filesystem backend; object-storage backends use the presigned flow
+        (`POST /api/v1/blobs/{hash}/upload-url` then `.../finalize`) so bytes go
+        directly to storage.
       security:
         - bearerAuth: []
       requestBody:
@@ -210,6 +229,124 @@ paths:
           description: Blob stored.
         '400':
           description: Provided hash did not match request body.
+        '507':
+          description: Per-workspace storage quota exceeded.
+
+  /api/v1/blobs/{hash}/upload-url:
+    parameters:
+      - name: hash
+        in: path
+        required: true
+        description: SHA-256 hex digest of the blob content.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{64}$'
+    post:
+      tags: [blobs]
+      summary: Request a presigned upload (object-storage backend)
+      description: |
+        Mint a short-lived presigned PUT so the client uploads blob bytes
+        directly to object storage, bypassing the relay; after the PUT, call
+        `finalize`. Returns `{ "exists": true }` when the workspace already holds
+        the blob (skip upload + finalize). On a filesystem backend the relay
+        cannot presign and returns 409 — clients then fall back to the proxy
+        `POST /api/blobs/{hash}`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [size]
+              properties:
+                size:
+                  type: integer
+                  format: int64
+                  description: Client-asserted byte length (re-verified at finalize).
+                mimeType:
+                  type: string
+      responses:
+        '200':
+          description: A presigned upload, or an already-exists marker for a dedup hit.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      exists:
+                        type: boolean
+                  - type: object
+                    properties:
+                      url:
+                        type: string
+                      headers:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: Headers the client must echo on the PUT.
+                      expiresAt:
+                        type: integer
+                        format: int64
+                        description: Unix-millis expiry of the presigned URL.
+                      key:
+                        type: string
+        '409':
+          description: Filesystem backend — presign unavailable; use the proxy upload.
+        '413':
+          description: Asserted size exceeds the per-blob limit.
+        '507':
+          description: Projected per-workspace storage quota exceeded.
+
+  /api/v1/blobs/{hash}/finalize:
+    parameters:
+      - name: hash
+        in: path
+        required: true
+        description: SHA-256 hex digest of the blob content.
+        schema:
+          type: string
+          pattern: '^[0-9a-f]{64}$'
+    post:
+      tags: [blobs]
+      summary: Finalize a presigned upload (object-storage backend)
+      description: |
+        Confirm a direct upload landed: the relay HEADs the object for its
+        authoritative size, re-checks the workspace quota (reclaiming the object
+        and returning 507 if over), then records the blob and grants the
+        workspace ACL.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mimeType:
+                  type: string
+      responses:
+        '200':
+          description: Blob recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  hash:
+                    type: string
+                  size:
+                    type: integer
+                    format: int64
+        '404':
+          description: No uploaded object found for this hash (the PUT never landed).
+        '507':
+          description: Storage quota exceeded at the authoritative size.
 
   /ws:
     get:

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -376,7 +376,7 @@ async fn blob_upload_url_handler(
     }
 
     let mime = req.mime_type.as_deref().unwrap_or("application/octet-stream");
-    let mint = s3.presign_put(&ws, &hash, mime, req.size);
+    let mint = s3.presign_put(&ws, &hash, mime);
     let headers_obj: serde_json::Map<String, Value> = mint
         .headers
         .iter()

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -69,6 +69,16 @@ pub(crate) fn blob_refs_from_doc(doc: &Value) -> HashSet<String> {
         .unwrap_or_default()
 }
 
+/// Whether `hash` is a well-formed SHA-256 hex digest (64 lowercase hex
+/// chars). Beyond rejecting junk, this is a **security gate** for the presign
+/// path: the hash becomes part of the R2 object key, so anything but `[0-9a-f]`
+/// (e.g. `/` or `..`) could escape the workspace prefix. The bytes are never
+/// re-hashed server-side under direct-to-R2, so the format check is the only
+/// structural guard at mint time.
+fn is_valid_blob_hash(hash: &str) -> bool {
+    hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
 /// Stringified role value used by the permissions layer.
 fn role_str(role: WorkspaceRole) -> &'static str {
     match role {
@@ -110,6 +120,8 @@ pub fn routes() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/api/v1/internal/revoke", post(revoke_handler))
         .route("/api/v1/usage", get(usage_handler))
+        .route("/api/v1/blobs/:hash/upload-url", post(blob_upload_url_handler))
+        .route("/api/v1/blobs/:hash/finalize", post(blob_finalize_handler))
         .route("/api/docs", get(list_docs_handler))
         .route("/api/docs/:id", get(get_doc_handler))
         .route("/api/docs/:id", put(save_doc_handler))
@@ -172,6 +184,25 @@ struct UsageResponse {
     storage_quota: Option<u64>,
     active_editors: u32,
     editor_limit: Option<u32>,
+}
+
+/// Body of `POST /api/v1/blobs/:hash/upload-url`. `size` is the client-asserted
+/// byte length (re-verified authoritatively at finalize via the object HEAD).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UploadUrlRequest {
+    size: u64,
+    #[serde(default)]
+    mime_type: Option<String>,
+}
+
+/// Body of `POST /api/v1/blobs/:hash/finalize`. The size is read from the
+/// object store, not the client, so only the (optional) MIME type is accepted.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct FinalizeRequest {
+    #[serde(default)]
+    mime_type: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -283,6 +314,170 @@ async fn usage_handler(
         }),
     )
         .into_response()
+}
+
+/// `POST /api/v1/blobs/:hash/upload-url` — mint a presigned PUT so the client
+/// uploads blob bytes **directly to object storage**, bypassing the relay.
+///
+/// Short-circuits with `{ "exists": true }` when the workspace already holds
+/// the blob (dedup), refuses oversize (413) and projected over-quota (507)
+/// before minting, and returns 409 `presign_unsupported` on the filesystem
+/// backend (the client then falls back to the proxy `POST /api/blobs/:hash`).
+/// The mint is advisory on size; finalize re-checks the real size.
+async fn blob_upload_url_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(hash): Path<String>,
+    Json(req): Json<UploadUrlRequest>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    if !is_valid_blob_hash(&hash) {
+        return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
+    }
+
+    let s3 = match state.s3_backend() {
+        Some(s3) => s3,
+        None => {
+            return (StatusCode::CONFLICT, ApiError::body("presign_unsupported")).into_response();
+        }
+    };
+
+    // Dedup: the workspace already has this blob → client skips upload+finalize.
+    if state.blob_store().exists(&ws, &hash) {
+        return (StatusCode::OK, Json(json!({ "exists": true }))).into_response();
+    }
+
+    // Per-request size ceiling (mirrors the proxy body limit, JP-125).
+    if req.size > state.max_blob_bytes() as u64 {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            ApiError::body("blob exceeds max size"),
+        )
+            .into_response();
+    }
+
+    // Projected per-workspace quota — re-checked authoritatively at finalize.
+    if let Some(quota) = state.resolve_limits(limits).quota_bytes {
+        let used = state.blob_store().get_workspace_size(&ws);
+        if used.saturating_add(req.size) > quota {
+            return (
+                StatusCode::INSUFFICIENT_STORAGE,
+                ApiError::body("storage quota exceeded"),
+            )
+                .into_response();
+        }
+    }
+
+    let mime = req.mime_type.as_deref().unwrap_or("application/octet-stream");
+    let mint = s3.presign_put(&ws, &hash, mime, req.size);
+    let headers_obj: serde_json::Map<String, Value> = mint
+        .headers
+        .iter()
+        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+        .collect();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "url": mint.url,
+            "headers": headers_obj,
+            "expiresAt": mint.expires_at,
+            "key": mint.key,
+        })),
+    )
+        .into_response()
+}
+
+/// `POST /api/v1/blobs/:hash/finalize` — after a direct presigned PUT, confirm
+/// the object landed, read its **authoritative size** from the store's HEAD,
+/// re-check the workspace quota against that real size (reclaiming + 507 if
+/// over), then record the blob + grant the workspace its ACL. This is the
+/// back half of the proxy upload, split out because the bytes never touch the
+/// relay.
+async fn blob_finalize_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(hash): Path<String>,
+    Json(req): Json<FinalizeRequest>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    if !is_valid_blob_hash(&hash) {
+        return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
+    }
+
+    let s3 = match state.s3_backend() {
+        Some(s3) => s3,
+        None => {
+            return (StatusCode::CONFLICT, ApiError::body("presign_unsupported")).into_response();
+        }
+    };
+
+    // Authoritative size from the object store; absent = the PUT never landed.
+    let size = match s3.head_object(&ws, &hash).await {
+        Ok(Some(size)) => size,
+        Ok(None) => {
+            return (StatusCode::NOT_FOUND, ApiError::body("object_not_uploaded")).into_response();
+        }
+        Err(e) => {
+            log::warn!("finalize HEAD failed for {}/{}: {}", ws.as_str(), hash, e);
+            return (
+                StatusCode::BAD_GATEWAY,
+                ApiError::body("blob store unavailable"),
+            )
+                .into_response();
+        }
+    };
+
+    // Re-run the quota against the *real* size; a new grant that would exceed
+    // it is refused and the just-uploaded object reclaimed (closes the
+    // lie-about-size hole in the advisory mint check). A re-finalize of an
+    // already-granted hash adds 0 (dedup) and skips the check.
+    if !state.blob_store().exists(&ws, &hash) {
+        if let Some(quota) = state.resolve_limits(limits).quota_bytes {
+            let used = state.blob_store().get_workspace_size(&ws);
+            if used.saturating_add(size) > quota {
+                if let Err(e) = s3.delete_object(&ws, &hash).await {
+                    log::warn!(
+                        "failed to reclaim over-quota object {}/{}: {}",
+                        ws.as_str(),
+                        hash,
+                        e
+                    );
+                }
+                return (
+                    StatusCode::INSUFFICIENT_STORAGE,
+                    ApiError::body("storage quota exceeded"),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let mime = req.mime_type.as_deref().unwrap_or("application/octet-stream");
+    match state
+        .blob_store()
+        .record_finalized_blob(&ws, &hash, size, mime, &claims.sub)
+    {
+        Ok(meta) => (
+            StatusCode::OK,
+            Json(json!({ "success": true, "hash": meta.hash, "size": meta.size })),
+        )
+            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
+    }
 }
 
 async fn get_doc_handler(
@@ -599,4 +794,25 @@ async fn require_auth(
         let (status, _) = crate::server::auth_error_to_http(&e);
         (status, ApiError::body(format!("invalid token: {}", e))).into_response()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_hash_validation_accepts_sha256_and_rejects_path_tricks() {
+        // A real lowercase-hex SHA-256 digest passes.
+        let good = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert!(is_valid_blob_hash(good));
+
+        // Anything that could escape the workspace key prefix is rejected.
+        assert!(!is_valid_blob_hash("../../etc/passwd"));
+        assert!(!is_valid_blob_hash("ab/cd/evil"));
+        assert!(!is_valid_blob_hash(&"a".repeat(63))); // too short
+        assert!(!is_valid_blob_hash(&"a".repeat(65))); // too long
+        assert!(!is_valid_blob_hash(&"A".repeat(64))); // uppercase not allowed
+        assert!(!is_valid_blob_hash(&"g".repeat(64))); // non-hex
+        assert!(!is_valid_blob_hash("")); // empty
+    }
 }

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -56,6 +56,13 @@ pub const DEFAULT_MAX_WS_PAYLOAD_BYTES: usize = 262_144; // 256 KiB
 /// Axum's 2 MiB default silently 413s larger blobs (JP-125).
 pub const DEFAULT_MAX_BLOB_BYTES: usize = 157_286_400; // 150 MiB
 
+/// Default presigned PUT URL lifetime when `backend = "s3"`. Generous so a
+/// slow large upload can finish inside the window; the content-length pinned
+/// into the signature keeps a long TTL safe.
+pub const DEFAULT_S3_PUT_TTL_SECS: u64 = 3600; // 1h
+/// Default presigned GET URL lifetime when `backend = "s3"`.
+pub const DEFAULT_S3_GET_TTL_SECS: u64 = 3600; // 1h
+
 // ---- JP-81: single-meter free-tier enforcement fallbacks ----
 //
 // These are the *fallback* limits applied when a JWT `wsp[]` claim omits
@@ -119,11 +126,20 @@ impl Default for ServerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
-    /// Storage backend identifier. Currently only `"filesystem"` is
-    /// supported. Postgres / S3 are explicit non-goals for Phase 20.
+    /// Blob byte-storage backend: `"filesystem"` (default — local sharded
+    /// files; the zero-dependency self-host + dev + test path) or `"s3"` (any
+    /// S3-compatible object store, e.g. Cloudflare R2; configured via [`s3`]).
+    /// Document/CRDT state always lives under `path`; only blob *bytes* follow
+    /// this selector.
+    ///
+    /// [`s3`]: StorageConfig::s3
     pub backend: String,
     /// Path to the storage root (documents, blobs, users.json).
     pub path: PathBuf,
+    /// S3/R2 connection details. Required when `backend = "s3"`, ignored for
+    /// `filesystem`. From `[storage.s3]` in TOML or the `RELAY_R2_*` env vars.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s3: Option<S3StorageConfig>,
 }
 
 impl Default for StorageConfig {
@@ -131,7 +147,56 @@ impl Default for StorageConfig {
         Self {
             backend: "filesystem".into(),
             path: PathBuf::from(DEFAULT_DATA_DIR),
+            s3: None,
         }
+    }
+}
+
+/// Connection + credentials for an S3-compatible blob byte store (Cloudflare
+/// R2 at Cloud; any S3 API for self-host). Mapped onto the runtime
+/// `server::blob_backend::S3Config` at startup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct S3StorageConfig {
+    /// Endpoint base URL (e.g. `https://<acct>.r2.cloudflarestorage.com`).
+    pub endpoint: String,
+    /// Bucket name (path-style addressing — robust against a custom endpoint).
+    pub bucket: String,
+    /// Signing region. `"auto"` for Cloudflare R2.
+    pub region: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// Optional key prefix (e.g. `"blobs/"`); empty for none.
+    pub key_prefix: String,
+    /// Presigned PUT URL lifetime (seconds).
+    pub put_ttl_secs: u64,
+    /// Presigned GET URL lifetime (seconds).
+    pub get_ttl_secs: u64,
+}
+
+impl Default for S3StorageConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: String::new(),
+            bucket: String::new(),
+            region: "auto".into(),
+            access_key_id: String::new(),
+            secret_access_key: String::new(),
+            key_prefix: String::new(),
+            put_ttl_secs: DEFAULT_S3_PUT_TTL_SECS,
+            get_ttl_secs: DEFAULT_S3_GET_TTL_SECS,
+        }
+    }
+}
+
+impl S3StorageConfig {
+    /// Whether the four required connection fields are all set — the gate for
+    /// auto-selecting `backend = "s3"` and for a usable backend at startup.
+    pub fn is_complete(&self) -> bool {
+        !self.endpoint.is_empty()
+            && !self.bucket.is_empty()
+            && !self.access_key_id.is_empty()
+            && !self.secret_access_key.is_empty()
     }
 }
 
@@ -453,6 +518,68 @@ impl RelayConfig {
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_BLOB_GC_GRACE_SECS must be a u64 (got {v:?})"))?;
         }
+
+        // Blob byte-storage backend selection + S3/R2 credentials. Any
+        // `RELAY_R2_*` var materializes `[storage.s3]`; a *complete* set
+        // auto-selects `backend = "s3"` unless the operator pinned
+        // `RELAY_STORAGE_BACKEND` (which always wins).
+        let backend_pinned = get("RELAY_STORAGE_BACKEND").is_some();
+        if let Some(v) = get("RELAY_STORAGE_BACKEND") {
+            match v.as_str() {
+                "filesystem" | "s3" => self.storage.backend = v,
+                other => anyhow::bail!(
+                    "RELAY_STORAGE_BACKEND must be 'filesystem' or 's3' (got {other:?})"
+                ),
+            }
+        }
+        let r2_vars = [
+            "RELAY_R2_ENDPOINT",
+            "RELAY_R2_BUCKET",
+            "RELAY_R2_REGION",
+            "RELAY_R2_ACCESS_KEY_ID",
+            "RELAY_R2_SECRET_ACCESS_KEY",
+            "RELAY_R2_KEY_PREFIX",
+            "RELAY_R2_PUT_TTL_SECS",
+            "RELAY_R2_GET_TTL_SECS",
+        ];
+        if r2_vars.iter().any(|k| get(k).is_some()) {
+            let s3 = self.storage.s3.get_or_insert_with(S3StorageConfig::default);
+            if let Some(v) = get("RELAY_R2_ENDPOINT") {
+                s3.endpoint = v;
+            }
+            if let Some(v) = get("RELAY_R2_BUCKET") {
+                s3.bucket = v;
+            }
+            if let Some(v) = get("RELAY_R2_REGION") {
+                s3.region = v;
+            }
+            if let Some(v) = get("RELAY_R2_ACCESS_KEY_ID") {
+                s3.access_key_id = v;
+            }
+            if let Some(v) = get("RELAY_R2_SECRET_ACCESS_KEY") {
+                s3.secret_access_key = v;
+            }
+            if let Some(v) = get("RELAY_R2_KEY_PREFIX") {
+                s3.key_prefix = v;
+            }
+            if let Some(v) = get("RELAY_R2_PUT_TTL_SECS") {
+                s3.put_ttl_secs = v.parse().map_err(|_| {
+                    anyhow::anyhow!("RELAY_R2_PUT_TTL_SECS must be a u64 (got {v:?})")
+                })?;
+            }
+            if let Some(v) = get("RELAY_R2_GET_TTL_SECS") {
+                s3.get_ttl_secs = v.parse().map_err(|_| {
+                    anyhow::anyhow!("RELAY_R2_GET_TTL_SECS must be a u64 (got {v:?})")
+                })?;
+            }
+        }
+        if !backend_pinned {
+            if let Some(s3) = &self.storage.s3 {
+                if s3.is_complete() {
+                    self.storage.backend = "s3".into();
+                }
+            }
+        }
         Ok(())
     }
 
@@ -588,6 +715,67 @@ mod tests {
             .is_err());
         assert!(cfg
             .apply_env_overrides(env_getter(&[("RELAY_NETWORK_MODE", "wan")]))
+            .is_err());
+    }
+
+    #[test]
+    fn env_overlay_r2_credentials_auto_select_s3_backend() {
+        let mut cfg = RelayConfig::default();
+        assert_eq!(cfg.storage.backend, "filesystem");
+        cfg.apply_env_overrides(env_getter(&[
+            ("RELAY_R2_ENDPOINT", "https://acct.r2.cloudflarestorage.com"),
+            ("RELAY_R2_BUCKET", "docushark-blobs"),
+            ("RELAY_R2_ACCESS_KEY_ID", "AKID"),
+            ("RELAY_R2_SECRET_ACCESS_KEY", "secret"),
+            ("RELAY_R2_KEY_PREFIX", "blobs/"),
+        ]))
+        .expect("overlay applies");
+        // A complete R2 credential set auto-selects the s3 backend.
+        assert_eq!(cfg.storage.backend, "s3");
+        let s3 = cfg.storage.s3.expect("s3 block materialized");
+        assert_eq!(s3.endpoint, "https://acct.r2.cloudflarestorage.com");
+        assert_eq!(s3.bucket, "docushark-blobs");
+        assert_eq!(s3.key_prefix, "blobs/");
+        assert_eq!(s3.region, "auto"); // default when unset
+        assert!(s3.is_complete());
+    }
+
+    #[test]
+    fn env_overlay_explicit_backend_pin_overrides_auto_select() {
+        let mut cfg = RelayConfig::default();
+        cfg.apply_env_overrides(env_getter(&[
+            ("RELAY_STORAGE_BACKEND", "filesystem"),
+            ("RELAY_R2_ENDPOINT", "https://acct.r2.cloudflarestorage.com"),
+            ("RELAY_R2_BUCKET", "docushark-blobs"),
+            ("RELAY_R2_ACCESS_KEY_ID", "AKID"),
+            ("RELAY_R2_SECRET_ACCESS_KEY", "secret"),
+        ]))
+        .expect("overlay applies");
+        // Operator pinned filesystem → no auto-switch, but the s3 block is
+        // still parsed (and stays available if they flip the backend later).
+        assert_eq!(cfg.storage.backend, "filesystem");
+        assert!(cfg.storage.s3.expect("s3 parsed").is_complete());
+    }
+
+    #[test]
+    fn env_overlay_partial_r2_does_not_select_s3() {
+        let mut cfg = RelayConfig::default();
+        cfg.apply_env_overrides(env_getter(&[
+            ("RELAY_R2_BUCKET", "docushark-blobs"), // endpoint + creds missing
+        ]))
+        .expect("overlay applies");
+        assert_eq!(cfg.storage.backend, "filesystem");
+        assert!(!cfg.storage.s3.expect("partial s3 parsed").is_complete());
+    }
+
+    #[test]
+    fn env_overlay_rejects_bad_r2_backend_and_ttl() {
+        let mut cfg = RelayConfig::default();
+        assert!(cfg
+            .apply_env_overrides(env_getter(&[("RELAY_STORAGE_BACKEND", "postgres")]))
+            .is_err());
+        assert!(cfg
+            .apply_env_overrides(env_getter(&[("RELAY_R2_PUT_TTL_SECS", "soon")]))
             .is_err());
     }
 

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -229,6 +229,7 @@ async fn run_serve(
 
     let server = Arc::new(WebSocketServer::new());
     server.set_app_data_dir(config.storage.path.clone()).await;
+    server.set_storage(config.storage.clone()).await;
     server.set_auth(auth.clone()).await;
     server
         .set_revocation_push_bearer(config.auth.revocation_push_bearer.clone())

--- a/relay/src/server/blob_backend/filesystem.rs
+++ b/relay/src/server/blob_backend/filesystem.rs
@@ -1,0 +1,123 @@
+//! Local-filesystem blob byte storage with two-level hash-prefix sharding.
+//!
+//! Layout (unchanged from the original in-`BlobStore` implementation):
+//! ```text
+//! <blobs_dir>/ab/cd/abcd1234...   # full SHA-256 hash as the filename
+//! ```
+//!
+//! Sharding by the first two hash-byte pairs keeps any one directory from
+//! accumulating an unbounded number of entries.
+
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+/// Content-addressed blob bytes on the local filesystem. The path is derived
+/// purely from the content hash, so identical bytes are stored once and shared
+/// across workspaces; the owning [`BlobStore`](crate::server::blobs::BlobStore)
+/// enforces per-workspace access through its ACL set.
+pub struct FilesystemBackend {
+    blobs_dir: PathBuf,
+}
+
+impl FilesystemBackend {
+    /// Create the backend, ensuring `blobs_dir` exists.
+    pub fn new(blobs_dir: PathBuf) -> Self {
+        let _ = std::fs::create_dir_all(&blobs_dir);
+        Self { blobs_dir }
+    }
+
+    /// Two-level sharded path `<dir>/<h[0..2]>/<h[2..4]>/<hash>`. Hashes shorter
+    /// than four chars (never produced by SHA-256) fall back to a flat path so
+    /// the function is total.
+    fn blob_path(&self, hash: &str) -> PathBuf {
+        if hash.len() < 4 {
+            return self.blobs_dir.join(hash);
+        }
+        self.blobs_dir.join(&hash[0..2]).join(&hash[2..4]).join(hash)
+    }
+
+    /// Whether the bytes for `hash` are present on disk.
+    pub fn has_bytes(&self, hash: &str) -> bool {
+        self.blob_path(hash).exists()
+    }
+
+    /// Write `data` to the sharded path, creating the shard directories.
+    pub fn put_bytes(&self, hash: &str, data: &[u8]) -> io::Result<()> {
+        let path = self.blob_path(hash);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, data)
+    }
+
+    /// Read the bytes for `hash`. A missing file surfaces as
+    /// [`io::ErrorKind::NotFound`] (the natural error from `File::open`).
+    pub fn get_bytes(&self, hash: &str) -> io::Result<Vec<u8>> {
+        let mut file = std::fs::File::open(self.blob_path(hash))?;
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)?;
+        Ok(data)
+    }
+
+    /// Remove the bytes and tidy now-empty shard directories. Returns whether
+    /// the file was present; a missing file is a no-op success so reclaim is
+    /// idempotent.
+    pub fn delete_bytes(&self, hash: &str) -> io::Result<bool> {
+        let path = self.blob_path(hash);
+        if !path.exists() {
+            return Ok(false);
+        }
+        std::fs::remove_file(&path)?;
+        // Best-effort cleanup of the two shard levels; non-empty dirs are left
+        // in place (the errors are intentionally ignored).
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir(parent);
+            if let Some(grandparent) = parent.parent() {
+                let _ = std::fs::remove_dir(grandparent);
+            }
+        }
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sharded_path_uses_two_levels() {
+        let dir = tempdir().unwrap();
+        let backend = FilesystemBackend::new(dir.path().join("blobs"));
+        let hash = "abcd1234567890abcd1234567890abcd1234567890abcd1234567890abcd1234";
+        let path = backend.blob_path(hash);
+        assert!(path.to_string_lossy().contains("ab"));
+        assert!(path.to_string_lossy().contains("cd"));
+        assert!(path.to_string_lossy().ends_with(hash));
+    }
+
+    #[test]
+    fn put_get_delete_roundtrip() {
+        let dir = tempdir().unwrap();
+        let backend = FilesystemBackend::new(dir.path().join("blobs"));
+        let hash = "abcd1234";
+
+        assert!(!backend.has_bytes(hash));
+        backend.put_bytes(hash, b"hello").unwrap();
+        assert!(backend.has_bytes(hash));
+        assert_eq!(backend.get_bytes(hash).unwrap(), b"hello");
+
+        assert!(backend.delete_bytes(hash).unwrap());
+        assert!(!backend.has_bytes(hash));
+        // A second delete is a no-op success.
+        assert!(!backend.delete_bytes(hash).unwrap());
+    }
+
+    #[test]
+    fn missing_bytes_surface_as_not_found() {
+        let dir = tempdir().unwrap();
+        let backend = FilesystemBackend::new(dir.path().join("blobs"));
+        let err = backend.get_bytes("deadbeef").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/relay/src/server/blob_backend/mod.rs
+++ b/relay/src/server/blob_backend/mod.rs
@@ -12,9 +12,6 @@
 //! stays the zero-dependency default for self-host, local dev, and tests.
 
 mod filesystem;
-// The S3 surface (presign / HEAD / DELETE / proxy) is consumed by the blob
-// handlers + GC across Slices 3–5; allow the not-yet-wired methods until then.
-#[allow(dead_code)]
 mod s3;
 
 pub use filesystem::FilesystemBackend;

--- a/relay/src/server/blob_backend/mod.rs
+++ b/relay/src/server/blob_backend/mod.rs
@@ -1,0 +1,73 @@
+//! Pluggable byte storage for [`BlobStore`](super::blobs::BlobStore).
+//!
+//! `BlobStore` owns all blob *bookkeeping* — the content index, the
+//! per-`(workspace, hash)` ACL set, the per-document reference map, and the
+//! orphan-GC machinery — plus the JSON sidecars that persist them. This module
+//! owns only the *bytes*: where a blob's content is physically stored and how
+//! it's written, read, and removed.
+//!
+//! Splitting the two lets the bytes move to object storage (S3 / Cloudflare R2)
+//! without disturbing the bookkeeping above it. Today the only backend is the
+//! local filesystem — the historical behavior, byte-for-byte unchanged — which
+//! stays the zero-dependency default for self-host, local dev, and tests.
+
+mod filesystem;
+// The S3 surface (presign / HEAD / DELETE / proxy) is consumed by the blob
+// handlers + GC across Slices 3–5; allow the not-yet-wired methods until then.
+#[allow(dead_code)]
+mod s3;
+
+pub use filesystem::FilesystemBackend;
+pub use s3::{S3Backend, S3Config};
+
+use std::io;
+use std::path::PathBuf;
+
+/// Physical byte storage for content-addressed blobs. Selected once at startup
+/// from the `[storage]` config; the index/ACL/reference bookkeeping in
+/// [`BlobStore`](super::blobs::BlobStore) is backend-agnostic.
+pub enum BlobBackend {
+    /// Local filesystem with two-level hash-prefix sharding. Bytes are
+    /// content-addressed and deduplicated globally across workspaces.
+    Filesystem(FilesystemBackend),
+}
+
+impl BlobBackend {
+    /// Build a filesystem backend rooted at `blobs_dir`, creating it if absent.
+    pub fn filesystem(blobs_dir: PathBuf) -> Self {
+        BlobBackend::Filesystem(FilesystemBackend::new(blobs_dir))
+    }
+
+    /// True if the blob's bytes are already stored. Content-addressed, so the
+    /// filesystem backend dedups identical bytes across every workspace.
+    pub fn has_bytes(&self, hash: &str) -> bool {
+        match self {
+            BlobBackend::Filesystem(fs) => fs.has_bytes(hash),
+        }
+    }
+
+    /// Write the blob's bytes. The caller guarantees `data` hashes to `hash`
+    /// and only calls this when [`Self::has_bytes`] returned false.
+    pub fn put_bytes(&self, hash: &str, data: &[u8]) -> io::Result<()> {
+        match self {
+            BlobBackend::Filesystem(fs) => fs.put_bytes(hash, data),
+        }
+    }
+
+    /// Read the blob's bytes. Absent bytes surface as
+    /// [`io::ErrorKind::NotFound`] so callers can map them to a 404 distinctly
+    /// from a genuine IO failure.
+    pub fn get_bytes(&self, hash: &str) -> io::Result<Vec<u8>> {
+        match self {
+            BlobBackend::Filesystem(fs) => fs.get_bytes(hash),
+        }
+    }
+
+    /// Remove the blob's bytes, returning whether any were present. A missing
+    /// object is a no-op success — reclaim is idempotent.
+    pub fn delete_bytes(&self, hash: &str) -> io::Result<bool> {
+        match self {
+            BlobBackend::Filesystem(fs) => fs.delete_bytes(hash),
+        }
+    }
+}

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -545,6 +545,76 @@ mod tests {
         assert_eq!(key, format!("p/ws/{}/ab/cd/abcd1234ef", ws.as_str()));
     }
 
+    /// Build a backend from `RELAY_TEST_S3_*` env, or `None` to skip. Lets the
+    /// roundtrip below run against MinIO / real R2 in CI or locally without
+    /// hard-failing a plain `cargo test`.
+    fn test_backend_from_env() -> Option<S3Backend> {
+        let endpoint = std::env::var("RELAY_TEST_S3_ENDPOINT").ok()?;
+        Some(S3Backend::new(S3Config {
+            endpoint,
+            bucket: std::env::var("RELAY_TEST_S3_BUCKET").unwrap_or_else(|_| "dsk-blobs-test".into()),
+            region: std::env::var("RELAY_TEST_S3_REGION").unwrap_or_else(|_| "us-east-1".into()),
+            access_key_id: std::env::var("RELAY_TEST_S3_ACCESS_KEY_ID").ok()?,
+            secret_access_key: std::env::var("RELAY_TEST_S3_SECRET_ACCESS_KEY").ok()?,
+            key_prefix: String::new(),
+            put_ttl_secs: 900,
+            get_ttl_secs: 900,
+        }))
+    }
+
+    /// End-to-end against a real S3 server (MinIO or R2): presigned PUT (client
+    /// upload) → HEAD → presigned GET (client download) → proxy PUT/GET →
+    /// DELETE. Skipped unless `RELAY_TEST_S3_*` is set. This is what proves the
+    /// SigV4 signer + wire actually validate against a live S3 implementation,
+    /// beyond the offline AWS vector above.
+    #[tokio::test]
+    async fn s3_presigned_roundtrip_against_live_endpoint() {
+        let Some(backend) = test_backend_from_env() else {
+            eprintln!("skipping s3 roundtrip: RELAY_TEST_S3_ENDPOINT unset");
+            return;
+        };
+        let ws = WorkspaceId::single_tenant();
+        let hash = "a".repeat(64);
+        let body = b"hello R2 presigned world".to_vec();
+        let http = reqwest::Client::new();
+
+        // 1. Mint a presigned PUT and upload directly, echoing the signed headers.
+        let mint = backend.presign_put(&ws, &hash, "text/plain", body.len() as u64);
+        let mut put = http.put(&mint.url).body(body.clone());
+        for (k, v) in &mint.headers {
+            put = put.header(k, v);
+        }
+        let status = put.send().await.unwrap().status();
+        assert!(status.is_success(), "presigned PUT failed: {status}");
+
+        // 2. HEAD returns the authoritative size (what finalize reads).
+        assert_eq!(
+            backend.head_object(&ws, &hash).await.unwrap(),
+            Some(body.len() as u64)
+        );
+
+        // 3. Mint a presigned GET and download directly — bytes round-trip.
+        let get_url = backend.presign_get(&ws, &hash);
+        let got = http.get(&get_url).send().await.unwrap();
+        assert!(got.status().is_success(), "presigned GET failed");
+        assert_eq!(got.bytes().await.unwrap().as_ref(), body.as_slice());
+
+        // 4. Proxy PUT/GET fallback also works against the same key.
+        backend.delete_object(&ws, &hash).await.unwrap();
+        backend
+            .put_object(&ws, &hash, body.clone(), "text/plain")
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.get_object(&ws, &hash).await.unwrap().as_deref(),
+            Some(body.as_slice())
+        );
+
+        // 5. DELETE reclaims the object; HEAD then reports absent.
+        backend.delete_object(&ws, &hash).await.unwrap();
+        assert_eq!(backend.head_object(&ws, &hash).await.unwrap(), None);
+    }
+
     #[test]
     fn presign_put_pins_content_type_and_length() {
         let backend = S3Backend::new(S3Config {

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -1,0 +1,576 @@
+//! S3 / Cloudflare R2 blob byte storage.
+//!
+//! The relay needs only a thin slice of the S3 API: **presigned PUT/GET URLs**
+//! so clients transfer blob bytes directly to/from R2 (never through the
+//! relay), plus server-side **HEAD** (confirm an upload landed + read its real
+//! size at finalize) and **DELETE** (reclaim GC'd bytes). That's a small,
+//! fully-specified SigV4 surface — implemented here over the `reqwest` client
+//! the relay already ships, deliberately *not* pulling in the `aws-sdk-s3`
+//! dependency tree (keeps the relay's low MSRV + a lean build; see the module
+//! comment in `Cargo.toml`).
+//!
+//! Object keys are **per-workspace**: `{prefix}ws/{workspace}/{ab}/{cd}/{hash}`.
+//! Scoping the key to the workspace makes tenant isolation a property of the
+//! storage layout itself — a presigned URL can only ever address one tenant's
+//! prefix — at the cost of cross-workspace byte dedup, consistent with the
+//! relay's existing full-size-per-grant metering.
+
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+use crate::server::protocol::WorkspaceId;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+const AWS4_REQUEST: &str = "aws4_request";
+const SERVICE: &str = "s3";
+const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
+/// SHA-256 of the empty string — the payload hash for body-less requests.
+const EMPTY_SHA256: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+/// Connection + credential parameters for the S3/R2 byte store.
+#[derive(Debug, Clone)]
+pub struct S3Config {
+    /// Base endpoint, e.g. `https://<acct>.r2.cloudflarestorage.com`. No
+    /// trailing slash (normalized on construction).
+    pub endpoint: String,
+    /// Bucket name (path-style addressing — the bucket is the first path
+    /// segment, which is the robust choice against a custom R2 endpoint).
+    pub bucket: String,
+    /// Signing region. `"auto"` for Cloudflare R2.
+    pub region: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// Optional key prefix (e.g. `"blobs/"`); empty for none. Always ends with
+    /// `/` when non-empty (normalized on construction).
+    pub key_prefix: String,
+    /// Presigned PUT URL lifetime. Generous by default — a slow large upload
+    /// must finish inside it; the content-length pin keeps a long TTL safe.
+    pub put_ttl_secs: u64,
+    /// Presigned GET URL lifetime.
+    pub get_ttl_secs: u64,
+}
+
+/// A minted presigned upload: the URL the client PUTs to, the headers it must
+/// echo for the signature to validate, the object key, and when the URL lapses.
+#[derive(Debug, Clone)]
+pub struct PresignedUpload {
+    pub url: String,
+    /// Headers the client must send on the PUT (these are signed).
+    pub headers: Vec<(String, String)>,
+    /// The object key the bytes land at (informational for the client/logs).
+    pub key: String,
+    /// Unix-millis expiry of the presigned URL.
+    pub expires_at: u64,
+}
+
+/// S3/R2-backed blob bytes. Holds the credentials + a `reqwest` client and
+/// exposes the presign / HEAD / DELETE / proxy-transfer operations the relay
+/// needs. All object keys are workspace-scoped (see the module docs).
+pub struct S3Backend {
+    config: S3Config,
+    http: reqwest::Client,
+}
+
+impl S3Backend {
+    /// Build the backend, normalizing the endpoint + key prefix.
+    pub fn new(mut config: S3Config) -> Self {
+        config.endpoint = config.endpoint.trim_end_matches('/').to_string();
+        if !config.key_prefix.is_empty() && !config.key_prefix.ends_with('/') {
+            config.key_prefix.push('/');
+        }
+        Self {
+            config,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Workspace-scoped, content-addressed object key
+    /// (`{prefix}ws/{workspace}/{ab}/{cd}/{hash}`). The two-level shard mirrors
+    /// the filesystem backend and keeps any one R2 listing prefix shallow.
+    pub fn object_key(&self, ws: &WorkspaceId, hash: &str) -> String {
+        let (a, b) = if hash.len() >= 4 {
+            (&hash[0..2], &hash[2..4])
+        } else {
+            ("zz", "zz")
+        };
+        format!(
+            "{}ws/{}/{}/{}/{}",
+            self.config.key_prefix,
+            ws.as_str(),
+            a,
+            b,
+            hash
+        )
+    }
+
+    /// Canonical request URI (path-style): `/{bucket}/{uri-encoded-key}`, with
+    /// `/` preserved inside the key. This exact string is both signed and used
+    /// as the request path, so they can never disagree.
+    fn canonical_uri(&self, key: &str) -> String {
+        format!(
+            "/{}/{}",
+            uri_encode(&self.config.bucket, false),
+            uri_encode(key, false)
+        )
+    }
+
+    fn scheme(&self) -> &str {
+        if self.config.endpoint.starts_with("http://") {
+            "http"
+        } else {
+            "https"
+        }
+    }
+
+    /// Host (with port if non-default) — must match what `reqwest` sends as the
+    /// `Host` header, since SigV4 signs it.
+    fn host_header(&self) -> String {
+        self.config
+            .endpoint
+            .strip_prefix("https://")
+            .or_else(|| self.config.endpoint.strip_prefix("http://"))
+            .unwrap_or(&self.config.endpoint)
+            .to_string()
+    }
+
+    /// Mint a presigned PUT URL for a workspace's blob. `content_type` is pinned
+    /// into the signature so the client can't upload a different type than was
+    /// quota-checked; `content_length` is likewise pinned (the finalize HEAD
+    /// re-verifies the real size regardless).
+    pub fn presign_put(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+        content_type: &str,
+        content_length: u64,
+    ) -> PresignedUpload {
+        let now = Utc::now();
+        let key = self.object_key(ws, hash);
+        let signed: Vec<(String, String)> = vec![
+            ("content-type".to_string(), content_type.to_string()),
+            ("content-length".to_string(), content_length.to_string()),
+        ];
+        let url = self.presign("PUT", &key, self.config.put_ttl_secs, &signed, now);
+        let expires_at =
+            now.timestamp_millis().max(0) as u64 + self.config.put_ttl_secs.saturating_mul(1000);
+        PresignedUpload {
+            url,
+            headers: signed,
+            key,
+            expires_at,
+        }
+    }
+
+    /// Mint a presigned GET URL for a workspace's blob (host-only signature; a
+    /// GET has no body or pinned headers).
+    pub fn presign_get(&self, ws: &WorkspaceId, hash: &str) -> String {
+        let key = self.object_key(ws, hash);
+        self.presign("GET", &key, self.config.get_ttl_secs, &[], Utc::now())
+    }
+
+    /// Core SigV4 query-string presigner. `extra_signed` are header
+    /// `(name, value)` pairs the client must echo; `host` is always signed.
+    fn presign(
+        &self,
+        method: &str,
+        key: &str,
+        expires_secs: u64,
+        extra_signed: &[(String, String)],
+        now: DateTime<Utc>,
+    ) -> String {
+        let canonical_uri = self.canonical_uri(key);
+        presign_url_at(
+            self.scheme(),
+            &self.host_header(),
+            &canonical_uri,
+            &self.config.region,
+            &self.config.access_key_id,
+            &self.config.secret_access_key,
+            method,
+            expires_secs,
+            extra_signed,
+            now,
+        )
+    }
+
+    /// HEAD the object: `Ok(Some(size))` if present, `Ok(None)` on 404,
+    /// `Err` on any other failure. Used by finalize to read the authoritative
+    /// size after a direct client upload.
+    pub async fn head_object(&self, ws: &WorkspaceId, hash: &str) -> Result<Option<u64>, String> {
+        let key = self.object_key(ws, hash);
+        let resp = self
+            .send_signed("HEAD", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
+            .await?;
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            return Err(format!("R2 HEAD {} -> {}", key, resp.status()));
+        }
+        let size = resp
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok());
+        match size {
+            Some(s) => Ok(Some(s)),
+            None => Err(format!("R2 HEAD {} missing content-length", key)),
+        }
+    }
+
+    /// DELETE the object. A 404 is treated as success (idempotent reclaim).
+    pub async fn delete_object(&self, ws: &WorkspaceId, hash: &str) -> Result<(), String> {
+        let key = self.object_key(ws, hash);
+        let resp = self
+            .send_signed("DELETE", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
+            .await?;
+        let code = resp.status().as_u16();
+        if resp.status().is_success() || code == 404 {
+            Ok(())
+        } else {
+            Err(format!("R2 DELETE {} -> {}", key, resp.status()))
+        }
+    }
+
+    /// Proxy upload: PUT bytes through the relay to R2 (the fallback path for
+    /// clients that can't reach R2 directly). The hot path is the presigned
+    /// direct PUT; this exists so a CORS/egress issue degrades instead of fails.
+    pub async fn put_object(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+        data: Vec<u8>,
+        content_type: &str,
+    ) -> Result<(), String> {
+        let key = self.object_key(ws, hash);
+        let payload_hash = hex::encode(Sha256::digest(&data));
+        let resp = self
+            .send_signed(
+                "PUT",
+                &key,
+                reqwest::Body::from(data),
+                &payload_hash,
+                &[("content-type".to_string(), content_type.to_string())],
+            )
+            .await?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(format!("R2 PUT {} -> {}", key, resp.status()))
+        }
+    }
+
+    /// Proxy download: GET bytes from R2 through the relay (download fallback).
+    pub async fn get_object(&self, ws: &WorkspaceId, hash: &str) -> Result<Option<Vec<u8>>, String> {
+        let key = self.object_key(ws, hash);
+        let resp = self
+            .send_signed("GET", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
+            .await?;
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            return Err(format!("R2 GET {} -> {}", key, resp.status()));
+        }
+        resp.bytes()
+            .await
+            .map(|b| Some(b.to_vec()))
+            .map_err(|e| format!("R2 GET {} body: {}", key, e))
+    }
+
+    /// Issue a SigV4 header-authenticated request to R2. `extra_headers` are
+    /// signed alongside `host`/`x-amz-date`/`x-amz-content-sha256`.
+    async fn send_signed(
+        &self,
+        method: &str,
+        key: &str,
+        body: reqwest::Body,
+        payload_hash: &str,
+        extra_headers: &[(String, String)],
+    ) -> Result<reqwest::Response, String> {
+        let canonical_uri = self.canonical_uri(key);
+        let url = format!("{}://{}{}", self.scheme(), self.host_header(), canonical_uri);
+        let signed = sign_headers_at(
+            &self.host_header(),
+            &canonical_uri,
+            &self.config.region,
+            &self.config.access_key_id,
+            &self.config.secret_access_key,
+            method,
+            payload_hash,
+            extra_headers,
+            Utc::now(),
+        );
+
+        let m = reqwest::Method::from_bytes(method.as_bytes())
+            .map_err(|e| format!("bad method {}: {}", method, e))?;
+        let mut req = self.http.request(m, &url).body(body);
+        for (k, v) in signed {
+            req = req.header(k, v);
+        }
+        req.send().await.map_err(|e| format!("R2 {} {}: {}", method, key, e))
+    }
+}
+
+/// RFC3986 URI-encode per AWS SigV4. Unreserved chars pass through; `/` is kept
+/// only when `encode_slash` is false (path segments preserve their slashes).
+fn uri_encode(input: &str, encode_slash: bool) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &b in input.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            b'/' if !encode_slash => out.push('/'),
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    hex::encode(Sha256::digest(data))
+}
+
+fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Derive the SigV4 signing key: `HMAC` chained over date → region → service →
+/// `aws4_request`, seeded with `"AWS4"+secret`.
+fn signing_key(secret: &str, datestamp: &str, region: &str) -> Vec<u8> {
+    let k_date = hmac(format!("AWS4{}", secret).as_bytes(), datestamp.as_bytes());
+    let k_region = hmac(&k_date, region.as_bytes());
+    let k_service = hmac(&k_region, SERVICE.as_bytes());
+    hmac(&k_service, AWS4_REQUEST.as_bytes())
+}
+
+/// Build the sorted canonical-headers block + the `;`-joined signed-headers
+/// list from `(name, value)` pairs (names lowercased, values trimmed).
+fn canonical_headers(pairs: &[(String, String)]) -> (String, String) {
+    let mut hs: Vec<(String, String)> = pairs
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.trim().to_string()))
+        .collect();
+    hs.sort_by(|a, b| a.0.cmp(&b.0));
+    let signed = hs.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>().join(";");
+    let canonical = hs.iter().map(|(k, v)| format!("{}:{}\n", k, v)).collect::<String>();
+    (canonical, signed)
+}
+
+/// SigV4 query-string presign with an injectable clock (the `_at` suffix marks
+/// the testable seam; the public callers pass `Utc::now()`).
+#[allow(clippy::too_many_arguments)]
+fn presign_url_at(
+    scheme: &str,
+    host: &str,
+    canonical_uri: &str,
+    region: &str,
+    access_key: &str,
+    secret: &str,
+    method: &str,
+    expires_secs: u64,
+    extra_signed: &[(String, String)],
+    now: DateTime<Utc>,
+) -> String {
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let datestamp = now.format("%Y%m%d").to_string();
+    let credential_scope = format!("{}/{}/{}/{}", datestamp, region, SERVICE, AWS4_REQUEST);
+
+    let mut header_pairs = vec![("host".to_string(), host.to_string())];
+    header_pairs.extend(extra_signed.iter().cloned());
+    let (canonical_header_block, signed_headers) = canonical_headers(&header_pairs);
+
+    // Canonical query string: the X-Amz-* params, sorted by key, URI-encoded.
+    let credential = format!("{}/{}", access_key, credential_scope);
+    let mut query = [
+        ("X-Amz-Algorithm".to_string(), ALGORITHM.to_string()),
+        ("X-Amz-Credential".to_string(), credential),
+        ("X-Amz-Date".to_string(), amz_date.clone()),
+        ("X-Amz-Expires".to_string(), expires_secs.to_string()),
+        ("X-Amz-SignedHeaders".to_string(), signed_headers.clone()),
+    ];
+    query.sort_by(|a, b| a.0.cmp(&b.0));
+    let canonical_query = query
+        .iter()
+        .map(|(k, v)| format!("{}={}", uri_encode(k, true), uri_encode(v, true)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method, canonical_uri, canonical_query, canonical_header_block, signed_headers, UNSIGNED_PAYLOAD
+    );
+    let string_to_sign = format!(
+        "{}\n{}\n{}\n{}",
+        ALGORITHM,
+        amz_date,
+        credential_scope,
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let signature = hex::encode(hmac(
+        &signing_key(secret, &datestamp, region),
+        string_to_sign.as_bytes(),
+    ));
+
+    format!(
+        "{}://{}{}?{}&X-Amz-Signature={}",
+        scheme, host, canonical_uri, canonical_query, signature
+    )
+}
+
+/// SigV4 header-authentication. Returns the headers to attach to the request
+/// (`Authorization`, `x-amz-date`, `x-amz-content-sha256`, plus any extras).
+#[allow(clippy::too_many_arguments)]
+fn sign_headers_at(
+    host: &str,
+    canonical_uri: &str,
+    region: &str,
+    access_key: &str,
+    secret: &str,
+    method: &str,
+    payload_hash: &str,
+    extra_headers: &[(String, String)],
+    now: DateTime<Utc>,
+) -> Vec<(String, String)> {
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let datestamp = now.format("%Y%m%d").to_string();
+    let credential_scope = format!("{}/{}/{}/{}", datestamp, region, SERVICE, AWS4_REQUEST);
+
+    let mut header_pairs = vec![
+        ("host".to_string(), host.to_string()),
+        ("x-amz-content-sha256".to_string(), payload_hash.to_string()),
+        ("x-amz-date".to_string(), amz_date.clone()),
+    ];
+    header_pairs.extend(extra_headers.iter().cloned());
+    let (canonical_header_block, signed_headers) = canonical_headers(&header_pairs);
+
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        method, canonical_uri, "", canonical_header_block, signed_headers, payload_hash
+    );
+    let string_to_sign = format!(
+        "{}\n{}\n{}\n{}",
+        ALGORITHM,
+        amz_date,
+        credential_scope,
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let signature = hex::encode(hmac(
+        &signing_key(secret, &datestamp, region),
+        string_to_sign.as_bytes(),
+    ));
+
+    let authorization = format!(
+        "{} Credential={}/{}, SignedHeaders={}, Signature={}",
+        ALGORITHM, access_key, credential_scope, signed_headers, signature
+    );
+
+    let mut out = vec![
+        ("authorization".to_string(), authorization),
+        ("x-amz-date".to_string(), amz_date),
+        ("x-amz-content-sha256".to_string(), payload_hash.to_string()),
+    ];
+    out.extend(extra_headers.iter().cloned());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    // AWS's documented worked example for a presigned S3 GET ("Authenticating
+    // Requests: Using Query Parameters"). Pinning to this fixed vector proves
+    // the whole canonicalize → derive-key → sign pipeline, deterministically
+    // and offline.
+    #[test]
+    fn presign_get_matches_aws_documented_vector() {
+        let now = Utc.with_ymd_and_hms(2013, 5, 24, 0, 0, 0).unwrap();
+        let url = presign_url_at(
+            "https",
+            "examplebucket.s3.amazonaws.com",
+            "/test.txt",
+            "us-east-1",
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "GET",
+            86400,
+            &[],
+            now,
+        );
+        assert!(
+            url.contains(
+                "X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404"
+            ),
+            "presigned URL had wrong signature: {url}"
+        );
+        // Sanity-check the surrounding query shape too.
+        assert!(url.contains("X-Amz-Algorithm=AWS4-HMAC-SHA256"));
+        assert!(url.contains(
+            "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request"
+        ));
+        assert!(url.contains("X-Amz-SignedHeaders=host"));
+    }
+
+    #[test]
+    fn uri_encode_preserves_unreserved_and_handles_slash() {
+        assert_eq!(uri_encode("AWS4-HMAC-SHA256", true), "AWS4-HMAC-SHA256");
+        assert_eq!(uri_encode("a/b", false), "a/b");
+        assert_eq!(uri_encode("a/b", true), "a%2Fb");
+        assert_eq!(uri_encode("a b+c", true), "a%20b%2Bc");
+    }
+
+    #[test]
+    fn object_key_is_workspace_scoped_and_sharded() {
+        let backend = S3Backend::new(S3Config {
+            endpoint: "https://acct.r2.cloudflarestorage.com".to_string(),
+            bucket: "blobs".to_string(),
+            region: "auto".to_string(),
+            access_key_id: "k".to_string(),
+            secret_access_key: "s".to_string(),
+            key_prefix: "p".to_string(),
+            put_ttl_secs: 3600,
+            get_ttl_secs: 3600,
+        });
+        let ws = WorkspaceId::single_tenant();
+        let key = backend.object_key(&ws, "abcd1234ef");
+        // Prefix normalized to end with '/', workspace-scoped, two-level shard.
+        assert_eq!(key, format!("p/ws/{}/ab/cd/abcd1234ef", ws.as_str()));
+    }
+
+    #[test]
+    fn presign_put_pins_content_type_and_length() {
+        let backend = S3Backend::new(S3Config {
+            endpoint: "https://acct.r2.cloudflarestorage.com".to_string(),
+            bucket: "blobs".to_string(),
+            region: "auto".to_string(),
+            access_key_id: "AKID".to_string(),
+            secret_access_key: "secret".to_string(),
+            key_prefix: String::new(),
+            put_ttl_secs: 900,
+            get_ttl_secs: 900,
+        });
+        let ws = WorkspaceId::single_tenant();
+        let mint = backend.presign_put(&ws, "deadbeefcafe", "image/png", 1234);
+        // content-type + content-length are signed → SignedHeaders lists both
+        // (plus host), and the client gets them back to echo on the PUT.
+        assert!(mint
+            .url
+            .contains("X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost"));
+        assert!(mint.url.contains("X-Amz-Signature="));
+        assert_eq!(
+            mint.headers,
+            vec![
+                ("content-type".to_string(), "image/png".to_string()),
+                ("content-length".to_string(), "1234".to_string()),
+            ]
+        );
+    }
+}

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -137,23 +137,17 @@ impl S3Backend {
             .to_string()
     }
 
-    /// Mint a presigned PUT URL for a workspace's blob. `content_type` is pinned
-    /// into the signature so the client can't upload a different type than was
-    /// quota-checked; `content_length` is likewise pinned (the finalize HEAD
-    /// re-verifies the real size regardless).
-    pub fn presign_put(
-        &self,
-        ws: &WorkspaceId,
-        hash: &str,
-        content_type: &str,
-        content_length: u64,
-    ) -> PresignedUpload {
+    /// Mint a presigned PUT URL for a workspace's blob. Only `content_type` is
+    /// pinned into the signature. `content-length` is deliberately **not** signed:
+    /// it's a forbidden header in browser `fetch` and is stripped by the Tauri
+    /// http plugin, so signing it would break the signature on those transports.
+    /// The finalize `HEAD` re-reads the authoritative size, so size is still
+    /// enforced (and over-quota objects reclaimed) regardless.
+    pub fn presign_put(&self, ws: &WorkspaceId, hash: &str, content_type: &str) -> PresignedUpload {
         let now = Utc::now();
         let key = self.object_key(ws, hash);
-        let signed: Vec<(String, String)> = vec![
-            ("content-type".to_string(), content_type.to_string()),
-            ("content-length".to_string(), content_length.to_string()),
-        ];
+        let signed: Vec<(String, String)> =
+            vec![("content-type".to_string(), content_type.to_string())];
         let url = self.presign("PUT", &key, self.config.put_ttl_secs, &signed, now);
         let expires_at =
             now.timestamp_millis().max(0) as u64 + self.config.put_ttl_secs.saturating_mul(1000);
@@ -583,7 +577,7 @@ mod tests {
         let http = reqwest::Client::new();
 
         // 1. Mint a presigned PUT and upload directly, echoing the signed headers.
-        let mint = backend.presign_put(&ws, &hash, "text/plain", body.len() as u64);
+        let mint = backend.presign_put(&ws, &hash, "text/plain");
         let mut put = http.put(&mint.url).body(body.clone());
         for (k, v) in &mint.headers {
             put = put.header(k, v);
@@ -620,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn presign_put_pins_content_type_and_length() {
+    fn presign_put_pins_content_type_only() {
         let backend = S3Backend::new(S3Config {
             endpoint: "https://acct.r2.cloudflarestorage.com".to_string(),
             bucket: "blobs".to_string(),
@@ -632,19 +626,14 @@ mod tests {
             get_ttl_secs: 900,
         });
         let ws = WorkspaceId::single_tenant();
-        let mint = backend.presign_put(&ws, "deadbeefcafe", "image/png", 1234);
-        // content-type + content-length are signed → SignedHeaders lists both
-        // (plus host), and the client gets them back to echo on the PUT.
-        assert!(mint
-            .url
-            .contains("X-Amz-SignedHeaders=content-length%3Bcontent-type%3Bhost"));
+        let mint = backend.presign_put(&ws, "deadbeefcafe", "image/png");
+        // Only content-type (+ host) is signed; content-length is omitted because
+        // it's a forbidden header on browser/Tauri transports.
+        assert!(mint.url.contains("X-Amz-SignedHeaders=content-type%3Bhost"));
         assert!(mint.url.contains("X-Amz-Signature="));
         assert_eq!(
             mint.headers,
-            vec![
-                ("content-type".to_string(), "image/png".to_string()),
-                ("content-length".to_string(), "1234".to_string()),
-            ]
+            vec![("content-type".to_string(), "image/png".to_string())]
         );
     }
 }

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -264,7 +264,11 @@ impl S3Backend {
         }
     }
 
-    /// Proxy download: GET bytes from R2 through the relay (download fallback).
+    /// Proxy download: GET bytes from R2 through the relay. Not wired into a
+    /// handler — downloads always 302-redirect straight to a presigned GET — but
+    /// kept (and integration-tested) as the symmetric counterpart to
+    /// `put_object` for any future proxy-download fallback.
+    #[allow(dead_code)]
     pub async fn get_object(&self, ws: &WorkspaceId, hash: &str) -> Result<Option<Vec<u8>>, String> {
         let key = self.object_key(ws, hash);
         let resp = self

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -17,12 +17,13 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
-use std::io::Read;
+use std::io;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::Instant;
 
+use super::blob_backend::BlobBackend;
 use super::protocol::WorkspaceId;
 
 /// Metadata for a stored blob
@@ -101,8 +102,13 @@ impl std::fmt::Display for SaveBlobError {
 
 /// Content-addressed blob storage with per-`(workspace, hash)` ACLs.
 pub struct BlobStore {
-    /// Directory for storing blobs
-    blobs_dir: PathBuf,
+    /// Physical byte storage (filesystem today; object storage in future).
+    /// Owns only the bytes — every map below is backend-agnostic bookkeeping.
+    backend: BlobBackend,
+    /// Directory holding the JSON sidecars (`blob_index.json`,
+    /// `blob_acl.json`, `blob_refs.json`). Stays local regardless of where the
+    /// blob *bytes* live.
+    meta_dir: PathBuf,
     /// In-memory metadata index for fast lookups
     index: RwLock<HashMap<String, BlobMetadata>>,
     /// In-memory ACL set — `(workspace, hash)` is granted access.
@@ -128,17 +134,27 @@ pub struct BlobStore {
 }
 
 impl BlobStore {
-    /// Create a new blob store, backfilling ACLs for any pre-existing
-    /// content-addressed blobs (every legacy blob is granted to the
-    /// single-tenant default workspace — preserves self-host behavior).
+    /// Create a filesystem-backed blob store rooted at `app_data_dir`,
+    /// backfilling ACLs for any pre-existing content-addressed blobs (every
+    /// legacy blob is granted to the single-tenant default workspace —
+    /// preserves self-host behavior).
     pub fn new(app_data_dir: PathBuf) -> Self {
-        let blobs_dir = app_data_dir.join("relay_documents").join("blobs");
+        let meta_dir = app_data_dir.join("relay_documents");
+        let backend = BlobBackend::filesystem(meta_dir.join("blobs"));
+        Self::with_backend(backend, meta_dir)
+    }
 
-        // Ensure blobs directory exists
-        let _ = std::fs::create_dir_all(&blobs_dir);
+    /// Create a blob store over an explicit byte [`BlobBackend`], with the JSON
+    /// sidecars persisted under `meta_dir`. `new` is the filesystem convenience
+    /// wrapper; an object-storage backend is constructed here.
+    pub fn with_backend(backend: BlobBackend, meta_dir: PathBuf) -> Self {
+        // The sidecars live in `meta_dir`; ensure it exists even if the backend
+        // stores its bytes elsewhere (e.g. object storage).
+        let _ = std::fs::create_dir_all(&meta_dir);
 
         let store = Self {
-            blobs_dir: blobs_dir.clone(),
+            backend,
+            meta_dir,
             index: RwLock::new(HashMap::new()),
             acls: RwLock::new(HashSet::new()),
             doc_refs: RwLock::new(HashMap::new()),
@@ -156,37 +172,17 @@ impl BlobStore {
 
     /// Get path to the metadata index file
     fn index_path(&self) -> PathBuf {
-        self.blobs_dir.parent()
-            .map(|p| p.join("blob_index.json"))
-            .unwrap_or_else(|| self.blobs_dir.join("blob_index.json"))
+        self.meta_dir.join("blob_index.json")
     }
 
     /// Path to the per-workspace ACL sidecar.
     fn acl_path(&self) -> PathBuf {
-        self.blobs_dir
-            .parent()
-            .map(|p| p.join("blob_acl.json"))
-            .unwrap_or_else(|| self.blobs_dir.join("blob_acl.json"))
+        self.meta_dir.join("blob_acl.json")
     }
 
     /// Path to the per-document blob-reference sidecar (JP-120).
     fn refs_path(&self) -> PathBuf {
-        self.blobs_dir
-            .parent()
-            .map(|p| p.join("blob_refs.json"))
-            .unwrap_or_else(|| self.blobs_dir.join("blob_refs.json"))
-    }
-
-    /// Get the sharded path for a blob hash
-    /// Uses two-level sharding: first 2 chars / next 2 chars / full hash
-    fn get_blob_path(&self, hash: &str) -> PathBuf {
-        if hash.len() < 4 {
-            // Fallback for short hashes (shouldn't happen with SHA-256)
-            return self.blobs_dir.join(hash);
-        }
-        let level1 = &hash[0..2];
-        let level2 = &hash[2..4];
-        self.blobs_dir.join(level1).join(level2).join(hash)
+        self.meta_dir.join("blob_refs.json")
     }
 
     /// Load the metadata index from disk
@@ -363,7 +359,7 @@ impl BlobStore {
                 return true;
             }
         }
-        self.get_blob_path(hash).exists()
+        self.backend.has_bytes(hash)
     }
 
     /// Get blob metadata for a workspace-scoped read. Returns `None`
@@ -454,19 +450,14 @@ impl BlobStore {
             }
         }
 
-        // If the bytes are already on disk, skip the rewrite — but
+        // If the bytes are already stored, skip the rewrite — but
         // still ensure the requesting workspace has an ACL row.
-        let blob_path = self.get_blob_path(&actual_hash);
-        let bytes_exist = blob_path.exists();
-        if !bytes_exist {
-            if let Some(parent) = blob_path.parent() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| SaveBlobError::Io(format!("Failed to create directories: {}", e)))?;
-            }
-            std::fs::write(&blob_path, data)
+        if !self.backend.has_bytes(&actual_hash) {
+            self.backend
+                .put_bytes(&actual_hash, data)
                 .map_err(|e| SaveBlobError::Io(format!("Failed to write blob: {}", e)))?;
         } else {
-            log::debug!("Blob {} bytes already on disk, deduped", actual_hash);
+            log::debug!("Blob {} bytes already stored, deduped", actual_hash);
         }
 
         let now = std::time::SystemTime::now()
@@ -521,6 +512,70 @@ impl BlobStore {
         Ok(final_meta)
     }
 
+    /// Record a blob whose bytes were uploaded **directly to object storage**
+    /// (the presigned-PUT path) and grant the uploading workspace an ACL.
+    ///
+    /// This is the bookkeeping tail of [`Self::save_blob_with_quota`] without
+    /// the byte write or the hash recompute: with a direct-to-R2 upload the
+    /// relay never sees the bytes, so `size` is the authoritative value the
+    /// caller read from the object store's `HEAD` at finalize (not a
+    /// client-asserted number). Quota is enforced by the finalize handler
+    /// against that real size *before* calling this — a re-record of an
+    /// already-granted hash is a harmless no-op (dedup).
+    pub fn record_finalized_blob(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+        size: u64,
+        mime_type: &str,
+        user_id: &str,
+    ) -> Result<BlobMetadata, String> {
+        // JP-127: a finalize re-references the hash — cancel any deferred GC.
+        self.reclaim_expired_orphans();
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let metadata = BlobMetadata {
+            hash: hash.to_string(),
+            size,
+            mime_type: mime_type.to_string(),
+            created_at: now,
+            uploaded_by: user_id.to_string(),
+        };
+
+        let metadata_changed = {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            let changed = !index.contains_key(hash);
+            index.entry(hash.to_string()).or_insert_with(|| metadata.clone());
+            changed
+        };
+        let acl_changed = {
+            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            acls.insert((ws.clone(), hash.to_string()))
+        };
+        if let Ok(mut orphaned) = self.orphaned_at.write() {
+            orphaned.remove(hash);
+        }
+
+        if metadata_changed {
+            self.save_index()?;
+            log::info!(
+                "Finalized blob: {}/{} ({} bytes, {})",
+                ws.as_str(),
+                hash,
+                size,
+                mime_type
+            );
+        }
+        if acl_changed {
+            self.save_acls()?;
+        }
+
+        Ok(self.get_metadata_unchecked(hash).unwrap_or(metadata))
+    }
+
     /// Load a blob by hash, scoped to the requesting workspace. Returns
     /// `Err("Blob not found: ...")` (404 by convention) for both
     /// genuinely-missing blobs and blobs the workspace lacks an ACL for —
@@ -530,19 +585,15 @@ impl BlobStore {
             return Err(format!("Blob not found: {}", hash));
         }
 
-        let blob_path = self.get_blob_path(hash);
-        if !blob_path.exists() {
-            return Err(format!("Blob not found: {}", hash));
+        match self.backend.get_bytes(hash) {
+            Ok(data) => Ok(data),
+            // Missing bytes get the same opaque 404 wording as a missing ACL;
+            // a genuine IO failure stays distinguishable for a 500.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                Err(format!("Blob not found: {}", hash))
+            }
+            Err(e) => Err(format!("Failed to read blob: {}", e)),
         }
-
-        let mut file = std::fs::File::open(&blob_path)
-            .map_err(|e| format!("Failed to open blob: {}", e))?;
-
-        let mut data = Vec::new();
-        file.read_to_end(&mut data)
-            .map_err(|e| format!("Failed to read blob: {}", e))?;
-
-        Ok(data)
     }
 
     /// Internal: lookup metadata without an ACL check. Reserved for
@@ -554,27 +605,16 @@ impl BlobStore {
 
     /// Delete a blob
     pub fn delete_blob(&self, hash: &str) -> Result<bool, String> {
-        let blob_path = self.get_blob_path(hash);
-
         // Remove from index first
         let existed = {
             let mut index = self.index.write().map_err(|e| e.to_string())?;
             index.remove(hash).is_some()
         };
 
-        // Remove file if it exists
-        if blob_path.exists() {
-            std::fs::remove_file(&blob_path)
-                .map_err(|e| format!("Failed to delete blob file: {}", e))?;
-
-            // Try to clean up empty parent directories
-            if let Some(parent) = blob_path.parent() {
-                let _ = std::fs::remove_dir(parent); // Ignore errors (dir might not be empty)
-                if let Some(grandparent) = parent.parent() {
-                    let _ = std::fs::remove_dir(grandparent);
-                }
-            }
-        }
+        // Remove the bytes (no-op if already gone).
+        self.backend
+            .delete_bytes(hash)
+            .map_err(|e| format!("Failed to delete blob file: {}", e))?;
 
         // Save index
         self.save_index()?;
@@ -1055,6 +1095,57 @@ mod tests {
         assert_eq!(per_ws.get(&beta).copied(), Some(shared.len() as u64));
     }
 
+    // ---- direct-to-R2 finalize: bookkeeping without a local byte write ----
+
+    #[test]
+    fn record_finalized_blob_grants_acl_and_meters_head_size() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        // A hash whose bytes the relay never sees (they went straight to R2).
+        let hash = "a".repeat(64);
+
+        // No local bytes are written — only the index + ACL are recorded, with
+        // the authoritative size the caller read from the object store's HEAD.
+        let meta = store
+            .record_finalized_blob(&ws, &hash, 4096, "image/png", "user-1")
+            .unwrap();
+        assert_eq!(meta.size, 4096);
+        assert_eq!(meta.mime_type, "image/png");
+
+        // Visible to the granting workspace; metered at the HEAD size; counted
+        // in the index — all without any bytes on the local filesystem.
+        assert!(store.exists(&ws, &hash));
+        assert_eq!(store.get_workspace_size(&ws), 4096);
+        assert_eq!(store.get_blob_count(), 1);
+        assert_eq!(store.get_metadata(&ws, &hash).unwrap().size, 4096);
+    }
+
+    #[test]
+    fn record_finalized_blob_is_workspace_scoped_and_dedup_safe() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let alpha = WorkspaceId::from_configured("alpha").unwrap();
+        let beta = WorkspaceId::from_configured("beta").unwrap();
+        let hash = "b".repeat(64);
+
+        store.record_finalized_blob(&alpha, &hash, 100, "application/octet-stream", "a").unwrap();
+        // Beta can't see alpha's blob until it finalizes its own grant.
+        assert!(store.exists(&alpha, &hash));
+        assert!(!store.exists(&beta, &hash));
+
+        store.record_finalized_blob(&beta, &hash, 100, "application/octet-stream", "b").unwrap();
+        assert!(store.exists(&beta, &hash));
+        // One index entry (per-hash metadata), two grants → full-size-per-grant.
+        assert_eq!(store.get_blob_count(), 1);
+        assert_eq!(store.get_workspace_size(&alpha), 100);
+        assert_eq!(store.get_workspace_size(&beta), 100);
+
+        // A re-finalize of an already-granted hash is a no-op (idempotent).
+        store.record_finalized_blob(&alpha, &hash, 100, "application/octet-stream", "a").unwrap();
+        assert_eq!(store.get_workspace_size(&alpha), 100);
+    }
+
     #[test]
     fn test_hash_mismatch() {
         let dir = tempdir().unwrap();
@@ -1084,20 +1175,6 @@ mod tests {
 
         // Should only have one blob
         assert_eq!(store.get_blob_count(), 1);
-    }
-
-    #[test]
-    fn test_blob_path_sharding() {
-        let dir = tempdir().unwrap();
-        let store = BlobStore::new(dir.path().to_path_buf());
-
-        let hash = "abcd1234567890abcd1234567890abcd1234567890abcd1234567890abcd1234";
-        let path = store.get_blob_path(hash);
-
-        // Should have two-level sharding
-        assert!(path.to_string_lossy().contains("ab"));
-        assert!(path.to_string_lossy().contains("cd"));
-        assert!(path.to_string_lossy().ends_with(hash));
     }
 
     #[test]

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -23,6 +23,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::Instant;
 
+use tokio::sync::mpsc::UnboundedSender;
+
 use super::blob_backend::BlobBackend;
 use super::protocol::WorkspaceId;
 
@@ -131,6 +133,19 @@ pub struct BlobStore {
     /// Grace (seconds) before reclaiming an orphaned blob's bytes. `0` =
     /// immediate (default; preserves self-host behavior).
     gc_grace_secs: AtomicU64,
+    /// Object-storage byte-delete sink. `Some` puts the store in **per-workspace
+    /// object mode** (the s3/R2 backend): each `(workspace, hash)` is its own
+    /// object, so GC reclaims a workspace's object the moment *that* workspace's
+    /// ACL is released — independent of other workspaces — by sending
+    /// `(workspace, hash)` here for a background worker to `DELETE`. `None` is
+    /// the filesystem shared-byte mode, where bytes are reclaimed only when the
+    /// last ACL across all workspaces is gone (see [`Self::gc_blob_if_orphaned`]).
+    object_delete_tx: Option<UnboundedSender<(WorkspaceId, String)>>,
+    /// JP-127 grace deferral for per-workspace objects (s3 mode): when a
+    /// `(workspace, hash)` ACL is released and `gc_grace_secs > 0`, the object
+    /// delete is deferred and recorded here, mirroring `orphaned_at` but keyed
+    /// per workspace since each workspace owns a distinct object.
+    orphaned_objects_at: RwLock<HashMap<(WorkspaceId, String), Instant>>,
 }
 
 impl BlobStore {
@@ -160,6 +175,8 @@ impl BlobStore {
             doc_refs: RwLock::new(HashMap::new()),
             orphaned_at: RwLock::new(HashMap::new()),
             gc_grace_secs: AtomicU64::new(0),
+            object_delete_tx: None,
+            orphaned_objects_at: RwLock::new(HashMap::new()),
         };
 
         // Load existing index + ACLs + per-doc references.
@@ -555,8 +572,14 @@ impl BlobStore {
             let mut acls = self.acls.write().map_err(|e| e.to_string())?;
             acls.insert((ws.clone(), hash.to_string()))
         };
+        // Cancel any deferred GC — both the shared-byte (hash) and the
+        // per-workspace ((ws, hash)) deferral — now that the blob is referenced
+        // again.
         if let Ok(mut orphaned) = self.orphaned_at.write() {
             orphaned.remove(hash);
+        }
+        if let Ok(mut orphaned) = self.orphaned_objects_at.write() {
+            orphaned.remove(&(ws.clone(), hash.to_string()));
         }
 
         if metadata_changed {
@@ -824,7 +847,14 @@ impl BlobStore {
         if removed {
             self.save_acls()?;
             log::info!("released blob ACL {}/{}", ws.as_str(), hash);
-            self.gc_blob_if_orphaned(hash)?;
+            if self.per_workspace_objects() {
+                // s3: this workspace's object is its own — reclaim it now,
+                // regardless of what other workspaces still hold.
+                self.gc_workspace_object(ws, hash)?;
+            } else {
+                // filesystem: shared bytes — reclaim only at the last ACL.
+                self.gc_blob_if_orphaned(hash)?;
+            }
         }
         Ok(removed)
     }
@@ -833,6 +863,77 @@ impl BlobStore {
     /// Called once at startup from `ServerState` with the configured value.
     pub fn set_gc_grace_secs(&self, secs: u64) {
         self.gc_grace_secs.store(secs, Ordering::Relaxed);
+    }
+
+    /// Switch the store into **per-workspace object mode** by installing the
+    /// object-delete sink (the s3/R2 backend). Released objects are sent here
+    /// for a background worker to `DELETE`. Called once at startup, before the
+    /// store is shared, when `[storage] backend = "s3"`.
+    pub fn set_object_delete_sink(&mut self, tx: UnboundedSender<(WorkspaceId, String)>) {
+        self.object_delete_tx = Some(tx);
+    }
+
+    /// Whether the store reclaims bytes per workspace (s3 object mode) vs. the
+    /// filesystem shared-byte model.
+    fn per_workspace_objects(&self) -> bool {
+        self.object_delete_tx.is_some()
+    }
+
+    /// Queue a `(workspace, hash)` object for background `DELETE` from object
+    /// storage. Best-effort: a closed channel (worker gone) is dropped — the
+    /// bucket lifecycle rule is the backstop.
+    fn enqueue_object_delete(&self, ws: &WorkspaceId, hash: &str) {
+        if let Some(tx) = &self.object_delete_tx {
+            let _ = tx.send((ws.clone(), hash.to_string()));
+        }
+    }
+
+    /// Drop the shared per-hash metadata entry once no workspace holds an ACL
+    /// for it (s3 mode). The bytes are per-workspace objects reclaimed via the
+    /// delete sink, so this only prunes the in-memory index + sidecar.
+    fn drop_index_if_no_acl(&self, hash: &str) -> Result<(), String> {
+        let any_acl = {
+            let acls = self.acls.read().map_err(|e| e.to_string())?;
+            acls.iter().any(|(_w, h)| h == hash)
+        };
+        if any_acl {
+            return Ok(());
+        }
+        let removed = {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            index.remove(hash).is_some()
+        };
+        if removed {
+            self.save_index()?;
+        }
+        Ok(())
+    }
+
+    /// Reclaim a workspace's object after *its* ACL is released (s3 per-workspace
+    /// mode). With `gc_grace_secs > 0` the delete is deferred (recorded in
+    /// `orphaned_objects_at`) so a transient reference-drop followed by a
+    /// correction keeps the object; otherwise it's enqueued immediately. Either
+    /// way the shared metadata is pruned once the last ACL is gone.
+    fn gc_workspace_object(&self, ws: &WorkspaceId, hash: &str) -> Result<(), String> {
+        let grace = self.gc_grace_secs.load(Ordering::Relaxed);
+        if grace == 0 {
+            self.enqueue_object_delete(ws, hash);
+            self.drop_index_if_no_acl(hash)?;
+            log::info!("GC'd workspace object {}/{}", ws.as_str(), hash);
+        } else {
+            if let Ok(mut orphaned) = self.orphaned_objects_at.write() {
+                orphaned
+                    .entry((ws.clone(), hash.to_string()))
+                    .or_insert_with(Instant::now);
+            }
+            log::info!(
+                "workspace object {}/{} orphaned; deferring delete by {}s",
+                ws.as_str(),
+                hash,
+                grace
+            );
+        }
+        Ok(())
     }
 
     /// Reclaim bytes for deferred orphans whose grace has elapsed and that are
@@ -866,6 +967,36 @@ impl BlobStore {
             }
             if let Ok(mut o) = self.orphaned_at.write() {
                 o.remove(&hash);
+            }
+        }
+
+        // s3 per-workspace objects: same deferral, keyed per (workspace, hash).
+        let expired_objs: Vec<(WorkspaceId, String)> = match self.orphaned_objects_at.read() {
+            Ok(o) => o
+                .iter()
+                .filter(|(_, t)| now.duration_since(**t).as_secs() >= grace)
+                .map(|(k, _)| k.clone())
+                .collect(),
+            Err(_) => Vec::new(),
+        };
+        for (ws, hash) in expired_objs {
+            // A re-grant of this exact (workspace, hash) rescues its object.
+            let still_orphaned = match self.acls.read() {
+                Ok(acls) => !acls.contains(&(ws.clone(), hash.clone())),
+                Err(_) => false,
+            };
+            if still_orphaned {
+                self.enqueue_object_delete(&ws, &hash);
+                let _ = self.drop_index_if_no_acl(&hash);
+                reclaimed += 1;
+                log::info!(
+                    "GC'd orphaned workspace object {}/{} (grace elapsed)",
+                    ws.as_str(),
+                    hash
+                );
+            }
+            if let Ok(mut o) = self.orphaned_objects_at.write() {
+                o.remove(&(ws.clone(), hash));
             }
         }
         reclaimed
@@ -1144,6 +1275,102 @@ mod tests {
         // A re-finalize of an already-granted hash is a no-op (idempotent).
         store.record_finalized_blob(&alpha, &hash, 100, "application/octet-stream", "a").unwrap();
         assert_eq!(store.get_workspace_size(&alpha), 100);
+    }
+
+    // ---- s3 per-workspace object GC (the delete sink is observed in tests) ----
+
+    type DeleteRx = tokio::sync::mpsc::UnboundedReceiver<(WorkspaceId, String)>;
+
+    /// A blob store in s3 (per-workspace object) mode, returning the receiver
+    /// the GC enqueues object deletes onto so tests can assert them.
+    fn s3_mode_store(dir: &std::path::Path) -> (BlobStore, DeleteRx) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut store = BlobStore::new(dir.to_path_buf());
+        store.set_object_delete_sink(tx);
+        (store, rx)
+    }
+
+    fn drain(rx: &mut DeleteRx) -> Vec<(WorkspaceId, String)> {
+        let mut out = Vec::new();
+        while let Ok(v) = rx.try_recv() {
+            out.push(v);
+        }
+        out
+    }
+
+    #[test]
+    fn s3_release_enqueues_object_delete_and_prunes_index() {
+        let dir = tempdir().unwrap();
+        let (store, mut rx) = s3_mode_store(dir.path());
+        let ws = WorkspaceId::single_tenant();
+        let hash = "a".repeat(64);
+
+        // Finalize records the index + ACL with the HEAD size — no local bytes.
+        store.record_finalized_blob(&ws, &hash, 100, "image/png", "u").unwrap();
+        store.sync_doc_refs(&ws, "doc1", refs(&[&hash])).unwrap();
+        assert_eq!(store.get_blob_count(), 1);
+
+        // Drop the only reference → the workspace object is enqueued for R2
+        // delete and the shared metadata is pruned (last ACL gone).
+        store.sync_doc_refs(&ws, "doc1", HashSet::new()).unwrap();
+        assert_eq!(drain(&mut rx), vec![(ws.clone(), hash.clone())]);
+        assert_eq!(store.get_blob_count(), 0);
+        assert!(!store.exists(&ws, &hash));
+    }
+
+    #[test]
+    fn s3_release_reclaims_only_the_releasing_workspaces_object() {
+        let dir = tempdir().unwrap();
+        let (store, mut rx) = s3_mode_store(dir.path());
+        let alpha = WorkspaceId::from_configured("alpha").unwrap();
+        let beta = WorkspaceId::from_configured("beta").unwrap();
+        let hash = "b".repeat(64);
+
+        // Per-workspace keys → each workspace has its own R2 object for the hash.
+        store.record_finalized_blob(&alpha, &hash, 50, "x", "a").unwrap();
+        store.record_finalized_blob(&beta, &hash, 50, "x", "b").unwrap();
+        store.sync_doc_refs(&alpha, "dA", refs(&[&hash])).unwrap();
+        store.sync_doc_refs(&beta, "dB", refs(&[&hash])).unwrap();
+
+        // Alpha drops → only alpha's object is reclaimed; metadata kept (beta
+        // still holds an ACL), and beta can still read.
+        store.release_doc_refs(&alpha, "dA").unwrap();
+        assert_eq!(drain(&mut rx), vec![(alpha.clone(), hash.clone())]);
+        assert_eq!(store.get_blob_count(), 1);
+        assert!(store.exists(&beta, &hash));
+
+        // Beta drops the last grant → beta's object reclaimed + metadata pruned.
+        store.release_doc_refs(&beta, "dB").unwrap();
+        assert_eq!(drain(&mut rx), vec![(beta.clone(), hash.clone())]);
+        assert_eq!(store.get_blob_count(), 0);
+    }
+
+    #[test]
+    fn s3_grace_defers_object_delete_and_refinalize_cancels_it() {
+        let dir = tempdir().unwrap();
+        let (store, mut rx) = s3_mode_store(dir.path());
+        store.set_gc_grace_secs(3600); // 1h grace
+        let ws = WorkspaceId::single_tenant();
+        let hash = "c".repeat(64);
+
+        store.record_finalized_blob(&ws, &hash, 10, "x", "u").unwrap();
+        store.sync_doc_refs(&ws, "d1", refs(&[&hash])).unwrap();
+
+        // Drop the reference under grace → the delete is deferred, not enqueued.
+        // The ACL is released (so the workspace can't see it), but the object's
+        // metadata survives the window — same shape as the filesystem grace path.
+        store.sync_doc_refs(&ws, "d1", HashSet::new()).unwrap();
+        assert!(drain(&mut rx).is_empty(), "delete deferred under grace");
+        assert_eq!(store.reclaim_expired_orphans(), 0); // not yet aged
+        assert!(drain(&mut rx).is_empty());
+        assert_eq!(store.get_blob_count(), 1, "object metadata survives the grace window");
+
+        // A correction re-finalizes + re-references → cancels the deferred GC.
+        store.record_finalized_blob(&ws, &hash, 10, "x", "u").unwrap();
+        store.sync_doc_refs(&ws, "d1", refs(&[&hash])).unwrap();
+        assert_eq!(store.reclaim_expired_orphans(), 0);
+        assert!(drain(&mut rx).is_empty(), "re-finalize cancels the deferred delete");
+        assert!(store.exists(&ws, &hash));
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1368,6 +1368,31 @@ async fn blob_download_handler(
         Err(resp) => return resp,
     };
 
+    // S3/R2 backend: gate on the workspace ACL (an unknown/cross-tenant hash
+    // has no ACL → opaque 404), then 302-redirect to a short-TTL presigned GET
+    // so the bytes stream straight from object storage, never through the
+    // relay. The presigned URL self-authenticates via its query string; the
+    // client must NOT forward the `Authorization` bearer to R2 (it would be
+    // rejected / leak the JWT) — browser fetch + the desktop reqwest transport
+    // both strip it on the cross-origin redirect.
+    if let Some(s3) = state.s3_backend() {
+        if !state.blob_store.exists(&ws, &hash) {
+            return (StatusCode::NOT_FOUND, format!("Blob not found: {}", hash)).into_response();
+        }
+        let url = s3.presign_get(&ws, &hash);
+        return Response::builder()
+            .status(StatusCode::FOUND)
+            .header(header::LOCATION, url)
+            .body(Body::empty())
+            .unwrap_or_else(|_| {
+                Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::from("Failed to build redirect"))
+                    .unwrap()
+            });
+    }
+
+    // Filesystem backend: stream the bytes through the relay (unchanged).
     // Get metadata for MIME type — workspace-scoped, so MIME type lookup
     // can't leak existence either.
     let mime_type = state.blob_store

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1346,10 +1346,70 @@ async fn blob_upload_handler(
         .unwrap_or("application/octet-stream")
         .to_string();
 
-    // Save blob with hash verification + per-workspace storage quota (JP-81)
-    // — grants ACL to the uploading workspace. Quota = claim value else
-    // config fallback; `None` = unlimited.
     let quota = state.resolve_limits(claim_limits).quota_bytes;
+
+    // s3 backend: proxy the bytes straight to object storage, then record the
+    // blob (the back half of finalize). Keeps the proxy upload coherent with the
+    // 302 download — a local filesystem write would 404 on the R2 redirect — so
+    // a client that can't do the presigned direct PUT still works end-to-end.
+    if let Some(s3) = state.s3_backend() {
+        // We hold the bytes here, so verify the content hash — the integrity
+        // check the presigned path can't perform.
+        let actual = BlobStore::compute_hash(&body);
+        if actual != hash {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Hash mismatch: expected {hash}, got {actual}"),
+            )
+                .into_response();
+        }
+        if state.blob_store.exists(&ws, &hash) {
+            let size = state
+                .blob_store
+                .get_metadata(&ws, &hash)
+                .map(|m| m.size)
+                .unwrap_or(body.len() as u64);
+            return (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({
+                    "success": true, "hash": hash, "size": size, "mimeType": mime_type,
+                })),
+            )
+                .into_response();
+        }
+        if let Some(q) = quota {
+            if state
+                .blob_store
+                .get_workspace_size(&ws)
+                .saturating_add(body.len() as u64)
+                > q
+            {
+                return (StatusCode::INSUFFICIENT_STORAGE, "storage quota exceeded".to_string())
+                    .into_response();
+            }
+        }
+        if let Err(e) = s3.put_object(&ws, &hash, body.to_vec(), &mime_type).await {
+            log::warn!("proxy upload to object storage failed for {}/{}: {}", ws.as_str(), hash, e);
+            return (StatusCode::BAD_GATEWAY, "blob store unavailable".to_string()).into_response();
+        }
+        return match state
+            .blob_store
+            .record_finalized_blob(&ws, &hash, body.len() as u64, &mime_type, &claims.sub)
+        {
+            Ok(meta) => (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({
+                    "success": true, "hash": meta.hash, "size": meta.size, "mimeType": meta.mime_type,
+                })),
+            )
+                .into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
+        };
+    }
+
+    // Filesystem backend: save bytes locally with hash verification + per-workspace
+    // storage quota (JP-81) — grants ACL to the uploading workspace. Quota = claim
+    // value else config fallback; `None` = unlimited.
     match state
         .blob_store
         .save_blob_with_quota(&ws, &hash, &body, &mime_type, &claims.sub, quota)

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -87,6 +87,23 @@ fn build_s3_backend(storage: &StorageConfig) -> Option<Arc<S3Backend>> {
     }
 }
 
+/// Background worker that DELETEs reclaimed per-workspace objects from R2.
+/// `BlobStore`'s GC runs synchronously and enqueues `(workspace, hash)` pairs;
+/// this drains them and issues the async `delete_object`. Best-effort: a failed
+/// delete is logged and dropped (the bucket lifecycle rule is the backstop), so
+/// one bad object can't wedge the queue. Exits when the sink is dropped (server
+/// shutdown).
+async fn run_blob_delete_worker(
+    mut rx: mpsc::UnboundedReceiver<(WorkspaceId, String)>,
+    s3: Arc<S3Backend>,
+) {
+    while let Some((ws, hash)) = rx.recv().await {
+        if let Err(e) = s3.delete_object(&ws, &hash).await {
+            log::warn!("R2 blob delete failed for {}/{}: {}", ws.as_str(), hash, e);
+        }
+    }
+}
+
 /// Build a fresh per-workspace write limiter from numeric limits. A
 /// zero burst falls back to 1 (governor requires `NonZeroU32`).
 pub fn build_workspace_limiter(
@@ -348,19 +365,28 @@ impl ServerState {
     ) -> Self {
         let (broadcast_tx, _) = broadcast::channel(100);
         let s3 = build_s3_backend(&storage);
+        let blob_store = {
+            // JP-127: defer orphaned-blob reclaim by the configured grace so a
+            // transient reference-drop can be corrected without losing bytes.
+            let mut bs = BlobStore::new(app_data_dir.clone());
+            bs.set_gc_grace_secs(tenancy.limits.blob_gc_grace_secs);
+            // s3 mode: route reclaimed per-workspace objects to a background
+            // worker that DELETEs them from R2, keeping the sync GC chain sync.
+            if let Some(s3) = &s3 {
+                let (tx, rx) = mpsc::unbounded_channel();
+                bs.set_object_delete_sink(tx);
+                let s3 = s3.clone();
+                tokio::spawn(async move { run_blob_delete_worker(rx, s3).await });
+            }
+            Arc::new(bs)
+        };
         Self {
             broadcast_tx,
             client_count: AtomicU16::new(0),
             next_client_id: AtomicU64::new(1),
             clients: RwLock::new(HashMap::new()),
-            doc_store: Arc::new(DocumentStore::new(app_data_dir.clone())),
-            blob_store: {
-                // JP-127: defer orphaned-blob reclaim by the configured grace so a
-                // transient reference-drop can be corrected without losing bytes.
-                let bs = BlobStore::new(app_data_dir);
-                bs.set_gc_grace_secs(tenancy.limits.blob_gc_grace_secs);
-                Arc::new(bs)
-            },
+            doc_store: Arc::new(DocumentStore::new(app_data_dir)),
+            blob_store,
             s3,
             auth,
             revocation_push_bearer,

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -13,6 +13,7 @@
 //! - Authentication is required for all connections
 //! - Consider firewall rules for additional protection
 
+mod blob_backend;
 pub mod blobs;
 pub mod documents;
 pub mod permissions;
@@ -46,12 +47,45 @@ use governor::{
 use std::num::NonZeroU32;
 use protocol::*;
 use crate::auth::{AuthError, OidcAuthState, OidcClaims, WorkspaceRole};
-use crate::config::{TenancyConfig, TenancyMode};
+use crate::config::{StorageConfig, TenancyConfig, TenancyMode};
+use blob_backend::S3Backend;
 
 /// Per-workspace token-bucket limiter shared between WS sync handlers
 /// and MCP write tools. Phase 21.3.
 pub type WorkspaceWriteLimiter =
     RateLimiter<WorkspaceId, DefaultKeyedStateStore<WorkspaceId>, DefaultClock>;
+
+/// Build the S3/R2 byte store from `[storage]` config. Returns `None` for the
+/// filesystem backend; logs and returns `None` if `backend = "s3"` but the
+/// `[storage.s3]` block is missing or incomplete (the relay then runs without
+/// a usable blob byte store rather than refusing to boot).
+fn build_s3_backend(storage: &StorageConfig) -> Option<Arc<S3Backend>> {
+    if storage.backend != "s3" {
+        return None;
+    }
+    match &storage.s3 {
+        Some(cfg) if cfg.is_complete() => {
+            Some(Arc::new(S3Backend::new(blob_backend::S3Config {
+                endpoint: cfg.endpoint.clone(),
+                bucket: cfg.bucket.clone(),
+                region: cfg.region.clone(),
+                access_key_id: cfg.access_key_id.clone(),
+                secret_access_key: cfg.secret_access_key.clone(),
+                key_prefix: cfg.key_prefix.clone(),
+                put_ttl_secs: cfg.put_ttl_secs,
+                get_ttl_secs: cfg.get_ttl_secs,
+            })))
+        }
+        _ => {
+            log::error!(
+                "storage.backend = \"s3\" but [storage.s3] is missing or incomplete \
+                 (need endpoint, bucket, access_key_id, secret_access_key); \
+                 blob byte store unavailable"
+            );
+            None
+        }
+    }
+}
 
 /// Build a fresh per-workspace write limiter from numeric limits. A
 /// zero burst falls back to 1 (governor requires `NonZeroU32`).
@@ -251,6 +285,10 @@ pub struct ServerState {
     doc_store: Arc<DocumentStore>,
     /// Blob store for embedded files
     blob_store: Arc<BlobStore>,
+    /// S3/R2 byte store, present only when `[storage] backend = "s3"`. Holds
+    /// the presign / HEAD / DELETE surface the blob handlers use for direct
+    /// client transfer; `None` for the filesystem backend.
+    s3: Option<Arc<S3Backend>>,
     /// OIDC validator + JWKS cache + revocation set. JP-77 — the relay
     /// no longer issues tokens, only validates them against an external
     /// issuer's JWKS.
@@ -297,6 +335,7 @@ impl ServerState {
     #[allow(clippy::too_many_arguments)]
     fn new(
         app_data_dir: PathBuf,
+        storage: StorageConfig,
         auth: OidcAuthState,
         revocation_push_bearer: Option<String>,
         relay_region: String,
@@ -308,6 +347,7 @@ impl ServerState {
         #[cfg(debug_assertions)] panic_tenant_trigger: Option<WorkspaceId>,
     ) -> Self {
         let (broadcast_tx, _) = broadcast::channel(100);
+        let s3 = build_s3_backend(&storage);
         Self {
             broadcast_tx,
             client_count: AtomicU16::new(0),
@@ -321,6 +361,7 @@ impl ServerState {
                 bs.set_gc_grace_secs(tenancy.limits.blob_gc_grace_secs);
                 Arc::new(bs)
             },
+            s3,
             auth,
             revocation_push_bearer,
             relay_region,
@@ -494,6 +535,19 @@ impl ServerState {
         &self.blob_store
     }
 
+    /// The S3/R2 byte store, present only under `backend = "s3"`. Blob
+    /// handlers use it to mint presigned URLs and to HEAD/DELETE objects.
+    pub(crate) fn s3_backend(&self) -> Option<&Arc<S3Backend>> {
+        self.s3.as_ref()
+    }
+
+    /// Configured per-request blob size ceiling (`[tenancy.limits]
+    /// max_blob_bytes`). The proxy path enforces this via `DefaultBodyLimit`;
+    /// the presign path checks the client-asserted size against it at mint.
+    pub(crate) fn max_blob_bytes(&self) -> usize {
+        self.tenancy.limits.max_blob_bytes
+    }
+
     /// Snapshot of per-workspace live connection counts (editor/viewer
     /// split), for the metering debug log.
     pub(crate) async fn workspace_conn_snapshot(&self) -> HashMap<WorkspaceId, WorkspaceConnCounts> {
@@ -649,6 +703,9 @@ pub struct WebSocketServer {
     config: RwLock<ServerConfig>,
     /// App data directory for document storage
     app_data_dir: RwLock<Option<PathBuf>>,
+    /// Blob byte-storage config (`[storage]`): backend selector + S3/R2
+    /// connection details. Set via [`set_storage`] before [`start`].
+    storage: RwLock<StorageConfig>,
     /// OIDC auth bundle (JWKS cache + revocation set + validator
     /// config). Set via [`set_auth`] before [`start`]; the cache's
     /// background refresh task is owned by `main.rs`.
@@ -702,6 +759,7 @@ impl WebSocketServer {
             state: Arc::new(RwLock::new(None)),
             config: RwLock::new(ServerConfig::default()),
             app_data_dir: RwLock::new(None),
+            storage: RwLock::new(StorageConfig::default()),
             auth: RwLock::new(None),
             revocation_push_bearer: RwLock::new(None),
             relay_region: RwLock::new("default".to_string()),
@@ -774,6 +832,13 @@ impl WebSocketServer {
     /// Set the app data directory (called during Tauri setup)
     pub async fn set_app_data_dir(&self, dir: PathBuf) {
         *self.app_data_dir.write().await = Some(dir);
+    }
+
+    /// Set the blob storage config (backend selector + S3/R2 details). Called
+    /// during startup from `relay.toml` + `RELAY_*` overrides; must precede
+    /// `start()` so the byte store is built when `ServerState` is created.
+    pub async fn set_storage(&self, storage: StorageConfig) {
+        *self.storage.write().await = storage;
     }
 
     /// Install the OIDC auth bundle. Must be called before `start()`.
@@ -907,6 +972,7 @@ impl WebSocketServer {
         let rate_limit_rejections = self.rate_limit_rejections.clone();
         let metering_debug_log = self.metering_debug_log.load(Ordering::Relaxed);
         let tenancy = self.tenancy.read().await.clone();
+        let storage = self.storage.read().await.clone();
         // JP-125: bound the blob upload body (Axum's default is a silent 2 MiB).
         let max_blob_bytes = tenancy.limits.max_blob_bytes;
         // Reuse the cached limiter so MCP and WS share one bucket.
@@ -917,6 +983,7 @@ impl WebSocketServer {
         // Create server state with document store
         let server_state = Arc::new(ServerState::new(
             app_data_dir,
+            storage,
             auth,
             revocation_push_bearer,
             relay_region,
@@ -2009,6 +2076,7 @@ mod tests {
         ));
         let state = Arc::new(ServerState::new(
             temp_dir.path().to_path_buf(),
+            StorageConfig::default(),
             test_auth_state(),
             None,
             "default".to_string(),
@@ -2061,6 +2129,7 @@ mod tests {
         ));
         Arc::new(ServerState::new(
             temp_dir,
+            StorageConfig::default(),
             test_auth_state(),
             None,
             "default".to_string(),

--- a/relay/tests/blob_presign_flow.rs
+++ b/relay/tests/blob_presign_flow.rs
@@ -1,0 +1,229 @@
+//! Full-relay end-to-end for the presigned-R2 blob path, against a live
+//! S3 server (MinIO locally, or real R2). Skipped unless `RELAY_TEST_S3_*`
+//! is set, so a plain `cargo test` is unaffected.
+//!
+//! Unlike the `S3Backend`-direct roundtrip (in `server::blob_backend::s3`),
+//! this drives the **real HTTP handlers** through the running relay:
+//! `upload-url` → direct PUT to storage → `finalize` → GET 302 → presigned
+//! download → `/api/v1/usage`, then a doc reference + delete exercises the
+//! GC ACL release.
+//!
+//! Run locally:
+//! ```bash
+//! docker run -d --name dsk-minio -p 9100:9000 \
+//!   -e MINIO_ROOT_USER=miniotest -e MINIO_ROOT_PASSWORD=miniotest123 \
+//!   minio/minio server /data
+//! docker run --rm --network container:dsk-minio --entrypoint sh minio/mc -c \
+//!   "mc alias set l http://localhost:9000 miniotest miniotest123 && mc mb l/dsk-blobs-test"
+//! RELAY_TEST_S3_ENDPOINT=http://localhost:9100 RELAY_TEST_S3_BUCKET=dsk-blobs-test \
+//!   RELAY_TEST_S3_ACCESS_KEY_ID=miniotest RELAY_TEST_S3_SECRET_ACCESS_KEY=miniotest123 \
+//!   RELAY_TEST_S3_REGION=us-east-1 cargo test --test blob_presign_flow -- --nocapture
+//! ```
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{S3StorageConfig, StorageConfig};
+use docushark_relay::server::blobs::BlobStore;
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use reqwest::header::{AUTHORIZATION, LOCATION};
+use serde_json::json;
+use tempfile::TempDir;
+
+/// Build an s3-backed `StorageConfig` from `RELAY_TEST_S3_*`, or `None` to skip.
+fn s3_storage_from_env() -> Option<StorageConfig> {
+    let endpoint = std::env::var("RELAY_TEST_S3_ENDPOINT").ok()?;
+    let access_key_id = std::env::var("RELAY_TEST_S3_ACCESS_KEY_ID").ok()?;
+    let secret_access_key = std::env::var("RELAY_TEST_S3_SECRET_ACCESS_KEY").ok()?;
+    Some(StorageConfig {
+        backend: "s3".into(),
+        path: std::path::PathBuf::from("data"),
+        s3: Some(S3StorageConfig {
+            endpoint,
+            bucket: std::env::var("RELAY_TEST_S3_BUCKET").unwrap_or_else(|_| "dsk-blobs-test".into()),
+            region: std::env::var("RELAY_TEST_S3_REGION").unwrap_or_else(|_| "us-east-1".into()),
+            access_key_id,
+            secret_access_key,
+            key_prefix: String::new(),
+            put_ttl_secs: 900,
+            get_ttl_secs: 900,
+        }),
+    })
+}
+
+struct S3Harness {
+    base: String,
+    issuer: OidcTestIssuer,
+    server: Arc<WebSocketServer>,
+    _tmp: TempDir,
+}
+
+impl S3Harness {
+    async fn start(storage: StorageConfig) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let issuer = OidcTestIssuer::new().await;
+        let server = Arc::new(WebSocketServer::new());
+        server.set_app_data_dir(tmp.path().to_path_buf()).await;
+        server.set_storage(storage).await;
+        server.set_auth(issuer.auth_state()).await;
+        server
+            .set_config(ServerConfig {
+                port: 0,
+                network_mode: NetworkMode::Localhost,
+                max_connections: 0,
+            })
+            .await
+            .expect("set_config");
+        let bound = server.start(0).await.expect("start");
+        let base = bound
+            .strip_prefix("ws://")
+            .map(|rest| format!("http://{rest}"))
+            .unwrap_or(bound);
+        S3Harness { base, issuer, server, _tmp: tmp }
+    }
+
+    fn token(&self, sub: &str) -> String {
+        self.issuer.mint(sub, "default", WorkspaceRole::Owner)
+    }
+
+    async fn stop(self) {
+        self.server.stop().await.expect("stop");
+    }
+}
+
+#[tokio::test]
+async fn presigned_blob_flow_end_to_end() {
+    let Some(storage) = s3_storage_from_env() else {
+        eprintln!("skipping presigned_blob_flow_end_to_end: RELAY_TEST_S3_ENDPOINT unset");
+        return;
+    };
+    let harness = S3Harness::start(storage).await;
+    let client = reqwest::Client::new();
+    let no_redirect = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let bearer = format!("Bearer {}", harness.token("alice"));
+
+    // Unique content per run so reruns don't dedup against a prior object.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let body = format!("presigned blob e2e {nanos}").into_bytes();
+    let hash = BlobStore::compute_hash(&body);
+
+    // 1. Mint a presigned upload through the relay.
+    let res = client
+        .post(format!("{}/api/v1/blobs/{}/upload-url", harness.base, hash))
+        .header(AUTHORIZATION, &bearer)
+        .json(&json!({ "size": body.len(), "mimeType": "text/plain" }))
+        .send()
+        .await
+        .expect("upload-url");
+    assert_eq!(res.status().as_u16(), 200, "upload-url should presign on s3 backend");
+    let mint: serde_json::Value = res.json().await.unwrap();
+    let url = mint["url"].as_str().expect("presigned url");
+    let headers = mint["headers"].as_object().expect("signed headers");
+
+    // 2. PUT the bytes straight to object storage, echoing the signed headers
+    //    (no Authorization — the URL self-authenticates).
+    let mut put = client.put(url).body(body.clone());
+    for (k, v) in headers {
+        put = put.header(k.as_str(), v.as_str().unwrap());
+    }
+    let put_res = put.send().await.expect("direct PUT");
+    assert!(put_res.status().is_success(), "direct PUT to storage: {}", put_res.status());
+
+    // 3. Finalize — the relay HEADs for the authoritative size + grants the ACL.
+    let res = client
+        .post(format!("{}/api/v1/blobs/{}/finalize", harness.base, hash))
+        .header(AUTHORIZATION, &bearer)
+        .json(&json!({ "mimeType": "text/plain" }))
+        .send()
+        .await
+        .expect("finalize");
+    assert_eq!(res.status().as_u16(), 200, "finalize");
+    let fin: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(fin["size"].as_u64(), Some(body.len() as u64), "finalize records the HEAD size");
+
+    // 4. Download: GET 302 → presigned URL → bytes round-trip (no auth on R2).
+    let res = no_redirect
+        .get(format!("{}/api/blobs/{}", harness.base, hash))
+        .header(AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get");
+    assert_eq!(res.status().as_u16(), 302, "s3 backend redirects download");
+    let location = res
+        .headers()
+        .get(LOCATION)
+        .expect("Location header")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let got = client.get(&location).send().await.expect("presigned GET");
+    assert!(got.status().is_success(), "presigned GET: {}", got.status());
+    assert_eq!(got.bytes().await.unwrap().as_ref(), body.as_slice(), "bytes round-trip");
+
+    // 5. Usage meters the blob at its real size.
+    let res = client
+        .get(format!("{}/api/v1/usage", harness.base))
+        .header(AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("usage");
+    assert_eq!(res.status().as_u16(), 200);
+    let usage: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(
+        usage["storageBytes"].as_u64(),
+        Some(body.len() as u64),
+        "usage meters the finalized blob"
+    );
+
+    // 6. Reference the blob from a doc → still reachable; delete the doc → the
+    //    ACL is released (grace 0) and the object reclaimed → 404.
+    let save = client
+        .put(format!("{}/api/docs/doc-blob", harness.base))
+        .header(AUTHORIZATION, &bearer)
+        .json(&json!({
+            "id": "doc-blob",
+            "name": "Blob Doc",
+            "version": 1,
+            "pages": [],
+            "createdAt": 1,
+            "modifiedAt": 1,
+            "blobReferences": [hash],
+        }))
+        .send()
+        .await
+        .expect("save doc");
+    assert_eq!(save.status().as_u16(), 200, "save doc referencing the blob");
+
+    let res = no_redirect
+        .get(format!("{}/api/blobs/{}", harness.base, hash))
+        .header(AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status().as_u16(), 302, "still reachable while a doc references it");
+
+    let del = client
+        .delete(format!("{}/api/docs/doc-blob", harness.base))
+        .header(AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("delete doc");
+    assert_eq!(del.status().as_u16(), 200);
+
+    let res = no_redirect
+        .get(format!("{}/api/blobs/{}", harness.base, hash))
+        .header(AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status().as_u16(), 404, "blob ACL released after the referencing doc is deleted");
+
+    harness.stop().await;
+}

--- a/relay/tests/blob_presign_flow.rs
+++ b/relay/tests/blob_presign_flow.rs
@@ -182,6 +182,34 @@ async fn presigned_blob_flow_end_to_end() {
         "usage meters the finalized blob"
     );
 
+    // 5b. Proxy upload (the old-client path): POST raw bytes through the relay →
+    //     they land in R2 → the 302 download round-trips. Distinct content.
+    let pbody = format!("proxy blob e2e {nanos}").into_bytes();
+    let phash = BlobStore::compute_hash(&pbody);
+    let res = client
+        .post(format!("{}/api/blobs/{}", harness.base, phash))
+        .header(AUTHORIZATION, &bearer)
+        .header("content-type", "text/plain")
+        .body(pbody.clone())
+        .send()
+        .await
+        .expect("proxy upload");
+    assert_eq!(res.status().as_u16(), 200, "proxy upload on s3 backend lands in R2");
+    let res = no_redirect
+        .get(format!("{}/api/blobs/{}", harness.base, phash))
+        .header(AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status().as_u16(), 302, "proxy-uploaded blob downloads via the R2 redirect");
+    let loc = res.headers().get(LOCATION).unwrap().to_str().unwrap().to_string();
+    let got = client.get(&loc).send().await.unwrap();
+    assert_eq!(
+        got.bytes().await.unwrap().as_ref(),
+        pbody.as_slice(),
+        "proxy blob round-trips through R2"
+    );
+
     // 6. Reference the blob from a doc → still reachable; delete the doc → the
     //    ACL is released (grace 0) and the object reclaimed → 404.
     let save = client

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -53,6 +53,7 @@
       "allow": [
         { "url": "https://*.fly.dev/*" },
         { "url": "https://*.docushark.app/*" },
+        { "url": "https://*.r2.cloudflarestorage.com/*" },
         { "url": "http://localhost:*/*" },
         { "url": "http://127.0.0.1:*/*" }
       ]

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -18,6 +18,7 @@
  */
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
+import type { BlobUploadMint } from '../collaboration/BlobSyncService';
 
 /**
  * Default per-request timeout. Bounds a stalled connection so a hung request
@@ -222,6 +223,78 @@ export class RelayClient {
       if (err instanceof RelayError && err.status === 404) return false;
       throw err;
     }
+  }
+
+  /**
+   * Request a presigned PUT so blob bytes upload directly to object storage,
+   * bypassing the relay (`POST /api/v1/blobs/:hash/upload-url`). Returns
+   * `exists` (dedup), `unsupported` (filesystem backend — use `uploadBlob`), or
+   * `presigned` (PUT then `finalizeBlob`). A 507/413 (over quota / too large)
+   * propagates as a `RelayError`.
+   */
+  async mintBlobPutUrl(
+    hash: string,
+    opts: { size: number; mimeType: string },
+  ): Promise<BlobUploadMint> {
+    const path = `/api/v1/blobs/${encodeURIComponent(hash)}/upload-url`;
+    try {
+      const res = await this.requestJson<{
+        exists?: boolean;
+        url?: string;
+        headers?: Record<string, string>;
+        expiresAt?: number;
+        key?: string;
+      }>('POST', path, { auth: true, body: { size: opts.size, mimeType: opts.mimeType } });
+      if (res.exists === true) {
+        return { kind: 'exists' };
+      }
+      if (typeof res.url === 'string') {
+        return {
+          kind: 'presigned',
+          url: res.url,
+          headers: res.headers ?? {},
+          expiresAt: res.expiresAt ?? 0,
+          key: res.key ?? '',
+        };
+      }
+      throw new RelayError(502, `${this.baseUrl}${path}`, 'malformed upload-url response');
+    } catch (err) {
+      // 409 = relay is filesystem-backed (no presign) → caller proxies instead.
+      if (err instanceof RelayError && err.status === 409) {
+        return { kind: 'unsupported' };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * PUT blob bytes directly to a presigned object-storage URL. No
+   * `Authorization` is sent (the URL self-authenticates via its query string),
+   * and the `Blob` is streamed as the body so a large upload never materializes
+   * as an ArrayBuffer on the JS heap. The signed headers (content-type /
+   * -length) are echoed so the signature validates.
+   */
+  async putBlobToUrl(url: string, headers: Record<string, string>, body: Blob): Promise<void> {
+    const res = await this.fetchWithTimeout(
+      url,
+      { method: 'PUT', headers, body },
+      BLOB_TRANSFER_TIMEOUT_MS,
+    );
+    if (!res.ok) {
+      throw await buildRelayError(res, url);
+    }
+  }
+
+  /**
+   * Tell the relay a direct upload landed (`POST /api/v1/blobs/:hash/finalize`):
+   * it HEADs the object for the authoritative size, enforces the quota, and
+   * grants the workspace ACL. A 404 (`object_not_uploaded`) or 507 propagates.
+   */
+  async finalizeBlob(hash: string, opts: { mimeType: string }): Promise<void> {
+    await this.requestJson('POST', `/api/v1/blobs/${encodeURIComponent(hash)}/finalize`, {
+      auth: true,
+      body: { mimeType: opts.mimeType },
+    });
   }
 
   // ============ Internals ============

--- a/src/collaboration/BlobSyncService.test.ts
+++ b/src/collaboration/BlobSyncService.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   BlobSyncService,
   type BlobTransport,
+  type BlobUploadMint,
   type BlobSyncProgress,
 } from './BlobSyncService';
 import type { BlobStorage } from '../storage/BlobStorage';
@@ -53,6 +54,18 @@ function makeTransport(overrides: Partial<BlobTransport> = {}): BlobTransport {
     blobExists: vi.fn(async () => false),
     uploadBlob: vi.fn(async () => {}),
     downloadBlob: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    // Default to the presigned (s3) path; tests override for proxy/exists.
+    mintBlobPutUrl: vi.fn(
+      async (): Promise<BlobUploadMint> => ({
+        kind: 'presigned',
+        url: 'https://r2.example/put',
+        headers: { 'content-type': 'application/octet-stream' },
+        expiresAt: 0,
+        key: 'ws/default/ab/cd/hash',
+      }),
+    ),
+    putBlobToUrl: vi.fn(async () => {}),
+    finalizeBlob: vi.fn(async () => {}),
     ...overrides,
   };
 }
@@ -74,23 +87,81 @@ describe('BlobSyncService', () => {
   });
 
   describe('uploadBlob', () => {
-    it('sends the blob bytes to the transport', async () => {
+    it('mints a presigned URL, streams the blob straight to it, then finalizes', async () => {
       const transport = makeTransport();
+      const svc = new BlobSyncService({ transport, ...fast });
+      const blob = new Blob([new Uint8Array([9, 8, 7])]);
+      await svc.uploadBlob('abc', blob);
+
+      expect(transport.mintBlobPutUrl).toHaveBeenCalledWith('abc', {
+        size: blob.size,
+        mimeType: 'application/octet-stream',
+      });
+      const putCall = (transport.putBlobToUrl as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(putCall[0]).toBe('https://r2.example/put');
+      // The Blob itself is streamed — not copied into a Uint8Array/ArrayBuffer.
+      expect(putCall[2]).toBe(blob);
+      expect(transport.finalizeBlob).toHaveBeenCalledWith('abc', {
+        mimeType: 'application/octet-stream',
+      });
+      // The relay-proxied byte path is not used when presigning.
+      expect(transport.uploadBlob).not.toHaveBeenCalled();
+    });
+
+    it('skips upload + finalize when the workspace already has the blob', async () => {
+      const transport = makeTransport({
+        mintBlobPutUrl: vi.fn(async (): Promise<BlobUploadMint> => ({ kind: 'exists' })),
+      });
+      const svc = new BlobSyncService({ transport, ...fast });
+      await svc.uploadBlob('abc', new Blob(['x']));
+      expect(transport.putBlobToUrl).not.toHaveBeenCalled();
+      expect(transport.finalizeBlob).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the proxy uploadBlob when the relay is filesystem-backed', async () => {
+      const transport = makeTransport({
+        mintBlobPutUrl: vi.fn(async (): Promise<BlobUploadMint> => ({ kind: 'unsupported' })),
+      });
       const svc = new BlobSyncService({ transport, ...fast });
       await svc.uploadBlob('abc', new Blob([new Uint8Array([9, 8, 7])]));
       const [hash, data] = (transport.uploadBlob as ReturnType<typeof vi.fn>).mock.calls[0]!;
       expect(hash).toBe('abc');
       expect(Array.from(data as Uint8Array)).toEqual([9, 8, 7]);
+      expect(transport.putBlobToUrl).not.toHaveBeenCalled();
     });
 
-    it('propagates a hash-mismatch (4xx) without retrying', async () => {
-      const uploadBlob = vi.fn(async () => {
-        throw httpError(400, 'Hash mismatch');
+    it('re-mints once when the presigned PUT 403s mid-flight', async () => {
+      let puts = 0;
+      const putBlobToUrl = vi.fn(async () => {
+        puts += 1;
+        if (puts === 1) throw httpError(403, 'expired');
       });
-      const transport = makeTransport({ uploadBlob });
+      const transport = makeTransport({ putBlobToUrl });
       const svc = new BlobSyncService({ transport, ...fast });
-      await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow('Hash mismatch');
-      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      await svc.uploadBlob('abc', new Blob(['x']));
+      expect(transport.mintBlobPutUrl).toHaveBeenCalledTimes(2); // re-minted once
+      expect(putBlobToUrl).toHaveBeenCalledTimes(2);
+      expect(transport.finalizeBlob).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates a non-retryable finalize error (4xx) without retrying', async () => {
+      const finalizeBlob = vi.fn(async () => {
+        throw httpError(400, 'bad finalize');
+      });
+      const transport = makeTransport({ finalizeBlob });
+      const svc = new BlobSyncService({ transport, ...fast });
+      await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow('bad finalize');
+      expect(finalizeBlob).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry a 507 (quota) on finalize', async () => {
+      const finalizeBlob = vi.fn(async () => {
+        throw httpError(507, 'storage quota exceeded');
+      });
+      const transport = makeTransport({ finalizeBlob });
+      const svc = new BlobSyncService({ transport, ...fast });
+      await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow('storage quota exceeded');
+      expect(finalizeBlob).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -119,22 +190,19 @@ describe('BlobSyncService', () => {
         missing: new Blob(['b']),
       });
       const blobExists = vi.fn(async (hash: string) => hash === 'present');
-      const uploadBlob = vi.fn(async () => {});
-      const svc = new BlobSyncService({
-        transport: makeTransport({ blobExists, uploadBlob }),
-        blobStorage,
-        ...fast,
-      });
+      const transport = makeTransport({ blobExists });
+      const svc = new BlobSyncService({ transport, blobStorage, ...fast });
 
       const result = await svc.ensureBlobsUploaded(['present', 'missing']);
 
       expect(result.total).toBe(2);
       expect(result.success).toBe(2);
-      // Only the missing blob was actually sent; the present one was skipped.
+      // Only the missing blob was actually sent (presigned path); the present
+      // one was skipped by the HEAD-gate.
       expect(result.uploaded).toBe(1);
       expect(result.failed).toBe(0);
-      expect(uploadBlob).toHaveBeenCalledTimes(1);
-      expect((uploadBlob as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe('missing');
+      expect(transport.finalizeBlob).toHaveBeenCalledTimes(1);
+      expect((transport.finalizeBlob as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe('missing');
     });
 
     it('records a failure when a referenced blob is absent locally', async () => {
@@ -221,26 +289,27 @@ describe('BlobSyncService', () => {
     });
 
     it('does not retry a 4xx', async () => {
-      const uploadBlob = vi.fn(async () => {
+      const putBlobToUrl = vi.fn(async () => {
         throw httpError(400);
       });
-      const svc = new BlobSyncService({ transport: makeTransport({ uploadBlob }), ...fast });
+      const svc = new BlobSyncService({ transport: makeTransport({ putBlobToUrl }), ...fast });
 
       await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow();
-      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      expect(putBlobToUrl).toHaveBeenCalledTimes(1);
     });
 
     it('does NOT retry a 504 client-timeout — fails fast (JP-127)', async () => {
-      // relayClient surfaces its AbortController upload timeout as RelayError(504).
-      // Re-sending a large body 5× just multiplies a slow upload, so the service
-      // must fail fast and let the save layer queue one clean replay instead.
-      const uploadBlob = vi.fn(async () => {
+      // The big direct-to-R2 PUT surfaces relayClient's AbortController upload
+      // timeout as RelayError(504). Re-sending a large body 5× just multiplies a
+      // slow upload, so the service fails fast and lets the save layer queue one
+      // clean replay instead.
+      const putBlobToUrl = vi.fn(async () => {
         throw httpError(504, 'Request timed out after 600000ms');
       });
-      const svc = new BlobSyncService({ transport: makeTransport({ uploadBlob }), ...fast });
+      const svc = new BlobSyncService({ transport: makeTransport({ putBlobToUrl }), ...fast });
 
       await expect(svc.uploadBlob('abc', new Blob(['x']))).rejects.toThrow();
-      expect(uploadBlob).toHaveBeenCalledTimes(1);
+      expect(putBlobToUrl).toHaveBeenCalledTimes(1);
     });
 
     it('retries network errors (no status) up to maxRetries then throws', async () => {

--- a/src/collaboration/BlobSyncService.test.ts
+++ b/src/collaboration/BlobSyncService.test.ts
@@ -205,18 +205,18 @@ describe('BlobSyncService', () => {
       expect((transport.finalizeBlob as ReturnType<typeof vi.fn>).mock.calls[0]![0]).toBe('missing');
     });
 
-    it('records a failure when a referenced blob is absent locally', async () => {
+    it('skips (does not fail) a referenced blob absent locally and not on the relay', async () => {
       const { mock: blobStorage } = makeBlobStorage(); // empty
-      const svc = new BlobSyncService({
-        transport: makeTransport({ blobExists: vi.fn(async () => false) }),
-        blobStorage,
-        ...fast,
-      });
+      const transport = makeTransport({ blobExists: vi.fn(async () => false) });
+      const svc = new BlobSyncService({ transport, blobStorage, ...fast });
 
       const result = await svc.ensureBlobsUploaded(['gone']);
 
-      expect(result.failed).toBe(1);
-      expect(result.errors.get('gone')).toMatch(/local storage/);
+      // A dangling reference must not fail the save — it's skipped, never uploaded.
+      expect(result.failed).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.uploaded).toBe(0);
+      expect(transport.mintBlobPutUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/src/collaboration/BlobSyncService.ts
+++ b/src/collaboration/BlobSyncService.ts
@@ -38,14 +38,42 @@ export interface BlobSyncProgress {
 }
 
 /**
+ * Result of requesting a presigned blob upload
+ * (`RelayClient.mintBlobPutUrl` → `POST /api/v1/blobs/:hash/upload-url`):
+ * - `exists`: the workspace already holds the blob — skip upload + finalize.
+ * - `unsupported`: the relay's storage backend is the filesystem (no presign),
+ *   so the caller falls back to the proxy `uploadBlob`.
+ * - `presigned`: PUT the bytes directly to `url` echoing `headers`, then
+ *   `finalizeBlob`.
+ */
+export type BlobUploadMint =
+  | { kind: 'exists' }
+  | { kind: 'unsupported' }
+  | {
+      kind: 'presigned';
+      url: string;
+      headers: Record<string, string>;
+      expiresAt: number;
+      key: string;
+    };
+
+/**
  * Low-level blob transport. The connected `RelayClient` implements this
- * directly (`uploadBlob`/`downloadBlob`/`blobExists`), so auth + refresh
- * are handled there; this service never touches tokens.
+ * directly, so auth + refresh are handled there; this service never touches
+ * tokens. The presigned trio (`mintBlobPutUrl`/`putBlobToUrl`/`finalizeBlob`)
+ * routes blob bytes straight to object storage; `uploadBlob`/`downloadBlob`
+ * are the relay-proxied path (filesystem backend, or download).
  */
 export interface BlobTransport {
   blobExists(hash: string): Promise<boolean>;
   uploadBlob(hash: string, data: Uint8Array): Promise<void>;
   downloadBlob(hash: string): Promise<Uint8Array>;
+  /** Request a presigned upload (or learn the blob already exists / isn't presignable). */
+  mintBlobPutUrl(hash: string, opts: { size: number; mimeType: string }): Promise<BlobUploadMint>;
+  /** PUT bytes straight to a presigned object-storage URL (no relay, no auth header). */
+  putBlobToUrl(url: string, headers: Record<string, string>, body: Blob): Promise<void>;
+  /** Tell the relay a direct upload landed so it records + ACL-grants the blob. */
+  finalizeBlob(hash: string, opts: { mimeType: string }): Promise<void>;
 }
 
 /** Options for BlobSyncService */
@@ -122,11 +150,45 @@ export class BlobSyncService {
   }
 
   /**
-   * Upload a blob to the relay.
+   * Upload a blob. Prefers the **direct-to-object-storage** path: mint a
+   * presigned PUT, stream the bytes straight to R2 (never through the relay),
+   * then finalize. Falls back to the relay-proxied `uploadBlob` when the relay
+   * is filesystem-backed (`unsupported`). The whole sequence is retried with
+   * backoff; a presigned URL that expires mid-flight (403) is re-minted once.
    */
   async uploadBlob(hash: string, blob: Blob): Promise<void> {
-    const data = new Uint8Array(await blob.arrayBuffer());
-    await this.withRetry(() => this.transport.uploadBlob(hash, data));
+    await this.withRetry(() => this.uploadOnce(hash, blob));
+  }
+
+  private async uploadOnce(hash: string, blob: Blob, allowRemint = true): Promise<void> {
+    const mimeType = blob.type || 'application/octet-stream';
+    const mint = await this.transport.mintBlobPutUrl(hash, { size: blob.size, mimeType });
+
+    if (mint.kind === 'exists') {
+      // Workspace already has the blob — nothing to upload or finalize.
+      return;
+    }
+    if (mint.kind === 'unsupported') {
+      // Filesystem-backed relay (no presign): proxy the bytes through it. This
+      // is the only path that materializes the full ArrayBuffer.
+      const data = new Uint8Array(await blob.arrayBuffer());
+      await this.transport.uploadBlob(hash, data);
+      return;
+    }
+
+    // Stream the Blob straight to object storage — no ArrayBuffer copy, so a
+    // large upload never lands on the JS heap (the desktop UI-freeze fix).
+    try {
+      await this.transport.putBlobToUrl(mint.url, mint.headers, blob);
+    } catch (error) {
+      // A 403 on the PUT usually means the presigned URL lapsed mid-upload;
+      // re-mint a fresh one and retry the transfer once.
+      if (allowRemint && (error as { status?: unknown })?.status === 403) {
+        return this.uploadOnce(hash, blob, false);
+      }
+      throw error;
+    }
+    await this.transport.finalizeBlob(hash, { mimeType });
   }
 
   /**
@@ -362,6 +424,10 @@ export class BlobSyncService {
       // body up to 5× just multiplies an already-slow upload — fail fast and let
       // the save layer queue it for a single clean replay instead.
       if (status === 504) return false;
+      // 507 (storage quota) is terminal: the quota won't change on retry, and on
+      // the presigned path finalize has already reclaimed the just-uploaded
+      // object, so a retry would only 404. Surface it so the save layer reports.
+      if (status === 507) return false;
       return status >= 500 || status === 429;
     }
     // No status -> treat as a network/transport error and retry.

--- a/src/collaboration/BlobSyncService.ts
+++ b/src/collaboration/BlobSyncService.ts
@@ -105,8 +105,17 @@ export interface BlobSyncResult {
    * instead of claiming everything was (re)uploaded.
    */
   uploaded: number;
-  /** Blobs that failed */
+  /** Blobs that failed transiently (upload error) — the caller blocks the save and retries. */
   failed: number;
+  /**
+   * Blobs referenced by the document whose bytes are missing from local storage
+   * *and* not already on the relay — this client can't upload what it doesn't
+   * have. Counted separately from `failed` so a pre-existing dangling reference
+   * (e.g. a blob evicted from IndexedDB) doesn't brick the document save: the
+   * save proceeds, the reference is kept, and the asset just isn't (re)synced
+   * from here. It resolves if the bytes reappear on a client that has them.
+   */
+  skipped: number;
   /** Error messages for failed blobs */
   errors: Map<string, string>;
 }
@@ -226,6 +235,7 @@ export class BlobSyncService {
       success: 0,
       uploaded: 0,
       failed: 0,
+      skipped: 0,
       errors: new Map(),
     };
 
@@ -277,8 +287,17 @@ export class BlobSyncService {
           // Load blob from local storage
           const blob = await this.blobStorage.loadBlob(hash);
           if (!blob) {
-            result.failed++;
-            result.errors.set(hash, 'Blob not found in local storage');
+            // The bytes aren't in local storage and the relay doesn't have them
+            // either (the HEAD-gate above already skipped blobs the relay has).
+            // We can't upload what we don't have — but a pre-existing dangling
+            // reference must NOT brick the whole document save. Skip it with a
+            // warning; the reference stays in the doc and resolves later if the
+            // bytes reappear on a client that has them.
+            result.skipped++;
+            console.warn(
+              `[BlobSyncService] Skipping ${hash}: missing from local storage and not on the relay — ` +
+                `the document will save without re-uploading this asset`,
+            );
             continue;
           }
 
@@ -309,6 +328,7 @@ export class BlobSyncService {
       success: 0,
       uploaded: 0,
       failed: 0,
+      skipped: 0,
       errors: new Map(),
     };
 
@@ -375,7 +395,7 @@ export class BlobSyncService {
     const blobHashes = collectBlobReferences(document);
 
     if (blobHashes.length === 0) {
-      return { total: 0, success: 0, uploaded: 0, failed: 0, errors: new Map() };
+      return { total: 0, success: 0, uploaded: 0, failed: 0, skipped: 0, errors: new Map() };
     }
 
     const uploadResult = await this.ensureBlobsUploaded(blobHashes);
@@ -386,6 +406,7 @@ export class BlobSyncService {
       success: Math.max(uploadResult.success, downloadResult.success),
       uploaded: uploadResult.uploaded + downloadResult.uploaded,
       failed: Math.min(uploadResult.failed, downloadResult.failed),
+      skipped: uploadResult.skipped + downloadResult.skipped,
       errors: new Map([...uploadResult.errors, ...downloadResult.errors]),
     };
   }

--- a/src/store/relayDocumentStore.blobSync.test.ts
+++ b/src/store/relayDocumentStore.blobSync.test.ts
@@ -35,7 +35,7 @@ import type { BlobSyncResult } from '../collaboration/BlobSyncService';
 import type { DiagramDocument } from '../types/Document';
 
 function ok(total: number): BlobSyncResult {
-  return { total, success: total, uploaded: total, failed: 0, errors: new Map() };
+  return { total, success: total, uploaded: total, failed: 0, skipped: 0, errors: new Map() };
 }
 
 /** A doc that references one blob (rich-text image + GC list). */
@@ -122,6 +122,7 @@ describe('relayDocumentStore — JP-118 blob routing', () => {
         success: 0,
         uploaded: 0,
         failed: 1,
+        skipped: 0,
         errors: new Map([['hashA', 'quota exceeded']]),
       })),
     });
@@ -178,6 +179,7 @@ describe('relayDocumentStore — JP-118 blob routing', () => {
         success: 0,
         uploaded: 0,
         failed: 1,
+        skipped: 0,
         errors: new Map([['hashC', 'offline']]),
       })),
     });

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -446,6 +446,15 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
                 `Failed to upload ${uploadResult.failed} of ${uploadResult.total} asset(s) to the relay: ${detail}`,
               );
             }
+            if (uploadResult.skipped > 0) {
+              // Pre-existing dangling references (bytes missing locally + not on
+              // the relay). Don't block the save — a missing asset must not brick
+              // the document; log it so the gap is visible.
+              console.warn(
+                `[relayDocumentStore] ${uploadResult.skipped} of ${uploadResult.total} asset(s) for ${doc.id} ` +
+                  `are missing locally and not on the relay — saving without them`,
+              );
+            }
             const bundleResult = await bundleDocumentWithAssets(doc, { mode: 'reference' });
             docToSave = bundleResult.document;
             console.log(


### PR DESCRIPTION
Moves blob upload/download from proxying bytes through the relay to **presigned direct-to-S3/R2**, with the relay owning the object store (mints presigned URLs, records refs, meters, GCs). Resolves JP-87. Builds on the JP-127 reqwest transport already in `master`.

## Why
Proxying blob bytes through the relay froze the editor UI on large desktop uploads and burned server CPU/bandwidth. Direct-to-object-storage streams the bytes off the relay's control channel (fixes the freeze), and an S3 backend lets a deployment keep blobs out of local disk entirely.

## What

**Relay**
- Pluggable `BlobBackend` (`filesystem` | `s3`); the index/ACL/reference/GC bookkeeping stays backend-agnostic. Filesystem remains the zero-dependency default for self-host, dev, and tests.
- A small **SigV4 signer** over the existing `reqwest` stack (one `hmac` dep — deliberately *not* `aws-sdk-s3`, so the relay's 1.77.2 MSRV and lean build are unchanged). Per-workspace object keys.
- New wire: `POST /api/v1/blobs/:hash/upload-url` (dedup short-circuit, projected-quota 507, mint) and `/finalize` (authoritative HEAD size, quota re-check + reclaim-if-over, record + grant ACL). `GET /api/blobs/:hash` 302-redirects to a presigned GET on the s3 backend. The proxy `POST /api/blobs/:hash` also streams to the object store, so a client that can't do the direct PUT still works. OpenAPI updated.
- Per-workspace object GC via an async delete worker (keeps the synchronous GC chain sync).

**Editor**
- `mint → PUT-direct-to-storage → finalize`, **streaming the `Blob`** (no ArrayBuffer copy — the desktop UI-freeze fix), with a proxy fallback on the filesystem backend, a one-shot re-mint on a 403 (URL expired mid-flight), and 507 treated as terminal.
- Hardening: a referenced blob whose bytes are missing from local storage *and* not on the relay is now **skipped** (with a warning) rather than **failed**, so a pre-existing dangling reference can't brick a document save.

## Verification
- Relay: 152 unit/integration tests; full TS suite **1702**; `tsc` + clippy clean (no net-new warnings).
- The SigV4 signer matches AWS's documented vector, and the full relay HTTP flow round-trips against **MinIO and real Cloudflare R2** — presigned PUT → finalize → 302 download → usage metering → GC reclaim — including the proxy path.
- Validated end-to-end against a deployed s3-backed relay (a real desktop upload landed in R2).

## Notes
- Signs only `content-type` (not `content-length` — a forbidden header that browser `fetch` and the Tauri http plugin strip; `finalize`'s HEAD re-verifies the authoritative size). The Tauri http capability allows `*.r2.cloudflarestorage.com`.
- Config: `[storage] backend = "s3"` + `[storage.s3]`, or the `RELAY_R2_*` environment variables (a complete credential set auto-selects the s3 backend).

Assisted-by: Opus 4.8
