### PR TITLE
JP-34: authoritative server-side Y.Doc (yrs) per active doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,19 @@ Real-time multi-user editing via "Protected Local" mode. The Tauri host runs a W
 
 **Critical**: The TypeScript protocol (`/src/collaboration/protocol.ts`) must stay in sync with the Rust protocol (`src-tauri/src/server/protocol.rs`). Message types include: SYNC (0), AWARENESS (1), AUTH (2), DOC_LIST/GET/SAVE/DELETE (3-6), DOC_EVENT (7), JOIN_DOC (10), AUTH_LOGIN (11).
 
+**Authoritative relay Y.Doc (JP-34):** the standalone relay (`relay/src/sync/`)
+now holds an authoritative server-side `Y.Doc` (the `yrs` crate) per active
+document. On `JOIN_DOC` it hydrates the doc's active page from the JSON snapshot
+and answers the joining client's `SyncStep1` with authoritative state; inbound
+SYNC frames are applied to the Y.Doc and rebroadcast to peers. This makes the
+relay the source of truth (removing whole-document last-write-wins) — it is a
+**behavior** change only: the wire frames are unchanged lib0-v1 sync bodies and
+`PROTOCOL_VERSION` does **not** move. The relay Y.Doc's shared types
+(`shapes` map, `shapeOrder` array, `metadata` map) must keep mirroring
+`src/collaboration/YjsDocument.ts`. Persisting the Y.Doc back to JSON is a
+separate, later step (the eviction hook in `relay/src/sync/mod.rs` is currently
+a no-op).
+
 **Offline-first architecture**:
 - **OfflineQueue**: Queues save/delete operations when disconnected, processes on reconnect
 - **SyncStateManager**: Coordinates queue, storage, and connection state with auto-retry

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -77,6 +77,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +511,7 @@ dependencies = [
  "toml",
  "tower 0.4.13",
  "tower-http 0.5.2",
+ "yrs",
 ]
 
 [[package]]
