### PR TITLE
JP-226: theming polish — finish shadow ladder, focus rings, fallback cleanup + status tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -211,6 +211,16 @@
   box-sizing: border-box;
 }
 
+/* Baseline keyboard-focus ring (JP-226). Guarantees a visible, on-brand focus
+   indicator everywhere a keyboard user lands — only on keyboard nav, never on
+   mouse click. Components that set their own focus ring, or deliberately
+   suppress it (e.g. content editors with `outline: none`), still win on
+   specificity; this only fills the gaps. */
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 html,
 body,
 #root {

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,14 @@
   --danger-text: #7a2238;
   --warning: #b8761f;
 
+  /* Subtle status-tint backgrounds (status badges + destructive/warning hovers) */
+  --success-bg: rgba(45, 143, 99, 0.10);
+  --warning-bg: rgba(184, 118, 31, 0.10);
+  --danger-bg: rgba(122, 34, 56, 0.10);
+
+  /* Tooltip surface — deep navy in both modes (inverted floating label) */
+  --bg-tooltip: var(--navy-900);
+
   /* Canvas */
   --canvas-bg: #f7f4ec;           /* warm off-white drawing surface */
   --grid-minor: rgba(14, 28, 48, 0.06);
@@ -191,6 +199,11 @@
   --danger: #7a2238;
   --danger-text: #e89b9b;
   --warning: #e0c690;
+
+  /* Status-tint backgrounds — lightened for the navy surface */
+  --success-bg: rgba(142, 220, 177, 0.12);
+  --warning-bg: rgba(224, 198, 144, 0.12);
+  --danger-bg: rgba(232, 155, 155, 0.12);
 
   /* Canvas — deepest navy void */
   --canvas-bg: #060c17;

