### PR TITLE
JP-36: persist the relay's authoritative Y.Doc to JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,9 +182,13 @@ relay the source of truth (removing whole-document last-write-wins) — it is a
 **behavior** change only: the wire frames are unchanged lib0-v1 sync bodies and
 `PROTOCOL_VERSION` does **not** move. The relay Y.Doc's shared types
 (`shapes` map, `shapeOrder` array, `metadata` map) must keep mirroring
-`src/collaboration/YjsDocument.ts`. Persisting the Y.Doc back to JSON is a
-separate, later step (the eviction hook in `relay/src/sync/mod.rs` is currently
-a no-op).
+`src/collaboration/YjsDocument.ts`. **Persistence (JP-36):** the relay flattens
+each dirty Y.Doc back to its JSON snapshot on a configurable interval
+(`[sync] snapshot_interval_secs`, default 10), on last-client eviction, and on
+graceful shutdown (SIGINT/SIGTERM) — keeping `serverVersion` and emitting no
+`DocEvent`, so durability no longer depends on a client REST save. The flatten
+targets the page the doc was hydrated from (`activePageId`); a live page-switch
+mid-session is the known active-page-only limitation.
 
 **Offline-first architecture**:
 - **OfflineQueue**: Queues save/delete operations when disconnected, processes on reconnect

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -406,6 +406,29 @@ impl Default for ObservabilityConfig {
     }
 }
 
+/// Default cadence for the relay's `Y.Doc → JSON` snapshot sweeper (JP-36).
+const DEFAULT_SNAPSHOT_INTERVAL_SECS: u64 = 10;
+
+/// Persistence section (JP-36). Controls how often the relay flattens its
+/// authoritative in-memory `Y.Doc`s back to their JSON snapshots. Snapshots
+/// also fire on last-client eviction and graceful shutdown regardless of this
+/// interval.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SyncConfig {
+    /// Seconds between snapshot sweeps. `0` disables the timer (eviction +
+    /// shutdown flushes still run).
+    pub snapshot_interval_secs: u64,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            snapshot_interval_secs: DEFAULT_SNAPSHOT_INTERVAL_SECS,
+        }
+    }
+}
+
 /// Top-level relay config. All sections optional in the TOML; missing
 /// sections fall back to `Default::default()`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -417,6 +440,7 @@ pub struct RelayConfig {
     pub mcp: McpConfig,
     pub tenancy: TenancyConfig,
     pub observability: ObservabilityConfig,
