### PR TITLE
JP-194: retire dead getStoreChangeKind; document the kept autosave guard (JP-184 Slice 3)

### DIFF
--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -192,10 +192,14 @@ export function useCollaborationSync(): void {
         const provenance = getProvenance();
         if (provenance === 'remote-apply' || provenance === 'load') return;
 
-        // Belt-and-suspenders: also skip while autosave is suppressed (a load
-        // replaying content). `loadDocumentToPageStore` wraps loads in
-        // `withAutoSaveSuppressed`; this still gates any non-bulk *edit* action
-        // dispatched inside a suppressed block, and serves autosave's own needs.
+        // Belt-and-suspenders, deliberately KEPT (JP-194): also skip while
+        // autosave is suppressed. This is COARSER than the provenance gate above
+        // — `withAutoSaveSuppressed` covers the entire doc-load block
+        // (`loadDocumentToPageStore`), whereas `'load'` provenance only covers the
+        // synchronous `documentStore.loadSnapshot`/`clear` window. Any store write
+        // during a load that doesn't route through those would slip the precise
+        // gate but not this one. It caused painful CRDT debugging once; it stays
+        // as cheap insurance against the #59 mass-deletion class.
         if (isAutoSaveSuppressed()) return;
 
         // Skip if collaboration not active

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -3,8 +3,8 @@ import {
   useDocumentStore,
   getShapesByIds,
   shapeExists,
-  getStoreChangeKind,
 } from './documentStore';
+import { getProvenance } from './writeProvenance';
 import { RectangleShape } from '../shapes/Shape';
 
 /**
@@ -36,27 +36,27 @@ describe('Document Store', () => {
     useDocumentStore.getState().clear();
   });
 
-  describe('change provenance (JP-178)', () => {
-    it('tags loadSnapshot and clear as replace, edits as edit', () => {
+  describe('write provenance (JP-178/JP-192)', () => {
+    it('runs loadSnapshot and clear under load provenance, edits under user-edit', () => {
       const store = useDocumentStore.getState();
-      const kinds: Array<'edit' | 'replace'> = [];
+      const seen: string[] = [];
       const unsub = useDocumentStore.subscribe(() => {
-        kinds.push(getStoreChangeKind());
+        seen.push(getProvenance());
       });
 
-      store.addShape(createTestRect({ id: 'a' })); // edit
-      store.loadSnapshot({ shapes: {}, shapeOrder: [], version: 1 }); // replace
-      store.addShape(createTestRect({ id: 'b' })); // edit
-      store.clear(); // replace
+      store.addShape(createTestRect({ id: 'a' })); // user-edit
+      store.loadSnapshot({ shapes: {}, shapeOrder: [], version: 1 }); // load
+      store.addShape(createTestRect({ id: 'b' })); // user-edit
+      store.clear(); // load
       unsub();
 
-      expect(kinds).toEqual(['edit', 'replace', 'edit', 'replace']);
-      // The flag brackets each bulk op and resets to 'edit' afterwards.
-      expect(getStoreChangeKind()).toBe('edit');
+      expect(seen).toEqual(['user-edit', 'load', 'user-edit', 'load']);
+      // Provenance is restored after each bulk op.
+      expect(getProvenance()).toBe('user-edit');
     });
 
-    it('defaults to edit (no bulk op in flight)', () => {
-      expect(getStoreChangeKind()).toBe('edit');
+    it('defaults to user-edit (no bulk op in flight)', () => {
+      expect(getProvenance()).toBe('user-edit');
     });
   });
 

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -5,7 +5,7 @@ import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Box } from '../math/Box';
 import { calculateConnectorWaypoints } from '../engine/OrthogonalRouter';
 import { wouldCreateCycle, wouldExceedMaxDepth, findParentGroup } from '../shapes/GroupHierarchy';
-import { getProvenance, runWithProvenance } from './writeProvenance';
+import { runWithProvenance } from './writeProvenance';
 
 /**
  * Document state containing all shape data.
@@ -123,23 +123,11 @@ let lastSnapshotIntegrity: SnapshotIntegrity = {
   at: 0,
 };
 
-/**
- * Provenance of the in-flight documentStore mutation, in the legacy
- * `'edit' | 'replace'` the collab bridge consumes — now **derived** from the
- * unified write-provenance context (JP-192). A `'load'` provenance (snapshot
- * restore, page-switch, `clear`) reads as `'replace'`; everything else
- * (`user-edit`, `programmatic`) reads as `'edit'`.
- *
- * The collaboration bridge (`useCollaborationSync`) MUST NOT propagate a
- * `'replace'` to the CRDT: diffing a wipe-and-reload as user edits broadcasts a
- * mass deletion to every client (the #59 mass-deletion bug, JP-178).
- * `loadSnapshot`/`clear` run their `set()` inside `runWithProvenance('load', …)`;
- * Zustand notifies subscribers synchronously inside `set()`, so the bridge sees
- * the `'load'` provenance exactly while it diffs that mutation.
- */
-export function getStoreChangeKind(): 'edit' | 'replace' {
-  return getProvenance() === 'load' ? 'replace' : 'edit';
-}
+// Write provenance (JP-192/JP-194): `loadSnapshot`/`clear` run their `set()`
+// inside `runWithProvenance('load', …)` so the collaboration bridge skips them —
+// diffing a wipe-and-reload as user edits would broadcast a mass deletion (the
+// #59 bug). The legacy `getStoreChangeKind()` accessor was removed once the
+// bridge read `getProvenance()` directly; `getProvenance` is the source of truth.
 
 /**
  * Initial empty document state.


### PR DESCRIPTION
Final slice of JP-184. Mostly a no-op because **JP-192 already retired the bulk** (removed the `isApplyingRemoteChanges` global; made `getStoreChangeKind` a derived shim). This closes it out:

- **Removed `getStoreChangeKind`** — dead since JP-192 (the bridge reads `getProvenance()` directly); only its own test referenced it. Retargeted the `documentStore` test to assert `getProvenance()` (`'user-edit'` for edits, `'load'` for `loadSnapshot`/`clear`).
- **Deliberately KEPT `isAutoSaveSuppressed()`** in the bridge — with a comment explaining why so it isn't "cleaned up" later. It is **coarser** than the `'load'` provenance gate (covers the entire `withAutoSaveSuppressed` load block, not just the synchronous `loadSnapshot`/`clear` window), so it catches any load-time store write that doesn't route through those. It cost real CRDT debugging once; it stays as cheap insurance against the #59 mass-deletion class.

No behavior change. Full suite **1847 pass**, typecheck clean.

With this, **JP-184 is complete**: Slice 1 (JP-192) provenance + `mutateDocument`, Slice 2 (JP-193) headless prose write, Slice 3 (this) cleanup. The collab write path is now a single provenance-aware seam, ready for the integration wave.