### PR TITLE
JP-93: MCP publish-target — agents create + manipulate DocuShark docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,33 +215,40 @@ Shape library tiers: basic shapes (Rectangle, Ellipse, Line, Text, Connector, Gr
 
 ## MCP (Model Context Protocol) Integration
 
-An embedded MCP server lives in `src-tauri/src/mcp/` and lets external MCP
-clients (Claude Code, IDE plugins, etc.) interact with documents over a
-local HTTP endpoint (default `127.0.0.1:9877/mcp`, gated by a persisted
-bearer token).
+The MCP server lives in the standalone relay at `relay/src/mcp/` (it was
+extracted from `src-tauri/` along with the rest of the sync server). It lets
+external MCP clients (Claude Code/Desktop, Cursor, Zed, etc.) create and
+manipulate documents over an HTTP endpoint (default `127.0.0.1:9877/mcp`,
+gated by a bearer token — the static MCP token or a relay JWT). The full tool
+reference is **`relay/docs/mcp/README.md`** — keep it in sync when changing the
+surface.
+
+The surface is no longer shape-only: an agent can `create_document`, write
+prose (`set_prose`/`add_prose_page`, Markdown → HTML), restructure an outline
+(`get_outline`/`insert_section`/`restructure_outline`), and build diagrams
+(`add_shape`/`add_shapes`/`connect`/`update_shape`, plus `generate_diagram` for
+a whole node/edge graph). A document carries both a canvas (`pages` → shapes)
+and prose (`richTextPages`, HTML).
 
 **Two-tier document model — enforced, not advisory:**
 
-- **Team documents** (`team_documents/`, host-stored). Writable via MCP.
-  Designed for safe concurrent writing — they're the only target for
-  AI-assisted drafting (`add_shape`, future `add_shapes`/`connect`/
-  `update_shape`/layout tools). Writes broadcast `DocEvent::Updated` so
-  the running app reloads, and concurrency is handled by the same
-  WebSocket protocol that powers Protected Local mode.
-- **Local documents** (renderer-owned, mirrored from `localStorage` into
-  `local_documents/` on each save). Read-only via MCP under all
-  conditions — this is enforced server-side by tool dispatch in
-  `src-tauri/src/mcp/tools.rs`, not a UI toggle. The frontend remains the
-  sole writer of localStorage. The mirror exists so MCP clients can
-  *review* personal documents without being able to mutate them, even
-  with a valid token.
+- **Team documents** (relay-stored under `relay_documents/workspaces/<ws>/docs/`).
+  Writable via MCP and scoped to the request's workspace (static token →
+  `single_tenant`; JWT → its `wsp` claim). Writes broadcast `DocEvent::Updated`
+  so a running app reloads.
+- **Local documents** (renderer-owned, mirrored read-only into the
+  per-workspace layout). Read-only via MCP under all conditions — enforced
+  server-side by `reject_if_local` in `relay/src/mcp/tools.rs`, not a UI
+  toggle. The mirror lets clients *review* personal documents without mutating
+  them.
 
-**When adding MCP tools that write,** they must call `ctx.team` (never
-`ctx.local`) and refuse local-doc IDs with a clear "promote to a team
-document" error. The `add_shape` handler is the reference pattern.
+**When adding MCP tools that write,** call `ctx.team` (never `ctx.local`),
+guard with `reject_if_local`, and persist through `mutate_with_retry` so the
+optimistic-concurrency (`serverVersion`) check protects live collaborators.
+The existing write tools are the reference pattern.
 
-**When extending the DSL adapter** (`src-tauri/src/mcp/adapter.rs`), keep
-field names and defaults in sync with the TS handlers in `src/shapes/*.ts`
+**When extending the DSL adapter** (`relay/src/mcp/adapter.rs`), keep field
+names and defaults in sync with the TS handlers in `src/shapes/*.ts`
 (DEFAULT_SHAPE_STYLE / DEFAULT_RECTANGLE / etc.). Drift will show up as a
 diff between MCP-created shapes and toolbar-created shapes.
 

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "local-ip-address",
  "log",
  "nanoid",
+ "pulldown-cmark",
  "rand 0.8.6",
  "reqwest",
  "rpassword",
@@ -1484,6 +1485,24 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quanta"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -81,6 +81,12 @@ rpassword = "7"
 # Config
 toml = "0.8"
 
+# Markdown → HTML for MCP prose tools (JP-93). Agents reliably emit
+# Markdown; the editor persists prose as HTML. pulldown-cmark is pure-Rust,
+# MSRV-friendly (rustdoc's own renderer), and tiny — deliberately not a
+# heavier CommonMark stack, matching the small-dep-tree stance above.
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
+
 # Per-workspace token-bucket rate limiting (Phase 21.3)
 governor = "0.7"
 

--- a/relay/docs/api/README.md
+++ b/relay/docs/api/README.md
@@ -2,6 +2,8 @@
 
 This directory is the **authoritative wire spec** for the DocuShark relay's HTTP and WebSocket surface. Anything that wants to talk to a relay — the editor, a self-hosted control plane, a third-party MCP client, a future replacement implementation — codes against the files here.
 
