### PR TITLE
JP-153: spacing + typography token scale

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -104,6 +104,70 @@
   --safe-area-right: env(safe-area-inset-right, 0px);
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-left: env(safe-area-inset-left, 0px);
+
+  /* ======================================================================
+     Dimensional scale (JP-153) — canonical spacing / radius / type / control
+     tokens. Mode-independent, so defined once here (no dark override). Values
+     are rem at the default 16px root (nothing sets `html { font-size }`), so
+     they map 1:1 onto the px the chrome used before this scale landed. Consume
+     these instead of hardcoding px; the long tail still migrates onto them.
+     ====================================================================== */
+
+  /* Font families */
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', monospace;
+
+  /* Spacing — 4px grid (rem /16) */
+  --space-0: 0;
+  --space-0-5: 0.125rem;  /* 2px */
+  --space-1: 0.25rem;     /* 4px */
+  --space-1-5: 0.375rem;  /* 6px */
+  --space-2: 0.5rem;      /* 8px */
+  --space-3: 0.75rem;     /* 12px */
+  --space-4: 1rem;        /* 16px */
+  --space-5: 1.25rem;     /* 20px */
+  --space-6: 1.5rem;      /* 24px */
+  --space-8: 2rem;        /* 32px */
+
+  /* Border radius */
+  --radius-sm: 0.25rem;   /* 4px */
+  --radius-md: 0.375rem;  /* 6px */
+  --radius-lg: 0.5rem;    /* 8px */
+  --radius-xl: 0.75rem;   /* 12px */
+  --radius-pill: 999px;
+  --radius-full: 50%;
+
+  /* Font sizes (rem /16) */
+  --font-size-2xs: 0.625rem;    /* 10px */
+  --font-size-xs: 0.6875rem;    /* 11px */
+  --font-size-sm: 0.75rem;      /* 12px */
+  --font-size-md: 0.8125rem;    /* 13px */
+  --font-size-base: 0.875rem;   /* 14px */
+  --font-size-lg: 1rem;         /* 16px */
+  --font-size-xl: 1.125rem;     /* 18px */
+  --font-size-2xl: 1.25rem;     /* 20px */
+  --font-size-3xl: 1.5rem;      /* 24px */
+
+  /* Font weights */
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Line heights (unitless) */
+  --line-height-tight: 1;
+  --line-height-snug: 1.3;
+  --line-height-normal: 1.4;
+  --line-height-relaxed: 1.5;
+
+  /* Control heights — buttons / inputs / selects (rem /16) */
+  --control-height-xs: 1.25rem;  /* 20px */
+  --control-height-sm: 1.5rem;   /* 24px */
+  --control-height-md: 1.75rem;  /* 28px */
+  --control-height-lg: 2rem;     /* 32px */
+  --control-height-xl: 2.25rem;  /* 36px */
 }
 
 /* --- Semantic: DARK (navy-native; elevation = lighter navy, not black) --- */
@@ -162,9 +226,7 @@ body,
   width: 100%;
   height: 100%;
   overflow: hidden;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/ui/CanvasToolbar.css
+++ b/src/ui/CanvasToolbar.css
@@ -6,8 +6,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: var(--space-2);
+  padding: var(--space-1-5) var(--space-3);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -4,10 +4,10 @@
   min-width: 180px;
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 4px 0;
-  font-size: 13px;
+  padding: var(--space-1) 0;
+  font-size: var(--font-size-md);
 }
 
 .context-menu-item {
@@ -15,7 +15,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
   color: var(--text-primary, #212529);
@@ -43,14 +43,14 @@
 }
 
 .context-menu-shortcut {
-  margin-left: 24px;
+  margin-left: var(--space-6);
   color: var(--text-secondary, #6c757d);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
 }
 
 .context-menu-separator {
   height: 1px;
-  margin: 4px 0;
+  margin: var(--space-1) 0;
   background: var(--border-color, #dee2e6);
 }
 
@@ -64,7 +64,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
   color: var(--text-primary, #212529);
@@ -77,8 +77,8 @@
 }
 
 .context-menu-arrow {
-  font-size: 10px;
-  margin-left: 12px;
+  font-size: var(--font-size-2xs);
+  margin-left: var(--space-3);
   opacity: 0.6;
 }
 
@@ -90,21 +90,21 @@
   min-width: 140px;
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 4px 0;
-  margin-left: 2px;
+  padding: var(--space-1) 0;
+  margin-left: var(--space-0-5);
   z-index: 1001;
 }
 
 .context-menu-submenu-content .context-menu-item {
-  padding-left: 8px;
+  padding-left: var(--space-2);
 }
 
 /* Checkmark for selected items */
 .context-menu-check {
   width: 18px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--accent-color, #4a90d9);
   flex-shrink: 0;
 }

--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -14,7 +14,7 @@
   height: 24px;
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -38,7 +38,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 /* Overflow ("⋮") dropdown menu */
@@ -48,12 +48,12 @@
   right: 0;
   z-index: 30;
   min-width: 168px;
-  padding: 4px;
+  padding: var(--space-1);
   display: flex;
   flex-direction: column;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-md);
 }
 
@@ -62,10 +62,10 @@
   width: 100%;
   padding: 7px 10px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-primary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
 }
@@ -82,7 +82,7 @@
   max-width: clamp(36rem, 60vw, 52rem);
   margin: 0 auto;
   width: 100%;
-  padding: 0 2rem;
+  padding: 0 var(--space-8);
 }
 
 /* Full-screen mode */
@@ -99,7 +99,7 @@
 @media (max-width: 640px) {
   .document-editor-panel.reading .document-editor-panel-content {
     max-width: 100%;
-    padding: 0 1rem;
+    padding: 0 var(--space-4);
   }
 }
 

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -10,20 +10,20 @@
   display: flex;
   align-items: flex-end;
   gap: 0;
-  padding: 0 0.5rem;
+  padding: 0 var(--space-2);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-color);
 }
 
 .ribbon-tab {
-  padding: 0.25rem 0.75rem;
+  padding: var(--space-1) var(--space-3);
   border: 1px solid transparent;
   border-bottom: none;
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 0.75rem;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   transition: all 0.15s ease;
   margin-bottom: -1px;
@@ -49,15 +49,15 @@
 .ribbon-panel-content {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  gap: var(--space-2);
+  padding: var(--space-1-5) var(--space-2);
   flex-wrap: wrap;
 }
 
 .document-editor-toolbar-group {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .document-editor-toolbar-btn {
@@ -65,14 +65,14 @@
   height: 32px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-primary);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.875rem;
+  font-size: var(--font-size-base);
   transition: all 0.15s ease;
 }
 
@@ -93,7 +93,7 @@
 }
 
 .document-editor-toolbar-btn strong {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 
 .document-editor-toolbar-btn em {
@@ -102,22 +102,22 @@
 
 .document-editor-toolbar-btn code {
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
 }
 
 .document-editor-toolbar-btn .toolbar-icon {
-  font-size: 0.875rem;
-  line-height: 1;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-tight);
 }
 
 .document-editor-toolbar-select {
   height: 32px;
-  padding: 0 1.75rem 0 0.5rem;
+  padding: 0 1.75rem 0 var(--space-2);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   cursor: pointer;
   outline: none;
   min-width: 100px;
@@ -143,7 +143,7 @@
 .document-editor-toolbar-select option {
   background: var(--bg-primary);
   color: var(--text-primary);
-  padding: 0.5rem;
+  padding: var(--space-2);
 }
 
 /* Dark mode dropdown */
@@ -160,7 +160,7 @@
   width: 1px;
   height: 24px;
   background: var(--border-color);
-  margin: 0 0.25rem;
+  margin: 0 var(--space-1);
 }
 
 /* Disabled group (e.g., table tools when not in table) */
@@ -202,8 +202,8 @@
 .math-input-content {
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
   min-width: 400px;
   max-width: 90vw;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
@@ -211,20 +211,20 @@
 
 .math-input-content label {
   display: block;
-  font-weight: 500;
-  margin-bottom: 0.5rem;
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--space-2);
   color: var(--text-primary);
 }
 
 .math-input-content input[type="text"] {
   width: 100%;
-  padding: 0.75rem;
+  padding: var(--space-3);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  font-size: 0.875rem;
+  font-size: var(--font-size-base);
   outline: none;
 }
 
@@ -240,18 +240,18 @@
 .math-input-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 1rem;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
 }
 
 .math-input-actions button {
-  padding: 0.5rem 1rem;
+  padding: var(--space-2) var(--space-4);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: var(--font-size-base);
   transition: all 0.15s ease;
 }
 
