### PR TITLE
JP-234: upload collab-doc blob bytes (fix the JP-108↔JP-118 collision)

### DIFF
--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -113,6 +113,36 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     void RelayDocumentCache.put(doc, homeRelayId).catch((e) =>
       console.error('[persistenceStore] Failed to cache collab edit:', e),
     );
+    // JP-234: the REST `saveToHost` is suppressed above for collab docs (the
+    // relay is the sole writer), but that path is also the only blob byte
+    // uploader (JP-118) — so a file added mid-collab would sync its FileShape
+    // via CRDT while its bytes never reach the relay (→ 404 on a fresh fetch).
+    // Push just the bytes here: content-addressed + immutable, so no doc save /
+    // serverVersion bump / CRDT clobber. Best-effort; debounced by autosave and
+    // deduped server-side.
+    void relayStore
+      .uploadCollabBlobs(doc)
+      .then((result) => {
+        if (result && result.failed > 0) {
+          const detail = Array.from(result.errors.values())[0] ?? 'unknown error';
+          console.warn(
+            `[persistenceStore] collab blob upload: ${result.failed} of ${result.total} ` +
+              `asset(s) for ${doc.id} failed: ${detail}`,
+          );
+        }
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        if (/quota exceeded/i.test(message)) {
+          useNotificationStore.getState().error(
+            'A file you added is out of storage room and was not uploaded — it’s kept ' +
+              'locally and will upload once you free up space.',
+            { category: 'permanent' },
+          );
+        } else {
+          console.warn('[persistenceStore] collab blob upload failed:', message);
+        }
+      });
     return;
   }
 

--- a/src/store/relayDocumentStore.test.ts
+++ b/src/store/relayDocumentStore.test.ts
@@ -76,7 +76,7 @@ describe('relayDocumentStore.uploadCollabBlobs (JP-234)', () => {
     const { provider } = makeProvider({
       uploadBlobs: vi.fn(async () => {
         throw new Error('storage quota exceeded');
-      }) as DocumentProvider['uploadBlobs'],
+      }) as NonNullable<DocumentProvider['uploadBlobs']>,
     });
     useRelayDocumentStore.getState().setProvider(provider);
 

--- a/src/store/relayDocumentStore.test.ts
+++ b/src/store/relayDocumentStore.test.ts
@@ -1,0 +1,87 @@
+/**
+ * relayDocumentStore — JP-234 collab blob upload.
+ *
+ * `uploadCollabBlobs` pushes a doc's referenced blob bytes to the relay
+ * WITHOUT a doc save, so files added during a collab session (where the REST
+ * `saveToHost` is suppressed — relay sole writer, JP-108) still reach the relay
+ * instead of living only in the browser's local cache.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRelayDocumentStore, type DocumentProvider } from './relayDocumentStore';
+import type { DiagramDocument } from '../types/Document';
+import type { BlobSyncResult } from '../collaboration/BlobSyncService';
+
+function makeDoc(blobReferences: string[]): DiagramDocument {
+  return {
+    id: 'doc-1',
+    name: 'Doc',
+    pages: {},
+    pageOrder: [],
+    blobReferences,
+  } as unknown as DiagramDocument;
+}
+
+function okResult(n: number): BlobSyncResult {
+  return { total: n, success: n, uploaded: n, failed: 0, skipped: 0, errors: new Map() };
+}
+
+function makeProvider(overrides: Partial<DocumentProvider> = {}) {
+  const uploadBlobs = vi.fn(async (hashes: string[]) => okResult(hashes.length));
+  const saveDocument = vi.fn(async () => ({ newVersion: 1 }));
+  const provider = { uploadBlobs, saveDocument, ...overrides } as unknown as DocumentProvider;
+  return { provider, uploadBlobs, saveDocument };
+}
+
+describe('relayDocumentStore.uploadCollabBlobs (JP-234)', () => {
+  beforeEach(() => {
+    useRelayDocumentStore.getState().setProvider(null);
+  });
+
+  it('uploads referenced blob bytes without saving the document', async () => {
+    const { provider, uploadBlobs, saveDocument } = makeProvider();
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    const result = await useRelayDocumentStore
+      .getState()
+      .uploadCollabBlobs(makeDoc(['hash-a', 'hash-b']));
+
+    expect(uploadBlobs).toHaveBeenCalledTimes(1);
+    const hashes = uploadBlobs.mock.calls[0]![0] as string[];
+    expect(new Set(hashes)).toEqual(new Set(['hash-a', 'hash-b']));
+    // Invariant: the collab path never does a doc save (relay is sole writer).
+    expect(saveDocument).not.toHaveBeenCalled();
+    expect(result?.uploaded).toBe(2);
+  });
+
+  it('no-ops when the document references no blobs', async () => {
+    const { provider, uploadBlobs } = makeProvider();
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    const result = await useRelayDocumentStore.getState().uploadCollabBlobs(makeDoc([]));
+
+    expect(result).toBeUndefined();
+    expect(uploadBlobs).not.toHaveBeenCalled();
+  });
+
+  it('no-ops on a filesystem-backed provider (no uploadBlobs)', async () => {
+    const provider = { saveDocument: vi.fn() } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    const result = await useRelayDocumentStore.getState().uploadCollabBlobs(makeDoc(['hash-a']));
+
+    expect(result).toBeUndefined();
+  });
+
+  it('propagates a transport error (caller decides how to surface it)', async () => {
+    const { provider } = makeProvider({
+      uploadBlobs: vi.fn(async () => {
+        throw new Error('storage quota exceeded');
+      }) as DocumentProvider['uploadBlobs'],
+    });
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await expect(
+      useRelayDocumentStore.getState().uploadCollabBlobs(makeDoc(['hash-a'])),
+    ).rejects.toThrow('storage quota exceeded');
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -144,6 +144,19 @@ interface RelayDocumentActions {
    */
   saveToHost: (doc: DiagramDocument, expectedVersion?: number) => Promise<{ newVersion?: number }>;
 