+> The relay's **MCP tool surface** (JSON-RPC over `/mcp`) is documented separately in [`../mcp/README.md`](../mcp/README.md).
+
 ## Layout
 
 | File | Purpose |

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -1,0 +1,162 @@
+# DocuShark Relay — MCP Tool Surface
+
+The relay embeds a [Model Context Protocol](https://modelcontextprotocol.io)
+server so external AI agents (Claude Code/Desktop, Cursor, Zed, ChatGPT,
+Notion, and any other MCP-capable client) can **create and manipulate
+DocuShark documents** — not just edit existing ones. This is the "publish
+target" surface: an agent can author a real document, with prose *and*
+diagrams, and a human drops into the editor when they want to touch it
+visually.
+
+This file is the authoritative reference for the MCP surface. The REST/WS wire
+spec lives next door in [`../api/`](../api/README.md).
+
+## Endpoint & transport
+
+- **HTTP endpoint:** `POST /mcp` on the MCP port (default **9877**;
+  `[mcp].port` in `relay.toml`). JSON-RPC 2.0 over HTTP (streamable-HTTP MCP).
+- **Send `Accept: application/json`.** If you send
+  `Accept: text/event-stream`, the server replies with SSE framing; plain
+  JSON clients should not advertise the event-stream type.
+
+## Authentication
+
+Every request carries `Authorization: Bearer <token>`. Two credential types
+are accepted, tried in this order:
+
+1. **Static MCP token** — a per-host bearer (generated on first run, persisted
+   to `mcp_token` under the data dir, logged at startup). Authenticates as the
+   single-tenant (`default`) workspace. This is the desktop / local default.
+2. **Relay app token (JWT)** — an RS256 token minted by the OIDC issuer;
+   validated via JWKS. The workspace is taken from the token's `wsp` claim
+   (see [`../api/token-format.md`](../api/token-format.md)). This is how a
+   multi-workspace deployment scopes an agent to one workspace.
+
+A missing or invalid credential returns `401` with no disambiguation.
+
+## Document model
+
+A DocuShark document carries **two surfaces in one object**:
+
+- **Canvas pages** (`pages`) — the diagram: shapes and connectors.
+- **Prose pages** (`richTextPages`) — the written body, stored as **HTML**.
+
+The MCP tools operate on both. Prose is authored in **Markdown** by default
+(agents produce it reliably) and rendered to the HTML the editor persists;
+pass `format: "html"` to supply HTML directly.
+
+## Tools
+
+All tools are namespaced `docushark.*`.
+
+### Read
+
+| Tool | Purpose |
+| -- | -- |
+| `list_documents` | List documents in the workspace (`id`, `name`, `pageCount`, `modifiedAt`, `source`). |
+| `get_document` | Document metadata + canvas `pages` summary + `prosePages` summary. The map of what exists. |
+| `get_page` | The shapes on one canvas page, as DSL objects. |
+| `get_prose` | All prose pages (or one, with `pageId`): `id`, `name`, `order`, HTML `content`. |
+| `get_outline` | A prose page's heading outline: ordered `{ index, level, title }`. `index` is used by the structural tools. |
+
+### Author
+
+| Tool | Purpose |
+| -- | -- |
+| `create_document` | Create a new document (one blank canvas page + one blank prose page). Returns `{ id, name }`. The starting point for authoring from scratch. |
+
+### Prose (write)
+
+| Tool | Purpose |
+| -- | -- |
+| `add_prose_page` | Append a prose page. Markdown by default. |
+| `set_prose` | Replace a prose page's entire body. Markdown by default. |
+| `rename_prose_page` | Rename a prose page. |
+
+### Structure (write)
+
+| Tool | Purpose |
+| -- | -- |
+| `insert_section` | Insert a heading (+ optional body) at `start`/`end` or after a heading `index`. |
+| `restructure_outline` | `promote`/`demote` a heading's level, or `move` a section to a new index. |
+
+### Diagram (write)
+
+| Tool | Purpose |
+| -- | -- |
+| `add_shape` | Add one shape (rectangle, ellipse, text, connector). |
+| `add_shapes` | Add many shapes in one all-or-nothing call. |
+| `connect` | Connect two existing shapes with a connector. |
+| `update_shape` | Patch an existing shape (`x`, `y`, `w`, `h`, `text`, `style`). |
+| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` or `grid`) and wires connectors. |
+
+## Concurrency
+
+All write tools persist through an **optimistic-concurrency check** on the
+document's `serverVersion`: a write reads the current version, applies its
+mutation, and saves only if the version still matches, retrying on conflict.
+A concurrent editor's live change is therefore never silently clobbered.
+
+## Limits & current constraints
+
+- **Local documents are read-only** via MCP. Renderer-owned (local) documents
+  are mirrored read-only; writes target team documents only, and a write to a
+  local id is refused with a clear message.
+- **Prose is HTML.** Markdown in is rendered (GFM tables / strikethrough /
+  task-lists on); HTML pass-through is re-parsed by the editor against its
+  schema on load, which drops anything unmodelled.
+- **Outlines are flat.** A section is a heading plus the content up to the
+  next heading; nesting is conveyed by `level`, not containment. `move` moves a
+  single section, not its descendants.
+- **`generate_diagram` layout is relay-side and approximate** — a layered or
+  grid placement, not the editor's full auto-layout. The editor can re-layout
+  on open. Node caps: 500 nodes / 1000 edges per call.
+- **No open-in-editor link yet.** `create_document` returns the document `id`;
+  a deep link back into the editor is not yet wired.
+
+## Example: author a document from scratch
+
+```jsonc
+// 1. create
+{"method":"tools/call","params":{"name":"docushark.create_document",
+  "arguments":{"name":"Architecture RFC"}}}
+// → { "id": "doc-…" }
+
+// 2. discover the page ids
+{"method":"tools/call","params":{"name":"docushark.get_document",
+  "arguments":{"docId":"doc-…"}}}
+// → pages:[{id:"page-…"}], prosePages:[{id:"page-…"}]
+
+// 3. write prose (Markdown)
+{"method":"tools/call","params":{"name":"docushark.set_prose",
+  "arguments":{"docId":"doc-…","pageId":"<prose page>",
+  "content":"# Overview\n\n## Goals\n\n## Approach"}}}
+
+// 4. draw a diagram
+{"method":"tools/call","params":{"name":"docushark.generate_diagram",
+  "arguments":{"docId":"doc-…","pageId":"<canvas page>",
+  "nodes":[{"id":"client","label":"Client"},{"id":"relay","label":"Relay"}],
+  "edges":[{"from":"client","to":"relay","label":"WebSocket"}]}}}
+```
+
+A runnable end-to-end smoke test of every tool lives in
+[`../../scripts/mcp-smoke.sh`](../../scripts/mcp-smoke.sh).
+
+## Per-provider verification
+
+The bar for this surface is "smooth on every MCP provider," not "works on
+one." Each provider should be able to (a) create a document, (b) generate a
+structured diagram, and (c) restructure an outline. Status:
+
+| Provider | Status |
+| -- | -- |
+| Claude Code | ✅ verified (create → prose → outline → diagram round-trip) |
+| Claude Desktop | ☐ to verify |
+| Cursor | ☐ to verify |
+| Zed | ☐ to verify |
+| ChatGPT (custom GPT) | ☐ to verify |
+| Notion custom agents | ☐ to verify |
+| Atlassian Rovo | ☐ to verify |
+
+To add a provider: point it at `http://<host>:9877/mcp` with the bearer token,
+run the three acceptance steps, and tick the box.

--- a/relay/scripts/mcp-smoke.sh
+++ b/relay/scripts/mcp-smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# mcp-smoke.sh — end-to-end smoke test of the relay MCP tool surface.
+#
+# Drives a running relay's /mcp endpoint through the full "publish target"
+# workflow: create a document, write prose from Markdown, read + restructure
+# its outline, generate a diagram from a graph, and read everything back.
+# Exercises every write tool and the optimistic-concurrency path.
+#
+# Usage:
+#   relay serve --config dev-relay.toml --data-dir ./data   # in another shell
+#   ./scripts/mcp-smoke.sh [URL] [TOKEN]
+#
+# Defaults: URL=http://127.0.0.1:9877/mcp, TOKEN from ./data/mcp_token.
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+URL="${1:-http://127.0.0.1:9877/mcp}"
+TOKEN="${2:-$(cat "${MCP_TOKEN_FILE:-./data/mcp_token}" 2>/dev/null || true)}"
+
+if [[ -z "${TOKEN}" ]]; then
+  echo "No token. Pass it as arg 2 or set MCP_TOKEN_FILE to the mcp_token path." >&2
+  exit 2
+fi
+
+RID=0
+# call <tool> <args-json> -> prints structuredContent, exits non-zero on error.
+call() {
+  RID=$((RID + 1))
+  local body resp
+  body=$(jq -nc --arg n "$1" --argjson a "$2" --argjson id "$RID" \
+    '{jsonrpc:"2.0", id:$id, method:"tools/call", params:{name:$n, arguments:$a}}')
+  resp=$(curl -s -X POST "$URL" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d "$body")
+  if [[ "$(jq -r '.error // .result.isError // false' <<<"$resp")" != "false" ]]; then
+    echo "✗ $1 failed: $resp" >&2
+    exit 1
+  fi
+  jq -c '.result.structuredContent' <<<"$resp"
+}
+
+echo "→ relay $URL"
+
+DOC=$(call docushark.create_document '{"name":"MCP smoke — RFC"}')
+DOCID=$(jq -r '.id' <<<"$DOC")
+echo "1. create_document            → $DOCID"
+
+GET=$(call docushark.get_document "$(jq -nc --arg d "$DOCID" '{docId:$d}')")
+CANVAS=$(jq -r '.pages[0].id' <<<"$GET")
+PROSE=$(jq -r '.prosePages[0].id' <<<"$GET")
+echo "2. get_document               → canvas=$CANVAS prose=$PROSE"
+
+call docushark.set_prose "$(jq -nc --arg d "$DOCID" --arg p "$PROSE" \
+  '{docId:$d, pageId:$p, content:"# Overview\n\nWhy.\n\n## Goals\n\nWhat.\n\n## Approach\n\nHow."}')" >/dev/null
+echo "3. set_prose (markdown)       → ok"
+
+OUTLINE=$(call docushark.get_outline "$(jq -nc --arg d "$DOCID" --arg p "$PROSE" '{docId:$d,pageId:$p}')")
+echo "4. get_outline                → $(jq -c '.outline|map(.title)' <<<"$OUTLINE")"
+
+call docushark.insert_section "$(jq -nc --arg d "$DOCID" --arg p "$PROSE" \
+  '{docId:$d, pageId:$p, level:2, title:"Risks", body:"- a\n- b", position:"end"}')" >/dev/null
+echo "5. insert_section Risks       → ok"
+
+MOVED=$(call docushark.restructure_outline "$(jq -nc --arg d "$DOCID" --arg p "$PROSE" \
+  '{docId:$d, pageId:$p, op:"move", index:3, toIndex:1}')")
+echo "6. restructure_outline (move) → $(jq -c '.outline|map(.title)' <<<"$MOVED")"
+
+DIAG=$(call docushark.generate_diagram "$(jq -nc --arg d "$DOCID" --arg p "$CANVAS" \
+  '{docId:$d, pageId:$p,
+    nodes:[{id:"client",label:"Client"},{id:"relay",label:"Relay"},{id:"r2",label:"R2",kind:"ellipse"}],
+    edges:[{from:"client",to:"relay",label:"WS"},{from:"relay",to:"r2"}]}')")
+echo "7. generate_diagram           → $(jq -c '{nodes:(.nodes|length),edges:(.edges|length),layout}' <<<"$DIAG")"
+
+PAGE=$(call docushark.get_page "$(jq -nc --arg d "$DOCID" --arg p "$CANVAS" '{docId:$d,pageId:$p}')")
+echo "8. get_page                   → $(jq -c '.shapes|map(.kind)' <<<"$PAGE")"
+
+echo "✓ all tools exercised on $DOCID"

--- a/relay/src/mcp/layout.rs
+++ b/relay/src/mcp/layout.rs
@@ -1,0 +1,152 @@
+//! Tiny graph layout for the bulk `generate_diagram` MCP tool (JP-93).
+//!
+//! The editor's real auto-layout (JP-164 shared graph layout) is TypeScript,
+//! editor-side, and can't run in the relay. So we compute a *good-enough*
+//! placement here — a grid for loose node sets, a longest-path layering for
+//! graphs with edges — and let the editor re-layout on open if the user wants.
+//! Coordinates are world-space, matching what the canvas tools already use.
+
+use std::collections::BTreeMap;
+
+/// Node footprint + spacing used when placing generated shapes.
+pub const NODE_W: f64 = 160.0;
+pub const NODE_H: f64 = 72.0;
+const COL_GAP: f64 = 80.0;
+const ROW_GAP: f64 = 80.0;
+const ORIGIN: f64 = 40.0;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Pos {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LayoutMode {
+    Grid,
+    Layered,
+}
+
+/// Place `node_ids` (input order preserved for determinism). `edges` are
+/// (from, to) pairs of node ids; endpoints not in `node_ids` are ignored.
+/// Returns positions in the same order as `node_ids`.
+pub fn layout(node_ids: &[String], edges: &[(String, String)], mode: LayoutMode) -> Vec<(String, Pos)> {
+    match mode {
+        LayoutMode::Grid => grid(node_ids),
+        LayoutMode::Layered => layered(node_ids, edges),
+    }
+}
+
+fn grid(node_ids: &[String]) -> Vec<(String, Pos)> {
+    let cols = ((node_ids.len() as f64).sqrt().ceil() as usize).max(1);
+    node_ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| {
+            let (row, col) = (i / cols, i % cols);
+            (
+                id.clone(),
+                Pos {
+                    x: ORIGIN + col as f64 * (NODE_W + COL_GAP),
+                    y: ORIGIN + row as f64 * (NODE_H + ROW_GAP),
+                },
+            )
+        })
+        .collect()
+}
+
+fn layered(node_ids: &[String], edges: &[(String, String)]) -> Vec<(String, Pos)> {
+    let known: std::collections::HashSet<&str> = node_ids.iter().map(|s| s.as_str()).collect();
+
+    // Longest-path layering: layer[v] = max(layer[u] + 1) over edges u->v.
+    // Bounded to node_ids.len() passes, so a cycle stops growing instead of
+    // looping forever (its members just settle at some depth).
+    let mut layer: BTreeMap<&str, usize> = node_ids.iter().map(|s| (s.as_str(), 0usize)).collect();
+    for _ in 0..node_ids.len() {
+        let mut changed = false;
+        for (u, v) in edges {
+            if let (Some(&lu), true) = (layer.get(u.as_str()), known.contains(v.as_str())) {
+                let lv = layer.get(v.as_str()).copied().unwrap_or(0);
+                if lv < lu + 1 {
+                    layer.insert(v.as_str(), lu + 1);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Bucket nodes by layer, preserving input order within each layer.
+    let mut by_layer: BTreeMap<usize, Vec<&str>> = BTreeMap::new();
+    for id in node_ids {
+        let l = layer.get(id.as_str()).copied().unwrap_or(0);
+        by_layer.entry(l).or_default().push(id.as_str());
+    }
+
+    let mut pos: std::collections::HashMap<&str, Pos> = std::collections::HashMap::new();
+    for (&l, members) in &by_layer {
+        for (idx, id) in members.iter().enumerate() {
+            pos.insert(
+                id,
+                Pos {
+                    x: ORIGIN + idx as f64 * (NODE_W + COL_GAP),
+                    y: ORIGIN + l as f64 * (NODE_H + ROW_GAP),
+                },
+            );
+        }
+    }
+
+    node_ids
+        .iter()
+        .map(|id| (id.clone(), pos.get(id.as_str()).copied().unwrap_or(Pos { x: ORIGIN, y: ORIGIN })))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn grid_places_all_nodes_starting_at_origin() {
+        let p = layout(&ids(&["a", "b", "c", "d"]), &[], LayoutMode::Grid);
+        assert_eq!(p.len(), 4);
+        assert_eq!(p[0].1, Pos { x: ORIGIN, y: ORIGIN });
+        // 4 nodes → 2 cols; node 2 starts a new row.
+        assert!(p[2].1.y > p[0].1.y);
+    }
+
+    #[test]
+    fn layered_increases_depth_along_edges() {
+        let nodes = ids(&["a", "b", "c"]);
+        let edges = vec![("a".to_string(), "b".to_string()), ("b".to_string(), "c".to_string())];
+        let p = layout(&nodes, &edges, LayoutMode::Layered);
+        let y = |id: &str| p.iter().find(|(n, _)| n == id).unwrap().1.y;
+        assert!(y("a") < y("b"));
+        assert!(y("b") < y("c"));
+    }
+
+    #[test]
+    fn layered_handles_a_cycle_without_hanging() {
+        let nodes = ids(&["a", "b"]);
+        let edges = vec![("a".to_string(), "b".to_string()), ("b".to_string(), "a".to_string())];
+        let p = layout(&nodes, &edges, LayoutMode::Layered);
+        assert_eq!(p.len(), 2); // terminates, both placed
+    }
+
+    #[test]
+    fn layered_siblings_share_a_row_but_differ_in_x() {
+        // a -> b, a -> c : b and c are both layer 1.
+        let nodes = ids(&["a", "b", "c"]);
+        let edges = vec![("a".to_string(), "b".to_string()), ("a".to_string(), "c".to_string())];
+        let p = layout(&nodes, &edges, LayoutMode::Layered);
+        let get = |id: &str| *p.iter().find(|(n, _)| n == id).map(|(_, q)| q).unwrap();
+        assert_eq!(get("b").y, get("c").y);
+        assert_ne!(get("b").x, get("c").x);
+    }
+}

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -11,6 +11,7 @@
 pub mod adapter;
 pub mod config;
 pub mod local_mirror;
+pub mod outline;
 pub mod token;
 pub mod tools;
 pub mod transport;

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod adapter;
 pub mod config;
+pub mod layout;
 pub mod local_mirror;
 pub mod outline;
 pub mod token;

--- a/relay/src/mcp/outline.rs
+++ b/relay/src/mcp/outline.rs
@@ -1,0 +1,249 @@
+//! Minimal HTML outline utilities for the MCP prose-structure tools (JP-93).
+//!
+//! Prose pages are stored as HTML; the editor (and our Markdown renderer)
+//! emit clean, attribute-free `<h1>..<h6>` blocks. We model a page as an
+//! optional **prefix** (any content before the first heading) plus a **flat
+//! list of sections**, where each section is a heading plus the content that
+//! follows it up to the next heading of *any* level.
+//!
+//! Flat (rather than nested) sectioning keeps reorder / promote / demote
+//! predictable and lossless to round-trip: nesting is conveyed by the level
+//! number, not by containment. Moving a section moves just its own heading +
+//! immediate body, not descendant subsections — the agent moves those
+//! separately if it wants to. This is intentional and documented on the MCP
+//! tools.
+//!
+//! Headings are re-emitted from `level` + `inner_html`, so any attributes on
+//! a passed-through `<h1 id="...">` are dropped on a structural edit; the
+//! editor's headings carry none, so this is a non-issue in practice.
+
+/// One flat section: a heading and the content immediately following it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Section {
+    /// Heading level, 1–6.
+    pub level: u8,
+    /// Inner HTML of the heading (may contain inline markup like `<em>`).
+    pub inner_html: String,
+    /// Plain-text heading title (tags stripped) — for the outline listing.
+    pub title: String,
+    /// HTML following the heading, up to the next heading (or end of page).
+    pub body_html: String,
+}
+
+impl Section {
+    fn heading_html(&self) -> String {
+        format!("<h{0}>{1}</h{0}>", self.level, self.inner_html)
+    }
+}
+
+/// A parsed prose page: leading content plus its flat sections.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Outline {
+    pub prefix: String,
+    pub sections: Vec<Section>,
+}
+
+impl Outline {
+    /// Parse a prose-page HTML string into prefix + flat sections.
+    pub fn parse(html: &str) -> Outline {
+        let headings = heading_spans(html);
+        if headings.is_empty() {
+            return Outline {
+                prefix: html.to_string(),
+                sections: Vec::new(),
+            };
+        }
+
+        let prefix = html[..headings[0].open_start].to_string();
+        let mut sections = Vec::with_capacity(headings.len());
+        for (idx, h) in headings.iter().enumerate() {
+            let body_start = h.after_close;
+            let body_end = headings
+                .get(idx + 1)
+                .map(|next| next.open_start)
+                .unwrap_or(html.len());
+            let inner_html = html[h.content_start..h.close_start].to_string();
+            sections.push(Section {
+                level: h.level,
+                title: strip_tags(&inner_html),
+                inner_html,
+                body_html: html[body_start..body_end].to_string(),
+            });
+        }
+
+        Outline { prefix, sections }
+    }
+
+    /// Reassemble the page HTML. `Outline::parse(x).to_html()` reproduces `x`
+    /// for editor/Markdown-generated HTML (headings carry no attributes).
+    pub fn to_html(&self) -> String {
+        let mut out = String::with_capacity(self.prefix.len() + 64 * self.sections.len());
+        out.push_str(&self.prefix);
+        for s in &self.sections {
+            out.push_str(&s.heading_html());
+            out.push_str(&s.body_html);
+        }
+        out
+    }
+}
+
+struct HeadingSpan {
+    /// Byte index of the `<` in `<hN>`.
+    open_start: usize,
+    /// Byte index just after the `>` of the opening tag.
+    content_start: usize,
+    /// Byte index of the `<` in `</hN>`.
+    close_start: usize,
+    /// Byte index just after the `>` of the closing tag.
+    after_close: usize,
+    level: u8,
+}
+
+/// Locate well-formed, non-nested `<hN>...</hN>` blocks in document order.
+/// A stray `<h7` or unmatched tag is skipped, not treated as a heading.
+fn heading_spans(html: &str) -> Vec<HeadingSpan> {
+    let mut spans = Vec::new();
+    let mut i = 0usize;
+    while let Some(rel) = html[i..].find("<h") {
+        let open_start = i + rel;
+        let level_idx = open_start + 2;
+        let level = html[level_idx..].chars().next().and_then(|c| {
+            if ('1'..='6').contains(&c) {
+                Some(c as u8 - b'0')
+            } else {
+                None
+            }
+        });
+        // Find the end of the opening tag and the matching close tag.
+        if let Some(level) = level {
+            if let Some(gt_rel) = html[level_idx..].find('>') {
+                let content_start = level_idx + gt_rel + 1;
+                let close_tag = format!("</h{}>", level);
+                if let Some(close_rel) = html[content_start..].find(&close_tag) {
+                    let close_start = content_start + close_rel;
+                    let after_close = close_start + close_tag.len();
+                    spans.push(HeadingSpan {
+                        open_start,
+                        content_start,
+                        close_start,
+                        after_close,
+                        level,
+                    });
+                    i = after_close;
+                    continue;
+                }
+            }
+        }
+        // Not a real heading start — step past this "<h" and keep scanning.
+        i = level_idx;
+    }
+    spans
+}
+
+/// Strip HTML tags, yielding the visible text of a heading. Good enough for
+/// titles (which are short and tag-light); not a general HTML-to-text pass.
+pub fn strip_tags(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    out.trim().to_string()
+}
+
+/// Escape text for safe insertion as HTML inner content.
+pub fn escape_html(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Clamp a heading level into the legal 1–6 range.
+pub fn clamp_level(level: i64) -> u8 {
+    level.clamp(1, 6) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOC: &str = "<p>intro</p><h1>Alpha</h1><p>a body</p><h2>Beta</h2><p>b body</p><h1>Gamma</h1>";
+
+    #[test]
+    fn parse_then_to_html_round_trips() {
+        let o = Outline::parse(DOC);
+        assert_eq!(o.to_html(), DOC);
+    }
+
+    #[test]
+    fn parse_extracts_prefix_and_sections() {
+        let o = Outline::parse(DOC);
+        assert_eq!(o.prefix, "<p>intro</p>");
+        assert_eq!(o.sections.len(), 3);
+        assert_eq!(o.sections[0].level, 1);
+        assert_eq!(o.sections[0].title, "Alpha");
+        assert_eq!(o.sections[0].body_html, "<p>a body</p>");
+        assert_eq!(o.sections[1].level, 2);
+        assert_eq!(o.sections[1].title, "Beta");
+        assert_eq!(o.sections[2].title, "Gamma");
+        assert_eq!(o.sections[2].body_html, "");
+    }
+
+    #[test]
+    fn no_headings_means_all_prefix() {
+        let o = Outline::parse("<p>just text</p>");
+        assert!(o.sections.is_empty());
+        assert_eq!(o.prefix, "<p>just text</p>");
+    }
+
+    #[test]
+    fn strip_tags_handles_inline_markup() {
+        assert_eq!(strip_tags("An <em>italic</em> title"), "An italic title");
+    }
+
+    #[test]
+    fn promote_demote_relevels_only_that_heading() {
+        let mut o = Outline::parse(DOC);
+        o.sections[1].level = clamp_level(o.sections[1].level as i64 - 1); // Beta h2 -> h1
+        assert!(o.to_html().contains("<h1>Beta</h1>"));
+        // Others unchanged.
+        assert!(o.to_html().contains("<h1>Alpha</h1>"));
+    }
+
+    #[test]
+    fn level_clamps_at_bounds() {
+        assert_eq!(clamp_level(0), 1);
+        assert_eq!(clamp_level(7), 6);
+        assert_eq!(clamp_level(3), 3);
+    }
+
+    #[test]
+    fn moving_a_section_reorders_heading_and_body() {
+        let mut o = Outline::parse(DOC);
+        let moved = o.sections.remove(2); // Gamma
+        o.sections.insert(0, moved);
+        let html = o.to_html();
+        // Gamma now precedes Alpha.
+        assert!(html.find("Gamma").unwrap() < html.find("Alpha").unwrap());
+    }
+
+    #[test]
+    fn skips_invalid_heading_like_tokens() {
+        let o = Outline::parse("<h7>not a heading</h7><h1>real</h1>");
+        assert_eq!(o.sections.len(), 1);
+        assert_eq!(o.sections[0].title, "real");
+        assert!(o.prefix.contains("<h7>not a heading</h7>"));
+    }
+}

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -23,6 +23,7 @@ use crate::server::protocol::{DocId, WorkspaceId};
 use super::adapter::{apply_dsl_patch, dsl_to_shape_json, shape_json_to_dsl, DslPatch, DslShape};
 use super::local_mirror::LocalDocumentMirror;
 use super::outline::{clamp_level, escape_html, Outline, Section};
+use super::layout::{layout, LayoutMode, NODE_H, NODE_W};
 
 /// Where a document came from, surfaced in MCP tool results so clients
 /// know whether they're looking at a team-shared or a (read-only) local
@@ -220,6 +221,48 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
             }),
         },
         ToolDescriptor {
+            name: "docushark.generate_diagram",
+            description:
+                "Generate a whole diagram in one call from a graph of nodes and edges. Each node becomes a labelled shape (rectangle by default, or ellipse); each edge becomes a connector between two nodes. The relay auto-positions everything: \"layered\" (top-down by edge direction, good for flow/architecture diagrams; the default when edges exist) or \"grid\". Reference nodes in edges by their caller-supplied 'id'. Returns the map of node id → created shape id, plus the connector ids. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "nodes": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string", "description": "Caller-supplied logical id, referenced by edges. Must be unique within the call."},
+                                "label": {"type": "string", "description": "Text shown in the shape. Defaults to the id."},
+                                "kind": {"type": "string", "enum": ["rectangle", "ellipse"], "description": "Shape kind. Default: \"rectangle\"."}
+                            },
+                            "required": ["id"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "edges": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "from": {"type": "string", "description": "Source node id."},
+                                "to": {"type": "string", "description": "Target node id."},
+                                "label": {"type": "string"}
+                            },
+                            "required": ["from", "to"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "layout": {"type": "string", "enum": ["layered", "grid"], "description": "Placement strategy. Default: \"layered\" when edges are present, else \"grid\"."}
+                },
+                "required": ["docId", "pageId", "nodes"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
             name: "docushark.add_shape",
             description:
                 "Add a single shape (rectangle, ellipse, text, or connector) to a page. Returns the id assigned. Warns if the document is locked by another user. Refuses local (renderer-owned) documents — those are read-only via MCP.",
@@ -390,6 +433,7 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.get_outline" => get_outline(ctx, args),
         "docushark.insert_section" => insert_section(ctx, args),
         "docushark.restructure_outline" => restructure_outline(ctx, args),
+        "docushark.generate_diagram" => generate_diagram(ctx, args),
         "docushark.add_shape" => add_shape(ctx, args),
         "docushark.add_shapes" => add_shapes(ctx, args),
         "docushark.connect" => connect(ctx, args),
@@ -1097,6 +1141,161 @@ fn restructure_outline(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, S
 
     Ok(ToolOutcome {
         result: json!({"pageId": parsed.page_id, "outline": summary}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Bulk diagram generation (JP-93 Slice D): turn a node/edge graph into shapes
+// + connectors in one call, auto-positioned by the relay.
+// ---------------------------------------------------------------------------
+
+/// Caps to keep a single call bounded (rate limiting handles repeated abuse;
+/// this guards one pathologically large request).
+const MAX_DIAGRAM_NODES: usize = 500;
+const MAX_DIAGRAM_EDGES: usize = 1000;
+
+#[derive(Deserialize)]
+struct GenNode {
+    id: String,
+    label: Option<String>,
+    kind: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GenEdge {
+    from: String,
+    to: String,
+    label: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GenerateDiagramArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    nodes: Vec<GenNode>,
+    #[serde(default)]
+    edges: Vec<GenEdge>,
+    layout: Option<String>,
+}
+
+fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: GenerateDiagramArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    if parsed.nodes.is_empty() {
+        return Err("'nodes' must contain at least one node".into());
+    }
+    if parsed.nodes.len() > MAX_DIAGRAM_NODES {
+        return Err(format!("too many nodes ({}); max {}", parsed.nodes.len(), MAX_DIAGRAM_NODES));
+    }
+    if parsed.edges.len() > MAX_DIAGRAM_EDGES {
+        return Err(format!("too many edges ({}); max {}", parsed.edges.len(), MAX_DIAGRAM_EDGES));
+    }
+
+    // Validate node ids are unique + non-empty, and that every edge endpoint
+    // names a known node — before we create anything.
+    let mut node_ids: Vec<String> = Vec::with_capacity(parsed.nodes.len());
+    let mut seen = std::collections::HashSet::new();
+    for n in &parsed.nodes {
+        let id = n.id.trim();
+        if id.is_empty() {
+            return Err("every node needs a non-empty 'id'".into());
+        }
+        if !seen.insert(id.to_string()) {
+            return Err(format!("duplicate node id '{}'", id));
+        }
+        node_ids.push(id.to_string());
+    }
+    for (i, e) in parsed.edges.iter().enumerate() {
+        if !seen.contains(e.from.trim()) {
+            return Err(format!("edge[{}] 'from' references unknown node '{}'", i, e.from));
+        }
+        if !seen.contains(e.to.trim()) {
+            return Err(format!("edge[{}] 'to' references unknown node '{}'", i, e.to));
+        }
+    }
+
+    // Mode: explicit wins; otherwise layered when there are edges to lay out.
+    let mode = match parsed.layout.as_deref() {
+        Some("layered") => LayoutMode::Layered,
+        Some("grid") => LayoutMode::Grid,
+        Some(other) => return Err(format!("Unknown layout '{}'; expected 'layered' or 'grid'", other)),
+        None if parsed.edges.is_empty() => LayoutMode::Grid,
+        None => LayoutMode::Layered,
+    };
+    let edge_pairs: Vec<(String, String)> = parsed
+        .edges
+        .iter()
+        .map(|e| (e.from.trim().to_string(), e.to.trim().to_string()))
+        .collect();
+    let positions = layout(&node_ids, &edge_pairs, mode);
+
+    let (node_map, edge_ids) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        // logical node id -> created shape id, for wiring connectors.
+        let mut node_map = serde_json::Map::new();
+        for (n, (_, pos)) in parsed.nodes.iter().zip(positions.iter()) {
+            let kind = match n.kind.as_deref() {
+                Some("ellipse") => super::adapter::DslKind::Ellipse,
+                _ => super::adapter::DslKind::Rectangle,
+            };
+            let dsl = DslShape {
+                kind,
+                x: pos.x,
+                y: pos.y,
+                w: Some(NODE_W),
+                h: Some(NODE_H),
+                text: Some(n.label.clone().unwrap_or_else(|| n.id.clone())),
+                style: None,
+                id: None,
+                start_shape_id: None,
+                end_shape_id: None,
+                start_anchor: None,
+                end_anchor: None,
+                start_arrow_style: None,
+                end_arrow_style: None,
+            };
+            let shape_id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
+            node_map.insert(n.id.trim().to_string(), json!(shape_id));
+        }
+
+        let mut edge_ids = Vec::with_capacity(parsed.edges.len());
+        for e in &parsed.edges {
+            let from = node_map.get(e.from.trim()).and_then(|v| v.as_str()).unwrap();
+            let to = node_map.get(e.to.trim()).and_then(|v| v.as_str()).unwrap();
+            let dsl = DslShape {
+                kind: super::adapter::DslKind::Connector,
+                x: 0.0,
+                y: 0.0,
+                w: None,
+                h: None,
+                text: e.label.clone(),
+                style: None,
+                id: None,
+                start_shape_id: Some(from.to_string()),
+                end_shape_id: Some(to.to_string()),
+                start_anchor: None,
+                end_anchor: None,
+                start_arrow_style: None,
+                end_arrow_style: None,
+            };
+            edge_ids.push(json!(append_shape_in_place(doc, &parsed.page_id, &dsl)?));
+        }
+
+        stamp_modified(doc, &parsed.page_id);
+        Ok((node_map, edge_ids))
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({
+            "nodes": node_map,
+            "edges": edge_ids,
+            "layout": match mode { LayoutMode::Layered => "layered", LayoutMode::Grid => "grid" },
+        }),
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
     })
@@ -2170,6 +2369,85 @@ mod tests {
         )
         .unwrap_err();
         assert!(no_to.contains("requires 'toIndex'"));
+    }
+
+    #[test]
+    fn generate_diagram_creates_shapes_and_connectors() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.generate_diagram",
+            &json!({
+                "docId": "doc1",
+                "pageId": "p1",
+                "nodes": [
+                    {"id": "client", "label": "Client"},
+                    {"id": "relay", "label": "Relay"},
+                    {"id": "store", "label": "R2", "kind": "ellipse"}
+                ],
+                "edges": [
+                    {"from": "client", "to": "relay", "label": "WS"},
+                    {"from": "relay", "to": "store"}
+                ]
+            }),
+        )
+        .unwrap();
+        assert_eq!(out.result["layout"], "layered");
+        // 3 nodes mapped, 2 connectors.
+        assert_eq!(out.result["nodes"].as_object().unwrap().len(), 3);
+        assert_eq!(out.result["edges"].as_array().unwrap().len(), 2);
+
+        // Page now holds 5 shapes: 3 nodes + 2 connectors.
+        let page = dispatch(
+            &f.ctx(true),
+            "docushark.get_page",
+            &json!({"docId": "doc1", "pageId": "p1"}),
+        )
+        .unwrap();
+        let kinds: Vec<&str> = page.result["shapes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|s| s["kind"].as_str())
+            .collect();
+        assert_eq!(kinds.iter().filter(|k| **k == "connector").count(), 2);
+        assert_eq!(kinds.iter().filter(|k| **k == "ellipse").count(), 1);
+        assert_eq!(kinds.iter().filter(|k| **k == "rectangle").count(), 2);
+    }
+
+    #[test]
+    fn generate_diagram_rejects_bad_graph() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let dup = dispatch(
+            &f.ctx(true),
+            "docushark.generate_diagram",
+            &json!({"docId":"doc1","pageId":"p1","nodes":[{"id":"a"},{"id":"a"}]}),
+        )
+        .unwrap_err();
+        assert!(dup.contains("duplicate node id"));
+
+        let dangling = dispatch(
+            &f.ctx(true),
+            "docushark.generate_diagram",
+            &json!({"docId":"doc1","pageId":"p1","nodes":[{"id":"a"}],"edges":[{"from":"a","to":"ghost"}]}),
+        )
+        .unwrap_err();
+        assert!(dangling.contains("unknown node 'ghost'"));
+
+        let local_refused = {
+            f.local.mirror(&WorkspaceId::single_tenant(), make_doc("local1", "p1", "Local")).unwrap();
+            dispatch(
+                &f.ctx(true),
+                "docushark.generate_diagram",
+                &json!({"docId":"local1","pageId":"p1","nodes":[{"id":"a"}]}),
+            )
+            .unwrap_err()
+        };
+        assert!(local_refused.contains("read-only"));
     }
 
     #[test]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -89,6 +89,21 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
             }),
         },
         ToolDescriptor {
+            name: "docushark.create_document",
+            description:
+                "Create a new, empty DocuShark document in the current workspace and return its id. The document starts with one blank canvas page (for diagrams) and one blank prose page (for text) — use add_shapes/connect to draw and the prose tools to write. This is the entry point for an agent authoring a document from scratch.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Title for the new document. Defaults to \"Untitled Document\"."
+                    }
+                },
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
             name: "docushark.add_shape",
             description:
                 "Add a single shape (rectangle, ellipse, text, or connector) to a page. Returns the id assigned. Warns if the document is locked by another user. Refuses local (renderer-owned) documents — those are read-only via MCP.",
