### PR TITLE
JP-151: unify the CSS token scheme onto the canonical brand tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -74,21 +74,6 @@
   --shadow-sm: 0 1px 2px rgba(14, 28, 48, 0.06);
   --shadow-md: 0 2px 6px rgba(14, 28, 48, 0.10);
 
-  /* --- Alias tokens — bridge the older competing token names onto the
-     canonical brand tokens (fills undefined global consumers; a component
-     that defines these locally still wins for its own subtree). --- */
-  --accent-color: var(--color-primary);
-  --accent-hover: var(--color-primary-dark);
-  --hover-bg: var(--bg-hover);
-  --color-text-primary: var(--text-primary);
-  --color-text-secondary: var(--text-secondary);
-  --text-color: var(--text-primary);
-  --text-tertiary: var(--text-muted);
-  --color-border: var(--border-color);
-  --danger-color: var(--danger);
-  --color-error: var(--danger);
-  --warning-color: var(--warning);
-
   /* Responsive breakpoints — shared tokens so layout CSS and the
    * `useBreakpoint` hook agree on the bands (see platform/device.ts
    * viewportBand: narrow < 640 <= medium < 1024 <= wide). The future mobile

--- a/src/ui/CommandPalette.css
+++ b/src/ui/CommandPalette.css
@@ -20,7 +20,7 @@
   width: 520px;
   max-height: 420px;
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-color, #444);
   border-radius: 10px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
   display: flex;
@@ -39,8 +39,8 @@
   padding: 14px 16px;
   background: transparent;
   border: none;
-  border-bottom: 1px solid var(--color-border, #444);
-  color: var(--color-text-primary, #cdd6f4);
+  border-bottom: 1px solid var(--border-color, #444);
+  color: var(--text-primary, #cdd6f4);
   font-size: 15px;
   outline: none;
   font-family: inherit;
@@ -71,7 +71,7 @@
   padding: 8px 16px;
   background: transparent;
   border: none;
-  color: var(--color-text-primary, #cdd6f4);
+  color: var(--text-primary, #cdd6f4);
   font-size: 13px;
   cursor: pointer;
   text-align: left;
@@ -100,7 +100,7 @@
 
 .command-palette-shortcut {
   background: var(--color-bg-secondary, #2a2a3a);
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-color, #444);
   border-radius: 4px;
   padding: 1px 6px;
   font-size: 11px;

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -105,7 +105,7 @@
 .context-menu-check {
   width: 18px;
   font-size: var(--font-size-sm);
-  color: var(--accent-color, #4a90d9);
+  color: var(--color-primary, #4a90d9);
   flex-shrink: 0;
 }
 
@@ -148,5 +148,5 @@
 }
 
 [data-theme="dark"] .context-menu-check {
-  color: var(--accent-color, #4a90d9);
+  color: var(--color-primary, #4a90d9);
 }

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -14,16 +14,16 @@
 
 .document-card:hover {
   background: var(--bg-hover, #f8fafc);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .document-card--active {
   background: var(--bg-secondary, #f1f5f9);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .document-card--selected {
-  box-shadow: 0 0 0 2px var(--accent-color, #3b82f6);
+  box-shadow: 0 0 0 2px var(--color-primary, #3b82f6);
 }
 
 /* Content */
@@ -54,7 +54,7 @@
   font-size: 13px;
   font-weight: 500;
   padding: 2px 6px;