@@ -272,13 +272,13 @@
 /* Math input textarea for block equations */
 .math-input-content textarea {
   width: 100%;
-  padding: 0.75rem;
+  padding: var(--space-3);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  font-size: 0.875rem;
+  font-size: var(--font-size-base);
   outline: none;
   resize: vertical;
   min-height: 80px;
@@ -294,9 +294,9 @@
 }
 
 .math-input-hint {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-muted);
-  margin-top: 0.5rem;
+  margin-top: var(--space-2);
 }
 
 /* Color picker button icons */
@@ -305,7 +305,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .color-underline {
@@ -316,7 +316,7 @@
 }
 
 .highlight-btn-icon {
-  font-size: 1rem;
+  font-size: var(--font-size-lg);
 }
 
 /* Color picker dropdown */
@@ -327,17 +327,17 @@
   z-index: 9999;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 0.5rem;
-  margin-top: 4px;
+  padding: var(--space-2);
+  margin-top: var(--space-1);
   pointer-events: auto;
 }
 
 .color-picker-grid {
   display: grid;
   grid-template-columns: repeat(10, 1fr);
-  gap: 2px;
+  gap: var(--space-0-5);
   pointer-events: auto;
 }
 
@@ -360,13 +360,13 @@
 
 .color-picker-clear {
   width: 100%;
-  margin-top: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  margin-top: var(--space-2);
+  padding: var(--space-1-5) var(--space-2);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
 }
 
@@ -382,24 +382,24 @@
   z-index: 100;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 0.25rem;
