### PR TITLE
JP-200: write workspace documents through to R2 (durable, region-portable)

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -292,6 +292,10 @@ async fn list_docs_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    // JP-200: on a cold machine, repopulate the workspace index from R2 first so
+    // a listing isn't empty after a recycle (best-effort; never clobbers a
+    // populated in-memory index).
+    state.ensure_workspace_index_local(&ws).await;
     let docs = state.doc_store().list_documents(&ws);
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
 }
@@ -551,6 +555,10 @@ async fn get_doc_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+
+    // JP-200: restore from R2 by id on a local miss before the permission check
+    // (which reads the in-memory index) so a recycled machine can serve the doc.
+    state.ensure_doc_local(&ws, &doc_id).await;
 
     if let Err(e) = check_read_permission(
         state.doc_store(),

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -302,6 +302,10 @@ async fn run_serve(
         // live on `ServerState`, so this must run after `server.start()` above.
         let sync_registry = server.sync_registry_handle().await;
         let on_doc_update = server.doc_update_broadcaster().await;
+        // JP-200: hand MCP the same R2 doc-mirror sink as the WS server so
+        // MCP-authored docs are written through to R2 (the MCP server keeps its
+        // own `DocumentStore` over the same volume).
+        let doc_mirror_tx = server.doc_mirror_sender().await;
         match McpServer::new(
             config.storage.path.clone(),
             on_doc_changed,
@@ -312,6 +316,7 @@ async fn run_serve(
             region.clone(),
             sync_registry,
             on_doc_update,
+            doc_mirror_tx,
         ) {
             Ok(mcp) => {
                 let mcp = Arc::new(mcp);

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -25,7 +25,7 @@ use tokio::sync::oneshot;
 use tokio::sync::RwLock;
 
 use crate::auth::OidcAuthState;
-use crate::server::documents::DocumentStore;
+use crate::server::documents::{DocumentStore, MirrorOp};
 use crate::server::protocol::DocId;
 use crate::server::WorkspaceWriteLimiter;
 use crate::sync::DocRegistry;
@@ -110,11 +110,21 @@ impl McpServer {
         relay_region: String,
         sync_registry: Arc<DocRegistry>,
         on_doc_update: Arc<OnDocUpdate>,
+        doc_mirror_tx: Option<tokio::sync::mpsc::UnboundedSender<MirrorOp>>,
     ) -> Result<Self, String> {
         let token = Arc::new(TokenStore::load_or_create(&app_data_dir)?);
         let feature_config = Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir));
         let local_mirror = Arc::new(LocalDocumentMirror::new(app_data_dir.clone()));
-        let doc_store = Arc::new(DocumentStore::new(app_data_dir));
+        // JP-200: share the WS server's R2 mirror sink so MCP-authored docs
+        // (create/prose/shape writes via this separate `DocumentStore`) are
+        // mirrored to R2 too. `None` on the filesystem backend.
+        let doc_store = {
+            let mut ds = DocumentStore::new(app_data_dir);
+            if let Some(tx) = doc_mirror_tx {
+                ds.set_mirror_sink(tx);
+            }
+            Arc::new(ds)
+        };
         Ok(Self {
             config: RwLock::new(McpConfig::default()),
             bound_port: RwLock::new(0),

--- a/relay/src/server/blob_backend/mod.rs
+++ b/relay/src/server/blob_backend/mod.rs
@@ -15,7 +15,7 @@ mod filesystem;
 mod s3;
 
 pub use filesystem::FilesystemBackend;
-pub use s3::{S3Backend, S3Config};
+pub use s3::{DocObjectStore, S3Backend, S3Config};
 
 use std::io;
 use std::path::PathBuf;

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
-use crate::server::protocol::WorkspaceId;
+use crate::server::protocol::{DocId, WorkspaceId};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -105,6 +105,30 @@ impl S3Backend {
             b,
             hash
         )
+    }
+
+    /// Object key for a workspace **document** object (JP-200), mirroring the
+    /// local volume layout (`workspaces/<ws>/docs/<id>.<ext>`):
+    /// `{prefix}docs/{ws}/docs/{doc_id}.{ext}`. Distinct from the
+    /// content-addressed `ws/<...>` blob keys, in the **same paired bucket** so a
+    /// region migration that copies the bucket carries documents along. The
+    /// `docs/<ws>/docs/` nesting keeps a doc named `index` from colliding with the
+    /// per-workspace index object below.
+    pub fn doc_object_key(&self, ws: &WorkspaceId, doc_id: &DocId, ext: &str) -> String {
+        format!(
+            "{}docs/{}/docs/{}.{}",
+            self.config.key_prefix,
+            ws.as_str(),
+            doc_id.as_str(),
+            ext
+        )
+    }
+
+    /// Object key for a workspace's document **index** (JP-200):
+    /// `{prefix}docs/{ws}/index.json`. Best-effort listing restore; doc
+    /// reachability never depends on it (restore is by-id).
+    pub fn workspace_index_key(&self, ws: &WorkspaceId) -> String {
+        format!("{}docs/{}/index.json", self.config.key_prefix, ws.as_str())
     }
 
     /// Canonical request URI (path-style): `/{bucket}/{uri-encoded-key}`, with
@@ -218,9 +242,56 @@ impl S3Backend {
 
     /// DELETE the object. A 404 is treated as success (idempotent reclaim).
     pub async fn delete_object(&self, ws: &WorkspaceId, hash: &str) -> Result<(), String> {
-        let key = self.object_key(ws, hash);
+        self.delete_object_at(&self.object_key(ws, hash)).await
+    }
+
+    /// PUT bytes at an **explicit key** (JP-200 document objects). Server-side
+    /// SigV4 PUT through the relay, signing the payload + content-type.
+    pub async fn put_object_at(
+        &self,
+        key: &str,
+        data: Vec<u8>,
+        content_type: &str,
+    ) -> Result<(), String> {
+        let payload_hash = hex::encode(Sha256::digest(&data));
         let resp = self
-            .send_signed("DELETE", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
+            .send_signed(
+                "PUT",
+                key,
+                reqwest::Body::from(data),
+                &payload_hash,
+                &[("content-type".to_string(), content_type.to_string())],
+            )
+            .await?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(format!("R2 PUT {} -> {}", key, resp.status()))
+        }
+    }
+
+    /// GET bytes at an **explicit key** (JP-200). `Ok(None)` on 404 so callers can
+    /// treat a truly-absent object distinctly from a transient failure.
+    pub async fn get_object_at(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+        let resp = self
+            .send_signed("GET", key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
+            .await?;
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            return Err(format!("R2 GET {} -> {}", key, resp.status()));
+        }
+        resp.bytes()
+            .await
+            .map(|b| Some(b.to_vec()))
+            .map_err(|e| format!("R2 GET {} body: {}", key, e))
+    }
+
+    /// DELETE the object at an **explicit key** (JP-200). 404 = success (idempotent).
+    pub async fn delete_object_at(&self, key: &str) -> Result<(), String> {
+        let resp = self
+            .send_signed("DELETE", key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
             .await?;
         let code = resp.status().as_u16();
         if resp.status().is_success() || code == 404 {
@@ -240,22 +311,8 @@ impl S3Backend {
         data: Vec<u8>,
         content_type: &str,
     ) -> Result<(), String> {
-        let key = self.object_key(ws, hash);
-        let payload_hash = hex::encode(Sha256::digest(&data));
-        let resp = self
-            .send_signed(
-                "PUT",
-                &key,
-                reqwest::Body::from(data),
-                &payload_hash,
-                &[("content-type".to_string(), content_type.to_string())],
-            )
-            .await?;
-        if resp.status().is_success() {
-            Ok(())
-        } else {
-            Err(format!("R2 PUT {} -> {}", key, resp.status()))
-        }
+        self.put_object_at(&self.object_key(ws, hash), data, content_type)
+            .await
     }
 
     /// Proxy download: GET bytes from R2 through the relay. Not wired into a
@@ -264,20 +321,7 @@ impl S3Backend {
     /// `put_object` for any future proxy-download fallback.
     #[allow(dead_code)]
     pub async fn get_object(&self, ws: &WorkspaceId, hash: &str) -> Result<Option<Vec<u8>>, String> {
-        let key = self.object_key(ws, hash);
-        let resp = self
-            .send_signed("GET", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
-            .await?;
-        if resp.status().as_u16() == 404 {
-            return Ok(None);
-        }
-        if !resp.status().is_success() {
-            return Err(format!("R2 GET {} -> {}", key, resp.status()));
-        }
-        resp.bytes()
-            .await
-            .map(|b| Some(b.to_vec()))
-            .map_err(|e| format!("R2 GET {} body: {}", key, e))
+        self.get_object_at(&self.object_key(ws, hash)).await
     }
 
     /// Issue a SigV4 header-authenticated request to R2. `extra_headers` are
@@ -311,6 +355,43 @@ impl S3Backend {
             req = req.header(k, v);
         }
         req.send().await.map_err(|e| format!("R2 {} {}: {}", method, key, e))
+    }
+}
+
+/// The read side of R2 document storage the **restore-on-miss** path (JP-200)
+/// needs, abstracted so the restore logic is unit-testable against an in-memory
+/// fake. Kept generic (no `dyn`) so it needs no `async-trait` dependency —
+/// callers use `impl DocObjectStore` / `<S: DocObjectStore>`. The write side
+/// (mirror worker) uses the concrete [`S3Backend`] methods directly.
+pub trait DocObjectStore: Send + Sync {
+    /// Fetch a document object (`json` / `ydoc`) by id. `Ok(None)` = absent (404),
+    /// `Err` = transient failure.
+    fn get_doc_object(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        ext: &str,
+    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
+
+    /// Fetch a workspace's document index (best-effort listing restore).
+    fn get_workspace_index(
+        &self,
+        ws: &WorkspaceId,
+    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
+}
+
+impl DocObjectStore for S3Backend {
+    async fn get_doc_object(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        ext: &str,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.get_object_at(&self.doc_object_key(ws, doc_id, ext)).await
+    }
+
+    async fn get_workspace_index(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
+        self.get_object_at(&self.workspace_index_key(ws)).await
     }
 }
 
@@ -543,6 +624,41 @@ mod tests {
         assert_eq!(key, format!("p/ws/{}/ab/cd/abcd1234ef", ws.as_str()));
     }
 
+    #[test]
+    fn doc_object_key_mirrors_local_layout_and_avoids_index_collision() {
+        let backend = S3Backend::new(S3Config {
+            endpoint: "https://acct.r2.cloudflarestorage.com".to_string(),
+            bucket: "blobs".to_string(),
+            region: "auto".to_string(),
+            access_key_id: "k".to_string(),
+            secret_access_key: "s".to_string(),
+            key_prefix: "p".to_string(),
+            put_ttl_secs: 3600,
+            get_ttl_secs: 3600,
+        });
+        let ws = WorkspaceId::single_tenant();
+        let doc = DocId::from_http_path("my-doc".to_string()).unwrap();
+        assert_eq!(
+            backend.doc_object_key(&ws, &doc, "json"),
+            format!("p/docs/{}/docs/my-doc.json", ws.as_str())
+        );
+        assert_eq!(
+            backend.doc_object_key(&ws, &doc, "ydoc"),
+            format!("p/docs/{}/docs/my-doc.ydoc", ws.as_str())
+        );
+        assert_eq!(
+            backend.workspace_index_key(&ws),
+            format!("p/docs/{}/index.json", ws.as_str())
+        );
+        // A doc literally named "index" must not collide with the index object:
+        // it nests under `.../docs/index.json`, distinct from `.../index.json`.
+        let index_doc = DocId::from_http_path("index".to_string()).unwrap();
+        assert_ne!(
+            backend.doc_object_key(&ws, &index_doc, "json"),
+            backend.workspace_index_key(&ws)
+        );
+    }
+
     /// Build a backend from `RELAY_TEST_S3_*` env, or `None` to skip. Lets the
     /// roundtrip below run against MinIO / real R2 in CI or locally without
     /// hard-failing a plain `cargo test`.
@@ -611,6 +727,45 @@ mod tests {
         // 5. DELETE reclaims the object; HEAD then reports absent.
         backend.delete_object(&ws, &hash).await.unwrap();
         assert_eq!(backend.head_object(&ws, &hash).await.unwrap(), None);
+    }
+
+    /// End-to-end doc-object path (JP-200) against a real S3 server: explicit-key
+    /// PUT → GET (via the `DocObjectStore` trait, the restore path) → DELETE →
+    /// GET-absent. Skipped unless `RELAY_TEST_S3_*` is set. Proves the doc keys +
+    /// server-side SigV4 PUT/GET/DELETE validate against a live implementation.
+    #[tokio::test]
+    async fn s3_doc_object_roundtrip_against_live_endpoint() {
+        let Some(backend) = test_backend_from_env() else {
+            eprintln!("skipping s3 doc-object roundtrip: RELAY_TEST_S3_ENDPOINT unset");
+            return;
+        };
+        let ws = WorkspaceId::single_tenant();
+        let doc = DocId::from_http_path("roundtrip-doc".to_string()).unwrap();
+        let json = br#"{"id":"roundtrip-doc","name":"R"}"#.to_vec();
+        let ydoc = b"DSKY-binary-sidecar".to_vec();
+
+        let json_key = backend.doc_object_key(&ws, &doc, "json");
+        let ydoc_key = backend.doc_object_key(&ws, &doc, "ydoc");
+
+        backend.put_object_at(&json_key, json.clone(), "application/json").await.unwrap();
+        backend.put_object_at(&ydoc_key, ydoc.clone(), "application/octet-stream").await.unwrap();
+
+        // Read back through the trait — exactly what restore-on-miss uses.
+        assert_eq!(
+            DocObjectStore::get_doc_object(&backend, &ws, &doc, "json").await.unwrap().as_deref(),
+            Some(json.as_slice())
+        );
+        assert_eq!(
+            DocObjectStore::get_doc_object(&backend, &ws, &doc, "ydoc").await.unwrap().as_deref(),
+            Some(ydoc.as_slice())
+        );
+
+        backend.delete_object_at(&json_key).await.unwrap();
+        backend.delete_object_at(&ydoc_key).await.unwrap();
+        assert_eq!(
+            DocObjectStore::get_doc_object(&backend, &ws, &doc, "json").await.unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -7,8 +7,31 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot;
 
+use super::blob_backend::DocObjectStore;
 use super::protocol::{DocId, WorkspaceId};
+
+/// A document-mirror operation enqueued for the background R2 worker (JP-200).
+/// Writes stay synchronous against the local volume; the worker re-reads the
+/// just-written file at processing time and mirrors it to R2. A single FIFO
+/// worker preserves order across ops.
+pub enum MirrorOp {
+    /// Upload a doc object — `ext` is `"json"` or `"ydoc"`. The worker re-reads
+    /// the local file; a missing file is skipped (a trailing `Delete` cleans R2).
+    Put {
+        ws: WorkspaceId,
+        doc_id: DocId,
+        ext: &'static str,
+    },
+    /// Upload a workspace's `index.json` (best-effort listing restore).
+    PutIndex { ws: WorkspaceId },
+    /// Delete a doc's objects (`json` + `ydoc`) from R2.
+    Delete { ws: WorkspaceId, doc_id: DocId },
+    /// Drain marker: the worker acks once every prior op has been processed.
+    Flush(oneshot::Sender<()>),
+}
 
 /// Document share entry for tracking who has access
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,6 +130,12 @@ pub struct DocumentStore {
     /// Loaded eagerly at startup; subsequent loads happen on demand
     /// when a new workspace is touched.
     index: RwLock<HashMap<WorkspaceId, HashMap<String, DocumentMetadata>>>,
+    /// JP-200 write-through R2 mirror sink. `Some` enqueues a [`MirrorOp`] after
+    /// each successful local write for a background worker to upload; `None`
+    /// (self-host / filesystem backend) keeps the store volume-only. The same
+    /// sender is shared into the MCP server's separate `DocumentStore` so
+    /// MCP-authored docs are mirrored too.
+    mirror_tx: Option<UnboundedSender<MirrorOp>>,
 }
 
 impl DocumentStore {
@@ -125,6 +154,7 @@ impl DocumentStore {
         let store = Self {
             documents_dir: documents_dir.clone(),
             index: RwLock::new(HashMap::new()),
+            mirror_tx: None,
         };
 
         // Eagerly preload every workspace index so `list_documents`
@@ -133,6 +163,197 @@ impl DocumentStore {
         store.preload_all_workspace_indexes();
 
         store
+    }
+
+    /// Attach the R2 mirror sink (JP-200). Call on the `&mut` store **before**
+    /// `Arc::new`, mirroring `BlobStore::set_object_delete_sink`. Wired only when
+    /// the s3 backend is active; shared into the MCP store too.
+    pub fn set_mirror_sink(&mut self, tx: UnboundedSender<MirrorOp>) {
+        self.mirror_tx = Some(tx);
+    }
+
+    /// Best-effort enqueue of a mirror op. No-op when no sink is attached
+    /// (filesystem backend). A closed channel (worker gone at shutdown) is
+    /// dropped silently — durability of the local write already succeeded.
+    fn enqueue_mirror(&self, op: MirrorOp) {
+        if let Some(tx) = &self.mirror_tx {
+            let _ = tx.send(op);
+        }
+    }
+
+    /// Read a document object's raw bytes off the local volume for the mirror
+    /// worker. `ext` is `"json"` or `"ydoc"`; `None` if the file is absent or
+    /// unreadable (worker skips — a trailing `Delete` reconciles R2).
+    pub fn read_doc_object(&self, ws: &WorkspaceId, doc_id: &DocId, ext: &str) -> Option<Vec<u8>> {
+        let path = match ext {
+            "json" => self.doc_path(ws, doc_id),
+            "ydoc" => self.ydoc_path(ws, doc_id),
+            _ => return None,
+        };
+        std::fs::read(path).ok()
+    }
+
+    /// Read a workspace's `index.json` bytes off the local volume for the mirror
+    /// worker. `None` if absent/unreadable.
+    pub fn read_workspace_index_bytes(&self, ws: &WorkspaceId) -> Option<Vec<u8>> {
+        std::fs::read(self.index_path(ws)).ok()
+    }
+
+    /// Enqueue a mirror of every locally-indexed document (JP-200 startup
+    /// backfill) so a pre-existing volume's corpus becomes durable in R2 without
+    /// waiting for an edit. Idempotent (the worker overwrites). A missing `ydoc`
+    /// sidecar is skipped by the worker. No-op without a sink.
+    pub fn backfill_mirror(&self) {
+        if self.mirror_tx.is_none() {
+            return;
+        }
+        // Snapshot (ws, doc-ids) under the read lock, then enqueue outside it.
+        let by_ws: Vec<(WorkspaceId, Vec<String>)> = match self.index.read() {
+            Ok(index) => index
+                .iter()
+                .map(|(ws, docs)| (ws.clone(), docs.keys().cloned().collect()))
+                .collect(),
+            Err(_) => return,
+        };
+        let mut count = 0usize;
+        for (ws, ids) in by_ws {
+            for id in ids {
+                if let Ok(doc_id) = DocId::from_body_id(id) {
+                    self.enqueue_mirror(MirrorOp::Put {
+                        ws: ws.clone(),
+                        doc_id: doc_id.clone(),
+                        ext: "json",
+                    });
+                    self.enqueue_mirror(MirrorOp::Put {
+                        ws: ws.clone(),
+                        doc_id,
+                        ext: "ydoc",
+                    });
+                    count += 1;
+                }
+            }
+            self.enqueue_mirror(MirrorOp::PutIndex { ws });
+        }
+        if count > 0 {
+            log::info!("R2 doc mirror: enqueued startup backfill for {count} document(s)");
+        }
+    }
+
+    /// Install a document restored from R2 onto the local volume + in-memory
+    /// index (JP-200), **bypassing every mirror enqueue** — the bytes just came
+    /// from R2, so re-uploading would be wasteful and could clobber a newer copy.
+    /// The doc body is written verbatim (no re-serialize) to preserve exactly
+    /// what R2 holds. Returns `Err` on a malformed body.
+    pub fn install_restored_doc(
+        &self,
+        ws: &WorkspaceId,
+        json_bytes: &[u8],
+        ydoc_bytes: Option<&[u8]>,
+    ) -> Result<(), String> {
+        let doc: serde_json::Value = serde_json::from_slice(json_bytes)
+            .map_err(|e| format!("restore: parse doc json: {}", e))?;
+        let id = doc
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or("restore: doc missing 'id'")?
+            .to_string();
+        let doc_id = DocId::from_body_id(id.clone())
+            .map_err(|e| format!("restore: invalid id: {}", e))?;
+        let version = doc.get("serverVersion").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
+        std::fs::write(self.doc_path(ws, &doc_id), json_bytes)
+            .map_err(|e| format!("restore: write json: {}", e))?;
+        if let Some(bin) = ydoc_bytes {
+            std::fs::write(self.ydoc_path(ws, &doc_id), bin)
+                .map_err(|e| format!("restore: write ydoc: {}", e))?;
+        }
+
+        let metadata = Self::metadata_from_body(&doc, doc_id, version);
+        {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            index.entry(ws.clone()).or_default().insert(id, metadata);
+        }
+        // Enqueue-free index write — restore must not feed the mirror back.
+        self.write_workspace_index_file(ws)?;
+        Ok(())
+    }
+
+    /// Restore a document **by id** from an object store on a local miss (JP-200
+    /// hydrate-on-join). Reachability never depends on the workspace index being
+    /// complete — the id comes from the request. `false` when the doc is truly
+    /// absent in R2 (404) or on a transient fetch error (logged); the caller then
+    /// falls through to its normal not-found handling.
+    pub async fn restore_doc_from<S: DocObjectStore>(
+        &self,
+        store: &S,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+    ) -> bool {
+        let json = match store.get_doc_object(ws, doc_id, "json").await {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return false, // truly absent — not a relay doc
+            Err(e) => {
+                log::warn!(
+                    "restore: R2 get json {}/{}: {}",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+                return false;
+            }
+        };
+        // The binary sidecar is optional; a missing/older one is reconciled on
+        // hydrate (the sync layer prefers JSON when the binary is stale).
+        let ydoc = match store.get_doc_object(ws, doc_id, "ydoc").await {
+            Ok(opt) => opt,
+            Err(e) => {
+                log::warn!(
+                    "restore: R2 get ydoc {}/{}: {} — restoring json-only",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+                None
+            }
+        };
+        match self.install_restored_doc(ws, &json, ydoc.as_deref()) {
+            Ok(()) => {
+                log::info!("restored {}/{} from R2", ws.as_str(), doc_id.as_str());
+                true
+            }
+            Err(e) => {
+                log::warn!(
+                    "restore: install {}/{}: {}",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+                false
+            }
+        }
+    }
+
+    /// Best-effort restore of a workspace's document index from R2 (JP-200
+    /// listing restore). Only repopulates the local index file; doc reachability
+    /// is by-id and never blocks on this. Caller guards against clobbering a
+    /// populated in-memory index (only call on a cold/empty workspace).
+    pub async fn restore_workspace_index_from<S: DocObjectStore>(
+        &self,
+        store: &S,
+        ws: &WorkspaceId,
+    ) {
+        match store.get_workspace_index(ws).await {
+            Ok(Some(bytes)) => {
+                let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
+                if std::fs::write(self.index_path(ws), &bytes).is_ok() {
+                    self.load_workspace_index(ws);
+                    log::info!("restored index for workspace {} from R2", ws.as_str());
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!("restore: R2 get index {}: {}", ws.as_str(), e),
+        }
     }
 
     /// Move a pre-21.5 flat layout (`<root>/{index.json, docs/}`) into
@@ -212,7 +433,13 @@ impl DocumentStore {
     ) -> Result<(), String> {
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
         std::fs::write(self.ydoc_path(ws, doc_id), bytes)
-            .map_err(|e| format!("Write error: {}", e))
+            .map_err(|e| format!("Write error: {}", e))?;
+        self.enqueue_mirror(MirrorOp::Put {
+            ws: ws.clone(),
+            doc_id: doc_id.clone(),
+            ext: "ydoc",
+        });
+        Ok(())
     }
 
     /// Read a document's binary `Y.Doc` sidecar (JP-108), or `None` if there
@@ -367,8 +594,10 @@ impl DocumentStore {
         }
     }
 
-    /// Persist a single workspace's index back to disk.
-    fn save_workspace_index(&self, ws: &WorkspaceId) -> Result<(), String> {
+    /// Write a single workspace's index to disk. The raw file write with **no**
+    /// R2 enqueue — used by the restore path (`install_restored_doc`) so a
+    /// restore doesn't re-upload (and risk clobbering a newer R2 copy).
+    fn write_workspace_index_file(&self, ws: &WorkspaceId) -> Result<(), String> {
         let snapshot = {
             let index = self.index.read().map_err(|e| e.to_string())?;
             index.get(ws).cloned().unwrap_or_default()
@@ -379,6 +608,15 @@ impl DocumentStore {
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
         std::fs::write(self.index_path(ws), json)
             .map_err(|e| format!("Write error: {}", e))?;
+        Ok(())
+    }
+
+    /// Persist a single workspace's index back to disk and mirror it to R2
+    /// (JP-200). The single chokepoint for `PutIndex` enqueues — index mirroring
+    /// is never duplicated by the per-doc write paths that call this.
+    fn save_workspace_index(&self, ws: &WorkspaceId) -> Result<(), String> {
+        self.write_workspace_index_file(ws)?;
+        self.enqueue_mirror(MirrorOp::PutIndex { ws: ws.clone() });
         Ok(())
     }
 
@@ -458,6 +696,52 @@ impl DocumentStore {
         }
     }
 
+    /// Build [`DocumentMetadata`] from a document body at a given server
+    /// version. Shared by the save / snapshot / restore write paths so the
+    /// derived index fields can't drift between them (JP-200 de-dup).
+    fn metadata_from_body(
+        doc: &serde_json::Value,
+        doc_id: DocId,
+        version: u64,
+    ) -> DocumentMetadata {
+        let modified_at = doc.get("modifiedAt").and_then(|v| v.as_u64()).unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0)
+        });
+        let created_at = doc.get("createdAt").and_then(|v| v.as_u64()).unwrap_or(modified_at);
+        DocumentMetadata {
+            id: doc_id,
+            name: doc.get("name").and_then(|v| v.as_str()).unwrap_or("Untitled").to_string(),
+            page_count: doc
+                .get("pageOrder")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.len())
+                .unwrap_or(1),
+            modified_at,
+            created_at,
+            is_relay_document: doc
+                .get("isRelayDocument")
+                .or_else(|| doc.get("isTeamDocument"))
+                .and_then(|v| v.as_bool()),
+            server_version: Some(version),
+            locked_by: doc.get("lockedBy").and_then(|v| v.as_str()).map(String::from),
+            locked_by_name: doc.get("lockedByName").and_then(|v| v.as_str()).map(String::from),
+            locked_at: doc.get("lockedAt").and_then(|v| v.as_u64()),
+            owner_id: doc.get("ownerId").and_then(|v| v.as_str()).map(String::from),
+            owner_name: doc.get("ownerName").and_then(|v| v.as_str()).map(String::from),
+            shared_with: doc
+                .get("sharedWith")
+                .and_then(|v| serde_json::from_value(v.clone()).ok()),
+            last_modified_by: doc.get("lastModifiedBy").and_then(|v| v.as_str()).map(String::from),
+            last_modified_by_name: doc
+                .get("lastModifiedByName")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        }
+    }
+
     /// Save a document with optimistic-concurrency check.
     ///
     /// When `expected` is `Some(N)`, refuses the write if the stored
@@ -510,51 +794,7 @@ impl DocumentStore {
             obj.insert("serverVersion".to_string(), serde_json::json!(new_version));
         }
 
-        let name = doc.get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("Untitled")
-            .to_string();
-
-        let page_order = doc.get("pageOrder")
-            .and_then(|v| v.as_array())
-            .map(|arr| arr.len())
-            .unwrap_or(1);
-
-        let modified_at = doc.get("modifiedAt")
-            .and_then(|v| v.as_u64())
-            .unwrap_or_else(|| {
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as u64)
-                    .unwrap_or(0)
-            });
-
-        let created_at = doc.get("createdAt")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(modified_at);
-
-        let metadata = DocumentMetadata {
-            id: doc_id.clone(),
-            name,
-            page_count: page_order,
-            modified_at,
-            created_at,
-            is_relay_document: doc
-                .get("isRelayDocument")
-                .or_else(|| doc.get("isTeamDocument"))
-                .and_then(|v| v.as_bool()),
-            server_version: Some(new_version),
-            locked_by: doc.get("lockedBy").and_then(|v| v.as_str()).map(String::from),
-            locked_by_name: doc.get("lockedByName").and_then(|v| v.as_str()).map(String::from),
-            locked_at: doc.get("lockedAt").and_then(|v| v.as_u64()),
-            owner_id: doc.get("ownerId").and_then(|v| v.as_str()).map(String::from),
-            owner_name: doc.get("ownerName").and_then(|v| v.as_str()).map(String::from),
-            shared_with: doc.get("sharedWith").and_then(|v| {
-                serde_json::from_value(v.clone()).ok()
-            }),
-            last_modified_by: doc.get("lastModifiedBy").and_then(|v| v.as_str()).map(String::from),
-            last_modified_by_name: doc.get("lastModifiedByName").and_then(|v| v.as_str()).map(String::from),
-        };
+        let metadata = Self::metadata_from_body(&doc, doc_id.clone(), new_version);
 
         let doc_json = serde_json::to_string_pretty(&doc)
             .map_err(|e| format!("Serialize error: {}", e))?;
@@ -573,6 +813,11 @@ impl DocumentStore {
         }
 
         self.save_workspace_index(ws)?;
+        self.enqueue_mirror(MirrorOp::Put {
+            ws: ws.clone(),
+            doc_id: doc_id.clone(),
+            ext: "json",
+        });
 
         log::info!("Saved relay document: {}/{} (v{})", ws.as_str(), id, new_version);
 
@@ -620,40 +865,7 @@ impl DocumentStore {
             obj.insert("serverVersion".to_string(), serde_json::json!(version));
         }
 
-        let name = doc.get("name").and_then(|v| v.as_str()).unwrap_or("Untitled").to_string();
-        let page_order = doc
-            .get("pageOrder")
-            .and_then(|v| v.as_array())
-            .map(|arr| arr.len())
-            .unwrap_or(1);
-        let modified_at = doc.get("modifiedAt").and_then(|v| v.as_u64()).unwrap_or_else(|| {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0)
-        });
-        let created_at = doc.get("createdAt").and_then(|v| v.as_u64()).unwrap_or(modified_at);
-
-        let metadata = DocumentMetadata {
-            id: doc_id.clone(),
-            name,
-            page_count: page_order,
-            modified_at,
-            created_at,
-            is_relay_document: doc
-                .get("isRelayDocument")
-                .or_else(|| doc.get("isTeamDocument"))
-                .and_then(|v| v.as_bool()),
-            server_version: Some(version),
-            locked_by: doc.get("lockedBy").and_then(|v| v.as_str()).map(String::from),
-            locked_by_name: doc.get("lockedByName").and_then(|v| v.as_str()).map(String::from),
-            locked_at: doc.get("lockedAt").and_then(|v| v.as_u64()),
-            owner_id: doc.get("ownerId").and_then(|v| v.as_str()).map(String::from),
-            owner_name: doc.get("ownerName").and_then(|v| v.as_str()).map(String::from),
-            shared_with: doc.get("sharedWith").and_then(|v| serde_json::from_value(v.clone()).ok()),
-            last_modified_by: doc.get("lastModifiedBy").and_then(|v| v.as_str()).map(String::from),
-            last_modified_by_name: doc.get("lastModifiedByName").and_then(|v| v.as_str()).map(String::from),
-        };
+        let metadata = Self::metadata_from_body(&doc, doc_id.clone(), version);
 
         let doc_json = serde_json::to_string_pretty(&doc).map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
@@ -664,6 +876,11 @@ impl DocumentStore {
             index.entry(ws.clone()).or_default().insert(id.clone(), metadata);
         }
         self.save_workspace_index(ws)?;
+        self.enqueue_mirror(MirrorOp::Put {
+            ws: ws.clone(),
+            doc_id: doc_id.clone(),
+            ext: "json",
+        });
 
         log::debug!("relay snapshot persisted: {}/{} (v{}, unchanged)", ws.as_str(), id, version);
         Ok(())
@@ -720,6 +937,10 @@ impl DocumentStore {
         }
 
         self.save_workspace_index(ws)?;
+        self.enqueue_mirror(MirrorOp::Delete {
+            ws: ws.clone(),
+            doc_id: doc_id.clone(),
+        });
 
         log::info!("Deleted relay document: {}/{}", ws.as_str(), doc_id.as_str());
         Ok(true)
@@ -933,6 +1154,163 @@ mod tests {
 
         // List should be empty again
         assert!(store.list_documents(&ws).is_empty());
+    }
+
+    #[test]
+    fn mirror_enqueues_expected_ops_without_duplicate_index() {
+        let dir = tempdir().unwrap();
+        let mut store = DocumentStore::new(dir.path().to_path_buf());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        store.set_mirror_sink(tx);
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("m-doc".into()).unwrap();
+
+        // save → one Put json + one PutIndex
+        store
+            .save_document(&ws, serde_json::json!({"id": "m-doc", "name": "M"}))
+            .unwrap();
+        // binary sidecar → one Put ydoc (no index write)
+        store.persist_ydoc_binary(&ws, &doc_id, b"bin").unwrap();
+        // delete → one Delete + one PutIndex
+        store.delete_document(&ws, &doc_id).unwrap();
+        drop(store); // close the sender so the drain terminates
+
+        let (mut put_json, mut put_ydoc, mut put_index, mut deletes) = (0, 0, 0, 0);
+        while let Ok(op) = rx.try_recv() {
+            match op {
+                MirrorOp::Put { ext: "json", .. } => put_json += 1,
+                MirrorOp::Put { ext: "ydoc", .. } => put_ydoc += 1,
+                MirrorOp::Put { .. } => {}
+                MirrorOp::PutIndex { .. } => put_index += 1,
+                MirrorOp::Delete { .. } => deletes += 1,
+                MirrorOp::Flush(_) => {}
+            }
+        }
+        assert_eq!(put_json, 1, "one json Put from the save");
+        assert_eq!(put_ydoc, 1, "one ydoc Put from the binary sidecar");
+        assert_eq!(deletes, 1, "one Delete");
+        // save (1) + delete (1) each write the index exactly once — never more,
+        // proving PutIndex isn't duplicated by the per-doc write paths.
+        assert_eq!(put_index, 2, "exactly one PutIndex per index-writing op");
+    }
+
+    #[test]
+    fn mirror_sink_absent_is_noop() {
+        // Filesystem backend (no sink) must not panic and writes still succeed.
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        store
+            .save_document(&ws, serde_json::json!({"id": "n", "name": "N"}))
+            .unwrap();
+        store.backfill_mirror(); // no-op without a sink
+    }
+
+    /// In-memory `DocObjectStore` standing in for R2 — lets the restore path be
+    /// unit-tested offline (the live SigV4 path is the env-gated s3 roundtrip).
+    struct FakeObjectStore {
+        json: Option<Vec<u8>>,
+        ydoc: Option<Vec<u8>>,
+        index: Option<Vec<u8>>,
+    }
+
+    impl DocObjectStore for FakeObjectStore {
+        async fn get_doc_object(
+            &self,
+            _ws: &WorkspaceId,
+            _doc_id: &DocId,
+            ext: &str,
+        ) -> Result<Option<Vec<u8>>, String> {
+            Ok(match ext {
+                "json" => self.json.clone(),
+                "ydoc" => self.ydoc.clone(),
+                _ => None,
+            })
+        }
+
+        async fn get_workspace_index(
+            &self,
+            _ws: &WorkspaceId,
+        ) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.index.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_doc_from_object_store_on_local_miss() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("r-doc".into()).unwrap();
+
+        // Cold: nothing on the local volume.
+        assert!(store.get_document(&ws, &doc_id).is_err());
+
+        let fake = FakeObjectStore {
+            json: Some(br#"{"id":"r-doc","name":"Restored","serverVersion":3}"#.to_vec()),
+            ydoc: Some(b"DSKY-bin".to_vec()),
+            index: None,
+        };
+        assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
+
+        // Now readable + indexed at the restored version, with the sidecar.
+        let got = store.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(got["name"], "Restored");
+        assert_eq!(
+            store.get_metadata(&ws, &doc_id).unwrap().server_version,
+            Some(3)
+        );
+        assert_eq!(store.load_ydoc_binary(&ws, &doc_id).as_deref(), Some(&b"DSKY-bin"[..]));
+    }
+
+    #[tokio::test]
+    async fn restore_doc_missing_ydoc_still_restores_json() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("j-doc".into()).unwrap();
+
+        let fake = FakeObjectStore {
+            json: Some(br#"{"id":"j-doc","name":"JsonOnly"}"#.to_vec()),
+            ydoc: None,
+            index: None,
+        };
+        assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
+        assert_eq!(store.get_document(&ws, &doc_id).unwrap()["name"], "JsonOnly");
+        // No sidecar → hydrate falls back to JSON (sync-layer reconciliation).
+        assert!(store.load_ydoc_binary(&ws, &doc_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn restore_absent_doc_returns_false() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("ghost".into()).unwrap();
+
+        let fake = FakeObjectStore { json: None, ydoc: None, index: None };
+        assert!(!store.restore_doc_from(&fake, &ws, &doc_id).await);
+        assert!(store.get_document(&ws, &doc_id).is_err());
+    }
+
+    #[tokio::test]
+    async fn restore_does_not_re_enqueue_a_mirror() {
+        // Restore must never feed the mirror back (no re-upload / clobber).
+        let dir = tempdir().unwrap();
+        let mut store = DocumentStore::new(dir.path().to_path_buf());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        store.set_mirror_sink(tx);
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("q-doc".into()).unwrap();
+
+        let fake = FakeObjectStore {
+            json: Some(br#"{"id":"q-doc","name":"Q"}"#.to_vec()),
+            ydoc: Some(b"bin".to_vec()),
+            index: None,
+        };
+        assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
+        drop(store);
+        assert!(rx.try_recv().is_err(), "restore enqueued a mirror op");
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -40,7 +40,7 @@ use tokio::sync::{broadcast, mpsc, RwLock};
 use tower_http::cors::{Any, CorsLayer};
 
 use blobs::{BlobStore, SaveBlobError};
-use documents::DocumentStore;
+use documents::{DocumentStore, MirrorOp};
 use governor::{
     clock::DefaultClock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter,
 };
@@ -104,6 +104,62 @@ async fn run_blob_delete_worker(
     while let Some((ws, hash)) = rx.recv().await {
         if let Err(e) = s3.delete_object(&ws, &hash).await {
             log::warn!("R2 blob delete failed for {}/{}: {}", ws.as_str(), hash, e);
+        }
+    }
+}
+
+/// Background worker that mirrors workspace **documents** to R2 (JP-200). The
+/// synchronous write paths enqueue a [`MirrorOp`] after each local write; this
+/// drains them in FIFO order and performs the async R2 PUT/DELETE, re-reading the
+/// local file at processing time (coalesces rapid re-snapshots; bounds memory vs
+/// carrying bytes through the channel). Best-effort: a failed transfer is logged
+/// and dropped — the next write re-enqueues, and the startup backfill + bucket
+/// lifecycle are backstops, so one bad object can't wedge the queue. Exits when
+/// the sink is dropped (server shutdown).
+async fn run_doc_mirror_worker(
+    mut rx: mpsc::UnboundedReceiver<MirrorOp>,
+    doc_store: Arc<DocumentStore>,
+    s3: Arc<S3Backend>,
+) {
+    while let Some(op) = rx.recv().await {
+        match op {
+            MirrorOp::Put { ws, doc_id, ext } => {
+                let Some(bytes) = doc_store.read_doc_object(&ws, &doc_id, ext) else {
+                    // File gone before we got here (a Put-then-Delete race) — skip;
+                    // the trailing Delete reconciles R2.
+                    continue;
+                };
+                let content_type = if ext == "json" {
+                    "application/json"
+                } else {
+                    "application/octet-stream"
+                };
+                let key = s3.doc_object_key(&ws, &doc_id, ext);
+                if let Err(e) = s3.put_object_at(&key, bytes, content_type).await {
+                    log::warn!("R2 doc mirror PUT failed for {}: {}", key, e);
+                }
+            }
+            MirrorOp::PutIndex { ws } => {
+                let Some(bytes) = doc_store.read_workspace_index_bytes(&ws) else {
+                    continue;
+                };
+                let key = s3.workspace_index_key(&ws);
+                if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                    log::warn!("R2 index mirror PUT failed for {}: {}", key, e);
+                }
+            }
+            MirrorOp::Delete { ws, doc_id } => {
+                for ext in ["json", "ydoc"] {
+                    let key = s3.doc_object_key(&ws, &doc_id, ext);
+                    if let Err(e) = s3.delete_object_at(&key).await {
+                        log::warn!("R2 doc mirror DELETE failed for {}: {}", key, e);
+                    }
+                }
+            }
+            MirrorOp::Flush(ack) => {
+                // FIFO ⇒ every prior op has been processed; release the drainer.
+                let _ = ack.send(());
+            }
         }
     }
 }
@@ -310,6 +366,11 @@ pub struct ServerState {
     /// the presign / HEAD / DELETE surface the blob handlers use for direct
     /// client transfer; `None` for the filesystem backend.
     s3: Option<Arc<S3Backend>>,
+    /// JP-200 document-mirror sink — the sender end of the channel drained by
+    /// `run_doc_mirror_worker`. `Some` when the s3 backend is active. Shared
+    /// (cloned) into the MCP server's separate `DocumentStore` and used by the
+    /// graceful-shutdown drain.
+    doc_mirror_tx: Option<mpsc::UnboundedSender<MirrorOp>>,
     /// OIDC validator + JWKS cache + revocation set. JP-77 — the relay
     /// no longer issues tokens, only validates them against an external
     /// issuer's JWKS.
@@ -398,14 +459,38 @@ impl ServerState {
             }
             Arc::new(bs)
         };
+        // JP-200: build the document store, wiring the R2 mirror sink + a
+        // background worker when the s3 backend is active. The sender is also
+        // stored on `ServerState` so it can be shared into the MCP store and used
+        // by the shutdown drain. Filesystem backend → no sink (volume-only).
+        let (doc_store, doc_mirror_tx) = {
+            let mut ds = DocumentStore::new(app_data_dir);
+            match &s3 {
+                Some(s3) => {
+                    let (tx, rx) = mpsc::unbounded_channel::<MirrorOp>();
+                    ds.set_mirror_sink(tx.clone());
+                    let ds = Arc::new(ds);
+                    let worker_store = ds.clone();
+                    let worker_s3 = s3.clone();
+                    tokio::spawn(async move {
+                        run_doc_mirror_worker(rx, worker_store, worker_s3).await
+                    });
+                    // Worker is up: push any pre-existing on-volume corpus to R2.
+                    ds.backfill_mirror();
+                    (ds, Some(tx))
+                }
+                None => (Arc::new(ds), None),
+            }
+        };
         Self {
             broadcast_tx,
             client_count: AtomicU16::new(0),
             next_client_id: AtomicU64::new(1),
             clients: RwLock::new(HashMap::new()),
-            doc_store: Arc::new(DocumentStore::new(app_data_dir)),
+            doc_store,
             blob_store,
             s3,
+            doc_mirror_tx,
             auth,
             revocation_push_bearer,
             relay_region,
@@ -469,6 +554,42 @@ impl ServerState {
 
     pub(crate) fn tenancy(&self) -> &TenancyConfig {
         &self.tenancy
+    }
+
+    /// JP-200: a clone of the document-mirror sender, shared into the MCP store
+    /// and used by the shutdown drain. `None` on the filesystem backend.
+    pub(crate) fn doc_mirror_sender(&self) -> Option<mpsc::UnboundedSender<MirrorOp>> {
+        self.doc_mirror_tx.clone()
+    }
+
+    /// JP-200: ensure a document's body is present locally, restoring it from R2
+    /// **by id** on a miss (recycled machine / cold volume). Returns whether the
+    /// doc is now available locally. Fast-returns when already indexed; a no-op
+    /// returning `false` on the filesystem backend (caller falls through to its
+    /// normal not-found handling).
+    pub(crate) async fn ensure_doc_local(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        if self.doc_store.get_metadata(ws, doc_id).is_some() {
+            return true;
+        }
+        match &self.s3 {
+            Some(s3) => self.doc_store.restore_doc_from(s3.as_ref(), ws, doc_id).await,
+            None => false,
+        }
+    }
+
+    /// JP-200: ensure a workspace's document index is locally populated,
+    /// restoring it from R2 on a cold machine. Never clobbers a populated
+    /// in-memory index (only restores when the workspace has nothing in memory),
+    /// so it's safe to call before a listing.
+    pub(crate) async fn ensure_workspace_index_local(&self, ws: &WorkspaceId) {
+        if !self.doc_store.list_documents(ws).is_empty() {
+            return;
+        }
+        if let Some(s3) = &self.s3 {
+            self.doc_store
+                .restore_workspace_index_from(s3.as_ref(), ws)
+                .await;
+        }
     }
 
     /// Try to register a new authenticated WS connection for the
@@ -1393,6 +1514,17 @@ impl WebSocketServer {
         // so a redeploy doesn't lose edits between snapshot ticks.
         if let Some(state) = self.state.read().await.as_ref() {
             state.snapshot_all();
+            // JP-200: drain the R2 doc-mirror queue so a graceful shutdown flushes
+            // pending uploads. The Flush sentinel acks only after every prior op
+            // (incl. the snapshots just enqueued) is processed; bounded by a
+            // timeout so a slow R2 can't blow the SIGTERM grace.
+            if let Some(tx) = state.doc_mirror_sender() {
+                let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+                if tx.send(MirrorOp::Flush(ack_tx)).is_ok() {
+                    let _ =
+                        tokio::time::timeout(std::time::Duration::from_secs(3), ack_rx).await;
+                }
+            }
         }
         if let Some(handle) = self.snapshot_task.write().await.take() {
             handle.abort();
@@ -1411,6 +1543,17 @@ impl WebSocketServer {
     /// Get the document store (for direct access)
     pub async fn get_doc_store(&self) -> Option<Arc<DocumentStore>> {
         self.state.read().await.as_ref().map(|s| s.doc_store.clone())
+    }
+
+    /// JP-200: the document-mirror sender from the running `ServerState`, shared
+    /// into the MCP server's separate `DocumentStore` so MCP-authored docs are
+    /// mirrored to R2 too. `None` before `start()` or on the filesystem backend.
+    pub async fn doc_mirror_sender(&self) -> Option<mpsc::UnboundedSender<MirrorOp>> {
+        self.state
+            .read()
+            .await
+            .as_ref()
+            .and_then(|s| s.doc_mirror_sender())
     }
 
     /// Broadcast a document event to all connected clients
@@ -2274,7 +2417,11 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
     // to cover the JOIN→SYNC race or a join-time body-load failure.
     let handle = match state.sync_registry().get(&workspace_id, &doc_id) {
         Some(handle) => Some(handle),
-        None => match state.doc_store().get_document(&workspace_id, &doc_id) {
+        None => {
+            // JP-200: cover the JOIN→SYNC race on a cold machine — restore from R2
+            // by id before the body load so hydrate-on-demand still works.
+            state.ensure_doc_local(&workspace_id, &doc_id).await;
+            match state.doc_store().get_document(&workspace_id, &doc_id) {
             Ok(doc_json) => {
                 let ydoc_bin = if state.binary_persistence() {
                     state.doc_store().load_ydoc_binary(&workspace_id, &doc_id)
@@ -2290,7 +2437,8 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
                 ))
             }
             Err(_) => None,
-        },
+            }
+        }
     };
 
     match handle {
@@ -2385,6 +2533,11 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
             None => return,
         }
     };
+
+    // JP-200: on a local miss (recycled machine / cold volume) try to restore the
+    // doc from R2 by id before the existence gate, so durability survives volume
+    // loss. No-op when already local or on the filesystem backend.
+    state.ensure_doc_local(&workspace_id, &request.doc_id).await;
 
     if state
         .doc_store()

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -158,6 +158,7 @@ impl Harness {
                 "default".to_string(),
                 sync_registry,
                 on_doc_update,
+                None, // JP-200: no R2 doc mirror in tests
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -72,6 +72,7 @@ impl Harness {
                 "default".to_string(),
                 sync_registry,
                 on_doc_update,
+                None, // JP-200: no R2 doc mirror in tests
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -583,6 +583,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             "default".to_string(),
             sync_registry,
             on_doc_update,
+            None, // JP-200: no R2 doc mirror in tests
         )
         .expect("McpServer::new"),
     );


### PR DESCRIPTION
## What

Persist relay workspace **documents** to R2, not just the Fly volume. A Fly volume is a single non-HA copy lost on host failure; this writes documents through to R2 (reusing JP-87's SigV4/blob infra) so they survive volume loss / machine recycle and become region-portable. The volume becomes a write-through cache; R2 is the durable corpus.

Resolves **JP-200**.

## How

- **`s3.rs`** — `doc_object_key` + explicit-key `put/get/delete_object_at` + a small `DocObjectStore` trait (generic, no `dyn`/`async-trait`). Docs live under `docs/<ws>/docs/<id>.{json,ydoc}` in the **same paired bucket** as blobs, so a region migration carries them for free. Nested under `docs/<ws>/docs/` so a doc named `index` can't collide with the per-workspace index object.
- **Write-through mirror** — a background worker (clone of the blob-delete worker) drains `MirrorOp` enqueued by the sync write paths. Single FIFO, **re-reads the file at processing time** (coalesces re-snapshots, bounds memory), `Put` tolerates a missing file (Put-then-Delete race). **Snapshots stay synchronous — no added latency.** Enqueues at single chokepoints (one `PutIndex` site). The sink is **shared into both the WS and the MCP `DocumentStore`** so MCP-authored docs mirror too. Startup backfill of the existing corpus; graceful-shutdown **Flush-sentinel drain** bounded to ~3s so a slow R2 can't blow the SIGTERM grace.
- **Lazy restore** — `ensure_doc_local` restores a doc **by id** from R2 on a local miss (no `ListObjectsV2`), wired into `JOIN_DOC`, the sync hydrate, and REST get/list. `install_restored_doc` bypasses the mirror to avoid a re-upload feedback loop. Partial mirrors (stale/missing `.ydoc`) are handled by the existing hydrate version reconciliation.

Gated on the existing `s3` backend (`state.s3.is_some()`); **no new config or crates**.

## Verification

- `cargo check` + `cargo test`: **228 lib + all integration suites green**. New tests cover the doc key shape, enqueue correctness (right ops, **no duplicate `PutIndex`**), restore-from-fake (incl. **missing-`.ydoc`** and absent), and that restore **enqueues nothing**.
- **Live (local MinIO):** the env-gated `s3_doc_object_roundtrip` passes (real SigV4 PUT/GET/DELETE), and a full local-relay run confirmed end-to-end write-through on **both** the editor (`.json` + `.ydoc`) and MCP paths, correctly scoped to the authenticated JWT workspace key. Live MCP→editor sync confirmed.
- Full Fly+R2 staging E2E (wipe volume → restore on JOIN) is the deploy-side gate.

## Scope / follow-ups (filed separately)

This PR is durability only. Filed as fast-follows: volume cache **eviction/cap** (the scaling layer), Fly **auto-extend** ops in `docushark-web`, **blob bookkeeping** durability (acl/refs sidecars), and an **MCP↔WS index reconciliation** bug surfaced during testing (a concurrent editor save can drop an MCP-created doc from `index.json`; bytes stay safe + reachable by id — listing only).

Assisted-by: Opus 4.8