### PR TITLE
JP-189: relay prose poison guard — recovery point on multi-page zeroing

### DIFF
--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -48,7 +48,10 @@ use std::num::NonZeroU32;
 use protocol::*;
 use crate::auth::{AuthError, OidcAuthState, OidcClaims, WorkspaceRole};
 use crate::config::{StorageConfig, SyncConfig, TenancyConfig, TenancyMode};
-use crate::sync::{active_page_shape_count, suspicious_zeroing, DocHandle, DocRegistry};
+use crate::sync::{
+    active_page_shape_count, prose_count_in_binary, suspicious_prose_zeroing, suspicious_zeroing,
+    DocHandle, DocRegistry,
+};
 use blob_backend::S3Backend;
 
 /// Per-workspace token-bucket limiter shared between WS sync handlers
@@ -749,25 +752,54 @@ impl ServerState {
             return;
         }
 
-        // JP-180 poison guard: if this snapshot would zero a resident doc
-        // (prior on-disk N>0 → live 0 shapes), copy the prior-good sidecar into
-        // the recovery store *before* the binary write below overwrites it.
-        // This runs ahead of every persist path so a tombstone-zeroing can't be
-        // permanent; a legitimate select-all+delete is backed up too (the two
-        // are indistinguishable here) and still persists normally.
+        // Poison guard (JP-180 shapes / JP-189 prose): if this snapshot would
+        // zero a resident doc's content, copy the prior-good sidecar into the
+        // recovery store *before* the binary write below overwrites it. Runs
+        // ahead of every persist path so a tombstone-zeroing can't be permanent.
+        // We back up + still persist (the relay can't always distinguish poison
+        // from a genuine delete), so a real edit still goes through.
         if self.poison_guard {
+            let mut reason: Option<String> = None;
+
+            // Shapes (JP-180): prior on-disk N>0 → live 0. The JSON snapshot is
+            // the baseline. A legitimate select-all+delete is indistinguishable
+            // here and is backed up too.
             if let Ok(prior_json) = self.doc_store.get_document(ws, doc_id) {
                 let prior = active_page_shape_count(&prior_json);
                 if suspicious_zeroing(prior, handle.shape_count()) {
-                    log::error!(
-                        "snapshot would zero {}/{} (prior {} shapes → 0); \
-                         backing up the prior state to the recovery store first",
-                        ws.as_str(),
-                        doc_id.as_str(),
-                        prior
-                    );
-                    self.doc_store.push_recovery_point(ws, doc_id);
+                    reason = Some(format!("prior {prior} shapes → 0"));
                 }
+            }
+
+            // Prose (JP-189): ≥2 prose pages emptied at once — structurally
+            // impossible from a real edit (you can only clear one focused
+            // editor). Prose has no JSON reference (the relay flattens shapes
+            // only), so the baseline is the prior *binary* sidecar.
+            if let Some(prior_prose) = self
+                .doc_store
+                .load_ydoc_binary(ws, doc_id)
+                .and_then(|b| prose_count_in_binary(&b))
+            {
+                let current_prose = handle.prose_count();
+                if suspicious_prose_zeroing(prior_prose, current_prose) {
+                    let msg = format!(
+                        "{prior_prose} prose pages → {current_prose} (≥2 emptied at once)"
+                    );
+                    reason = Some(match reason {
+                        Some(shapes) => format!("{shapes}; {msg}"),
+                        None => msg,
+                    });
+                }
+            }
+
+            if let Some(reason) = reason {
+                log::error!(
+                    "snapshot would zero {}/{} ({reason}); \
+                     backing up the prior state to the recovery store first",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                );
+                self.doc_store.push_recovery_point(ws, doc_id);
             }
         }
 

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
-use yrs::{Doc, Map, Transact};
+use yrs::{Doc, Map, ReadTxn, Transact, XmlFragment};
 
 use crate::server::protocol::{DocId, WorkspaceId};
 
