### PR TITLE
JP-108 step 3 / Stage 1: persist the collab Y.Doc (y-indexeddb) + gate the view adopt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "react-dom": "^18.2.0",
         "simple-icons": "^16.9.0",
         "xlsx": "^0.18.5",
+        "y-indexeddb": "^9.0.12",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.29",
         "zustand": "^4.4.7",
@@ -1365,6 +1366,8 @@
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "y-indexeddb": ["y-indexeddb@9.0.12", "", { "dependencies": { "lib0": "^0.2.74" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg=="],
 
     "y-prosemirror": ["y-prosemirror@1.3.7", "", { "dependencies": { "lib0": "^0.2.109" }, "peerDependencies": { "prosemirror-model": "^1.7.1", "prosemirror-state": "^1.2.3", "prosemirror-view": "^1.9.10", "y-protocols": "^1.0.1", "yjs": "^13.5.38" } }, "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dom": "^18.2.0",
     "simple-icons": "^16.9.0",
     "xlsx": "^0.18.5",
+    "y-indexeddb": "^9.0.12",
     "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.29",
     "zustand": "^4.4.7"

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -16,6 +16,7 @@
  */
 
 import { create } from 'zustand';
+import { IndexeddbPersistence } from 'y-indexeddb';
 import { YjsDocument } from './YjsDocument';
 import { UnifiedSyncProvider, AwarenessUserState } from './UnifiedSyncProvider';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
@@ -85,6 +86,13 @@ interface CollaborationState {
   connectionStatus: ConnectionStatus;
   /** Whether the document is synced with server */
   isSynced: boolean;
+  /**
+   * Whether the local `y-indexeddb` persistence has finished loading the
+   * Y.Doc from IndexedDB (JP-108 step 3). The CRDT→view adopt must wait for
+   * this AND `isSynced`, so it adopts the fully-loaded Y.Doc (persisted offline
+   * edits + relay state) rather than a partial one.
+   */
+  isIdbSynced: boolean;
   /** Connection error message */
   error: string | null;
   /** Remote users currently viewing the document */
@@ -127,6 +135,8 @@ interface CollaborationActions {
   _setConnectionStatus: (status: ConnectionStatus) => void;
   /** Set synced state (internal) */
   _setSynced: (synced: boolean) => void;
+  /** Set IndexedDB-loaded state (internal) */
+  _setIdbSynced: (synced: boolean) => void;
   /** Set error (internal) */
   _setError: (error: string | null) => void;
   /** Update remote users (internal) */
@@ -144,6 +154,13 @@ interface CollaborationActions {
  */
 let yjsDoc: YjsDocument | null = null;
 let syncProvider: UnifiedSyncProvider | null = null;
+/**
+ * Local CRDT persistence for the shared Y.Doc (JP-108 step 3). Loads the doc's
+ * persisted Yjs state from IndexedDB at session start and persists every update,
+ * so offline edits survive reload and reconcile via the normal sync handshake
+ * instead of being clobbered. Room-keyed per relay+doc.
+ */
+let idbPersistence: IndexeddbPersistence | null = null;
 let relayClient: RelayClient | null = null;
 let connectionUnsubscribe: (() => void) | null = null;
 let awarenessUnsubscribe: (() => void) | null = null;
@@ -193,6 +210,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     isActive: false,
     connectionStatus: 'disconnected',
     isSynced: false,
+    isIdbSynced: false,
     error: null,
     remoteUsers: [],
     config: null,
@@ -213,6 +231,27 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // default (JP-172) — NOT keyed off documentId; doc identity is the relay
       // room below, not the clientID.
       yjsDoc = new YjsDocument();
+
+      // JP-108 step 3: attach local CRDT persistence BEFORE the provider connects.
+      // Room is scoped per relay+doc (matching the cache/queue relay-tagging, JP-117)
+      // so the same doc on a different relay can't bleed. y-indexeddb loads any
+      // persisted state into the Y.Doc; `isIdbSynced` gates the view adopt so it
+      // waits for the persisted offline edits to load. Browser-only (skips under
+      // jsdom/tests). The relay preserves CRDT identity (JP-108 step 1) + JP-172
+      // gave random clientIDs, so this no longer corrupts merges.
+      get()._setIdbSynced(false);
+      if (typeof indexedDB !== 'undefined') {
+        const idbRoom = `${new URL(config.serverUrl).host}:${config.documentId}`;
+        idbPersistence = new IndexeddbPersistence(idbRoom, yjsDoc.getDoc());
+        idbPersistence.whenSynced
+          .then(() => get()._setIdbSynced(true))
+          .catch((e) => {
+            console.warn('[collab][idb] load failed:', e);
+            get()._setIdbSynced(true); // unblock adopt; fall back to relay state
+          });
+      } else {
+        get()._setIdbSynced(true); // no IndexedDB → nothing to wait for
+      }
 
       // Create unified sync provider
       syncProvider = new UnifiedSyncProvider(yjsDoc.getDoc(), {
@@ -408,6 +447,14 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         syncProvider = null;
       }
 
+      // Detach local persistence. `destroy()` closes the IndexedDB connection
+      // but leaves the persisted data on disk (it's the durability store), so
+      // the next session reloads it.
+      if (idbPersistence) {
+        void idbPersistence.destroy();
+        idbPersistence = null;
+      }
+
       if (yjsDoc) {
         yjsDoc.destroy();
         yjsDoc = null;
@@ -428,6 +475,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         isActive: false,
         connectionStatus: 'disconnected',
         isSynced: false,
+        isIdbSynced: false,
         error: null,
         remoteUsers: [],
         config: null,
@@ -496,6 +544,10 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
 
     _setSynced: (synced: boolean) => {
       set({ isSynced: synced });
+    },
+
+    _setIdbSynced: (synced: boolean) => {
+      set({ isIdbSynced: synced });
     },
 
     _setError: (error: string | null) => {

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -33,6 +33,7 @@ let isApplyingRemoteChanges = false;
 export function useCollaborationSync(): void {
   const isActive = useCollaborationStore((state) => state.isActive);
   const isSynced = useCollaborationStore((state) => state.isSynced);
+  const isIdbSynced = useCollaborationStore((state) => state.isIdbSynced);
   const getYjsDocument = useCollaborationStore((state) => state.getYjsDocument);
   const syncShape = useCollaborationStore((state) => state.syncShape);
   const syncDeleteShape = useCollaborationStore((state) => state.syncDeleteShape);
@@ -92,9 +93,13 @@ export function useCollaborationSync(): void {
     };
   }, [isActive, getYjsDocument]);
 
-  // Initialize CRDT with current document state when session starts and synced
+  // Initialize the views from the Y.Doc once the session has the *complete*
+  // merged truth — gated on BOTH the relay sync (`isSynced`) AND the local
+  // `y-indexeddb` load (`isIdbSynced`, JP-108 step 3). Adopting before both
+  // would clobber the views with a partial Y.Doc (missing persisted offline
+  // edits or relay state).
   useEffect(() => {
-    if (!isActive || !isSynced || initializedRef.current) return;
+    if (!isActive || !isSynced || !isIdbSynced || initializedRef.current) return;
 
     const yjsDoc = getYjsDocument();
     if (!yjsDoc) return;
@@ -103,11 +108,11 @@ export function useCollaborationSync(): void {
     const { shapes, shapeOrder } = useDocumentStore.getState();
     const shapesArray = Object.values(shapes);
 
-    // Check if CRDT already has data (we're joining an existing session)
+    // Check if the Y.Doc has data (persisted IndexedDB state and/or relay state).
     const crdtShapes = yjsDoc.getAllShapes();
 
     if (crdtShapes.size > 0) {
-      // CRDT has data - apply it to local store
+      // The Y.Doc is the complete merged truth — replace the views with it.
       isApplyingRemoteChanges = true;
       try {
         const store = useDocumentStore.getState();
@@ -121,12 +126,16 @@ export function useCollaborationSync(): void {
         isApplyingRemoteChanges = false;
       }
     } else if (shapesArray.length > 0) {
-      // CRDT is empty but we have local data - push to CRDT
+      // The Y.Doc is empty AND the relay confirmed it synced empty (we waited
+      // for isSynced) AND IndexedDB had nothing — so this is a genuinely empty
+      // doc. Safe to seed from local without risking the duplication the
+      // identity rule guards against (a non-empty relay would have populated
+      // the Y.Doc above). [JP-108 step 3 — Stage 2 hardens the offline case.]
       yjsDoc.initializeFromState(shapesArray, shapeOrder);
     }
 
     initializedRef.current = true;
-  }, [isActive, isSynced, getYjsDocument]);
+  }, [isActive, isSynced, isIdbSynced, getYjsDocument]);
 
   // Subscribe to local document store changes and sync to CRDT
   useEffect(() => {


### PR DESCRIPTION
First, low-risk stage of offline-first (JP-108 step 3). Foundation only — Stage 2 is the user-facing fix.

## Why
Offline-first needs the **persisted Y.Doc to be the source of truth**. Today the Y.Doc is transient (per connected session) and `useCollaborationSync` adopts relay state by `store.clear()` + re-add — so anything not already a CRDT op is clobbered. This stage adds local persistence and fixes the adopt *timing*; Stage 2 makes the Y.Doc live before the connection so offline edits are CRDT ops.

## What
- **Re-add `y-indexeddb`**; attach `IndexeddbPersistence(relayHost:docId, ydoc)` in `startSession`. The doc's CRDT state (shapes + prose + history) now persists locally and **survives reload**. Safe now: step 1 preserves CRDT identity across evict/rehydrate, JP-172 gave random clientIDs.
- **Gate the adopt** (`useCollaborationSync` init) on a new **`isIdbSynced`** (y-indexeddb `whenSynced`) **AND** `isSynced` (relay). It replaces the views only once the Y.Doc is the *complete merged truth* — never a partial state that would clobber persisted offline edits or relay content.
- The local **seed** branch stays guarded behind `isSynced` (relay confirmed empty), so it can't fork a **duplicate CRDT identity** for a doc that already exists on the relay.

## De-risking (Stage 0 spike, throwaway)
- **Duplication confirmed:** independently local-seeding a doc that exists on the relay, then merging, yields `shapeOrder = [s1,s2,s1,s2]` and doubled prose (`Y.Map` dedups by key; sequence types concatenate). → the seed guard above + the Stage-2 "never locally-seed a relay-origin doc" identity rule.
- **Provider degrades gracefully** with no/expired token (offline → backoff; no hot-loop) → confirms Stage 2's engine ≠ provider split.

## Tests
`bun run typecheck`; `bun run test --run src/collaboration src/store` — **503 pass**, no regressions. Reload-survival is an E2E behavior (manual).

## Next
**Stage 2** — activate the Y.Doc on doc-open, decoupled from the connection (provider attaches only with a token). That's what fixes "edit offline, then connect → merges". **Stage 3** drains the stale REST queue. Prose seed removal rides the `collab-prose` rebase.

Assisted-by: Opus 4.8