+    pub sync: SyncConfig,
 }
 
 impl RelayConfig {
@@ -517,6 +541,11 @@ impl RelayConfig {
             self.tenancy.limits.blob_gc_grace_secs = v
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_BLOB_GC_GRACE_SECS must be a u64 (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_SNAPSHOT_INTERVAL_SECS") {
+            self.sync.snapshot_interval_secs = v.parse().map_err(|_| {
+                anyhow::anyhow!("RELAY_SNAPSHOT_INTERVAL_SECS must be a u64 (got {v:?})")
+            })?;
         }
 
         // Blob byte-storage backend selection + S3/R2 credentials. Any

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -236,6 +236,7 @@ async fn run_serve(
         .await;
     server.set_relay_region(region.clone()).await;
     server.set_tenancy(config.tenancy.clone()).await;
+    server.set_sync_config(config.sync.clone()).await;
     server.set_metering_debug_log(config.observability.metering_debug_log);
     log::info!(
         "tenancy: mode={:?} workspace_id={:?} region={}",
@@ -336,7 +337,7 @@ async fn run_serve(
     };
 
     log::info!("press Ctrl-C to shut down");
-    tokio::signal::ctrl_c().await?;
+    wait_for_shutdown_signal().await?;
     log::info!("shutdown requested");
 
     if let Some(mcp) = mcp {
@@ -350,6 +351,30 @@ async fn run_serve(
         .await
         .map_err(|e| anyhow::anyhow!("failed to stop relay cleanly: {}", e))?;
     Ok(())
+}
+
+/// Block until the process is asked to shut down. We wait on **both** SIGINT
+/// (Ctrl-C, local dev) and SIGTERM (container orchestrators — Fly/Docker send
+/// it on redeploy/scale-down) so the graceful path in `server.stop()` — which
+/// runs the JP-36 final snapshot flush — actually fires in production. A
+/// SIGINT-only wait would miss SIGTERM and lose edits accumulated since the
+/// last snapshot tick.
+async fn wait_for_shutdown_signal() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate())?;
+        tokio::select! {
+            r = tokio::signal::ctrl_c() => r?,
+            _ = sigterm.recv() => log::info!("received SIGTERM"),
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await?;
+        Ok(())
+    }
 }
 
 /// Polling fallback for the revocation transport (see

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -435,6 +435,92 @@ impl DocumentStore {
         })
     }
 
+    /// Persist a relay-authored snapshot of an **existing** document (JP-36).
+    ///
+    /// Unlike [`save_document_with_expected_version`], this **preserves**
+    /// `serverVersion` (no bump) and emits no `DocEvent`: the relay's periodic
+    /// `Y.Doc → JSON` flush is a quiet durability mechanism, not a client save.
+    /// Bumping the version would make a connected client's next REST save
+    /// spuriously conflict, and a `DocEvent` would trigger needless reloads —
+    /// the clients are already CRDT-synced with this exact content.
+    ///
+    /// Returns `Err` if the doc isn't in this workspace's index (the relay only
+    /// snapshots docs it hydrated from an existing body).
+    pub fn persist_snapshot(&self, ws: &WorkspaceId, mut doc: serde_json::Value) -> Result<(), String> {
+        let id = doc
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or("Document missing 'id' field")?
+            .to_string();
+        let doc_id = DocId::from_body_id(id.clone())
+            .map_err(|e| format!("Invalid document id: {}", e))?;
+
+        // Preserve the stored version; refuse to snapshot a doc that doesn't
+        // already exist (no version to preserve, and persist_snapshot is never
+        // a create path).
+        let version = {
+            let index = self.index.read().map_err(|e| e.to_string())?;
+            match index.get(ws).and_then(|m| m.get(&id)) {
+                Some(meta) => meta.server_version.unwrap_or(0),
+                None => return Err("Document not found".to_string()),
+            }
+        };
+
+        // Keep the body's serverVersion in lockstep with the preserved index
+        // version so a subsequent read doesn't see a stale number.
+        if let Some(obj) = doc.as_object_mut() {
+            obj.insert("serverVersion".to_string(), serde_json::json!(version));
+        }
+
+        let name = doc.get("name").and_then(|v| v.as_str()).unwrap_or("Untitled").to_string();
+        let page_order = doc
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.len())
+            .unwrap_or(1);
+        let modified_at = doc.get("modifiedAt").and_then(|v| v.as_u64()).unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0)
+        });
+        let created_at = doc.get("createdAt").and_then(|v| v.as_u64()).unwrap_or(modified_at);
+
+        let metadata = DocumentMetadata {
+            id: doc_id.clone(),
+            name,
+            page_count: page_order,
+            modified_at,
+            created_at,
+            is_relay_document: doc
+                .get("isRelayDocument")
+                .or_else(|| doc.get("isTeamDocument"))
+                .and_then(|v| v.as_bool()),
+            server_version: Some(version),
+            locked_by: doc.get("lockedBy").and_then(|v| v.as_str()).map(String::from),
+            locked_by_name: doc.get("lockedByName").and_then(|v| v.as_str()).map(String::from),
+            locked_at: doc.get("lockedAt").and_then(|v| v.as_u64()),
+            owner_id: doc.get("ownerId").and_then(|v| v.as_str()).map(String::from),
+            owner_name: doc.get("ownerName").and_then(|v| v.as_str()).map(String::from),
+            shared_with: doc.get("sharedWith").and_then(|v| serde_json::from_value(v.clone()).ok()),
+            last_modified_by: doc.get("lastModifiedBy").and_then(|v| v.as_str()).map(String::from),
+            last_modified_by_name: doc.get("lastModifiedByName").and_then(|v| v.as_str()).map(String::from),
+        };
+
+        let doc_json = serde_json::to_string_pretty(&doc).map_err(|e| format!("Serialize error: {}", e))?;
+        let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
+        std::fs::write(self.doc_path(ws, &doc_id), doc_json).map_err(|e| format!("Write error: {}", e))?;
+
+        {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            index.entry(ws.clone()).or_default().insert(id.clone(), metadata);
+        }
+        self.save_workspace_index(ws)?;
+
+        log::debug!("relay snapshot persisted: {}/{} (v{}, unchanged)", ws.as_str(), id, version);
+        Ok(())
+    }
+
     /// Delete a document scoped to the requesting workspace. Returns
     /// `Ok(false)` if the doc isn't in this workspace's index — even
     /// when another workspace holds a doc with the same id.
