### PR TITLE
JP-225: theming — elevation/shadow ladder + migrate overlay surfaces

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -70,9 +70,12 @@
   --grid-minor: rgba(14, 28, 48, 0.06);
   --grid-major: rgba(14, 28, 48, 0.12);
 
-  /* Shadows (navy-based) */
+  /* Shadows (navy-based) — elevation ladder: sm (subtle) < md (raised) <
+     lg (floating menus/dropdowns/toasts) < xl (modals/large overlays) */
   --shadow-sm: 0 1px 2px rgba(14, 28, 48, 0.06);
   --shadow-md: 0 2px 6px rgba(14, 28, 48, 0.10);
+  --shadow-lg: 0 4px 16px rgba(14, 28, 48, 0.12);
+  --shadow-xl: 0 12px 40px rgba(14, 28, 48, 0.20);
 
   /* Responsive breakpoints — shared tokens so layout CSS and the
    * `useBreakpoint` hook agree on the bands (see platform/device.ts
@@ -194,9 +197,12 @@
   --grid-minor: rgba(214, 224, 240, 0.04);
   --grid-major: rgba(214, 224, 240, 0.08);
 
-  /* Shadows — kept subtle; overlays still need a little separation */
+  /* Shadows — deeper on the navy void; the ladder geometry matches light, only
+     the colour darkens */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.40);
   --shadow-md: 0 6px 20px rgba(0, 0, 0, 0.50);
+  --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.45);
+  --shadow-xl: 0 12px 40px rgba(0, 0, 0, 0.60);
 }
 
 * {

--- a/src/ui/BorderStylePicker.css
+++ b/src/ui/BorderStylePicker.css
@@ -60,7 +60,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px;
   min-width: 160px;
 }
@@ -92,5 +92,5 @@
 
 /* Dark mode adjustments */
 :root[data-theme='dark'] .border-style-dropdown {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }

--- a/src/ui/CommandPalette.css
+++ b/src/ui/CommandPalette.css
@@ -22,7 +22,7 @@
   background: var(--color-bg-primary, #1e1e2e);
   border: 1px solid var(--border-color, #444);
   border-radius: 10px;
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-xl);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -5,7 +5,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
   font-size: var(--font-size-md);
 }
@@ -91,7 +91,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
   margin-left: var(--space-0-5);
   z-index: 1001;
