### PR TITLE
JP-180: relay poisoned-state guard (binary-vs-JSON sanity + self-heal)

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -132,6 +132,11 @@ pub fn routes() -> Router<Arc<ServerState>> {
         .route("/api/docs/:id", delete(delete_doc_handler))
         .route("/api/docs/:id/share", post(share_doc_handler))
         .route("/api/docs/:id/transfer", post(transfer_doc_handler))
+        .route("/api/docs/:id/recovery", get(list_recovery_handler))
+        .route(
+            "/api/docs/:id/recovery/:pointId/restore",
+            post(restore_recovery_handler),
+        )
 }
 
 // ============ Request / Response shapes ============
@@ -561,6 +566,76 @@ async fn get_doc_handler(
         Ok(doc) => (StatusCode::OK, Json(doc)).into_response(),
         Err(e) => (StatusCode::NOT_FOUND, ApiError::body(e)).into_response(),
     }
+}
+
+/// `GET /api/docs/:id/recovery` — list a document's recovery points (JP-180),
+/// newest first. Read-scoped exactly like `GET /api/docs/:id`. The backups are
+/// written by the relay's poison guard before a suspicious N→0 zeroing; this is
+/// what makes them addressable (and, via JP-183, restorable from the web UI).
+async fn list_recovery_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = check_read_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+    let points = state.doc_store().list_recovery_points(&ws, &doc_id);
+    (StatusCode::OK, Json(json!({ "recoveryPoints": points }))).into_response()
+}
+
+/// `POST /api/docs/:id/recovery/:pointId/restore` — restore a recovery point as
+/// the live document. **Stub (JP-180):** authed + workspace-scoped, but the
+/// actual restore (decode sidecar → flatten to JSON → versioned save + DocEvent
+/// broadcast) and the web-interface surface are tracked in JP-183.
+async fn restore_recovery_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path((id, _point_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+    // Don't leak existence across tenants: 404 if the doc isn't in this
+    // workspace before advertising the not-yet-implemented restore.
+    if state.doc_store().get_metadata(&ws, &doc_id).is_none() {
+        return (StatusCode::NOT_FOUND, ApiError::body("document not found")).into_response();
+    }
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(json!({
+            "error": "recovery restore not yet implemented",
+            "issue": "JP-183",
+        })),
+    )
+        .into_response()
 }
 
 async fn save_doc_handler(

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -424,6 +424,13 @@ pub struct SyncConfig {
     /// identity + prose across evict/rehydrate) when current. Default on;
     /// set false to fall back to pure-JSON persistence (ops rollback).
     pub binary_persistence: bool,
+    /// Defense-in-depth against a poisoned persisted `Y.Doc` (JP-180). On
+    /// hydrate, if a current binary sidecar decodes to 0 shapes while the JSON
+    /// snapshot still holds N>0, prefer JSON (and rebuild the binary) instead of
+    /// silently serving empty. On snapshot, if a resident doc would drop from
+    /// N>0 to 0 shapes, copy the prior state into the recovery store first so a
+    /// single bad client can't permanently zero a document. Default on.
+    pub poison_guard: bool,
 }
 
 impl Default for SyncConfig {
@@ -431,6 +438,7 @@ impl Default for SyncConfig {
         Self {
             snapshot_interval_secs: DEFAULT_SNAPSHOT_INTERVAL_SECS,
             binary_persistence: true,
+            poison_guard: true,
         }
     }
 }
@@ -559,6 +567,15 @@ impl RelayConfig {
                 "0" | "false" | "no" | "off" => false,
                 other => anyhow::bail!(
                     "RELAY_BINARY_PERSISTENCE must be a boolean (got {other:?})"
+                ),
+            };
+        }
+        if let Some(v) = get("RELAY_POISON_GUARD") {
+            self.sync.poison_guard = match v.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                other => anyhow::bail!(
+                    "RELAY_POISON_GUARD must be a boolean (got {other:?})"
                 ),
             };
         }

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -56,6 +56,28 @@ pub struct DocumentMetadata {
     pub last_modified_by_name: Option<String>,
 }
 
