### PR TITLE
JP-193: CRDT-native headless prose write (JP-184 Slice 2)

### DIFF
--- a/src/collaboration/YjsDocument.prose.test.ts
+++ b/src/collaboration/YjsDocument.prose.test.ts
@@ -1,0 +1,97 @@
+/**
+ * JP-193 — CRDT-native headless prose write (`YjsDocument.setProse`/`appendProse`).
+ * Promoted from the JP-184 spike; asserts the primitive against a registered
+ * schema (here a StarterKit-only stand-in; the app registers the full editor
+ * schema from the prose chunk at runtime — see TiptapEditor.tsx).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getSchema, Editor, type JSONContent } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import Collaboration from '@tiptap/extension-collaboration';
+import { yXmlFragmentToProseMirrorRootNode } from 'y-prosemirror';
+import { YjsDocument } from './YjsDocument';
+import { registerProseSchema, __resetProseSchemaForTests } from './proseSchema';
+
+// History off — Collaboration owns undo; matches CollaborativeProseEditor.
+const testExtensions = [StarterKit.configure({ history: false })];
+const schema = getSchema(testExtensions);
+
+function paras(...texts: string[]): JSONContent {
+  return {
+    type: 'doc',
+    content: texts.map((text) => ({
+      type: 'paragraph',
+      content: text ? [{ type: 'text', text }] : [],
+    })),
+  };
+}
+
+function readText(doc: YjsDocument, pageId: string): string {
+  const node = yXmlFragmentToProseMirrorRootNode(
+    doc.getDoc().getXmlFragment(`prose:${pageId}`),
+    schema,
+  );
+  return node.textBetween(0, node.content.size, '\n');
+}
+
+describe('YjsDocument prose (JP-193)', () => {
+  beforeEach(() => registerProseSchema(schema));
+  afterEach(() => __resetProseSchemaForTests());
+
+  it('setProse then appendProse merges — existing content preserved', () => {
+    const doc = new YjsDocument();
+    doc.setProse('p1', paras('Hello world'));
+    expect(readText(doc, 'p1')).toBe('Hello world');
+
+    doc.appendProse('p1', paras('Injected by an agent'));
+    expect(readText(doc, 'p1')).toBe('Hello world\nInjected by an agent');
+  });
+
+  it('setProse replaces the page content (merge-safe diff, not a wipe)', () => {
+    const doc = new YjsDocument();
+    doc.setProse('p1', paras('First', 'Second'));
+    doc.setProse('p1', paras('Replaced'));
+    expect(readText(doc, 'p1')).toBe('Replaced');
+  });
+
+  it('scopes writes per page via the prose:<pageId> fragment', () => {
+    const doc = new YjsDocument();
+    doc.setProse('p1', paras('Page one'));
+    doc.setProse('p2', paras('Page two'));
+    expect(readText(doc, 'p1')).toBe('Page one');
+    expect(readText(doc, 'p2')).toBe('Page two');
+  });
+
+  it('a mounted Collaboration editor live-reflects a headless append without clobber', async () => {
+    const doc = new YjsDocument();
+    doc.setProse('p1', paras('Hello world'));
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({
+      element,
+      extensions: [
+        ...testExtensions,
+        Collaboration.configure({ document: doc.getDoc(), field: 'prose:p1' }),
+      ],
+    });
+    expect(editor.getHTML()).toContain('Hello world');
+
+    // Write headlessly — NOT via editor commands — and let ySyncPlugin observe.
+    doc.appendProse('p1', paras('Injected by an agent'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const html = editor.getHTML();
+    expect(html).toContain('Hello world'); // not clobbered
+    expect(html).toContain('Injected by an agent'); // live-reflected
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('throws a clear error when no schema is registered', () => {
+    __resetProseSchemaForTests();
+    const doc = new YjsDocument();
+    expect(() => doc.setProse('p1', paras('x'))).toThrow(/no schema registered/);
+  });
+});

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -17,7 +17,10 @@
  */
 
 import * as Y from 'yjs';