-  border: 1px solid var(--accent-color, #3b82f6);
+  border: 1px solid var(--color-primary, #3b82f6);
   border-radius: 4px;
   background: var(--bg-primary, #ffffff);
   color: var(--text-primary, #1e293b);
@@ -65,7 +65,7 @@
   font-size: 10px;
   font-weight: 500;
   padding: 2px 6px;
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: rgba(31, 51, 84, 0.1);
   border-radius: 4px;
   flex-shrink: 0;
@@ -169,7 +169,7 @@
 .document-card__action:focus-visible,
 .document-card__expand:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--accent-color, #3b82f6);
+  box-shadow: 0 0 0 2px var(--color-primary, #3b82f6);
 }
 
 .document-card__action:disabled {
@@ -412,8 +412,8 @@
 }
 
 .document-card__select--checked {
-  background: var(--accent-color, #3b82f6);
-  border-color: var(--accent-color, #3b82f6);
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   opacity: 1;
 }
 

--- a/src/ui/DocumentChangedBanner.css
+++ b/src/ui/DocumentChangedBanner.css
@@ -11,7 +11,7 @@
   background: var(--color-info-bg, #1e2a4a);
   border-bottom: 1px solid var(--color-info-border, #2a3a6a);
   font-size: 13px;
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
   animation: dcb-slideDown 0.2s ease-out;
 }
 
@@ -29,9 +29,9 @@
 .document-changed-banner__btn {
   padding: 4px 10px;
   border-radius: 4px;
-  border: 1px solid var(--color-border, #363649);
+  border: 1px solid var(--border-color, #363649);
   background: var(--color-bg-secondary, #252537);
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
   font-size: 12px;
   cursor: pointer;
   flex-shrink: 0;

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -143,11 +143,11 @@
 
 /* Danger menu item */
 .doc-editor-context-menu-item.danger {
-  color: var(--color-error, #dc3545);
+  color: var(--danger, #dc3545);
 }
 
 .doc-editor-context-menu-item.danger .doc-editor-context-menu-icon {
-  color: var(--color-error, #dc3545);
+  color: var(--danger, #dc3545);
 }
 
 .doc-editor-context-menu-item.danger:hover {

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -177,7 +177,7 @@
 }
 
 .document-editor-toolbar-btn.danger {
-  color: var(--color-error, #dc3545);
+  color: var(--danger, #dc3545);
 }
 
 .document-editor-toolbar-btn.danger:hover:not(:disabled) {

--- a/src/ui/ErrorBoundary.css
+++ b/src/ui/ErrorBoundary.css
@@ -6,7 +6,7 @@
   padding: 24px 16px;
   gap: 8px;
   min-height: 120px;
-  color: var(--color-text-secondary, #888);
+  color: var(--text-secondary, #888);
   text-align: center;
 }
 
@@ -17,7 +17,7 @@
 .error-boundary__message {
   font-size: 13px;
   font-weight: 500;
-  color: var(--color-text-primary, #ccc);
+  color: var(--text-primary, #ccc);
 }
 
 .error-boundary__details {
@@ -33,10 +33,10 @@
 .error-boundary__reload {
   margin-top: 8px;
   padding: 6px 16px;
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-color, #444);
   border-radius: 4px;
   background: var(--color-bg-secondary, #2a2a3e);
-  color: var(--color-text-primary, #ccc);
+  color: var(--text-primary, #ccc);
   cursor: pointer;
   font-size: 12px;
   transition: background 0.15s;

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -162,7 +162,7 @@
   width: 32px;
   height: 32px;
   border: 3px solid var(--border-color, #e2e8f0);
-  border-top-color: var(--accent-color, #3b82f6);
+  border-top-color: var(--color-primary, #3b82f6);
   border-radius: 50%;
   animation: file-viewer-spin 0.8s linear infinite;
 }

--- a/src/ui/IconListEditor.css
+++ b/src/ui/IconListEditor.css
@@ -57,7 +57,7 @@
 
 .icon-list-empty {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--text-muted);
   text-align: center;
   padding: 12px;
 }
@@ -71,7 +71,7 @@
 }
 
 .icon-config-item.expanded {
-  border-color: var(--accent-color);
+  border-color: var(--color-primary);
 }
 
 .icon-config-header {
@@ -102,7 +102,7 @@
 
 .icon-config-position {
   font-size: 10px;
-  color: var(--text-tertiary);
+  color: var(--text-muted);
   background: var(--bg-secondary);
   padding: 2px 4px;
   border-radius: 2px;
@@ -121,7 +121,7 @@
 
 .icon-config-remove:hover {
   background: var(--danger-bg);
-  color: var(--danger-color);
+  color: var(--danger);
 }
 
 .icon-config-body {
@@ -203,7 +203,7 @@
 
 .icon-mini-input > .suffix {
   font-size: 10px;
-  color: var(--text-tertiary);
+  color: var(--text-muted);
 }
 
 .icon-color-reset-mini {

--- a/src/ui/IconPicker.css
+++ b/src/ui/IconPicker.css
@@ -173,7 +173,7 @@
 .icon-picker-error {
   padding: 8px;
   background: var(--color-error-bg);
-  color: var(--color-error);
+  color: var(--danger);
   font-size: 12px;
   border-bottom: 1px solid var(--border-color);
 }

--- a/src/ui/KeyboardShortcutPanel.css
+++ b/src/ui/KeyboardShortcutPanel.css
@@ -16,7 +16,7 @@
 
 .shortcut-panel {
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-color, #444);
   border-radius: 8px;
   width: 460px;
   max-height: 70vh;
@@ -42,13 +42,13 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
 }
 
 .shortcut-panel__close {
   background: none;
   border: none;
-  color: var(--color-text-secondary, #888);
+  color: var(--text-secondary, #888);
   cursor: pointer;
   font-size: 16px;
   padding: 4px 8px;
@@ -62,10 +62,10 @@
 .shortcut-panel__search {
   margin: 4px 16px 8px;
   padding: 8px 12px;
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-color, #444);
   border-radius: 4px;
   background: var(--color-bg-secondary, #2a2a3e);
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
   font-size: 13px;
   outline: none;
 }
@@ -89,7 +89,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-secondary, #888);
+  color: var(--text-secondary, #888);
 }
 
 .shortcut-panel__row {
@@ -101,7 +101,7 @@
 
 .shortcut-panel__description {
   font-size: 13px;
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
 }
 
 .shortcut-panel__keys {
@@ -110,7 +110,7 @@
   padding: 2px 8px;
   border-radius: 3px;
   background: var(--color-bg-secondary, #2a2a3e);
-  border: 1px solid var(--color-border, #444);
-  color: var(--color-text-secondary, #aaa);
+  border: 1px solid var(--border-color, #444);
+  color: var(--text-secondary, #aaa);
   white-space: nowrap;
 }

--- a/src/ui/LayerPanel.css
+++ b/src/ui/LayerPanel.css
@@ -38,7 +38,7 @@
 }
 
 .layer-panel-resize-handle-vertical:hover {
-  background: var(--accent-color, var(--color-primary));
+  background: var(--color-primary, var(--color-primary));
   opacity: 0.3;
 }
 
@@ -55,7 +55,7 @@
 }
 
 .layer-panel-resize-handle-horizontal:hover {
-  background: var(--accent-color, var(--color-primary));
+  background: var(--color-primary, var(--color-primary));
   opacity: 0.3;
 }
 
@@ -119,18 +119,18 @@
 
 /* Drop indicator - before target */
 .layer-item.drop-before {
-  box-shadow: inset 0 3px 0 0 var(--accent-color, var(--color-primary));
+  box-shadow: inset 0 3px 0 0 var(--color-primary, var(--color-primary));
 }
 
 /* Drop indicator - after target */
 .layer-item.drop-after {
-  box-shadow: inset 0 -3px 0 0 var(--accent-color, var(--color-primary));
+  box-shadow: inset 0 -3px 0 0 var(--color-primary, var(--color-primary));
 }
 
 /* Drop indicator - into group */
 .layer-item.drop-into {
   background: var(--color-primary-light, #e3f2fd) !important;
-  outline: 2px solid var(--accent-color, var(--color-primary));
+  outline: 2px solid var(--color-primary, var(--color-primary));
   outline-offset: -2px;
 }
 
@@ -230,7 +230,7 @@
 }
 
 .layer-action-btn.active {
-  color: var(--accent-color, var(--color-primary));
+  color: var(--color-primary, var(--color-primary));
 }
 
 .layer-action-btn.inactive {
@@ -296,7 +296,7 @@
 
 [data-theme="dark"] .layer-panel-resize-handle-vertical:hover,
 [data-theme="dark"] .layer-panel-resize-handle-horizontal:hover {
-  background: var(--accent-color, #60a5fa);
+  background: var(--color-primary, #60a5fa);
 }
 
 [data-theme="dark"] .layer-item {
@@ -360,7 +360,7 @@
 
 .layer-panel-action-btn:hover {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 /* Layer context menu */
@@ -557,7 +557,7 @@
 
 .layer-view-selector select:focus {
   outline: none;
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .layer-view-manage-btn {
@@ -596,8 +596,8 @@
 }
 
 .layer-view-create-btn:hover {
-  border-color: var(--accent-color, var(--color-primary));
-  color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
+  color: var(--color-primary, var(--color-primary));
 }
 
 [data-theme="dark"] .layer-view-selector {
@@ -620,6 +620,6 @@
 }
 
 [data-theme="dark"] .layer-view-create-btn:hover {
-  border-color: var(--accent-color, #60a5fa);
-  color: var(--accent-color, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
+  color: var(--color-primary, #60a5fa);
 }

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -111,7 +111,7 @@
 
 .layer-view-form-row input:focus {
   outline: none;
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
@@ -191,7 +191,7 @@
 
 .layer-view-list-item-manual {
   font-size: var(--font-size-xs);
-  color: var(--accent-color, var(--color-primary));
+  color: var(--color-primary, var(--color-primary));
 }
 
 .layer-view-list-item-actions {
@@ -243,7 +243,7 @@
 
 .layer-view-edit-form input:focus {
   outline: none;
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .layer-view-edit-actions {
@@ -264,7 +264,7 @@
 
 .layer-view-edit-actions button:first-child {
   background: var(--color-cta));
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
   color: var(--color-cta-text);
 }
 
@@ -393,7 +393,7 @@
 
 .layer-view-form-test:hover:not(:disabled) {
   background: var(--bg-hover, #e9ecef);
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .layer-view-form-test:disabled {

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -54,7 +54,7 @@
 }
 
 .logo-picker-close:hover {
-  background: var(--hover-bg, #f0f0f0);
+  background: var(--bg-hover, #f0f0f0);
 }
 
 .logo-picker-content {
@@ -70,7 +70,7 @@
 .logo-picker-upload-btn {
   width: 100%;
   padding: 12px 16px;
-  background: var(--hover-bg, #f5f5f5);
+  background: var(--bg-hover, #f5f5f5);
   border: 2px dashed var(--border-color, #ccc);
   border-radius: 6px;
   cursor: pointer;
@@ -81,7 +81,7 @@
 
 .logo-picker-upload-btn:hover:not(:disabled) {
   background: var(--accent-light, #e3f2fd);
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .logo-picker-upload-btn:disabled {
@@ -103,7 +103,7 @@
 }
 
 .logo-picker-item {
-  background: var(--hover-bg, #f8f8f8);
+  background: var(--bg-hover, #f8f8f8);
   border: 2px solid transparent;
   border-radius: 8px;
   padding: 8px;
@@ -119,7 +119,7 @@
 
 .logo-picker-item.selected {
   background: var(--accent-light, #e3f2fd);
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
 }
 
 .logo-picker-preview {
@@ -199,7 +199,7 @@
 }
 
 .logo-picker-btn-secondary:hover:not(:disabled) {
-  background: var(--hover-bg, #f5f5f5);
+  background: var(--bg-hover, #f5f5f5);
 }
 
 .logo-picker-btn-secondary:disabled {

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -66,11 +66,11 @@
 }
 
 .notification-toast--error {
-  border-left-color: var(--color-error, #ef4444);
+  border-left-color: var(--danger, #ef4444);
 }
 
 .notification-toast--error .notification-toast__icon {
-  color: var(--color-error, #ef4444);
+  color: var(--danger, #ef4444);
 }
 
 /* Icon */
@@ -99,7 +99,7 @@
   display: block;
   margin-top: 4px;
   font-size: 12px;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
 }
 
 /* Actions */
@@ -137,7 +137,7 @@
   background: transparent;
   border: none;
   border-radius: 4px;
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--text-secondary, #6b7280);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -54,7 +54,7 @@
 }
 
 .pdf-export-close:hover {
-  background: var(--hover-bg, #f0f0f0);
+  background: var(--bg-hover, #f0f0f0);
 }
 
 .pdf-export-content {
@@ -92,7 +92,7 @@
   gap: 8px;
   width: 100%;
   padding: 12px 16px;
-  background: var(--hover-bg, #f8f8f8);
+  background: var(--bg-hover, #f8f8f8);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -100,7 +100,7 @@
 }
 
 .pdf-export-section-header:hover {
-  background: var(--hover-bg, #f0f0f0);
+  background: var(--bg-hover, #f0f0f0);
 }
 
 .pdf-export-section-header .pdf-export-section-title {
@@ -211,7 +211,7 @@
 
 .pdf-export-extension {
   padding: 8px 12px;
-  background: var(--hover-bg, #f0f0f0);
+  background: var(--bg-hover, #f0f0f0);
   border: 1px solid var(--border-color, #ccc);
   border-left: none;
   border-radius: 0 6px 6px 0;
@@ -227,7 +227,7 @@
 .pdf-export-toggle button {
   flex: 1;
   padding: 8px 16px;
-  background: var(--hover-bg, #f5f5f5);
+  background: var(--bg-hover, #f5f5f5);
   border: 1px solid var(--border-color, #ccc);
   font-size: 13px;
   color: var(--text-primary, #333);
@@ -246,12 +246,12 @@
 
 .pdf-export-toggle button.active {
   background: var(--color-cta));
-  border-color: var(--accent-color, var(--color-primary));
+  border-color: var(--color-primary, var(--color-primary));
   color: var(--color-cta-text);
 }
 
 .pdf-export-toggle button:hover:not(.active) {
-  background: var(--hover-bg, #e8e8e8);
+  background: var(--bg-hover, #e8e8e8);
 }
 
 .pdf-export-margins {
@@ -353,7 +353,7 @@
 .pdf-export-logo-btn {
   flex: 1;
   padding: 8px 16px;
-  background: var(--hover-bg, #f5f5f5);
+  background: var(--bg-hover, #f5f5f5);
   border: 1px solid var(--border-color, #ccc);
   border-radius: 6px;
   font-size: 13px;
@@ -363,7 +363,7 @@
 }
 
 .pdf-export-logo-btn:hover:not(:disabled) {
-  background: var(--hover-bg, #e8e8e8);
+  background: var(--bg-hover, #e8e8e8);
 }
 
 .pdf-export-logo-btn:disabled {
@@ -377,7 +377,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--hover-bg, #f5f5f5);
+  background: var(--bg-hover, #f5f5f5);
   border: 1px solid var(--border-color, #ccc);
   border-radius: 6px;
   font-size: 18px;
@@ -447,7 +447,7 @@
 }
 
 .pdf-export-btn-secondary:hover {
-  background: var(--hover-bg, #f5f5f5);
+  background: var(--bg-hover, #f5f5f5);
 }
 
 .pdf-export-btn-tertiary {

--- a/src/ui/PresenceIndicators.css
+++ b/src/ui/PresenceIndicators.css
@@ -34,11 +34,11 @@
 }
 
 .presence-status-disconnected .presence-status-dot {
-  background-color: var(--color-text-secondary);
+  background-color: var(--text-secondary);
 }
 
 .presence-status-error .presence-status-dot {
-  background-color: var(--color-error, #e53e3e);
+  background-color: var(--danger, #e53e3e);
 }
 
 @keyframes pulse {
@@ -92,14 +92,14 @@
 /* Overflow indicator */
 .presence-overflow {
   background-color: var(--color-bg-tertiary);
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   font-size: 10px;
 }
 
 /* User count text */
 .presence-count {
   font-size: 12px;
-  color: var(--color-text-secondary);
+  color: var(--text-secondary);
   margin-left: 4px;
   white-space: nowrap;
 }

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -941,7 +941,7 @@
 
 .erd-member-remove:hover {
   opacity: 1;
-  color: var(--color-error, #e53e3e);
+  color: var(--danger, #e53e3e);
   background: rgba(229, 62, 62, 0.1);
 }
 
@@ -1102,7 +1102,7 @@
 
 .uml-member-remove:hover {
   opacity: 1;
-  color: var(--color-error, #e53e3e);
+  color: var(--danger, #e53e3e);
   background: rgba(229, 62, 62, 0.1);
 }
 
@@ -1363,7 +1363,7 @@
 
 .swimlane-lane-remove:hover {
   opacity: 1;
-  color: var(--color-error, #e53e3e);
+  color: var(--danger, #e53e3e);
   background: rgba(229, 62, 62, 0.1);
 }
 

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -193,7 +193,7 @@
 }
 
 .rich-text-tab-context-item.danger {
-  color: var(--color-error, #dc3545);
+  color: var(--danger, #dc3545);
 }
 
 .rich-text-tab-context-item.danger:hover:not(.disabled) {

--- a/src/ui/SettingsModal.css
+++ b/src/ui/SettingsModal.css
@@ -173,7 +173,7 @@
   width: 3px;
   height: 60%;
   border-radius: 0 3px 3px 0;
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-primary, #3b82f6);
   transition: transform 0.2s ease;
 }
 
@@ -184,7 +184,7 @@
 
 .settings-tab-btn.active {
   background: linear-gradient(135deg, rgba(31, 51, 84, 0.12) 0%, rgba(31, 51, 84, 0.06) 100%);
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   font-weight: 600;
 }
 
@@ -362,7 +362,7 @@
 }
 
 .settings-form-input:focus {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
@@ -463,7 +463,7 @@
 }
 
 .settings-form-input:focus {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 

--- a/src/ui/ShapePicker.css
+++ b/src/ui/ShapePicker.css
@@ -230,5 +230,5 @@
   font-size: 10px;
   color: var(--color-text-muted, #666);
   text-align: center;
-  border-top: 1px solid var(--color-border, #333);
+  border-top: 1px solid var(--border-color, #333);
 }

--- a/src/ui/ShapeSearchPanel.css
+++ b/src/ui/ShapeSearchPanel.css
@@ -6,7 +6,7 @@
   right: 16px;
   z-index: 900;
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--color-border, #444);
+  border: 1px solid var(--border-color, #444);
   border-radius: 8px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   display: flex;
@@ -31,7 +31,7 @@
   flex: 1;
   background: transparent;
   border: none;
-  color: var(--color-text-primary, #cdd6f4);
+  color: var(--text-primary, #cdd6f4);
   font-size: 13px;
   outline: none;
   padding: 4px 0;
@@ -70,7 +70,7 @@
 
 .shape-search-btn:hover {
   background: var(--color-bg-hover, #313244);
-  color: var(--color-text-primary, #cdd6f4);
+  color: var(--text-primary, #cdd6f4);
 }
 
 .shape-search-btn:disabled {
@@ -80,8 +80,8 @@
 
 .shape-search-btn.active {
   background: var(--color-bg-selected, #45475a);
-  color: var(--color-text-primary, #cdd6f4);
-  border-color: var(--color-border, #444);
+  color: var(--text-primary, #cdd6f4);
+  border-color: var(--border-color, #444);
 }
 
 .shape-search-close {

--- a/src/ui/StorageManager.css
+++ b/src/ui/StorageManager.css
@@ -43,7 +43,7 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: var(--text-color);
+  color: var(--text-primary);
 }
 
 .storage-manager-close {
@@ -59,8 +59,8 @@
 }
 
 .storage-manager-close:hover {
-  background: var(--hover-bg);
-  color: var(--text-color);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 /* Stats */
@@ -79,7 +79,7 @@
 }
 
 .storage-stat-warning {
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning, #f59e0b);
 }
 
 .storage-stat-label {
@@ -92,7 +92,7 @@
 .storage-stat-value {
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-color);
+  color: var(--text-primary);
 }
 
 /* Progress bar */
@@ -104,7 +104,7 @@
 
 .storage-progress-bar {
   height: 100%;
-  background: var(--accent-color);
+  background: var(--color-primary);
   transition: width 0.3s;
 }
 
@@ -121,7 +121,7 @@
   padding: 8px 16px;
   border: 1px solid var(--border-color);
   background: var(--panel-bg);
-  color: var(--text-color);
+  color: var(--text-primary);
   border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
@@ -130,7 +130,7 @@
 }
 
 .storage-manager-btn:hover:not(:disabled) {
-  background: var(--hover-bg);
+  background: var(--bg-hover);
   border-color: var(--text-secondary);
 }
 
@@ -142,12 +142,12 @@
 .storage-manager-btn-primary {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--accent-color);
+  border-color: var(--color-primary);
 }
 
 .storage-manager-btn-primary:hover:not(:disabled) {
   opacity: 0.9;
-  border-color: var(--accent-color);
+  border-color: var(--color-primary);
 }
 
 .storage-manager-gc-result {
@@ -205,7 +205,7 @@
 
 .storage-manager-list-item {
   font-size: 13px;
-  color: var(--text-color);
+  color: var(--text-primary);
 }
 
 .storage-manager-list-item:hover {
@@ -237,7 +237,7 @@
   display: inline-block;
   padding: 2px 6px;
   background: var(--warning-bg, #f59e0b20);
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning, #f59e0b);
   border-radius: 4px;
   font-size: 11px;
   font-weight: 600;
@@ -267,9 +267,9 @@
 }
 
 .storage-manager-btn-small:hover {
-  background: var(--hover-bg);
-  color: var(--danger-color, #ef4444);
-  border-color: var(--danger-color, #ef4444);
+  background: var(--bg-hover);
+  color: var(--danger, #ef4444);
+  border-color: var(--danger, #ef4444);
 }
 
 /* Tabs */
@@ -294,13 +294,13 @@
 }
 
 .storage-manager-tab:hover {
-  color: var(--text-color);
+  color: var(--text-primary);
   background: var(--panel-hover);
 }
 
 .storage-manager-tab.active {
-  color: var(--accent-color);
-  border-bottom-color: var(--accent-color);
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
 }
 
 /* Icon grid */
@@ -323,7 +323,7 @@
 }
 
 .storage-icon-item:hover {
-  border-color: var(--accent-color);
+  border-color: var(--color-primary);
   background: var(--panel-bg);
 }
 
@@ -364,7 +364,7 @@
 
 .storage-icon-name {
   font-size: 11px;
-  color: var(--text-color);
+  color: var(--text-primary);
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -400,7 +400,7 @@
   padding: 0;
   border: none;
   background: var(--danger-bg, #ef444420);
-  color: var(--danger-color, #ef4444);
+  color: var(--danger, #ef4444);
   border-radius: 50%;
   cursor: pointer;
   font-size: 12px;
@@ -417,7 +417,7 @@
 }
 
 .storage-icon-delete:hover {
-  background: var(--danger-color, #ef4444);
+  background: var(--danger, #ef4444);
   color: white;
 }
 
@@ -452,7 +452,7 @@
   margin: 0 0 12px;
   font-size: 18px;
   font-weight: 600;
-  color: var(--text-color);
+  color: var(--text-primary);
 }
 
 .storage-manager-modal-text {
@@ -484,7 +484,7 @@
 
 .storage-manager-modal-item-name {
   font-size: 13px;
-  color: var(--text-color);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -502,7 +502,7 @@
   margin: 0 0 16px;
   font-size: 14px;
   font-weight: 500;
-  color: var(--text-color);
+  color: var(--text-primary);
   text-align: right;
 }
 
@@ -513,9 +513,9 @@
 }
 
 .storage-manager-btn-danger {
-  background: var(--danger-color, #ef4444);
+  background: var(--danger, #ef4444);
   color: white;
-  border-color: var(--danger-color, #ef4444);
+  border-color: var(--danger, #ef4444);
 }
 
 .storage-manager-btn-danger:hover {

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -31,18 +31,18 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .style-profile-view-btn:hover {
-  background: var(--hover-bg, #f1f5f9);
+  background: var(--bg-hover, #f1f5f9);
   color: var(--text-secondary, #64748b);
 }
 
 .style-profile-view-btn.active {
-  background: var(--hover-bg, #f1f5f9);
+  background: var(--bg-hover, #f1f5f9);
   color: var(--text-primary, #1e293b);
 }
 
@@ -71,7 +71,7 @@
 .style-profile-create {
   padding: 8px 12px;
   margin-bottom: 8px;
-  background: var(--hover-bg, #f8fafc);
+  background: var(--bg-hover, #f8fafc);
   border-radius: 4px;
   margin-left: 8px;
   margin-right: 8px;
@@ -90,7 +90,7 @@
 }
 
 .style-profile-input:focus {
-  border-color: var(--accent-color, #4a90d9);
+  border-color: var(--color-primary, #4a90d9);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
@@ -125,7 +125,7 @@
 }
 
 .style-profile-btn.cancel {
-  background: var(--hover-bg, #e2e8f0);
+  background: var(--bg-hover, #e2e8f0);
   color: var(--text-secondary, #64748b);
 }
 
@@ -154,7 +154,7 @@
 }
 
 .style-profile-search-input:focus {
-  border-color: var(--accent-color, #4a90d9);
+  border-color: var(--color-primary, #4a90d9);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
@@ -169,8 +169,8 @@
   padding: 0;
   border: none;
   border-radius: 50%;
-  background: var(--hover-bg, #e2e8f0);
-  color: var(--text-tertiary, #94a3b8);
+  background: var(--bg-hover, #e2e8f0);
+  color: var(--text-muted, #94a3b8);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -203,7 +203,7 @@
   border: none;
   border-radius: 50%;
   background: transparent;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   cursor: pointer;
   transition: all 0.15s ease;
 }
@@ -245,7 +245,7 @@
 }
 
 .style-profile-grid-item:hover:not(.disabled) {
-  background: var(--hover-bg, #f1f5f9);
+  background: var(--bg-hover, #f1f5f9);
   border-color: var(--border-color, #e2e8f0);
 }
 
@@ -272,7 +272,7 @@
   top: 2px;
   right: 2px;
   font-size: 10px;
-  color: var(--warning-color, #eab308);
+  color: var(--warning, #eab308);
 }
 
 .style-profile-grid-name {
@@ -361,7 +361,7 @@
 }
 
 .style-profile-item:hover:not(.disabled) {
-  background: var(--hover-bg, #f1f5f9);
+  background: var(--bg-hover, #f1f5f9);
 }
 
 .style-profile-item.disabled {
@@ -397,7 +397,7 @@
   flex: 1;
   padding: 2px 6px;
   font-size: 12px;
-  border: 1px solid var(--accent-color, #4a90d9);
+  border: 1px solid var(--color-primary, #4a90d9);
   border-radius: 3px;
   background: var(--input-bg, #fff);
   color: var(--text-primary, #1e293b);
@@ -432,7 +432,7 @@
 }
 
 .style-profile-action:hover:not(:disabled) {
-  background: var(--hover-bg, #e2e8f0);
+  background: var(--bg-hover, #e2e8f0);
 }
 
 .style-profile-action.apply:hover:not(:disabled) {
@@ -440,11 +440,11 @@
 }
 
 .style-profile-action.overwrite:hover:not(:disabled) {
-  color: var(--accent-color, #4a90d9);
+  color: var(--color-primary, #4a90d9);
 }
 
 .style-profile-action.delete:hover {
-  color: var(--danger-color, #e53e3e);
+  color: var(--danger, #e53e3e);
 }
 
 /* Favorite star button - always visible */
@@ -458,11 +458,11 @@
 
 .style-profile-action.favorite.active {
   opacity: 1;
-  color: var(--warning-color, #eab308);
+  color: var(--warning, #eab308);
 }
 
 .style-profile-action.favorite:hover {
-  color: var(--warning-color, #eab308);
+  color: var(--warning, #eab308);
 }
 
 /* Confirmation buttons */
@@ -476,12 +476,12 @@
 }
 
 .style-profile-action.cancel {
-  color: var(--danger-color, #e53e3e);
+  color: var(--danger, #e53e3e);
 }
 
 .style-profile-action.cancel:hover {
   background: rgba(229, 62, 62, 0.15);
-  color: var(--danger-color, #e53e3e);
+  color: var(--danger, #e53e3e);
 }
 
 .style-profile-action:disabled {
@@ -493,7 +493,7 @@
 .style-profile-hint {
   padding: 8px 12px;
   font-size: 11px;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   text-align: center;
   font-style: italic;
 }
@@ -524,7 +524,7 @@
 }
 
 .style-profile-context-menu-item:hover {
-  background: var(--hover-bg, #f1f5f9);
+  background: var(--bg-hover, #f1f5f9);
 }
 
 .style-profile-context-menu-item.danger:hover {
@@ -548,16 +548,16 @@
 }
 
 :root[data-theme='dark'] .style-profile-view-btn {
-  color: var(--text-tertiary, #64748b);
+  color: var(--text-muted, #64748b);
 }
 
 :root[data-theme='dark'] .style-profile-view-btn:hover {
-  background: var(--hover-bg, #334155);
+  background: var(--bg-hover, #334155);
   color: var(--text-secondary, #94a3b8);
 }
 
 :root[data-theme='dark'] .style-profile-view-btn.active {
-  background: var(--hover-bg, #334155);
+  background: var(--bg-hover, #334155);
   color: var(--text-primary, #f1f5f9);
 }
 
@@ -571,7 +571,7 @@
 }
 
 :root[data-theme='dark'] .style-profile-create {
-  background: var(--hover-bg, #1e293b);
+  background: var(--bg-hover, #1e293b);
 }
 
 :root[data-theme='dark'] .style-profile-input {
@@ -581,12 +581,12 @@
 }
 
 :root[data-theme='dark'] .style-profile-input:focus {
-  border-color: var(--accent-color, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
   box-shadow: 0 0 0 2px rgba(224, 198, 144, 0.2);
 }
 
 :root[data-theme='dark'] .style-profile-btn.save {
-  background: var(--accent-color, #60a5fa);
+  background: var(--color-primary, #60a5fa);
 }
 
 :root[data-theme='dark'] .style-profile-btn.save:hover:not(:disabled) {
@@ -594,7 +594,7 @@
 }
 
 :root[data-theme='dark'] .style-profile-btn.cancel {
-  background: var(--hover-bg, #334155);
+  background: var(--bg-hover, #334155);
   color: var(--text-secondary, #94a3b8);
 }
 
@@ -608,7 +608,7 @@
 }
 
 :root[data-theme='dark'] .style-profile-grid-item:hover:not(.disabled) {
-  background: var(--hover-bg, #334155);
+  background: var(--bg-hover, #334155);
   border-color: var(--border-color, #475569);
 }
 
@@ -621,12 +621,12 @@
 }
 
 :root[data-theme='dark'] .style-profile-grid-star {
-  color: var(--warning-color, #facc15);
+  color: var(--warning, #facc15);
 }
 
 /* Dark mode list items */
 :root[data-theme='dark'] .style-profile-item:hover:not(.disabled) {
-  background: var(--hover-bg, #1e293b);
+  background: var(--bg-hover, #1e293b);
 }
 
 :root[data-theme='dark'] .style-profile-name {
@@ -634,7 +634,7 @@
 }
 
 :root[data-theme='dark'] .style-profile-edit-input {
-  border-color: var(--accent-color, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
   background: var(--input-bg, #0f172a);
   color: var(--text-primary, #f1f5f9);
 }
@@ -644,19 +644,19 @@
 }
 
 :root[data-theme='dark'] .style-profile-action:hover:not(:disabled) {
-  background: var(--hover-bg, #334155);
+  background: var(--bg-hover, #334155);
 }
 
 :root[data-theme='dark'] .style-profile-hint {
-  color: var(--text-tertiary, #64748b);
+  color: var(--text-muted, #64748b);
 }
 
 :root[data-theme='dark'] .style-profile-action.favorite.active {
-  color: var(--warning-color, #facc15);
+  color: var(--warning, #facc15);
 }
 
 :root[data-theme='dark'] .style-profile-action.favorite:hover {
-  color: var(--warning-color, #facc15);
+  color: var(--warning, #facc15);
 }
 
 :root[data-theme='dark'] .style-profile-action.confirm {
@@ -669,12 +669,12 @@
 }
 
 :root[data-theme='dark'] .style-profile-action.cancel {
-  color: var(--danger-color, #f87171);
+  color: var(--danger, #f87171);
 }
 
 :root[data-theme='dark'] .style-profile-action.cancel:hover {
   background: rgba(248, 113, 113, 0.15);
-  color: var(--danger-color, #f87171);
+  color: var(--danger, #f87171);
 }
 
 /* Dark mode context menu */
@@ -689,7 +689,7 @@
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-item:hover {
-  background: var(--hover-bg, #334155);
+  background: var(--bg-hover, #334155);
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-item.danger:hover {

--- a/src/ui/SyncStatusBadge.css
+++ b/src/ui/SyncStatusBadge.css
@@ -35,7 +35,7 @@
 }
 
 .sync-status--syncing {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: rgba(31, 51, 84, 0.1);
 }
 

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -109,7 +109,7 @@
 }
 
 .tiptap-editor .ProseMirror .spellcheck-error {
-  text-decoration: underline wavy var(--color-error, #dc2626);
+  text-decoration: underline wavy var(--danger, #dc2626);
   text-decoration-skip-ink: none;
 }
 

--- a/src/ui/VersionConflictDialog.css
+++ b/src/ui/VersionConflictDialog.css
@@ -17,7 +17,7 @@
 
 .version-conflict-dialog {
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--color-border, #363649);
+  border: 1px solid var(--border-color, #363649);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   width: 440px;
@@ -33,20 +33,20 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--color-border, #363649);
+  border-bottom: 1px solid var(--border-color, #363649);
 }
 
 .version-conflict-dialog__header h3 {
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
 }
 
 .version-conflict-dialog__close {
   background: none;
   border: none;
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
   font-size: 20px;
   cursor: pointer;
   padding: 2px 6px;
@@ -56,7 +56,7 @@
 
 .version-conflict-dialog__close:hover {
   background: var(--color-bg-hover, #2a2a3d);
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
 }
 
 .version-conflict-dialog__content {
@@ -67,7 +67,7 @@
 .version-conflict-dialog__message {
   margin: 0 0 8px;
   font-size: 13px;
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
   line-height: 1.5;
 }
 
@@ -110,7 +110,7 @@
 }
 
 .version-conflict-dialog__option--danger.version-conflict-dialog__option--selected {
-  border-color: var(--color-error, #e06060);
+  border-color: var(--danger, #e06060);
 }
 
 .version-conflict-dialog__option input[type='radio'] {
@@ -126,7 +126,7 @@
 
 .version-conflict-dialog__option-label {
   font-size: 13px;
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
 }
 
 .version-conflict-dialog__option-note {
@@ -139,7 +139,7 @@
   margin: 0 0 16px;
   padding: 10px 12px;
   font-size: 12px;
-  color: var(--color-text-secondary, #999);
+  color: var(--text-secondary, #999);
   background: var(--color-bg-secondary, #252537);
   border-radius: 6px;
   line-height: 1.5;
@@ -154,9 +154,9 @@
 .version-conflict-dialog__btn {
   padding: 8px 16px;
   border-radius: 6px;
-  border: 1px solid var(--color-border, #363649);
+  border: 1px solid var(--border-color, #363649);
   background: var(--color-bg-secondary, #252537);
-  color: var(--color-text-primary, #e0e0e0);
+  color: var(--text-primary, #e0e0e0);
   font-size: 13px;
   cursor: pointer;
   transition: background 0.1s;
@@ -177,8 +177,8 @@
 }
 
 .version-conflict-dialog__btn--danger {
-  background: var(--color-error, #e06060);
-  border-color: var(--color-error, #e06060);
+  background: var(--danger, #e06060);
+  border-color: var(--danger, #e06060);
 }
 
 @keyframes vcd-fadeIn {

--- a/src/ui/settings/BackupSettings.css
+++ b/src/ui/settings/BackupSettings.css
@@ -48,7 +48,7 @@
 .backup-option-row input[type="checkbox"] {
   width: 16px;
   height: 16px;
-  accent-color: var(--accent-color, #3b82f6);
+  accent-color: var(--color-primary, #3b82f6);
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -75,7 +75,7 @@
 
 .backup-link-btn {
   font-size: 12px;
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: none;
   border: none;
   cursor: pointer;
@@ -84,7 +84,7 @@
 }
 
 .backup-link-btn:hover {
-  color: var(--accent-hover, #2563eb);
+  color: var(--color-primary-dark, #2563eb);
 }
 
 /* Size estimation */
@@ -129,7 +129,7 @@
 .backup-btn-primary {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .backup-btn-primary:hover:not(:disabled) {
@@ -171,7 +171,7 @@
 
 .backup-progress-bar-fill {
   height: 100%;
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-primary, #3b82f6);
   border-radius: 3px;
   transition: width 0.3s ease;
 }
@@ -195,7 +195,7 @@
 
 .backup-dropzone:hover,
 .backup-dropzone.drag-active {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   background: var(--bg-hover, #f1f5f9);
 }
 
@@ -206,12 +206,12 @@
 }
 
 .backup-dropzone-label strong {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
 }
 
 .backup-dropzone-hint {
   font-size: 11px;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   margin: 4px 0 0;
 }
 
@@ -244,7 +244,7 @@
 }
 
 .backup-validation-warning {
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning, #f59e0b);
   font-size: 12px;
   margin: 4px 0 0;
 }
@@ -270,24 +270,24 @@
 }
 
 .backup-mode-option:hover {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .backup-mode-option.active {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   background: var(--accent-bg, #eff6ff);
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   font-weight: 600;
 }
 
 .backup-mode-description {
   font-size: 11px;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   margin-top: 2px;
 }
 
 .backup-mode-option.active .backup-mode-description {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   opacity: 0.75;
 }
 
@@ -299,7 +299,7 @@
 .backup-conflicts-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning, #f59e0b);
   margin: 0 0 8px;
 }
 
@@ -321,7 +321,7 @@
 
 .backup-conflict-type {
   font-size: 11px;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   text-transform: uppercase;
 }
 

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -37,7 +37,7 @@
 
 .document-browser__action:hover {
   background: var(--bg-hover, #f8fafc);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   transform: translateY(-1px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
@@ -48,13 +48,13 @@
 
 .document-browser__action--primary {
   background: var(--color-cta);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   color: var(--color-cta-text);
 }
 
 .document-browser__action--primary:hover {
   background: var(--color-cta-hover);
-  border-color: var(--accent-hover, #2563eb);
+  border-color: var(--color-primary-dark, #2563eb);
   box-shadow: 0 4px 12px rgba(31, 51, 84, 0.25);
 }
 
@@ -101,7 +101,7 @@
 .document-browser__refresh:hover {
   background: var(--bg-hover, #f1f5f9);
   color: var(--text-primary, #1e293b);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .document-browser__refresh:disabled {
@@ -157,7 +157,7 @@
 }
 
 .document-browser__search:focus {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
@@ -197,7 +197,7 @@
 
 .document-browser__filter-btn--active {
   background: var(--bg-primary, #ffffff);
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   font-weight: 600;
 }
@@ -342,11 +342,11 @@
 }
 
 .document-browser__select-input:hover {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .document-browser__select-input:focus {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.15);
 }
 
@@ -378,7 +378,7 @@
 
 .document-browser__view-btn--active {
   background: var(--bg-primary, #ffffff);
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
@@ -398,8 +398,8 @@
 }
 
 .document-browser__new-group-btn:hover {
-  border-color: var(--accent-color, #3b82f6);
-  color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary, #3b82f6);
 }
 
 /* Grid layout for the doc list */
@@ -425,7 +425,7 @@
 .document-browser__selection-count {
   font-size: 12px;
   font-weight: 600;
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
 }
 
 .document-browser__selection-actions {
@@ -447,8 +447,8 @@
 }
 
 .document-browser__bulk-btn:hover {
-  border-color: var(--accent-color, #3b82f6);
-  color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary, #3b82f6);
 }
 
 .document-browser__bulk-btn--danger:hover {
@@ -495,7 +495,7 @@
 }
 
 .document-browser__assign-item--new {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   font-weight: 500;
 }
 

--- a/src/ui/settings/DocumentsSettings.css
+++ b/src/ui/settings/DocumentsSettings.css
@@ -28,18 +28,18 @@
 
 .documents-action-btn:hover {
   background: var(--bg-hover, #f1f5f9);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .documents-action-btn.documents-action-primary {
   background: var(--color-cta);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   color: var(--color-cta-text);
 }
 
 .documents-action-btn.documents-action-primary:hover {
   background: var(--color-cta-hover);
-  border-color: var(--accent-hover, #2563eb);
+  border-color: var(--color-primary-dark, #2563eb);
 }
 
 .documents-action-icon {
@@ -176,7 +176,7 @@
   font-weight: 500;
   color: var(--text-primary, #1e293b);
   background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--accent-color, #3b82f6);
+  border: 1px solid var(--color-primary, #3b82f6);
   border-radius: 4px;
   outline: none;
   width: 100%;
@@ -228,7 +228,7 @@
   padding: 2px 6px;
   font-size: 10px;
   font-weight: 600;
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: var(--accent-bg, rgba(31, 51, 84, 0.1));
   border-radius: 4px;
   text-transform: uppercase;
@@ -247,7 +247,7 @@
 
 :root[data-theme='dark'] .documents-action-btn.documents-action-primary {
   background: var(--color-cta);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   color: var(--color-cta-text);
 }
 
@@ -308,7 +308,7 @@
 
 /* Transfer button */
 .documents-item-btn-transfer.to-relay {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
 }
 
 .documents-item-btn-transfer.to-personal {
@@ -390,7 +390,7 @@
 
 .documents-transfer-modal-btn-confirm {
   background: var(--color-cta);
-  border: 1px solid var(--accent-color, #3b82f6);
+  border: 1px solid var(--color-primary, #3b82f6);
   color: var(--color-cta-text);
 }
 

--- a/src/ui/settings/GeneralSettings.css
+++ b/src/ui/settings/GeneralSettings.css
@@ -85,7 +85,7 @@
   display: block;
   margin-top: 6px;
   font-size: 12px;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
 }
 
 /* Checkbox rows */
@@ -130,16 +130,16 @@
   padding: 8px 16px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--danger-color, #ef4444);
+  color: var(--danger, #ef4444);
   background: transparent;
-  border: 1px solid var(--danger-color, #ef4444);
+  border: 1px solid var(--danger, #ef4444);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .settings-reset-btn:hover {
-  background: var(--danger-color, #ef4444);
+  background: var(--danger, #ef4444);
   color: white;
 }
 
@@ -171,12 +171,12 @@
 }
 
 :root[data-theme='dark'] .settings-select:focus {
-  border-color: var(--accent-color, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
   box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.15);
 }
 
 :root[data-theme='dark'] .settings-hint {
-  color: var(--text-tertiary, #64748b);
+  color: var(--text-muted, #64748b);
 }
 
 :root[data-theme='dark'] .settings-checkbox-text {
@@ -184,12 +184,12 @@
 }
 
 :root[data-theme='dark'] .settings-reset-btn {
-  color: var(--danger-color, #f87171);
-  border-color: var(--danger-color, #f87171);
+  color: var(--danger, #f87171);
+  border-color: var(--danger, #f87171);
 }
 
 :root[data-theme='dark'] .settings-reset-btn:hover {
-  background: var(--danger-color, #f87171);
+  background: var(--danger, #f87171);
   color: var(--bg-primary, #0f172a);
 }
 
@@ -220,12 +220,12 @@
 }
 
 .settings-checkbox:hover {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .settings-checkbox:checked {
-  background: var(--accent-color, #3b82f6);
-  border-color: var(--accent-color, #3b82f6);
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .settings-checkbox:checked::after {
@@ -251,12 +251,12 @@
 }
 
 :root[data-theme='dark'] .settings-checkbox:hover {
-  border-color: var(--accent-color, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
 }
 
 :root[data-theme='dark'] .settings-checkbox:checked {
-  background: var(--accent-color, #60a5fa);
-  border-color: var(--accent-color, #60a5fa);
+  background: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
 }
 
 :root[data-theme='dark'] .settings-checkbox:focus {

--- a/src/ui/settings/RelaySettings.css
+++ b/src/ui/settings/RelaySettings.css
@@ -15,7 +15,7 @@
   padding: 1px 6px;
   font-size: 12px;
   background: var(--color-bg, #f8fafc);
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 4px;
 }
 
@@ -25,7 +25,7 @@
   gap: 14px;
   padding: 18px;
   background: var(--color-bg-secondary, #ffffff);
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 8px;
 }
 
@@ -93,7 +93,7 @@
   font-size: 14px;
   color: var(--color-text, #1e293b);
   background: var(--color-bg, #ffffff);
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 6px;
   transition: border-color 0.15s ease;
 }
@@ -139,7 +139,7 @@
 .relay-settings__btn--secondary {
   color: var(--color-text, #1e293b);
   background: var(--color-bg, #f1f5f9);
-  border-color: var(--color-border, #e2e8f0);
+  border-color: var(--border-color, #e2e8f0);
   align-self: flex-start;
 }
 
@@ -232,7 +232,7 @@
   letter-spacing: 4px;
   color: var(--color-text, #1e293b);
   background: var(--color-bg, #f1f5f9);
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 8px;
 }
 

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -30,7 +30,7 @@
 }
 
 .storage-tab.active {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: var(--bg-primary, #ffffff);
   border-color: var(--border-color, #e2e8f0);
   border-bottom-color: transparent;
@@ -60,7 +60,7 @@
 }
 
 .storage-stat-warning .storage-stat-value {
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning, #f59e0b);
 }
 
 /* Progress bar */
@@ -74,7 +74,7 @@
 
 .storage-progress-bar {
   height: 100%;
-  background: var(--accent-color, #3b82f6);
+  background: var(--color-primary, #3b82f6);
   border-radius: 3px;
   transition: width 0.3s ease;
 }
@@ -112,18 +112,18 @@
 .storage-btn-primary {
   color: var(--color-cta-text);
   background: var(--color-cta);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .storage-btn-primary:hover:not(:disabled) {
   background: var(--color-cta-hover);
-  border-color: var(--accent-hover, #2563eb);
+  border-color: var(--color-primary-dark, #2563eb);
 }
 
 .storage-btn-danger {
   color: white;
-  background: var(--danger-color, #ef4444);
-  border-color: var(--danger-color, #ef4444);
+  background: var(--danger, #ef4444);
+  border-color: var(--danger, #ef4444);
 }
 
 .storage-btn-danger:hover:not(:disabled) {
@@ -148,7 +148,7 @@
 .storage-empty {
   padding: 32px;
   text-align: center;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   font-size: 13px;
 }
 
@@ -199,13 +199,13 @@
   padding: 2px 6px;
   font-size: 10px;
   font-weight: 500;
-  color: var(--warning-color, #f59e0b);
+  color: var(--warning, #f59e0b);
   background: rgba(245, 158, 11, 0.1);
   border-radius: 4px;
 }
 
 .storage-orphan-badge.protected {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: rgba(31, 51, 84, 0.1);
 }
 
@@ -215,7 +215,7 @@
   padding: 1px 5px;
   font-size: 9px;
   font-weight: 600;
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: rgba(31, 51, 84, 0.1);
   border-radius: 3px;
   text-transform: uppercase;
@@ -224,9 +224,9 @@
 .storage-delete-btn {
   padding: 4px 8px;
   font-size: 11px;
-  color: var(--danger-color, #ef4444);
+  color: var(--danger, #ef4444);
   background: transparent;
-  border: 1px solid var(--danger-color, #ef4444);
+  border: 1px solid var(--danger, #ef4444);
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -234,7 +234,7 @@
 
 .storage-delete-btn:hover {
   color: white;
-  background: var(--danger-color, #ef4444);
+  background: var(--danger, #ef4444);
 }
 
 /* Icon grid */
@@ -281,7 +281,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   font-size: 16px;
 }
 
@@ -315,7 +315,7 @@
 }
 
 .storage-icon-type.custom {
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: rgba(31, 51, 84, 0.1);
 }
 
@@ -327,7 +327,7 @@
   height: 18px;
   font-size: 12px;
   line-height: 1;
-  color: var(--text-tertiary, #94a3b8);
+  color: var(--text-muted, #94a3b8);
   background: transparent;
   border: none;
   border-radius: 3px;
@@ -341,7 +341,7 @@
 }
 
 .storage-icon-delete:hover {
-  color: var(--danger-color, #ef4444);
+  color: var(--danger, #ef4444);
   background: rgba(239, 68, 68, 0.1);
 }
 
@@ -401,7 +401,7 @@
 }
 
 :root[data-theme='dark'] .storage-tab.active {
-  color: var(--accent-color, #60a5fa);
+  color: var(--color-primary, #60a5fa);
   background: var(--bg-primary, #1e293b);
   border-color: var(--border-color, #334155);
 }

--- a/src/ui/settings/StyleProfileSettings.css
+++ b/src/ui/settings/StyleProfileSettings.css
@@ -30,7 +30,7 @@
   justify-content: center;
   font-size: 12px;
   font-weight: 600;
-  color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
   background: rgba(31, 51, 84, 0.1);
   border-radius: 50%;
 }
@@ -56,7 +56,7 @@
 }
 
 :root[data-theme='dark'] .settings-info-icon {
-  color: var(--accent-color, #60a5fa);
+  color: var(--color-primary, #60a5fa);
   background: rgba(224, 198, 144, 0.15);
 }
 

--- a/src/ui/viewers/ImageViewer.css
+++ b/src/ui/viewers/ImageViewer.css
@@ -45,7 +45,7 @@
 
 .image-viewer-btn.active {
   background: var(--color-cta);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   color: var(--color-cta-text);
 }
 
@@ -114,8 +114,8 @@
 }
 
 [data-theme="dark"] .image-viewer-btn.active {
-  background: var(--accent-color, #60a5fa);
-  border-color: var(--accent-color, #60a5fa);
+  background: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary, #60a5fa);
   color: #0f172a;
 }
 

--- a/src/ui/viewers/PdfViewer.css
+++ b/src/ui/viewers/PdfViewer.css
@@ -66,12 +66,12 @@
 .pdf-viewer__btn--active {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 .pdf-viewer__btn--active:hover:not(:disabled) {
-  background: var(--accent-color, #3b82f6);
-  border-color: var(--accent-color, #3b82f6);
+  background: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   opacity: 0.9;
 }
 
@@ -106,7 +106,7 @@
 
 .pdf-viewer__page-input:focus {
   outline: none;
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
@@ -176,7 +176,7 @@
   width: 32px;
   height: 32px;
   border: 3px solid var(--border-color, #e2e8f0);
-  border-top-color: var(--accent-color, #3b82f6);
+  border-top-color: var(--color-primary, #3b82f6);
   border-radius: 50%;
   animation: pdf-viewer-spin 0.8s linear infinite;
 }
@@ -219,7 +219,7 @@
 [data-theme="dark"] .pdf-viewer__btn--active {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
 }
 
 [data-theme="dark"] .pdf-viewer__page-input {
@@ -229,7 +229,7 @@
 }
 
 [data-theme="dark"] .pdf-viewer__page-input:focus {
-  border-color: var(--accent-color, #3b82f6);
+  border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.25);
 }
 

--- a/src/ui/viewers/SpreadsheetViewer.css
+++ b/src/ui/viewers/SpreadsheetViewer.css
@@ -26,7 +26,7 @@
   width: 28px;
   height: 28px;
   border: 3px solid var(--border-color, #e2e8f0);
-  border-top-color: var(--accent-color, #3b82f6);
+  border-top-color: var(--color-primary, #3b82f6);
   border-radius: 50%;
   animation: spreadsheet-spin 0.8s linear infinite;
 }
@@ -96,8 +96,8 @@
 }
 
 .spreadsheet-tab.active {
-  color: var(--accent-color, #3b82f6);
-  border-bottom-color: var(--accent-color, #3b82f6);
+  color: var(--color-primary, #3b82f6);
+  border-bottom-color: var(--color-primary, #3b82f6);
 }
 
 /* Scroll container */

--- a/src/ui/viewers/TextViewer.css
+++ b/src/ui/viewers/TextViewer.css
@@ -34,7 +34,7 @@
 }
 
 .text-viewer-wrap-toggle input[type="checkbox"] {
-  accent-color: var(--accent-color, #3b82f6);
+  accent-color: var(--color-primary, #3b82f6);
   cursor: pointer;
 }
 


### PR DESCRIPTION
## What

Retires the **alias/shim tokens** JP-147 (#39) added to bridge older competing token names onto the brand. Every consumer is migrated onto the canonical tokens, then the shims are deleted from `index.css` — one source of truth.

## How — value-preserving rename

Grep-verified the 11 alias names are used **only in CSS** (0 TS/TSX) and **defined only in `index.css`** as `--alias: var(--canonical)`, with each canonical token always defined. So renaming consumers renders identically. Inline fallbacks are left intact (inert). **275 references across 38 files:**

| alias → canonical | alias → canonical |
|---|---|
| `--accent-color` → `--color-primary` | `--text-tertiary` → `--text-muted` |
| `--accent-hover` → `--color-primary-dark` | `--color-border` → `--border-color` |
| `--hover-bg` → `--bg-hover` | `--danger-color` → `--danger` |
| `--color-text-primary` → `--text-primary` | `--color-error` → `--danger` |
| `--color-text-secondary` → `--text-secondary` | `--warning-color` → `--warning` |
| `--text-color` → `--text-primary` | |

Then the 11-line alias block is removed from `index.css`. A regex lookahead guard ensured the distinct (undefined) `--accent-color-dark` was **not** clobbered.

## Scope corrections vs the issue text

- The "~17 per-file `:root` blocks" are `:root[data-theme="dark"] .component {…}` **dark-mode selector scopes**, not token redefinitions — deleting them would break dark mode, so they **stay**.
- The ~14 *undefined* competing tokens (`--panel-bg`/`--panel-hover` render transparent today, `--note-*`, `--color-warning`, etc.) are a separate visual change → **JP-158**.

## Verification

- ✅ Grep gate: zero remaining definitions **or** consumers of the 11 alias names.
- ✅ `bun run typecheck` clean · `bun run test --run` 1734 passed · `bun run build` green.
- Visual: value-preserving rename — settings dialogs/panels/banners/pickers render identically in light/dark.

Assisted-by: Opus 4.8