### PR TITLE
JP-108: relay binary Y.Doc persistence (CRDT identity + prose survive eviction)

### DIFF
--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -419,12 +419,18 @@ pub struct SyncConfig {
     /// Seconds between snapshot sweeps. `0` disables the timer (eviction +
     /// shutdown flushes still run).
     pub snapshot_interval_secs: u64,
+    /// Persist the authoritative `Y.Doc` as a **binary** sidecar (JP-108)
+    /// alongside the JSON snapshot, and hydrate from it (preserving CRDT
+    /// identity + prose across evict/rehydrate) when current. Default on;
+    /// set false to fall back to pure-JSON persistence (ops rollback).
+    pub binary_persistence: bool,
 }
 
 impl Default for SyncConfig {
     fn default() -> Self {
         Self {
             snapshot_interval_secs: DEFAULT_SNAPSHOT_INTERVAL_SECS,
+            binary_persistence: true,
         }
     }
 }
@@ -546,6 +552,15 @@ impl RelayConfig {
             self.sync.snapshot_interval_secs = v.parse().map_err(|_| {
                 anyhow::anyhow!("RELAY_SNAPSHOT_INTERVAL_SECS must be a u64 (got {v:?})")
             })?;
+        }
+        if let Some(v) = get("RELAY_BINARY_PERSISTENCE") {
+            self.sync.binary_persistence = match v.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                other => anyhow::bail!(
+                    "RELAY_BINARY_PERSISTENCE must be a boolean (got {other:?})"
+                ),
+            };
         }
 
         // Blob byte-storage backend selection + S3/R2 credentials. Any

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -173,6 +173,32 @@ impl DocumentStore {
         self.workspace_root(ws).join("docs").join(format!("{}.json", doc_id.as_str()))
     }
 
+    /// Path to a document's binary `Y.Doc` sidecar (JP-108), next to its JSON.
+    fn ydoc_path(&self, ws: &WorkspaceId, doc_id: &DocId) -> PathBuf {
+        self.workspace_root(ws).join("docs").join(format!("{}.ydoc", doc_id.as_str()))
+    }
+
+    /// Write the binary `Y.Doc` sidecar (JP-108). `bytes` already carries the
+    /// self-describing header (`sync::binary`); this layer is format-agnostic.
+    /// Best-effort: callers log and retry on the next snapshot rather than
+    /// failing a save.
+    pub fn persist_ydoc_binary(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        bytes: &[u8],
+    ) -> Result<(), String> {
+        let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
+        std::fs::write(self.ydoc_path(ws, doc_id), bytes)
+            .map_err(|e| format!("Write error: {}", e))
+    }
+
+    /// Read a document's binary `Y.Doc` sidecar (JP-108), or `None` if there
+    /// is none yet (pre-binary / MCP-created doc) or it can't be read.
+    pub fn load_ydoc_binary(&self, ws: &WorkspaceId, doc_id: &DocId) -> Option<Vec<u8>> {
+        std::fs::read(self.ydoc_path(ws, doc_id)).ok()
+    }
+
     /// Reload every workspace's index from disk. Public so external
     /// callers (e.g. the MCP server) can refresh after an out-of-band
     /// write.