+  /**
+   * JP-234: upload the blob bytes a document references to the relay blob
+   * store **without** a doc save. The collab/CRDT path (JP-108) suppresses
+   * `saveToHost` for the active collab doc, but its referenced blob bytes must
+   * still reach the relay or collaborators (and the same client after a cache
+   * clear) get a 404. Blobs are content-addressed + immutable, so uploading
+   * them never touches the relay's authoritative doc state / `serverVersion` /
+   * Y.Doc sidecar — the relay-sole-writer invariant holds. Best-effort: only
+   * blobs the relay is missing are sent (deduped); resolves to the upload
+   * result, or `undefined` when there's nothing to do (no provider / no refs).
+   */
+  uploadCollabBlobs: (doc: DiagramDocument) => Promise<BlobSyncResult | undefined>;
+
   /** Delete a relay document from host */
   deleteFromHost: (docId: string) => Promise<void>;
 
@@ -520,6 +533,23 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         set({ error });
         registry.setSyncState(doc.id, 'error');
         throw e;
+      }
+    },
+
+    uploadCollabBlobs: async (doc) => {
+      // No blob-store provider (filesystem/legacy backend) → nothing to do; the
+      // legacy base64-embedding path only runs through `saveToHost`.
+      if (!docProvider?.uploadBlobs) return undefined;
+      const hashes = collectBlobReferences(doc);
+      if (hashes.length === 0) return undefined;
+      // Reuse the upload-progress channel so the indicator works for collab
+      // uploads too (JP-126/JP-234). `ensureBlobsUploaded` HEADs each hash first,
+      // so already-present blobs are skipped — safe to call on the autosave tick.
+      const uploadStatus = useUploadStatusStore.getState();
+      try {
+        return await docProvider.uploadBlobs(hashes, uploadStatus.report);
+      } finally {
+        uploadStatus.clear();
       }
     },
 


### PR DESCRIPTION
## Bug

Files added to the **active collab doc** synced their `FileShape` (with the blob hash) to the relay via the CRDT Y.Doc, but their **bytes never uploaded**. So a fresh fetch / cache-clear / a second collaborator → **404 `blob not found`**. (Surfaced during blob-durability testing on staging; the JP-230/231 relay deploy is **not** implicated.)

## Root cause — JP-108 ↔ JP-118 collision

- **JP-118** hangs blob byte-upload off the client REST save (`relayDocumentStore.saveToHost` → `uploadBlobs` before the doc save). It's the only upload trigger.
- **JP-108** (relay sole writer) **suppresses that REST save** for the active collab doc (`pushRelaySaveOrQueue` returns early for `isCollabContentDoc`).
- The CRDT sync path uploads no blobs.

⇒ in the normal relay-PWA collab flow, the FileShape propagates but the bytes stay in the browser's local IndexedDB only.

## Fix

New `relayDocumentStore.uploadCollabBlobs(doc)` pushes the doc's referenced blob bytes via the existing presigned `BlobSyncService` flow **without** a doc save. Blobs are content-addressed + immutable, so this never touches the relay's authoritative doc state / `serverVersion` / Y.Doc sidecar — **the relay-sole-writer invariant holds**. `pushRelaySaveOrQueue` triggers it in the `isCollabContentDoc` branch (debounced by autosave, deduped server-side via `checkBlobExists`), surfaces an out-of-storage notification on quota, and reuses the upload-progress channel so the indicator works for collab uploads too.

## Tests (typecheck + 678 store/collab/storage tests green)

- uploads referenced bytes **without** calling `saveDocument` (the invariant)
- no-ops with no refs / on a filesystem-backed provider
- propagates a transport error for the caller to surface

## Acceptance (staging)

Drop a file into a collab doc → `upload-url` + `finalize` fire → clear site data → reopen → the blob loads (no 404).

## Notes / follow-ups

- The upload fires on the autosave debounce (so within ~1 tick of the drop, not "never"). A more eager on-insert trigger + a client-side "already-uploaded" set to skip the per-tick HEADs are possible optimizations, not needed for correctness.
- Operational: the JP-127 blob GC grace must be ≥ the relay snapshot interval, so a freshly-uploaded blob stays protected until the relay's next Y.Doc→JSON flatten records the FileShape reference. (Grace is already configured on staging.)

Assisted-by: Opus 4.8