### PR TITLE
JP-35: MCP shape writes target the live Y.Doc, not JSON rewrites

### DIFF
--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -297,6 +297,11 @@ async fn run_serve(
         let panic_counter = server.panic_counter_handle();
         let rate_limit_rejections = server.rate_limit_rejections_handle();
         let write_limiter = server.build_write_limiter().await;
+        // JP-35: share the live Y.Doc registry + a broadcast sink so MCP shape
+        // writes hit the authoritative doc and reach connected clients. Both
+        // live on `ServerState`, so this must run after `server.start()` above.
+        let sync_registry = server.sync_registry_handle().await;
+        let on_doc_update = server.doc_update_broadcaster().await;
         match McpServer::new(
             config.storage.path.clone(),
             on_doc_changed,
@@ -305,6 +310,8 @@ async fn run_serve(
             write_limiter,
             auth.clone(),
             region.clone(),
+            sync_registry,
+            on_doc_update,
         ) {
             Ok(mcp) => {
                 let mcp = Arc::new(mcp);

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -28,6 +28,8 @@ use crate::auth::OidcAuthState;
 use crate::server::documents::DocumentStore;
 use crate::server::protocol::DocId;
 use crate::server::WorkspaceWriteLimiter;
+use crate::sync::DocRegistry;
+use tools::OnDocUpdate;
 use config::McpFeatureConfigStore;
 use local_mirror::LocalDocumentMirror;
 use token::TokenStore;
@@ -81,6 +83,13 @@ pub struct McpServer {
     auth: OidcAuthState,
     /// Region this relay pod runs in.
     relay_region: String,
+    /// Shared authoritative Y.Doc registry (JP-34) — the same `Arc` the WS
+    /// server uses, so MCP writes hit the live doc connected clients are
+    /// editing. JP-35.
+    sync_registry: Arc<DocRegistry>,
+    /// Broadcast sink for live-path CRDT deltas, wired to the WS server's
+    /// `broadcast_to_doc`. JP-35.
+    on_doc_update: Arc<OnDocUpdate>,
 }
 
 impl McpServer {
@@ -90,6 +99,7 @@ impl McpServer {
     /// `panic_counter` is the shared `Arc<AtomicU64>` from
     /// `WebSocketServer::panic_counter_handle()` so MCP tool panics
     /// surface at the same `/metrics` counter.
+    #[allow(clippy::too_many_arguments)] // shared handles wired from main.rs
     pub fn new(
         app_data_dir: PathBuf,
         on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
@@ -98,6 +108,8 @@ impl McpServer {
         write_limiter: Arc<WorkspaceWriteLimiter>,
         auth: OidcAuthState,
         relay_region: String,
+        sync_registry: Arc<DocRegistry>,
+        on_doc_update: Arc<OnDocUpdate>,
     ) -> Result<Self, String> {
         let token = Arc::new(TokenStore::load_or_create(&app_data_dir)?);
         let feature_config = Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir));
@@ -117,6 +129,8 @@ impl McpServer {
             write_limiter,
             auth,
             relay_region,
+            sync_registry,
+            on_doc_update,
         })
     }
 
@@ -191,6 +205,8 @@ impl McpServer {
             write_limiter: self.write_limiter.clone(),
             auth: self.auth.clone(),
             relay_region: self.relay_region.clone(),
+            sync_registry: self.sync_registry.clone(),
+            on_doc_update: self.on_doc_update.clone(),
         };
         let app = transport::router(state);
 

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -19,6 +19,7 @@ use serde_json::{json, Value};
 
 use crate::server::documents::{DocumentStore, SaveOutcome};
 use crate::server::protocol::{DocId, WorkspaceId};
+use crate::sync::{DocHandle, DocRegistry};
 
 use super::adapter::{apply_dsl_patch, dsl_to_shape_json, shape_json_to_dsl, DslPatch, DslShape};
 use super::local_mirror::LocalDocumentMirror;
@@ -44,6 +45,27 @@ pub struct ToolContext<'a> {
     /// (→ `single_tenant()`) or a relay JWT's `wsp` claim. Threaded
     /// through every team/local storage call.
     pub workspace_id: WorkspaceId,
+    /// Authoritative Y.Doc registry (JP-34). When a shape write targets a
+    /// doc that's resident here *and* the doc's hydrated active page, the
+    /// write applies to the live Y.Doc (JP-35) and is broadcast to peers,
+    /// instead of rewriting the lagging JSON snapshot.
+    pub registry: &'a Arc<DocRegistry>,
+    /// Sink for live-path CRDT deltas. See [`OnDocUpdate`].
+    pub on_doc_update: &'a OnDocUpdate,
+}
+
+/// Callback the MCP write path invokes to push a framed CRDT sync update to
+/// the clients joined to `(workspace, doc)` — wired to the WS server's
+/// `broadcast_to_doc` (JP-35). Synchronous (a `broadcast::Sender::send`), so
+/// it's safe to call from the sync tool-dispatch path.
+pub type OnDocUpdate = dyn Fn(&WorkspaceId, &DocId, Vec<u8>) + Send + Sync;
+
+impl ToolContext<'_> {
+    /// Push a framed CRDT update to the clients joined to this request's
+    /// workspace + `doc_id`.
+    fn broadcast_update(&self, doc_id: &DocId, framed: Vec<u8>) {
+        (self.on_doc_update)(&self.workspace_id, doc_id, framed);
+    }
 }
 
 /// A single MCP tool descriptor (name, description, input schema).
@@ -1340,16 +1362,56 @@ fn lock_warning(doc: &Value) -> Option<String> {
         .map(|uid| format!("Document is locked by user '{}' — write may be overwritten.", uid))
 }
 
+/// The shape id a DSL shape will use: its caller-supplied id, or a fresh one.
+fn shape_id_or_gen(shape: &DslShape) -> String {
+    shape
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("shape-{}", nanoid::nanoid!(10)))
+}
+
+/// Stamp a shape with MCP write provenance (JP-35). Durable, additive, and
+/// namespaced so it survives flatten → JSON → reload without colliding with
+/// shape geometry. Groundwork for agent-change highlighting (JP-202); the
+/// ephemeral "recent change" view is *derived* from `at`. Applied identically
+/// on the live-Y.Doc and JSON write paths so attribution doesn't depend on
+/// which backend served the write.
+fn stamp_provenance(shape: &mut Value) {
+    if let Some(obj) = shape.as_object_mut() {
+        obj.insert("provenance".into(), json!({"source": "mcp", "at": now_ms()}));
+    }
+}
+
+/// Build the on-disk shape JSON for a DSL shape, provenance-stamped. The one
+/// chokepoint both write paths route through.
+fn build_shape_json(shape: &DslShape, id: &str) -> Value {
+    let mut json = dsl_to_shape_json(shape, id);
+    stamp_provenance(&mut json);
+    json
+}
+
+/// Resolve the live authoritative Y.Doc handle for a write, but only when the
+/// JP-35 two-condition gate holds: the doc is **resident** in the registry
+/// (clients are connected → it's hydrated) *and* the target `page_id` is the
+/// page the handle was hydrated from (`activePageId`). Anything else — closed
+/// doc, or a non-active page the live Y.Doc doesn't physically hold — returns
+/// `None`, and the caller falls back to the durable JSON path.
+fn live_handle(ctx: &ToolContext, doc_id: &DocId, page_id: &str) -> Option<Arc<DocHandle>> {
+    let handle = ctx.registry.get(&ctx.workspace_id, doc_id)?;
+    if handle.page_id() == Some(page_id) {
+        Some(handle)
+    } else {
+        None
+    }
+}
+
 /// Insert one DSL shape into a doc that's already in memory. Returns the
 /// id used. Does **not** save — callers batch a sequence of these and
 /// then call `save_document` once, so a partial failure rolls back by
 /// virtue of discarding the in-memory doc.
 fn append_shape_in_place(doc: &mut Value, page_id: &str, shape: &DslShape) -> Result<String, String> {
-    let id = shape
-        .id
-        .clone()
-        .unwrap_or_else(|| format!("shape-{}", nanoid::nanoid!(10)));
-    let shape_json = dsl_to_shape_json(shape, &id);
+    let id = shape_id_or_gen(shape);
+    let shape_json = build_shape_json(shape, &id);
 
     let pages = doc
         .get_mut("pages")
@@ -1438,6 +1500,22 @@ fn add_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
 
     reject_if_local(ctx, &parsed.doc_id)?;
+
+    // JP-35: when the doc is live + on its active page, apply to the
+    // authoritative Y.Doc and broadcast the CRDT delta (clients merge, no
+    // reload). The JP-36 snapshot sweeper persists it — no JSON write here.
+    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
+        let id = shape_id_or_gen(&parsed.shape);
+        let shape = build_shape_json(&parsed.shape, &id);
+        let framed = handle.insert_shapes(&[(id.clone(), shape)])?;
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({"id": id, "warning": Value::Null}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
     let (id, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
         let warning = lock_warning(doc);
         let id = append_shape_in_place(doc, &parsed.page_id, &parsed.shape)?;
@@ -1481,6 +1559,29 @@ fn add_shapes(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     }
 
     reject_if_local(ctx, &parsed.doc_id)?;
+
+    // JP-35: live Y.Doc path — every shape inserted in one transaction with a
+    // single broadcast (atomic, unlike the JSON loop's incremental append).
+    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
+        let items: Vec<(String, Value)> = parsed
+            .shapes
+            .iter()
+            .map(|s| {
+                let id = shape_id_or_gen(s);
+                let shape = build_shape_json(s, &id);
+                (id, shape)
+            })
+            .collect();
+        let ids: Vec<String> = items.iter().map(|(id, _)| id.clone()).collect();
+        let framed = handle.insert_shapes(&items)?;
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({"ids": ids, "warning": Value::Null}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
     let (ids, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
         let warning = lock_warning(doc);
         let mut ids = Vec::with_capacity(parsed.shapes.len());
@@ -1523,6 +1624,50 @@ fn connect(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
 
     reject_if_local(ctx, &parsed.doc_id)?;
+
+    let dsl = DslShape {
+        kind: super::adapter::DslKind::Connector,
+        x: 0.0,
+        y: 0.0,
+        w: None,
+        h: None,
+        text: parsed.label.clone(),
+        style: None,
+        id: None,
+        start_shape_id: Some(parsed.from_id.clone()),
+        end_shape_id: Some(parsed.to_id.clone()),
+        start_anchor: parsed.from_anchor.clone(),
+        end_anchor: parsed.to_anchor.clone(),
+        start_arrow_style: None,
+        end_arrow_style: None,
+    };
+
+    // JP-35: live Y.Doc path — validate endpoints against the live shapes,
+    // then insert the connector + broadcast.
+    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
+        if !handle.has_shape(&parsed.from_id) {
+            return Err(format!(
+                "fromId '{}' does not exist on page '{}'",
+                parsed.from_id, parsed.page_id
+            ));
+        }
+        if !handle.has_shape(&parsed.to_id) {
+            return Err(format!(
+                "toId '{}' does not exist on page '{}'",
+                parsed.to_id, parsed.page_id
+            ));
+        }
+        let id = shape_id_or_gen(&dsl);
+        let shape = build_shape_json(&dsl, &id);
+        let framed = handle.insert_shapes(&[(id.clone(), shape)])?;
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({"id": id, "warning": Value::Null}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
     let (id, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
         // Validate the endpoints actually exist on the page before we mutate.
         let page = doc
@@ -1544,22 +1689,6 @@ fn connect(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         }
 
         let warning = lock_warning(doc);
-        let dsl = DslShape {
-            kind: super::adapter::DslKind::Connector,
-            x: 0.0,
-            y: 0.0,
-            w: None,
-            h: None,
-            text: parsed.label.clone(),
-            style: None,
-            id: None,
-            start_shape_id: Some(parsed.from_id.clone()),
-            end_shape_id: Some(parsed.to_id.clone()),
-            start_anchor: parsed.from_anchor.clone(),
-            end_anchor: parsed.to_anchor.clone(),
-            start_arrow_style: None,
-            end_arrow_style: None,
-        };
         let id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
         stamp_modified(doc, &parsed.page_id);
         Ok((id, warning))
@@ -1587,6 +1716,28 @@ fn update_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
 
     reject_if_local(ctx, &parsed.doc_id)?;
+
+    // JP-35: live Y.Doc path — read the live shape, merge the patch, overwrite
+    // + broadcast. Read-then-write across two short txns; field-level
+    // last-write-wins, inherent to a concurrent edit on the same shape.
+    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
+        let mut shape = handle
+            .get_shape_json(&parsed.id)
+            .ok_or_else(|| format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id))?;
+        let changed = apply_dsl_patch(&mut shape, &parsed.patch);
+        if changed.is_empty() {
+            return Err("Patch did not specify any updatable fields".into());
+        }
+        stamp_provenance(&mut shape);
+        let framed = handle.overwrite_shape(&parsed.id, shape)?;
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({"id": parsed.id, "changed": changed, "warning": Value::Null}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
     let (changed, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
         let warning = lock_warning(doc);
 
@@ -1610,6 +1761,7 @@ fn update_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
         if changed.is_empty() {
             return Err("Patch did not specify any updatable fields".into());
         }
+        stamp_provenance(shape);
 
         stamp_modified(doc, &parsed.page_id);
         Ok((changed, warning))
@@ -1631,6 +1783,9 @@ mod tests {
     struct Fixture {
         team: Arc<DocumentStore>,
         local: Arc<LocalDocumentMirror>,
+        registry: Arc<DocRegistry>,
+        broadcasts: Arc<std::sync::Mutex<Vec<(WorkspaceId, DocId, Vec<u8>)>>>,
+        on_doc_update: Arc<OnDocUpdate>,
     }
 
     impl Fixture {
@@ -1640,7 +1795,23 @@ mod tests {
                 local: &self.local,
                 local_enabled,
                 workspace_id: WorkspaceId::single_tenant(),
+                registry: &self.registry,
+                on_doc_update: &*self.on_doc_update,
             }
+        }
+
+        /// Hydrate a team doc into the registry so it counts as "live"
+        /// (resident on its active page) — exercises the JP-35 Y.Doc path.
+        fn make_resident(&self, doc_id: &str) -> Arc<DocHandle> {
+            let ws = WorkspaceId::single_tenant();
+            let doc_id = DocId::from_http_path(doc_id.to_string()).unwrap();
+            let json = self.team.get_document(&ws, &doc_id).unwrap();
+            self.registry.ensure(&ws, &doc_id, &json, None, false)
+        }
+
+        /// (ws, doc, framed) updates pushed on the live broadcast path.
+        fn broadcasts(&self) -> Vec<(WorkspaceId, DocId, Vec<u8>)> {
+            self.broadcasts.lock().unwrap().clone()
         }
     }
 
@@ -1670,7 +1841,152 @@ mod tests {
         let team = Arc::new(DocumentStore::new(dir.clone()));
         let local = Arc::new(LocalDocumentMirror::new(dir.clone()));
         team.save_document(&WorkspaceId::single_tenant(), make_doc("doc1", "p1", "Team Doc")).unwrap();
-        Fixture { team, local }
+        let registry = Arc::new(DocRegistry::new());
+        let broadcasts = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = broadcasts.clone();
+        let on_doc_update: Arc<OnDocUpdate> =
+            Arc::new(move |ws: &WorkspaceId, doc: &DocId, framed: Vec<u8>| {
+                sink.lock().unwrap().push((ws.clone(), doc.clone(), framed));
+            });
+        Fixture { team, local, registry, broadcasts, on_doc_update }
+    }
+
+    // ---- JP-35: live Y.Doc write path ----
+
+    #[test]
+    fn add_shape_live_mutates_ydoc_broadcasts_and_skips_json() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let handle = f.make_resident("doc1");
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_shape",
+            &json!({"docId": "doc1", "pageId": "p1",
+                    "shape": {"kind": "rectangle", "x": 5.0, "y": 6.0}}),
+        )
+        .unwrap();
+        let id = out.result["id"].as_str().unwrap().to_string();
+
+        // Applied to the live Y.Doc, provenance-stamped.
+        assert!(handle.has_shape(&id), "shape applied to the live Y.Doc");
+        let shape = handle.get_shape_json(&id).unwrap();
+        assert_eq!(shape["provenance"]["source"], "mcp");
+        assert!(shape["provenance"]["at"].as_u64().unwrap() > 0);
+
+        // One CRDT delta broadcast to (single_tenant, doc1), MESSAGE_SYNC-framed.
+        let bc = f.broadcasts();
+        assert_eq!(bc.len(), 1, "exactly one broadcast");
+        assert_eq!(bc[0].1.as_str(), "doc1");
+        assert!(!bc[0].2.is_empty());
+
+        // JSON snapshot is NOT rewritten on the live path (sweeper persists it),
+        // and changed_doc_id is None so transport won't also fire DocEvent.
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".to_string()).unwrap();
+        let json = f.team.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(
+            json["pages"]["p1"]["shapes"].as_object().unwrap().len(),
+            0,
+            "live write must not touch the JSON store"
+        );
+        assert!(out.changed_doc_id.is_none());
+    }
+
+    #[test]
+    fn update_shape_live_patches_ydoc_and_broadcasts() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let handle = f.make_resident("doc1");
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.add_shape",
+            &json!({"docId": "doc1", "pageId": "p1",
+                    "shape": {"kind": "rectangle", "x": 1.0, "y": 2.0, "id": "s1"}}),
+        )
+        .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.update_shape",
+            &json!({"docId": "doc1", "pageId": "p1", "id": "s1", "patch": {"x": 99.0}}),
+        )
+        .unwrap();
+        assert!(out.result["changed"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c == "x"));
+
+        let shape = handle.get_shape_json("s1").unwrap();
+        assert_eq!(shape["x"].as_f64(), Some(99.0));
+        assert_eq!(shape["provenance"]["source"], "mcp");
+        assert_eq!(f.broadcasts().len(), 2, "add + update each broadcast once");
+        assert!(out.changed_doc_id.is_none());
+    }
+
+    #[test]
+    fn connect_live_validates_endpoints_against_ydoc() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let handle = f.make_resident("doc1");
+
+        // Missing endpoints → error, nothing applied, nothing broadcast.
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.connect",
+            &json!({"docId": "doc1", "pageId": "p1", "fromId": "a", "toId": "b"}),
+        )
+        .unwrap_err();
+        assert!(err.contains("fromId 'a' does not exist"));
+        assert!(f.broadcasts().is_empty());
+
+        // Seed two shapes, then connect succeeds against the live Y.Doc.
+        dispatch(
+            &f.ctx(true),
+            "docushark.add_shapes",
+            &json!({"docId": "doc1", "pageId": "p1", "shapes": [
+                {"kind": "rectangle", "id": "a"}, {"kind": "rectangle", "id": "b"}]}),
+        )
+        .unwrap();
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.connect",
+            &json!({"docId": "doc1", "pageId": "p1", "fromId": "a", "toId": "b"}),
+        )
+        .unwrap();
+        let cid = out.result["id"].as_str().unwrap();
+        assert!(handle.has_shape(cid), "connector inserted into the live Y.Doc");
+    }
+
+    #[test]
+    fn add_shape_non_resident_uses_json_and_no_broadcast() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        // Doc is not made resident → not live → JSON path.
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_shape",
+            &json!({"docId": "doc1", "pageId": "p1",
+                    "shape": {"kind": "rectangle", "x": 1.0, "y": 2.0}}),
+        )
+        .unwrap();
+        let id = out.result["id"].as_str().unwrap().to_string();
+
+        // JSON store updated, provenance stamped on the JSON path too.
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".to_string()).unwrap();
+        let json = f.team.get_document(&ws, &doc_id).unwrap();
+        let shape = json["pages"]["p1"]["shapes"]
+            .get(id.as_str())
+            .expect("shape persisted to JSON");
+        assert_eq!(shape["provenance"]["source"], "mcp");
+
+        // No live broadcast; changed_doc_id set so transport fires DocEvent.
+        assert!(f.broadcasts().is_empty());
+        assert_eq!(out.changed_doc_id.unwrap().as_str(), "doc1");
     }
 
     #[test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -70,6 +70,14 @@ pub struct McpAppState {
     pub auth: OidcAuthState,
     /// Region this relay pod runs in; used to enforce `wsp[].region`.
     pub relay_region: String,
