### PR TITLE
Route connector/group label rendering through the label engine (JP-161)

### DIFF
--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -15,6 +15,9 @@ import {
 } from './Shape';
 import { isAutoColor } from '../engine/ContrastResolver';
 import { getRenderContext } from '../engine/RenderContext';
+import { renderLabel } from './label/renderLabel';
+import { CONNECTOR_LABEL_SPEC } from './label/specs';
+import type { LabelOverflow } from './label/LabelSpec';
 
 /**
  * Resolve a stroke colour at the midpoint of a single line segment, sampling
@@ -720,57 +723,36 @@ function renderConnectorLabel(
   color: string,
   backgroundColor?: string,
   offsetX: number = 0,
-  offsetY: number = 0
+  offsetY: number = 0,
+  overflow?: LabelOverflow
 ): void {
-  ctx.save();
-
-  // Apply offset to position
-  const drawX = position.x + offsetX;
-  const drawY = position.y + offsetY;
-
-  ctx.font = `${fontSize}px sans-serif`;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-
-  // Background semantics:
-  //   undefined          → unset; draw the legacy default white pill for readability
-  //   '' (or 'transparent') → user explicitly chose No Fill; skip background entirely
-  //   <colour>           → draw with that colour
+  // Background tri-state, resolved here so the label engine stays generic:
+  //   undefined            → legacy default white pill (with subtle border)
+  //   '' (or 'transparent') → user chose No Fill; no pill
+  //   <colour>             → that colour, no border
   const noBackground = backgroundColor === '' || backgroundColor === 'transparent';
   const usingDefault = backgroundColor === undefined;
+  const pillColor = noBackground ? undefined : backgroundColor || 'rgba(255, 255, 255, 0.9)';
 
-  if (!noBackground) {
-    const metrics = ctx.measureText(label);
-    const padding = 4;
-    const bgWidth = metrics.width + padding * 2;
-    const bgHeight = fontSize + padding * 2;
-
-    const bgColor = backgroundColor || 'rgba(255, 255, 255, 0.9)';
-    ctx.fillStyle = bgColor;
-    ctx.fillRect(
-      drawX - bgWidth / 2,
-      drawY - bgHeight / 2,
-      bgWidth,
-      bgHeight
-    );
-
-    // Subtle border only on the legacy default pill.
-    if (usingDefault) {
-      ctx.strokeStyle = 'rgba(0, 0, 0, 0.2)';
-      ctx.lineWidth = 1;
-      ctx.strokeRect(
-        drawX - bgWidth / 2,
-        drawY - bgHeight / 2,
-        bgWidth,
-        bgHeight
-      );
-    }
-  }
-
-  // Draw text
-  ctx.fillStyle = color;
-  ctx.fillText(label, drawX, drawY);
-
+  ctx.save();
+  ctx.translate(position.x, position.y);
+  renderLabel(ctx, {
+    text: label,
+    spec: CONNECTOR_LABEL_SPEC,
+    overflow,
+    // Single-line label; the box only governs the (rare) overflow clip flag.
+    boxWidth: 1000,
+    boxHeight: fontSize * 2,
+    fontSize,
+    color,
+    background: pillColor,
+    backgroundBorder: usingDefault,
+    backgroundPadX: 8,
+    backgroundPadY: 8,
+    anchor: { textAlign: 'center', textBaseline: 'middle' },
+    offsetX,
+    offsetY,
+  });
   ctx.restore();
 }
 
@@ -981,7 +963,7 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
       const offsetX = shape.labelOffsetX ?? 0;
       const offsetY = shape.labelOffsetY ?? 0;
 
-      renderConnectorLabel(ctx, shape.label, point, fontSize, color, backgroundColor, offsetX, offsetY);
+      renderConnectorLabel(ctx, shape.label, point, fontSize, color, backgroundColor, offsetX, offsetY, shape.labelOverflow);
     }
 
     // Draw guard condition if present (for activity diagrams)

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -7,6 +7,8 @@ import { createPatternFill, createRoundedRectPath } from '../utils/patternUtils'
 import type { GroupLabelPosition } from './GroupStyles';
 import { isAutoColor } from '../engine/ContrastResolver';
 import { getRenderContext } from '../engine/RenderContext';
+import { renderLabel } from './label/renderLabel';
+import { GROUP_LABEL_SPEC } from './label/specs';
 
 /**
  * Resolve the AUTO sentinel against the active render frame, sampling at the
@@ -213,49 +215,26 @@ export const groupHandler: GroupShapeHandler = {
 
     ctx.save();
     ctx.globalAlpha = shape.opacity * parentOpacity;
-
-    // Apply offsets
-    const drawX = pos.x + labelOffsetX;
-    const drawY = pos.y + labelOffsetY;
-
-    ctx.font = `${fontSize}px sans-serif`;
-    ctx.textAlign = pos.textAlign;
-    ctx.textBaseline = pos.textBaseline;
-
-    // Draw label background if specified
-    if (labelBackground) {
-      const metrics = ctx.measureText(shape.label);
-      const bgPadding = 4;
-
-      // Calculate background rect based on alignment
-      let bgX = drawX;
-      const bgWidth = metrics.width + bgPadding * 2;
-      const bgHeight = fontSize + bgPadding * 2;
-
-      if (pos.textAlign === 'center') {
-        bgX -= bgWidth / 2;
-      } else if (pos.textAlign === 'right') {
-        bgX -= bgWidth;
-      }
-
-      let bgY = drawY;
-      if (pos.textBaseline === 'middle') {
-        bgY -= bgHeight / 2;
-      } else if (pos.textBaseline === 'bottom') {
-        bgY -= bgHeight;
-      }
-
-      ctx.fillStyle = labelBackground;
-      const bgRadius = 4;
-      ctx.beginPath();
-      ctx.roundRect(bgX, bgY, bgWidth, bgHeight, bgRadius);
-      ctx.fill();
-    }
-
-    // Draw label text
-    ctx.fillStyle = labelColor;
-    ctx.fillText(shape.label, drawX, drawY);
-
+    // Anchor at the 9-grid point; the shared engine draws the (rounded) pill +
+    // text using the position's align/baseline. AUTO color already resolved.
+    ctx.translate(pos.x, pos.y);
+    renderLabel(ctx, {
+      text: shape.label,
+      spec: GROUP_LABEL_SPEC,
+      overflow: shape.labelOverflow,
+      boxWidth: 1000,
+      boxHeight: fontSize * 2,
+      fontSize,
+      color: labelColor,
+      background: labelBackground,
+      backgroundRound: true,
+      backgroundRadius: 4,
+      backgroundPadX: 8,
+      backgroundPadY: 8,
+      anchor: { textAlign: pos.textAlign, textBaseline: pos.textBaseline },
+      offsetX: labelOffsetX,
+      offsetY: labelOffsetY,
+    });
     ctx.restore();
   },
 

--- a/src/shapes/Shape.ts
+++ b/src/shapes/Shape.ts
@@ -513,6 +513,8 @@ export interface ConnectorShape extends BaseShape {
   labelOffsetX?: number;
   /** Label vertical offset from calculated position (default: 0) */
   labelOffsetY?: number;
