### PR TITLE
JP-192: unified write provenance (JP-184 Slice 1)

### DIFF
--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -16,16 +16,11 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { useDocumentStore, getStoreChangeKind } from '../store/documentStore';
+import { useDocumentStore } from '../store/documentStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { getProvenance, runWithProvenance } from '../store/writeProvenance';
 import { useCollaborationStore } from './collaborationStore';
-
-/**
- * Flag to prevent sync loops.
- * When applying remote changes, we don't want to re-sync them back.
- */
-let isApplyingRemoteChanges = false;
 
 /**
  * Hook that manages bidirectional sync between CRDT and document store.
@@ -71,8 +66,7 @@ export function useCollaborationSync(): void {
 
     // Handle remote shape changes
     const unsubShapes = yjsDoc.onShapeChange((added, updated, removed) => {
-      isApplyingRemoteChanges = true;
-      try {
+      runWithProvenance('remote-apply', () => {
         const store = useDocumentStore.getState();
 
         // Add new shapes
@@ -89,19 +83,14 @@ export function useCollaborationSync(): void {
         if (removed.length > 0) {
           store.deleteShapes(removed);
         }
-      } finally {
-        isApplyingRemoteChanges = false;
-      }
+      });
     });
 
     // Handle remote order changes
     const unsubOrder = yjsDoc.onOrderChange((order) => {
-      isApplyingRemoteChanges = true;
-      try {
+      runWithProvenance('remote-apply', () => {
         useDocumentStore.getState().reorderShapes(order);
-      } finally {
-        isApplyingRemoteChanges = false;
-      }
+      });
     });
 
     // Handle remote document-name changes (CRDT-native rename). The name lives
@@ -144,8 +133,7 @@ export function useCollaborationSync(): void {
       // The Y.Doc is the complete truth — replace the views with it. Safe in
       // both modes: online it's the idb+relay merge, offline it's the persisted
       // state for this exact doc's room.
-      isApplyingRemoteChanges = true;
-      try {
+      runWithProvenance('remote-apply', () => {
         const store = useDocumentStore.getState();
         store.clear();
         store.addShapes(Array.from(crdtShapes.values()));
@@ -153,9 +141,7 @@ export function useCollaborationSync(): void {
         if (crdtOrder.length > 0) {
           store.reorderShapes(crdtOrder);
         }
-      } finally {
-        isApplyingRemoteChanges = false;
-      }
+      });
       // Adopt the relay's authoritative document name too (CRDT-native rename),
       // so a joining client picks up a rename made before it connected.
       const docId = useCollaborationStore.getState().config?.documentId;
@@ -177,12 +163,9 @@ export function useCollaborationSync(): void {
       // doc never reaches this branch: its REST `saveToHost` populates the relay
       // first, so it syncs in via the `crdtShapes.size > 0` adopt above. Offline
       // (`!hasProvider`) never reaches here either (isSynced is false).
-      isApplyingRemoteChanges = true;
-      try {
+      runWithProvenance('remote-apply', () => {
         useDocumentStore.getState().clear();
-      } finally {
-        isApplyingRemoteChanges = false;
-      }
+      });
       initializedRef.current = true;
     }
     // else: offline + empty Y.Doc — defer (leave `initializedRef` false). The
@@ -197,17 +180,17 @@ export function useCollaborationSync(): void {
     // Subscribe to document store changes
     const unsubscribe = useDocumentStore.subscribe(
       (state, prevState) => {
-        // Skip if we're applying remote changes (prevents sync loops)
-        if (isApplyingRemoteChanges) return;
-
-        // Skip a programmatic whole-store replacement (JP-178). A document load,
+        // Propagate only human-authored deltas. `remote-apply` is the bridge
+        // re-applying an inbound CRDT change (skipping it prevents sync loops);
+        // `load` is a programmatic whole-store load/replace — a document load,
         // page-switch, or undo/redo snapshot restore wipes-and-reloads
-        // documentStore via `loadSnapshot`/`clear`, which tag the mutation
-        // `'replace'`. Without this the diff below reads that wipe as user
-        // deletions and broadcasts CRDT tombstones to every client (the #59
-        // mass-deletion bug). This is the structural guarantee — it no longer
-        // depends on every load caller remembering to suppress.
-        if (getStoreChangeKind() === 'replace') return;
+        // documentStore via `loadSnapshot`/`clear`. Diffing either as user edits
+        // would broadcast CRDT tombstones to every client (the #59 mass-deletion
+        // bug, JP-178/JP-192). `user-edit` and `programmatic` fall through and
+        // propagate. This is the structural guarantee — no caller need remember
+        // to set a suppression flag.
+        const provenance = getProvenance();
+        if (provenance === 'remote-apply' || provenance === 'load') return;
 
         // Belt-and-suspenders: also skip while autosave is suppressed (a load
         // replaying content). `loadDocumentToPageStore` wraps loads in
@@ -294,7 +277,7 @@ export function useCollaborationSync(): void {
  * Useful for preventing redundant operations.
  */
 export function isRemoteSyncInProgress(): boolean {
-  return isApplyingRemoteChanges;
+  return getProvenance() === 'remote-apply';
 }
 
 export default useCollaborationSync;

