### PR TITLE
Fix multi-client mass deletion: collab sync must ignore document loads

### DIFF
--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -18,6 +18,7 @@
 import { useEffect, useRef } from 'react';
 import { useDocumentStore } from '../store/documentStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
+import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { useCollaborationStore } from './collaborationStore';
 
 /**
@@ -191,6 +192,15 @@ export function useCollaborationSync(): void {
       (state, prevState) => {
         // Skip if we're applying remote changes (prevents sync loops)
         if (isApplyingRemoteChanges) return;
+
+        // Skip while a document LOAD is replaying content into the stores — these
+        // are not user edits. `loadDocumentToPageStore` wraps the load in
+        // `withAutoSaveSuppressed`, which synchronously clears+repopulates
+        // documentStore; without this guard the subscription reads that wholesale
+        // replacement as user deletions and writes CRDT tombstones (persisted to
+        // y-indexeddb + broadcast to the relay → mass deletion of every client's
+        // shapes, the "juggling" bug). Same signal autosave already honors.
+        if (isAutoSaveSuppressed()) return;
 
         // Skip if collaboration not active
         if (!useCollaborationStore.getState().isActive) return;


### PR DESCRIPTION
## Symptom

Multi-client editing "juggled" shapes — a client would connect and see shapes
vanish (the canvas going empty), then reappear, oscillating across reconnects.
Shapes were being **deleted**, not merged.

## Root cause (verified end-to-end, not guessed)

The `documentStore → CRDT` subscription (`useCollaborationSync`) propagated
**deletions that came from a programmatic document load, not a user edit**.

`loadDocumentToPageStore` clears + repopulates `documentStore` *synchronously*
inside `withAutoSaveSuppressed`. On a reconnect/reopen that loaded a transiently
empty relay doc, `documentStore` went `N → 0`, and the collab subscription read
that wholesale replacement as `N` user deletions → wrote `N` CRDT **tombstones**.
Those tombstones were:
- persisted to the client's **y-indexeddb**, and
- broadcast to the **relay**, zeroing its authoritative Y.Doc.

The empty Y.Doc was then snapshotted into the binary sidecar, so every later
join **rehydrated empty**, and each joining client re-cleared its own store →
a self-reinforcing mass-deletion loop across all clients.

This was confirmed with temporary instrumentation (relay per-applied-frame shape
count + client adopt/delete logs) before any fix. The instrumentation also
**disproved** an earlier hypothesis (a seed-clear via `initializeFromState`) —
that branch never fired in the logs.

## Fix

The subscription now bails when `isAutoSaveSuppressed()` — the exact same "this
is a load, not a user edit" signal that **autosave already honors**. Every load
path (`loadDocument` / `loadRemoteDocument` / reattach) routes through
`loadDocumentToPageStore`, so this one guard covers them all.

```ts
// Skip while a document LOAD is replaying content into the stores …
if (isAutoSaveSuppressed()) return;
```

## Verification

- Live multi-client E2E: shapes now accumulate/merge across reconnects; the
  `documentStore DELETE → syncDeleteShape` path only fires on real user deletes;
  the relay's shape count no longer drops to 0 on join.
- `bun run typecheck` clean; client `src/collaboration` + `src/store` suites
  green (519); relay `cargo test` (sync) green.

## Notes / follow-ups (not in this PR)

- **Already-poisoned state isn't self-healed:** a doc whose binary was zeroed,
  or a client whose y-indexeddb already holds tombstones, stays broken until
  recreated / storage cleared. A production self-heal (relay rejecting a
  full-clear, or a binary-vs-JSON sanity check) is worth a ticket.
- **Latent seed risk:** `initializeFromState` (the adopt seed branch) would
  clobber peers *if* it ever ran while connected. It didn't here, but it should
  be hardened (non-destructive / never-while-connected) separately.