### PR TITLE
JP-150: settings/dialog brand pass + light-mode brightness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,7 +35,7 @@
 
   /* --- Semantic: LIGHT (warm paper + navy accent) --- */
   /* Backgrounds */
-  --bg-primary: #ffffff;          /* surface — cards, panels, inputs */
+  --bg-primary: #f9f6ee;          /* surface — cards, panels, inputs (soft warm white) */
   --bg-secondary: #f6f4ec;        /* page background — warm paper */
   --bg-tertiary: #efece1;         /* sunken / alt section */
   --bg-hover: rgba(14, 28, 48, 0.06);
@@ -66,7 +66,7 @@
   --warning: #b8761f;
 
   /* Canvas */
-  --canvas-bg: #fbfaf6;           /* soft warm white drawing surface */
+  --canvas-bg: #f7f4ec;           /* warm off-white drawing surface */
   --grid-minor: rgba(14, 28, 48, 0.06);
   --grid-major: rgba(14, 28, 48, 0.12);
 

--- a/src/ui/ColorPalette.css
+++ b/src/ui/ColorPalette.css
@@ -144,8 +144,8 @@
 }
 
 .color-palette-info-btn:hover {
-  background: var(--color-primary, var(--color-primary));
-  color: #fff;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .color-palette-info-tooltip {
@@ -275,8 +275,8 @@
   padding: 4px 8px;
   font-size: 0.75rem;
   font-weight: 500;
-  color: #fff;
-  background: var(--color-primary, var(--color-primary));
+  color: var(--color-cta-text);
+  background: var(--color-cta));
   border: none;
   border-radius: 4px;
   cursor: pointer;

--- a/src/ui/CompactColorInput.css
+++ b/src/ui/CompactColorInput.css
@@ -166,8 +166,8 @@
 }
 
 .compact-color-edit:hover {
-  background: var(--color-primary, var(--color-primary));
-  color: #ffffff;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
   border-color: var(--color-primary, var(--color-primary));
 }
 

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -35,7 +35,7 @@
 
 .context-menu-item.danger:hover {
   background: #fee2e2;
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 .context-menu-label {
@@ -126,7 +126,7 @@
 
 [data-theme="dark"] .context-menu-item.danger:hover {
   background: #450a0a;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .context-menu-separator {

--- a/src/ui/CustomShapePicker.css
+++ b/src/ui/CustomShapePicker.css
@@ -28,8 +28,8 @@
 }
 
 .custom-shape-picker-trigger.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 .custom-shape-picker-trigger.active:hover {
@@ -111,8 +111,8 @@
 }
 
 .custom-shape-picker-library.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 /* Shapes grid */
@@ -229,8 +229,8 @@
 }
 
 .custom-shape-picker-view-btn.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 /* Size variants */

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -66,7 +66,7 @@
   font-weight: 500;
   padding: 2px 6px;
   color: var(--accent-color, #3b82f6);
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(31, 51, 84, 0.1);
   border-radius: 4px;
   flex-shrink: 0;
 }
@@ -107,7 +107,7 @@
 }
 
 .document-card__type--cached {
-  color: #f59e0b;
+  color: var(--warning);
   background: rgba(245, 158, 11, 0.1);
 }
 
@@ -180,7 +180,7 @@
 .document-card__action--danger:hover {
   background: rgba(239, 68, 68, 0.1);
   border-color: rgba(239, 68, 68, 0.3);
-  color: #ef4444;
+  color: var(--danger-text);
 }
 
 /* Delete confirmation */
@@ -192,7 +192,7 @@
 
 .document-card__confirm-text {
   font-size: 11px;
-  color: #ef4444;
+  color: var(--danger-text);
   font-weight: 500;
 }
 
@@ -207,12 +207,12 @@
 }
 
 .document-card__confirm-yes {
-  background: #ef4444;
+  background: var(--danger);
   color: white;
 }
 
 .document-card__confirm-yes:hover {
-  background: #dc2626;
+  background: var(--danger);
 }
 
 .document-card__confirm-no {
@@ -240,7 +240,7 @@
 }
 
 .document-card__relay--connected {
-  color: #16a34a;
+  color: var(--success-text);
   background: rgba(22, 163, 74, 0.1);
 }
 
@@ -480,7 +480,7 @@
 }
 
 :root[data-theme="dark"] .document-card__relay--connected {
-  color: #4ade80;
+  color: var(--success-text);
   background: rgba(74, 222, 128, 0.15);
 }
 

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -260,9 +260,9 @@
 }
 
 .math-input-actions button.primary {
-  background: var(--color-primary);
+  background: var(--color-cta);
   border-color: var(--color-primary);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .math-input-actions button.primary:hover {

--- a/src/ui/DocumentManager.css
+++ b/src/ui/DocumentManager.css
@@ -89,9 +89,9 @@
 }
 
 .document-manager-action-btn.primary {
-  background-color: var(--color-primary);
+  background-color: var(--color-cta);
   border-color: var(--color-primary);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .document-manager-action-btn.primary:hover {
@@ -220,7 +220,7 @@
 }
 
 .document-manager-confirm-btn.danger:hover {
-  background-color: #dc2626;
+  background-color: var(--danger);
 }
 
 .document-manager-footer {
@@ -254,9 +254,9 @@
 }
 
 .document-manager-btn.primary {
-  background-color: var(--color-primary);
+  background-color: var(--color-cta);
   border-color: var(--color-primary);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .document-manager-btn.primary:hover:not(:disabled) {

--- a/src/ui/DocumentPermissionsDialog.css
+++ b/src/ui/DocumentPermissionsDialog.css
@@ -51,7 +51,7 @@
   justify-content: space-between;
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-color, #e0e0e0);
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--navy-900) 0%, var(--navy-700) 100%);
   border-radius: 12px 12px 0 0;
 }
 
@@ -130,7 +130,7 @@
   background: #fef2f2;
   border: 1px solid #fecaca;
   border-radius: 6px;
-  color: #dc2626;
+  color: var(--danger-text);
   font-size: 13px;
   margin-bottom: 16px;
 }
