### PR TITLE
ci(relay): publish GHCR image from staging, master is build-check only

### DIFF
--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -1,16 +1,18 @@
 name: Relay image
 
-# Build, and on the default branch / release tags publish, the relay
-# container image. The published image is what any operator can run to
-# self-host the relay (see relay/README.md → "One-command run (Docker)").
+# Internal/testing channel for the relay container image. Pushes to `staging`
+# build + publish to GHCR (`:edge` tracks `staging`, plus `:sha-<short>`) — this
+# is the image docushark-web's staging deploy pulls. `master` is the OSS /
+# production source: PRs into it get a build-check (verify the Dockerfile, no
+# publish), and the production image is *promoted* from a tested GHCR digest to
+# the production registry on a `relay-v*` tag by a separate release workflow
+# (deferred — see Linear "Release Channels & Artifact Promotion").
 on:
   push:
-    branches: [master]
+    branches: [staging]
     paths:
       - "relay/**"
       - ".github/workflows/relay-image.yml"
-    tags:
-      - "relay-v*"
   pull_request:
     branches: [master]
     paths:
@@ -39,17 +41,13 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=edge,branch=master
+            type=edge,branch=staging
             type=sha,prefix=sha-
-            type=match,pattern=relay-v(\d+\.\d+\.\d+),group=1
-            type=match,pattern=relay-v(\d+\.\d+),group=1
-            type=match,pattern=relay-v(\d+),group=1
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/relay-v') }}
           flavor: |
             latest=false
 
-      # Only the default branch and release tags push; PRs build to verify
-      # the Dockerfile without publishing.
+      # Only `staging` pushes publish (internal GHCR image); PRs into master
+      # build to verify the Dockerfile without publishing.
       - name: Log in to GHCR
         if: github.event_name == 'push'
         uses: docker/login-action@v3


### PR DESCRIPTION
## What

Reworks the relay image's channel triggers so the **internal/testing** image publishes from `staging` and `master` stays the curated **OSS/production** source.

## Changes (`.github/workflows/relay-image.yml`)

| Trigger | Before | After |
|---|---|---|
| push `staging` | — | **build + push GHCR** (`:edge` tracks staging, `:sha-<short>`) |
| push `master` | build + push GHCR | _(removed)_ |
| PR → `master` | build-check | build-check (unchanged) |
| tag `relay-v*` | build + push versioned + `latest` to GHCR | _(removed — deferred to the promote workflow)_ |

- `:edge` now follows `staging` (the bleeding edge) instead of `master`.
- Dropped the version-match + `latest` tags here — those belong to the production promote.

## Why

Keeps in-flight/unstable relay code off the public `master` that OSS users self-host from. `master` is reserved for the OSS promote: PRs get a build-check, and production images are later **promoted from a tested GHCR digest** (retag + sign, no rebuild) on a `relay-v*` tag — see Linear *Release Channels & Artifact Promotion*.

## Follow-ups (deferred, per that doc)

- Tag-driven Docker Hub promote (digest retag) + cosign signing + SBOM.
- Concurrency cancel, GHCR `sha-` retention, multi-arch (amd64+arm64).
- Create the `docushark-app` `staging` branch (off `master`) so the new trigger fires; pin docushark-web's staging relay to the `sha-<short>` digest.

Assisted-by: Opus 4.8