@@ -251,6 +266,7 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.list_documents" => list_documents(ctx),
         "docushark.get_document" => get_document(ctx, args),
         "docushark.get_page" => get_page(ctx, args),
+        "docushark.create_document" => create_document(ctx, args),
         "docushark.add_shape" => add_shape(ctx, args),
         "docushark.add_shapes" => add_shapes(ctx, args),
         "docushark.connect" => connect(ctx, args),
@@ -407,6 +423,85 @@ fn get_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     Ok(ToolOutcome {
         result: json!({"shapes": shapes, "source": source}),
         changed_doc_id: None,
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct CreateDocumentArgs {
+    /// Optional title; defaults to "Untitled Document".
+    name: Option<String>,
+}
+
+/// Build a fresh, minimal `DiagramDocument` body equivalent to what the
+/// editor's `persistenceStore.newDocument` produces: one blank canvas page
+/// and one blank prose page. Field names + defaults mirror the TS types
+/// (`src/types/Document.ts`, `richTextPagesStore.ts`) — drift here shows up
+/// as a document that won't open cleanly in the editor.
+fn build_new_document(name: &str) -> Value {
+    let now = now_ms();
+    let doc_id = format!("doc-{}", nanoid::nanoid!(12));
+    let canvas_page_id = format!("page-{}", nanoid::nanoid!(12));
+    let prose_page_id = format!("page-{}", nanoid::nanoid!(12));
+
+    json!({
+        "id": doc_id,
+        "name": name,
+        "version": 1,
+        "createdAt": now,
+        "modifiedAt": now,
+        // Created in the team store, so it's a relay document from birth.
+        "isRelayDocument": true,
+        "activePageId": canvas_page_id,
+        "pageOrder": [canvas_page_id],
+        "pages": {
+            canvas_page_id.clone(): {
+                "id": canvas_page_id,
+                "name": "Page 1",
+                "shapes": {},
+                "shapeOrder": [],
+                "createdAt": now,
+                "modifiedAt": now,
+            }
+        },
+        "richTextPages": {
+            "pages": {
+                prose_page_id.clone(): {
+                    "id": prose_page_id,
+                    "name": "Page 1",
+                    "content": "",
+                    "order": 0,
+                    "createdAt": now,
+                    "modifiedAt": now,
+                }
+            },
+            "pageOrder": [prose_page_id],
+            "activePageId": prose_page_id,
+        }
+    })
+}
+
+fn create_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: CreateDocumentArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    let name = parsed
+        .name
+        .map(|n| n.trim().to_string())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| "Untitled Document".to_string());
+
+    let doc = build_new_document(&name);
+    let id_str = doc["id"].as_str().expect("factory always sets id").to_string();
+    let doc_id = DocId::from_body_id(id_str.clone())
+        .map_err(|e| format!("Generated document id was invalid: {}", e))?;
+
+    // Brand-new id, so there's nothing to race — the unconditional save
+    // creates it at version 1.
+    ctx.team.save_document(&ctx.workspace_id, doc)?;
+
+    Ok(ToolOutcome {
+        result: json!({"id": id_str, "name": name}),
+        changed_doc_id: Some(doc_id),
         change_detail: None,
     })
 }
