### PR TITLE
Fix live collab: re-bind view effects on session restart (sessionEpoch)

### DIFF
--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -180,6 +180,17 @@ describe('collaborationStore', () => {
       expect(UnifiedSyncProvider).toHaveBeenCalled();
     });
 
+    it('bumps sessionEpoch on each (re)start so view effects re-bind', () => {
+      const e0 = useCollaborationStore.getState().sessionEpoch;
+      useCollaborationStore.getState().startSession(createTestConfig({ documentId: 'a' }));
+      const e1 = useCollaborationStore.getState().sessionEpoch;
+      expect(e1).toBe(e0 + 1);
+
+      // switchDocument restarts the session (new YjsDocument instance) → bump.
+      useCollaborationStore.getState().switchDocument('b');
+      expect(useCollaborationStore.getState().sessionEpoch).toBe(e1 + 1);
+    });
+
     it('sets host in connection store', async () => {
       const config = createTestConfig({ serverUrl: 'ws://myhost:1234/ws' });
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -99,6 +99,15 @@ interface CollaborationState {
   remoteUsers: RemoteUser[];
   /** Current collaboration config */
   config: CollaborationConfig | null;
+  /**
+   * Monotonic counter bumped on every `startSession` — i.e. every time a NEW
+   * `YjsDocument` instance is created (incl. `switchDocument`'s restart). React
+   * effects that bind to the Y.Doc (registering `onShapeChange` etc.) depend on
+   * this so they re-subscribe to the new instance; without it a `switchDocument`
+   * restart (where `isActive` nets true→true) would leave callbacks registered
+   * on the old, destroyed Y.Doc and remote changes would never reach the view.
+   */
+  sessionEpoch: number;
 }
 
 /**
@@ -222,6 +231,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     error: null,
     remoteUsers: [],
     config: null,
+    sessionEpoch: 0,
 
     startSession: (config: CollaborationConfig) => {
       // Stop any existing session
@@ -266,7 +276,10 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // are CRDT ops from here, so anything typed offline/pre-sign-in is captured
       // and persisted, then merges on connect (JP-108 step 3). Set this BEFORE
       // attaching the provider so the engine doesn't depend on the network.
-      set({ isActive: true, config, error: null });
+      // Bump `sessionEpoch` so the view effects re-bind to this fresh
+      // YjsDocument — a switchDocument restart nets isActive true→true and would
+      // otherwise leave onShapeChange registered on the old, destroyed instance.
+      set({ isActive: true, config, error: null, sessionEpoch: get().sessionEpoch + 1 });
 
       // Only attach the WS provider when we have a token. A token-less provider
       // would no-auth-join → get rejected → fire the "this document isn't syncing

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -43,6 +43,9 @@ export function useCollaborationSync(): void {
   // merge). `config.token` is the reactive proxy for "provider attached".
   const hasProvider = useCollaborationStore((state) => state.config?.token != null);
   const getYjsDocument = useCollaborationStore((state) => state.getYjsDocument);
+  // Bumped per startSession (incl. switchDocument's restart) — drives the view
+  // effects to re-bind to the new YjsDocument instance.
+  const sessionEpoch = useCollaborationStore((state) => state.sessionEpoch);
   const syncShape = useCollaborationStore((state) => state.syncShape);
   const syncDeleteShape = useCollaborationStore((state) => state.syncDeleteShape);
   const syncShapeOrder = useCollaborationStore((state) => state.syncShapeOrder);
@@ -59,6 +62,12 @@ export function useCollaborationSync(): void {
 
     const yjsDoc = getYjsDocument();
     if (!yjsDoc) return;
+
+    // This effect re-runs whenever `sessionEpoch` bumps — i.e. a NEW YjsDocument
+    // instance (switchDocument restart). Reset `initializedRef` so the adopt
+    // effect re-runs against the new instance; otherwise it stays `true` from
+    // the previous session and the new doc is never adopted into the view.
+    initializedRef.current = false;
 
     // Handle remote shape changes
     const unsubShapes = yjsDoc.onShapeChange((added, updated, removed) => {
@@ -109,7 +118,7 @@ export function useCollaborationSync(): void {
       unsubOrder();
       unsubMeta();
     };
-  }, [isActive, getYjsDocument]);
+  }, [isActive, getYjsDocument, sessionEpoch]);
 
   // Initialize the views from the Y.Doc once it holds the *complete* truth.
   //
@@ -181,7 +190,7 @@ export function useCollaborationSync(): void {
     // else: offline + empty Y.Doc — defer (leave `initializedRef` false). The
     // doc-store→CRDT subscription below stays gated off so an edit can't fork a
     // new identity; the engine will adopt once it goes online and syncs.
-  }, [isActive, isSynced, isIdbSynced, hasProvider, getYjsDocument]);
+  }, [isActive, isSynced, isIdbSynced, hasProvider, getYjsDocument, sessionEpoch]);
 
   // Subscribe to local document store changes and sync to CRDT
   useEffect(() => {


### PR DESCRIPTION
## Symptom

In a live collab session, remote changes didn't reach the view — a shape edited
on client A never appeared on client B (and switching documents didn't help);
only a full **app reload** showed them.

## Root cause (verified, not guessed)

A temporary Y.Doc-observer probe showed the observer firing for remote updates
but with **`callbacks: 0`** — no `onShapeChange` listener was attached to the
*live* Y.Doc.

`useCollaborationSync` registers `onShapeChange` (and runs the CRDT→view adopt)
on `getYjsDocument()`, with effect deps `[isActive, getYjsDocument]`. But
`switchDocument` now performs a **restart** (`stopSession` + `startSession` → a
brand-new `YjsDocument` instance), and across that restart `isActive` nets
`true → true` while `getYjsDocument` is a stable function reference — so the
effects **never re-ran**. The callbacks stayed bound to the old, destroyed
instance, and `initializedRef` stayed `true` (so adopt didn't re-run either).

This is a regression from the Stage-2 `switchDocument`-restart rework: the
previous in-place `clear()` reused the same `YjsDocument`, so the bindings
survived.

## Fix

The store bumps a monotonic **`sessionEpoch`** on every `startSession` (every new
`YjsDocument` instance, including the `switchDocument` restart). The view effects
depend on it, so they re-subscribe `onShapeChange`/`onOrderChange`/
`onMetadataChange` and reset `initializedRef` → re-adopt against the new instance.

## Verification

- Live 2-client E2E: the observer now reports `callbacks: 1`, `onShapeChange`
  fires, and edits render in real time (no reload). Doc-switch shows changes too.
- New unit test: `startSession` / `switchDocument` bump `sessionEpoch`.
- `bun run typecheck` clean; `src/collaboration` + `src/store` suites green (520).