### PR TITLE
JP-178: harden local→CRDT sync (store-tagged bulk-replace)

### DIFF
--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -181,6 +181,34 @@ describe('useCollaborationSync', () => {
     expect(currentYjs.deleteShape).not.toHaveBeenCalled();
   });
 
+  it('does NOT propagate a bare loadSnapshot — no suppression wrapper (JP-178)', () => {
+    startSyncedSession();
+    currentYjs.getAllShapes.mockReturnValue(new Map([['S1', shape('S1')]]));
+    renderHook(() => useCollaborationSync());
+    expect(Object.keys(useDocumentStore.getState().shapes)).toContain('S1');
+    currentYjs.deleteShape.mockClear();
+
+    // A page-switch / undo / new-doc load that did NOT wrap in
+    // withAutoSaveSuppressed: the store tags it 'replace', so the bridge must
+    // still skip it (the structural fix that no longer relies on callers).
+    act(() => {
+      useDocumentStore.getState().loadSnapshot({ shapes: {}, shapeOrder: [], version: 1 });
+    });
+    expect(currentYjs.deleteShape).not.toHaveBeenCalled();
+  });
+
+  it('does NOT propagate a bare clear() — no suppression wrapper (JP-178)', () => {
+    startSyncedSession();
+    currentYjs.getAllShapes.mockReturnValue(new Map([['S1', shape('S1')]]));
+    renderHook(() => useCollaborationSync());
+    currentYjs.deleteShape.mockClear();
+
+    act(() => {
+      useDocumentStore.getState().clear();
+    });
+    expect(currentYjs.deleteShape).not.toHaveBeenCalled();
+  });
+
   it('DOES propagate a genuine user delete (control for #59)', () => {
     startSyncedSession();
     currentYjs.getAllShapes.mockReturnValue(new Map([['S1', shape('S1')]]));

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -16,7 +16,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { useDocumentStore } from '../store/documentStore';
+import { useDocumentStore, getStoreChangeKind } from '../store/documentStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { useCollaborationStore } from './collaborationStore';
@@ -200,13 +200,19 @@ export function useCollaborationSync(): void {
         // Skip if we're applying remote changes (prevents sync loops)
         if (isApplyingRemoteChanges) return;
 
-        // Skip while a document LOAD is replaying content into the stores — these
-        // are not user edits. `loadDocumentToPageStore` wraps the load in
-        // `withAutoSaveSuppressed`, which synchronously clears+repopulates
-        // documentStore; without this guard the subscription reads that wholesale
-        // replacement as user deletions and writes CRDT tombstones (persisted to
-        // y-indexeddb + broadcast to the relay → mass deletion of every client's
-        // shapes, the "juggling" bug). Same signal autosave already honors.
+        // Skip a programmatic whole-store replacement (JP-178). A document load,
+        // page-switch, or undo/redo snapshot restore wipes-and-reloads
+        // documentStore via `loadSnapshot`/`clear`, which tag the mutation
+        // `'replace'`. Without this the diff below reads that wipe as user
+        // deletions and broadcasts CRDT tombstones to every client (the #59
+        // mass-deletion bug). This is the structural guarantee — it no longer
+        // depends on every load caller remembering to suppress.
+        if (getStoreChangeKind() === 'replace') return;
+
+        // Belt-and-suspenders: also skip while autosave is suppressed (a load
+        // replaying content). `loadDocumentToPageStore` wraps loads in
+        // `withAutoSaveSuppressed`; this still gates any non-bulk *edit* action
+        // dispatched inside a suppressed block, and serves autosave's own needs.
         if (isAutoSaveSuppressed()) return;
 
         // Skip if collaboration not active
@@ -242,6 +248,27 @@ export function useCollaborationSync(): void {
               syncShape(current);
             }
           }
+        }
+
+        // Tripwire (JP-178): a wholesale deletion (N>0 → 0) reaching the CRDT on
+        // 'edit' provenance is either a genuine select-all+delete (fine) or a
+        // future bulk path that forgot the 'replace' tag (a regression). We
+        // can't distinguish them without per-op provenance, so this is a
+        // dev-only, NON-blocking canary — never block, a real delete-all must
+        // still propagate. The guarantee is the 'replace' guard above; this is
+        // just an early-warning signal.
+        if (
+          import.meta.env.DEV &&
+          prevIds.size > 0 &&
+          currentIds.size === 0
+        ) {
+          // eslint-disable-next-line no-console
+          console.error(
+            '[useCollaborationSync] wholesale deletion propagated to the CRDT ' +
+              `(${prevIds.size} → 0 shapes). Expected only on a user select-all+delete; ` +
+              'if this fired during a load/page-switch/teardown, a bulk path is ' +
+              "missing the documentStore 'replace' tag (JP-178).",
+          );
         }
 
         // Find deleted shapes

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useDocumentStore, getShapesByIds, shapeExists } from './documentStore';
+import {
+  useDocumentStore,
+  getShapesByIds,
+  shapeExists,
+  getStoreChangeKind,
+} from './documentStore';
 import { RectangleShape } from '../shapes/Shape';
 
 /**
@@ -29,6 +34,30 @@ describe('Document Store', () => {
   beforeEach(() => {
     // Clear the store before each test
     useDocumentStore.getState().clear();
+  });
+
+  describe('change provenance (JP-178)', () => {
+    it('tags loadSnapshot and clear as replace, edits as edit', () => {
+      const store = useDocumentStore.getState();
+      const kinds: Array<'edit' | 'replace'> = [];
+      const unsub = useDocumentStore.subscribe(() => {
+        kinds.push(getStoreChangeKind());
+      });
+
+      store.addShape(createTestRect({ id: 'a' })); // edit
+      store.loadSnapshot({ shapes: {}, shapeOrder: [], version: 1 }); // replace
+      store.addShape(createTestRect({ id: 'b' })); // edit
+      store.clear(); // replace
+      unsub();
+
+      expect(kinds).toEqual(['edit', 'replace', 'edit', 'replace']);
+      // The flag brackets each bulk op and resets to 'edit' afterwards.
+      expect(getStoreChangeKind()).toBe('edit');
+    });
+
+    it('defaults to edit (no bulk op in flight)', () => {
+      expect(getStoreChangeKind()).toBe('edit');
+    });
   });
 
   describe('addShape', () => {

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -123,6 +123,31 @@ let lastSnapshotIntegrity: SnapshotIntegrity = {
 };
 
 /**
+ * Provenance of the in-flight documentStore mutation (JP-178).
+ *
+ * `'replace'` means a programmatic **whole-store replacement** — a document
+ * load, page-switch, or undo/redo snapshot restore (always via `loadSnapshot`
+ * or `clear`). `'edit'` means a genuine per-shape/structural mutation.
+ *
+ * The collaboration bridge (`useCollaborationSync`) MUST NOT propagate a
+ * `'replace'` to the CRDT: diffing a wipe-and-reload as user edits broadcasts a
+ * mass deletion to every client (the #59 mass-deletion bug). Making the two
+ * bulk ops tag themselves here removes the reliance on every caller remembering
+ * to set a suppression flag.
+ *
+ * Zustand notifies subscribers **synchronously inside `set()`**, so a bulk op
+ * brackets its `set()` with `'replace'` … `'edit'`: the flag reads `'replace'`
+ * exactly while the bridge's subscription runs for that mutation, and `'edit'`
+ * at all other times. No reset bookkeeping in the other actions is needed.
+ */
+let lastChangeKind: 'edit' | 'replace' = 'edit';
+
+/** Provenance of the most recent documentStore mutation — see {@link lastChangeKind}. */
+export function getStoreChangeKind(): 'edit' | 'replace' {
+  return lastChangeKind;
+}
+
+/**
  * Initial empty document state.
  */
 const initialState: DocumentState = {
@@ -358,6 +383,10 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
         at: Date.now(),
       };
 
