### PR TITLE
JP-228: toolbar redesign — graceful atomic wrap for the prose ribbon (slice 2)

### DIFF
--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -49,15 +49,21 @@
 .ribbon-panel-content {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  /* row-gap (wrapped rows) < column-gap (between groups) — the larger column-gap
+   * separates the clusters now that the vertical dividers are gone. */
+  gap: var(--space-2) var(--space-3);
   padding: var(--space-1-5) var(--space-2);
   flex-wrap: wrap;
 }
 
+/* Each cluster stays atomic — it never splits across rows when the ribbon wraps;
+ * whole groups wrap as units. */
 .document-editor-toolbar-group {
   display: flex;
   align-items: center;
   gap: var(--space-0-5);
+  flex-wrap: nowrap;
+  flex-shrink: 0;
 }
 
 .document-editor-toolbar-btn {
@@ -154,13 +160,6 @@
 
 [data-theme="dark"] .document-editor-toolbar-select option {
   background: var(--bg-tertiary);
-}
-
-.document-editor-toolbar-divider {
-  width: 1px;
-  height: 24px;
-  background: var(--border-color);
-  margin: 0 var(--space-1);
 }
 
 /* Disabled group (e.g., table tools when not in table) */

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -186,7 +186,6 @@ export function DocumentEditorToolbar() {
               </select>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Text formatting */}
             <div className="document-editor-toolbar-group">
@@ -207,7 +206,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Subscript/Superscript */}
             <div className="document-editor-toolbar-group">
@@ -219,7 +217,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Color controls */}
             <div className="document-editor-toolbar-group">
@@ -261,7 +258,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Lists & Blockquote */}
             <div className="document-editor-toolbar-group">
@@ -285,7 +281,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Text Alignment */}
             <div className="document-editor-toolbar-group">
@@ -315,7 +310,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Math/LaTeX */}
             <div className="document-editor-toolbar-group">
@@ -327,7 +321,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Media */}
             <div className="document-editor-toolbar-group">
@@ -337,7 +330,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Search */}
             <div className="document-editor-toolbar-group">
@@ -358,7 +350,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Structure - disabled when not in table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
@@ -376,7 +367,6 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Options - disabled when not in table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
@@ -414,7 +404,6 @@ export function DocumentEditorToolbar() {
               </ToolbarDropdown>
             </div>
 
-            <div className="document-editor-toolbar-divider" />
 
             {/* Delete table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>


### PR DESCRIPTION
Slice 2 of the toolbar redesign — applies the JP-227 grouping/wrap pattern to the **dense prose ribbon** (`DocumentEditorToolbar`, the Home/Insert/Table ribbon with 20+ controls). Follows JP-227 (CanvasToolbar + the shared `ToolbarGroup`, merged in #92).

## Change

- `.document-editor-toolbar-group` is now **atomic** (`flex-wrap:nowrap; flex-shrink:0`) — a cluster never splits its buttons across rows when the ribbon wraps; whole groups wrap as units.
- **Removed the 11 vertical divider divs** (they dangle on wrap) + the now-dead `.document-editor-toolbar-divider` CSS. Groups are gap-separated, with the ribbon's `row-gap < column-gap` so the wider between-group gap carries the visual separation the dividers used to.

Matches the CanvasToolbar treatment. Net −12 lines.

**Guardrail honoured:** no visibility-logic changes.

## Verify

- `bun run typecheck` ✅ · `bun run build` ✅. Pure structure/CSS.
- **Eyeball:** narrow the prose column (Relaxed reading column, or a small window) and watch the Home ribbon wrap — the alignment / lists / color clusters should drop to a new row **whole**, never splitting a group's buttons across two rows, and the groups should still read as distinct now that the dividers are gone.

Slice 3 (later): app-bar refinement + context-switch crispness.

Assisted-by: Opus 4.8