--- a/src/services/importPipeline.ts
+++ b/src/services/importPipeline.ts
@@ -13,6 +13,7 @@ import type { Shape } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { findImportAdapter, type ImportResult, type ImportWarning } from '../shapes/import/ImportAdapter';
 import { useDocumentStore } from '../store/documentStore';
+import { mutateDocument } from '../store/writeProvenance';
 import { useSessionStore } from '../store/sessionStore';
 import { useShapeLibraryStore } from '../store/shapeLibraryStore';
 import { useNotificationStore } from '../store/notificationStore';
@@ -80,7 +81,12 @@ export function applyImportResult(
     useShapeLibraryStore.getState().registerShapes(libraryDefs);
   }
 
-  useDocumentStore.getState().addShapes(shapes);
+  // An import is app-generated content, not a keystroke — route through the
+  // provenance entrypoint (JP-192) so it propagates to collaborators as a
+  // distinct `programmatic` write rather than masquerading as a user edit.
+  mutateDocument('programmatic', () => {
+    useDocumentStore.getState().addShapes(shapes);
+  });
 
   const ids = shapes.map((s) => s.id);
   if (ids.length > 0) {

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -5,6 +5,7 @@ import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Box } from '../math/Box';
 import { calculateConnectorWaypoints } from '../engine/OrthogonalRouter';
 import { wouldCreateCycle, wouldExceedMaxDepth, findParentGroup } from '../shapes/GroupHierarchy';
+import { getProvenance, runWithProvenance } from './writeProvenance';
 
 /**
  * Document state containing all shape data.
@@ -123,28 +124,21 @@ let lastSnapshotIntegrity: SnapshotIntegrity = {
 };
 
 /**
- * Provenance of the in-flight documentStore mutation (JP-178).
- *
- * `'replace'` means a programmatic **whole-store replacement** — a document
- * load, page-switch, or undo/redo snapshot restore (always via `loadSnapshot`
- * or `clear`). `'edit'` means a genuine per-shape/structural mutation.
+ * Provenance of the in-flight documentStore mutation, in the legacy
+ * `'edit' | 'replace'` the collab bridge consumes — now **derived** from the
+ * unified write-provenance context (JP-192). A `'load'` provenance (snapshot
+ * restore, page-switch, `clear`) reads as `'replace'`; everything else
+ * (`user-edit`, `programmatic`) reads as `'edit'`.
  *
  * The collaboration bridge (`useCollaborationSync`) MUST NOT propagate a
  * `'replace'` to the CRDT: diffing a wipe-and-reload as user edits broadcasts a
- * mass deletion to every client (the #59 mass-deletion bug). Making the two
- * bulk ops tag themselves here removes the reliance on every caller remembering
- * to set a suppression flag.
- *
- * Zustand notifies subscribers **synchronously inside `set()`**, so a bulk op
- * brackets its `set()` with `'replace'` … `'edit'`: the flag reads `'replace'`
- * exactly while the bridge's subscription runs for that mutation, and `'edit'`
- * at all other times. No reset bookkeeping in the other actions is needed.
+ * mass deletion to every client (the #59 mass-deletion bug, JP-178).
+ * `loadSnapshot`/`clear` run their `set()` inside `runWithProvenance('load', …)`;
+ * Zustand notifies subscribers synchronously inside `set()`, so the bridge sees
+ * the `'load'` provenance exactly while it diffs that mutation.
  */
