### PR TITLE
JP-230: one shared DocumentStore — fix the MCP↔WS index clobber

### DIFF
--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -302,46 +302,55 @@ async fn run_serve(
         // live on `ServerState`, so this must run after `server.start()` above.
         let sync_registry = server.sync_registry_handle().await;
         let on_doc_update = server.doc_update_broadcaster().await;
-        // JP-200: hand MCP the same R2 doc-mirror sink as the WS server so
-        // MCP-authored docs are written through to R2 (the MCP server keeps its
-        // own `DocumentStore` over the same volume).
-        let doc_mirror_tx = server.doc_mirror_sender().await;
-        match McpServer::new(
-            config.storage.path.clone(),
-            on_doc_changed,
-            panic_counter,
-            rate_limit_rejections,
-            write_limiter,
-            auth.clone(),
-            region.clone(),
-            sync_registry,
-            on_doc_update,
-            doc_mirror_tx,
-        ) {
-            Ok(mcp) => {
-                let mcp = Arc::new(mcp);
-                mcp.set_config(InternalMcpConfig {
-                    port: config.mcp.port,
-                })
-                .await
-                .map_err(|e| anyhow::anyhow!("apply mcp config: {}", e))?;
-                match mcp.start().await {
-                    Ok(addr) => {
-                        log::info!("MCP endpoint on {}", addr);
-                        log::info!("MCP bearer token: {}", mcp.get_token().await);
-                        Some(mcp)
-                    }
-                    Err(e) => {
-                        log::error!("failed to start MCP endpoint: {}", e);
-                        log::warn!("relay sync listener stays up; MCP is disabled this run");
-                        None
-                    }
-                }
-            }
-            Err(e) => {
-                log::error!("failed to initialize MCP server: {}", e);
+        // JP-230: the MCP server shares the WS server's single `DocumentStore`
+        // (one in-memory index, one writer) so MCP- and editor-authored docs
+        // never clobber each other's `index.json`. It's available after start, and
+        // its JP-200 R2 mirror sink carries through, so MCP writes still mirror.
+        match server.get_doc_store().await {
+            None => {
+                log::error!(
+                    "MCP enabled but the shared document store is unavailable after \
+                     start; disabling MCP this run (sync listener stays up)"
+                );
                 None
             }
+            Some(shared_doc_store) => match McpServer::new(
+                config.storage.path.clone(),
+                on_doc_changed,
+                panic_counter,
+                rate_limit_rejections,
+                write_limiter,
+                auth.clone(),
+                region.clone(),
+                sync_registry,
+                on_doc_update,
+                shared_doc_store,
+            ) {
+                Ok(mcp) => {
+                    let mcp = Arc::new(mcp);
+                    mcp.set_config(InternalMcpConfig {
+                        port: config.mcp.port,
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("apply mcp config: {}", e))?;
+                    match mcp.start().await {
+                        Ok(addr) => {
+                            log::info!("MCP endpoint on {}", addr);
+                            log::info!("MCP bearer token: {}", mcp.get_token().await);
+                            Some(mcp)
+                        }
+                        Err(e) => {
+                            log::error!("failed to start MCP endpoint: {}", e);
+                            log::warn!("relay sync listener stays up; MCP is disabled this run");
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::error!("failed to initialize MCP server: {}", e);
+                    None
+                }
+            },
         }
     } else {
         log::info!("MCP endpoint disabled in config");

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -25,7 +25,7 @@ use tokio::sync::oneshot;
 use tokio::sync::RwLock;
 
 use crate::auth::OidcAuthState;
-use crate::server::documents::{DocumentStore, MirrorOp};
+use crate::server::documents::DocumentStore;
 use crate::server::protocol::DocId;
 use crate::server::WorkspaceWriteLimiter;
 use crate::sync::DocRegistry;
@@ -110,21 +110,16 @@ impl McpServer {
         relay_region: String,
         sync_registry: Arc<DocRegistry>,
         on_doc_update: Arc<OnDocUpdate>,
-        doc_mirror_tx: Option<tokio::sync::mpsc::UnboundedSender<MirrorOp>>,
+        doc_store: Arc<DocumentStore>,
     ) -> Result<Self, String> {
         let token = Arc::new(TokenStore::load_or_create(&app_data_dir)?);
         let feature_config = Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir));
         let local_mirror = Arc::new(LocalDocumentMirror::new(app_data_dir.clone()));
-        // JP-200: share the WS server's R2 mirror sink so MCP-authored docs
-        // (create/prose/shape writes via this separate `DocumentStore`) are
-        // mirrored to R2 too. `None` on the filesystem backend.
-        let doc_store = {
-            let mut ds = DocumentStore::new(app_data_dir);
-            if let Some(tx) = doc_mirror_tx {
-                ds.set_mirror_sink(tx);
-            }
-            Arc::new(ds)
-        };
+        // JP-230: the MCP server shares the WS server's single `DocumentStore`
+        // (one in-memory index, one writer) instead of building its own over the
+        // same files — so MCP- and editor-authored docs never clobber each other's
+        // `index.json`. The shared store already carries the JP-200 R2 mirror sink,
+        // so MCP-authored docs are still mirrored to R2.
         Ok(Self {
             config: RwLock::new(McpConfig::default()),
             bound_port: RwLock::new(0),

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -439,10 +439,9 @@ pub struct ToolOutcome {
 /// Dispatch a `tools/call` request. `name` is the tool name as advertised
 /// in `descriptors()`; `args` is the `arguments` object from the call.
 pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutcome, String> {
-    // Always refresh the index from disk first so reads see any writes the
-    // WebSocket server (or another MCP write) made since last call.
-    ctx.team.reload_index();
-
+    // JP-230: MCP and the WS/REST path now share one `DocumentStore`, so reads
+    // already see every write through the shared in-memory index — no per-call
+    // reload-from-disk needed (it was a band-aid for the old two-store split).
     match name {
         "docushark.list_documents" => list_documents(ctx),
         "docushark.get_document" => get_document(ctx, args),

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -206,13 +206,18 @@ pub struct DocumentStore {
     /// JP-200 write-through R2 mirror sink. `Some` enqueues a [`MirrorOp`] after
     /// each successful local write for a background worker to upload; `None`
     /// (self-host / filesystem backend) keeps the store volume-only. The same
-    /// sender is shared into the MCP server's separate `DocumentStore` so
-    /// MCP-authored docs are mirrored too.
+    /// sender is set once on this single shared store (JP-230), so MCP-authored
+    /// docs are mirrored too.
     mirror_tx: Option<UnboundedSender<MirrorOp>>,
     /// JP-231 working-set cache bookkeeping, keyed like `index` (workspace →
     /// doc id). Machine-local LRU recency + mirror-generation + footprint; drives
     /// eviction of cold, R2-confirmed docs. Never serialized / mirrored.
     cache: RwLock<HashMap<WorkspaceId, HashMap<String, CacheState>>>,
+    /// JP-230: serializes `index.json` file writes. The in-memory index is shared
+    /// (a single store), but `write_workspace_index_file` snapshots then writes —
+    /// without this, two interleaved writers could land a stale snapshot after a
+    /// fresher one and drop an entry. Held across snapshot+write.
+    index_write_lock: std::sync::Mutex<()>,
 }
 
 impl DocumentStore {
@@ -233,6 +238,7 @@ impl DocumentStore {
             index: RwLock::new(HashMap::new()),
             mirror_tx: None,
             cache: RwLock::new(HashMap::new()),
+            index_write_lock: std::sync::Mutex::new(()),
         };
 
         // Eagerly preload every workspace index so `list_documents`
@@ -830,13 +836,6 @@ impl DocumentStore {
         points
     }
 
-    /// Reload every workspace's index from disk. Public so external
-    /// callers (e.g. the MCP server) can refresh after an out-of-band
-    /// write.
-    pub fn reload_index(&self) {
-        self.preload_all_workspace_indexes();
-    }
-
     /// Walk `workspaces/*` and load every workspace's `index.json` into
     /// the in-memory map. Best-effort — missing or malformed index files
     /// surface as empty maps.
@@ -883,6 +882,15 @@ impl DocumentStore {
     /// R2 enqueue — used by the restore path (`install_restored_doc`) so a
     /// restore doesn't re-upload (and risk clobbering a newer R2 copy).
     fn write_workspace_index_file(&self, ws: &WorkspaceId) -> Result<(), String> {
+        // JP-230: serialize index writes so two interleaved writers can't drop an
+        // entry (a stale snapshot's write landing after a fresher one). The
+        // snapshot is taken **under** this lock, so each serialized write flushes
+        // the latest complete in-memory map. Poisoned-lock recovery: take the
+        // inner guard anyway — the data it guards is `()`, never corrupt.
+        let _guard = self
+            .index_write_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let snapshot = {
             let index = self.index.read().map_err(|e| e.to_string())?;
             index.get(ws).cloned().unwrap_or_default()
@@ -1932,5 +1940,47 @@ mod tests {
         let snap = store.cache_snapshot();
         let e = snap.iter().find(|e| e.doc_id.as_str() == "rt-doc").unwrap();
         assert!(e.evictable_by_gen, "restored doc is confirmed-mirrored");
+    }
+
+    // ---- JP-230 index-write serialization -----------------------------------
+
+    #[test]
+    fn concurrent_saves_all_land_in_the_index() {
+        // Many threads saving distinct docs into ONE shared store must not lose
+        // an entry — neither in memory nor on disk. Without `index_write_lock`,
+        // interleaved snapshot-then-write index flushes drop entries on disk.
+        use std::sync::Arc;
+        let dir = tempdir().unwrap();
+        let store = Arc::new(DocumentStore::new(dir.path().to_path_buf()));
+        let ws = WorkspaceId::single_tenant();
+        let n = 32usize;
+
+        let handles: Vec<_> = (0..n)
+            .map(|i| {
+                let store = store.clone();
+                let ws = ws.clone();
+                std::thread::spawn(move || {
+                    store
+                        .save_document(
+                            &ws,
+                            serde_json::json!({"id": format!("doc-{i}"), "name": format!("D{i}")}),
+                        )
+                        .unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(store.list_documents(&ws).len(), n, "in-memory index complete");
+        // A fresh store over the same dir reads the on-disk index — the real test
+        // that no serialized file write clobbered a concurrent one.
+        let reloaded = DocumentStore::new(dir.path().to_path_buf());
+        assert_eq!(
+            reloaded.list_documents(&ws).len(),
+            n,
+            "on-disk index.json retained every concurrent save"
+        );
     }
 }

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -137,16 +137,21 @@ impl Harness {
         let rate_limit_rejections = self.server.rate_limit_rejections_handle();
         let write_limiter = self.server.build_write_limiter().await;
         let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
-        // MCP is brought up before the server here, so it can't share the
-        // server's (not-yet-created) Y.Doc registry — use a standalone one +
-        // noop broadcaster. Cross-tenant isolation still holds: a separate
-        // registry never resolves a live handle, so MCP writes take the JSON
-        // path, which already enforces workspace scoping (JP-35 live path
-        // isolation is covered by the in-module unit tests).
+        // This harness deliberately hands MCP a *standalone* Y.Doc registry +
+        // noop broadcaster (not the server's): a separate registry never resolves
+        // a live handle, so MCP writes take the JSON path, which already enforces
+        // workspace scoping (JP-35 live-path isolation is covered by the in-module
+        // unit tests). JP-230: the *DocumentStore*, by contrast, is shared with the
+        // WS server (the server started in `new`), matching production.
         let sync_registry = Arc::new(docushark_relay::sync::DocRegistry::new());
         let on_doc_update: Arc<
             dyn Fn(&docushark_relay::server::protocol::WorkspaceId, &DocId, Vec<u8>) + Send + Sync,
         > = Arc::new(|_, _, _| {});
+        let shared_doc_store = self
+            .server
+            .get_doc_store()
+            .await
+            .expect("doc store available after start");
         let mcp = Arc::new(
             McpServer::new(
                 self.data_dir.clone(),
@@ -158,7 +163,7 @@ impl Harness {
                 "default".to_string(),
                 sync_registry,
                 on_doc_update,
-                None, // JP-200: no R2 doc mirror in tests
+                shared_doc_store,
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -1,0 +1,154 @@
+//! JP-230 regression: MCP- and editor-authored docs must not clobber each
+//! other's `index.json`.
+//!
+//! Before the fix the relay ran two `DocumentStore` instances over the same
+//! per-workspace index — an editor (REST/WS) save rewrote `index.json` from its
+//! stale in-memory view and **dropped** a doc the MCP store had just created.
+//! The fix shares one `DocumentStore` between the WS server and MCP. This test
+//! reproduces the exact scenario: create a doc via MCP, save a *different* doc
+//! via REST, and assert both survive in the REST **and** MCP listings.
+//!
+//! The MCP static token and a REST OIDC token minted for `"default"` resolve to
+//! the same single-tenant workspace, so both writes target the same index.
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer};
+use docushark_relay::server::protocol::{DocId, WorkspaceId};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::json;
+
+#[tokio::test]
+async fn mcp_create_and_editor_save_dont_clobber_the_index() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+    let bound = server.start(0).await.expect("server start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+
+    // JP-230: MCP shares the server's single DocumentStore (built on start()).
+    let shared_doc_store = server
+        .get_doc_store()
+        .await
+        .expect("doc store available after start");
+    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    let on_doc_update: Arc<dyn Fn(&WorkspaceId, &DocId, Vec<u8>) + Send + Sync> =
+        Arc::new(|_, _, _| {});
+    let mcp = Arc::new(
+        McpServer::new(
+            tmp.path().to_path_buf(),
+            on_doc_changed,
+            server.panic_counter_handle(),
+            server.rate_limit_rejections_handle(),
+            server.build_write_limiter().await,
+            issuer.auth_state(),
+            "default".to_string(),
+            server.sync_registry_handle().await,
+            on_doc_update,
+            shared_doc_store,
+        )
+        .expect("McpServer::new"),
+    );
+    mcp.set_config(InternalMcpConfig { port: 0 })
+        .await
+        .expect("mcp set_config");
+    let mcp_base = mcp.start().await.expect("mcp start");
+    let mcp_token = mcp.get_token().await;
+
+    let client = reqwest::Client::new();
+
+    // 1) Create a doc via MCP (static token → workspace "default").
+    let res = client
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(&mcp_token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "docushark.create_document",
+                "arguments": { "name": "MCP Doc" }
+            }
+        }))
+        .send()
+        .await
+        .expect("mcp create");
+    assert_eq!(res.status().as_u16(), 200, "MCP create_document");
+
+    // 2) Save a DIFFERENT doc via the editor (REST), same workspace "default".
+    let bearer = format!("Bearer {}", issuer.mint("alice", "default", WorkspaceRole::Owner));
+    let res = client
+        .put(format!("{http}/api/docs/editor-doc"))
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({
+            "id": "editor-doc",
+            "name": "Editor Doc",
+            "version": 1,
+            "pages": [],
+            "createdAt": 1000,
+            "modifiedAt": 1000
+        }))
+        .send()
+        .await
+        .expect("rest save");
+    assert_eq!(res.status().as_u16(), 200, "REST save");
+
+    // 3) The REST listing — the WS-path store that used to clobber — must show
+    //    BOTH. Pre-fix this returned only "Editor Doc".
+    let res = client
+        .get(format!("{http}/api/docs"))
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("rest list");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    let names: Vec<&str> = body["documents"]
+        .as_array()
+        .expect("documents array")
+        .iter()
+        .filter_map(|d| d["name"].as_str())
+        .collect();
+    assert!(names.contains(&"MCP Doc"), "MCP doc dropped from REST listing: {names:?}");
+    assert!(names.contains(&"Editor Doc"), "editor doc missing: {names:?}");
+    assert_eq!(names.len(), 2, "exactly the two docs, no clobber: {names:?}");
+
+    // 4) The MCP listing must agree (shared store).
+    let res = client
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(&mcp_token)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": { "name": "docushark.list_documents", "arguments": {} }
+        }))
+        .send()
+        .await
+        .expect("mcp list");
+    assert_eq!(res.status().as_u16(), 200);
+    let text = res.text().await.unwrap();
+    assert!(
+        text.contains("MCP Doc") && text.contains("Editor Doc"),
+        "MCP list_documents missing a doc: {text}"
+    );
+
+    mcp.stop().await.expect("mcp stop");
+    server.stop().await.expect("server stop");
+}

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -47,16 +47,28 @@ impl Harness {
             .await
             .expect("set_config");
 
-        // Bring up MCP first so we share the limiter with the
-        // not-yet-started server. `start()` reuses the cached Arc.
         let panic_counter = server.panic_counter_handle();
         let rate_limit_rejections = server.rate_limit_rejections_handle();
         let write_limiter = server.build_write_limiter().await;
         let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
-        // This harness brings MCP up *before* the server starts, so the
-        // server's Y.Doc registry doesn't exist yet — hand MCP a standalone
-        // one + a noop broadcaster. The JP-35 live-write path isn't exercised
-        // here (these tests cover rate limits via the JSON path).
+
+        // Start the server first so MCP can share its single `DocumentStore`
+        // (JP-230). The write limiter is already built + cached above, so this
+        // ordering doesn't change which limiter the two subsystems see.
+        let bound = server.start(0).await.expect("server start");
+        // The sync listener also serves `/metrics`; derive its HTTP base.
+        let http_base = bound
+            .strip_prefix("ws://")
+            .map(|rest| format!("http://{rest}"))
+            .unwrap_or(bound);
+        let shared_doc_store = server
+            .get_doc_store()
+            .await
+            .expect("doc store available after start");
+
+        // Hand MCP a *standalone* Y.Doc registry + noop broadcaster — the JP-35
+        // live-write path isn't exercised here (these tests cover rate limits via
+        // the JSON path). The DocumentStore, by contrast, is shared with the server.
         let sync_registry = Arc::new(docushark_relay::sync::DocRegistry::new());
         let on_doc_update: Arc<
             dyn Fn(&docushark_relay::server::protocol::WorkspaceId, &DocId, Vec<u8>) + Send + Sync,
@@ -72,7 +84,7 @@ impl Harness {
                 "default".to_string(),
                 sync_registry,
                 on_doc_update,
-                None, // JP-200: no R2 doc mirror in tests
+                shared_doc_store,
             )
             .expect("McpServer::new"),
         );
@@ -81,13 +93,6 @@ impl Harness {
             .expect("mcp set_config");
         let mcp_addr = mcp.start().await.expect("mcp start");
         let mcp_token = mcp.get_token().await;
-
-        let bound = server.start(0).await.expect("server start");
-        // The sync listener also serves `/metrics`; derive its HTTP base.
-        let http_base = bound
-            .strip_prefix("ws://")
-            .map(|rest| format!("http://{rest}"))
-            .unwrap_or(bound);
 
         Self {
             mcp_base: mcp_addr,

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -572,6 +572,12 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
     let write_limiter = relay.server.build_write_limiter().await;
     let sync_registry = relay.server.sync_registry_handle().await;
     let on_doc_update = relay.server.doc_update_broadcaster().await;
+    // JP-230: MCP shares the WS server's single DocumentStore (built on start()).
+    let shared_doc_store = relay
+        .server
+        .get_doc_store()
+        .await
+        .expect("doc store available after start");
     let mcp = Arc::new(
         McpServer::new(
             relay._tmp.path().to_path_buf(),
@@ -583,7 +589,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             "default".to_string(),
             sync_registry,
             on_doc_update,
-            None, // JP-200: no R2 doc mirror in tests
+            shared_doc_store,
         )
         .expect("McpServer::new"),
     );


### PR DESCRIPTION
## Bug

The relay ran **two `DocumentStore` instances** over the same per-workspace `index.json` — one on `ServerState` (WS/REST), one the MCP server built for itself — each with its own in-memory index. A write from one rewrote `index.json` from its stale view and **dropped docs the other created**. Repro: create a doc via MCP → save a *different* doc in the editor → the MCP doc vanishes from `list_documents` / `GET /api/docs` (body intact on disk + R2, still reachable by id; listing-completeness only). JP-200 mirrors whatever `index.json` is on disk, so the R2 index inherited the gap.

## Fix — one shared store (the issue's preferred option)

MCP now **shares the WS server's single `DocumentStore`**. Production `main.rs` builds MCP *after* `server.start()`, so the server's `Arc<DocumentStore>` is already available via `get_doc_store()` — MCP takes that instead of building its own. One in-memory index, one writer, no divergence. The shared store already carries the JP-200 R2 mirror sink, so MCP-authored docs still mirror to R2 (cleaner than the old cloned-sink). `main.rs` logs + skips MCP rather than panicking if the store were somehow absent.

### Also closes the latent *concurrent* clobber

`write_workspace_index_file` snapshotted the index under a read lock then wrote the file **after releasing it**, so two interleaved writers could land a stale snapshot after a fresher one (a race the deterministic divergence masked, and that's *worse* today with two stores hitting one file). Added an **`index_write_lock`** held across snapshot+write — index file writes are serialized, each flushing the latest complete map. This is the issue's "file lock" option; together with the shared store it eliminates the whole clobber class.

### Cleanup

Removed the per-dispatch `ctx.team.reload_index()` band-aid (and the orphaned `reload_index`) — it existed only to cross the two-store gap; with one shared, always-disk-flushed in-memory index, reads already see every write.

## Tests (full relay suite green)

- **`tests/index_no_clobber.rs`** (new) — reproduces the exact scenario: MCP `create_document` + REST `PUT /api/docs/:id` of a *different* doc → **both** survive in the REST *and* MCP listings. Pre-fix this dropped the MCP doc (`len == 2` would fail).
- **`documents.rs` concurrency test** — N threads saving distinct docs into one shared store → all land in the **on-disk** index (flakes without `index_write_lock`).
- The three MCP harnesses now pass the shared store; `rate_limits` starts the server first (the cached write limiter makes the reorder a no-op).

## Acceptance (live staging)

Original repro on `dsk-relay-staging-yyz`: `create_document` via MCP, then save a different doc via the editor; the MCP doc stays in both `list_documents` and `GET /api/docs` (and in the R2 `index.json`).

Assisted-by: Opus 4.8