### PR TITLE
JP-152: make the gold CTA actually render on primary buttons

### DIFF
--- a/src/ui/ColorPalette.css
+++ b/src/ui/ColorPalette.css
@@ -144,7 +144,7 @@
 }
 
 .color-palette-info-btn:hover {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 
@@ -276,7 +276,7 @@
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--color-cta-text);
-  background: var(--color-cta));
+  background: var(--color-cta);
   border: none;
   border-radius: 4px;
   cursor: pointer;

--- a/src/ui/CompactColorInput.css
+++ b/src/ui/CompactColorInput.css
@@ -166,7 +166,7 @@
 }
 
 .compact-color-edit:hover {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
   border-color: var(--color-primary, var(--color-primary));
 }

--- a/src/ui/DocumentManager.css
+++ b/src/ui/DocumentManager.css
@@ -95,7 +95,7 @@
 }
 
 .document-manager-action-btn.primary:hover {
-  background-color: var(--color-primary-hover);
+  background-color: var(--color-cta-hover);
 }
 
 .document-manager-list {
@@ -260,7 +260,7 @@
 }
 
 .document-manager-btn.primary:hover:not(:disabled) {
-  background-color: var(--color-primary-hover);
+  background-color: var(--color-cta-hover);
 }
 
 /* Dark mode adjustments */

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -110,7 +110,7 @@
 }
 
 .export-format-btn.active {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 
@@ -281,7 +281,7 @@
 }
 
 .export-btn-primary {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -130,7 +130,7 @@
   padding: var(--space-2) var(--space-4);
   border: none;
   border-radius: var(--radius-md);
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
@@ -263,7 +263,7 @@
 }
 
 .layer-view-edit-actions button:first-child {
-  background: var(--color-cta));
+  background: var(--color-cta);
   border-color: var(--color-primary, var(--color-primary));
   color: var(--color-cta-text);
 }
@@ -438,7 +438,7 @@
 }
 
 .layer-view-preview-type {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
   padding: var(--space-0-5) var(--space-1-5);
   border-radius: var(--radius-sm);

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -183,13 +183,13 @@
 }
 
 .logo-picker-btn-primary {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
   border: none;
 }
 
 .logo-picker-btn-primary:hover {
-  background: var(--color-cta-hover));
+  background: var(--color-cta-hover);
 }
 
 .logo-picker-btn-secondary {

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -245,7 +245,7 @@
 }
 
 .pdf-export-toggle button.active {
-  background: var(--color-cta));
+  background: var(--color-cta);
   border-color: var(--color-primary, var(--color-primary));
   color: var(--color-cta-text);
 }
@@ -426,13 +426,13 @@
 }
 
 .pdf-export-btn-primary {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
   border: none;
 }
 
 .pdf-export-btn-primary:hover:not(:disabled) {
-  background: var(--color-cta-hover));
+  background: var(--color-cta-hover);
 }
 
 .pdf-export-btn-primary:disabled {

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -202,7 +202,7 @@
 }
 
 .save-to-library-create-btn {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 
@@ -270,7 +270,7 @@
 }
 
 .save-to-library-btn-primary {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -152,7 +152,7 @@
 }
 
 .shape-library-create-btn {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 
@@ -204,7 +204,7 @@
 }
 
 .shape-library-item.selected {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -132,7 +132,7 @@
 }
 
 .status-bar-zoom-btn:active {
-  background: var(--color-cta));
+  background: var(--color-cta);
   color: var(--color-cta-text);
 }
 

--- a/src/ui/settings/RelaySettings.css
+++ b/src/ui/settings/RelaySettings.css
@@ -133,7 +133,7 @@
 }
 
 .relay-settings__btn--primary:not(:disabled):hover {
-  background: var(--color-primary-hover, #1d4ed8);
+  background: var(--color-cta-hover);
 }
 
 .relay-settings__btn--secondary {


### PR DESCRIPTION
## What

Makes the gold CTA that JP-150 *coded* onto primary buttons **actually render** — it was silently broken.

## Root cause

JP-150's CTA conversion left a stray closing paren, producing **18 invalid declarations** — all `background: var(--color-cta));` / `var(--color-cta-hover));` (one `var(`, extra `)`). Browsers drop an invalid declaration, so those buttons + active-states fell back to a gray/unstyled background. CSS semantic errors don't fail `tsc`/Vitest/Vite build and the gray looked "fine enough," so it shipped in #40.

## Changes

- **Part A** — fix the 18 invalid declarations → single paren, across 9 files (ExportDialog, PDFExportDialog, SaveToLibraryDialog, LogoPicker, ColorPalette, CompactColorInput, StatusBar, ShapeLibraryManager, LayerViewManager). The intended gold now renders on dialog primary/confirm buttons, manager buttons, and picker active-states + selected colour swatches.
- **Part B** — 3 gold-CTA buttons used an **undefined** `--color-primary-hover` for `:hover` (rendered a stale blue) → repoint to `--color-cta-hover` (DocumentManager ×2, RelaySettings ×1). `--color-primary-hover` is now eliminated entirely.

Scope held tight per the plan: the 102 *valid-but-redundant* `var(--x, var(--x))` self-fallbacks are left alone (cosmetic), and `DocumentChangedBanner`'s off-brand blue Reload → JP-158 (undefined tokens).

## Verification

- ✅ Grep gate: **zero** `var(--color-cta…))` and **zero** `--color-primary-hover` remaining.
- ✅ `bun run typecheck` clean · `bun run test --run` 1734 passed · `bun run build` green.
- 👀 **Visible change** (light + dark): the affected primary buttons / active-states go from broken gray → **gold fill + navy text**; gold-button hovers deepen to gold (not blue). Worth an eyeball — this is the fix landing.

Assisted-by: Opus 4.8