@@ -113,7 +113,7 @@
 [data-theme="dark"] .context-menu {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #3d3d3d);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .context-menu-item {
@@ -144,7 +144,7 @@
 [data-theme="dark"] .context-menu-submenu-content {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #3d3d3d);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .context-menu-check {

--- a/src/ui/CustomShapePicker.css
+++ b/src/ui/CustomShapePicker.css
@@ -70,7 +70,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   z-index: 200;
   overflow: hidden;
 }
@@ -197,7 +197,7 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .custom-shape-picker-dropdown {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .custom-shape-picker-item-preview {

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -9,7 +9,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px;
   font-size: 0.875rem;
 }
@@ -92,7 +92,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px;
   font-size: 0.875rem;
   display: flex;
@@ -157,12 +157,12 @@
 /* Dark mode */
 [data-theme="dark"] .doc-editor-context-menu {
   background: var(--bg-secondary);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .doc-editor-context-submenu {
   background: var(--bg-secondary);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .doc-editor-context-menu-item:hover {

--- a/src/ui/DocumentManager.css
+++ b/src/ui/DocumentManager.css
@@ -18,7 +18,7 @@
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
   overflow: hidden;
 }
 
@@ -269,7 +269,7 @@
 }
 
 :root.dark .document-manager {
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-xl);
 }
 
 :root.dark .document-manager-item.selected {

--- a/src/ui/DocumentPermissionsDialog.css
+++ b/src/ui/DocumentPermissionsDialog.css
@@ -25,7 +25,7 @@
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
   animation: slideIn 0.2s ease;
 }
 

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -16,7 +16,7 @@
 .export-dialog {
   background: var(--bg-primary, #ffffff);
   border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
   width: 360px;
   max-width: 90vw;
   overflow: hidden;

--- a/src/ui/FileMenu.css
+++ b/src/ui/FileMenu.css
@@ -42,7 +42,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
   z-index: 1000;
 }
@@ -93,7 +93,7 @@
 [data-theme="dark"] .file-menu-dropdown {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #3d3d3d);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .file-menu-item {

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -34,7 +34,7 @@
 .file-viewer-modal {
   background: var(--bg-primary, #ffffff);
   border-radius: 12px;
-  box-shadow: 0 16px 64px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-xl);
   width: 90vw;
   height: 85vh;
   max-width: 1200px;
@@ -212,7 +212,7 @@
 
 [data-theme="dark"] .file-viewer-modal {
   background: var(--bg-primary, #1e293b);
-  box-shadow: 0 16px 64px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-xl);
 }
 
 [data-theme="dark"] .file-viewer-header {

--- a/src/ui/IconPicker.css
+++ b/src/ui/IconPicker.css
@@ -60,7 +60,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   max-height: 320px;
   display: flex;
   flex-direction: column;
@@ -300,5 +300,5 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .icon-picker-dropdown {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }

--- a/src/ui/InsertLinkDialog.css
+++ b/src/ui/InsertLinkDialog.css
@@ -15,7 +15,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 10px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  box-shadow: var(--shadow-xl);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/ui/KeyboardShortcutPanel.css
+++ b/src/ui/KeyboardShortcutPanel.css
@@ -22,7 +22,7 @@
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-xl);
   animation: shortcut-slide-in 0.15s ease-out;
 }
 

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -12,7 +12,7 @@
 .layer-view-manager {
   background: var(--bg-primary, #ffffff);
   border-radius: var(--radius-xl);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
   width: 400px;
   max-width: 90vw;
   max-height: 80vh;

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -15,7 +15,7 @@
 .logo-picker-modal {
   background: var(--bg-primary);
   border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-xl);
   width: 90%;
   max-width: 600px;
   max-height: 80vh;

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -22,7 +22,7 @@
   gap: 12px;
   padding: 12px 16px;
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   pointer-events: auto;
   animation: toast-slide-in 0.2s ease-out;
   background: var(--color-surface, #fff);
@@ -150,7 +150,7 @@
 /* Dark theme support */
 [data-theme='dark'] .notification-toast {
   background: var(--color-surface, #1f2937);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme='dark'] .notification-toast__message {

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -15,7 +15,7 @@
 .pdf-export-dialog {
   background: var(--bg-primary);
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-xl);
   width: 90%;
   max-width: 500px;
   max-height: 85vh;

--- a/src/ui/PatternPicker.css
+++ b/src/ui/PatternPicker.css
@@ -63,7 +63,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px;
   min-width: 180px;
   max-height: 300px;
@@ -134,7 +134,7 @@
 
 /* Dark mode adjustments */
 :root[data-theme='dark'] .pattern-picker-dropdown {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 :root[data-theme='dark'] .pattern-preview svg rect[stroke='#ccc'] {

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -16,7 +16,7 @@
 .save-to-library-dialog {
   background: var(--bg-primary, #ffffff);
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
   width: 400px;
   max-width: 90vw;
   overflow: hidden;

--- a/src/ui/SettingsModal.css
+++ b/src/ui/SettingsModal.css
@@ -27,7 +27,7 @@
 .settings-modal {
   background: var(--bg-primary, #ffffff);
   border-radius: 16px;
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-xl), 0 0 0 1px var(--border-color);
   width: 850px;
   max-width: 92vw;
   height: 620px;
@@ -518,7 +518,7 @@
 
 [data-theme="dark"] .settings-modal {
   background: var(--bg-primary, #0f172a);
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-xl), 0 0 0 1px var(--border-color);
 }
 
 [data-theme="dark"] .settings-modal-header {

--- a/src/ui/ShapePicker.css
+++ b/src/ui/ShapePicker.css
@@ -60,7 +60,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   z-index: 200;
   overflow: hidden;
 }
@@ -163,7 +163,7 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .shape-picker-dropdown {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 /* View options */

--- a/src/ui/StorageManager.css
+++ b/src/ui/StorageManager.css
@@ -27,7 +27,7 @@
   max-height: 90vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-xl);
 }
 
 /* Header */
@@ -445,7 +445,7 @@
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-xl);
 }
 
 .storage-manager-modal-title {

--- a/src/ui/ToolbarDropdown.css
+++ b/src/ui/ToolbarDropdown.css
@@ -8,13 +8,13 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-2);
   pointer-events: auto;
 }
 
 [data-theme="dark"] .toolbar-dropdown-portal {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 /* Color picker grid */

--- a/src/ui/VersionConflictDialog.css
+++ b/src/ui/VersionConflictDialog.css
@@ -19,7 +19,7 @@
   background: var(--color-bg-primary, #1e1e2e);
   border: 1px solid var(--border-color, #363649);
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-xl);
   width: 440px;
   max-width: 90vw;
   max-height: 80vh;

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -47,7 +47,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-lg);
   z-index: 1000;
   padding: var(--space-1-5);
 }

--- a/src/ui/layout/PanelChromeMenu.css
+++ b/src/ui/layout/PanelChromeMenu.css
@@ -4,7 +4,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1);
   z-index: 2000;
 }

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -361,7 +361,7 @@
   border-radius: 8px;
   padding: 20px;
   max-width: 360px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
 }
 
 .storage-confirm-title {


### PR DESCRIPTION
First **theming-polish** slice of JP-147 (the "elevation/shadows" bullet).

## Problem

`index.css` defined `--shadow-sm`/`--shadow-md` but they were barely used — instead ~204 hardcoded `box-shadow`s across ~60 files, with nearly every floating surface duplicating itself via a `[data-theme="dark"]` override (light `rgba(0,0,0,0.15)` + dark `0.4`). No `--shadow-lg`/`--shadow-xl` despite ~50 large-overlay shadows.

## Change

- **New rungs in `index.css`:** `--shadow-lg` (floating menus/dropdowns/toasts) and `--shadow-xl` (modals/large overlays), each with a `[data-theme="dark"]` variant. Geometry is shared across modes; only the colour darkens. The ladder is now `sm < md < lg < xl`.
- **Migrated 27 overlay files** onto the ladder:
  - **→ `--shadow-xl`:** SettingsModal, FileViewerModal, PDFExportDialog, SaveToLibraryDialog, ExportDialog, DocumentPermissionsDialog, VersionConflictDialog, CommandPalette, KeyboardShortcutPanel, InsertLinkDialog, LogoPicker, LayerViewManager, StorageManager, DocumentManager, StorageSettings.
  - **→ `--shadow-lg`:** ContextMenu, FileMenu, DocumentEditorContextMenu, ToolbarDropdown, ShapePicker, CustomShapePicker, IconPicker, PatternPicker, BorderStylePicker, NotificationToast, PanelChromeMenu, LayoutSelector.

~25 bespoke elevation values collapse to two, and dark-mode elevation now flows from the token. SettingsModal keeps its hairline (`var(--shadow-xl), 0 0 0 1px var(--border-color)`).

## Notes / scope

- This is a **visual change** toward consistency — the biggest overlays (e.g. FileViewerModal's `0 16px 64px`, CommandPalette's `0 16px 48px`) tighten to the unified `xl`; dark-mode shadows generally deepen. **Needs a light + dark eyeball.**
- The paired `[data-theme="dark"]` overrides now reference the token too (mode-correct). The **standalone** ones are redundant and prunable — I kept the diff a pure value→token swap (no structural CSS deletions) so it's safe to review without running it; happy to prune the redundant dark rules in a quick follow-up.
- Lower-elevation surfaces (panels, button-hover lifts, sticky notes, inset/border shadows, minimap) are a later slice.

## Verify

- `bun run build` ✅ (CSS-only; no JS/TS touched, tests unaffected). Tokens defined + referenced by 27 files; no hardcoded overlay shadows remain in the migrated files; OSS-leak grep clean.
- **Author eyeball:** modals, dialogs, dropdowns, context menus, the command palette, and toasts — light + dark.

Assisted-by: Opus 4.8