@@ -680,6 +766,40 @@ mod tests {
 
         // List should be empty again
         assert!(store.list_documents(&ws).is_empty());
+    }
+
+    #[test]
+    fn persist_snapshot_preserves_server_version() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("snap-doc".to_string()).unwrap();
+
+        // Two real saves → serverVersion is now 2.
+        let doc = serde_json::json!({
+            "id": "snap-doc", "name": "Snap", "pageOrder": ["p1"],
+            "activePageId": "p1", "createdAt": 1, "modifiedAt": 2,
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        });
+        store.save_document(&ws, doc.clone()).unwrap();
+        store.save_document(&ws, doc).unwrap();
+        let before = store.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(before["serverVersion"], serde_json::json!(2));
+
+        // A snapshot writes new content but must NOT bump the version.
+        let mut snap = before.clone();
+        snap["pages"]["p1"]["shapes"]["s1"] = serde_json::json!({ "id": "s1" });
+        snap["modifiedAt"] = serde_json::json!(9999);
+        store.persist_snapshot(&ws, snap).unwrap();
+
+        let after = store.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(after["serverVersion"], serde_json::json!(2), "version preserved");
+        assert!(after["pages"]["p1"]["shapes"].get("s1").is_some(), "content written");
+        assert_eq!(after["modifiedAt"], serde_json::json!(9999), "modifiedAt updated");
+
+        // Snapshotting a non-existent doc errors (never a create path).
+        let ghost = serde_json::json!({ "id": "ghost", "pageOrder": [] });
+        assert!(store.persist_snapshot(&ws, ghost).is_err());
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -47,8 +47,8 @@ use governor::{
 use std::num::NonZeroU32;
 use protocol::*;
 use crate::auth::{AuthError, OidcAuthState, OidcClaims, WorkspaceRole};
-use crate::config::{StorageConfig, TenancyConfig, TenancyMode};
-use crate::sync::DocRegistry;
+use crate::config::{StorageConfig, SyncConfig, TenancyConfig, TenancyMode};
+use crate::sync::{DocHandle, DocRegistry};
 use blob_backend::S3Backend;
 
 /// Per-workspace token-bucket limiter shared between WS sync handlers
@@ -712,7 +712,63 @@ impl ServerState {
                 .any(|c| &c.current_workspace_id == ws && c.current_doc_id.as_ref() == Some(doc_id))
         };
         if !still_used {
+            // JP-36: flush any unsaved edits to JSON before the handle drops.
+            if let Some(handle) = self.sync_registry.get(ws, doc_id) {
+                self.snapshot_doc(ws, doc_id, &handle);
+            }
             self.sync_registry.evict(ws, doc_id);
+        }
+    }
+
+    /// Flatten one dirty Y.Doc back to its JSON snapshot (JP-36). No-op if the
+    /// doc isn't dirty, has no active page, was deleted, or the stored
+    /// `activePageId` has diverged from the page this handle hydrated (we never
+    /// risk writing the wrong page — see the active-page-only limitation).
+    pub(crate) fn snapshot_doc(&self, ws: &WorkspaceId, doc_id: &DocId, handle: &Arc<DocHandle>) {
+        if !handle.take_dirty() {
+            return;
+        }
+        let Some(page) = handle.page_id() else { return };
+        let mut json = match self.doc_store.get_document(ws, doc_id) {
+            Ok(json) => json,
+            // Doc deleted out from under us → nothing to persist.
+            Err(_) => return,
+        };
+        // Divergence guard: only persist when the stored active page still
+        // matches what we hydrated. Leaves `dirty` cleared so we don't spin;
+        // a later edit re-marks it.
+        let stored_page = json.get("activePageId").and_then(|v| v.as_str());
+        if stored_page != Some(page) {
+            log::debug!(
+                "snapshot skipped (active page diverged: stored={:?} hydrated={}) {}/{}",
+                stored_page,
+                page,
+                ws.as_str(),
+                doc_id.as_str()
+            );
+            return;
+        }
+        if !handle.flatten_into(&mut json) {
+            // Page object missing in the body — treat like divergence.
+            return;
+        }
+        if let Err(e) = self.doc_store.persist_snapshot(ws, json) {
+            // Retry on the next tick rather than dropping the edit.
+            handle.mark_dirty();
+            log::warn!(
+                "snapshot persist failed for {}/{}: {} — will retry",
+                ws.as_str(),
+                doc_id.as_str(),
+                e
+            );
+        }
+    }
+
+    /// Snapshot every resident dirty doc (JP-36). Driven by the interval
+    /// sweeper and the graceful-shutdown flush.
+    pub(crate) fn snapshot_all(&self) {
+        for ((ws, doc_id), handle) in self.sync_registry.entries() {
+            self.snapshot_doc(&ws, &doc_id, &handle);
         }
     }
 
