### PR TITLE
JP-147: unify picker + upload-button icons on lucide-react

### DIFF
--- a/src/ui/CustomShapePicker.tsx
+++ b/src/ui/CustomShapePicker.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { Boxes, ChevronUp, ChevronDown } from 'lucide-react';
 import { useCustomShapeLibraryStore, initializeCustomShapeLibrary } from '../store/customShapeLibraryStore';
 import { useSessionStore } from '../store/sessionStore';
 import type { CustomShapeItem, CustomShapeLibrary } from '../storage/ShapeLibraryTypes';
@@ -144,13 +145,13 @@ export function CustomShapePicker() {
             {activeCustomItem.thumbnail ? (
               <img src={activeCustomItem.thumbnail} alt="" className="custom-shape-picker-trigger-thumb" />
             ) : (
-              '📦'
+              <Boxes size={16} strokeWidth={1.5} />
             )}
           </span>
         ) : (
-          <span className="custom-shape-picker-trigger-icon">📦</span>
+          <span className="custom-shape-picker-trigger-icon"><Boxes size={16} strokeWidth={1.5} /></span>
         )}
-        <span className="custom-shape-picker-chevron">{isOpen ? '\u25B2' : '\u25BC'}</span>
+        <span className="custom-shape-picker-chevron">{isOpen ? <ChevronUp size={12} strokeWidth={1.5} /> : <ChevronDown size={12} strokeWidth={1.5} />}</span>
       </button>
 
       {isOpen && (

--- a/src/ui/FileImportButton.tsx
+++ b/src/ui/FileImportButton.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback } from 'react';
+import { Import } from 'lucide-react';
 import { importFiles, ImportContext } from '../services/FileImportService';
 import './FileImportButton.css';
 
@@ -57,11 +58,7 @@ export function FileImportButton({ getImportContext }: FileImportButtonProps) {
               </path>
             </svg>
           ) : (
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M14 10v3a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-3" />
-              <path d="M8 2v8" />
-              <path d="M5 7l3 3 3-3" />
-            </svg>
+            <Import size={16} strokeWidth={1.5} />
           )}
         </span>
       </button>

--- a/src/ui/ImageUploadButton.tsx
+++ b/src/ui/ImageUploadButton.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useRef, useState } from 'react';
+import { Image as ImageIcon } from 'lucide-react';
 import { useTiptapEditor } from './TiptapEditorContext';
 import { blobStorage } from '../storage/BlobStorage';
 import { processImageForUpload, formatFileSize } from '../utils/imageUtils';
@@ -104,11 +105,7 @@ export function ImageUploadButton({ className }: ImageUploadButtonProps) {
             </path>
           </svg>
         ) : (
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-            {/* Image icon */}
-            <path d="M2 2h12a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm1 2v8h10V4H3zm2 6l2-2 1 1 2-3 3 4H5z" />
-            <circle cx="5.5" cy="6.5" r="1" />
-          </svg>
+          <ImageIcon size={16} strokeWidth={1.5} />
         )}
       </button>
 

--- a/src/ui/ShapePicker.tsx
+++ b/src/ui/ShapePicker.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { Shapes, ChevronUp, ChevronDown } from 'lucide-react';
 import { useShapeLibraryStore } from '../store/shapeLibraryStore';
 import { useSessionStore } from '../store/sessionStore';
 import { createShapeAtCenter } from '../engine/CommandRegistry';
@@ -177,9 +178,9 @@ export function ShapePicker() {
         {activeLibraryShape ? (
           <span className="shape-picker-trigger-icon">{activeLibraryShape.icon}</span>
         ) : (
-          <span className="shape-picker-trigger-icon">◇</span>
+          <span className="shape-picker-trigger-icon"><Shapes size={16} strokeWidth={1.5} /></span>
         )}
-        <span className="shape-picker-chevron">{isOpen ? '\u25B2' : '\u25BC'}</span>
+        <span className="shape-picker-chevron">{isOpen ? <ChevronUp size={12} strokeWidth={1.5} /> : <ChevronDown size={12} strokeWidth={1.5} />}</span>
       </button>
 
       {isOpen && (


### PR DESCRIPTION
Final icon slice of JP-147 — the canvas **pickers** and **upload buttons**, completing the lucide migration of the editor's interactive chrome. No dependency change (`lucide-react` already `^1.8.0`).

## Swaps
- **ShapePicker** trigger: `◇` → `Shapes`; `▲/▼` chevron → `ChevronUp/ChevronDown`.
- **CustomShapePicker** trigger: `📦` → `Boxes`; chevron → `ChevronUp/ChevronDown`.
- **FileImportButton**: idle "embed file" glyph → `Import` (custom animated spinner kept for the importing state).
- **ImageUploadButton**: idle image glyph → `Image` (animated spinner kept).

## Left as-is (intentional)
- The **active** library/custom shape's own icon shown on the trigger (data-driven shape metadata, not chrome).
- Per-item glyph fallbacks inside the shape grids.

## Verification
`bun run typecheck` clean · 1734 tests pass · production build green.

With this, the editor toolbars + chrome + ribbon + pickers are all on a single icon set. Remaining JP-147 work is non-icon (spacing/typography/theming polish).

Assisted-by: Opus 4.8