### PR TITLE
Diagram import pipeline + Excalidraw adapter (JP-164 slice 1, JP-165)

### DIFF
--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -103,6 +103,15 @@ export function getAllCommands(): Command[] {
     { id: 'add.line', label: 'Add line', category: 'Editing', execute: () => createShapeAtCenter('line') },
     { id: 'add.connector', label: 'Add connector', category: 'Editing', execute: () => createShapeAtCenter('connector') },
 
+    // --- Import ---
+    {
+      id: 'import.diagram',
+      label: 'Import diagram (Excalidraw)…',
+      category: 'File',
+      // The palette can't reach the engine; CanvasContainer opens the picker.
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:import-diagram')),
+    },
+
     // --- Editing ---
     {
       id: 'edit.undo', label: 'Undo', category: 'Editing', shortcut: 'Ctrl+Z',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,9 @@
 // the Engine. Re-ordering this below `App` re-introduces the v2 blank-
 // canvas bug where ERD/UML shapes throw "No handler registered."
 import './shapes/registerBuiltInShapes';
+// Register import adapters (Excalidraw, …) so file-drop / paste / the Import
+// command can recognize and parse diagram files.
+import './shapes/import/registerImportAdapters';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/src/services/FileImportService.ts
+++ b/src/services/FileImportService.ts
@@ -5,6 +5,7 @@
 
 import { nanoid } from 'nanoid';
 import { Vec2 } from '../math/Vec2';
+import type { Box } from '../math/Box';
 import type { FileShape, FileCategory } from '../shapes/Shape';
 import { DEFAULT_FILE_SHAPE } from '../shapes/Shape';
 import { blobStorage } from '../storage/BlobStorage';
@@ -38,6 +39,8 @@ export interface ImportContext {
     camera: {
       screenToWorld(point: Vec2): Vec2;
       getViewportCenter(): Vec2;
+      /** Frame a set of bounds in the viewport (used by diagram import). */
+      zoomToFit(bounds: Box, padding?: number): void;
     };
     spatialIndex: { insert(shape: unknown): void };
     requestRender(): void;

--- a/src/services/importPipeline.test.ts
+++ b/src/services/importPipeline.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '../shapes/Rectangle'; // registers the 'rectangle' handler (for bounds/framing)
+import { applyImportResult, importDiagramText, importDiagramFiles } from './importPipeline';
+import type { ImportContext } from './FileImportService';
+import { registerImportAdapter, unregisterImportAdapter, type ImportAdapter } from '../shapes/import/ImportAdapter';
+import { DEFAULT_RECTANGLE, type Shape } from '../shapes/Shape';
+import { useDocumentStore } from '../store/documentStore';
+import { useSessionStore } from '../store/sessionStore';
+
+function rect(id: string, x: number): Shape {
+  return { ...DEFAULT_RECTANGLE, id, type: 'rectangle', x, y: 0, width: 100, height: 60 } as Shape;
+}
+
+function makeCtx() {
+  const zoomToFit = vi.fn();
+  const requestRender = vi.fn();
+  const ctx: ImportContext = {
+    engine: {
+      camera: {
+        screenToWorld: (p) => p,
+        getViewportCenter: () => ({ x: 0, y: 0 }) as never,
+        zoomToFit,
+      },
+      spatialIndex: { insert: vi.fn() },
+      requestRender,
+    },
+  };
+  return { ctx, zoomToFit, requestRender };
+}
+
+const graphAdapter: ImportAdapter = {
+  id: 'fake-graph',
+  label: 'Fake',
+  canImport: (raw) => raw.trimStart().startsWith('graph'),
+  import: (raw) =>
+    Promise.resolve({
+      shapes: [rect('g1', 0), rect('g2', 200)],
+      warnings: raw.includes('warn') ? [{ kind: 'x', detail: '1 thing skipped', count: 1 }] : [],
+    }),
+};
+
+describe('importPipeline', () => {
+  beforeEach(() => {
+    useDocumentStore.getState().loadSnapshot({ shapes: {}, shapeOrder: [], version: 1 });
+  });
+
+  describe('applyImportResult', () => {
+    it('adds shapes, selects, frames, and reports', () => {
+      const { ctx, zoomToFit, requestRender } = makeCtx();
+      const report = applyImportResult('test', { shapes: [rect('a', 0), rect('b', 300)] }, ctx);
+
+      const shapes = useDocumentStore.getState().shapes;
+      expect(shapes['a']).toBeTruthy();
+      expect(shapes['b']).toBeTruthy();
+      expect(useSessionStore.getState().getSelectedIds().sort()).toEqual(['a', 'b']);
+      expect(zoomToFit).toHaveBeenCalled();
+      expect(requestRender).toHaveBeenCalled();
+      expect(report.shapeCount).toBe(2);
+    });
+
+    it('surfaces adapter warnings in the report', () => {
+      const { ctx } = makeCtx();
+      const report = applyImportResult('test', {
+        shapes: [rect('a', 0)],
+        warnings: [{ kind: 'freedraw', detail: '2 skipped', count: 2 }],
+      }, ctx);
+      expect(report.warnings).toHaveLength(1);
+      expect(report.warnings[0]!.kind).toBe('freedraw');
+    });
+  });
+
+  describe('importDiagramText', () => {
+    beforeEach(() => registerImportAdapter(graphAdapter));
+    afterEach(() => {
+      unregisterImportAdapter('fake-graph');
+    });
+
+    it('imports when an adapter matches', async () => {
+      const { ctx } = makeCtx();
+      const report = await importDiagramText('graph TD; A-->B', ctx);
+      expect(report).not.toBeNull();
+      expect(report!.shapeCount).toBe(2);
+      expect(Object.keys(useDocumentStore.getState().shapes)).toHaveLength(2);
+    });
+
+    it('returns null when no adapter recognizes the text', async () => {
+      const { ctx } = makeCtx();
+      expect(await importDiagramText('just some prose', ctx)).toBeNull();
+    });
+  });
+
+  describe('importDiagramFiles', () => {
+    beforeEach(() => registerImportAdapter(graphAdapter));
+    afterEach(() => {
+      unregisterImportAdapter('fake-graph');
+    });
+
+    // jsdom's File has no .text(); the pipeline only reads name + text().
+    const fakeFile = (name: string, content: string): File =>
+      ({ name, text: () => Promise.resolve(content) }) as unknown as File;
+
+    it('imports diagram files and returns non-diagram files for embed', async () => {
+      const { ctx } = makeCtx();
+      const diagram = fakeFile('flow.mmd', 'graph TD; A-->B');
+      const image = fakeFile('photo.png', 'binary');
+      const passthrough = await importDiagramFiles([diagram, image], ctx);
+      expect(passthrough.map((f) => f.name)).toEqual(['photo.png']);
+      expect(Object.keys(useDocumentStore.getState().shapes)).toHaveLength(2);
+    });
+
+    it('passes a diagram-extension file through when no adapter claims it', async () => {
+      const { ctx } = makeCtx();
+      const notReally = fakeFile('note.mmd', 'hello world');
+      const passthrough = await importDiagramFiles([notReally], ctx);
+      expect(passthrough.map((f) => f.name)).toEqual(['note.mmd']);
+    });
+  });
+});

--- a/src/services/importPipeline.ts
+++ b/src/services/importPipeline.ts
@@ -1,0 +1,150 @@
+/**
+ * Diagram import pipeline (JP-164) — turns an `ImportAdapter`'s parsed result
+ * into shapes on the canvas as ONE undoable step, frames them, and reports
+ * anything that couldn't be converted ("safe parsing").
+ *
+ * The engine's `documentStore` subscription (`Engine.ts`) rebuilds the spatial
+ * index + repaints on shape changes, so the pipeline only mutates the store
+ * (plus an explicit `requestRender`) and frames via the camera.
+ */
+
+import { Box } from '../math/Box';
+import type { Shape } from '../shapes/Shape';
+import { shapeRegistry } from '../shapes/ShapeRegistry';
+import { findImportAdapter, type ImportResult, type ImportWarning } from '../shapes/import/ImportAdapter';
+import { useDocumentStore } from '../store/documentStore';
+import { useSessionStore } from '../store/sessionStore';
+import { useShapeLibraryStore } from '../store/shapeLibraryStore';
+import { useNotificationStore } from '../store/notificationStore';
+import { pushHistory } from '../store/historyStore';
+import type { Vec2 } from '../math/Vec2';
+import { importFiles, type ImportContext } from './FileImportService';
+
+/** File extensions that route to diagram import rather than file-embed. */
+export const DIAGRAM_EXTENSIONS = [
+  '.excalidraw',
+  '.drawio',
+  '.mmd',
+  '.mermaid',
+  '.puml',
+  '.plantuml',
+];
+
+export interface ImportReport {
+  adapterId: string;
+  shapeCount: number;
+  warnings: ImportWarning[];
+}
+
+/** Union of the world-space bounds of all shapes (for framing). */
+function combinedBounds(shapes: Shape[]): Box | null {
+  let box: Box | null = null;
+  for (const shape of shapes) {
+    if (!shapeRegistry.hasHandler(shape.type)) continue;
+    const b = shapeRegistry.getHandler(shape.type).getBounds(shape);
+    box = box ? box.union(b) : b;
+  }
+  return box;
+}
+
+function reportImport(shapeCount: number, warnings: ImportWarning[]): void {
+  const notifications = useNotificationStore.getState();
+  if (shapeCount === 0 && warnings.length === 0) {
+    notifications.warning('Nothing to import from that file');
+    return;
+  }
+  const noun = (n: number) => `${n} object${n === 1 ? '' : 's'}`;
+  if (warnings.length === 0) {
+    notifications.success(`Imported ${noun(shapeCount)}`);
+    return;
+  }
+  const skipped = warnings.reduce((n, w) => n + (w.count ?? 1), 0);
+  const detail = warnings.map((w) => w.detail).join('; ');
+  notifications.warning(`Imported ${noun(shapeCount)}; ${skipped} couldn't be converted: ${detail}`);
+}
+
+/**
+ * Insert a parsed result onto the canvas as one undoable step: register any new
+ * shape kinds, batch-add the shapes, select + frame them, and notify the user.
+ */
+export function applyImportResult(
+  adapterId: string,
+  result: ImportResult,
+  ctx: ImportContext,
+): ImportReport {
+  const { shapes, libraryDefs, warnings = [] } = result;
+
+  pushHistory(`Import ${adapterId}`);
+
+  if (libraryDefs && libraryDefs.length > 0) {
+    useShapeLibraryStore.getState().registerShapes(libraryDefs);
+  }
+
+  useDocumentStore.getState().addShapes(shapes);
+
+  const ids = shapes.map((s) => s.id);
+  if (ids.length > 0) {
+    useSessionStore.getState().select(ids);
+    useSessionStore.getState().setActiveTool('select');
+  }
+
+  const bounds = combinedBounds(shapes);
+  if (bounds) ctx.engine.camera.zoomToFit(bounds, 80);
+  ctx.engine.requestRender();
+
+  reportImport(ids.length, warnings);
+  return { adapterId, shapeCount: ids.length, warnings };
+}
+
+/**
+ * Parse + import source text via the first matching registered adapter.
+ * Returns the report, or `null` if no adapter recognizes the text (so the
+ * caller can fall back to embedding the file).
+ */
+export async function importDiagramText(raw: string, ctx: ImportContext): Promise<ImportReport | null> {
+  const adapter = findImportAdapter(raw);
+  if (!adapter) return null;
+  try {
+    const result = await adapter.import(raw);
+    return applyImportResult(adapter.id, result, ctx);
+  } catch (err) {
+    useNotificationStore
+      .getState()
+      .error(`Import failed: ${err instanceof Error ? err.message : String(err)}`);
+    return { adapterId: adapter.id, shapeCount: 0, warnings: [] };
+  }
+}
+
+/**
+ * Import any diagram files (by extension + adapter sniff) and return the files
+ * that were NOT diagrams, for the caller to embed as usual. Keeps the existing
+ * file-embed path intact — we branch, not replace.
+ */
+export async function importDiagramFiles(files: File[], ctx: ImportContext): Promise<File[]> {
+  const passthrough: File[] = [];
+  for (const file of files) {
+    const lower = file.name.toLowerCase();
+    if (!DIAGRAM_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
+      passthrough.push(file);
+      continue;
+    }
+    const text = await file.text();
+    const report = await importDiagramText(text, ctx);
+    // Extension looked like a diagram but no adapter claimed it → embed instead.
+    if (report === null) passthrough.push(file);
+  }
+  return passthrough;
+}
+
+/**
+ * Single entry point for dropped/picked files: import any diagrams, then embed
+ * the rest via the existing file-embed path. Keeps embedding behavior intact.
+ */
+export async function routeImportFiles(
+  files: File[],
+  worldPosition: Vec2,
+  ctx: ImportContext,
+): Promise<void> {
+  const remaining = await importDiagramFiles(files, ctx);
+  if (remaining.length > 0) await importFiles(remaining, worldPosition, ctx);
+}

--- a/src/shapes/import/ImportAdapter.test.ts
+++ b/src/shapes/import/ImportAdapter.test.ts
@@ -12,7 +12,7 @@ const fakeMermaid: ImportAdapter = {
   id: 'fake-mermaid',
   label: 'Fake Mermaid',
   canImport: (raw) => raw.trimStart().startsWith('graph'),
-  import: () => ({ shapes: [] }),
+  import: () => Promise.resolve({ shapes: [] }),
 };
 
 describe('ImportAdapter registry', () => {

--- a/src/shapes/import/ImportAdapter.ts
+++ b/src/shapes/import/ImportAdapter.ts
@@ -19,6 +19,19 @@ import type { Shape } from '../Shape';
 import type { LibraryShapeDefinition } from '../library/ShapeLibraryTypes';
 
 /**
+ * A construct the adapter could not convert — surfaced to the user by the
+ * import pipeline ("safe parsing": never fail hard or silently drop).
+ */
+export interface ImportWarning {
+  /** Machine-ish category, e.g. 'freedraw' | 'unsupported-element' | 'image'. */
+  kind: string;
+  /** Human-readable detail for the import report. */
+  detail: string;
+  /** How many occurrences this warning represents (default 1). */
+  count?: number;
+}
+
+/**
  * The product of importing a source document.
  */
 export interface ImportResult {
@@ -29,6 +42,8 @@ export interface ImportResult {
    * `useShapeLibraryStore.registerShapes` before inserting the shapes.
    */
   libraryDefs?: LibraryShapeDefinition[];
+  /** Constructs that couldn't be converted (shown in the import report). */
+  warnings?: ImportWarning[];
 }
 
 /**
@@ -41,8 +56,11 @@ export interface ImportAdapter {
   label: string;
   /** Cheap sniff test: does this adapter recognize the given source text? */
   canImport(raw: string): boolean;
-  /** Parse the source into shapes (+ any library definitions they need). */
-  import(raw: string): ImportResult;
+  /**
+   * Parse the source into shapes (+ any library definitions they need).
+   * Async: adapters may store image blobs or dynamically import heavy parsers.
+   */
+  import(raw: string): Promise<ImportResult>;
 }
 
 const registry = new Map<string, ImportAdapter>();

--- a/src/shapes/import/adapters/excalidrawAdapter.test.ts
+++ b/src/shapes/import/adapters/excalidrawAdapter.test.ts
@@ -6,8 +6,8 @@ const scene = {
   type: 'excalidraw',
   version: 2,
   elements: [
-    { id: 'r1', type: 'rectangle', x: 10, y: 20, width: 100, height: 40, strokeColor: '#111', backgroundColor: '#eee', strokeWidth: 2, roundness: { type: 3 } },
-    { id: 'e1', type: 'ellipse', x: 200, y: 0, width: 80, height: 60 },
+    { id: 'r1', type: 'rectangle', x: 10, y: 20, width: 100, height: 40, strokeColor: '#1e1e1e', backgroundColor: '#a5d8ff', strokeWidth: 2, roundness: { type: 3 } },
+    { id: 'e1', type: 'ellipse', x: 200, y: 0, width: 80, height: 60, strokeColor: '#e03131' },
     { id: 't1', type: 'text', x: 12, y: 22, width: 50, height: 20, text: 'Box A', containerId: 'r1', fontSize: 16 },
     { id: 'a1', type: 'arrow', x: 110, y: 40, width: 90, height: 0, points: [[0, 0], [90, 0]], startBinding: { elementId: 'r1' }, endBinding: { elementId: 'e1' } },
     { id: 'd1', type: 'diamond', x: 300, y: 300, width: 60, height: 60 },
@@ -33,9 +33,15 @@ describe('excalidrawAdapter', () => {
     expect(rect.y).toBe(40);
     expect((rect as { cornerRadius: number }).cornerRadius).toBeGreaterThan(0); // roundness → rounded
 
-    const ell = find(shapes, 'ellipse') as { radiusX: number; radiusY: number };
+    const ell = find(shapes, 'ellipse') as { radiusX: number; radiusY: number; stroke: string | null };
     expect(ell.radiusX).toBe(40);
     expect(ell.radiusY).toBe(30);
+    expect(ell.stroke).toBe('#e03131'); // explicit colour passes through
+
+    // Excalidraw's default stroke maps to the theme-adaptive AUTO sentinel;
+    // explicit fill colour passes through literally.
+    expect((rect as { stroke: string | null }).stroke).toBe('auto');
+    expect((rect as { fill: string | null }).fill).toBe('#a5d8ff');
 
     expect(find(shapes, 'diamond')).toBeTruthy(); // library shape
   });

--- a/src/shapes/import/adapters/excalidrawAdapter.test.ts
+++ b/src/shapes/import/adapters/excalidrawAdapter.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { excalidrawAdapter } from './excalidrawAdapter';
+import type { Shape } from '../../Shape';
+
+const scene = {
+  type: 'excalidraw',
+  version: 2,
+  elements: [
+    { id: 'r1', type: 'rectangle', x: 10, y: 20, width: 100, height: 40, strokeColor: '#111', backgroundColor: '#eee', strokeWidth: 2, roundness: { type: 3 } },
+    { id: 'e1', type: 'ellipse', x: 200, y: 0, width: 80, height: 60 },
+    { id: 't1', type: 'text', x: 12, y: 22, width: 50, height: 20, text: 'Box A', containerId: 'r1', fontSize: 16 },
+    { id: 'a1', type: 'arrow', x: 110, y: 40, width: 90, height: 0, points: [[0, 0], [90, 0]], startBinding: { elementId: 'r1' }, endBinding: { elementId: 'e1' } },
+    { id: 'd1', type: 'diamond', x: 300, y: 300, width: 60, height: 60 },
+    { id: 'fd1', type: 'freedraw', x: 0, y: 0, width: 10, height: 10, points: [[0, 0], [5, 5]] },
+  ],
+};
+
+const find = (shapes: Shape[], type: string) => shapes.find((s) => s.type === type);
+
+describe('excalidrawAdapter', () => {
+  it('canImport recognizes excalidraw JSON only', () => {
+    expect(excalidrawAdapter.canImport(JSON.stringify(scene))).toBe(true);
+    expect(excalidrawAdapter.canImport('{"type":"drawio"}')).toBe(false);
+    expect(excalidrawAdapter.canImport('not json')).toBe(false);
+  });
+
+  it('maps elements to shapes, recentring box coordinates', async () => {
+    const { shapes } = await excalidrawAdapter.import(JSON.stringify(scene));
+
+    const rect = find(shapes, 'rectangle')!;
+    // top-left (10,20) + half-size (50,20) → centre (60,40)
+    expect(rect.x).toBe(60);
+    expect(rect.y).toBe(40);
+    expect((rect as { cornerRadius: number }).cornerRadius).toBeGreaterThan(0); // roundness → rounded
+
+    const ell = find(shapes, 'ellipse') as { radiusX: number; radiusY: number };
+    expect(ell.radiusX).toBe(40);
+    expect(ell.radiusY).toBe(30);
+
+    expect(find(shapes, 'diamond')).toBeTruthy(); // library shape
+  });
+
+  it('applies container-bound text as the container label (not a text shape)', async () => {
+    const { shapes } = await excalidrawAdapter.import(JSON.stringify(scene));
+    const rect = find(shapes, 'rectangle') as { label?: string };
+    expect(rect.label).toBe('Box A');
+    expect(find(shapes, 'text')).toBeUndefined(); // bound text did not become a standalone text shape
+  });
+
+  it('wires bound arrows to connector endpoints via id remap', async () => {
+    const { shapes } = await excalidrawAdapter.import(JSON.stringify(scene));
+    const rect = find(shapes, 'rectangle')!;
+    const ell = find(shapes, 'ellipse')!;
+    const conn = find(shapes, 'connector') as { startShapeId?: string; endShapeId?: string };
+    expect(conn.startShapeId).toBe(rect.id);
+    expect(conn.endShapeId).toBe(ell.id);
+  });
+
+  it('skips freedraw and reports it', async () => {
+    const { shapes, warnings } = await excalidrawAdapter.import(JSON.stringify(scene));
+    expect(find(shapes, 'freedraw')).toBeUndefined();
+    expect(warnings?.some((w) => w.kind === 'freedraw')).toBe(true);
+  });
+});

--- a/src/shapes/import/adapters/excalidrawAdapter.ts
+++ b/src/shapes/import/adapters/excalidrawAdapter.ts
@@ -1,0 +1,317 @@
+/**
+ * Excalidraw (`.excalidraw`) document import adapter (JP-165).
+ *
+ * Excalidraw stores a flat `elements[]` array with absolute coordinates, so no
+ * graph layout is needed. Element `x,y` is the TOP-LEFT corner; DocuShark
+ * rect/ellipse/library shapes are CENTER-anchored, so box shapes are recentred.
+ * Bound text (`containerId`) becomes the container's label; arrows with
+ * `startBinding`/`endBinding` become connectors wired to the mapped shape ids.
+ * Freehand `freedraw` is intentionally skipped (a non-goal) and reported.
+ */
+
+import { nanoid } from 'nanoid';
+import type { ImportAdapter, ImportResult, ImportWarning } from '../ImportAdapter';
+import type { Shape, FileCategory } from '../../Shape';
+import {
+  DEFAULT_RECTANGLE,
+  DEFAULT_ELLIPSE,
+  DEFAULT_LINE,
+  DEFAULT_TEXT,
+  DEFAULT_CONNECTOR,
+  DEFAULT_LIBRARY_SHAPE,
+  DEFAULT_FILE_SHAPE,
+} from '../../Shape';
+import { blobStorage } from '../../../storage/BlobStorage';
+
+/** Loosely-typed view of the Excalidraw element fields we read. */
+interface ExElement {
+  id: string;
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  angle?: number;
+  strokeColor?: string;
+  backgroundColor?: string;
+  strokeWidth?: number;
+  opacity?: number; // 0–100
+  roundness?: { type: number } | null;
+  points?: Array<[number, number]>;
+  text?: string;
+  fontSize?: number;
+  fontFamily?: number;
+  textAlign?: string;
+  containerId?: string | null;
+  startBinding?: { elementId?: string } | null;
+  endBinding?: { elementId?: string } | null;
+  fileId?: string | null;
+  isDeleted?: boolean;
+}
+
+interface ExScene {
+  type?: string;
+  elements?: ExElement[];
+  files?: Record<string, { dataURL?: string; mimeType?: string }>;
+}
+
+function parseScene(raw: string): ExScene | null {
+  try {
+    const obj = JSON.parse(raw) as ExScene;
+    return obj && typeof obj === 'object' ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+const opacityOf = (el: ExElement): number =>
+  el.opacity === undefined ? 1 : Math.max(0, Math.min(1, el.opacity / 100));
+
+/** Excalidraw 'transparent' background → no fill. */
+const fillOf = (el: ExElement): string | null =>
+  !el.backgroundColor || el.backgroundColor === 'transparent' ? null : el.backgroundColor;
+
+const strokeOf = (el: ExElement): string => el.strokeColor ?? '#1e1e1e';
+
+/** Common base for centre-anchored box shapes (rect/ellipse/diamond/image). */
+function boxBase(el: ExElement) {
+  return {
+    id: nanoid(),
+    x: el.x + el.width / 2,
+    y: el.y + el.height / 2,
+    rotation: el.angle ?? 0,
+    opacity: opacityOf(el),
+    locked: false,
+    visible: true,
+  };
+}
+
+const FONT_FAMILY: Record<number, string> = { 1: 'sans-serif', 2: 'sans-serif', 3: 'monospace' };
+
+/** Decode a `data:<mime>;base64,<data>` URL to a Blob (jsdom-safe, no fetch). */
+function dataUrlToBlob(dataUrl: string): Blob {
+  const comma = dataUrl.indexOf(',');
+  const header = dataUrl.slice(0, comma);
+  const b64 = dataUrl.slice(comma + 1);
+  const mime = /data:([^;]+)/.exec(header)?.[1] ?? 'application/octet-stream';
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Blob([bytes], { type: mime });
+}
+
+async function importExcalidraw(raw: string): Promise<ImportResult> {
+  const scene = parseScene(raw);
+  const shapes: Shape[] = [];
+  const warnings: ImportWarning[] = [];
+  if (!scene || !Array.isArray(scene.elements)) {
+    return { shapes, warnings: [{ kind: 'parse', detail: 'not a valid Excalidraw scene' }] };
+  }
+
+  const elements = scene.elements.filter((el) => !el.isDeleted);
+  const idMap = new Map<string, string>(); // excalidraw id → DocuShark shape id
+  const boundText = new Map<string, ExElement>(); // containerId → text element
+  const labelById = new Map<string, string>(); // DocuShark shape id → label text
+  let skippedFreedraw = 0;
+  const unsupported = new Map<string, number>();
+
+  // Pass A: shapes (everything except arrows + container-bound text).
+  for (const el of elements) {
+    if (el.type === 'text' && el.containerId) {
+      boundText.set(el.containerId, el);
+      continue;
+    }
+    if (el.type === 'arrow') continue; // pass B
+
+    const stroke = strokeOf(el);
+    const strokeWidth = el.strokeWidth ?? DEFAULT_RECTANGLE.strokeWidth;
+
+    switch (el.type) {
+      case 'rectangle': {
+        const base = boxBase(el);
+        idMap.set(el.id, base.id);
+        shapes.push({
+          ...DEFAULT_RECTANGLE,
+          ...base,
+          type: 'rectangle',
+          width: el.width,
+          height: el.height,
+          fill: fillOf(el),
+          stroke,
+          strokeWidth,
+          cornerRadius: el.roundness ? 12 : 0,
+        });
+        break;
+      }
+      case 'ellipse': {
+        const base = boxBase(el);
+        idMap.set(el.id, base.id);
+        shapes.push({
+          ...DEFAULT_ELLIPSE,
+          ...base,
+          type: 'ellipse',
+          radiusX: el.width / 2,
+          radiusY: el.height / 2,
+          fill: fillOf(el),
+          stroke,
+          strokeWidth,
+        });
+        break;
+      }
+      case 'diamond': {
+        const base = boxBase(el);
+        idMap.set(el.id, base.id);
+        shapes.push({
+          ...DEFAULT_LIBRARY_SHAPE,
+          ...base,
+          type: 'diamond',
+          width: el.width,
+          height: el.height,
+          fill: fillOf(el),
+          stroke,
+          strokeWidth,
+        });
+        break;
+      }
+      case 'line': {
+        const pts = el.points ?? [[0, 0], [el.width, el.height]];
+        const a = pts[0] ?? [0, 0];
+        const b = pts[pts.length - 1] ?? [el.width, el.height];
+        const id = nanoid();
+        idMap.set(el.id, id);
+        shapes.push({
+          ...DEFAULT_LINE,
+          id,
+          type: 'line',
+          x: el.x + a[0],
+          y: el.y + a[1],
+          x2: el.x + b[0],
+          y2: el.y + b[1],
+          rotation: el.angle ?? 0,
+          opacity: opacityOf(el),
+          locked: false,
+          visible: true,
+          stroke,
+          strokeWidth,
+          startArrow: false,
+          endArrow: false,
+        });
+        break;
+      }
+      case 'text': {
+        const base = { id: nanoid(), rotation: el.angle ?? 0, opacity: opacityOf(el), locked: false, visible: true };
+        idMap.set(el.id, base.id);
+        shapes.push({
+          ...DEFAULT_TEXT,
+          ...base,
+          type: 'text',
+          x: el.x, // text is top-left anchored in DocuShark too
+          y: el.y,
+          width: el.width,
+          height: el.height,
+          text: el.text ?? '',
+          fontSize: el.fontSize ?? DEFAULT_TEXT.fontSize,
+          fontFamily: FONT_FAMILY[el.fontFamily ?? 2] ?? 'sans-serif',
+          textAlign: (el.textAlign as 'left' | 'center' | 'right') ?? 'left',
+          fill: stroke, // text colour
+        });
+        break;
+      }
+      case 'image': {
+        const fileEntry = el.fileId ? scene.files?.[el.fileId] : undefined;
+        if (!fileEntry?.dataURL) {
+          unsupported.set('image', (unsupported.get('image') ?? 0) + 1);
+          break;
+        }
+        try {
+          const blob = dataUrlToBlob(fileEntry.dataURL);
+          const blobRef = await blobStorage.saveBlob(blob, `${el.id}.img`);
+          const base = boxBase(el);
+          idMap.set(el.id, base.id);
+          const fileCategory: FileCategory = 'image';
+          shapes.push({
+            ...base,
+            type: 'file',
+            width: el.width,
+            height: el.height,
+            fill: DEFAULT_FILE_SHAPE.fill,
+            stroke: DEFAULT_FILE_SHAPE.stroke,
+            strokeWidth: DEFAULT_FILE_SHAPE.strokeWidth,
+            blobRef,
+            fileName: `${el.id}.img`,
+            mimeType: fileEntry.mimeType ?? blob.type ?? 'image/png',
+            fileSize: blob.size,
+            fileCategory,
+          });
+        } catch {
+          unsupported.set('image', (unsupported.get('image') ?? 0) + 1);
+        }
+        break;
+      }
+      case 'freedraw':
+        skippedFreedraw++;
+        break;
+      default:
+        unsupported.set(el.type, (unsupported.get(el.type) ?? 0) + 1);
+    }
+  }
+
+  // Pass B: arrows → connectors, wired to mapped shape ids when bound.
+  for (const el of elements) {
+    if (el.type !== 'arrow') continue;
+    const pts = el.points ?? [[0, 0], [el.width, el.height]];
+    const a = pts[0] ?? [0, 0];
+    const b = pts[pts.length - 1] ?? [el.width, el.height];
+    const startId = el.startBinding?.elementId ? idMap.get(el.startBinding.elementId) : undefined;
+    const endId = el.endBinding?.elementId ? idMap.get(el.endBinding.elementId) : undefined;
+    shapes.push({
+      ...DEFAULT_CONNECTOR,
+      id: nanoid(),
+      type: 'connector',
+      x: el.x + a[0],
+      y: el.y + a[1],
+      x2: el.x + b[0],
+      y2: el.y + b[1],
+      rotation: 0,
+      opacity: opacityOf(el),
+      locked: false,
+      visible: true,
+      stroke: strokeOf(el),
+      strokeWidth: el.strokeWidth ?? DEFAULT_CONNECTOR.strokeWidth,
+      startArrow: false,
+      endArrow: true,
+      ...(startId ? { startShapeId: startId } : {}),
+      ...(endId ? { endShapeId: endId } : {}),
+    });
+  }
+
+  // Pass C: apply container-bound text as the container shape's label.
+  for (const [containerId, textEl] of boundText) {
+    const shapeId = idMap.get(containerId);
+    if (!shapeId) continue;
+    labelById.set(shapeId, textEl.text ?? '');
+  }
+  if (labelById.size > 0) {
+    for (const shape of shapes) {
+      const label = labelById.get(shape.id);
+      if (label !== undefined) (shape as { label?: string }).label = label;
+    }
+  }
+
+  // Aggregate warnings.
+  if (skippedFreedraw > 0) {
+    warnings.push({ kind: 'freedraw', detail: `${skippedFreedraw} freehand drawing(s) skipped`, count: skippedFreedraw });
+  }
+  for (const [kind, count] of unsupported) {
+    warnings.push({ kind, detail: `${count} unsupported "${kind}" element(s)`, count });
+  }
+
+  return { shapes, warnings };
+}
+
+export const excalidrawAdapter: ImportAdapter = {
+  id: 'excalidraw',
+  label: 'Excalidraw',
+  canImport: (raw) => parseScene(raw)?.type === 'excalidraw',
+  import: importExcalidraw,
+};

--- a/src/shapes/import/adapters/excalidrawAdapter.ts
+++ b/src/shapes/import/adapters/excalidrawAdapter.ts
@@ -22,6 +22,10 @@ import {
   DEFAULT_FILE_SHAPE,
 } from '../../Shape';
 import { blobStorage } from '../../../storage/BlobStorage';
+import { AUTO_COLOR } from '../../../engine/ContrastResolver';
+
+/** Excalidraw's default stroke — theme-inverted by Excalidraw at render time. */
+const EXCALIDRAW_DEFAULT_STROKE = '#1e1e1e';
 
 /** Loosely-typed view of the Excalidraw element fields we read. */
 interface ExElement {
@@ -71,7 +75,18 @@ const opacityOf = (el: ExElement): number =>
 const fillOf = (el: ExElement): string | null =>
   !el.backgroundColor || el.backgroundColor === 'transparent' ? null : el.backgroundColor;
 
-const strokeOf = (el: ExElement): string => el.strokeColor ?? '#1e1e1e';
+/**
+ * Map an element's stroke. Excalidraw stores its default stroke as `#1e1e1e`
+ * and theme-inverts it at render (white on a dark canvas); we map that default
+ * to DocuShark's AUTO sentinel so it stays visible on any theme. Explicit user
+ * colours (reds/greens) pass through literally; an explicit transparent stroke
+ * becomes no stroke.
+ */
+function strokeOf(el: ExElement): string | null {
+  const c = el.strokeColor;
+  if (!c || c === 'transparent') return null;
+  return c.toLowerCase() === EXCALIDRAW_DEFAULT_STROKE ? AUTO_COLOR : c;
+}
 
 /** Common base for centre-anchored box shapes (rect/ellipse/diamond/image). */
 function boxBase(el: ExElement) {
@@ -199,14 +214,14 @@ async function importExcalidraw(raw: string): Promise<ImportResult> {
         break;
       }
       case 'text': {
-        const base = { id: nanoid(), rotation: el.angle ?? 0, opacity: opacityOf(el), locked: false, visible: true };
+        // DocuShark TextShape x,y is the CENTRE (offset to top-left at render);
+        // Excalidraw text x,y is top-left, so recentre like the box shapes.
+        const base = boxBase(el);
         idMap.set(el.id, base.id);
         shapes.push({
           ...DEFAULT_TEXT,
           ...base,
           type: 'text',
-          x: el.x, // text is top-left anchored in DocuShark too
-          y: el.y,
           width: el.width,
           height: el.height,
           text: el.text ?? '',

--- a/src/shapes/import/registerImportAdapters.ts
+++ b/src/shapes/import/registerImportAdapters.ts
@@ -1,0 +1,12 @@
+/**
+ * Boot-time registration of import adapters (mirrors registerBuiltInShapes).
+ * Side-effect module: imported once from main.tsx. Guarded so HMR re-imports
+ * don't throw on duplicate registration.
+ */
+
+import { registerImportAdapter, getImportAdapter } from './ImportAdapter';
+import { excalidrawAdapter } from './adapters/excalidrawAdapter';
+
+if (!getImportAdapter(excalidrawAdapter.id)) {
+  registerImportAdapter(excalidrawAdapter);
+}

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -17,7 +17,9 @@ import { useSettingsStore } from '../store/settingsStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
-import { importFiles, ImportContext } from '../services/FileImportService';
+import type { ImportContext } from '../services/FileImportService';
+import { routeImportFiles, importDiagramText } from '../services/importPipeline';
+import { dialog } from '../platform/dialog';
 import { getMimeType } from '../utils/fileUtils';
 import { isTauri } from '../tauri/commands';
 import { fileDrop } from '../platform/fileDrop';
@@ -284,7 +286,7 @@ export function CanvasContainer({
           (f) => new File([new Uint8Array(f.bytes)], f.fileName, { type: getMimeType(f.fileName) }),
         );
         if (fileObjs.length > 0) {
-          void importFiles(fileObjs, worldPoint, ctx);
+          void routeImportFiles(fileObjs, worldPoint, ctx);
         }
       })
       .then((un) => {
@@ -308,19 +310,53 @@ export function CanvasContainer({
       // Only handle when canvas is focused
       if (document.activeElement !== canvasRef.current) return;
 
-      const files = e.clipboardData?.files;
-      if (!files || files.length === 0) return;
-
-      e.preventDefault();
       const ctx = getImportContext();
       if (!ctx) return;
 
+      // Capture synchronously — clipboardData isn't available after the handler.
+      const text = e.clipboardData?.getData('text') ?? '';
+      const fileArr = e.clipboardData?.files ? Array.from(e.clipboardData.files) : [];
       const center = ctx.engine.camera.getViewportCenter();
-      void importFiles(files, center, ctx);
+
+      // 1) Pasted diagram source (e.g. Excalidraw JSON, Mermaid). If no adapter
+      //    claims the text, fall back to any pasted files.
+      if (text.trim().length > 0) {
+        e.preventDefault();
+        void importDiagramText(text, ctx).then((report) => {
+          if (report === null && fileArr.length > 0) {
+            void routeImportFiles(fileArr, center, ctx);
+          }
+        });
+        return;
+      }
+
+      // 2) Pasted files (images/docs embed; diagram files import).
+      if (fileArr.length === 0) return;
+      e.preventDefault();
+      void routeImportFiles(fileArr, center, ctx);
     };
 
     document.addEventListener('paste', handlePaste);
     return () => document.removeEventListener('paste', handlePaste);
+  }, [getImportContext]);
+
+  /**
+   * "Import diagram…" command bridge. The command palette can't reach the
+   * engine, so it dispatches a window event; we open the picker here where the
+   * import context (camera, render) is available.
+   */
+  useEffect(() => {
+    const handleImportDiagram = () => {
+      const ctx = getImportContext();
+      if (!ctx) return;
+      void dialog.openFiles({ accept: ['.excalidraw'], multiple: true }).then((files) => {
+        if (files.length === 0) return;
+        const center = ctx.engine.camera.getViewportCenter();
+        void routeImportFiles(files, center, ctx);
+      });
+    };
+    window.addEventListener('docushark:import-diagram', handleImportDiagram);
+    return () => window.removeEventListener('docushark:import-diagram', handleImportDiagram);
   }, [getImportContext]);
 
   /**
@@ -427,7 +463,7 @@ export function CanvasContainer({
     if (!isTauri() && e.dataTransfer.files.length > 0) {
       const ctx = getImportContext();
       if (ctx) {
-        void importFiles(e.dataTransfer.files, worldPoint, ctx);
+        void routeImportFiles(Array.from(e.dataTransfer.files), worldPoint, ctx);
       }
       return;
     }

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StickyNote, CircleHelp, Settings } from 'lucide-react';
+import { StickyNote, CircleHelp, Settings, Import } from 'lucide-react';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
 import { useAutoSave } from '../hooks/useAutoSave';
@@ -155,6 +155,14 @@ export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings }: Unified
         {activeLayout === 'relaxed' && <RelaxedFocusControl />}
         <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} />
         <div className="toolbar-divider" />
+        <button
+          className="toolbar-help-btn"
+          onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
+          title="Import diagram (Excalidraw)"
+          aria-label="Import diagram"
+        >
+          <Import size={16} strokeWidth={1.5} />
+        </button>
         <button
           className="toolbar-whiteboard-btn"
           onClick={() => useWhiteboardStore.getState().toggleVisibility()}


### PR DESCRIPTION
Turns the (types-only) `ImportAdapter` seam into a working pipeline and ships **Excalidraw** as the reference adapter. Graph-layout is deferred — Excalidraw is coordinate-bearing — so `layoutGraph` lands with the Mermaid wave.

## Pipeline (`src/services/importPipeline.ts`)
- **`applyImportResult`** — one undoable step: `registerShapes(libraryDefs)` → `addShapes` → select → frame (`camera.zoomToFit`) → `requestRender`. (The engine's `documentStore` subscription auto-syncs the spatial index + repaint, so no manual index work.)
- **`importDiagramText` / `importDiagramFiles` / `routeImportFiles`** — sniff via `findImportAdapter`; diagram payloads import, everything else falls through to the existing file-embed path (`FileImportService`) — **branch, not replace**.
- **Safe-parse import report** — aggregates adapter `warnings` into one success/warning notification (*"Imported N; M couldn't be converted: …"*). The shared mechanism every future adapter feeds.

## Seam (`ImportAdapter.ts`)
`import()` is now **async** (`Promise<ImportResult>`); added `ImportWarning` + `ImportResult.warnings`.

## Excalidraw adapter
Element→shape mapping (rect/ellipse→core, diamond→library, line, text, arrow→connector, image→`file`). Recentres box coords (Excalidraw `x/y` is top-left; DocuShark box shapes are centre-anchored), maps **container-bound text → the container's label**, **arrow bindings → connector ids**, **images → blob + FileShape**, and **intentionally skips `freedraw`** (reported, not a goal).

## Entry points
"Import diagram…" command (window-event bridge → file picker) + drop + paste branches in `CanvasContainer`. Registered at boot via `registerImportAdapters.ts`.

## Verification
- `bun run typecheck` clean; `bun run test --run` — **1791 tests** (new `excalidrawAdapter` + `importPipeline` suites: mapping, bound-text→label, arrow remap, freedraw warning, routing, framing/report).
- Field assumptions checked against the real test asset (`test-assets/Excalidraw-Test-Asset.excalidraw`).
- **Author E2E recommended** with that asset (5 rect, 3 ellipse, diamond, line, 21 bound arrows, 18 text incl. 10 container-bound, 1 image) via command + drop + paste: expect correct positions, attached arrows, bound text as labels, the image rendered, one undo step, framed view, and a report notification. Confirm a dropped PNG still embeds (regression).

## Follow-ups
`layoutGraph` (Mermaid, JP-85), shared id-remap extraction, drawio/PlantUML adapters, a richer "Details" report modal.

Assisted-by: Opus 4.8