+    /// Authoritative Y.Doc registry shared with the WS subsystem (JP-34).
+    /// Lets MCP shape writes target the live Y.Doc when a doc is resident on
+    /// its active page, instead of rewriting the lagging JSON snapshot (JP-35).
+    pub sync_registry: Arc<crate::sync::DocRegistry>,
+    /// Broadcast sink for live-path CRDT deltas — wired to the WS server's
+    /// `broadcast_to_doc` so MCP-authored changes reach connected clients as a
+    /// normal sync frame (they merge, no reload). JP-35.
+    pub on_doc_update: Arc<super::tools::OnDocUpdate>,
 }
 
 /// Build the Axum router for the MCP endpoint.
@@ -267,6 +275,8 @@ fn handle_tools_call(
         local: &state.local_mirror,
         local_enabled: state.feature_config.local_access_enabled(),
         workspace_id: workspace.clone(),
+        registry: &state.sync_registry,
+        on_doc_update: state.on_doc_update.as_ref(),
     };
 
     // Phase 21.3: per-workspace write rate limit. Only mutating tools
@@ -407,6 +417,8 @@ mod tests {
             write_limiter: Arc::new(crate::server::build_workspace_limiter(1000, 1000)),
             auth: test_auth_state(),
             relay_region: "default".to_string(),
+            sync_registry: Arc::new(crate::sync::DocRegistry::new()),
+            on_doc_update: Arc::new(|_, _, _| {}),
         };
         (state, token_str)
     }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1043,6 +1043,45 @@ impl WebSocketServer {
         self.rate_limit_rejections.clone()
     }
 
