### PR TITLE
JP-147: light/dark brand theming (Claude Design palette)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,35 +1,93 @@
-/* Theme CSS Variables */
+/* ==========================================================================
+   Theme tokens — DocuShark brand (Claude Design palette)
+
+   Layout: raw brand ramps + brand-independent tokens are defined once in
+   :root; per-mode semantic tokens are set in :root (light) and overridden in
+   [data-theme="dark"]. Components should consume the *semantic* tokens
+   (--bg-*, --text-*, --border-*, --color-*) — not the raw ramps — so a future
+   re-skin is a one-file change.
+   ========================================================================== */
+
 :root {
+  /* --- Brand ramps (mode-independent) --- */
+  --brand-navy: #0e1c30;
+  --brand-gold: #c9a262;       /* fills only (CTA, dots, active fills) */
+  --brand-gold-deep: #9a7a3e;  /* gold text/icons on LIGHT surfaces */
+  --brand-gold-soft: #e0c690;  /* gold text/icons on NAVY surfaces */
+
+  --navy-1000: #060c17;
+  --navy-950: #0a1525;
+  --navy-900: #0e1c30;
+  --navy-800: #16273f;
+  --navy-700: #1f3354;
+  --navy-600: #2b466e;
+
+  --steel-500: #6a7a93;
+  --steel-400: #8d9bb1;
+  --steel-300: #b6c1d1;
+  --steel-200: #d5dbe4;
+  --steel-100: #e7ebf2;
+
+  /* --- CTA (mode-independent): gold fill + navy ink --- */
+  --color-cta: var(--brand-gold);
+  --color-cta-text: var(--navy-1000);
+  --color-cta-hover: var(--brand-gold-deep);
+
+  /* --- Semantic: LIGHT (warm paper + navy accent) --- */
   /* Backgrounds */
-  --bg-primary: #ffffff;
-  --bg-secondary: #f8f9fa;
-  --bg-tertiary: #e9ecef;
-  --bg-hover: #e9ecef;
-  --bg-active: #e7f1ff;
+  --bg-primary: #ffffff;          /* surface — cards, panels, inputs */
+  --bg-secondary: #f6f4ec;        /* page background — warm paper */
+  --bg-tertiary: #efece1;         /* sunken / alt section */
+  --bg-hover: rgba(14, 28, 48, 0.06);
+  --bg-active: rgba(31, 51, 84, 0.10);
 
   /* Text */
-  --text-primary: #495057;
-  --text-secondary: #6c757d;
-  --text-muted: #adb5bd;
+  --text-primary: #0a1525;        /* ink */
+  --text-secondary: #1f3354;      /* navy-700 */
+  --text-muted: #6a7a93;          /* steel-500 */
+  --text-faint: #8d9bb1;          /* steel-400 */
 
   /* Borders */
-  --border-color: #dee2e6;
-  --border-color-light: #e9ecef;
-  --border-color-input: #ced4da;
+  --border-color: rgba(14, 28, 48, 0.10);
+  --border-color-light: rgba(14, 28, 48, 0.06);
+  --border-color-input: rgba(14, 28, 48, 0.18);
 
-  /* Primary/Accent */
-  --color-primary: #2196f3;
-  --color-primary-dark: #1976d2;
-  --color-primary-light: #e7f1ff;
+  /* Primary/Accent (navy-based) */
+  --color-primary: #1f3354;       /* navy-700 — active borders, links */
+  --color-primary-dark: #0e1c30;  /* hover / pressed */
+  --color-primary-light: #e9edf3; /* soft navy wash — active backgrounds */
+  --color-primary-alpha: rgba(31, 51, 84, 0.18); /* focus ring */
+
+  /* Semantic status (fills + readable text) */
+  --success: #2d8f63;
+  --success-text: #2d8f63;
+  --danger: #7a2238;
+  --danger-text: #7a2238;
+  --warning: #b8761f;
 
   /* Canvas */
-  --canvas-bg: #ffffff;
-  --grid-minor: #e0e0e0;
-  --grid-major: #c0c0c0;
+  --canvas-bg: #fbfaf6;           /* soft warm white drawing surface */
+  --grid-minor: rgba(14, 28, 48, 0.06);
+  --grid-major: rgba(14, 28, 48, 0.12);
 
-  /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
+  /* Shadows (navy-based) */
+  --shadow-sm: 0 1px 2px rgba(14, 28, 48, 0.06);
+  --shadow-md: 0 2px 6px rgba(14, 28, 48, 0.10);
+
+  /* --- Alias tokens — bridge the older competing token names onto the
+     canonical brand tokens (fills undefined global consumers; a component
+     that defines these locally still wins for its own subtree). --- */
+  --accent-color: var(--color-primary);
+  --accent-hover: var(--color-primary-dark);
+  --hover-bg: var(--bg-hover);
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --text-color: var(--text-primary);
+  --text-tertiary: var(--text-muted);
+  --color-border: var(--border-color);
+  --danger-color: var(--danger);
+  --color-error: var(--danger);
+  --warning-color: var(--warning);
 
   /* Responsive breakpoints — shared tokens so layout CSS and the
    * `useBreakpoint` hook agree on the bands (see platform/device.ts
@@ -48,38 +106,48 @@
   --safe-area-left: env(safe-area-inset-left, 0px);
 }
 
-/* Dark Theme */
+/* --- Semantic: DARK (navy-native; elevation = lighter navy, not black) --- */
 [data-theme="dark"] {
-  /* Backgrounds */
-  --bg-primary: #1e1e1e;
-  --bg-secondary: #252526;
-  --bg-tertiary: #333333;
-  --bg-hover: #3c3c3c;
-  --bg-active: #0d3868;
+  /* Backgrounds — elevation ladder: app(body) #060c17 < page #0a1525 <
+     surface #0e1c30 < raised #16273f */
+  --bg-primary: #0e1c30;          /* surface — cards, panels, inputs */
+  --bg-secondary: #0a1525;        /* page / sunken sections */
+  --bg-tertiary: #16273f;         /* raised / hover surface */
+  --bg-hover: rgba(214, 224, 240, 0.06);
+  --bg-active: rgba(224, 198, 144, 0.14); /* gold-soft wash */
 
-  /* Text */
-  --text-primary: #cccccc;
-  --text-secondary: #9d9d9d;
-  --text-muted: #6d6d6d;
+  /* Text — steel ramp / warm paper, never pure white */
+  --text-primary: #f6f4ec;        /* paper */
+  --text-secondary: #d5dbe4;      /* steel-200 */
+  --text-muted: #8d9bb1;          /* steel-400 */
+  --text-faint: #6a7a93;          /* steel-500 */
 
-  /* Borders */
-  --border-color: #404040;
-  --border-color-light: #333333;
-  --border-color-input: #505050;
+  /* Borders — low-alpha light strokes, never #000 */
+  --border-color: rgba(214, 224, 240, 0.10);
+  --border-color-light: rgba(214, 224, 240, 0.06);
+  --border-color-input: rgba(214, 224, 240, 0.20);
 
-  /* Primary/Accent */
-  --color-primary: #0078d4;
-  --color-primary-dark: #005a9e;
-  --color-primary-light: #0d3868;
+  /* Primary/Accent — gold-soft for text/icons/borders on navy */
+  --color-primary: #e0c690;       /* gold-soft */
+  --color-primary-dark: #c9a262;  /* solid gold (hover / pressed) */
+  --color-primary-light: rgba(224, 198, 144, 0.14);
+  --color-primary-alpha: rgba(224, 198, 140, 0.30);
 
-  /* Canvas */
-  --canvas-bg: #1e1e1e;
-  --grid-minor: #2d2d2d;
-  --grid-major: #3d3d3d;
+  /* Semantic status — fills stay solid; text is lightened for navy */
+  --success: #2d8f63;
+  --success-text: #8edcb1;
+  --danger: #7a2238;
+  --danger-text: #e89b9b;
+  --warning: #e0c690;
 
-  /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.4);
+  /* Canvas — deepest navy void */
+  --canvas-bg: #060c17;
+  --grid-minor: rgba(214, 224, 240, 0.04);
+  --grid-major: rgba(214, 224, 240, 0.08);
+
+  /* Shadows — kept subtle; overlays still need a little separation */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.40);
+  --shadow-md: 0 6px 20px rgba(0, 0, 0, 0.50);
 }
 
 * {
@@ -104,4 +172,9 @@ body,
 body {
   background-color: var(--bg-secondary);
   color: var(--text-primary);
+}
+
+/* Deepest layer of the dark elevation ladder sits behind every surface. */
+[data-theme="dark"] body {
+  background-color: var(--navy-1000);
 }

--- a/src/ui/ColorPalette.css
+++ b/src/ui/ColorPalette.css
@@ -52,12 +52,12 @@
 
 .color-swatch:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.3);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .color-swatch.selected {
   border: 2px solid #fff;
-  box-shadow: 0 0 0 2px var(--color-primary, #2196f3);
+  box-shadow: 0 0 0 2px var(--color-primary, var(--color-primary));
 }
 
 /* ── Automatic swatch row ─────────────────────────────── */
@@ -86,7 +86,7 @@
 }
 
 .auto-color-icon {
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
   font-size: 13px;
   font-weight: 700;
   line-height: 1;
@@ -144,7 +144,7 @@
 }
 
 .color-palette-info-btn:hover {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: #fff;
 }
 