@@ -1171,6 +1266,95 @@ mod tests {
         let f = seed(&dir.path().to_path_buf());
         let err = dispatch(&f.ctx(true), "docushark.nope", &json!({})).unwrap_err();
         assert!(err.contains("Unknown tool"));
+    }
+
+    #[test]
+    fn create_document_persists_and_is_listable() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.create_document",
+            &json!({"name": "Architecture RFC"}),
+        )
+        .unwrap();
+        let new_id = out.result["id"].as_str().unwrap().to_string();
+        assert_eq!(out.result["name"], "Architecture RFC");
+        assert!(new_id.starts_with("doc-"));
+        // Should broadcast a change for the running app.
+        assert_eq!(out.changed_doc_id.as_ref().map(|d| d.as_str()), Some(new_id.as_str()));
+
+        // It shows up in list_documents as a team doc.
+        let list = dispatch(&f.ctx(true), "docushark.list_documents", &json!({})).unwrap();
+        let ids: Vec<&str> = list.result["documents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["id"].as_str().unwrap())
+            .collect();
+        assert!(ids.contains(&new_id.as_str()));
+
+        // get_document returns the blank canvas page.
+        let got = dispatch(
+            &f.ctx(true),
+            "docushark.get_document",
+            &json!({"docId": new_id}),
+        )
+        .unwrap();
+        assert_eq!(got.result["source"], "team");
+        let pages = got.result["pages"].as_array().unwrap();
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0]["shapeCount"], 0);
+    }
+
+    #[test]
+    fn create_document_defaults_name_and_starts_with_a_prose_page() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(&f.ctx(true), "docushark.create_document", &json!({})).unwrap();
+        assert_eq!(out.result["name"], "Untitled Document");
+        let new_id = out.result["id"].as_str().unwrap().to_string();
+
+        // The raw stored body carries a blank prose page so the editor's
+        // Relaxed (prose) layout has something to open.
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_body_id(new_id).unwrap();
+        let raw = f.team.get_document(&ws, &doc_id).unwrap();
+        let prose = &raw["richTextPages"];
+        assert_eq!(prose["pageOrder"].as_array().unwrap().len(), 1);
+        let active = prose["activePageId"].as_str().unwrap();
+        assert_eq!(prose["pages"][active]["content"], "");
+    }
+
+    #[test]
+    fn create_document_then_add_shape_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let created = dispatch(&f.ctx(true), "docushark.create_document", &json!({"name": "Flow"})).unwrap();
+        let doc_id = created.result["id"].as_str().unwrap().to_string();
+
+        // Discover the canvas page id via get_document.
+        let got = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": doc_id})).unwrap();
+        let page_id = got.result["pages"][0]["id"].as_str().unwrap().to_string();
+
+        // An agent can immediately draw on the fresh doc.
+        dispatch(
+            &f.ctx(true),
+            "docushark.add_shape",
+            &json!({"docId": doc_id, "pageId": page_id, "shape": {"kind": "rectangle", "x": 10, "y": 10}}),
+        )
+        .unwrap();
+
+        let page = dispatch(
+            &f.ctx(true),
+            "docushark.get_page",
+            &json!({"docId": doc_id, "pageId": page_id}),
+        )
+        .unwrap();
+        assert_eq!(page.result["shapes"].as_array().unwrap().len(), 1);
     }
 
     /// A write that loses the optimistic-concurrency race re-reads and

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -22,6 +22,7 @@ use crate::server::protocol::{DocId, WorkspaceId};
 
 use super::adapter::{apply_dsl_patch, dsl_to_shape_json, shape_json_to_dsl, DslPatch, DslShape};
 use super::local_mirror::LocalDocumentMirror;
