### PR TITLE
JP-224: icon unification slice 4 — adopt the shared Icon wrapper

### DIFF
--- a/src/ui/CustomShapePicker.tsx
+++ b/src/ui/CustomShapePicker.tsx
@@ -146,13 +146,13 @@ export function CustomShapePicker() {
             {activeCustomItem.thumbnail ? (
               <img src={activeCustomItem.thumbnail} alt="" className="custom-shape-picker-trigger-thumb" />
             ) : (
-              <Boxes size={16} strokeWidth={1.5} />
+              <Icon icon={Boxes} />
             )}
           </span>
         ) : (
-          <span className="custom-shape-picker-trigger-icon"><Boxes size={16} strokeWidth={1.5} /></span>
+          <span className="custom-shape-picker-trigger-icon"><Icon icon={Boxes} /></span>
         )}
-        <span className="custom-shape-picker-chevron">{isOpen ? <ChevronUp size={12} strokeWidth={1.5} /> : <ChevronDown size={12} strokeWidth={1.5} />}</span>
+        <span className="custom-shape-picker-chevron">{isOpen ? <Icon icon={ChevronUp} size={12} /> : <Icon icon={ChevronDown} size={12} />}</span>
       </button>
 
       {isOpen && (

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { EllipsisVertical } from 'lucide-react';
+import { Icon } from './icons';
 import type { Editor } from '@tiptap/core';
 import { history } from 'prosemirror-history';
 import { DocumentEditorToolbar } from './DocumentEditorToolbar';
@@ -447,7 +448,7 @@ export function DocumentEditorPanel({
         aria-expanded={menuOpen}
         aria-label="Editor options"
       >
-        <EllipsisVertical size={16} strokeWidth={1.5} aria-hidden="true" />
+        <Icon icon={EllipsisVertical} aria-hidden="true" />
       </button>
       {menuOpen && (
         <div className="document-editor-panel-menu" role="menu">

--- a/src/ui/FileImportButton.tsx
+++ b/src/ui/FileImportButton.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback } from 'react';
 import { Import } from 'lucide-react';
+import { Icon } from './icons';
 import { importFiles, ImportContext } from '../services/FileImportService';
 import './FileImportButton.css';
 
@@ -58,7 +59,7 @@ export function FileImportButton({ getImportContext }: FileImportButtonProps) {
               </path>
             </svg>
           ) : (
-            <Import size={16} strokeWidth={1.5} />
+            <Icon icon={Import} />
           )}
         </span>
       </button>

--- a/src/ui/ImageUploadButton.tsx
+++ b/src/ui/ImageUploadButton.tsx
@@ -10,6 +10,7 @@
 
 import { useRef, useState } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
+import { Icon } from './icons';
 import { useTiptapEditor } from './TiptapEditorContext';
 import { blobStorage } from '../storage/BlobStorage';
 import { processImageForUpload, formatFileSize } from '../utils/imageUtils';
@@ -105,7 +106,7 @@ export function ImageUploadButton({ className }: ImageUploadButtonProps) {
             </path>
           </svg>
         ) : (
-          <ImageIcon size={16} strokeWidth={1.5} />
+          <Icon icon={ImageIcon} />
         )}
       </button>
 

--- a/src/ui/InlinePageTabs.tsx
+++ b/src/ui/InlinePageTabs.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import { Plus } from 'lucide-react';
+import { Icon } from './icons';
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
@@ -187,7 +188,7 @@ export function InlinePageTabs() {
         })}
       </div>
       <button className="inline-tab-add" onClick={handleAddPage} title="Add page" aria-label="Add page">
-        <Plus size={14} strokeWidth={1.5} />
+        <Icon icon={Plus} size={14} />
       </button>
 
       {/* Context Menu */}

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -12,6 +12,7 @@
 
 import { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
 import { Plus } from 'lucide-react';
+import { Icon } from './icons';
 import { createPortal } from 'react-dom';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import './RichTextTabBar.css';
@@ -258,7 +259,7 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
         title="Add new page"
         aria-label="Add new page"
       >
-        <Plus size={16} strokeWidth={1.5} />
+        <Icon icon={Plus} />
       </button>
 
       {trailing && <div className="rich-text-tab-trailing">{trailing}</div>}

--- a/src/ui/ShapePicker.tsx
+++ b/src/ui/ShapePicker.tsx
@@ -10,6 +10,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { Shapes, ChevronUp, ChevronDown } from 'lucide-react';
+import { Icon } from './icons';
 import { useShapeLibraryStore } from '../store/shapeLibraryStore';
 import { useSessionStore } from '../store/sessionStore';
 import { createShapeAtCenter } from '../engine/CommandRegistry';
@@ -178,9 +179,9 @@ export function ShapePicker() {
         {activeLibraryShape ? (
           <span className="shape-picker-trigger-icon">{activeLibraryShape.icon}</span>
         ) : (
-          <span className="shape-picker-trigger-icon"><Shapes size={16} strokeWidth={1.5} /></span>
+          <span className="shape-picker-trigger-icon"><Icon icon={Shapes} /></span>
         )}
-        <span className="shape-picker-chevron">{isOpen ? <ChevronUp size={12} strokeWidth={1.5} /> : <ChevronDown size={12} strokeWidth={1.5} />}</span>
+        <span className="shape-picker-chevron">{isOpen ? <Icon icon={ChevronUp} size={12} /> : <Icon icon={ChevronDown} size={12} />}</span>
       </button>
 
       {isOpen && (

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { StickyNote, CircleHelp, Settings, Import } from 'lucide-react';
+import { Icon } from './icons';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
 import { useAutoSave } from '../hooks/useAutoSave';
@@ -161,7 +162,7 @@ export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings }: Unified
           title="Import diagram (Excalidraw)"
           aria-label="Import diagram"
         >
-          <Import size={16} strokeWidth={1.5} />
+          <Icon icon={Import} />
         </button>
         <button
           className="toolbar-whiteboard-btn"
@@ -169,14 +170,14 @@ export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings }: Unified
           title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
           aria-label="Whiteboard"
         >
-          <StickyNote size={16} strokeWidth={1.5} />
+          <Icon icon={StickyNote} />
         </button>
         <button
           className="toolbar-help-btn"
           onClick={() => void openDocsHandler()}
           title="Open documentation (F1)"
         >
-          <CircleHelp size={16} strokeWidth={1.5} />
+          <Icon icon={CircleHelp} />
         </button>
         {onOpenSettings && (
           <button
@@ -184,7 +185,7 @@ export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings }: Unified
             onClick={onOpenSettings}
             title="Settings (Documents, Theme, Storage, Libraries)"
           >
-            <Settings size={14} strokeWidth={1.5} />
+            <Icon icon={Settings} size={14} />
             <span>Settings</span>
           </button>
         )}

--- a/src/ui/layout/DocumentToggleRail.tsx
+++ b/src/ui/layout/DocumentToggleRail.tsx
@@ -6,6 +6,7 @@
  */
 
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Icon } from '../icons';
 import { useLayoutActions } from './useLayout';
 import './DocumentToggleRail.css';
 
@@ -26,9 +27,9 @@ export function DocumentToggleRail({ side }: DocumentToggleRailProps) {
       aria-label="Show document editor"
     >
       {side === 'left' ? (
-        <ChevronRight size={14} strokeWidth={1.5} aria-hidden="true" />
+        <Icon icon={ChevronRight} size={14} aria-hidden="true" />
       ) : (
-        <ChevronLeft size={14} strokeWidth={1.5} aria-hidden="true" />
+        <Icon icon={ChevronLeft} size={14} aria-hidden="true" />
       )}
     </button>
   );

--- a/src/ui/layout/RelaxedFocusControl.tsx
+++ b/src/ui/layout/RelaxedFocusControl.tsx
@@ -13,6 +13,7 @@
 
 import type { ReactNode } from 'react';
 import { PenLine, Columns2, Workflow } from 'lucide-react';
+import { Icon } from '../icons';
 import { useSessionStore } from '../../store/sessionStore';
 import { useBreakpoint } from './useBreakpoint';
 import type { RelaxedFocus } from './types';
@@ -31,11 +32,11 @@ export function RelaxedFocusControl() {
   const allowSplit = band !== 'narrow';
 
   const segments: Segment[] = [
-    { id: 'write', label: 'Write', icon: <PenLine size={14} strokeWidth={1.5} /> },
+    { id: 'write', label: 'Write', icon: <Icon icon={PenLine} size={14} /> },
     ...(allowSplit
-      ? [{ id: 'split' as const, label: 'Split', icon: <Columns2 size={14} strokeWidth={1.5} /> }]
+      ? [{ id: 'split' as const, label: 'Split', icon: <Icon icon={Columns2} size={14} /> }]
       : []),
-    { id: 'diagram', label: 'Diagram', icon: <Workflow size={14} strokeWidth={1.5} /> },
+    { id: 'diagram', label: 'Diagram', icon: <Icon icon={Workflow} size={14} /> },
   ];
 
   // When Split is unavailable, a lingering 'split' focus reads as document-primary


### PR DESCRIPTION
Final slice of **JP-219** (icon set unification). Retire the remaining hardcoded `size={16} strokeWidth={1.5}` lucide call sites in favour of the shared `Icon` wrapper (`src/ui/icons.tsx`) — one source of truth for icon sizing, no magic numbers. **Pure consistency cleanup, no visual change.**

## Converted (10 files)

`UnifiedToolbar`, `RelaxedFocusControl`, `CustomShapePicker`, `ShapePicker`, `DocumentToggleRail`, `RichTextTabBar`, `InlinePageTabs`, `ImageUploadButton`, `FileImportButton`, `DocumentEditorPanel`:

`<X size={16} strokeWidth={1.5} />` → `<Icon icon={X} />`, and `<Icon icon={X} size={N} />` for off-default sizes (aria-hidden etc. pass through the wrapper).

## Left as-is (deliberate)

- The dense ribbons (`DocumentEditorToolbar` / `CanvasToolbar`) already consume the shared `ICON` token via `{...ICON}` — a valid second spelling for ~40 call sites, not worth the churn to re-spell.
- The bespoke animated save-status / upload spinners stay hand-rolled (no faithful lucide equivalent).

This closes out **JP-219** (icon unification). Note: the parent **JP-147** visual-design epic still has non-icon work (toolbar redesign, spacing/typography polish, theming, JP-155/156/157, etc.).

## Verify

- `bun run typecheck` ✅ · `bun run build` ✅ · `bun run test --run` ✅ (1857).
- Mechanical exact-string swaps; no size/stroke values changed. A quick eyeball that nothing resized is the only manual check.

Assisted-by: Opus 4.8