### PR TITLE
JP-173: collab prose parity — shared editor chrome, spellcheck/menu, scroll

### DIFF
--- a/src/store/richTextStore.test.ts
+++ b/src/store/richTextStore.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { JSONContent } from '@tiptap/core';
+import { useRichTextStore } from './richTextStore';
+import { RICH_TEXT_VERSION } from '../types/RichText';
+
+describe('richTextStore.setContent — preserves sibling content fields (JP-173)', () => {
+  beforeEach(() => {
+    useRichTextStore.getState().reset();
+  });
+
+  it('keeps customDictionary when an editor update calls setContent', () => {
+    // A document loads with a custom dictionary (words 'Added to Dictionary').
+    useRichTextStore.getState().loadContent({
+      content: { type: 'doc', content: [] },
+      version: RICH_TEXT_VERSION,
+      customDictionary: ['Tiptap', 'Yjs'],
+    });
+
+    // An editor `onUpdate` carries only the Tiptap JSON.
+    const edited: JSONContent = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+    };
+    useRichTextStore.getState().setContent(edited);
+
+    const { content } = useRichTextStore.getState();
+    expect(content.content).toEqual(edited);
+    // The dictionary must survive the keystroke (was previously wiped).
+    expect(content.customDictionary).toEqual(['Tiptap', 'Yjs']);
+    expect(content.version).toBe(RICH_TEXT_VERSION);
+  });
+
+  it('does not invent a customDictionary when there was none', () => {
+    useRichTextStore.getState().setContent({ type: 'doc', content: [] });
+    expect(useRichTextStore.getState().content.customDictionary).toBeUndefined();
+  });
+});

