### PR TITLE
feat(editor): finish web one-click workspace handoff

### DIFF
--- a/src/api/authCallback.test.ts
+++ b/src/api/authCallback.test.ts
@@ -1,4 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the completion + persistence seams so we can assert what the callback
+// hands off without starting a real collaboration session.
+const completeCloudSignIn = vi.fn(async () => {});
+const loadConnection = vi.fn(async () => null as unknown);
+vi.mock('./completeCloudSignIn', () => ({
+  completeCloudSignIn: (...args: unknown[]) => completeCloudSignIn(...(args as [])),
+}));
+vi.mock('./relayConnection', () => ({
+  loadConnection: () => loadConnection(),
+  DEFAULT_CLOUD_BASE_URL: 'https://cloud.test',
+}));
+
 import {
   parseAuthCallback,
   isAuthCallbackRoute,
@@ -8,12 +21,8 @@ import {
 } from './authCallback';
 
 describe('authCallback', () => {
-  it('is disabled until the docushark-web bridge (JP-103) ships', () => {
-    expect(AUTH_CALLBACK_ENABLED).toBe(false);
-  });
-
-  it('handleAuthCallbackIfPresent is a no-op while disabled', async () => {
-    expect(await handleAuthCallbackIfPresent()).toBe(false);
+  it('is enabled (docushark-web web one-click bridge is live)', () => {
+    expect(AUTH_CALLBACK_ENABLED).toBe(true);
   });
 
   it('recognizes the callback route', () => {
@@ -43,5 +52,74 @@ describe('authCallback', () => {
 
   it('flags an unparseable URL', () => {
     expect(parseAuthCallback('not a url').error).toBe('invalid_callback_url');
+  });
+
+  describe('handleAuthCallbackIfPresent', () => {
+    beforeEach(() => {
+      completeCloudSignIn.mockClear();
+      loadConnection.mockClear();
+      loadConnection.mockResolvedValue(null);
+      // jsdom: pushState updates window.location.{pathname,href,search}.
+      window.history.pushState({}, '', '/');
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      window.history.pushState({}, '', '/');
+    });
+
+    it('is a no-op when not on the callback route', async () => {
+      window.history.pushState({}, '', '/settings');
+      expect(await handleAuthCallbackIfPresent()).toBe(false);
+      expect(completeCloudSignIn).not.toHaveBeenCalled();
+    });
+
+    it('consumes the code and signs in with the relay URL from the response', async () => {
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ token: 'tok', expires_at: 1700, relay_url: 'https://relay.test' }),
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+      window.history.pushState({}, '', '/auth/callback?handoff_code=abc123');
+
+      const consumed = await handleAuthCallbackIfPresent();
+
+      expect(consumed).toBe(true);
+      // Posts the code to the configured cloud origin's consume route.
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://cloud.test/api/v1/auth/web-handoff/consume',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      // Drives the session with the server-resolved relay URL (not a persisted
+      // one — there is none for a first-time user) and ms-scaled expiry.
+      expect(completeCloudSignIn).toHaveBeenCalledWith({
+        relayUrl: 'https://relay.test',
+        cloudBaseUrl: 'https://cloud.test',
+        token: 'tok',
+        expiresAt: 1700 * 1000,
+      });
+      // Handoff code is scrubbed from the URL.
+      expect(window.location.search).toBe('');
+    });
+
+    it('bails without signing in when the consume payload is missing relay_url', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({ ok: true, json: async () => ({ token: 'tok', expires_at: 1700 }) })),
+      );
+      window.history.pushState({}, '', '/auth/callback?handoff_code=abc123');
+
+      expect(await handleAuthCallbackIfPresent()).toBe(true);
+      expect(completeCloudSignIn).not.toHaveBeenCalled();
+    });
+
+    it('consumes the route but does not sign in when the redirect carried an error', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      window.history.pushState({}, '', '/auth/callback?error=access_denied');
+
+      expect(await handleAuthCallbackIfPresent()).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(completeCloudSignIn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/api/authCallback.ts
+++ b/src/api/authCallback.ts
@@ -1,26 +1,32 @@
 /**
- * PWA web OAuth callback (JP-100) — **inert until JP-103 ships** in
- * `docushark-web`, then flip [[AUTH_CALLBACK_ENABLED]] to true. The
- * docushark-web bridge owns the OAuth round-trip end-to-end and delivers a
- * single-use **handoff code** as `?handoff_code=…` (chosen over an
- * implicit-grant `#access_token` so PKCE stays on docushark.app and no relay
- * JWT ever lives in a URL — see Final OSS App Design §2).
+ * PWA web OAuth callback. The `docushark-web` bridge owns the OAuth round-trip
+ * end-to-end and delivers a single-use **handoff code** as `?handoff_code=…`
+ * (chosen over an implicit-grant `#access_token` so PKCE stays on docushark.app
+ * and no relay JWT ever lives in a URL — see Final OSS App Design §2).
  *
- * Flow when enabled:
+ * Flow:
  *   1. Land on `/auth/callback?handoff_code=…` (Supabase OAuth has already
  *      completed on `docushark.app/auth/callback`).
  *   2. POST the code to `${cloudBaseUrl}/api/v1/auth/web-handoff/consume`
  *      (CORS-enabled on the docushark-web side).
- *   3. Consume route mints + returns the relay app token; we hand it to
- *      [[completeCloudSignIn]] which reuses the device-code completion path.
+ *   3. The consume route mints + returns the relay app token **and** the relay
+ *      URL for the user's primary workspace (region resolved server-side — the
+ *      editor never decodes the JWT). We hand both to [[completeCloudSignIn]],
+ *      which reuses the device-code completion path. This makes the *first-time*
+ *      user case work: there's no persisted relay URL to fall back on.
  *   4. Clean the URL via `history.replaceState`.
  */
 
 import { completeCloudSignIn } from './completeCloudSignIn';
 import { loadConnection, DEFAULT_CLOUD_BASE_URL } from './relayConnection';
+import { showStorageInfoToastOnce } from './storageInfoToast';
 
-/** Flip to `true` once JP-103 (docushark-web web OAuth bridge) is deployed. */
-export const AUTH_CALLBACK_ENABLED = false;
+/**
+ * The web one-click handoff is live (docushark-web bridge deployed). The
+ * `cloudBaseUrl` the consume call targets comes from [[DEFAULT_CLOUD_BASE_URL]]
+ * (build-time `VITE_CLOUD_BASE_URL`) when no connection is yet persisted.
+ */
+export const AUTH_CALLBACK_ENABLED = true;
 
 /** SPA path the web OAuth redirect lands on. */
 export const AUTH_CALLBACK_PATH = '/auth/callback';
@@ -59,17 +65,18 @@ export function isAuthCallbackRoute(pathname: string): boolean {
 interface ConsumeResponse {
   token: string;
   expires_at: number; // Unix seconds
+  relay_url: string; // relay pod for the user's primary workspace
 }
 
 /**
- * Swap the single-use handoff code for a relay app token. Throws on a non-200
- * or malformed payload — the caller logs + bails (today's "Session expired"
- * UX, since the user can retry sign-in).
+ * Swap the single-use handoff code for a relay app token + the relay URL to
+ * connect it to. Throws on a non-200 or malformed payload — the caller logs +
+ * bails (today's "Session expired" UX, since the user can retry sign-in).
  */
 async function consumeHandoff(
   cloudBaseUrl: string,
   handoffCode: string,
-): Promise<{ token: string; expiresAt: number }> {
+): Promise<{ token: string; expiresAt: number; relayUrl: string }> {
   const res = await fetch(
     `${cloudBaseUrl.replace(/\/+$/, '')}/api/v1/auth/web-handoff/consume`,
     {
@@ -80,10 +87,14 @@ async function consumeHandoff(
   );
   if (!res.ok) throw new Error(`handoff consume failed: ${res.status}`);
   const data = (await res.json()) as Partial<ConsumeResponse>;
-  if (typeof data.token !== 'string' || typeof data.expires_at !== 'number') {
+  if (
+    typeof data.token !== 'string' ||
+    typeof data.expires_at !== 'number' ||
+    typeof data.relay_url !== 'string'
+  ) {
     throw new Error('handoff consume returned malformed payload');
   }
-  return { token: data.token, expiresAt: data.expires_at * 1000 };
+  return { token: data.token, expiresAt: data.expires_at * 1000, relayUrl: data.relay_url };
 }
 
 /**
@@ -114,9 +125,12 @@ export async function handleAuthCallbackIfPresent(): Promise<boolean> {
   try {
     const persisted = await loadConnection();
     const cloudBaseUrl = persisted?.cloudBaseUrl ?? DEFAULT_CLOUD_BASE_URL;
-    const relayUrl = persisted?.relayUrl ?? '';
-    const { token, expiresAt } = await consumeHandoff(cloudBaseUrl, handoffCode);
+    // The relay URL comes from the consume response (region resolved by
+    // docushark-web), not the persisted record — a first-time user has none.
+    const { token, expiresAt, relayUrl } = await consumeHandoff(cloudBaseUrl, handoffCode);
     await completeCloudSignIn({ relayUrl, cloudBaseUrl, token, expiresAt });
+    // First-connect explainer of the storage model (once per browser).
+    showStorageInfoToastOnce();
   } catch (err) {
     console.warn('[authCallback] handoff consume failed:', err);
   }

--- a/src/api/relayConnection.ts
+++ b/src/api/relayConnection.ts
@@ -21,8 +21,16 @@ import { secureStore } from '../platform/secureStore';
 
 const STORAGE_KEY = 'docushark-relay-connection';
 
-/** Default docushark-web (Cloud) origin used when none is persisted. */
-export const DEFAULT_CLOUD_BASE_URL = 'http://localhost:3000';
+/**
+ * Default Cloud (docushark-web) origin used when none is persisted — e.g. a
+ * first-time user arriving via the web one-click handoff, who has no saved
+ * connection record yet. Build-time configurable via `VITE_CLOUD_BASE_URL` so a
+ * hosted build can pair with its environment's control plane; falls back to the
+ * local dev origin. The value is just an origin (not a secret), so the repo
+ * default stays generic.
+ */
+export const DEFAULT_CLOUD_BASE_URL =
+  import.meta.env.VITE_CLOUD_BASE_URL ?? 'http://localhost:3000';
 
 export interface RelayConnection {
   /** Origin of the relay (e.g. `http://localhost:9876`). */

--- a/src/api/storageInfoToast.test.ts
+++ b/src/api/storageInfoToast.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { showStorageInfoToastOnce } from './storageInfoToast';
+import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+describe('showStorageInfoToastOnce', () => {
+  beforeEach(() => {
+    useNotificationStore.getState().dismissAll();
+    useUIPreferencesStore.setState({ storageInfoToastSeen: false });
+  });
+
+  it('shows the storage explainer the first time and marks it seen', () => {
+    showStorageInfoToastOnce();
+    const notifications = useNotificationStore.getState().notifications;
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.message).toContain('metered by total size');
+    expect(useUIPreferencesStore.getState().storageInfoToastSeen).toBe(true);
+  });
+
+  it('does nothing on subsequent connects', () => {
+    showStorageInfoToastOnce();
+    useNotificationStore.getState().dismissAll();
+    showStorageInfoToastOnce();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+});

--- a/src/api/storageInfoToast.ts
+++ b/src/api/storageInfoToast.ts
@@ -1,0 +1,27 @@
+/**
+ * One-time "how storage works" toast, shown after a Cloud workspace connect.
+ *
+ * The PWA is public and un-gated — a first-time user can land via the web
+ * one-click handoff and be editing in seconds. The first time they connect to a
+ * workspace we surface a single, dismissable explainer of the storage model so
+ * the metering isn't a surprise later. Persisted via `uiPreferencesStore` so it
+ * fires at most once per browser.
+ *
+ * Lives in the api layer (not a React component) and only touches plain Zustand
+ * store singletons — the same pattern as `notifyError` in `notificationStore`.
+ */
+
+import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+const STORAGE_INFO_MESSAGE =
+  'Connected to your workspace. Cloud storage is metered by total size — ' +
+  'viewers are always free, and documents you keep on this device stay free and offline.';
+
+/** Show the storage explainer once, then remember it was shown. */
+export function showStorageInfoToastOnce(): void {
+  const prefs = useUIPreferencesStore.getState();
+  if (prefs.storageInfoToastSeen) return;
+  prefs.markStorageInfoToastSeen();
+  useNotificationStore.getState().info(STORAGE_INFO_MESSAGE, { duration: 10000 });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -33,6 +33,7 @@ function mountApp(): void {
   registerPwa();
 }
 
-// JP-100: intercept the PWA web OAuth callback before mounting. Inert (resolves
-// false immediately) until the docushark-web bridge flips AUTH_CALLBACK_ENABLED.
+// Intercept the PWA web one-click handoff (`/auth/callback?handoff_code=…`)
+// before mounting: consume the code, connect the relay, then mount. A no-op on
+// every other route (and in the Tauri build).
 void handleAuthCallbackIfPresent().then(mountApp);

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -41,6 +41,11 @@ export interface UIPreferencesState {
   documentBrowserGroupBy: DocumentBrowserGroupBy;
   /** Per-group collapsed state in the browser (groupId -> collapsed). */
   documentBrowserCollapsed: Record<string, boolean>;
+  /**
+   * Whether the one-time "how storage works" toast has been shown after a
+   * Cloud workspace connect. Persisted so it fires at most once per browser.
+   */
+  storageInfoToastSeen: boolean;
   /** Layout manager slice — modes, per-doc memory, per-mode overrides, chrome. */
   layout: LayoutState;
 }
@@ -65,6 +70,8 @@ export interface UIPreferencesActions {
   setDocumentBrowserGroupBy: (groupBy: DocumentBrowserGroupBy) => void;
   /** Toggle a group's collapsed state in the document browser */
   toggleDocumentBrowserGroupCollapsed: (groupId: string) => void;
+  /** Record that the one-time storage-info toast has been shown. */
+  markStorageInfoToastSeen: () => void;
 
   // ── Layout actions (low-level; the `useLayout` hook composes ergonomic
   // "infer current mode" wrappers on top of these for normal call sites.)
@@ -133,6 +140,7 @@ const initialState: UIPreferencesState = {
   documentBrowserSort: 'modified-desc',
   documentBrowserGroupBy: 'none',
   documentBrowserCollapsed: {},
+  storageInfoToastSeen: false,
   layout: initialLayoutState,
 };
 
@@ -254,6 +262,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         });
       },
 
+      markStorageInfoToastSeen: () => set({ storageInfoToastSeen: true }),
+
       setDefaultLayout: (mode) => {
         set({ layout: { ...get().layout, defaultMode: mode } });
       },
@@ -351,6 +361,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         documentBrowserSort: state.documentBrowserSort,
         documentBrowserGroupBy: state.documentBrowserGroupBy,
         documentBrowserCollapsed: state.documentBrowserCollapsed,
+        storageInfoToastSeen: state.storageInfoToastSeen,
         layout: state.layout,
       }),
       migrate: (persisted, fromVersion) => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,6 +12,15 @@
 declare const __APP_VERSION__: string;
 declare const __IS_TAURI__: boolean;
 
+interface ImportMetaEnv {
+  /**
+   * Cloud (docushark-web) origin this build pairs with, used as the default
+   * when no connection record is persisted (e.g. the web one-click handoff).
+   * Optional — falls back to the local dev origin in `relayConnection.ts`.
+   */
+  readonly VITE_CLOUD_BASE_URL?: string;
+}
+
 declare module 'nspell' {
   interface NSpell {
     correct(word: string): boolean;


### PR DESCRIPTION
## What

Completes the editor side of the web one-click "Open in DocuShark" handoff so a **first-time** user (no persisted connection) lands from the Cloud control plane straight into a connected workspace. Pairs with the `docushark-web` change that adds `relay_url` to the handoff consume response.

## Changes

- **Enable the web OAuth callback** — flip `AUTH_CALLBACK_ENABLED` on (the `docushark-web` bridge is live) and update the stale "inert until JP-103" comments.
- **Consume the relay URL from the handoff response** — `authCallback.ts` now reads `relay_url` (region resolved server-side; the editor never decodes the JWT) and drives `completeCloudSignIn` with it instead of falling back to an empty persisted `relayUrl`. This is the missing piece for first-time users.
- **Build-time Cloud origin** — `DEFAULT_CLOUD_BASE_URL` reads `import.meta.env.VITE_CLOUD_BASE_URL` (localhost fallback unchanged), so a hosted build pairs with its environment's control plane without baking infra into the repo. Typed via `ImportMetaEnv`.
- **One-time storage explainer** — after a successful one-click connect, show a single dismissable toast about the storage model (single meter, viewers free, local docs free + offline). Persisted via `uiPreferencesStore.storageInfoToastSeen`.

## Testing

- `bun run typecheck` clean.
- `bun run test --run` — 1721 passed (rewrote `authCallback.test.ts` for the enabled path + added `storageInfoToast.test.ts`).
- The PWA shell stays public/un-gated; auth remains opt-in.

Assisted-by: Opus 4.8