+    /// Handle to the authoritative Y.Doc registry (JP-34). Lives on
+    /// `ServerState`, so this is valid only **after** `start()`. `main.rs`
+    /// hands it to `McpServer::new` so MCP shape writes hit the same live
+    /// docs the WS path serves (JP-35).
+    pub async fn sync_registry_handle(&self) -> Arc<DocRegistry> {
+        self.state
+            .read()
+            .await
+            .as_ref()
+            .expect("sync_registry_handle() requires start() first")
+            .sync_registry
+            .clone()
+    }
+
+    /// A synchronous sink that broadcasts a framed CRDT update to the clients
+    /// joined to `(workspace, doc)` — the relay-originated counterpart of an
+    /// inbound SYNC frame's rebroadcast. Wired into the MCP write path so an
+    /// MCP-authored change reaches connected editors as a normal sync frame
+    /// they merge (no reload). Valid only after `start()`. JP-35.
+    pub async fn doc_update_broadcaster(
+        &self,
+    ) -> Arc<dyn Fn(&WorkspaceId, &DocId, Vec<u8>) + Send + Sync> {
+        let tx = self
+            .state
+            .read()
+            .await
+            .as_ref()
+            .expect("doc_update_broadcaster() requires start() first")
+            .broadcast_tx
+            .clone();
+        Arc::new(move |ws: &WorkspaceId, doc_id: &DocId, framed: Vec<u8>| {
+            let _ = tx.send(BroadcastMessage {
+                target: BroadcastTarget::Doc(ws.clone(), doc_id.clone()),
+                exclude_client: None,
+                data: framed,
+            });
+        })
+    }
+
     /// DEBUG-only: set the workspace-id whose handlers should panic on
     /// entry. Called by the relay binary's `--panic-tenant` flag.
     /// No-op (and the trigger field doesn't exist) in release builds.

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -97,7 +97,7 @@ fn metadata_title_and_updated(meta_any: &Any) -> (Option<String>, Option<u64>) {
 /// Convert a yrs `Any` into a `serde_json::Value` — the inverse of
 /// `hydration::json_to_any`. Integral numbers are emitted as JSON integers so
 /// a shape's `x: 10` round-trips as `10` rather than `10.0`.
-fn any_to_json(any: &Any) -> Value {
+pub(crate) fn any_to_json(any: &Any) -> Value {
     match any {
         Any::Null | Any::Undefined => Value::Null,
         Any::Bool(b) => Value::Bool(*b),

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -84,7 +84,7 @@ pub fn active_page_shape_count(doc_json: &Value) -> usize {
 /// `Any` values (matching the JS side), so this preserves nested objects and
 /// arrays. JSON numbers become `f64` — Yjs has no plain integer type, and the
 /// client reads them back as JS numbers regardless.
-fn json_to_any(value: &Value) -> Any {
+pub(crate) fn json_to_any(value: &Value) -> Any {
     match value {
         Value::Null => Any::Null,
         Value::Bool(b) => Any::Bool(*b),

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
-use yrs::{Doc, Map, ReadTxn, Transact, XmlFragment};
+use yrs::{Any, Array, Doc, Map, ReadTxn, Transact, XmlFragment};
 
 use crate::server::protocol::{DocId, WorkspaceId};
 
@@ -243,6 +243,76 @@ impl DocHandle {
             Some(page_id) => flatten::flatten_into(&self.doc, page_id, json),
             None => false,
         }
+    }
+
+    // ---- MCP authoritative write surface (JP-35) ----
+    //
+    // These let the MCP write tools mutate the *live* Y.Doc directly when a
+    // doc is resident, instead of rewriting the lagging JSON snapshot. Each
+    // op validates against, and applies to, the active-page `shapes` map +
+    // `shapeOrder` array in one transaction, returns the framed CRDT delta
+    // for `broadcast_to_doc`, and marks the handle dirty so the JP-36 snapshot
+    // sweeper persists it (no JSON write on this path). Mirrors how an inbound
+    // SYNC frame mutates the doc — durability is snapshot-driven, identical to
+    // a connected editor's own edits.
+
+    /// True if a shape with `id` exists on the active-page surface.
+    pub fn has_shape(&self, id: &str) -> bool {
+        let shapes = self.doc.get_or_insert_map("shapes");
+        shapes.contains_key(&self.doc.transact(), id)
+    }
+
+    /// Read a shape's whole JSON value from the active-page surface. `None`
+    /// if absent (or, defensively, if the stored value isn't a plain JSON
+    /// `Any` — every shape is stored that way, matching `YjsDocument`).
+    pub fn get_shape_json(&self, id: &str) -> Option<Value> {
+        let shapes = self.doc.get_or_insert_map("shapes");
+        match shapes.get(&self.doc.transact(), id) {
+            Some(yrs::Out::Any(any)) => Some(flatten::any_to_json(&any)),
+            _ => None,
+        }
+    }
+
+    /// Insert one or more new shapes (`id` + whole JSON value) and append
+    /// their ids to `shapeOrder`, in a single transaction. Validates *all*
+    /// ids are absent before mutating anything, so a duplicate id applies
+    /// nothing. Returns the framed sync update to broadcast; marks dirty.
+    pub fn insert_shapes(&self, items: &[(String, Value)]) -> Result<Vec<u8>, String> {
+        let shapes = self.doc.get_or_insert_map("shapes");
+        let order = self.doc.get_or_insert_array("shapeOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        for (id, _) in items {
+            if shapes.contains_key(&txn, id) {
+                // No shape inserted yet → returning here commits nothing.
+                return Err(format!("Shape id '{}' already exists on page", id));
+            }
+        }
+        for (id, shape) in items {
+            shapes.insert(&mut txn, id.clone(), hydration::json_to_any(shape));
+            order.push_back(&mut txn, Any::String(id.clone().into()));
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        Ok(protocol::frame_update(update))
+    }
+
+    /// Overwrite an existing shape's whole JSON value (used by `update_shape`
+    /// after the caller merges its patch). Errors (applying nothing) if `id`
+    /// is absent. Returns the framed sync update to broadcast; marks dirty.
+    pub fn overwrite_shape(&self, id: &str, shape: Value) -> Result<Vec<u8>, String> {
+        let shapes = self.doc.get_or_insert_map("shapes");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        if !shapes.contains_key(&txn, id) {
+            return Err(format!("Shape '{}' not found on page", id));
+        }
+        shapes.insert(&mut txn, id.to_string(), hydration::json_to_any(&shape));
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        Ok(protocol::frame_update(update))
     }
 }
 

--- a/relay/src/sync/protocol.rs
+++ b/relay/src/sync/protocol.rs
@@ -71,6 +71,16 @@ pub fn initial_sync_step1(doc: &Doc) -> Vec<u8> {
     frame_sync(SyncMessage::SyncStep1(sv))
 }
 
+/// Frame a raw lib0-v1 Yjs `update` as a server-initiated sync message
+/// (`MESSAGE_SYNC` + `SyncMessage::Update`), ready for `broadcast_to_doc`.
+/// Relay-originated writes (MCP, JP-35) push a CRDT delta to the clients
+/// joined to a doc using the *same* frame shape `process_sync_message`
+/// rebroadcasts for peer updates — so clients apply it identically, merging
+/// rather than reloading.
+pub fn frame_update(update: Vec<u8>) -> Vec<u8> {
+    frame_sync(SyncMessage::Update(update))
+}
+
 /// Prefix a `SyncMessage`'s lib0-v1 encoding with the `MESSAGE_SYNC` byte.
 fn frame_sync(msg: SyncMessage) -> Vec<u8> {
     let mut data = Vec::with_capacity(1 + 64);

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -137,6 +137,16 @@ impl Harness {
         let rate_limit_rejections = self.server.rate_limit_rejections_handle();
         let write_limiter = self.server.build_write_limiter().await;
         let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+        // MCP is brought up before the server here, so it can't share the
+        // server's (not-yet-created) Y.Doc registry — use a standalone one +
+        // noop broadcaster. Cross-tenant isolation still holds: a separate
+        // registry never resolves a live handle, so MCP writes take the JSON
+        // path, which already enforces workspace scoping (JP-35 live path
+        // isolation is covered by the in-module unit tests).
+        let sync_registry = Arc::new(docushark_relay::sync::DocRegistry::new());
+        let on_doc_update: Arc<
+            dyn Fn(&docushark_relay::server::protocol::WorkspaceId, &DocId, Vec<u8>) + Send + Sync,
+        > = Arc::new(|_, _, _| {});
         let mcp = Arc::new(
             McpServer::new(
                 self.data_dir.clone(),
@@ -146,6 +156,8 @@ impl Harness {
                 write_limiter,
                 self.issuer.auth_state(),
                 "default".to_string(),
+                sync_registry,
+                on_doc_update,
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -53,6 +53,14 @@ impl Harness {
         let rate_limit_rejections = server.rate_limit_rejections_handle();
         let write_limiter = server.build_write_limiter().await;
         let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+        // This harness brings MCP up *before* the server starts, so the
+        // server's Y.Doc registry doesn't exist yet — hand MCP a standalone
+        // one + a noop broadcaster. The JP-35 live-write path isn't exercised
+        // here (these tests cover rate limits via the JSON path).
+        let sync_registry = Arc::new(docushark_relay::sync::DocRegistry::new());
+        let on_doc_update: Arc<
+            dyn Fn(&docushark_relay::server::protocol::WorkspaceId, &DocId, Vec<u8>) + Send + Sync,
+        > = Arc::new(|_, _, _| {});
         let mcp = Arc::new(
             McpServer::new(
                 data_dir,
@@ -62,6 +70,8 @@ impl Harness {
                 write_limiter,
                 issuer.auth_state(),
                 "default".to_string(),
+                sync_registry,
+                on_doc_update,
             )
             .expect("McpServer::new"),
         );


### PR DESCRIPTION
## What

Closes the dual-source-of-truth seam between MCP shape writes and the authoritative relay `Y.Doc` (JP-34/36). The four shape write tools (`add_shape`/`add_shapes`/`connect`/`update_shape`) now apply to the **live Y.Doc** — generating Yjs updates — instead of rewriting the lagging JSON snapshot, when the doc is live.

## Why

For a *live* doc (resident in the registry because clients are connected), the authoritative state is the relay's `Y.Doc`, not the on-disk JSON (flushed only every ~10s by the JP-36 sweeper). An MCP write through the old `mutate_with_retry` JSON path therefore raced the snapshot flatten and could be clobbered, and connected editors only saw the change via a disruptive `DocEvent::Updated` full reload.

## How

Two-condition gate (`live_handle`): a write goes to the Y.Doc only when the doc is **resident** AND the target page is its **hydrated active page**. Everything else (closed doc, or a non-active page the Y.Doc doesn't physically hold) takes the durable JSON path, unchanged.

| Doc state | Target page | Write goes to |
|---|---|---|
| Resident (live) | active page | **live Y.Doc** → broadcast CRDT delta, sweeper persists |
| Resident (live) | non-active page | JSON store |
| Not resident (closed) | any page | JSON store |

- **sync:** `DocHandle` gains `has_shape` / `get_shape_json` / `insert_shapes` / `overwrite_shape`, each validating + applying + encoding the per-transaction delta (`encode_state_as_update_v1` from `before_state`) in one txn and marking the handle dirty. `yrs` stays inside `sync/`; `tools.rs` deals only in `serde_json::Value`. New `protocol::frame_update` frames a raw update as `MESSAGE_SYNC` + `SyncMessage::Update` (the same frame shape peers rebroadcast).
- **mcp/server:** `McpAppState` + `ToolContext` carry the shared registry and a synchronous broadcast sink, resolved post-`start()` in `main.rs` via new `WebSocketServer::sync_registry_handle` + `doc_update_broadcaster`.
- The live path skips `DocEvent::Updated` (clients merge the delta) and the lock-warning (CRDT merges, doesn't overwrite — the warning would mislead).
- Durability is unchanged in spirit: the live path is persisted by the JP-36 snapshot sweeper, exactly like a connected editor's own edits.

## Provenance groundwork (JP-202)

Each shape write is stamped at one chokepoint with a durable, additive, namespaced field — identical on both paths:

```json
"provenance": { "source": "mcp", "at": <epoch-ms> }
```

This is the data foundation for VS Code-style agent-change highlighting (tracked in JP-202). No migration / version bump (additive + optional).

## Scope / follow-ups

- Reads still come from JSON; resident-read enrichment is **JP-201**.
- Prose/outline writers stay on JSON (their CRDT surface is `prose:*`).

## Testing

`cargo test` full relay suite green (218 lib + all integration suites incl. cross-tenant isolation, rate limits, yjs_authority); clippy clean on touched files. New unit tests:
- `add_shape_live_mutates_ydoc_broadcasts_and_skips_json`
- `update_shape_live_patches_ydoc_and_broadcasts`
- `connect_live_validates_endpoints_against_ydoc`
- `add_shape_non_resident_uses_json_and_no_broadcast`

Assisted-by: Opus 4.8