@@ -530,10 +560,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1311,6 +1365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2054,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "smallvec"
@@ -2989,6 +3058,24 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "yrs"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89512f2d869f9947e1c58d57ef86c8f4ca1b1e8ccf24d6e1ff8c7cdbd67d54df"
+dependencies = [
+ "arc-swap",
+ "async-lock",
+ "async-trait",
+ "dashmap",
+ "fastrand",
+ "serde",
+ "serde_json",
+ "smallstr",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -6,7 +6,11 @@ authors = ["DocuShark Team"]
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/JPE-Net-Technologies/docushark"
 edition = "2021"
-rust-version = "1.77.2"
+# Bumped from 1.77.2 for JP-34: the authoritative server-side CRDT (`yrs`
+# 0.26) and its modern transitive stack (thiserror 2.x, the icu4x 2.x crates
+# pulled via url/reqwest) require a newer compiler. We take the latest `yrs`
+# for its CRDT fixes rather than pinning an older release to hold the old MSRV.
+rust-version = "1.82"
 
 # Independent crate. Not a workspace member of `src-tauri/`. Built with
 # its own `cargo build` / `cargo test` from this directory.
@@ -83,6 +87,12 @@ toml = "0.8"
 
 # Per-workspace token-bucket rate limiting (Phase 21.3)
 governor = "0.7"
+
+# Authoritative server-side Yjs CRDT (Phase 20.4 / JP-34). Holds a Y.Doc
+# per active document, applies inbound SYNC frames, and answers a joining
+# client's SyncStep1 with authoritative state. lib0-v1 wire-compatible with
+# the JS `y-protocols` client. Pulls serde/serde_json/dashmap — already deps.
+yrs = "0.26"
 
 [dev-dependencies]
 docushark-relay = { path = ".", features = ["test-helpers"] }

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -14,6 +14,7 @@ pub mod auth;
 pub mod config;
 pub mod mcp;
 pub mod server;
+pub mod sync;
 
 #[cfg(feature = "test-helpers")]
 pub mod test_support;

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -48,6 +48,7 @@ use std::num::NonZeroU32;
 use protocol::*;
 use crate::auth::{AuthError, OidcAuthState, OidcClaims, WorkspaceRole};
 use crate::config::{StorageConfig, TenancyConfig, TenancyMode};
+use crate::sync::DocRegistry;
 use blob_backend::S3Backend;
 
 /// Per-workspace token-bucket limiter shared between WS sync handlers
@@ -329,6 +330,10 @@ pub struct ServerState {
     /// MCP server so a tenant's CRDT frames and MCP write tools draw
     /// from the same bucket. Phase 21.3.
     write_limiter: Arc<WorkspaceWriteLimiter>,
+    /// Authoritative server-side Y.Doc per active document (JP-34). Hydrated
+    /// on `JOIN_DOC`, fed by inbound SYNC frames, evicted when the last client
+    /// on a doc disconnects.
+    sync_registry: Arc<DocRegistry>,
     /// Process-wide counter of caught handler panics. Shared with the
     /// MCP server so both subsystems' panics surface at the same
     /// `/metrics` counter. Phase 21.2.
@@ -394,6 +399,7 @@ impl ServerState {
             tenancy,
             workspace_client_counts: RwLock::new(HashMap::new()),
             write_limiter,
+            sync_registry: Arc::new(DocRegistry::new()),
             panic_count,
             rate_limit_rejections,
             metering_debug_log,
@@ -687,6 +693,27 @@ impl ServerState {
 
     pub(crate) fn doc_store(&self) -> &Arc<DocumentStore> {
         &self.doc_store
+    }
+
+    /// Authoritative Y.Doc registry (JP-34).
+    pub(crate) fn sync_registry(&self) -> &Arc<DocRegistry> {
+        &self.sync_registry
+    }
+
+    /// Evict the authoritative Y.Doc for `(ws, doc_id)` if no currently
+    /// connected client is still joined to it. Called from the disconnect
+    /// path and on a doc switch, so a doc's handle is dropped as soon as its
+    /// last participant leaves.
+    async fn evict_doc_if_unused(&self, ws: &WorkspaceId, doc_id: &DocId) {
+        let still_used = {
+            let clients = self.clients.read().await;
+            clients
+                .values()
+                .any(|c| &c.current_workspace_id == ws && c.current_doc_id.as_ref() == Some(doc_id))
+        };
+        if !still_used {
+            self.sync_registry.evict(ws, doc_id);
+        }
     }
 
     /// Broadcast a synthetic `DocEvent` to every authenticated client.
@@ -1691,20 +1718,27 @@ async fn handle_socket(socket: WebSocket, state: Arc<ServerState>) {
     broadcast_task.abort();
     send_task.abort();
 
-    let disconnect = {
+    let removed = {
         let mut clients = state.clients.write().await;
-        clients
-            .remove(&client_id)
-            .filter(|c| c.authenticated)
+        clients.remove(&client_id)
+    };
+    if let Some(client) = removed {
+        if client.authenticated {
             // Classify from the stored role string so release balances the
             // same editor/viewer bucket that registration incremented.
-            .map(|c| {
-                let is_editor = c.role.as_deref() != Some("viewer");
-                (c.current_workspace_id, is_editor)
-            })
-    };
-    if let Some((ws, is_editor)) = disconnect {
-        state.release_workspace_connection(&ws, is_editor).await;
+            let is_editor = client.role.as_deref() != Some("viewer");
+            state
+                .release_workspace_connection(&client.current_workspace_id, is_editor)
+                .await;
+        }
+        // JP-34: drop the authoritative Y.Doc once its last participant has
+        // left. The client is already out of the table above, so the scan
+        // inside `evict_doc_if_unused` reflects post-removal membership.
+        if let Some(doc_id) = &client.current_doc_id {
+            state
+                .evict_doc_if_unused(&client.current_workspace_id, doc_id)
+                .await;
+        }
     }
 
     state.decrement_clients();
@@ -1992,10 +2026,50 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
         return;
     }
 
-    if let Some(doc_id) = doc_id {
-        // Forward to clients on the same (workspace, doc) — both keys
-        // are required so same-id docs in two workspaces don't cross.
-        state.broadcast_to_doc(&workspace_id, &doc_id, data.to_vec(), Some(client_id));
+    let Some(doc_id) = doc_id else { return };
+
+    // JP-34: apply the frame to the authoritative Y.Doc, then answer/broadcast.
+    // The handle should already exist (created on JOIN_DOC); hydrate on demand
+    // to cover the JOIN→SYNC race or a join-time body-load failure.
+    let handle = match state.sync_registry().get(&workspace_id, &doc_id) {
+        Some(handle) => Some(handle),
+        None => match state.doc_store().get_document(&workspace_id, &doc_id) {
+            Ok(doc_json) => Some(state.sync_registry().ensure(&workspace_id, &doc_id, &doc_json)),
+            Err(_) => None,
+        },
+    };
+
+    match handle {
+        Some(handle) => match handle.handle_sync_message(&data[1..]) {
+            Ok(outcome) => {
+                if let Some(reply) = outcome.reply {
+                    send_to_client(client_id, reply, state).await;
+                }
+                if let Some(update) = outcome.broadcast {
+                    // Both keys required so same-id docs in two workspaces
+                    // don't cross-talk.
+                    state.broadcast_to_doc(&workspace_id, &doc_id, update, Some(client_id));
+                }
+            }
+            Err(e) => {
+                // The frame didn't decode as a Yjs sync message. Valid clients
+                // never hit this; to stay backwards-compatible (and preserve
+                // the workspace-scoped routing for any non-standard frame) we
+                // fall back to opaque forwarding rather than dropping it.
+                log::warn!(
+                    "sync decode/apply failed (doc {} ws {}): {:?} — forwarding opaque",
+                    doc_id.as_str(),
+                    workspace_id.as_str(),
+                    e
+                );
+                state.broadcast_to_doc(&workspace_id, &doc_id, data.to_vec(), Some(client_id));
+            }
+        },
+        // No authoritative Y.Doc available — fall back to opaque forwarding so
+        // the frame isn't silently dropped.
+        None => {
+            state.broadcast_to_doc(&workspace_id, &doc_id, data.to_vec(), Some(client_id));
+        }
     }
 }
 
@@ -2083,11 +2157,44 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
         return;
     }
 
-    {
+    let previous_doc_id = {
         let mut clients = state.clients.write().await;
-        if let Some(client) = clients.get_mut(&client_id) {
-            log::info!("Client {} joined document {}", client_id, request.doc_id.as_str());
-            client.current_doc_id = Some(request.doc_id);
+        match clients.get_mut(&client_id) {
+            Some(client) => {
+                log::info!("Client {} joined document {}", client_id, request.doc_id.as_str());
+                client.current_doc_id.replace(request.doc_id.clone())
+            }
+            // Client record vanished mid-join (disconnect race) — nothing to do.
+            None => return,
+        }
+    };
+
+    // If the client switched away from another doc, evict that doc's
+    // authoritative handle when it has no remaining participants.
+    if let Some(prev) = previous_doc_id {
+        if prev != request.doc_id {
+            state.evict_doc_if_unused(&workspace_id, &prev).await;
+        }
+    }
+
+    // JP-34: hydrate (or reuse) the authoritative Y.Doc and push the client a
+    // relay-initiated SyncStep1 so it converges onto authoritative state. The
+    // metadata-exists check above guarantees the doc is known; a body-load
+    // failure is logged but non-fatal — `handle_sync` hydrates on demand.
+    match state.doc_store().get_document(&workspace_id, &request.doc_id) {
+        Ok(doc_json) => {
+            let handle =
+                state
+                    .sync_registry()
+                    .ensure(&workspace_id, &request.doc_id, &doc_json);
+            send_to_client(client_id, handle.sync_step1_frame(), state).await;
+        }
+        Err(e) => {
+            log::warn!(
+                "join_doc: could not load body for {} to hydrate Y.Doc: {}",
+                request.doc_id.as_str(),
+                e
+            );
         }
     }
 }

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -1,0 +1,173 @@
+//! Hydrate an authoritative `Y.Doc` from a persisted JSON snapshot (JP-34).
+//!
+//! The relay Y.Doc must byte-match the client's `YjsDocument`
+//! (`src/collaboration/YjsDocument.ts`): a flat, **active-page-only** surface
+//! of three shared types —
+//!   * `shapes`     — `Y.Map`, each shape stored as a whole JSON value
+//!                    (the client does `shapes.set(id, plainObject)`, i.e. a
+//!                    JSON/`Any` value, *not* a nested `Y.Map`);
+//!   * `shapeOrder` — `Y.Array` of shape-id strings (z-order);
+//!   * `metadata`   — `Y.Map` of `{ title, createdAt, updatedAt }`.
+//!
+//! The persisted document is multi-page; we hydrate the active page
+//! (`pages[activePageId]`). Missing/empty pages hydrate an empty doc — never
+//! panic on a malformed or partial snapshot.
+//!
+//! The inverse (Y.Doc → JSON snapshot) is **JP-36** and is intentionally not
+//! implemented here.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+use yrs::{Any, Array, Doc, Map, Transact};
+
+/// Populate `doc`'s `shapes` / `shapeOrder` / `metadata` shared types from the
+/// active page of a persisted document JSON body.
+pub fn json_to_ydoc(doc_json: &Value, doc: &Doc) {
+    let shapes = doc.get_or_insert_map("shapes");
+    let shape_order = doc.get_or_insert_array("shapeOrder");
+    let metadata = doc.get_or_insert_map("metadata");
+
+    let mut txn = doc.transact_mut();
+
+    // Locate the active page; tolerate any missing piece by hydrating empty.
+    let active_page = doc_json
+        .get("activePageId")
+        .and_then(Value::as_str)
+        .zip(doc_json.get("pages").and_then(Value::as_object))
+        .and_then(|(active, pages)| pages.get(active));
+
+    if let Some(page) = active_page {
+        if let Some(page_shapes) = page.get("shapes").and_then(Value::as_object) {
+            for (id, shape) in page_shapes {
+                shapes.insert(&mut txn, id.clone(), json_to_any(shape));
+            }
+        }
+        if let Some(order) = page.get("shapeOrder").and_then(Value::as_array) {
+            for id in order.iter().filter_map(Value::as_str) {
+                shape_order.push_back(&mut txn, Any::String(id.into()));
+            }
+        }
+    }
+
+    // Metadata mirrors YjsDocumentMetadata { title, createdAt, updatedAt }.
+    if let Some(name) = doc_json.get("name").and_then(Value::as_str) {
+        metadata.insert(&mut txn, "title", Any::String(name.into()));
+    }
+    if let Some(created) = doc_json.get("createdAt").and_then(Value::as_u64) {
+        metadata.insert(&mut txn, "createdAt", Any::Number(created as f64));
+    }
+    // The client's `updatedAt` corresponds to the document's `modifiedAt`.
+    if let Some(modified) = doc_json.get("modifiedAt").and_then(Value::as_u64) {
+        metadata.insert(&mut txn, "updatedAt", Any::Number(modified as f64));
+    }
+}
+
+/// Convert a `serde_json::Value` into a yrs `Any`. Shapes are stored as whole
+/// `Any` values (matching the JS side), so this preserves nested objects and
+/// arrays. JSON numbers become `f64` — Yjs has no plain integer type, and the
+/// client reads them back as JS numbers regardless.
+fn json_to_any(value: &Value) -> Any {
+    match value {
+        Value::Null => Any::Null,
+        Value::Bool(b) => Any::Bool(*b),
+        Value::Number(n) => Any::Number(n.as_f64().unwrap_or(0.0)),
+        Value::String(s) => Any::String(s.as_str().into()),
+        Value::Array(items) => {
+            let converted: Vec<Any> = items.iter().map(json_to_any).collect();
+            Any::Array(converted.into())
+        }
+        Value::Object(map) => {
+            let converted: HashMap<String, Any> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), json_to_any(v)))
+                .collect();
+            Any::Map(Arc::new(converted))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::json_to_ydoc;
+    use serde_json::{json, Value};
+    use yrs::{Array, Doc, Map, Transact};
+
+    fn multi_page_doc() -> Value {
+        json!({
+            "id": "doc-1",
+            "name": "Sample",
+            "createdAt": 1000,
+            "modifiedAt": 2000,
+            "pageOrder": ["p1", "p2"],
+            "activePageId": "p1",
+            "pages": {
+                "p1": {
+                    "id": "p1",
+                    "shapes": {
+                        "s1": {"id": "s1", "type": "rectangle", "x": 1.0, "y": 2.0},
+                        "s2": {"id": "s2", "type": "ellipse"}
+                    },
+                    "shapeOrder": ["s1", "s2"]
+                },
+                "p2": {
+                    "id": "p2",
+                    "shapes": {"s9": {"id": "s9"}},
+                    "shapeOrder": ["s9"]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn hydrates_active_page_only() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page_doc(), &doc);
+
+        let shapes = doc.get_or_insert_map("shapes");
+        let order = doc.get_or_insert_array("shapeOrder");
+        let meta = doc.get_or_insert_map("metadata");
+        let txn = doc.transact();
+
+        assert_eq!(shapes.len(&txn), 2, "only the active page's shapes");
+        assert!(shapes.contains_key(&txn, "s1"));
+        assert!(shapes.contains_key(&txn, "s2"));
+        assert!(!shapes.contains_key(&txn, "s9"), "must not pull other pages");
+        assert_eq!(order.len(&txn), 2);
+
+        assert!(meta.contains_key(&txn, "title"));
+        assert!(meta.contains_key(&txn, "createdAt"));
+        assert!(meta.contains_key(&txn, "updatedAt"));
+    }
+
+    #[test]
+    fn empty_active_page_hydrates_empty() {
+        let doc = Doc::new();
+        json_to_ydoc(
+            &json!({"id": "d", "name": "x", "activePageId": "p1",
+                    "pages": {"p1": {"shapes": {}, "shapeOrder": []}}}),
+            &doc,
+        );
+        // Grab the shared-type handles before opening a read txn — calling
+        // `get_or_insert_*` while a txn is live deadlocks (it transacts).
+        let shapes = doc.get_or_insert_map("shapes");
+        let order = doc.get_or_insert_array("shapeOrder");
+        let txn = doc.transact();
+        assert_eq!(shapes.len(&txn), 0);
+        assert_eq!(order.len(&txn), 0);
+    }
+
+    #[test]
+    fn tolerates_missing_pages_and_active_id() {
+        // A malformed/partial snapshot must hydrate empty, never panic.
+        let doc = Doc::new();
+        json_to_ydoc(&json!({"id": "d", "name": "x"}), &doc);
+        let shapes = doc.get_or_insert_map("shapes");
+        let meta = doc.get_or_insert_map("metadata");
+        let txn = doc.transact();
+        assert_eq!(shapes.len(&txn), 0);
+        // metadata still hydrated from the top-level fields.
+        assert!(meta.contains_key(&txn, "title"));
+    }
+}

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1,0 +1,161 @@
+//! Authoritative server-side Yjs CRDT (Phase 20.4 / JP-34).
+//!
+//! Holds one `Y.Doc` per *active* document. The relay is the source of
+//! truth: on `JOIN_DOC` it hydrates the doc from the JSON snapshot and
+//! answers the joining client's `SyncStep1` with authoritative state;
+//! inbound SYNC frames are applied to the Y.Doc and rebroadcast to peers.
+//! This removes whole-document last-write-wins and is the foundation for
+//! JP-36 (Y.Doc → JSON persistence) and MCP write tools.
+//!
+//! **Scope:** JP-34 is read + live-sync only. There is no durable
+//! persistence here — when the last client on a doc disconnects the handle
+//! is evicted and its in-memory state dropped (durability still rides on the
+//! client REST snapshot until JP-36 lands `on_evict`).
+//!
+//! **Concurrency:** `yrs::Doc` carries its own internal transaction lock and
+//! is `Send + Sync`, so handles are shared via `Arc` with no extra `Mutex`.
+//! Every decode/apply/encode is a short, fully synchronous critical section —
+//! a transaction is **never** held across an `.await`.
+
+mod hydration;
+mod protocol;
+
+pub use protocol::{SyncError, SyncOutcome};
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use serde_json::Value;
+use yrs::Doc;
+
+use crate::server::protocol::{DocId, WorkspaceId};
+
+/// The authoritative Y.Doc for a single active document, plus the sync
+/// operations over it.
+pub struct DocHandle {
+    doc: Doc,
+}
+
+impl DocHandle {
+    /// Build a handle by hydrating a fresh `Doc` from a JSON snapshot.
+    fn hydrate(doc_json: &Value) -> Self {
+        let doc = Doc::new();
+        hydration::json_to_ydoc(doc_json, &doc);
+        Self { doc }
+    }
+
+    /// Apply one inbound sync frame body (bytes *after* the `MESSAGE_SYNC`
+    /// prefix) and report what to send back / broadcast.
+    pub fn handle_sync_message(&self, body: &[u8]) -> Result<SyncOutcome, SyncError> {
+        protocol::process_sync_message(&self.doc, body)
+    }
+
+    /// The relay-initiated `SyncStep1` frame to push authoritative state to a
+    /// client that just joined.
+    pub fn sync_step1_frame(&self) -> Vec<u8> {
+        protocol::initial_sync_step1(&self.doc)
+    }
+}
+
+/// In-memory registry of active-document Y.Docs, keyed by `(workspace, doc)`.
+///
+/// Entries are pure caches: created on demand (hydrated from the snapshot)
+/// and evicted by the WS server when no connected client references the doc.
+/// Liveness is owned by the server's client table — this type holds no
+/// refcount of its own, which keeps eviction race-free against the
+/// connect/disconnect path.
+#[derive(Default)]
+pub struct DocRegistry {
+    docs: RwLock<HashMap<(WorkspaceId, DocId), Arc<DocHandle>>>,
+}
+
+impl DocRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the handle for `(ws, doc_id)` if one is already resident.
+    pub fn get(&self, ws: &WorkspaceId, doc_id: &DocId) -> Option<Arc<DocHandle>> {
+        let key = (ws.clone(), doc_id.clone());
+        self.docs.read().unwrap().get(&key).cloned()
+    }
+
+    /// Return the resident handle, or hydrate one from `doc_json` and insert
+    /// it. Idempotent: concurrent callers share the first hydration.
+    pub fn ensure(&self, ws: &WorkspaceId, doc_id: &DocId, doc_json: &Value) -> Arc<DocHandle> {
+        if let Some(handle) = self.get(ws, doc_id) {
+            return handle;
+        }
+        let key = (ws.clone(), doc_id.clone());
+        let mut docs = self.docs.write().unwrap();
+        docs.entry(key)
+            .or_insert_with(|| Arc::new(DocHandle::hydrate(doc_json)))
+            .clone()
+    }
+
+    /// Drop the handle for `(ws, doc_id)`. Called by the server once the last
+    /// client on the doc disconnects.
+    pub fn evict(&self, ws: &WorkspaceId, doc_id: &DocId) {
+        let key = (ws.clone(), doc_id.clone());
+        let removed = self.docs.write().unwrap().remove(&key);
+        if let Some(handle) = removed {
+            on_evict(&handle);
+        }
+    }
+
+    /// Number of resident docs (diagnostics / tests).
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.docs.read().unwrap().len()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.docs.read().unwrap().is_empty()
+    }
+}
+
+/// Hook run when a doc handle is evicted. **JP-36** will flatten the Y.Doc to
+/// JSON and persist it here before the handle drops. JP-34 intentionally does
+/// nothing — it holds no durable state of its own.
+fn on_evict(_handle: &DocHandle) {
+    // JP-36: ydoc_to_json(&_handle.doc) + doc_store.save_document(...)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DocRegistry;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    use crate::server::protocol::{DocId, WorkspaceId};
+
+    fn key() -> (WorkspaceId, DocId) {
+        (
+            WorkspaceId::single_tenant(),
+            DocId::from_http_path("doc-1".to_string()).unwrap(),
+        )
+    }
+
+    #[test]
+    fn ensure_is_idempotent_then_evicts() {
+        let reg = DocRegistry::new();
+        let (ws, doc) = key();
+        let body = json!({"id": "doc-1", "name": "x"});
+
+        assert!(reg.is_empty());
+
+        let h1 = reg.ensure(&ws, &doc, &body);
+        assert_eq!(reg.len(), 1);
+
+        // A second ensure returns the same handle — one hydration only.
+        let h2 = reg.ensure(&ws, &doc, &body);
+        assert!(Arc::ptr_eq(&h1, &h2));
+        assert_eq!(reg.len(), 1);
+        assert!(reg.get(&ws, &doc).is_some());
+
+        reg.evict(&ws, &doc);
+        assert!(reg.is_empty());
+        assert!(reg.get(&ws, &doc).is_none());
+    }
+}

--- a/relay/src/sync/protocol.rs
+++ b/relay/src/sync/protocol.rs
@@ -1,0 +1,183 @@
+//! Yjs sync-protocol glue (JP-34).
+//!
+//! DocuShark frames a CRDT message as `[MESSAGE_SYNC=0][lib0 sync body]`.
+//! The single `MESSAGE_SYNC` prefix byte *replaces* the y-protocols
+//! top-level message tag, so the body is a bare y-protocols **sync**
+//! message — `yrs::sync::SyncMessage`, not the top-level `yrs::sync::Message`.
+//! We decode it with `SyncMessage::decode_v1` (lib0-v1, wire-compatible with
+//! the JS `y-protocols/sync` client) and drive the authoritative `Doc`.
+
+use yrs::sync::SyncMessage;
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
+use yrs::{Doc, ReadTxn, Transact, Update};
+
+use crate::server::protocol::MESSAGE_SYNC;
+
+/// What a single inbound sync frame produced. Both fields are already
+/// `MESSAGE_SYNC`-prefixed and ready to put on the wire.
+#[derive(Debug, Default)]
+pub struct SyncOutcome {
+    /// Send only back to the frame's sender (e.g. the SyncStep2 answer to a
+    /// SyncStep1 request).
+    pub reply: Option<Vec<u8>>,
+    /// Fan out to the *other* clients on the same `(workspace, doc)`.
+    pub broadcast: Option<Vec<u8>>,
+}
+
+/// Failure decoding or applying a sync frame. Non-fatal: the caller logs
+/// and keeps the connection open.
+#[derive(Debug)]
+pub enum SyncError {
+    Decode(String),
+    Apply(String),
+}
+
+/// Decode one inbound sync `body` (the bytes *after* the `MESSAGE_SYNC`
+/// prefix), apply it to `doc`, and report what to send.
+///
+/// * `SyncStep1(sv)` → reply with `SyncStep2(state-as-update)` to the sender.
+/// * `SyncStep2(update)` / `Update(update)` → apply, then rebroadcast the
+///   update to peers. (Rebroadcasting the received update is idempotent and
+///   is exactly what other peers need to converge.)
+pub fn process_sync_message(doc: &Doc, body: &[u8]) -> Result<SyncOutcome, SyncError> {
+    let msg = SyncMessage::decode_v1(body).map_err(|e| SyncError::Decode(e.to_string()))?;
+    match msg {
+        SyncMessage::SyncStep1(sv) => {
+            let update = doc.transact().encode_state_as_update_v1(&sv);
+            Ok(SyncOutcome {
+                reply: Some(frame_sync(SyncMessage::SyncStep2(update))),
+                broadcast: None,
+            })
+        }
+        SyncMessage::SyncStep2(update) | SyncMessage::Update(update) => {
+            let decoded =
+                Update::decode_v1(&update).map_err(|e| SyncError::Decode(e.to_string()))?;
+            doc.transact_mut()
+                .apply_update(decoded)
+                .map_err(|e| SyncError::Apply(e.to_string()))?;
+            Ok(SyncOutcome {
+                reply: None,
+                broadcast: Some(frame_sync(SyncMessage::Update(update))),
+            })
+        }
+    }
+}
+
+/// Build the relay-initiated `SyncStep1` frame sent to a client on join, so
+/// it converges onto the relay's authoritative state.
+pub fn initial_sync_step1(doc: &Doc) -> Vec<u8> {
+    let sv = doc.transact().state_vector();
+    frame_sync(SyncMessage::SyncStep1(sv))
+}
+
+/// Prefix a `SyncMessage`'s lib0-v1 encoding with the `MESSAGE_SYNC` byte.
+fn frame_sync(msg: SyncMessage) -> Vec<u8> {
+    let mut data = Vec::with_capacity(1 + 64);
+    data.push(MESSAGE_SYNC);
+    data.extend(msg.encode_v1());
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::sync::SyncMessage;
+    use yrs::updates::decoder::Decode;
+    use yrs::updates::encoder::Encode;
+    use yrs::{Any, Doc, Map, StateVector, Transact, Update};
+
+    /// A doc carrying a single shape keyed by `id` in the `shapes` map.
+    fn doc_with_shape(id: &str) -> Doc {
+        let doc = Doc::new();
+        let shapes = doc.get_or_insert_map("shapes");
+        {
+            let mut txn = doc.transact_mut();
+            shapes.insert(&mut txn, id, Any::String("rect".into()));
+        }
+        doc
+    }
+
+    #[test]
+    fn sync_step1_is_answered_with_step2_state() {
+        let server = doc_with_shape("s1");
+        let body = SyncMessage::SyncStep1(StateVector::default()).encode_v1();
+
+        let outcome = process_sync_message(&server, &body).unwrap();
+        assert!(outcome.broadcast.is_none());
+        let reply = outcome.reply.expect("SyncStep1 must be answered");
+        assert_eq!(reply[0], MESSAGE_SYNC);
+
+        // The reply must be a SyncStep2 that, applied to a fresh client doc,
+        // delivers the server's shape — i.e. the relay is authoritative.
+        let update = match SyncMessage::decode_v1(&reply[1..]).unwrap() {
+            SyncMessage::SyncStep2(u) => u,
+            _ => panic!("expected SyncStep2 reply"),
+        };
+        let client = Doc::new();
+        let cshapes = client.get_or_insert_map("shapes");
+        client
+            .transact_mut()
+            .apply_update(Update::decode_v1(&update).unwrap())
+            .unwrap();
+        assert!(cshapes.contains_key(&client.transact(), "s1"));
+    }
+
+    #[test]
+    fn update_is_applied_and_rebroadcast() {
+        let server = Doc::new();
+        let shapes = server.get_or_insert_map("shapes");
+
+        // An update produced elsewhere that inserts s2.
+        let producer = doc_with_shape("s2");
+        let update = producer
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        let body = SyncMessage::Update(update).encode_v1();
+
+        let outcome = process_sync_message(&server, &body).unwrap();
+        assert!(outcome.reply.is_none());
+        let bc = outcome.broadcast.expect("update must be rebroadcast");
+        assert_eq!(bc[0], MESSAGE_SYNC);
+        assert!(shapes.contains_key(&server.transact(), "s2"));
+    }
+
+    /// Independent wire-framing guard: hand-encode the y-protocols sync
+    /// "Update" framing (`varuint(messageYjsUpdate=2)` then a
+    /// length-prefixed `varuint8array`) WITHOUT yrs's `SyncMessage` encoder,
+    /// proving our decode matches the JS `y-protocols` framing — a yrs↔yrs
+    /// round-trip alone can't catch a framing bug shared by both ends.
+    #[test]
+    fn decodes_hand_framed_yprotocols_update() {
+        let producer = doc_with_shape("s3");
+        let update = producer
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+
+        let mut body = Vec::new();
+        write_varuint(&mut body, 2); // messageYjsUpdate
+        write_varuint(&mut body, update.len() as u64); // varuint8array length
+        body.extend_from_slice(&update);
+
+        let server = Doc::new();
+        let shapes = server.get_or_insert_map("shapes");
+        let outcome = process_sync_message(&server, &body).unwrap();
+        assert!(outcome.broadcast.is_some());
+        assert!(shapes.contains_key(&server.transact(), "s3"));
+    }
+
+    /// lib0 unsigned variable-length integer (matches y-protocols/lib0).
+    fn write_varuint(out: &mut Vec<u8>, mut n: u64) {
+        loop {
+            let mut byte = (n & 0x7f) as u8;
+            n >>= 7;
+            if n != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if n == 0 {
+                break;
+            }
+        }
+    }
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -1,0 +1,356 @@
+//! JP-34 — the relay holds an authoritative Y.Doc per active document.
+//!
+//! These tests drive a real in-process relay over a WebSocket and assert the
+//! two guarantees JP-34 adds on top of the pre-existing opaque-forwarding
+//! sync path:
+//!
+//!   1. **Authority on join** — a client that joins a doc and asks for state
+//!      (`SyncStep1`) receives the relay's hydrated state (`SyncStep2`),
+//!      with `shapeOrder` carrying each id exactly once (the no-duplication
+//!      guarantee — the client adopts relay state rather than independently
+//!      re-hydrating).
+//!   2. **Live broadcast** — an `Update` from one client is applied to the
+//!      authoritative Y.Doc and rebroadcast to the other client on the doc.
+//!
+//! The WS client harness mirrors `tests/cross_tenant_isolation.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::protocol::{
+    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
+    PROTOCOL_VERSION,
+};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use yrs::sync::SyncMessage;
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
+use yrs::{Any, Array, ArrayRef, Doc, Map, MapRef, ReadTxn, StateVector, Transact, Update};
+
+// ----------------------------------------------------------------------
+// Relay + WS client harness
+// ----------------------------------------------------------------------
+
+struct Relay {
+    ws_base: String,
+    http: String,
+    server: Arc<WebSocketServer>,
+    issuer: OidcTestIssuer,
+    _tmp: TempDir,
+}
+
+async fn start_relay() -> Relay {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or_else(|| bound.clone());
+
+    Relay {
+        ws_base: bound,
+        http,
+        server,
+        issuer,
+        _tmp: tmp,
+    }
+}
+
+/// Seed a document over REST so JOIN_DOC's existence check passes and the
+/// relay has a snapshot to hydrate from.
+async fn put_doc(http: &str, token: &str, body: Value) {
+    let id = body["id"].as_str().expect("doc id").to_string();
+    let resp = reqwest::Client::new()
+        .put(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("PUT doc");
+    assert!(resp.status().is_success(), "seed PUT: {}", resp.status());
+}
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+struct WsClient {
+    stream: WsStream,
+}
+
+impl WsClient {
+    async fn connect(ws_base: &str) -> Self {
+        let url = format!("{ws_base}/ws?protocolVersion={PROTOCOL_VERSION}");
+        let (stream, _resp) = tokio_tungstenite::connect_async(&url)
+            .await
+            .expect("ws connect");
+        Self { stream }
+    }
+
+    async fn auth(&mut self, token: &str) {
+        let frame = encode_message(MESSAGE_AUTH, &token.to_string()).expect("encode auth");
+        self.stream
+            .send(WsMessage::Binary(frame))
+            .await
+            .expect("send auth");
+        loop {
+            let msg = self.stream.next().await.expect("auth stream end").expect("auth");
+            if let WsMessage::Binary(bytes) = msg {
+                if bytes.first().copied() == Some(MESSAGE_AUTH_RESPONSE) {
+                    let body: Value = serde_json::from_slice(&bytes[1..]).expect("auth json");
+                    assert_eq!(body["success"], json!(true), "auth failed: {body}");
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn join_doc(&mut self, doc_id: &str) {
+        let frame =
+            encode_message(MESSAGE_JOIN_DOC, &json!({ "docId": doc_id })).expect("encode join");
+        self.stream
+            .send(WsMessage::Binary(frame))
+            .await
+            .expect("send join");
+    }
+
+    async fn send_sync(&mut self, body: &[u8]) {
+        let mut frame = Vec::with_capacity(1 + body.len());
+        frame.push(MESSAGE_SYNC);
+        frame.extend_from_slice(body);
+        self.stream
+            .send(WsMessage::Binary(frame))
+            .await
+            .expect("send sync");
+    }
+
+    async fn recv_within(&mut self, ms: u64) -> Option<(u8, Vec<u8>)> {
+        match tokio::time::timeout(Duration::from_millis(ms), self.stream.next()).await {
+            Ok(Some(Ok(WsMessage::Binary(bytes)))) => {
+                let ty = *bytes.first()?;
+                Some((ty, bytes))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// A client-side Y.Doc that mirrors `YjsDocument`'s shared types.
+struct LocalDoc {
+    doc: Doc,
+    shapes: MapRef,
+    order: ArrayRef,
+}
+
+impl LocalDoc {
+    fn new() -> Self {
+        let doc = Doc::new();
+        let shapes = doc.get_or_insert_map("shapes");
+        let order = doc.get_or_insert_array("shapeOrder");
+        Self { doc, shapes, order }
+    }
+
+    /// Apply any inbound SYNC frame; SyncStep2/Update are applied to the doc.
+    /// Returns true if the frame mutated state.
+    fn apply_frame(&self, full_bytes: &[u8]) -> bool {
+        let Ok(msg) = SyncMessage::decode_v1(&full_bytes[1..]) else {
+            return false;
+        };
+        let update = match msg {
+            SyncMessage::SyncStep2(u) | SyncMessage::Update(u) => u,
+            SyncMessage::SyncStep1(_) => return false,
+        };
+        let Ok(update) = Update::decode_v1(&update) else {
+            return false;
+        };
+        self.doc.transact_mut().apply_update(update).is_ok()
+    }
+
+    /// Insert a shape locally and return the incremental update frame body
+    /// (a `SyncMessage::Update`, lib0-encoded) the client would send.
+    fn insert_shape_update(&self, id: &str) -> Vec<u8> {
+        let before = self.doc.transact().state_vector();
+        {
+            let mut txn = self.doc.transact_mut();
+            self.shapes.insert(&mut txn, id, sample_shape(id));
+        }
+        let update = self
+            .doc
+            .transact()
+            .encode_state_as_update_v1(&before);
+        SyncMessage::Update(update).encode_v1()
+    }
+
+    fn has_shape(&self, id: &str) -> bool {
+        self.shapes.contains_key(&self.doc.transact(), id)
+    }
+
+    fn order_len(&self) -> u32 {
+        self.order.len(&self.doc.transact())
+    }
+}
+
+fn sample_shape(id: &str) -> Any {
+    Any::Map(std::sync::Arc::new(std::collections::HashMap::from([
+        ("id".to_string(), Any::String(id.into())),
+        ("type".to_string(), Any::String("rectangle".into())),
+        ("x".to_string(), Any::Number(5.0)),
+        ("y".to_string(), Any::Number(6.0)),
+    ])))
+}
+
+// ----------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------
+
+#[tokio::test]
+async fn join_delivers_authoritative_state_without_duplication() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-a", "name": "Authority", "pageOrder": ["p1"],
+            "activePageId": "p1", "createdAt": 1, "modifiedAt": 2,
+            "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {
+                "id": "p1",
+                "shapes": {"s1": {"id": "s1", "type": "rectangle", "x": 10, "y": 20}},
+                "shapeOrder": ["s1"]
+            }}
+        }),
+    )
+    .await;
+
+    let mut client = WsClient::connect(&relay.ws_base).await;
+    client.auth(&token).await;
+    client.join_doc("doc-a").await;
+
+    // Ask the relay for full state; an empty state vector means "I have nothing".
+    let local = LocalDoc::new();
+    client
+        .send_sync(&SyncMessage::SyncStep1(StateVector::default()).encode_v1())
+        .await;
+
+    // Read frames until the seeded shape lands (relay sends its own SyncStep1
+    // plus the SyncStep2 answer to ours).
+    for _ in 0..10 {
+        if let Some((ty, bytes)) = client.recv_within(300).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape("s1") {
+            break;
+        }
+    }
+
+    assert!(
+        local.has_shape("s1"),
+        "client did not receive the relay's authoritative shape"
+    );
+    assert_eq!(
+        local.order_len(),
+        1,
+        "shapeOrder must carry s1 exactly once — no independent-hydration dup"
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn update_from_one_client_reaches_the_other() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-b", "name": "Live", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Two clients on the same doc.
+    let mut a = WsClient::connect(&relay.ws_base).await;
+    a.auth(&token).await;
+    a.join_doc("doc-b").await;
+    let a_local = LocalDoc::new();
+
+    let mut b = WsClient::connect(&relay.ws_base).await;
+    b.auth(&token).await;
+    b.join_doc("doc-b").await;
+    let b_local = LocalDoc::new();
+
+    // Both sync to the (empty) authoritative doc first so they share roots.
+    for client_doc in [(&mut a, &a_local), (&mut b, &b_local)] {
+        let (client, local) = client_doc;
+        client
+            .send_sync(&SyncMessage::SyncStep1(StateVector::default()).encode_v1())
+            .await;
+        for _ in 0..5 {
+            if let Some((ty, bytes)) = client.recv_within(150).await {
+                if ty == MESSAGE_SYNC {
+                    local.apply_frame(&bytes);
+                }
+            }
+        }
+    }
+
+    // A inserts a shape and sends the incremental update.
+    let update = a_local.insert_shape_update("s2");
+    a.send_sync(&update).await;
+
+    // B must receive and apply it.
+    let mut delivered = false;
+    for _ in 0..12 {
+        if let Some((ty, bytes)) = b.recv_within(300).await {
+            if ty == MESSAGE_SYNC {
+                b_local.apply_frame(&bytes);
+            }
+        }
+        if b_local.has_shape("s2") {
+            delivered = true;
+            break;
+        }
+    }
+
+    assert!(
+        delivered,
+        "peer B never received A's shape via the authoritative relay broadcast"
+    );
+
+    relay.server.stop().await.expect("stop");
+}


### PR DESCRIPTION
Closes JP-34 (Phase 20.4). Paves the way for JP-36 (Y.Doc → JSON persistence) and the MCP-via-Yjs write path.

## What this does

The relay previously **opaque-forwarded** sync frames and held no authoritative copy of any document. This adds an authoritative server-side `Y.Doc` (`yrs` 0.26) per active document, so the relay becomes the source of truth — removing whole-document last-write-wins.

New `relay/src/sync/` module:
- **`hydration.rs`** — `json_to_ydoc` hydrates the snapshot's **active page** (`pages[activePageId]`) into the three shared types mirroring `src/collaboration/YjsDocument.ts` (`shapes` map with each shape stored as a whole `Any` value, `shapeOrder` array, `metadata` map). Tolerates missing/empty pages.
- **`protocol.rs`** — decodes the lib0 body as a bare `yrs::sync::SyncMessage` (the `MESSAGE_SYNC` prefix byte replaces y-protocols' top-level tag, so it is **not** the top-level `Message`). `SyncStep1` → reply `SyncStep2(state)`; `Update`/`SyncStep2` → apply + rebroadcast.
- **`mod.rs`** — `DocRegistry` keyed by `(WorkspaceId, DocId)`; membership-based eviction drops a doc's handle when its last participant leaves. `on_evict` is a deliberate no-op stub for JP-36.

Wired into `relay/src/server/mod.rs`:
- `handle_join_doc` hydrates the doc (from the JSON snapshot) and pushes the client a relay `SyncStep1` so it converges onto authoritative state.
- `handle_sync` applies inbound frames to the Y.Doc and answers/broadcasts. **Undecodable frames fall back to opaque forwarding** — preserves the Phase 21.4 workspace-scoped routing/isolation behaviour for any non-standard frame.
- disconnect / doc-switch evict the handle when no participant remains.

## Notes

- **`yrs = "0.26"`; MSRV bumped 1.77.2 → 1.82** (yrs 0.26 + thiserror 2 + the icu4x 2.x stack pulled via url/reqwest). Deliberate — taking the latest `yrs` for its CRDT fixes rather than pinning an older release.
- **Behaviour-only: no `PROTOCOL_VERSION` bump.** Same wire frames. AGENTS.md "Collaboration Architecture" note added.
- **No durable persistence yet** — eviction drops in-memory state; durability still rides the existing client REST save until JP-36 lands `ydoc_to_json` + the snapshot interval + the real `on_evict`.

## Scope / not in this PR

- Flatten `Y.Doc → JSON` persistence → **JP-36** (next).
- The JS client's deterministic per-doc `clientID` (`YjsDocument.ts:85`) is now vestigial and a latent corruption risk under relay authority — worth a follow-up to move clients to random client IDs.

## Tests

All green (`cargo test`, 160 lib + every integration suite):
- Unit: hydration mapping (active-page-only, empty/partial), `SyncStep1 → SyncStep2` authority, `Update` apply + rebroadcast, and a **hand-encoded y-protocols framing fixture** (independent of yrs's own encoder, to catch a framing bug a yrs↔yrs round-trip would miss).
- Integration (`tests/yjs_authority.rs`, real WebSocket): a join delivers authoritative state with `shapeOrder` carrying each id exactly once (no independent-hydration duplication); an `Update` from one client reaches the other.
- `cross_tenant_isolation` 7/7 — confirms the opaque-forward fallback kept routing/isolation intact.

Manual E2E still to confirm locally (two browsers on a shared doc; reload pulls authoritative state from the relay).

Assisted-by: Opus 4.8