### PR TITLE
JP-221: icon unification slice 2 — chrome hand-rolled SVG → lucide

### DIFF
--- a/src/ui/FileMenu.tsx
+++ b/src/ui/FileMenu.tsx
@@ -3,6 +3,8 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Icon } from './icons';
 import { useSessionStore } from '../store/sessionStore';
 import {
   usePersistenceStore,
@@ -153,9 +155,7 @@ export function FileMenu({ onOpenDocumentManager }: FileMenuProps) {
           aria-expanded={isMenuOpen}
         >
           File
-          <svg width="10" height="6" viewBox="0 0 10 6" className="file-menu-arrow">
-            <path d="M1 1L5 5L9 1" stroke="currentColor" strokeWidth="1.5" fill="none" />
-          </svg>
+          <Icon icon={ChevronDown} size={12} className="file-menu-arrow" />
         </button>
 
         {isMenuOpen && (

--- a/src/ui/InsertLinkDialog.tsx
+++ b/src/ui/InsertLinkDialog.tsx
@@ -3,6 +3,8 @@ import { createPortal } from 'react-dom';
 import type { Editor } from '@tiptap/core';
 import type { Mark, MarkType } from '@tiptap/pm/model';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { Link2, Heading } from 'lucide-react';
+import { Icon } from './icons';
 import './InsertLinkDialog.css';
 
 /**
@@ -232,9 +234,7 @@ export function InsertLinkDialog({ editor, onClose }: InsertLinkDialogProps) {
               className={mode === 'web' ? 'active' : ''}
               onClick={() => setMode('web')}
             >
-              <svg className="link-dialog-segment-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path d="M6.5 9.5l3-3M5 11a2.5 2.5 0 010-3.5l2-2a2.5 2.5 0 013.5 3.5M11 5a2.5 2.5 0 010 3.5l-2 2a2.5 2.5 0 01-3.5-3.5" strokeLinecap="round" />
-              </svg>
+              <Icon icon={Link2} size={14} className="link-dialog-segment-icon" />
               Web URL
             </button>
             <button
@@ -243,9 +243,7 @@ export function InsertLinkDialog({ editor, onClose }: InsertLinkDialogProps) {
               className={mode === 'internal' ? 'active' : ''}
               onClick={() => setMode('internal')}
             >
-              <svg className="link-dialog-segment-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path d="M3 4h10M3 8h7M3 12h10" strokeLinecap="round" />
-              </svg>
+              <Icon icon={Heading} size={14} className="link-dialog-segment-icon" />
               Heading
             </button>
           </div>

--- a/src/ui/NotificationToast.tsx
+++ b/src/ui/NotificationToast.tsx
@@ -6,7 +6,9 @@
  * Phase 14.9.2 - Error Handling & Resilience
  */
 
+import { Info, CircleCheck, TriangleAlert, CircleX, X } from 'lucide-react';
 import { useNotificationStore, type Notification } from '../store/notificationStore';
+import { Icon } from './icons';
 import './NotificationToast.css';
 
 /** Single toast notification */
@@ -31,10 +33,10 @@ function Toast({ notification }: { notification: Notification }) {
       aria-live={notification.severity === 'error' ? 'assertive' : 'polite'}
     >
       <div className="notification-toast__icon">
-        {notification.severity === 'info' && <InfoIcon />}
-        {notification.severity === 'success' && <SuccessIcon />}
-        {notification.severity === 'warning' && <WarningIcon />}
-        {notification.severity === 'error' && <ErrorIcon />}
+        {notification.severity === 'info' && <Icon icon={Info} size={20} />}
+        {notification.severity === 'success' && <Icon icon={CircleCheck} size={20} />}
+        {notification.severity === 'warning' && <Icon icon={TriangleAlert} size={20} />}
+        {notification.severity === 'error' && <Icon icon={CircleX} size={20} />}
       </div>
 
       <div className="notification-toast__content">
@@ -60,7 +62,7 @@ function Toast({ notification }: { notification: Notification }) {
           type="button"
           aria-label="Dismiss notification"
         >
-          <CloseIcon />
+          <Icon icon={X} size={16} />
         </button>
       </div>
     </div>
@@ -84,64 +86,4 @@ export function NotificationToast() {
   );
 }
 
-// ============ Icons ============
-
-function InfoIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v1a1 1 0 102 0V7zm-1 3a1 1 0 00-1 1v3a1 1 0 102 0v-3a1 1 0 00-1-1z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
-
-function SuccessIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
-
-function WarningIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
-
-function ErrorIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M4.293 4.293a1 1 0 011.414 0L8 6.586l2.293-2.293a1 1 0 111.414 1.414L9.414 8l2.293 2.293a1 1 0 01-1.414 1.414L8 9.414l-2.293 2.293a1 1 0 01-1.414-1.414L6.586 8 4.293 5.707a1 1 0 010-1.414z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
-}
+// Toast severity + dismiss icons now come from lucide (see imports).

--- a/src/ui/chrome/WindowControls.tsx
+++ b/src/ui/chrome/WindowControls.tsx
@@ -10,6 +10,8 @@
  */
 
 import { useEffect, useState } from 'react';
+import { Minus, Square, Copy, X } from 'lucide-react';
+import { Icon } from '../icons';
 import { windowControls } from '../../platform/window';
 import './WindowControls.css';
 
@@ -66,9 +68,7 @@ export function WindowControls() {
         aria-label="Minimize"
         title="Minimize"
       >
-        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-          <rect x="1" y="4.5" width="8" height="1" fill="currentColor" />
-        </svg>
+        <Icon icon={Minus} size={10} />
       </button>
       <button
         type="button"
@@ -77,16 +77,7 @@ export function WindowControls() {
         aria-label={isMaximized ? 'Restore' : 'Maximize'}
         title={isMaximized ? 'Restore' : 'Maximize'}
       >
-        {isMaximized ? (
-          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-            <rect x="2.5" y="1" width="6.5" height="6.5" fill="none" stroke="currentColor" />
-            <rect x="1" y="2.5" width="6.5" height="6.5" fill="none" stroke="currentColor" />
-          </svg>
-        ) : (
-          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-            <rect x="1" y="1" width="8" height="8" fill="none" stroke="currentColor" />
-          </svg>
-        )}
+        {isMaximized ? <Icon icon={Copy} size={10} /> : <Icon icon={Square} size={10} />}
       </button>
       <button
         type="button"
@@ -95,9 +86,7 @@ export function WindowControls() {
         aria-label="Close"
         title="Close"
       >
-        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
-          <path d="M1 1 L9 9 M9 1 L1 9" stroke="currentColor" strokeWidth="1" />
-        </svg>
+        <Icon icon={X} size={10} />
       </button>
     </div>
   );


### PR DESCRIPTION
Slice 2 of **JP-219** (icon set unification) — the React-rendered hand-rolled inline-SVG chrome icons that have faithful lucide equivalents, via the shared `Icon` wrapper from `src/ui/icons.tsx`.

## Converted

- **NotificationToast** — Info/Success/Warning/Error/Close → `Info`/`CircleCheck`/`TriangleAlert`/`CircleX`/`X` (the 5 inline-SVG helpers deleted).
- **FileMenu** — dropdown arrow → `ChevronDown`.
- **WindowControls** — minimize/maximize/restore/close → `Minus`/`Square`/`Copy`/`X`.
- **InsertLinkDialog** — web-link / heading segment glyphs → `Link2` / `Heading`.

Net −71 lines.

## Deliberately not in this slice

- **Save-status icons** (`UnifiedToolbar`/`SaveStatusIndicator`) + the **upload spinners** (`FileImportButton`/`ImageUploadButton`) — a small custom-**animated** micro-system (`saving-spin`, `saved-check`/`.check-path` draw) with no faithful lucide equivalent; kept bespoke per the standing note.
- **LayerPanel** (11 icons, incl. functional visibility/lock toggles) — split to **JP-223** for a focused eyeball.
- Genuinely bespoke kept: AlignmentPanel align/distribute glyphs, BorderStylePicker dash previews, PatternPicker pattern demos.

## Verify

- `bun run typecheck` ✅ · `bun run build` ✅ · `bun run test --run` ✅ (1857).
- **Remaining for the author — eyeball (light + dark):** toast notifications (info/success/warning/error + dismiss), the File menu arrow (incl. open-state rotation), window controls with custom chrome on (min/max/restore/close), and the insert-link dialog's Web-URL / Heading segmented control.

Assisted-by: Opus 4.8