+  /** How the label behaves when it overflows (default: 'overflow') */
+  labelOverflow?: LabelOverflow;
   /** ERD cardinality notation at start point (overrides startArrow) */
   startCardinality?: ERDCardinality;
   /** ERD cardinality notation at end point (overrides endArrow) */
@@ -625,6 +627,8 @@ export interface GroupShape extends BaseShape {
   labelOffsetX?: number;
   /** Label vertical offset from position (default: 0) */
   labelOffsetY?: number;
+  /** How the label behaves when it overflows (default: 'overflow') */
+  labelOverflow?: LabelOverflow;
   /** Label position anchor (default: 'top') */
   labelPosition?: import('./GroupStyles').GroupLabelPosition;
 

--- a/src/shapes/label/renderLabel.test.ts
+++ b/src/shapes/label/renderLabel.test.ts
@@ -1,29 +1,43 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderLabel } from './renderLabel';
-import { RECT_LABEL_SPEC } from './specs';
+import { RECT_LABEL_SPEC, CONNECTOR_LABEL_SPEC, GROUP_LABEL_SPEC } from './specs';
 import { clearMeasureCache } from './measureCache';
+
+type SpyCtx = CanvasRenderingContext2D & {
+  fillText: ReturnType<typeof vi.fn>;
+  fillRect: ReturnType<typeof vi.fn>;
+  strokeRect: ReturnType<typeof vi.fn>;
+  roundRect: ReturnType<typeof vi.fn>;
+};
 
 /**
  * Mock canvas context whose `measureText` is font-driven (`chars * fontPx * 0.5`)
- * so wrapping is deterministic; `fillText` is a spy for asserting drawn lines.
+ * so wrapping is deterministic; draw methods are spies for asserting output.
  */