-let lastChangeKind: 'edit' | 'replace' = 'edit';
-
-/** Provenance of the most recent documentStore mutation — see {@link lastChangeKind}. */
 export function getStoreChangeKind(): 'edit' | 'replace' {
-  return lastChangeKind;
+  return getProvenance() === 'load' ? 'replace' : 'edit';
 }
 
 /**
@@ -384,21 +378,22 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
       };
 
       // A snapshot load is a programmatic whole-store replacement, never user
-      // edits — tag it so the collab bridge skips it (JP-178). Reset right
-      // after `set()`, whose subscribers (incl. the bridge) ran synchronously.
-      lastChangeKind = 'replace';
-      set((state) => {
-        // Clear existing data
-        state.shapes = {};
-        state.shapeOrder = [];
+      // edits — run under `'load'` provenance so the collab bridge skips it
+      // (JP-178/JP-192). Zustand's subscribers (incl. the bridge) run
+      // synchronously inside `set()`, so the provenance holds exactly then.
+      runWithProvenance('load', () => {
+        set((state) => {
+          // Clear existing data
+          state.shapes = {};
+          state.shapeOrder = [];
 
-        // Load snapshot data
-        state.shapes = JSON.parse(JSON.stringify(incomingShapes));
-        // Filter out any orphaned IDs to keep rendering stable; the integrity
-        // flag above lets the persistence layer refuse a save if needed.
-        state.shapeOrder = incomingOrder.filter((id) => state.shapes[id]);
+          // Load snapshot data
+          state.shapes = JSON.parse(JSON.stringify(incomingShapes));
+          // Filter out any orphaned IDs to keep rendering stable; the integrity
+          // flag above lets the persistence layer refuse a save if needed.
+          state.shapeOrder = incomingOrder.filter((id) => state.shapes[id]);
+        });
       });
-      lastChangeKind = 'edit';
     },
 
     getLastSnapshotIntegrity: (): SnapshotIntegrity => lastSnapshotIntegrity,
@@ -417,13 +412,14 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
     clear: () => {
       // A wholesale clear is a programmatic replacement, never user edits
-      // (JP-178) — tag it so the collab bridge skips it. See loadSnapshot.
-      lastChangeKind = 'replace';
-      set((state) => {
-        state.shapes = {};
-        state.shapeOrder = [];
+      // (JP-178/JP-192) — run under `'load'` provenance so the collab bridge
+      // skips it. See loadSnapshot.
+      runWithProvenance('load', () => {
+        set((state) => {
+          state.shapes = {};
+          state.shapeOrder = [];
+        });
       });
-      lastChangeKind = 'edit';
     },
 
     // Group operations

--- a/src/store/writeProvenance.test.ts
+++ b/src/store/writeProvenance.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getProvenance,
+  runWithProvenance,
+  mutateDocument,
+  type Provenance,
+} from './writeProvenance';
+
+describe('writeProvenance (JP-192)', () => {
+  it('defaults to user-edit', () => {
+    expect(getProvenance()).toBe('user-edit');
+  });
+
+  it('sets provenance for the callback duration and restores after', () => {
+    const seen: Provenance[] = [];
+    const ret = runWithProvenance('load', () => {
+      seen.push(getProvenance());
+      return 42;
+    });
+    expect(seen).toEqual(['load']);
+    expect(ret).toBe(42);
+    expect(getProvenance()).toBe('user-edit');
+  });
+
+  it('nests and unwinds to the enclosing provenance', () => {
+    // Mirrors the real case: a clear() (load) dispatched inside the bridge's
+    // remote-apply adopt block must restore to remote-apply, not user-edit.
+    const trail: Provenance[] = [];
+    runWithProvenance('remote-apply', () => {
+      trail.push(getProvenance());
+      runWithProvenance('load', () => {
+        trail.push(getProvenance());
+      });
+      trail.push(getProvenance());
+    });
+    expect(trail).toEqual(['remote-apply', 'load', 'remote-apply']);
+    expect(getProvenance()).toBe('user-edit');
+  });
+
+  it('restores provenance even when the callback throws', () => {
+    expect(() =>
+      runWithProvenance('load', () => {
+        throw new Error('boom');
+      }),
+    ).toThrow('boom');
+    expect(getProvenance()).toBe('user-edit');
+  });
+
+  it('mutateDocument tags the write provenance', () => {
+    const seen: Provenance[] = [];
+    mutateDocument('programmatic', () => seen.push(getProvenance()));
+    expect(seen).toEqual(['programmatic']);
+    expect(getProvenance()).toBe('user-edit');
+  });
+});

--- a/src/store/writeProvenance.ts
+++ b/src/store/writeProvenance.ts
@@ -1,0 +1,73 @@
+/**
+ * Write provenance — the single source of truth for *who* is writing to the
+ * document right now, so every content producer is collab-safe by construction
+ * instead of re-deriving ad-hoc guards (JP-184 / JP-192, Slice 1).
+ *
+ * It unifies flags that previously each encoded one slice of "is this a real
+ * user delta the CRDT should propagate?":
+ *   - `documentStore.lastChangeKind` (`'replace'` ⇒ a load) — now derived here.
+ *   - `useCollaborationSync.isApplyingRemoteChanges` (the bridge re-applying an
+ *     inbound CRDT change) — now `runWithProvenance('remote-apply', …)`.
+ *   (`autoSaveGuard` stays an independent belt-and-suspenders flag for now;
+ *    folded in by Slice 3 — JP-194.)
+ *
+ * Rule the collab bridge enforces: a `documentStore` mutation is diffed into the
+ * CRDT only for `user-edit` and `programmatic` provenance. `load` and
+ * `remote-apply` are NOT human-authored deltas and must never be diffed as
+ * edits — that is the #59 mass-deletion class of bug.
+ */
+
+export type Provenance =
+  /** A live human edit — the default when nothing sets otherwise. */
+  | 'user-edit'
+  /** App/agent/import-generated content. Propagates to the CRDT, but is not a
+   *  human edit (lets consumers treat it distinctly when they need to). */
+  | 'programmatic'
+  /** The bridge applying an inbound CRDT change to the local store. */
+  | 'remote-apply'
+  /** A programmatic whole-store load/replace: snapshot restore, page switch,
+   *  `clear`. Never a per-shape user delta. */
+  | 'load';
+
+let current: Provenance = 'user-edit';
+
+/** The active write provenance. Readers (e.g. the collab bridge) gate on this. */
+export function getProvenance(): Provenance {
+  return current;
+}
+
+/**
+ * Run `fn` with the active write provenance set to `provenance`, restoring the
+ * previous value on exit. Nestable — a `clear()` (`load`) invoked inside a
+ * `remote-apply` block, or a load inside a load, unwinds to the right value.
+ *
+ * Zustand notifies subscribers **synchronously inside `set()`**, so any store
+ * mutation dispatched within `fn` is observed by the collab bridge while this
+ * provenance holds — no async bookkeeping needed.
+ */
+export function runWithProvenance<T>(provenance: Provenance, fn: () => T): T {
+  const previous = current;
+  current = provenance;
+  try {
+    return fn();
+  } finally {
+    current = previous;
+  }
+}
+
+/**
+ * The canonical client write entrypoint (JP-184). Content producers — canvas
+ * tools, importers, prose injectors (Slice 2), the dictionary update, auto-gen —
+ * route writes through here so provenance is attached by construction rather
+ * than re-derived per writer.
+ *
+ * In Slice 1 `mutate` performs the existing store/CRDT writes (no dataflow
+ * inversion); the typed op-as-data stream that lets the bridge consume ops
+ * instead of diffing the whole store layers on later (JP-195).
+ */
+export function mutateDocument<T>(
+  provenance: 'user-edit' | 'programmatic',
+  mutate: () => T,
+): T {
+  return runWithProvenance(provenance, mutate);
+}