+import { yXmlFragmentToProseMirrorRootNode, updateYFragment } from 'y-prosemirror';
+import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
+import { getProseSchema } from './proseSchema';
 
 /**
  * Document metadata stored in Yjs
@@ -120,6 +123,53 @@ export class YjsDocument {
    */
   getShapeOrderArray(): Y.Array<string> {
     return this.shapeOrder;
+  }
+
+  // ============ Prose (CRDT-native, JP-193) ============
+
+  /**
+   * The Y.XmlFragment backing a prose page, matching the field the live
+   * `CollaborativeProseEditor` binds (`prose:<pageId>`) — so a headless write
+   * here is reflected by a mounted editor, and vice versa.
+   */
+  private proseFragment(pageId: string): Y.XmlFragment {
+    return this.doc.getXmlFragment(`prose:${pageId}`);
+  }
+
+  /**
+   * Replace a prose page's content with `docJSON` (a ProseMirror *doc* node — the
+   * shape `editor.getJSON()` returns) as a minimal, merge-safe CRDT diff, never a
+   * wholesale fragment wipe. Built with the registered editor schema so the
+   * result is structurally identical to a typed edit. Headless — needs no
+   * mounted editor; a bound editor live-reflects the change via y-prosemirror.
+   */
+  setProse(pageId: string, docJSON: JSONContent): void {
+    const schema = getProseSchema();
+    const node = schema.nodeFromJSON(docJSON);
+    const fragment = this.proseFragment(pageId);
+    this.doc.transact(() => {
+      updateYFragment(this.doc, fragment, node, { mapping: new Map(), isOMark: new Map() });
+    });
+  }
+
+  /**
+   * Append `docJSON`'s top-level blocks to a prose page, preserving existing
+   * content — the merge-safe injector path (never clobbers what's there).
+   */
+  appendProse(pageId: string, docJSON: JSONContent): void {
+    const schema = getProseSchema();
+    const fragment = this.proseFragment(pageId);
+    const current = yXmlFragmentToProseMirrorRootNode(fragment, schema).toJSON() as {
+      content?: unknown[];
+    };
+    const merged: JSONContent = {
+      type: 'doc',
+      content: [...(current.content ?? []), ...(docJSON.content ?? [])] as JSONContent[],
+    };
+    const node = schema.nodeFromJSON(merged);
+    this.doc.transact(() => {
+      updateYFragment(this.doc, fragment, node, { mapping: new Map(), isOMark: new Map() });
+    });
   }
 
   // ============ Local to Remote Sync ============

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -37,6 +37,8 @@ import { clearJwt, saveConnection } from '../api/relayConnection';
 import { useNotificationStore } from '../store/notificationStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { isRemoteDocument } from '../types/DocumentRegistry';
+import { mutateDocument } from '../store/writeProvenance';
+import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
 import type { DocEvent } from './protocol';
 import { isUnknownDocError } from './protocol';
@@ -146,6 +148,17 @@ interface CollaborationActions {
    * stale title vs an out-of-band REST rename.
    */
   syncDocumentName: (name: string) => void;
+
+  // Prose (CRDT-native programmatic writes, JP-193)
+  /**
+   * Append prose blocks to a page's `prose:<pageId>` CRDT fragment as a
+   * `programmatic` write (merge-safe; preserves existing content). The single
+   * safe path for injectors/auto-gen to write collab prose without a mounted
+   * editor — stores stay read-only projections.
+   */
+  appendProse: (pageId: string, docJSON: JSONContent) => void;
+  /** Replace a page's prose with a merge-safe CRDT diff (`programmatic` write). */
+  setProse: (pageId: string, docJSON: JSONContent) => void;
 
   // Document switching
   /** Switch to a different document for CRDT sync */
@@ -610,6 +623,21 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         // relay order this against a possibly-concurrent REST rename.
         yjsDoc.setMetadata({ title: name, updatedAt: Date.now() });
       }