-function makeCtx() {
+function makeCtx(): SpyCtx {
   const ctx = {
     font: '',
     fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
     textAlign: '',
     textBaseline: '',
     save: vi.fn(),
     restore: vi.fn(),
     translate: vi.fn(),
+    beginPath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
     fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    roundRect: vi.fn(),
     fillText: vi.fn(),
     measureText(text: string) {
       const px = parseInt(ctx.font, 10) || 0;
       return { width: text.length * px * 0.5 } as TextMetrics;
     },
   };
-  return ctx as unknown as CanvasRenderingContext2D & { fillText: ReturnType<typeof vi.fn> };
+  return ctx as unknown as SpyCtx;
 }
 
 const baseInput = {
@@ -69,11 +83,77 @@ describe('renderLabel', () => {
   });
 
   it('paints a background pill when a background color is supplied', () => {
-    const ctx = makeCtx() as CanvasRenderingContext2D & {
-      fillText: ReturnType<typeof vi.fn>;
-      fillRect: ReturnType<typeof vi.fn>;
-    };
+    const ctx = makeCtx();
     renderLabel(ctx, { ...baseInput, text: 'hi', background: '#ffffff' });
     expect(ctx.fillRect).toHaveBeenCalled();
+  });
+
+  describe('point-anchored mode', () => {
+    it('connector: draws text at the anchor with a square pill + border', () => {
+      const ctx = makeCtx();
+      renderLabel(ctx, {
+        spec: CONNECTOR_LABEL_SPEC,
+        boxWidth: 1000,
+        boxHeight: 24,
+        fontSize: 12,
+        color: '#000000',
+        background: 'rgba(255,255,255,0.9)',
+        backgroundBorder: true,
+        backgroundPadX: 8,
+        backgroundPadY: 8,
+        anchor: { textAlign: 'center', textBaseline: 'middle' },
+        offsetX: 0,
+        offsetY: 0,
+        text: 'edge',
+      });
+      expect(ctx.textAlign).toBe('center');
+      expect(ctx.textBaseline).toBe('middle');
+      expect(ctx.fillRect).toHaveBeenCalled(); // square pill
+      expect(ctx.strokeRect).toHaveBeenCalled(); // default-pill border
+      expect(ctx.fillText.mock.calls.map((c) => c[0])).toEqual(['edge']);
+      // single line drawn at the anchor origin
+      expect(ctx.fillText.mock.calls[0]![1]).toBe(0);
+      expect(ctx.fillText.mock.calls[0]![2]).toBe(0);
+    });
+
+    it('group: rounded pill, honoring the 9-grid baseline', () => {
+      const ctx = makeCtx();
+      renderLabel(ctx, {
+        spec: GROUP_LABEL_SPEC,
+        boxWidth: 1000,
+        boxHeight: 28,
+        fontSize: 14,
+        color: '#000000',
+        background: '#222222',
+        backgroundRound: true,
+        backgroundRadius: 4,
+        anchor: { textAlign: 'left', textBaseline: 'bottom' },
+        offsetX: 0,
+        offsetY: 0,
+        text: 'Group A',
+      });
+      expect(ctx.roundRect).toHaveBeenCalled();
+      expect(ctx.textAlign).toBe('left');
+      expect(ctx.textBaseline).toBe('bottom');
+      expect(ctx.fillText.mock.calls.map((c) => c[0])).toEqual(['Group A']);
+    });
+
+    it('no pill when background is undefined (No Fill)', () => {
+      const ctx = makeCtx();
+      renderLabel(ctx, {
+        spec: CONNECTOR_LABEL_SPEC,
+        boxWidth: 1000,
+        boxHeight: 24,
+        fontSize: 12,
+        color: '#000000',
+        background: undefined,
+        anchor: { textAlign: 'center', textBaseline: 'middle' },
+        offsetX: 0,
+        offsetY: 0,
+        text: 'x',
+      });
+      expect(ctx.fillRect).not.toHaveBeenCalled();
+      expect(ctx.strokeRect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/shapes/label/renderLabel.ts
+++ b/src/shapes/label/renderLabel.ts
@@ -1,13 +1,16 @@
 /**
  * Canvas label renderer — the single replacement for the per-handler label
- * blocks that were duplicated across Rectangle/Ellipse/Library (and, in later
- * phases, Connector/Group/File).
+ * blocks that were duplicated across Rectangle/Ellipse/Library/Line and
+ * Connector/Group/File.
  *
- * Contract: the caller has already transformed `ctx` so the label's anchor
- * origin is at `(0, 0)` (e.g. shape center for `inside-centered`, the mid-path
- * point for `along-path`, the 9-grid anchor for groups). This function applies
- * the label offset, lays out the text via the pure `layoutLabel`, optionally
- * paints a background pill, and draws the lines with the spec's alignment.
+ * Two anchoring modes:
+ *
+ * - **Box-anchored** (default): the caller has transformed `ctx` so the shape
+ *   *center* is at the origin; text is aligned within a `boxWidth × boxHeight`
+ *   inset region (rectangles, ellipses, library shapes, line midpoints).
+ * - **Point-anchored** (`input.anchor` present): the origin *is* the text
+ *   anchor, drawn with the given `textAlign`/`textBaseline` (connector mid-path,
+ *   group 9-grid). The background pill follows the anchor.
  *
  * LaTeX labels (text starting with `=`) are delegated to the existing
  * `renderLatexText` path unchanged.
@@ -35,6 +38,21 @@ export interface LabelRenderInput {
   color: string;
   /** Optional background pill color. */
   background?: string | undefined;
+  /** Draw a subtle 1px border around the pill (the connector default pill). */
+  backgroundBorder?: boolean | undefined;
+  /** Draw the pill with rounded corners (groups). */
+  backgroundRound?: boolean | undefined;
+  /** Corner radius when `backgroundRound`. Default 4. */
+  backgroundRadius?: number | undefined;
+  /** Total horizontal pill padding (added to text width). Default 12. */
+  backgroundPadX?: number | undefined;
+  /** Total vertical pill padding (added to text height). Default 8. */
+  backgroundPadY?: number | undefined;
+  /**
+   * Point-anchored mode. When set, the origin is the text anchor drawn with
+   * these canvas alignment values (instead of box-edge alignment).
+   */
+  anchor?: { textAlign: CanvasTextAlign; textBaseline: CanvasTextBaseline } | undefined;
   /** Label offset from the anchor origin. */
   offsetX: number;
   offsetY: number;
@@ -42,12 +60,58 @@ export interface LabelRenderInput {
   requestRender?: (() => void) | undefined;
 }
 
-/** Padding around the background pill, matching the historical values. */
+/** Default padding around the background pill, matching the historical values. */
 const BG_PAD_X = 12;
 const BG_PAD_Y = 8;
+const BG_BORDER_COLOR = 'rgba(0, 0, 0, 0.2)';
+
+/**
+ * Compute the top-left corner of the background pill.
+ * Box-anchored pills are centered; point-anchored pills follow the text
+ * align/baseline so the pill hugs the drawn text.
+ */
+function pillCorner(
+  anchor: { textAlign: CanvasTextAlign; textBaseline: CanvasTextBaseline } | undefined,
+  w: number,
+  h: number,
+  padX: number,
+  padY: number
+): { x: number; y: number } {
+  if (!anchor) {
+    return { x: -w / 2, y: -h / 2 };
+  }
+  let x: number;
+  switch (anchor.textAlign) {
+    case 'left':
+    case 'start':
+      x = -padX / 2;
+      break;
+    case 'right':
+    case 'end':
+      x = -(w - padX / 2);
+      break;
+    default:
+      x = -w / 2;
+  }
+  let y: number;
+  switch (anchor.textBaseline) {
+    case 'top':
+    case 'hanging':
+      y = -padY / 2;
+      break;
+    case 'bottom':
+    case 'alphabetic':
+    case 'ideographic':
+      y = -(h - padY / 2);
+      break;
+    default:
+      y = -h / 2;
+  }
+  return { x, y };
+}
 
 export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInput): void {
-  const { text, spec, boxWidth, boxHeight, fontSize, color } = input;
+  const { text, spec, boxWidth, boxHeight, fontSize, color, anchor } = input;
   if (!text) return;
 
   const insetW = spec.insetRatio?.w ?? 1;
@@ -80,19 +144,48 @@ export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInp
     getMeasurer(ctx)
   );
 
-  // Background pill (sized to the laid-out text, clamped to the box).
+  // Background pill.
   if (spec.background && input.background) {
-    const bgWidth = Math.min(layout.totalWidth + BG_PAD_X, maxWidth + BG_PAD_X);
-    const bgHeight = Math.min(layout.totalHeight + BG_PAD_Y, maxHeight + BG_PAD_Y);
+    const padX = input.backgroundPadX ?? BG_PAD_X;
+    const padY = input.backgroundPadY ?? BG_PAD_Y;
+    // Box-anchored pills clamp to the inset box; point-anchored pills don't.
+    const bgWidth = anchor ? layout.totalWidth + padX : Math.min(layout.totalWidth + padX, maxWidth + padX);
+    const bgHeight = anchor ? layout.totalHeight + padY : Math.min(layout.totalHeight + padY, maxHeight + padY);
+    const { x: bgX, y: bgY } = pillCorner(anchor, bgWidth, bgHeight, padX, padY);
+
     ctx.fillStyle = input.background;
-    ctx.fillRect(-bgWidth / 2, -bgHeight / 2, bgWidth, bgHeight);
+    if (input.backgroundRound) {
+      ctx.beginPath();
+      ctx.roundRect(bgX, bgY, bgWidth, bgHeight, input.backgroundRadius ?? 4);
+      ctx.fill();
+    } else {
+      ctx.fillRect(bgX, bgY, bgWidth, bgHeight);
+    }
+    if (input.backgroundBorder) {
+      ctx.strokeStyle = BG_BORDER_COLOR;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(bgX, bgY, bgWidth, bgHeight);
+    }
   }
 
   ctx.fillStyle = color;
   ctx.font = `${layout.fontSize}px ${fontFamily}`;
-  ctx.textBaseline = 'middle';
+  const { lineHeight } = layout;
 
-  // Horizontal anchor from align.
+  if (anchor) {
+    // Point-anchored: draw directly with the given canvas alignment. Lines
+    // stack downward from the anchor (connector/group labels are single-line).
+    ctx.textAlign = anchor.textAlign;
+    ctx.textBaseline = anchor.textBaseline;
+    layout.lines.forEach((line, i) => {
+      ctx.fillText(line, 0, i * lineHeight);
+    });
+    ctx.restore();
+    return;
+  }
+
+  // Box-anchored: align within the inset box.
+  ctx.textBaseline = 'middle';
   const align = spec.align ?? 'center';
   let anchorX = 0;
   if (align === 'left') {
@@ -106,9 +199,8 @@ export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInp
     ctx.textAlign = 'center';
   }
 
-  // Vertical anchor from verticalAlign (default middle = historical behavior).
   const vAlign = spec.verticalAlign ?? 'middle';
-  const { lineHeight, totalHeight } = layout;
+  const { totalHeight } = layout;
   let startY: number;
   if (vAlign === 'top') {
     startY = -maxHeight / 2 + lineHeight / 2;

--- a/src/shapes/label/specs.ts
+++ b/src/shapes/label/specs.ts
@@ -30,3 +30,21 @@ export const LINE_LABEL_SPEC: LabelSpec = mergeLabelSpec(DEFAULT_LABEL_SPEC, {
   defaultFontSize: 12,
   insetRatio: { w: 1, h: 1 },
 });
+
+/** Connector: single-line label at the mid-path point, with a readability pill. */
+export const CONNECTOR_LABEL_SPEC: LabelSpec = mergeLabelSpec(DEFAULT_LABEL_SPEC, {
+  placement: { kind: 'along-path', t: 0.5 },
+  singleLine: true,
+  defaultFontSize: 12,
+  background: true,
+  insetRatio: { w: 1, h: 1 },
+});
+
+/** Group: single-line label anchored at the 9-grid position around the bounds. */
+export const GROUP_LABEL_SPEC: LabelSpec = mergeLabelSpec(DEFAULT_LABEL_SPEC, {
+  placement: { kind: 'nine-grid', position: 'top' },
+  singleLine: true,
+  defaultFontSize: 14,
+  background: true,
+  insetRatio: { w: 1, h: 1 },
+});

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -1727,6 +1727,18 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                     onChange={(color) => handleBulkUpdate({ labelBackground: color })}
                     showNoFill
                   />
+                  <div className="compact-select-row">
+                    <label className="compact-select-label">Overflow</label>
+                    <select
+                      value={(shape as GroupShape).labelOverflow ?? 'overflow'}
+                      onChange={(e) => handleBulkUpdate({ labelOverflow: e.target.value as LabelOverflow })}
+                      className="compact-select"
+                    >
+                      <option value="overflow">Overflow</option>
+                      <option value="squeeze-into">Shrink to fit</option>
+                      <option value="break-word">Break words</option>
+                    </select>
+                  </div>
                   <LabelPositionPicker
                     value={(shape as GroupShape).labelPosition}
                     onChange={(pos) => handleBulkUpdate({ labelPosition: pos })}
@@ -2751,6 +2763,25 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
               }}
               showNoFill
             />
+            <div className="compact-select-row">
+              <label className="compact-select-label">Overflow</label>
+              <select
+                value={shape.labelOverflow ?? 'overflow'}
+                onChange={(e) => {
+                  const overflow = e.target.value as LabelOverflow;
+                  selectedShapes.forEach((s) => {
+                    if (isConnector(s)) {
+                      updateShape(s.id, { labelOverflow: overflow });
+                    }
+                  });
+                }}
+                className="compact-select"
+              >
+                <option value="overflow">Overflow</option>
+                <option value="squeeze-into">Shrink to fit</option>
+                <option value="break-word">Break words</option>
+              </select>
+            </div>
             {/* Label offset controls */}
             {shape.label && (
               <div className="label-offset-row">


### PR DESCRIPTION
Finishes the label-engine convergence from JP-102 (PR #45): connector and group labels now render via the shared `renderLabel` instead of bespoke per-handler blocks. **File header-bar deferred** per the issue.

## What changed

**`renderLabel` — point-anchored mode**
- New `anchor: { textAlign, textBaseline }` → the origin *is* the text anchor (vs. box-edge alignment), for connector mid-path and group 9-grid labels.
- Optional pill styling: `backgroundBorder`, `backgroundRound` + `backgroundRadius`, `backgroundPadX/Y`. The existing box callers (rect/ellipse/library/line) pass none of these and are unchanged.

**Connector** (`renderConnectorLabel`)
- Delegates to `renderLabel`. The caller resolves the background **tri-state** (`undefined` → default white pill *with border*; `''`/`transparent` → no pill; colour → that colour) so the engine stays generic. Message-number + guard-condition rendering stay bespoke.

**Group** (two-pass label method)
- Delegates to `renderLabel` with the 9-grid `align`/`baseline` from `calculateLabelPosition` and a rounded pill. AUTO colour still resolved by the caller via `resolveGroupAutoColor`.

**Overflow control**
- `labelOverflow` added to `ConnectorShape` / `GroupShape` + PropertyPanel dropdowns (overflow / shrink-to-fit / break-word). Both default `singleLine: true`, so the current single-line look is preserved unless the user changes it.

## Compatibility
New fields optional + read-time defaulted → existing documents render identically, **no migration**.

## Verification
- `bun run typecheck` clean
- `bun run test --run` — 1773 tests pass (87 files); new point-anchored `renderLabel` tests cover the connector pill+border, group rounded pill/baseline, and the No-Fill case; existing Connector/Group suites green
- Parity by design: single-line defaults + tri-state pill preserved. **Author visual E2E recommended** (connector mid-path pill, group 9-grid positions, overflow toggles).

## Follow-up
File header-bar convergence remains (deferred); the broader core-shape collapse is JP-160.

Assisted-by: Opus 4.8