### PR TITLE
JP-199: isRelaySessionLive() selector (JP-123 residual)

### DIFF
--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -25,6 +25,7 @@ import { getSyncStateManager } from './SyncStateManager';
 import {
   useConnectionStore,
   type ConnectionStatus,
+  isRelayAuthenticated,
   startTokenExpirationMonitor,
   stopTokenExpirationMonitor,
   muteConnectionToasts,
@@ -720,6 +721,32 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     getSyncProvider: () => syncProvider,
   })
 );
+
+// ============ Relay session liveness (JP-123 / JP-199) ============
+//
+// `isRelayAuthenticated()` means only "token accepted on a live WS" — NOT that
+// the active doc is joined + CRDT-synced. JP-123 showed those differ: a relay
+// switch can be `authenticated` while the target doc isn't synced yet. These
+// selectors are the STRICTER "the active doc is actually live-synced" signal.
+//
+// Which to use:
+//   - token-scoped concerns (permissions, REST save, doc listing, the sign-in
+//     indicator, reconnect gating) → `isRelayAuthenticated` / `useIsRelayAuthenticated`.
+//   - "this doc is synced and safe to treat as a live collaborator" → these.
+
+/** Imperative: token accepted on a live WS AND the active doc has CRDT-synced. */
+export function isRelaySessionLive(): boolean {
+  const collab = useCollaborationStore.getState();
+  return isRelayAuthenticated() && collab.isActive && collab.isSynced;
+}
+
+/** Reactive variant of {@link isRelaySessionLive} for React components. */
+export function useIsRelaySessionLive(): boolean {
+  const authed = useConnectionStore((s) => s.status === 'authenticated');
+  const isActive = useCollaborationStore((s) => s.isActive);
+  const isSynced = useCollaborationStore((s) => s.isSynced);
+  return authed && isActive && isSynced;
+}
 
 /**
  * Subscribe to remote shape changes.

--- a/src/collaboration/index.ts
+++ b/src/collaboration/index.ts
@@ -21,6 +21,8 @@ export {
   subscribeToRemoteChanges,
   initializeCRDTFromState,
   isCollabContentDoc,
+  isRelaySessionLive,
+  useIsRelaySessionLive,
 } from './collaborationStore';
 export type { CollaborationConfig, RemoteUser } from './collaborationStore';
 

--- a/src/collaboration/isRelaySessionLive.test.ts
+++ b/src/collaboration/isRelaySessionLive.test.ts
@@ -1,0 +1,38 @@
+/**
+ * JP-199 — `isRelaySessionLive()` distinguishes a token-accepted session from
+ * one where the active doc is actually CRDT-synced (the JP-123 gap).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useConnectionStore } from '../store/connectionStore';
+import { useCollaborationStore, isRelaySessionLive } from './collaborationStore';
+
+describe('isRelaySessionLive (JP-199)', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({ status: 'disconnected' });
+    useCollaborationStore.setState({ isActive: false, isSynced: false });
+  });
+
+  it('is false when not authenticated (no token / WS)', () => {
+    useConnectionStore.setState({ status: 'connecting' });
+    useCollaborationStore.setState({ isActive: true, isSynced: true });
+    expect(isRelaySessionLive()).toBe(false);
+  });
+
+  it('is false when authenticated but no active session', () => {
+    useConnectionStore.setState({ status: 'authenticated' });
+    useCollaborationStore.setState({ isActive: false, isSynced: false });
+    expect(isRelaySessionLive()).toBe(false);
+  });
+
+  it('is false when authenticated + active but the doc has not synced yet (the JP-123 case)', () => {
+    useConnectionStore.setState({ status: 'authenticated' });
+    useCollaborationStore.setState({ isActive: true, isSynced: false });
+    expect(isRelaySessionLive()).toBe(false);
+  });
+
+  it('is true only when authenticated AND the active doc is synced', () => {
+    useConnectionStore.setState({ status: 'authenticated' });
+    useCollaborationStore.setState({ isActive: true, isSynced: true });
+    expect(isRelaySessionLive()).toBe(true);
+  });
+});

--- a/src/ui/settings/RelaySettings.tsx
+++ b/src/ui/settings/RelaySettings.tsx
@@ -20,7 +20,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Cloud, LogIn, LogOut, AlertCircle, ExternalLink, Loader2, KeyRound } from 'lucide-react';
 import { useConnectionStore } from '../../store/connectionStore';
-import { useCollaborationStore } from '../../collaboration';
+import { useCollaborationStore, useIsRelaySessionLive } from '../../collaboration';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import {
   loadConnection,
@@ -43,6 +43,9 @@ export function RelaySettings() {
   const collabError = useCollaborationStore((s) => s.error);
   const stopSession = useCollaborationStore((s) => s.stopSession);
   const currentDocumentId = usePersistenceStore((s) => s.currentDocumentId);
+  // Token-accepted ("Signed in") vs the active doc actually live-synced — the
+  // JP-123 distinction made first-class (JP-199).
+  const sessionLive = useIsRelaySessionLive();
 
   const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
   const [cloudUrl, setCloudUrl] = useState(DEFAULT_CLOUD_BASE_URL);
@@ -187,6 +190,14 @@ export function RelaySettings() {
             <div>
               <dt>Relay</dt>
               <dd>{host?.url ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>Session</dt>
+              <dd>
+                {sessionLive
+                  ? 'Live · current document synced'
+                  : 'Signed in · no document synced yet'}
+              </dd>
             </div>
           </dl>
 


### PR DESCRIPTION
Closes the JP-123 residual. `connectionStore.status === 'authenticated'` means only **token accepted on a live WS** — not that the active doc is joined + CRDT-synced. JP-123 fixed the acute ordering bug but left the semantic gap; this makes the distinction first-class so future code gates on the right signal instead of re-deriving it (the JP-123 trap).

## Changes
- **`isRelaySessionLive()` + `useIsRelaySessionLive()`** in `collaborationStore` (exported via the barrel) — `token-authed AND active doc isSynced`. Placed there because it reads both stores and `collaborationStore` already imports `connectionStore` (no circular import). Documented inline: use `isRelayAuthenticated` for token-scoped concerns (permissions, REST save, doc listing, sign-in, reconnect); use this for "the doc is synced and safe to treat as live."
- **`RelaySettings`** — a visible consumer: the signed-in panel now shows **"Live · current document synced"** vs **"Signed in · no document synced yet"**, so the distinction is observable.

## On retargeting
I walked every existing `'authenticated'` gate — permissions, REST save, doc-list UIs, the sign-in indicator, reconnect. They **legitimately** want token-authed (you can list/save/sign-in before any one doc syncs), so none were retargeted. The selector's value is codifying the distinction for the *next* feature, plus the visible indicator.

## Verification
Full suite **1856 pass**, typecheck clean. Unit test covers the four states (not-authed / authed-no-session / authed-active-not-synced / authed+synced). E2E in the PR thread.