--- a/src/ui/AlignmentPanel.css
+++ b/src/ui/AlignmentPanel.css
@@ -1,6 +1,6 @@
 .alignment-panel {
   padding: 12px 16px;
-  border-top: 1px solid var(--border-color, #dee2e6);
+  border-top: 1px solid var(--border-color);
 }
 
 .alignment-section {
@@ -16,7 +16,7 @@
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 
@@ -33,21 +33,21 @@
   width: 28px;
   height: 28px;
   padding: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-primary, #495057);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .alignment-button:hover {
-  background: var(--bg-tertiary, #e9ecef);
-  border-color: var(--text-secondary, #6c757d);
+  background: var(--bg-tertiary);
+  border-color: var(--text-secondary);
 }
 
 .alignment-button:active {
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
 }
 
 .alignment-button svg {

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -338,7 +338,7 @@
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
   transition: transform 0.15s ease;
 }
 
@@ -353,7 +353,7 @@
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
 }
 
 .styled-slider:focus {

--- a/src/ui/CollaborativeCursors.css
+++ b/src/ui/CollaborativeCursors.css
@@ -33,7 +33,7 @@
   font-size: 11px;
   font-weight: 500;
   white-space: nowrap;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
   max-width: 120px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ui/ColorPalette.css
+++ b/src/ui/ColorPalette.css
@@ -21,7 +21,7 @@
 .color-palette-label {
   font-size: 0.625rem;
   font-weight: 500;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -37,7 +37,7 @@
 .color-swatch {
   width: 22px;
   height: 22px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   padding: 0;
@@ -120,7 +120,7 @@
 .color-palette-special-label {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 /* ── Info button with CSS tooltip ────────────────────── */
@@ -133,8 +133,8 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--bg-secondary, #e9ecef);
-  color: var(--text-secondary, #6c757d);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
   font-size: 11px;
   font-weight: 700;
   font-style: normal;
@@ -156,7 +156,7 @@
   transform: translateY(-50%);
   width: 220px;
   padding: 8px 10px;
-  background: var(--bg-tooltip, #1a1a2e);
+  background: var(--bg-tooltip);
   color: #fff;
   font-size: 0.7rem;
   font-weight: 400;
@@ -175,7 +175,7 @@
   top: 50%;
   transform: translateY(-50%);
   border: 5px solid transparent;
-  border-right-color: var(--bg-tooltip, #1a1a2e);
+  border-right-color: var(--bg-tooltip);
 }
 
 .color-palette-info-btn:hover .color-palette-info-tooltip {
@@ -200,7 +200,7 @@
 
 .color-palette-nofill-label {
   font-size: 0.75rem;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 /* Custom Color Section */
@@ -214,7 +214,7 @@
   width: 28px;
   height: 28px;
   padding: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   background: transparent;
@@ -234,9 +234,9 @@
   padding: 4px 8px;
   font-size: 0.75rem;
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  color: var(--text-primary, #495057);
-  background: var(--bg-secondary, #f8f9fa);
-  border: 1px solid var(--border-color, #dee2e6);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   text-align: left;
@@ -244,7 +244,7 @@
 }
 
 .color-palette-custom-toggle:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -260,8 +260,8 @@
   padding: 4px 6px;
   font-size: 0.75rem;
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  color: var(--text-primary, #495057);
-  background: var(--bg-primary, #ffffff);
+  color: var(--text-primary);
+  background: var(--bg-primary);
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 4px;
   outline: none;
@@ -289,7 +289,7 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .color-swatch {
-  border-color: var(--border-color, #404040);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .color-swatch--nofill,
@@ -304,26 +304,26 @@
 }
 
 [data-theme="dark"] .color-palette-picker {
-  border-color: var(--border-color, #404040);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .color-palette-custom-toggle {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .color-palette-custom-toggle:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .color-palette-custom-input {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #cccccc);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .color-palette-info-btn {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--text-secondary, #aaa);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 /* Legacy .color-palette support for backwards compatibility */
@@ -352,7 +352,7 @@
   width: 50px;
   font-size: 0.6rem;
   font-weight: 500;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.3px;
   flex-shrink: 0;
@@ -378,5 +378,5 @@
 }
 
 [data-theme="dark"] .color-palette-ramp-label {
-  color: var(--text-secondary, #8b8b8b);
+  color: var(--text-secondary);
 }

--- a/src/ui/ColorPalette.css
+++ b/src/ui/ColorPalette.css
@@ -47,7 +47,7 @@
 
 .color-swatch:hover {
   transform: scale(1.1);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-md);
 }
 
 .color-swatch:focus {
@@ -162,7 +162,7 @@
   font-weight: 400;
   line-height: 1.5;
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-lg);
   z-index: 10001;
   pointer-events: none;
   white-space: normal;

--- a/src/ui/CommandPalette.css
+++ b/src/ui/CommandPalette.css
@@ -20,7 +20,7 @@
   width: 520px;
   max-height: 420px;
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--border-color, #444);
+  border: 1px solid var(--border-color);
   border-radius: 10px;
   box-shadow: var(--shadow-xl);
   display: flex;
@@ -39,8 +39,8 @@
   padding: 14px 16px;
   background: transparent;
   border: none;
-  border-bottom: 1px solid var(--border-color, #444);
-  color: var(--text-primary, #cdd6f4);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
   font-size: 15px;
   outline: none;
   font-family: inherit;
@@ -71,7 +71,7 @@
   padding: 8px 16px;
   background: transparent;
   border: none;
-  color: var(--text-primary, #cdd6f4);
+  color: var(--text-primary);
   font-size: 13px;
   cursor: pointer;
   text-align: left;
@@ -100,7 +100,7 @@
 
 .command-palette-shortcut {
   background: var(--color-bg-secondary, #2a2a3a);
-  border: 1px solid var(--border-color, #444);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   padding: 1px 6px;
   font-size: 11px;

--- a/src/ui/CompactColorInput.css
+++ b/src/ui/CompactColorInput.css
@@ -9,7 +9,7 @@
 /* Label */
 .compact-color-label {
   font-size: 0.75rem;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   min-width: 40px;
 }
 
@@ -26,7 +26,7 @@
   width: 26px;
   height: 26px;
   padding: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   background: transparent;
@@ -57,7 +57,7 @@
   width: 26px;
   height: 26px;
   padding: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   flex-shrink: 0;
@@ -101,12 +101,12 @@
 }
 
 [data-theme="dark"] .compact-color-swatch {
-  border-color: var(--border-color, #404040);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .compact-color-swatch:hover,
 [data-theme="dark"] .compact-color-swatch:focus {
-  border-color: var(--color-primary, #0078d4);
+  border-color: var(--color-primary);
 }
 
 /* "Auto" accent label inside the hex button */
@@ -124,9 +124,9 @@
   padding: 0 6px;
   font-size: 0.75rem;
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  color: var(--text-primary, #495057);
-  background: var(--bg-secondary, #f8f9fa);
-  border: 1px solid var(--border-color, #dee2e6);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   text-align: left;
   cursor: pointer;
@@ -134,7 +134,7 @@
 }
 
 .compact-color-hex-input:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -145,7 +145,7 @@
 }
 
 .compact-color-hex-input.editing {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   cursor: text;
 }
 
@@ -156,9 +156,9 @@
   padding: 0;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--text-secondary, #6c757d);
-  background: var(--bg-tertiary, #e9ecef);
-  border: 1px solid var(--border-color, #dee2e6);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   flex-shrink: 0;
@@ -184,8 +184,8 @@
   right: 0;
   margin-top: 4px;
   padding: 8px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   box-shadow: var(--shadow-lg);
   z-index: 100;
@@ -193,39 +193,39 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .compact-color-picker {
-  border-color: var(--border-color, #404040);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .compact-color-picker:hover,
 [data-theme="dark"] .compact-color-picker:focus {
-  border-color: var(--color-primary, #0078d4);
+  border-color: var(--color-primary);
 }
 
 [data-theme="dark"] .compact-color-hex-input {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
-  color: var(--text-primary, #cccccc);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .compact-color-hex-input:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .compact-color-hex-input.editing {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .compact-color-edit {
-  background: var(--bg-tertiary, #333333);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .compact-color-edit:hover {
-  background: var(--color-primary, #0078d4);
+  background: var(--color-primary);
 }
 
 [data-theme="dark"] .compact-color-palette-dropdown {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }

--- a/src/ui/CompactColorInput.css
+++ b/src/ui/CompactColorInput.css
@@ -187,7 +187,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   z-index: 100;
 }
 
@@ -227,5 +227,5 @@
 [data-theme="dark"] .compact-color-palette-dropdown {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #404040);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -2,8 +2,8 @@
   position: fixed;
   z-index: 1000;
   min-width: 180px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
@@ -18,18 +18,18 @@
   padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   cursor: pointer;
   text-align: left;
   transition: background-color 0.1s ease;
 }
 
 .context-menu-item:hover:not(.disabled) {
-  background: var(--bg-hover, #f8f9fa);
+  background: var(--bg-hover);
 }
 
 .context-menu-item.disabled {
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: default;
 }
 
@@ -44,14 +44,14 @@
 
 .context-menu-shortcut {
   margin-left: var(--space-6);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: var(--font-size-xs);
 }
 
 .context-menu-separator {
   height: 1px;
   margin: var(--space-1) 0;
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
 }
 
 /* Submenu container */
@@ -67,13 +67,13 @@
   padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   cursor: pointer;
   text-align: left;
 }
 
 .context-menu-submenu:hover > .has-submenu {
-  background: var(--bg-hover, #f8f9fa);
+  background: var(--bg-hover);
 }
 
 .context-menu-arrow {
@@ -88,8 +88,8 @@
   left: 100%;
   top: 0;
   min-width: 140px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
@@ -105,23 +105,23 @@
 .context-menu-check {
   width: 18px;
   font-size: var(--font-size-sm);
-  color: var(--color-primary, #1f3354);
+  color: var(--color-primary);
   flex-shrink: 0;
 }
 
 /* Dark mode */
 [data-theme="dark"] .context-menu {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .context-menu-item {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .context-menu-item:hover:not(.disabled) {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .context-menu-item.danger:hover {
@@ -130,23 +130,23 @@
 }
 
 [data-theme="dark"] .context-menu-separator {
-  background: var(--border-color, #3d3d3d);
+  background: var(--border-color);
 }
 
 [data-theme="dark"] .context-menu-submenu .has-submenu {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .context-menu-submenu:hover > .has-submenu {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .context-menu-submenu-content {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .context-menu-check {
-  color: var(--color-primary, #1f3354);
+  color: var(--color-primary);
 }

--- a/src/ui/CustomShapePicker.css
+++ b/src/ui/CustomShapePicker.css
@@ -196,9 +196,6 @@
 }
 
 /* Dark mode adjustments */
-[data-theme="dark"] .custom-shape-picker-dropdown {
-  box-shadow: var(--shadow-lg);
-}
 
 [data-theme="dark"] .custom-shape-picker-item-preview {
   background: var(--bg-tertiary);

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -5,25 +5,25 @@
   align-items: flex-start;
   justify-content: space-between;
   padding: 10px 12px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .document-card:hover {
-  background: var(--bg-hover, #f8fafc);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--bg-hover);
+  border-color: var(--color-primary);
 }
 
 .document-card--active {
-  background: var(--bg-secondary, #f1f5f9);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--bg-secondary);
+  border-color: var(--color-primary);
 }
 
 .document-card--selected {
-  box-shadow: 0 0 0 2px var(--color-primary, #3b82f6);
+  box-shadow: 0 0 0 2px var(--color-primary);
 }
 
 /* Content */
@@ -43,7 +43,7 @@
 .document-card__name {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -54,10 +54,10 @@
   font-size: 13px;
   font-weight: 500;
   padding: 2px 6px;
-  border: 1px solid var(--color-primary, #3b82f6);
+  border: 1px solid var(--color-primary);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   outline: none;
 }
 
@@ -65,7 +65,7 @@
   font-size: 10px;
   font-weight: 500;
   padding: 2px 6px;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: rgba(31, 51, 84, 0.1);
   border-radius: 4px;
   flex-shrink: 0;
@@ -108,12 +108,12 @@
 
 .document-card__type--cached {
   color: var(--warning);
-  background: rgba(245, 158, 11, 0.1);
+  background: var(--warning-bg);
 }
 
 .document-card__date {
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
 }
 
 /* Actions */
@@ -147,7 +147,7 @@
   justify-content: center;
   width: 30px;
   height: 30px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -161,15 +161,15 @@
 }
 
 .document-card__action:hover {
-  background: var(--bg-secondary, #f1f5f9);
-  border-color: var(--border-color, #e2e8f0);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 .document-card__action:focus-visible,
 .document-card__expand:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary, #3b82f6);
+  box-shadow: 0 0 0 2px var(--color-primary);
 }
 
 .document-card__action:disabled {
@@ -178,7 +178,7 @@
 }
 
 .document-card__action--danger:hover {
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--danger-bg);
   border-color: rgba(239, 68, 68, 0.3);
   color: var(--danger-text);
 }
@@ -216,12 +216,12 @@
 }
 
 .document-card__confirm-no {
-  background: var(--bg-secondary, #f1f5f9);
-  color: var(--text-secondary, #64748b);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
 }
 
 .document-card__confirm-no:hover {
-  background: var(--bg-tertiary, #e2e8f0);
+  background: var(--bg-tertiary);
 }
 
 /* Relay badge */
@@ -245,7 +245,7 @@
 }
 
 .document-card__relay--disconnected {
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   background: rgba(148, 163, 184, 0.12);
 }
 
@@ -258,7 +258,7 @@
   width: 30px;
   height: 30px;
   margin-left: 4px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -268,9 +268,9 @@
 }
 
 .document-card__expand:hover {
-  background: var(--bg-secondary, #f1f5f9);
-  border-color: var(--border-color, #e2e8f0);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 .document-card__chevron {
@@ -300,8 +300,8 @@
   display: grid;
   grid-template-columns: max-content 1fr;
   gap: 5px 14px;
-  background: var(--bg-secondary, #f8fafc);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: default;
 }
@@ -313,13 +313,13 @@
 .document-card__detail dt {
   font-size: 11px;
   font-weight: 500;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
 }
 
 .document-card__detail dd {
   margin: 0;
   font-size: 11px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   word-break: break-word;
 }
 
@@ -390,9 +390,9 @@
   height: 18px;
   margin-right: 8px;
   margin-top: 2px;
-  border: 1.5px solid var(--border-color, #cbd5e1);
+  border: 1.5px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   color: white;
   font-size: 12px;
   font-weight: 700;
@@ -412,8 +412,8 @@
 }
 
 .document-card__select--checked {
-  background: var(--color-primary, #3b82f6);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   opacity: 1;
 }
 
@@ -442,7 +442,7 @@
   padding: 2px 6px;
   border-radius: 10px;
   color: white;
-  background: var(--text-muted, #94a3b8);
+  background: var(--text-muted);
   max-width: 96px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -452,16 +452,16 @@
 
 /* Dark mode */
 :root[data-theme="dark"] .document-card {
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-card:hover {
-  background: var(--bg-tertiary, #334155);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme="dark"] .document-card--active {
-  background: var(--bg-tertiary, #334155);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme="dark"] .document-card__type--local {
@@ -490,10 +490,10 @@
 }
 
 :root[data-theme="dark"] .document-card__details {
-  background: var(--bg-tertiary, #334155);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-card__expand:hover {
-  background: var(--bg-tertiary, #334155);
+  background: var(--bg-tertiary);
 }

--- a/src/ui/DocumentChangedBanner.css
+++ b/src/ui/DocumentChangedBanner.css
@@ -11,7 +11,7 @@
   background: var(--color-info-bg, #1e2a4a);
   border-bottom: 1px solid var(--color-info-border, #2a3a6a);
   font-size: 13px;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   animation: dcb-slideDown 0.2s ease-out;
 }
 
@@ -29,9 +29,9 @@
 .document-changed-banner__btn {
   padding: 4px 10px;
   border-radius: 4px;
-  border: 1px solid var(--border-color, #363649);
+  border: 1px solid var(--border-color);
   background: var(--color-bg-secondary, #252537);
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   font-size: 12px;
   cursor: pointer;
   flex-shrink: 0;

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -143,15 +143,15 @@
 
 /* Danger menu item */
 .doc-editor-context-menu-item.danger {
-  color: var(--danger, #dc3545);
+  color: var(--danger);
 }
 
 .doc-editor-context-menu-item.danger .doc-editor-context-menu-icon {
-  color: var(--danger, #dc3545);
+  color: var(--danger);
 }
 
 .doc-editor-context-menu-item.danger:hover {
-  background: rgba(220, 53, 69, 0.1);
+  background: var(--danger-bg);
 }
 
 /* Dark mode */

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -177,11 +177,11 @@
 }
 
 .document-editor-toolbar-btn.danger {
-  color: var(--danger, #dc3545);
+  color: var(--danger);
 }
 
 .document-editor-toolbar-btn.danger:hover:not(:disabled) {
-  background: rgba(220, 53, 69, 0.1);
+  background: var(--danger-bg);
   border-color: rgba(220, 53, 69, 0.3);
 }
 

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -206,7 +206,7 @@
   padding: var(--space-6);
   min-width: 400px;
   max-width: 90vw;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
 }
 
 .math-input-content label {
@@ -328,7 +328,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-2);
   margin-top: var(--space-1);
   pointer-events: auto;
@@ -355,7 +355,7 @@
 .color-picker-swatch:hover {
   transform: scale(1.2);
   z-index: 1;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-md);
 }
 
 .color-picker-clear {
@@ -383,7 +383,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1);
   margin-top: var(--space-1);
   min-width: 160px;
@@ -436,9 +436,6 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .color-picker-dropdown,
-[data-theme="dark"] .table-styles-dropdown {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-}
 
 [data-theme="dark"] .ribbon-tab-bar {
   background: var(--bg-tertiary);

--- a/src/ui/DocumentPermissionsDialog.css
+++ b/src/ui/DocumentPermissionsDialog.css
@@ -18,7 +18,7 @@
 }
 
 .document-permissions-dialog {
-  background: var(--bg-primary, #fff);
+  background: var(--bg-primary);
   border-radius: 12px;
   width: 90%;
   max-width: 520px;
@@ -50,7 +50,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  border-bottom: 1px solid var(--border-color);
   background: linear-gradient(135deg, var(--navy-900) 0%, var(--navy-700) 100%);
   border-radius: 12px 12px 0 0;
 }
@@ -92,13 +92,13 @@
   background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
   border-radius: 8px;
   margin-bottom: 16px;
-  border: 1px solid var(--border-color, #e0e0e0);
+  border: 1px solid var(--border-color);
 }
 
 .document-permissions-dialog__doc-name {
   font-weight: 600;
   font-size: 15px;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
 }
 
 .document-permissions-dialog__doc-meta {
@@ -122,7 +122,7 @@
 
 .document-permissions-dialog__access-count {
   font-size: 12px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
 }
 
 .document-permissions-dialog__error {
@@ -154,16 +154,16 @@
 .document-permissions-dialog__quick-btn {
   padding: 6px 12px;
   font-size: 12px;
-  border: 1px solid var(--border-color, #ddd);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #fff);
-  color: var(--text-primary, #333);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .document-permissions-dialog__quick-btn:hover {
-  background: var(--bg-secondary, #f5f5f5);
+  background: var(--bg-secondary);
   border-color: var(--color-primary);
 }
 
@@ -181,18 +181,18 @@
   margin: 0 0 12px 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .document-permissions-dialog__empty {
-  color: var(--text-muted, #999);
+  color: var(--text-muted);
   font-size: 13px;
   font-style: italic;
   padding: 16px;
   text-align: center;
-  background: var(--bg-secondary, #f5f5f5);
+  background: var(--bg-secondary);
   border-radius: 8px;
 }
 
@@ -213,7 +213,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 10px 12px;
-  background: var(--bg-secondary, #f5f5f5);
+  background: var(--bg-secondary);
   border-radius: 8px;
   border: 1px solid transparent;
   transition: all 0.15s;
@@ -236,7 +236,7 @@
 .document-permissions-dialog__member-name {
   font-weight: 500;
   font-size: 14px;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -245,8 +245,8 @@
 .document-permissions-dialog__offline-badge {
   font-size: 10px;
   font-weight: 400;
-  color: var(--text-muted, #999);
-  background: var(--bg-secondary, #e5e5e5);
+  color: var(--text-muted);
+  background: var(--bg-secondary);
   padding: 1px 6px;
   border-radius: 3px;
 }
@@ -260,10 +260,10 @@
 
 .document-permissions-dialog__permission-select {
   padding: 6px 10px;
-  border: 1px solid var(--border-color, #ddd);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #fff);
-  color: var(--text-primary, #333);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
   cursor: pointer;
   min-width: 100px;
@@ -302,7 +302,7 @@
 
 .document-permissions-dialog__transfer-confirm p {
   margin: 0 0 8px 0;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
 }
 
 .document-permissions-dialog__transfer-warning {
@@ -322,15 +322,15 @@
   gap: 8px;
   justify-content: flex-end;
   padding-top: 16px;
-  border-top: 1px solid var(--border-color, #e0e0e0);
+  border-top: 1px solid var(--border-color);
 }
 
 .document-permissions-dialog__btn {
   padding: 10px 18px;
-  border: 1px solid var(--border-color, #ddd);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #fff);
-  color: var(--text-primary, #333);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -338,7 +338,7 @@
 }
 
 .document-permissions-dialog__btn:hover:not(:disabled) {
-  background: var(--bg-secondary, #f5f5f5);
+  background: var(--bg-secondary);
 }
 
 .document-permissions-dialog__btn:disabled {
@@ -374,7 +374,7 @@
 
 :root[data-theme="dark"] .document-permissions-dialog__doc-info {
   background: linear-gradient(135deg, #2d2d2d 0%, #252525 100%);
-  border-color: var(--border-color-dark, #444);
+  border-color: var(--border-color-dark);
 }
 
 :root[data-theme="dark"] .document-permissions-dialog__doc-name,
@@ -395,17 +395,17 @@
 :root[data-theme="dark"] .document-permissions-dialog__permission-select,
 :root[data-theme="dark"] .document-permissions-dialog__quick-btn {
   background: var(--bg-secondary-dark, #2d2d2d);
-  border-color: var(--border-color-dark, #444);
+  border-color: var(--border-color-dark);
   color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-permissions-dialog__actions {
-  border-color: var(--border-color-dark, #444);
+  border-color: var(--border-color-dark);
 }
 
 :root[data-theme="dark"] .document-permissions-dialog__btn {
   background: var(--bg-secondary-dark, #2d2d2d);
-  border-color: var(--border-color-dark, #444);
+  border-color: var(--border-color-dark);
   color: var(--text-primary);
 }
 

--- a/src/ui/ErrorBoundary.css
+++ b/src/ui/ErrorBoundary.css
@@ -6,7 +6,7 @@
   padding: 24px 16px;
   gap: 8px;
   min-height: 120px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   text-align: center;
 }
 
@@ -17,7 +17,7 @@
 .error-boundary__message {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary, #ccc);
+  color: var(--text-primary);
 }
 
 .error-boundary__details {
@@ -33,10 +33,10 @@
 .error-boundary__reload {
   margin-top: 8px;
   padding: 6px 16px;
-  border: 1px solid var(--border-color, #444);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   background: var(--color-bg-secondary, #2a2a3e);
-  color: var(--text-primary, #ccc);
+  color: var(--text-primary);
   cursor: pointer;
   font-size: 12px;
   transition: background 0.15s;

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -14,7 +14,7 @@
 }
 
 .export-dialog {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: 8px;
   box-shadow: var(--shadow-xl);
   width: 360px;
@@ -27,15 +27,15 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  background: var(--bg-secondary, #f8f9fa);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .export-dialog-header h2 {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 .export-dialog-close {
@@ -48,15 +48,15 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: 20px;
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .export-dialog-close:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #212529);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .export-dialog-content {
@@ -75,7 +75,7 @@
 .export-label {
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -84,7 +84,7 @@
 .export-format-toggle {
   display: flex;
   gap: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -93,8 +93,8 @@
   flex: 1;
   padding: 8px 16px;
   border: none;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-secondary, #6c757d);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -102,11 +102,11 @@
 }
 
 .export-format-btn:not(:last-child) {
-  border-right: 1px solid var(--border-color, #dee2e6);
+  border-right: 1px solid var(--border-color);
 }
 
 .export-format-btn:hover {
-  background: var(--bg-hover, #f8f9fa);
+  background: var(--bg-hover);
 }
 
 .export-format-btn.active {
@@ -117,10 +117,10 @@
 /* Select */
 .export-select {
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
   cursor: pointer;
 }
@@ -143,7 +143,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   cursor: pointer;
 }
 
@@ -158,7 +158,7 @@
   width: 36px;
   height: 28px;
   padding: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
   background: none;
@@ -183,10 +183,10 @@
 .export-number {
   width: 80px;
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
 }
 
@@ -198,7 +198,7 @@
 
 .export-unit {
   font-size: 12px;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 /* Filename */
@@ -210,10 +210,10 @@
 .export-text {
   flex: 1;
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px 0 0 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
 }
 
@@ -227,11 +227,11 @@
 
 .export-extension {
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-left: none;
   border-radius: 0 6px 6px 0;
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-secondary, #6c757d);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -251,8 +251,8 @@
   justify-content: flex-end;
   gap: 8px;
   padding: 16px 20px;
-  background: var(--bg-secondary, #f8f9fa);
-  border-top: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
 }
 
 .export-btn {
@@ -271,13 +271,13 @@
 }
 
 .export-btn-cancel {
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
 }
 
 .export-btn-cancel:hover:not(:disabled) {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .export-btn-primary {
@@ -291,61 +291,61 @@
 
 /* Dark mode */
 [data-theme="dark"] .export-dialog {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .export-dialog-header {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .export-dialog-header h2 {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .export-dialog-close:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .export-format-toggle {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .export-format-btn {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-secondary, #9e9e9e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .export-format-btn:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .export-format-btn.active {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
   color: #1e1e1e;
 }
 
 [data-theme="dark"] .export-select,
 [data-theme="dark"] .export-number,
 [data-theme="dark"] .export-text {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .export-color {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .export-extension {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-secondary, #9e9e9e);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .export-checkbox-label {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .export-error {
@@ -355,25 +355,25 @@
 }
 
 [data-theme="dark"] .export-dialog-footer {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .export-btn-cancel {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .export-btn-cancel:hover:not(:disabled) {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .export-btn-primary {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
   color: #1e1e1e;
 }
 
 [data-theme="dark"] .export-btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-dark, #3b82f6);
+  background: var(--color-primary-dark);
 }

--- a/src/ui/FileMenu.css
+++ b/src/ui/FileMenu.css
@@ -39,8 +39,8 @@
   left: 0;
   margin-top: var(--space-1);
   min-width: 240px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
@@ -55,7 +55,7 @@
   padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
@@ -63,12 +63,12 @@
 }
 
 .file-menu-item:hover:not(:disabled) {
-  background: var(--bg-hover, #f8f9fa);
+  background: var(--bg-hover);
 }
 
 .file-menu-item:disabled,
 .file-menu-item.disabled {
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -80,34 +80,34 @@
 .file-menu-item-shortcut {
   margin-left: var(--space-6);
   font-size: var(--font-size-xs);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 .file-menu-separator {
   height: 1px;
   margin: var(--space-1) var(--space-2);
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
 }
 
 /* Dark mode */
 [data-theme="dark"] .file-menu-dropdown {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .file-menu-item {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .file-menu-item:hover:not(:disabled) {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .file-menu-item-shortcut {
-  color: var(--text-secondary, #9e9e9e);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .file-menu-separator {
-  background: var(--border-color, #3d3d3d);
+  background: var(--border-color);
 }

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -32,7 +32,7 @@
 }
 
 .file-viewer-modal {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: 12px;
   box-shadow: var(--shadow-xl);
   width: 90vw;
@@ -50,8 +50,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-secondary, #f8fafc);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   flex-shrink: 0;
 }
 
@@ -71,7 +71,7 @@
 .file-viewer-filename {
   font-weight: 600;
   font-size: 14px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -80,14 +80,14 @@
 
 .file-viewer-meta {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 .file-viewer-mime {
   padding: 2px 6px;
-  background: var(--bg-tertiary, #f1f5f9);
+  background: var(--bg-tertiary);
   border-radius: 4px;
   font-family: monospace;
   font-size: 11px;
@@ -103,10 +103,10 @@
 
 .file-viewer-action-btn {
   padding: 6px 12px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
@@ -114,7 +114,7 @@
 }
 
 .file-viewer-action-btn:hover {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
   border-color: var(--border-hover, #cbd5e1);
 }
 
@@ -124,7 +124,7 @@
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 16px;
   cursor: pointer;
   display: flex;
@@ -134,8 +134,8 @@
 }
 
 .file-viewer-close-btn:hover {
-  background: var(--bg-hover, #f1f5f9);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 /* Body */
@@ -154,15 +154,15 @@
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
 .file-viewer-spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid var(--border-color, #e2e8f0);
-  border-top-color: var(--color-primary, #3b82f6);
+  border: 3px solid var(--border-color);
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: file-viewer-spin 0.8s linear infinite;
 }
@@ -177,7 +177,7 @@
   flex-direction: column;
   align-items: center;
   gap: 8px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -211,27 +211,27 @@
 }
 
 [data-theme="dark"] .file-viewer-modal {
-  background: var(--bg-primary, #1e293b);
+  background: var(--bg-primary);
   box-shadow: var(--shadow-xl);
 }
 
 [data-theme="dark"] .file-viewer-header {
-  border-bottom-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
+  border-bottom-color: var(--border-color);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .file-viewer-action-btn {
-  border-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
-  color: var(--text-primary, #f1f5f9);
+  border-color: var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .file-viewer-action-btn:hover {
-  background: var(--bg-hover, #1e293b);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .file-viewer-close-btn:hover {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 /* Recovery UI */
@@ -252,12 +252,12 @@
 .file-viewer-recovery-title {
   font-size: 18px;
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .file-viewer-recovery-message {
   font-size: 14px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.5;
 }

--- a/src/ui/IconListEditor.css
+++ b/src/ui/IconListEditor.css
@@ -163,8 +163,8 @@
 }
 
 .icon-config-row > select option {
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-primary, #212529);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 .icon-config-row.checkbox > label {
@@ -272,8 +272,8 @@
 
 .icon-preset-selector > select option,
 .icon-preset-selector > select optgroup {
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-primary, #212529);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 /* Dark mode support */
@@ -285,11 +285,11 @@
 [data-theme="dark"] .icon-config-row > select option,
 [data-theme="dark"] .icon-preset-selector > select option,
 [data-theme="dark"] .icon-preset-selector > select optgroup {
-  background: var(--bg-secondary, #252526);
-  color: var(--text-primary, #e5e7eb);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .icon-mini-input > input {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }

--- a/src/ui/IconPicker.css
+++ b/src/ui/IconPicker.css
@@ -299,6 +299,4 @@
 }
 
 /* Dark mode adjustments */
-[data-theme="dark"] .icon-picker-dropdown {
-  box-shadow: var(--shadow-lg);
-}
+

--- a/src/ui/InsertLinkDialog.css
+++ b/src/ui/InsertLinkDialog.css
@@ -275,8 +275,8 @@
   color: var(--color-cta-text);
 }
 .link-dialog-btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-dark, #1d4ed8);
-  border-color: var(--color-primary-dark, #1d4ed8);
+  background: var(--color-primary-dark);
+  border-color: var(--color-primary-dark);
 }
 .link-dialog-btn-danger {
   color: var(--danger-text);

--- a/src/ui/InsertLinkDialog.css
+++ b/src/ui/InsertLinkDialog.css
@@ -104,7 +104,7 @@
 .link-dialog-segment button.active {
   background: var(--bg-primary);
   color: var(--text-primary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-sm);
 }
 .link-dialog-segment-icon {
   display: inline-block;

--- a/src/ui/KeyboardShortcutPanel.css
+++ b/src/ui/KeyboardShortcutPanel.css
@@ -16,7 +16,7 @@
 
 .shortcut-panel {
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--border-color, #444);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   width: 460px;
   max-height: 70vh;
@@ -42,13 +42,13 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .shortcut-panel__close {
   background: none;
   border: none;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 16px;
   padding: 4px 8px;
@@ -62,10 +62,10 @@
 .shortcut-panel__search {
   margin: 4px 16px 8px;
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #444);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   background: var(--color-bg-secondary, #2a2a3e);
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   font-size: 13px;
   outline: none;
 }
@@ -89,7 +89,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .shortcut-panel__row {
@@ -101,7 +101,7 @@
 
 .shortcut-panel__description {
   font-size: 13px;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .shortcut-panel__keys {
@@ -110,7 +110,7 @@
   padding: 2px 8px;
   border-radius: 3px;
   background: var(--color-bg-secondary, #2a2a3e);
-  border: 1px solid var(--border-color, #444);
-  color: var(--text-secondary, #aaa);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
   white-space: nowrap;
 }

--- a/src/ui/LayerPanel.css
+++ b/src/ui/LayerPanel.css
@@ -7,7 +7,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -371,7 +371,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
   font-size: var(--font-size-sm);
 }
@@ -422,7 +422,7 @@
 [data-theme="dark"] .layer-context-menu {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #3d3d3d);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .layer-context-menu-item {
@@ -486,7 +486,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1);
   z-index: 1001;
 }
@@ -498,7 +498,7 @@
 [data-theme="dark"] .layer-context-menu-submenu-content {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #3d3d3d);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 /* Color picker grid */
@@ -527,7 +527,7 @@
 
 .layer-color-swatch:hover {
   transform: scale(1.1);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
 }
 
 [data-theme="dark"] .layer-color-swatch {

--- a/src/ui/LayerPanel.css
+++ b/src/ui/LayerPanel.css
@@ -4,8 +4,8 @@
   left: 20px;
   min-width: 180px;
   max-width: 400px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
   display: flex;
@@ -63,9 +63,9 @@
   padding: 10px var(--space-3);
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-md);
-  color: var(--text-primary, #495057);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
-  background: var(--bg-secondary, #f8f9fa);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   flex-shrink: 0;
   cursor: pointer;
   display: flex;
@@ -75,7 +75,7 @@
 }
 
 .layer-panel-header:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .layer-panel.collapsed .layer-panel-header {
@@ -85,7 +85,7 @@
 .layer-panel-empty {
   padding: var(--space-6) var(--space-4);
   text-align: center;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: var(--font-size-md);
 }
 
@@ -99,18 +99,18 @@
   align-items: center;
   padding: var(--space-2) var(--space-3);
   gap: var(--space-2);
-  border-bottom: 1px solid var(--border-color-light, #f0f0f0);
+  border-bottom: 1px solid var(--border-color-light);
   cursor: pointer;
   transition: background-color 0.15s ease;
   user-select: none;
 }
 
 .layer-item:hover {
-  background: var(--bg-hover, #f8f9fa);
+  background: var(--bg-hover);
 }
 
 .layer-item.selected {
-  background: var(--bg-selected, #e7f3ff);
+  background: var(--color-primary-light);
 }
 
 .layer-item.dragging {
@@ -129,18 +129,18 @@
 
 /* Drop indicator - into group */
 .layer-item.drop-into {
-  background: var(--color-primary-light, #e3f2fd) !important;
+  background: var(--color-primary-light) !important;
   outline: 2px solid var(--color-primary, var(--color-primary));
   outline-offset: -2px;
 }
 
 [data-theme="dark"] .layer-item.drop-into {
-  background: var(--color-primary-dark, #1e3a5f) !important;
+  background: var(--color-primary-dark) !important;
 }
 
 .layer-item-drag-handle {
   cursor: grab;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   opacity: 0.5;
   flex-shrink: 0;
 }
@@ -160,7 +160,7 @@
 .layer-item-type {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -169,8 +169,8 @@
 .layer-item-rename-input {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #495057);
-  background: var(--bg-primary, #ffffff);
+  color: var(--text-primary);
+  background: var(--bg-primary);
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
   padding: var(--space-0-5) var(--space-1);
@@ -183,19 +183,19 @@
 }
 
 [data-theme="dark"] .layer-item-rename-input {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #cccccc);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .layer-item-id {
   font-size: var(--font-size-2xs);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-family: monospace;
 }
 
 .layer-item-preview {
   font-size: var(--font-size-2xs);
-  color: var(--text-muted, #868e96);
+  color: var(--text-muted);
   font-style: italic;
   white-space: nowrap;
   overflow: hidden;
@@ -219,14 +219,14 @@
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .layer-action-btn:hover {
-  background: var(--bg-tertiary, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 .layer-action-btn.active {
@@ -248,99 +248,99 @@
   border: none;
   border-radius: 3px;
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   flex-shrink: 0;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .layer-item-expand-btn:hover {
-  background: var(--bg-tertiary, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 /* Group children container */
 .layer-group-children {
-  border-left: 2px solid var(--border-color, #dee2e6);
+  border-left: 2px solid var(--border-color);
   margin-left: 18px;
 }
 
 /* Child items - indented */
 .layer-item.child {
   padding-left: var(--space-2);
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
 }
 
 .layer-item.child:hover {
-  background: var(--bg-hover, #f0f0f0);
+  background: var(--bg-hover);
 }
 
 .layer-item.child.selected {
-  background: var(--bg-selected, #d4e8ff);
+  background: var(--color-primary-light);
 }
 
 /* Dark mode support */
 [data-theme="dark"] .layer-panel {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-panel-header {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-panel-header:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-panel-resize-handle-vertical:hover,
 [data-theme="dark"] .layer-panel-resize-handle-horizontal:hover {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
 }
 
 [data-theme="dark"] .layer-item {
-  border-color: var(--border-color-light, #2d2d2d);
+  border-color: var(--border-color-light);
 }
 
 [data-theme="dark"] .layer-item:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-item.selected {
-  background: var(--bg-selected, #264f78);
+  background: var(--color-primary-light);
 }
 
 [data-theme="dark"] .layer-action-btn:hover {
-  background: var(--bg-tertiary, #3d3d3d);
+  background: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .layer-item-expand-btn:hover {
-  background: var(--bg-tertiary, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-group-children {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-item.child {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .layer-item.child:hover {
-  background: var(--bg-hover, #2d2d2d);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-item.child.selected {
-  background: var(--bg-selected, #1e3a5f);
+  background: var(--color-primary-light);
 }
 
 /* Layer panel actions bar */
 .layer-panel-actions {
   padding: var(--space-2);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
-  background: var(--bg-secondary, #f8f9fa);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
 }
 
 .layer-panel-action-btn {
@@ -349,17 +349,17 @@
   gap: var(--space-1-5);
   width: 100%;
   padding: var(--space-1-5) 10px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #495057);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .layer-panel-action-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -368,8 +368,8 @@
   position: fixed;
   z-index: 1000;
   min-width: 150px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1) 0;
@@ -382,14 +382,14 @@
   padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.1s ease;
 }
 
 .layer-context-menu-item:hover {
-  background: var(--bg-hover, #f8f9fa);
+  background: var(--bg-hover);
 }
 
 .layer-context-menu-item.danger:hover {
@@ -400,37 +400,37 @@
 .layer-context-menu-separator {
   height: 1px;
   margin: var(--space-1) 0;
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
 }
 
 /* Dark mode for layer panel actions and context menu */
 [data-theme="dark"] .layer-panel-actions {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-panel-action-btn {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-panel-action-btn:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-context-menu {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .layer-context-menu-item {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-context-menu-item:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-context-menu-item.danger:hover {
@@ -439,7 +439,7 @@
 }
 
 [data-theme="dark"] .layer-context-menu-separator {
-  background: var(--border-color, #3d3d3d);
+  background: var(--border-color);
 }
 
 /* Color badge for groups */
@@ -483,8 +483,8 @@
   left: 100%;
   top: 0;
   min-width: 120px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   padding: var(--space-1);
@@ -496,8 +496,8 @@
 }
 
 [data-theme="dark"] .layer-context-menu-submenu-content {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
@@ -508,11 +508,11 @@
   gap: var(--space-1);
   padding: var(--space-1);
   margin-bottom: var(--space-1);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  border-bottom: 1px solid var(--border-color);
 }
 
 [data-theme="dark"] .layer-color-picker-grid {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 .layer-color-swatch {
@@ -540,18 +540,18 @@
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-2) var(--space-3);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
-  background: var(--bg-secondary, #f8f9fa);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
 }
 
 .layer-view-selector select {
   flex: 1;
   padding: var(--space-1) var(--space-2);
   font-size: var(--font-size-xs);
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #495057);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   cursor: pointer;
 }
 
@@ -570,14 +570,14 @@
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .layer-view-manage-btn:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .layer-view-selector-empty {
@@ -587,10 +587,10 @@
 .layer-view-create-btn {
   padding: var(--space-1) var(--space-3);
   font-size: var(--font-size-xs);
-  border: 1px dashed var(--border-color, #dee2e6);
+  border: 1px dashed var(--border-color);
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: border-color 0.15s ease, color 0.15s ease;
 }
@@ -601,25 +601,25 @@
 }
 
 [data-theme="dark"] .layer-view-selector {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-view-selector select {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-view-manage-btn:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-view-create-btn {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-view-create-btn:hover {
-  border-color: var(--color-primary, #60a5fa);
-  color: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }

--- a/src/ui/LayerViewManager.css
+++ b/src/ui/LayerViewManager.css
@@ -10,7 +10,7 @@
 }
 
 .layer-view-manager {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-xl);
   width: 400px;
@@ -26,15 +26,15 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-4) var(--space-5);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
-  background: var(--bg-secondary, #f8f9fa);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
 }
 
 .layer-view-manager-header h3 {
   margin: 0;
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 .layer-view-manager-close {
@@ -43,7 +43,7 @@
   border: none;
   background: transparent;
   font-size: var(--font-size-2xl);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   border-radius: var(--radius-sm);
   display: flex;
@@ -53,8 +53,8 @@
 }
 
 .layer-view-manager-close:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #212529);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .layer-view-manager-content {
@@ -75,7 +75,7 @@
   margin: 0 0 var(--space-3) 0;
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-semibold);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -96,16 +96,16 @@
 .layer-view-form-row label {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 .layer-view-form-row input {
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   font-size: var(--font-size-md);
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -117,7 +117,7 @@
 
 .layer-view-form-hint {
   font-size: var(--font-size-xs);
-  color: var(--text-muted, #868e96);
+  color: var(--text-muted);
 }
 
 .layer-view-form-error {
@@ -144,7 +144,7 @@
 
 /* View list */
 .layer-view-empty {
-  color: var(--text-muted, #868e96);
+  color: var(--text-muted);
   font-size: var(--font-size-md);
   font-style: italic;
   margin: 0;
@@ -164,9 +164,9 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px var(--space-3);
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: var(--radius-md);
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
 }
 
 .layer-view-list-item-info {
@@ -180,12 +180,12 @@
 .layer-view-list-item-name {
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 .layer-view-list-item-regex {
   font-size: var(--font-size-xs);
-  color: var(--text-muted, #868e96);
+  color: var(--text-muted);
   font-family: monospace;
 }
 
@@ -205,7 +205,7 @@
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: var(--font-size-base);
   display: flex;
@@ -215,8 +215,8 @@
 }
 
 .layer-view-list-item-actions button:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #212529);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .layer-view-list-item-actions button.danger:hover {
@@ -234,11 +234,11 @@
 
 .layer-view-edit-form input {
   padding: var(--space-1-5) 10px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-md);
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .layer-view-edit-form input:focus {
@@ -253,10 +253,10 @@
 
 .layer-view-edit-actions button {
   padding: var(--space-1) var(--space-3);
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   cursor: pointer;
   transition: background-color 0.15s ease;
@@ -269,7 +269,7 @@
 }
 
 .layer-view-edit-actions button:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .layer-view-edit-actions button:first-child:hover {
@@ -278,7 +278,7 @@
 
 /* Help section */
 .layer-view-help {
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   padding: var(--space-3) var(--space-4);
   margin-top: var(--space-4);
@@ -292,7 +292,7 @@
   margin: 0;
   padding-left: var(--space-5);
   font-size: var(--font-size-sm);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 .layer-view-help li {
@@ -300,7 +300,7 @@
 }
 
 .layer-view-help code {
-  background: var(--bg-tertiary, #e9ecef);
+  background: var(--bg-tertiary);
   padding: 1px var(--space-1);
   border-radius: 3px;
   font-size: var(--font-size-xs);
@@ -308,35 +308,35 @@
 
 /* Dark mode */
 [data-theme="dark"] .layer-view-manager {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .layer-view-manager-header {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-view-manager-header h3 {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-view-manager-close:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-view-form-row input {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-view-list-item {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-view-list-item-actions button:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-view-list-item-actions button.danger:hover {
@@ -345,27 +345,27 @@
 }
 
 [data-theme="dark"] .layer-view-edit-form input {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-view-edit-actions button {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-view-edit-actions button:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-view-help {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .layer-view-help code {
-  background: var(--bg-tertiary, #3d3d3d);
+  background: var(--bg-tertiary);
 }
 
 /* Regex test button and preview */
@@ -380,10 +380,10 @@
 
 .layer-view-form-test {
   padding: var(--space-1-5) var(--space-3);
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-primary, #212529);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
@@ -392,7 +392,7 @@
 }
 
 .layer-view-form-test:hover:not(:disabled) {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -404,20 +404,20 @@
 .layer-view-preview {
   margin-top: var(--space-2);
   padding: 10px var(--space-3);
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: var(--radius-md);
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   font-size: var(--font-size-sm);
 }
 
 .layer-view-preview strong {
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   display: block;
   margin-bottom: var(--space-1-5);
 }
 
 .layer-view-preview-empty {
-  color: var(--text-muted, #868e96);
+  color: var(--text-muted);
   font-style: italic;
   margin-left: var(--space-2);
 }
@@ -448,7 +448,7 @@
 }
 
 .layer-view-preview-label {
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-style: italic;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -456,27 +456,27 @@
 }
 
 .layer-view-preview-more {
-  color: var(--text-muted, #868e96);
+  color: var(--text-muted);
   font-style: italic;
   margin-top: var(--space-1);
 }
 
 /* Dark mode for regex test */
 [data-theme="dark"] .layer-view-form-test {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .layer-view-form-test:hover:not(:disabled) {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .layer-view-preview {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .layer-view-preview strong {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }

--- a/src/ui/LogoPicker.css
+++ b/src/ui/LogoPicker.css
@@ -29,14 +29,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .logo-picker-header h3 {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-primary, #1a1a1a);
+  color: var(--text-primary);
 }
 
 .logo-picker-close {
@@ -44,7 +44,7 @@
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   width: 32px;
   height: 32px;
   display: flex;
@@ -54,7 +54,7 @@
 }
 
 .logo-picker-close:hover {
-  background: var(--bg-hover, #f0f0f0);
+  background: var(--bg-hover);
 }
 
 .logo-picker-content {
@@ -70,12 +70,12 @@
 .logo-picker-upload-btn {
   width: 100%;
   padding: 12px 16px;
-  background: var(--bg-hover, #f5f5f5);
-  border: 2px dashed var(--border-color, #ccc);
+  background: var(--bg-hover);
+  border: 2px dashed var(--border-color);
   border-radius: 6px;
   cursor: pointer;
   font-size: 14px;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   transition: all 0.2s;
 }
 
@@ -93,7 +93,7 @@
 .logo-picker-empty {
   text-align: center;
   padding: 40px 20px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
 }
 
 .logo-picker-grid {
@@ -103,7 +103,7 @@
 }
 
 .logo-picker-item {
-  background: var(--bg-hover, #f8f8f8);
+  background: var(--bg-hover);
   border: 2px solid transparent;
   border-radius: 8px;
   padding: 8px;
@@ -114,7 +114,7 @@
 
 .logo-picker-item:hover {
   background: var(--color-primary-light);
-  border-color: var(--border-color, #ddd);
+  border-color: var(--border-color);
 }
 
 .logo-picker-item.selected {
@@ -142,13 +142,13 @@
 
 .logo-picker-placeholder {
   font-size: 24px;
-  color: var(--text-secondary, #999);
+  color: var(--text-secondary);
 }
 
 .logo-picker-name {
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -156,7 +156,7 @@
 
 .logo-picker-size {
   font-size: 10px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .logo-picker-footer {
@@ -164,7 +164,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-top: 1px solid var(--border-color, #e0e0e0);
+  border-top: 1px solid var(--border-color);
   gap: 12px;
 }
 
@@ -194,12 +194,12 @@
 
 .logo-picker-btn-secondary {
   background: transparent;
-  color: var(--text-primary, #333);
-  border: 1px solid var(--border-color, #ccc);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
 }
 
 .logo-picker-btn-secondary:hover:not(:disabled) {
-  background: var(--bg-hover, #f5f5f5);
+  background: var(--bg-hover);
 }
 
 .logo-picker-btn-secondary:disabled {

--- a/src/ui/Minimap.css
+++ b/src/ui/Minimap.css
@@ -7,8 +7,8 @@
   border-radius: 8px;
   overflow: hidden;
   box-shadow: var(--shadow-lg);
-  border: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-primary, #ffffff);
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
@@ -19,13 +19,13 @@
 .minimap-canvas {
   display: block;
   cursor: crosshair;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
 }
 
 /* Dark mode */
 :root[data-theme='dark'] .minimap-container {
-  border-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #1e293b);
+  border-color: var(--border-color);
+  background: var(--bg-secondary);
   box-shadow: var(--shadow-lg);
 }
 
@@ -34,5 +34,5 @@
 }
 
 :root[data-theme='dark'] .minimap-canvas {
-  background: var(--bg-secondary, #1e293b);
+  background: var(--bg-secondary);
 }

--- a/src/ui/Minimap.css
+++ b/src/ui/Minimap.css
@@ -6,14 +6,14 @@
   z-index: 100;
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   border: 1px solid var(--border-color, #e2e8f0);
   background: var(--bg-primary, #ffffff);
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
 .minimap-container:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-lg);
 }
 
 .minimap-canvas {
@@ -26,11 +26,11 @@
 :root[data-theme='dark'] .minimap-container {
   border-color: var(--border-color, #334155);
   background: var(--bg-secondary, #1e293b);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 :root[data-theme='dark'] .minimap-container:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
 }
 
 :root[data-theme='dark'] .minimap-canvas {

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -66,11 +66,11 @@
 }
 
 .notification-toast--error {
-  border-left-color: var(--danger, #ef4444);
+  border-left-color: var(--danger);
 }
 
 .notification-toast--error .notification-toast__icon {
-  color: var(--danger, #ef4444);
+  color: var(--danger);
 }
 
 /* Icon */
@@ -99,7 +99,7 @@
   display: block;
   margin-top: 4px;
   font-size: 12px;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 
 /* Actions */
@@ -114,9 +114,9 @@
   padding: 4px 12px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: transparent;
-  border: 1px solid var(--color-primary, #3b82f6);
+  border: 1px solid var(--color-primary);
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
@@ -137,7 +137,7 @@
   background: transparent;
   border: none;
   border-radius: 4px;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }

--- a/src/ui/NumberInput.css
+++ b/src/ui/NumberInput.css
@@ -18,7 +18,7 @@
   display: flex;
   align-items: stretch;
   height: 28px;
-  border: 1px solid var(--border-color-input, #ced4da);
+  border: 1px solid var(--border-color-input);
   border-radius: 6px;
   background: var(--bg-secondary);
   overflow: hidden;
@@ -26,7 +26,7 @@
 }
 
 .number-input-container:hover {
-  border-color: var(--border-color, #adb5bd);
+  border-color: var(--border-color);
 }
 
 .number-input-container:focus-within {
@@ -66,15 +66,15 @@
   width: 22px;
   padding: 0;
   border: none;
-  background: var(--bg-tertiary, #e9ecef);
-  color: var(--text-secondary, #6c757d);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background-color 0.1s ease, color 0.1s ease;
   flex-shrink: 0;
 }
 
 .number-input-btn:hover:not(.disabled) {
-  background: var(--bg-hover, #dee2e6);
+  background: var(--bg-hover);
   color: var(--color-primary, var(--color-primary));
 }
 
@@ -88,11 +88,11 @@
 }
 
 .number-input-btn.decrement {
-  border-right: 1px solid var(--border-color-input, #ced4da);
+  border-right: 1px solid var(--border-color-input);
 }
 
 .number-input-btn.increment {
-  border-left: 1px solid var(--border-color-input, #ced4da);
+  border-left: 1px solid var(--border-color-input);
 }
 
 .number-input-btn svg {
@@ -109,22 +109,22 @@
 
 /* Dark Mode */
 [data-theme="dark"] .number-input-container {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color-input, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color-input);
 }
 
 [data-theme="dark"] .number-input-container:hover {
-  border-color: var(--border-color, #505050);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .number-input-btn {
-  background: var(--bg-tertiary, #333333);
-  color: var(--text-secondary, #999);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .number-input-btn:hover:not(.disabled) {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  color: var(--color-primary);
 }
 
 [data-theme="dark"] .number-input-btn:active:not(.disabled) {
@@ -132,9 +132,9 @@
 }
 
 [data-theme="dark"] .number-input-btn.decrement {
-  border-right-color: var(--border-color-input, #404040);
+  border-right-color: var(--border-color-input);
 }
 
 [data-theme="dark"] .number-input-btn.increment {
-  border-left-color: var(--border-color-input, #404040);
+  border-left-color: var(--border-color-input);
 }

--- a/src/ui/PDFExportDialog.css
+++ b/src/ui/PDFExportDialog.css
@@ -29,14 +29,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .pdf-export-header h2 {
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: var(--text-primary, #1a1a1a);
+  color: var(--text-primary);
 }
 
 .pdf-export-close {
@@ -44,7 +44,7 @@
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   width: 32px;
   height: 32px;
   display: flex;
@@ -54,7 +54,7 @@
 }
 
 .pdf-export-close:hover {
-  background: var(--bg-hover, #f0f0f0);
+  background: var(--bg-hover);
 }
 
 .pdf-export-content {
@@ -75,13 +75,13 @@
   margin: 0 0 12px 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .pdf-export-section-collapsible {
-  border: 1px solid var(--border-color, #e0e0e0);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 0;
 }
@@ -92,7 +92,7 @@
   gap: 8px;
   width: 100%;
   padding: 12px 16px;
-  background: var(--bg-hover, #f8f8f8);
+  background: var(--bg-hover);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -100,7 +100,7 @@
 }
 
 .pdf-export-section-header:hover {
-  background: var(--bg-hover, #f0f0f0);
+  background: var(--bg-hover);
 }
 
 .pdf-export-section-header .pdf-export-section-title {
@@ -110,7 +110,7 @@
 
 .pdf-export-chevron {
   font-size: 10px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   transition: transform 0.2s;
 }
 
@@ -124,7 +124,7 @@
 
 .pdf-export-section-content {
   padding: 16px;
-  border-top: 1px solid var(--border-color, #e0e0e0);
+  border-top: 1px solid var(--border-color);
 }
 
 .pdf-export-field {
@@ -139,7 +139,7 @@
   display: block;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   margin-bottom: 6px;
 }
 
@@ -148,11 +148,11 @@
 .pdf-export-field textarea {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #ccc);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 14px;
-  background: var(--bg-secondary, #f8fafc);
-  color: var(--text-primary, #333);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -162,11 +162,11 @@
   -moz-appearance: none;
   width: 100%;
   padding: 8px 32px 8px 12px;
-  border: 1px solid var(--border-color, #ccc);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 14px;
-  background-color: var(--bg-secondary, #f8fafc);
-  color: var(--text-primary, #333);
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
   cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
@@ -211,12 +211,12 @@
 
 .pdf-export-extension {
   padding: 8px 12px;
-  background: var(--bg-hover, #f0f0f0);
-  border: 1px solid var(--border-color, #ccc);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-color);
   border-left: none;
   border-radius: 0 6px 6px 0;
   font-size: 14px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
 }
 
 .pdf-export-toggle {
@@ -227,10 +227,10 @@
 .pdf-export-toggle button {
   flex: 1;
   padding: 8px 16px;
-  background: var(--bg-hover, #f5f5f5);
-  border: 1px solid var(--border-color, #ccc);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-color);
   font-size: 13px;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -251,7 +251,7 @@
 }
 
 .pdf-export-toggle button:hover:not(.active) {
-  background: var(--bg-hover, #e8e8e8);
+  background: var(--bg-hover);
 }
 
 .pdf-export-margins {
@@ -268,7 +268,7 @@
 
 .pdf-export-margin-input span {
   font-size: 11px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .pdf-export-margin-input input {
@@ -289,7 +289,7 @@
   gap: 8px;
   font-size: 14px;
   cursor: pointer;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
 }
 
 .pdf-export-checkbox input[type="checkbox"] {
@@ -298,9 +298,9 @@
   -moz-appearance: none;
   width: 16px;
   height: 16px;
-  border: 2px solid var(--border-color, #ccc);
+  border: 2px solid var(--border-color);
   border-radius: 4px;
-  background-color: var(--bg-secondary, #f8fafc);
+  background-color: var(--bg-secondary);
   cursor: pointer;
   position: relative;
   transition: all 0.15s ease;
@@ -308,12 +308,12 @@
 }
 
 .pdf-export-checkbox input[type="checkbox"]:hover {
-  border-color: var(--color-primary-light, #60a5fa);
+  border-color: var(--color-primary-light);
 }
 
 .pdf-export-checkbox input[type="checkbox"]:checked {
-  background-color: var(--color-primary, #3b82f6);
-  border-color: var(--color-primary, #3b82f6);
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .pdf-export-checkbox input[type="checkbox"]:checked::after {
@@ -346,24 +346,24 @@
 .pdf-export-logo-meta {
   margin-top: 6px;
   font-size: 12px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   word-break: break-all;
 }
 
 .pdf-export-logo-btn {
   flex: 1;
   padding: 8px 16px;
-  background: var(--bg-hover, #f5f5f5);
-  border: 1px solid var(--border-color, #ccc);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 13px;
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .pdf-export-logo-btn:hover:not(:disabled) {
-  background: var(--bg-hover, #e8e8e8);
+  background: var(--bg-hover);
 }
 
 .pdf-export-logo-btn:disabled {
@@ -377,11 +377,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-hover, #f5f5f5);
-  border: 1px solid var(--border-color, #ccc);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 18px;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -413,7 +413,7 @@
   justify-content: flex-end;
   gap: 8px;
   padding: 16px 20px;
-  border-top: 1px solid var(--border-color, #e0e0e0);
+  border-top: 1px solid var(--border-color);
 }
 
 .pdf-export-btn {
@@ -442,23 +442,23 @@
 
 .pdf-export-btn-secondary {
   background: transparent;
-  color: var(--text-primary, #333);
-  border: 1px solid var(--border-color, #ccc);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
 }
 
 .pdf-export-btn-secondary:hover {
-  background: var(--bg-hover, #f5f5f5);
+  background: var(--bg-hover);
 }
 
 .pdf-export-btn-tertiary {
   background: transparent;
-  color: var(--text-secondary, #666);
+  color: var(--text-secondary);
   border: none;
   font-size: 13px;
 }
 
 .pdf-export-btn-tertiary:hover {
-  color: var(--text-primary, #333);
+  color: var(--text-primary);
   text-decoration: underline;
 }
 

--- a/src/ui/PageTabs.css
+++ b/src/ui/PageTabs.css
@@ -124,7 +124,7 @@
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
 }
 
 .page-tab-context-menu button {
@@ -152,5 +152,5 @@
 
 /* Dark mode adjustments */
 :root.dark .page-tab-context-menu {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }

--- a/src/ui/PresenceIndicators.css
+++ b/src/ui/PresenceIndicators.css
@@ -38,7 +38,7 @@
 }
 
 .presence-status-error .presence-status-dot {
-  background-color: var(--danger, #e53e3e);
+  background-color: var(--danger);
 }
 
 @keyframes pulse {

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -136,7 +136,7 @@
   padding: 0 var(--space-2);
   padding-right: var(--space-1);
   font-size: var(--font-size-sm);
-  border: 1px solid var(--border-color-input, #ced4da);
+  border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -154,8 +154,8 @@
   height: 100%;
   margin: 0;
   margin-left: var(--space-1);
-  background: var(--bg-tertiary, #e9ecef);
-  border-left: 1px solid var(--border-color-input, #ced4da);
+  background: var(--bg-tertiary);
+  border-left: 1px solid var(--border-color-input);
   border-radius: 0 5px 5px 0;
   cursor: pointer;
   opacity: 1;
@@ -168,7 +168,7 @@
     linear-gradient(var(--text-secondary) 0 0) no-repeat center 40% / 6px 1px,
     linear-gradient(var(--text-secondary) 0 0) no-repeat center 40% / 1px 6px,
     linear-gradient(var(--text-secondary) 0 0) no-repeat center 65% / 6px 1px,
-    var(--bg-tertiary, #e9ecef);
+    var(--bg-tertiary);
   background-origin: content-box;
 }
 
@@ -177,7 +177,7 @@
     linear-gradient(var(--color-primary, var(--color-primary)) 0 0) no-repeat center 40% / 6px 1px,
     linear-gradient(var(--color-primary, var(--color-primary)) 0 0) no-repeat center 40% / 1px 6px,
     linear-gradient(var(--color-primary, var(--color-primary)) 0 0) no-repeat center 65% / 6px 1px,
-    var(--bg-hover, #dee2e6);
+    var(--bg-hover);
 }
 
 .compact-number-input:hover {
@@ -277,7 +277,7 @@
   height: 30px;
   padding: 0 10px;
   font-size: var(--font-size-sm);
-  border: 1px solid var(--border-color-input, #ced4da);
+  border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -296,7 +296,7 @@
 }
 
 .property-text-input::placeholder {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
 }
 
 /* Text Area */
@@ -305,7 +305,7 @@
   padding: 10px;
   font-size: var(--font-size-sm);
   font-family: inherit;
-  border: 1px solid var(--border-color-input, #ced4da);
+  border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -395,7 +395,7 @@
   height: 28px;
   padding: 0 var(--space-2);
   font-size: var(--font-size-sm);
-  border: 1px solid var(--border-color-input, #ced4da);
+  border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -412,8 +412,8 @@
 }
 
 .compact-select option {
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-primary, #212529);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   padding: var(--space-2);
 }
 
@@ -624,8 +624,8 @@
 }
 
 .property-select option {
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .property-select:focus {
@@ -653,11 +653,11 @@
 
 /* Dark mode */
 [data-theme="dark"] .property-panel {
-  background-color: var(--bg-primary, #1e1e1e);
+  background-color: var(--bg-primary);
 }
 
 [data-theme="dark"] .property-panel-header {
-  background-color: var(--bg-secondary, #252526);
+  background-color: var(--bg-secondary);
 }
 
 [data-theme="dark"] .property-type-badge {
@@ -668,8 +668,8 @@
 [data-theme="dark"] .property-text-input,
 [data-theme="dark"] .property-textarea,
 [data-theme="dark"] .compact-select {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color-input, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color-input);
 }
 
 [data-theme="dark"] .compact-select {
@@ -677,40 +677,40 @@
 }
 
 [data-theme="dark"] .compact-select option {
-  background: var(--bg-secondary, #252526);
-  color: var(--text-primary, #e5e7eb);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .compact-number-input:hover,
 [data-theme="dark"] .property-text-input:hover,
 [data-theme="dark"] .property-textarea:hover,
 [data-theme="dark"] .compact-select:hover {
-  background: var(--bg-tertiary, #333333);
+  background: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .compact-number-input:focus,
 [data-theme="dark"] .property-text-input:focus,
 [data-theme="dark"] .property-textarea:focus,
 [data-theme="dark"] .compact-select:focus {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .info-value {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .align-button {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .align-button:hover {
-  background: var(--bg-tertiary, #333333);
+  background: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .property-hint {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 /* Icon Color Row */
@@ -749,12 +749,12 @@
 }
 
 [data-theme="dark"] .icon-color-reset {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .icon-color-reset:hover {
-  background: var(--bg-tertiary, #333333);
+  background: var(--bg-tertiary);
 }
 
 /* Migrate to Multi-Icon Button */
@@ -777,7 +777,7 @@
 }
 
 [data-theme="dark"] .migrate-to-multi-icon {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .migrate-to-multi-icon:hover {
@@ -824,12 +824,12 @@
 }
 
 [data-theme="dark"] .label-offset-reset {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .label-offset-reset:hover {
-  background: var(--bg-tertiary, #333333);
+  background: var(--bg-tertiary);
 }
 
 /* ERD Entity Members List */
@@ -941,7 +941,7 @@
 
 .erd-member-remove:hover {
   opacity: 1;
-  color: var(--danger, #e53e3e);
+  color: var(--danger);
   background: rgba(229, 62, 62, 0.1);
 }
 
@@ -965,8 +965,8 @@
 
 [data-theme="dark"] .erd-member-name,
 [data-theme="dark"] .erd-member-type {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 /* UML Class Members List */
@@ -1018,8 +1018,8 @@
 }
 
 .uml-member-visibility option {
-  background: var(--bg-secondary, #f8f9fa);
-  color: var(--text-primary, #212529);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   text-align: center;
 }
 
@@ -1102,7 +1102,7 @@
 
 .uml-member-remove:hover {
   opacity: 1;
-  color: var(--danger, #e53e3e);
+  color: var(--danger);
   background: rgba(229, 62, 62, 0.1);
 }
 
@@ -1127,13 +1127,13 @@
 [data-theme="dark"] .uml-member-visibility,
 [data-theme="dark"] .uml-member-name,
 [data-theme="dark"] .uml-member-type {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .uml-member-visibility option {
-  background: var(--bg-secondary, #252526);
-  color: var(--text-primary, #e5e7eb);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .property-select {
@@ -1141,8 +1141,8 @@
 }
 
 [data-theme="dark"] .property-select option {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #e5e7eb);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 /* UML Preset Buttons */
@@ -1178,12 +1178,12 @@
 }
 
 [data-theme="dark"] .preset-button {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .preset-button:hover {
-  background: var(--bg-hover, #2a2d2e);
+  background: var(--bg-hover);
 }
 
 /* Drag Handle for Member Reordering */
@@ -1218,7 +1218,7 @@
   align-items: center;
   gap: 10px;
   padding: 10px var(--space-3);
-  background: var(--bg-tertiary, #f1f5f9);
+  background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   margin-bottom: var(--space-3);
 }
@@ -1273,7 +1273,7 @@
 }
 
 [data-theme="dark"] .file-info-card {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 /* Swimlane Lanes List */
@@ -1363,7 +1363,7 @@
 
 .swimlane-lane-remove:hover {
   opacity: 1;
-  color: var(--danger, #e53e3e);
+  color: var(--danger);
   background: rgba(229, 62, 62, 0.1);
 }
 
@@ -1420,15 +1420,15 @@
 }
 
 [data-theme="dark"] .swimlane-lane-name {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .swimlane-reset-widths {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .swimlane-reset-widths:hover {
-  background: var(--bg-tertiary, #333333);
+  background: var(--bg-tertiary);
 }

--- a/src/ui/PropertySection.css
+++ b/src/ui/PropertySection.css
@@ -9,7 +9,7 @@
 }
 
 .property-section-container:hover {
-  border-color: var(--border-color-light, #e9ecef);
+  border-color: var(--border-color-light);
 }
 
 .property-section-container:last-child {
@@ -29,18 +29,18 @@
 }
 
 .property-section-header:hover {
-  background-color: var(--bg-tertiary, #f0f0f0);
+  background-color: var(--bg-tertiary);
 }
 
 .property-section-header:focus {
   outline: none;
-  background-color: var(--bg-tertiary, #f0f0f0);
+  background-color: var(--bg-tertiary);
 }
 
 /* Chevron */
 .property-section-chevron {
   font-size: 0.5625rem;
-  color: var(--text-muted, var(--text-secondary, #6c757d));
+  color: var(--text-muted, var(--text-secondary));
   transition: transform 0.2s ease, color 0.15s ease;
   width: 12px;
   text-align: center;
@@ -57,7 +57,7 @@
   flex: 1;
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -99,20 +99,20 @@
 
 /* Dark mode adjustments */
 [data-theme="dark"] .property-section-container {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .property-section-container:hover {
-  border-color: var(--border-color, #404040);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .property-section-header:hover,
 [data-theme="dark"] .property-section-header:focus {
-  background-color: var(--bg-tertiary, #333333);
+  background-color: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .property-section-title {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .property-section-badge {

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -162,7 +162,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: var(--space-1);
   font-size: var(--font-size-md);
 }
@@ -221,7 +221,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   z-index: 10001;
 }
 
@@ -244,7 +244,7 @@
 
 .rich-text-tab-color-swatch:hover {
   transform: scale(1.15);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-md);
 }
 
 .rich-text-tab-color-clear {
@@ -266,10 +266,10 @@
 /* Dark mode */
 [data-theme="dark"] .rich-text-tab-context-menu {
   background: var(--bg-secondary);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .rich-text-tab-color-picker {
   background: var(--bg-secondary);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -193,11 +193,11 @@
 }
 
 .rich-text-tab-context-item.danger {
-  color: var(--danger, #dc3545);
+  color: var(--danger);
 }
 
 .rich-text-tab-context-item.danger:hover:not(.disabled) {
-  background: rgba(220, 53, 69, 0.1);
+  background: var(--danger-bg);
 }
 
 .rich-text-tab-context-arrow {

--- a/src/ui/SaveStatusIndicator.css
+++ b/src/ui/SaveStatusIndicator.css
@@ -67,7 +67,7 @@
 }
 
 .save-status-badge.dirty {
-  background-color: rgba(245, 158, 11, 0.1);
+  background-color: var(--warning-bg);
   color: var(--warning);
 }
 

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -14,7 +14,7 @@
 }
 
 .save-to-library-dialog {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: 12px;
   box-shadow: var(--shadow-xl);
   width: 400px;
@@ -27,15 +27,15 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  background: var(--bg-secondary, #f8f9fa);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .save-to-library-header h2 {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 .save-to-library-close {
@@ -48,15 +48,15 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: 20px;
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .save-to-library-close:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #212529);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .save-to-library-content {
@@ -73,7 +73,7 @@
   align-items: center;
   gap: 8px;
   padding: 16px;
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: 8px;
 }
 
@@ -82,7 +82,7 @@
   height: 120px;
   object-fit: contain;
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
 }
 
 .save-to-library-preview-placeholder {
@@ -92,14 +92,14 @@
   align-items: center;
   justify-content: center;
   font-size: 48px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: 4px;
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
 }
 
 .save-to-library-preview-info {
   font-size: 12px;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 /* Form fields */
@@ -112,17 +112,17 @@
 .save-to-library-label {
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .save-to-library-input {
   padding: 10px 12px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 14px;
 }
 
@@ -133,7 +133,7 @@
 }
 
 .save-to-library-input::placeholder {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
 }
 
 /* Library select */
@@ -145,10 +145,10 @@
 .save-to-library-select {
   flex: 1;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 14px;
   cursor: pointer;
 }
@@ -165,10 +165,10 @@
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 18px;
   font-weight: 500;
   cursor: pointer;
@@ -176,7 +176,7 @@
 }
 
 .save-to-library-new-library-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -216,12 +216,12 @@
 }
 
 .save-to-library-cancel-btn {
-  background: var(--bg-tertiary, #e9ecef);
-  color: var(--text-secondary, #6c757d);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 .save-to-library-cancel-btn:hover {
-  background: var(--bg-hover, #dee2e6);
+  background: var(--bg-hover);
 }
 
 /* Error */
@@ -240,8 +240,8 @@
   justify-content: flex-end;
   gap: 8px;
   padding: 16px 20px;
-  background: var(--bg-secondary, #f8f9fa);
-  border-top: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
 }
 
 .save-to-library-btn {
@@ -260,13 +260,13 @@
 }
 
 .save-to-library-btn-cancel {
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
 }
 
 .save-to-library-btn-cancel:hover:not(:disabled) {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .save-to-library-btn-primary {
@@ -280,60 +280,60 @@
 
 /* Dark mode */
 [data-theme="dark"] .save-to-library-dialog {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .save-to-library-header {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .save-to-library-header h2 {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .save-to-library-close:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .save-to-library-preview {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .save-to-library-preview img,
 [data-theme="dark"] .save-to-library-preview-placeholder {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .save-to-library-input,
 [data-theme="dark"] .save-to-library-select {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .save-to-library-new-library-btn {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .save-to-library-new-library-btn:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .save-to-library-create-btn {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
   color: #1e1e1e;
 }
 
 [data-theme="dark"] .save-to-library-cancel-btn {
-  background: var(--bg-tertiary, #2a2a2a);
-  color: var(--text-secondary, #9e9e9e);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .save-to-library-cancel-btn:hover {
-  background: var(--bg-hover, #3d3d3d);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .save-to-library-error {
@@ -343,25 +343,25 @@
 }
 
 [data-theme="dark"] .save-to-library-footer {
-  background: var(--bg-secondary, #252526);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .save-to-library-btn-cancel {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .save-to-library-btn-cancel:hover:not(:disabled) {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .save-to-library-btn-primary {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
   color: #1e1e1e;
 }
 
 [data-theme="dark"] .save-to-library-btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-dark, #3b82f6);
+  background: var(--color-primary-dark);
 }

--- a/src/ui/SearchReplacePanel.css
+++ b/src/ui/SearchReplacePanel.css
@@ -8,7 +8,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   min-width: 320px;
   max-width: 400px;
   user-select: none;
@@ -16,7 +16,7 @@
 
 .search-replace-panel.dragging {
   cursor: grabbing;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-xl);
 }
 
 .search-replace-header {
@@ -206,6 +206,4 @@
 }
 
 /* Dark mode */
-[data-theme="dark"] .search-replace-panel {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-}
+

--- a/src/ui/SettingsModal.css
+++ b/src/ui/SettingsModal.css
@@ -25,7 +25,7 @@
 }
 
 .settings-modal {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: 16px;
   box-shadow: var(--shadow-xl), 0 0 0 1px var(--border-color);
   width: 850px;
@@ -74,14 +74,14 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .settings-modal-fullscreen:hover {
-  background: var(--bg-secondary, #f1f5f9);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   transform: scale(1.05);
 }
 
@@ -90,8 +90,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 18px 24px;
-  background: linear-gradient(135deg, var(--bg-secondary, #f8f9fa) 0%, var(--bg-primary, #ffffff) 100%);
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+  border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
 }
 
@@ -99,7 +99,7 @@
   margin: 0;
   font-size: 20px;
   font-weight: 700;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   letter-spacing: -0.02em;
 }
 
@@ -113,14 +113,14 @@
   border: none;
   border-radius: 8px;
   background: transparent;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 22px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .settings-modal-close:hover {
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--danger-bg);
   color: var(--danger-text);
   transform: scale(1.05);
 }
@@ -136,8 +136,8 @@
 /* Sidebar navigation */
 .settings-modal-sidebar {
   width: 210px;
-  background: var(--bg-secondary, #f8fafc);
-  border-right: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
   padding: 16px 10px;
   flex-shrink: 0;
   overflow-y: auto;
@@ -155,7 +155,7 @@
   border: none;
   border-radius: 10px;
   background: transparent;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
   font-weight: 500;
   text-align: left;
@@ -173,18 +173,18 @@
   width: 3px;
   height: 60%;
   border-radius: 0 3px 3px 0;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   transition: transform 0.2s ease;
 }
 
 .settings-tab-btn:hover {
-  background: var(--bg-hover, #f1f5f9);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .settings-tab-btn.active {
   background: linear-gradient(135deg, rgba(31, 51, 84, 0.12) 0%, rgba(31, 51, 84, 0.06) 100%);
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   font-weight: 600;
 }
 
@@ -283,7 +283,7 @@
   min-width: 0;
   overflow: auto;
   padding: 24px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   /* Flex column so a tab that opts into `flex: 1` (e.g. the document
      browser) can fill the available height — including in fullscreen.
      Natural-height tabs still scroll normally. */
@@ -306,7 +306,7 @@
   gap: 12px;
   margin-bottom: 20px;
   padding-bottom: 12px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .settings-section__title {
@@ -314,7 +314,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -339,7 +339,7 @@
 .settings-form-label {
   font-size: 14px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   text-align: right;
   padding-top: 8px;
 }
@@ -353,38 +353,38 @@
 .settings-form-input {
   padding: 10px 14px;
   font-size: 14px;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   outline: none;
   transition: all 0.15s ease;
 }
 
 .settings-form-input:focus {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .settings-form-description {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.4;
 }
 
 /* Dark mode for settings sections */
 [data-theme="dark"] .settings-section__header {
-  border-bottom-color: var(--border-color, #334155);
+  border-bottom-color: var(--border-color);
 }
 
 [data-theme="dark"] .settings-section__title {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .settings-form-input {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .settings-form-input:focus {
@@ -407,7 +407,7 @@
   gap: 12px;
   margin-bottom: 20px;
   padding-bottom: 12px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .settings-section__title {
@@ -415,7 +415,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -440,7 +440,7 @@
 .settings-form-label {
   font-size: 14px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   text-align: right;
   padding-top: 8px;
 }
@@ -454,38 +454,38 @@
 .settings-form-input {
   padding: 10px 14px;
   font-size: 14px;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   outline: none;
   transition: all 0.15s ease;
 }
 
 .settings-form-input:focus {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .settings-form-description {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.4;
 }
 
 /* Dark mode for settings sections */
 [data-theme="dark"] .settings-section__header {
-  border-bottom-color: var(--border-color, #334155);
+  border-bottom-color: var(--border-color);
 }
 
 [data-theme="dark"] .settings-section__title {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .settings-form-input {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .settings-form-input:focus {
@@ -503,12 +503,12 @@
 }
 
 .settings-modal-content::-webkit-scrollbar-thumb {
-  background: var(--border-color, #e2e8f0);
+  background: var(--border-color);
   border-radius: 4px;
 }
 
 .settings-modal-content::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary, #94a3b8);
+  background: var(--text-secondary);
 }
 
 /* Dark mode */
@@ -517,21 +517,21 @@
 }
 
 [data-theme="dark"] .settings-modal {
-  background: var(--bg-primary, #0f172a);
+  background: var(--bg-primary);
   box-shadow: var(--shadow-xl), 0 0 0 1px var(--border-color);
 }
 
 [data-theme="dark"] .settings-modal-header {
-  background: linear-gradient(135deg, var(--bg-secondary, #1e293b) 0%, var(--bg-primary, #0f172a) 100%);
-  border-color: var(--border-color, #334155);
+  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .settings-modal-header h2 {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .settings-modal-close {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .settings-modal-close:hover {
@@ -540,17 +540,17 @@
 }
 
 [data-theme="dark"] .settings-modal-sidebar {
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .settings-tab-btn {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .settings-tab-btn:hover {
   background: rgba(255, 255, 255, 0.05);
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .settings-tab-btn.active {
@@ -563,15 +563,15 @@
 }
 
 [data-theme="dark"] .settings-modal-content {
-  background: var(--bg-primary, #0f172a);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .settings-modal-content::-webkit-scrollbar-thumb {
-  background: var(--border-color, #334155);
+  background: var(--border-color);
 }
 
 [data-theme="dark"] .settings-modal-content::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary, #64748b);
+  background: var(--text-secondary);
 }
 
 /* Responsive adjustments */
@@ -606,10 +606,10 @@
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
-  background: var(--bg-secondary, #f8fafc);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -617,7 +617,7 @@
 }
 
 .settings-server-badge:hover:not(:disabled) {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
 }
 
 .settings-server-badge:disabled {
@@ -650,8 +650,8 @@
 
 [data-theme="dark"] .settings-server-badge {
   background: rgba(255, 255, 255, 0.04);
-  border-color: var(--border-color, #334155);
-  color: var(--text-primary, #f1f5f9);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .settings-server-badge.is-online {

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -318,7 +318,7 @@
 
 .shape-library-shape-item:hover {
   border-color: var(--color-primary, var(--color-primary));
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-md);
 }
 
 .shape-library-shape-preview {

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -11,7 +11,7 @@
   align-items: center;
   justify-content: center;
   height: 200px;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -60,7 +60,7 @@
   width: 200px;
   display: flex;
   flex-direction: column;
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: 8px;
   overflow: hidden;
   flex-shrink: 0;
@@ -71,14 +71,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px;
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .shape-library-sidebar-header h3 {
   margin: 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -98,15 +98,15 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: 14px;
   cursor: pointer;
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .shape-library-action-btn:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #212529);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .shape-library-action-btn.danger:hover {
@@ -120,18 +120,18 @@
   flex-wrap: wrap;
   gap: 6px;
   padding: 8px 12px;
-  background: var(--bg-primary, #ffffff);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .shape-library-create-input {
   flex: 1;
   min-width: 120px;
   padding: 6px 8px;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 12px;
 }
 
@@ -166,12 +166,12 @@
 }
 
 .shape-library-cancel-btn {
-  background: var(--bg-tertiary, #e9ecef);
-  color: var(--text-secondary, #6c757d);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 .shape-library-cancel-btn:hover {
-  background: var(--bg-hover, #dee2e6);
+  background: var(--bg-hover);
 }
 
 /* Library list */
@@ -184,7 +184,7 @@
 .shape-library-empty {
   padding: 20px 12px;
   text-align: center;
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
   font-size: 12px;
   line-height: 1.5;
 }
@@ -200,7 +200,7 @@
 }
 
 .shape-library-item:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .shape-library-item.selected {
@@ -233,8 +233,8 @@
   padding: 4px 6px;
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
 }
 
@@ -244,7 +244,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -254,14 +254,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .shape-library-content-header h3 {
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 .shape-library-content-actions {
@@ -284,14 +284,14 @@
 .shape-library-no-selection p,
 .shape-library-items-empty p {
   margin: 0;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
 .shape-library-no-selection-hint,
 .shape-library-items-hint {
   margin-top: 8px !important;
-  color: var(--text-muted, #adb5bd) !important;
+  color: var(--text-muted) !important;
   font-size: 12px !important;
 }
 
@@ -310,8 +310,8 @@
   align-items: center;
   gap: 6px;
   padding: 12px 8px 8px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
@@ -327,7 +327,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-secondary, #f8f9fa);
+  background: var(--bg-secondary);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -340,13 +340,13 @@
 
 .shape-library-shape-placeholder {
   font-size: 24px;
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
 }
 
 .shape-library-shape-name {
   font-size: 11px;
   font-weight: 500;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   text-align: center;
   max-width: 100%;
   overflow: hidden;
@@ -360,8 +360,8 @@
   padding: 2px 4px;
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #212529);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 11px;
   text-align: center;
 }
@@ -393,7 +393,7 @@
 }
 
 .shape-library-shape-action-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .shape-library-shape-action-btn.danger:hover {
@@ -412,20 +412,20 @@
 }
 
 [data-theme="dark"] .shape-library-sidebar {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .shape-library-sidebar-header {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .shape-library-sidebar-header h3 {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-action-btn:hover {
-  background: var(--bg-hover, #2a2a2a);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-action-btn.danger:hover {
@@ -434,80 +434,80 @@
 }
 
 [data-theme="dark"] .shape-library-create-form {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .shape-library-create-input {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-create-btn {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
   color: #1e1e1e;
 }
 
 [data-theme="dark"] .shape-library-cancel-btn {
-  background: var(--bg-tertiary, #2a2a2a);
-  color: var(--text-secondary, #9e9e9e);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .shape-library-cancel-btn:hover {
-  background: var(--bg-hover, #3d3d3d);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .shape-library-item:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .shape-library-item.selected {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
   color: #1e1e1e;
 }
 
 [data-theme="dark"] .shape-library-edit-input {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-content {
-  background: var(--bg-secondary, #252526);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .shape-library-content-header {
-  border-color: var(--border-color, #3d3d3d);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .shape-library-content-header h3 {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-shape-item {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #3d3d3d);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .shape-library-shape-item:hover {
-  border-color: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary);
 }
 
 [data-theme="dark"] .shape-library-shape-preview {
-  background: var(--bg-tertiary, #2a2a2a);
+  background: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .shape-library-shape-name {
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-shape-edit-input {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #e0e0e0);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .shape-library-shape-action-btn:hover {
-  background: var(--bg-hover, #2a2a2a);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .shape-library-shape-action-btn.danger:hover {

--- a/src/ui/ShapePicker.css
+++ b/src/ui/ShapePicker.css
@@ -162,9 +162,6 @@
 }
 
 /* Dark mode adjustments */
-[data-theme="dark"] .shape-picker-dropdown {
-  box-shadow: var(--shadow-lg);
-}
 
 /* View options */
 .shape-picker-view-options {

--- a/src/ui/ShapePicker.css
+++ b/src/ui/ShapePicker.css
@@ -227,5 +227,5 @@
   font-size: 10px;
   color: var(--color-text-muted, #666);
   text-align: center;
-  border-top: 1px solid var(--border-color, #333);
+  border-top: 1px solid var(--border-color);
 }

--- a/src/ui/ShapeSearchPanel.css
+++ b/src/ui/ShapeSearchPanel.css
@@ -8,7 +8,7 @@
   background: var(--color-bg-primary, #1e1e2e);
   border: 1px solid var(--border-color, #444);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
   width: 340px;

--- a/src/ui/ShapeSearchPanel.css
+++ b/src/ui/ShapeSearchPanel.css
@@ -6,7 +6,7 @@
   right: 16px;
   z-index: 900;
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--border-color, #444);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   box-shadow: var(--shadow-lg);
   display: flex;
@@ -31,7 +31,7 @@
   flex: 1;
   background: transparent;
   border: none;
-  color: var(--text-primary, #cdd6f4);
+  color: var(--text-primary);
   font-size: 13px;
   outline: none;
   padding: 4px 0;
@@ -70,7 +70,7 @@
 
 .shape-search-btn:hover {
   background: var(--color-bg-hover, #313244);
-  color: var(--text-primary, #cdd6f4);
+  color: var(--text-primary);
 }
 
 .shape-search-btn:disabled {
@@ -80,8 +80,8 @@
 
 .shape-search-btn.active {
   background: var(--color-bg-selected, #45475a);
-  color: var(--text-primary, #cdd6f4);
-  border-color: var(--border-color, #444);
+  color: var(--text-primary);
+  border-color: var(--border-color);
 }
 
 .shape-search-close {

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -5,10 +5,10 @@
   justify-content: space-between;
   height: 24px;
   padding: 0 var(--space-3);
-  background: var(--bg-secondary, #f8f9fa);
-  border-top: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
   font-size: var(--font-size-xs);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 /* Sections */
@@ -33,12 +33,12 @@
 
 /* Labels and Values */
 .status-bar-label {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
 }
 
 .status-bar-value {
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   min-width: 40px;
 }
 
@@ -106,7 +106,7 @@
 .status-bar-divider {
   width: 1px;
   height: 12px;
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
   margin: 0 var(--space-1);
 }
 
@@ -117,17 +117,17 @@
   padding: 0;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
-  color: var(--text-secondary, #6c757d);
-  background: var(--bg-tertiary, #e9ecef);
-  border: 1px solid var(--border-color, #dee2e6);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
   border-radius: 3px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .status-bar-zoom-btn:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-hover);
+  color: var(--text-primary);
   border-color: var(--color-primary, var(--color-primary));
 }
 
@@ -138,7 +138,7 @@
 
 .status-bar-zoom-value {
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   min-width: 36px;
   text-align: center;
 }
@@ -148,39 +148,39 @@
   padding: var(--space-0-5) var(--space-1-5);
   font-size: var(--font-size-2xs);
   font-weight: var(--font-weight-medium);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: 3px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .status-bar-btn:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-hover);
+  color: var(--text-primary);
   border-color: var(--color-primary, var(--color-primary));
 }
 
 /* Dark Mode */
 [data-theme="dark"] .status-bar {
-  background: var(--bg-secondary, #252526);
-  border-top-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-top-color: var(--border-color);
 }
 
 [data-theme="dark"] .status-bar-zoom-btn {
-  background: var(--bg-tertiary, #333333);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .status-bar-zoom-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .status-bar-btn {
-  border-color: var(--border-color, #404040);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .status-bar-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }

--- a/src/ui/StorageManager.css
+++ b/src/ui/StorageManager.css
@@ -79,7 +79,7 @@
 }
 
 .storage-stat-warning {
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
 }
 
 .storage-stat-label {
@@ -237,7 +237,7 @@
   display: inline-block;
   padding: 2px 6px;
   background: var(--warning-bg, #f59e0b20);
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
   border-radius: 4px;
   font-size: 11px;
   font-weight: 600;
@@ -268,8 +268,8 @@
 
 .storage-manager-btn-small:hover {
   background: var(--bg-hover);
-  color: var(--danger, #ef4444);
-  border-color: var(--danger, #ef4444);
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 /* Tabs */
@@ -400,7 +400,7 @@
   padding: 0;
   border: none;
   background: var(--danger-bg, #ef444420);
-  color: var(--danger, #ef4444);
+  color: var(--danger);
   border-radius: 50%;
   cursor: pointer;
   font-size: 12px;
@@ -417,7 +417,7 @@
 }
 
 .storage-icon-delete:hover {
-  background: var(--danger, #ef4444);
+  background: var(--danger);
   color: white;
 }
 
@@ -513,9 +513,9 @@
 }
 
 .storage-manager-btn-danger {
-  background: var(--danger, #ef4444);
+  background: var(--danger);
   color: white;
-  border-color: var(--danger, #ef4444);
+  border-color: var(--danger);
 }
 
 .storage-manager-btn-danger:hover {

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -1,6 +1,6 @@
 .style-profile-panel {
   padding: 8px 0;
-  border-top: 1px solid var(--border-color, #e2e8f0);
+  border-top: 1px solid var(--border-color);
 }
 
 .style-profile-header {
@@ -10,7 +10,7 @@
   padding: 0 12px 8px;
   font-size: 12px;
   font-weight: 600;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -31,19 +31,19 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .style-profile-view-btn:hover {
-  background: var(--bg-hover, #f1f5f9);
-  color: var(--text-secondary, #64748b);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 .style-profile-view-btn.active {
-  background: var(--bg-hover, #f1f5f9);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .style-profile-add-btn {
@@ -56,7 +56,7 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
   margin-left: 4px;
@@ -71,7 +71,7 @@
 .style-profile-create {
   padding: 8px 12px;
   margin-bottom: 8px;
-  background: var(--bg-hover, #f8fafc);
+  background: var(--bg-hover);
   border-radius: 4px;
   margin-left: 8px;
   margin-right: 8px;
@@ -81,16 +81,16 @@
   width: 100%;
   padding: 6px 8px;
   font-size: 12px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   background: var(--bg-primary);
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   outline: none;
   margin-bottom: 8px;
 }
 
 .style-profile-input:focus {
-  border-color: var(--color-primary, #1f3354);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
@@ -125,12 +125,12 @@
 }
 
 .style-profile-btn.cancel {
-  background: var(--bg-hover, #e2e8f0);
-  color: var(--text-secondary, #64748b);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 .style-profile-btn.cancel:hover {
-  background: var(--border-color, #cbd5e1);
+  background: var(--border-color);
 }
 
 /* Search bar */
@@ -146,15 +146,15 @@
   flex: 1;
   padding: 6px 28px 6px 8px;
   font-size: 12px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   background: var(--bg-primary);
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   outline: none;
 }
 
 .style-profile-search-input:focus {
-  border-color: var(--color-primary, #1f3354);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
@@ -169,15 +169,15 @@
   padding: 0;
   border: none;
   border-radius: 50%;
-  background: var(--bg-hover, #e2e8f0);
-  color: var(--text-muted, #94a3b8);
+  background: var(--bg-hover);
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .style-profile-search-clear:hover {
-  background: var(--border-color, #cbd5e1);
-  color: var(--text-secondary, #64748b);
+  background: var(--border-color);
+  color: var(--text-secondary);
 }
 
 /* Active filter indicator */
@@ -187,7 +187,7 @@
   justify-content: space-between;
   padding: 4px 12px 8px;
   font-size: 11px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: rgba(74, 144, 217, 0.1);
   margin: 0 8px 8px;
   border-radius: 4px;
@@ -203,14 +203,14 @@
   border: none;
   border-radius: 50%;
   background: transparent;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .style-profile-filter-clear:hover {
   background: rgba(74, 144, 217, 0.2);
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 /* Profile container - handles both grid and list modes */
@@ -240,13 +240,13 @@
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
-  background: var(--bg-secondary, #f8fafc);
+  background: var(--bg-secondary);
   border: 1px solid transparent;
 }
 
 .style-profile-grid-item:hover:not(.disabled) {
-  background: var(--bg-hover, #f1f5f9);
-  border-color: var(--border-color, #e2e8f0);
+  background: var(--bg-hover);
+  border-color: var(--border-color);
 }
 
 .style-profile-grid-item.disabled {
@@ -255,7 +255,7 @@
 }
 
 .style-profile-grid-item.favorite {
-  background: rgba(234, 179, 8, 0.08);
+  background: var(--warning-bg);
 }
 
 .style-profile-grid-preview {
@@ -272,12 +272,12 @@
   top: 2px;
   right: 2px;
   font-size: 10px;
-  color: var(--warning, #eab308);
+  color: var(--warning);
 }
 
 .style-profile-grid-name {
   font-size: 10px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   max-width: 100%;
   text-align: center;
   word-wrap: break-word;
@@ -361,7 +361,7 @@
 }
 
 .style-profile-item:hover:not(.disabled) {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
 }
 
 .style-profile-item.disabled {
@@ -381,7 +381,7 @@
 .style-profile-name {
   flex: 1;
   font-size: 12px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -397,10 +397,10 @@
   flex: 1;
   padding: 2px 6px;
   font-size: 12px;
-  border: 1px solid var(--color-primary, #1f3354);
+  border: 1px solid var(--color-primary);
   border-radius: 3px;
   background: var(--bg-primary);
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   outline: none;
 }
 
@@ -426,13 +426,13 @@
   border: none;
   border-radius: 4px;
   background: transparent;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .style-profile-action:hover:not(:disabled) {
-  background: var(--bg-hover, #e2e8f0);
+  background: var(--bg-hover);
 }
 
 .style-profile-action.apply:hover:not(:disabled) {
@@ -440,11 +440,11 @@
 }
 
 .style-profile-action.overwrite:hover:not(:disabled) {
-  color: var(--color-primary, #1f3354);
+  color: var(--color-primary);
 }
 
 .style-profile-action.delete:hover {
-  color: var(--danger, #e53e3e);
+  color: var(--danger);
 }
 
 /* Favorite star button - always visible */
@@ -458,11 +458,11 @@
 
 .style-profile-action.favorite.active {
   opacity: 1;
-  color: var(--warning, #eab308);
+  color: var(--warning);
 }
 
 .style-profile-action.favorite:hover {
-  color: var(--warning, #eab308);
+  color: var(--warning);
 }
 
 /* Confirmation buttons */
@@ -476,12 +476,12 @@
 }
 
 .style-profile-action.cancel {
-  color: var(--danger, #e53e3e);
+  color: var(--danger);
 }
 
 .style-profile-action.cancel:hover {
   background: rgba(229, 62, 62, 0.15);
-  color: var(--danger, #e53e3e);
+  color: var(--danger);
 }
 
 .style-profile-action:disabled {
@@ -493,7 +493,7 @@
 .style-profile-hint {
   padding: 8px 12px;
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   text-align: center;
   font-style: italic;
 }
@@ -503,8 +503,8 @@
   position: fixed;
   z-index: 1000;
   min-width: 160px;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   box-shadow: var(--shadow-lg);
   padding: 4px 0;
@@ -517,14 +517,14 @@
   padding: 8px 12px;
   border: none;
   background: transparent;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.1s ease;
 }
 
 .style-profile-context-menu-item:hover {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
 }
 
 .style-profile-context-menu-item.danger:hover {
@@ -535,34 +535,34 @@
 .style-profile-context-menu-separator {
   height: 1px;
   margin: 4px 0;
-  background: var(--border-color, #e2e8f0);
+  background: var(--border-color);
 }
 
 /* Dark mode support */
 :root[data-theme='dark'] .style-profile-panel {
-  border-top-color: var(--border-color, #334155);
+  border-top-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .style-profile-header {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .style-profile-view-btn {
-  color: var(--text-muted, #64748b);
+  color: var(--text-muted);
 }
 
 :root[data-theme='dark'] .style-profile-view-btn:hover {
-  background: var(--bg-hover, #334155);
-  color: var(--text-secondary, #94a3b8);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .style-profile-view-btn.active {
-  background: var(--bg-hover, #334155);
-  color: var(--text-primary, #f1f5f9);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .style-profile-add-btn {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .style-profile-add-btn:hover {
@@ -571,22 +571,22 @@
 }
 
 :root[data-theme='dark'] .style-profile-create {
-  background: var(--bg-hover, #1e293b);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .style-profile-input {
-  border-color: var(--border-color, #475569);
+  border-color: var(--border-color);
   background: var(--bg-primary);
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .style-profile-input:focus {
-  border-color: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(224, 198, 144, 0.2);
 }
 
 :root[data-theme='dark'] .style-profile-btn.save {
-  background: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
 }
 
 :root[data-theme='dark'] .style-profile-btn.save:hover:not(:disabled) {
@@ -594,69 +594,69 @@
 }
 
 :root[data-theme='dark'] .style-profile-btn.cancel {
-  background: var(--bg-hover, #334155);
-  color: var(--text-secondary, #94a3b8);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .style-profile-btn.cancel:hover {
-  background: var(--border-color, #475569);
+  background: var(--border-color);
 }
 
 /* Dark mode grid items */
 :root[data-theme='dark'] .style-profile-grid-item {
-  background: var(--bg-tertiary, #1e293b);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme='dark'] .style-profile-grid-item:hover:not(.disabled) {
-  background: var(--bg-hover, #334155);
-  border-color: var(--border-color, #475569);
+  background: var(--bg-hover);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .style-profile-grid-item.favorite {
-  background: rgba(234, 179, 8, 0.1);
+  background: var(--warning-bg);
 }
 
 :root[data-theme='dark'] .style-profile-grid-name {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .style-profile-grid-star {
-  color: var(--warning, #facc15);
+  color: var(--warning);
 }
 
 /* Dark mode list items */
 :root[data-theme='dark'] .style-profile-item:hover:not(.disabled) {
-  background: var(--bg-hover, #1e293b);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .style-profile-name {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .style-profile-edit-input {
-  border-color: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary);
   background: var(--bg-primary);
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .style-profile-action {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .style-profile-action:hover:not(:disabled) {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .style-profile-hint {
-  color: var(--text-muted, #64748b);
+  color: var(--text-muted);
 }
 
 :root[data-theme='dark'] .style-profile-action.favorite.active {
-  color: var(--warning, #facc15);
+  color: var(--warning);
 }
 
 :root[data-theme='dark'] .style-profile-action.favorite:hover {
-  color: var(--warning, #facc15);
+  color: var(--warning);
 }
 
 :root[data-theme='dark'] .style-profile-action.confirm {
@@ -669,27 +669,27 @@
 }
 
 :root[data-theme='dark'] .style-profile-action.cancel {
-  color: var(--danger, #f87171);
+  color: var(--danger);
 }
 
 :root[data-theme='dark'] .style-profile-action.cancel:hover {
   background: rgba(248, 113, 113, 0.15);
-  color: var(--danger, #f87171);
+  color: var(--danger);
 }
 
 /* Dark mode context menu */
 :root[data-theme='dark'] .style-profile-context-menu {
-  background: var(--bg-primary, #1e293b);
-  border-color: var(--border-color, #475569);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-item {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-item:hover {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-item.danger:hover {
@@ -698,5 +698,5 @@
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-separator {
-  background: var(--border-color, #475569);
+  background: var(--border-color);
 }

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -506,7 +506,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px 0;
   font-size: 12px;
 }
@@ -681,7 +681,7 @@
 :root[data-theme='dark'] .style-profile-context-menu {
   background: var(--bg-primary, #1e293b);
   border-color: var(--border-color, #475569);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 :root[data-theme='dark'] .style-profile-context-menu-item {

--- a/src/ui/SyncStatusBadge.css
+++ b/src/ui/SyncStatusBadge.css
@@ -35,7 +35,7 @@
 }
 
 .sync-status--syncing {
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: rgba(31, 51, 84, 0.1);
 }
 
@@ -45,7 +45,7 @@
 
 .sync-status--pending {
   color: var(--warning);
-  background: rgba(245, 158, 11, 0.1);
+  background: var(--warning-bg);
 }
 
 .sync-status--pending .sync-status-icon {
@@ -54,11 +54,11 @@
 
 .sync-status--error {
   color: var(--danger-text);
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--danger-bg);
 }
 
 .sync-status--local {
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: rgba(100, 116, 139, 0.1);
 }
 
@@ -114,7 +114,7 @@
 }
 
 :root[data-theme="dark"] .sync-status--local {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   background: rgba(148, 163, 184, 0.15);
 }
 

--- a/src/ui/TextEditor.css
+++ b/src/ui/TextEditor.css
@@ -17,7 +17,7 @@
   padding: 4px 8px;
   resize: both;
   overflow: auto;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-md);
   outline: none;
   line-height: 1.4;
   box-sizing: border-box;
@@ -36,7 +36,7 @@
 [data-theme="dark"] .text-editor-textarea {
   background: #1e293b;
   color: #f1f5f9;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-md);
 }
 
 [data-theme="dark"] .text-editor-textarea::placeholder {

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -124,7 +124,7 @@
   color: var(--text-primary, #111);
   border: 1px solid var(--border-color, #ddd);
   border-radius: 6px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-lg);
   min-width: 180px;
   font-size: 13px;
   padding: 6px 0;

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -103,7 +103,7 @@
   padding: 0.75rem 1rem;
   border-radius: 4px;
   margin: 0.75rem 0;
-  border: 1px solid var(--border-color, #e0e0e0);
+  border: 1px solid var(--border-color);
   white-space: pre;
   overflow-x: auto;
   tab-size: 2;
@@ -115,14 +115,14 @@
 }
 
 .tiptap-editor .ProseMirror .spellcheck-error {
-  text-decoration: underline wavy var(--danger, #dc2626);
+  text-decoration: underline wavy var(--danger);
   text-decoration-skip-ink: none;
 }
 
 .spellcheck-popover {
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #111);
-  border: 1px solid var(--border-color, #ddd);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   box-shadow: var(--shadow-lg);
   min-width: 180px;
@@ -133,13 +133,13 @@
 .spellcheck-popover-header {
   padding: 4px 12px;
   font-weight: 600;
-  color: var(--text-secondary, #555);
+  color: var(--text-secondary);
   font-style: italic;
 }
 
 .spellcheck-popover-empty {
   padding: 4px 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .spellcheck-popover-list {
@@ -162,12 +162,12 @@
 }
 
 .spellcheck-popover-list button:hover {
-  background: var(--bg-secondary, #f0f0f0);
+  background: var(--bg-secondary);
 }
 
 .spellcheck-popover-divider {
   height: 1px;
-  background: var(--border-color, #e5e5e5);
+  background: var(--border-color);
   margin: 4px 0;
 }
 
@@ -179,17 +179,17 @@
   padding: 6px 12px;
   cursor: pointer;
   font: inherit;
-  color: var(--color-primary, #2563eb);
+  color: var(--color-primary);
   font-weight: 500;
 }
 
 .spellcheck-popover-add:hover {
-  background: var(--bg-secondary, #f0f0f0);
+  background: var(--bg-secondary);
 }
 
 .tiptap-editor .ProseMirror a.tiptap-link,
 .tiptap-editor .ProseMirror a {
-  color: var(--color-primary, #2563eb);
+  color: var(--color-primary);
   text-decoration: underline;
   cursor: pointer;
 }

--- a/src/ui/ToolbarDropdown.css
+++ b/src/ui/ToolbarDropdown.css
@@ -13,10 +13,6 @@
   pointer-events: auto;
 }
 
-[data-theme="dark"] .toolbar-dropdown-portal {
-  box-shadow: var(--shadow-lg);
-}
-
 /* Color picker grid */
 .toolbar-dropdown-portal .color-picker-grid {
   display: grid;
@@ -37,7 +33,7 @@
 .toolbar-dropdown-portal .color-picker-swatch:hover {
   transform: scale(1.2);
   z-index: 1;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-md);
 }
 
 .toolbar-dropdown-portal .color-picker-clear {

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -99,7 +99,7 @@
   white-space: nowrap;
   z-index: 1000;
   pointer-events: none;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   display: flex;
   align-items: center;
   gap: var(--space-1-5);
@@ -153,7 +153,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-lg);
   z-index: 1000;
 }
 
@@ -632,7 +632,7 @@
 [data-theme="dark"] .file-menu-dropdown {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #404040);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .file-menu-dropdown button:hover {
@@ -672,7 +672,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   z-index: 2000;
 }
 
@@ -717,7 +717,7 @@
 [data-theme="dark"] .inline-tab-context-menu {
   background: var(--bg-primary, #1e1e1e);
   border-color: var(--border-color, #404040);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .inline-tab-context-menu button:hover {

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -4,8 +4,8 @@
   align-items: center;
   height: 44px;
   padding: 0 var(--space-3);
-  background: var(--bg-secondary, #f8f9fa);
-  border-bottom: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
   gap: var(--space-2);
 }
 
@@ -36,7 +36,7 @@
 .toolbar-divider {
   width: 1px;
   height: 24px;
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
 }
 
 /* Tool Buttons */
@@ -64,7 +64,7 @@
 }
 
 .tool-button:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .tool-button.active {
@@ -81,7 +81,7 @@
 .tool-button-icon {
   font-size: var(--font-size-lg);
   line-height: var(--line-height-tight);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
 }
 
 /* Tool Tooltip */
@@ -92,8 +92,8 @@
   transform: translateX(-50%);
   margin-top: var(--space-1-5);
   padding: var(--space-1) var(--space-2);
-  background: var(--bg-tertiary, #333);
-  color: var(--text-primary, #fff);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   border-radius: var(--radius-sm);
   white-space: nowrap;
@@ -125,7 +125,7 @@
   padding: var(--space-1-5) 10px;
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -135,7 +135,7 @@
 
 .file-menu-trigger:hover,
 .file-menu-trigger.open {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .file-menu-arrow {
@@ -150,8 +150,8 @@
   margin-top: var(--space-1);
   min-width: 180px;
   padding: var(--space-1);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   z-index: 1000;
@@ -164,7 +164,7 @@
   width: 100%;
   padding: var(--space-2) var(--space-3);
   font-size: var(--font-size-md);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
@@ -173,18 +173,18 @@
 }
 
 .file-menu-dropdown button:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .file-menu-shortcut {
   font-size: var(--font-size-xs);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 .file-menu-divider {
   height: 1px;
   margin: var(--space-1) 0;
-  background: var(--border-color, #dee2e6);
+  background: var(--border-color);
 }
 
 /* Document Info */
@@ -198,7 +198,7 @@
   padding: var(--space-1) var(--space-2);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
@@ -211,16 +211,16 @@
 }
 
 .document-name-button:hover {
-  background: var(--bg-hover, #e9ecef);
-  border-color: var(--border-color, #dee2e6);
+  background: var(--bg-hover);
+  border-color: var(--border-color);
 }
 
 .document-name-input {
   padding: var(--space-1) var(--space-2);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #495057);
-  background: var(--bg-primary, #ffffff);
+  color: var(--text-primary);
+  background: var(--bg-primary);
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: var(--radius-sm);
   outline: none;
@@ -241,7 +241,7 @@
 }
 
 .document-status.saving {
-  color: var(--color-primary, #1f3354);
+  color: var(--color-primary);
 }
 
 .document-status.saved {
@@ -296,7 +296,7 @@
 .inline-tab {
   padding: var(--space-1) 10px;
   font-size: var(--font-size-sm);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
@@ -307,8 +307,8 @@
 }
 
 .inline-tab:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .inline-tab.active {
@@ -326,9 +326,9 @@
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-lg);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
-  border: 1px dashed var(--border-color, #dee2e6);
+  border: 1px dashed var(--border-color);
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
@@ -336,7 +336,7 @@
 }
 
 .inline-tab-add:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   color: var(--color-primary, var(--color-primary));
   border-color: var(--color-primary, var(--color-primary));
 }
@@ -350,7 +350,7 @@
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-lg);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -359,8 +359,8 @@
 }
 
 .toolbar-action-button:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .toolbar-action-button:focus {
@@ -383,7 +383,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -392,8 +392,8 @@
 }
 
 .toolbar-icon-btn:hover {
-  background: var(--bg-hover, #e9ecef);
-  color: var(--text-primary, #495057);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .toolbar-icon-btn:focus {
@@ -415,16 +415,16 @@
   align-items: center;
   justify-content: center;
   font-size: var(--font-size-lg);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .toolbar-rebuild-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   color: var(--color-primary, var(--color-primary));
   border-color: var(--color-primary, var(--color-primary));
 }
@@ -446,16 +446,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
-  border: 1px solid var(--border-color, #dee2e6);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .toolbar-action-btn:hover:not(:disabled) {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   color: var(--color-primary, var(--color-primary));
   border-color: var(--color-primary, var(--color-primary));
 }
@@ -478,7 +478,7 @@
   width: 32px;
   height: 32px;
   padding: 0;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -487,8 +487,8 @@
 }
 
 .toolbar-help-btn:hover {
-  background: var(--bg-hover, #e9ecef);
-  border-color: var(--border-color, #dee2e6);
+  background: var(--bg-hover);
+  border-color: var(--border-color);
   color: var(--color-primary, var(--color-primary));
 }
 
@@ -510,7 +510,7 @@
   width: 32px;
   height: 32px;
   padding: 0;
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
@@ -519,7 +519,7 @@
 }
 
 .toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   color: var(--color-primary, var(--color-primary));
 }
 
@@ -541,7 +541,7 @@
   width: 32px;
   height: 32px;
   padding: 0;
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
@@ -550,7 +550,7 @@
 }
 
 .toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   color: var(--color-primary, var(--color-primary));
 }
 
@@ -572,16 +572,16 @@
   padding: var(--space-1-5) var(--space-3);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #495057);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .toolbar-settings-btn:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
   color: var(--color-primary, var(--color-primary));
 }
@@ -599,69 +599,69 @@
 
 /* Dark Mode */
 [data-theme="dark"] .unified-toolbar {
-  background: var(--bg-secondary, #252526);
-  border-bottom-color: var(--border-color, #404040);
+  background: var(--bg-secondary);
+  border-bottom-color: var(--border-color);
 }
 
 [data-theme="dark"] .tool-button {
-  color: var(--text-primary, #cccccc);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .tool-button-icon {
-  color: var(--text-primary, #cccccc);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .tool-button:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .tool-button.active {
-  background: var(--color-primary-light, #0d3868);
+  background: var(--color-primary-light);
 }
 
 [data-theme="dark"] .tool-button-tooltip {
-  background: var(--bg-tertiary, #1e1e1e);
-  color: var(--text-primary, #cccccc);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .file-menu-trigger:hover,
 [data-theme="dark"] .file-menu-trigger.open {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .file-menu-dropdown {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .file-menu-dropdown button:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .document-name-button:hover {
-  background: var(--bg-hover, #3c3c3c);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-hover);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .document-name-input {
-  background: var(--bg-primary, #1e1e1e);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .inline-tab:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .inline-tab.active {
-  background: var(--color-primary-light, #0d3868);
+  background: var(--color-primary-light);
 }
 
 [data-theme="dark"] .inline-tab-add:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .toolbar-action-button:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 /* Inline Tab Context Menu */
@@ -669,8 +669,8 @@
   position: fixed;
   min-width: 120px;
   padding: var(--space-1);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #dee2e6);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   z-index: 2000;
@@ -681,7 +681,7 @@
   width: 100%;
   padding: var(--space-1-5) 10px;
   font-size: var(--font-size-sm);
-  color: var(--text-primary, #495057);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
@@ -690,11 +690,11 @@
 }
 
 .inline-tab-context-menu button:hover {
-  background: var(--bg-hover, #e9ecef);
+  background: var(--bg-hover);
 }
 
 .inline-tab-context-menu button.disabled {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted);
   cursor: not-allowed;
 }
 
@@ -707,102 +707,102 @@
   width: 60px;
   padding: var(--space-0-5) var(--space-1);
   font-size: var(--font-size-sm);
-  color: var(--text-primary, #495057);
-  background: var(--bg-primary, #ffffff);
+  color: var(--text-primary);
+  background: var(--bg-primary);
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: 3px;
   outline: none;
 }
 
 [data-theme="dark"] .inline-tab-context-menu {
-  background: var(--bg-primary, #1e1e1e);
-  border-color: var(--border-color, #404040);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   box-shadow: var(--shadow-lg);
 }
 
 [data-theme="dark"] .inline-tab-context-menu button:hover {
-  background: var(--bg-hover, #3c3c3c);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .inline-tab-input {
-  background: var(--bg-primary, #1e1e1e);
-  color: var(--text-primary, #cccccc);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 /* Dark mode for icon buttons */
 [data-theme="dark"] .toolbar-icon-btn {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .toolbar-icon-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--text-primary, #cccccc);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 /* Dark mode for rebuild button */
 [data-theme="dark"] .toolbar-rebuild-btn {
-  color: var(--text-secondary, #94a3b8);
-  border-color: var(--border-color, #404040);
+  color: var(--text-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .toolbar-rebuild-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--color-primary, #60a5fa);
-  border-color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 /* Dark mode for undo/redo buttons */
 [data-theme="dark"] .toolbar-action-btn {
-  color: var(--text-secondary, #94a3b8);
-  border-color: var(--border-color, #404040);
+  color: var(--text-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .toolbar-action-btn:hover:not(:disabled) {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--color-primary, #60a5fa);
-  border-color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 /* Dark mode for help button */
 [data-theme="dark"] .toolbar-help-btn {
-  color: var(--text-secondary, #8b8b8b);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .toolbar-help-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
-  border-color: var(--border-color, #404040);
-  color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  border-color: var(--border-color);
+  color: var(--color-primary);
 }
 
 /* Dark mode for settings button */
 [data-theme="dark"] .toolbar-settings-btn {
-  color: var(--text-primary, #cccccc);
-  background: var(--bg-secondary, #2d2d2d);
-  border-color: var(--border-color, #404040);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 [data-theme="dark"] .toolbar-settings-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--color-primary, #60a5fa);
-  border-color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 /* Dark mode for whiteboard button */
 [data-theme="dark"] .toolbar-whiteboard-btn {
-  color: var(--text-secondary, #8b8b8b);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  color: var(--color-primary);
 }
 
 /* Dark mode for whiteboard button */
 [data-theme="dark"] .toolbar-whiteboard-btn {
-  color: var(--text-secondary, #8b8b8b);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover, #3c3c3c);
-  color: var(--color-primary, #60a5fa);
+  background: var(--bg-hover);
+  color: var(--color-primary);
 }

--- a/src/ui/VersionConflictDialog.css
+++ b/src/ui/VersionConflictDialog.css
@@ -17,7 +17,7 @@
 
 .version-conflict-dialog {
   background: var(--color-bg-primary, #1e1e2e);
-  border: 1px solid var(--border-color, #363649);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   box-shadow: var(--shadow-xl);
   width: 440px;
@@ -33,20 +33,20 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--border-color, #363649);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .version-conflict-dialog__header h3 {
   margin: 0;
   font-size: 15px;
   font-weight: 600;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .version-conflict-dialog__close {
   background: none;
   border: none;
-  color: var(--text-secondary, #999);
+  color: var(--text-secondary);
   font-size: 20px;
   cursor: pointer;
   padding: 2px 6px;
@@ -56,7 +56,7 @@
 
 .version-conflict-dialog__close:hover {
   background: var(--color-bg-hover, #2a2a3d);
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .version-conflict-dialog__content {
@@ -67,7 +67,7 @@
 .version-conflict-dialog__message {
   margin: 0 0 8px;
   font-size: 13px;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   line-height: 1.5;
 }
 
@@ -110,7 +110,7 @@
 }
 
 .version-conflict-dialog__option--danger.version-conflict-dialog__option--selected {
-  border-color: var(--danger, #e06060);
+  border-color: var(--danger);
 }
 
 .version-conflict-dialog__option input[type='radio'] {
@@ -126,7 +126,7 @@
 
 .version-conflict-dialog__option-label {
   font-size: 13px;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .version-conflict-dialog__option-note {
@@ -139,7 +139,7 @@
   margin: 0 0 16px;
   padding: 10px 12px;
   font-size: 12px;
-  color: var(--text-secondary, #999);
+  color: var(--text-secondary);
   background: var(--color-bg-secondary, #252537);
   border-radius: 6px;
   line-height: 1.5;
@@ -154,9 +154,9 @@
 .version-conflict-dialog__btn {
   padding: 8px 16px;
   border-radius: 6px;
-  border: 1px solid var(--border-color, #363649);
+  border: 1px solid var(--border-color);
   background: var(--color-bg-secondary, #252537);
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   font-size: 13px;
   cursor: pointer;
   transition: background 0.1s;
@@ -177,8 +177,8 @@
 }
 
 .version-conflict-dialog__btn--danger {
-  background: var(--danger, #e06060);
-  border-color: var(--danger, #e06060);
+  background: var(--danger);
+  border-color: var(--danger);
 }
 
 @keyframes vcd-fadeIn {

--- a/src/ui/Whiteboard.css
+++ b/src/ui/Whiteboard.css
@@ -28,7 +28,7 @@
   height: 85vh;
   background-color: rgba(248, 248, 248, 0.95);
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-xl);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -247,7 +247,7 @@
   position: fixed;
   background: #fff;
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px;
   z-index: 1100;
   min-width: 140px;
@@ -257,7 +257,7 @@
 .dark-mode .whiteboard-board-context-menu {
   background: #2a2a2a;
   border-color: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 .whiteboard-board-context-menu button {

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -23,7 +23,7 @@
   gap: var(--space-1-5);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   min-width: 0;
   overflow: hidden;
   padding: 0 var(--space-3);
@@ -44,5 +44,5 @@
 }
 
 .title-bar-status-dirty { color: var(--warning); }
-.title-bar-status-saving { color: var(--text-secondary, #6c757d); }
+.title-bar-status-saving { color: var(--text-secondary); }
 .title-bar-status-saved { color: var(--success); }

--- a/src/ui/chrome/WindowControls.css
+++ b/src/ui/chrome/WindowControls.css
@@ -14,7 +14,7 @@
   padding: 0;
   border: none;
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background-color 0.12s ease, color 0.12s ease;
 }
@@ -22,7 +22,7 @@
 .window-control:hover,
 .window-control:focus-visible {
   background: var(--bg-secondary);
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   outline: none;
 }
 

--- a/src/ui/layout/DocumentToggleRail.css
+++ b/src/ui/layout/DocumentToggleRail.css
@@ -14,7 +14,7 @@
   justify-content: center;
   transform: translateY(-50%);
   transition: background-color 0.15s ease, color 0.15s ease, width 0.15s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-md);
 }
 
 .document-toggle-rail-left {

--- a/src/ui/layout/DocumentToggleRail.css
+++ b/src/ui/layout/DocumentToggleRail.css
@@ -7,7 +7,7 @@
   padding: 0;
   border: 1px solid var(--border-color);
   background: var(--bg-secondary);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -32,7 +32,7 @@
 .document-toggle-rail:hover,
 .document-toggle-rail:focus-visible {
   background: var(--bg-tertiary, var(--bg-secondary));
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   width: 26px;
   outline: none;
 }

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -33,7 +33,7 @@
   padding: var(--space-2) 0;
   border: none;
   background: var(--bg-secondary);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
   outline: none;
 }
@@ -54,7 +54,7 @@
 .flyout-panel-rail:hover,
 .flyout-panel-rail:focus-visible {
   background: var(--bg-tertiary, var(--bg-secondary));
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
 }
 
 .flyout-panel-rail:focus-visible {
@@ -142,7 +142,7 @@
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   background: var(--bg-secondary);
 }
 
@@ -156,14 +156,14 @@
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   cursor: pointer;
 }
 
 .flyout-panel-pin:hover,
 .flyout-panel-pin:focus-visible {
   background: var(--bg-tertiary, rgba(0, 0, 0, 0.06));
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   outline: none;
 }
 

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -15,7 +15,7 @@
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background: var(--bg-primary);
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   cursor: pointer;
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
@@ -68,7 +68,7 @@
   border-radius: var(--radius-md);
   cursor: pointer;
   text-align: left;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   width: 100%;
 }
 
@@ -102,13 +102,13 @@
 .layout-selector-option-shortcut {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-normal);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .layout-selector-option-desc {
   font-size: var(--font-size-xs);
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   line-height: var(--line-height-snug);
 }
 
@@ -128,7 +128,7 @@
   padding: 7px 10px;
   border: none;
   background: transparent;
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   text-align: left;
   cursor: pointer;

--- a/src/ui/layout/PanelChromeMenu.css
+++ b/src/ui/layout/PanelChromeMenu.css
@@ -17,7 +17,7 @@
   background: transparent;
   text-align: left;
   font-size: var(--font-size-sm);
-  color: var(--text-primary, #212529);
+  color: var(--text-primary);
   border-radius: var(--radius-sm);
   cursor: pointer;
 }

--- a/src/ui/settings/BackupSettings.css
+++ b/src/ui/settings/BackupSettings.css
@@ -7,7 +7,7 @@
 .backup-section {
   margin-bottom: 24px;
   padding-bottom: 20px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .backup-section:last-child {
@@ -19,14 +19,14 @@
   margin: 0 0 12px 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .backup-section-description {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0 0 12px 0;
   line-height: 1.5;
 }
@@ -48,20 +48,20 @@
 .backup-option-row input[type="checkbox"] {
   width: 16px;
   height: 16px;
-  accent-color: var(--color-primary, #3b82f6);
+  accent-color: var(--color-primary);
   cursor: pointer;
   flex-shrink: 0;
 }
 
 .backup-option-label {
   font-size: 13px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   cursor: pointer;
   user-select: none;
 }
 
 .backup-option-label .option-detail {
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 12px;
   margin-left: 4px;
 }
@@ -75,7 +75,7 @@
 
 .backup-link-btn {
   font-size: 12px;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: none;
   border: none;
   cursor: pointer;
@@ -84,7 +84,7 @@
 }
 
 .backup-link-btn:hover {
-  color: var(--color-primary-dark, #2563eb);
+  color: var(--color-primary-dark);
 }
 
 /* Size estimation */
@@ -94,18 +94,18 @@
   gap: 8px;
   margin-bottom: 16px;
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .backup-size-value {
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 /* Last backup info */
 .backup-last-info {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin-bottom: 12px;
 }
 
@@ -129,7 +129,7 @@
 .backup-btn-primary {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .backup-btn-primary:hover:not(:disabled) {
@@ -163,7 +163,7 @@
 
 .backup-progress-bar-track {
   height: 6px;
-  background: var(--bg-tertiary, #e2e8f0);
+  background: var(--bg-tertiary);
   border-radius: 3px;
   overflow: hidden;
   margin-bottom: 6px;
@@ -171,54 +171,54 @@
 
 .backup-progress-bar-fill {
   height: 100%;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   border-radius: 3px;
   transition: width 0.3s ease;
 }
 
 .backup-progress-detail {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 /* File drop zone */
 .backup-dropzone {
-  border: 2px dashed var(--border-color, #e2e8f0);
+  border: 2px dashed var(--border-color);
   border-radius: 8px;
   padding: 24px;
   text-align: center;
   cursor: pointer;
   transition: all 0.15s ease;
   margin-bottom: 16px;
-  background: var(--bg-secondary, #f8fafc);
+  background: var(--bg-secondary);
 }
 
 .backup-dropzone:hover,
 .backup-dropzone.drag-active {
-  border-color: var(--color-primary, #3b82f6);
-  background: var(--bg-hover, #f1f5f9);
+  border-color: var(--color-primary);
+  background: var(--bg-hover);
 }
 
 .backup-dropzone-label {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin: 0;
 }
 
 .backup-dropzone-label strong {
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
 }
 
 .backup-dropzone-hint {
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   margin: 4px 0 0;
 }
 
 /* Validation summary */
 .backup-validation {
-  background: var(--bg-secondary, #f8fafc);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 12px 16px;
   margin-bottom: 16px;
@@ -227,13 +227,13 @@
 .backup-validation-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   margin: 0 0 8px;
 }
 
 .backup-validation-item {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   padding: 2px 0;
 }
 
@@ -252,7 +252,7 @@
 }
 
 .backup-validation-warning {
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
   font-size: 12px;
   margin: 4px 0 0;
 }
@@ -268,34 +268,34 @@
   flex: 1;
   padding: 10px 12px;
   font-size: 13px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: var(--bg-secondary, #f8fafc);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   cursor: pointer;
   text-align: center;
   transition: all 0.15s ease;
 }
 
 .backup-mode-option:hover {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .backup-mode-option.active {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   background: var(--accent-bg, #eff6ff);
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   font-weight: 600;
 }
 
 .backup-mode-description {
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   margin-top: 2px;
 }
 
 .backup-mode-option.active .backup-mode-description {
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   opacity: 0.75;
 }
 
@@ -307,7 +307,7 @@
 .backup-conflicts-title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
   margin: 0 0 8px;
 }
 
@@ -316,30 +316,30 @@
   align-items: center;
   justify-content: space-between;
   padding: 8px 12px;
-  background: var(--bg-secondary, #f8fafc);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   margin-bottom: 4px;
 }
 
 .backup-conflict-info {
   font-size: 12px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .backup-conflict-type {
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   text-transform: uppercase;
 }
 
 .backup-conflict-select {
   font-size: 12px;
   padding: 4px 8px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 /* Result message */

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -39,7 +39,7 @@
   background: var(--bg-hover, #f8fafc);
   border-color: var(--color-primary, #3b82f6);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-md);
 }
 
 .document-browser__action:active {
@@ -198,7 +198,7 @@
 .document-browser__filter-btn--active {
   background: var(--bg-primary, #ffffff);
   color: var(--color-primary, #3b82f6);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-sm);
   font-weight: 600;
 }
 
@@ -379,7 +379,7 @@
 .document-browser__view-btn--active {
   background: var(--bg-primary, #ffffff);
   color: var(--color-primary, #3b82f6);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-sm);
 }
 
 .document-browser__new-group-btn {
@@ -470,7 +470,7 @@
   background: var(--bg-primary, #ffffff);
   border: 1px solid var(--border-color, #e2e8f0);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-lg);
   padding: 4px;
   display: flex;
   flex-direction: column;

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -26,9 +26,9 @@
   padding: var(--space-3) var(--space-2);
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
@@ -36,8 +36,8 @@
 }
 
 .document-browser__action:hover {
-  background: var(--bg-hover, #f8fafc);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--bg-hover);
+  border-color: var(--color-primary);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
@@ -48,13 +48,13 @@
 
 .document-browser__action--primary {
   background: var(--color-cta);
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   color: var(--color-cta-text);
 }
 
 .document-browser__action--primary:hover {
   background: var(--color-cta-hover);
-  border-color: var(--color-primary-dark, #2563eb);
+  border-color: var(--color-primary-dark);
   box-shadow: 0 4px 12px rgba(31, 51, 84, 0.25);
 }
 
@@ -71,8 +71,8 @@
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
-  background: var(--bg-secondary, #f8fafc);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 10px;
 }
 
@@ -80,7 +80,7 @@
   flex: 1;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .document-browser__refresh {
@@ -90,18 +90,18 @@
   width: 28px;
   height: 28px;
   font-size: 14px;
-  color: var(--text-secondary, #64748b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .document-browser__refresh:hover {
-  background: var(--bg-hover, #f1f5f9);
-  color: var(--text-primary, #1e293b);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--color-primary);
 }
 
 .document-browser__refresh:disabled {
@@ -118,7 +118,7 @@
   font-size: 13px;
   font-weight: 500;
   color: var(--danger-text);
-  background: rgba(239, 68, 68, 0.08);
+  background: var(--danger-bg);
   border: 1px solid rgba(239, 68, 68, 0.2);
   border-radius: 8px;
 }
@@ -148,28 +148,28 @@
   padding: 10px var(--space-4);
   font-size: 14px;
   font-weight: 400;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   outline: none;
   transition: all 0.15s ease;
 }
 
 .document-browser__search:focus {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.1);
 }
 
 .document-browser__search::placeholder {
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
 }
 
 /* Filter buttons - Improved pill styling */
 .document-browser__filter {
   display: flex;
   gap: var(--space-1);
-  background: var(--bg-secondary, #f1f5f9);
+  background: var(--bg-secondary);
   padding: 4px;
   border-radius: 10px;
   flex-wrap: wrap;
@@ -181,7 +181,7 @@
   padding: 8px var(--space-3);
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: transparent;
   border: none;
   border-radius: 6px;
@@ -192,12 +192,12 @@
 
 .document-browser__filter-btn:hover {
   background: var(--bg-hover, rgba(255, 255, 255, 0.5));
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .document-browser__filter-btn--active {
-  background: var(--bg-primary, #ffffff);
-  color: var(--color-primary, #3b82f6);
+  background: var(--bg-primary);
+  color: var(--color-primary);
   box-shadow: var(--shadow-sm);
   font-weight: 600;
 }
@@ -234,8 +234,8 @@
   justify-content: center;
   padding: var(--space-6) var(--space-4);
   text-align: center;
-  background: var(--bg-secondary, #f8fafc);
-  border: 1px dashed var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border: 1px dashed var(--border-color);
   border-radius: 12px;
   margin: var(--space-2) 0;
 }
@@ -243,7 +243,7 @@
 .document-browser__empty p {
   font-size: 14px;
   font-weight: 500;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   margin: 0;
   line-height: 1.5;
 }
@@ -286,12 +286,12 @@
 }
 
 .document-browser__list::-webkit-scrollbar-thumb {
-  background: var(--border-color, #e2e8f0);
+  background: var(--border-color);
   border-radius: 3px;
 }
 
 .document-browser__list::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted, #94a3b8);
+  background: var(--text-muted);
 }
 
 /* Controls row (filter pills + view/sort/group selectors) */
@@ -313,7 +313,7 @@
   align-items: center;
   gap: 6px;
   font-size: 11px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .document-browser__select-label {
@@ -327,9 +327,9 @@
   -moz-appearance: none;
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
-  background-color: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 5px 24px 5px 8px;
   cursor: pointer;
@@ -342,22 +342,22 @@
 }
 
 .document-browser__select-input:hover {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .document-browser__select-input:focus {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(31, 51, 84, 0.15);
 }
 
 .document-browser__select-input option {
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .document-browser__view-toggle {
   display: inline-flex;
-  background: var(--bg-secondary, #f1f5f9);
+  background: var(--bg-secondary);
   border-radius: 8px;
   padding: 2px;
 }
@@ -373,12 +373,12 @@
   border: none;
   border-radius: 6px;
   cursor: pointer;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .document-browser__view-btn--active {
-  background: var(--bg-primary, #ffffff);
-  color: var(--color-primary, #3b82f6);
+  background: var(--bg-primary);
+  color: var(--color-primary);
   box-shadow: var(--shadow-sm);
 }
 
@@ -390,16 +390,16 @@
   font-size: 11px;
   font-weight: 600;
   padding: 6px 10px;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px dashed var(--border-color, #cbd5e1);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px dashed var(--border-color);
   border-radius: 6px;
   cursor: pointer;
 }
 
 .document-browser__new-group-btn:hover {
-  border-color: var(--color-primary, #3b82f6);
-  color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 /* Grid layout for the doc list */
@@ -425,7 +425,7 @@
 .document-browser__selection-count {
   font-size: 12px;
   font-weight: 600;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
 }
 
 .document-browser__selection-actions {
@@ -439,16 +439,16 @@
   font-size: 12px;
   font-weight: 500;
   padding: 6px 10px;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: pointer;
 }
 
 .document-browser__bulk-btn:hover {
-  border-color: var(--color-primary, #3b82f6);
-  color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .document-browser__bulk-btn--danger:hover {
@@ -467,8 +467,8 @@
   right: 0;
   min-width: 200px;
   z-index: 20;
-  background: var(--bg-primary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   box-shadow: var(--shadow-lg);
   padding: 4px;
@@ -483,7 +483,7 @@
   font-size: 12px;
   text-align: left;
   padding: 6px 8px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   border-radius: 4px;
@@ -491,11 +491,11 @@
 }
 
 .document-browser__assign-item:hover {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
 }
 
 .document-browser__assign-item--new {
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   font-weight: 500;
 }
 
@@ -504,12 +504,12 @@
 }
 
 .document-browser__assign-item--danger:hover {
-  background: rgba(239, 68, 68, 0.08);
+  background: var(--danger-bg);
 }
 
 .document-browser__assign-sep {
   height: 1px;
-  background: var(--border-color, #e2e8f0);
+  background: var(--border-color);
   margin: 4px 0;
 }
 
@@ -517,7 +517,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: var(--text-muted, #94a3b8);
+  background: var(--text-muted);
   flex-shrink: 0;
 }
 
@@ -543,7 +543,7 @@
   flex: 1;
   font-size: 12px;
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -553,7 +553,7 @@
 
 .document-browser__caret {
   flex-shrink: 0;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   transition: transform 0.15s ease;
 }
 
@@ -565,7 +565,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: var(--text-muted, #94a3b8);
+  background: var(--text-muted);
   flex-shrink: 0;
 }
 
@@ -576,8 +576,8 @@
 .document-browser__section-count {
   font-size: 10px;
   font-weight: 600;
-  color: var(--text-muted, #94a3b8);
-  background: var(--bg-secondary, #f1f5f9);
+  color: var(--text-muted);
+  background: var(--bg-secondary);
   padding: 1px 6px;
   border-radius: 8px;
 }
@@ -601,8 +601,8 @@
 }
 
 .document-browser__section-status--disconnected {
-  color: var(--text-muted, #94a3b8);
-  background: var(--bg-secondary, #f1f5f9);
+  color: var(--text-muted);
+  background: var(--bg-secondary);
 }
 
 .document-browser__section-menu-wrap {
@@ -619,12 +619,12 @@
   background: transparent;
   border-radius: 4px;
   cursor: pointer;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .document-browser__section-menu-btn:hover {
-  background: var(--bg-secondary, #f1f5f9);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 .document-browser__section-body {
@@ -642,7 +642,7 @@
 
 .document-browser__section-empty {
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   padding: var(--space-2) 0;
   font-style: italic;
 }
@@ -667,16 +667,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-secondary, #64748b);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
   line-height: 1;
 }
 
 /* Dark mode tweaks for new controls */
 :root[data-theme="dark"] .document-browser__select-input {
-  background-color: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
-  color: var(--text-primary, #e2e8f0);
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
@@ -686,48 +686,48 @@
 }
 
 :root[data-theme="dark"] .document-browser__select-input option {
-  background: var(--bg-secondary, #0f172a);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-browser__view-toggle {
-  background: var(--bg-tertiary, #1e293b);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme="dark"] .document-browser__view-btn--active {
-  background: var(--bg-secondary, #0f172a);
+  background: var(--bg-secondary);
   color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__new-group-btn {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-browser__bulk-btn {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-browser__assign-menu,
 :root[data-theme="dark"] .document-browser__section-menu {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-browser__assign-item {
-  color: var(--text-primary, #e2e8f0);
+  color: var(--text-primary);
 }
 
 :root[data-theme="dark"] .document-browser__assign-item:hover {
-  background: var(--bg-tertiary, #1e293b);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme="dark"] .document-browser__section-count {
-  background: var(--bg-tertiary, #1e293b);
-  color: var(--text-muted, #94a3b8);
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
 }
 
 :root[data-theme="dark"] .document-browser__section-status--connected {
@@ -736,8 +736,8 @@
 }
 
 :root[data-theme="dark"] .document-browser__section-status--disconnected {
-  background: var(--bg-tertiary, #1e293b);
-  color: var(--text-muted, #94a3b8);
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
 }
 
 :root[data-theme="dark"] .document-browser__selection-bar {
@@ -761,12 +761,12 @@
 
 /* Dark mode - Improved contrast */
 :root[data-theme="dark"] .document-browser__status {
-  background: var(--bg-tertiary, #1e293b);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-browser__filter {
-  background: var(--bg-tertiary, #1e293b);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme="dark"] .document-browser__filter-btn:hover {
@@ -774,13 +774,13 @@
 }
 
 :root[data-theme="dark"] .document-browser__filter-btn--active {
-  background: var(--bg-secondary, #0f172a);
+  background: var(--bg-secondary);
   color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__empty {
-  background: var(--bg-tertiary, #1e293b);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-browser__error {
@@ -790,18 +790,18 @@
 }
 
 :root[data-theme="dark"] .document-browser__refresh {
-  background: var(--bg-tertiary, #1e293b);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-browser__refresh:hover {
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   border-color: var(--color-primary);
 }
 
 :root[data-theme="dark"] .document-browser__search {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-browser__search:focus {
@@ -810,12 +810,12 @@
 }
 
 :root[data-theme="dark"] .document-browser__action {
-  background: var(--bg-secondary, #0f172a);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme="dark"] .document-browser__action:hover {
-  background: var(--bg-tertiary, #1e293b);
+  background: var(--bg-tertiary);
   border-color: var(--color-primary);
 }
 

--- a/src/ui/settings/GeneralSettings.css
+++ b/src/ui/settings/GeneralSettings.css
@@ -7,13 +7,13 @@
   margin: 0 0 20px 0;
   font-size: 18px;
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .settings-group {
   margin-bottom: 24px;
   padding-bottom: 20px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .settings-group:last-child {
@@ -25,7 +25,7 @@
   margin: 0 0 12px 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -43,7 +43,7 @@
   margin-bottom: 6px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .settings-select {
@@ -54,10 +54,10 @@
   max-width: 300px;
   padding: 8px 32px 8px 12px;
   font-size: 13px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background-color: var(--bg-secondary, #f8fafc);
-  color: var(--text-primary, #1e293b);
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
   cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
@@ -67,12 +67,12 @@
 }
 
 .settings-select:hover {
-  border-color: var(--color-primary-light, #60a5fa);
+  border-color: var(--color-primary-light);
 }
 
 .settings-select:focus {
   outline: none;
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px var(--color-primary-alpha, rgba(31, 51, 84, 0.15));
 }
 
@@ -85,7 +85,7 @@
   display: block;
   margin-top: 6px;
   font-size: 12px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
 }
 
 /* Checkbox rows */
@@ -105,7 +105,7 @@
 .settings-checkbox-text {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 /* Slider row styling */
@@ -120,7 +120,7 @@
 .settings-slider-value {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   min-width: 40px;
   text-align: right;
 }
@@ -130,40 +130,40 @@
   padding: 8px 16px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--danger, #ef4444);
+  color: var(--danger);
   background: transparent;
-  border: 1px solid var(--danger, #ef4444);
+  border: 1px solid var(--danger);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .settings-reset-btn:hover {
-  background: var(--danger, #ef4444);
+  background: var(--danger);
   color: white;
 }
 
 /* Dark mode */
 :root[data-theme='dark'] .settings-section-title {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .settings-group {
-  border-color: var(--border-color, #334155);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .settings-group-title {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .settings-label {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .settings-select {
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #334155);
-  color: var(--text-primary, #f1f5f9);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .settings-select:hover {
@@ -171,32 +171,32 @@
 }
 
 :root[data-theme='dark'] .settings-select:focus {
-  border-color: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(224, 198, 144, 0.15);
 }
 
 :root[data-theme='dark'] .settings-hint {
-  color: var(--text-muted, #64748b);
+  color: var(--text-muted);
 }
 
 :root[data-theme='dark'] .settings-checkbox-text {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .settings-reset-btn {
-  color: var(--danger, #f87171);
-  border-color: var(--danger, #f87171);
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 :root[data-theme='dark'] .settings-reset-btn:hover {
-  background: var(--danger, #f87171);
-  color: var(--bg-primary, #0f172a);
+  background: var(--danger);
+  color: var(--bg-primary);
 }
 
 /* Select option styling for dark mode */
 :root[data-theme='dark'] .settings-select option {
-  background: var(--bg-secondary, #1e293b);
-  color: var(--text-primary, #f1f5f9);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .settings-select option:checked {
@@ -211,21 +211,21 @@
   width: 18px;
   height: 18px;
   margin: 0;
-  border: 2px solid var(--border-color, #d1d5db);
+  border: 2px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   cursor: pointer;
   transition: all 0.15s ease;
   position: relative;
 }
 
 .settings-checkbox:hover {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .settings-checkbox:checked {
-  background: var(--color-primary, #3b82f6);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .settings-checkbox:checked::after {
@@ -246,17 +246,17 @@
 }
 
 :root[data-theme='dark'] .settings-checkbox {
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #475569);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .settings-checkbox:hover {
-  border-color: var(--color-primary, #60a5fa);
+  border-color: var(--color-primary);
 }
 
 :root[data-theme='dark'] .settings-checkbox:checked {
-  background: var(--color-primary, #60a5fa);
-  border-color: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 :root[data-theme='dark'] .settings-checkbox:focus {

--- a/src/ui/settings/LayoutSettings.css
+++ b/src/ui/settings/LayoutSettings.css
@@ -12,7 +12,7 @@
 
 .layout-settings-header p {
   margin: 0;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.45;
 }
@@ -72,7 +72,7 @@
 
 .layout-settings-default-desc {
   font-size: 10px;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   line-height: 1.3;
 }
 
@@ -89,7 +89,7 @@
 .layout-settings-mode-desc {
   margin: 0;
   font-size: 12px;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
 }
 
 .layout-settings-table {
@@ -104,7 +104,7 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--text-secondary, #6c757d);
+  color: var(--text-secondary);
   padding: 6px 8px;
   border-bottom: 1px solid var(--border-color);
 }

--- a/src/ui/settings/RelaySettings.css
+++ b/src/ui/settings/RelaySettings.css
@@ -7,7 +7,7 @@
 .relay-settings__intro {
   margin: 0 0 20px 0;
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -15,7 +15,7 @@
   padding: 1px 6px;
   font-size: 12px;
   background: var(--color-bg, #f8fafc);
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
 }
 
@@ -25,7 +25,7 @@
   gap: 14px;
   padding: 18px;
   background: var(--color-bg-secondary, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
 }
 
@@ -56,11 +56,11 @@
 
 .relay-settings__status--busy {
   color: #b45309;
-  background: rgba(245, 158, 11, 0.12);
+  background: var(--warning-bg);
 }
 
 .relay-settings__status--idle {
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: var(--color-bg, #f1f5f9);
 }
 
@@ -71,9 +71,9 @@
   align-self: flex-start;
   padding: 6px 10px;
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: var(--color-bg, #f1f5f9);
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
 }
 
@@ -84,7 +84,7 @@
   padding: 10px 12px;
   font-size: 13px;
   color: var(--danger-text);
-  background: rgba(239, 68, 68, 0.08);
+  background: var(--danger-bg);
   border: 1px solid rgba(239, 68, 68, 0.25);
   border-radius: 6px;
 }
@@ -98,7 +98,7 @@
 .relay-settings__field label {
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .relay-settings__field input {
@@ -106,14 +106,14 @@
   font-size: 14px;
   color: var(--color-text, #1e293b);
   background: var(--color-bg, #ffffff);
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   transition: border-color 0.15s ease;
 }
 
 .relay-settings__field input:focus {
   outline: none;
-  border-color: var(--color-primary, #2563eb);
+  border-color: var(--color-primary);
 }
 
 .relay-settings__field input:disabled {
@@ -152,7 +152,7 @@
 .relay-settings__btn--secondary {
   color: var(--color-text, #1e293b);
   background: var(--color-bg, #f1f5f9);
-  border-color: var(--border-color, #e2e8f0);
+  border-color: var(--border-color);
   align-self: flex-start;
 }
 
@@ -175,7 +175,7 @@
 .relay-settings__info dt {
   font-size: 12px;
   font-weight: 600;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.4px;
 }
@@ -214,7 +214,7 @@
   padding: 1px 8px;
   font-size: 11px;
   font-weight: 600;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: var(--color-bg, #f1f5f9);
   border-radius: 999px;
   text-transform: uppercase;
@@ -233,7 +233,7 @@
 .relay-settings__device-hint {
   margin: 0;
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -245,7 +245,7 @@
   letter-spacing: 4px;
   color: var(--color-text, #1e293b);
   background: var(--color-bg, #f1f5f9);
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
 }
 
@@ -254,7 +254,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: var(--color-primary, #2563eb);
+  color: var(--color-primary);
   text-decoration: none;
 }
 

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -8,7 +8,7 @@
   display: flex;
   gap: 4px;
   margin-bottom: 16px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
   padding-bottom: 8px;
 }
 
@@ -16,7 +16,7 @@
   padding: 8px 16px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px 6px 0 0;
@@ -25,14 +25,14 @@
 }
 
 .storage-tab:hover {
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-hover, #f1f5f9);
+  color: var(--text-primary);
+  background: var(--bg-hover);
 }
 
 .storage-tab.active {
-  color: var(--color-primary, #3b82f6);
-  background: var(--bg-primary, #ffffff);
-  border-color: var(--border-color, #e2e8f0);
+  color: var(--color-primary);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
   border-bottom-color: transparent;
 }
 
@@ -51,22 +51,22 @@
 }
 
 .storage-stat-label {
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .storage-stat-value {
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .storage-stat-warning .storage-stat-value {
-  color: var(--warning, #f59e0b);
+  color: var(--warning);
 }
 
 /* Progress bar */
 .storage-progress {
   height: 6px;
-  background: var(--bg-tertiary, #e2e8f0);
+  background: var(--bg-tertiary);
   border-radius: 3px;
   margin-bottom: 16px;
   overflow: hidden;
@@ -74,7 +74,7 @@
 
 .storage-progress-bar {
   height: 100%;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
   border-radius: 3px;
   transition: width 0.3s ease;
 }
@@ -91,16 +91,16 @@
   padding: 8px 14px;
   font-size: 12px;
   font-weight: 500;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-secondary, #f1f5f9);
-  border: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .storage-btn:hover:not(:disabled) {
-  background: var(--bg-hover, #e2e8f0);
+  background: var(--bg-hover);
   border-color: var(--border-hover, #cbd5e1);
 }
 
@@ -112,18 +112,18 @@
 .storage-btn-primary {
   color: var(--color-cta-text);
   background: var(--color-cta);
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .storage-btn-primary:hover:not(:disabled) {
   background: var(--color-cta-hover);
-  border-color: var(--color-primary-dark, #2563eb);
+  border-color: var(--color-primary-dark);
 }
 
 .storage-btn-danger {
   color: white;
-  background: var(--danger, #ef4444);
-  border-color: var(--danger, #ef4444);
+  background: var(--danger);
+  border-color: var(--danger);
 }
 
 .storage-btn-danger:hover:not(:disabled) {
@@ -139,7 +139,7 @@
 
 /* List container */
 .storage-list-container {
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   max-height: 300px;
   overflow-y: auto;
@@ -148,7 +148,7 @@
 .storage-empty {
   padding: 32px;
   text-align: center;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   font-size: 13px;
 }
 
@@ -162,10 +162,10 @@
   grid-template-columns: 1fr 60px 70px 60px 80px 60px;
   gap: 8px;
   padding: 10px 12px;
-  background: var(--bg-secondary, #f8fafc);
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
   font-weight: 600;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   position: sticky;
   top: 0;
 }
@@ -175,9 +175,9 @@
   grid-template-columns: 1fr 60px 70px 60px 80px 60px;
   gap: 8px;
   padding: 8px 12px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
   align-items: center;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .storage-list-item:last-child {
@@ -185,7 +185,7 @@
 }
 
 .storage-list-item:hover {
-  background: var(--bg-hover, #f8fafc);
+  background: var(--bg-hover);
 }
 
 .storage-col-name {
@@ -199,13 +199,13 @@
   padding: 2px 6px;
   font-size: 10px;
   font-weight: 500;
-  color: var(--warning, #f59e0b);
-  background: rgba(245, 158, 11, 0.1);
+  color: var(--warning);
+  background: var(--warning-bg);
   border-radius: 4px;
 }
 
 .storage-orphan-badge.protected {
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: rgba(31, 51, 84, 0.1);
 }
 
@@ -215,7 +215,7 @@
   padding: 1px 5px;
   font-size: 9px;
   font-weight: 600;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: rgba(31, 51, 84, 0.1);
   border-radius: 3px;
   text-transform: uppercase;
@@ -224,9 +224,9 @@
 .storage-delete-btn {
   padding: 4px 8px;
   font-size: 11px;
-  color: var(--danger, #ef4444);
+  color: var(--danger);
   background: transparent;
-  border: 1px solid var(--danger, #ef4444);
+  border: 1px solid var(--danger);
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -234,7 +234,7 @@
 
 .storage-delete-btn:hover {
   color: white;
-  background: var(--danger, #ef4444);
+  background: var(--danger);
 }
 
 /* Icon grid */
@@ -252,12 +252,12 @@
   align-items: center;
   padding: 8px;
   border-radius: 6px;
-  background: var(--bg-secondary, #f8fafc);
+  background: var(--bg-secondary);
   transition: background 0.15s ease;
 }
 
 .storage-icon-item:hover {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
 }
 
 .storage-icon-preview {
@@ -281,7 +281,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   font-size: 16px;
 }
 
@@ -294,7 +294,7 @@
 
 .storage-icon-name {
   font-size: 10px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   max-width: 70px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -310,12 +310,12 @@
 }
 
 .storage-icon-type.builtin {
-  color: var(--text-secondary, #64748b);
-  background: var(--bg-tertiary, #e2e8f0);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
 }
 
 .storage-icon-type.custom {
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: rgba(31, 51, 84, 0.1);
 }
 
@@ -327,7 +327,7 @@
   height: 18px;
   font-size: 12px;
   line-height: 1;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted);
   background: transparent;
   border: none;
   border-radius: 3px;
@@ -341,8 +341,8 @@
 }
 
 .storage-icon-delete:hover {
-  color: var(--danger, #ef4444);
-  background: rgba(239, 68, 68, 0.1);
+  color: var(--danger);
+  background: var(--danger-bg);
 }
 
 /* Confirm modal */
@@ -357,7 +357,7 @@
 }
 
 .storage-confirm-modal {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
   border-radius: 8px;
   padding: 20px;
   max-width: 360px;
@@ -368,20 +368,20 @@
   margin: 0 0 12px 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .storage-confirm-text {
   margin: 0 0 8px 0;
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .storage-confirm-total {
   margin: 0 0 16px 0;
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .storage-confirm-actions {
@@ -392,82 +392,82 @@
 
 /* Dark mode */
 :root[data-theme='dark'] .storage-tab {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .storage-tab:hover {
-  color: var(--text-primary, #f1f5f9);
-  background: var(--bg-hover, #334155);
+  color: var(--text-primary);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .storage-tab.active {
-  color: var(--color-primary, #60a5fa);
-  background: var(--bg-primary, #1e293b);
-  border-color: var(--border-color, #334155);
+  color: var(--color-primary);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .storage-stat-value {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .storage-progress {
-  background: var(--bg-tertiary, #334155);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme='dark'] .storage-btn {
-  color: var(--text-primary, #f1f5f9);
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #334155);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .storage-btn:hover:not(:disabled) {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .storage-list-container {
-  border-color: var(--border-color, #334155);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .storage-list-header {
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #334155);
-  color: var(--text-secondary, #94a3b8);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .storage-list-item {
-  border-color: var(--border-color, #334155);
-  color: var(--text-primary, #f1f5f9);
+  border-color: var(--border-color);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .storage-list-item:hover {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .storage-icon-item {
-  background: var(--bg-secondary, #1e293b);
+  background: var(--bg-secondary);
 }
 
 :root[data-theme='dark'] .storage-icon-item:hover {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 :root[data-theme='dark'] .storage-icon-name {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .storage-icon-type.builtin {
-  color: var(--text-secondary, #94a3b8);
-  background: var(--bg-tertiary, #334155);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
 }
 
 :root[data-theme='dark'] .storage-confirm-modal {
-  background: var(--bg-primary, #1e293b);
+  background: var(--bg-primary);
 }
 
 :root[data-theme='dark'] .storage-confirm-title {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 :root[data-theme='dark'] .storage-confirm-total {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }

--- a/src/ui/settings/StyleProfileSettings.css
+++ b/src/ui/settings/StyleProfileSettings.css
@@ -6,7 +6,7 @@
 .settings-description {
   margin: 0 0 20px 0;
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -15,8 +15,8 @@
   display: flex;
   gap: 12px;
   padding: 12px 14px;
-  background: var(--bg-secondary, #f8fafc);
-  border: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   margin-top: 24px;
 }
@@ -30,40 +30,40 @@
   justify-content: center;
   font-size: 12px;
   font-weight: 600;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
   background: rgba(31, 51, 84, 0.1);
   border-radius: 50%;
 }
 
 .settings-info-content {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
 .settings-info-content strong {
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 /* Dark mode */
 :root[data-theme='dark'] .settings-description {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .settings-info-box {
-  background: var(--bg-secondary, #1e293b);
-  border-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
 }
 
 :root[data-theme='dark'] .settings-info-icon {
-  color: var(--color-primary, #60a5fa);
+  color: var(--color-primary);
   background: rgba(224, 198, 144, 0.15);
 }
 
 :root[data-theme='dark'] .settings-info-content {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 :root[data-theme='dark'] .settings-info-content strong {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }

--- a/src/ui/viewers/GenericFileViewer.css
+++ b/src/ui/viewers/GenericFileViewer.css
@@ -12,9 +12,9 @@
 .generic-viewer-card {
   text-align: center;
   padding: 40px 48px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
-  background: var(--bg-secondary, #f8fafc);
+  background: var(--bg-secondary);
   max-width: 400px;
   width: 100%;
 }
@@ -28,23 +28,23 @@
 .generic-viewer-name {
   font-weight: 600;
   font-size: 16px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   word-break: break-all;
   margin-bottom: 8px;
 }
 
 .generic-viewer-meta {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   margin-bottom: 16px;
 }
 
 .generic-viewer-message {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   opacity: 0.7;
   padding-top: 16px;
-  border-top: 1px solid var(--border-color, #e2e8f0);
+  border-top: 1px solid var(--border-color);
 }
 
 .generic-viewer-open-btn {
@@ -81,20 +81,20 @@
 .generic-viewer-hint {
   margin-top: 16px;
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   opacity: 0.6;
 }
 
 /* Dark mode */
 [data-theme="dark"] .generic-viewer-card {
-  border-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
+  border-color: var(--border-color);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .generic-viewer-name {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .generic-viewer-message {
-  border-top-color: var(--border-color, #334155);
+  border-top-color: var(--border-color);
 }

--- a/src/ui/viewers/ImageViewer.css
+++ b/src/ui/viewers/ImageViewer.css
@@ -13,8 +13,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-secondary, #f8fafc);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   flex-shrink: 0;
   gap: 12px;
 }
@@ -27,10 +27,10 @@
 
 .image-viewer-btn {
   padding: 4px 10px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
@@ -39,19 +39,19 @@
 }
 
 .image-viewer-btn:hover {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
   border-color: var(--border-hover, #cbd5e1);
 }
 
 .image-viewer-btn.active {
   background: var(--color-cta);
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   color: var(--color-cta-text);
 }
 
 .image-viewer-zoom-label {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   min-width: 40px;
   text-align: center;
   user-select: none;
@@ -59,7 +59,7 @@
 
 .image-viewer-dimensions {
   font-size: 12px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-family: monospace;
   white-space: nowrap;
 }
@@ -99,23 +99,23 @@
 
 /* Dark mode */
 [data-theme="dark"] .image-viewer-toolbar {
-  border-bottom-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
+  border-bottom-color: var(--border-color);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .image-viewer-btn {
-  border-color: var(--border-color, #334155);
-  background: var(--bg-primary, #1e293b);
-  color: var(--text-primary, #f1f5f9);
+  border-color: var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .image-viewer-btn:hover {
-  background: var(--bg-hover, #334155);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .image-viewer-btn.active {
-  background: var(--color-primary, #60a5fa);
-  border-color: var(--color-primary, #60a5fa);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   color: #0f172a;
 }
 

--- a/src/ui/viewers/PdfViewer.css
+++ b/src/ui/viewers/PdfViewer.css
@@ -18,15 +18,15 @@
   justify-content: center;
   gap: 16px;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-secondary, #f8fafc);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   flex-shrink: 0;
 }
 
 .pdf-viewer__toolbar-divider {
   width: 1px;
   height: 24px;
-  background: var(--border-color, #e2e8f0);
+  background: var(--border-color);
   flex-shrink: 0;
 }
 
@@ -41,10 +41,10 @@
 
 .pdf-viewer__btn {
   padding: 4px 10px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
   line-height: 1.4;
   cursor: pointer;
@@ -54,7 +54,7 @@
 }
 
 .pdf-viewer__btn:hover:not(:disabled) {
-  background: var(--bg-hover, #f1f5f9);
+  background: var(--bg-hover);
   border-color: var(--border-hover, #cbd5e1);
 }
 
@@ -66,12 +66,12 @@
 .pdf-viewer__btn--active {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .pdf-viewer__btn--active:hover:not(:disabled) {
-  background: var(--color-primary, #3b82f6);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   opacity: 0.9;
 }
 
@@ -79,7 +79,7 @@
 
 .pdf-viewer__page-info {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   white-space: nowrap;
   display: flex;
   align-items: center;
@@ -89,10 +89,10 @@
 .pdf-viewer__page-input {
   width: 48px;
   padding: 2px 4px;
-  border: 1px solid var(--border-color, #e2e8f0);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
-  color: var(--text-primary, #1e293b);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-size: 13px;
   text-align: center;
   -moz-appearance: textfield;
@@ -106,7 +106,7 @@
 
 .pdf-viewer__page-input:focus {
   outline: none;
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
 }
 
@@ -114,7 +114,7 @@
 
 .pdf-viewer__zoom-level {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   min-width: 44px;
   text-align: center;
 }
@@ -131,7 +131,7 @@
   justify-content: center;
   padding: 16px;
   position: relative;
-  background: var(--bg-tertiary, #f1f5f9);
+  background: var(--bg-tertiary);
 }
 
 .pdf-viewer__canvas {
@@ -162,7 +162,7 @@
   gap: 12px;
   width: 100%;
   height: 100%;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -175,8 +175,8 @@
 .pdf-viewer__spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid var(--border-color, #e2e8f0);
-  border-top-color: var(--color-primary, #3b82f6);
+  border: 3px solid var(--border-color);
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: pdf-viewer-spin 0.8s linear infinite;
 }
@@ -198,43 +198,43 @@
    --------------------------------------------------------------------------- */
 
 [data-theme="dark"] .pdf-viewer__toolbar {
-  border-bottom-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
+  border-bottom-color: var(--border-color);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .pdf-viewer__toolbar-divider {
-  background: var(--border-color, #334155);
+  background: var(--border-color);
 }
 
 [data-theme="dark"] .pdf-viewer__btn {
-  border-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
-  color: var(--text-primary, #f1f5f9);
+  border-color: var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .pdf-viewer__btn:hover:not(:disabled) {
-  background: var(--bg-hover, #1e293b);
+  background: var(--bg-hover);
 }
 
 [data-theme="dark"] .pdf-viewer__btn--active {
   background: var(--color-cta);
   color: var(--color-cta-text);
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 [data-theme="dark"] .pdf-viewer__page-input {
-  border-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
-  color: var(--text-primary, #f1f5f9);
+  border-color: var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .pdf-viewer__page-input:focus {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.25);
 }
 
 [data-theme="dark"] .pdf-viewer__content {
-  background: var(--bg-primary, #1e293b);
+  background: var(--bg-primary);
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/ui/viewers/PdfViewer.css
+++ b/src/ui/viewers/PdfViewer.css
@@ -136,7 +136,7 @@
 
 .pdf-viewer__canvas {
   display: block;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-md);
   background: #ffffff;
 }
 
@@ -235,10 +235,6 @@
 
 [data-theme="dark"] .pdf-viewer__content {
   background: var(--bg-primary, #1e293b);
-}
-
-[data-theme="dark"] .pdf-viewer__canvas {
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/ui/viewers/SpreadsheetViewer.css
+++ b/src/ui/viewers/SpreadsheetViewer.css
@@ -7,7 +7,7 @@
   height: 100%;
   overflow: hidden;
   font-size: 13px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 /* Loading */
@@ -18,15 +18,15 @@
   justify-content: center;
   gap: 12px;
   height: 100%;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
 .spreadsheet-spinner {
   width: 28px;
   height: 28px;
-  border: 3px solid var(--border-color, #e2e8f0);
-  border-top-color: var(--color-primary, #3b82f6);
+  border: 3px solid var(--border-color);
+  border-top-color: var(--color-primary);
   border-radius: 50%;
   animation: spreadsheet-spin 0.8s linear infinite;
 }
@@ -43,7 +43,7 @@
   justify-content: center;
   gap: 8px;
   height: 100%;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -59,7 +59,7 @@
   justify-content: center;
   gap: 8px;
   flex: 1;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -72,8 +72,8 @@
   display: flex;
   gap: 0;
   padding: 0 8px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-secondary, #f8fafc);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   overflow-x: auto;
   flex-shrink: 0;
 }
@@ -83,7 +83,7 @@
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -92,12 +92,12 @@
 }
 
 .spreadsheet-tab:hover {
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
 }
 
 .spreadsheet-tab.active {
-  color: var(--color-primary, #3b82f6);
-  border-bottom-color: var(--color-primary, #3b82f6);
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
 }
 
 /* Scroll container */
@@ -128,12 +128,12 @@
 
 .spreadsheet-col-header {
   padding: 4px 8px;
-  background: var(--bg-secondary, #f1f5f9);
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  border-right: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  border-right: 1px solid var(--border-color);
   font-weight: 600;
   font-size: 11px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   text-align: center;
   white-space: nowrap;
   min-width: 80px;
@@ -155,12 +155,12 @@
 /* Row header (row numbers) */
 .spreadsheet-row-header {
   padding: 4px 8px;
-  background: var(--bg-secondary, #f1f5f9);
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  border-right: 1px solid var(--border-color, #e2e8f0);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  border-right: 1px solid var(--border-color);
   font-weight: 500;
   font-size: 11px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   text-align: center;
   position: sticky;
   left: 0;
@@ -173,8 +173,8 @@
 /* Cells */
 .spreadsheet-cell {
   padding: 4px 8px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  border-right: 1px solid var(--border-color, #e2e8f0);
+  border-bottom: 1px solid var(--border-color);
+  border-right: 1px solid var(--border-color);
   height: 32px;
   box-sizing: border-box;
   min-width: 80px;
@@ -190,86 +190,86 @@
 
 /* Alternating rows */
 .spreadsheet-table tbody tr.even .spreadsheet-cell {
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-primary);
 }
 
 .spreadsheet-table tbody tr.odd .spreadsheet-cell {
-  background: var(--bg-tertiary, #f8fafc);
+  background: var(--bg-tertiary);
 }
 
 .spreadsheet-table tbody tr.even .spreadsheet-row-header {
-  background: var(--bg-secondary, #f1f5f9);
+  background: var(--bg-secondary);
 }
 
 .spreadsheet-table tbody tr.odd .spreadsheet-row-header {
-  background: var(--bg-secondary, #eef2f7);
+  background: var(--bg-secondary);
 }
 
 /* Status bar */
 .spreadsheet-status-bar {
   padding: 4px 12px;
-  border-top: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-secondary, #f8fafc);
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   font-size: 11px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   flex-shrink: 0;
   white-space: nowrap;
 }
 
 /* Dark mode */
 [data-theme="dark"] .spreadsheet-viewer {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .spreadsheet-tabs {
-  background: var(--bg-secondary, #0f172a);
-  border-bottom-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-bottom-color: var(--border-color);
 }
 
 [data-theme="dark"] .spreadsheet-tab {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .spreadsheet-tab:hover {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .spreadsheet-col-header {
-  background: var(--bg-secondary, #1e293b);
-  border-bottom-color: var(--border-color, #334155);
-  border-right-color: var(--border-color, #334155);
-  color: var(--text-secondary, #94a3b8);
+  background: var(--bg-secondary);
+  border-bottom-color: var(--border-color);
+  border-right-color: var(--border-color);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .spreadsheet-row-header {
-  background: var(--bg-secondary, #1e293b);
-  border-bottom-color: var(--border-color, #334155);
-  border-right-color: var(--border-color, #334155);
-  color: var(--text-secondary, #94a3b8);
+  background: var(--bg-secondary);
+  border-bottom-color: var(--border-color);
+  border-right-color: var(--border-color);
+  color: var(--text-secondary);
 }
 
 [data-theme="dark"] .spreadsheet-cell {
-  border-bottom-color: var(--border-color, #334155);
-  border-right-color: var(--border-color, #334155);
+  border-bottom-color: var(--border-color);
+  border-right-color: var(--border-color);
 }
 
 [data-theme="dark"] .spreadsheet-table tbody tr.even .spreadsheet-cell {
-  background: var(--bg-primary, #0f172a);
+  background: var(--bg-primary);
 }
 
 [data-theme="dark"] .spreadsheet-table tbody tr.odd .spreadsheet-cell {
-  background: var(--bg-tertiary, #1e293b);
+  background: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .spreadsheet-table tbody tr.even .spreadsheet-row-header {
-  background: var(--bg-secondary, #1e293b);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .spreadsheet-table tbody tr.odd .spreadsheet-row-header {
-  background: var(--bg-secondary, #162032);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .spreadsheet-status-bar {
-  background: var(--bg-secondary, #0f172a);
-  border-top-color: var(--border-color, #334155);
+  background: var(--bg-secondary);
+  border-top-color: var(--border-color);
 }

--- a/src/ui/viewers/TextViewer.css
+++ b/src/ui/viewers/TextViewer.css
@@ -13,14 +13,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--border-color, #e2e8f0);
-  background: var(--bg-secondary, #f8fafc);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
   flex-shrink: 0;
 }
 
 .text-viewer-line-count {
   font-size: 13px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
 }
 
 .text-viewer-wrap-toggle {
@@ -28,13 +28,13 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: var(--text-primary, #1e293b);
+  color: var(--text-primary);
   cursor: pointer;
   user-select: none;
 }
 
 .text-viewer-wrap-toggle input[type="checkbox"] {
-  accent-color: var(--color-primary, #3b82f6);
+  accent-color: var(--color-primary);
   cursor: pointer;
 }
 
@@ -55,9 +55,9 @@
   font-size: 13px;
   line-height: 1.5;
   text-align: right;
-  color: var(--text-secondary, #94a3b8);
-  background: var(--bg-secondary, #f8fafc);
-  border-right: 1px solid var(--border-color, #e2e8f0);
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
   user-select: none;
   overflow: hidden;
   min-width: 48px;
@@ -71,8 +71,8 @@
   font-family: Consolas, Monaco, 'Courier New', monospace;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--text-primary, #1e293b);
-  background: var(--bg-primary, #ffffff);
+  color: var(--text-primary);
+  background: var(--bg-primary);
   overflow: auto;
   white-space: pre;
   tab-size: 4;
@@ -92,7 +92,7 @@
   justify-content: center;
   height: 100%;
   gap: 8px;
-  color: var(--text-secondary, #64748b);
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -102,21 +102,21 @@
 
 /* Dark mode */
 [data-theme="dark"] .text-viewer-toolbar {
-  border-bottom-color: var(--border-color, #334155);
-  background: var(--bg-secondary, #0f172a);
+  border-bottom-color: var(--border-color);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .text-viewer-wrap-toggle {
-  color: var(--text-primary, #f1f5f9);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .text-viewer-gutter {
-  color: var(--text-secondary, #64748b);
-  background: var(--bg-secondary, #0f172a);
-  border-right-color: var(--border-color, #334155);
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border-right-color: var(--border-color);
 }
 
 [data-theme="dark"] .text-viewer-content {
-  color: var(--text-primary, #f1f5f9);
-  background: var(--bg-primary, #1e293b);
+  color: var(--text-primary);
+  background: var(--bg-primary);
 }


### PR DESCRIPTION
The **theming-polish** completion for JP-147 (stacked into one PR per request). Four axes:

## 1. Shadow ladder — finished
Migrated the remaining elevation surfaces onto `sm/md/lg/xl` (dropdowns/popovers/Minimap/Whiteboard→lg, flyouts→xl, panels/button-lifts/PDF page→md, tiny→sm) and **pruned** the redundant standalone `[data-theme="dark"]` shadow overrides (from JP-225 + this pass). Left bespoke: StickyNote paper shadows, ShadowEditor preview swatches, FlyoutPanel directional shadows.

## 2. Focus-ring baseline
One rule in `index.css`:
```css
:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
```
Keyboard-only, fills the gaps (KeyboardShortcutPanel, PropertySection, PatternPicker…); component rings / deliberate `outline: none` win on specificity.

## 3. Fallback cleanup (60 files, zero visual change)
Dropped the dead `var(--token, #hex)` fallbacks on the canonical **always-defined** tokens (`--color-primary*`, `--bg-*`, `--text-*`, `--border-color*`, `--danger`/`--warning`/`--success`) — ~1500 lines of stale `#3b82f6`/`#e2e8f0`/`#ffffff` Tailwind/slate/old-navy fallbacks that never fired (the token always resolves). Pure hygiene. Dead `DocumentsSettings.css` left untouched (JP-217).

## 4. Status-tint tokens
Added `--success-bg` / `--warning-bg` / `--danger-bg` (subtle semantic backgrounds, light + dark) and routed the hardcoded `rgba(220,53,69,.1)` etc. status-badge + destructive/warning hover backgrounds onto them (stronger ≥0.15 active states left). Also mapped the last two undefined competing tokens — `--bg-selected` → `--color-primary-light`, and defined `--bg-tooltip` on brand navy.

## Verify
- `bun run build` ✅ (CSS-only; no JS/TS, tests unaffected); OSS-leak grep clean.
- **Author eyeball (light + dark):** elevation across modals/menus/panels/toasts; keyboard-tab focus rings; status badges / destructive-hover tints. The fallback cleanup (#3) is visually a no-op — review can skim it.

Assisted-by: Opus 4.8