+/// One recovery point for a document (JP-180). A copy of the binary `Y.Doc`
+/// sidecar taken just before a suspicious N→0 zeroing snapshot, so a single
+/// bad client can't permanently zero a document. Surfaced over the REST
+/// recovery routes and (eventually) the web interface.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveryPoint {
+    /// Opaque id addressing this point — the sidecar filename stem
+    /// (`<createdAtMs>-v<serverVersion>`).
+    pub id: String,
+    /// Wall-clock millis when the recovery point was captured.
+    pub created_at: u64,
+    /// The document `serverVersion` carried by the backed-up state.
+    pub server_version: u64,
+    /// Size of the backed-up sidecar on disk.
+    pub size_bytes: u64,
+}
+
+/// How many recovery points to retain per document (bounded ring — the backup
+/// captures a copy on each suspicious zeroing, not every snapshot).
+const RECOVERY_RING: usize = 5;
+
 /// Outcome of a save attempt with optimistic-concurrency support.
 /// IO and validation errors continue to surface via the `Result::Err`
 /// channel; this enum carries only application-level outcomes.
@@ -197,6 +219,106 @@ impl DocumentStore {
     /// is none yet (pre-binary / MCP-created doc) or it can't be read.
     pub fn load_ydoc_binary(&self, ws: &WorkspaceId, doc_id: &DocId) -> Option<Vec<u8>> {
         std::fs::read(self.ydoc_path(ws, doc_id)).ok()
+    }
+
+    /// Directory holding a document's recovery points (JP-180), under its
+    /// workspace next to the doc's JSON + sidecar.
+    fn recovery_dir(&self, ws: &WorkspaceId, doc_id: &DocId) -> PathBuf {
+        self.workspace_root(ws)
+            .join("docs")
+            .join("recovery")
+            .join(doc_id.as_str())
+    }
+
+    /// Copy the current binary sidecar into the doc's recovery ring (JP-180),
+    /// taken just before a suspicious N→0 zeroing snapshot overwrites it.
+    /// Best-effort: a missing source or any IO error is logged, never fatal.
+    /// Retains the newest [`RECOVERY_RING`] points.
+    pub fn push_recovery_point(&self, ws: &WorkspaceId, doc_id: &DocId) {
+        let src = self.ydoc_path(ws, doc_id);
+        if !src.exists() {
+            return; // nothing persisted yet — nothing to back up
+        }
+        let dir = self.recovery_dir(ws, doc_id);
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            log::warn!(
+                "recovery dir create failed {}/{}: {}",
+                ws.as_str(),
+                doc_id.as_str(),
+                e
+            );
+            return;
+        }
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let version = self
+            .get_metadata(ws, doc_id)
+            .and_then(|m| m.server_version)
+            .unwrap_or(0);
+        let dest = dir.join(format!("{ts}-v{version}.ydoc"));
+        if let Err(e) = std::fs::copy(&src, &dest) {
+            log::warn!(
+                "recovery point copy failed {}/{}: {}",
+                ws.as_str(),
+                doc_id.as_str(),
+                e
+            );
+            return;
+        }
+        self.prune_recovery_points(&dir);
+    }
+
+    /// Drop all but the newest [`RECOVERY_RING`] recovery points in `dir`.
+    /// Filenames lead with the millisecond timestamp, so a lexical sort is
+    /// chronological.
+    fn prune_recovery_points(&self, dir: &std::path::Path) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        let mut files: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|x| x == "ydoc"))
+            .collect();
+        files.sort();
+        if files.len() > RECOVERY_RING {
+            for p in &files[..files.len() - RECOVERY_RING] {
+                let _ = std::fs::remove_file(p);
+            }
+        }
+    }
+
+    /// List a document's recovery points (JP-180), newest first. Empty when the
+    /// doc has never been backed up or the directory can't be read.
+    pub fn list_recovery_points(&self, ws: &WorkspaceId, doc_id: &DocId) -> Vec<RecoveryPoint> {
+        let dir = self.recovery_dir(ws, doc_id);
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return Vec::new();
+        };
+        let mut points: Vec<RecoveryPoint> = entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let path = e.path();
+                if path.extension().is_none_or(|x| x != "ydoc") {
+                    return None;
+                }
+                // Stem is `<createdAtMs>-v<serverVersion>`.
+                let stem = path.file_stem()?.to_str()?.to_string();
+                let (ts_str, ver_str) = stem.split_once("-v")?;
+                let created_at = ts_str.parse::<u64>().ok()?;
+                let server_version = ver_str.parse::<u64>().ok()?;
+                let size_bytes = e.metadata().map(|m| m.len()).unwrap_or(0);
+                Some(RecoveryPoint {
+                    id: stem,
+                    created_at,
+                    server_version,
+                    size_bytes,
+                })
+            })
+            .collect();
+        points.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        points
     }
 
     /// Reload every workspace's index from disk. Public so external
