### PR TITLE
JP-220: icon unification slice 1 — shared sizing token + emoji → lucide

### DIFF
--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -30,10 +30,8 @@ import { CustomShapePicker } from './CustomShapePicker';
 import { FileImportButton } from './FileImportButton';
 import { InlinePageTabs } from './InlinePageTabs';
 import type { ImportContext } from '../services/FileImportService';
+import { ICON } from './icons';
 import './CanvasToolbar.css';
-
-/** Uniform sizing for all chrome icons in this toolbar. */
-const ICON = { size: 16, strokeWidth: 1.5 } as const;
 
 /** Tool definition. */
 interface ToolDef {

--- a/src/ui/CustomShapePicker.tsx
+++ b/src/ui/CustomShapePicker.tsx
@@ -9,7 +9,8 @@
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { Boxes, ChevronUp, ChevronDown } from 'lucide-react';
+import { Boxes, Square, ChevronUp, ChevronDown } from 'lucide-react';
+import { Icon } from './icons';
 import { useCustomShapeLibraryStore, initializeCustomShapeLibrary } from '../store/customShapeLibraryStore';
 import { useSessionStore } from '../store/sessionStore';
 import type { CustomShapeItem, CustomShapeLibrary } from '../storage/ShapeLibraryTypes';
@@ -208,7 +209,7 @@ export function CustomShapePicker() {
                       <img src={item.thumbnail} alt={item.name} />
                     ) : (
                       <span className="custom-shape-picker-item-placeholder">
-                        {item.type === 'group' ? '📦' : '◻️'}
+                        {item.type === 'group' ? <Icon icon={Boxes} size={28} /> : <Icon icon={Square} size={28} />}
                       </span>
                     )}
                   </div>

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -21,6 +21,7 @@ import { ImageUploadButton } from './ImageUploadButton';
 import { SearchReplacePanel } from './SearchReplacePanel';
 import { ToolbarDropdown } from './ToolbarDropdown';
 import { InsertLinkDialog } from './InsertLinkDialog';
+import { ICON } from './icons';
 import './DocumentEditorToolbar.css';
 
 /** Color palette for text and highlight colors */
@@ -37,9 +38,6 @@ const HIGHLIGHT_PALETTE = [
 ];
 
 type RibbonTab = 'home' | 'insert' | 'table';
-
-/** Uniform sizing for all lucide icons in the ribbon. */
-const ICON = { size: 16, strokeWidth: 1.5 } as const;
 
 export function DocumentEditorToolbar() {
   const editor = useTiptapEditor();

--- a/src/ui/SaveToLibraryDialog.tsx
+++ b/src/ui/SaveToLibraryDialog.tsx
@@ -12,6 +12,8 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useCustomShapeLibraryStore, initializeCustomShapeLibrary } from '../store/customShapeLibraryStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useSessionStore } from '../store/sessionStore';
+import { Boxes, Square } from 'lucide-react';
+import { Icon } from './icons';
 import { generateThumbnail } from '../utils/shapeSerializer';
 import type { Shape } from '../shapes/Shape';
 import './SaveToLibraryDialog.css';
@@ -165,7 +167,7 @@ export function SaveToLibraryDialog({ isOpen, onClose }: SaveToLibraryDialogProp
               <img src={thumbnail} alt="Shape preview" />
             ) : (
               <div className="save-to-library-preview-placeholder">
-                {isGroup ? '📦' : '◻️'}
+                {isGroup ? <Icon icon={Boxes} size={28} /> : <Icon icon={Square} size={28} />}
               </div>
             )}
             <span className="save-to-library-preview-info">

--- a/src/ui/ShapeLibraryManager.tsx
+++ b/src/ui/ShapeLibraryManager.tsx
@@ -10,8 +10,10 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { Plus, Upload, Download, Pencil, Trash2, Boxes, Square } from 'lucide-react';
 import { useCustomShapeLibraryStore, initializeCustomShapeLibrary } from '../store/customShapeLibraryStore';
 import type { CustomShapeLibrary, CustomShapeItem } from '../storage/ShapeLibraryTypes';