@@ -770,6 +826,11 @@ pub struct WebSocketServer {
     relay_region: RwLock<String>,
     /// Tenancy + per-workspace limits (Phase 21.3 + 21.5).
     tenancy: RwLock<TenancyConfig>,
+    /// Persistence (JP-36): snapshot-sweeper cadence. Read in `start()`.
+    sync_config: RwLock<SyncConfig>,
+    /// Handle to the JP-36 snapshot sweeper task, aborted on `stop()` after the
+    /// final flush.
+    snapshot_task: RwLock<Option<tokio::task::JoinHandle<()>>>,
     /// Shared per-workspace write limiter; lazily constructed by
     /// `build_write_limiter`. Both `ServerState` (WS path) and
     /// `McpServer` (MCP path) hold an `Arc` to the same instance so
@@ -817,6 +878,8 @@ impl WebSocketServer {
             revocation_push_bearer: RwLock::new(None),
             relay_region: RwLock::new("default".to_string()),
             tenancy: RwLock::new(TenancyConfig::default()),
+            sync_config: RwLock::new(SyncConfig::default()),
+            snapshot_task: RwLock::new(None),
             write_limiter: RwLock::new(None),
             panic_count: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
@@ -837,6 +900,11 @@ impl WebSocketServer {
     /// `relay.toml` + CLI overrides). Must be called before `start()`.
     pub async fn set_tenancy(&self, tenancy: TenancyConfig) {
         *self.tenancy.write().await = tenancy;
+    }
+
+    /// Replace the persistence config (JP-36). Must precede `start()`.
+    pub async fn set_sync_config(&self, sync: SyncConfig) {
+        *self.sync_config.write().await = sync;
     }
 
     /// Get-or-build the shared per-workspace write limiter from the
@@ -1055,6 +1123,25 @@ impl WebSocketServer {
 
         *self.state.write().await = Some(server_state.clone());
 
+        // JP-36: spawn the snapshot sweeper that periodically flattens dirty
+        // Y.Docs back to their JSON snapshots. `0` disables the timer (eviction
+        // + shutdown flushes still run). Aborted on `stop()` after a final flush.
+        let snapshot_interval_secs = self.sync_config.read().await.snapshot_interval_secs;
+        if snapshot_interval_secs > 0 {
+            let sweeper_state = server_state.clone();
+            let handle = tokio::spawn(async move {
+                let mut ticker =
+                    tokio::time::interval(std::time::Duration::from_secs(snapshot_interval_secs));
+                // Skip the immediate first tick; nothing is dirty at startup.
+                ticker.tick().await;
+                loop {
+                    ticker.tick().await;
+                    sweeper_state.snapshot_all();
+                }
+            });
+            *self.snapshot_task.write().await = Some(handle);
+        }
+
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
         {
@@ -1155,6 +1242,16 @@ impl WebSocketServer {
         let mut tx = self.shutdown_tx.write().await;
         if let Some(shutdown_tx) = tx.take() {
             let _ = shutdown_tx.send(());
+        }
+
+        // JP-36: final durability flush before tearing state down, then stop
+        // the sweeper. Runs on graceful shutdown (SIGINT/SIGTERM via main.rs)
+        // so a redeploy doesn't lose edits between snapshot ticks.
+        if let Some(state) = self.state.read().await.as_ref() {
+            state.snapshot_all();
+        }
+        if let Some(handle) = self.snapshot_task.write().await.take() {
+            handle.abort();
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -1,0 +1,155 @@
+//! Flatten an authoritative `Y.Doc` back to the persisted JSON snapshot (JP-36).
+//!
+//! Inverse of [`super::hydration::json_to_ydoc`]. The Y.Doc is a flat,
+//! **active-page-only** surface (`shapes` map + `shapeOrder` array), so we
+//! merge those two collections back into the page they were hydrated from
+//! (`pages[page_id]`), leaving every other page and all top-level fields
+//! untouched. We deliberately do **not** write `name` or other metadata —
+//! renames persist via the existing REST path, and clobbering `name` with a
+//! possibly-stale Y.Doc `metadata.title` would lose edits.
+//!
+//! Durability is the relay's job here, but the JSON stays the source format:
+//! this is what gets written to disk and served on the next load.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{Map as JsonMap, Value};
+use yrs::types::ToJson;
+use yrs::{Any, Doc, Transact};
+
+/// Merge the Y.Doc's `shapes` + `shapeOrder` into `json["pages"][page_id]` and
+/// bump `json["modifiedAt"]`. Returns `false` (writing nothing) if the target
+/// page object is absent — the caller treats that as a divergence and skips.
+pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
+    // Grab the shared-type handles *before* opening a read txn — calling
+    // `get_or_insert_*` while a txn is live deadlocks.
+    let shapes = doc.get_or_insert_map("shapes");
+    let shape_order = doc.get_or_insert_array("shapeOrder");
+
+    let (shapes_any, order_any) = {
+        let txn = doc.transact();
+        (shapes.to_json(&txn), shape_order.to_json(&txn))
+    };
+
+    // Merge into the existing page object so the page's own id/name/timestamps
+    // survive. Bail (write nothing) if the page is gone.
+    {
+        let Some(pages) = json.get_mut("pages").and_then(Value::as_object_mut) else {
+            return false;
+        };
+        let Some(page) = pages.get_mut(page_id).and_then(Value::as_object_mut) else {
+            return false;
+        };
+        page.insert("shapes".to_string(), any_to_json(&shapes_any));
+        page.insert("shapeOrder".to_string(), any_to_json(&order_any));
+    }
+
+    if let Some(obj) = json.as_object_mut() {
+        obj.insert("modifiedAt".to_string(), Value::from(now_ms()));
+    }
+    true
+}
+
+/// Convert a yrs `Any` into a `serde_json::Value` — the inverse of
+/// `hydration::json_to_any`. Integral numbers are emitted as JSON integers so
+/// a shape's `x: 10` round-trips as `10` rather than `10.0`.
+fn any_to_json(any: &Any) -> Value {
+    match any {
+        Any::Null | Any::Undefined => Value::Null,
+        Any::Bool(b) => Value::Bool(*b),
+        Any::Number(n) => number_to_json(*n),
+        Any::BigInt(i) => Value::from(*i),
+        Any::String(s) => Value::String(s.to_string()),
+        Any::Buffer(bytes) => Value::Array(bytes.iter().map(|b| Value::from(*b)).collect()),
+        Any::Array(items) => Value::Array(items.iter().map(any_to_json).collect()),
+        Any::Map(map) => {
+            let obj: JsonMap<String, Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), any_to_json(v)))
+                .collect();
+            Value::Object(obj)
+        }
+    }
+}
+
+/// Yjs numbers are all `f64`; emit whole values as JSON integers so they match
+/// how the client/JSON stored them, falling back to a float otherwise.
+fn number_to_json(n: f64) -> Value {
+    if n.is_finite() && n.fract() == 0.0 && n >= i64::MIN as f64 && n <= i64::MAX as f64 {
+        Value::from(n as i64)
+    } else {
+        serde_json::Number::from_f64(n)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::hydration::json_to_ydoc;
+    use serde_json::json;
+    use yrs::{Any, Array, Doc, Map, Transact};
+
+    fn multi_page() -> Value {
+        json!({
+            "id": "doc-1", "name": "Doc", "activePageId": "p1",
+            "createdAt": 1, "modifiedAt": 2, "pageOrder": ["p1", "p2"],
+            "pages": {
+                "p1": {"id": "p1", "name": "One", "shapes": {"s1": {"id": "s1"}}, "shapeOrder": ["s1"]},
+                "p2": {"id": "p2", "name": "Two", "shapes": {"s9": {"id": "s9"}}, "shapeOrder": ["s9"]}
+            }
+        })
+    }
+
+    #[test]
+    fn flattens_active_page_preserving_others() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page(), &doc);
+
+        // Mutate the live Y.Doc: add a shape with an integer coordinate.
+        let shapes = doc.get_or_insert_map("shapes");
+        let order = doc.get_or_insert_array("shapeOrder");
+        {
+            let mut txn = doc.transact_mut();
+            let shape = Any::Map(std::sync::Arc::new(std::collections::HashMap::from([
+                ("id".to_string(), Any::String("s2".into())),
+                ("x".to_string(), Any::Number(10.0)),
+            ])));
+            shapes.insert(&mut txn, "s2", shape);
+            order.push_back(&mut txn, Any::String("s2".into()));
+        }
+
+        let mut json = multi_page();
+        assert!(flatten_into(&doc, "p1", &mut json));
+
+        let p1 = &json["pages"]["p1"];
+        assert!(p1["shapes"].get("s1").is_some(), "kept original shape");
+        assert!(p1["shapes"].get("s2").is_some(), "added shape persisted");
+        // Integer coordinate round-trips as an integer, not 10.0.
+        assert_eq!(p1["shapes"]["s2"]["x"], json!(10));
+        assert_eq!(p1["shapeOrder"], json!(["s1", "s2"]));
+        assert_eq!(p1["name"], json!("One"), "page's own fields survive");
+
+        // Other page untouched; modifiedAt bumped past the original.
+        assert_eq!(json["pages"]["p2"]["shapes"]["s9"]["id"], json!("s9"));
+        assert!(json["modifiedAt"].as_u64().unwrap() > 2);
+    }
+
+    #[test]
+    fn missing_page_skips() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page(), &doc);
+        let mut json = multi_page();
+        assert!(!flatten_into(&doc, "does-not-exist", &mut json));
+        // Nothing written.
+        assert_eq!(json["pages"]["p1"]["shapeOrder"], json!(["s1"]));
+    }
+}

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -7,22 +7,24 @@
 //! This removes whole-document last-write-wins and is the foundation for
 //! JP-36 (Y.Doc → JSON persistence) and MCP write tools.
 //!