--- a/src/store/richTextStore.ts
+++ b/src/store/richTextStore.ts
@@ -69,15 +69,19 @@ export const useRichTextStore = create<RichTextState & RichTextActions>()(
     // State
     ...initialState,
 
-    // Set content from editor updates
+    // Set content from editor updates. Preserve sibling fields on the current
+    // content (notably `customDictionary`) — an editor `onUpdate` only carries
+    // the Tiptap JSON, so replacing `content` wholesale here would wipe words
+    // the user has 'Added to Dictionary' on the very next keystroke.
     setContent: (content: JSONContent) => {
-      set({
+      set((state) => ({
         content: {
+          ...state.content,
           content,
           version: RICH_TEXT_VERSION,
         },
         isDirty: true,
-      });
+      }));
     },
 
     // Load content from saved document

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -29,7 +29,7 @@ import type { Doc as YDoc } from 'yjs';
 import { sharedProseExtensions } from './TiptapEditor';
 import { useRichTextStore } from '../store/richTextStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
-import { resolveBlobUrl } from '../storage/blobResolver';
+import { useProseEditorChrome } from './useProseEditorChrome';
 import './TiptapEditor.css';
 
 export interface CollaborativeProseEditorProps {
@@ -116,53 +116,10 @@ export function CollaborativeProseEditor({
     [ydoc, field],
   );
 
-  // Resolve blob:// images to object URLs (initial + on every update) — same as
-  // the local editor; collaborators on other devices embed images we must load.
-  useEffect(() => {
-    if (!editor) return;
-    const convert = async () => {
-      const images = editor.view.dom.querySelectorAll('img[src^="blob://"]');
-      for (const el of Array.from(images)) {
-        const img = el as HTMLImageElement;
-        const blobUrl = img.getAttribute('src');
-        if (!blobUrl) continue;
-        const objectUrl = await resolveBlobUrl(blobUrl);
-        if (objectUrl && objectUrl !== blobUrl) {
-          img.setAttribute('src', objectUrl);
-        } else if (!objectUrl) {
-          img.setAttribute('alt', '(Image not found)');
-          img.style.border = '2px dashed var(--border-color)';
-          img.style.padding = '8px';
-        }
-      }
-    };
-    void convert();
-    const onUpdate = () => void convert();
-    editor.on('update', onUpdate);
-    return () => {
-      editor.off('update', onUpdate);
-    };
-  }, [editor]);
-
-  // Inline link clicks (http(s)/mailto open in a new tab) — same as the local
-  // editor; heading-anchor nav is a local-doc concern and omitted here.
-  useEffect(() => {
-    if (!editor) return;
-    const dom = editor.view.dom;
-    const onClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
-      if (!anchor || !dom.contains(anchor)) return;
-      const href = anchor.getAttribute('href') || '';
-      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
-        event.preventDefault();
-        event.stopPropagation();
-        window.open(href, '_blank', 'noopener,noreferrer');
-      }
-    };
-    dom.addEventListener('click', onClick);
-    return () => dom.removeEventListener('click', onClick);
-  }, [editor]);
+  // Shared editor chrome: right-click formatting menu, spellcheck popover,
+  // custom-dictionary loader, inline-link handling, and blob:// image
+  // resolution. Heading-anchor nav is a local multi-page concern, omitted here.
+  const { onContextMenu, overlay } = useProseEditorChrome(editor, { headingAnchors: false });
 
   // Expose the editor instance to the panel (autosave + toolbar).
   useEffect(() => {
@@ -171,8 +128,9 @@ export function CollaborativeProseEditor({
   }, [editor, onEditorReady]);
 
   return (
-    <div className={`tiptap-editor ${className ?? ''}`}>
+    <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={onContextMenu}>
       <EditorContent editor={editor} />
+      {overlay}
     </div>
   );
 }

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -27,6 +27,48 @@ import { ProsePreview } from './ProsePreview';
 import { RICH_TEXT_VERSION } from '../types/RichText';
 import './DocumentEditorPanel.css';
 
+/**
+ * Restore a scroll container to `target`, retrying across frames.
+ *
+ * Tiptap reports `scrollHeight` in stages while it paints, and for a relay doc
+ * the collab editor's Yjs content can hydrate a few frames after mount — so a
+ * single `scrollTop =` often lands short. Retry until the target is reachable
+ * (capped), and abort the instant the user scrolls so we never fight live
+ * input. `onDone` runs when finished or cancelled (the caller clears its
+ * in-progress guard there). Shared by the local page-switch path and the
+ * relay-doc remount path.
+ */
+function restoreScrollTop(el: HTMLElement, target: number, onDone: () => void): void {
+  let attempts = 0;
+  let cancelled = false;
+  const cancel = () => {
+    cancelled = true;
+  };
+  el.addEventListener('wheel', cancel, { once: true, passive: true });
+  el.addEventListener('touchmove', cancel, { once: true, passive: true });
+  el.addEventListener('keydown', cancel, { once: true });
+  const cleanup = () => {
+    el.removeEventListener('wheel', cancel);
+    el.removeEventListener('touchmove', cancel);
+    el.removeEventListener('keydown', cancel);
+    onDone();
+  };
+  const tryRestore = () => {
+    if (cancelled) {
+      cleanup();
+      return;
+    }
+    el.scrollTop = target;
+    attempts++;
+    if (el.scrollTop < target - 1 && attempts < 30) {
+      requestAnimationFrame(tryRestore);
+    } else {
+      cleanup();
+    }
+  };
+  requestAnimationFrame(tryRestore);
+}
+
 export interface DocumentEditorPanelProps {
   /** Optional callback when "Hide editor" is chosen (docked presentation only) */
   onCollapse?: () => void;
@@ -238,9 +280,8 @@ export function DocumentEditorPanel({
           content: editorRef.current.getJSON(),
           version: RICH_TEXT_VERSION,
         });
-        // Restore scroll position after layout settles. Tiptap reports `scrollHeight`
-        // in stages while it paints, so we retry until the target is reachable —
-        // and abort the moment the user scrolls (so we don't fight live input).
+        // Restore scroll position after layout settles (retries + aborts on
+        // user scroll — see restoreScrollTop).
         const savedScroll = useSessionStore.getState().getEditorScroll(targetPageId) ?? 0;
         const restoreEl = getScrollEl(editorRef.current);
         const finishRestore = () => {
@@ -249,32 +290,7 @@ export function DocumentEditorPanel({
         if (!restoreEl) {
           finishRestore();
         } else {
-          let attempts = 0;
-          let cancelled = false;
-          const cancel = () => { cancelled = true; };
-          restoreEl.addEventListener('wheel', cancel, { once: true, passive: true });
-          restoreEl.addEventListener('touchmove', cancel, { once: true, passive: true });
-          restoreEl.addEventListener('keydown', cancel, { once: true });
-          const cleanup = () => {
-            restoreEl.removeEventListener('wheel', cancel);
-            restoreEl.removeEventListener('touchmove', cancel);
-            restoreEl.removeEventListener('keydown', cancel);
-            finishRestore();
-          };
-          const tryRestore = () => {
-            if (cancelled) {
-              cleanup();
-              return;
-            }
-            restoreEl.scrollTop = savedScroll;
-            attempts++;
-            if (restoreEl.scrollTop < savedScroll - 1 && attempts < 30) {
-              requestAnimationFrame(tryRestore);
-            } else {
-              cleanup();
-            }
-          };
-          requestAnimationFrame(tryRestore);
+          restoreScrollTop(restoreEl, savedScroll, finishRestore);
         }
       }
       isLoadingRef.current = false;
@@ -282,6 +298,25 @@ export function DocumentEditorPanel({
     // `pages` is intentionally excluded from deps — it is read imperatively
     // inside the timeout to avoid stale closures and spurious re-runs.
   }, [activePageId, updatePageContent, editor, clearTiptapHistory, isRelayDoc]);
+
+  // Relay docs: the collab editor is keyed per page (`docId:pageId:sessionEpoch`)
+  // so a page-switch remounts it and scroll resets to 0. The page-switch effect
+  // above owns content for relay docs and skips the local restore, so restore
+  // here once the freshly-mounted editor reports ready (`editor` changes). The
+  // leaving page's scrollTop was already saved by the page-switch effect.
+  useEffect(() => {
+    if (!isRelayDoc || !editor) return;
+    const pageId = lastActivePageRef.current;
+    if (!pageId) return;
+    const saved = useSessionStore.getState().getEditorScroll(pageId) ?? 0;
+    if (saved <= 0) return;
+    const el = getScrollEl(editor);
+    if (!el) return;
+    restoreInProgressRef.current = true;
+    restoreScrollTop(el, saved, () => {
+      restoreInProgressRef.current = false;
+    });
+  }, [editor, isRelayDoc, getScrollEl]);
 
   // Continuously persist scroll position of the active page (debounced).
   // Re-attaches whenever the editor instance changes since the scroll container

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -15,7 +15,7 @@
  * - Embedded groups from canvas
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { history } from 'prosemirror-history';
@@ -35,15 +35,13 @@ import Color from '@tiptap/extension-color';
 import TextAlign from '@tiptap/extension-text-align';
 import Link from '@tiptap/extension-link';
 import { useRichTextStore } from '../store/richTextStore';
-import { resolveBlobUrl } from '../storage/blobResolver';
 import { EmbeddedGroup } from '../tiptap/EmbeddedGroupExtension';
 import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
-import { SpellcheckExtension, rebuildSpellcheck } from '../tiptap/SpellcheckExtension';
-import { SpellcheckService } from '../services/SpellcheckService';
-import { SpellcheckPopover } from './SpellcheckPopover';
-import { DocumentEditorContextMenu } from './DocumentEditorContextMenu';
+import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
+import { useProseEditorChrome } from './useProseEditorChrome';
+import { resolveBlobImagesIn } from './proseBlobImages';
 import 'katex/dist/katex.min.css';
 import './TiptapEditor.css';
 
@@ -171,15 +169,6 @@ export const extensions = [
   ...sharedProseExtensions,
 ];
 
-/**
- * Context menu state for the document editor.
- */
-interface ContextMenuState {
-  isOpen: boolean;
-  x: number;
-  y: number;
-}
-
 export interface TiptapEditorProps {
   /** Optional class name */
   className?: string;
@@ -192,21 +181,6 @@ import type { Editor } from '@tiptap/core';
 export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
   const content = useRichTextStore((state) => state.content);
   const setContent = useRichTextStore((state) => state.setContent);
-
-  // Context menu state
-  const [contextMenu, setContextMenu] = useState<ContextMenuState>({
-    isOpen: false,
-    x: 0,
-    y: 0,
-  });
-
-  // Spellcheck popover state
-  const [spellPopover, setSpellPopover] = useState<{
-    word: string;
-    range: { from: number; to: number };
-    x: number;
-    y: number;
-  } | null>(null);
 
   const editor = useEditor({
     extensions,
@@ -226,90 +200,10 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
     },
   });
 
-  // DOM-level click handler so inline link clicks reliably fire (handleClickOn
-  // doesn't trigger consistently for inline marks in all browsers).
-  useEffect(() => {
-    if (!editor) return;
-    const dom = editor.view.dom;
-    const onClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
-      if (!anchor || !dom.contains(anchor)) return;
-      const href = anchor.getAttribute('href') || '';
-
-      const headingMatch = href.match(/^docushark:\/\/heading\/([^/]+)\/(\d+)$/);
-      if (headingMatch) {
-        event.preventDefault();
-        event.stopPropagation();
-        const pageId = headingMatch[1]!;
-        const headingIndex = parseInt(headingMatch[2]!, 10);
-        import('../store/richTextPagesStore').then(({ useRichTextPagesStore }) => {
-          const store = useRichTextPagesStore.getState();
-          if (store.activePageId !== pageId) store.setActivePage(pageId);
-          const scrollToHeading = (attempts = 0) => {
-            const headings = document.querySelectorAll(
-              '.tiptap-prose h1, .tiptap-prose h2, .tiptap-prose h3, .tiptap-prose h4, .tiptap-prose h5, .tiptap-prose h6',
-            );
-            const el = headings[headingIndex] as HTMLElement | undefined;
-            if (el) {
-              el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            } else if (attempts < 30) {
-              requestAnimationFrame(() => scrollToHeading(attempts + 1));
-            }
-          };
-          requestAnimationFrame(() => scrollToHeading());
-        });
-        return;
-      }
-      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
-        event.preventDefault();
-        event.stopPropagation();
-        window.open(href, '_blank', 'noopener,noreferrer');
-      }
-    };
-    dom.addEventListener('click', onClick);
-    return () => dom.removeEventListener('click', onClick);
-  }, [editor]);
-
-  // Handle context menu — show spellcheck popover when right-clicking a misspelled word,
-  // otherwise show the regular formatting context menu.
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    const target = e.target as HTMLElement | null;
-    const errorSpan = target?.closest('.spellcheck-error') as HTMLElement | null;
-    if (errorSpan && editor) {
-      e.preventDefault();
-      const word = errorSpan.textContent || '';
-      const view = editor.view;
-      const pos = view.posAtDOM(errorSpan, 0);
-      const range = { from: pos, to: pos + word.length };
-      setSpellPopover({ word, range, x: e.clientX, y: e.clientY });
-      return;
-    }
-    e.preventDefault();
-    setContextMenu({
-      isOpen: true,
-      x: e.clientX,
-      y: e.clientY,
-    });
-  }, [editor]);
-
-  const handleCloseContextMenu = useCallback(() => {
-    setContextMenu((prev) => ({ ...prev, isOpen: false }));
-  }, []);
-
-  // Push the document's custom dictionary into the spellcheck service whenever it changes
-  useEffect(() => {
-    if (!editor) return;
-    const words = content.customDictionary;
-    if (words && words.length > 0) {
-      SpellcheckService.loadCustomWords(words);
-      // rebuildSpellcheck dispatches a Tiptap transaction; defer past
-      // the effect commit so flushSync doesn't fire inside a lifecycle.
-      queueMicrotask(() => {
-        if (!editor.isDestroyed) rebuildSpellcheck(editor.view);
-      });
-    }
-  }, [editor, content.customDictionary]);
+  // Shared editor chrome: right-click formatting menu, spellcheck popover,
+  // custom-dictionary loader, inline-link handling (heading anchors on for the
+  // local multi-page editor), and blob:// image resolution.
+  const { onContextMenu, overlay } = useProseEditorChrome(editor, { headingAnchors: true });
 
   // Update editor content when loaded from document.
   // setContent dispatches a Tiptap transaction that synchronously mounts
@@ -340,26 +234,9 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
       });
       editor.view.updateState(editor.state.reconfigure({ plugins: newPlugins }));
 
