### PR TITLE
JP-210: expose relay MCP on the public HTTP listener

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -13,11 +13,21 @@ spec lives next door in [`../api/`](../api/README.md).
 
 ## Endpoint & transport
 
-- **HTTP endpoint:** `POST /mcp` on the MCP port (default **9877**;
-  `[mcp].port` in `relay.toml`). JSON-RPC 2.0 over HTTP (streamable-HTTP MCP).
+- **HTTP endpoint:** `POST /mcp`. JSON-RPC 2.0 over HTTP (streamable-HTTP MCP).
 - **Send `Accept: application/json`.** If you send
   `Accept: text/event-stream`, the server replies with SSE framing; plain
   JSON clients should not advertise the event-stream type.
+
+### Where it listens — `[mcp].expose`
+
+| `expose` | Where `/mcp` lives | Use |
+|---|---|---|
+| `local` (default) | a loopback-only listener on `[mcp].port` (default **9877**) | desktop / self-host on one machine |
+| `public` | folded onto the relay's **main** HTTP listener (the one already serving `/ws` + REST, `[server].port`) | a relay reachable over the network, so a remote MCP client can connect |
+
+With `expose = "public"` there is no second port or TLS endpoint: `/mcp` and
+its discovery doc ride the relay's real origin. `[mcp].port` is ignored. Set it
+in `relay.toml` (`[mcp] expose = "public"`) or via `RELAY_MCP_EXPOSE=public`.
 
 ## Authentication
 
@@ -27,12 +37,29 @@ are accepted, tried in this order:
 1. **Static MCP token** — a per-host bearer (generated on first run, persisted
    to `mcp_token` under the data dir, logged at startup). Authenticates as the
    single-tenant (`default`) workspace. This is the desktop / local default.
+   **Refused when `expose = "public"`** — it resolves to the catch-all
+   `default` workspace, so a network-reachable (potentially multi-tenant) pod
+   accepts only the JWT below.
 2. **Relay app token (JWT)** — an RS256 token minted by the OIDC issuer;
    validated via JWKS. The workspace is taken from the token's `wsp` claim
    (see [`../api/token-format.md`](../api/token-format.md)). This is how a
    multi-workspace deployment scopes an agent to one workspace.
 
 A missing or invalid credential returns `401` with no disambiguation.
+
+### OAuth discovery (self-serve auth)
+
+So an MCP client can authenticate without a hand-pasted token, `/mcp` advertises
+its authorization server per the MCP auth profile (`2025-06-18`):
+
+- An unauthenticated `/mcp` request returns `401` with
+  `WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`.
+- `GET /.well-known/oauth-protected-resource` (RFC 9728) returns the resource
+  identifier (`<origin>/mcp`) and the configured authorization server
+  (`[auth].issuer`). The client runs the auth-code + PKCE dance there and comes
+  back with a JWT. The discovery URLs echo the origin the request arrived on
+  (honoring `X-Forwarded-Proto` behind a TLS-terminating proxy), so they're
+  correct whether reached on loopback or a public host.
 
 ## Document model
 
@@ -158,5 +185,7 @@ structured diagram, and (c) restructure an outline. Status:
 | Notion custom agents | ☐ to verify |
 | Atlassian Rovo | ☐ to verify |
 
