### PR TITLE
"Shrink to fit" label toggle + bound connector label width (JP-163)

### DIFF
--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -16,7 +16,7 @@ import {
 import { isAutoColor } from '../engine/ContrastResolver';
 import { getRenderContext } from '../engine/RenderContext';
 import { renderLabel } from './label/renderLabel';
-import { CONNECTOR_LABEL_SPEC } from './label/specs';
+import { CONNECTOR_LABEL_SPEC, CONNECTOR_LABEL_MAX_WIDTH } from './label/specs';
 import type { LabelOverflow } from './label/LabelSpec';
 
 /**
@@ -740,9 +740,10 @@ function renderConnectorLabel(
     text: label,
     spec: CONNECTOR_LABEL_SPEC,
     overflow,
-    // Single-line label; the box only governs the (rare) overflow clip flag.
-    boxWidth: 1000,
-    boxHeight: fontSize * 2,
+    // Bound the label width so long text wraps to a finite pill instead of
+    // stretching indefinitely; height allows a few wrapped lines before clip.
+    boxWidth: CONNECTOR_LABEL_MAX_WIDTH,
+    boxHeight: fontSize * 6,
     fontSize,
     color,
     background: pillColor,

--- a/src/shapes/label/renderLabel.test.ts
+++ b/src/shapes/label/renderLabel.test.ts
@@ -155,5 +155,27 @@ describe('renderLabel', () => {
       expect(ctx.fillRect).not.toHaveBeenCalled();
       expect(ctx.strokeRect).not.toHaveBeenCalled();
     });
+
+    it('wraps a long connector label within the bounded width, centered on the anchor', () => {
+      const ctx = makeCtx();
+      // font 10 → 5px/char; maxWidth 20 fits ~4 chars/line → 3 wrapped lines.
+      renderLabel(ctx, {
+        spec: CONNECTOR_LABEL_SPEC, // singleLine: false → wraps
+        overflow: 'overflow',
+        boxWidth: 20,
+        boxHeight: 1000,
+        fontSize: 10,
+        color: '#000000',
+        background: 'rgba(255,255,255,0.9)',
+        anchor: { textAlign: 'center', textBaseline: 'middle' },
+        offsetX: 0,
+        offsetY: 0,
+        text: 'aaaa bbbb cccc',
+      });
+      const ys = ctx.fillText.mock.calls.map((c) => c[2] as number);
+      expect(ys.length).toBeGreaterThan(1); // bounded width forced a wrap
+      expect(ys[0]!).toBeLessThan(0); // first line above the center anchor
+      expect(ys[ys.length - 1]!).toBeGreaterThan(0); // last line below it
+    });
   });
 });

--- a/src/shapes/label/renderLabel.ts
+++ b/src/shapes/label/renderLabel.ts
@@ -173,12 +173,25 @@ export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInp
   const { lineHeight } = layout;
 
   if (anchor) {
-    // Point-anchored: draw directly with the given canvas alignment. Lines
-    // stack downward from the anchor (connector/group labels are single-line).
+    // Point-anchored: draw with the given canvas alignment. Multi-line stacks
+    // are centered for a 'middle' baseline (connectors) and bottom-anchored for
+    // a 'bottom' baseline, so wrapped text sits correctly within its pill.
+    // Single-line labels are unaffected (startY = 0).
     ctx.textAlign = anchor.textAlign;
     ctx.textBaseline = anchor.textBaseline;
+    const lineCount = layout.lines.length;
+    let startY = 0;
+    if (anchor.textBaseline === 'middle') {
+      startY = -((lineCount - 1) * lineHeight) / 2;
+    } else if (
+      anchor.textBaseline === 'bottom' ||
+      anchor.textBaseline === 'alphabetic' ||
+      anchor.textBaseline === 'ideographic'
+    ) {
+      startY = -(lineCount - 1) * lineHeight;
+    }
     layout.lines.forEach((line, i) => {
-      ctx.fillText(line, 0, i * lineHeight);
+      ctx.fillText(line, 0, startY + i * lineHeight);
     });
     ctx.restore();
     return;

--- a/src/shapes/label/specs.ts
+++ b/src/shapes/label/specs.ts
@@ -34,11 +34,16 @@ export const LINE_LABEL_SPEC: LabelSpec = mergeLabelSpec(DEFAULT_LABEL_SPEC, {
 /** Connector: single-line label at the mid-path point, with a readability pill. */
 export const CONNECTOR_LABEL_SPEC: LabelSpec = mergeLabelSpec(DEFAULT_LABEL_SPEC, {
   placement: { kind: 'along-path', t: 0.5 },
-  singleLine: true,
+  // Wrap within a bounded width (set by the caller) instead of stretching the
+  // pill indefinitely; short labels still render on one line.
+  singleLine: false,
   defaultFontSize: 12,
   background: true,
   insetRatio: { w: 1, h: 1 },
 });
+
+/** Max width (world units) a connector label wraps within before going multi-line. */
+export const CONNECTOR_LABEL_MAX_WIDTH = 200;
 
 /** Group: single-line label anchored at the 9-grid position around the bounds. */
 export const GROUP_LABEL_SPEC: LabelSpec = mergeLabelSpec(DEFAULT_LABEL_SPEC, {

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -380,17 +380,15 @@ function LibraryShapeProperties({
             onChange={(color) => handleUpdate('labelBackground', color)}
             showNoFill
           />
-          <div className="compact-select-row">
-            <label className="compact-select-label">Overflow</label>
-            <select
-              value={shape.labelOverflow ?? 'overflow'}
-              onChange={(e) => handleUpdate('labelOverflow', e.target.value)}
-              className="compact-select"
-            >
-              <option value="overflow">Overflow</option>
-              <option value="squeeze-into">Shrink to fit</option>
-              <option value="break-word">Break words</option>
-            </select>
+          <div className="compact-checkbox-row">
+            <label>
+              <input
+                type="checkbox"
+                checked={shape.labelOverflow === 'squeeze-into'}
+                onChange={(e) => handleUpdate('labelOverflow', e.target.checked ? 'squeeze-into' : 'overflow')}
+              />
+              <span>Shrink text to fit</span>
+            </label>
           </div>
           {/* Label offset controls */}
           {shape.label && (
@@ -1727,17 +1725,17 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                     onChange={(color) => handleBulkUpdate({ labelBackground: color })}
                     showNoFill
                   />
-                  <div className="compact-select-row">
-                    <label className="compact-select-label">Overflow</label>
-                    <select
-                      value={(shape as GroupShape).labelOverflow ?? 'overflow'}
-                      onChange={(e) => handleBulkUpdate({ labelOverflow: e.target.value as LabelOverflow })}
-                      className="compact-select"
-                    >
-                      <option value="overflow">Overflow</option>
-                      <option value="squeeze-into">Shrink to fit</option>
-                      <option value="break-word">Break words</option>
-                    </select>
+                  <div className="compact-checkbox-row">
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={(shape as GroupShape).labelOverflow === 'squeeze-into'}
+                        onChange={(e) =>
+                          handleBulkUpdate({ labelOverflow: e.target.checked ? 'squeeze-into' : 'overflow' })
+                        }
+                      />
+                      <span>Shrink text to fit</span>
+                    </label>
                   </div>
                   <LabelPositionPicker
                     value={(shape as GroupShape).labelPosition}
@@ -1905,24 +1903,22 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
               }}
               showNoFill
             />
-            <div className="compact-select-row">
-              <label className="compact-select-label">Overflow</label>
-              <select
-                value={shape.labelOverflow ?? 'overflow'}
-                onChange={(e) => {
-                  const overflow = e.target.value as LabelOverflow;
-                  selectedShapes.forEach((s) => {
-                    if (isRectangle(s) || isEllipse(s)) {
-                      updateShape(s.id, { labelOverflow: overflow });
-                    }
-                  });
-                }}
-                className="compact-select"
-              >
-                <option value="overflow">Overflow</option>
-                <option value="squeeze-into">Shrink to fit</option>
-                <option value="break-word">Break words</option>
-              </select>
+            <div className="compact-checkbox-row">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={shape.labelOverflow === 'squeeze-into'}
+                  onChange={(e) => {
+                    const overflow: LabelOverflow = e.target.checked ? 'squeeze-into' : 'overflow';
+                    selectedShapes.forEach((s) => {
+                      if (isRectangle(s) || isEllipse(s)) {
+                        updateShape(s.id, { labelOverflow: overflow });
+                      }
+                    });
+                  }}
+                />
+                <span>Shrink text to fit</span>
+              </label>
             </div>
             {/* Label offset controls */}
             {shape.label && (
@@ -2763,24 +2759,22 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
               }}
               showNoFill
             />
-            <div className="compact-select-row">
-              <label className="compact-select-label">Overflow</label>
-              <select
-                value={shape.labelOverflow ?? 'overflow'}
-                onChange={(e) => {
-                  const overflow = e.target.value as LabelOverflow;
-                  selectedShapes.forEach((s) => {
-                    if (isConnector(s)) {
-                      updateShape(s.id, { labelOverflow: overflow });
-                    }
-                  });
-                }}
-                className="compact-select"
-              >
-                <option value="overflow">Overflow</option>
-                <option value="squeeze-into">Shrink to fit</option>
-                <option value="break-word">Break words</option>
-              </select>
+            <div className="compact-checkbox-row">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={shape.labelOverflow === 'squeeze-into'}
+                  onChange={(e) => {
+                    const overflow: LabelOverflow = e.target.checked ? 'squeeze-into' : 'overflow';
+                    selectedShapes.forEach((s) => {
+                      if (isConnector(s)) {
+                        updateShape(s.id, { labelOverflow: overflow });
+                      }
+                    });
+                  }}
+                />
+                <span>Shrink text to fit</span>
+              </label>
             </div>
             {/* Label offset controls */}
             {shape.label && (


### PR DESCRIPTION
Acts on label feedback: of the three overflow modes only **shrink-to-fit** is useful, and connector labels stretched their pill indefinitely.

## Changes
- **PropertyPanel** — replaced the 3-way "Overflow" dropdown with a single **"Shrink text to fit"** checkbox in every label section (library/generic, rectangle+ellipse, group, connector). Checked → `labelOverflow: 'squeeze-into'`, unchecked → `'overflow'`. The engine still supports all three modes (`break-word` stays available for import adapters / long IDs); only the user-facing control is simplified. **No migration** — field + values unchanged.
- **Connector label width is now bounded** — `CONNECTOR_LABEL_SPEC` switched to `singleLine: false`, wrapping within `CONNECTOR_LABEL_MAX_WIDTH` (200 world units), so a long label wraps to a finite pill instead of growing forever. Short labels still render on one line.
- **`renderLabel`** — point-anchored multi-line stacks now center for a `middle` baseline (connectors) and bottom-anchor for `bottom` (groups), so wrapped text sits correctly within its pill. Single-line rendering is unchanged.

## Verification
- `bun run typecheck` clean; `bun run test --run` — **1780 tests pass**. New test covers the bounded connector wrap + centered multi-line stacking; existing connector/label suites green.
- **Author E2E:** toggle "Shrink text to fit" on a small box with long text (shrinks vs. wraps); type a long connector label and confirm it wraps to a bounded pill instead of stretching.

## Notes
Group labels left single-line for now (typically short titles); revisit if they need bounding too.

Assisted-by: Opus 4.8