+use super::outline::{clamp_level, escape_html, Outline, Section};
 
 /// Where a document came from, surfaced in MCP tool results so clients
 /// know whether they're looking at a team-shared or a (read-only) local
@@ -164,6 +165,57 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                     "name": {"type": "string"}
                 },
                 "required": ["docId", "pageId", "name"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.get_outline",
+            description:
+                "Return the heading outline of a prose page as an ordered list of { index, level, title }. 'index' is the 0-based heading position used by insert_section and restructure_outline. Sections are flat: nesting is conveyed by 'level' (1–6), not containment.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"}
+                },
+                "required": ["docId", "pageId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.insert_section",
+            description:
+                "Insert a new section (a heading plus optional body) into a prose page. Body is Markdown by default (set format:\"html\"). Place it with position:\"start\"|\"end\" (default \"end\"), or afterIndex to drop it right after an existing heading's section. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "level": {"type": "integer", "minimum": 1, "maximum": 6, "description": "Heading level 1–6."},
+                    "title": {"type": "string", "description": "Heading text (plain)."},
+                    "body": {"type": "string", "description": "Optional section body below the heading."},
+                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of body. Default: \"markdown\"."},
+                    "position": {"type": "string", "enum": ["start", "end"], "description": "Where to insert when afterIndex is absent. Default: \"end\"."},
+                    "afterIndex": {"type": "integer", "minimum": 0, "description": "Insert after the section at this 0-based heading index (takes precedence over position)."}
+                },
+                "required": ["docId", "pageId", "level", "title"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.restructure_outline",
+            description:
+                "Restructure a prose page's outline. op=\"promote\" makes a heading more prominent (level −1), \"demote\" less (level +1), \"move\" relocates a section to toIndex. 'index' is the 0-based heading index from get_outline. Returns the updated outline. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "op": {"type": "string", "enum": ["promote", "demote", "move"]},
+                    "index": {"type": "integer", "minimum": 0, "description": "0-based heading index to act on."},
+                    "toIndex": {"type": "integer", "minimum": 0, "description": "Target section index for op=\"move\"."}
+                },
+                "required": ["docId", "pageId", "op", "index"],
                 "additionalProperties": false
             }),
         },
@@ -335,6 +387,9 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.add_prose_page" => add_prose_page(ctx, args),
         "docushark.set_prose" => set_prose(ctx, args),
         "docushark.rename_prose_page" => rename_prose_page(ctx, args),
+        "docushark.get_outline" => get_outline(ctx, args),
+        "docushark.insert_section" => insert_section(ctx, args),
+        "docushark.restructure_outline" => restructure_outline(ctx, args),
         "docushark.add_shape" => add_shape(ctx, args),
         "docushark.add_shapes" => add_shapes(ctx, args),
         "docushark.connect" => connect(ctx, args),
@@ -864,6 +919,187 @@ fn stamp_doc_modified(doc: &mut Value, now: u64) {
     if let Some(o) = doc.as_object_mut() {
         o.insert("modifiedAt".into(), json!(now));
     }
+}
+
+/// Read a prose page's HTML content. Errors if the page doesn't exist;
+/// returns "" for an existing page with no content yet.
+fn read_prose_content(doc: &Value, page_id: &str) -> Result<String, String> {
+    let page = doc
+        .get("richTextPages")
+        .and_then(|r| r.get("pages"))
+        .and_then(|p| p.get(page_id))
+        .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
+    Ok(page.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string())
+}
+
+/// Write a prose page's content + bump its `modifiedAt`. Mirrors the lookup
+/// in `set_prose`; used by the structural tools.
+fn write_prose_content(doc: &mut Value, page_id: &str, html: String, now: u64) -> Result<(), String> {
+    let rtp = rich_text_pages_mut(doc)?;
+    let page = rtp
+        .get_mut("pages")
+        .and_then(|v| v.as_object_mut())
+        .and_then(|pages| pages.get_mut(page_id))
+        .and_then(|p| p.as_object_mut())
+        .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
+    page.insert("content".into(), json!(html));
+    page.insert("modifiedAt".into(), json!(now));
+    stamp_doc_modified(doc, now);
+    Ok(())
+}
+
+/// Summarise an outline's sections as `[{index, level, title}]`.
+fn outline_summary(outline: &Outline) -> Vec<Value> {
+    outline
+        .sections
+        .iter()
+        .enumerate()
+        .map(|(i, s)| json!({"index": i, "level": s.level, "title": s.title}))
+        .collect()
+}
+
+#[derive(Deserialize)]
+struct GetOutlineArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+}
+
+fn get_outline(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: GetOutlineArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
+    let content = read_prose_content(&doc, &parsed.page_id)?;
+    let outline = Outline::parse(&content);
+    Ok(ToolOutcome {
+        result: json!({"outline": outline_summary(&outline), "source": source}),
+        changed_doc_id: None,
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct InsertSectionArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    level: i64,
+    title: String,
+    body: Option<String>,
+    format: Option<String>,
+    position: Option<String>,
+    #[serde(rename = "afterIndex")]
+    after_index: Option<usize>,
+}
+
+fn insert_section(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: InsertSectionArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    let level = clamp_level(parsed.level);
+    let title = parsed.title.trim().to_string();
+    let inner_html = escape_html(&title);
+    // Render the body once, up front, so a bad format fails before any write.
+    let body_html = match &parsed.body {
+        Some(b) => content_to_html(b, parsed.format.as_deref())?,
+        None => String::new(),
+    };
+
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let content = read_prose_content(doc, &parsed.page_id)?;
+        let mut outline = Outline::parse(&content);
+        let len = outline.sections.len();
+        let pos = match parsed.after_index {
+            Some(ai) => (ai + 1).min(len),
+            None => match parsed.position.as_deref() {
+                Some("start") => 0,
+                _ => len,
+            },
+        };
+        outline.sections.insert(
+            pos,
+            Section {
+                level,
+                inner_html: inner_html.clone(),
+                title: title.clone(),
+                body_html: body_html.clone(),
+            },
+        );
+        write_prose_content(doc, &parsed.page_id, outline.to_html(), now)
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "ok": true}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct RestructureOutlineArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    op: String,
+    index: usize,
+    #[serde(rename = "toIndex")]
+    to_index: Option<usize>,
+}
+
+fn restructure_outline(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: RestructureOutlineArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    let summary = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let content = read_prose_content(doc, &parsed.page_id)?;
+        let mut outline = Outline::parse(&content);
+        let n = outline.sections.len();
+        if parsed.index >= n {
+            return Err(format!(
+                "No section at index {} — the page has {} heading(s)",
+                parsed.index, n
+            ));
+        }
+        match parsed.op.as_str() {
+            "promote" => {
+                let lvl = outline.sections[parsed.index].level as i64;
+                outline.sections[parsed.index].level = clamp_level(lvl - 1);
+            }
+            "demote" => {
+                let lvl = outline.sections[parsed.index].level as i64;
+                outline.sections[parsed.index].level = clamp_level(lvl + 1);
+            }
+            "move" => {
+                let to = parsed
+                    .to_index
+                    .ok_or("op 'move' requires 'toIndex'")?
+                    .min(n - 1);
+                let section = outline.sections.remove(parsed.index);
+                outline.sections.insert(to, section);
+            }
+            other => {
+                return Err(format!(
+                    "Unknown op '{}'; expected 'promote', 'demote', or 'move'",
+                    other
+                ))
+            }
+        }
+        write_prose_content(doc, &parsed.page_id, outline.to_html(), now)?;
+        Ok(outline_summary(&outline))
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "outline": summary}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
 }
 
 #[derive(Deserialize)]
@@ -1806,6 +2042,134 @@ mod tests {
             let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();
             assert!(err.contains("read-only"), "{} -> {}", tool, err);
         }
