### PR TITLE
JP-108 step 3 (Stage 2): activate the Y.Doc engine on doc-open (offline-first)

### DIFF
--- a/src/api/completeCloudSignIn.ts
+++ b/src/api/completeCloudSignIn.ts
@@ -12,7 +12,7 @@ import { useCollaborationStore } from '../collaboration';
 import { saveConnection } from './relayConnection';
 
 /** Convert a REST origin (http://host:port) to the matching WS URL (ws://host:port/ws). */
-function restUrlToWsUrl(restUrl: string): string {
+export function restUrlToWsUrl(restUrl: string): string {
   return restUrl
     .replace(/\/+$/, '')
     .replace(/^http:\/\//, 'ws://')

--- a/src/api/completeCloudSignIn.ts
+++ b/src/api/completeCloudSignIn.ts
@@ -36,9 +36,7 @@ export interface CompleteCloudSignInArgs {
 export async function completeCloudSignIn(args: CompleteCloudSignInArgs): Promise<void> {
   const { relayUrl, cloudBaseUrl, token, expiresAt, documentId } = args;
 
-  // Make the token available to the REST client seed + persist it alongside the
-  // URLs before the session subscribes.
-  useConnectionStore.getState().setToken(token, expiresAt);
+  // Persist the URLs + token before the session starts.
   await saveConnection(relayUrl, token, { cloudBaseUrl, jwtExpiresAt: expiresAt });
 
   useCollaborationStore.getState().startSession({
@@ -47,4 +45,13 @@ export async function completeCloudSignIn(args: CompleteCloudSignInArgs): Promis
     token,
     user: { id: 'pending', name: 'You', color: '#4a90d9' },
   });
+
+  // Assert the token into the connection store AFTER `startSession`: it tears
+  // down any prior (Stage 2 engine-only) session first, which RESETS the
+  // connection store — so setting the token *before* would be wiped, leaving
+  // `connectionStore.token` null while authenticated (the token-expiry monitor
+  // would go blind and the REST sync subscription would push a null bearer).
+  // The session's REST client is seeded from `config.token` directly, so this
+  // is purely to keep the connection store coherent for the auth/refresh path.
+  useConnectionStore.getState().setToken(token, expiresAt);
 }

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -59,7 +59,9 @@ vi.mock('../store/connectionStore', () => ({
     getState: vi.fn(() => ({
       setHost: vi.fn(),
       reset: vi.fn(),
+      setToken: vi.fn(),
       token: null,
+      tokenExpiresAt: null,
     })),
     subscribe: vi.fn(() => vi.fn()),
   },
@@ -280,28 +282,48 @@ describe('collaborationStore', () => {
   });
 
   describe('switchDocument', () => {
-    it('switches to a different document', () => {
+    it('restarts the engine for the new document', () => {
       const config = createTestConfig({ documentId: 'doc-1' });
       useCollaborationStore.getState().startSession(config);
+
+      const firstYjs = useCollaborationStore.getState().getYjsDocument();
+      const firstProvider = useCollaborationStore.getState().getSyncProvider();
 
       useCollaborationStore.getState().switchDocument('doc-2');
 
       const state = useCollaborationStore.getState();
+      expect(state.isActive).toBe(true);
       expect(state.config?.documentId).toBe('doc-2');
-      expect(state.isSynced).toBe(false);
+      // Per-doc RESTART (JP-108 step 3): the old session is torn down and a fresh
+      // Y.Doc + provider come up for the new doc — keyed to a new y-indexeddb
+      // room. An in-place `clear()` would have wiped the previous doc's room.
+      expect(firstYjs?.destroy).toHaveBeenCalled();
+      expect(firstProvider?.destroy).toHaveBeenCalled();
 
-      const yjsDoc = useCollaborationStore.getState().getYjsDocument();
-      expect(yjsDoc?.clear).toHaveBeenCalled();
+      // The new engine is a distinct, freshly-connected instance.
+      const newYjs = useCollaborationStore.getState().getYjsDocument();
+      const newProvider = useCollaborationStore.getState().getSyncProvider();
+      expect(newYjs).not.toBe(firstYjs);
+      expect(newProvider).not.toBe(firstProvider);
+      expect(newProvider?.connect).toHaveBeenCalled();
+    });
 
-      const syncProvider = useCollaborationStore.getState().getSyncProvider();
-      expect(syncProvider?.joinDocument).toHaveBeenCalledWith('doc-2');
-      expect(syncProvider?.requestSync).toHaveBeenCalled();
+    it('carries the token so an online collaborator stays connected', () => {
+      const config = createTestConfig({ documentId: 'doc-1', token: 'tok-abc' });
+      useCollaborationStore.getState().startSession(config);
+
+      useCollaborationStore.getState().switchDocument('doc-2');
+
+      // A provider (the token-gated transport) is present after the switch.
+      expect(useCollaborationStore.getState().getSyncProvider()).not.toBeNull();
+      expect(useCollaborationStore.getState().config?.token).toBe('tok-abc');
     });
 
     it('does nothing when no session', () => {
       expect(() => {
         useCollaborationStore.getState().switchDocument('doc-2');
       }).not.toThrow();
+      expect(useCollaborationStore.getState().isActive).toBe(false);
     });
   });
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -407,10 +407,16 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         // the in-memory store is the source of truth (last-write-wins).
         void saveConnection(restBaseUrl, state.token);
       });
-      // Seed with whatever the connection store already has.
-      const seedToken = useConnectionStore.getState().token;
-      relayClient.setToken(seedToken ?? undefined);
-      void saveConnection(restBaseUrl, seedToken);
+      // Seed the REST client from the SESSION's own token (the same one the WS
+      // provider uses), NOT `connectionStore.token`. The internal `stopSession`
+      // at the top of `startSession` resets the connection store, so on an
+      // engine-only→authenticated transition (Stage 2: an engine-only session is
+      // live before sign-in) `connectionStore.token` is transiently null here —
+      // seeding from it would leave the REST client unauthenticated (401 on
+      // /api/docs) even though the WS authenticated fine. `config.token` is
+      // always set in this block (the token-less path returned early above).
+      relayClient.setToken(config.token ?? undefined);
+      void saveConnection(restBaseUrl, config.token ?? null);
 
       useRelayDocumentStore
         .getState()

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -253,6 +253,20 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         get()._setIdbSynced(true); // no IndexedDB → nothing to wait for
       }
 
+      // The local engine is live now — Y.Doc + y-indexeddb + the view binding
+      // (which activates on `isActive`) — independent of any connection. Edits
+      // are CRDT ops from here, so anything typed offline/pre-sign-in is captured
+      // and persisted, then merges on connect (JP-108 step 3). Set this BEFORE
+      // attaching the provider so the engine doesn't depend on the network.
+      set({ isActive: true, config, error: null });
+
+      // Only attach the WS provider when we have a token. A token-less provider
+      // would no-auth-join → get rejected → fire the "this document isn't syncing
+      // — saved locally only" toast while the user edits offline pre-sign-in.
+      // The provider attaches on sign-in (a later `startSession` with a token)
+      // onto this same live Y.Doc.
+      if (!config.token) return;
+
       // Create unified sync provider
       syncProvider = new UnifiedSyncProvider(yjsDoc.getDoc(), {
         url: config.serverUrl,
@@ -417,12 +431,6 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
             if (!refreshed) dropSessionWithToast();
           });
         },
-      });
-
-      set({
-        isActive: true,
-        config,
-        error: null,
       });
     },
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -515,27 +515,44 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     },
 
     switchDocument: (docId: string) => {
-      
-      if (yjsDoc) {
-        // Clear the CRDT document state for the new document
-        yjsDoc.clear();
-      }
-      
-      if (syncProvider) {
-        // Tell the server we're now on a different document
-        syncProvider.joinDocument(docId);
-        // Request initial sync for the new document
-        syncProvider.requestSync();
-      }
-      
-      // Update the config
+      // Per-doc engine RESTART (JP-108 step 3, Stage 2). The old implementation
+      // cleared the CRDT in place (`yjsDoc.clear()`) and re-joined on the same
+      // Y.Doc. That is unsafe now that `y-indexeddb` is attached (Stage 1):
+      // `clear()` persists the EMPTY state into the *current* doc's room, wiping
+      // its offline edits, and a single Y.Doc can't be keyed to two rooms. So we
+      // tear the session down and start a fresh one for the new doc — new Y.Doc,
+      // new `host:docId` room, correct persistence — carrying the live token so
+      // an online collaborator stays connected across the switch.
+      //
+      // Always restarts, even when `docId` equals the current doc: that's how a
+      // just-promoted local→relay doc (DocumentBrowser) forces a real JOIN_DOC
+      // now that the relay has a record of it.
       const config = get().config;
-      if (config) {
-        set({
-          config: { ...config, documentId: docId },
-          isSynced: false,
-        });
+      if (!config) return;
+
+      // Freshest token: the auth path / refresh updates connectionStore; fall
+      // back to the config's original. `undefined` → engine-only restart.
+      const conn = useConnectionStore.getState();
+      const token = conn.token ?? config.token;
+      const tokenExpiresAt = conn.tokenExpiresAt;
+
+      get().stopSession();
+
+      // `stopSession` resets the connection store (token → null). Re-assert the
+      // identity BEFORE the new `startSession` so its REST-client seed + token
+      // monitor pick it up — otherwise an authenticated collaborator would drop
+      // to unauthenticated across a doc switch.
+      if (token) {
+        useConnectionStore.getState().setToken(token, tokenExpiresAt);
       }
+
+      get().startSession({
+        serverUrl: config.serverUrl,
+        documentId: docId,
+        ...(token ? { token } : {}),
+        // Reset to a placeholder; `onAuthenticated` re-adopts the token `sub`.
+        user: { id: 'pending', name: 'You', color: '#4a90d9' },
+      });
     },
 
     updateCursor: (x: number, y: number) => {

--- a/src/collaboration/ensureCollabSession.test.ts
+++ b/src/collaboration/ensureCollabSession.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Mocks for the modules ensureCollabSession depends on -------------------
+
+const collab = {
+  isActive: false,
+  config: null as { documentId: string; serverUrl: string; token?: string } | null,
+  startSession: vi.fn(),
+  switchDocument: vi.fn(),
+};
+
+vi.mock('./collaborationStore', () => ({
+  useCollaborationStore: { getState: () => collab },
+}));
+
+let flagEnabled = true;
+vi.mock('./offlineFirstEngine', () => ({
+  isOfflineFirstEngineEnabled: () => flagEnabled,
+}));
+
+let record: { type: 'local' | 'remote' | 'cached' } | undefined;
+vi.mock('../store/documentRegistry', () => ({
+  useDocumentRegistry: { getState: () => ({ getRecord: () => record }) },
+}));
+
+let connection: { relayUrl: string } | null;
+vi.mock('../api/relayConnection', () => ({
+  loadConnection: () => Promise.resolve(connection),
+}));
+
+// Use the real restUrlToWsUrl (pure string transform).
+import { ensureCollabSessionForDoc } from './ensureCollabSession';
+
+describe('ensureCollabSessionForDoc', () => {
+  beforeEach(() => {
+    collab.isActive = false;
+    collab.config = null;
+    collab.startSession.mockReset();
+    collab.switchDocument.mockReset();
+    flagEnabled = true;
+    record = { type: 'remote' };
+    connection = { relayUrl: 'http://relay.example:9876' };
+  });
+
+  it('no-ops when already active for the same doc', async () => {
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-1', serverUrl: 'ws://x/ws' };
+
+    await ensureCollabSessionForDoc('doc-1');
+
+    expect(collab.switchDocument).not.toHaveBeenCalled();
+    expect(collab.startSession).not.toHaveBeenCalled();
+  });
+
+  it('switches the engine when active for a different doc', async () => {
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-1', serverUrl: 'ws://x/ws', token: 't' };
+
+    await ensureCollabSessionForDoc('doc-2');
+
+    expect(collab.switchDocument).toHaveBeenCalledWith('doc-2');
+    expect(collab.startSession).not.toHaveBeenCalled();
+  });
+
+  it('starts an engine-only session (no token) on a cold open', async () => {
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.startSession).toHaveBeenCalledTimes(1);
+    const arg = collab.startSession.mock.calls[0]![0] as {
+      serverUrl: string;
+      documentId: string;
+      token?: string;
+    };
+    expect(arg.documentId).toBe('doc-9');
+    expect(arg.serverUrl).toBe('ws://relay.example:9876/ws');
+    // Engine-only: no token attached, so startSession won't attach the provider.
+    expect(arg.token).toBeUndefined();
+  });
+
+  it('never starts an engine for a local-only doc', async () => {
+    record = { type: 'local' };
+
+    await ensureCollabSessionForDoc('local-1');
+
+    expect(collab.startSession).not.toHaveBeenCalled();
+    expect(collab.switchDocument).not.toHaveBeenCalled();
+  });
+
+  it('respects the kill-switch for cold starts', async () => {
+    flagEnabled = false;
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.startSession).not.toHaveBeenCalled();
+  });
+
+  it('still switches an already-active session when the kill-switch is off', async () => {
+    flagEnabled = false;
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-1', serverUrl: 'ws://x/ws', token: 't' };
+
+    await ensureCollabSessionForDoc('doc-2');
+
+    expect(collab.switchDocument).toHaveBeenCalledWith('doc-2');
+  });
+
+  it('leaves the doc on the local path when no relay is configured', async () => {
+    connection = null;
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.startSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/collaboration/ensureCollabSession.ts
+++ b/src/collaboration/ensureCollabSession.ts
@@ -1,0 +1,97 @@
+/**
+ * Idempotent doc-open activation of the local CRDT engine (JP-108 step 3,
+ * Stage 2 — "the Y.Doc is the source of truth").
+ *
+ * The collaboration session used to be created only on an explicit Cloud
+ * sign-in (`completeCloudSignIn`). That made the Y.Doc a transient sync layer:
+ * a doc opened offline had no engine, so anything typed before connecting was
+ * adopted-clobbered on the first sync. This inverts the model — whenever a
+ * *relay* document becomes the active doc we bring up its **engine** (Y.Doc +
+ * `y-indexeddb` + the view binding), regardless of connectivity. Edits are CRDT
+ * ops from the first keystroke and persist locally; the WS provider attaches
+ * later (on sign-in, which restarts the session *with* a token onto the same
+ * `y-indexeddb` room) and merges via the normal Yjs handshake.
+ *
+ * The engine never depends on the network — `collaborationStore.startSession`
+ * only attaches the provider when a token is present, so a token-less start is
+ * engine-only (no "not syncing" toast).
+ */
+
+import { useCollaborationStore } from './collaborationStore';
+import { isOfflineFirstEngineEnabled } from './offlineFirstEngine';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import { loadConnection } from '../api/relayConnection';
+import { restUrlToWsUrl } from '../api/completeCloudSignIn';
+
+/**
+ * Placeholder awareness identity used until the provider authenticates and
+ * `onAuthenticated` adopts the token's `sub` (awareness only matters once
+ * connected, so a placeholder is harmless offline).
+ */
+const PLACEHOLDER_USER = { id: 'pending', name: 'You', color: '#4a90d9' };
+
+/**
+ * Ensure the local CRDT engine is live for `docId` (a relay-backed document).
+ *
+ * - No-op if a session is already active for this exact doc (so it's safe to
+ *   call on every doc-open path, including the on-connect reattach which loads
+ *   the doc that's already the session's target — avoids tearing down the
+ *   provider whose callback is running).
+ * - If a session is active for a *different* doc, switch to this one (a per-doc
+ *   engine restart that re-keys the `y-indexeddb` room — see
+ *   `collaborationStore.switchDocument`), preserving the live token so an online
+ *   collaborator stays connected across the switch.
+ * - If no session is active, start an **engine-only** session (no token) from
+ *   the persisted relay URL, so offline editing works immediately. We do NOT
+ *   auto-assert a saved token here — connecting stays an explicit user action;
+ *   `completeCloudSignIn` restarts this session with the token when they do.
+ *
+ * Callers must only pass relay-backed doc ids; local-only docs are
+ * renderer-owned and never get an engine (guarded here as a safety net).
+ */
+export async function ensureCollabSessionForDoc(docId: string): Promise<void> {
+  if (!docId) return;
+
+  const collab = useCollaborationStore.getState();
+
+  // Already the live engine for this doc.
+  if (collab.isActive && collab.config?.documentId === docId) return;
+
+  // A local-only doc must never get a CRDT engine (it would emit a JOIN_DOC the
+  // relay rejects, and risks a cross-client leak — see JP-64). Unknown records
+  // are allowed through: the caller vouches it's a relay doc, and the registry
+  // may not have caught up on a cold offline boot.
+  const record = useDocumentRegistry.getState().getRecord(docId);
+  if (record?.type === 'local') return;
+
+  // A session is live for another doc — switch the engine to this one, carrying
+  // the freshest token (connectionStore is updated by the auth path / refresh;
+  // fall back to the config's original). This force-restarts even if the new id
+  // equals the current (callers gate that with the no-op above).
+  if (collab.isActive && collab.config) {
+    collab.switchDocument(docId);
+    return;
+  }
+
+  // Cold start. The kill-switch only gates *starting an engine where none was
+  // running* — the switch path above stays correct either way.
+  if (!isOfflineFirstEngineEnabled()) return;
+
+  const conn = await loadConnection();
+  if (!conn?.relayUrl) return; // No relay configured — leave the doc on the local path.
+
+  // Another path may have started a session while we awaited `loadConnection`.
+  const latest = useCollaborationStore.getState();
+  if (latest.isActive) {
+    if (latest.config?.documentId !== docId) latest.switchDocument(docId);
+    return;
+  }
+
+  // Engine-only start: no token, so `startSession` brings up the Y.Doc +
+  // `y-indexeddb` + view binding without attaching the WS provider.
+  latest.startSession({
+    serverUrl: restUrlToWsUrl(conn.relayUrl),
+    documentId: docId,
+    user: { ...PLACEHOLDER_USER },
+  });
+}

--- a/src/collaboration/index.ts
+++ b/src/collaboration/index.ts
@@ -26,6 +26,10 @@ export type { CollaborationConfig, RemoteUser } from './collaborationStore';
 
 export { useCollaborationSync, isRemoteSyncInProgress } from './useCollaborationSync';
 
+// Offline-first engine activation (JP-108 step 3, Stage 2)
+export { ensureCollabSessionForDoc } from './ensureCollabSession';
+export { isOfflineFirstEngineEnabled } from './offlineFirstEngine';
+
 // Protocol types and helpers
 export * from './protocol';
 

--- a/src/collaboration/offlineFirstEngine.test.ts
+++ b/src/collaboration/offlineFirstEngine.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isOfflineFirstEngineEnabled } from './offlineFirstEngine';
+
+const FLAG_KEY = 'docushark:flags:offlineFirstEngine';
+
+describe('isOfflineFirstEngineEnabled', () => {
+  afterEach(() => {
+    localStorage.removeItem(FLAG_KEY);
+  });
+
+  it('defaults ON when the flag is unset', () => {
+    expect(isOfflineFirstEngineEnabled()).toBe(true);
+  });
+
+  it('stays ON for any value other than "0"', () => {
+    localStorage.setItem(FLAG_KEY, '1');
+    expect(isOfflineFirstEngineEnabled()).toBe(true);
+  });
+
+  it('is disabled only by an explicit "0"', () => {
+    localStorage.setItem(FLAG_KEY, '0');
+    expect(isOfflineFirstEngineEnabled()).toBe(false);
+  });
+});

--- a/src/collaboration/offlineFirstEngine.ts
+++ b/src/collaboration/offlineFirstEngine.ts
@@ -1,0 +1,22 @@
+/**
+ * Kill-switch for the offline-first local CRDT engine (JP-108 step 3, Stage 2).
+ *
+ * When enabled (the default), a relay document's Y.Doc engine activates on
+ * doc-open — even with no connection — so edits are CRDT ops from the first
+ * keystroke and survive offline (see `ensureCollabSession.ts`). Set the
+ * localStorage key to `'0'` to fall back to the pre-Stage-2 behavior (a collab
+ * session only starts on an explicit connect/sign-in), without reverting code.
+ *
+ * Defaults ON: only an explicit `'0'` disables it, so a hosted build with the
+ * key unset still gets the feature.
+ */
+const FLAG_KEY = 'docushark:flags:offlineFirstEngine';
+
+export function isOfflineFirstEngineEnabled(): boolean {
+  try {
+    return localStorage.getItem(FLAG_KEY) !== '0';
+  } catch {
+    // No localStorage (SSR / locked-down env) — default to the feature being on.
+    return true;
+  }
+}

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -34,6 +34,12 @@ export function useCollaborationSync(): void {
   const isActive = useCollaborationStore((state) => state.isActive);
   const isSynced = useCollaborationStore((state) => state.isSynced);
   const isIdbSynced = useCollaborationStore((state) => state.isIdbSynced);
+  // A WS provider is attached only when the session has a token (engine ≠
+  // provider, JP-108 step 3). Offline / pre-sign-in there is no provider, so
+  // `isSynced` never flips — the adopt must instead key off the local
+  // `y-indexeddb` load alone (the Y.Doc IS the complete truth with no relay to
+  // merge). `config.token` is the reactive proxy for "provider attached".
+  const hasProvider = useCollaborationStore((state) => state.config?.token != null);
   const getYjsDocument = useCollaborationStore((state) => state.getYjsDocument);
   const syncShape = useCollaborationStore((state) => state.syncShape);
   const syncDeleteShape = useCollaborationStore((state) => state.syncDeleteShape);
@@ -93,13 +99,19 @@ export function useCollaborationSync(): void {
     };
   }, [isActive, getYjsDocument]);
 
-  // Initialize the views from the Y.Doc once the session has the *complete*
-  // merged truth — gated on BOTH the relay sync (`isSynced`) AND the local
-  // `y-indexeddb` load (`isIdbSynced`, JP-108 step 3). Adopting before both
-  // would clobber the views with a partial Y.Doc (missing persisted offline
-  // edits or relay state).
+  // Initialize the views from the Y.Doc once it holds the *complete* truth.
+  //
+  // - With a provider attached (online), that means BOTH the relay sync
+  //   (`isSynced`) AND the local `y-indexeddb` load (`isIdbSynced`).
+  // - With no provider (offline / pre-sign-in, JP-108 step 3 Stage 2), there is
+  //   no relay to merge, so the complete truth is just the `y-indexeddb` state —
+  //   adopt as soon as `isIdbSynced`.
+  //
+  // Adopting earlier would clobber the views with a partial Y.Doc.
   useEffect(() => {
-    if (!isActive || !isSynced || !isIdbSynced || initializedRef.current) return;
+    if (!isActive || !isIdbSynced || initializedRef.current) return;
+    // Online: also wait for the relay's authoritative state before adopting.
+    if (hasProvider && !isSynced) return;
 
     const yjsDoc = getYjsDocument();
     if (!yjsDoc) return;
@@ -112,7 +124,9 @@ export function useCollaborationSync(): void {
     const crdtShapes = yjsDoc.getAllShapes();
 
     if (crdtShapes.size > 0) {
-      // The Y.Doc is the complete merged truth — replace the views with it.
+      // The Y.Doc is the complete truth — replace the views with it. Safe in
+      // both modes: online it's the idb+relay merge, offline it's the persisted
+      // state for this exact doc's room.
       isApplyingRemoteChanges = true;
       try {
         const store = useDocumentStore.getState();
@@ -125,17 +139,23 @@ export function useCollaborationSync(): void {
       } finally {
         isApplyingRemoteChanges = false;
       }
-    } else if (shapesArray.length > 0) {
-      // The Y.Doc is empty AND the relay confirmed it synced empty (we waited
-      // for isSynced) AND IndexedDB had nothing — so this is a genuinely empty
-      // doc. Safe to seed from local without risking the duplication the
-      // identity rule guards against (a non-empty relay would have populated
-      // the Y.Doc above). [JP-108 step 3 — Stage 2 hardens the offline case.]
+      initializedRef.current = true;
+    } else if (isSynced && shapesArray.length > 0) {
+      // The Y.Doc is empty AND the relay confirmed it synced empty (`isSynced`)
+      // AND IndexedDB had nothing — a genuinely empty doc whose relay has no
+      // content. Safe to seed from local without the duplication the identity
+      // rule guards against (a non-empty relay would have populated the Y.Doc
+      // above). We deliberately do NOT seed when offline (`!isSynced`): a
+      // relay-origin doc never synced on this device must be opened online once
+      // before offline edits are safe, or local-seeding forks a new CRDT
+      // identity that duplicates on first sync. [JP-108 step 3 — hard constraint]
       yjsDoc.initializeFromState(shapesArray, shapeOrder);
+      initializedRef.current = true;
     }
-
-    initializedRef.current = true;
-  }, [isActive, isSynced, isIdbSynced, getYjsDocument]);
+    // else: offline + empty Y.Doc — defer (leave `initializedRef` false). The
+    // doc-store→CRDT subscription below stays gated off so an edit can't fork a
+    // new identity; the engine will adopt once it goes online and syncs.
+  }, [isActive, isSynced, isIdbSynced, hasProvider, getYjsDocument]);
 
   // Subscribe to local document store changes and sync to CRDT
   useEffect(() => {
@@ -149,6 +169,14 @@ export function useCollaborationSync(): void {
 
         // Skip if collaboration not active
         if (!useCollaborationStore.getState().isActive) return;
+
+        // Skip until the Y.Doc is the established truth (adopted/seeded). Pushing
+        // edits into a not-yet-initialized Y.Doc would give them fresh CRDT
+        // identities — for a relay-origin doc that hasn't synced yet, those
+        // duplicate every shape on the first sync (JP-108 step 3 hard
+        // constraint). Once `initializedRef` is set the Y.Doc owns the content
+        // and live edits flow normally.
+        if (!initializedRef.current) return;
 
         // Detect shape changes
         const currentIds = new Set(Object.keys(state.shapes));

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -140,16 +140,25 @@ export function useCollaborationSync(): void {
         isApplyingRemoteChanges = false;
       }
       initializedRef.current = true;
-    } else if (isSynced && shapesArray.length > 0) {
-      // The Y.Doc is empty AND the relay confirmed it synced empty (`isSynced`)
-      // AND IndexedDB had nothing — a genuinely empty doc whose relay has no
-      // content. Safe to seed from local without the duplication the identity
-      // rule guards against (a non-empty relay would have populated the Y.Doc
-      // above). We deliberately do NOT seed when offline (`!isSynced`): a
+    } else if (isSynced) {
+      // The Y.Doc is empty AND the relay confirmed its state (`isSynced`) — so
+      // this doc genuinely has no relay content. Seed from local when this
+      // device has content (a genuinely-new / just-promoted doc); otherwise it's
+      // a legitimately blank doc. Either way the Y.Doc is now the source of
+      // truth and READY FOR EDITS, so mark initialized — without this, a blank
+      // synced doc would leave the doc-store→CRDT subscription gated off forever
+      // and no edits would ever reach the relay.
+      //
+      // Seeding is safe here only because the relay confirmed empty: a non-empty
+      // relay would have populated the Y.Doc (adopt branch above). We do NOT
+      // reach this branch offline (`hasProvider && !isSynced` returned early; an
+      // engine-only session has `!hasProvider` and `isSynced` is false) — a
       // relay-origin doc never synced on this device must be opened online once
       // before offline edits are safe, or local-seeding forks a new CRDT
       // identity that duplicates on first sync. [JP-108 step 3 — hard constraint]
-      yjsDoc.initializeFromState(shapesArray, shapeOrder);
+      if (shapesArray.length > 0) {
+        yjsDoc.initializeFromState(shapesArray, shapeOrder);
+      }
       initializedRef.current = true;
     }
     // else: offline + empty Y.Doc — defer (leave `initializedRef` false). The

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -29,7 +29,7 @@ import { useSessionStore } from './sessionStore';
 import { useHistoryStore } from './historyStore';
 import { useDocumentRegistry } from './documentRegistry';
 import { isRemoteDocument, isCachedDocument } from '../types/DocumentRegistry';
-import { useCollaborationStore, isCollabContentDoc } from '../collaboration';
+import { isCollabContentDoc, ensureCollabSessionForDoc } from '../collaboration';
 import { useWhiteboardStore } from './whiteboardStore';
 import { blobStorage } from '../storage/BlobStorage';
 import { collectBlobReferences } from '../storage/AssetBundler';
@@ -773,14 +773,16 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         useDocumentRegistry.getState().setActiveDocument(id);
         useDocumentRegistry.getState().setDocumentContent(id, doc);
 
-        // Switch collaboration session only for team documents. Local
-        // documents are renderer-owned and never round-trip through the
-        // relay — emitting JOIN_DOC for them produces a misleading
-        // server log and (worse) opens a cross-client leak if a second
-        // client ever joins the same phantom doc id. See JP-64.
-        const collabStore = useCollaborationStore.getState();
-        if (collabStore.isActive && doc.isRelayDocument) {
-          collabStore.switchDocument(id);
+        // Activate the local CRDT engine for relay documents (JP-108 step 3).
+        // This brings up the Y.Doc + y-indexeddb engine even with no connection
+        // (engine ≠ provider), so edits are CRDT ops from the first keystroke
+        // and survive offline. Local documents are renderer-owned and never get
+        // an engine — emitting JOIN_DOC for them produces a misleading server
+        // log and (worse) opens a cross-client leak if a second client ever
+        // joins the same phantom doc id (JP-64); `ensureCollabSessionForDoc`
+        // guards that. No-op if already the active engine for this doc.
+        if (doc.isRelayDocument) {
+          void ensureCollabSessionForDoc(id);
         }
 
         // Save current document ID
@@ -1138,10 +1140,7 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
           // mirroring DocumentBrowser's proven promote path. [JP-174]
           useDocumentRegistry.getState().removeDocument(newId);
           await teamDocStore.fetchDocumentList();
-          const collabStore = useCollaborationStore.getState();
-          if (collabStore.isActive) {
-            collabStore.switchDocument(newId);
-          }
+          await ensureCollabSessionForDoc(newId);
 
           return { ok: true, docId: newId };
         } catch (err) {
@@ -1240,12 +1239,12 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         registry.setActiveDocument(docWithTeamFlag.id);
         registry.setDocumentContent(docWithTeamFlag.id, docWithTeamFlag);
 
-        // Switch collaboration session to this document
-        // This ensures CRDT sync happens for the correct document
-        const collabStore = useCollaborationStore.getState();
-        if (collabStore.isActive) {
-          collabStore.switchDocument(docWithTeamFlag.id);
-        }
+        // Activate / switch the local CRDT engine to this relay document
+        // (JP-108 step 3). No-op if it's already the active engine's doc — which
+        // is the case on the on-connect reattach path (loading the doc that's
+        // already the session target), so this won't tear down the provider
+        // whose callback is driving the reattach.
+        void ensureCollabSessionForDoc(docWithTeamFlag.id);
 
         // Save current document ID
         localStorage.setItem(STORAGE_KEYS.CURRENT_DOCUMENT, docWithTeamFlag.id);
@@ -1324,6 +1323,12 @@ export function initializePersistence(): void {
         isAwaitingTeamLoad: true,
         teamDocContentPending: true,
       });
+      // Bring up the local CRDT engine for the parked relay doc (JP-108 step 3).
+      // If this device has persisted Y.Doc state in y-indexeddb (synced before,
+      // but the localStorage cache was lost), the engine adopts it — recovering
+      // offline content even without a connection. No-op without persisted
+      // state until the provider attaches on connect.
+      void ensureCollabSessionForDoc(lastDocId);
       return;
     }
   }


### PR DESCRIPTION
## What & why

Stage 2 of the offline-first inversion (JP-108 step 3). Steps 1 (relay binary
persistence) and 2 (relay sole-writer for collab content) are merged; Stage 1
(persist the client Y.Doc via `y-indexeddb` + gate the view adopt) merged in #56.

This stage makes a **relay doc's persisted Y.Doc the source of truth, live
whenever the doc is open — even with no connection**. Edits are CRDT ops from
the first keystroke; the WebSocket provider is just a transport that attaches
when a token exists and merges via the normal Yjs handshake. This ends the
"edit offline → connect → edit wiped" clobber class instead of patching it a
sixth time.

## Changes

- **`ensureCollabSessionForDoc(docId)`** (new) — idempotent doc-open trigger.
  No-op if already the active engine for the doc (so the on-connect reattach,
  which loads the doc that's already the session target, can't tear down the
  provider whose callback is running). Active-but-different → switch the engine;
  cold open → **engine-only** start (no token) from the persisted relay URL, so
  offline editing works immediately. Gated by an `offlineFirstEngine`
  kill-switch (`localStorage docushark:flags:offlineFirstEngine`, default on).
- **`switchDocument`** — reworked from an in-place `yjsDoc.clear()` to a per-doc
  engine **restart** (`stopSession` + `startSession`). With `y-indexeddb`
  attached (Stage 1), `clear()` persisted the *empty* state into the current
  doc's room, wiping its offline edits, and a single Y.Doc can't be keyed to two
  rooms. Re-asserts the token across the restart so an authenticated
  collaborator stays connected across a doc switch.
- **`useCollaborationSync`** — adopt the Y.Doc as soon as `y-indexeddb` loads
  when there is no provider (offline); online still also waits for the relay
  sync (`isSynced`). Seed-from-local only when the relay confirmed empty
  (online) — **never offline**, honoring the "open online once first" identity
  rule. Gate the doc-store→CRDT subscription on the adopt so an edit to a
  not-yet-synced relay doc can't fork a new CRDT identity (the duplication trap
  the hard constraint guards against).
- Wire the trigger into `loadDocument` / `loadRemoteDocument` /
  `createRelayDocumentAs` / boot restore; drop the old `isActive`-gated
  `switchDocument` calls.

## Safety / kill-switch

The cold-start engine activation (the new offline behavior) is behind
`offlineFirstEngine` (default on; set the localStorage key to `'0'` to fall
back to pre-Stage-2 behavior without reverting). The `switchDocument` restart
applies regardless — it fixes the `y-indexeddb` room-wipe bug.

## Known limitation (documented, deferred)

A relay doc that has **never synced on this device** can't be safely offline-
edited yet (no shared CRDT identity in `y-indexeddb`): the seed is deferred and
the subscription stays gated, so such edits don't fork/duplicate, but they are
not captured until the doc is opened online once. This is the standard
offline-first "first sync online" constraint.

## Tests

- New: `ensureCollabSession.test.ts` (idempotency, switch, cold engine-only
  start, local-doc skip, kill-switch), `offlineFirstEngine.test.ts`.
- Updated: `switchDocument` tests for restart semantics.
- `bun run typecheck` clean; full suite green (1806 tests, 92 files).

E2E (the offline→connect *merge* half) is best verified with a live
network-toggle on the user's tested flow: open a relay doc offline, add a shape
and modify another's text, then sign in → both preserved and merged; reload
while offline → edits persist.