-      // Convert blob:// URLs after content is set (slight delay for DOM update)
-      requestAnimationFrame(async () => {
-        const editorElement = editor.view.dom;
-        const images = editorElement.querySelectorAll('img[src^="blob://"]');
-
-        for (const element of Array.from(images)) {
-          const img = element as HTMLImageElement;
-          const blobUrl = img.getAttribute('src');
-          if (!blobUrl) continue;
-
-          const objectUrl = await resolveBlobUrl(blobUrl);
-          if (objectUrl && objectUrl !== blobUrl) {
-            img.setAttribute('src', objectUrl);
-          } else if (!objectUrl) {
-            img.setAttribute('alt', '(Image not found)');
-            img.style.border = '2px dashed var(--border-color)';
-            img.style.padding = '8px';
-          }
-        }
-      });
+      // Resolve blob:// images after content is set (slight delay for DOM
+      // update); on-update resolution is handled by useProseEditorChrome.
+      requestAnimationFrame(() => void resolveBlobImagesIn(editor.view.dom));
     });
   }, [editor, content.content]);
 
@@ -375,66 +252,10 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
     };
   }, [editor, onEditorReady]);
 
-  // Convert blob:// URLs to object URLs for rendering
-  useEffect(() => {
-    if (!editor) return;
-
-    const convertBlobUrls = async () => {
-      const editorElement = editor.view.dom;
-      const images = editorElement.querySelectorAll('img[src^="blob://"]');
-
-      for (const element of Array.from(images)) {
-        const img = element as HTMLImageElement;
-        const blobUrl = img.getAttribute('src');
-        if (!blobUrl) continue;
-
-        const objectUrl = await resolveBlobUrl(blobUrl);
-        if (objectUrl && objectUrl !== blobUrl) {
-          img.setAttribute('src', objectUrl);
-        } else if (!objectUrl) {
-          // Show placeholder for missing blobs
-          img.setAttribute('alt', '(Image not found)');
-          img.style.border = '2px dashed var(--border-color)';
-          img.style.padding = '8px';
-        }
-      }
-    };
-
-    // Convert on initial load
-    convertBlobUrls();
-
-    // Convert whenever content updates
-    const handleUpdate = () => {
-      convertBlobUrls();
-    };
-
-    editor.on('update', handleUpdate);
-    return () => {
-      editor.off('update', handleUpdate);
-    };
-  }, [editor]);
-
   return (
-    <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={handleContextMenu}>
+    <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={onContextMenu}>
       <EditorContent editor={editor} />
-      {contextMenu.isOpen && (
-        <DocumentEditorContextMenu
-          x={contextMenu.x}
-          y={contextMenu.y}
-          onClose={handleCloseContextMenu}
-          editor={editor}
-        />
-      )}
-      {spellPopover && editor && (
-        <SpellcheckPopover
-          editor={editor}
-          word={spellPopover.word}
-          range={spellPopover.range}
-          x={spellPopover.x}
-          y={spellPopover.y}
-          onClose={() => setSpellPopover(null)}
-        />
-      )}
+      {overlay}
     </div>
   );
 }