@@ -140,7 +140,7 @@
   background: #f0fdf4;
   border: 1px solid #86efac;
   border-radius: 6px;
-  color: #16a34a;
+  color: var(--success-text);
   font-size: 13px;
   margin-bottom: 16px;
 }
@@ -169,8 +169,8 @@
 
 .document-permissions-dialog__quick-btn--danger:hover {
   background: #fef2f2;
-  border-color: #dc2626;
-  color: #dc2626;
+  border-color: var(--danger);
+  color: var(--danger-text);
 }
 
 .document-permissions-dialog__section {
@@ -347,7 +347,7 @@
 }
 
 .document-permissions-dialog__btn--primary {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--navy-900) 0%, var(--navy-700) 100%);
   border-color: transparent;
   color: white;
 }
@@ -358,13 +358,13 @@
 }
 
 .document-permissions-dialog__btn--danger {
-  background: #dc2626;
-  border-color: #dc2626;
+  background: var(--danger);
+  border-color: var(--danger);
   color: white;
 }
 
 .document-permissions-dialog__btn--danger:hover:not(:disabled) {
-  background: #b91c1c;
+  background: var(--danger);
 }
 
 /* Dark mode */

--- a/src/ui/EmbeddedGroupComponent.css
+++ b/src/ui/EmbeddedGroupComponent.css
@@ -128,7 +128,7 @@
 
 .embedded-group-error-icon {
   font-size: 24px;
-  color: #f59e0b;
+  color: var(--warning);
 }
 
 .embedded-group-retry-btn {

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -110,8 +110,8 @@
 }
 
 .export-format-btn.active {
-  background: var(--color-primary, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 /* Select */
@@ -241,7 +241,7 @@
   background: #fee2e2;
   border: 1px solid #fecaca;
   border-radius: 6px;
-  color: #dc2626;
+  color: var(--danger-text);
   font-size: 13px;
 }
 
@@ -281,8 +281,8 @@
 }
 
 .export-btn-primary {
-  background: var(--color-primary, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .export-btn-primary:hover:not(:disabled) {
@@ -351,7 +351,7 @@
 [data-theme="dark"] .export-error {
   background: #450a0a;
   border-color: #7f1d1d;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .export-dialog-footer {

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -246,8 +246,8 @@
   padding: 10px 20px;
   border: none;
   border-radius: 8px;
-  background: var(--accent-color, #3b82f6);
-  color: #ffffff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -256,7 +256,7 @@
 }
 
 .file-viewer-recovery-btn:hover {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
 }
 
 .file-viewer-recovery-btn:disabled {

--- a/src/ui/IconPicker.css
+++ b/src/ui/IconPicker.css
@@ -109,8 +109,8 @@
 
 .icon-picker-upload-btn {
   padding: 6px 10px;
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -149,8 +149,8 @@
 }
 
 .icon-picker-category.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 .icon-picker-category.lazy {

--- a/src/ui/InsertLinkDialog.css
+++ b/src/ui/InsertLinkDialog.css
@@ -139,7 +139,7 @@
 .link-dialog-field input[type="text"]:focus,
 .link-dialog-field input[type="search"]:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px rgba(14, 28, 48, 0.18);
 }
 .link-dialog-field input::placeholder {
   color: var(--text-muted);
@@ -179,12 +179,12 @@
   background: var(--bg-hover, rgba(0, 0, 0, 0.04));
 }
 .link-dialog-heading-item.selected {
-  background: rgba(37, 99, 235, 0.1);
+  background: rgba(14, 28, 48, 0.1);
   color: var(--text-primary);
 }
 .link-dialog-heading-item.selected .link-dialog-heading-level {
-  background: var(--color-primary);
-  color: #fff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border-color: transparent;
 }
 .link-dialog-heading-level {
@@ -270,20 +270,20 @@
   cursor: not-allowed;
 }
 .link-dialog-btn-primary {
-  background: var(--color-primary);
+  background: var(--color-cta);
   border-color: var(--color-primary);
-  color: #fff;
+  color: var(--color-cta-text);
 }
 .link-dialog-btn-primary:hover:not(:disabled) {
   background: var(--color-primary-dark, #1d4ed8);
   border-color: var(--color-primary-dark, #1d4ed8);
 }
 .link-dialog-btn-danger {
-  color: #dc2626;
+  color: var(--danger-text);
   border-color: rgba(220, 38, 38, 0.4);
   background: transparent;
 }
 .link-dialog-btn-danger:hover {
   background: rgba(220, 38, 38, 0.08);
-  border-color: #dc2626;
+  border-color: var(--danger);
 }

--- a/src/ui/LayerPanel.css
+++ b/src/ui/LayerPanel.css
@@ -394,7 +394,7 @@
 
 .layer-context-menu-item.danger:hover {
   background: #fee2e2;
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 .layer-context-menu-separator {
@@ -435,7 +435,7 @@
 
 [data-theme="dark"] .layer-context-menu-item.danger:hover {
   background: #450a0a;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .layer-context-menu-separator {

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -122,7 +122,7 @@
 
 .layer-view-form-error {
   font-size: 12px;
-  color: #dc2626;
+  color: var(--danger-text);
   padding: 4px 0;
 }
 
@@ -130,8 +130,8 @@
   padding: 8px 16px;
   border: none;
   border-radius: 6px;
-  background: var(--accent-color, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -221,7 +221,7 @@
 
 .layer-view-list-item-actions button.danger:hover {
   background: #fee2e2;
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 /* Edit form within list */
@@ -263,9 +263,9 @@
 }
 
 .layer-view-edit-actions button:first-child {
-  background: var(--accent-color, var(--color-primary));
+  background: var(--color-cta));
   border-color: var(--accent-color, var(--color-primary));
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .layer-view-edit-actions button:hover {
@@ -341,7 +341,7 @@
 
 [data-theme="dark"] .layer-view-list-item-actions button.danger:hover {
   background: #450a0a;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .layer-view-edit-form input {
@@ -438,8 +438,8 @@
 }
 
 .layer-view-preview-type {
-  background: var(--accent-color, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 10px;

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -183,13 +183,13 @@
 }
 
 .logo-picker-btn-primary {
-  background: var(--accent-color, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
   border: none;
 }
 
 .logo-picker-btn-primary:hover {
-  background: var(--accent-hover, var(--color-primary-dark));
+  background: var(--color-cta-hover));
 }
 
 .logo-picker-btn-secondary {

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -123,8 +123,8 @@
 }
 
 .notification-toast__action-btn:hover {
-  background: var(--color-primary, #3b82f6);
-  color: #fff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 .notification-toast__dismiss-btn {

--- a/src/ui/NumberInput.css
+++ b/src/ui/NumberInput.css
@@ -128,7 +128,7 @@
 }
 
 [data-theme="dark"] .number-input-btn:active:not(.disabled) {
-  background: var(--color-primary-light, rgba(96, 165, 250, 0.2));
+  background: var(--color-primary-light, rgba(224, 198, 144, 0.2));
 }
 
 [data-theme="dark"] .number-input-btn.decrement {

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -245,9 +245,9 @@
 }
 
 .pdf-export-toggle button.active {
-  background: var(--accent-color, var(--color-primary));
+  background: var(--color-cta));
   border-color: var(--accent-color, var(--color-primary));
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .pdf-export-toggle button:hover:not(.active) {
@@ -330,7 +330,7 @@
 
 .pdf-export-checkbox input[type="checkbox"]:focus {
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-alpha, rgba(59, 130, 246, 0.15));
+  box-shadow: 0 0 0 2px var(--color-primary-alpha, rgba(31, 51, 84, 0.15));
 }
 
 .pdf-export-inline-select {
@@ -426,13 +426,13 @@
 }
 
 .pdf-export-btn-primary {
-  background: var(--accent-color, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
   border: none;
 }
 
 .pdf-export-btn-primary:hover:not(:disabled) {
-  background: var(--accent-hover, var(--color-primary-dark));
+  background: var(--color-cta-hover));
 }
 
 .pdf-export-btn-primary:disabled {
@@ -545,9 +545,9 @@
 }
 
 [data-theme="dark"] .pdf-export-toggle button.active {
-  background: var(--color-primary);
+  background: var(--color-cta);
   border-color: var(--color-primary);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 [data-theme="dark"] .pdf-export-margin-input span {
@@ -572,14 +572,14 @@
 
 [data-theme="dark"] .pdf-export-logo-clear:hover:not(:disabled) {
   background: #450a0a;
-  color: #f87171;
+  color: var(--danger-text);
   border-color: #7f1d1d;
 }
 
 [data-theme="dark"] .pdf-export-error {
   background: #450a0a;
   border-color: #7f1d1d;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .pdf-export-footer {

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -365,8 +365,8 @@
 }
 
 .align-button.active {
-  background: var(--color-primary);
-  color: #ffffff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border-color: var(--color-primary);
 }
 

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -202,8 +202,8 @@
 }
 
 .save-to-library-create-btn {
-  background: var(--color-primary, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .save-to-library-create-btn:hover:not(:disabled) {
@@ -230,7 +230,7 @@
   background: #fee2e2;
   border: 1px solid #fecaca;
   border-radius: 6px;
-  color: #dc2626;
+  color: var(--danger-text);
   font-size: 13px;
 }
 
@@ -270,8 +270,8 @@
 }
 
 .save-to-library-btn-primary {
-  background: var(--color-primary, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .save-to-library-btn-primary:hover:not(:disabled) {
@@ -339,7 +339,7 @@
 [data-theme="dark"] .save-to-library-error {
   background: #450a0a;
   border-color: #7f1d1d;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .save-to-library-footer {

--- a/src/ui/SearchReplacePanel.css
+++ b/src/ui/SearchReplacePanel.css
@@ -150,9 +150,9 @@
 }
 
 .search-option input[type="checkbox"]:checked + span {
-  background: var(--color-primary);
+  background: var(--color-cta);
   border-color: var(--color-primary);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .search-option-label {
@@ -196,9 +196,9 @@
 }
 
 .search-action-btn.replace-all-btn {
-  background: var(--color-primary);
+  background: var(--color-cta);
   border-color: var(--color-primary);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .search-action-btn.replace-all-btn:hover:not(:disabled) {

--- a/src/ui/SettingsModal.css
+++ b/src/ui/SettingsModal.css
@@ -121,7 +121,7 @@
 
 .settings-modal-close:hover {
   background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
+  color: var(--danger-text);
   transform: scale(1.05);
 }
 
@@ -183,7 +183,7 @@
 }
 
 .settings-tab-btn.active {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(59, 130, 246, 0.06) 100%);
+  background: linear-gradient(135deg, rgba(31, 51, 84, 0.12) 0%, rgba(31, 51, 84, 0.06) 100%);
   color: var(--accent-color, #3b82f6);
   font-weight: 600;
 }
@@ -205,12 +205,12 @@
 /* Icon colors and glow effects by tab position */
 /* Documents - Blue glow */
 .settings-tab-btn:nth-child(1) .settings-tab-icon {
-  color: #3b82f6;
-  filter: drop-shadow(0 0 8px rgba(59, 130, 246, 0.4));
+  color: var(--color-primary);
+  filter: drop-shadow(0 0 8px rgba(31, 51, 84, 0.4));
 }
 
 .settings-tab-btn:nth-child(1).active .settings-tab-icon {
-  filter: drop-shadow(0 0 12px rgba(59, 130, 246, 0.6));
+  filter: drop-shadow(0 0 12px rgba(31, 51, 84, 0.6));
 }
 
 /* General - Purple glow */
@@ -235,7 +235,7 @@
 
 /* Storage - Orange glow */
 .settings-tab-btn:nth-child(4) .settings-tab-icon {
-  color: #f59e0b;
+  color: var(--warning);
   filter: drop-shadow(0 0 8px rgba(245, 158, 11, 0.4));
 }
 
@@ -245,7 +245,7 @@
 
 /* Backup - Red glow */
 .settings-tab-btn:nth-child(5) .settings-tab-icon {
-  color: #ef4444;
+  color: var(--danger-text);
   filter: drop-shadow(0 0 8px rgba(239, 68, 68, 0.4));
 }
 
@@ -363,7 +363,7 @@
 
 .settings-form-input:focus {
   border-color: var(--accent-color, #3b82f6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .settings-form-description {
@@ -388,8 +388,8 @@
 }
 
 [data-theme="dark"] .settings-form-input:focus {
-  border-color: #60a5fa;
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.15);
 }
 
 /* Settings Section - Shared pattern for all settings tabs */
@@ -464,7 +464,7 @@
 
 .settings-form-input:focus {
   border-color: var(--accent-color, #3b82f6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .settings-form-description {
@@ -489,8 +489,8 @@
 }
 
 [data-theme="dark"] .settings-form-input:focus {
-  border-color: #60a5fa;
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.15);
 }
 
 /* Scrollbar styling */
@@ -536,7 +536,7 @@
 
 [data-theme="dark"] .settings-modal-close:hover {
   background: rgba(239, 68, 68, 0.2);
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .settings-modal-sidebar {
@@ -554,12 +554,12 @@
 }
 
 [data-theme="dark"] .settings-tab-btn.active {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.15) 0%, rgba(96, 165, 250, 0.08) 100%);
-  color: #60a5fa;
+  background: linear-gradient(135deg, rgba(224, 198, 144, 0.15) 0%, rgba(224, 198, 144, 0.08) 100%);
+  color: var(--color-primary);
 }
 
 [data-theme="dark"] .settings-tab-btn.active::before {
-  background: #60a5fa;
+  background: var(--color-primary);
 }
 
 [data-theme="dark"] .settings-modal-content {
@@ -644,7 +644,7 @@
 }
 
 .settings-server-badge__dot.is-online {
-  background: #22c55e;
+  background: var(--success);
   box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.18);
 }
 
@@ -657,5 +657,5 @@
 [data-theme="dark"] .settings-server-badge.is-online {
   background: rgba(34, 197, 94, 0.12);
   border-color: rgba(34, 197, 94, 0.55);
-  color: #4ade80;
+  color: var(--success-text);
 }

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -24,7 +24,7 @@
   background: #fee2e2;
   border: 1px solid #fecaca;
   border-radius: 6px;
-  color: #dc2626;
+  color: var(--danger-text);
   font-size: 13px;
 }
 
@@ -38,7 +38,7 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: #dc2626;
+  color: var(--danger-text);
   font-size: 16px;
   cursor: pointer;
 }
@@ -111,7 +111,7 @@
 
 .shape-library-action-btn.danger:hover {
   background: #fee2e2;
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 /* Create form */
@@ -152,8 +152,8 @@
 }
 
 .shape-library-create-btn {
-  background: var(--color-primary, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .shape-library-create-btn:hover:not(:disabled) {
@@ -204,8 +204,8 @@
 }
 
 .shape-library-item.selected {
-  background: var(--color-primary, var(--color-primary));
-  color: white;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .shape-library-item-name {
@@ -404,7 +404,7 @@
 [data-theme="dark"] .shape-library-error {
   background: #450a0a;
   border-color: #7f1d1d;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .shape-library-error-dismiss:hover {
@@ -430,7 +430,7 @@
 
 [data-theme="dark"] .shape-library-action-btn.danger:hover {
   background: #450a0a;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 [data-theme="dark"] .shape-library-create-form {

--- a/src/ui/ShapePicker.css
+++ b/src/ui/ShapePicker.css
@@ -28,8 +28,8 @@
 }
 
 .shape-picker-trigger.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 .shape-picker-trigger.active:hover {
@@ -101,8 +101,8 @@
 }
 
 .shape-picker-category.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 /* Shapes grid */
@@ -191,8 +191,8 @@
 }
 
 .shape-picker-view-btn.active {
-  background: var(--color-primary);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 /* Size variants */

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -132,8 +132,8 @@
 }
 
 .status-bar-zoom-btn:active {
-  background: var(--color-primary, var(--color-primary));
-  color: #ffffff;
+  background: var(--color-cta));
+  color: var(--color-cta-text);
 }
 
 .status-bar-zoom-value {

--- a/src/ui/StorageManager.css
+++ b/src/ui/StorageManager.css
@@ -140,8 +140,8 @@
 }
 
 .storage-manager-btn-primary {
-  background: var(--accent-color);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border-color: var(--accent-color);
 }
 
@@ -519,6 +519,6 @@
 }
 
 .storage-manager-btn-danger:hover {
-  background: #dc2626;
-  border-color: #dc2626;
+  background: var(--danger);
+  border-color: var(--danger);
 }

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -63,8 +63,8 @@
 }
 
 .style-profile-add-btn:hover {
-  background: var(--accent-color, #4a90d9);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 /* Create new profile form */
@@ -111,12 +111,12 @@
 }
 
 .style-profile-btn.save {
-  background: var(--accent-color, #4a90d9);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 .style-profile-btn.save:hover:not(:disabled) {
-  background: var(--accent-hover, #3a7bc8);
+  background: var(--color-cta-hover);
 }
 
 .style-profile-btn.save:disabled {
@@ -529,7 +529,7 @@
 
 .style-profile-context-menu-item.danger:hover {
   background: #fee2e2;
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 .style-profile-context-menu-separator {
@@ -566,8 +566,8 @@
 }
 
 :root[data-theme='dark'] .style-profile-add-btn:hover {
-  background: var(--accent-color, #60a5fa);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 :root[data-theme='dark'] .style-profile-create {
@@ -582,7 +582,7 @@
 
 :root[data-theme='dark'] .style-profile-input:focus {
   border-color: var(--accent-color, #60a5fa);
-  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.2);
+  box-shadow: 0 0 0 2px rgba(224, 198, 144, 0.2);
 }
 
 :root[data-theme='dark'] .style-profile-btn.save {
@@ -590,7 +590,7 @@
 }
 
 :root[data-theme='dark'] .style-profile-btn.save:hover:not(:disabled) {
-  background: var(--accent-hover, #3b82f6);
+  background: var(--color-cta-hover);
 }
 
 :root[data-theme='dark'] .style-profile-btn.cancel {
@@ -694,7 +694,7 @@
 
 :root[data-theme='dark'] .style-profile-context-menu-item.danger:hover {
   background: #450a0a;
-  color: #f87171;
+  color: var(--danger-text);
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-separator {

--- a/src/ui/SyncStatusBadge.css
+++ b/src/ui/SyncStatusBadge.css
@@ -30,13 +30,13 @@
 
 /* State variants */
 .sync-status--synced {
-  color: #22c55e;
+  color: var(--success-text);
   background: rgba(34, 197, 94, 0.1);
 }
 
 .sync-status--syncing {
   color: var(--accent-color, #3b82f6);
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(31, 51, 84, 0.1);
 }
 
 .sync-status--syncing .sync-status-icon {
@@ -44,7 +44,7 @@
 }
 
 .sync-status--pending {
-  color: #f59e0b;
+  color: var(--warning);
   background: rgba(245, 158, 11, 0.1);
 }
 
@@ -53,7 +53,7 @@
 }
 
 .sync-status--error {
-  color: #ef4444;
+  color: var(--danger-text);
   background: rgba(239, 68, 68, 0.1);
 }
 
@@ -88,12 +88,12 @@
 
 /* Dark mode adjustments */
 :root[data-theme="dark"] .sync-status--synced {
-  color: #4ade80;
+  color: var(--success-text);
   background: rgba(74, 222, 128, 0.15);
 }
 
 :root[data-theme="dark"] .sync-status--syncing {
-  background: rgba(59, 130, 246, 0.15);
+  background: rgba(31, 51, 84, 0.15);
 }
 
 :root[data-theme="dark"] .sync-status--pending {
@@ -102,7 +102,7 @@
 }
 
 :root[data-theme="dark"] .sync-status--error {
-  color: #f87171;
+  color: var(--danger-text);
   background: rgba(248, 113, 113, 0.15);
 }
 

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -236,7 +236,7 @@
 }
 
 .document-status.dirty {
-  color: #f59e0b;
+  color: var(--warning);
   cursor: pointer;
 }
 

--- a/src/ui/Whiteboard.css
+++ b/src/ui/Whiteboard.css
@@ -341,12 +341,12 @@
   height: 48px;
   border: none;
   border-radius: 50%;
-  background-color: #3b82f6;
-  color: #fff;
+  background-color: var(--color-cta);
+  color: var(--color-cta-text);
   font-size: 24px;
   font-weight: 400;
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
+  box-shadow: 0 4px 12px rgba(31, 51, 84, 0.4);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   display: flex;
   align-items: center;
@@ -355,7 +355,7 @@
 
 .whiteboard-add-btn:hover {
   transform: scale(1.05);
-  box-shadow: 0 6px 16px rgba(59, 130, 246, 0.5);
+  box-shadow: 0 6px 16px rgba(31, 51, 84, 0.5);
 }
 
 .whiteboard-add-btn:active {

--- a/src/ui/layout/RelaxedFocusControl.css
+++ b/src/ui/layout/RelaxedFocusControl.css
@@ -29,8 +29,8 @@
 }
 
 .relaxed-focus-segment.active {
-  background: var(--color-primary);
-  color: #fff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 .relaxed-focus-segment:focus-visible {

--- a/src/ui/settings/BackupSettings.css
+++ b/src/ui/settings/BackupSettings.css
@@ -127,13 +127,13 @@
 }
 
 .backup-btn-primary {
-  background: var(--accent-color, #3b82f6);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border-color: var(--accent-color, #3b82f6);
 }
 
 .backup-btn-primary:hover:not(:disabled) {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
 }
 
 .backup-btn-primary:disabled {
@@ -148,7 +148,7 @@
 }
 
 .backup-btn-danger:hover:not(:disabled) {
-  background: #dc2626;
+  background: var(--danger);
 }
 
 .backup-btn-danger:disabled {

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -54,15 +54,15 @@
 }
 
 .document-browser__action--primary {
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-cta);
   border-color: var(--accent-color, #3b82f6);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .document-browser__action--primary:hover {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
   border-color: var(--accent-hover, #2563eb);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.25);
+  box-shadow: 0 4px 12px rgba(31, 51, 84, 0.25);
 }
 
 .document-browser__action-icon {
@@ -124,7 +124,7 @@
   padding: var(--space-3) var(--space-4);
   font-size: 13px;
   font-weight: 500;
-  color: #dc2626;
+  color: var(--danger-text);
   background: rgba(239, 68, 68, 0.08);
   border: 1px solid rgba(239, 68, 68, 0.2);
   border-radius: 8px;
@@ -165,7 +165,7 @@
 
 .document-browser__search:focus {
   border-color: var(--accent-color, #3b82f6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .document-browser__search::placeholder {
@@ -354,7 +354,7 @@
 
 .document-browser__select-input:focus {
   border-color: var(--accent-color, #3b82f6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+  box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.15);
 }
 
 .document-browser__select-input option {
@@ -424,8 +424,8 @@
   flex-wrap: wrap;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  background: rgba(59, 130, 246, 0.08);
-  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(31, 51, 84, 0.08);
+  border: 1px solid rgba(31, 51, 84, 0.25);
   border-radius: 8px;
 }
 
@@ -459,8 +459,8 @@
 }
 
 .document-browser__bulk-btn--danger:hover {
-  border-color: #ef4444;
-  color: #ef4444;
+  border-color: var(--danger);
+  color: var(--danger-text);
 }
 
 .document-browser__assign-wrap {
@@ -507,7 +507,7 @@
 }
 
 .document-browser__assign-item--danger {
-  color: #ef4444;
+  color: var(--danger-text);
 }
 
 .document-browser__assign-item--danger:hover {
@@ -603,7 +603,7 @@
 }
 
 .document-browser__section-status--connected {
-  color: #16a34a;
+  color: var(--success-text);
   background: rgba(22, 163, 74, 0.12);
 }
 
@@ -689,7 +689,7 @@
 
 :root[data-theme="dark"] .document-browser__select-input:hover,
 :root[data-theme="dark"] .document-browser__select-input:focus {
-  border-color: #60a5fa;
+  border-color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__select-input option {
@@ -703,7 +703,7 @@
 
 :root[data-theme="dark"] .document-browser__view-btn--active {
   background: var(--bg-secondary, #0f172a);
-  color: #60a5fa;
+  color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__new-group-btn {
@@ -738,7 +738,7 @@
 }
 
 :root[data-theme="dark"] .document-browser__section-status--connected {
-  color: #4ade80;
+  color: var(--success-text);
   background: rgba(74, 222, 128, 0.15);
 }
 
@@ -748,12 +748,12 @@
 }
 
 :root[data-theme="dark"] .document-browser__selection-bar {
-  background: rgba(96, 165, 250, 0.1);
-  border-color: rgba(96, 165, 250, 0.3);
+  background: rgba(224, 198, 144, 0.1);
+  border-color: rgba(224, 198, 144, 0.3);
 }
 
 :root[data-theme="dark"] .document-browser__selection-count {
-  color: #60a5fa;
+  color: var(--color-primary);
 }
 
 /* Animation */
@@ -782,7 +782,7 @@
 
 :root[data-theme="dark"] .document-browser__filter-btn--active {
   background: var(--bg-secondary, #0f172a);
-  color: #60a5fa;
+  color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__empty {
@@ -791,7 +791,7 @@
 }
 
 :root[data-theme="dark"] .document-browser__error {
-  color: #f87171;
+  color: var(--danger-text);
   background: rgba(248, 113, 113, 0.1);
   border-color: rgba(248, 113, 113, 0.25);
 }
@@ -803,7 +803,7 @@
 
 :root[data-theme="dark"] .document-browser__refresh:hover {
   background: var(--bg-secondary, #334155);
-  border-color: #60a5fa;
+  border-color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__search {
@@ -812,8 +812,8 @@
 }
 
 :root[data-theme="dark"] .document-browser__search:focus {
-  border-color: #60a5fa;
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.15);
 }
 
 :root[data-theme="dark"] .document-browser__action {
@@ -823,17 +823,17 @@
 
 :root[data-theme="dark"] .document-browser__action:hover {
   background: var(--bg-tertiary, #1e293b);
-  border-color: #60a5fa;
+  border-color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__action--primary {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__action--primary:hover {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 /* Transfer progress banner (Local ↔ Cloud, JP-83) */
@@ -845,8 +845,8 @@
   padding: 8px 10px;
   font-size: 13px;
   border-radius: 6px;
-  background: rgba(37, 99, 235, 0.08);
-  border: 1px solid rgba(37, 99, 235, 0.25);
+  background: rgba(14, 28, 48, 0.08);
+  border: 1px solid rgba(14, 28, 48, 0.25);
 }
 
 .document-browser__transfer-text {

--- a/src/ui/settings/DocumentsSettings.css
+++ b/src/ui/settings/DocumentsSettings.css
@@ -32,13 +32,13 @@
 }
 
 .documents-action-btn.documents-action-primary {
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-cta);
   border-color: var(--accent-color, #3b82f6);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .documents-action-btn.documents-action-primary:hover {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
   border-color: var(--accent-hover, #2563eb);
 }
 
@@ -128,7 +128,7 @@
 }
 
 .documents-item.active {
-  background: var(--accent-bg, rgba(59, 130, 246, 0.08));
+  background: var(--accent-bg, rgba(31, 51, 84, 0.08));
 }
 
 .documents-item-content {
@@ -158,8 +158,8 @@
   padding: 2px 5px;
   font-size: 9px;
   font-weight: 700;
-  color: white;
-  background: var(--accent-color, #3b82f6);
+  color: var(--color-cta-text);
+  background: var(--color-cta);
   border-radius: 3px;
   flex-shrink: 0;
   letter-spacing: 0.5px;
@@ -216,12 +216,12 @@
 }
 
 .documents-item-btn-danger {
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 .documents-item-btn-danger:hover {
   background: rgba(220, 38, 38, 0.1);
-  color: #dc2626;
+  color: var(--danger-text);
 }
 
 .documents-item-badge {
@@ -229,7 +229,7 @@
   font-size: 10px;
   font-weight: 600;
   color: var(--accent-color, #3b82f6);
-  background: var(--accent-bg, rgba(59, 130, 246, 0.1));
+  background: var(--accent-bg, rgba(31, 51, 84, 0.1));
   border-radius: 4px;
   text-transform: uppercase;
 }
@@ -246,9 +246,9 @@
 }
 
 :root[data-theme='dark'] .documents-action-btn.documents-action-primary {
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-cta);
   border-color: var(--accent-color, #3b82f6);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 :root[data-theme='dark'] .documents-list {
@@ -265,7 +265,7 @@
 }
 
 :root[data-theme='dark'] .documents-item.active {
-  background: rgba(59, 130, 246, 0.15);
+  background: rgba(31, 51, 84, 0.15);
 }
 
 :root[data-theme='dark'] .documents-item-name {
@@ -316,7 +316,7 @@
 }
 
 .documents-item-btn-transfer:hover {
-  background: var(--accent-bg, rgba(59, 130, 246, 0.1)) !important;
+  background: var(--accent-bg, rgba(31, 51, 84, 0.1)) !important;
 }
 
 /* Transfer Modal */
@@ -389,13 +389,13 @@
 }
 
 .documents-transfer-modal-btn-confirm {
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-cta);
   border: 1px solid var(--accent-color, #3b82f6);
-  color: white;
+  color: var(--color-cta-text);
 }
 
 .documents-transfer-modal-btn-confirm:hover {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
 }
 
 .documents-transfer-modal-btn-confirm.toPersonal {
@@ -449,7 +449,7 @@
 }
 
 .documents-sync-status.connected {
-  border-color: #22c55e;
+  border-color: var(--success);
   background: rgba(34, 197, 94, 0.08);
 }
 
@@ -467,7 +467,7 @@
 }
 
 .documents-sync-status.connected .documents-sync-indicator {
-  background: #22c55e;
+  background: var(--success);
   box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
 }
 
@@ -498,7 +498,7 @@
 
 .documents-refresh-btn:hover:not(:disabled) {
   background: rgba(34, 197, 94, 0.15);
-  color: #16a34a;
+  color: var(--success-text);
 }
 
 .documents-refresh-btn:disabled {
@@ -510,7 +510,7 @@
   margin-top: 8px;
   padding: 8px 12px;
   font-size: 12px;
-  color: #dc2626;
+  color: var(--danger-text);
   background: rgba(220, 38, 38, 0.08);
   border: 1px solid rgba(220, 38, 38, 0.2);
   border-radius: 4px;
@@ -540,7 +540,7 @@
 }
 
 :root[data-theme='dark'] .documents-sync-status.connected {
-  border-color: #22c55e;
+  border-color: var(--success);
   background: rgba(34, 197, 94, 0.1);
 }
 
@@ -558,7 +558,7 @@
 
 :root[data-theme='dark'] .documents-refresh-btn:hover:not(:disabled) {
   background: rgba(34, 197, 94, 0.2);
-  color: #4ade80;
+  color: var(--success-text);
 }
 
 :root[data-theme='dark'] .documents-error {

--- a/src/ui/settings/GeneralSettings.css
+++ b/src/ui/settings/GeneralSettings.css
@@ -73,7 +73,7 @@
 .settings-select:focus {
   outline: none;
   border-color: var(--color-primary, #3b82f6);
-  box-shadow: 0 0 0 3px var(--color-primary-alpha, rgba(59, 130, 246, 0.15));
+  box-shadow: 0 0 0 3px var(--color-primary-alpha, rgba(31, 51, 84, 0.15));
 }
 
 /* Dark mode arrow */
@@ -172,7 +172,7 @@
 
 :root[data-theme='dark'] .settings-select:focus {
   border-color: var(--accent-color, #60a5fa);
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.15);
+  box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.15);
 }
 
 :root[data-theme='dark'] .settings-hint {
@@ -200,8 +200,8 @@
 }
 
 :root[data-theme='dark'] .settings-select option:checked {
-  background: var(--accent-color, #3b82f6);
-  color: white;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
 }
 
 /* Improved checkbox styling */
@@ -242,7 +242,7 @@
 
 .settings-checkbox:focus {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.2);
 }
 
 :root[data-theme='dark'] .settings-checkbox {
@@ -260,5 +260,5 @@
 }
 
 :root[data-theme='dark'] .settings-checkbox:focus {
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25);
+  box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.25);
 }

--- a/src/ui/settings/RelaySettings.css
+++ b/src/ui/settings/RelaySettings.css
@@ -70,7 +70,7 @@
   gap: 8px;
   padding: 10px 12px;
   font-size: 13px;
-  color: #b91c1c;
+  color: var(--danger-text);
   background: rgba(239, 68, 68, 0.08);
   border: 1px solid rgba(239, 68, 68, 0.25);
   border-radius: 6px;
@@ -128,8 +128,8 @@
 }
 
 .relay-settings__btn--primary {
-  color: #ffffff;
-  background: var(--color-primary, #2563eb);
+  color: var(--color-cta-text);
+  background: var(--color-cta);
 }
 
 .relay-settings__btn--primary:not(:disabled):hover {

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -110,13 +110,13 @@
 }
 
 .storage-btn-primary {
-  color: white;
-  background: var(--accent-color, #3b82f6);
+  color: var(--color-cta-text);
+  background: var(--color-cta);
   border-color: var(--accent-color, #3b82f6);
 }
 
 .storage-btn-primary:hover:not(:disabled) {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
   border-color: var(--accent-hover, #2563eb);
 }
 
@@ -127,8 +127,8 @@
 }
 
 .storage-btn-danger:hover:not(:disabled) {
-  background: #dc2626;
-  border-color: #dc2626;
+  background: var(--danger);
+  border-color: var(--danger);
 }
 
 .storage-gc-result {
@@ -206,7 +206,7 @@
 
 .storage-orphan-badge.protected {
   color: var(--accent-color, #3b82f6);
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(31, 51, 84, 0.1);
 }
 
 /* Icon tag in blob list */
@@ -216,7 +216,7 @@
   font-size: 9px;
   font-weight: 600;
   color: var(--accent-color, #3b82f6);
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(31, 51, 84, 0.1);
   border-radius: 3px;
   text-transform: uppercase;
 }
@@ -316,7 +316,7 @@
 
 .storage-icon-type.custom {
   color: var(--accent-color, #3b82f6);
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(31, 51, 84, 0.1);
 }
 
 .storage-icon-delete {

--- a/src/ui/settings/StyleProfileSettings.css
+++ b/src/ui/settings/StyleProfileSettings.css
@@ -31,7 +31,7 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--accent-color, #3b82f6);
-  background: rgba(59, 130, 246, 0.1);
+  background: rgba(31, 51, 84, 0.1);
   border-radius: 50%;
 }
 
@@ -57,7 +57,7 @@
 
 :root[data-theme='dark'] .settings-info-icon {
   color: var(--accent-color, #60a5fa);
-  background: rgba(96, 165, 250, 0.15);
+  background: rgba(224, 198, 144, 0.15);
 }
 
 :root[data-theme='dark'] .settings-info-content {

--- a/src/ui/viewers/GenericFileViewer.css
+++ b/src/ui/viewers/GenericFileViewer.css
@@ -52,8 +52,8 @@
   padding: 10px 20px;
   font-size: 14px;
   font-weight: 500;
-  color: #ffffff;
-  background: var(--accent-color, #3b82f6);
+  color: var(--color-cta-text);
+  background: var(--color-cta);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -61,7 +61,7 @@
 }
 
 .generic-viewer-open-btn:hover {
-  background: var(--accent-hover, #2563eb);
+  background: var(--color-cta-hover);
 }
 
 .generic-viewer-open-btn:disabled {
@@ -73,7 +73,7 @@
   margin-top: 12px;
   padding: 8px 12px;
   font-size: 12px;
-  color: #dc2626;
+  color: var(--danger-text);
   background: rgba(220, 38, 38, 0.1);
   border-radius: 6px;
 }

--- a/src/ui/viewers/ImageViewer.css
+++ b/src/ui/viewers/ImageViewer.css
@@ -44,9 +44,9 @@
 }
 
 .image-viewer-btn.active {
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-cta);
   border-color: var(--accent-color, #3b82f6);
-  color: #ffffff;
+  color: var(--color-cta-text);
 }
 
 .image-viewer-zoom-label {

--- a/src/ui/viewers/PdfViewer.css
+++ b/src/ui/viewers/PdfViewer.css
@@ -64,8 +64,8 @@
 }
 
 .pdf-viewer__btn--active {
-  background: var(--accent-color, #3b82f6);
-  color: #ffffff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border-color: var(--accent-color, #3b82f6);
 }
 
@@ -107,7 +107,7 @@
 .pdf-viewer__page-input:focus {
   outline: none;
   border-color: var(--accent-color, #3b82f6);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
 /* Zoom level display */
@@ -217,8 +217,8 @@
 }
 
 [data-theme="dark"] .pdf-viewer__btn--active {
-  background: var(--accent-color, #3b82f6);
-  color: #ffffff;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
   border-color: var(--accent-color, #3b82f6);
 }
 
@@ -230,7 +230,7 @@
 
 [data-theme="dark"] .pdf-viewer__page-input:focus {
   border-color: var(--accent-color, #3b82f6);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+  box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.25);
 }
 
 [data-theme="dark"] .pdf-viewer__content {


### PR DESCRIPTION
Finishes branding the settings/dialog cluster and tones down light-mode brightness (your ask).

## Key insight
The cluster wasn't 2157 colours of work — those files already consume the global tokens via `var(--token, #fallback)`, so #39 branded most of them (the hex is an inert fallback). Only the **bare** hardcoded colours (~100, mostly Tailwind blue/slate + semantic reds/greens inside `[data-theme="dark"]` blocks) were still off-brand.

## What's in here
- **Brightness** (`index.css`, light only): `--bg-primary` `#ffffff → #f9f6ee`, `--canvas-bg` `#fbfaf6 → #f7f4ec` — warm off-white so the primaries aren't glaring; elevation (surface > page > sunken) preserved. Dark unchanged.
- **De-Tailwind bare colours → brand tokens** (context-aware: `color:` → `*-text` token, `background`/`border` → fill token): blue → `--color-primary`, green → `--success`/`--success-text`, red → `--danger`/`--danger-text`, amber → `--warning`; plus the Tailwind-blue **rgba** washes → navy / gold-soft. Inert `var(…, #…)` fallbacks left alone.
- **Primary buttons → gold CTA**: any rule with an accent/primary background **and** white text becomes `var(--color-cta)` fill + `var(--color-cta-text)` navy text — the brand "primary = gold + navy ink", legible in both modes (fixes white-on-gold-soft in dark). Danger/success buttons and accent *selections* are deliberately left as-is.
- **Gradients**: DocumentPermissionsDialog purple `#667eea→#764ba2` → navy brand gradient.

`grep` confirms **0** bare Tailwind blue/red/green left.

## Please eyeball (Settings + dialogs, both modes)
- Light primaries visibly softer (warm off-white), still elevated.
- No stray Tailwind blue/red/green; accents navy (light) / gold-soft (dark); destructive = brand maroon; success = brand green.
- Primary buttons = gold fill + navy text in both modes.
- Permissions dialog header = navy (no purple).

## Verification
`bun run typecheck` clean · 1734 tests · build green.

Remainders already filed: token-scheme unification + per-file `:root`/dark-block cleanup (**JP-151**), the rest of gold-CTA (**JP-152**), spacing/typography (**JP-153**).

Assisted-by: Opus 4.8