### PR TITLE
JP-138: Relaxed prose-first + app-level layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ The four layouts in `src/ui/layout/modes.ts` map to the wedge personas:
 
 | Mode | Document | Canvas | Properties | Persona |
 |------|----------|--------|------------|---------|
-| `relaxed` (default) | left, dominant | secondary toggle | hidden | Personal — writing |
+| `relaxed` (default) | primary (reading column) | secondary, focus switch | hidden (on selection) | Personal — writing |
 | `designer` | hidden, toggle | dominant | fly-out (auto-collapse) | Personal — diagramming |
 | `technician` | left, split | split | fly-out (auto-collapse) | Researcher / mid-power |
 | `power` | left, split | split | docked, pinned | Power-User |
@@ -297,22 +297,32 @@ The four layouts in `src/ui/layout/modes.ts` map to the wedge personas:
 Switch via the **layout selector** chip in the toolbar, `Cmd+Shift+1..4`, or
 the command palette ("Switch to … layout"). Zen is a backlog item (Linear).
 
+In **Relaxed** the document editor is the *primary* region (a centered reading
+column), not a sidebar. A `Write · Split · Diagram` segmented control
+(`RelaxedFocusControl`, toolbar-only in Relaxed; also `Cmd+Shift+\` and a
+command-palette entry) switches focus between prose-only, prose + secondary
+canvas, and canvas-primary. The focus is ephemeral app-level state
+(`sessionStore.relaxedFocus`); `resolveRegions(mode, focus, band)` in
+`modes.ts` maps it (plus the viewport band from `useBreakpoint`) to which region
+is primary — a `compact` viewport forbids split, the single-pane shape a future
+mobile (PWA) layout reuses.
+
 ### Persistence model
 
-All layout state lives in the `layout` slice on `uiPreferencesStore`
-(`docushark-ui-preferences` localStorage key, version 1):
+Layout is an **app-level** concern — a single active mode for the whole editor,
+not keyed per document. All layout state lives in the `layout` slice on
+`uiPreferencesStore` (`docushark-ui-preferences` localStorage key, version 3):
 
-- `defaultMode` — global default for newly created documents.
-- `perDoc[docId]` — last-used mode per document. **Client-side only — never
-  written into the doc file.** Opening a doc on another machine inherits
-  that machine's default. Garbage-collected when a doc is deleted.
+- `defaultMode` — the single active layout for the app.
 - `modeOverrides[mode][panelId]` — user customization deltas scoped per
   layout. Moving Properties to the left in Technician does not move it in
   Power.
 - `customChrome` — opt-in for the in-app TitleBar; reload required to apply.
 
-The resolution order on doc open: `perDoc[docId] ?? defaultMode`. The first
-explicit mode change for a doc writes `perDoc[docId]`.
+(An earlier design kept a per-document `perDoc` map here; it coupled UI prefs to
+document identity and was removed in the v3 migration. A document that needs to
+*suggest* a layout should carry that in its own isolated metadata, not this UI
+slice.)
 
 ### Key components
 

--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -9,7 +9,6 @@ import { useSessionStore, deleteSelected, getSelectedShapes } from '../store/ses
 import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore, pushHistory } from '../store/historyStore';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
-import { usePersistenceStore } from '../store/persistenceStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
@@ -130,6 +129,15 @@ export function getAllCommands(): Command[] {
 
     // --- Layouts ---
     ...layoutCommands(),
+    {
+      id: 'view.cycleRelaxedFocus',
+      label: 'Cycle prose / split / diagram focus',
+      category: 'View',
+      shortcut: 'Ctrl+Shift+\\',
+      execute: () => useSessionStore.getState().cycleRelaxedFocus(),
+      // Focus only applies to the writing-first Relaxed layout.
+      canExecute: () => useUIPreferencesStore.getState().layout.defaultMode === 'relaxed',
+    },
   ];
 }
 
@@ -144,18 +152,11 @@ function layoutCommands(): Command[] {
 }
 
 /**
- * Apply a layout to the currently open document — or, if no doc is open, set
- * it as the new global default so the next doc-open lands in the user's
- * chosen layout.
+ * Apply a layout. Layout is app-level (a single active mode for the whole
+ * editor), so this just sets the active mode.
  */
 export function applyLayoutMode(mode: LayoutMode): void {
-  const docId = usePersistenceStore.getState().currentDocumentId;
-  const store = useUIPreferencesStore.getState();
-  if (docId) {
-    store.setLayoutForDoc(docId, mode);
-  } else {
-    store.setDefaultLayout(mode);
-  }
+  useUIPreferencesStore.getState().setDefaultLayout(mode);
 }
 
 function alignmentCommands(): Command[] {

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,22 @@
   /* Shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  /* Responsive breakpoints — shared tokens so layout CSS and the
+   * `useBreakpoint` hook agree on the bands (see platform/device.ts
+   * viewportBand: narrow < 640 <= medium < 1024 <= wide). The future mobile
+   * (PWA) layout keys off these too; new responsive CSS should reference them
+   * rather than hard-coding pixel widths. */
+  --bp-compact: 640px;
+  --bp-regular: 1024px;
+
+  /* Safe-area insets — 0 on desktop, real values inside a standalone PWA on
+   * notched devices. Reserved now so the future mobile shell has somewhere to
+   * hang chrome padding without a second pass. */
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
 }
 
 /* Dark Theme */

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -20,7 +20,6 @@ import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
-import { useUIPreferencesStore } from './uiPreferencesStore';
 import { useUserStore } from './userStore';
 import { isRelayAuthenticated, useConnectionStore } from './connectionStore';
 import { useRelayDocumentStore } from './relayDocumentStore';
@@ -803,10 +802,6 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
 
         // Remove from document registry
         useDocumentRegistry.getState().removeDocument(id);
-
-        // Drop any per-doc layout memory so the perDoc map doesn't grow
-        // forever as docs are created and deleted.
-        useUIPreferencesStore.getState().clearLayoutForDoc(id);
 
         // If we deleted the current document, create a new one
         if (state.currentDocumentId === id) {

--- a/src/store/sessionStore.test.ts
+++ b/src/store/sessionStore.test.ts
@@ -423,4 +423,32 @@ describe('Session Store', () => {
       expect(useSessionStore.getState().viewingFileShapeId).toBe('file-2');
     });
   });
+
+  describe('relaxed focus', () => {
+    it('defaults to write', () => {
+      expect(useSessionStore.getState().relaxedFocus).toBe('write');
+    });
+
+    it('setRelaxedFocus sets the focus directly', () => {
+      useSessionStore.getState().setRelaxedFocus('diagram');
+      expect(useSessionStore.getState().relaxedFocus).toBe('diagram');
+    });
+
+    it('cycleRelaxedFocus advances write → split → diagram → write', () => {
+      const s = () => useSessionStore.getState();
+      expect(s().relaxedFocus).toBe('write');
+      s().cycleRelaxedFocus();
+      expect(s().relaxedFocus).toBe('split');
+      s().cycleRelaxedFocus();
+      expect(s().relaxedFocus).toBe('diagram');
+      s().cycleRelaxedFocus();
+      expect(s().relaxedFocus).toBe('write');
+    });
+
+    it('reset returns focus to write', () => {
+      useSessionStore.getState().setRelaxedFocus('split');
+      useSessionStore.getState().reset();
+      expect(useSessionStore.getState().relaxedFocus).toBe('write');
+    });
+  });
 });

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { useDocumentStore } from './documentStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
+import type { RelaxedFocus } from '../ui/layout/types';
 
 /**
  * Core tool types that are always available.
@@ -146,6 +147,12 @@ export interface SessionState {
    * Escape, tool switch, selection clear, or deletion of the group.
    */
   editingGroupId: string | null;
+  /**
+   * Focus within the writing-first Relaxed layout (prose / split / diagram).
+   * App-level and ephemeral — resets to 'write' on reload. Ignored outside the
+   * Relaxed layout. See `resolveRegions` in ui/layout/modes.ts.
+   */
+  relaxedFocus: RelaxedFocus;
 }
 
 /**
@@ -209,6 +216,12 @@ export interface SessionActions {
   /** Enter or exit transient group-edit context. */
   setEditingGroupId: (id: string | null) => void;
 
+  // Relaxed-layout focus
+  /** Set the Relaxed layout focus (prose / split / diagram). */
+  setRelaxedFocus: (focus: RelaxedFocus) => void;
+  /** Advance the Relaxed focus write → split → diagram → write. */
+  cycleRelaxedFocus: () => void;
+
   // Page Camera
   /** Save current camera state for a page */
   savePageCamera: (pageId: string) => void;
@@ -267,6 +280,7 @@ const initialState: SessionState = {
   cursorWorldPosition: null,
   blobSyncProgress: null,
   editingGroupId: null,
+  relaxedFocus: 'write',
 };
 
 /**
@@ -469,6 +483,18 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
   // Group drill-down
   setEditingGroupId: (id: string | null) => {
     set({ editingGroupId: id });
+  },
+
+  // Relaxed-layout focus
+  setRelaxedFocus: (focus: RelaxedFocus) => {
+    set({ relaxedFocus: focus });
+  },
+
+  cycleRelaxedFocus: () => {
+    const order: RelaxedFocus[] = ['write', 'split', 'diagram'];
+    const idx = order.indexOf(get().relaxedFocus);
+    const next = order[(idx + 1) % order.length] ?? 'write';
+    set({ relaxedFocus: next });
   },
 
   // Page Camera

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -11,10 +11,9 @@ beforeEach(() => {
 });
 
 describe('uiPreferencesStore — layout slice', () => {
-  it('starts with Relaxed default, no per-doc memory, no overrides, native chrome', () => {
+  it('starts with Relaxed default (app-level), no overrides, native chrome', () => {
     const { layout } = useUIPreferencesStore.getState();
     expect(layout.defaultMode).toBe('relaxed');
-    expect(layout.perDoc).toEqual({});
     expect(layout.modeOverrides).toEqual({
       relaxed: {},
       designer: {},
@@ -22,28 +21,13 @@ describe('uiPreferencesStore — layout slice', () => {
       power: {},
     });
     expect(layout.customChrome).toBe(false);
+    // Layout is app-level — there is no per-document map.
+    expect('perDoc' in layout).toBe(false);
   });
 
-  it('setDefaultLayout updates only the global default', () => {
+  it('setDefaultLayout sets the single app-level active layout', () => {
     useUIPreferencesStore.getState().setDefaultLayout('power');
     expect(useUIPreferencesStore.getState().layout.defaultMode).toBe('power');
-    expect(useUIPreferencesStore.getState().layout.perDoc).toEqual({});
-  });
-
-  it('setLayoutForDoc records per-doc memory without touching the default', () => {
-    useUIPreferencesStore.getState().setLayoutForDoc('doc-1', 'technician');
-    useUIPreferencesStore.getState().setLayoutForDoc('doc-2', 'designer');
-    const { layout } = useUIPreferencesStore.getState();
-    expect(layout.perDoc).toEqual({ 'doc-1': 'technician', 'doc-2': 'designer' });
-    expect(layout.defaultMode).toBe('relaxed');
-  });
-
-  it('clearLayoutForDoc removes a single entry without affecting others', () => {
-    const s = useUIPreferencesStore.getState();
-    s.setLayoutForDoc('doc-1', 'power');
-    s.setLayoutForDoc('doc-2', 'technician');
-    s.clearLayoutForDoc('doc-1');
-    expect(useUIPreferencesStore.getState().layout.perDoc).toEqual({ 'doc-2': 'technician' });
   });
 
   it('setPanelDockFor scopes overrides to the named layout only', () => {
@@ -90,17 +74,15 @@ describe('uiPreferencesStore — layout slice', () => {
     expect(useUIPreferencesStore.getState().layout.customChrome).toBe(false);
   });
 
-  it('resetLayoutCustomization clears overrides and perDoc, keeps default + chrome', () => {
+  it('resetLayoutCustomization clears overrides, keeps default + chrome', () => {
     const s = useUIPreferencesStore.getState();
     s.setDefaultLayout('technician');
     s.setCustomChrome(true);
-    s.setLayoutForDoc('doc-1', 'power');
     s.setPanelDockFor('power', 'properties', 'left');
     s.resetLayoutCustomization();
     const { layout } = useUIPreferencesStore.getState();
     expect(layout.defaultMode).toBe('technician');
     expect(layout.customChrome).toBe(true);
-    expect(layout.perDoc).toEqual({});
     expect(layout.modeOverrides.power).toEqual({});
   });
 });
@@ -124,6 +106,12 @@ describe('layout presets', () => {
   it('Relaxed hides properties, Power pins them', () => {
     expect(LAYOUT_PRESETS.relaxed.properties.visible).toBe(false);
     expect(LAYOUT_PRESETS.power.properties.pinned).toBe(true);
+  });
+
+  it('Relaxed is writing-first: document fills the region (no fixed width), layers hidden', () => {
+    expect(LAYOUT_PRESETS.relaxed.document.visible).toBe(true);
+    expect(LAYOUT_PRESETS.relaxed.document.width).toBeUndefined();
+    expect(LAYOUT_PRESETS.relaxed.layers.visible).toBe(false);
   });
 
   it('Designer hides the document panel (canvas-immersive) but preserves the dock side', () => {
@@ -212,5 +200,42 @@ describe('uiPreferencesStore — migration', () => {
     const { layout } = useUIPreferencesStore.getState();
     expect(layout.modeOverrides.relaxed.document?.width).toBe(420);
     expect(layout.modeOverrides.power.document?.width).toBe(420);
+  });
+
+  it('v2 → v3 drops the per-document perDoc map, preserving the default mode + overrides', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          expandedSections: {},
+          propertyPanelWidth: 240,
+          documentBrowserView: 'list',
+          documentBrowserSort: 'modified-desc',
+          documentBrowserGroupBy: 'none',
+          documentBrowserCollapsed: {},
+          layout: {
+            defaultMode: 'technician',
+            perDoc: { 'doc-1': 'power', 'doc-2': 'designer' },
+            modeOverrides: {
+              relaxed: {},
+              designer: {},
+              technician: { properties: { dock: 'left', visible: true, order: 0 } },
+              power: {},
+            },
+            customChrome: true,
+          },
+        },
+        version: 2,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    const { layout } = useUIPreferencesStore.getState();
+    // perDoc is gone; the app-level default + overrides + chrome survive.
+    expect('perDoc' in layout).toBe(false);
+    expect(layout.defaultMode).toBe('technician');
+    expect(layout.customChrome).toBe(true);
+    expect(layout.modeOverrides.technician.properties?.dock).toBe('left');
   });
 });

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -33,6 +33,11 @@ export interface UIPreferencesState {
   expandedSections: Record<string, boolean>;
   /** Property panel width */
   propertyPanelWidth: number;
+  /**
+   * Width (px) of the secondary canvas pane in the Relaxed `split` focus — the
+   * draggable divider between the prose editor and the canvas. App-level.
+   */
+  relaxedSplitCanvasWidth: number;
   /** Document browser layout */
   documentBrowserView: DocumentBrowserView;
   /** Document browser sort key */
@@ -62,6 +67,8 @@ export interface UIPreferencesActions {
   isSectionExpanded: (sectionId: string, defaultExpanded?: boolean) => boolean;
   /** Set property panel width */
   setPropertyPanelWidth: (width: number) => void;
+  /** Set the Relaxed split secondary-canvas width (px). */
+  setRelaxedSplitCanvasWidth: (width: number) => void;
   /** Set the document browser view (list/grid) */
   setDocumentBrowserView: (view: DocumentBrowserView) => void;
   /** Set the document browser sort key */
@@ -76,12 +83,8 @@ export interface UIPreferencesActions {
   // ── Layout actions (low-level; the `useLayout` hook composes ergonomic
   // "infer current mode" wrappers on top of these for normal call sites.)
 
-  /** Set the global default layout for newly created documents. */
+  /** Set the single app-level active layout. */
   setDefaultLayout: (mode: LayoutMode) => void;
-  /** Record the layout choice for a specific document (client-only memory). */
-  setLayoutForDoc: (docId: string, mode: LayoutMode) => void;
-  /** Forget any per-doc layout choice for the given doc. */
-  clearLayoutForDoc: (docId: string) => void;
   /** Override a panel's dock side within a specific layout. */
   setPanelDockFor: (mode: LayoutMode, panel: PanelId, dock: DockSide) => void;
   /** Override a panel's visibility within a specific layout. */
@@ -125,7 +128,6 @@ const EMPTY_MODE_OVERRIDES: LayoutState['modeOverrides'] = {
 /** Initial layout state — Relaxed default, no overrides, native chrome. */
 const initialLayoutState: LayoutState = {
   defaultMode: 'relaxed',
-  perDoc: {},
   modeOverrides: EMPTY_MODE_OVERRIDES,
   customChrome: false,
 };
@@ -136,6 +138,7 @@ const initialLayoutState: LayoutState = {
 const initialState: UIPreferencesState = {
   expandedSections: { ...DEFAULT_EXPANDED },
   propertyPanelWidth: 240,
+  relaxedSplitCanvasWidth: 480,
   documentBrowserView: 'list',
   documentBrowserSort: 'modified-desc',
   documentBrowserGroupBy: 'none',
@@ -249,6 +252,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ propertyPanelWidth: width });
       },
 
+      setRelaxedSplitCanvasWidth: (width: number) => {
+        set({ relaxedSplitCanvasWidth: width });
+      },
+
       setDocumentBrowserView: (view) => set({ documentBrowserView: view }),
       setDocumentBrowserSort: (sort) => set({ documentBrowserSort: sort }),
       setDocumentBrowserGroupBy: (groupBy) => set({ documentBrowserGroupBy: groupBy }),
@@ -266,24 +273,6 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setDefaultLayout: (mode) => {
         set({ layout: { ...get().layout, defaultMode: mode } });
-      },
-
-      setLayoutForDoc: (docId, mode) => {
-        const { layout } = get();
-        set({
-          layout: {
-            ...layout,
-            perDoc: { ...layout.perDoc, [docId]: mode },
-          },
-        });
-      },
-
-      clearLayoutForDoc: (docId) => {
-        const { layout } = get();
-        if (!(docId in layout.perDoc)) return;
-        const nextPerDoc = { ...layout.perDoc };
-        delete nextPerDoc[docId];
-        set({ layout: { ...layout, perDoc: nextPerDoc } });
       },
 
       setPanelDockFor: (mode, panel, dock) => {
@@ -342,7 +331,6 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
           layout: {
             ...layout,
             modeOverrides: EMPTY_MODE_OVERRIDES,
-            perDoc: {},
           },
         });
       },
@@ -353,10 +341,11 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 2,
+      version: 3,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
+        relaxedSplitCanvasWidth: state.relaxedSplitCanvasWidth,
         documentBrowserView: state.documentBrowserView,
         documentBrowserSort: state.documentBrowserSort,
         documentBrowserGroupBy: state.documentBrowserGroupBy,
@@ -413,6 +402,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
           }
           layout = { ...layout, modeOverrides: upgraded };
         }
+        // v2 → v3: layout became app-level; drop the per-document `perDoc` map.
+        // The active mode falls back to `defaultMode`, which is preserved.
+        if (fromVersion < 3 && layout && 'perDoc' in (layout as unknown as Record<string, unknown>)) {
+          const { perDoc: _dropped, ...rest } = layout as LayoutState & {
+            perDoc?: unknown;
+          };
+          void _dropped;
+          layout = rest as LayoutState;
+        }
         next['layout'] = layout;
         return next as unknown as UIPreferencesState;
       },
@@ -427,7 +425,6 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...EMPTY_MODE_OVERRIDES,
             ...(p.layout?.modeOverrides ?? {}),
           },
-          perDoc: { ...(p.layout?.perDoc ?? {}) },
         };
         return { ...current, ...p, layout };
       },

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -94,6 +94,44 @@
   position: relative;
 }
 
+/* Relaxed writing-first layout: the document editor is the primary (flex)
+ * region — a generous reading column — rather than a fixed-width sidebar. */
+.document-area-wrapper {
+  flex: 1 1 auto;
+  min-width: 0;
+  position: relative;
+  display: flex;
+  overflow: hidden;
+}
+
+/* The editor panel (rendered transparently through ErrorBoundary/Suspense) must
+ * fill the wrapper. As a flex item it would otherwise shrink to its toolbar's
+ * intrinsic width, leaving the rest of the region empty. */
+.document-area-wrapper > * {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* In Relaxed split focus the canvas becomes a secondary pane beside the prose.
+ * Fluid width so it adapts to the viewport (and the future mobile layout). */
+.canvas-area-wrapper--secondary {
+  flex: 0 0 clamp(320px, 40%, 640px);
+}
+
+/* A region collapsed by the active focus (e.g. canvas in write focus, prose in
+ * diagram focus). Kept mounted so engine/editor state survives the toggle. */
+.app-main > .is-collapsed {
+  display: none;
+}
+
+/* Narrow viewports never show a side-by-side split — collapse the secondary
+ * canvas to single-pane (defense-in-depth alongside resolveRegions). */
+@media (max-width: 640px) {
+  .canvas-area-wrapper--secondary {
+    display: none;
+  }
+}
+
 /* Presence indicators - positioned in top-right of canvas area */
 .app-presence {
   position: fixed;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,11 +4,13 @@ import { CanvasContainer } from './CanvasContainer';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
-import { isFlyoutLayout } from './layout/modes';
+import { isFlyoutLayout, resolveRegions } from './layout/modes';
+import { useBreakpoint } from './layout/useBreakpoint';
 import { FlyoutPanel } from './layout/FlyoutPanel';
 import { PanelChromeWrapper } from './layout/PanelChromeWrapper';
 import { DockedPanel } from './layout/DockedPanel';
 import { DocumentToggleRail } from './layout/DocumentToggleRail';
+import { RelaxedSplitHandle } from './layout/RelaxedSplitHandle';
 import { LAYOUT_MODES } from './layout/types';
 import { applyLayoutMode } from '../engine/CommandRegistry';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
@@ -110,6 +112,27 @@ function App() {
     activeMode === 'relaxed' && !isPropertiesVisible && selectionCount > 0;
   const renderProperties = isPropertiesVisible || relaxedTransientProps;
 
+  // Relaxed writing-first layout: the prose editor is the primary region and
+  // `relaxedFocus` (plus the viewport band) decides how the canvas appears.
+  // Other layouts ignore this and use the docked panel machinery below.
+  const relaxedFocus = useSessionStore((s) => s.relaxedFocus);
+  const { band } = useBreakpoint();
+  const regions = resolveRegions(activeMode, relaxedFocus, band);
+  const isRelaxed = activeMode === 'relaxed';
+  // The canvas wrapper is rendered once for every layout (so the engine never
+  // remounts on a layout switch). In Relaxed it becomes a resizable secondary
+  // pane in split focus, or hides in write focus; elsewhere it stays dominant.
+  const canvasIsSecondary = isRelaxed && regions.primary === 'document' && regions.split;
+  const canvasIsHidden = isRelaxed && regions.primary === 'document' && !regions.split;
+  const relaxedSplitCanvasWidth = useUIPreferencesStore((s) => s.relaxedSplitCanvasWidth);
+  const canvasWrapperClass = [
+    'canvas-area-wrapper',
+    canvasIsSecondary && 'canvas-area-wrapper--secondary',
+    canvasIsHidden && 'is-collapsed',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   // Full-screen editor state
   const [isEditorFullscreen, setIsEditorFullscreen] = useState(false);
 
@@ -205,6 +228,16 @@ function App() {
         const idx = parseInt(e.key, 10) - 1;
         const mode = LAYOUT_MODES[idx];
         if (mode) applyLayoutMode(mode);
+        return;
+      }
+
+      // Ctrl/Cmd+Shift+\ — Cycle Relaxed focus (prose / split / diagram).
+      // `e.code` is layout-independent (Shift+\ produces '|' on US keyboards).
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'Backslash') {
+        e.preventDefault();
+        if (useUIPreferencesStore.getState().layout.defaultMode === 'relaxed') {
+          useSessionStore.getState().cycleRelaxedFocus();
+        }
         return;
       }
 
@@ -335,21 +368,47 @@ function App() {
           getImportContext={getImportContext}
         />
         <main className="app-main">
-          {/* Document on left */}
+          {/* Document on left. In Relaxed the editor is the primary reading
+              column (not a fixed sidebar); the focus switch in the toolbar
+              decides whether the canvas shows alongside it. Hidden — not
+              unmounted — in diagram focus so editor state survives switches. */}
           {isDocumentVisible && documentPanelState.dock === 'left' && (
-            <PanelChromeWrapper panelId="document">
-              <DockedPanel panelId="document" side="left" defaultWidth={320}>
+            isRelaxed ? (
+              <div
+                className={`document-area-wrapper${
+                  regions.primary === 'canvas' ? ' is-collapsed' : ''
+                }`}
+              >
                 <ErrorBoundary sectionName="Document Editor">
                   <Suspense fallback={<div className="document-editor-loading" />}>
                     <DocumentEditorPanel
-                      onCollapse={handleCollapseEditor}
                       isFullscreen={isEditorFullscreen}
                       onToggleFullscreen={handleToggleFullscreen}
+                      onCustomizeLayout={handleOpenLayoutSettings}
+                      // Centered reading column when prose owns the full width
+                      // (write); fill the pane edge-to-edge when sharing with
+                      // the canvas (split).
+                      presentation={regions.split ? 'docked' : 'reading'}
                     />
                   </Suspense>
                 </ErrorBoundary>
-              </DockedPanel>
-            </PanelChromeWrapper>
+              </div>
+            ) : (
+              <PanelChromeWrapper panelId="document">
+                <DockedPanel panelId="document" side="left" defaultWidth={320}>
+                  <ErrorBoundary sectionName="Document Editor">
+                    <Suspense fallback={<div className="document-editor-loading" />}>
+                      <DocumentEditorPanel
+                        onCollapse={handleCollapseEditor}
+                        isFullscreen={isEditorFullscreen}
+                        onToggleFullscreen={handleToggleFullscreen}
+                        onCustomizeLayout={handleOpenLayoutSettings}
+                      />
+                    </Suspense>
+                  </ErrorBoundary>
+                </DockedPanel>
+              </PanelChromeWrapper>
+            )
           )}
 
           {/* Properties on left */}
@@ -374,8 +433,14 @@ function App() {
             </PanelChromeWrapper>
           )}
 
-          {/* Canvas (always present, takes remaining space) */}
-          <div className="canvas-area-wrapper">
+          {/* Canvas — always present (one mount across every layout). Sizing
+              for the Relaxed secondary/hidden states comes from the class; in
+              split focus the explicit width is user-draggable. */}
+          <div
+            className={canvasWrapperClass}
+            style={canvasIsSecondary ? { flex: `0 0 ${relaxedSplitCanvasWidth}px` } : undefined}
+          >
+            {canvasIsSecondary && <RelaxedSplitHandle />}
             <CanvasContainer
               className="canvas-area"
               showGrid={true}
@@ -424,6 +489,7 @@ function App() {
                       onCollapse={handleCollapseEditor}
                       isFullscreen={isEditorFullscreen}
                       onToggleFullscreen={handleToggleFullscreen}
+                      onCustomizeLayout={handleOpenLayoutSettings}
                     />
                   </Suspense>
                 </ErrorBoundary>

--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -51,11 +51,56 @@
   overflow: hidden;
 }
 
-/* Header action buttons group */
+/* Header action buttons group (anchors the overflow menu) */
 .document-editor-panel-actions {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 2px;
+}
+
+/* Overflow ("⋮") dropdown menu */
+.document-editor-panel-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 30;
+  min-width: 168px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: var(--shadow-md);
+}
+
+.document-editor-panel-menu button {
+  display: block;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.document-editor-panel-menu button:hover {
+  background: var(--bg-hover);
+}
+
+/* Centered reading column — shared by full-screen mode and the `reading`
+ * presentation (Relaxed write/split). Fluid so it adapts to viewport size and
+ * the future mobile layout; capped at a comfortable measure on wide screens. */
+.document-editor-panel.fullscreen .document-editor-panel-content,
+.document-editor-panel.reading .document-editor-panel-content {
+  max-width: clamp(36rem, 60vw, 52rem);
+  margin: 0 auto;
+  width: 100%;
+  padding: 0 2rem;
 }
 
 /* Full-screen mode */
@@ -67,11 +112,13 @@
   animation: editor-fullscreen-in 0.25s ease-out;
 }
 
-.document-editor-panel.fullscreen .document-editor-panel-content {
-  max-width: 52rem;
-  margin: 0 auto;
-  width: 100%;
-  padding: 0 2rem;
+/* On a narrow viewport the reading column uses the full width (no room for
+ * generous side gutters). */
+@media (max-width: 640px) {
+  .document-editor-panel.reading .document-editor-panel-content {
+    max-width: 100%;
+    padding: 0 1rem;
+  }
 }
 
 @keyframes editor-fullscreen-in {

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -22,15 +22,29 @@ import { RICH_TEXT_VERSION } from '../types/RichText';
 import './DocumentEditorPanel.css';
 
 export interface DocumentEditorPanelProps {
-  /** Optional callback when collapse button is clicked */
+  /** Optional callback when "Hide editor" is chosen (docked presentation only) */
   onCollapse?: () => void;
   /** Whether the editor is in full-screen mode */
   isFullscreen?: boolean;
   /** Toggle full-screen mode */
   onToggleFullscreen?: () => void;
+  /** Open the layout customization settings (overflow menu item) */
+  onCustomizeLayout?: () => void;
+  /**
+   * How the editor presents itself for the active layout. `reading` is the
+   * generous centered column used when the editor is the primary region
+   * (Relaxed write/split); `docked` is the compact sidebar used elsewhere.
+   */
+  presentation?: 'reading' | 'docked';
 }
 
-export function DocumentEditorPanel({ onCollapse, isFullscreen, onToggleFullscreen }: DocumentEditorPanelProps) {
+export function DocumentEditorPanel({
+  onCollapse,
+  isFullscreen,
+  onToggleFullscreen,
+  onCustomizeLayout,
+  presentation = 'docked',
+}: DocumentEditorPanelProps) {
   const { activePageId, updatePageContent } = useRichTextPagesStore();
   const lastActivePageRef = useRef<string | null>(null);
   const isLoadingRef = useRef(false);
@@ -292,41 +306,94 @@ export function DocumentEditorPanel({ onCollapse, isFullscreen, onToggleFullscre
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isFullscreen, handleKeyDown]);
 
+  // Overflow ("⋮") menu — consolidates the editor's header actions.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [menuOpen]);
+
+  // "Hide editor" only makes sense in the docked sidebar presentation; in the
+  // primary reading column the focus switch governs prose vs canvas instead.
+  const canHideEditor = !!onCollapse && !isFullscreen && presentation === 'docked';
+  const hasMenu = !!onToggleFullscreen || canHideEditor || !!onCustomizeLayout;
+
   return (
     <TiptapEditorProvider value={editor}>
-      <div className={`document-editor-panel ${isFullscreen ? 'fullscreen' : ''}`}>
+      <div
+        className={`document-editor-panel ${isFullscreen ? 'fullscreen' : ''} ${
+          presentation === 'reading' ? 'reading' : ''
+        }`}
+      >
         <div className="document-editor-panel-header">
           <span className="document-editor-panel-title">Document</span>
-          <div className="document-editor-panel-actions">
-            {onToggleFullscreen && (
+          {hasMenu && (
+            <div className="document-editor-panel-actions" ref={menuRef}>
               <button
                 className="document-editor-panel-collapse"
-                onClick={onToggleFullscreen}
-                title={isFullscreen ? 'Exit full-screen (Esc)' : 'Full-screen editor'}
+                onClick={() => setMenuOpen((v) => !v)}
+                title="Editor options"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                aria-label="Editor options"
               >
-                {isFullscreen ? (
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M5.5 1a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1 0-1H5V1.5a.5.5 0 0 1 .5-.5zm5 0a.5.5 0 0 1 .5.5V4h2.5a.5.5 0 0 1 0 1h-3a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 .5-.5zM2 10.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0V11H2.5a.5.5 0 0 1-.5-.5zm8 0a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 0 1H11v2.5a.5.5 0 0 1-1 0v-3z" />
-                  </svg>
-                ) : (
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M1.5 1a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 1 0V2h2.5a.5.5 0 0 0 0-1h-3zm11 0a.5.5 0 0 0 0 1H15v2.5a.5.5 0 0 0 1 0v-3a.5.5 0 0 0-.5-.5h-3zM.5 11a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 0-1H1v-2.5a.5.5 0 0 0-1 0zm15 0a.5.5 0 0 0-1 0V14h-2.5a.5.5 0 0 0 0 1h3a.5.5 0 0 0 .5-.5v-3z" />
-                  </svg>
-                )}
-              </button>
-            )}
-            {onCollapse && !isFullscreen && (
-              <button
-                className="document-editor-panel-collapse"
-                onClick={onCollapse}
-                title="Hide document editor"
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z" />
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <circle cx="8" cy="3" r="1.4" />
+                  <circle cx="8" cy="8" r="1.4" />
+                  <circle cx="8" cy="13" r="1.4" />
                 </svg>
               </button>
-            )}
-          </div>
+              {menuOpen && (
+                <div className="document-editor-panel-menu" role="menu">
+                  {onToggleFullscreen && (
+                    <button
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onToggleFullscreen();
+                      }}
+                    >
+                      {isFullscreen ? 'Exit full-screen' : 'Full screen'}
+                    </button>
+                  )}
+                  {canHideEditor && (
+                    <button
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onCollapse?.();
+                      }}
+                    >
+                      Hide editor
+                    </button>
+                  )}
+                  {onCustomizeLayout && (
+                    <button
+                      role="menuitem"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onCustomizeLayout();
+                      }}
+                    >
+                      Customize layout…
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
         <RichTextTabBar />
         <DocumentEditorToolbar />

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -22,6 +22,8 @@ import type { ImportContext } from '../services/FileImportService';
 import { clampToViewport } from './contextMenuUtils';
 import { opener } from '../platform/opener';
 import { LayoutSelector } from './layout/LayoutSelector';
+import { RelaxedFocusControl } from './layout/RelaxedFocusControl';
+import { useActiveLayoutMode } from './layout/useLayout';
 import './UnifiedToolbar.css';
 
 /**
@@ -417,6 +419,7 @@ async function openDocsHandler() {
 export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings, onRebuildConnectors, getImportContext }: UnifiedToolbarProps) {
   const activeTool = useSessionStore((state) => state.activeTool);
   const setActiveTool = useSessionStore((state) => state.setActiveTool);
+  const activeLayout = useActiveLayoutMode();
 
   // Subscribe to history state for undo/redo button updates
   const pageHistory = useHistoryStore((state) => state.pageHistory);
@@ -511,6 +514,7 @@ export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings, onRebuild
           <HelpIcon />
         </button>
         <div className="toolbar-divider" />
+        {activeLayout === 'relaxed' && <RelaxedFocusControl />}
         <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} />
         {onOpenSettings && (
           <button

--- a/src/ui/layout/RelaxedFocusControl.css
+++ b/src/ui/layout/RelaxedFocusControl.css
@@ -1,0 +1,59 @@
+.relaxed-focus-control {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
+  background: var(--bg-secondary);
+}
+
+.relaxed-focus-segment {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.relaxed-focus-segment:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.relaxed-focus-segment.active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.relaxed-focus-segment:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary-light);
+}
+
+.relaxed-focus-segment-label {
+  line-height: 1;
+}
+
+/* Touch ergonomics: give the segments a comfortable hit target on coarse
+ * pointers — the same affordance the future mobile layout will rely on. */
+@media (pointer: coarse) {
+  .relaxed-focus-segment {
+    min-height: 44px;
+    padding: 4px 14px;
+  }
+}
+
+/* On a narrow viewport the labels are dropped to save room (icons remain). */
+@media (max-width: 640px) {
+  .relaxed-focus-segment-label {
+    display: none;
+  }
+}

--- a/src/ui/layout/RelaxedFocusControl.tsx
+++ b/src/ui/layout/RelaxedFocusControl.tsx
@@ -1,0 +1,86 @@
+/**
+ * RelaxedFocusControl — the writing-first focus switch.
+ *
+ * A segmented Write / Split / Diagram control shown in the toolbar only while
+ * the Relaxed layout is active. It's the convenient, all-skill-levels way to
+ * move between the expanded prose editor and the canvas (the design driver for
+ * the prose-first rework), and the seed of the single-pane switcher a future
+ * mobile (PWA) layout will reuse.
+ *
+ * On a narrow viewport the `Split` segment is dropped (no room for side-by-side)
+ * — matching `resolveRegions`, which collapses split to single-pane prose there.
+ */
+
+import type { ReactNode } from 'react';
+import { useSessionStore } from '../../store/sessionStore';
+import { useBreakpoint } from './useBreakpoint';
+import type { RelaxedFocus } from './types';
+import './RelaxedFocusControl.css';
+
+interface Segment {
+  id: RelaxedFocus;
+  label: string;
+  icon: ReactNode;
+}
+
+export function RelaxedFocusControl() {
+  const focus = useSessionStore((s) => s.relaxedFocus);
+  const setRelaxedFocus = useSessionStore((s) => s.setRelaxedFocus);
+  const { band } = useBreakpoint();
+  const allowSplit = band !== 'narrow';
+
+  const segments: Segment[] = [
+    { id: 'write', label: 'Write', icon: <WriteIcon /> },
+    ...(allowSplit ? [{ id: 'split' as const, label: 'Split', icon: <SplitIcon /> }] : []),
+    { id: 'diagram', label: 'Diagram', icon: <DiagramIcon /> },
+  ];
+
+  // When Split is unavailable, a lingering 'split' focus reads as document-primary
+  // (write) per resolveRegions — reflect that in the active highlight.
+  const active: RelaxedFocus = !allowSplit && focus === 'split' ? 'write' : focus;
+
+  return (
+    <div className="relaxed-focus-control" role="group" aria-label="Editor focus">
+      {segments.map((seg) => (
+        <button
+          key={seg.id}
+          type="button"
+          className={`relaxed-focus-segment ${active === seg.id ? 'active' : ''}`}
+          onClick={() => setRelaxedFocus(seg.id)}
+          aria-pressed={active === seg.id}
+          title={`${seg.label} (Ctrl+Shift+\\ to cycle)`}
+        >
+          {seg.icon}
+          <span className="relaxed-focus-segment-label">{seg.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function WriteIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" aria-hidden="true">
+      <path d="M3 4h10M3 7h10M3 10h7M3 13h5" />
+    </svg>
+  );
+}
+
+function SplitIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+      <rect x="2" y="3" width="12" height="10" rx="1" />
+      <path d="M9 3v10" />
+    </svg>
+  );
+}
+
+function DiagramIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+      <rect x="2" y="2.5" width="5" height="4" rx="0.5" />
+      <rect x="9" y="9.5" width="5" height="4" rx="0.5" />
+      <path d="M7 4.5h3.5v5" />
+    </svg>
+  );
+}

--- a/src/ui/layout/RelaxedSplitHandle.css
+++ b/src/ui/layout/RelaxedSplitHandle.css
@@ -1,0 +1,28 @@
+/* Sits on the left edge of the secondary canvas pane (which is position:
+ * relative). A thin invisible grab strip that highlights on hover/drag. */
+.relaxed-split-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 7px;
+  height: 100%;
+  margin-left: -3px;
+  z-index: 20;
+  cursor: ew-resize;
+  background: transparent;
+  transition: background 0.12s ease;
+}
+
+.relaxed-split-handle:hover,
+.relaxed-split-handle.dragging {
+  background: var(--color-primary);
+  opacity: 0.6;
+}
+
+/* Larger grab target on coarse pointers. */
+@media (pointer: coarse) {
+  .relaxed-split-handle {
+    width: 16px;
+    margin-left: -8px;
+  }
+}

--- a/src/ui/layout/RelaxedSplitHandle.tsx
+++ b/src/ui/layout/RelaxedSplitHandle.tsx
@@ -1,0 +1,63 @@
+/**
+ * RelaxedSplitHandle — draggable divider between the prose editor and the
+ * secondary canvas in the Relaxed `split` focus. Lives on the left edge of the
+ * canvas pane; dragging resizes the prose editor (the canvas takes a fixed
+ * width, the prose flexes to fill the rest). Width persists app-level in
+ * `uiPreferencesStore.relaxedSplitCanvasWidth`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import './RelaxedSplitHandle.css';
+
+const MIN_CANVAS = 280;
+const MAX_CANVAS = 960;
+
+export function RelaxedSplitHandle() {
+  const width = useUIPreferencesStore((s) => s.relaxedSplitCanvasWidth);
+  const setWidth = useUIPreferencesStore((s) => s.setRelaxedSplitCanvasWidth);
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(width);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      startXRef.current = e.clientX;
+      startWidthRef.current = width;
+      setIsDragging(true);
+    },
+    [width]
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const handleMove = (e: MouseEvent) => {
+      // Canvas is docked right: dragging left (smaller clientX) widens it.
+      const delta = startXRef.current - e.clientX;
+      const next = Math.max(MIN_CANVAS, Math.min(MAX_CANVAS, startWidthRef.current + delta));
+      setWidth(next);
+    };
+    const handleUp = () => setIsDragging(false);
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+    document.body.style.cursor = 'ew-resize';
+    document.body.style.userSelect = 'none';
+    return () => {
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [isDragging, setWidth]);
+
+  return (
+    <div
+      className={`relaxed-split-handle ${isDragging ? 'dragging' : ''}`}
+      onMouseDown={handleMouseDown}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize prose editor"
+    />
+  );
+}

--- a/src/ui/layout/modes.test.ts
+++ b/src/ui/layout/modes.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { LAYOUT_PRESETS, primaryRegion, resolveRegions } from './modes';
+import { LAYOUT_MODES } from './types';
+
+describe('primaryRegion', () => {
+  it('makes Relaxed document-primary (writing-first) and everything else canvas-primary', () => {
+    expect(primaryRegion('relaxed')).toBe('document');
+    for (const mode of LAYOUT_MODES) {
+      if (mode === 'relaxed') continue;
+      expect(primaryRegion(mode)).toBe('canvas');
+    }
+  });
+});
+
+describe('resolveRegions', () => {
+  it('non-Relaxed layouts are always canvas-primary, no split', () => {
+    expect(resolveRegions('designer', 'write', 'wide')).toEqual({ primary: 'canvas', split: false });
+    expect(resolveRegions('power', 'split', 'wide')).toEqual({ primary: 'canvas', split: false });
+  });
+
+  it('Relaxed write is document-primary with no canvas pane', () => {
+    expect(resolveRegions('relaxed', 'write', 'wide')).toEqual({ primary: 'document', split: false });
+  });
+
+  it('Relaxed split shows the secondary canvas only when there is room', () => {
+    expect(resolveRegions('relaxed', 'split', 'wide')).toEqual({ primary: 'document', split: true });
+    expect(resolveRegions('relaxed', 'split', 'medium')).toEqual({ primary: 'document', split: true });
+    // Narrow viewport collapses to single-pane prose (the mobile-shaped fallback).
+    expect(resolveRegions('relaxed', 'split', 'narrow')).toEqual({ primary: 'document', split: false });
+  });
+
+  it('Relaxed diagram promotes the canvas to primary', () => {
+    expect(resolveRegions('relaxed', 'diagram', 'wide')).toEqual({ primary: 'canvas', split: false });
+    expect(resolveRegions('relaxed', 'diagram', 'narrow')).toEqual({ primary: 'canvas', split: false });
+  });
+});
+
+describe('Relaxed preset (writing-first)', () => {
+  it('document fills the primary region (no fixed width) and layers are hidden', () => {
+    expect(LAYOUT_PRESETS.relaxed.document.visible).toBe(true);
+    expect(LAYOUT_PRESETS.relaxed.document.width).toBeUndefined();
+    expect(LAYOUT_PRESETS.relaxed.layers.visible).toBe(false);
+    expect(LAYOUT_PRESETS.relaxed.properties.visible).toBe(false);
+  });
+});

--- a/src/ui/layout/modes.ts
+++ b/src/ui/layout/modes.ts
@@ -8,7 +8,8 @@
  * is data only.
  */
 
-import type { LayoutMode, LayoutPanelMap, PanelId, PanelState } from './types';
+import type { ViewportBand } from '../../platform/device';
+import type { LayoutMode, LayoutPanelMap, PanelId, PanelState, RelaxedFocus } from './types';
 
 /**
  * Whether a layout renders unpinned panels as fly-outs. Layouts not listed
@@ -28,9 +29,13 @@ export function isFlyoutLayout(mode: LayoutMode): boolean {
  */
 export const LAYOUT_PRESETS: Record<LayoutMode, LayoutPanelMap> = {
   relaxed: {
-    document: { dock: 'left', visible: true, order: 0, width: 320 },
+    // Writing-first: the document editor is the *primary* region (it fills the
+    // flex space, not a fixed sidebar — so no `width` here), properties appear
+    // on selection only, and layers stay hidden. Canvas focus is driven by
+    // `relaxedFocus` via `resolveRegions`, not by panel docking.
+    document: { dock: 'left', visible: true, order: 0 },
     properties: { dock: 'right', visible: false, order: 0, width: 240 },
-    layers: { dock: 'right', visible: true, order: 0 },
+    layers: { dock: 'right', visible: false, order: 0 },
   },
   designer: {
     document: { dock: 'left', visible: false, order: 0, width: 320 },
@@ -62,6 +67,57 @@ export function resolvePanelState(
   const preset = LAYOUT_PRESETS[mode][panel];
   if (!override) return preset;
   return { ...preset, ...override };
+}
+
+/**
+ * Which region owns the dominant (flex) slot for a layout, before focus is
+ * applied. Relaxed is writing-first (document primary); every other layout is
+ * canvas-first. A future `mobile` mode would return based on `useBreakpoint`.
+ */
+export function primaryRegion(mode: LayoutMode): 'canvas' | 'document' {
+  return mode === 'relaxed' ? 'document' : 'canvas';
+}
+
+/** Resolved arrangement of the two main regions for the current frame. */
+export interface RegionLayout {
+  /** Which region gets the dominant flex slot. */
+  primary: 'canvas' | 'document';
+  /** Whether the non-primary region is shown as a secondary pane. */
+  split: boolean;
+}
+
+/**
+ * Resolve how the document and canvas regions share the main area, given the
+ * layout, the Relaxed focus, and the viewport band. Pure + breakpoint-aware so
+ * the same logic powers desktop split views and the single-pane shape a future
+ * mobile (PWA) layout needs.
+ *
+ * - Non-Relaxed layouts always render canvas-primary; the document panel is a
+ *   docked sidebar handled by the existing panel machinery (`split: false`
+ *   here — the docked path doesn't consult this).
+ * - Relaxed maps `relaxedFocus` to regions: `write` → document only, `split` →
+ *   document primary + secondary canvas (only when the viewport isn't
+ *   `narrow`), `diagram` → canvas primary with the prose tucked away.
+ */
+export function resolveRegions(
+  mode: LayoutMode,
+  focus: RelaxedFocus,
+  band: ViewportBand
+): RegionLayout {
+  if (mode !== 'relaxed') {
+    return { primary: 'canvas', split: false };
+  }
+  switch (focus) {
+    case 'diagram':
+      return { primary: 'canvas', split: false };
+    case 'split':
+      // A side-by-side split needs horizontal room; collapse to single-pane
+      // (prose) on narrow viewports — the mobile-shaped fallback.
+      return { primary: 'document', split: band !== 'narrow' };
+    case 'write':
+    default:
+      return { primary: 'document', split: false };
+  }
 }
 
 /** Human-readable label for a layout mode (UI display). */

--- a/src/ui/layout/types.ts
+++ b/src/ui/layout/types.ts
@@ -15,6 +15,15 @@ export type PanelId = 'document' | 'properties' | 'layers';
 export type DockSide = 'left' | 'right';
 
 /**
+ * Focus within the writing-first Relaxed layout. `write` is prose-only (canvas
+ * one tap away), `split` shows prose alongside a secondary canvas, `diagram`
+ * promotes the canvas to primary. Ephemeral app-level UI state (sessionStore),
+ * never persisted. On a `compact` viewport `split` is unavailable — the same
+ * single-pane shape the future mobile layout will reuse.
+ */
+export type RelaxedFocus = 'write' | 'split' | 'diagram';
+
+/**
  * Per-panel state within a given layout. `dock` always holds a side (so the
  * user's preferred side survives a hide-then-show round trip); `visible`
  * drives rendering.
@@ -38,15 +47,21 @@ export interface PanelState {
 /** All panels' state for one layout. */
 export type LayoutPanelMap = Record<PanelId, PanelState>;
 
-/** The persisted layout slice in `uiPreferencesStore`. */
+/**
+ * The persisted layout slice in `uiPreferencesStore`.
+ *
+ * Layout is an **app-level** concern: a single active mode for the whole
+ * editor, not keyed per document. (An earlier design kept a `perDoc` map here;
+ * it coupled UI prefs to document identity and was removed in the v3
+ * migration.) If a document ever needs to *suggest* a layout, that belongs in a
+ * separate, isolated metadata payload owned by the document — not in this UI
+ * preferences slice — so the access boundary stays clean. A future `mobile`
+ * LayoutMode would slot into `LayoutMode` + `LAYOUT_PRESETS` and be selected by
+ * the `useBreakpoint` seam rather than stored here.
+ */
 export interface LayoutState {
-  /** Default mode used for newly created documents. */
+  /** The single active layout for the whole app (app-level, not per-doc). */
   defaultMode: LayoutMode;
-  /**
-   * Last-used mode per document id, written on the first explicit mode change
-   * for that doc. Stored client-side only — never serialized into the doc.
-   */
-  perDoc: Record<string, LayoutMode>;
   /** User customization deltas, scoped per layout so switching is clean. */
   modeOverrides: Record<LayoutMode, Partial<LayoutPanelMap>>;
   /**

--- a/src/ui/layout/useBreakpoint.test.ts
+++ b/src/ui/layout/useBreakpoint.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readBreakpointState } from './useBreakpoint';
+
+/**
+ * `readBreakpointState` is the pure snapshot reader behind the hook — it leans
+ * on `platform.device` (innerWidth-based band, coarse-pointer detection) plus a
+ * `(display-mode: standalone)` check. We drive it by stubbing `innerWidth` and
+ * `matchMedia` so it can be unit-tested without a DOM render harness.
+ */
+
+function stubMatchMedia(matchedQueries: string[]): void {
+  vi.spyOn(window, 'matchMedia').mockImplementation(
+    (query: string) =>
+      ({
+        matches: matchedQueries.includes(query),
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: null,
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList
+  );
+}
+
+function stubWidth(width: number): void {
+  Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('readBreakpointState', () => {
+  it('classifies the viewport band from width', () => {
+    stubMatchMedia([]);
+    stubWidth(500);
+    expect(readBreakpointState().band).toBe('narrow');
+    stubWidth(800);
+    expect(readBreakpointState().band).toBe('medium');
+    stubWidth(1400);
+    expect(readBreakpointState().band).toBe('wide');
+  });
+
+  it('reports coarse pointer and standalone capability flags', () => {
+    stubWidth(1400);
+    stubMatchMedia(['(pointer: coarse)', '(display-mode: standalone)']);
+    const state = readBreakpointState();
+    expect(state.isTouch).toBe(true);
+    expect(state.standalone).toBe(true);
+  });
+
+  it('defaults capability flags to false when nothing matches', () => {
+    stubWidth(1400);
+    stubMatchMedia([]);
+    const state = readBreakpointState();
+    expect(state.isTouch).toBe(false);
+    expect(state.standalone).toBe(false);
+  });
+});

--- a/src/ui/layout/useBreakpoint.ts
+++ b/src/ui/layout/useBreakpoint.ts
@@ -1,0 +1,82 @@
+/**
+ * useBreakpoint — the single seam for responsive layout decisions.
+ *
+ * Builds on `platform.device` (which already classifies the viewport into
+ * narrow/medium/wide bands and detects coarse pointers) and adds standalone-PWA
+ * detection, then makes the result reactive to viewport + capability changes.
+ * Layout logic (`resolveRegions`, the Relaxed focus control) consults this so
+ * desktop split views and the future dedicated mobile (PWA) layout share one
+ * source of truth instead of scattering `matchMedia` reads.
+ *
+ * jsdom/SSR-safe: every `window`/`matchMedia` access is guarded so the hook
+ * (and its pure `readBreakpointState` reader) can run under Vitest.
+ */
+
+import { useEffect, useState } from 'react';
+import { device, type ViewportBand } from '../../platform/device';
+
+export interface BreakpointState {
+  /** Coarse viewport width band (narrow < 640 ≤ medium < 1024 ≤ wide). */
+  band: ViewportBand;
+  /** Primary input is touch / coarse pointer. */
+  isTouch: boolean;
+  /** Running as an installed standalone PWA (vs a browser tab). */
+  standalone: boolean;
+}
+
+/** Is the app running as an installed standalone PWA? */
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  const displayMode =
+    typeof window.matchMedia === 'function'
+      ? window.matchMedia('(display-mode: standalone)').matches
+      : false;
+  // iOS Safari exposes a legacy non-standard flag instead of display-mode.
+  const iosStandalone =
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+  return displayMode || iosStandalone;
+}
+
+/** Read the current breakpoint state once (pure; no subscription). */
+export function readBreakpointState(): BreakpointState {
+  return {
+    band: device.viewportBand(),
+    isTouch: device.isTouch(),
+    standalone: isStandalone(),
+  };
+}
+
+function sameState(a: BreakpointState, b: BreakpointState): boolean {
+  return a.band === b.band && a.isTouch === b.isTouch && a.standalone === b.standalone;
+}
+
+/** Reactive viewport/capability classification. */
+export function useBreakpoint(): BreakpointState {
+  const [state, setState] = useState<BreakpointState>(readBreakpointState);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const update = () =>
+      setState((prev) => {
+        const next = readBreakpointState();
+        return sameState(prev, next) ? prev : next;
+      });
+
+    window.addEventListener('resize', update);
+    const queries = ['(pointer: coarse)', '(display-mode: standalone)']
+      .map((q) => (typeof window.matchMedia === 'function' ? window.matchMedia(q) : null))
+      .filter((mq): mq is MediaQueryList => mq !== null);
+    for (const mq of queries) mq.addEventListener?.('change', update);
+
+    // Re-sync in case the viewport changed between first render and effect.
+    update();
+
+    return () => {
+      window.removeEventListener('resize', update);
+      for (const mq of queries) mq.removeEventListener?.('change', update);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/ui/layout/useLayout.ts
+++ b/src/ui/layout/useLayout.ts
@@ -1,23 +1,19 @@
 /**
- * useLayout — ergonomic React hook that composes the low-level layout actions
- * on `uiPreferencesStore` with "current document" inference from
- * `persistenceStore`. Most UI call sites use this; tests and the Settings
- * editor reach for the explicit `*For(mode, ...)` store actions instead.
+ * useLayout — ergonomic React hook over the low-level layout actions on
+ * `uiPreferencesStore`. Layout is app-level (a single active mode for the whole
+ * editor), so the active mode is just `layout.defaultMode`. Most UI call sites
+ * use these hooks; tests and the Settings editor reach for the explicit
+ * `*For(mode, ...)` store actions instead.
  */
 
 import { useMemo } from 'react';
 import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
-import { usePersistenceStore } from '../../store/persistenceStore';
 import { LAYOUT_PRESETS, resolvePanelState } from './modes';
 import type { DockSide, LayoutMode, PanelId, PanelState } from './types';
 
-/** Effective layout for the currently open document. */
+/** The single app-level active layout. */
 export function useActiveLayoutMode(): LayoutMode {
-  const defaultMode = useUIPreferencesStore((s) => s.layout.defaultMode);
-  const perDoc = useUIPreferencesStore((s) => s.layout.perDoc);
-  const docId = usePersistenceStore((s) => s.currentDocumentId);
-  if (docId && perDoc[docId]) return perDoc[docId];
-  return defaultMode;
+  return useUIPreferencesStore((s) => s.layout.defaultMode);
 }
 
 /** Effective panel state under the active layout, with user overrides applied. */
@@ -40,7 +36,6 @@ export function useLayoutActions(): {
   setPanelWidth: (panel: PanelId, width: number) => void;
   togglePin: (panel: PanelId) => void;
 } {
-  const setLayoutForDoc = useUIPreferencesStore((s) => s.setLayoutForDoc);
   const setDefaultLayout = useUIPreferencesStore((s) => s.setDefaultLayout);
   const setPanelDockFor = useUIPreferencesStore((s) => s.setPanelDockFor);
   const setPanelVisibleFor = useUIPreferencesStore((s) => s.setPanelVisibleFor);
@@ -50,14 +45,8 @@ export function useLayoutActions(): {
   return useMemo(
     () => ({
       setActiveLayout(mode: LayoutMode) {
-        const docId = usePersistenceStore.getState().currentDocumentId;
-        if (docId) {
-          setLayoutForDoc(docId, mode);
-        } else {
-          // No doc open — treat the choice as the new global default so a
-          // later doc-open lands in the user's chosen layout.
-          setDefaultLayout(mode);
-        }
+        // Layout is app-level — switching always sets the single active mode.
+        setDefaultLayout(mode);
       },
       setPanelDock(panel: PanelId, dock: DockSide) {
         const mode = readActiveMode();
@@ -84,7 +73,7 @@ export function useLayoutActions(): {
         togglePinFor(mode, panel);
       },
     }),
-    [setLayoutForDoc, setDefaultLayout, setPanelDockFor, setPanelVisibleFor, setPanelWidthFor, togglePinFor]
+    [setDefaultLayout, setPanelDockFor, setPanelVisibleFor, setPanelWidthFor, togglePinFor]
   );
 }
 
@@ -93,10 +82,7 @@ export function useLayoutActions(): {
  * action callbacks where re-rendering on every layout change is unwanted.
  */
 function readActiveMode(): LayoutMode {
-  const { layout } = useUIPreferencesStore.getState();
-  const docId = usePersistenceStore.getState().currentDocumentId;
-  if (docId && layout.perDoc[docId]) return layout.perDoc[docId];
-  return layout.defaultMode;
+  return useUIPreferencesStore.getState().layout.defaultMode;
 }
 
 /** Re-export the preset table for components that need to enumerate panels. */


### PR DESCRIPTION
Closes JP-138.

## Why
**Relaxed** was documented as writing-first ("prose dominant, canvas one tap away") but the code never did it — the canvas was hardcoded `flex:1` and the document was a fixed 320px sidebar, so clicking Relaxed "didn't do much." The layout dial gates the app for all skill levels (Relaxed = beginner/writing → Power = expert), so making Relaxed credible matters.

## What's in here
- **Relaxed is prose-first**: the editor is the primary region — a centered, fluid reading column (`presentation="reading"`, `clamp(36rem,60vw,52rem)`). `relaxed` preset fixed (document fills the region; layers hidden).
- **Write · Split · Diagram focus switch** (`RelaxedFocusControl`, toolbar, Relaxed-only) + `Cmd/Ctrl+Shift+\` + palette `view.cycleRelaxedFocus`, backed by ephemeral `sessionStore.relaxedFocus`. `resolveRegions(mode, focus, band)` maps focus→regions; narrow viewport forbids split (single-pane).
- **Resizable prose in split** — `RelaxedSplitHandle` drag divider; width persisted (`uiPreferencesStore.relaxedSplitCanvasWidth`).
- **Layouts are app-level, not per-document** — removed `perDoc`/`setLayoutForDoc`/`clearLayoutForDoc`; **`uiPreferencesStore` v2→v3 migration** drops the persisted map.
- **Responsive foundation** for the future mobile PWA layout — `useBreakpoint` hook (on `platform/device.ts`) + shared `--bp-*`/`--safe-area-*` CSS tokens.
- **Editor "⋮" overflow menu** consolidates the old collapse/fullscreen buttons (+ Customize layout…).
- One `CanvasContainer` mount across all layouts (engine never remounts on a layout switch); fixed a flex-fill bug so the editor fills its region (Write/Split regressions).

## Verification
`bun run typecheck` clean · **1734 unit tests pass** (new `modes.test.ts`, `useBreakpoint.test.ts`; updated `uiPreferencesStore.test.ts` incl. the v2→v3 migration, `sessionStore.test.ts`) · production build green. AGENTS.md UI Layout section updated. Manually verified Write/Split/Diagram by the reporter.

Follow-ups filed: JP-139…JP-147 (mobile layout, breakpoint-token adoption, canvas-as-region, render tests, cleanups, visual design epic).

Assisted-by: Opus 4.8