--- a/src/ui/proseBlobImages.ts
+++ b/src/ui/proseBlobImages.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve `blob://<hash>` rich-text images inside an editor DOM subtree to
+ * directly-loadable object URLs.
+ *
+ * Shared by both prose editors (the local `TiptapEditor` and the
+ * `CollaborativeProseEditor`) and the local content-load swap — a single
+ * implementation so the two editors can't drift on how embedded images render.
+ *
+ * Resolution goes through the shared `blobResolver` (JP-129): cached object URL
+ * → local IndexedDB → download from the relay/R2 on a miss, so images embedded
+ * on another device render here too. Already-loadable `data:`/`http(s):` srcs
+ * are returned unchanged; a true miss shows an inline placeholder.
+ */
+
+import { resolveBlobUrl } from '../storage/blobResolver';
+
+export async function resolveBlobImagesIn(dom: HTMLElement): Promise<void> {
+  const images = dom.querySelectorAll('img[src^="blob://"]');
+  for (const el of Array.from(images)) {
+    const img = el as HTMLImageElement;
+    const blobUrl = img.getAttribute('src');
+    if (!blobUrl) continue;
+
+    const objectUrl = await resolveBlobUrl(blobUrl);
+    if (objectUrl && objectUrl !== blobUrl) {
+      img.setAttribute('src', objectUrl);
+    } else if (!objectUrl) {
+      // Show a placeholder for a blob we genuinely can't resolve.
+      img.setAttribute('alt', '(Image not found)');
+      img.style.border = '2px dashed var(--border-color)';
+      img.style.padding = '8px';
+    }
+  }
+}

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -1,0 +1,196 @@
+/**
+ * useProseEditorChrome — the shared chrome both prose editors hang off a Tiptap
+ * instance.
+ *
+ * The local-only `TiptapEditor` and the relay `CollaborativeProseEditor` differ
+ * only in their essential axes (extensions: history vs Collaboration; content
+ * source: `richTextStore` vs the Y.XmlFragment; the `onUpdate` target). Every
+ * other per-instance behavior — the right-click formatting menu, the spellcheck
+ * popover, the custom-dictionary loader, inline-link handling, and `blob://`
+ * image resolution — is identical, and used to be copied into both. That
+ * duplication is the "two editors drift apart" seam that caused the collab-prose
+ * data-loss bugs, so it lives here once and both editors call it.
+ *
+ * Returns the `onContextMenu` handler to spread on the editor container plus the
+ * `overlay` node (the menu + popover portals) to render inside it.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { Editor } from '@tiptap/core';
+import { useRichTextStore } from '../store/richTextStore';
+import { rebuildSpellcheck } from '../tiptap/SpellcheckExtension';
+import { SpellcheckService } from '../services/SpellcheckService';
+import { SpellcheckPopover } from './SpellcheckPopover';
+import { DocumentEditorContextMenu } from './DocumentEditorContextMenu';
+import { resolveBlobImagesIn } from './proseBlobImages';
+
+interface ContextMenuState {
+  isOpen: boolean;
+  x: number;
+  y: number;
+}
+
+interface SpellPopoverState {
+  word: string;
+  range: { from: number; to: number };
+  x: number;
+  y: number;
+}
+
+export interface ProseEditorChromeOptions {
+  /**
+   * Handle in-document `docushark://heading/<pageId>/<index>` anchors as
+   * cross-page heading navigation. This is a local-doc concern (the legacy
+   * editor owns multi-page nav); the collab editor leaves it off so its
+   * behavior is unchanged.
+   */
+  headingAnchors?: boolean;
+}
+
+export interface ProseEditorChrome {
+  /** Spread onto the editor container `div`. */
+  onContextMenu: (e: React.MouseEvent) => void;
+  /** Render inside the editor container (context menu + spellcheck popover). */
+  overlay: React.ReactNode;
+}
+
+export function useProseEditorChrome(
+  editor: Editor | null,
+  opts: ProseEditorChromeOptions = {},
+): ProseEditorChrome {
+  const { headingAnchors = false } = opts;
+  const customDictionary = useRichTextStore((s) => s.content.customDictionary);
+
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>({
+    isOpen: false,
+    x: 0,
+    y: 0,
+  });
+  const [spellPopover, setSpellPopover] = useState<SpellPopoverState | null>(null);
+
+  // Right-click: show the spellcheck popover when over a misspelled word,
+  // otherwise the formatting context menu.
+  const onContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      if (!editor) return;
+      const target = e.target as HTMLElement | null;
+      const errorSpan = target?.closest('.spellcheck-error') as HTMLElement | null;
+      if (errorSpan) {
+        e.preventDefault();
+        const word = errorSpan.textContent || '';
+        const pos = editor.view.posAtDOM(errorSpan, 0);
+        const range = { from: pos, to: pos + word.length };
+        setSpellPopover({ word, range, x: e.clientX, y: e.clientY });
+        return;
+      }
+      e.preventDefault();
+      setContextMenu({ isOpen: true, x: e.clientX, y: e.clientY });
+    },
+    [editor],
+  );
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenu((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  // Push the document's custom dictionary into the spellcheck service whenever
+  // it changes, then force a fresh pass so already-typed words update.
+  useEffect(() => {
+    if (!editor) return;
+    if (customDictionary && customDictionary.length > 0) {
+      SpellcheckService.loadCustomWords(customDictionary);
+      // rebuildSpellcheck dispatches a Tiptap transaction; defer past the
+      // effect commit so flushSync doesn't fire inside a lifecycle.
+      queueMicrotask(() => {
+        if (!editor.isDestroyed) rebuildSpellcheck(editor.view);
+      });
+    }
+  }, [editor, customDictionary]);
+
+  // DOM-level click handler so inline link clicks reliably fire (handleClickOn
+  // doesn't trigger consistently for inline marks in all browsers). Opens
+  // http(s)/mailto in a new tab; with `headingAnchors`, also resolves
+  // `docushark://heading` cross-page nav.
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+    const onClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
+      if (!anchor || !dom.contains(anchor)) return;
+      const href = anchor.getAttribute('href') || '';
+
+      if (headingAnchors) {
+        const headingMatch = href.match(/^docushark:\/\/heading\/([^/]+)\/(\d+)$/);
+        if (headingMatch) {
+          event.preventDefault();
+          event.stopPropagation();
+          const pageId = headingMatch[1]!;
+          const headingIndex = parseInt(headingMatch[2]!, 10);
+          import('../store/richTextPagesStore').then(({ useRichTextPagesStore }) => {
+            const store = useRichTextPagesStore.getState();
+            if (store.activePageId !== pageId) store.setActivePage(pageId);
+            const scrollToHeading = (attempts = 0) => {
+              const headings = document.querySelectorAll(
+                '.tiptap-prose h1, .tiptap-prose h2, .tiptap-prose h3, .tiptap-prose h4, .tiptap-prose h5, .tiptap-prose h6',
+              );
+              const el = headings[headingIndex] as HTMLElement | undefined;
+              if (el) {
+                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              } else if (attempts < 30) {
+                requestAnimationFrame(() => scrollToHeading(attempts + 1));
+              }
+            };
+            requestAnimationFrame(() => scrollToHeading());
+          });
+          return;
+        }
+      }
+
+      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
+        event.preventDefault();
+        event.stopPropagation();
+        window.open(href, '_blank', 'noopener,noreferrer');
+      }
+    };
+    dom.addEventListener('click', onClick);
+    return () => dom.removeEventListener('click', onClick);
+  }, [editor, headingAnchors]);
+
+  // Resolve blob:// images to object URLs (initial + on every update) —
+  // collaborators on other devices embed images we must load.
+  useEffect(() => {
+    if (!editor) return;
+    const convert = () => void resolveBlobImagesIn(editor.view.dom);
+    convert();
+    editor.on('update', convert);
+    return () => {
+      editor.off('update', convert);
+    };
+  }, [editor]);
+
+  const overlay = (
+    <>
+      {contextMenu.isOpen && editor && (
+        <DocumentEditorContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onClose={closeContextMenu}
+          editor={editor}
+        />
+      )}
+      {spellPopover && editor && (
+        <SpellcheckPopover
+          editor={editor}
+          word={spellPopover.word}
+          range={spellPopover.range}
+          x={spellPopover.x}
+          y={spellPopover.y}
+          onClose={() => setSpellPopover(null)}
+        />
+      )}
+    </>
+  );
+
+  return { onContextMenu, overlay };
+}


