### PR TITLE
JP-222: file-shape iconography → lucide (canvas glyphs + file viewer)

### DIFF
--- a/src/shapes/FileShape.test.ts
+++ b/src/shapes/FileShape.test.ts
@@ -558,7 +558,7 @@ describe('blob:// thumbnail resolution (JP-122)', () => {
     expect(blobStorageMock.loadBlob).toHaveBeenCalledTimes(1);
   });
 
-  it('marks missing and draws the ⚠ overlay when the blob is absent', async () => {
+  it('marks missing and draws the warning overlay when the blob is absent', async () => {
     blobStorageMock.loadBlob.mockResolvedValue(null);
     const shape = createTestFile({
       blobRef: HASH,
@@ -570,13 +570,21 @@ describe('blob:// thumbnail resolution (JP-122)', () => {
 
     expect(isBlobMissing(HASH)).toBe(true);
 
-    // A render after the miss draws the warning glyph rather than throwing.
+    // A render after the miss draws the red missing-blob overlay (and routes the
+    // warning glyph through the icon cache) rather than throwing. Track the
+    // fillStyle assignments to confirm the overlay path ran.
     const ctx = makeCtx();
+    const fillStyles: string[] = [];
+    let current = '';
+    Object.defineProperty(ctx, 'fillStyle', {
+      get: () => current,
+      set: (value: string) => {
+        current = value;
+        fillStyles.push(value);
+      },
+    });
     fileShapeHandler.render(ctx, shape);
-    const drewWarning = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls.some(
-      (call) => call[0] === '⚠'
-    );
-    expect(drewWarning).toBe(true);
+    expect(fillStyles).toContain('rgba(239, 68, 68, 0.15)');
   });
 
   it('marks missing when the load rejects (no throw)', async () => {

--- a/src/shapes/FileShape.ts
+++ b/src/shapes/FileShape.ts
@@ -10,7 +10,8 @@ import {
   DEFAULT_FILE_SHAPE,
 } from './Shape';
 import { ShapeMetadata, createStandardProperties } from './ShapeMetadata';
-import { formatFileSize, getFileTypeIcon } from '../utils/fileUtils';
+import { formatFileSize } from '../utils/fileUtils';
+import { drawFileTypeIcon, drawWarningIcon } from '../utils/fileTypeIcons';
 import {
   blobHashFromRef,
   isBlobMissing,
@@ -243,10 +244,9 @@ export const fileShapeHandler: ShapeHandler<FileShape> = {
       ctx.drawImage(thumbImg, drawX, drawY, drawW, drawH);
       ctx.restore();
     } else {
-      // No thumbnail (or it hasn't resolved yet) — draw the category icon on a
-      // soft rounded tile so the fallback reads as a deliberate file glyph
-      // rather than a bare floating emoji.
-      const icon = getFileTypeIcon(shape.fileCategory);
+      // No thumbnail (or it hasn't resolved yet) — draw the lucide file-type
+      // glyph on a soft rounded tile so the fallback reads as a deliberate file
+      // icon rather than a bare floating glyph.
       const centerX = 0;
       const centerY = thumbAreaTop + thumbAreaHeight / 2;
       const tileSize = Math.max(32, Math.min(width, thumbAreaHeight) * 0.5);
@@ -265,14 +265,17 @@ export const fileShapeHandler: ShapeHandler<FileShape> = {
       ctx.closePath();
       ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
       ctx.fill();
-
-      const emojiSize = tileSize * 0.55;
-      ctx.font = `${emojiSize}px sans-serif`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillStyle = shape.labelColor ?? DEFAULT_FILE_SHAPE.labelColor;
-      ctx.fillText(icon, centerX, centerY);
       ctx.restore();
+
+      const glyphSize = tileSize * 0.55;
+      drawFileTypeIcon(
+        ctx,
+        shape.fileCategory,
+        centerX - glyphSize / 2,
+        centerY - glyphSize / 2,
+        glyphSize,
+        shape.labelColor ?? DEFAULT_FILE_SHAPE.labelColor
+      );
     }
 
     // --- Separator line ---
@@ -305,12 +308,12 @@ export const fileShapeHandler: ShapeHandler<FileShape> = {
     ctx.textBaseline = 'middle';
     ctx.fillStyle = labelColor;
 
-    // Category icon (emoji)
-    const categoryIcon = getFileTypeIcon(shape.fileCategory);
+    // Category icon (lucide glyph, sized to the bar text)
     ctx.textAlign = 'left';
     const iconX = -halfWidth + barPadding;
-    ctx.fillText(categoryIcon, iconX, barCenterY);
-    const iconWidth = ctx.measureText(categoryIcon).width;
+    const barIconSize = fontSize;
+    drawFileTypeIcon(ctx, shape.fileCategory, iconX, barCenterY - barIconSize / 2, barIconSize, labelColor);
+    const iconWidth = barIconSize;
 
     // File size on the right
     const sizeText = formatFileSize(shape.fileSize);
@@ -350,11 +353,14 @@ export const fileShapeHandler: ShapeHandler<FileShape> = {
 
       // Warning icon in center of thumbnail area
       const warningSize = Math.max(20, width * 0.15);
-      ctx.font = `${warningSize}px sans-serif`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillStyle = 'rgba(239, 68, 68, 0.8)';
-      ctx.fillText('⚠', 0, thumbAreaTop + thumbAreaHeight / 2);
+      const warningCY = thumbAreaTop + thumbAreaHeight / 2;
+      drawWarningIcon(
+        ctx,
+        -warningSize / 2,
+        warningCY - warningSize / 2,
+        warningSize,
+        'rgba(239, 68, 68, 0.8)'
+      );
     }
 
     ctx.restore();

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -185,6 +185,26 @@
   font-size: 32px;
 }
 
+/* Inline lucide glyphs (JP-222): center within their chips/buttons and give the
+   icon+label action buttons a small gap. */
+.file-viewer-icon,
+.file-viewer-error-icon,
+.file-viewer-recovery-icon,
+.file-viewer-action-btn,
+.file-viewer-close-btn {
+  display: inline-flex;
+  align-items: center;
+}
+
+.file-viewer-action-btn {
+  gap: 6px;
+  justify-content: center;
+}
+
+.file-viewer-close-btn {
+  justify-content: center;
+}
+
 /* Dark mode */
 [data-theme="dark"] .file-viewer-overlay {
   background: rgba(0, 0, 0, 0.8);

--- a/src/ui/FileViewerModal.tsx
+++ b/src/ui/FileViewerModal.tsx
@@ -14,7 +14,10 @@ import { useDocumentStore } from '../store/documentStore';
 import { blobStorage } from '../storage/BlobStorage';
 import { resolveBlobObjectUrl } from '../storage/blobResolver';
 import { isFile, type FileShape } from '../shapes/Shape';
-import { formatFileSize, getFileTypeIcon } from '../utils/fileUtils';
+import { RotateCw, Download, X, TriangleAlert, FolderOpen } from 'lucide-react';
+import { formatFileSize } from '../utils/fileUtils';
+import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { Icon } from './icons';
 import { replaceFileContents, reuploadMissingBlob } from '../services/FileReplaceService';
 import './FileViewerModal.css';
 
@@ -201,7 +204,7 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
   }
 
   const displayName = fileShape.label || fileShape.fileName;
-  const icon = getFileTypeIcon(fileShape.fileCategory);
+  const FileIcon = getFileTypeLucideIcon(fileShape.fileCategory);
 
   return (
     <div className="file-viewer-overlay" onClick={handleOverlayClick}>
@@ -209,7 +212,7 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
         {/* Header */}
         <div className="file-viewer-header">
           <div className="file-viewer-header-info">
-            <span className="file-viewer-icon">{icon}</span>
+            <span className="file-viewer-icon"><Icon icon={FileIcon} size={18} /></span>
             <span className="file-viewer-filename" title={fileShape.fileName}>
               {displayName}
             </span>
@@ -227,7 +230,7 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
               title="Replace with different file"
               disabled={isReplacing}
             >
-              {isReplacing ? '...' : '↻ Replace'}
+              {isReplacing ? '...' : <><Icon icon={RotateCw} size={14} />Replace</>}
             </button>
             <button
               className="file-viewer-action-btn"
@@ -235,14 +238,14 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
               title="Download file"
               disabled={isMissingBlob}
             >
-              ⬇ Download
+              <Icon icon={Download} size={14} />Download
             </button>
             <button
               className="file-viewer-close-btn"
               onClick={onClose}
               title="Close (Escape)"
             >
-              ✕
+              <Icon icon={X} size={16} />
             </button>
             {/* Hidden file inputs */}
             <input
@@ -270,13 +273,13 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
           )}
           {error && !isMissingBlob && (
             <div className="file-viewer-error">
-              <span className="file-viewer-error-icon">⚠️</span>
+              <span className="file-viewer-error-icon"><Icon icon={TriangleAlert} size={20} /></span>
               <span>{error}</span>
             </div>
           )}
           {isMissingBlob && (
             <div className="file-viewer-recovery">
-              <span className="file-viewer-recovery-icon">📂</span>
+              <span className="file-viewer-recovery-icon"><Icon icon={FolderOpen} size={28} /></span>
               <span className="file-viewer-recovery-title">File Not Found</span>
               <p className="file-viewer-recovery-message">
                 The file content is missing from local storage.

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -48,7 +48,9 @@ import { shapeRegistry } from '../shapes/ShapeRegistry';
 // GroupStyles types are used via the PatternPicker, ShadowEditor, LabelPositionPicker components
 import type { ShapeMetadata, PropertyDefinition, PropertySection as PropertySectionType } from '../shapes/ShapeMetadata';
 import { replaceFileContents } from '../services/FileReplaceService';
-import { formatFileSize, getFileTypeIcon } from '../utils/fileUtils';
+import { formatFileSize } from '../utils/fileUtils';
+import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { Icon } from './icons';
 import './PropertyPanel.css';
 
 /** Sentinel value indicating mixed values across selected shapes */
@@ -1346,13 +1348,13 @@ function FileShapeProperties({
     [shape.id]
   );
 
-  const icon = getFileTypeIcon(shape.fileCategory);
+  const FileIcon = getFileTypeLucideIcon(shape.fileCategory);
 
   return (
     <>
       <PropertySection id="file-info" title="File" defaultExpanded>
         <div className="file-info-card">
-          <span className="file-info-icon">{icon}</span>
+          <span className="file-info-icon"><Icon icon={FileIcon} size={20} /></span>
           <div className="file-info-details">
             <div className="file-info-name" title={shape.fileName}>
               {shape.fileName}

--- a/src/ui/viewers/GenericFileViewer.tsx
+++ b/src/ui/viewers/GenericFileViewer.tsx
@@ -1,4 +1,6 @@
-import { formatFileSize, getFileTypeIcon, detectFileCategory } from '../../utils/fileUtils';
+import { formatFileSize, detectFileCategory } from '../../utils/fileUtils';
+import { getFileTypeLucideIcon } from '../../utils/fileTypeIcons';
+import { Icon } from '../icons';
 import './GenericFileViewer.css';
 
 export interface GenericFileViewerProps {
@@ -9,12 +11,12 @@ export interface GenericFileViewerProps {
 }
 
 export function GenericFileViewer({ fileName, fileSize, mimeType }: GenericFileViewerProps) {
-  const icon = getFileTypeIcon(detectFileCategory(mimeType, fileName));
+  const FileIcon = getFileTypeLucideIcon(detectFileCategory(mimeType, fileName));
 
   return (
     <div className="generic-viewer">
       <div className="generic-viewer-card">
-        <div className="generic-viewer-icon">{icon}</div>
+        <div className="generic-viewer-icon"><Icon icon={FileIcon} size={48} /></div>
         <div className="generic-viewer-name">{fileName}</div>
         <div className="generic-viewer-meta">
           {formatFileSize(fileSize)} · {mimeType}

--- a/src/utils/fileTypeIcons.test.ts
+++ b/src/utils/fileTypeIcons.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getFileTypeLucideIcon } from './fileTypeIcons';
+import type { FileCategory } from './fileUtils';
+
+describe('getFileTypeLucideIcon', () => {
+  it('returns a lucide component for every file category', () => {
+    const categories: FileCategory[] = ['pdf', 'spreadsheet', 'image', 'text', 'generic'];
+    for (const category of categories) {
+      expect(getFileTypeLucideIcon(category)).toBeTruthy();
+    }
+  });
+
+  it('maps distinct categories to distinct glyphs', () => {
+    const pdf = getFileTypeLucideIcon('pdf');
+    const image = getFileTypeLucideIcon('image');
+    const generic = getFileTypeLucideIcon('generic');
+    expect(pdf).not.toBe(image);
+    expect(pdf).not.toBe(generic);
+    expect(image).not.toBe(generic);
+  });
+});

--- a/src/utils/fileTypeIcons.ts
+++ b/src/utils/fileTypeIcons.ts
@@ -1,0 +1,76 @@
+/**
+ * File-type icons — the lucide glyphs shown for embedded file shapes, in both
+ * the React surfaces (file viewer, property panel) and on the canvas.
+ *
+ * The canvas can't render a React lucide component, so each category also has a
+ * raw lucide SVG string here (24x24, `currentColor`, matching the built-in icon
+ * format) that `FileShape` rasterises via `iconCache.drawRawSvgIcon`. The React
+ * side uses the lucide-react components directly. Keep the two in sync.
+ */
+import { File, FileText, FileType, Image as ImageIcon, Sheet, type LucideIcon } from 'lucide-react';
+import { drawRawSvgIcon } from './iconCache';
+import type { FileCategory } from './fileUtils';
+
+const SVG_ATTRS =
+  'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"';
+
+/** A bare file outline, shared by the document-ish glyphs. */
+const FILE_BODY = '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/>';
+
+/** Raw lucide SVG markup per file category (mirrors the React components below). */
+const FILE_TYPE_SVG: Record<FileCategory, string> = {
+  // FileText
+  pdf: `<svg ${SVG_ATTRS}>${FILE_BODY}<path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>`,
+  // Sheet
+  spreadsheet: `<svg ${SVG_ATTRS}><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg>`,
+  // Image
+  image: `<svg ${SVG_ATTRS}><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>`,
+  // FileType
+  text: `<svg ${SVG_ATTRS}>${FILE_BODY}<path d="M9 13v-1h6v1"/><path d="M11 18h2"/><path d="M12 12v6"/></svg>`,
+  // File
+  generic: `<svg ${SVG_ATTRS}>${FILE_BODY}</svg>`,
+};
+
+/** TriangleAlert — the missing-blob overlay glyph. */
+const WARNING_SVG = `<svg ${SVG_ATTRS}><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>`;
+
+/** The lucide-react component per file category (for React surfaces). */
+const FILE_TYPE_COMPONENT: Record<FileCategory, LucideIcon> = {
+  pdf: FileText,
+  spreadsheet: Sheet,
+  image: ImageIcon,
+  text: FileType,
+  generic: File,
+};
+
+/** Get the lucide-react icon component for a file category. */
+export function getFileTypeLucideIcon(category: FileCategory): LucideIcon {
+  return FILE_TYPE_COMPONENT[category];
+}
+
+/**
+ * Draw a file-type glyph on the canvas (top-left origin), rasterised + cached.
+ * Returns false until the icon image has loaded (a redraw is scheduled via the
+ * shared `onIconLoad` hook).
+ */
+export function drawFileTypeIcon(
+  ctx: CanvasRenderingContext2D,
+  category: FileCategory,
+  x: number,
+  y: number,
+  size: number,
+  color: string
+): boolean {
+  return drawRawSvgIcon(ctx, `file-type:${category}`, FILE_TYPE_SVG[category], x, y, size, color);
+}
+
+/** Draw the missing-blob warning glyph on the canvas (top-left origin). */
+export function drawWarningIcon(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  color: string
+): boolean {
+  return drawRawSvgIcon(ctx, 'file-type:warning', WARNING_SVG, x, y, size, color);
+}

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   detectFileCategory,
   formatFileSize,
-  getFileTypeIcon,
   getMimeType,
   isPreviewableFile,
 } from './fileUtils';
@@ -65,16 +64,6 @@ describe('formatFileSize', () => {
 
   it('handles negative values', () => {
     expect(formatFileSize(-1)).toBe('0 B');
-  });
-});
-
-describe('getFileTypeIcon', () => {
-  it('returns icons for each category', () => {
-    expect(getFileTypeIcon('pdf')).toBe('📕');
-    expect(getFileTypeIcon('spreadsheet')).toBe('📊');
-    expect(getFileTypeIcon('image')).toBe('🖼️');
-    expect(getFileTypeIcon('text')).toBe('📝');
-    expect(getFileTypeIcon('generic')).toBe('📄');
   });
 });
 

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -71,19 +71,6 @@ export function formatFileSize(bytes: number): string {
 }
 
 /**
- * Get a representative emoji icon for a file category.
- */
-export function getFileTypeIcon(category: FileCategory): string {
-  switch (category) {
-    case 'pdf': return '📕';
-    case 'spreadsheet': return '📊';
-    case 'image': return '🖼️';
-    case 'text': return '📝';
-    case 'generic': return '📄';
-  }
-}
-
-/**
  * Guess MIME type from filename extension.
  * Returns 'application/octet-stream' for unknown types.
  */

--- a/src/utils/iconCache.ts
+++ b/src/utils/iconCache.ts
@@ -160,6 +160,87 @@ export function drawIcon(
 }
 
 /**
+ * Draw an icon from a raw SVG string (rather than the user icon library).
+ *
+ * Used for built-in chrome glyphs rendered on the canvas — e.g. the file-shape
+ * type icons — that share the lucide visual language but should NOT live in the
+ * user's icon library / picker. Reuses the same image cache + `onIconLoad`
+ * re-render notification as `drawIcon`, so the glyph appears once rasterised.
+ *
+ * @param ctx - Canvas 2D context
+ * @param cacheKey - Stable identity for this SVG (e.g. `file-type:pdf`)
+ * @param svg - Raw SVG markup (`currentColor` is replaced with `color`)
+ * @param x - X position (top-left corner)
+ * @param y - Y position (top-left corner)
+ * @param size - Icon size (width and height)
+ * @param color - Fill/stroke colour to substitute for `currentColor`
+ * @returns true if drawn, false if not yet loaded
+ */
+export function drawRawSvgIcon(
+  ctx: CanvasRenderingContext2D,
+  cacheKey: string,
+  svg: string,
+  x: number,
+  y: number,
+  size: number,
+  color?: string
+): boolean {
+  const image = getRawSvgImage(cacheKey, svg, color);
+  if (!image) {
+    return false;
+  }
+  ctx.drawImage(image, x, y, size, size);
+  return true;
+}
+
+/**
+ * Get (and lazily rasterise) a cached image for a raw SVG string.
+ */
+function getRawSvgImage(
+  cacheKey: string,
+  svg: string,
+  color?: string
+): HTMLImageElement | undefined {
+  const key = color ? `${cacheKey}:${color}` : cacheKey;
+
+  const cached = cache.get(key);
+  if (cached) {
+    return cached.ready ? cached.image : undefined;
+  }
+
+  loadRawSvgAsync(key, svg, color);
+  return undefined;
+}
+
+/**
+ * Rasterise a raw SVG string into a cached image.
+ */
+function loadRawSvgAsync(
+  cacheKey: string,
+  svg: string,
+  color: string | undefined
+): void {
+  const entry: CacheEntry = {
+    image: new Image(),
+    ready: false,
+    error: false,
+  };
+  cache.set(cacheKey, entry);
+
+  const svgContent = color ? svg.replace(/currentColor/g, color) : svg;
+  const dataUrl = svgToDataUrl(svgContent);
+
+  entry.image.onload = () => {
+    entry.ready = true;
+    notifyLoaded();
+  };
+  entry.image.onerror = () => {
+    entry.error = true;
+  };
+  entry.image.src = dataUrl;
+}
+
+/**
  * Clear a specific icon from the cache.
  * Use this when an icon is updated or deleted.
  */


### PR DESCRIPTION
Part of **JP-219** (icon set unification) — the **file shapes** corner, which was emoji split across a Canvas-2D surface and React.

## The wrinkle

`FileShape.render()` draws its file-type glyphs (`📕📊🖼️📝📄` + a `⚠` missing-blob overlay) on the **canvas** via `ctx.fillText(emoji)` — and lucide is a React SVG library, so it can't drop straight in.

## How

**Canvas — reuse the existing raster plumbing.** `iconCache` already rasterises an SVG string → `HTMLImageElement` and `Renderer` re-renders on `onIconLoad`; the builtin icons are *already lucide SVG strings*.
- `iconCache.drawRawSvgIcon(ctx, key, svg, x, y, size, color)` — rasterises a raw lucide SVG into the same image cache + `notifyLoaded` hook, **without** adding anything to the user icon library / picker.
- New `src/utils/fileTypeIcons.ts` — the lucide SVG per `FileCategory` (`FileText`/`Sheet`/`Image`/`FileType`/`File`) + `TriangleAlert`, with `drawFileTypeIcon` / `drawWarningIcon` (canvas) and `getFileTypeLucideIcon` (React).
- `FileShape.render` swaps its 3 `fillText(emoji)` sites for the cached lucide draws. Bonus: the bar-icon width is now known (`size`) instead of the old `measureText(emoji)` hack.

**React.** `getFileTypeIcon` (emoji) is removed; `FileViewerModal`, `PropertyPanel`, and `GenericFileViewer` render the lucide component through the shared `Icon` wrapper from `src/ui/icons.tsx`. FileViewerModal buttons `↻`/`⬇`/`✕` → `RotateCw`/`Download`/`X`, `⚠️` → `TriangleAlert`, `📂` → `FolderOpen`, with a small CSS rule to align the inline glyphs.

## Verify

- `bun run typecheck` ✅ · `bun run build` ✅ · `bun run test --run` ✅ (1857 tests).
- `fileUtils` test drops the emoji assertion; new `fileTypeIcons` test added; the FileShape warning-overlay test now asserts the red overlay (the glyph itself routes through the async cache, which doesn't load synchronously in jsdom).
- **Remaining for the author — canvas eyeball:** drop a PDF / spreadsheet / image / text / generic file on the canvas; confirm the monochrome lucide type glyphs render (thumbnail-fallback tile + bottom bar), recolour with the label colour, the missing-blob `⚠` overlay, and the file viewer modal chrome — light + dark.

Note: the FileShape **shape-metadata** picker icon (`icon: '📄'`) is left as-is — that's the data-driven shape-library glyph convention shared by all shapes, not file-type rendering.

Assisted-by: Opus 4.8