+    }
+
+    /// Seed a prose page with Markdown and return (docId, pageId).
+    fn seed_prose(f: &Fixture, md: &str) -> String {
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_prose_page",
+            &json!({"docId": "doc1", "content": md}),
+        )
+        .unwrap();
+        out.result["id"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn get_outline_lists_headings_in_order() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let page_id = seed_prose(&f, "# Alpha\n\ntext\n\n## Beta\n\n# Gamma");
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.get_outline",
+            &json!({"docId": "doc1", "pageId": page_id}),
+        )
+        .unwrap();
+        let o = out.result["outline"].as_array().unwrap();
+        assert_eq!(o.len(), 3);
+        assert_eq!(o[0]["title"], "Alpha");
+        assert_eq!(o[0]["level"], 1);
+        assert_eq!(o[1]["title"], "Beta");
+        assert_eq!(o[1]["level"], 2);
+        assert_eq!(o[2]["title"], "Gamma");
+    }
+
+    #[test]
+    fn insert_section_places_at_position_and_after_index() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let page_id = seed_prose(&f, "# A\n\n# B");
+
+        // Insert at start.
+        dispatch(
+            &f.ctx(true),
+            "docushark.insert_section",
+            &json!({"docId":"doc1","pageId":page_id,"level":1,"title":"Intro","position":"start"}),
+        )
+        .unwrap();
+        // Insert after the second heading (index 1, which is now "A").
+        dispatch(
+            &f.ctx(true),
+            "docushark.insert_section",
+            &json!({"docId":"doc1","pageId":page_id,"level":2,"title":"A.1","body":"detail","afterIndex":1}),
+        )
+        .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.get_outline",
+            &json!({"docId":"doc1","pageId":page_id}),
+        )
+        .unwrap();
+        let titles: Vec<&str> = out.result["outline"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["title"].as_str().unwrap())
+            .collect();
+        assert_eq!(titles, vec!["Intro", "A", "A.1", "B"]);
+
+        // Body Markdown was rendered into the page HTML.
+        let prose = dispatch(
+            &f.ctx(true),
+            "docushark.get_prose",
+            &json!({"docId":"doc1","pageId":page_id}),
+        )
+        .unwrap();
+        assert!(prose.result["page"]["content"].as_str().unwrap().contains("<p>detail</p>"));
+    }
+
+    #[test]
+    fn restructure_outline_promotes_demotes_and_moves() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let page_id = seed_prose(&f, "# First\n\n## Second\n\n## Third");
+
+        // Promote "Second" (index 1, h2 -> h1).
+        dispatch(
+            &f.ctx(true),
+            "docushark.restructure_outline",
+            &json!({"docId":"doc1","pageId":page_id,"op":"promote","index":1}),
+        )
+        .unwrap();
+        // Move "Third" (index 2) to the front.
+        let moved = dispatch(
+            &f.ctx(true),
+            "docushark.restructure_outline",
+            &json!({"docId":"doc1","pageId":page_id,"op":"move","index":2,"toIndex":0}),
+        )
+        .unwrap();
+        let outline = moved.result["outline"].as_array().unwrap();
+        assert_eq!(outline[0]["title"], "Third");
+        assert_eq!(outline[1]["title"], "First");
+        // Second was promoted to level 1.
+        let second = outline.iter().find(|s| s["title"] == "Second").unwrap();
+        assert_eq!(second["level"], 1);
+    }
+
+    #[test]
+    fn restructure_outline_errors_on_bad_index_and_missing_to_index() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let page_id = seed_prose(&f, "# Only");
+
+        let oob = dispatch(
+            &f.ctx(true),
+            "docushark.restructure_outline",
+            &json!({"docId":"doc1","pageId":page_id,"op":"promote","index":5}),
+        )
+        .unwrap_err();
+        assert!(oob.contains("No section at index"));
+
+        let no_to = dispatch(
+            &f.ctx(true),
+            "docushark.restructure_outline",
+            &json!({"docId":"doc1","pageId":page_id,"op":"move","index":0}),
+        )
+        .unwrap_err();
+        assert!(no_to.contains("requires 'toIndex'"));
     }
 
     #[test]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::server::documents::DocumentStore;
+use crate::server::documents::{DocumentStore, SaveOutcome};
 use crate::server::protocol::{DocId, WorkspaceId};
 
 use super::adapter::{apply_dsl_patch, dsl_to_shape_json, shape_json_to_dsl, DslPatch, DslShape};
@@ -490,16 +490,70 @@ fn append_shape_in_place(doc: &mut Value, page_id: &str, shape: &DslShape) -> Re
     Ok(id)
 }
 
+/// Maximum optimistic-concurrency retries before a write gives up. A
+/// conflict means a concurrent writer (a live collaborator's WS save, or
+/// another MCP call) bumped the doc's `serverVersion` between our read and
+/// save; we re-read and replay the mutation. Five attempts comfortably
+/// absorbs realistic contention without spinning.
+const MAX_WRITE_ATTEMPTS: usize = 5;
+
+/// Read a team doc, apply `mutate`, then persist under optimistic
+/// concurrency, retrying on `VersionConflict`. This is the write path for
+/// every mutating MCP tool: the previous code called the unconditional
+/// `save_document` (last-writer-wins), which silently clobbered concurrent
+/// edits from a live collaborator. We instead echo the doc's `serverVersion`
+/// back as the expected version (see `documents.rs`) so a stale write is
+/// rejected and replayed on a fresh read.
+///
+/// `mutate` may run more than once (once per attempt), so it must be a pure
+/// function of the doc it's handed — don't capture side effects. It returns
+/// whatever per-call value the tool reports (an id, a list of ids, …); the
+/// value from the attempt that actually persisted is returned.
+///
+/// A doc that predates server versioning has no `serverVersion` field; in
+/// that case `expected` is `None` and the save proceeds unconditionally
+/// (matching the prior behavior for legacy docs — they can't conflict).
+fn mutate_with_retry<R>(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    mut mutate: impl FnMut(&mut Value) -> Result<R, String>,
+) -> Result<R, String> {
+    let mut last_seen = 0u64;
+    for _ in 0..MAX_WRITE_ATTEMPTS {
+        let mut doc = ctx.team.get_document(&ctx.workspace_id, doc_id)?;
+        let expected = doc.get("serverVersion").and_then(|v| v.as_u64());
+        let value = mutate(&mut doc)?;
+        match ctx
+            .team
+            .save_document_with_expected_version(&ctx.workspace_id, doc, expected)?
+        {
+            SaveOutcome::Created { .. } | SaveOutcome::Updated { .. } => return Ok(value),
+            SaveOutcome::VersionConflict { current } => {
+                last_seen = current;
+                continue;
+            }
+        }
+    }
+    Err(format!(
+        "document '{}' was modified concurrently during the write (current version {}); \
+         retried {} times without success — re-read and try again",
+        doc_id.as_str(),
+        last_seen,
+        MAX_WRITE_ATTEMPTS
+    ))
+}
+
 fn add_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: AddShapeArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
 
     reject_if_local(ctx, &parsed.doc_id)?;
-    let mut doc = ctx.team.get_document(&ctx.workspace_id, &parsed.doc_id)?;
-    let warning = lock_warning(&doc);
-    let id = append_shape_in_place(&mut doc, &parsed.page_id, &parsed.shape)?;
-    stamp_modified(&mut doc, &parsed.page_id);
-    ctx.team.save_document(&ctx.workspace_id, doc)?;
+    let (id, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let warning = lock_warning(doc);
+        let id = append_shape_in_place(doc, &parsed.page_id, &parsed.shape)?;
+        stamp_modified(doc, &parsed.page_id);
+        Ok((id, warning))
+    })?;
 
     Ok(ToolOutcome {
         result: json!({"id": id, "warning": warning}),
@@ -537,18 +591,18 @@ fn add_shapes(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     }
 
     reject_if_local(ctx, &parsed.doc_id)?;
-    let mut doc = ctx.team.get_document(&ctx.workspace_id, &parsed.doc_id)?;
-    let warning = lock_warning(&doc);
-
-    let mut ids = Vec::with_capacity(parsed.shapes.len());
-    for (idx, shape) in parsed.shapes.iter().enumerate() {
-        match append_shape_in_place(&mut doc, &parsed.page_id, shape) {
-            Ok(id) => ids.push(id),
-            Err(e) => return Err(format!("shape[{}]: {}", idx, e)),
+    let (ids, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let warning = lock_warning(doc);
+        let mut ids = Vec::with_capacity(parsed.shapes.len());
+        for (idx, shape) in parsed.shapes.iter().enumerate() {
+            match append_shape_in_place(doc, &parsed.page_id, shape) {
+                Ok(id) => ids.push(id),
+                Err(e) => return Err(format!("shape[{}]: {}", idx, e)),
+            }
         }
-    }
-    stamp_modified(&mut doc, &parsed.page_id);
-    ctx.team.save_document(&ctx.workspace_id, doc)?;
+        stamp_modified(doc, &parsed.page_id);
+        Ok((ids, warning))
+    })?;
 
     Ok(ToolOutcome {
         result: json!({"ids": ids, "warning": warning}),
@@ -579,47 +633,47 @@ fn connect(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
 
     reject_if_local(ctx, &parsed.doc_id)?;
-    let mut doc = ctx.team.get_document(&ctx.workspace_id, &parsed.doc_id)?;
+    let (id, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        // Validate the endpoints actually exist on the page before we mutate.
+        let page = doc
+            .get("pages")
+            .and_then(|p| p.get(&parsed.page_id))
+            .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
+        let shapes = page.get("shapes").ok_or("Page has no shapes")?;
+        if shapes.get(&parsed.from_id).is_none() {
+            return Err(format!(
+                "fromId '{}' does not exist on page '{}'",
+                parsed.from_id, parsed.page_id
+            ));
+        }
+        if shapes.get(&parsed.to_id).is_none() {
+            return Err(format!(
+                "toId '{}' does not exist on page '{}'",
+                parsed.to_id, parsed.page_id
+            ));
+        }
 
-    // Validate the endpoints actually exist on the page before we mutate.
-    let page = doc
-        .get("pages")
-        .and_then(|p| p.get(&parsed.page_id))
-        .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
-    let shapes = page.get("shapes").ok_or("Page has no shapes")?;
-    if shapes.get(&parsed.from_id).is_none() {
-        return Err(format!(
-            "fromId '{}' does not exist on page '{}'",
-            parsed.from_id, parsed.page_id
-        ));
-    }
-    if shapes.get(&parsed.to_id).is_none() {
-        return Err(format!(
-            "toId '{}' does not exist on page '{}'",
-            parsed.to_id, parsed.page_id
-        ));
-    }
-
-    let warning = lock_warning(&doc);
-    let dsl = DslShape {
-        kind: super::adapter::DslKind::Connector,
-        x: 0.0,
-        y: 0.0,
-        w: None,
-        h: None,
-        text: parsed.label,
-        style: None,
-        id: None,
-        start_shape_id: Some(parsed.from_id),
-        end_shape_id: Some(parsed.to_id),
-        start_anchor: parsed.from_anchor,
-        end_anchor: parsed.to_anchor,
-        start_arrow_style: None,
-        end_arrow_style: None,
-    };
-    let id = append_shape_in_place(&mut doc, &parsed.page_id, &dsl)?;
-    stamp_modified(&mut doc, &parsed.page_id);
-    ctx.team.save_document(&ctx.workspace_id, doc)?;
+        let warning = lock_warning(doc);
+        let dsl = DslShape {
+            kind: super::adapter::DslKind::Connector,
+            x: 0.0,
+            y: 0.0,
+            w: None,
+            h: None,
+            text: parsed.label.clone(),
+            style: None,
+            id: None,
+            start_shape_id: Some(parsed.from_id.clone()),
+            end_shape_id: Some(parsed.to_id.clone()),
+            start_anchor: parsed.from_anchor.clone(),
+            end_anchor: parsed.to_anchor.clone(),
+            start_arrow_style: None,
+            end_arrow_style: None,
+        };
+        let id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
+        stamp_modified(doc, &parsed.page_id);
+        Ok((id, warning))
+    })?;
 
     Ok(ToolOutcome {
         result: json!({"id": id, "warning": warning}),
@@ -643,32 +697,33 @@ fn update_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
 
     reject_if_local(ctx, &parsed.doc_id)?;
-    let mut doc = ctx.team.get_document(&ctx.workspace_id, &parsed.doc_id)?;
-    let warning = lock_warning(&doc);
+    let (changed, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let warning = lock_warning(doc);
 
-    let pages = doc
-        .get_mut("pages")
-        .and_then(|v| v.as_object_mut())
-        .ok_or("Document missing 'pages'")?;
-    let page = pages
-        .get_mut(&parsed.page_id)
-        .and_then(|v| v.as_object_mut())
-        .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
-    let shapes = page
-        .get_mut("shapes")
-        .and_then(|v| v.as_object_mut())
-        .ok_or("Page 'shapes' is not an object")?;
-    let shape = shapes
-        .get_mut(&parsed.id)
-        .ok_or_else(|| format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id))?;
+        let pages = doc
+            .get_mut("pages")
+            .and_then(|v| v.as_object_mut())
+            .ok_or("Document missing 'pages'")?;
+        let page = pages
+            .get_mut(&parsed.page_id)
+            .and_then(|v| v.as_object_mut())
+            .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
+        let shapes = page
+            .get_mut("shapes")
+            .and_then(|v| v.as_object_mut())
+            .ok_or("Page 'shapes' is not an object")?;
+        let shape = shapes
+            .get_mut(&parsed.id)
+            .ok_or_else(|| format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id))?;
 
-    let changed = apply_dsl_patch(shape, &parsed.patch);
-    if changed.is_empty() {
-        return Err("Patch did not specify any updatable fields".into());
-    }
+        let changed = apply_dsl_patch(shape, &parsed.patch);
+        if changed.is_empty() {
+            return Err("Patch did not specify any updatable fields".into());
+        }
 
-    stamp_modified(&mut doc, &parsed.page_id);
-    ctx.team.save_document(&ctx.workspace_id, doc)?;
+        stamp_modified(doc, &parsed.page_id);
+        Ok((changed, warning))
+    })?;
 
     Ok(ToolOutcome {
         result: json!({"id": parsed.id, "changed": changed, "warning": warning}),
@@ -1116,5 +1171,84 @@ mod tests {
         let f = seed(&dir.path().to_path_buf());
         let err = dispatch(&f.ctx(true), "docushark.nope", &json!({})).unwrap_err();
         assert!(err.contains("Unknown tool"));
+    }
+
+    /// A write that loses the optimistic-concurrency race re-reads and
+    /// replays its mutation rather than clobbering the concurrent edit.
+    /// Simulates a live collaborator's save landing between our read and
+    /// our save; the final doc must carry *both* changes.
+    #[test]
+    fn write_retries_and_preserves_concurrent_edit() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let ctx = f.ctx(true);
+        let doc_id = DocId::from_body_id("doc1".to_string()).unwrap();
+
+        let mut attempts = 0usize;
+        mutate_with_retry(&ctx, &doc_id, |doc| {
+            attempts += 1;
+            if attempts == 1 {
+                // A collaborator renames the doc after we read but before
+                // we save, bumping serverVersion and forcing a conflict.
+                let mut other = f.team.get_document(&ws, &doc_id).unwrap();
+                other
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("name".into(), json!("Renamed by collaborator"));
+                f.team.save_document(&ws, other).unwrap();
+            }
+            // Our mutation: stamp a marker field.
+            doc.as_object_mut()
+                .unwrap()
+                .insert("mcpNote".into(), json!("mcp-was-here"));
+            Ok::<(), String>(())
+        })
+        .unwrap();
+
+        assert_eq!(attempts, 2, "should re-read and replay exactly once after the conflict");
+
+        let final_doc = f.team.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(
+            final_doc["mcpNote"], "mcp-was-here",
+            "our mutation must persist"
+        );
+        assert_eq!(
+            final_doc["name"], "Renamed by collaborator",
+            "the concurrent edit must NOT be clobbered"
+        );
+    }
+
+    /// Retries are bounded: a writer that never wins the race fails with a
+    /// clear conflict message rather than spinning forever.
+    #[test]
+    fn write_gives_up_after_max_attempts() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let ctx = f.ctx(true);
+        let doc_id = DocId::from_body_id("doc1".to_string()).unwrap();
+
+        let err = mutate_with_retry(&ctx, &doc_id, |doc| {
+            // Always bump the version out from under ourselves before saving.
+            let mut other = f.team.get_document(&ws, &doc_id).unwrap();
+            let bump = other["modifiedAt"].as_u64().unwrap_or(0) + 1;
+            other
+                .as_object_mut()
+                .unwrap()
+                .insert("modifiedAt".into(), json!(bump));
+            f.team.save_document(&ws, other).unwrap();
+            doc.as_object_mut()
+                .unwrap()
+                .insert("mcpNote".into(), json!("never lands"));
+            Ok::<(), String>(())
+        })
+        .unwrap_err();
+
+        assert!(
+            err.contains("modified concurrently"),
+            "expected a concurrency error, got: {}",
+            err
+        );
     }
 }

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1,13 +1,16 @@
-//! MCP tool surface for DocuShark — foundation set.
+//! MCP tool surface for DocuShark, all namespaced `docushark.*`.
 //!
-//! Four tools, all namespaced `docushark.*`:
-//!   - list_documents
-//!   - get_document
-//!   - get_page
-//!   - add_shape
+//! Reads:   list_documents, get_document, get_page, get_prose
+//! Authoring (JP-93 "publish target"): create_document
+//! Diagram writes: add_shape, add_shapes, connect, update_shape
+//! Prose writes:   add_prose_page, set_prose, rename_prose_page
 //!
-//! Richer write tools (batch add, connect, layout, group, comments) are
-//! deferred until the foundation is debugged.
+//! A "document" carries both a diagram canvas (`pages` → shapes) and a
+//! written body (`richTextPages`, multi-page TipTap prose stored as HTML).
+//! All write tools target the team store (`ctx.team`), refuse local
+//! renderer-owned docs, and persist through `mutate_with_retry` so a
+//! concurrent collaborator edit is never clobbered (optimistic concurrency
+//! on `serverVersion`).
 
 use std::sync::Arc;
 
@@ -100,6 +103,67 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                         "description": "Title for the new document. Defaults to \"Untitled Document\"."
                     }
                 },
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.get_prose",
+            description:
+                "Read a document's prose (the written body, separate from the diagram canvas). With no pageId, returns every prose page (id, name, order, HTML content); with a pageId, returns just that page. Prose is stored as HTML.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string", "description": "Optional prose page id; omit to get all prose pages."}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.add_prose_page",
+            description:
+                "Add a new prose page to a document and return its id. Content is Markdown by default (set format:\"html\" to pass HTML through). Use this to start a new section/chapter of the written document.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "name": {"type": "string", "description": "Page title. Defaults to \"Page N\"."},
+                    "content": {"type": "string", "description": "Initial body. Markdown unless format is \"html\". Optional (blank page if omitted)."},
+                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.set_prose",
+            description:
+                "Replace the entire content of a prose page. Content is Markdown by default (set format:\"html\" to pass HTML through). Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "content": {"type": "string", "description": "New full body. Markdown unless format is \"html\"."},
+                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."}
+                },
+                "required": ["docId", "pageId", "content"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.rename_prose_page",
+            description:
+                "Rename a prose page. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "name": {"type": "string"}
+                },
+                "required": ["docId", "pageId", "name"],
                 "additionalProperties": false
             }),
         },
