### PR TITLE
JP-158: migrate undefined competing colour tokens onto brand

### DIFF
--- a/src/ui/CollaborativeCursors.css
+++ b/src/ui/CollaborativeCursors.css
@@ -42,7 +42,7 @@
 /* Selection indicator (optional - shows what shape they have selected) */
 .collab-selection-indicator {
   position: absolute;
-  border: 2px dashed var(--cursor-color, #4a90d9);
+  border: 2px dashed var(--cursor-color, var(--color-primary));
   border-radius: 2px;
   pointer-events: none;
   opacity: 0.6;

--- a/src/ui/ConnectionStatusBanner.css
+++ b/src/ui/ConnectionStatusBanner.css
@@ -13,9 +13,9 @@
 }
 
 .connection-banner--warning {
-  background: var(--color-warning-bg, #3d3520);
-  color: var(--color-warning-text, #f0c040);
-  border-bottom: 1px solid var(--color-warning-border, #5a4a20);
+  background: var(--bg-tertiary);
+  color: var(--warning);
+  border-bottom: 1px solid var(--warning);
 }
 
 .connection-banner--error {

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -105,7 +105,7 @@
 .context-menu-check {
   width: 18px;
   font-size: var(--font-size-sm);
-  color: var(--color-primary, #4a90d9);
+  color: var(--color-primary, #1f3354);
   flex-shrink: 0;
 }
 
@@ -148,5 +148,5 @@
 }
 
 [data-theme="dark"] .context-menu-check {
-  color: var(--color-primary, #4a90d9);
+  color: var(--color-primary, #1f3354);
 }

--- a/src/ui/DocumentChangedBanner.css
+++ b/src/ui/DocumentChangedBanner.css
@@ -43,8 +43,8 @@
 }
 
 .document-changed-banner__btn--reload {
-  background: var(--color-accent, #6c7aff);
-  border-color: var(--color-accent, #6c7aff);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   color: #fff;
 }
 

--- a/src/ui/DocumentPermissionsDialog.css
+++ b/src/ui/DocumentPermissionsDialog.css
@@ -164,7 +164,7 @@
 
 .document-permissions-dialog__quick-btn:hover {
   background: var(--bg-secondary, #f5f5f5);
-  border-color: var(--primary-color, #4a90d9);
+  border-color: var(--color-primary);
 }
 
 .document-permissions-dialog__quick-btn--danger:hover {
@@ -271,7 +271,7 @@
 
 .document-permissions-dialog__permission-select:focus {
   outline: none;
-  border-color: var(--primary-color, #4a90d9);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.1);
 }
 
@@ -379,7 +379,7 @@
 
 :root[data-theme="dark"] .document-permissions-dialog__doc-name,
 :root[data-theme="dark"] .document-permissions-dialog__member-name {
-  color: var(--text-primary-dark, #eee);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-permissions-dialog__member,
@@ -396,7 +396,7 @@
 :root[data-theme="dark"] .document-permissions-dialog__quick-btn {
   background: var(--bg-secondary-dark, #2d2d2d);
   border-color: var(--border-color-dark, #444);
-  color: var(--text-primary-dark, #eee);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-permissions-dialog__actions {
@@ -406,7 +406,7 @@
 :root[data-theme="dark"] .document-permissions-dialog__btn {
   background: var(--bg-secondary-dark, #2d2d2d);
   border-color: var(--border-color-dark, #444);
-  color: var(--text-primary-dark, #eee);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-permissions-dialog__btn:hover:not(:disabled) {

--- a/src/ui/KeyboardShortcutPanel.css
+++ b/src/ui/KeyboardShortcutPanel.css
@@ -71,7 +71,7 @@
 }
 
 .shortcut-panel__search:focus {
-  border-color: var(--color-accent, var(--color-primary));
+  border-color: var(--color-primary);
 }
 
 .shortcut-panel__content {

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -139,7 +139,7 @@
 }
 
 .layer-view-form-submit:hover {
-  background: var(--accent-color-dark, var(--color-primary-dark));
+  background: var(--color-primary-dark);
 }
 
 /* View list */
@@ -273,7 +273,7 @@
 }
 
 .layer-view-edit-actions button:first-child:hover {
-  background: var(--accent-color-dark, var(--color-primary-dark));
+  background: var(--color-primary-dark);
 }
 
 /* Help section */

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -13,7 +13,7 @@
 }
 
 .logo-picker-modal {
-  background: var(--panel-bg, #ffffff);
+  background: var(--bg-primary);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   width: 90%;
@@ -80,7 +80,7 @@
 }
 
 .logo-picker-upload-btn:hover:not(:disabled) {
-  background: var(--accent-light, #e3f2fd);
+  background: var(--color-primary-light);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -113,12 +113,12 @@
 }
 
 .logo-picker-item:hover {
-  background: var(--accent-light, #e8f4fc);
+  background: var(--color-primary-light);
   border-color: var(--border-color, #ddd);
 }
 
 .logo-picker-item.selected {
-  background: var(--accent-light, #e3f2fd);
+  background: var(--color-primary-light);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -128,7 +128,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--panel-bg, #fff);
+  background: var(--bg-primary);
   border-radius: 4px;
   overflow: hidden;
   margin-bottom: 8px;

--- a/src/ui/Minimap.tsx
+++ b/src/ui/Minimap.tsx
@@ -205,8 +205,13 @@ export function Minimap({ canvasWidth, canvasHeight }: MinimapProps) {
     canvas.height = MINIMAP_HEIGHT * dpr;
     ctx.scale(dpr, dpr);
 
-    // Clear canvas
-    ctx.fillStyle = 'var(--minimap-bg, rgba(255, 255, 255, 0.95))';
+    // Clear canvas. CSS variables don't resolve in a canvas context, so read
+    // the brand surface token off the document element (fall back to the brand
+    // light surface literal).
+    ctx.fillStyle =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--bg-primary')
+        .trim() || '#f9f6ee';
     ctx.fillRect(0, 0, MINIMAP_WIDTH, MINIMAP_HEIGHT);
 
     const { scale, offsetX, offsetY } = minimapTransform;

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -50,19 +50,19 @@
 }
 
 .notification-toast--success {
-  border-left-color: var(--color-success, #22c55e);
+  border-left-color: var(--success);
 }
 
 .notification-toast--success .notification-toast__icon {
-  color: var(--color-success, #22c55e);
+  color: var(--success);
 }
 
 .notification-toast--warning {
-  border-left-color: var(--color-warning, #f59e0b);
+  border-left-color: var(--warning);
 }
 
 .notification-toast--warning .notification-toast__icon {
-  color: var(--color-warning, #f59e0b);
+  color: var(--warning);
 }
 
 .notification-toast--error {

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -13,7 +13,7 @@
 }
 
 .pdf-export-dialog {
-  background: var(--panel-bg, #ffffff);
+  background: var(--bg-primary);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   width: 90%;

--- a/src/ui/PresenceIndicators.css
+++ b/src/ui/PresenceIndicators.css
@@ -25,11 +25,11 @@
 }
 
 .presence-status-connected .presence-status-dot {
-  background-color: var(--color-success, #48bb78);
+  background-color: var(--success);
 }
 
 .presence-status-connecting .presence-status-dot {
-  background-color: var(--color-warning, #ecc94b);
+  background-color: var(--warning);
   animation: pulse 1s ease-in-out infinite;
 }
 

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -884,9 +884,9 @@
 }
 
 .erd-member-pk.active {
-  color: var(--color-warning, #f59e0b);
+  color: var(--warning);
   background: rgba(245, 158, 11, 0.15);
-  border-color: var(--color-warning, #f59e0b);
+  border-color: var(--warning);
   box-shadow: 0 0 6px rgba(245, 158, 11, 0.3);
 }
 

--- a/src/ui/SaveStatusIndicator.css
+++ b/src/ui/SaveStatusIndicator.css
@@ -34,7 +34,7 @@
 }
 
 .save-status-dirty-dot {
-  color: var(--color-warning, #f59e0b);
+  color: var(--warning);
   font-size: 0.625rem;
   margin-left: 0.125rem;
 }
@@ -68,11 +68,11 @@
 
 .save-status-badge.dirty {
   background-color: rgba(245, 158, 11, 0.1);
-  color: var(--color-warning, #f59e0b);
+  color: var(--warning);
 }
 
 .save-status-badge.saved {
-  color: var(--color-success, #10b981);
+  color: var(--success);
 }
 
 .save-status-icon {

--- a/src/ui/SelectionHighlight.css
+++ b/src/ui/SelectionHighlight.css
@@ -15,7 +15,7 @@
 
 .collab-selection-box {
   position: absolute;
-  border: 2px dashed var(--selection-color, #4a90d9);
+  border: 2px dashed var(--selection-color, var(--color-primary));
   border-radius: 3px;
   pointer-events: none;
   opacity: 0.7;

--- a/src/ui/ShapePicker.tsx
+++ b/src/ui/ShapePicker.tsx
@@ -273,8 +273,8 @@ function ShapePreview({ metadata, size }: { metadata: ShapeMetadata; size: numbe
     ctx.clearRect(0, 0, size, size);
 
     // Get theme-aware colors (CSS variables don't work directly in canvas)
-    const fillColor = getCSSVariable('--color-primary', '#4a90d9');
-    const strokeColor = getCSSVariable('--color-primary-dark', '#2c5282');
+    const fillColor = getCSSVariable('--color-primary', '#1f3354');
+    const strokeColor = getCSSVariable('--color-primary-dark', '#0e1c30');
 
     // Try to render using the shape's path builder
     const shapeLibraryStore = useShapeLibraryStore.getState();
@@ -312,7 +312,7 @@ function ShapePreview({ metadata, size }: { metadata: ShapeMetadata; size: numbe
       ctx.restore();
     } else {
       // Fallback: render the icon as text
-      const textColor = getCSSVariable('--text-primary', '#333');
+      const textColor = getCSSVariable('--text-primary', '#0a1525');
       ctx.fillStyle = textColor;
       ctx.font = `${size * 0.6}px sans-serif`;
       ctx.textAlign = 'center';

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -88,7 +88,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  color: var(--color-warning, #f59e0b);
+  color: var(--warning);
   font-weight: var(--font-weight-medium);
   animation: pulse 1.5s ease-in-out infinite;
 }

--- a/src/ui/StorageManager.css
+++ b/src/ui/StorageManager.css
@@ -19,7 +19,7 @@
 
 /* Modal */
 .storage-manager {
-  background: var(--panel-bg);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
   width: 100%;
@@ -69,7 +69,7 @@
   gap: 24px;
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-color);
-  background: var(--panel-hover);
+  background: var(--bg-tertiary);
 }
 
 .storage-stat {
@@ -120,7 +120,7 @@
 .storage-manager-btn {
   padding: 8px 16px;
   border: 1px solid var(--border-color);
-  background: var(--panel-bg);
+  background: var(--bg-primary);
   color: var(--text-primary);
   border-radius: 6px;
   cursor: pointer;
@@ -190,7 +190,7 @@
   grid-template-columns: 2fr 1fr 1fr 1fr 1.2fr 1fr;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--panel-bg);
+  background: var(--bg-primary);
   align-items: center;
 }
 
@@ -200,7 +200,7 @@
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  background: var(--panel-hover);
+  background: var(--bg-tertiary);
 }
 
 .storage-manager-list-item {
@@ -209,7 +209,7 @@
 }
 
 .storage-manager-list-item:hover {
-  background: var(--panel-hover);
+  background: var(--bg-hover);
 }
 
 .storage-blob-name {
@@ -257,7 +257,7 @@
 .storage-manager-btn-small {
   padding: 4px 10px;
   border: 1px solid var(--border-color);
-  background: var(--panel-bg);
+  background: var(--bg-primary);
   color: var(--text-secondary);
   border-radius: 4px;
   cursor: pointer;
@@ -277,7 +277,7 @@
   display: flex;
   padding: 0 20px;
   border-bottom: 1px solid var(--border-color);
-  background: var(--panel-bg);
+  background: var(--bg-primary);
 }
 
 .storage-manager-tab {
@@ -295,7 +295,7 @@
 
 .storage-manager-tab:hover {
   color: var(--text-primary);
-  background: var(--panel-hover);
+  background: var(--bg-hover);
 }
 
 .storage-manager-tab.active {
@@ -316,7 +316,7 @@
   flex-direction: column;
   align-items: center;
   padding: 12px;
-  background: var(--panel-hover);
+  background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
   transition: all 0.15s;
@@ -324,7 +324,7 @@
 
 .storage-icon-item:hover {
   border-color: var(--color-primary);
-  background: var(--panel-bg);
+  background: var(--bg-primary);
 }
 
 .storage-icon-preview {
@@ -436,7 +436,7 @@
 }
 
 .storage-manager-modal {
-  background: var(--panel-bg, #1e1e1e);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 24px;

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -83,14 +83,14 @@
   font-size: 12px;
   border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 4px;
-  background: var(--input-bg, #fff);
+  background: var(--bg-primary);
   color: var(--text-primary, #1e293b);
   outline: none;
   margin-bottom: 8px;
 }
 
 .style-profile-input:focus {
-  border-color: var(--color-primary, #4a90d9);
+  border-color: var(--color-primary, #1f3354);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
@@ -148,13 +148,13 @@
   font-size: 12px;
   border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 4px;
-  background: var(--input-bg, #fff);
+  background: var(--bg-primary);
   color: var(--text-primary, #1e293b);
   outline: none;
 }
 
 .style-profile-search-input:focus {
-  border-color: var(--color-primary, #4a90d9);
+  border-color: var(--color-primary, #1f3354);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
@@ -397,9 +397,9 @@
   flex: 1;
   padding: 2px 6px;
   font-size: 12px;
-  border: 1px solid var(--color-primary, #4a90d9);
+  border: 1px solid var(--color-primary, #1f3354);
   border-radius: 3px;
-  background: var(--input-bg, #fff);
+  background: var(--bg-primary);
   color: var(--text-primary, #1e293b);
   outline: none;
 }
@@ -440,7 +440,7 @@
 }
 
 .style-profile-action.overwrite:hover:not(:disabled) {
-  color: var(--color-primary, #4a90d9);
+  color: var(--color-primary, #1f3354);
 }
 
 .style-profile-action.delete:hover {
@@ -576,7 +576,7 @@
 
 :root[data-theme='dark'] .style-profile-input {
   border-color: var(--border-color, #475569);
-  background: var(--input-bg, #0f172a);
+  background: var(--bg-primary);
   color: var(--text-primary, #f1f5f9);
 }
 
@@ -635,7 +635,7 @@
 
 :root[data-theme='dark'] .style-profile-edit-input {
   border-color: var(--color-primary, #60a5fa);
-  background: var(--input-bg, #0f172a);
+  background: var(--bg-primary);
   color: var(--text-primary, #f1f5f9);
 }
 

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -241,7 +241,7 @@
 }
 
 .document-status.saving {
-  color: var(--color-primary, #4a90d9);
+  color: var(--color-primary, #1f3354);
 }
 
 .document-status.saved {

--- a/src/ui/VersionConflictDialog.css
+++ b/src/ui/VersionConflictDialog.css
@@ -101,7 +101,7 @@
 
 .version-conflict-dialog__option--selected {
   background: var(--color-bg-selected, #2a2a4d);
-  border-color: var(--color-accent, #6c7aff);
+  border-color: var(--color-primary);
 }
 
 .version-conflict-dialog__option--disabled {
@@ -167,8 +167,8 @@
 }
 
 .version-conflict-dialog__btn--primary {
-  background: var(--color-accent, #6c7aff);
-  border-color: var(--color-accent, #6c7aff);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   color: #fff;
 }
 

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -43,6 +43,6 @@
   align-items: center;
 }
 
-.title-bar-status-dirty { color: var(--color-warning, #f59e0b); }
+.title-bar-status-dirty { color: var(--warning); }
 .title-bar-status-saving { color: var(--text-secondary, #6c757d); }
-.title-bar-status-saved { color: var(--color-success, #10b981); }
+.title-bar-status-saved { color: var(--success); }

--- a/src/ui/settings/BackupSettings.css
+++ b/src/ui/settings/BackupSettings.css
@@ -142,9 +142,9 @@
 }
 
 .backup-btn-danger {
-  background: var(--error-color, #ef4444);
+  background: var(--danger);
   color: white;
-  border-color: var(--error-color, #ef4444);
+  border-color: var(--danger);
 }
 
 .backup-btn-danger:hover:not(:disabled) {
@@ -238,7 +238,7 @@
 }
 
 .backup-validation-error {
-  color: var(--error-color, #ef4444);
+  color: var(--danger);
   font-size: 12px;
   margin: 8px 0 0;
 }
@@ -350,6 +350,6 @@
 
 .backup-result-error {
   background: var(--error-bg, #fef2f2);
-  color: var(--error-color, #ef4444);
+  color: var(--danger);
   border: 1px solid var(--error-border, #fecaca);
 }


### PR DESCRIPTION
## Context

JP-151 unified the CSS token scheme onto the canonical brand tokens and retired 11 *aliased* names. It deliberately left the riskier half — ~14 colour tokens that are **referenced via `var()` but never defined**. Because they're undefined, every site rendered its hardcoded fallback: mostly stale pre-brand Tailwind blue/red/yellow, and in `StorageManager`'s case **nothing** (no fallback → transparent panels, a latent bug). This points them at the canonical brand tokens in `index.css`.

This is an intentional **visual change**, not a value-preserving rename.

## Changes

**Bucket A — orphaned global tokens → replaced with the canonical token** (fallback dropped; the canonical is always defined):

| Was | Now |
|---|---|
| `--panel-bg` | `--bg-primary` |
| `--panel-hover` | `--bg-tertiary` (section bg) / `--bg-hover` (`:hover`) |
| `--color-warning` (+`-bg`/`-text`/`-border`) | `--warning` (bg → `--bg-tertiary`) |
| `--color-success` | `--success` |
| `--color-accent` | `--color-primary` |
| `--error-color` | `--danger` |
| `--primary-color` | `--color-primary` |
| `--accent-light` | `--color-primary-light` |
| `--accent-color-dark` | `--color-primary-dark` |
| `--text-primary-dark` | `--text-primary` |
| `--input-bg` | `--bg-primary` (collapses the hand-rolled light `#fff`/dark `#0f172a` pair onto one mode-aware token) |

**Bucket B — component-scoped, runtime-injected tokens → custom property kept, only the stale fallback refreshed:**
- `--selection-color` / `--cursor-color` (set inline from user colour) — `#4a90d9` fallback → `var(--color-primary)`.
- `Minimap.tsx`: `ctx.fillStyle = 'var(--minimap-bg, …)'` is inert in a canvas context — now reads `--bg-primary` off the document element so the viewport box actually paints.
- `ShapePicker.tsx` canvas reads + the remaining `var(--color-primary, #4a90d9)` fallbacks — stale navy literals refreshed to the current brand navy.

`--note-*` and `--tab-color` were left untouched (always injected inline from `note.color` / `page.color`; never render undefined in practice).

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅
- Grep gate: no Bucket A orphan `var(--…)` refs and no stale `#4a90d9`/`#2c5282`/`#6c7aff` literals remain.
- Dark mode comes for free — the canonical tokens carry both light + dark values.

**Remaining for the author:** a light + dark eyeball pass — Storage Manager panels (were transparent), save-status / presence / connection banners (should read brand amber/green, not Tailwind), and the Minimap background.

Assisted-by: Opus 4.8