### PR TITLE
Soften dark-mode prose editor background with subtle gradient

### DIFF
--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -6,6 +6,20 @@
   background-color: var(--bg-primary);
 }
 
+/* Dark mode: replace the flat navy slab with a soft top-center glow that
+ * settles into the deep page navy — adds depth without an aggressive blue
+ * block. Stays within the navy elevation ladder (raised -> surface -> page).
+ * Applied to the panel so the toolbar + prose share one continuous backdrop;
+ * the prose surface (.tiptap-editor) is transparent in dark mode to show it. */
+[data-theme="dark"] .document-editor-panel {
+  background: radial-gradient(
+    140% 90% at 50% 0%,
+    #16273f 0%,
+    #0e1c30 42%,
+    #0a1525 100%
+  );
+}
+
 .document-editor-panel-collapse {
   display: flex;
   align-items: center;

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -4,6 +4,12 @@
   background-color: var(--bg-primary);
 }
 
+/* Dark mode: let the panel's gradient backdrop show through the prose surface
+ * so the two don't paint competing flat fills (see DocumentEditorPanel.css). */
+[data-theme="dark"] .tiptap-editor {
+  background-color: transparent;
+}
+
 .tiptap-editor .ProseMirror {
   min-height: 100%;
   padding: 1rem;


### PR DESCRIPTION
## Problem

In dark mode the prose editor rendered as a flat slab of `--bg-primary`
(`#0e1c30`) navy — a large, polarizing blue block on the primary reading
surface.

## Change

Replace the flat fill with a soft top-center **radial glow** built entirely
from the existing dark navy elevation ladder (raised `#16273f` → surface
`#0e1c30` → page `#0a1525`), so it adds depth while staying on-brand and not
aggressive.

- `DocumentEditorPanel.css` — gradient applied to the panel (dark mode only),
  so the toolbar/ribbon and prose share one continuous backdrop.
- `TiptapEditor.css` — prose surface goes transparent in dark mode so the
  panel gradient shows through (no competing flat fill / seam).

**Light/warm-paper mode is untouched** — the complaint was dark-mode only.

## Verification

- Dark mode, Relaxed layout: gentle top-center lift fading to deep navy, stays
  fixed while scrolling; no seam between ribbon and prose body.
- Light mode: visually unchanged.
- Fullscreen reading + Technician/Power split inherit the panel rule correctly.

Tuning knobs if needed: the `42%` mid-stop and the `140% 90% at 50% 0%` glow
size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)