-To add a provider: point it at `http://<host>:9877/mcp` with the bearer token,
-run the three acceptance steps, and tick the box.
+To add a provider: point it at `/mcp` on the relay (loopback
+`http://127.0.0.1:9877/mcp` with `expose = "local"`, or the relay's origin
+`https://<host>/mcp` with `expose = "public"`) with the bearer token, run the
+three acceptance steps, and tick the box.

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -279,8 +279,34 @@ impl AuthConfig {
 pub struct McpConfig {
     /// Whether the MCP endpoint is exposed at all.
     pub enabled: bool,
-    /// Loopback-only TCP port for the MCP HTTP listener.
+    /// TCP port for the loopback MCP HTTP listener. Used only by
+    /// `expose = "local"`; ignored when `expose = "public"` (the MCP
+    /// routes then ride the main sync/REST listener's port instead).
     pub port: u16,
+    /// Where the MCP endpoint is reachable. `local` (default) binds a
+    /// loopback-only listener on `port` — desktop and self-host. `public`
+    /// folds `/mcp` + the RFC 9728 discovery doc onto the main HTTP
+    /// listener (the one already serving `/ws` + REST), so a remote MCP
+    /// client can reach it on the relay's real origin. A `public` pod also
+    /// refuses the static bearer token: callers must present a JWT whose
+    /// `wsp` claim scopes the request to a workspace.
+    pub expose: McpExpose,
+}
+
+/// Reachability of the MCP endpoint. See [`McpConfig::expose`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum McpExpose {
+    Local,
+    Public,
+}
+
+impl Default for McpExpose {
+    fn default() -> Self {
+        // Loopback-only by default: a self-hoster or desktop build never
+        // exposes MCP to the network without explicitly opting in.
+        Self::Local
+    }
 }
 
 impl Default for McpConfig {
@@ -288,6 +314,7 @@ impl Default for McpConfig {
         Self {
             enabled: true,
             port: DEFAULT_MCP_PORT,
+            expose: McpExpose::default(),
         }
     }
 }
@@ -510,6 +537,27 @@ impl RelayConfig {
                 }
             };
         }
+        if let Some(v) = get("RELAY_MCP_ENABLED") {
+            self.mcp.enabled = match v.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                other => anyhow::bail!("RELAY_MCP_ENABLED must be a boolean (got {other:?})"),
+            };
+        }
+        if let Some(v) = get("RELAY_MCP_PORT") {
+            self.mcp.port = v
+                .parse()
+                .map_err(|_| anyhow::anyhow!("RELAY_MCP_PORT must be a u16 (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_MCP_EXPOSE") {
+            self.mcp.expose = match v.as_str() {
+                "local" => McpExpose::Local,
+                "public" => McpExpose::Public,
+                other => {
+                    anyhow::bail!("RELAY_MCP_EXPOSE must be 'local' or 'public' (got {other:?})")
+                }
+            };
+        }
         if let Some(v) = get("RELAY_DATA_DIR") {
             self.storage.path = PathBuf::from(v);
         }
@@ -708,7 +756,31 @@ mod tests {
         assert_eq!(parsed.auth.audience, DEFAULT_AUDIENCE);
         assert_eq!(parsed.server.port, DEFAULT_LISTEN_PORT);
         assert_eq!(parsed.mcp.port, DEFAULT_MCP_PORT);
+        assert_eq!(parsed.mcp.expose, McpExpose::Local);
         assert_eq!(parsed.storage.backend, "filesystem");
+    }
+
+    #[test]
+    fn mcp_env_overlay_sets_expose_enabled_and_port() {
+        let mut cfg = RelayConfig::default();
+        cfg.apply_env_overrides(env_getter(&[
+            ("RELAY_MCP_EXPOSE", "public"),
+            ("RELAY_MCP_ENABLED", "false"),
+            ("RELAY_MCP_PORT", "9999"),
+        ]))
+        .expect("overlay");
+        assert_eq!(cfg.mcp.expose, McpExpose::Public);
+        assert!(!cfg.mcp.enabled);
+        assert_eq!(cfg.mcp.port, 9999);
+    }
+
+    #[test]
+    fn mcp_expose_rejects_unknown_value() {
+        let mut cfg = RelayConfig::default();
+        let err = cfg
+            .apply_env_overrides(env_getter(&[("RELAY_MCP_EXPOSE", "internet")]))
+            .unwrap_err();
+        assert!(err.to_string().contains("RELAY_MCP_EXPOSE"), "{err}");
     }
 
     #[test]

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -19,8 +19,8 @@ use clap::{Parser, Subcommand};
 use docushark_relay::auth::{
     JwksCache, OidcAuthState, OidcValidationConfig, RevocationSet,
 };
-use docushark_relay::config::{NetworkMode, RelayConfig};
-use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer};
+use docushark_relay::config::{McpExpose, NetworkMode, RelayConfig};
+use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer, PublicMount};
 use docushark_relay::server::protocol::{DocEventType, DocId, WorkspaceId};
 use docushark_relay::server::{NetworkMode as ServerNetworkMode, ServerConfig, WebSocketServer};
 
