### PR TITLE
JP-227: toolbar redesign — ToolbarGroup primitive + graceful atomic wrap (canvas + prose toolbars)

### DIFF
--- a/src/ui/CanvasToolbar.css
+++ b/src/ui/CanvasToolbar.css
@@ -6,11 +6,20 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2);
+  /* row-gap (wrapped rows) < column-gap (between groups) so the groups read as
+   * distinct clusters and wrapped rows stay tight. */
+  gap: var(--space-2) var(--space-3);
   padding: var(--space-1-5) var(--space-3);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
+}
+
+/* Page-tabs group fills the remaining width on a single row, and wraps to its
+ * own row in a narrow pane instead of squeezing the tool groups. */
+.canvas-toolbar-pages {
+  flex: 1 1 200px;
+  min-width: 120px;
 }
 
 /* Keep the page tabs from monopolizing a wrapped row's width. */

--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -31,6 +31,7 @@ import { FileImportButton } from './FileImportButton';
 import { InlinePageTabs } from './InlinePageTabs';
 import type { ImportContext } from '../services/FileImportService';
 import { ICON } from './icons';
+import { ToolbarGroup } from './ToolbarGroup';
 import './CanvasToolbar.css';
 
 /** Tool definition. */
@@ -128,7 +129,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
 
   return (
     <div className="canvas-toolbar">
-      <div className="tool-buttons">
+      <ToolbarGroup label="Drawing tools" className="tool-buttons">
         {TOOLS.map((tool) => (
           <ToolButton
             key={tool.type}
@@ -137,47 +138,53 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
             onClick={() => setActiveTool(tool.type)}
           />
         ))}
+      </ToolbarGroup>
+
+      <ToolbarGroup label="Shapes">
         <ShapePicker />
         <CustomShapePicker />
-        {getImportContext && <FileImportButton getImportContext={getImportContext} />}
-      </div>
+      </ToolbarGroup>
 
-      {onRebuildConnectors && (
-        <>
-          <div className="toolbar-divider" />
-          <button
-            className="toolbar-rebuild-btn"
-            onClick={onRebuildConnectors}
-            title="Rebuild all connector routes"
-            aria-label="Rebuild all connector routes"
-          >
-            <RefreshCw size={ICON.size} strokeWidth={ICON.strokeWidth} />
-          </button>
-        </>
+      {(getImportContext || onRebuildConnectors) && (
+        <ToolbarGroup label="Insert">
+          {getImportContext && <FileImportButton getImportContext={getImportContext} />}
+          {onRebuildConnectors && (
+            <button
+              className="toolbar-rebuild-btn"
+              onClick={onRebuildConnectors}
+              title="Rebuild all connector routes"
+              aria-label="Rebuild all connector routes"
+            >
+              <RefreshCw size={ICON.size} strokeWidth={ICON.strokeWidth} />
+            </button>
+          )}
+        </ToolbarGroup>
       )}
 
-      <div className="toolbar-divider" />
-      <button
-        className="toolbar-action-btn"
-        onClick={undo}
-        disabled={collabActive || !canUndo()}
-        title={undoTitle}
-        aria-label={undoTitle}
-      >
-        <Undo2 size={ICON.size} strokeWidth={ICON.strokeWidth} />
-      </button>
-      <button
-        className="toolbar-action-btn"
-        onClick={redo}
-        disabled={collabActive || !canRedo()}
-        title={redoTitle}
-        aria-label={redoTitle}
-      >
-        <Redo2 size={ICON.size} strokeWidth={ICON.strokeWidth} />
-      </button>
+      <ToolbarGroup label="History">
+        <button
+          className="toolbar-action-btn"
+          onClick={undo}
+          disabled={collabActive || !canUndo()}
+          title={undoTitle}
+          aria-label={undoTitle}
+        >
+          <Undo2 size={ICON.size} strokeWidth={ICON.strokeWidth} />
+        </button>
+        <button
+          className="toolbar-action-btn"
+          onClick={redo}
+          disabled={collabActive || !canRedo()}
+          title={redoTitle}
+          aria-label={redoTitle}
+        >
+          <Redo2 size={ICON.size} strokeWidth={ICON.strokeWidth} />
+        </button>
+      </ToolbarGroup>
 
-      <div className="toolbar-divider" />
-      <InlinePageTabs />
+      <ToolbarGroup label="Pages" className="canvas-toolbar-pages">
+        <InlinePageTabs />
+      </ToolbarGroup>
     </div>
   );
 }

--- a/src/ui/ToolbarGroup.tsx
+++ b/src/ui/ToolbarGroup.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+/**
+ * A toolbar cluster of related controls. Stays on a single line — a group never
+ * splits across rows when its toolbar wraps; instead whole groups wrap as units,
+ * separated by the parent toolbar's column-gap (no dangling dividers). Shared by
+ * the region toolbars (canvas + prose ribbon) for consistent grouping + a
+ * graceful wrap.
+ */
+export function ToolbarGroup({
+  children,
+  label,
+  className,
+}: {
+  children: ReactNode;
+  /** Accessible group name (also handy for future overflow labelling). */
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`toolbar-group${className ? ` ${className}` : ''}`}
+      role="group"
+      aria-label={label}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -39,6 +39,17 @@
   background: var(--border-color, #dee2e6);
 }
 
+/* A cluster of related toolbar controls. Stays atomic — never splits across
+ * rows when the toolbar wraps; whole groups wrap as units. Tight gap inside the
+ * group; the parent toolbar's larger column-gap separates groups. */
+.toolbar-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+}
+
 /* Tool Buttons */
 .tool-buttons {
   display: flex;


### PR DESCRIPTION
First two slices of the **toolbar redesign** (JP-147). Architecture: **context-aware, region-anchored** — the region split already exists (canvas tools in `CanvasToolbar`, prose ribbon in `DocumentEditorToolbar`, slim `UnifiedToolbar` app bar), so this is grouping + graceful collapse + affordances *within* it. Collapse per your steer: a **graceful atomic wrap** (not a ResizeObserver "⋮ More" engine — deferrable).

## The pattern

- **New shared `ToolbarGroup`** (`src/ui/ToolbarGroup.tsx`) + `.toolbar-group` CSS: an atomic cluster (`inline-flex; flex-wrap:nowrap; flex-shrink:0`). A group never splits across rows when its toolbar wraps — whole groups wrap as **units**, separated by the parent's column-gap. No dangling dividers.

## Slice 1 — CanvasToolbar
Refactored onto `ToolbarGroup`: Drawing tools / Shapes / Insert (file + rebuild) / History / Pages, gap-separated (old vertical dividers removed). Pages group fills the row and wraps to its own line in a narrow pane instead of squeezing the tools. Outer `gap: row < column`.

## Slice 2 — DocumentEditorToolbar (the dense one)
The Home/Insert/Table ribbon (20+ controls) already had groups but they weren't atomic, so clusters split mid-group on wrap. Made `.document-editor-toolbar-group` atomic, **removed the 11 vertical divider divs** (they dangle on wrap) in favour of gap separation (ribbon `row-gap < column-gap`), and dropped the now-dead divider CSS.

**Guardrail honoured:** zero visibility-logic changes — **Relaxed keeps its canvas tools** (Split/Diagram focus).

## Verify
- `bun run typecheck` ✅ · `bun run build` ✅. Pure structure/CSS; no JS logic touched.
- **Eyeball (the point of this PR):** narrow the panes (Relaxed *Split*, or a small window) and watch both toolbars wrap — clusters should drop to a new row **whole** (e.g. canvas History/Pages, or the prose alignment/lists groups), never splitting a group's buttons across two rows. Check the prose ribbon still reads as distinct groups now that dividers are gone (the wider column-gap carries it).

Slice 3 (later): app-bar refinement + context-switch crispness.

Assisted-by: Opus 4.8