@@ -580,6 +702,15 @@ impl DocumentStore {
             }
         }
 
+        // Remove the document's recovery points too (JP-180). Best-effort —
+        // a leftover recovery dir is harmless once the doc id is gone.
+        let recovery = self.recovery_dir(ws, doc_id);
+        if recovery.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&recovery) {
+                log::warn!("Failed to delete recovery dir {}/{}: {}", ws.as_str(), doc_id.as_str(), e);
+            }
+        }
+
         // Remove from this workspace's index.
         {
             let mut index = self.index.write().map_err(|e| e.to_string())?;
@@ -802,6 +933,81 @@ mod tests {
 
         // List should be empty again
         assert!(store.list_documents(&ws).is_empty());
+    }
+
+    #[test]
+    fn recovery_point_push_and_list() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("rec-doc".to_string()).unwrap();
+
+        // No sidecar yet → push is a no-op, list is empty.
+        store.push_recovery_point(&ws, &doc_id);
+        assert!(store.list_recovery_points(&ws, &doc_id).is_empty());
+
+        // Save the doc (→ serverVersion 1) and lay down a sidecar to back up.
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({"id": "rec-doc", "name": "R", "pages": {}}),
+            )
+            .unwrap();
+        store
+            .persist_ydoc_binary(&ws, &doc_id, b"DSKY-fake-sidecar")
+            .unwrap();
+
+        store.push_recovery_point(&ws, &doc_id);
+        let points = store.list_recovery_points(&ws, &doc_id);
+        assert_eq!(points.len(), 1, "one recovery point captured");
+        assert_eq!(points[0].server_version, 1, "version parsed from filename");
+        assert!(points[0].created_at > 0, "timestamp parsed");
+        assert_eq!(points[0].size_bytes, b"DSKY-fake-sidecar".len() as u64);
+    }
+
+    #[test]
+    fn recovery_ring_prunes_to_newest_five() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("ring-doc".to_string()).unwrap();
+        let recovery = store.recovery_dir(&ws, &doc_id);
+        std::fs::create_dir_all(&recovery).unwrap();
+
+        // Seven points with distinct, increasing timestamps.
+        for ts in 1000u64..1007 {
+            std::fs::write(recovery.join(format!("{ts}-v1.ydoc")), b"x").unwrap();
+        }
+        store.prune_recovery_points(&recovery);
+
+        let points = store.list_recovery_points(&ws, &doc_id);
+        assert_eq!(points.len(), RECOVERY_RING, "ring bounded to newest five");
+        // Newest first, and the two oldest (1000, 1001) were pruned.
+        assert_eq!(points[0].created_at, 1006);
+        assert_eq!(points[4].created_at, 1002);
+    }
+
+    #[test]
+    fn delete_document_clears_recovery_points() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("del-doc".to_string()).unwrap();
+
+        store
+            .save_document(&ws, serde_json::json!({"id": "del-doc", "name": "D"}))
+            .unwrap();
+        store
+            .persist_ydoc_binary(&ws, &doc_id, b"sidecar")
+            .unwrap();
+        store.push_recovery_point(&ws, &doc_id);
+        assert_eq!(store.list_recovery_points(&ws, &doc_id).len(), 1);
+
+        store.delete_document(&ws, &doc_id).unwrap();
+        assert!(
+            store.list_recovery_points(&ws, &doc_id).is_empty(),
+            "recovery points removed with the document"
+        );
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -48,7 +48,7 @@ use std::num::NonZeroU32;
 use protocol::*;
 use crate::auth::{AuthError, OidcAuthState, OidcClaims, WorkspaceRole};
 use crate::config::{StorageConfig, SyncConfig, TenancyConfig, TenancyMode};
-use crate::sync::{DocHandle, DocRegistry};
+use crate::sync::{active_page_shape_count, suspicious_zeroing, DocHandle, DocRegistry};
 use blob_backend::S3Backend;
 
 /// Per-workspace token-bucket limiter shared between WS sync handlers