+import { Icon } from './icons';
 import './ShapeLibraryManager.css';
 
 /**
@@ -198,14 +200,14 @@ export function ShapeLibraryManager() {
                 onClick={() => setIsCreating(true)}
                 title="Create library"
               >
-                +
+                <Icon icon={Plus} />
               </button>
               <button
                 className="shape-library-action-btn"
                 onClick={handleImportClick}
                 title="Import library"
               >
-                ↓
+                <Icon icon={Upload} />
               </button>
               <input
                 ref={fileInputRef}
@@ -308,21 +310,21 @@ export function ShapeLibraryManager() {
                     onClick={() => handleStartEditLibrary(selectedLibrary)}
                     title="Rename library"
                   >
-                    ✏️
+                    <Icon icon={Pencil} />
                   </button>
                   <button
                     className="shape-library-action-btn"
                     onClick={() => handleExportLibrary(selectedLibrary)}
                     title="Export library"
                   >
-                    ↑
+                    <Icon icon={Download} />
                   </button>
                   <button
                     className="shape-library-action-btn danger"
                     onClick={() => handleDeleteLibrary(selectedLibrary)}
                     title="Delete library"
                   >
-                    🗑️
+                    <Icon icon={Trash2} />
                   </button>
                 </div>
               </div>
@@ -343,7 +345,7 @@ export function ShapeLibraryManager() {
                           <img src={item.thumbnail} alt={item.name} />
                         ) : (
                           <div className="shape-library-shape-placeholder">
-                            {item.type === 'group' ? '📦' : '◻️'}
+                            {item.type === 'group' ? <Icon icon={Boxes} size={28} /> : <Icon icon={Square} size={28} />}
                           </div>
                         )}
                       </div>
@@ -378,14 +380,14 @@ export function ShapeLibraryManager() {
                           onClick={() => handleStartEditItem(item)}
                           title="Rename"
                         >
-                          ✏️
+                          <Icon icon={Pencil} />
                         </button>
                         <button
                           className="shape-library-shape-action-btn danger"
                           onClick={() => handleDeleteItem(item)}
                           title="Delete"
                         >
-                          🗑️
+                          <Icon icon={Trash2} />
                         </button>
                       </div>
                     </div>

--- a/src/ui/Whiteboard.tsx
+++ b/src/ui/Whiteboard.tsx
@@ -6,9 +6,11 @@
  */
 
 import React, { useCallback, useEffect, useState, useRef, useLayoutEffect } from 'react';
+import { NotebookPen } from 'lucide-react';
 import { useWhiteboardStore } from '../store/whiteboardStore';
 import { StickyNote } from './StickyNote';
 import { clampToViewport } from './contextMenuUtils';
+import { Icon } from './icons';
 import './Whiteboard.css';
 
 /**
@@ -272,7 +274,7 @@ export const Whiteboard: React.FC = () => {
         >
           {noteOrder.length === 0 && (
             <div className="whiteboard-empty-state">
-              <div className="whiteboard-empty-icon">📝</div>
+              <div className="whiteboard-empty-icon"><Icon icon={NotebookPen} size={48} /></div>
               <div className="whiteboard-empty-text">
                 Click <strong>+</strong> or double-click to add a note
               </div>

--- a/src/ui/icons.tsx
+++ b/src/ui/icons.tsx
@@ -1,0 +1,26 @@
+/**
+ * Shared lucide-react icon conventions for editor chrome.
+ *
+ * Use these instead of re-declaring a local `const ICON` per toolbar so every
+ * chrome icon shares one size + stroke. Spread the token onto a lucide glyph
+ * (`<Bold {...ICON} />`) or use the `Icon` wrapper (`<Icon icon={Bold} />`).
+ *
+ * This is the single source of truth for icon sizing (JP-219 / JP-220). The
+ * remaining inline `size=/strokeWidth=` call sites migrate onto it over the
+ * later icon-unification slices.
+ */
+import type { LucideIcon, LucideProps } from 'lucide-react';
+
+/** Canonical chrome icon: 16px glyph, 1.5 stroke. */
+export const ICON = { size: 16, strokeWidth: 1.5 } as const;
+
+/** Dense variant for inline affordances (chevrons, small badges): 12px. */
+export const ICON_SM = { size: 12, strokeWidth: 1.5 } as const;
+
+/**
+ * Renders a lucide icon with the canonical chrome defaults. Any lucide prop
+ * (`size`, `strokeWidth`, `className`, …) overrides the default.
+ */
+export function Icon({ icon: Glyph, ...props }: { icon: LucideIcon } & LucideProps) {
+  return <Glyph size={ICON.size} strokeWidth={ICON.strokeWidth} {...props} />;
+}

--- a/src/ui/settings/BackupSettings.css
+++ b/src/ui/settings/BackupSettings.css
@@ -237,6 +237,14 @@
   padding: 2px 0;
 }
 
