### PR TITLE
Collab identity fixes: deterministic clientID (JP-172) + session follows new relay doc (JP-174)

### DIFF
--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -79,11 +79,18 @@ export class YjsDocument {
 
   private isLocalUpdate = false;
 
-  constructor(docId?: string) {
+  constructor() {
+    // NOTE (JP-172): the Y.Doc clientID is intentionally left as Yjs's random
+    // per-instance default. An earlier version pinned it deterministically to
+    // hash(docId) so every client on a doc shared one clientID — which is
+    // backwards for Yjs: sequence-type item IDs are (clientID, clock) tuples,
+    // so colliding clientIDs corrupt ordering/dedup, and two users overwrite
+    // each other's awareness. The bug was masked while the doc was ephemeral
+    // (fresh clocks each session, relay-mediated) but surfaces hard with
+    // persistence (y-indexeddb resumes a clock that, under a shared clientID,
+    // makes peers skip each other's updates). Document identity belongs to the
+    // provider room (relay docId), never the clientID.
     this.doc = new Y.Doc();
-    if (docId) {
-      this.doc.clientID = hashStringToNumber(docId);
-    }
 
     // Initialize shared types
     this.shapes = this.doc.getMap('shapes');
@@ -369,19 +376,6 @@ export class YjsDocument {
     }, this); // Mark transaction origin
     this.isLocalUpdate = false;
   }
-}
-
-/**
- * Hash a string to a number for use as client ID.
- */
-function hashStringToNumber(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
-  return Math.abs(hash);
 }
 
 export default YjsDocument;

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -165,7 +165,10 @@ describe('collaborationStore', () => {
       const config = createTestConfig();
       useCollaborationStore.getState().startSession(config);
 
-      expect(YjsDocument).toHaveBeenCalledWith('doc-1');
+      // JP-172: the Y.Doc clientID is Yjs's random default, not keyed off the
+      // documentId — so the constructor takes no args (doc identity lives in the
+      // provider room, not the clientID).
+      expect(YjsDocument).toHaveBeenCalledWith();
       expect(UnifiedSyncProvider).toHaveBeenCalled();
     });
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -208,8 +208,10 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         url: config.serverUrl,
       });
 
-      // Create Yjs document
-      yjsDoc = new YjsDocument(config.documentId);
+      // Create Yjs document. The Y.Doc clientID is Yjs's random per-instance
+      // default (JP-172) — NOT keyed off documentId; doc identity is the relay
+      // room below, not the clientID.
+      yjsDoc = new YjsDocument();
 
       // Create unified sync provider
       syncProvider = new UnifiedSyncProvider(yjsDoc.getDoc(), {

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -1113,6 +1113,22 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
 
         try {
           await teamDocStore.saveToHost(doc);
+
+          // Make the just-created relay doc the live collab target. Without this
+          // the session stays pinned to the previously open doc: `collabDocId`
+          // diverges from `currentDocumentId`, `collabMode` goes false, and prose
+          // silently falls back to the non-collab editor (canvas masks it because
+          // its sync ignores the id match). `saveToHost` doesn't change the
+          // registry record type, so the doc is still registered `local` from
+          // `saveDocumentAs` — re-register it as remote via the list, then switch,
+          // mirroring DocumentBrowser's proven promote path. [JP-174]
+          useDocumentRegistry.getState().removeDocument(newId);
+          await teamDocStore.fetchDocumentList();
+          const collabStore = useCollaborationStore.getState();
+          if (collabStore.isActive) {
+            collabStore.switchDocument(newId);
+          }
+
           return { ok: true, docId: newId };
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown relay error';


### PR DESCRIPTION
Two small, independent correctness fixes surfaced while spiking offline-first collaboration. Both are validated (live two-client + the offline-first diagnostics) and have no dependency on the in-flight collab-prose work.

## JP-172 — drop the deterministic Y.Doc clientID
`YjsDocument` pinned `clientID = hash(docId)`, so every client on a document shared one Yjs clientID. That corrupts sequence-CRDT (prose `XmlFragment`) item IDs and makes two users overwrite each other's awareness. It was masked while the Y.Doc was ephemeral but breaks under CRDT persistence. Now uses Yjs's random per-instance default; document identity is the provider room, not the clientID.

Closes JP-172.

## JP-174 (partial) — keep the collab session on the just-created relay doc
`createRelayDocumentAs` never switched the collab session to the new doc, so `collabDocId` diverged from `currentDocumentId`, `collabMode` went false, and prose silently fell back to the non-collab editor (canvas masked it, since its sync ignores the id match). Now re-registers the new doc as remote (`fetchDocumentList`) and `switchDocument`s onto it, mirroring `DocumentBrowser`'s proven promote path.

Partial JP-174 — the branded `DocumentId` type + the general session/active-doc invariant remain tracked in the issue.

## Testing
- `bun run typecheck` clean.
- `bun run test --run src/collaboration src/store` — 499 pass (incl. the updated clientID construction assertion).
- Live two-client: prose syncs; `idsMatch` confirmed true after creating a relay doc mid-session; canvas merges cleanly.

Assisted-by: Opus 4.8