+    },
+
+    appendProse: (pageId: string, docJSON: JSONContent) => {
+      const doc = yjsDoc;
+      if (!doc) return;
+      // Tag as `programmatic` (JP-192) — distinct from a keystroke, but still a
+      // real authored write. The CRDT fragment is the truth; a mounted editor
+      // (if any) live-reflects it, and richTextPages stays a pure projection.
+      mutateDocument('programmatic', () => doc.appendProse(pageId, docJSON));
+    },
+
+    setProse: (pageId: string, docJSON: JSONContent) => {
+      const doc = yjsDoc;
+      if (!doc) return;
+      mutateDocument('programmatic', () => doc.setProse(pageId, docJSON));
     },
 
     switchDocument: (docId: string) => {

--- a/src/collaboration/proseSchema.ts
+++ b/src/collaboration/proseSchema.ts
@@ -1,0 +1,54 @@
+/**
+ * Prose schema registry (JP-193).
+ *
+ * The CRDT-native prose write primitive (`YjsDocument.setProse`/`appendProse`)
+ * must build ProseMirror nodes with the SAME schema the live editor uses, so
+ * `updateYFragment` diffs them into the shared `prose:<pageId>` fragment exactly
+ * as a typed edit would. But that schema is defined by the editor's Tiptap
+ * extensions — some (EmbeddedGroup) pull React + UI components, and the whole
+ * stack (katex, nspell) is deliberately lazy-loaded out of the main bundle.
+ *
+ * Statically importing the extensions into the collaboration layer would invert
+ * layering and drag UI/heavy deps into headless code. So the prose chunk
+ * *registers* its built schema when it loads (see `TiptapEditor.tsx`), and the
+ * collaboration layer reads it here — the same seam as `registerAutoSaveFlush` /
+ * `registerTokenRefresher`.
+ *
+ * Consequence: a programmatic prose write requires the prose chunk to have
+ * loaded (an editor shown at least once). That holds while the only writers are
+ * editor-adjacent; a future pre-editor injector must ensure the chunk is
+ * imported first.
+ */
+import type { Schema } from '@tiptap/pm/model';
+
+let proseSchema: Schema | null = null;
+
+/** Register the editor's ProseMirror schema (called from the prose chunk at load). */
+export function registerProseSchema(schema: Schema): void {
+  proseSchema = schema;
+}
+
+/** True once a schema has been registered. */
+export function hasProseSchema(): boolean {
+  return proseSchema !== null;
+}
+
+/**
+ * The registered prose schema. Throws if called before registration — a
+ * programmatic prose write before the editor schema is wired is a bug, not a
+ * silent no-op to swallow.
+ */
+export function getProseSchema(): Schema {
+  if (!proseSchema) {
+    throw new Error(
+      '[proseSchema] no schema registered — the prose chunk must load (an editor shown) ' +
+        'before a programmatic prose write (JP-193)',
+    );
+  }
+  return proseSchema;
+}
+
+/** Test-only: clear the registered schema between cases. */
+export function __resetProseSchemaForTests(): void {
+  proseSchema = null;
+}

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
+import { getSchema } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import { history } from 'prosemirror-history';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -42,6 +43,7 @@ import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import { resolveBlobImagesIn } from './proseBlobImages';
+import { registerProseSchema } from '../collaboration/proseSchema';
 import 'katex/dist/katex.min.css';
 import './TiptapEditor.css';
 
@@ -168,6 +170,12 @@ export const extensions = [
   }),
   ...sharedProseExtensions,
 ];
+
+// Register this schema for headless/programmatic prose writes (JP-193). It lives
+// here, in the lazily-loaded prose chunk, so the heavy tiptap/katex/nspell stack
+// stays out of the main bundle. History on/off and the Collaboration plugin add
+// no nodes/marks, so this schema matches `CollaborativeProseEditor`'s exactly.
+registerProseSchema(getSchema(extensions));
 
 export interface TiptapEditorProps {
   /** Optional class name */


### PR DESCRIPTION
Second slice of JP-184. Closes the one real gap the spike de-risked: **prose had no programmatic CRDT write** — the only way to write collab prose was typing in a mounted editor, so the coming injector/auto-gen wave had nowhere safe to write.

## What's here
- **`YjsDocument.setProse(pageId, docJSON)` / `appendProse(pageId, docJSON)`** — write the shared `prose:<pageId>` `Y.XmlFragment` **headlessly** via `y-prosemirror`'s `yXmlFragmentToProseMirrorRootNode` + `updateYFragment` inside a `transact`. Minimal **merge-safe** diffs (never a wholesale wipe); inherits Yjs convergence. A mounted `CollaborativeProseEditor` live-reflects the change; an unmounted page persists it in the Y.Doc.
- **`proseSchema.ts`** — a `registerProseSchema`/`getProseSchema` seam (same pattern as `registerAutoSaveFlush`/`registerTokenRefresher`). The prose chunk (`TiptapEditor.tsx`) registers `getSchema(extensions)` on load.
- **`collaborationStore.appendProse`/`setProse`** — the canonical entry, tagged `programmatic` via `mutateDocument` (JP-192), so a prose injection is distinct authored provenance, not a keystroke. `richTextPages`/`richTextStore` stay pure projections.

## Layering decisions (flagged)
- The prose schema **needs the heavy editor extensions** (EmbeddedGroup pulls React; katex/nspell are lazy-chunked). So the schema is **registered from the lazy prose chunk**, not statically imported — keeps the heavy stack out of the main bundle and avoids a UI→collaboration layering inversion. Consequence: a programmatic prose write requires the prose chunk to have loaded (an editor shown at least once); fine while writers are editor-adjacent, documented in `proseSchema.ts` for a future pre-editor injector.
- The custom-dictionary "drop a sibling field" hazard cited in JP-184 is **already mitigated** (richTextStore.setContent spreads to preserve siblings) and isn't a prose-fragment write, so it's intentionally out of scope here.

## Verification
- Full suite **1847 pass**, typecheck clean. `YjsDocument.prose.test.ts` (promoted from the spike): merge / replace / per-page scoping / live-editor reflection / unregistered-schema guard.
- **Suggested E2E**: with the editor open on a relay doc, call `collaborationStore.appendProse(activePageId, …)` from the console (or via a future injector) → text appears live, existing prose intact, and propagates to a second client.

Builds on JP-192 (`mutateDocument`/provenance). Branch off fresh master.