@@ -350,6 +350,10 @@ pub struct ServerState {
     /// relay writes a binary `Y.Doc` sidecar on snapshot and hydrates from it
     /// (preserving CRDT identity + prose); when false it uses pure-JSON.
     binary_persistence: bool,
+    /// Snapshot of `config.sync.poison_guard` (JP-180). Gates the
+    /// binary-vs-JSON hydrate sanity check + self-heal and the N→0 persist
+    /// backup so a single bad client can't permanently zero a document.
+    poison_guard: bool,
     /// DEBUG-only trigger: when set, any WS handler that observes a
     /// client with this workspace id will panic on entry. Compiled out
     /// of release builds. Phase 21.2.
@@ -371,6 +375,7 @@ impl ServerState {
         rate_limit_rejections: Arc<AtomicU64>,
         metering_debug_log: bool,
         binary_persistence: bool,
+        poison_guard: bool,
         #[cfg(debug_assertions)] panic_tenant_trigger: Option<WorkspaceId>,
     ) -> Self {
         let (broadcast_tx, _) = broadcast::channel(100);
@@ -409,6 +414,7 @@ impl ServerState {
             rate_limit_rejections,
             metering_debug_log,
             binary_persistence,
+            poison_guard,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
         }
@@ -569,6 +575,10 @@ impl ServerState {
 
     pub(crate) fn binary_persistence(&self) -> bool {
         self.binary_persistence
+    }
+
+    pub(crate) fn poison_guard(&self) -> bool {
+        self.poison_guard
     }
 
     /// Accessor for the blob store — used by `/metrics` to read storage
@@ -737,6 +747,28 @@ impl ServerState {
     pub(crate) fn snapshot_doc(&self, ws: &WorkspaceId, doc_id: &DocId, handle: &Arc<DocHandle>) {
         if !handle.take_dirty() {
             return;
+        }
+
+        // JP-180 poison guard: if this snapshot would zero a resident doc
+        // (prior on-disk N>0 → live 0 shapes), copy the prior-good sidecar into
+        // the recovery store *before* the binary write below overwrites it.
+        // This runs ahead of every persist path so a tombstone-zeroing can't be
+        // permanent; a legitimate select-all+delete is backed up too (the two
+        // are indistinguishable here) and still persists normally.
+        if self.poison_guard {
+            if let Ok(prior_json) = self.doc_store.get_document(ws, doc_id) {
+                let prior = active_page_shape_count(&prior_json);
+                if suspicious_zeroing(prior, handle.shape_count()) {
+                    log::error!(
+                        "snapshot would zero {}/{} (prior {} shapes → 0); \
+                         backing up the prior state to the recovery store first",
+                        ws.as_str(),
+                        doc_id.as_str(),
+                        prior
+                    );
+                    self.doc_store.push_recovery_point(ws, doc_id);
+                }
+            }
         }
 
         // JP-108: persist the whole Y.Doc as a binary sidecar *first*, before
@@ -1130,6 +1162,7 @@ impl WebSocketServer {
         let rate_limit_rejections = self.rate_limit_rejections.clone();
         let metering_debug_log = self.metering_debug_log.load(Ordering::Relaxed);
         let binary_persistence = self.sync_config.read().await.binary_persistence;
+        let poison_guard = self.sync_config.read().await.poison_guard;
         let tenancy = self.tenancy.read().await.clone();
         let storage = self.storage.read().await.clone();
         // JP-125: bound the blob upload body (Axum's default is a silent 2 MiB).
@@ -1152,6 +1185,7 @@ impl WebSocketServer {
             rate_limit_rejections,
             metering_debug_log,
             binary_persistence,
+            poison_guard,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
         ));
@@ -2181,6 +2215,7 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
                     &doc_id,
                     &doc_json,
                     ydoc_bin.as_deref(),
+                    state.poison_guard(),
                 ))
             }
             Err(_) => None,
@@ -2343,6 +2378,7 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
                 &request.doc_id,
                 &doc_json,
                 ydoc_bin.as_deref(),
+                state.poison_guard(),
             );
             send_to_client(client_id, handle.sync_step1_frame(), state).await;
         }
@@ -2461,6 +2497,7 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             false,
             true,
+            true,
             trigger,
         ));
 
@@ -2514,6 +2551,7 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             false,
+            true,
             true,
             #[cfg(debug_assertions)]
             None,

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -64,6 +64,22 @@ pub fn json_to_ydoc(doc_json: &Value, doc: &Doc) {
     }
 }
 