@@ -267,6 +331,10 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.get_document" => get_document(ctx, args),
         "docushark.get_page" => get_page(ctx, args),
         "docushark.create_document" => create_document(ctx, args),
+        "docushark.get_prose" => get_prose(ctx, args),
+        "docushark.add_prose_page" => add_prose_page(ctx, args),
+        "docushark.set_prose" => set_prose(ctx, args),
+        "docushark.rename_prose_page" => rename_prose_page(ctx, args),
         "docushark.add_shape" => add_shape(ctx, args),
         "docushark.add_shapes" => add_shapes(ctx, args),
         "docushark.connect" => connect(ctx, args),
@@ -369,12 +437,44 @@ fn get_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
             "name": doc.get("name").cloned().unwrap_or(Value::Null),
             "modifiedAt": doc.get("modifiedAt").cloned().unwrap_or(Value::Null),
             "lockedBy": doc.get("lockedBy").cloned().unwrap_or(Value::Null),
+            // Canvas pages (diagrams).
             "pages": pages,
+            // Prose pages (the written body) — id/name/order only; fetch
+            // content with get_prose. Empty for diagram-only documents.
+            "prosePages": prose_page_summaries(&doc),
             "source": source,
         }),
         changed_doc_id: None,
         change_detail: None,
     })