@@ -245,7 +245,7 @@
 
 .color-palette-custom-toggle:hover {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .color-palette-custom-input-group {
@@ -262,13 +262,13 @@
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--color-primary, #2196f3);
+  border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 4px;
   outline: none;
 }
 
 .color-palette-custom-input:focus {
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .color-palette-custom-apply {
@@ -276,7 +276,7 @@
   font-size: 0.75rem;
   font-weight: 500;
   color: #fff;
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -284,7 +284,7 @@
 }
 
 .color-palette-custom-apply:hover {
-  background: var(--color-primary-dark, #1976d2);
+  background: var(--color-primary-dark, var(--color-primary-dark));
 }
 
 /* Dark mode adjustments */

--- a/src/ui/CompactColorInput.css
+++ b/src/ui/CompactColorInput.css
@@ -43,13 +43,13 @@
 }
 
 .compact-color-picker:hover {
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .compact-color-picker:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 /* Swatch button — opens our palette instead of the OS picker */
@@ -69,21 +69,21 @@
 }
 
 .compact-color-swatch:hover {
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
   transform: translateY(-1px);
 }
 
 .compact-color-swatch:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.25);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .compact-color-swatch-auto {
   font-size: 11px;
   font-weight: 700;
   line-height: 1;
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
   background: rgba(255, 255, 255, 0.85);
   width: 14px;
   height: 14px;
@@ -111,7 +111,7 @@
 
 /* "Auto" accent label inside the hex button */
 .compact-color-auto-label {
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
   font-style: italic;
   font-weight: 600;
 }
@@ -135,13 +135,13 @@
 
 .compact-color-hex-input:hover {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .compact-color-hex-input:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .compact-color-hex-input.editing {
@@ -166,14 +166,14 @@
 }
 
 .compact-color-edit:hover {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: #ffffff;
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .compact-color-edit:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 /* Palette Dropdown */

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -134,7 +134,7 @@
 
 /* Active menu item */
 .doc-editor-context-menu-item.active {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.1));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.1));
 }
 
 .doc-editor-context-menu-item.active .doc-editor-context-menu-icon {

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -89,7 +89,7 @@
 
 .document-editor-toolbar-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.3);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .document-editor-toolbar-btn strong {
@@ -137,7 +137,7 @@
 
 .document-editor-toolbar-select:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .document-editor-toolbar-select option {
@@ -230,7 +230,7 @@
 
 .math-input-content input[type="text"]:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .math-input-content input[type="text"]::placeholder {
@@ -286,7 +286,7 @@
 
 .math-input-content textarea:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .math-input-content textarea::placeholder {

--- a/src/ui/DocumentManager.css
+++ b/src/ui/DocumentManager.css
@@ -130,7 +130,7 @@
 
 .document-manager-item.selected {
   border-color: var(--color-primary);
-  background-color: rgba(33, 150, 243, 0.1);
+  background-color: rgba(31, 51, 84, 0.1);
 }
 
 .document-manager-item.current {
@@ -273,5 +273,5 @@
 }
 
 :root.dark .document-manager-item.selected {
-  background-color: rgba(33, 150, 243, 0.15);
+  background-color: rgba(31, 51, 84, 0.15);
 }

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -110,7 +110,7 @@
 }
 
 .export-format-btn.active {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: white;
 }
 
@@ -127,8 +127,8 @@
 
 .export-select:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 /* Background options */
@@ -151,7 +151,7 @@
   width: 16px;
   height: 16px;
   cursor: pointer;
-  accent-color: var(--color-primary, #2196f3);
+  accent-color: var(--color-primary, var(--color-primary));
 }
 
 .export-color {
@@ -192,8 +192,8 @@
 
 .export-number:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .export-unit {
@@ -219,8 +219,8 @@
 
 .export-text:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
   z-index: 1;
   position: relative;
 }
@@ -281,12 +281,12 @@
 }
 
 .export-btn-primary {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: white;
 }
 
 .export-btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-dark, #1976d2);
+  background: var(--color-primary-dark, var(--color-primary-dark));
 }
 
 /* Dark mode */

--- a/src/ui/KeyboardShortcutPanel.css
+++ b/src/ui/KeyboardShortcutPanel.css
@@ -71,7 +71,7 @@
 }
 
 .shortcut-panel__search:focus {
-  border-color: var(--color-accent, #2196f3);
+  border-color: var(--color-accent, var(--color-primary));
 }
 
 .shortcut-panel__content {

--- a/src/ui/LayerPanel.css
+++ b/src/ui/LayerPanel.css
@@ -38,7 +38,7 @@
 }
 
 .layer-panel-resize-handle-vertical:hover {
-  background: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
   opacity: 0.3;
 }
 
@@ -55,7 +55,7 @@
 }
 
 .layer-panel-resize-handle-horizontal:hover {
-  background: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
   opacity: 0.3;
 }
 
@@ -119,18 +119,18 @@
 
 /* Drop indicator - before target */
 .layer-item.drop-before {
-  box-shadow: inset 0 3px 0 0 var(--accent-color, #2196f3);
+  box-shadow: inset 0 3px 0 0 var(--accent-color, var(--color-primary));
 }
 
 /* Drop indicator - after target */
 .layer-item.drop-after {
-  box-shadow: inset 0 -3px 0 0 var(--accent-color, #2196f3);
+  box-shadow: inset 0 -3px 0 0 var(--accent-color, var(--color-primary));
 }
 
 /* Drop indicator - into group */
 .layer-item.drop-into {
   background: var(--color-primary-light, #e3f2fd) !important;
-  outline: 2px solid var(--accent-color, #2196f3);
+  outline: 2px solid var(--accent-color, var(--color-primary));
   outline-offset: -2px;
 }
 
@@ -171,7 +171,7 @@
   font-weight: 500;
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--color-primary, #2196f3);
+  border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
   padding: 2px 4px;
   width: 100%;
@@ -179,7 +179,7 @@
 }
 
 .layer-item-rename-input:focus {
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 [data-theme="dark"] .layer-item-rename-input {
@@ -230,7 +230,7 @@
 }
 
 .layer-action-btn.active {
-  color: var(--accent-color, #2196f3);
+  color: var(--accent-color, var(--color-primary));
 }
 
 .layer-action-btn.inactive {
@@ -360,7 +360,7 @@
 
 .layer-panel-action-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
 }
 
 /* Layer context menu */
@@ -557,7 +557,7 @@
 
 .layer-view-selector select:focus {
   outline: none;
-  border-color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
 }
 
 .layer-view-manage-btn {
@@ -596,8 +596,8 @@
 }
 
 .layer-view-create-btn:hover {
-  border-color: var(--accent-color, #2196f3);
-  color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
+  color: var(--accent-color, var(--color-primary));
 }
 
 [data-theme="dark"] .layer-view-selector {

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -111,8 +111,8 @@
 
 .layer-view-form-row input:focus {
   outline: none;
-  border-color: var(--accent-color, #2196f3);
-  box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.1);
+  border-color: var(--accent-color, var(--color-primary));
+  box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .layer-view-form-hint {
@@ -130,7 +130,7 @@
   padding: 8px 16px;
   border: none;
   border-radius: 6px;
-  background: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
   color: white;
   font-size: 13px;
   font-weight: 500;
@@ -139,7 +139,7 @@
 }
 
 .layer-view-form-submit:hover {
-  background: var(--accent-color-dark, #1976d2);
+  background: var(--accent-color-dark, var(--color-primary-dark));
 }
 
 /* View list */
@@ -191,7 +191,7 @@
 
 .layer-view-list-item-manual {
   font-size: 11px;
-  color: var(--accent-color, #2196f3);
+  color: var(--accent-color, var(--color-primary));
 }
 
 .layer-view-list-item-actions {
@@ -243,7 +243,7 @@
 
 .layer-view-edit-form input:focus {
   outline: none;
-  border-color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
 }
 
 .layer-view-edit-actions {
@@ -263,8 +263,8 @@
 }
 
 .layer-view-edit-actions button:first-child {
-  background: var(--accent-color, #2196f3);
-  border-color: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
+  border-color: var(--accent-color, var(--color-primary));
   color: white;
 }
 
@@ -273,7 +273,7 @@
 }
 
 .layer-view-edit-actions button:first-child:hover {
-  background: var(--accent-color-dark, #1976d2);
+  background: var(--accent-color-dark, var(--color-primary-dark));
 }
 
 /* Help section */
@@ -393,7 +393,7 @@
 
 .layer-view-form-test:hover:not(:disabled) {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
 }
 
 .layer-view-form-test:disabled {
@@ -438,7 +438,7 @@
 }
 
 .layer-view-preview-type {
-  background: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
   color: white;
   padding: 2px 6px;
   border-radius: 4px;

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -81,7 +81,7 @@
 
 .logo-picker-upload-btn:hover:not(:disabled) {
   background: var(--accent-light, #e3f2fd);
-  border-color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
 }
 
 .logo-picker-upload-btn:disabled {
@@ -119,7 +119,7 @@
 
 .logo-picker-item.selected {
   background: var(--accent-light, #e3f2fd);
-  border-color: var(--accent-color, #2196f3);
+  border-color: var(--accent-color, var(--color-primary));
 }
 
 .logo-picker-preview {
@@ -183,13 +183,13 @@
 }
 
 .logo-picker-btn-primary {
-  background: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
   color: white;
   border: none;
 }
 
 .logo-picker-btn-primary:hover {
-  background: var(--accent-hover, #1976d2);
+  background: var(--accent-hover, var(--color-primary-dark));
 }
 
 .logo-picker-btn-secondary {

--- a/src/ui/NumberInput.css
+++ b/src/ui/NumberInput.css
@@ -30,8 +30,8 @@
 }
 
 .number-input-container:focus-within {
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
 .number-input-container.disabled {
@@ -75,11 +75,11 @@
 
 .number-input-btn:hover:not(.disabled) {
   background: var(--bg-hover, #dee2e6);
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
 }
 
 .number-input-btn:active:not(.disabled) {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.2));
+  background: var(--color-primary-light, var(--color-primary-alpha));
 }
 
 .number-input-btn.disabled {

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -183,8 +183,8 @@
 .pdf-export-field select:focus,
 .pdf-export-field textarea:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 3px var(--color-primary-alpha, rgba(33, 150, 243, 0.15));
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 3px var(--color-primary-alpha, rgba(31, 51, 84, 0.15));
 }
 
 .pdf-export-field input:disabled,
@@ -245,8 +245,8 @@
 }
 
 .pdf-export-toggle button.active {
-  background: var(--accent-color, #2196f3);
-  border-color: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
+  border-color: var(--accent-color, var(--color-primary));
   color: white;
 }
 
@@ -426,13 +426,13 @@
 }
 
 .pdf-export-btn-primary {
-  background: var(--accent-color, #2196f3);
+  background: var(--accent-color, var(--color-primary));
   color: white;
   border: none;
 }
 
 .pdf-export-btn-primary:hover:not(:disabled) {
-  background: var(--accent-hover, #1976d2);
+  background: var(--accent-hover, var(--color-primary-dark));
 }
 
 .pdf-export-btn-primary:disabled {

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -37,7 +37,7 @@
 
 .property-panel-resize-handle:hover,
 .property-panel-resize-handle.resizing {
-  background-color: var(--color-primary, #2196f3);
+  background-color: var(--color-primary, var(--color-primary));
 }
 
 /* Header */
@@ -93,8 +93,8 @@
   padding: 4px 10px;
   font-size: 0.6875rem;
   font-weight: 600;
-  color: var(--color-primary, #2196f3);
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.1));
+  color: var(--color-primary, var(--color-primary));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.1));
   border-radius: 12px;
   text-transform: capitalize;
   margin-bottom: 12px;
@@ -174,9 +174,9 @@
 
 .compact-number-input::-webkit-inner-spin-button:hover {
   background:
-    linear-gradient(var(--color-primary, #2196f3) 0 0) no-repeat center 40% / 6px 1px,
-    linear-gradient(var(--color-primary, #2196f3) 0 0) no-repeat center 40% / 1px 6px,
-    linear-gradient(var(--color-primary, #2196f3) 0 0) no-repeat center 65% / 6px 1px,
+    linear-gradient(var(--color-primary, var(--color-primary)) 0 0) no-repeat center 40% / 6px 1px,
+    linear-gradient(var(--color-primary, var(--color-primary)) 0 0) no-repeat center 40% / 1px 6px,
+    linear-gradient(var(--color-primary, var(--color-primary)) 0 0) no-repeat center 65% / 6px 1px,
     var(--bg-hover, #dee2e6);
 }
 
@@ -187,7 +187,7 @@
 .compact-number-input:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
   background: var(--bg-primary);
 }
 
@@ -291,7 +291,7 @@
 .property-text-input:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
   background: var(--bg-primary);
 }
 
@@ -321,7 +321,7 @@
 .property-textarea:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
   background: var(--bg-primary);
 }
 
@@ -372,7 +372,7 @@
 
 .align-button:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
 /* Compact Select Row */
@@ -424,7 +424,7 @@
 .compact-select:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
   background: var(--bg-primary);
 }
 
@@ -584,7 +584,7 @@
 .property-text:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .property-number {
@@ -601,7 +601,7 @@
 .property-number:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .property-select {
@@ -631,7 +631,7 @@
 .property-select:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .property-slider {
@@ -661,7 +661,7 @@
 }
 
 [data-theme="dark"] .property-type-badge {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.15));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
 }
 
 [data-theme="dark"] .compact-number-input,
@@ -745,7 +745,7 @@
 
 .icon-color-reset:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
 [data-theme="dark"] .icon-color-reset {
@@ -820,7 +820,7 @@
 
 .label-offset-reset:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
 [data-theme="dark"] .label-offset-reset {
@@ -858,7 +858,7 @@
 }
 
 .erd-member-row.drag-over {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.15));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
   border-radius: 4px;
 }
 
@@ -959,7 +959,7 @@
 }
 
 .erd-add-member:hover {
-  background: rgba(33, 150, 243, 0.05);
+  background: rgba(31, 51, 84, 0.05);
   border-color: var(--color-primary);
 }
 
@@ -995,7 +995,7 @@
 }
 
 .uml-member-row.drag-over {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.15));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
   border-radius: 4px;
 }
 
@@ -1120,7 +1120,7 @@
 }
 
 .uml-add-member:hover {
-  background: rgba(33, 150, 243, 0.05);
+  background: rgba(31, 51, 84, 0.05);
   border-color: var(--color-primary);
 }
 
@@ -1174,7 +1174,7 @@
 }
 
 .preset-button:active {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.15));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
 }
 
 [data-theme="dark"] .preset-button {
@@ -1304,7 +1304,7 @@
 }
 
 .swimlane-lane-row.drag-over {
-  background: var(--color-primary-light, rgba(33, 150, 243, 0.15));
+  background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
 }
 
 .swimlane-lane-name {
@@ -1397,7 +1397,7 @@
 }
 
 .swimlane-add-lane:hover {
-  background: rgba(33, 150, 243, 0.05);
+  background: rgba(31, 51, 84, 0.05);
   border-color: var(--color-primary);
 }
 

--- a/src/ui/PropertySection.css
+++ b/src/ui/PropertySection.css
@@ -48,7 +48,7 @@
 }
 
 .property-section-header:hover .property-section-chevron {
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
   opacity: 1;
 }
 
@@ -67,8 +67,8 @@
   font-size: 0.625rem;
   font-weight: 600;
   padding: 2px 8px;
-  background-color: var(--color-primary-light, rgba(33, 150, 243, 0.1));
-  color: var(--color-primary, #2196f3);
+  background-color: var(--color-primary-light, rgba(31, 51, 84, 0.1));
+  color: var(--color-primary, var(--color-primary));
   border-radius: 10px;
 }
 
@@ -116,5 +116,5 @@
 }
 
 [data-theme="dark"] .property-section-badge {
-  background-color: var(--color-primary-light, rgba(33, 150, 243, 0.15));
+  background-color: var(--color-primary-light, rgba(31, 51, 84, 0.15));
 }

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -128,8 +128,8 @@
 
 .save-to-library-input:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .save-to-library-input::placeholder {
@@ -155,8 +155,8 @@
 
 .save-to-library-select:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .save-to-library-new-library-btn {
@@ -177,7 +177,7 @@
 
 .save-to-library-new-library-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 /* Create library inline form */
@@ -202,12 +202,12 @@
 }
 
 .save-to-library-create-btn {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: white;
 }
 
 .save-to-library-create-btn:hover:not(:disabled) {
-  background: var(--color-primary-dark, #1976d2);
+  background: var(--color-primary-dark, var(--color-primary-dark));
 }
 
 .save-to-library-create-btn:disabled {
@@ -270,12 +270,12 @@
 }
 
 .save-to-library-btn-primary {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: white;
 }
 
 .save-to-library-btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-dark, #1976d2);
+  background: var(--color-primary-dark, var(--color-primary-dark));
 }
 
 /* Dark mode */

--- a/src/ui/SearchReplacePanel.css
+++ b/src/ui/SearchReplacePanel.css
@@ -101,7 +101,7 @@
 
 .search-input:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .search-input::placeholder {

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -137,7 +137,7 @@
 
 .shape-library-create-input:focus {
   outline: none;
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .shape-library-create-btn,
@@ -152,12 +152,12 @@
 }
 
 .shape-library-create-btn {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: white;
 }
 
 .shape-library-create-btn:hover:not(:disabled) {
-  background: var(--color-primary-dark, #1976d2);
+  background: var(--color-primary-dark, var(--color-primary-dark));
 }
 
 .shape-library-create-btn:disabled {
@@ -204,7 +204,7 @@
 }
 
 .shape-library-item.selected {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: white;
 }
 
@@ -231,7 +231,7 @@
 .shape-library-edit-input {
   flex: 1;
   padding: 4px 6px;
-  border: 1px solid var(--color-primary, #2196f3);
+  border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 4px;
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #212529);
@@ -317,7 +317,7 @@
 }
 
 .shape-library-shape-item:hover {
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
@@ -358,7 +358,7 @@
 .shape-library-shape-edit-input {
   width: 100%;
   padding: 2px 4px;
-  border: 1px solid var(--color-primary, #2196f3);
+  border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #212529);

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -51,7 +51,7 @@
 
 /* Tool Display */
 .status-bar-tool {
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
   font-weight: 500;
 }
 
@@ -63,17 +63,17 @@
   padding: 1px 6px;
   font-size: 0.625rem;
   font-weight: 500;
-  color: var(--color-primary, #2196f3);
-  background: rgba(33, 150, 243, 0.12);
-  border: 1px solid rgba(33, 150, 243, 0.4);
+  color: var(--color-primary, var(--color-primary));
+  background: rgba(31, 51, 84, 0.12);
+  border: 1px solid var(--color-primary-alpha);
   border-radius: 10px;
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .status-bar-drill-badge:hover {
-  background: rgba(33, 150, 243, 0.22);
-  border-color: var(--color-primary, #2196f3);
+  background: var(--color-primary-alpha);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .status-bar-drill-badge-x {
@@ -128,11 +128,11 @@
 .status-bar-zoom-btn:hover {
   background: var(--bg-hover, #e9ecef);
   color: var(--text-primary, #495057);
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .status-bar-zoom-btn:active {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
   color: #ffffff;
 }
 
@@ -159,7 +159,7 @@
 .status-bar-btn:hover {
   background: var(--bg-hover, #e9ecef);
   color: var(--text-primary, #495057);
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 /* Dark Mode */

--- a/src/ui/TextEditor.css
+++ b/src/ui/TextEditor.css
@@ -12,7 +12,7 @@
   pointer-events: auto;
   background: #ffffff;
   color: #1e293b;
-  border: 2px solid var(--selection-color, #2196f3);
+  border: 2px solid var(--selection-color, var(--color-primary));
   border-radius: 4px;
   padding: 4px 8px;
   resize: both;
@@ -28,8 +28,8 @@
 }
 
 .text-editor-textarea:focus {
-  border-color: #1976d2;
-  box-shadow: 0 2px 12px rgba(33, 150, 243, 0.4);
+  border-color: var(--color-primary-dark);
+  box-shadow: 0 2px 12px var(--color-primary-alpha);
 }
 
 /* Dark mode */

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -290,7 +290,7 @@
 }
 
 [data-theme="dark"] .tiptap-editor .ProseMirror ::selection {
-  background-color: rgba(33, 150, 243, 0.3);
+  background-color: var(--color-primary-alpha);
 }
 
 /* ============================================

--- a/src/ui/Toolbar.css
+++ b/src/ui/Toolbar.css
@@ -41,7 +41,7 @@
 
 .toolbar-button:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.3);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-icon {

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -68,14 +68,14 @@
 }
 
 .tool-button.active {
-  background: var(--color-primary-light, #e7f1ff);
-  border-color: var(--color-primary, #2196f3);
-  color: var(--color-primary, #2196f3);
+  background: var(--color-primary-light, var(--color-primary-light));
+  border-color: var(--color-primary, var(--color-primary));
+  color: var(--color-primary, var(--color-primary));
 }
 
 .tool-button:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .tool-button-icon {
@@ -221,7 +221,7 @@
   font-weight: 500;
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--color-primary, #2196f3);
+  border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 4px;
   outline: none;
   max-width: 200px;
@@ -312,9 +312,9 @@
 }
 
 .inline-tab.active {
-  background: var(--color-primary-light, #e7f1ff);
-  color: var(--color-primary, #2196f3);
-  border-color: var(--color-primary, #2196f3);
+  background: var(--color-primary-light, var(--color-primary-light));
+  color: var(--color-primary, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
   font-weight: 500;
 }
 
@@ -337,8 +337,8 @@
 
 .inline-tab-add:hover {
   background: var(--bg-hover, #e9ecef);
-  color: var(--color-primary, #2196f3);
-  border-color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 /* Action Buttons */
@@ -365,7 +365,7 @@
 
 .toolbar-action-button:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 /* Action button group */
@@ -398,7 +398,7 @@
 
 .toolbar-icon-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-icon-btn svg {
@@ -425,13 +425,13 @@
 
 .toolbar-rebuild-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  color: var(--color-primary, #2196f3);
-  border-color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .toolbar-rebuild-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-rebuild-btn:active {
@@ -456,8 +456,8 @@
 
 .toolbar-action-btn:hover:not(:disabled) {
   background: var(--bg-hover, #e9ecef);
-  color: var(--color-primary, #2196f3);
-  border-color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .toolbar-action-btn:disabled {
@@ -467,7 +467,7 @@
 
 .toolbar-action-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 /* Help button */
@@ -489,12 +489,12 @@
 .toolbar-help-btn:hover {
   background: var(--bg-hover, #e9ecef);
   border-color: var(--border-color, #dee2e6);
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
 }
 
 .toolbar-help-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-help-btn svg {
@@ -520,12 +520,12 @@
 
 .toolbar-whiteboard-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
 }
 
 .toolbar-whiteboard-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-whiteboard-btn svg {
@@ -551,12 +551,12 @@
 
 .toolbar-whiteboard-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
 }
 
 .toolbar-whiteboard-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-whiteboard-btn svg {
@@ -582,13 +582,13 @@
 
 .toolbar-settings-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--color-primary, #2196f3);
-  color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
+  color: var(--color-primary, var(--color-primary));
 }
 
 .toolbar-settings-btn:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
 .toolbar-settings-btn svg {
@@ -709,7 +709,7 @@
   font-size: 0.75rem;
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--color-primary, #2196f3);
+  border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
   outline: none;
 }

--- a/src/ui/layout/DockedPanel.css
+++ b/src/ui/layout/DockedPanel.css
@@ -37,5 +37,5 @@
 
 .docked-panel-handle:hover,
 .docked-panel-handle.dragging {
-  background: var(--color-primary, #2196f3);
+  background: var(--color-primary, var(--color-primary));
 }

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -58,7 +58,7 @@
 }
 
 .flyout-panel-rail:focus-visible {
-  box-shadow: inset 2px 0 0 var(--color-primary, #2196f3);
+  box-shadow: inset 2px 0 0 var(--color-primary, var(--color-primary));
 }
 
 .flyout-panel-rail-icon {

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -26,7 +26,7 @@
 .layout-selector-chip.open,
 .layout-selector-chip:focus-visible {
   background: var(--bg-secondary);
-  border-color: var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
   outline: none;
 }
 

--- a/src/ui/settings/LayoutSettings.css
+++ b/src/ui/settings/LayoutSettings.css
@@ -57,8 +57,8 @@
 }
 
 .layout-settings-default-option.active {
-  border-color: var(--color-primary, #2196f3);
-  box-shadow: inset 0 0 0 1px var(--color-primary, #2196f3);
+  border-color: var(--color-primary, var(--color-primary));
+  box-shadow: inset 0 0 0 1px var(--color-primary, var(--color-primary));
 }
 
 .layout-settings-default-text {
@@ -117,7 +117,7 @@
 .layout-settings-customized {
   margin-left: 8px;
   font-size: 11px;
-  color: var(--color-primary, #2196f3);
+  color: var(--color-primary, var(--color-primary));
 }
 
 .layout-settings-table select {


### PR DESCRIPTION
Applies the DocuShark brand palette (Claude Design) to the editor in **both modes**, fixing the "extremely bright" light mode and putting the app on-brand. Decisions (yours): **navy-based accent**, gold reserved for the primary CTA; **light + dark together**.

## What's in here
- **`src/index.css` — full brand token system.** Brand ramps (navy/steel/gold) + CTA + semantic defined once; per-mode semantic tokens:
  - **Light:** warm-paper surfaces (`#f6f4ec` page / `#fff` cards), ink text `#0a1525`, navy-700 accent, soft-warm-white canvas, navy hairlines/shadows.
  - **Dark:** navy elevation ladder (app `#060c17` < page `#0a1525` < surface `#0e1c30` < raised `#16273f`), **paper/steel text (never `#fff`)**, **gold-soft accent** (gold-soft for text/icons, solid gold for CTA fills), low-alpha light borders, lightened semantic text (`#8edcb1`/`#e89b9b`). Per your dark-mode tips.
  - New tokens: `--color-primary-alpha`, `--text-faint`, `--success/-text`, `--danger/-text`, CTA (`--color-cta/-text/-hover`).
- **Alias tokens** bridge the older competing names (`--accent-color`, `--hover-bg`, `--color-text-primary`, `--danger-color`, …) onto the canonical brand tokens — re-skins hundreds of previously-undefined-global consumers for free.
- **De-blued all CSS**: `rgba(33,150,243,·)` focus rings → `var(--color-primary-alpha)` (gold on dark / navy on light), low-alpha washes → navy hue at same opacity; bare `#2196f3/#1976d2/#e7f1ff` → the primary tokens.

## Please eyeball (both modes via the theme toggle)
- Light: warm paper, not stark white; active tool = soft-navy wash + navy border; focus rings navy.
- Dark: navy surfaces, gold-soft accents, legible steel text; **check primary-fill buttons** — a few that were blue-fill + white-text now use the gold-soft accent and may want navy CTA text (that's the gold-CTA follow-up).
- Settings/dialogs are intentionally only de-blued here (their grays/surfaces are the follow-up) — confirm they're still readable.

## Verification
`bun run typecheck` clean · 1734 tests pass · build green.

## Follow-ups (filing as related issues)
1. Settings/dialog cluster brand pass (~2157 hardcoded colours, 17 self-themed files).
2. Token-scheme unification (kill competing names + per-file `:root`).
3. Gold CTA application to real primary buttons (navy text on gold).
4. Spacing/typography token scale.

Assisted-by: Opus 4.8