@@ -542,6 +568,16 @@ impl DocumentStore {
         if path.exists() {
             std::fs::remove_file(&path)
                 .map_err(|e| format!("Failed to delete document file: {}", e))?;
+        }
+
+        // Remove the binary Y.Doc sidecar if present (JP-108). Best-effort:
+        // a leftover sidecar is harmless (its doc id is gone from the index),
+        // so don't fail the delete on a sidecar removal error.
+        let ydoc = self.ydoc_path(ws, doc_id);
+        if ydoc.exists() {
+            if let Err(e) = std::fs::remove_file(&ydoc) {
+                log::warn!("Failed to delete Y.Doc sidecar {}/{}: {}", ws.as_str(), doc_id.as_str(), e);
+            }
         }
 
         // Remove from this workspace's index.

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -346,6 +346,10 @@ pub struct ServerState {
     /// Snapshot of `config.observability.metering_debug_log`. When true,
     /// `/metrics` also logs the per-workspace metering breakdown.
     metering_debug_log: bool,
+    /// Snapshot of `config.sync.binary_persistence` (JP-108). When true, the
+    /// relay writes a binary `Y.Doc` sidecar on snapshot and hydrates from it
+    /// (preserving CRDT identity + prose); when false it uses pure-JSON.
+    binary_persistence: bool,
     /// DEBUG-only trigger: when set, any WS handler that observes a
     /// client with this workspace id will panic on entry. Compiled out
     /// of release builds. Phase 21.2.
@@ -366,6 +370,7 @@ impl ServerState {
         panic_count: Arc<AtomicU64>,
         rate_limit_rejections: Arc<AtomicU64>,
         metering_debug_log: bool,
+        binary_persistence: bool,
         #[cfg(debug_assertions)] panic_tenant_trigger: Option<WorkspaceId>,
     ) -> Self {
         let (broadcast_tx, _) = broadcast::channel(100);
@@ -403,6 +408,7 @@ impl ServerState {
             panic_count,
             rate_limit_rejections,
             metering_debug_log,
+            binary_persistence,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
         }
@@ -559,6 +565,10 @@ impl ServerState {
     /// snapshot at debug level.
     pub(crate) fn metering_debug_log(&self) -> bool {
         self.metering_debug_log
+    }
+
+    pub(crate) fn binary_persistence(&self) -> bool {
+        self.binary_persistence
     }
 
     /// Accessor for the blob store — used by `/metrics` to read storage
@@ -728,6 +738,33 @@ impl ServerState {
         if !handle.take_dirty() {
             return;
         }
+
+        // JP-108: persist the whole Y.Doc as a binary sidecar *first*, before
+        // the JSON path's active-page guards (which can early-return). This
+        // captures every shared type — incl. prose — and preserves CRDT
+        // identity across evict/rehydrate, independent of the active-page-only
+        // JSON flatten below. Tagged with the doc's current serverVersion so a
+        // later out-of-band JSON write can be detected on hydrate. Best-effort:
+        // a write failure is logged; `dirty` is re-marked at the JSON step's
+        // retry, and the next sweep rewrites both.
+        if self.binary_persistence {
+            let version = self
+                .doc_store
+                .get_metadata(ws, doc_id)
+                .and_then(|m| m.server_version)
+                .unwrap_or(0);
+            let bytes = handle.encode_binary(version);
+            if let Err(e) = self.doc_store.persist_ydoc_binary(ws, doc_id, &bytes) {
+                handle.mark_dirty();
+                log::warn!(
+                    "binary Y.Doc snapshot failed for {}/{}: {} — will retry",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+            }
+        }
+
         let Some(page) = handle.page_id() else { return };
         let mut json = match self.doc_store.get_document(ws, doc_id) {
             Ok(json) => json,
@@ -1092,6 +1129,7 @@ impl WebSocketServer {
         let panic_count = self.panic_count.clone();
         let rate_limit_rejections = self.rate_limit_rejections.clone();
         let metering_debug_log = self.metering_debug_log.load(Ordering::Relaxed);
+        let binary_persistence = self.sync_config.read().await.binary_persistence;
         let tenancy = self.tenancy.read().await.clone();
         let storage = self.storage.read().await.clone();
         // JP-125: bound the blob upload body (Axum's default is a silent 2 MiB).
@@ -1113,6 +1151,7 @@ impl WebSocketServer {
             panic_count,
             rate_limit_rejections,
             metering_debug_log,
+            binary_persistence,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
         ));
@@ -2131,7 +2170,19 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
     let handle = match state.sync_registry().get(&workspace_id, &doc_id) {
         Some(handle) => Some(handle),
         None => match state.doc_store().get_document(&workspace_id, &doc_id) {
-            Ok(doc_json) => Some(state.sync_registry().ensure(&workspace_id, &doc_id, &doc_json)),
+            Ok(doc_json) => {
+                let ydoc_bin = if state.binary_persistence() {
+                    state.doc_store().load_ydoc_binary(&workspace_id, &doc_id)
+                } else {
+                    None
+                };
+                Some(state.sync_registry().ensure(
+                    &workspace_id,
+                    &doc_id,
+                    &doc_json,
+                    ydoc_bin.as_deref(),
+                ))
+            }
             Err(_) => None,
         },
     };
@@ -2280,10 +2331,19 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
     // failure is logged but non-fatal — `handle_sync` hydrates on demand.
     match state.doc_store().get_document(&workspace_id, &request.doc_id) {
         Ok(doc_json) => {
-            let handle =
+            let ydoc_bin = if state.binary_persistence() {
                 state
-                    .sync_registry()
-                    .ensure(&workspace_id, &request.doc_id, &doc_json);
+                    .doc_store()
+                    .load_ydoc_binary(&workspace_id, &request.doc_id)
+            } else {
+                None
+            };
+            let handle = state.sync_registry().ensure(
+                &workspace_id,
+                &request.doc_id,
+                &doc_json,
+                ydoc_bin.as_deref(),
+            );
             send_to_client(client_id, handle.sync_step1_frame(), state).await;
         }
         Err(e) => {
@@ -2400,6 +2460,7 @@ mod tests {
             panic_count.clone(),
             Arc::new(AtomicU64::new(0)),
             false,
+            true,
             trigger,
         ));
 
@@ -2453,6 +2514,7 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             false,
+            true,
             #[cfg(debug_assertions)]
             None,
         ))

--- a/relay/src/sync/binary.rs
+++ b/relay/src/sync/binary.rs
@@ -1,0 +1,173 @@
+//! Binary Y.Doc persistence for the authoritative relay CRDT (JP-108).
+//!
+//! JP-36 persists the relay `Y.Doc` only as a JSON snapshot, rebuilt on every
+//! hydrate via [`super::hydration::json_to_ydoc`] — which mints fresh Yjs items
+//! (new clientID + clocks) and so **discards CRDT identity** across
+//! evict→rehydrate, and keeps only active-page shapes (dropping prose and every
+//! other shared type). This module adds a companion **binary** snapshot (a
+//! lib0-v1 full-state update) so the relay can restore the exact `Y.Doc` —
+//! identity, causal history, prose, every shared type — on the next join.
+//!
+//! On-disk sidecar layout (`<doc_id>.ydoc`): a small self-describing header
+//! followed by the encoded state —
+//! ```text
+//! b"DSKY" | format_version: u32 LE | server_version: u64 LE | lib0-v1 state update
+//! ```
+//! The `server_version` lets the hydrator detect an out-of-band JSON write
+//! (MCP/REST writes *bump* the version; the JP-36 JSON flush *preserves* it) and
+//! fall back to JSON when the binary is stale.
+
+use yrs::updates::decoder::Decode;
+use yrs::{Doc, ReadTxn, StateVector, Transact, Update};
+
+/// Magic prefix identifying a DocuShark binary Y.Doc sidecar.
+const MAGIC: &[u8; 4] = b"DSKY";
+/// Bump when the header or payload framing changes incompatibly.
+pub const FORMAT_VERSION: u32 = 1;
+/// Header size: magic(4) + format_version(4) + server_version(8).
+const HEADER_LEN: usize = 4 + 4 + 8;
+
+/// Serialize `doc`'s full state into a sidecar byte blob tagged with
+/// `server_version`. `encode_state_as_update_v1` emits the **compacted full
+/// state** (not an append log), so the blob tracks live content size, not edit
+/// count — no unbounded growth, no GC needed.
+pub fn encode_snapshot(server_version: u64, doc: &Doc) -> Vec<u8> {
+    let update = doc
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+    let mut out = Vec::with_capacity(HEADER_LEN + update.len());
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+    out.extend_from_slice(&server_version.to_le_bytes());
+    out.extend_from_slice(&update);
+    out
+}
+
+/// Parse a sidecar blob into `(server_version, state_update_bytes)`. Returns
+/// `None` on a bad magic, an unknown format version, or a short buffer — the
+/// caller then falls back to JSON hydration. Never panics.
+pub fn decode_header(bytes: &[u8]) -> Option<(u64, &[u8])> {
+    if bytes.len() < HEADER_LEN || &bytes[0..4] != MAGIC {
+        return None;
+    }
+    let format = u32::from_le_bytes(bytes[4..8].try_into().ok()?);
+    if format != FORMAT_VERSION {
+        return None;
+    }
+    let server_version = u64::from_le_bytes(bytes[8..16].try_into().ok()?);
+    Some((server_version, &bytes[HEADER_LEN..]))
+}
+
+/// Build a fresh `Doc` by applying a lib0-v1 state update. Returns `Err` on a
+/// malformed/corrupt update so the caller can fall back to JSON hydration —
+/// a bad sidecar must never take a document down.
+pub fn doc_from_update(update: &[u8]) -> Result<Doc, String> {
+    let doc = Doc::new();
+    let decoded = Update::decode_v1(update).map_err(|e| e.to_string())?;
+    doc.transact_mut()
+        .apply_update(decoded)
+        .map_err(|e| e.to_string())?;
+    Ok(doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yrs::{Any, GetString, Map, Text, Transact};
+
+    fn doc_with_shape(id: &str) -> Doc {
+        let doc = Doc::new();
+        let shapes = doc.get_or_insert_map("shapes");
+        let mut txn = doc.transact_mut();
+        shapes.insert(&mut txn, id, Any::String("rect".into()));
+        drop(txn);
+        doc
+    }
+
+    #[test]
+    fn round_trips_state_and_version() {
+        let doc = doc_with_shape("s1");
+        let blob = encode_snapshot(7, &doc);
+
+        let (version, update) = decode_header(&blob).expect("valid header");
+        assert_eq!(version, 7);
+
+        let restored = doc_from_update(update).expect("apply update");
+        let shapes = restored.get_or_insert_map("shapes");
+        assert!(shapes.contains_key(&restored.transact(), "s1"));
+    }
+
+    #[test]
+    fn non_shape_shared_types_survive() {
+        // A `prose:<page>` shared type stands in for the prose fragment: any
+        // shared type that isn't `shapes`/`shapeOrder`/`metadata` is invisible
+        // to the JSON flatten but is captured by the full-state binary. (Real
+        // prose is an XmlFragment; the durability property is identical.)
+        let doc = Doc::new();
+        let prose = doc.get_or_insert_text("prose:p1");
+        {
+            let mut txn = doc.transact_mut();
+            prose.insert(&mut txn, 0, "hello prose");
+        }
+
+        let blob = encode_snapshot(1, &doc);
+        let (_v, update) = decode_header(&blob).unwrap();
+        let restored = doc_from_update(update).unwrap();
+
+        let rprose = restored.get_or_insert_text("prose:p1");
+        assert_eq!(rprose.get_string(&restored.transact()), "hello prose");
+    }
+
+    #[test]
+    fn hydration_preserves_identity_so_concurrent_edits_merge() {
+        // Author s1 in doc A, persist + rehydrate B from the binary.
+        let a = doc_with_shape("s1");
+        let blob = encode_snapshot(1, &a);
+        let (_v, update) = decode_header(&blob).unwrap();
+        let b = doc_from_update(update).unwrap();
+
+        // A *different* client C concurrently inserts s2; apply to B. With
+        // identity preserved this merges; an identity-resetting rebuild would
+        // be at risk of clobber.
+        let c = doc_with_shape("s2");
+        let c_update = c
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        b.transact_mut()
+            .apply_update(Update::decode_v1(&c_update).unwrap())
+            .unwrap();
+
+        let b_shapes = b.get_or_insert_map("shapes");
+        let txn = b.transact();
+        assert!(b_shapes.contains_key(&txn, "s1"), "rehydrated state kept");
+        assert!(
+            b_shapes.contains_key(&txn, "s2"),
+            "concurrent edit merged, not clobbered"
+        );
+    }
+
+    #[test]
+    fn rejects_bad_magic_wrong_format_and_short() {
+        let doc = doc_with_shape("s1");
+        let mut blob = encode_snapshot(1, &doc);
+        assert!(decode_header(&blob).is_some());
+
+        // Short buffer.
+        assert!(decode_header(&blob[..4]).is_none());
+
+        // Bad magic.
+        let mut bad = blob.clone();
+        bad[0] = b'X';
+        assert!(decode_header(&bad).is_none());
+
+        // Unknown format version.
+        blob[4] = 0xFF;
+        assert!(decode_header(&blob).is_none());
+    }
+
+    #[test]
+    fn corrupt_update_errors_not_panics() {
+        // Valid header, garbage payload → Err (caller falls back to JSON).
+        assert!(doc_from_update(&[0xff, 0x00, 0x13, 0x37]).is_err());
+    }
+}

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -17,6 +17,7 @@
 //! Every decode/apply/encode is a short, fully synchronous critical section —
 //! a transaction is **never** held across an `.await`.
 
+mod binary;
 mod flatten;
 mod hydration;
 mod protocol;
@@ -47,19 +48,53 @@ pub struct DocHandle {
 }
 
 impl DocHandle {
-    /// Build a handle by hydrating a fresh `Doc` from a JSON snapshot.
-    fn hydrate(doc_json: &Value) -> Self {
-        let doc = Doc::new();
-        hydration::json_to_ydoc(doc_json, &doc);
+    /// Build a handle by hydrating a fresh `Doc`. Prefers the binary sidecar
+    /// (`ydoc_bin`, JP-108) — which preserves CRDT identity + prose across
+    /// evict/rehydrate — and falls back to JSON hydration (JP-34) when the
+    /// binary is absent, stale, or corrupt.
+    fn hydrate(doc_json: &Value, ydoc_bin: Option<&[u8]>) -> Self {
         let page_id = doc_json
             .get("activePageId")
             .and_then(Value::as_str)
             .map(str::to_string);
+        let doc = Self::hydrate_doc(doc_json, ydoc_bin);
         Self {
             doc,
             page_id,
             dirty: AtomicBool::new(false),
         }
+    }
+
+    /// Choose the hydration source. The binary is authoritative only when it's
+    /// at least as new as the JSON body: `persist_snapshot` preserves
+    /// `serverVersion` while MCP/REST writes bump it, so a binary tagged with an
+    /// older version means an out-of-band JSON write landed after it — in which
+    /// case we hydrate from JSON and let the next snapshot rewrite the binary.
+    fn hydrate_doc(doc_json: &Value, ydoc_bin: Option<&[u8]>) -> Doc {
+        if let Some(bytes) = ydoc_bin {
+            if let Some((bin_version, update)) = binary::decode_header(bytes) {
+                let json_version = doc_json.get("serverVersion").and_then(Value::as_u64);
+                let current = json_version.map_or(true, |jv| bin_version >= jv);
+                if current {
+                    match binary::doc_from_update(update) {
+                        Ok(doc) => return doc,
+                        Err(e) => log::warn!(
+                            "binary Y.Doc hydrate failed ({e}); falling back to JSON"
+                        ),
+                    }
+                }
+            }
+        }
+        let doc = Doc::new();
+        hydration::json_to_ydoc(doc_json, &doc);
+        doc
+    }
+
+    /// Encode the live `Y.Doc` as a binary sidecar blob tagged with
+    /// `server_version` (JP-108). Captures the whole doc — every shared type,
+    /// incl. prose — not just the active-page shapes the JSON flatten writes.
+    pub fn encode_binary(&self, server_version: u64) -> Vec<u8> {
+        binary::encode_snapshot(server_version, &self.doc)
     }
 
     /// Apply one inbound sync frame body (bytes *after* the `MESSAGE_SYNC`
@@ -129,16 +164,23 @@ impl DocRegistry {
         self.docs.read().unwrap().get(&key).cloned()
     }
 
-    /// Return the resident handle, or hydrate one from `doc_json` and insert
-    /// it. Idempotent: concurrent callers share the first hydration.
-    pub fn ensure(&self, ws: &WorkspaceId, doc_id: &DocId, doc_json: &Value) -> Arc<DocHandle> {
+    /// Return the resident handle, or hydrate one from `doc_json` (preferring
+    /// the binary sidecar `ydoc_bin` when current, JP-108) and insert it.
+    /// Idempotent: concurrent callers share the first hydration.
+    pub fn ensure(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        doc_json: &Value,
+        ydoc_bin: Option<&[u8]>,
+    ) -> Arc<DocHandle> {
         if let Some(handle) = self.get(ws, doc_id) {
             return handle;
         }
         let key = (ws.clone(), doc_id.clone());
         let mut docs = self.docs.write().unwrap();
         docs.entry(key)
-            .or_insert_with(|| Arc::new(DocHandle::hydrate(doc_json)))
+            .or_insert_with(|| Arc::new(DocHandle::hydrate(doc_json, ydoc_bin)))
             .clone()
     }
 
@@ -175,11 +217,57 @@ impl DocRegistry {
 
 #[cfg(test)]
 mod tests {
-    use super::DocRegistry;
+    use super::{binary, DocHandle, DocRegistry};
     use serde_json::json;
     use std::sync::Arc;
+    use yrs::{Doc, GetString, Map, Text, Transact};
 
     use crate::server::protocol::{DocId, WorkspaceId};
+
+    /// A JSON body with one shape on its active page, at `server_version`.
+    fn json_body(server_version: u64) -> serde_json::Value {
+        json!({
+            "id": "d", "serverVersion": server_version, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {"s1": {"id": "s1"}}, "shapeOrder": ["s1"]}}
+        })
+    }
+
+    /// A binary sidecar carrying a `prose:p1` text the JSON body never has, so
+    /// tests can tell which source hydration chose.
+    fn binary_with_prose(server_version: u64, text: &str) -> Vec<u8> {
+        let doc = Doc::new();
+        let prose = doc.get_or_insert_text("prose:p1");
+        let mut txn = doc.transact_mut();
+        prose.insert(&mut txn, 0, text);
+        drop(txn);
+        binary::encode_snapshot(server_version, &doc)
+    }
+
+    #[test]
+    fn hydrate_prefers_binary_when_version_matches() {
+        let handle = DocHandle::hydrate(&json_body(5), Some(&binary_with_prose(5, "from binary")));
+        // Binary used → its prose is present (JSON hydration never creates it).
+        let prose = handle.doc.get_or_insert_text("prose:p1");
+        assert_eq!(prose.get_string(&handle.doc.transact()), "from binary");
+    }
+
+    #[test]
+    fn hydrate_falls_back_to_json_when_binary_is_stale() {
+        // Binary tagged v4, JSON body bumped to v7 by an out-of-band write.
+        let handle = DocHandle::hydrate(&json_body(7), Some(&binary_with_prose(4, "stale")));
+        let shapes = handle.doc.get_or_insert_map("shapes");
+        let prose = handle.doc.get_or_insert_text("prose:p1");
+        let txn = handle.doc.transact();
+        assert!(shapes.contains_key(&txn, "s1"), "JSON shapes hydrated");
+        assert_eq!(prose.get_string(&txn), "", "stale binary prose ignored");
+    }
+
+    #[test]
+    fn hydrate_uses_json_when_no_binary() {
+        let handle = DocHandle::hydrate(&json_body(1), None);
+        let shapes = handle.doc.get_or_insert_map("shapes");
+        assert!(shapes.contains_key(&handle.doc.transact(), "s1"));
+    }
 
     fn key() -> (WorkspaceId, DocId) {
         (
@@ -196,11 +284,11 @@ mod tests {
 
         assert!(reg.is_empty());
 
-        let h1 = reg.ensure(&ws, &doc, &body);
+        let h1 = reg.ensure(&ws, &doc, &body, None);
         assert_eq!(reg.len(), 1);
 
         // A second ensure returns the same handle — one hydration only.
-        let h2 = reg.ensure(&ws, &doc, &body);
+        let h2 = reg.ensure(&ws, &doc, &body, None);
         assert!(Arc::ptr_eq(&h1, &h2));
         assert_eq!(reg.len(), 1);
         assert!(reg.get(&ws, &doc).is_some());

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -32,7 +32,9 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use yrs::sync::SyncMessage;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
-use yrs::{Any, Array, ArrayRef, Doc, Map, MapRef, ReadTxn, StateVector, Transact, Update};
+use yrs::{
+    Any, Array, ArrayRef, Doc, GetString, Map, MapRef, ReadTxn, StateVector, Text, Transact, Update,
+};
 
 // ----------------------------------------------------------------------
 // Relay + WS client harness
@@ -206,6 +208,28 @@ impl LocalDoc {
             .transact()
             .encode_state_as_update_v1(&before);
         SyncMessage::Update(update).encode_v1()
+    }
+
+    /// Insert prose text into a page's `prose:<page>` fragment (a Text type,
+    /// not a shape) and return the incremental `Update` frame. Prose is invisible
+    /// to the relay's shapes-only JSON flatten, so it only survives eviction via
+    /// the binary sidecar (JP-108).
+    fn insert_prose_update(&self, page: &str, text: &str) -> Vec<u8> {
+        let before = self.doc.transact().state_vector();
+        // Grab the shared-type handle before opening a txn (get_or_insert_*
+        // transacts internally; doing it under a live txn deadlocks).
+        let prose = self.doc.get_or_insert_text(format!("prose:{page}"));
+        {
+            let mut txn = self.doc.transact_mut();
+            prose.insert(&mut txn, 0, text);
+        }
+        let update = self.doc.transact().encode_state_as_update_v1(&before);
+        SyncMessage::Update(update).encode_v1()
+    }
+
+    fn prose_text(&self, page: &str) -> String {
+        let prose = self.doc.get_or_insert_text(format!("prose:{page}"));
+        prose.get_string(&self.doc.transact())
     }
 
     fn has_shape(&self, id: &str) -> bool {
@@ -426,6 +450,52 @@ async fn evict_flush_persists_without_rest_save() {
     assert_eq!(
         doc["serverVersion"], version_before,
         "relay snapshot must not bump serverVersion"
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-108: prose (a non-shape shared type) must survive eviction. The relay's
+/// JSON snapshot is shapes-only, so the only way a fresh client gets the prose
+/// back is the binary `Y.Doc` sidecar persisted on evict-flush and re-hydrated
+/// on the next join.
+#[tokio::test]
+async fn prose_survives_eviction_via_binary_sidecar() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "prose-doc", "name": "Prose", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Client A writes prose over CRDT, then leaves (last participant → evict).
+    let mut a = WsClient::connect(&relay.ws_base).await;
+    a.auth(&token).await;
+    let local_a = LocalDoc::new();
+    join_and_sync(&mut a, &local_a, "prose-doc").await;
+    a.send_sync(&local_a.insert_prose_update("p1", "hello from prose"))
+        .await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    drop(a);
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // A fresh client joins; the relay re-hydrates (from the binary sidecar) and
+    // answers SyncStep1 with state that still carries the prose.
+    let mut b = WsClient::connect(&relay.ws_base).await;
+    b.auth(&token).await;
+    let local_b = LocalDoc::new();
+    join_and_sync(&mut b, &local_b, "prose-doc").await;
+    assert_eq!(
+        local_b.prose_text("p1"),
+        "hello from prose",
+        "prose did not survive eviction — binary Y.Doc sidecar not used on re-hydrate"
     );
 
     relay.server.stop().await.expect("stop");


### PR DESCRIPTION
First step of the offline-first build (JP-108), reordered to the front after the `collab-prose` spike showed the naive "client `y-indexeddb` first" approach loses data.

## Why
The relay holds an authoritative `Y.Doc` per active doc (JP-34) but persists it only as a **JSON snapshot** (JP-36). On eviction the handle drops; the next join rebuilds it with `json_to_ydoc`, minting **brand-new Yjs items** (fresh clientID + clocks) — which **discards CRDT identity** and keeps only active-page shapes. Two consequences:
- **Prose dies on eviction** today (a present bug — the JSON flatten is shapes-only).
- A client carrying persisted CRDT state (the future `y-indexeddb`) reconnecting after evict+rehydrate **merges by clobber, not union** — the exact two-way data loss the spike hit.

## What
Persist the `Y.Doc` as a **binary lib0-v1 full-state sidecar** (`<doc_id>.ydoc`) next to the JSON, and hydrate from it (identity + prose preserved) when current, falling back to JSON otherwise.

- **`sync/binary.rs`** (new) — encode/decode the sidecar: `b"DSKY"` magic + `format_version` + `server_version` header + the state update. `encode_state_as_update_v1` emits the compacted full state (no unbounded growth). Never panics on a corrupt blob.
- **`DocHandle::hydrate`** — binary-first, **version-guarded**: trust the binary only when its `server_version >= ` the JSON body's. `persist_snapshot` preserves the version while MCP/REST writes bump it, so an out-of-band JSON write is detected → JSON wins, next snapshot rewrites the binary.
- **`snapshot_doc`** — writes the binary *before* the JSON path's active-page guards, so prose persists even when the JSON flatten is skipped on page divergence.
- **`documents.rs`** — `ydoc_path` + `persist_ydoc_binary`/`load_ydoc_binary` + sidecar removal on delete.
- **`[sync] binary_persistence`** flag (env `RELAY_BINARY_PERSISTENCE`, default **on**) for ops rollback to pure-JSON.

Server-side only; wire frames unchanged → **no `PROTOCOL_VERSION` bump** (same as JP-34/36).

## Trade-off
An out-of-band MCP/REST JSON write resets that doc's CRDT identity (binary goes stale → JSON re-hydrates → next snapshot re-establishes binary). Acceptable: an MCP/REST write is a non-collab snapshot mutation and clients reload via `DocEvent`. The pre-existing "resident doc doesn't reflect an MCP write until evict" limitation is unchanged and out of scope.

## Tests
- `cargo test` — full suite green (199 unit + all integration).
- New `sync::binary` unit tests: round-trip, **prose/non-shape type survives**, **identity preserved → concurrent edits merge**, staleness fallback, corrupt-blob fallback.
- New `DocHandle::hydrate` tests: binary-vs-JSON selection (current / stale / none).
- New **end-to-end** `yjs_authority::prose_survives_eviction_via_binary_sidecar`: a client writes prose over CRDT, disconnects (evict), a fresh client joins and gets the prose back — impossible without the binary sidecar (JSON is shapes-only).

## Unblocks (follow-on JP-108 steps, not here)
1. Client `y-indexeddb` on the shared Y.Doc (re-introduce the reverted spike, now safe to merge).
2. REST/CRDT dual-write fix — stop the client REST offline-queue + stale-refresh from clobbering the CRDT merge.

Assisted-by: Opus 4.8