### PR TITLE
JP-179: neutralize the seed-clobber in the collab adopt path

### DIFF
--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -267,7 +267,12 @@ export class YjsDocument {
 
   /**
    * Initialize the document with existing shapes.
-   * Used when loading a document or syncing initial state.
+   *
+   * ⚠️ DANGER (JP-179): this calls `shapes.clear()` on the Y.Doc. If the doc is
+   * attached to a provider, that clear broadcasts a CRDT DELETION that wipes
+   * every peer's shapes (proven in `seedClobber.proof.test.ts`). Only call this
+   * on a brand-new, NEVER-synced, provider-less Y.Doc. The collab adopt path
+   * must never seed a connected/synced doc — use "adopt-to-empty" instead.
    */
   initializeFromState(
     shapes: Shape[],

--- a/src/collaboration/seedClobber.proof.test.ts
+++ b/src/collaboration/seedClobber.proof.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression guard (JP-179): proves WHY the collab adopt path must never seed a
+ * provider-attached Y.Doc via `initializeFromState`.
+ *
+ * `initializeFromState` calls `this.shapes.clear()` on the shared Y.Doc. If that
+ * runs while synced with a peer, the `clear()` propagates as a CRDT DELETION and
+ * wipes the peer's shapes. The adopt path therefore uses "adopt-to-empty" (clear
+ * the local view only) instead — see `useCollaborationSync`. If this test starts
+ * failing because the behavior changed, do NOT "fix" it by re-seeding a
+ * connected doc.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+import type { Shape } from '../shapes/Shape';
+
+function shape(id: string): Shape {
+  return {
+    id,
+    type: 'rectangle',
+    position: { x: 0, y: 0 },
+    size: { width: 1, height: 1 },
+    rotation: 0,
+    style: {},
+  } as unknown as Shape;
+}
+
+/** Apply `from`'s full state onto `to` — stands in for a relay sync exchange. */
+function sync(from: YjsDocument, to: YjsDocument): void {
+  Y.applyUpdate(to.getDoc(), Y.encodeStateAsUpdate(from.getDoc()));
+}
+
+describe('seed-clobber proof (JP-179)', () => {
+  it('initializeFromState on a synced doc deletes the peer’s shapes', () => {
+    // The relay's authoritative doc holds two shapes.
+    const relay = new YjsDocument();
+    relay.setShapes([shape('S1'), shape('S2')]);
+    expect(relay.getAllShapes().size).toBe(2);
+
+    // A client connects and syncs — it now mirrors the relay.
+    const client = new YjsDocument();
+    sync(relay, client);
+    expect(client.getAllShapes().size).toBe(2);
+
+    // Seeding the client (the OLD adopt behavior) clears its shapes map…
+    client.initializeFromState([shape('S3')], ['S3']);
+
+    // …and that clear propagates back to the relay, wiping S1 + S2.
+    sync(client, relay);
+
+    const relayShapes = relay.getAllShapes();
+    expect(relayShapes.has('S1')).toBe(false);
+    expect(relayShapes.has('S2')).toBe(false);
+    expect(relayShapes.has('S3')).toBe(true);
+
+    relay.destroy();
+    client.destroy();
+  });
+});

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -137,10 +137,6 @@ export function useCollaborationSync(): void {
     const yjsDoc = getYjsDocument();
     if (!yjsDoc) return;
 
-    // Get current document state
-    const { shapes, shapeOrder } = useDocumentStore.getState();
-    const shapesArray = Object.values(shapes);
-
     // Check if the Y.Doc has data (persisted IndexedDB state and/or relay state).
     const crdtShapes = yjsDoc.getAllShapes();
 
@@ -167,23 +163,25 @@ export function useCollaborationSync(): void {
       if (docId && name) applyRemoteDocumentName(docId, name);
       initializedRef.current = true;
     } else if (isSynced) {
-      // The Y.Doc is empty AND the relay confirmed its state (`isSynced`) — so
-      // this doc genuinely has no relay content. Seed from local when this
-      // device has content (a genuinely-new / just-promoted doc); otherwise it's
-      // a legitimately blank doc. Either way the Y.Doc is now the source of
-      // truth and READY FOR EDITS, so mark initialized — without this, a blank
-      // synced doc would leave the doc-store→CRDT subscription gated off forever
-      // and no edits would ever reach the relay.
+      // The Y.Doc is empty AND the relay confirmed its state (`isSynced`) — the
+      // doc is genuinely empty on the relay (the authoritative source). The
+      // local view's cached shapes, if any, are stale, so ADOPT TO EMPTY: clear
+      // only the VIEW. The Y.Doc is now the established (empty) truth and READY
+      // FOR EDITS, so mark initialized — otherwise the doc-store→CRDT
+      // subscription stays gated off and no edits ever reach the relay.
       //
-      // Seeding is safe here only because the relay confirmed empty: a non-empty
-      // relay would have populated the Y.Doc (adopt branch above). We do NOT
-      // reach this branch offline (`hasProvider && !isSynced` returned early; an
-      // engine-only session has `!hasProvider` and `isSynced` is false) — a
-      // relay-origin doc never synced on this device must be opened online once
-      // before offline edits are safe, or local-seeding forks a new CRDT
-      // identity that duplicates on first sync. [JP-108 step 3 — hard constraint]
-      if (shapesArray.length > 0) {
-        yjsDoc.initializeFromState(shapesArray, shapeOrder);
+      // We deliberately do NOT seed via `initializeFromState` here (JP-179): it
+      // calls `shapes.clear()` on the SHARED Y.Doc, and with a provider attached
+      // that broadcasts a CRDT deletion that wipes every peer's shapes (a proven
+      // hazard — see seedClobber.proof.test.ts). A genuinely-new/just-promoted
+      // doc never reaches this branch: its REST `saveToHost` populates the relay
+      // first, so it syncs in via the `crdtShapes.size > 0` adopt above. Offline
+      // (`!hasProvider`) never reaches here either (isSynced is false).
+      isApplyingRemoteChanges = true;
+      try {
+        useDocumentStore.getState().clear();
+      } finally {
+        isApplyingRemoteChanges = false;
       }
       initializedRef.current = true;
     }


### PR DESCRIPTION
Closes JP-179. **Stacked on #60** (debug-live-sync) — base will retarget to master once #60 merges.

## What

The adopt "empty + relay-confirmed" branch called `yjsDoc.initializeFromState(...)`, which does `shapes.clear()` on the **shared** Y.Doc. With a provider attached, that `clear()` broadcasts a CRDT **deletion** that wipes every peer's shapes — a proven hazard (`seedClobber.proof.test.ts`). It never fired in production logs, but it was a loaded gun in the hot path.

## Fix

**Adopt-to-empty:** when the relay confirms the doc is empty (`isSynced`, `crdtShapes === 0`), clear only the **local view** (suppressed via `isApplyingRemoteChanges`) and mark `initialized` so edits flow — never seed the shared Y.Doc.

- A genuinely-new / just-promoted doc never reaches this branch: its REST `saveToHost` populates the relay first, so it syncs in via the `crdtShapes > 0` adopt.
- Offline never reaches it either (`isSynced` is false there).

Also re-adds the deterministic proof as a permanent regression guard, and adds a ⚠️ DANGER note to `initializeFromState` so it can't be reintroduced on a connected doc.

## Tests
- `seedClobber.proof.test.ts` (regression guard) + typecheck clean.
- `src/collaboration` (213) and `src/store` (308) suites green.