@@ -268,6 +268,22 @@ async fn run_serve(
         .await
         .map_err(|e| anyhow::anyhow!("apply server config: {}", e))?;
 
+    // JP-210: when MCP is exposed publicly, hand the WS server the MCP-owned
+    // state *before* start so it folds `/mcp` + the RFC 9728 discovery doc onto
+    // the main public listener (one origin, one TLS story). The loopback
+    // `McpServer` below is then skipped — a public pod runs no second listener.
+    if config.mcp.enabled && config.mcp.expose == McpExpose::Public {
+        let mount = PublicMount::new(config.storage.path.clone(), make_doc_changed(&server))
+            .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
+        // Logged for local diagnostics only; public pods reject the static
+        // token and require a `wsp`-scoped JWT.
+        log::info!(
+            "MCP static token (diagnostics only — public pods require a JWT): {}",
+            mount.token()
+        );
+        server.set_mcp_public_mount(mount).await;
+    }
+
     let bound = server
         .start(config.server.port)
         .await
@@ -281,18 +297,10 @@ async fn run_serve(
         config.auth.jwks_url,
     );
 
-    let mcp = if config.mcp.enabled {
-        let server_for_mcp = server.clone();
-        let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> =
-            Arc::new(move |doc_id: DocId| {
-                let server = server_for_mcp.clone();
-                tokio::spawn(async move {
-                    let ws = WorkspaceId::single_tenant();
-                    server
-                        .broadcast_doc_event(&ws, &doc_id, DocEventType::Updated, None)
-                        .await;
-                });
-            });
+    // Loopback MCP listener — desktop / self-host (`expose = "local"`). The
+    // public path was wired before `start()` above and rides the main listener.
+    let mcp = if config.mcp.enabled && config.mcp.expose == McpExpose::Local {
+        let on_doc_changed = make_doc_changed(&server);
 
         let panic_counter = server.panic_counter_handle();
         let rate_limit_rejections = server.rate_limit_rejections_handle();
@@ -352,6 +360,11 @@ async fn run_serve(
                 }
             },
         }
+    } else if config.mcp.enabled {
+        // expose = "public": the endpoint was folded onto the main listener
+        // before start; there's no separate listener to own or shut down.
+        log::info!("MCP endpoint on the public HTTP listener at {}/mcp", http_origin(&bound));
+        None
     } else {
         log::info!("MCP endpoint disabled in config");
         None
@@ -372,6 +385,35 @@ async fn run_serve(
         .await
         .map_err(|e| anyhow::anyhow!("failed to stop relay cleanly: {}", e))?;
     Ok(())
+}
+
+/// The post-write reload signal handed to both MCP paths: broadcast a
+/// `DocEvent::Updated` so a running editor refreshes after an MCP write.
+/// (The real-time CRDT merge rides the separate `on_doc_update` sink; this is
+/// the coarse "something changed" nudge.)
+fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<dyn Fn(DocId) + Send + Sync> {
+    let server_for_mcp = server.clone();
+    Arc::new(move |doc_id: DocId| {
+        let server = server_for_mcp.clone();
+        tokio::spawn(async move {
+            let ws = WorkspaceId::single_tenant();
+            server
+                .broadcast_doc_event(&ws, &doc_id, DocEventType::Updated, None)
+                .await;
+        });
+    })
+}
+
+/// Map the `ws://` / `wss://` address `server.start()` returns to its HTTP
+/// origin, for logging the public `/mcp` URL.
+fn http_origin(bound: &str) -> String {
+    if let Some(rest) = bound.strip_prefix("wss://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = bound.strip_prefix("ws://") {
+        format!("http://{rest}")
+    } else {
+        bound.to_string()
+    }
 }
 
 /// Block until the process is asked to shut down. We wait on **both** SIGINT

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -92,6 +92,81 @@ pub struct McpServer {
     on_doc_update: Arc<OnDocUpdate>,
 }
 
+/// The MCP-owned pieces needed to fold the endpoint onto the relay's public
+/// HTTP listener (JP-210, `[mcp] expose = "public"`). Unlike [`McpServer`],
+/// these depend only on the app-data dir, so they can be built **before**
+/// `WebSocketServer::start()` and handed to it; the server then combines them
+/// with its post-start shared handles ([`McpSharedHandles`]) to build the
+/// merged router. A `public` mount runs no loopback listener of its own.
+pub struct PublicMount {
+    token: Arc<TokenStore>,
+    local_mirror: Arc<LocalDocumentMirror>,
+    feature_config: Arc<McpFeatureConfigStore>,
+    on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+}
+
+/// The server-owned handles a [`PublicMount`] needs to build its router. The
+/// WS server extracts these from its `ServerState` after `start()` (they share
+/// the same `Arc`s the WS path and the loopback MCP server use, so a public MCP
+/// request and a WS frame on the same workspace see one rate-limiter bucket,
+/// one panic counter, one live Y.Doc registry).
+pub struct McpSharedHandles {
+    pub doc_store: Arc<DocumentStore>,
+    pub panic_counter: Arc<AtomicU64>,
+    pub rate_limit_rejections: Arc<AtomicU64>,
+    pub write_limiter: Arc<WorkspaceWriteLimiter>,
+    pub auth: OidcAuthState,
+    pub relay_region: String,
+    pub sync_registry: Arc<DocRegistry>,
+    pub on_doc_update: Arc<OnDocUpdate>,
+}
+
+impl PublicMount {
+    /// Load (or generate) the MCP-owned state from `app_data_dir`. Mirrors the
+    /// MCP-owned half of [`McpServer::new`]; `on_doc_changed` is invoked after a
+    /// successful write so the caller can broadcast a `DocEvent`.
+    pub fn new(
+        app_data_dir: PathBuf,
+        on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            token: Arc::new(TokenStore::load_or_create(&app_data_dir)?),
+            local_mirror: Arc::new(LocalDocumentMirror::new(app_data_dir.clone())),
+            feature_config: Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir)),
+            on_doc_changed,
+        })
+    }
+
+    /// The static bearer token — public pods don't accept it for auth, but it's
+    /// still logged at startup so an operator can use it for local diagnostics.
+    pub fn token(&self) -> String {
+        self.token.current()
+    }
+
+    /// Build the public MCP router (`/mcp` + RFC 9728 discovery) by combining
+    /// this mount with the server's post-start shared handles. Static-token auth
+    /// is **off** here — a public, potentially multi-tenant pod requires a
+    /// `wsp`-scoped JWT (see [`McpAppState::allow_static_token`]).
+    pub fn into_public_router(self, shared: McpSharedHandles) -> axum::Router {
+        let state = McpAppState {
+            doc_store: shared.doc_store,
+            local_mirror: self.local_mirror,
+            feature_config: self.feature_config,
+            token: self.token,
+            on_doc_changed: self.on_doc_changed,
+            panic_counter: shared.panic_counter,
+            rate_limit_rejections: shared.rate_limit_rejections,
+            write_limiter: shared.write_limiter,
+            auth: shared.auth,
+            relay_region: shared.relay_region,
+            sync_registry: shared.sync_registry,
+            on_doc_update: shared.on_doc_update,
+            allow_static_token: false,
+        };
+        transport::public_router(state)
+    }
+}
+
 impl McpServer {
     /// Build a new MCP server. The token is loaded (or generated) from
     /// `app_data_dir`. `on_doc_changed` is invoked after each successful
@@ -212,6 +287,8 @@ impl McpServer {
             relay_region: self.relay_region.clone(),
             sync_registry: self.sync_registry.clone(),
             on_doc_update: self.on_doc_update.clone(),
+            // Loopback listener: the static token gates a single-tenant store.
+            allow_static_token: true,
         };
         let app = transport::router(state);
 

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -78,6 +78,14 @@ pub struct McpAppState {
     /// `broadcast_to_doc` so MCP-authored changes reach connected clients as a
     /// normal sync frame (they merge, no reload). JP-35.
     pub on_doc_update: Arc<super::tools::OnDocUpdate>,
+    /// Whether the static bearer token is accepted. `true` for the
+    /// loopback listener (desktop / self-host, where the token gates a
+    /// single-tenant store). `false` when the endpoint is folded onto the
+    /// public HTTP surface (JP-210): a public, potentially multi-tenant pod
+    /// must not honour a static token that resolves to the catch-all
+    /// `single_tenant` workspace — callers there present a JWT whose `wsp`
+    /// claim scopes them to a real workspace.
+    pub allow_static_token: bool,
 }
 
 /// Build the Axum router for the MCP endpoint.
@@ -89,14 +97,31 @@ pub struct McpAppState {
 ///   must exist or clients will treat the server as unhealthy.
 /// - `DELETE` — session termination. Accepted as a no-op.
 pub fn router(state: McpAppState) -> Router {
+    mcp_routes()
+        // Liveness/info page — only on the dedicated loopback listener, where
+        // `/` is the relay's whole surface. On the public surface (`public_router`)
+        // `/` belongs to the sync/REST server, so it's omitted there.
+        .route("/", get(root_info))
+        .with_state(state)
+}
+
+/// Router for folding the MCP endpoint onto the relay's **public** HTTP
+/// listener (JP-210) — just `/mcp` + the RFC 9728 discovery doc, no `/`
+/// info page (that path is owned by the sync/REST server it merges into).
+/// Returned already finalized (`Router<()>`) so the caller can `.merge()` it
+/// into the main router after `with_state`.
+pub fn public_router(state: McpAppState) -> Router {
+    mcp_routes().with_state(state)
+}
+
+/// The MCP route set shared by the loopback and public routers.
+fn mcp_routes() -> Router<McpAppState> {
     Router::new()
         .route("/mcp", post(handle_rpc).get(handle_sse).delete(handle_delete))
         .route(
             "/.well-known/oauth-protected-resource",
             get(oauth_protected_resource),
         )
-        .route("/", get(root_info))
-        .with_state(state)
 }
 
 /// RFC 9728 OAuth Protected Resource Metadata (JP-203). Public — no auth: an
@@ -183,7 +208,7 @@ async fn handle_sse(
     State(state): State<McpAppState>,
     headers: HeaderMap,
 ) -> Response {
-    if authenticate(&headers, &state.token, &state.auth, &state.relay_region).await.is_none() {
+    if authenticate(&headers, &state.token, &state.auth, &state.relay_region, state.allow_static_token).await.is_none() {
         log::warn!("MCP SSE: missing or invalid bearer token");
         return unauthorized(&headers);
     }
@@ -200,7 +225,7 @@ async fn handle_delete(
     State(state): State<McpAppState>,
     headers: HeaderMap,
 ) -> Response {
-    if authenticate(&headers, &state.token, &state.auth, &state.relay_region).await.is_none() {
+    if authenticate(&headers, &state.token, &state.auth, &state.relay_region, state.allow_static_token).await.is_none() {
         return unauthorized(&headers);
     }
     StatusCode::NO_CONTENT.into_response()
@@ -211,7 +236,7 @@ async fn handle_rpc(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
-    let auth = match authenticate(&headers, &state.token, &state.auth, &state.relay_region).await {
+    let auth = match authenticate(&headers, &state.token, &state.auth, &state.relay_region, state.allow_static_token).await {
         Some(a) => a,
         None => {
             log::warn!(
@@ -274,9 +299,13 @@ async fn authenticate(
     token: &TokenStore,
     auth: &OidcAuthState,
     relay_region: &str,
+    allow_static_token: bool,
 ) -> Option<AuthOutcome> {
     let presented = extract_bearer(headers)?;
-    if token.validate(presented) {
+    // The static token only ever resolves to the catch-all single-tenant
+    // workspace, so it's accepted on the loopback listener but refused on a
+    // public (multi-tenant) pod — see `McpAppState::allow_static_token`.
+    if allow_static_token && token.validate(presented) {
         return Some(AuthOutcome {
             workspace: WorkspaceId::single_tenant(),
         });
@@ -490,6 +519,7 @@ mod tests {
             relay_region: "default".to_string(),
             sync_registry: Arc::new(crate::sync::DocRegistry::new()),
             on_doc_update: Arc::new(|_, _, _| {}),
+            allow_static_token: true,
         };
         (state, token_str)
     }
@@ -632,6 +662,61 @@ mod tests {
         assert!(names.contains(&"docushark.restructure_outline"));
         assert!(names.contains(&"docushark.generate_diagram"));
         assert_eq!(tools.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn public_router_omits_root_info_but_serves_metadata() {
+        let dir = TempDir::new().unwrap();
+        let (state, _) = make_state(&dir);
+        let app = public_router(state);
+        // `/` belongs to the sync/REST server it merges into — not served here.
+        let root = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(root.status(), StatusCode::NOT_FOUND);
+        // The RFC 9728 discovery doc is still served.
+        let meta = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/.well-known/oauth-protected-resource")
+                    .header("host", "relay.example.com")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(meta.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn public_mode_refuses_static_token() {
+        let dir = TempDir::new().unwrap();
+        let (mut state, token) = make_state(&dir);
+        // Public pods set this off — the static single-tenant token must not
+        // authenticate (callers present a `wsp`-scoped JWT instead).
+        state.allow_static_token = false;
+        let app = public_router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", token))
+            .body(axum::body::Body::from(
+                serde_json::to_vec(&json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
+                    .unwrap(),
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1142,6 +1142,13 @@ pub struct WebSocketServer {
     /// metering snapshot at debug level. Mirrors
     /// `config.observability.metering_debug_log`; set before `start()`.
     metering_debug_log: AtomicBool,
+    /// MCP-owned state for folding `/mcp` onto this public listener
+    /// (JP-210, `[mcp] expose = "public"`). Set via
+    /// [`set_mcp_public_mount`] before `start()`; `start()` takes it and
+    /// merges the MCP router into the main router before binding. `None`
+    /// (the default, and in every test) leaves the public surface
+    /// MCP-free — the loopback `McpServer` is the only path.
+    mcp_public_mount: RwLock<Option<crate::mcp::PublicMount>>,
     /// DEBUG-only panic-injection trigger; see ServerState.
     #[cfg(debug_assertions)]
     panic_tenant_trigger: RwLock<Option<WorkspaceId>>,
@@ -1173,9 +1180,18 @@ impl WebSocketServer {
             panic_count: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             metering_debug_log: AtomicBool::new(false),
+            mcp_public_mount: RwLock::new(None),
             #[cfg(debug_assertions)]
             panic_tenant_trigger: RwLock::new(None),
         }
+    }
+
+    /// Provide the MCP-owned state so `start()` folds `/mcp` + the RFC 9728
+    /// discovery doc onto this public listener (JP-210). Must precede
+    /// `start()`. Only the relay binary, when `[mcp] expose = "public"`, calls
+    /// this; leaving it unset (the default) keeps MCP off the public surface.
+    pub async fn set_mcp_public_mount(&self, mount: crate::mcp::PublicMount) {
+        *self.mcp_public_mount.write().await = Some(mount);
     }
 
     /// Enable/disable the per-workspace metering debug-log on each
@@ -1502,9 +1518,42 @@ impl WebSocketServer {
             .allow_methods(Any)
             .allow_headers(Any);
 
+        // JP-210: when a public MCP mount was provided (`[mcp] expose =
+        // "public"`), build the MCP router from the mount + this server's
+        // post-start shared handles, so `/mcp` rides this listener's origin
+        // and TLS. Built before `server_state` is moved into the WS router's
+        // state; the MCP path reuses the same `Arc`s (one write-limiter bucket,
+        // one panic counter, one live Y.Doc registry) the WS path holds.
+        let mcp_public_router = match self.mcp_public_mount.write().await.take() {
+            Some(mount) => {
+                let tx = server_state.broadcast_tx.clone();
+                let on_doc_update: Arc<crate::mcp::tools::OnDocUpdate> =
+                    Arc::new(move |ws: &WorkspaceId, doc_id: &DocId, framed: Vec<u8>| {
+                        let _ = tx.send(BroadcastMessage {
+                            target: BroadcastTarget::Doc(ws.clone(), doc_id.clone()),
+                            exclude_client: None,
+                            data: framed,
+                        });
+                    });
+                let shared = crate::mcp::McpSharedHandles {
+                    doc_store: server_state.doc_store.clone(),
+                    panic_counter: server_state.panic_count.clone(),
+                    rate_limit_rejections: server_state.rate_limit_rejections.clone(),
+                    write_limiter: server_state.write_limiter.clone(),
+                    auth: server_state.auth.clone(),
+                    relay_region: server_state.relay_region.clone(),
+                    sync_registry: server_state.sync_registry.clone(),
+                    on_doc_update,
+                };
+                log::info!("MCP endpoint folded onto the public HTTP listener at /mcp (expose=public)");
+                Some(mount.into_public_router(shared))
+            }
+            None => None,
+        };
+
         // Create router with WebSocket + blob endpoints, merged with
         // the REST surface defined in `crate::api`.
-        let app = Router::new()
+        let mut app = Router::new()
             .route("/ws", get(ws_handler))
             .route("/health", get(health_handler))
             .route("/metrics", get(metrics_handler))
@@ -1515,8 +1564,11 @@ impl WebSocketServer {
             .route("/api/blobs/:hash", get(blob_download_handler))
             .route("/api/blobs/:hash", head(blob_exists_handler))
             .merge(crate::api::routes())
-            .with_state(server_state)
-            .layer(cors);
+            .with_state(server_state);
+        if let Some(mcp_router) = mcp_public_router {
+            app = app.merge(mcp_router);
+        }
+        let app = app.layer(cors);
 
         // Bind address based on network mode
         let bind_addr = match config.network_mode {

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -1,0 +1,119 @@
+//! JP-210: when `[mcp] expose = "public"`, the MCP endpoint rides the relay's
+//! main HTTP listener (the one serving `/ws` + REST) instead of a separate
+//! loopback listener. This exercises the merged surface end-to-end: the RFC
+//! 9728 discovery doc + the `/mcp` auth contract on the public origin, plus
+//! the public-pod hardening that the static token is refused (a `wsp`-scoped
+//! JWT is required).
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::mcp::PublicMount;
+use docushark_relay::server::protocol::DocId;
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::json;
+
+#[tokio::test]
+async fn public_mcp_rides_main_listener_and_requires_jwt() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+
+    // JP-210: fold MCP onto the public listener before start().
+    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed).expect("mount");
+    let static_token = mount.token();
+    server.set_mcp_public_mount(mount).await;
+
+    let bound = server.start(0).await.expect("server start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .expect("ws url");
+
+    let client = reqwest::Client::new();
+
+    // RFC 9728 discovery doc is served on the *main* origin and echoes it.
+    let meta: serde_json::Value = client
+        .get(format!("{http}/.well-known/oauth-protected-resource"))
+        .send()
+        .await
+        .expect("metadata request")
+        .json()
+        .await
+        .expect("metadata json");
+    assert_eq!(meta["resource"], format!("{http}/mcp"));
+    assert!(
+        meta["authorization_servers"][0]
+            .as_str()
+            .unwrap()
+            .contains("test.docushark.local"),
+        "advertises the configured issuer as the AS: {meta}"
+    );
+
+    // Unauthenticated /mcp → 401 with the RFC 9728 challenge.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .json(&json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
+        .send()
+        .await
+        .expect("unauth post");
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(
+        resp.headers().contains_key("www-authenticate"),
+        "401 carries the WWW-Authenticate challenge"
+    );
+
+    // The static token is refused on a public pod.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&static_token)
+        .json(&json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
+        .send()
+        .await
+        .expect("static-token post");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "the static single-tenant token must not authenticate on a public pod"
+    );
+
+    // A `wsp`-scoped JWT is accepted and the tool surface answers.
+    let jwt = issuer.mint("user-1", "ws-public", WorkspaceRole::Member);
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
+        .send()
+        .await
+        .expect("jwt post");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.expect("tools json");
+    let names: Vec<&str> = body["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    assert!(names.contains(&"docushark.create_document"), "{names:?}");
+
+    // The sync/REST surface still answers on the same listener.
+    let health = client
+        .get(format!("{http}/health"))
+        .send()
+        .await
+        .expect("health");
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+}


### PR DESCRIPTION
Closes the remote-MCP gap under the JP-203 epic: a Cloud/remote relay can now serve `/mcp` so a stock MCP client connects over the network, not just on loopback.

## What

Fold `/mcp` + the RFC 9728 discovery doc (`/.well-known/oauth-protected-resource`) onto the relay's **main** HTTP listener — the one already serving `/ws` + REST — when `[mcp] expose = "public"`. One origin, one TLS story (Fly-proxied `:443`), no second port. Default stays `local` (loopback), so desktop and self-host are unchanged.

## How

- **config** — `[mcp] expose = "local" | "public"` (default `local`), plus `RELAY_MCP_EXPOSE` / `RELAY_MCP_ENABLED` / `RELAY_MCP_PORT` env overrides. Old `relay.toml` without the field deserializes fine.
- **transport** — `public_router` serves just `/mcp` + the well-known (no `/` info page, which belongs to the sync/REST server it merges into). `McpAppState.allow_static_token` gates the static-token branch in `authenticate`.
- **public-pod hardening** — a public pod **refuses** the static bearer (it resolves to the catch-all `single_tenant` workspace); callers present a `wsp`-scoped JWT. The public path reuses the **same** per-workspace write-limiter bucket, panic counter, and region check as the WS path.
- **mcp** — `PublicMount` carries the MCP-owned state (token, mirror, feature config, `on_doc_changed`) so it's built **before** `start()`; the WS server merges the router from the mount + its post-start shared handles (`McpSharedHandles`).
- `start()`'s signature is unchanged — the merge is gated behind an optional pre-set field, so all existing callers/tests are untouched.

## Tests

- config env-overlay + TOML round-trip; `public_router` omits `/` but serves the metadata; public-mode static-token refusal.
- `tests/public_mcp.rs` integration: the WS public listener serves the discovery doc (echoing the real origin + advertising the configured issuer), `/mcp` → `401` + `WWW-Authenticate`, static token refused, a minted JWT accepted (`tools/list` round-trips), and `/health` still answers on the same listener.

Full relay suite green; no new clippy warnings.

## Follow-ups

Filed **JP-235** (multi-tenant polish, non-blocking): route the coarse `DocEvent` nudge to the writing workspace (live edits already correct via `on_doc_update`), and force `local_access` off on a public pod for defense-in-depth.

Scoping note from the issue still holds: a **local** relay already works end-to-end with the OAuth dance once the consent page (JP-209) lands; this PR is specifically the Cloud/remote exposure.

Assisted-by: Opus 4.8