@@ -49,6 +49,54 @@ fn doc_shape_count(doc: &Doc) -> usize {
 /// permanent and a real delete-all still goes through.
 pub fn suspicious_zeroing(prior: usize, current: usize) -> bool {
     prior > 0 && current == 0
+}
+
+/// Count the `prose:<pageId>` roots that currently hold content (JP-189). Prose
+/// pages bind to Tiptap's `Collaboration` extension as `Y.XmlFragment`s named
+/// `prose:<pageId>`. A page is "non-empty" when its fragment has ≥1 child node —
+/// Tiptap never leaves a page truly empty (it keeps an empty paragraph), so a
+/// `prose:*` root at 0 length is an abnormal zeroing, not a user edit.
+///
+/// `root_refs` is used only for the **names**: a doc hydrated from a binary
+/// update (`doc_from_update`) — or the live relay doc, whose prose roots only
+/// ever arrive via applied client updates — hasn't *branded* its root type
+/// kinds, so the `Out` value isn't reliably `YXmlFragment`. The name is always
+/// present, though; we read each prose root through the typed getter, which
+/// brands + exposes its length.
+fn doc_prose_count(doc: &Doc) -> usize {
+    let names: Vec<String> = {
+        let txn = doc.transact();
+        txn.root_refs()
+            .map(|(name, _)| name)
+            .filter(|name| name.starts_with("prose:"))
+            .map(String::from)
+            .collect()
+    };
+    names
+        .iter()
+        .filter(|name| doc.get_or_insert_xml_fragment(name.as_str()).len(&doc.transact()) > 0)
+        .count()
+}
+
+/// Non-empty `prose:*` page count of a binary `Y.Doc` sidecar (JP-189), or
+/// `None` if the blob can't be decoded. Used to read the *prior* persisted prose
+/// state — unlike shapes, prose has no JSON reference (the relay only flattens
+/// shapes), so the comparison baseline is the previous binary sidecar.
+pub fn prose_count_in_binary(bytes: &[u8]) -> Option<usize> {
+    let (_version, update) = binary::decode_header(bytes)?;
+    let doc = binary::doc_from_update(update).ok()?;
+    Some(doc_prose_count(&doc))
+}
+
+/// True when a snapshot would empty **≥2** prose pages at once (JP-189). A user
+/// can only clear the one prose editor they're focused on, so multiple pages
+/// going non-empty → empty in a single snapshot is structurally impossible from
+/// a real edit — unambiguous poison. (Unlike shapes, where a select-all+delete
+/// legitimately zeroes everything, so JP-180 can only back-up-and-still-persist;
+/// here the signal is high enough to alarm on confidently.) A single page
+/// emptying is left alone to avoid false positives on a genuine page clear/delete.
+pub fn suspicious_prose_zeroing(prior: usize, current: usize) -> bool {
+    prior.saturating_sub(current) >= 2
 }
 
 /// The authoritative Y.Doc for a single active document, plus the sync
@@ -138,6 +186,13 @@ impl DocHandle {
     /// written to disk.
     pub fn shape_count(&self) -> usize {
         doc_shape_count(&self.doc)
+    }
+
+    /// Number of non-empty `prose:*` pages currently in the live `Y.Doc`. Used
+    /// by the JP-189 persist guard to detect a multi-page prose zeroing before
+    /// it's written to disk.
+    pub fn prose_count(&self) -> usize {
+        doc_prose_count(&self.doc)
     }
 
     /// Encode the live `Y.Doc` as a binary sidecar blob tagged with
@@ -404,6 +459,59 @@ mod tests {
         assert!(!super::suspicious_zeroing(0, 0), "empty → empty is fine");
         assert!(!super::suspicious_zeroing(0, 3), "growth is fine");
         assert!(!super::suspicious_zeroing(3, 2), "partial delete is fine");
+    }
+
+    // ---- JP-189 prose poison guard ----
+
+    /// A `Y.Doc` with `non_empty` populated `prose:*` pages (one `<paragraph>`
+    /// child each, the production `Y.XmlFragment` shape) plus `empty` empty ones
+    /// and an unrelated `shapes` map (must be ignored by the prose count).
+    fn prose_doc(non_empty: usize, empty: usize) -> Doc {
+        use yrs::{XmlElementPrelim, XmlFragment};
+        let doc = Doc::new();
+        // Grab the root handles *before* the txn (`get_or_insert_*` transacts).
+        let full: Vec<_> = (0..non_empty)
+            .map(|i| doc.get_or_insert_xml_fragment(format!("prose:p{i}")))
+            .collect();
+        for i in 0..empty {
+            doc.get_or_insert_xml_fragment(format!("prose:empty{i}"));
+        }
+        let shapes = doc.get_or_insert_map("shapes");
+        let mut txn = doc.transact_mut();
+        for frag in &full {
+            frag.insert(&mut txn, 0, XmlElementPrelim::empty("paragraph"));
+        }
+        shapes.insert(&mut txn, "s1", yrs::Any::String("rect".into()));
+        drop(txn);
+        doc
+    }
+
+    #[test]
+    fn doc_prose_count_counts_only_non_empty_prose_pages() {
+        // 2 populated + 1 empty prose page; the shapes map is not prose.
+        assert_eq!(super::doc_prose_count(&prose_doc(2, 1)), 2);
+        assert_eq!(super::doc_prose_count(&prose_doc(0, 3)), 0);
+        assert_eq!(super::doc_prose_count(&prose_doc(5, 0)), 5);
+    }
+
+    #[test]
+    fn prose_count_in_binary_roundtrips() {
+        let blob = binary::encode_snapshot(1, &prose_doc(3, 0));
+        assert_eq!(super::prose_count_in_binary(&blob), Some(3));
+        assert_eq!(super::prose_count_in_binary(b"not a sidecar"), None);
+    }
+
+    #[test]
+    fn suspicious_prose_zeroing_needs_two_pages_emptied() {
+        assert!(super::suspicious_prose_zeroing(3, 1), "2 pages emptied = poison");
+        assert!(super::suspicious_prose_zeroing(2, 0), "both pages emptied = poison");
+        assert!(
+            !super::suspicious_prose_zeroing(2, 1),
+            "one page cleared is a legit edit"
+        );
+        assert!(!super::suspicious_prose_zeroing(1, 0), "single page emptied is allowed");
+        assert!(!super::suspicious_prose_zeroing(0, 0), "no prose, no trigger");
+        assert!(!super::suspicious_prose_zeroing(1, 5), "growth is fine");
     }
 
     fn key() -> (WorkspaceId, DocId) {


### PR DESCRIPTION
Closes JP-189. Sibling of JP-180 (which guards canvas shapes). Defends collab **prose** against the kind of mass-deletion seen during rapid PWA reloads.

## The invariant that makes this stronger than the shape guard

JP-180 has to "back up + still persist" because a select-all+delete legitimately zeroes every shape — poison and intent are indistinguishable. **Prose is different:** a user can only clear the one prose editor they're focused on, so **≥2 `prose:<pageId>` fragments going non-empty → empty in a single snapshot is structurally impossible from a real edit** — unambiguous poison.

## What landed (v1: backup + alarm, the chosen scope)

- **`sync/mod.rs`**
  - `doc_prose_count` — counts non-empty `prose:*` pages. Uses `root_refs` only for the **names** (a binary-hydrated doc, and the live relay doc whose prose arrives via applied client updates, don't *brand* root type kinds), then reads each via the typed `XmlFragment` getter. "Non-empty" = ≥1 child node (Tiptap never leaves a page truly empty, so 0 = abnormal).
  - `prose_count_in_binary` — the **prior** baseline. Unlike shapes, prose has no JSON reference (the relay flattens shapes only), so the baseline is the previous **binary sidecar**.
  - `suspicious_prose_zeroing(prior, current)` = `prior - current >= 2`. A single page clear is left alone (avoids false positives on a genuine page delete).
  - `DocHandle::prose_count()`.
- **`server/mod.rs` `snapshot_doc`** — folds prose detection into the existing JP-180 poison block: push **one** recovery point (the bounded ring) if shapes *or* prose zeroing is detected, with a combined log line. Gated by the same `[sync] poison_guard` flag (`RELAY_POISON_GUARD`). Backup + alarm; the state still persists.

## Tests

Mirrors JP-180's strategy — helper unit tests + the existing recovery-store tests:
- `doc_prose_count_counts_only_non_empty_prose_pages`
- `prose_count_in_binary_roundtrips` (encode → decode → count, incl. the unbranded-root case)
- `suspicious_prose_zeroing_needs_two_pages_emptied` (threshold + no-false-positive cases)
- `DocumentStore::push_recovery_point`/`list_recovery_points` already covered.

**214 relay tests green; clippy clean.** The `snapshot_doc` wiring is a direct structural mirror of JP-180's (itself helper-tested) — same live-E2E acceptance as JP-180.

## Deferred (per JP-189)

Auto-heal/reject (restore prior prose while keeping current shapes) needs a JSON prose reference (JP-186) or CRDT surgery; recovery → restore is JP-183 (501 stub today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)