### PR TITLE
JP-108: relay is sole writer for active-collab docs (stop the REST clobber + protect the binary)

### DIFF
--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -3,9 +3,12 @@ import {
   useCollaborationStore,
   subscribeToRemoteChanges,
   initializeCRDTFromState,
+  isCollabContentDoc,
   type CollaborationConfig,
 } from './collaborationStore';
 import type { Shape } from '../shapes/Shape';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import type { DocumentMetadata } from '../types/Document';
 
 // Mock dependencies
 vi.mock('./YjsDocument', () => ({
@@ -472,5 +475,58 @@ describe('initializeCRDTFromState', () => {
 
     const yjsDoc = useCollaborationStore.getState().getYjsDocument();
     expect(yjsDoc?.initializeFromState).toHaveBeenCalledWith(shapes, order);
+  });
+});
+
+describe('isCollabContentDoc (JP-108 relay-sole-writer predicate)', () => {
+  function makeMeta(id: string): DocumentMetadata {
+    return {
+      id,
+      name: id,
+      pageCount: 1,
+      ownerId: 'owner-1',
+      ownerName: 'owner',
+      createdAt: 1,
+      modifiedAt: 1,
+      isRelayDocument: true,
+    };
+  }
+
+  beforeEach(() => {
+    useDocumentRegistry.getState().clearAll();
+    useCollaborationStore.setState({ isActive: false, config: null });
+  });
+  afterEach(() => {
+    useDocumentRegistry.getState().clearAll();
+    useCollaborationStore.setState({ isActive: false, config: null });
+  });
+
+  it('is false when no collab session is active', () => {
+    expect(isCollabContentDoc('doc-1')).toBe(false);
+  });
+
+  it('is true for the active session document', () => {
+    useCollaborationStore.setState({
+      isActive: true,
+      config: createTestConfig({ documentId: 'doc-1' }),
+    });
+    expect(isCollabContentDoc('doc-1')).toBe(true);
+  });
+
+  it('is false for a document other than the active session doc', () => {
+    useCollaborationStore.setState({
+      isActive: true,
+      config: createTestConfig({ documentId: 'doc-1' }),
+    });
+    expect(isCollabContentDoc('doc-2')).toBe(false);
+  });
+
+  it('is false for an errored doc — REST stays its durability fallback', () => {
+    useCollaborationStore.setState({
+      isActive: true,
+      config: createTestConfig({ documentId: 'doc-1' }),
+    });
+    useDocumentRegistry.getState().registerRemote(makeMeta('doc-1'), 'relay-1', 'owner', 'error');
+    expect(isCollabContentDoc('doc-1')).toBe(false);
   });
 });

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -34,6 +34,7 @@ import { RestDocumentProvider } from '../api/restDocumentProvider';
 import { clearJwt, saveConnection } from '../api/relayConnection';
 import { useNotificationStore } from '../store/notificationStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
+import { isRemoteDocument } from '../types/DocumentRegistry';
 import type { Shape } from '../shapes/Shape';
 import type { DocEvent } from './protocol';
 import { isUnknownDocError } from './protocol';
@@ -557,6 +558,33 @@ export function initializeCRDTFromState(
   if (yjsDoc) {
     yjsDoc.initializeFromState(shapes, order);
   }
+}
+
+/**
+ * Whether `docId` is the document of an active collaboration session — i.e. its
+ * content is owned by the relay-mediated CRDT (and the relay's own persistence,
+ * JP-36 + JP-108), so the client must NOT also REST-save/queue it. Doing so
+ * would replay an LWW snapshot that clobbers the merge, and would bump
+ * `serverVersion` (invalidating the relay's binary Y.Doc sidecar → prose +
+ * identity loss). See JP-108 "relay sole writer".
+ *
+ * Deliberately does NOT require `isSynced`: an offline (unsynced) edit must also
+ * stay off the REST queue, or the clobber returns on reconnect. The one
+ * exception is an **errored** doc — the relay has no record of it (rejected
+ * JOIN_DOC), so the CRDT can't own it; REST stays its durability fallback (the
+ * "saved locally only" safety net).
+ */
+export function isCollabContentDoc(docId: string): boolean {
+  const collab = useCollaborationStore.getState();
+  if (!collab.isActive || collab.config?.documentId !== docId) return false;
+
+  // An errored doc (relay rejected JOIN_DOC / has no record) can't be CRDT-owned
+  // — keep it on the REST path. `syncState` lives on RemoteDocument only.
+  const record = useDocumentRegistry.getState().getRecord(docId);
+  if (record && isRemoteDocument(record) && record.syncState === 'error') {
+    return false;
+  }
+  return true;
 }
 
 // Re-export types for backwards compatibility

--- a/src/collaboration/index.ts
+++ b/src/collaboration/index.ts
@@ -20,6 +20,7 @@ export {
   useCollaborationStore,
   subscribeToRemoteChanges,
   initializeCRDTFromState,
+  isCollabContentDoc,
 } from './collaborationStore';
 export type { CollaborationConfig, RemoteUser } from './collaborationStore';
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -29,7 +29,7 @@ import { useSessionStore } from './sessionStore';
 import { useHistoryStore } from './historyStore';
 import { useDocumentRegistry } from './documentRegistry';
 import { isRemoteDocument, isCachedDocument } from '../types/DocumentRegistry';
-import { useCollaborationStore } from '../collaboration';
+import { useCollaborationStore, isCollabContentDoc } from '../collaboration';
 import { useWhiteboardStore } from './whiteboardStore';
 import { blobStorage } from '../storage/BlobStorage';
 import { collectBlobReferences } from '../storage/AssetBundler';
@@ -101,6 +101,20 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
   const connected = useConnectionStore.getState().host?.address;
   // A brand-new doc with no origin yet is being created on the connected relay.
   const homeRelayId = home ?? connected ?? 'unknown';
+
+  // JP-108 (relay sole writer): a doc in an active collab session is relay-owned
+  // content — the CRDT sync + the relay's own persistence (JP-36 JSON + JP-108
+  // binary) carry it. The client must NOT REST push or queue it: a queued LWW
+  // snapshot would replay over the relay's merged state (clobber), and any REST
+  // save bumps serverVersion, which strands the relay's binary Y.Doc sidecar
+  // (→ prose + CRDT identity lost on the next hydrate). Keep only the local
+  // cache so the doc still opens offline.
+  if (isCollabContentDoc(doc.id)) {
+    void RelayDocumentCache.put(doc, homeRelayId).catch((e) =>
+      console.error('[persistenceStore] Failed to cache collab edit:', e),
+    );
+    return;
+  }
 
   const queueForReplay = (reason: string): void => {
     void RelayDocumentCache.put(doc, homeRelayId).catch((e) =>
@@ -1362,18 +1376,24 @@ export async function reattachAwaitingTeamDocument(): Promise<void> {
         void RelayDocumentCache.put(pinned, home).catch((e) =>
           console.error('[persistence] Failed to re-cache newer local copy:', e),
         );
-        getSyncStateManager().queueSave(pinned, home);
-        usePersistenceStore.setState({ isAwaitingTeamLoad: false });
-        console.warn(
-          `[persistence] Local copy of ${docId} is newer than the relay copy ` +
-            '(unsynced edit) — keeping it and queuing a replay instead of ' +
-            'overwriting with the older relay copy (JP-127).',
-        );
-        // Push promptly rather than waiting for the next reconnect; the
-        // host-queue processor is guarded against concurrent runs.
-        if (home === connected) {
-          void getSyncStateManager().processQueueForHost(home).catch(() => {});
+        // JP-108: for a collab-session doc the relay owns content — don't queue
+        // an LWW replay (it would clobber the CRDT merge and bump serverVersion,
+        // stranding the relay's binary Y.Doc). Keep the cached local copy; the
+        // CRDT sync handshake reconciles. (Non-collab docs keep the JP-127 net.)
+        if (!isCollabContentDoc(docId)) {
+          getSyncStateManager().queueSave(pinned, home);
+          // Push promptly rather than waiting for the next reconnect; the
+          // host-queue processor is guarded against concurrent runs.
+          if (home === connected) {
+            void getSyncStateManager().processQueueForHost(home).catch(() => {});
+          }
+          console.warn(
+            `[persistence] Local copy of ${docId} is newer than the relay copy ` +
+              '(unsynced edit) — keeping it and queuing a replay instead of ' +
+              'overwriting with the older relay copy (JP-127).',
+          );
         }
+        usePersistenceStore.setState({ isAwaitingTeamLoad: false });
         return;
       }
     }
@@ -1397,6 +1417,11 @@ export async function syncCurrentDocToRelayOnConnect(): Promise<void> {
   const ps = usePersistenceStore.getState();
   const docId = ps.currentDocumentId;
   if (!docId || ps.teamDocContentPending) return;
+
+  // JP-108: a doc in an active collab session is relay-owned — the WS sync
+  // handshake reconciles its content on reconnect. A REST push here would
+  // clobber the merge and bump serverVersion (stranding the binary Y.Doc).
+  if (isCollabContentDoc(docId)) return;
 
   // The durable queue owns docs with queued offline edits — it auto-replays
   // on reconnect, so don't double-write them here (a second unversioned write

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -29,6 +29,7 @@ import {
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
 import { registerBlobDownloader } from '../storage/blobResolver';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
+import { isCollabContentDoc } from '../collaboration/collaborationStore';
 import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
 import { useUploadStatusStore } from './uploadStatusStore';
 
@@ -726,6 +727,11 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       let evicted = 0;
 
       for (const docId of cachedIds) {
+        // JP-108: never stale-refresh the doc in an active collab session — its
+        // content is owned by the live CRDT (relay-mediated + relay-persisted).
+        // Invalidating/re-fetching its REST body would race the merge.
+        if (isCollabContentDoc(docId)) continue;
+
         const remoteMeta = teamDocs[docId];
         if (!remoteMeta) {
           // The cache entry was recorded under this host, but the server


### PR DESCRIPTION
JP-108 step 2 — the make-or-break slice. Stops the offline two-way clobber the user still sees, **and** protects the step-1 binary persistence that just merged.

## Why
A doc in a live collab session had **two** content writers: the relay-mediated CRDT (now relay-persisted via JP-36 JSON + JP-108 binary) and the client REST save path (`pushRelaySaveOrQueue` → cache + offline-queue LWW replay + reconnect push). For collab docs that REST path:

1. **Clobbers the merge** — an offline edit is queued as a whole-doc LWW snapshot; on reconnect the queue replays it and `syncCurrentDocToRelayOnConnect` re-pushes, overwriting the relay's CRDT-merged state (dropping the other client's edits).
2. **Defeats step 1** — a client REST save **bumps `serverVersion`**, and the JP-108 hydrate trusts the binary only when its tag `>=` the JSON's. So every save strands the binary → next hydrate falls back to **shapes-only JSON** → prose + CRDT identity lost. Clients REST-saving collab docs silently dismantle the feature we just shipped.

The relay self-persists collab docs now, so the client REST write is redundant. **Fix: for an active collab-session doc, the relay is the sole content writer.**

## What
- **`collaborationStore.isCollabContentDoc(docId)`** — `isActive && config.documentId === docId` **and not errored**. An errored doc (relay rejected `JOIN_DOC`) keeps REST as its "saved locally only" fallback. Deliberately **not** gated on `isSynced`, or offline (unsynced) edits re-queue and re-clobber on reconnect.
- **`persistenceStore`** — for collab docs: `pushRelaySaveOrQueue` caches locally then returns (no relay push, no `queueSave`); `reattachAwaitingTeamDocument` skips the "local-newer" LWW replay; `syncCurrentDocToRelayOnConnect` early-returns.
- **`relayDocumentStore.refreshStaleCachedDocuments`** — skips the active collab doc so a REST re-fetch can't race the merge.

Guarding at every **enqueue/push** site means a collab doc never enters the queue, so the three `processQueueForHost` reconnect hooks are all no-ops for it. Non-collab + local docs are byte-for-byte unchanged.

## Verification
- `bun run typecheck`; `bun run test --run src/store src/collaboration` — **503 pass** (incl. new `isCollabContentDoc` coverage: active / other-doc / inactive / errored).
- Manual two-client: A offline-edits canvas + prose, B online-edits; A reconnects → both converge, no clobber; relay `serverVersion` stays constant for the collab doc and the `.ydoc` binary is used on rejoin (prose intact). *(awaiting user E2E)*

## Known limits / follow-ups
- **Offline-*then-reload*** merge of collab edits needs **client `y-indexeddb`** (JP-108 step 3) — this slice stops the clobber and protects the binary; in-session offline→reconnect merges via the live Y.Doc.
- **Rename / metadata writes** still bump `serverVersion` (intentionally left on REST). Narrow stale-binary window that self-heals on the next content edit; a small relay `mark_dirty`-on-REST-write follow-up closes it fully.
- **Page-structure during collab** rides the existing active-page-only relay limitation.

Assisted-by: Opus 4.8