### PR TITLE
JP-123: make relay auth readiness atomic (+ relay token-stored indicator)

### DIFF
--- a/src/collaboration/SyncStateManager.ts
+++ b/src/collaboration/SyncStateManager.ts
@@ -265,7 +265,10 @@ export class SyncStateManager {
    */
   async processQueue(): Promise<ProcessResult[]> {
     if (!this.provider || !this.provider.isReady()) {
-      console.log('[SyncStateManager] Cannot process queue: not connected');
+      // Not an error or an outage: the provider isn't ready yet (no token / auth
+      // still settling). The queue is durable and replays once auth completes
+      // (JP-123). Logged at debug to avoid reading like a connection failure.
+      console.debug('[SyncStateManager] Provider not ready — deferring queue replay until authenticated');
       return [];
     }
 
@@ -324,7 +327,8 @@ export class SyncStateManager {
    */
   async processQueueForHost(relayId: string): Promise<ProcessResult[]> {
     if (!this.provider || !this.provider.isReady()) {
-      console.log('[SyncStateManager] Cannot process queue: not connected');
+      // See processQueue(): a deferral, not a failure — replays once authenticated (JP-123).
+      console.debug('[SyncStateManager] Provider not ready — deferring queue replay until authenticated');
       return [];
     }
 

--- a/src/collaboration/UnifiedSyncProvider.test.ts
+++ b/src/collaboration/UnifiedSyncProvider.test.ts
@@ -314,6 +314,29 @@ describe('UnifiedSyncProvider', () => {
       });
     });
 
+    it('JP-123: notifies onAuthenticated before flipping status to authenticated', () => {
+      // "Ready to operate" is a two-flag composite: connectionStore.status ===
+      // 'authenticated' AND a flag the onAuthenticated handler sets. connectionStore
+      // notifies subscribers synchronously inside setStatus, so onAuthenticated must
+      // run first — otherwise a status-flip subscriber sees the second flag still
+      // false and bails ("Cannot process queue: not connected"). Guard the ordering.
+      provider = createProvider({ token: 'valid-token' });
+      provider.connect();
+      mockWebSocket?.simulateOpen();
+
+      mockWebSocket?.simulateMessage(
+        encodeMessage(MESSAGE_AUTH_RESPONSE, { success: true, userId: 'user-1' }),
+      );
+
+      const authedStatusOrder = onStatusChange.mock.calls
+        .map((args, i) => ({ status: args[0], order: onStatusChange.mock.invocationCallOrder[i]! }))
+        .find((c) => c.status === 'authenticated')?.order;
+      const onAuthOrder = onAuthenticated.mock.invocationCallOrder[0];
+
+      expect(authedStatusOrder).toBeDefined();
+      expect(onAuthOrder).toBeLessThan(authedStatusOrder!);
+    });
+
     it('transitions to error on failed auth response', () => {
       provider = createProvider({ token: 'invalid-token' });
       provider.connect();

--- a/src/collaboration/UnifiedSyncProvider.ts
+++ b/src/collaboration/UnifiedSyncProvider.ts
@@ -507,7 +507,6 @@ export class UnifiedSyncProvider {
 
       if (response.success) {
         this.authenticated = true;
-        this.setStatus('authenticated');
 
         const user: AuthenticatedUser | undefined = response.userId
           ? { id: response.userId, username: response.username ?? '', role: response.role ?? undefined }
@@ -515,7 +514,19 @@ export class UnifiedSyncProvider {
 
         useConnectionStore.getState().setUser(user ?? null);
 
+        // JP-123: notify the auth listener BEFORE flipping connectionStore.status
+        // to 'authenticated'. "Ready to operate" is a two-flag composite —
+        // connectionStore.status === 'authenticated' AND a second flag the
+        // onAuthenticated handler sets (relayDocumentStore.authenticated). Because
+        // connectionStore notifies its subscribers *synchronously* inside
+        // setStatus(), flipping status first would run those subscribers (e.g.
+        // SyncStateManager's queue-replay hook) while the second flag was still
+        // false — the benign-but-misleading "Cannot process queue: not connected".
+        // Setting the dependent flag first makes readiness atomic from any
+        // subscriber's view.
         this.options.onAuthenticated?.(true, user);
+
+        this.setStatus('authenticated');
       } else {
         this.setStatus('error', response.error ?? 'Authentication failed');
         this.options.onAuthenticated?.(false);

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -432,11 +432,15 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
           // unsynced in-session edits, so a save fires on connect — not only
           // on the next edit (JP-106 follow-up).
           //
-          // NOTE: SyncStateManager's own autoProcessOnReconnect hook fires on
-          // the connectionStore status flip to 'authenticated', which happens
-          // *before* setAuthenticated() above — so at that instant the
-          // provider's isReady() is still false and the auto-process bails.
-          // We re-trigger here, after setAuthenticated, where isReady() holds.
+          // SyncStateManager's autoProcessOnReconnect hook also fires on the
+          // connectionStore status flip to 'authenticated'. Since JP-123 the
+          // provider sets relayDocumentStore.authenticated (via setAuthenticated
+          // above) BEFORE flipping that status, so the generic hook now sees a
+          // ready provider and replays on its own. This block stays as the
+          // explicit on-connect orchestration (reattach → drain THIS relay's
+          // queue → push unsynced edits); the queue drain overlaps the generic
+          // hook harmlessly — processQueueForHost no-ops while already syncing
+          // or when the queue is empty.
           if (success) {
             // Replay only this relay's queued entries — not another relay's
             // (JP-117). `config.serverUrl` is the relay we just authenticated to.

--- a/src/ui/settings/RelaySettings.css
+++ b/src/ui/settings/RelaySettings.css
@@ -64,6 +64,19 @@
   background: var(--color-bg, #f1f5f9);
 }
 
+.relay-settings__token-stored {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-secondary, #64748b);
+  background: var(--color-bg, #f1f5f9);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+}
+
 .relay-settings__error {
   display: flex;
   align-items: flex-start;

--- a/src/ui/settings/RelaySettings.tsx
+++ b/src/ui/settings/RelaySettings.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { Cloud, LogIn, LogOut, AlertCircle, ExternalLink, Loader2 } from 'lucide-react';
+import { Cloud, LogIn, LogOut, AlertCircle, ExternalLink, Loader2, KeyRound } from 'lucide-react';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useCollaborationStore } from '../../collaboration';
 import { usePersistenceStore } from '../../store/persistenceStore';
@@ -47,6 +47,7 @@ export function RelaySettings() {
   const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
   const [cloudUrl, setCloudUrl] = useState(DEFAULT_CLOUD_BASE_URL);
 
+  const [hasStoredToken, setHasStoredToken] = useState(false);
   const [phase, setPhase] = useState<SignInPhase>('idle');
   const [userCode, setUserCode] = useState<string | null>(null);
   const [verificationUri, setVerificationUri] = useState<string | null>(null);
@@ -68,6 +69,25 @@ export function RelaySettings() {
       active = false;
     };
   }, []);
+
+  // Surface whether a relay token is already persisted (JP-100 IndexedDB store),
+  // so a signed-out-looking page still tells the user a session is saved and will
+  // resume on sign-in. Re-checked on every status change — a successful sign-in
+  // persists the token, Disconnect clears it via clearJwt().
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const persisted = await loadConnection();
+      if (!active) return;
+      const valid =
+        !!persisted?.jwt &&
+        (persisted.jwtExpiresAt === null || persisted.jwtExpiresAt > Date.now());
+      setHasStoredToken(valid);
+    })();
+    return () => {
+      active = false;
+    };
+  }, [status]);
 
   // Cancel any in-flight device-code poll if the tab unmounts.
   useEffect(() => {
@@ -194,6 +214,13 @@ export function RelaySettings() {
               !isConnecting &&
               'Disconnected'}
           </div>
+
+          {hasStoredToken && !isBusy ? (
+            <div className="relay-settings__token-stored" role="status">
+              <KeyRound size={14} />
+              <span>Saved session token — sign in to resume</span>
+            </div>
+          ) : null}
 
           {(collabError || signInError) && phase !== 'awaiting' ? (
             <div className="relay-settings__error" role="alert">


### PR DESCRIPTION
Resolves the JP-123 investigation: the "auth up, transport down" relay-switch symptom.

## Root cause
"Ready to operate" is a two-flag composite (`App.tsx`): `connectionStore.status === 'authenticated'` **AND** `relayDocumentStore.authenticated`. `UnifiedSyncProvider.handleAuthResponse` set those in two steps straddling a *synchronous* subscription — it flipped `connectionStore.status` first (notifying `SyncStateManager`'s queue-replay hook), then set the second flag via `onAuthenticated`. At the flip the second flag was still false → `isReady()` false → the misleading **"Cannot process queue: not connected"** (a benign early-bail that `onAuthenticated` immediately re-triggered). No data loss, but confusing — it cost ~an hour of debugging.

## Fix (minimal, root-cause)
- `handleAuthResponse` calls `onAuthenticated` (which sets `relayDocumentStore.authenticated`) **before** `setStatus('authenticated')`, so readiness is atomic from any subscriber's view and the spurious bail can't occur.
- Demoted + clarified the two `SyncStateManager` "Cannot process queue" logs to `console.debug` deferrals.
- Updated the `collaborationStore` on-connect comment to match the new ordering.
- Regression guard in `UnifiedSyncProvider.test.ts`: asserts `onAuthenticated` fires before the `'authenticated'` status flip.

Decision (logged on JP-123): keep `connectionStore.status` semantics — no new "joined session" enum value, no relay-protocol churn. The rest of the issue's suspect list (queue mis-route, staleness sweep, ERR_UNKNOWN_DOC) was already mitigated by JP-117 + existing `onError`/`shouldJoinDocument` handling.

## Also included
A **"Saved session token"** indicator in the Relay Connection settings panel: when a valid relay token is persisted (JP-100 IndexedDB store) but the panel is signed out, it tells the user the session resumes on sign-in. Re-checked on every status change.

## Verification
- Full suite: 1840 tests pass; typecheck clean.
- **Left for E2E**: relay switch local→staging (confirm the debug log is gone and queue/sync fire once on auth), and the indicator appears after Disconnect / clears after full sign-out.