-  margin-top: 4px;
+  padding: var(--space-1);
+  margin-top: var(--space-1);
   min-width: 160px;
 }
 
 .table-styles-dropdown button {
   display: block;
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .table-styles-dropdown button:hover {
@@ -410,7 +410,7 @@
 .align-icon {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   width: 14px;
 }
 

--- a/src/ui/FileMenu.css
+++ b/src/ui/FileMenu.css
@@ -7,14 +7,14 @@
 .file-menu-trigger {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 6px 12px;
+  gap: var(--space-1);
+  padding: var(--space-1-5) var(--space-3);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: white;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
@@ -25,7 +25,7 @@
 }
 
 .file-menu-arrow {
-  margin-left: 2px;
+  margin-left: var(--space-0-5);
   transition: transform 0.15s ease;
 }
 
@@ -37,13 +37,13 @@
   position: absolute;
   top: 100%;
   left: 0;
-  margin-top: 4px;
+  margin-top: var(--space-1);
   min-width: 240px;
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 4px 0;
+  padding: var(--space-1) 0;
   z-index: 1000;
 }
 
@@ -52,11 +52,11 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
   color: var(--text-primary, #212529);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.1s ease;
@@ -78,14 +78,14 @@
 }
 
 .file-menu-item-shortcut {
-  margin-left: 24px;
-  font-size: 11px;
+  margin-left: var(--space-6);
+  font-size: var(--font-size-xs);
   color: var(--text-secondary, #6c757d);
 }
 
 .file-menu-separator {
   height: 1px;
-  margin: 4px 8px;
+  margin: var(--space-1) var(--space-2);
   background: var(--border-color, #dee2e6);
 }
 

--- a/src/ui/LayerPanel.css
+++ b/src/ui/LayerPanel.css
@@ -6,7 +6,7 @@
   max-width: 400px;
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
@@ -60,9 +60,9 @@
 }
 
 .layer-panel-header {
-  padding: 10px 12px;
-  font-weight: 600;
-  font-size: 13px;
+  padding: 10px var(--space-3);
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-md);
   color: var(--text-primary, #495057);
   border-bottom: 1px solid var(--border-color, #dee2e6);
   background: var(--bg-secondary, #f8f9fa);
@@ -70,7 +70,7 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   user-select: none;
 }
 
@@ -83,10 +83,10 @@
 }
 
 .layer-panel-empty {
-  padding: 24px 16px;
+  padding: var(--space-6) var(--space-4);
   text-align: center;
   color: var(--text-secondary, #6c757d);
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .layer-panel-list {
@@ -97,8 +97,8 @@
 .layer-item {
   display: flex;
   align-items: center;
-  padding: 8px 12px;
-  gap: 8px;
+  padding: var(--space-2) var(--space-3);
+  gap: var(--space-2);
   border-bottom: 1px solid var(--border-color-light, #f0f0f0);
   cursor: pointer;
   transition: background-color 0.15s ease;
@@ -154,12 +154,12 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .layer-item-type {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #495057);
   white-space: nowrap;
   overflow: hidden;
@@ -167,13 +167,13 @@
 }
 
 .layer-item-rename-input {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
-  padding: 2px 4px;
+  padding: var(--space-0-5) var(--space-1);
   width: 100%;
   outline: none;
 }
@@ -188,13 +188,13 @@
 }
 
 .layer-item-id {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   color: var(--text-secondary, #6c757d);
   font-family: monospace;
 }
 
 .layer-item-preview {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   color: var(--text-muted, #868e96);
   font-style: italic;
   white-space: nowrap;
@@ -205,7 +205,7 @@
 
 .layer-item-actions {
   display: flex;
-  gap: 2px;
+  gap: var(--space-0-5);
   flex-shrink: 0;
 }
 
@@ -217,7 +217,7 @@
   height: 22px;
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary, #6c757d);
   cursor: pointer;
@@ -267,7 +267,7 @@
 
 /* Child items - indented */
 .layer-item.child {
-  padding-left: 8px;
+  padding-left: var(--space-2);
   background: var(--bg-secondary, #f8f9fa);
 }
 
@@ -338,7 +338,7 @@
 
 /* Layer panel actions bar */
 .layer-panel-actions {
-  padding: 8px;
+  padding: var(--space-2);
   border-bottom: 1px solid var(--border-color, #dee2e6);
   background: var(--bg-secondary, #f8f9fa);
 }
@@ -346,14 +346,14 @@
 .layer-panel-action-btn {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   width: 100%;
-  padding: 6px 10px;
+  padding: var(--space-1-5) 10px;
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #495057);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease;
 }
@@ -370,16 +370,16 @@
   min-width: 150px;
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  padding: 4px 0;
-  font-size: 12px;
+  padding: var(--space-1) 0;
+  font-size: var(--font-size-sm);
 }
 
 .layer-context-menu-item {
   display: block;
   width: 100%;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
   color: var(--text-primary, #495057);
@@ -399,7 +399,7 @@
 
 .layer-context-menu-separator {
   height: 1px;
-  margin: 4px 0;
+  margin: var(--space-1) 0;
   background: var(--border-color, #dee2e6);
 }
 
@@ -448,7 +448,7 @@
   height: 20px;
   border-radius: 2px;
   flex-shrink: 0;
-  margin-right: 4px;
+  margin-right: var(--space-1);
 }
 
 .layer-item-color-badge.inherited {
@@ -474,7 +474,7 @@
 .layer-context-menu-arrow {
   font-size: 8px;
   opacity: 0.6;
-  margin-left: 8px;
+  margin-left: var(--space-2);
 }
 
 .layer-context-menu-submenu-content {
@@ -485,9 +485,9 @@
   min-width: 120px;
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  padding: 4px;
+  padding: var(--space-1);
   z-index: 1001;
 }
 
@@ -505,9 +505,9 @@
 .layer-color-picker-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 4px;
-  padding: 4px;
-  margin-bottom: 4px;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  margin-bottom: var(--space-1);
   border-bottom: 1px solid var(--border-color, #dee2e6);
 }
 
@@ -519,7 +519,7 @@
   width: 24px;
   height: 24px;
   border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   padding: 0;
   transition: transform 0.1s ease, box-shadow 0.1s ease;
@@ -538,18 +538,18 @@
 .layer-view-selector {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 8px 12px;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-color, #dee2e6);
   background: var(--bg-secondary, #f8f9fa);
 }
 
 .layer-view-selector select {
   flex: 1;
-  padding: 4px 8px;
-  font-size: 11px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #495057);
   cursor: pointer;
@@ -568,7 +568,7 @@
   height: 24px;
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary, #6c757d);
   cursor: pointer;
@@ -585,10 +585,10 @@
 }
 
 .layer-view-create-btn {
-  padding: 4px 12px;
-  font-size: 11px;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-xs);
   border: 1px dashed var(--border-color, #dee2e6);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary, #6c757d);
   cursor: pointer;

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -11,7 +11,7 @@
 
 .layer-view-manager {
   background: var(--bg-primary, #ffffff);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
   width: 400px;
   max-width: 90vw;
@@ -25,15 +25,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--border-color, #dee2e6);
   background: var(--bg-secondary, #f8f9fa);
 }
 
 .layer-view-manager-header h3 {
   margin: 0;
-  font-size: 16px;
-  font-weight: 600;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-primary, #212529);
 }
 
@@ -42,10 +42,10 @@
   height: 28px;
   border: none;
   background: transparent;
-  font-size: 20px;
+  font-size: var(--font-size-2xl);
   color: var(--text-secondary, #6c757d);
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -60,11 +60,11 @@
 .layer-view-manager-content {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: var(--space-4) var(--space-5);
 }
 
 .layer-view-manager-section {
-  margin-bottom: 20px;
+  margin-bottom: var(--space-5);
 }
 
 .layer-view-manager-section:last-child {
@@ -72,9 +72,9 @@
 }
 
 .layer-view-manager-section h4 {
-  margin: 0 0 12px 0;
-  font-size: 13px;
-  font-weight: 600;
+  margin: 0 0 var(--space-3) 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-secondary, #6c757d);
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -84,26 +84,26 @@
 .layer-view-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .layer-view-form-row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .layer-view-form-row label {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary, #6c757d);
 }
 
 .layer-view-form-row input {
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
-  font-size: 13px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-md);
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #212529);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -116,24 +116,24 @@
 }
 
 .layer-view-form-hint {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted, #868e96);
 }
 
 .layer-view-form-error {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--danger-text);
-  padding: 4px 0;
+  padding: var(--space-1) 0;
 }
 
 .layer-view-form-submit {
-  padding: 8px 16px;
+  padding: var(--space-2) var(--space-4);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--color-cta));
   color: var(--color-cta-text);
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
@@ -145,7 +145,7 @@
 /* View list */
 .layer-view-empty {
   color: var(--text-muted, #868e96);
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-style: italic;
   margin: 0;
 }
@@ -156,58 +156,58 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .layer-view-list-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   background: var(--bg-secondary, #f8f9fa);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-color, #dee2e6);
 }
 
 .layer-view-list-item-info {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   flex: 1;
   min-width: 0;
 }
 
 .layer-view-list-item-name {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #212529);
 }
 
 .layer-view-list-item-regex {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted, #868e96);
   font-family: monospace;
 }
 
 .layer-view-list-item-manual {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--accent-color, var(--color-primary));
 }
 
 .layer-view-list-item-actions {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .layer-view-list-item-actions button {
   width: 28px;
   height: 28px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary, #6c757d);
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -228,15 +228,15 @@
 .layer-view-edit-form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
 }
 
 .layer-view-edit-form input {
-  padding: 6px 10px;
+  padding: var(--space-1-5) 10px;
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 4px;
-  font-size: 13px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-md);
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #212529);
 }
@@ -248,16 +248,16 @@
 
 .layer-view-edit-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .layer-view-edit-actions button {
-  padding: 4px 12px;
+  padding: var(--space-1) var(--space-3);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #212529);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
@@ -279,31 +279,31 @@
 /* Help section */
 .layer-view-help {
   background: var(--bg-secondary, #f8f9fa);
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-top: 16px;
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  margin-top: var(--space-4);
 }
 
 .layer-view-help h4 {
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .layer-view-help ul {
   margin: 0;
-  padding-left: 20px;
-  font-size: 12px;
+  padding-left: var(--space-5);
+  font-size: var(--font-size-sm);
   color: var(--text-secondary, #6c757d);
 }
 
 .layer-view-help li {
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .layer-view-help code {
   background: var(--bg-tertiary, #e9ecef);
-  padding: 1px 4px;
+  padding: 1px var(--space-1);
   border-radius: 3px;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
 }
 
 /* Dark mode */
@@ -371,7 +371,7 @@
 /* Regex test button and preview */
 .layer-view-form-regex-row {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .layer-view-form-regex-row input {
@@ -379,13 +379,13 @@
 }
 
 .layer-view-form-test {
-  padding: 6px 12px;
+  padding: var(--space-1-5) var(--space-3);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary, #f8f9fa);
   color: var(--text-primary, #212529);
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   white-space: nowrap;
   transition: background-color 0.15s ease, border-color 0.15s ease;
@@ -402,24 +402,24 @@
 }
 
 .layer-view-preview {
-  margin-top: 8px;
-  padding: 10px 12px;
+  margin-top: var(--space-2);
+  padding: 10px var(--space-3);
   background: var(--bg-secondary, #f8f9fa);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-color, #dee2e6);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 
 .layer-view-preview strong {
   color: var(--text-primary, #212529);
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: var(--space-1-5);
 }
 
 .layer-view-preview-empty {
   color: var(--text-muted, #868e96);
   font-style: italic;
-  margin-left: 8px;
+  margin-left: var(--space-2);
 }
 
 .layer-view-preview-list {
@@ -428,22 +428,22 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .layer-view-preview-list li {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .layer-view-preview-type {
   background: var(--color-cta));
   color: var(--color-cta-text);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 10px;
-  font-weight: 500;
+  padding: var(--space-0-5) var(--space-1-5);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
 }
 
@@ -458,7 +458,7 @@
 .layer-view-preview-more {
   color: var(--text-muted, #868e96);
   font-style: italic;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 /* Dark mode for regex test */

--- a/src/ui/PageTabs.css
+++ b/src/ui/PageTabs.css
@@ -1,8 +1,8 @@
 .page-tabs {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 1rem;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-4);
   background-color: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   min-height: 36px;
@@ -11,7 +11,7 @@
 .page-tabs-list {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
   overflow-x: auto;
   flex: 1;
   scrollbar-width: thin;
@@ -34,12 +34,12 @@
 .page-tab {
   display: flex;
   align-items: center;
-  padding: 0.375rem 0.75rem;
+  padding: var(--space-1-5) var(--space-3);
   background-color: transparent;
   border: 1px solid transparent;
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   color: var(--text-secondary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   cursor: pointer;
   transition: all 0.15s ease;
   white-space: nowrap;
@@ -58,7 +58,7 @@
   border-color: var(--border-color);
   border-bottom-color: var(--bg-primary);
   color: var(--text-primary);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   margin-bottom: -1px;
 }
 
@@ -78,8 +78,8 @@
 .page-tab-input {
   width: 100%;
   min-width: 50px;
-  padding: 0.125rem 0.25rem;
-  font-size: 0.8125rem;
+  padding: var(--space-0-5) var(--space-1);
+  font-size: var(--font-size-md);
   border: 1px solid var(--color-primary);
   border-radius: 2px;
   background-color: var(--bg-primary);
@@ -95,10 +95,10 @@
   height: 28px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background-color: transparent;
   color: var(--text-secondary);
-  font-size: 1.25rem;
+  font-size: var(--font-size-2xl);
   font-weight: 300;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -120,21 +120,21 @@
   position: fixed;
   z-index: 1000;
   min-width: 120px;
-  padding: 0.25rem 0;
+  padding: var(--space-1) 0;
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .page-tab-context-menu button {
   display: block;
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: none;
   color: var(--text-primary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.1s ease;

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -42,9 +42,9 @@
 
 /* Header */
 .property-panel-header {
-  padding: 12px 14px;
-  font-weight: 600;
-  font-size: 0.8125rem;
+  padding: var(--space-3) 14px;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-md);
   background-color: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   color: var(--text-primary);
@@ -53,18 +53,18 @@
 
 /* Empty State */
 .property-panel-empty {
-  padding: 24px 16px;
+  padding: var(--space-6) var(--space-4);
   color: var(--text-muted, var(--text-secondary));
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   text-align: center;
-  line-height: 1.5;
+  line-height: var(--line-height-relaxed);
 }
 
 /* Content */
 .property-panel-content {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
 }
 
 /* Scrollbar styling */
@@ -89,25 +89,25 @@
 .property-type-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  gap: var(--space-1);
+  padding: var(--space-1) 10px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-primary, var(--color-primary));
   background: var(--color-primary-light, rgba(31, 51, 84, 0.1));
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   text-transform: capitalize;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
   letter-spacing: 0.02em;
 }
 
 /* Hint Text */
 .property-hint {
   margin-top: 10px;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   background: var(--bg-tertiary);
-  border-radius: 6px;
-  font-size: 0.6875rem;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
   text-align: center;
   border: 1px dashed var(--border-color);
@@ -118,26 +118,26 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 6px;
-  padding: 4px 0;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1-5);
+  padding: var(--space-1) 0;
 }
 
 .compact-number-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 70px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .compact-number-input {
   width: 64px;
   height: 28px;
-  padding: 0 8px;
-  padding-right: 4px;
-  font-size: 0.75rem;
+  padding: 0 var(--space-2);
+  padding-right: var(--space-1);
+  font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input, #ced4da);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
   text-align: right;
@@ -153,7 +153,7 @@
   width: 16px;
   height: 100%;
   margin: 0;
-  margin-left: 4px;
+  margin-left: var(--space-1);
   background: var(--bg-tertiary, #e9ecef);
   border-left: 1px solid var(--border-color-input, #ced4da);
   border-radius: 0 5px 5px 0;
@@ -196,7 +196,7 @@
 }
 
 .compact-number-suffix {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-xs);
   color: var(--text-muted, var(--text-secondary));
   opacity: 0.8;
 }
@@ -205,15 +205,15 @@
 .compact-slider-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 2px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-0-5);
 }
 
 .compact-slider-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 55px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .compact-slider {
@@ -225,42 +225,42 @@
 }
 
 .compact-slider-value {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
   min-width: 36px;
   text-align: right;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Info Row */
 .info-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 0;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
 }
 
 .info-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 55px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .info-value {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
   background: var(--bg-secondary);
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: var(--space-0-5) var(--space-1-5);
+  border-radius: var(--radius-sm);
 }
 
 /* Stroke Row (color + width inline) */
 .stroke-row {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .stroke-row .compact-number-row {
@@ -276,9 +276,9 @@
   width: 100%;
   height: 30px;
   padding: 0 10px;
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input, #ced4da);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
   transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
@@ -303,10 +303,10 @@
 .property-textarea {
   width: 100%;
   padding: 10px;
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   font-family: inherit;
   border: 1px solid var(--border-color-input, #ced4da);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
   resize: vertical;
@@ -329,31 +329,31 @@
 .align-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 2px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-0-5);
 }
 
 .align-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 40px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .align-buttons {
   display: flex;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .align-button {
   width: 28px;
   height: 28px;
   padding: 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -379,24 +379,24 @@
 .compact-select-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 2px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-0-5);
 }
 
 .compact-select-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 55px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .compact-select {
   flex: 1;
   height: 28px;
-  padding: 0 8px;
-  font-size: 0.75rem;
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input, #ced4da);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
   cursor: pointer;
@@ -408,13 +408,13 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M3 5l3 3 3-3'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 8px center;
-  padding-right: 24px;
+  padding-right: var(--space-6);
 }
 
 .compact-select option {
   background: var(--bg-secondary, #f8f9fa);
   color: var(--text-primary, #212529);
-  padding: 8px;
+  padding: var(--space-2);
 }
 
 .compact-select:hover {
@@ -432,14 +432,14 @@
 .compact-string-row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 2px;
+  gap: var(--space-1);
+  margin-bottom: var(--space-0-5);
 }
 
 .compact-string-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Compact Checkbox Row */
@@ -447,15 +447,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 6px;
-  padding: 4px 0;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1-5);
+  padding: var(--space-1) 0;
 }
 
 .compact-checkbox-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .compact-checkbox {
@@ -465,7 +465,7 @@
   width: 16px;
   height: 16px;
   border: 2px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background-color: var(--bg-secondary);
   cursor: pointer;
   position: relative;
@@ -501,14 +501,14 @@
 
 /* Legacy styles for backwards compatibility */
 .property-section {
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
-  padding-bottom: 0.25rem;
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-1);
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -519,8 +519,8 @@
 .property-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 .property-row-full {
@@ -530,17 +530,17 @@
 
 .property-label {
   flex: 0 0 70px;
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
 .property-row-full .property-label {
   flex: none;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 .property-value {
-  font-size: 0.875rem;
+  font-size: var(--font-size-base);
   color: var(--text-primary);
 }
 
@@ -548,7 +548,7 @@
   flex: 1;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .property-color {
@@ -556,13 +556,13 @@
   height: 24px;
   padding: 0;
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
 }
 
 .property-color::-webkit-color-swatch-wrapper {
-  padding: 2px;
+  padding: var(--space-0-5);
 }
 
 .property-color::-webkit-color-swatch {
@@ -572,11 +572,11 @@
 
 .property-text {
   flex: 1;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
   font-family: monospace;
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary);
   color: var(--text-primary);
 }
@@ -589,10 +589,10 @@
 
 .property-number {
   width: 60px;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary);
   color: var(--text-primary);
   text-align: right;
@@ -606,10 +606,10 @@
 
 .property-select {
   flex: 1;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-primary);
   color: var(--text-primary);
   cursor: pointer;
@@ -620,7 +620,7 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M3 5l3 3 3-3'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 6px center;
-  padding-right: 20px;
+  padding-right: var(--space-5);
 }
 
 .property-select option {
@@ -642,11 +642,11 @@
 }
 
 .property-group-hint {
-  margin-top: 0.75rem;
-  padding: 0.5rem;
+  margin-top: var(--space-3);
+  padding: var(--space-2);
   background: var(--bg-tertiary);
-  border-radius: 4px;
-  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   text-align: center;
 }
@@ -717,7 +717,7 @@
 .icon-color-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .icon-color-row .compact-color-row {
@@ -725,13 +725,13 @@
 }
 
 .icon-color-reset {
-  padding: 4px 8px;
-  font-size: 0.6875rem;
-  font-weight: 500;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
   white-space: nowrap;
@@ -760,14 +760,14 @@
 /* Migrate to Multi-Icon Button */
 .migrate-to-multi-icon {
   width: 100%;
-  padding: 6px 12px;
-  margin-bottom: 8px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: var(--space-1-5) var(--space-3);
+  margin-bottom: var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-primary);
   background: var(--bg-secondary);
   border: 1px dashed var(--color-primary);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -788,9 +788,9 @@
 .label-offset-row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-top: 8px;
-  padding-top: 8px;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
   border-top: 1px dashed var(--border-color);
 }
 
@@ -800,13 +800,13 @@
 
 .label-offset-reset {
   align-self: flex-end;
-  padding: 4px 8px;
-  font-size: 0.6875rem;
-  font-weight: 500;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
   white-space: nowrap;
@@ -836,14 +836,14 @@
 .erd-members-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: var(--space-1-5);
+  margin-bottom: var(--space-2);
 }
 
 .erd-member-row {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   cursor: grab;
   transition: background-color 0.15s ease, opacity 0.15s ease;
 }
@@ -859,7 +859,7 @@
 
 .erd-member-row.drag-over {
   background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .erd-member-pk {
@@ -871,7 +871,7 @@
   height: 22px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -898,22 +898,22 @@
 .erd-member-name {
   flex: 1;
   min-width: 60px;
-  padding: 4px 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-1-5);
+  font-size: var(--font-size-sm);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
 }
 
 .erd-member-type {
   flex: 1;
   min-width: 50px;
-  padding: 4px 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-1-5);
+  font-size: var(--font-size-sm);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   color: var(--text-secondary);
 }
 
@@ -928,12 +928,12 @@
   width: 20px;
   height: 20px;
   padding: 0;
-  font-size: 14px;
-  line-height: 1;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-tight);
   color: var(--text-secondary);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.6;
   transition: all 0.15s ease;
@@ -947,13 +947,13 @@
 
 .erd-add-member {
   width: 100%;
-  padding: 6px 10px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: var(--space-1-5) 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-primary);
   background: transparent;
   border: 1px dashed var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -973,14 +973,14 @@
 .uml-members-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: var(--space-1-5);
+  margin-bottom: var(--space-2);
 }
 
 .uml-member-row {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   cursor: grab;
   transition: background-color 0.15s ease, opacity 0.15s ease;
 }
@@ -996,7 +996,7 @@
 
 .uml-member-row.drag-over {
   background: var(--color-primary-light, rgba(31, 51, 84, 0.15));
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .uml-member-visibility {
@@ -1005,12 +1005,12 @@
   -moz-appearance: none;
   flex-shrink: 0;
   width: 36px;
-  padding: 4px 2px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-0-5);
+  font-size: var(--font-size-sm);
   font-family: monospace;
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
   text-align: center;
   cursor: pointer;
@@ -1030,22 +1030,22 @@
 .uml-member-name {
   flex: 2;
   min-width: 50px;
-  padding: 4px 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-1-5);
+  font-size: var(--font-size-sm);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
 }
 
 .uml-member-type {
   flex: 1;
   min-width: 40px;
-  padding: 4px 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-1-5);
+  font-size: var(--font-size-sm);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   color: var(--text-secondary);
 }
 
@@ -1058,7 +1058,7 @@
   height: 22px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -1089,12 +1089,12 @@
   width: 20px;
   height: 20px;
   padding: 0;
-  font-size: 14px;
-  line-height: 1;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-tight);
   color: var(--text-secondary);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.6;
   transition: all 0.15s ease;
@@ -1108,13 +1108,13 @@
 
 .uml-add-member {
   width: 100%;
-  padding: 6px 10px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: var(--space-1-5) 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-primary);
   background: transparent;
   border: 1px dashed var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -1149,18 +1149,18 @@
 .preset-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 4px;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
 }
 
 .preset-button {
-  padding: 4px 8px;
-  font-size: 0.6875rem;
-  font-weight: 500;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   min-width: 32px;
   text-align: center;
@@ -1190,7 +1190,7 @@
 .member-drag-handle {
   flex-shrink: 0;
   width: 16px;
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-muted, var(--text-secondary));
   cursor: grab;
   user-select: none;
@@ -1217,14 +1217,14 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   background: var(--bg-tertiary, #f1f5f9);
-  border-radius: 8px;
-  margin-bottom: 12px;
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-3);
 }
 
 .file-info-icon {
-  font-size: 24px;
+  font-size: var(--font-size-3xl);
   flex-shrink: 0;
 }
 
@@ -1234,8 +1234,8 @@
 }
 
 .file-info-name {
-  font-size: 0.8125rem;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -1243,20 +1243,20 @@
 }
 
 .file-info-meta {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
-  margin-top: 2px;
+  margin-top: var(--space-0-5);
 }
 
 .file-replace-btn {
   width: 100%;
-  padding: 8px 12px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -1280,17 +1280,17 @@
 .swimlane-lanes-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: var(--space-1-5);
+  margin-bottom: var(--space-2);
 }
 
 .swimlane-lane-row {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   cursor: grab;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
   transition: background-color 0.15s ease, opacity 0.15s ease;
 }
 
@@ -1310,11 +1310,11 @@
 .swimlane-lane-name {
   flex: 1;
   min-width: 60px;
-  padding: 4px 6px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-1-5);
+  font-size: var(--font-size-sm);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
 }
 
@@ -1326,7 +1326,7 @@
 .swimlane-width-control {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .swimlane-width-slider {
@@ -1338,7 +1338,7 @@
 }
 
 .swimlane-width-value {
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   color: var(--text-secondary);
   min-width: 28px;
   text-align: right;
@@ -1350,12 +1350,12 @@
   width: 20px;
   height: 20px;
   padding: 0;
-  font-size: 14px;
-  line-height: 1;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-tight);
   color: var(--text-secondary);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   opacity: 0.6;
   transition: all 0.15s ease;
@@ -1379,19 +1379,19 @@
 
 .swimlane-actions {
   display: flex;
-  gap: 8px;
-  margin-bottom: 8px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 .swimlane-add-lane {
   flex: 1;
-  padding: 6px 10px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: var(--space-1-5) 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-primary);
   background: transparent;
   border: 1px dashed var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -1402,13 +1402,13 @@
 }
 
 .swimlane-reset-widths {
-  padding: 6px 10px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: var(--space-1-5) 10px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }

--- a/src/ui/PropertySection.css
+++ b/src/ui/PropertySection.css
@@ -1,7 +1,7 @@
 /* Property Section Container */
 .property-section-container {
-  margin-bottom: 4px;
-  border-radius: 8px;
+  margin-bottom: var(--space-1);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--bg-secondary);
   border: 1px solid transparent;
@@ -20,12 +20,12 @@
 .property-section-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--space-2);
+  padding: 10px var(--space-3);
   cursor: pointer;
   user-select: none;
   transition: background-color 0.15s ease;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .property-section-header:hover {
@@ -55,8 +55,8 @@
 /* Title */
 .property-section-title {
   flex: 1;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-primary, #495057);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -64,9 +64,9 @@
 
 /* Badge */
 .property-section-badge {
-  font-size: 0.625rem;
-  font-weight: 600;
-  padding: 2px 8px;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-0-5) var(--space-2);
   background-color: var(--color-primary-light, rgba(31, 51, 84, 0.1));
   color: var(--color-primary, var(--color-primary));
   border-radius: 10px;
@@ -76,8 +76,8 @@
 .property-section-content {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 0 12px 12px 12px;
+  gap: var(--space-2);
+  padding: 0 var(--space-3) var(--space-3) var(--space-3);
   overflow: hidden;
   transition: max-height 0.25s ease, opacity 0.2s ease, padding 0.25s ease;
 }

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -5,8 +5,8 @@
 .rich-text-tab-bar {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   min-height: 36px;
@@ -15,7 +15,7 @@
 .rich-text-tabs-container {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   /* Scroll horizontally only. Without an explicit overflow-y, it computes to
    * `auto` and the active tab's ~1px overhang triggers a stray vertical
    * scrollbar (ugly with classic scrollbars on Tauri/PWA). */
@@ -41,13 +41,13 @@
 .rich-text-tab {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
+  gap: var(--space-1-5);
+  padding: var(--space-1-5) var(--space-3);
   background: var(--bg-tertiary);
   border: 1px solid transparent;
-  border-radius: 6px 6px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   cursor: pointer;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
   white-space: nowrap;
   transition: all 0.15s ease;
@@ -63,7 +63,7 @@
   right: 0;
   height: 3px;
   background: var(--tab-color);
-  border-radius: 6px 6px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   opacity: 0;
   transition: opacity 0.15s ease;
 }
@@ -101,7 +101,7 @@
 .rich-text-tab-color {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--tab-color);
   flex-shrink: 0;
 }
@@ -114,12 +114,12 @@
 
 .rich-text-tab-edit-input {
   width: 100px;
-  padding: 2px 4px;
+  padding: var(--space-0-5) var(--space-1);
   border: 1px solid var(--color-primary);
   border-radius: 3px;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   outline: none;
 }
 
@@ -139,9 +139,9 @@
   justify-content: center;
   background: transparent;
   border: 1px dashed var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
-  font-size: 1.25rem;
+  font-size: var(--font-size-2xl);
   cursor: pointer;
   transition: all 0.15s ease;
   flex-shrink: 0;
@@ -161,18 +161,18 @@
   min-width: 140px;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 4px;
-  font-size: 0.8125rem;
+  padding: var(--space-1);
+  font-size: var(--font-size-md);
 }
 
 .rich-text-tab-context-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   color: var(--text-primary);
   transition: background-color 0.1s ease;
@@ -202,13 +202,13 @@
 
 .rich-text-tab-context-arrow {
   color: var(--text-muted);
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
 }
 
 .rich-text-tab-context-divider {
   height: 1px;
   background: var(--border-color);
-  margin: 4px 8px;
+  margin: var(--space-1) var(--space-2);
 }
 
 /* Color Picker Submenu */
@@ -217,10 +217,10 @@
   left: 100%;
   top: -4px;
   margin-left: 0;
-  padding: 12px 8px 8px 12px;
+  padding: var(--space-3) var(--space-2) var(--space-2) var(--space-3);
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   z-index: 10001;
 }
@@ -228,15 +228,15 @@
 .rich-text-tab-color-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-  margin-bottom: 8px;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
 }
 
 .rich-text-tab-color-swatch {
   width: 24px;
   height: 24px;
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: transform 0.1s ease;
   padding: 0;
@@ -249,12 +249,12 @@
 
 .rich-text-tab-color-clear {
   width: 100%;
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -4,10 +4,10 @@
   align-items: center;
   justify-content: space-between;
   height: 24px;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   background: var(--bg-secondary, #f8f9fa);
   border-top: 1px solid var(--border-color, #dee2e6);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary, #6c757d);
 }
 
@@ -15,7 +15,7 @@
 .status-bar-section {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .status-bar-left {
@@ -46,23 +46,23 @@
 .status-bar-info {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 /* Tool Display */
 .status-bar-tool {
   color: var(--color-primary, var(--color-primary));
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Drill-down Badge */
 .status-bar-drill-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 1px 6px;
-  font-size: 0.625rem;
-  font-weight: 500;
+  gap: var(--space-1);
+  padding: 1px var(--space-1-5);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-medium);
   color: var(--color-primary, var(--color-primary));
   background: rgba(31, 51, 84, 0.12);
   border: 1px solid var(--color-primary-alpha);
@@ -77,9 +77,9 @@
 }
 
 .status-bar-drill-badge-x {
-  margin-left: 2px;
-  font-size: 0.75rem;
-  line-height: 1;
+  margin-left: var(--space-0-5);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
   opacity: 0.7;
 }
 
@@ -87,9 +87,9 @@
 .status-bar-sync {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--color-warning, #f59e0b);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   animation: pulse 1.5s ease-in-out infinite;
 }
 
@@ -107,7 +107,7 @@
   width: 1px;
   height: 12px;
   background: var(--border-color, #dee2e6);
-  margin: 0 4px;
+  margin: 0 var(--space-1);
 }
 
 /* Zoom Controls */
@@ -115,8 +115,8 @@
   width: 20px;
   height: 18px;
   padding: 0;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-secondary, #6c757d);
   background: var(--bg-tertiary, #e9ecef);
   border: 1px solid var(--border-color, #dee2e6);
@@ -145,9 +145,9 @@
 
 /* Buttons */
 .status-bar-btn {
-  padding: 2px 6px;
-  font-size: 0.625rem;
-  font-weight: 500;
+  padding: var(--space-0-5) var(--space-1-5);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-medium);
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid var(--border-color, #dee2e6);

--- a/src/ui/ToolbarDropdown.css
+++ b/src/ui/ToolbarDropdown.css
@@ -7,9 +7,9 @@
   z-index: 10000;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  padding: 0.5rem;
+  padding: var(--space-2);
   pointer-events: auto;
 }
 
@@ -21,7 +21,7 @@
 .toolbar-dropdown-portal .color-picker-grid {
   display: grid;
   grid-template-columns: repeat(10, 1fr);
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .toolbar-dropdown-portal .color-picker-swatch {
@@ -42,13 +42,13 @@
 
 .toolbar-dropdown-portal .color-picker-clear {
   width: 100%;
-  margin-top: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  margin-top: var(--space-2);
+  padding: var(--space-1-5) var(--space-2);
   border: 1px solid var(--border-color-input);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
 }
 
@@ -60,19 +60,19 @@
 .toolbar-dropdown-portal .table-styles-menu {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 160px;
 }
 
 .toolbar-dropdown-portal .table-styles-menu button {
   display: block;
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-primary);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.15s ease;

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -3,17 +3,17 @@
   display: flex;
   align-items: center;
   height: 44px;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   background: var(--bg-secondary, #f8f9fa);
   border-bottom: 1px solid var(--border-color, #dee2e6);
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* Sections */
 .unified-toolbar-left {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .unified-toolbar-center {
@@ -28,7 +28,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -42,7 +42,7 @@
 /* Tool Buttons */
 .tool-buttons {
   display: flex;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .tool-button-wrapper {
@@ -58,7 +58,7 @@
   justify-content: center;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -79,8 +79,8 @@
 }
 
 .tool-button-icon {
-  font-size: 1rem;
-  line-height: 1;
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-tight);
   color: var(--text-primary, #495057);
 }
 
@@ -90,27 +90,27 @@
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 6px;
-  padding: 4px 8px;
+  margin-top: var(--space-1-5);
+  padding: var(--space-1) var(--space-2);
   background: var(--bg-tertiary, #333);
   color: var(--text-primary, #fff);
-  font-size: 0.75rem;
-  border-radius: 4px;
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   z-index: 1000;
   pointer-events: none;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .tool-button-tooltip-shortcut {
-  padding: 1px 4px;
+  padding: 1px var(--space-1);
   background: rgba(255, 255, 255, 0.2);
   border-radius: 3px;
-  font-size: 0.625rem;
-  font-weight: 600;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
 }
 
 /* File Menu */
@@ -121,14 +121,14 @@
 .file-menu-trigger {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 6px 10px;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  gap: var(--space-1);
+  padding: var(--space-1-5) 10px;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #495057);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -147,12 +147,12 @@
   position: absolute;
   top: 100%;
   left: 0;
-  margin-top: 4px;
+  margin-top: var(--space-1);
   min-width: 180px;
-  padding: 4px;
+  padding: var(--space-1);
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
   z-index: 1000;
 }
@@ -162,12 +162,12 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 8px 12px;
-  font-size: 0.8125rem;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-md);
   color: var(--text-primary, #495057);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   text-align: left;
 }
@@ -177,13 +177,13 @@
 }
 
 .file-menu-shortcut {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary, #6c757d);
 }
 
 .file-menu-divider {
   height: 1px;
-  margin: 4px 0;
+  margin: var(--space-1) 0;
   background: var(--border-color, #dee2e6);
 }
 
@@ -191,17 +191,17 @@
 .document-info {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .document-name-button {
-  padding: 4px 8px;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #495057);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
   max-width: 200px;
@@ -216,13 +216,13 @@
 }
 
 .document-name-input {
-  padding: 4px 8px;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--color-primary, var(--color-primary));
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   outline: none;
   max-width: 200px;
 }
@@ -231,7 +231,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.875rem;
+  font-size: var(--font-size-base);
   cursor: default;
 }
 
@@ -275,7 +275,7 @@
 .inline-page-tabs {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   max-width: 400px;
   min-width: 150px;
   position: relative;
@@ -283,7 +283,7 @@
 
 .inline-tabs-scroll {
   display: flex;
-  gap: 2px;
+  gap: var(--space-0-5);
   overflow-x: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -294,12 +294,12 @@
 }
 
 .inline-tab {
-  padding: 4px 10px;
-  font-size: 0.75rem;
+  padding: var(--space-1) 10px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   white-space: nowrap;
   transition: all 0.15s ease;
@@ -315,7 +315,7 @@
   background: var(--color-primary-light, var(--color-primary-light));
   color: var(--color-primary, var(--color-primary));
   border-color: var(--color-primary, var(--color-primary));
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .inline-tab-add {
@@ -325,11 +325,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px dashed var(--border-color, #dee2e6);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
   flex-shrink: 0;
@@ -349,11 +349,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -372,7 +372,7 @@
 .toolbar-action-group {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 /* Icon buttons (settings, theme) */
@@ -386,7 +386,7 @@
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -414,11 +414,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1rem;
+  font-size: var(--font-size-lg);
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -449,7 +449,7 @@
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -481,7 +481,7 @@
   color: var(--text-secondary, #6c757d);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -513,7 +513,7 @@
   color: var(--text-primary, #495057);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -544,7 +544,7 @@
   color: var(--text-primary, #495057);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -568,14 +568,14 @@
 .toolbar-settings-btn {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  gap: var(--space-1-5);
+  padding: var(--space-1-5) var(--space-3);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -668,10 +668,10 @@
 .inline-tab-context-menu {
   position: fixed;
   min-width: 120px;
-  padding: 4px;
+  padding: var(--space-1);
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   z-index: 2000;
 }
@@ -679,12 +679,12 @@
 .inline-tab-context-menu button {
   display: block;
   width: 100%;
-  padding: 6px 10px;
-  font-size: 0.75rem;
+  padding: var(--space-1-5) 10px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary, #495057);
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   text-align: left;
 }
@@ -705,8 +705,8 @@
 /* Inline Tab Input */
 .inline-tab-input {
   width: 60px;
-  padding: 2px 4px;
-  font-size: 0.75rem;
+  padding: var(--space-0-5) var(--space-1);
+  font-size: var(--font-size-sm);
   color: var(--text-primary, #495057);
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--color-primary, var(--color-primary));

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -20,13 +20,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: var(--space-1-5);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary, #212529);
   min-width: 0;
   overflow: hidden;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
 }
 
 .title-bar-name {
@@ -37,8 +37,8 @@
 
 .title-bar-status {
   flex-shrink: 0;
-  font-size: 10px;
-  line-height: 1;
+  font-size: var(--font-size-2xs);
+  line-height: var(--line-height-tight);
   display: inline-flex;
   align-items: center;
 }

--- a/src/ui/layout/DocumentToggleRail.css
+++ b/src/ui/layout/DocumentToggleRail.css
@@ -20,13 +20,13 @@
 .document-toggle-rail-left {
   left: 0;
   border-left: none;
-  border-radius: 0 6px 6px 0;
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
 }
 
 .document-toggle-rail-right {
   right: 0;
   border-right: none;
-  border-radius: 6px 0 0 6px;
+  border-radius: var(--radius-md) 0 0 var(--radius-md);
 }
 
 .document-toggle-rail:hover,

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -29,8 +29,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 8px 0;
+  gap: var(--space-1-5);
+  padding: var(--space-2) 0;
   border: none;
   background: var(--bg-secondary);
   color: var(--text-secondary, #6c757d);
@@ -63,14 +63,14 @@
 
 .flyout-panel-rail-icon {
   display: inline-flex;
-  font-size: 14px;
-  line-height: 1;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-tight);
 }
 
 .flyout-panel-rail-chevron {
   display: inline-flex;
-  font-size: 12px;
-  line-height: 1;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
   opacity: 0.6;
 }
 
@@ -136,10 +136,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 8px 6px 12px;
+  padding: var(--space-1-5) var(--space-2) var(--space-1-5) var(--space-3);
   border-bottom: 1px solid var(--border-color);
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-secondary, #6c757d);
@@ -154,7 +154,7 @@
   height: 22px;
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary, #6c757d);
   cursor: pointer;

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -9,16 +9,16 @@
 .layout-selector-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   height: 28px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-primary);
   color: var(--text-primary, #212529);
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   transition: background-color 0.12s ease, border-color 0.12s ease;
 }
 
@@ -35,7 +35,7 @@
 }
 
 .layout-selector-chip-chevron {
-  font-size: 10px;
+  font-size: var(--font-size-2xs);
   opacity: 0.6;
 }
 
@@ -46,26 +46,26 @@
   width: 320px;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
   z-index: 1000;
-  padding: 6px;
+  padding: var(--space-1-5);
 }
 
 .layout-selector-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .layout-selector-option {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 8px;
+  padding: var(--space-2) var(--space-2);
   border: none;
   background: transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   text-align: left;
   color: var(--text-primary, #212529);
@@ -86,7 +86,7 @@
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 0;
 }
 
@@ -94,45 +94,45 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  font-size: 13px;
-  font-weight: 600;
-  gap: 8px;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  gap: var(--space-2);
 }
 
 .layout-selector-option-shortcut {
-  font-size: 11px;
-  font-weight: 400;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
   color: var(--text-secondary, #6c757d);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .layout-selector-option-desc {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary, #6c757d);
-  line-height: 1.3;
+  line-height: var(--line-height-snug);
 }
 
 .layout-selector-footer {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  margin-top: 4px;
-  padding-top: 6px;
+  gap: var(--space-0-5);
+  margin-top: var(--space-1);
+  padding-top: var(--space-1-5);
   border-top: 1px solid var(--border-color);
 }
 
 .layout-selector-footer-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 7px 10px;
   border: none;
   background: transparent;
   color: var(--text-primary, #212529);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   text-align: left;
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   width: 100%;
 }
 

--- a/src/ui/layout/PanelChromeMenu.css
+++ b/src/ui/layout/PanelChromeMenu.css
@@ -3,22 +3,22 @@
   min-width: 180px;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
-  padding: 4px;
+  padding: var(--space-1);
   z-index: 2000;
 }
 
 .panel-chrome-menu-item {
   display: block;
   width: 100%;
-  padding: 6px 10px;
+  padding: var(--space-1-5) 10px;
   border: none;
   background: transparent;
   text-align: left;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary, #212529);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
@@ -35,6 +35,6 @@
 
 .panel-chrome-menu-divider {
   height: 1px;
-  margin: 4px 0;
+  margin: var(--space-1) 0;
   background: var(--border-color);
 }

--- a/src/ui/layout/RelaxedFocusControl.css
+++ b/src/ui/layout/RelaxedFocusControl.css
@@ -1,8 +1,8 @@
 .relaxed-focus-control {
   display: inline-flex;
   align-items: stretch;
-  gap: 2px;
-  padding: 2px;
+  gap: var(--space-0-5);
+  padding: var(--space-0-5);
   border: 1px solid var(--border-color);
   border-radius: 7px;
   background: var(--bg-secondary);
@@ -12,13 +12,13 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 4px 9px;
+  padding: var(--space-1) 9px;
   border: none;
   border-radius: 5px;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
 }
@@ -39,7 +39,7 @@
 }
 
 .relaxed-focus-segment-label {
-  line-height: 1;
+  line-height: var(--line-height-tight);
 }
 
 /* Touch ergonomics: give the segments a comfortable hit target on coarse
@@ -47,7 +47,7 @@
 @media (pointer: coarse) {
   .relaxed-focus-segment {
     min-height: 44px;
-    padding: 4px 14px;
+    padding: var(--space-1) 14px;
   }
 }
 

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -1,14 +1,7 @@
 /* DocumentBrowser styles - Improved Visual Hierarchy */
 
-/* 8pt Grid Spacing System */
-:root {
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 20px;
-  --space-6: 24px;
-}
+/* Spacing tokens (--space-1..6) are the canonical 8pt grid defined globally in
+   src/index.css; this file just consumes them. */
 
 .document-browser {
   display: flex;


### PR DESCRIPTION
## What

Defines a canonical, **rem-based dimensional token scale** in `src/index.css` and adopts it across the core chrome — the non-colour half of the JP-147 visual-design pass.

Tokens added (`:root`, mode-independent): `--font-sans`/`--font-mono`, `--space-*` (4px grid), `--radius-*`, `--font-size-*`, `--font-weight-*`, `--line-height-*`, `--control-height-*`.

## Why

Previously the chrome hardcoded every dimension — 42 distinct font-sizes (px/rem mixed inconsistently), spacing/radius scattered as raw px, and one lone local `--space-1..6` in `DocumentBrowser.css`. There was also a latent bug: `--font-mono` was referenced by `DocumentCard.css` but never defined. This establishes a single source of truth the rest of the UI migrates onto.

## How — pure value-preserving refactor

The root font-size is the browser default 16px (nothing sets `html { font-size }`), so `px → rem ÷16` renders **identically today** while letting the chrome scale with the root font. The conversion is **property-context-aware** and only swaps a literal when it matches a token's value exactly; off-grid oddballs (`10px`, `14px`, odd rem), `em`/`%`/`calc()` values, and structural bar heights are left untouched.

- `index.css`: add the scale; repoint `html/body/#root` at `--font-sans`; define `--font-mono`.
- `DocumentBrowser.css`: delete the redundant local `--space-1..6` `:root` block (its consumers now resolve to the identical global tokens).
- ~21 chrome files (toolbars, ribbon, panels, menus, bars): adopt the tokens.

## Out of scope (deferred to JP-151 token unification)

Long-tail adoption (settings/dialog cluster, canvas-element CSS) and retiring the alias shims.

## Verification

- ✅ `bun run typecheck` clean
- ✅ `bun run test --run` — 1734 passed
- ✅ `bun run build` green
- ✅ every consumed token resolves; local `--space-*` block removed
- Visual: value-preserving by construction — worth a quick light/dark eyeball of toolbars, ribbon, panels, menus, status bar.

Assisted-by: Opus 4.8