### PR TITLE
JP-187: explorer sync badge reflects connection (no more stale "Synced")

### DIFF
--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -103,11 +103,19 @@ function TypeIcon({ type }: { type: DocumentRecord['type'] }) {
   }
 }
 
-function getSyncState(record: DocumentRecord): ExtendedSyncState {
+function getSyncState(record: DocumentRecord, relayConnected: boolean): ExtendedSyncState {
   switch (record.type) {
     case 'local':
       return 'local';
     case 'remote':
+      // A remote doc whose relay isn't connected is offline-cached, not
+      // "synced": `record.syncState` only tracks REST save/queue outcomes and
+      // defaults to 'synced' (registerRemote) — it never reflects a dropped
+      // connection. Show 'offline' when disconnected, but still surface a real
+      // 'error' so it isn't hidden.
+      if (!relayConnected && record.syncState !== 'error') {
+        return 'offline';
+      }
       return record.syncState;
     case 'cached':
       return 'offline';
@@ -285,8 +293,11 @@ export function DocumentCard({
     setShowDeleteConfirm(false);
   }, []);
 
-  const syncState = getSyncState(record);
   const relay = formatRelayLabel(record, connectedRelayAddress);
+  // The sync badge must reflect the live connection, not the stale registry
+  // default — drive it off the same connected/disconnected signal as the relay
+  // badge above it.
+  const syncState = getSyncState(record, relay?.status === 'connected');
   const showDetails = mode === 'full';
 
   const showCheckbox = Boolean(onSelectToggle) && (showSelectionCheckbox || isSelected);

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -143,8 +143,15 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
 
   // Currently-connected relay address (host:port) — drives per-card relay
-  // badges and the "By relay" section ordering.
-  const connectedRelayAddress = useConnectionStore((s) => s.host?.address);
+  // badges and the "By relay" section ordering. "Connected" must mean *actually
+  // connected*, not merely that a relay address is configured: opening a doc
+  // calls `connectionStore.setHost(address)` (engine start) even while offline,
+  // so keying off `host?.address` alone falsely flips every card to
+  // connected/synced. Gate on the real WS-connected signal (`hostConnected`,
+  // which only goes true on an authenticated connection).
+  const relayHostAddress = useConnectionStore((s) => s.host?.address);
+  const hostConnected = useRelayDocumentStore((s) => s.hostConnected);
+  const connectedRelayAddress = hostConnected ? relayHostAddress : undefined;
 
   // User store
   const currentUser = useUserStore((s) => s.currentUser);


### PR DESCRIPTION
Closes JP-187. In the document explorer, a relay/remote doc's **sync badge always showed "Synced"** even with the relay disconnected (refresh while offline: the Wifi badge correctly showed disconnected, but the sync badge said "Synced").

**Cause:** `getSyncState(record)` returned `record.syncState`, which `documentRegistry.registerRemote()` **defaults to `'synced'`** and which is only updated by REST save/queue outcomes — never on connect/disconnect.

**Fix:** make `getSyncState` connection-aware by passing the card's already-computed `relay.status` (the exact signal the Wifi badge uses). A disconnected remote doc now shows **"Offline"** (the existing "cached — changes will sync when reconnected" state); a real `'error'` is preserved; connected docs show their true sync state.

Cosmetic only — the data-safety `collaborationStore.isSynced` signal is separate and accurate (confirmed via instrumentation during JP-171 testing). Found during JP-171 prose testing.

## Verification
`bun run typecheck` clean; `DocumentCard.relay` tests green (10).

Assisted-by: Opus 4.8