### PR TITLE
JP-176: make the relay :edge build cache-safe against untrusted PRs

### DIFF
--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -64,5 +64,8 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Only trusted `staging` pushes WRITE the shared build cache. PR
+          # build-checks read it but never write, so an untrusted PR can't
+          # poison the cache the published `:edge` image is built from (JP-176).
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max' || '' }}


### PR DESCRIPTION
## Why

`relay-image.yml` publishes `:edge` on `staging` pushes and runs a build-check on PRs into `master`. The gap (JP-176 — *"staging build can be created by anyone"*): PR build-checks wrote the shared GitHub Actions build cache (`cache-to: type=gha`) that the published `:edge` image reads (`cache-from: type=gha`), so an untrusted PR could seed layers a later `staging` publish reuses.

## What changed

- **`cache-to` runs only on trusted `staging` pushes.** PR builds read the cache (fast) but never write it, so an untrusted PR can't poison the cache the published image is built from.

That's the whole change — one line + a comment.

## Model (unchanged)
- Publish stays **automatic on push to `staging`**; `staging` is branch-protected so only admins can push it (the admin gate JP-176 asked for).
- PRs into `master` still build to verify the Dockerfile, with no GHCR login and no publish.

## Verification
- `yaml.safe_load` parses clean.
- This PR edits the workflow (in `paths`), so it self-exercises the `pull_request` build-check — should run green and **not** publish.

Assisted-by: Opus 4.8