+      // A snapshot load is a programmatic whole-store replacement, never user
+      // edits — tag it so the collab bridge skips it (JP-178). Reset right
+      // after `set()`, whose subscribers (incl. the bridge) ran synchronously.
+      lastChangeKind = 'replace';
       set((state) => {
         // Clear existing data
         state.shapes = {};
@@ -369,6 +398,7 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
         // flag above lets the persistence layer refuse a save if needed.
         state.shapeOrder = incomingOrder.filter((id) => state.shapes[id]);
       });
+      lastChangeKind = 'edit';
     },
 
     getLastSnapshotIntegrity: (): SnapshotIntegrity => lastSnapshotIntegrity,
@@ -386,10 +416,14 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
     },
 
     clear: () => {
+      // A wholesale clear is a programmatic replacement, never user edits
+      // (JP-178) — tag it so the collab bridge skips it. See loadSnapshot.
+      lastChangeKind = 'replace';
       set((state) => {
         state.shapes = {};
         state.shapeOrder = [];
       });
+      lastChangeKind = 'edit';
     },
 
     // Group operations

--- a/src/store/historyStore.test.ts
+++ b/src/store/historyStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useHistoryStore } from './historyStore';
 import { useDocumentStore } from './documentStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { RectangleShape } from '../shapes/Shape';
 
 /**
@@ -39,6 +40,9 @@ describe('History Store', () => {
       shapes: {},
       shapeOrder: [],
     });
+    // Undo/redo are gated on collab being inactive (JP-178); keep it off by
+    // default so the single-writer history tests behave normally.
+    useCollaborationStore.setState({ isActive: false });
   });
 
   describe('push', () => {
@@ -180,6 +184,26 @@ describe('History Store', () => {
 
       // Shape should still exist
       expect(useDocumentStore.getState().shapes['rect1']).toBeDefined();
+    });
+
+    it('does nothing while a collab session is active (JP-178)', async () => {
+      const store = useHistoryStore.getState();
+      const docStore = useDocumentStore.getState();
+
+      docStore.addShape(createTestRect('rect1', 0, 0));
+      await new Promise((r) => setTimeout(r, 350));
+      store.push('Before move');
+      docStore.updateShape('rect1', { x: 100, y: 100 });
+
+      // A collab session makes the relay Y.Doc authoritative — snapshot undo is
+      // disabled (it would diverge and be clobbered on sync). Undo must no-op.
+      useCollaborationStore.setState({ isActive: true });
+      try {
+        store.undo();
+        expect(useDocumentStore.getState().shapes['rect1']?.x).toBe(100);
+      } finally {
+        useCollaborationStore.setState({ isActive: false });
+      }
     });
   });
 

--- a/src/store/historyStore.ts
+++ b/src/store/historyStore.ts
@@ -1,6 +1,21 @@
 import { create } from 'zustand';
 import { useDocumentStore, DocumentSnapshot } from './documentStore';
 import { useNotificationStore } from './notificationStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
+
+/**
+ * Snapshot-based undo/redo is disabled while a collaboration session is active
+ * (JP-178). The relay Y.Doc is the authoritative source whenever a collab
+ * *engine* session is live — including offline-first relay docs (engine ≠
+ * provider) — so restoring a local history snapshot would diverge from the
+ * Y.Doc and be silently clobbered on the next sync/reload. Undo/redo therefore
+ * apply only to pure local documents (no session); proper per-user collab undo
+ * / version history is roadmap work. Read at call time so there is no module
+ * eval-order dependency on the collaboration store.
+ */
+function isCollabSessionActive(): boolean {
+  return useCollaborationStore.getState().isActive;
+}
 
 /**
  * Maximum number of history entries to keep per page.
@@ -288,6 +303,8 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   undo: () => {
+    // Disabled in a collab session — see isCollabSessionActive (JP-178).
+    if (isCollabSessionActive()) return;
     const state = get();
     const { activePageId } = state;
 
@@ -367,6 +384,8 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   redo: () => {
+    // Disabled in a collab session — see isCollabSessionActive (JP-178).
+    if (isCollabSessionActive()) return;
     const state = get();
     const { activePageId } = state;
 

--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { useSessionStore, type ToolType } from '../store/sessionStore';
 import { useHistoryStore } from '../store/historyStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { ShapePicker } from './ShapePicker';
 import { CustomShapePicker } from './CustomShapePicker';
 import { FileImportButton } from './FileImportButton';
@@ -105,13 +106,27 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
   const getUndoDescription = useHistoryStore((state) => state.getUndoDescription);
   const getRedoDescription = useHistoryStore((state) => state.getRedoDescription);
 
+  // Undo/redo are disabled in a collaboration session (JP-178): snapshot-based
+  // history would diverge from the authoritative relay Y.Doc. Subscribe so the
+  // buttons react when a session starts/stops.
+  const collabActive = useCollaborationStore((state) => state.isActive);
+
   // Derive descriptions reactively (pageHistory triggers re-render)
   const _ph = pageHistory; const _ap = activeHistoryPage; // ensure subscription
   void _ph; void _ap;
   const undoDesc = getUndoDescription();
   const redoDesc = getRedoDescription();
-  const undoTitle = undoDesc ? `Undo: ${undoDesc} (Ctrl+Z)` : 'Undo (Ctrl+Z)';
-  const redoTitle = redoDesc ? `Redo: ${redoDesc} (Ctrl+Y)` : 'Redo (Ctrl+Y)';
+  const collabUndoNote = 'Undo/redo are unavailable in shared documents';
+  const undoTitle = collabActive
+    ? collabUndoNote
+    : undoDesc
+      ? `Undo: ${undoDesc} (Ctrl+Z)`
+      : 'Undo (Ctrl+Z)';
+  const redoTitle = collabActive
+    ? collabUndoNote
+    : redoDesc
+      ? `Redo: ${redoDesc} (Ctrl+Y)`
+      : 'Redo (Ctrl+Y)';
 
   return (
     <div className="canvas-toolbar">
@@ -147,7 +162,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
       <button
         className="toolbar-action-btn"
         onClick={undo}
-        disabled={!canUndo()}
+        disabled={collabActive || !canUndo()}
         title={undoTitle}
         aria-label={undoTitle}
       >
@@ -156,7 +171,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
       <button
         className="toolbar-action-btn"
         onClick={redo}
-        disabled={!canRedo()}
+        disabled={collabActive || !canRedo()}
         title={redoTitle}
         aria-label={redoTitle}
       >


### PR DESCRIPTION
Closes JP-178. The collab bridge inferred edits by **diffing all of `documentStore` on every change** (`src/collaboration/useCollaborationSync.ts`), so any programmatic whole-store replacement that forgot a suppression flag was broadcast as mass deletions (the #59 class). An audit found **three live unsuppressed bulk-replace paths**: page-switch (`pageStore.syncDocumentToCurrentPage`), `newDocument`, and undo/redo (`historyStore.restoreSnapshot`).

Chosen approach (with the user): **store-tagged "replace"** — small, low-regression, reuses the proven diff — over a full op-event rewrite (filed JP-184).

## Changes
- **`documentStore`** — the only two bulk replacements (`loadSnapshot`, `clear`) bracket their `set()` with a `'replace'` tag; new `getStoreChangeKind()`. Zustand fires subscribers synchronously inside `set()`, so the flag is `'replace'` exactly while the bridge runs for that mutation and `'edit'` everywhere else (the other 13 actions are untouched).
- **`useCollaborationSync`** — first guard `if (getStoreChangeKind() === 'replace') return;` structurally fixes all three leaks at the chokepoint (no caller has to remember to suppress). Plus a **dev-only, non-blocking** wholesale-deletion canary — the requested invariant; it never blocks (a real select-all+delete must still propagate), it's an early-warning signal.
- **Undo/redo disabled while a collab session is active** — `historyStore.undo()/redo()` no-op (snapshot undo would diverge from the authoritative relay Y.Doc, incl. offline-first relay docs) + reactive toolbar disable/tooltip in `CanvasToolbar`. **Stays fully enabled for pure local docs** (works offline). The axis is "collaborative doc?", not "online?".

## Verification
- `bun run test --run` — **1823 tests green** (5 new: bare-`loadSnapshot`/bare-`clear` not propagated, `getStoreChangeKind` provenance, undo no-op in collab), `bun run typecheck` clean, leak grep clean.

**E2E left for the reviewer/author** (before Done): 2-client session — page-switch / undo / new-doc must NOT delete peers' shapes, while a real edit and a real delete still sync.

## Follow-ups filed
- **JP-184** — op-event model (optional perf; removes diffing).
- **JP-185** — version history + preview (the collab-native "undo": Ctrl+Z toast → version history, undo/redo buttons replaced by a Version History button with very readable, flip-between diffs; builds on JP-180/JP-183).

Assisted-by: Opus 4.8