### PR TITLE
CRDT-native document rename (name propagates over the Y.Doc)

### DIFF
--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -3,10 +3,15 @@
 //! Inverse of [`super::hydration::json_to_ydoc`]. The Y.Doc is a flat,
 //! **active-page-only** surface (`shapes` map + `shapeOrder` array), so we
 //! merge those two collections back into the page they were hydrated from
-//! (`pages[page_id]`), leaving every other page and all top-level fields
-//! untouched. We deliberately do **not** write `name` or other metadata —
-//! renames persist via the existing REST path, and clobbering `name` with a
-//! possibly-stale Y.Doc `metadata.title` would lose edits.
+//! (`pages[page_id]`), leaving every other page untouched.
+//!
+//! Document **`name`** is also written back from the Y.Doc `metadata.title`
+//! (CRDT-native rename): renames now propagate through the CRDT like shapes, so
+//! the relay must flatten them. To avoid clobbering an out-of-band REST rename
+//! (which bumps `modifiedAt` without touching the Y.Doc) with a stale
+//! `metadata.title`, we only adopt the title when its `metadata.updatedAt` is at
+//! least as new as the stored `modifiedAt`. All other top-level fields are left
+//! untouched.
 //!
 //! Durability is the relay's job here, but the JSON stays the source format:
 //! this is what gets written to disk and served on the next load.
@@ -25,10 +30,15 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
     // `get_or_insert_*` while a txn is live deadlocks.
     let shapes = doc.get_or_insert_map("shapes");
     let shape_order = doc.get_or_insert_array("shapeOrder");
+    let metadata = doc.get_or_insert_map("metadata");
 
-    let (shapes_any, order_any) = {
+    let (shapes_any, order_any, meta_any) = {
         let txn = doc.transact();
-        (shapes.to_json(&txn), shape_order.to_json(&txn))
+        (
+            shapes.to_json(&txn),
+            shape_order.to_json(&txn),
+            metadata.to_json(&txn),
+        )
     };
 
     // Merge into the existing page object so the page's own id/name/timestamps
@@ -44,10 +54,44 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
         page.insert("shapeOrder".to_string(), any_to_json(&order_any));
     }
 
+    // CRDT-native rename: adopt `metadata.title` as the document `name`, but
+    // only when its `updatedAt` is at least as fresh as the currently-stored
+    // `modifiedAt`. A REST rename bumps `modifiedAt` (now) without touching the
+    // Y.Doc, so a stale title (older `updatedAt`) is left alone; a CRDT rename
+    // bumps `updatedAt` past the last persisted write and wins. Read the stored
+    // `modifiedAt` BEFORE we overwrite it below.
+    let stored_modified = json.get("modifiedAt").and_then(Value::as_u64).unwrap_or(0);
+    let (meta_title, meta_updated) = metadata_title_and_updated(&meta_any);
+    if let Some(title) = meta_title {
+        if !title.is_empty() && meta_updated.unwrap_or(0) >= stored_modified {
+            if let Some(obj) = json.as_object_mut() {
+                obj.insert("name".to_string(), Value::String(title));
+            }
+        }
+    }
+
     if let Some(obj) = json.as_object_mut() {
         obj.insert("modifiedAt".to_string(), Value::from(now_ms()));
     }
     true
+}
+
+/// Extract `(title, updatedAt)` from the Y.Doc `metadata` map's JSON form.
+/// `updatedAt` is a Yjs number (`f64` ms) coerced to `u64` for comparison with
+/// the JSON `modifiedAt`.
+fn metadata_title_and_updated(meta_any: &Any) -> (Option<String>, Option<u64>) {
+    let Any::Map(map) = meta_any else {
+        return (None, None);
+    };
+    let title = match map.get("title") {
+        Some(Any::String(s)) => Some(s.to_string()),
+        _ => None,
+    };
+    let updated = match map.get("updatedAt") {
+        Some(Any::Number(n)) if n.is_finite() && *n >= 0.0 => Some(*n as u64),
+        _ => None,
+    };
+    (title, updated)
 }
 
 /// Convert a yrs `Any` into a `serde_json::Value` — the inverse of
