### PR TITLE
JP-229: toolbar redesign — app-bar grouping + context cluster + narrow collapse (slice 3)

### DIFF
--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -28,8 +28,31 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: var(--space-2);
+  /* Larger gap separates the two clusters (View vs Actions); each cluster's own
+   * smaller gap groups its controls. */
+  gap: var(--space-3);
   min-width: 0;
+}
+
+/* View cluster — larger controls (focus switch + layout chip) want a touch more
+ * room than the icon-button gap the base .toolbar-group provides. */
+.unified-toolbar-view {
+  gap: var(--space-2);
+}
+
+/* On a narrow viewport, collapse Settings to icon-only so the app bar keeps its
+ * full action set without crowding the document name. */
+@media (max-width: 640px) {
+  .toolbar-settings-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .toolbar-settings-btn span {
+    display: none;
+  }
 }
 
 /* Divider */

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -10,6 +10,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { StickyNote, CircleHelp, Settings, Import } from 'lucide-react';
 import { Icon } from './icons';
+import { ToolbarGroup } from './ToolbarGroup';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
 import { useAutoSave } from '../hooks/useAutoSave';
@@ -151,44 +152,48 @@ export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings }: Unified
         <DocumentInfo />
       </div>
 
-      {/* Right: layout + app controls */}
+      {/* Right: view controls (the context cluster) + app actions */}
       <div className="unified-toolbar-right">
-        {activeLayout === 'relaxed' && <RelaxedFocusControl />}
-        <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} />
-        <div className="toolbar-divider" />
-        <button
-          className="toolbar-help-btn"
-          onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
-          title="Import diagram (Excalidraw)"
-          aria-label="Import diagram"
-        >
-          <Icon icon={Import} />
-        </button>
-        <button
-          className="toolbar-whiteboard-btn"
-          onClick={() => useWhiteboardStore.getState().toggleVisibility()}
-          title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
-          aria-label="Whiteboard"
-        >
-          <Icon icon={StickyNote} />
-        </button>
-        <button
-          className="toolbar-help-btn"
-          onClick={() => void openDocsHandler()}
-          title="Open documentation (F1)"
-        >
-          <Icon icon={CircleHelp} />
-        </button>
-        {onOpenSettings && (
+        <ToolbarGroup label="View" className="unified-toolbar-view">
+          {activeLayout === 'relaxed' && <RelaxedFocusControl />}
+          <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} />
+        </ToolbarGroup>
+
+        <ToolbarGroup label="Actions" className="unified-toolbar-actions">
           <button
-            className="toolbar-settings-btn"
-            onClick={onOpenSettings}
-            title="Settings (Documents, Theme, Storage, Libraries)"
+            className="toolbar-help-btn"
+            onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
+            title="Import diagram (Excalidraw)"
+            aria-label="Import diagram"
           >
-            <Icon icon={Settings} size={14} />
-            <span>Settings</span>
+            <Icon icon={Import} />
           </button>
-        )}
+          <button
+            className="toolbar-whiteboard-btn"
+            onClick={() => useWhiteboardStore.getState().toggleVisibility()}
+            title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
+            aria-label="Whiteboard"
+          >
+            <Icon icon={StickyNote} />
+          </button>
+          <button
+            className="toolbar-help-btn"
+            onClick={() => void openDocsHandler()}
+            title="Open documentation (F1)"
+          >
+            <Icon icon={CircleHelp} />
+          </button>
+          {onOpenSettings && (
+            <button
+              className="toolbar-settings-btn"
+              onClick={onOpenSettings}
+              title="Settings (Documents, Theme, Storage, Libraries)"
+            >
+              <Icon icon={Settings} size={14} />
+              <span>Settings</span>
+            </button>
+          )}
+        </ToolbarGroup>
       </div>
     </div>
   );


### PR DESCRIPTION
Slice 3 — the global app bar (`UnifiedToolbar`). Completes the **context-aware, region-anchored** model: the app bar is the *stable* layer (identity · view controls · app actions) while the region tool ribbons (slices 1–2) switch by editor.

## Change

- **Grouping → two clusters** on the right side via `ToolbarGroup`:
  - **View** — `RelaxedFocusControl` + `LayoutSelector` (the context / layout switchers).
  - **Actions** — Import / Whiteboard / Help / Settings.
  - Dropped the lone `.toolbar-divider`; clusters are gap-separated (bigger gap between clusters, tighter within) — consistent with slices 1–2.
  - This *is* the "context-switch crispness": the layout/focus controls read as one cohesive context cluster, distinct from the app actions, while the bar itself never changes out from under you.
- **Narrow collapse** (≤640px): the Settings button drops its text label → icon-only 32px, so the bar keeps its full action set without crowding the (ellipsised) document name.

**Guardrail honoured:** no visibility-logic changes. The app bar is fixed-height (can't wrap), so a future "⋮ More" overflow could fold the secondary actions if it ever gets denser — not needed at 4 actions.

## Verify

- `bun run typecheck` ✅ · `bun run build` ✅.
- **Eyeball:** the app bar's right side should read as two distinct clusters (View | Actions) with a clear gap between them; narrow the window past 640px and Settings should collapse to just its gear icon.

This wraps the toolbar redesign's three planned slices (canvas ribbon → prose ribbon → app bar). Remaining JP-147 epic work is the screenshot fixes (JP-155/156/157).

Assisted-by: Opus 4.8