### PR TITLE
JP-198: weld the prose-projection write rails

### DIFF
--- a/src/store/proseWriteBoundary.test.ts
+++ b/src/store/proseWriteBoundary.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Prose-projection write boundary (JP-198).
+ *
+ * `richTextStore` / `richTextPagesStore` hold a PROJECTION of prose content: the
+ * editor (and, in collab, the Y.Doc fragment) is the source of truth; the store
+ * mirrors it. To keep that single-source invariant **by construction, not just
+ * by convention**, only an allowlisted set of modules may imperatively WRITE
+ * prose content. Everyone else — metadata like the custom dictionary, future
+ * injectors — must go through a dedicated method (e.g. `addDictionaryWord`) or
+ * the CRDT bus (`mutateDocument` / `YjsDocument.appendProse`).
+ *
+ * Detection (modeled on `src/platform/importBoundary.test.ts`):
+ *  - the precise imperative vector `useRichText{Store,PagesStore}.getState().<write>(`
+ *    and `.setState(` — how an external writer bypasses the mirror; and
+ *  - the bespoke method names `loadContent`/`loadPages`/`updatePageContent` in any
+ *    form (incl. a variable holding `getState()`), since those names don't collide
+ *    with editor commands.
+ * `setContent`/`reset` via a variable-held `getState()` is the known residual gap
+ * (those names collide with `editor.commands.setContent`); the inline `getState()`
+ * form is still caught. The editors' own hook destructuring IS the sanctioned
+ * mirror and is allowlisted regardless.
+ *
+ * If this fails: do NOT add your file to the allowlist to make it pass. Route the
+ * write through the editor mirror, a load, or a purpose-built action.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = resolve(__dirname, '..');
+
+/** Recursively collect non-test `.ts`/`.tsx` files under `dir`. */
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Imperative bypass: `useRichText*.getState().<write>(` or `useRichText*.setState(`. */
+const IMPERATIVE_RE =
+  /(?:useRichTextStore|useRichTextPagesStore)\s*\.\s*(?:getState\(\)\s*\.\s*(?:setContent|loadContent|reset|updatePageContent|loadPages)|setState)\s*\(/g;
+/** Bespoke content-write names that can't collide with editor commands. */
+const DISTINCTIVE_RE = /\.(?:loadContent|loadPages|updatePageContent)\s*\(/g;
+const REFERENCES_PROSE_STORE = /useRichText(?:Store|PagesStore)/;
+
+/**
+ * Files permitted to imperatively write prose CONTENT, each with WHY. This is
+ * the sanctioned mirror/load surface — keep it small.
+ */
+const ALLOWLIST = new Set<string>([
+  'store/persistenceStore.ts', // document load + reset + page setState reset
+  'ui/CollaborativeProseEditor.tsx', // collab editor onUpdate mirror
+  'ui/TiptapEditor.tsx', // local editor onUpdate mirror
+  'ui/DocumentEditorPanel.tsx', // page-switch mirror sync
+  'ui/settings/DocumentsSettings.tsx', // restore / import load
+  'ui/PDFExportDialog.tsx', // pre-export active-page sync (TODO: flush via editor instead)
+]);
+
+describe('prose-projection write boundary (JP-198)', () => {
+  const files = listSourceFiles(SRC_ROOT);
+
+  it('smoke: found a representative number of source files', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('only allowlisted modules imperatively write prose content', () => {
+    const offenders: Array<{ file: string; match: string }> = [];
+    for (const file of files) {
+      const rel = relative(SRC_ROOT, file).split(sep).join('/');
+      if (ALLOWLIST.has(rel)) continue;
+      const source = readFileSync(file, 'utf-8');
+
+      for (const m of source.matchAll(IMPERATIVE_RE)) {
+        offenders.push({ file: rel, match: m[0] });
+      }
+      if (REFERENCES_PROSE_STORE.test(source)) {
+        for (const m of source.matchAll(DISTINCTIVE_RE)) {
+          offenders.push({ file: rel, match: m[0] });
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('smoke: the allowlisted mirror/load files actually do write (regex works)', () => {
+    const writers = [...ALLOWLIST].filter((rel) => {
+      const source = readFileSync(resolve(SRC_ROOT, rel), 'utf-8');
+      IMPERATIVE_RE.lastIndex = 0;
+      DISTINCTIVE_RE.lastIndex = 0;
+      return (
+        IMPERATIVE_RE.test(source) ||
+        (REFERENCES_PROSE_STORE.test(source) && DISTINCTIVE_RE.test(source))
+      );
+    });
+    // At least the loaders + collab mirror should match; a near-empty result
+    // means the detection regex silently stopped working.
+    expect(writers.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/store/richTextPagesStore.ts
+++ b/src/store/richTextPagesStore.ts
@@ -4,6 +4,12 @@
  * Manages multiple pages within the document editor, each with its own
  * content, name, and color. Pages are persisted alongside the main
  * rich text content.
+ *
+ * WRITE RAIL (JP-198): page **content** (`updatePageContent`/`loadPages`) is a
+ * PROJECTION — set only by the editor `onUpdate` mirror or a load. Don't write
+ * page content from elsewhere. Page-structure ops (add/rename/reorder/setActive)
+ * are ordinary user actions and are not governed. Enforced by
+ * `proseWriteBoundary.test.ts`.
  */
 
 import { create } from 'zustand';

--- a/src/store/richTextStore.ts
+++ b/src/store/richTextStore.ts
@@ -2,6 +2,14 @@
  * Rich text store for managing document editor content.
  *
  * Stores Tiptap editor content separately from diagram data.
+ *
+ * WRITE RAIL (JP-198): prose **content** here is a PROJECTION — the editor (and,
+ * in collab, the Y.Doc fragment) is the source of truth; this store mirrors it.
+ * Content is set ONLY by the editor `onUpdate` mirror (`TiptapEditor` /
+ * `CollaborativeProseEditor`) or a load (`persistenceStore` / settings restore).
+ * Do NOT write content from anywhere else — metadata like the custom dictionary
+ * has its own method (`addDictionaryWord`), so it never rides the content path.
+ * Enforced by `proseWriteBoundary.test.ts`.
  */
 
 import { create } from 'zustand';
@@ -38,6 +46,14 @@ export interface RichTextActions {
   clearDirty: () => void;
   /** Reset to empty content */
   reset: () => void;
+  /**
+   * Add a word to the document's custom spellcheck dictionary — metadata, not
+   * prose content. A structural merge (dedupe + mark dirty); callers must NOT
+   * round-trip through `loadContent` to append a word (that abused the
+   * content-write path and once dropped the dictionary — see JP-198 /
+   * `proseWriteBoundary.test.ts`).
+   */
+  addDictionaryWord: (word: string) => void;
 }
 
 /**
@@ -110,6 +126,17 @@ export const useRichTextStore = create<RichTextState & RichTextActions>()(
     // Reset to empty
     reset: () => {
       set(initialState);
+    },
+
+    // Merge a word into the custom dictionary WITHOUT touching prose content.
+    // Guarded read first so a duplicate add doesn't fire a spurious update.
+    addDictionaryWord: (word: string) => {
+      const current = get().content.customDictionary ?? [];
+      if (current.includes(word)) return;
+      set((state) => ({
+        content: { ...state.content, customDictionary: [...current, word] },
+        isDirty: true,
+      }));
     },
   })
 );

--- a/src/ui/SpellcheckPopover.tsx
+++ b/src/ui/SpellcheckPopover.tsx
@@ -45,15 +45,10 @@ export function SpellcheckPopover({ editor, word, range, x, y, onClose }: Spellc
 
   const addToDictionary = () => {
     SpellcheckService.addToSession(word);
-    // Persist on the document's customDictionary
-    const store = useRichTextStore.getState();
-    const current = store.content.customDictionary ?? [];
-    if (!current.includes(word)) {
-      store.loadContent({
-        ...store.content,
-        customDictionary: [...current, word],
-      });
-    }
+    // Persist via the structural metadata method — never round-trip through
+    // loadContent to append a word (that abused the prose content-write path
+    // and once dropped the dictionary; JP-198).
+    useRichTextStore.getState().addDictionaryWord(word);
     rebuildSpellcheck(editor.view);
     onClose();
   };


### PR DESCRIPTION
JP-184 *put up* the rails (safe prose write path exists); this **welds** them (the unsafe path now fails CI). `richTextStore`/`richTextPagesStore` hold a projection of prose content — editor/Y.Doc fragment is the source of truth — but were freely writable, so the single-source invariant was convention-only. Confirmed external pokers: the dictionary add, PDF-export sync, page-switch sync.

## Changes
- **`proseWriteBoundary.test.ts`** (new, modeled on `importBoundary.test.ts`) — fails CI if any non-allowlisted module imperatively writes prose content (`useRichText*.getState().<write>`/`.setState`, or the bespoke `loadContent`/`loadPages`/`updatePageContent` names that can't collide with editor commands). The allowlist is the sanctioned mirror/load surface (both editors, `persistenceStore`, page-switch/restore/pre-export syncs), each justified inline. **Negative-checked**: an offender in a non-allowlisted file fails the test; revert passes.
- **`richTextStore.addDictionaryWord(word)`** — structural metadata merge. `SpellcheckPopover` now uses it instead of round-tripping the dictionary through `loadContent` (the straggler that abused the content path and once dropped the dictionary). The dictionary is no longer a governed content writer — proving the weld.
- **WRITE RAIL** invariant documented in both store headers.

## Scope (deliberate)
Prose only. **documentStore (shapes) is excluded** — it's the store-first write surface, already welded by the provenance gate (JP-192) + the DEV wholesale-deletion tripwire (JP-178); a direct `addShapes` gets the correct default `user-edit` and propagates. Page-structure ops and `whiteboardStore` are out of scope by design.

## Verification
Full suite **1852 pass**, typecheck clean. Boundary test passes with the allowlist; negative check confirms it bites. Manual: dictionary add still persists + clears the underline, now via `addDictionaryWord`.

Completes the "by construction, not by convention" finish of JP-184's thesis (for prose). Follow-up JP-197 (async-callback guard) hardens the shape side's chokepoint.