@@ -141,6 +185,38 @@ mod tests {
         // Other page untouched; modifiedAt bumped past the original.
         assert_eq!(json["pages"]["p2"]["shapes"]["s9"]["id"], json!("s9"));
         assert!(json["modifiedAt"].as_u64().unwrap() > 2);
+    }
+
+    #[test]
+    fn crdt_rename_flattens_to_name() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page(), &doc); // metadata.title="Doc", updatedAt=2
+
+        // Simulate a CRDT rename: a fresher metadata.title + updatedAt.
+        let metadata = doc.get_or_insert_map("metadata");
+        {
+            let mut txn = doc.transact_mut();
+            metadata.insert(&mut txn, "title", Any::String("Renamed".into()));
+            metadata.insert(&mut txn, "updatedAt", Any::Number(100.0));
+        }
+
+        let mut json = multi_page(); // name="Doc", modifiedAt=2
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(json["name"], json!("Renamed"), "CRDT rename is flattened into name");
+    }
+
+    #[test]
+    fn stale_title_does_not_clobber_rest_rename() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page(), &doc); // metadata.title="Doc", updatedAt=2
+
+        // The stored doc was renamed out-of-band (REST): a fresher modifiedAt
+        // than the Y.Doc title's updatedAt. The stale CRDT title must not win.
+        let mut json = multi_page();
+        json["name"] = json!("RestName");
+        json["modifiedAt"] = json!(1000);
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(json["name"], json!("RestName"), "stale title did not clobber the REST rename");
     }
 
     #[test]

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -241,6 +241,18 @@ export class YjsDocument {
   }
 
   /**
+   * The document name from the `metadata` map (stored under `title`), or
+   * `undefined` if unset. Unlike {@link getMetadata}, this does NOT substitute
+   * a default — callers applying a remote rename must distinguish "no name in
+   * the Y.Doc" from a doc legitimately named "Untitled", or they'd clobber the
+   * local name with the placeholder.
+   */
+  getName(): string | undefined {
+    const title = this.metadata.get('title');
+    return typeof title === 'string' ? title : undefined;
+  }
+
+  /**
    * Get document metadata.
    */
   getMetadata(): YjsDocumentMetadata {

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -18,10 +18,13 @@ vi.mock('./YjsDocument', () => ({
     setShapes: vi.fn(),
     deleteShape: vi.fn(),
     setShapeOrder: vi.fn(),
+    setMetadata: vi.fn(),
+    getName: vi.fn(() => undefined),
     clear: vi.fn(),
     destroy: vi.fn(),
     onShapeChange: vi.fn(() => vi.fn()),
     onOrderChange: vi.fn(() => vi.fn()),
+    onMetadataChange: vi.fn(() => vi.fn()),
     initializeFromState: vi.fn(),
   })),
 }));