+/// Count the shapes on a persisted document's **active page** — the same flat
+/// surface [`json_to_ydoc`] hydrates into the `shapes` map, so it's directly
+/// comparable with a `Y.Doc`'s `shapes.len()` (JP-180 poison detection).
+/// Returns 0 for any missing/malformed piece (no active id, no pages, no shapes
+/// object) — never panics.
+pub fn active_page_shape_count(doc_json: &Value) -> usize {
+    doc_json
+        .get("activePageId")
+        .and_then(Value::as_str)
+        .zip(doc_json.get("pages").and_then(Value::as_object))
+        .and_then(|(active, pages)| pages.get(active))
+        .and_then(|page| page.get("shapes"))
+        .and_then(Value::as_object)
+        .map_or(0, serde_json::Map::len)
+}
+
 /// Convert a `serde_json::Value` into a yrs `Any`. Shapes are stored as whole
 /// `Any` values (matching the JS side), so this preserves nested objects and
 /// arrays. JSON numbers become `f64` — Yjs has no plain integer type, and the
@@ -90,9 +106,32 @@ fn json_to_any(value: &Value) -> Any {
 
 #[cfg(test)]
 mod tests {
-    use super::json_to_ydoc;
+    use super::{active_page_shape_count, json_to_ydoc};
     use serde_json::{json, Value};
     use yrs::{Array, Doc, Map, Transact};
+
+    #[test]
+    fn active_page_shape_count_counts_active_page_only() {
+        let doc = multi_page_doc(); // active page p1 has 2 shapes, p2 has 1
+        assert_eq!(active_page_shape_count(&doc), 2);
+    }
+
+    #[test]
+    fn active_page_shape_count_tolerates_malformed() {
+        assert_eq!(active_page_shape_count(&json!({"id": "d"})), 0, "no pages");
+        assert_eq!(
+            active_page_shape_count(&json!({"activePageId": "p1", "pages": {}})),
+            0,
+            "active id with no matching page"
+        );
+        assert_eq!(
+            active_page_shape_count(
+                &json!({"activePageId": "p1", "pages": {"p1": {"shapeOrder": []}}})
+            ),
+            0,
+            "page with no shapes object"
+        );
+    }
 
     fn multi_page_doc() -> Value {
         json!({

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -22,6 +22,7 @@ mod flatten;
 mod hydration;
 mod protocol;
 
+pub use hydration::active_page_shape_count;
 pub use protocol::{SyncError, SyncOutcome};
 
 use std::collections::HashMap;
@@ -29,9 +30,26 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
-use yrs::Doc;
+use yrs::{Doc, Map, Transact};
 
 use crate::server::protocol::{DocId, WorkspaceId};
+
+/// Count entries in a `Y.Doc`'s `shapes` map — the active-page surface that
+/// mirrors the client `YjsDocument`. Grab the map handle *before* opening the
+/// read txn (`get_or_insert_map` transacts; nesting deadlocks).
+fn doc_shape_count(doc: &Doc) -> usize {
+    let shapes = doc.get_or_insert_map("shapes");
+    shapes.len(&doc.transact()) as usize
+}
+
+/// True when a snapshot would drop a resident doc from N>0 shapes to 0 — the
+/// signature of a tombstone poisoning (and, indistinguishably at the relay, a
+/// genuine select-all+delete). JP-180 backs the prior state up into the
+/// recovery store before persisting either way, so the zeroing is never
+/// permanent and a real delete-all still goes through.
+pub fn suspicious_zeroing(prior: usize, current: usize) -> bool {
+    prior > 0 && current == 0
+}
 
 /// The authoritative Y.Doc for a single active document, plus the sync
 /// operations over it.
@@ -52,32 +70,57 @@ impl DocHandle {
     /// (`ydoc_bin`, JP-108) — which preserves CRDT identity + prose across
     /// evict/rehydrate — and falls back to JSON hydration (JP-34) when the
     /// binary is absent, stale, or corrupt.
-    fn hydrate(doc_json: &Value, ydoc_bin: Option<&[u8]>) -> Self {
+    fn hydrate(doc_json: &Value, ydoc_bin: Option<&[u8]>, poison_guard: bool) -> Self {
         let page_id = doc_json
             .get("activePageId")
             .and_then(Value::as_str)
             .map(str::to_string);
-        let doc = Self::hydrate_doc(doc_json, ydoc_bin);
+        let (doc, poison_healed) = Self::hydrate_doc(doc_json, ydoc_bin, poison_guard);
         Self {
             doc,
             page_id,
-            dirty: AtomicBool::new(false),
+            // Self-heal (JP-180): when the sanity check rejected a poisoned
+            // binary sidecar and rebuilt from JSON, mark the handle dirty so the
+            // next snapshot sweep overwrites the bad sidecar with the
+            // JSON-correct state. Otherwise a fresh handle starts clean.
+            dirty: AtomicBool::new(poison_healed),
         }
     }
 
-    /// Choose the hydration source. The binary is authoritative only when it's
-    /// at least as new as the JSON body: `persist_snapshot` preserves
-    /// `serverVersion` while MCP/REST writes bump it, so a binary tagged with an
-    /// older version means an out-of-band JSON write landed after it — in which
-    /// case we hydrate from JSON and let the next snapshot rewrite the binary.
-    fn hydrate_doc(doc_json: &Value, ydoc_bin: Option<&[u8]>) -> Doc {
+    /// Choose the hydration source, returning `(doc, poison_healed)`. The binary
+    /// is authoritative only when it's at least as new as the JSON body:
+    /// `persist_snapshot` preserves `serverVersion` while MCP/REST writes bump
+    /// it, so a binary tagged with an older version means an out-of-band JSON
+    /// write landed after it — in which case we hydrate from JSON and let the
+    /// next snapshot rewrite the binary.
+    ///
+    /// Poison sanity check (JP-180): even a *current* binary is rejected when it
+    /// decodes to 0 shapes while the JSON snapshot still holds N>0 — the
+    /// signature of a tombstone-zeroed sidecar. We log loud, rebuild from JSON
+    /// instead of silently serving empty, and flag `poison_healed` so the caller
+    /// rewrites the bad binary. A legitimate delete-all leaves *both* at 0, so
+    /// this never fires on real empties.
+    fn hydrate_doc(doc_json: &Value, ydoc_bin: Option<&[u8]>, poison_guard: bool) -> (Doc, bool) {
+        let mut poison_healed = false;
         if let Some(bytes) = ydoc_bin {
             if let Some((bin_version, update)) = binary::decode_header(bytes) {
                 let json_version = doc_json.get("serverVersion").and_then(Value::as_u64);
-                let current = json_version.map_or(true, |jv| bin_version >= jv);
+                let current = json_version.is_none_or(|jv| bin_version >= jv);
                 if current {
                     match binary::doc_from_update(update) {
-                        Ok(doc) => return doc,
+                        Ok(doc) => {
+                            let json_shapes = hydration::active_page_shape_count(doc_json);
+                            if poison_guard && doc_shape_count(&doc) == 0 && json_shapes > 0 {
+                                log::error!(
+                                    "poisoned binary Y.Doc sidecar (0 shapes, JSON snapshot has {json_shapes}); \
+                                     rebuilding from JSON and rewriting the sidecar"
+                                );
+                                poison_healed = true;
+                                // fall through to the JSON rebuild below
+                            } else {
+                                return (doc, false);
+                            }
+                        }
                         Err(e) => log::warn!(
                             "binary Y.Doc hydrate failed ({e}); falling back to JSON"
                         ),
@@ -87,7 +130,14 @@ impl DocHandle {
         }
         let doc = Doc::new();
         hydration::json_to_ydoc(doc_json, &doc);
-        doc
+        (doc, poison_healed)
+    }
+
+    /// Number of shapes currently in the live `Y.Doc` (active-page surface).
+    /// Used by the JP-180 persist guard to detect an N→0 zeroing before it's
+    /// written to disk.
+    pub fn shape_count(&self) -> usize {
+        doc_shape_count(&self.doc)
     }
 
     /// Encode the live `Y.Doc` as a binary sidecar blob tagged with
@@ -173,6 +223,7 @@ impl DocRegistry {
         doc_id: &DocId,
         doc_json: &Value,
         ydoc_bin: Option<&[u8]>,
+        poison_guard: bool,
     ) -> Arc<DocHandle> {
         if let Some(handle) = self.get(ws, doc_id) {
             return handle;
@@ -180,7 +231,7 @@ impl DocRegistry {
         let key = (ws.clone(), doc_id.clone());
         let mut docs = self.docs.write().unwrap();
         docs.entry(key)
-            .or_insert_with(|| Arc::new(DocHandle::hydrate(doc_json, ydoc_bin)))
+            .or_insert_with(|| Arc::new(DocHandle::hydrate(doc_json, ydoc_bin, poison_guard)))
             .clone()
     }
 
@@ -237,15 +288,39 @@ mod tests {
     fn binary_with_prose(server_version: u64, text: &str) -> Vec<u8> {
         let doc = Doc::new();
         let prose = doc.get_or_insert_text("prose:p1");
+        let shapes = doc.get_or_insert_map("shapes");
         let mut txn = doc.transact_mut();
         prose.insert(&mut txn, 0, text);
+        // Carry the same shape `json_body` has so a *current* binary isn't a
+        // false poison-guard trigger (0 binary shapes while JSON has N>0).
+        shapes.insert(&mut txn, "s1", yrs::Any::String("rect".into()));
         drop(txn);
         binary::encode_snapshot(server_version, &doc)
     }
 
+    /// A binary sidecar with `server_version` and **no shapes** (only prose) —
+    /// the poison signature when paired with a JSON body that has shapes.
+    fn poisoned_binary(server_version: u64) -> Vec<u8> {
+        let doc = Doc::new();
+        let prose = doc.get_or_insert_text("prose:p1");
+        let mut txn = doc.transact_mut();
+        prose.insert(&mut txn, 0, "orphan prose");
+        drop(txn);
+        binary::encode_snapshot(server_version, &doc)
+    }
+
+    /// A JSON body whose active page has no shapes, at `server_version`.
+    fn empty_json_body(server_version: u64) -> serde_json::Value {
+        json!({
+            "id": "d", "serverVersion": server_version, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}}
+        })
+    }
+
     #[test]
     fn hydrate_prefers_binary_when_version_matches() {
-        let handle = DocHandle::hydrate(&json_body(5), Some(&binary_with_prose(5, "from binary")));
+        let handle =
+            DocHandle::hydrate(&json_body(5), Some(&binary_with_prose(5, "from binary")), true);
         // Binary used → its prose is present (JSON hydration never creates it).
         let prose = handle.doc.get_or_insert_text("prose:p1");
         assert_eq!(prose.get_string(&handle.doc.transact()), "from binary");
@@ -254,7 +329,8 @@ mod tests {
     #[test]
     fn hydrate_falls_back_to_json_when_binary_is_stale() {
         // Binary tagged v4, JSON body bumped to v7 by an out-of-band write.
-        let handle = DocHandle::hydrate(&json_body(7), Some(&binary_with_prose(4, "stale")));
+        let handle =
+            DocHandle::hydrate(&json_body(7), Some(&binary_with_prose(4, "stale")), true);
         let shapes = handle.doc.get_or_insert_map("shapes");
         let prose = handle.doc.get_or_insert_text("prose:p1");
         let txn = handle.doc.transact();
@@ -264,9 +340,70 @@ mod tests {
 
     #[test]
     fn hydrate_uses_json_when_no_binary() {
-        let handle = DocHandle::hydrate(&json_body(1), None);
+        let handle = DocHandle::hydrate(&json_body(1), None, true);
         let shapes = handle.doc.get_or_insert_map("shapes");
         assert!(shapes.contains_key(&handle.doc.transact(), "s1"));
+    }
+
+    #[test]
+    fn poison_binary_zero_json_nonzero_prefers_json_and_self_heals() {
+        // Current-version binary with 0 shapes, JSON snapshot with 1 → poison.
+        let handle = DocHandle::hydrate(&json_body(5), Some(&poisoned_binary(5)), true);
+        let shapes = handle.doc.get_or_insert_map("shapes");
+        let prose = handle.doc.get_or_insert_text("prose:p1");
+        let txn = handle.doc.transact();
+        // Rebuilt from JSON: the shape is present…
+        assert!(shapes.contains_key(&txn, "s1"), "rebuilt from JSON");
+        // …and the poisoned binary's orphan prose was discarded.
+        assert_eq!(prose.get_string(&txn), "", "poisoned binary ignored");
+        drop(txn);
+        // Self-heal: handle is dirty so the next snapshot rewrites the sidecar.
+        assert!(handle.take_dirty(), "poison heal marks the handle dirty");
+    }
+
+    #[test]
+    fn both_empty_is_not_a_false_poison() {
+        // Binary 0 shapes + JSON 0 shapes (a legitimate empty doc) → no trigger,
+        // not dirtied. Uses the binary unchanged (prose present proves it).
+        let handle = DocHandle::hydrate(&empty_json_body(5), Some(&poisoned_binary(5)), true);
+        let prose = handle.doc.get_or_insert_text("prose:p1");
+        assert_eq!(
+            prose.get_string(&handle.doc.transact()),
+            "orphan prose",
+            "empty-vs-empty serves the binary unchanged"
+        );
+        assert!(!handle.take_dirty(), "no heal, no dirty");
+    }
+
+    #[test]
+    fn binary_nonzero_json_empty_keeps_binary() {
+        // Binary has the shape, JSON is empty → binary is authoritative, no
+        // false trigger (the guard only fires on binary 0 / JSON N>0).
+        let handle =
+            DocHandle::hydrate(&empty_json_body(5), Some(&binary_with_prose(5, "live")), true);
+        let shapes = handle.doc.get_or_insert_map("shapes");
+        let prose = handle.doc.get_or_insert_text("prose:p1");
+        let txn = handle.doc.transact();
+        assert!(shapes.contains_key(&txn, "s1"), "binary shapes kept");
+        assert_eq!(prose.get_string(&txn), "live", "binary preferred");
+    }
+
+    #[test]
+    fn poison_guard_off_serves_binary_empty() {
+        // Flag disabled → the old behavior: a current 0-shape binary is served
+        // even though JSON has shapes (proves the guard gates the new path).
+        let handle = DocHandle::hydrate(&json_body(5), Some(&poisoned_binary(5)), false);
+        let shapes = handle.doc.get_or_insert_map("shapes");
+        assert_eq!(shapes.len(&handle.doc.transact()), 0, "served empty binary");
+        assert!(!handle.take_dirty(), "no heal when guard is off");
+    }
+
+    #[test]
+    fn suspicious_zeroing_only_fires_on_n_to_zero() {
+        assert!(super::suspicious_zeroing(3, 0), "N>0 → 0 is suspicious");
+        assert!(!super::suspicious_zeroing(0, 0), "empty → empty is fine");
+        assert!(!super::suspicious_zeroing(0, 3), "growth is fine");
+        assert!(!super::suspicious_zeroing(3, 2), "partial delete is fine");
     }
 
     fn key() -> (WorkspaceId, DocId) {
@@ -284,11 +421,11 @@ mod tests {
 
         assert!(reg.is_empty());
 
-        let h1 = reg.ensure(&ws, &doc, &body, None);
+        let h1 = reg.ensure(&ws, &doc, &body, None, true);
         assert_eq!(reg.len(), 1);
 
         // A second ensure returns the same handle — one hydration only.
-        let h2 = reg.ensure(&ws, &doc, &body, None);
+        let h2 = reg.ensure(&ws, &doc, &body, None, true);
         assert!(Arc::ptr_eq(&h1, &h2));
         assert_eq!(reg.len(), 1);
         assert!(reg.get(&ws, &doc).is_some());


### PR DESCRIPTION
Closes JP-180. Relay-side defense-in-depth so a tombstone-zeroed `Y.Doc` can't silently or permanently zero a document for real users (the 2026-06-03 mass-deletion fallout; client root cause fixed in #59). Contained to the OSS relay; behavior-only, no `PROTOCOL_VERSION` bump.

## Three guards (gated by new `[sync] poison_guard`, default on, `RELAY_POISON_GUARD`)

1. **Hydrate sanity check** — a *current* binary sidecar that decodes to **0 shapes** while the JSON snapshot still holds **N>0** is the poison signature → log loud and rebuild from JSON instead of serving empty. Only runs after the version guard passes, and a legitimate delete-all leaves *both* at 0, so it never false-fires.
2. **Self-heal** — a poison-healed handle is marked dirty so the next snapshot sweep overwrites the bad sidecar from the JSON-correct state.
3. **Persist N→0 guard** — before a snapshot would zero a resident doc, copy the prior sidecar into a **bounded per-doc recovery ring** (newest 5), then persist normally. Delete-all still works (poison and delete-all are indistinguishable at the relay); the backup makes a zeroing *recoverable*, not permanent.

## Backups aren't a dead file

- `GET /api/docs/:id/recovery` — **real**, lists recovery points (authed + workspace-scoped like `/api/docs`).
- `POST /api/docs/:id/recovery/:pointId/restore` — **stub** (`501`, points to JP-183).
- Full restore (decode → flatten → versioned save + `DocEvent` broadcast) + the `docushark-web` "Recover document" UI → **JP-183**.

## Verification

- `cargo test --manifest-path relay/Cargo.toml` — full suite green; **10 new unit tests** (hydrate poison matrix incl. flag-off + self-heal-dirty, `active_page_shape_count`, `suspicious_zeroing`, recovery push/list/ring-prune, delete cleanup).
- `cargo clippy` clean (no new warnings; tidied one relocated `map_or` → `is_none_or`).
- OSS-relay leak grep clean on added lines (comments are purely technical).

**E2E left for the reviewer/author:** live multi-client poison → recovery-point capture → confirm `GET /recovery` lists it (before flipping the issue to Done).

Assisted-by: Opus 4.8