+}
+
+/// Summarise a doc's prose pages (id, name, order) in `pageOrder` order,
+/// without their (potentially large) HTML bodies. Empty list when the doc
+/// has no `richTextPages` (diagram-only or pre-prose documents).
+fn prose_page_summaries(doc: &Value) -> Vec<Value> {
+    let rtp = match doc.get("richTextPages") {
+        Some(v) => v,
+        None => return Vec::new(),
+    };
+    let pages = rtp.get("pages");
+    rtp.get("pageOrder")
+        .and_then(|v| v.as_array())
+        .map(|order| {
+            order
+                .iter()
+                .filter_map(|id| id.as_str())
+                .filter_map(|id| {
+                    let page = pages?.get(id)?;
+                    Some(json!({
+                        "id": id,
+                        "name": page.get("name").cloned().unwrap_or(json!("")),
+                        "order": page.get("order").cloned().unwrap_or(json!(0)),
+                    }))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[derive(Deserialize)]
@@ -504,6 +604,266 @@ fn create_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
         changed_doc_id: Some(doc_id),
         change_detail: None,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Prose tools (JP-93 Slice B): read/write the document's written body, which
+// lives in `richTextPages` (multi-page TipTap prose) alongside the diagram
+// canvas. Prose is persisted as HTML; agents author in Markdown by default.
+// ---------------------------------------------------------------------------
+
+/// Render Markdown to the HTML TipTap persists. GFM tables / strikethrough /
+/// task-lists are enabled to match the editor's extension set.
+fn markdown_to_html(md: &str) -> String {
+    use pulldown_cmark::{html, Options, Parser};
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+    opts.insert(Options::ENABLE_TASKLISTS);
+    let parser = Parser::new_ext(md, opts);
+    let mut out = String::new();
+    html::push_html(&mut out, parser);
+    out
+}
+
+/// Turn agent-supplied content into the HTML stored on a prose page.
+/// Markdown is the default (agents produce it reliably); `html` is a
+/// pass-through escape hatch. The editor re-parses this HTML against the
+/// ProseMirror schema on load, which silently drops anything the schema
+/// doesn't model — a natural sanitizer for pass-through HTML.
+fn content_to_html(content: &str, format: Option<&str>) -> Result<String, String> {
+    match format.unwrap_or("markdown") {
+        "markdown" | "md" => Ok(markdown_to_html(content)),
+        "html" => Ok(content.to_string()),
+        other => Err(format!(
+            "Unknown content format '{}'; expected 'markdown' or 'html'",
+            other
+        )),
+    }
+}
+
+/// Mutable handle to the doc's `richTextPages` container, initialising an
+/// empty one for documents that predate multi-page prose so writes always
+/// have somewhere to land.
+fn rich_text_pages_mut(doc: &mut Value) -> Result<&mut serde_json::Map<String, Value>, String> {
+    let obj = doc.as_object_mut().ok_or("Document is not an object")?;
+    let rtp = obj.entry("richTextPages").or_insert_with(|| {
+        json!({ "pages": {}, "pageOrder": [], "activePageId": Value::Null })
+    });
+    rtp.as_object_mut()
+        .ok_or_else(|| "'richTextPages' is not an object".to_string())
+}
+
+#[derive(Deserialize)]
+struct GetProseArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: Option<String>,
+}
+
+fn get_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: GetProseArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
+
+    let empty_pages = json!({});
+    let rtp = doc.get("richTextPages");
+    let pages_obj = rtp.and_then(|r| r.get("pages")).unwrap_or(&empty_pages);
+
+    let render = |id: &str, page: &Value| {
+        json!({
+            "id": id,
+            "name": page.get("name").cloned().unwrap_or(json!("")),
+            "order": page.get("order").cloned().unwrap_or(json!(0)),
+            "content": page.get("content").cloned().unwrap_or(json!("")),
+        })
+    };
+
+    if let Some(page_id) = parsed.page_id {
+        let page = pages_obj
+            .get(&page_id)
+            .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
+        return Ok(ToolOutcome {
+            result: json!({"page": render(&page_id, page), "source": source}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    let order: Vec<String> = rtp
+        .and_then(|r| r.get("pageOrder"))
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    let pages: Vec<Value> = order
+        .iter()
+        .filter_map(|id| pages_obj.get(id).map(|p| render(id, p)))
+        .collect();
+
+    Ok(ToolOutcome {
+        result: json!({"pages": pages, "source": source}),
+        changed_doc_id: None,
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct AddProsePageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    name: Option<String>,
+    content: Option<String>,
+    format: Option<String>,
+}
+
+fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: AddProsePageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    // Render once, outside the retry loop — deterministic and lets a bad
+    // format fail fast before we touch the store.
+    let html = match &parsed.content {
+        Some(c) => content_to_html(c, parsed.format.as_deref())?,
+        None => String::new(),
+    };
+
+    let id = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let rtp = rich_text_pages_mut(doc)?;
+        let order = rtp
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        let page_id = format!("page-{}", nanoid::nanoid!(12));
+        let name = parsed
+            .name
+            .clone()
+            .map(|n| n.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| format!("Page {}", order + 1));
+
+        rtp.entry("pages")
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .ok_or("'richTextPages.pages' is not an object")?
+            .insert(
+                page_id.clone(),
+                json!({
+                    "id": page_id,
+                    "name": name,
+                    "content": html,
+                    "order": order,
+                    "createdAt": now,
+                    "modifiedAt": now,
+                }),
+            );
+        rtp.entry("pageOrder")
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .ok_or("'richTextPages.pageOrder' is not an array")?
+            .push(json!(page_id.clone()));
+        if rtp.get("activePageId").map(|v| v.is_null()).unwrap_or(true) {
+            rtp.insert("activePageId".into(), json!(page_id.clone()));
+        }
+
+        stamp_doc_modified(doc, now);
+        Ok(page_id)
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"id": id}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct SetProseArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    content: String,
+    format: Option<String>,
+}
+
+fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: SetProseArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+    let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
+
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let rtp = rich_text_pages_mut(doc)?;
+        let page = rtp
+            .get_mut("pages")
+            .and_then(|v| v.as_object_mut())
+            .and_then(|pages| pages.get_mut(&parsed.page_id))
+            .and_then(|p| p.as_object_mut())
+            .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
+        page.insert("content".into(), json!(html.clone()));
+        page.insert("modifiedAt".into(), json!(now));
+        stamp_doc_modified(doc, now);
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "ok": true}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct RenameProsePageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    name: String,
+}
+
+fn rename_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: RenameProsePageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+    let name = parsed.name.trim().to_string();
+    if name.is_empty() {
+        return Err("Page name must not be empty".into());
+    }
+
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let rtp = rich_text_pages_mut(doc)?;
+        let page = rtp
+            .get_mut("pages")
+            .and_then(|v| v.as_object_mut())
+            .and_then(|pages| pages.get_mut(&parsed.page_id))
+            .and_then(|p| p.as_object_mut())
+            .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
+        page.insert("name".into(), json!(name.clone()));
+        page.insert("modifiedAt".into(), json!(now));
+        stamp_doc_modified(doc, now);
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "name": name}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+/// Stamp the document's top-level `modifiedAt` (prose edits don't belong to
+/// a canvas page, so `stamp_modified`'s page arm doesn't apply).
+fn stamp_doc_modified(doc: &mut Value, now: u64) {
+    if let Some(o) = doc.as_object_mut() {
+        o.insert("modifiedAt".into(), json!(now));
+    }
 }
 
 #[derive(Deserialize)]
@@ -1326,6 +1686,126 @@ mod tests {
         assert_eq!(prose["pageOrder"].as_array().unwrap().len(), 1);
         let active = prose["activePageId"].as_str().unwrap();
         assert_eq!(prose["pages"][active]["content"], "");
+    }
+
+    #[test]
+    fn add_prose_page_renders_markdown_to_html() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_prose_page",
+            &json!({
+                "docId": "doc1",
+                "name": "Overview",
+                "content": "# Title\n\nA **bold** idea.\n\n- one\n- two"
+            }),
+        )
+        .unwrap();
+        let page_id = out.result["id"].as_str().unwrap().to_string();
+
+        let got = dispatch(
+            &f.ctx(true),
+            "docushark.get_prose",
+            &json!({"docId": "doc1", "pageId": page_id}),
+        )
+        .unwrap();
+        let html = got.result["page"]["content"].as_str().unwrap();
+        assert!(html.contains("<h1>Title</h1>"), "got: {}", html);
+        assert!(html.contains("<strong>bold</strong>"));
+        assert!(html.contains("<li>one</li>"));
+        assert_eq!(got.result["page"]["name"], "Overview");
+    }
+
+    #[test]
+    fn set_prose_replaces_content_and_html_passthrough_works() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let added = dispatch(
+            &f.ctx(true),
+            "docushark.add_prose_page",
+            &json!({"docId": "doc1", "content": "old"}),
+        )
+        .unwrap();
+        let page_id = added.result["id"].as_str().unwrap().to_string();
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.set_prose",
+            &json!({"docId": "doc1", "pageId": page_id, "content": "<p>verbatim</p>", "format": "html"}),
+        )
+        .unwrap();
+
+        let got = dispatch(
+            &f.ctx(true),
+            "docushark.get_prose",
+            &json!({"docId": "doc1", "pageId": page_id}),
+        )
+        .unwrap();
+        assert_eq!(got.result["page"]["content"], "<p>verbatim</p>");
+    }
+
+    #[test]
+    fn set_prose_rejects_unknown_format_and_missing_page() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let bad_fmt = dispatch(
+            &f.ctx(true),
+            "docushark.set_prose",
+            &json!({"docId": "doc1", "pageId": "nope", "content": "x", "format": "rtf"}),
+        )
+        .unwrap_err();
+        assert!(bad_fmt.contains("Unknown content format"));
+
+        let missing = dispatch(
+            &f.ctx(true),
+            "docushark.set_prose",
+            &json!({"docId": "doc1", "pageId": "nope", "content": "x"}),
+        )
+        .unwrap_err();
+        assert!(missing.contains("not found"));
+    }
+
+    #[test]
+    fn rename_prose_page_updates_name_and_get_document_lists_prose() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let added = dispatch(
+            &f.ctx(true),
+            "docushark.add_prose_page",
+            &json!({"docId": "doc1", "name": "Draft"}),
+        )
+        .unwrap();
+        let page_id = added.result["id"].as_str().unwrap().to_string();
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.rename_prose_page",
+            &json!({"docId": "doc1", "pageId": page_id, "name": "Final"}),
+        )
+        .unwrap();
+
+        let doc = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": "doc1"})).unwrap();
+        let prose = doc.result["prosePages"].as_array().unwrap();
+        assert_eq!(prose.len(), 1);
+        assert_eq!(prose[0]["id"], page_id.as_str());
+        assert_eq!(prose[0]["name"], "Final");
+    }
+
+    #[test]
+    fn prose_writes_refuse_local_docs() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        f.local.mirror(&WorkspaceId::single_tenant(), make_doc("local1", "p1", "Local")).unwrap();
+        for (tool, args) in [
+            ("docushark.add_prose_page", json!({"docId":"local1","content":"x"})),
+            ("docushark.set_prose", json!({"docId":"local1","pageId":"p","content":"x"})),
+            ("docushark.rename_prose_page", json!({"docId":"local1","pageId":"p","name":"y"})),
+        ] {
+            let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();
+            assert!(err.contains("read-only"), "{} -> {}", tool, err);
+        }
     }
 
     #[test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -480,11 +480,12 @@ mod tests {
         let tools = body["result"]["tools"].as_array().unwrap();
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
         assert!(names.contains(&"docushark.list_documents"));
+        assert!(names.contains(&"docushark.create_document"));
         assert!(names.contains(&"docushark.add_shape"));
         assert!(names.contains(&"docushark.add_shapes"));
         assert!(names.contains(&"docushark.connect"));
         assert!(names.contains(&"docushark.update_shape"));
-        assert_eq!(tools.len(), 7);
+        assert_eq!(tools.len(), 8);
     }
 
     #[tokio::test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -485,7 +485,11 @@ mod tests {
         assert!(names.contains(&"docushark.add_shapes"));
         assert!(names.contains(&"docushark.connect"));
         assert!(names.contains(&"docushark.update_shape"));
-        assert_eq!(tools.len(), 8);
+        assert!(names.contains(&"docushark.get_prose"));
+        assert!(names.contains(&"docushark.add_prose_page"));
+        assert!(names.contains(&"docushark.set_prose"));
+        assert!(names.contains(&"docushark.rename_prose_page"));
+        assert_eq!(tools.len(), 12);
     }
 
     #[tokio::test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -492,7 +492,8 @@ mod tests {
         assert!(names.contains(&"docushark.get_outline"));
         assert!(names.contains(&"docushark.insert_section"));
         assert!(names.contains(&"docushark.restructure_outline"));
-        assert_eq!(tools.len(), 15);
+        assert!(names.contains(&"docushark.generate_diagram"));
+        assert_eq!(tools.len(), 16);
     }
 
     #[tokio::test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -489,7 +489,10 @@ mod tests {
         assert!(names.contains(&"docushark.add_prose_page"));
         assert!(names.contains(&"docushark.set_prose"));
         assert!(names.contains(&"docushark.rename_prose_page"));
-        assert_eq!(tools.len(), 12);
+        assert!(names.contains(&"docushark.get_outline"));
+        assert!(names.contains(&"docushark.insert_section"));
+        assert!(names.contains(&"docushark.restructure_outline"));
+        assert_eq!(tools.len(), 15);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## JP-93 — MCP "publish target": agents create + manipulate DocuShark docs

Extends the relay MCP surface (**7 → 16 tools**) so external AI agents can
*create and author* documents — prose **and** diagrams — not just edit shapes
on a doc a human already made. This is the lead-wedge "your agent writes into a
real document with diagrams, not just text" capability.

### Slices
| Commit | Slice | What |
|---|---|---|
| Slice 0 | optimistic-concurrency CAS on every MCP write (`mutate_with_retry` → `save_document_with_expected_version`) so an agent write never clobbers a live collaborator. WS live-sync handler left untouched. |
| Slice A | `create_document` — build a minimal `DiagramDocument` (1 canvas + 1 prose page), return `{id,name}`. |
| Slice B | `get_prose`/`add_prose_page`/`set_prose`/`rename_prose_page` on `richTextPages`; agents author **Markdown** (default) → HTML via `pulldown-cmark`. `get_document` now also returns a `prosePages` summary. |
| Slice C | `get_outline`/`insert_section`/`restructure_outline` via new `mcp/outline.rs` (flat section model, no HTML-parser dep). |
| Slice D | `generate_diagram` — node/edge graph → shapes + connectors, auto-positioned by `mcp/layout.rs` (layered/grid). |
| Slice E | `relay/docs/mcp/README.md` reference + `scripts/mcp-smoke.sh` + AGENTS.md MCP section refresh (was pointing at the long-gone `src-tauri/src/mcp/`). |

### Design notes
- Tools are **semantic/intent-level**; the relay owns translation→apply. The full-rewrite apply can later swap to yrs/Y.Doc (JP-34/35/36) with **no tool-signature change**. Prose isn't in that CRDT scope, so it carries zero migration debt.
- Prose rides the existing `DiagramDocument.richTextPages` — no new persistence/sync path.
- `generate_diagram` layout is relay-side and approximate (the editor's TS auto-layout can't run in the relay); the editor can re-layout on open.

### Testing
- **181 relay lib tests pass, clippy clean.**
- Slices A–C verified live end-to-end against a local relay, both via raw `/mcp` curl and through the Claude Code MCP client (create → set_prose(md) → outline → insert → restructure → add_shapes → connect → read-back).
- `scripts/mcp-smoke.sh` exercises the full surface against a running relay.

### Follow-ups (not in this PR)
- The "open in editor" loop: `create_document` smart-link (`openUrl`) + MCP-created docs not visible in the editor (workspace/owner scoping). Filed separately.
- Per-provider sign-off beyond Claude Code (checklist in `docs/mcp/README.md`).

Closes part of JP-93. JP-75 (MCP workspace-claim awareness) verified + closed during this work.

Assisted-by: Opus 4.8