@@ -278,6 +281,27 @@ describe('collaborationStore', () => {
 
       const yjsDoc = useCollaborationStore.getState().getYjsDocument();
       expect(yjsDoc?.setShapeOrder).toHaveBeenCalledWith(order);
+    });
+  });
+
+  describe('syncDocumentName', () => {
+    it('writes the name into the Y.Doc metadata with a fresh updatedAt', () => {
+      const config = createTestConfig();
+      useCollaborationStore.getState().startSession(config);
+
+      const before = Date.now();
+      useCollaborationStore.getState().syncDocumentName('Renamed Doc');
+
+      const yjsDoc = useCollaborationStore.getState().getYjsDocument();
+      expect(yjsDoc?.setMetadata).toHaveBeenCalledTimes(1);
+      const arg = (yjsDoc?.setMetadata as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0]![0] as { title: string; updatedAt: number };
+      expect(arg.title).toBe('Renamed Doc');
+      expect(arg.updatedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it('does nothing when no session', () => {
+      expect(() => useCollaborationStore.getState().syncDocumentName('x')).not.toThrow();
     });
   });
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -119,6 +119,14 @@ interface CollaborationActions {
   syncDeleteShape: (shapeId: string) => void;
   /** Sync shape order to remote peers */
   syncShapeOrder: (order: string[]) => void;
+  /**
+   * Sync the document name (a rename) to peers via the Y.Doc `metadata` map
+   * (CRDT-native rename, so it propagates + persists like shapes rather than
+   * via the REST path that `isCollabContentDoc` suppresses). Bumps
+   * `updatedAt` so the relay's flatten can tell a fresh CRDT rename from a
+   * stale title vs an out-of-band REST rename.
+   */
+  syncDocumentName: (name: string) => void;
 
   // Document switching
   /** Switch to a different document for CRDT sync */
@@ -517,6 +525,15 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     syncShapeOrder: (order: string[]) => {
       if (yjsDoc) {
         yjsDoc.setShapeOrder(order);
+      }
+    },
+
+    syncDocumentName: (name: string) => {
+      if (yjsDoc) {
+        // Stored under `title` in the metadata map (the relay seeds it from the
+        // doc `name` on hydrate and flattens it back). `updatedAt` lets the
+        // relay order this against a possibly-concurrent REST rename.
+        yjsDoc.setMetadata({ title: name, updatedAt: Date.now() });
       }
     },
 

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -17,6 +17,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useDocumentStore } from '../store/documentStore';
+import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { useCollaborationStore } from './collaborationStore';
 
 /**
@@ -93,9 +94,19 @@ export function useCollaborationSync(): void {
       }
     });
 
+    // Handle remote document-name changes (CRDT-native rename). The name lives
+    // in the Y.Doc `metadata` map (`title`); apply it to local state without
+    // writing back (applyRemoteDocumentName is local-only, so no loop).
+    const unsubMeta = yjsDoc.onMetadataChange(() => {
+      const docId = useCollaborationStore.getState().config?.documentId;
+      const name = yjsDoc.getName(); // raw, no "Untitled" default
+      if (docId && name) applyRemoteDocumentName(docId, name);
+    });
+
     return () => {
       unsubShapes();
       unsubOrder();
+      unsubMeta();
     };
   }, [isActive, getYjsDocument]);
 
@@ -139,6 +150,11 @@ export function useCollaborationSync(): void {
       } finally {
         isApplyingRemoteChanges = false;
       }
+      // Adopt the relay's authoritative document name too (CRDT-native rename),
+      // so a joining client picks up a rename made before it connected.
+      const docId = useCollaborationStore.getState().config?.documentId;
+      const name = yjsDoc.getName(); // raw, no "Untitled" default
+      if (docId && name) applyRemoteDocumentName(docId, name);
       initializedRef.current = true;
     } else if (isSynced) {
       // The Y.Doc is empty AND the relay confirmed its state (`isSynced`) — so

--- a/src/store/persistenceStore.rename.test.ts
+++ b/src/store/persistenceStore.rename.test.ts
@@ -1,0 +1,78 @@
+/**
+ * CRDT-native rename: `applyRemoteDocumentName` applies a name received over the
+ * collaboration channel (Y.Doc metadata) to local state, without writing back
+ * to the relay/CRDT (which would loop).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  put: vi.fn(async () => {}),
+  getMeta: vi.fn(() => null),
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+
+const syncManagerMock = vi.hoisted(() => ({
+  queueSave: vi.fn(() => ({ id: 'op-1' })),
+  hasPendingChanges: vi.fn(() => false),
+  processQueueForHost: vi.fn(async () => []),
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => syncManagerMock,
+}));
+
+import { applyRemoteDocumentName, usePersistenceStore } from './persistenceStore';
+import { useDocumentRegistry } from './documentRegistry';
+import type { DocumentMetadata } from '../types/Document';
+
+function meta(id: string, name: string): DocumentMetadata {
+  return { id, name, createdAt: 1, modifiedAt: 1 } as DocumentMetadata;
+}
+
+describe('applyRemoteDocumentName', () => {
+  beforeEach(() => {
+    usePersistenceStore.setState({
+      currentDocumentId: 'doc-1',
+      currentDocumentName: 'Old Name',
+      documents: { 'doc-1': meta('doc-1', 'Old Name') },
+    } as never);
+    vi.restoreAllMocks();
+  });
+
+  it('updates the active doc name, the index, and the registry', () => {
+    const updateSpy = vi
+      .spyOn(useDocumentRegistry.getState(), 'updateRecord')
+      .mockImplementation(() => {});
+
+    applyRemoteDocumentName('doc-1', 'New Name');
+
+    const s = usePersistenceStore.getState();
+    expect(s.currentDocumentName).toBe('New Name');
+    expect(s.documents['doc-1']?.name).toBe('New Name');
+    expect(updateSpy).toHaveBeenCalledWith('doc-1', { name: 'New Name' });
+  });
+
+  it('updates a non-active doc without touching the active display name', () => {
+    vi.spyOn(useDocumentRegistry.getState(), 'updateRecord').mockImplementation(() => {});
+    usePersistenceStore.setState((s) => ({
+      documents: { ...s.documents, 'doc-2': meta('doc-2', 'Two') },
+    }));
+
+    applyRemoteDocumentName('doc-2', 'Two Renamed');
+
+    const s = usePersistenceStore.getState();
+    expect(s.currentDocumentName).toBe('Old Name');
+    expect(s.documents['doc-2']?.name).toBe('Two Renamed');
+  });
+
+  it('is a no-op for an unchanged name or an empty name', () => {
+    const updateSpy = vi
+      .spyOn(useDocumentRegistry.getState(), 'updateRecord')
+      .mockImplementation(() => {});
+
+    applyRemoteDocumentName('doc-1', 'Old Name'); // unchanged
+    applyRemoteDocumentName('doc-1', ''); // empty — ignored
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(usePersistenceStore.getState().currentDocumentName).toBe('Old Name');
+  });
+});

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -29,7 +29,7 @@ import { useSessionStore } from './sessionStore';
 import { useHistoryStore } from './historyStore';
 import { useDocumentRegistry } from './documentRegistry';
 import { isRemoteDocument, isCachedDocument } from '../types/DocumentRegistry';
-import { isCollabContentDoc, ensureCollabSessionForDoc } from '../collaboration';
+import { isCollabContentDoc, ensureCollabSessionForDoc, useCollaborationStore } from '../collaboration';
 import { useWhiteboardStore } from './whiteboardStore';
 import { blobStorage } from '../storage/BlobStorage';
 import { collectBlobReferences } from '../storage/AssetBundler';
@@ -849,6 +849,15 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
           // Also update the document registry for reactivity
           useDocumentRegistry.getState().updateRecord(docId, { name });
         }
+
+        // CRDT-native rename: when this is the active collab content doc, push
+        // the name through the Y.Doc metadata so it reaches the relay + peers.
+        // The REST save path that would otherwise carry the name is suppressed
+        // for collab docs (isCollabContentDoc), so without this the rename never
+        // leaves the device. Local-only docs stay local (no active session).
+        if (docId && isCollabContentDoc(docId)) {
+          useCollaborationStore.getState().syncDocumentName(name);
+        }
       },
 
       // Export current document as JSON
@@ -1335,6 +1344,31 @@ export function initializePersistence(): void {
 
   // No last document or failed to load - create new document
   store.newDocument();
+}
+
+/**
+ * Apply a document name received over the collaboration channel (a remote
+ * rename via the Y.Doc `metadata` map) to local state — WITHOUT writing back to
+ * the relay or the Y.Doc, which would loop. Updates the active doc's display
+ * name, the persisted document index, and the registry record. The cached doc
+ * file is refreshed from the relay on the next full load. [CRDT-native rename]
+ */
+export function applyRemoteDocumentName(docId: string, name: string): void {
+  if (!docId || typeof name !== 'string' || name.length === 0) return;
+  const s = usePersistenceStore.getState();
+  const isActive = s.currentDocumentId === docId;
+  // Idempotent: skip if nothing would change (avoids churn from echoed updates).
+  if (s.documents[docId]?.name === name && (!isActive || s.currentDocumentName === name)) {
+    return;
+  }
+  usePersistenceStore.setState((prev) => {
+    const meta = prev.documents[docId];
+    return {
+      ...(prev.currentDocumentId === docId ? { currentDocumentName: name } : {}),
+      documents: meta ? { ...prev.documents, [docId]: { ...meta, name } } : prev.documents,
+    };
+  });
+  useDocumentRegistry.getState().updateRecord(docId, { name });
 }
 
 /**


### PR DESCRIPTION
## Problem

Renaming a relay document never reached the relay or other clients. The
document `name` is a top-level field carried only by the client's REST save —
and JP-108 step 2 (`isCollabContentDoc`) suppresses that whole-document REST
save for active-collab docs to protect the canvas CRDT. So the rename only ever
updated local state. (Same root cause behind prose not persisting.)

Confirmed on disk: a renamed relay doc still stored `name: "Untitled Document"`
while its canvas shapes were current. The relay's `flatten.rs` even documented
the now-obsolete assumption that *"renames persist via the existing REST path."*

## Fix — make `name` CRDT-native (like shapes)

The relay already seeds the Y.Doc `metadata.title` from `name` on hydrate; this
wires the missing return path so the name propagates in real time and persists
via the relay's snapshot/binary, with **no REST involved**.

**Relay (`flatten.rs`)**
- Flatten now writes `metadata.title` → doc `name`, **guarded by
  `updatedAt >= modifiedAt`** so a stale CRDT title can't clobber an out-of-band
  REST rename (which bumps `modifiedAt` without touching the Y.Doc). Doc comment
  updated.

**Client**
- `collaborationStore.syncDocumentName(name)` writes the name into the Y.Doc
  `metadata` map (`title` + a fresh `updatedAt`).
- `persistenceStore.renameDocument` pushes via `syncDocumentName` when the doc is
  the active collab content doc (local-only docs stay local).
- `useCollaborationSync` applies remote metadata changes — and the relay's name
  on adopt — to local state via the new `applyRemoteDocumentName` (updates the
  display name + index + registry; local-only, so no write-back / loop).
- `YjsDocument.getName()` reads the **raw** title (no `'Untitled'` default) so an
  unset name can't clobber the local one.

Offline renames ride the same path (engine-only writes metadata to
`y-indexeddb`, merges on reconnect). Prose will follow this same model when
`collab-prose` lands.

## Tests
- Relay: `crdt_rename_flattens_to_name` + `stale_title_does_not_clobber_rest_rename`; full lib suite **201 green**.
- Client: `syncDocumentName` (collab store) + `applyRemoteDocumentName` (idempotent/active/non-active/empty); full suite **1811 green**; typecheck clean.

## Verify
Rename a relay doc on client A → the new name appears on client B and in the
relay's stored JSON (`name`), with `serverVersion` unchanged (CRDT path, not a
REST bump).

## Note
Stacked conceptually on the offline-first work (now merged via #57). Document-
level **prose/settings** remain on the REST-suppressed path and will move onto
this same CRDT-metadata model next.