+/* Inline lucide glyphs in the validation summary: nudge onto the text baseline
+   with a small trailing gap (kept out of flexbox so the multi-fragment text
+   stays on one run). */
+.backup-validation-item svg {
+  vertical-align: -2px;
+  margin-right: 6px;
+}
+
 .backup-validation-error {
   color: var(--error-color, #ef4444);
   font-size: 12px;

--- a/src/ui/settings/BackupSettings.tsx
+++ b/src/ui/settings/BackupSettings.tsx
@@ -8,6 +8,8 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { FileText, Image as ImageIcon, Palette, Paintbrush, Library, Settings, Package } from 'lucide-react';
+import { Icon } from '../icons';
 import type {
   BackupOptions,
   ArchiveProgress,
@@ -349,26 +351,26 @@ export function BackupSettings() {
             {validation.manifest && (
               <>
                 <div className="backup-validation-item">
-                  📄 {validation.manifest.contents.documentCount} document(s)
+                  <Icon icon={FileText} size={14} />{validation.manifest.contents.documentCount} document(s)
                 </div>
                 <div className="backup-validation-item">
-                  🖼️ {validation.manifest.contents.blobCount} blob(s) ({formatBytes(validation.manifest.contents.blobTotalSize)})
+                  <Icon icon={ImageIcon} size={14} />{validation.manifest.contents.blobCount} blob(s) ({formatBytes(validation.manifest.contents.blobTotalSize)})
                 </div>
                 <div className="backup-validation-item">
-                  🎨 {validation.manifest.contents.styleProfileCount} style profile(s)
+                  <Icon icon={Paintbrush} size={14} />{validation.manifest.contents.styleProfileCount} style profile(s)
                 </div>
                 <div className="backup-validation-item">
-                  📚 {validation.manifest.contents.shapeLibraryCount} shape library(ies),{' '}
+                  <Icon icon={Library} size={14} />{validation.manifest.contents.shapeLibraryCount} shape library(ies),{' '}
                   {validation.manifest.contents.shapeLibraryItemCount} item(s)
                 </div>
                 {validation.manifest.contents.hasSettings && (
-                  <div className="backup-validation-item">⚙️ Settings included</div>
+                  <div className="backup-validation-item"><Icon icon={Settings} size={14} />Settings included</div>
                 )}
                 {validation.manifest.contents.hasColorPalette && (
-                  <div className="backup-validation-item">🎨 Color palette included</div>
+                  <div className="backup-validation-item"><Icon icon={Palette} size={14} />Color palette included</div>
                 )}
                 {validation.manifest.contents.hasIconLibrary && (
-                  <div className="backup-validation-item">📦 Icon library included</div>
+                  <div className="backup-validation-item"><Icon icon={Package} size={14} />Icon library included</div>
                 )}
                 <div className="backup-validation-item" style={{ marginTop: 4, fontSize: 11, opacity: 0.7 }}>
                   Created: {formatTimestamp(validation.manifest.createdAt)} · App v{validation.manifest.appVersion}


### PR DESCRIPTION
Foundation slice of **JP-219** (icon set unification), itself part of the JP-147 visual-design epic.

## What

**Foundation — shared icon sizing**
- New `src/ui/icons.tsx`: the single source of truth for chrome icon sizing — `ICON` (16/1.5) + `ICON_SM` (12/1.5) tokens and a tiny `Icon` wrapper that applies the canonical lucide defaults (`<Icon icon={Bold} />`, any prop overrides).
- `CanvasToolbar` and `DocumentEditorToolbar` drop their duplicated local `const ICON = { size: 16, strokeWidth: 1.5 }` and import the shared token.

**Emoji → lucide** (via the new `Icon` wrapper)
- Whiteboard empty state `📝` → `NotebookPen`.
- `ShapeLibraryManager` — swept the whole action cluster for coherence (not just the emoji): `+`→`Plus`, import `↓`/export `↑` → `Upload`/`Download`, `✏️`→`Pencil`, `🗑️`→`Trash2`, `📦`/`◻️` placeholder → `Boxes`/`Square`.
- `CustomShapePicker` + `SaveToLibraryDialog` group/item placeholder `📦`/`◻️` → `Boxes`/`Square`.
- `BackupSettings` validation summary — the whole `📄🖼️🎨📚⚙️🎨📦` list → `FileText`/`Image`/`Paintbrush`/`Library`/`Settings`/`Palette`/`Package`, plus a small CSS rule (`.backup-validation-item svg`) to baseline-align the inline glyphs (kept out of flexbox so the multi-fragment text stays on one run).

## Scope notes

A couple of touched components had non-emoji glyphs co-located with the emoji (the ShapeLibraryManager `+`/`↑`/`↓` arrows); I converted those too so no component is left half-emoji. Remaining hand-rolled status/toast/menu SVGs, the table `+⇥`/`+↓` text-glyphs, and broad adoption of the `Icon` helper across the rest of the call sites are the later JP-219 slices (2–4).

## Verify

- `bun run typecheck` ✅ · `bun run build` ✅
- Grep: target emoji gone from the touched files; only the shared `ICON` token remains.
- **Remaining for the author:** a light + dark eyeball of the whiteboard empty state, the shape-library manager buttons + placeholder tiles, the custom-shape picker / save-to-library placeholders, and the backup-restore validation summary.

Assisted-by: Opus 4.8