### PR DESCRIPTION
Closes JP-173. Finishes off collaborative prose (Slice 3 polish) by bringing `CollaborativeProseEditor` — now the prose editor for **every relay doc** since JP-171 dropped the flag — to parity with the legacy local-doc `TiptapEditor`.

## What & why

The two editors duplicated a cluster of per-instance effects. That duplication *is* the "two editors drift apart" seam behind this sprint's offline data-loss bugs, so the fix extracts the shared chrome once instead of copying a fourth thing into the second editor.

- **New `useProseEditorChrome`** — right-click formatting menu + spellcheck popover, custom-dictionary loader, inline-link handling (`headingAnchors` opt for the local multi-page editor), and `blob://` image resolution. Both editors consume it. New `proseBlobImages.resolveBlobImagesIn` de-dups the **3** copies of blob-image resolution.
- **`richTextStore.setContent` preserves `customDictionary`** — it previously replaced `content` wholesale, wiping the dictionary on the next keystroke and making "Add to Dictionary" a no-op across reloads. The collab editor's new popover surfaces this, so it's fixed here (+ store test).
- **Collab scroll-restore** — extracted `restoreScrollTop`; the per-page-keyed collab editor now restores scroll on remount (the relay path previously skipped it).
- **Yjs undo — verified, no code.** The canvas undo handler is bound to the canvas element (canvas-focus scoped), so `Mod-Z`/`Mod-Y` in the prose editor route to the `Collaboration` UndoManager (local-only undo). The JP-178 `historyStore` no-op isn't on this path.

Net **−235 lines** across the two editors.

## Verification

- `bun run typecheck` clean; `bun run test --run` → **1828 passed** (+2 new `setContent` dictionary tests).
- Manual E2E pending (real acceptance): on a **relay** doc with a live session — right-click selection → formatting menu applies; right-click a red-underlined word → suggestions + Add to Dictionary, both apply, clear the underline, and **survive a reload**; switch prose pages and back → scroll restores; `Mod-Z`/`Mod-Y` undoes only your own edits. Confirm a **local-only** doc is unchanged. Two-client check that a context-menu format edit syncs live.

## Out of scope (follow-ups to file)

Full `BaseProseEditor` unification; `posAtDOM` spellcheck-range fragility; per-update blob-resolution cost; deprecated `getTiptapEditor()` global; collab-doc custom-dictionary cross-session persistence (belongs with the JP-186 relay round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)