### PR DESCRIPTION
First slice of JP-184 (collab-safe content mutation bus). Establishes the single, provenance-aware write seam — **no dataflow inversion**, mostly mechanical, preserves the #59 mass-deletion guarantees.

## What's here
- **`src/store/writeProvenance.ts`** (new) — `type Provenance = 'user-edit' | 'programmatic' | 'remote-apply' | 'load'`, a nestable `runWithProvenance(p, fn)`, `getProvenance()`, and the canonical `mutateDocument(provenance, mutate)` client write entrypoint. (Op-as-data stream for the diff-free bridge is deferred to JP-195.)
- **`documentStore.ts`** — `loadSnapshot`/`clear` run their `set()` under `runWithProvenance('load', …)`; `getStoreChangeKind()` is **derived** from provenance (kept as a shim). Removed the standalone `lastChangeKind` global.
- **`useCollaborationSync.ts`** — replaced the `isApplyingRemoteChanges` module global with `runWithProvenance('remote-apply', …)` around all remote-apply blocks; the bridge skip gate reads `getProvenance()` (skips `load` + `remote-apply`, propagates `user-edit` + `programmatic`). `isRemoteSyncInProgress()` derives.
- **`importPipeline.ts`** — `applyImportResult` routes `addShapes` through `mutateDocument('programmatic', …)`: the first real consumer of `programmatic`, so an import propagates to collaborators as a distinct programmatic write rather than masquerading as a keystroke.

## Deferred (by design)
- `autoSaveGuard` left as independent belt-and-suspenders (the bridge still also checks `isAutoSaveSuppressed()`); folded in by Slice 3 (JP-194).
- Prose CRDT-native write primitive is Slice 2 (JP-193) — it plugs into `mutateDocument`.

## Verification
- Full suite **1844 pass**, typecheck clean. New `writeProvenance.test.ts` covers default/set/restore/nesting/throw/`mutateDocument`. JP-181 hook net + documentStore provenance test pass unchanged.
- **Suggested E2E** (regression-confirmation, two clients on one relay doc): a load/page-switch/undo on A must NOT delete B's shapes (#59 guard); a live edit on A appears on B; an Excalidraw import on A appears on B without dupes/wipes.

Rebased onto master post-#72.