-//! **Scope:** JP-34 is read + live-sync only. There is no durable
-//! persistence here — when the last client on a doc disconnects the handle
-//! is evicted and its in-memory state dropped (durability still rides on the
-//! client REST snapshot until JP-36 lands `on_evict`).
+//! **Persistence (JP-36):** the server flattens each dirty Y.Doc back to its
+//! JSON snapshot on an interval, on last-client eviction, and on graceful
+//! shutdown (`ServerState::snapshot_*` + `DocHandle::flatten_into`). Durability
+//! no longer depends on a client REST save.
 //!
 //! **Concurrency:** `yrs::Doc` carries its own internal transaction lock and
 //! is `Send + Sync`, so handles are shared via `Arc` with no extra `Mutex`.
 //! Every decode/apply/encode is a short, fully synchronous critical section —
 //! a transaction is **never** held across an `.await`.
 
+mod flatten;
 mod hydration;
 mod protocol;
 
 pub use protocol::{SyncError, SyncOutcome};
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
@@ -34,6 +36,14 @@ use crate::server::protocol::{DocId, WorkspaceId};
 /// operations over it.
 pub struct DocHandle {
     doc: Doc,
+    /// The page this doc was hydrated from (`activePageId`). Flattening writes
+    /// the live shapes back into this page (JP-36). `None` when the snapshot
+    /// had no active page — such a doc is never persisted.
+    page_id: Option<String>,
+    /// Set when an inbound update mutates the Y.Doc; cleared when the snapshot
+    /// sweeper persists it. Gates the relay's JSON snapshots so unchanged docs
+    /// aren't rewritten.
+    dirty: AtomicBool,
 }
 
 impl DocHandle {
@@ -41,19 +51,58 @@ impl DocHandle {
     fn hydrate(doc_json: &Value) -> Self {
         let doc = Doc::new();
         hydration::json_to_ydoc(doc_json, &doc);
-        Self { doc }
+        let page_id = doc_json
+            .get("activePageId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        Self {
+            doc,
+            page_id,
+            dirty: AtomicBool::new(false),
+        }
     }
 
     /// Apply one inbound sync frame body (bytes *after* the `MESSAGE_SYNC`
-    /// prefix) and report what to send back / broadcast.
+    /// prefix) and report what to send back / broadcast. Marks the doc dirty
+    /// when the frame actually changed state (an applied update → a broadcast).
     pub fn handle_sync_message(&self, body: &[u8]) -> Result<SyncOutcome, SyncError> {
-        protocol::process_sync_message(&self.doc, body)
+        let outcome = protocol::process_sync_message(&self.doc, body)?;
+        if outcome.broadcast.is_some() {
+            self.dirty.store(true, Ordering::Relaxed);
+        }
+        Ok(outcome)
     }
 
     /// The relay-initiated `SyncStep1` frame to push authoritative state to a
     /// client that just joined.
     pub fn sync_step1_frame(&self) -> Vec<u8> {
         protocol::initial_sync_step1(&self.doc)
+    }
+
+    /// The page id to flatten into, if this doc has one.
+    pub fn page_id(&self) -> Option<&str> {
+        self.page_id.as_deref()
+    }
+
+    /// Atomically read-and-clear the dirty flag. Loss-safe: an apply landing
+    /// during/after a snapshot re-sets `dirty`, so the next tick re-persists.
+    pub fn take_dirty(&self) -> bool {
+        self.dirty.swap(false, Ordering::Relaxed)
+    }
+
+    /// Re-mark dirty (used to retry after a failed snapshot write).
+    pub fn mark_dirty(&self) {
+        self.dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Flatten the live Y.Doc into `json`'s active page (JP-36). Returns
+    /// `false` (writing nothing) if this doc has no page id or the page is
+    /// absent in `json`.
+    pub fn flatten_into(&self, json: &mut Value) -> bool {
+        match &self.page_id {
+            Some(page_id) => flatten::flatten_into(&self.doc, page_id, json),
+            None => false,
+        }
     }
 }
 
@@ -94,13 +143,22 @@ impl DocRegistry {
     }
 
     /// Drop the handle for `(ws, doc_id)`. Called by the server once the last
-    /// client on the doc disconnects.
+    /// client on the doc disconnects (the server snapshots it first, JP-36).
     pub fn evict(&self, ws: &WorkspaceId, doc_id: &DocId) {
         let key = (ws.clone(), doc_id.clone());
-        let removed = self.docs.write().unwrap().remove(&key);
-        if let Some(handle) = removed {
-            on_evict(&handle);
-        }
+        self.docs.write().unwrap().remove(&key);
+    }
+
+    /// Snapshot of all resident `(key, handle)` pairs, cloned under the read
+    /// lock so the caller can iterate (and do I/O) without holding it. Used by
+    /// the JP-36 snapshot sweeper.
+    pub fn entries(&self) -> Vec<((WorkspaceId, DocId), Arc<DocHandle>)> {
+        self.docs
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
     }
 
     /// Number of resident docs (diagnostics / tests).
@@ -113,13 +171,6 @@ impl DocRegistry {
     pub fn is_empty(&self) -> bool {
         self.docs.read().unwrap().is_empty()
     }
-}
-
-/// Hook run when a doc handle is evicted. **JP-36** will flatten the Y.Doc to
-/// JSON and persist it here before the handle drops. JP-34 intentionally does
-/// nothing — it holds no durable state of its own.
-fn on_evict(_handle: &DocHandle) {
-    // JP-36: ydoc_to_json(&_handle.doc) + doc_store.save_document(...)
 }
 
 #[cfg(test)]

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -354,3 +354,135 @@ async fn update_from_one_client_reaches_the_other() {
 
     relay.server.stop().await.expect("stop");
 }
+
+// ----------------------------------------------------------------------
+// JP-36 — relay-side persistence (no client REST save required)
+// ----------------------------------------------------------------------
+
+/// REST `GET /api/docs/:id` → the doc body.
+async fn get_doc(http: &str, token: &str, id: &str) -> Value {
+    reqwest::Client::new()
+        .get(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("GET doc")
+        .json()
+        .await
+        .expect("doc json")
+}
+
+/// Join a doc and pull the relay's authoritative state into `local`.
+async fn join_and_sync(client: &mut WsClient, local: &LocalDoc, doc_id: &str) {
+    client.join_doc(doc_id).await;
+    client
+        .send_sync(&SyncMessage::SyncStep1(StateVector::default()).encode_v1())
+        .await;
+    for _ in 0..6 {
+        if let Some((ty, bytes)) = client.recv_within(150).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn evict_flush_persists_without_rest_save() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "persist-doc", "name": "Persist", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    let version_before = get_doc(&relay.http, &token, "persist-doc").await["serverVersion"].clone();
+
+    // Client edits over CRDT only — never calls REST save.
+    let mut client = WsClient::connect(&relay.ws_base).await;
+    client.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut client, &local, "persist-doc").await;
+    client.send_sync(&local.insert_shape_update("s1")).await;
+    // Let the relay apply the update before we disconnect.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    // Disconnecting drops the last participant → relay evict-flush snapshots.
+    drop(client);
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    let doc = get_doc(&relay.http, &token, "persist-doc").await;
+    assert!(
+        doc["pages"]["p1"]["shapes"].get("s1").is_some(),
+        "shape was not persisted by the relay (no client REST save): {doc}"
+    );
+    assert_eq!(
+        doc["serverVersion"], version_before,
+        "relay snapshot must not bump serverVersion"
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn snapshot_skips_when_active_page_diverged() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "div-doc", "name": "Diverge", "pageOrder": ["p1", "p2"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {
+                "p1": {"id": "p1", "shapes": {}, "shapeOrder": []},
+                "p2": {"id": "p2", "shapes": {}, "shapeOrder": []}
+            }
+        }),
+    )
+    .await;
+
+    // Client hydrates page p1 and edits it.
+    let mut client = WsClient::connect(&relay.ws_base).await;
+    client.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut client, &local, "div-doc").await;
+    client.send_sync(&local.insert_shape_update("s1")).await;
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    // Stored active page diverges from the hydrated page (now p2).
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "div-doc", "name": "Diverge", "pageOrder": ["p1", "p2"],
+            "activePageId": "p2", "ownerId": "alice", "ownerName": "alice",
+            "pages": {
+                "p1": {"id": "p1", "shapes": {}, "shapeOrder": []},
+                "p2": {"id": "p2", "shapes": {}, "shapeOrder": []}
+            }
+        }),
+    )
+    .await;
+
+    drop(client);
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    // The relay must NOT have written the hydrated-page (p1) shapes into the
+    // doc — the divergence guard skips rather than risk the wrong page.
+    let doc = get_doc(&relay.http, &token, "div-doc").await;
+    assert!(
+        doc["pages"]["p1"]["shapes"].get("s1").is_none(),
+        "divergence guard failed: relay wrote s1 into p1 despite activePageId=p2: {doc}"
+    );
+
+    relay.server.stop().await.expect("stop");
+}


