### PR TITLE
JP-147: reclaim dead editor header + fix tab-bar scrollbar

### DIFF
--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -6,24 +6,6 @@
   background-color: var(--bg-primary);
 }
 
-.document-editor-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.625rem 0.75rem;
-  background-color: var(--bg-tertiary);
-  border-bottom: 1px solid var(--border-color);
-  flex-shrink: 0;
-}
-
-.document-editor-panel-title {
-  font-weight: 600;
-  font-size: 0.8125rem;
-  color: var(--text-primary);
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-}
-
 .document-editor-panel-collapse {
   display: flex;
   align-items: center;

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -330,6 +330,64 @@ export function DocumentEditorPanel({
   const canHideEditor = !!onCollapse && !isFullscreen && presentation === 'docked';
   const hasMenu = !!onToggleFullscreen || canHideEditor || !!onCustomizeLayout;
 
+  // The overflow ("⋮") menu lives in the page-tab row (there's no separate panel
+  // header) so it doesn't cost a dead row of vertical space above the editor.
+  const overflowMenu = hasMenu ? (
+    <div className="document-editor-panel-actions" ref={menuRef}>
+      <button
+        className="document-editor-panel-collapse"
+        onClick={() => setMenuOpen((v) => !v)}
+        title="Editor options"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        aria-label="Editor options"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <circle cx="8" cy="3" r="1.4" />
+          <circle cx="8" cy="8" r="1.4" />
+          <circle cx="8" cy="13" r="1.4" />
+        </svg>
+      </button>
+      {menuOpen && (
+        <div className="document-editor-panel-menu" role="menu">
+          {onToggleFullscreen && (
+            <button
+              role="menuitem"
+              onClick={() => {
+                setMenuOpen(false);
+                onToggleFullscreen();
+              }}
+            >
+              {isFullscreen ? 'Exit full-screen' : 'Full screen'}
+            </button>
+          )}
+          {canHideEditor && (
+            <button
+              role="menuitem"
+              onClick={() => {
+                setMenuOpen(false);
+                onCollapse?.();
+              }}
+            >
+              Hide editor
+            </button>
+          )}
+          {onCustomizeLayout && (
+            <button
+              role="menuitem"
+              onClick={() => {
+                setMenuOpen(false);
+                onCustomizeLayout();
+              }}
+            >
+              Customize layout…
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  ) : null;
+
   return (
     <TiptapEditorProvider value={editor}>
       <div
@@ -337,65 +395,7 @@ export function DocumentEditorPanel({
           presentation === 'reading' ? 'reading' : ''
         }`}
       >
-        <div className="document-editor-panel-header">
-          <span className="document-editor-panel-title">Document</span>
-          {hasMenu && (
-            <div className="document-editor-panel-actions" ref={menuRef}>
-              <button
-                className="document-editor-panel-collapse"
-                onClick={() => setMenuOpen((v) => !v)}
-                title="Editor options"
-                aria-haspopup="menu"
-                aria-expanded={menuOpen}
-                aria-label="Editor options"
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                  <circle cx="8" cy="3" r="1.4" />
-                  <circle cx="8" cy="8" r="1.4" />
-                  <circle cx="8" cy="13" r="1.4" />
-                </svg>
-              </button>
-              {menuOpen && (
-                <div className="document-editor-panel-menu" role="menu">
-                  {onToggleFullscreen && (
-                    <button
-                      role="menuitem"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        onToggleFullscreen();
-                      }}
-                    >
-                      {isFullscreen ? 'Exit full-screen' : 'Full screen'}
-                    </button>
-                  )}
-                  {canHideEditor && (
-                    <button
-                      role="menuitem"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        onCollapse?.();
-                      }}
-                    >
-                      Hide editor
-                    </button>
-                  )}
-                  {onCustomizeLayout && (
-                    <button
-                      role="menuitem"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        onCustomizeLayout();
-                      }}
-                    >
-                      Customize layout…
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-        <RichTextTabBar />
+        <RichTextTabBar trailing={overflowMenu} />
         <DocumentEditorToolbar />
         <div className="document-editor-panel-content">
           <TiptapEditor onEditorReady={handleEditorReady} />

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -16,7 +16,11 @@
   display: flex;
   align-items: center;
   gap: 2px;
+  /* Scroll horizontally only. Without an explicit overflow-y, it computes to
+   * `auto` and the active tab's ~1px overhang triggers a stray vertical
+   * scrollbar (ugly with classic scrollbars on Tauri/PWA). */
   overflow-x: auto;
+  overflow-y: hidden;
   flex: 1;
   scrollbar-width: thin;
 }
@@ -117,6 +121,14 @@
   color: var(--text-primary);
   font-size: 0.8125rem;
   outline: none;
+}
+
+/* Trailing slot (e.g. the editor overflow "⋮" menu) pinned to the right end. */
+.rich-text-tab-trailing {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .rich-text-add-tab {

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -10,10 +10,15 @@
  * - Add new page button
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import './RichTextTabBar.css';
+
+interface RichTextTabBarProps {
+  /** Optional content rendered flush-right in the tab row (e.g. an overflow menu). */
+  trailing?: ReactNode;
+}
 
 /** Colors available for tab customization */
 const TAB_COLORS = [
@@ -35,7 +40,7 @@ interface ContextMenuState {
   pageId: string;
 }
 
-export function RichTextTabBar() {
+export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
   const { pages, pageOrder, activePageId, setActivePage, createPage, deletePage, renamePage, setPageColor, reorderPages } = useRichTextPagesStore();
   
   const [editingPageId, setEditingPageId] = useState<string | null>(null);
@@ -253,6 +258,8 @@ export function RichTextTabBar() {
       >
         +
       </button>
+
+      {trailing && <div className="rich-text-tab-trailing">{trailing}</div>}
 
       {/* Context menu */}
       {contextMenu.isOpen && createPortal(


### PR DESCRIPTION
First slice of JP-147 (editor visual-design pass). Builds on JP-138 (#33, merged).

## Changes
- **Drop the dead "Document" header.** `DocumentEditorPanel` had a header row whose only visible content was the uppercase "DOCUMENT" label (the "⋮" overflow menu shared it). The menu now renders flush-right in the page-tab row via a new optional `trailing` slot on `RichTextTabBar`; the header row is gone, reclaiming ~40px of vertical space above the prose (worst-felt in Relaxed reading mode).
- **Fix the page-tabs vertical scrollbar.** `.rich-text-tabs-container` set only `overflow-x: auto`, so `overflow-y` computed to `auto` and the active tab's ~1px overhang (`padding-bottom:7px` + `margin-bottom:-1px`) produced a stray vertical scrollbar — ugly with classic scrollbars on Tauri/PWA. Now `overflow-y: hidden` explicitly (active-tab bottom is square, so nothing visible is clipped).

## Verification
`bun run typecheck` clean · 1734 tests pass (no logic touched) · production build green. Manual: header gone; "⋮" menu in the tab row (Full screen / Hide editor (docked) / Customize layout) works; many pages → horizontal scroll only, no vertical scrollbar.

Next slice (separate PR `jp-147-canvas-toolbar`): contain the canvas toolbar in the canvas region + wrap it downward in Split.

Assisted-by: Opus 4.8