### PR TITLE
JP-197: guard write-provenance against async callbacks

### DIFF
--- a/src/store/writeProvenance.test.ts
+++ b/src/store/writeProvenance.test.ts
@@ -52,4 +52,16 @@ describe('writeProvenance (JP-192)', () => {
     expect(seen).toEqual(['programmatic']);
     expect(getProvenance()).toBe('user-edit');
   });
+
+  it('throws on an async callback (provenance does not survive await) and restores state', () => {
+    // The callback's writes would run after provenance was restored → mis-tagged.
+    expect(() => runWithProvenance('programmatic', async () => {})).toThrow(/synchronous/);
+    // Restored despite the throw — no leaked provenance for the next write.
+    expect(getProvenance()).toBe('user-edit');
+  });
+
+  it('mutateDocument also rejects an async callback', () => {
+    expect(() => mutateDocument('programmatic', async () => {})).toThrow(/synchronous/);
+    expect(getProvenance()).toBe('user-edit');
+  });
 });

--- a/src/store/writeProvenance.ts
+++ b/src/store/writeProvenance.ts
@@ -15,6 +15,13 @@
  * CRDT only for `user-edit` and `programmatic` provenance. `load` and
  * `remote-apply` are NOT human-authored deltas and must never be diffed as
  * edits — that is the #59 mass-deletion class of bug.
+ *
+ * CONTRACT: the callbacks passed to `runWithProvenance`/`mutateDocument` MUST be
+ * synchronous. Provenance is an ambient flag set only for the synchronous
+ * duration of the call (it relies on Zustand notifying subscribers synchronously
+ * inside `set()`). An `async` callback returns before its writes run, so those
+ * writes land under the wrong provenance — the guard below throws on that misuse
+ * (JP-197). Do async work *outside*, then write synchronously inside.
  */
 
 export type Provenance =
@@ -48,11 +55,33 @@ export function getProvenance(): Provenance {
 export function runWithProvenance<T>(provenance: Provenance, fn: () => T): T {
   const previous = current;
   current = provenance;
+  let result: T;
   try {
-    return fn();
+    result = fn();
   } finally {
+    // Restore BEFORE the async-misuse check, so a throw never leaks provenance.
     current = previous;
   }
+  // A thenable return means the callback was async: its writes run after we've
+  // already restored provenance, so they'd be mis-tagged. Surface it loudly — a
+  // silent mis-tag (e.g. a programmatic bulk write read as a user edit) is far
+  // worse than a crash. See the CONTRACT note above (JP-197).
+  if (isThenable(result)) {
+    throw new Error(
+      '[writeProvenance] callback must be synchronous — provenance does not survive an ' +
+        '`await` (the write would be mis-tagged). Do async work outside, then write ' +
+        'synchronously inside runWithProvenance/mutateDocument.',
+    );
+  }
+  return result;
+}
+
+function isThenable(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
 }
 
 /**


### PR DESCRIPTION
A foot-gun spotted reviewing the JP-184 write path: `writeProvenance` is a **synchronous-only ambient flag** (it works because Zustand notifies subscribers synchronously inside `set()`). An `async` callback returns before its writes run, so they land *after* provenance is restored — mis-tagged (a `programmatic` bulk write could read as `user-edit`, or worse). The coming injector/MCP write-back wave is the most likely caller to hit it.

## Fix
`runWithProvenance` (which `mutateDocument` delegates to) now **throws** if the callback returns a thenable — after restoring provenance in `finally`, so the throw never leaks state. A silent mis-tag is worse than a crash, so the guard is unconditional. Module header documents the synchronous contract.

## Verification
Full suite **1849 pass**, typecheck clean — no existing caller passes an async callback. New tests cover the throw + state restoration for both `runWithProvenance` and `mutateDocument`.

Hardens the chokepoint that JP-198 ("weld the rails") will force all content writes through. Relates JP-192, JP-184.