### PR DESCRIPTION
Closes JP-36 (Phase 20.4). Builds directly on the merged JP-34 (#51): now that the relay holds an authoritative `Y.Doc` per active doc, it persists that state itself instead of depending on the client REST save.

## Why

After JP-34 the relay had the live authoritative state but **no durable persistence of its own** — the `on_evict` hook was a deliberate no-op. So:
- edits were **lost** if a doc evicted (last client left) before any client REST-saved, and
- a long-lived session (a client that stays connected) was **never persisted server-side**.

JP-36 flattens each dirty `Y.Doc → JSON` on an **interval**, on **last-client eviction**, and on **graceful shutdown**. JSON stays the durable format.

> Note: this is unrelated to the "PWA is tardy at sending updates" symptom — that's a client-side request-queue/cadence concern (JP-110 territory). JP-36 only guarantees that whatever the relay's Y.Doc holds gets persisted.

## What

- **`relay/src/sync/flatten.rs`** — `flatten_into(doc, page_id, json)` + `any_to_json` (inverse of `hydration::json_to_any`; integral `f64` → JSON integer so `x: 10` round-trips as `10`). Merges `shapes`/`shapeOrder` back into `pages[page_id]`, preserving every other page and all top-level fields; skips if the page is gone. Never touches `name` (renames persist via REST).
- **`relay/src/sync/mod.rs`** — `DocHandle` gains `page_id` (captured from `activePageId` at hydrate) and a `dirty` flag set on applied updates; `take_dirty`/`mark_dirty`/`flatten_into`; `DocRegistry::entries()`; the no-op `on_evict` is removed.
- **`relay/src/server/documents.rs`** — `persist_snapshot`: writes the body while **preserving `serverVersion`** (no bump) and emitting **no `DocEvent`**. A quiet durability flush mustn't make a connected client's next REST save spuriously conflict or trigger reload churn (clients are already CRDT-synced with this exact content).
- **`relay/src/server/mod.rs`** — `snapshot_doc` (dirty-gated; divergence guard; `mark_dirty` retry on write error) and `snapshot_all`; an interval sweeper spawned in `start()` with a stored `JoinHandle`; an **evict-flush** in `evict_doc_if_unused`; a **final flush + sweeper abort** in `stop()`.
- **`relay/src/config.rs`** — `[sync] snapshot_interval_secs` (default `10`) on `RelayConfig` + a `RELAY_SNAPSHOT_INTERVAL_SECS` env override; `0` disables the timer (evict/shutdown still fire).
- **`relay/src/main.rs`** — wire `set_sync_config`; wait on **SIGINT *and* SIGTERM** so the shutdown flush actually fires on Fly/Docker redeploys (`ctrl_c()` alone misses SIGTERM).

Behaviour-only — **no `PROTOCOL_VERSION` change**. AGENTS.md note updated.

## Confirmed design decisions

- **Active-page-only persistence** — the relay Y.Doc is a flat, active-page surface (JP-34), so flatten targets the page it hydrated from. A **divergence guard** skips (rather than risk writing the wrong page) if the stored `activePageId` no longer matches. A pure client-side page-switch mid-session that never hits REST can't be observed server-side — that's the documented active-page-only limitation; proper multi-page CRDT persistence is a follow-up.
- **Preserve `serverVersion`, quiet** — see `persist_snapshot` above.

## Tests (full suite green)

- **Unit:** `flatten_into` round-trips an active-page edit (other pages untouched, `modifiedAt` bumped, integer coords stay integers) + missing-page skip; `persist_snapshot` preserves `serverVersion` and errors on a non-existent doc.
- **Integration (extends `tests/yjs_authority.rs`):** a client edits over CRDT, does **no REST save**, disconnects → the evict-flush persists the shape and **`serverVersion` is unchanged**; a divergence test confirms a wrong-page write is skipped.
- `cargo test` all green incl. `cross_tenant_isolation` (7/7).

Manual E2E to confirm: edit a team doc without saving, close the tab (or wait an interval), reopen from a fresh client → edits present, no client REST save involved.

## Follow-ups (noted, not in this PR)

- Multi-page live persistence (the active-page-only limitation above).
- Making the relay the **sole writer** of relay-doc bodies (clients stop body-saving relay docs) — removes the rare read-modify-write race with a concurrent REST save and dovetails with the JP-110 / PWA send-cadence cleanup.

Assisted-by: Opus 4.8