### PR TITLE
Deploy JP-201 (live MCP prose reads) to staging

### DIFF
--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -787,38 +787,28 @@ fn get_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
 
-    let empty_pages = json!({});
-    let rtp = doc.get("richTextPages");
-    let pages_obj = rtp.and_then(|r| r.get("pages")).unwrap_or(&empty_pages);
-
-    let render = |id: &str, page: &Value| {
-        json!({
-            "id": id,
-            "name": page.get("name").cloned().unwrap_or(json!("")),
-            "order": page.get("order").cloned().unwrap_or(json!(0)),
-            "content": page.get("content").cloned().unwrap_or(json!("")),
-        })
+    // Live Y.Doc content overlaid on the JSON page list when the doc is
+    // resident (JP-201), so an agent sees prose a connected editor just typed.
+    let resolved = resolve_prose_pages(ctx, &parsed.doc_id, &doc);
+    let render = |id: &str, name: &Value, order: &Value, content: &str| {
+        json!({"id": id, "name": name, "order": order, "content": content})
     };
 
     if let Some(page_id) = parsed.page_id {
-        let page = pages_obj
-            .get(&page_id)
+        let page = resolved
+            .iter()
+            .find(|e| e.0 == page_id)
             .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
         return Ok(ToolOutcome {
-            result: json!({"page": render(&page_id, page), "source": source}),
+            result: json!({"page": render(&page.0, &page.1, &page.2, &page.3), "source": source}),
             changed_doc_id: None,
             change_detail: None,
         });
     }
 
-    let order: Vec<String> = rtp
-        .and_then(|r| r.get("pageOrder"))
-        .and_then(|v| v.as_array())
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-        .unwrap_or_default();
-    let pages: Vec<Value> = order
+    let pages: Vec<Value> = resolved
         .iter()
-        .filter_map(|id| pages_obj.get(id).map(|p| render(id, p)))
+        .map(|e| render(&e.0, &e.1, &e.2, &e.3))
         .collect();
 
     Ok(ToolOutcome {
@@ -1013,6 +1003,70 @@ fn write_prose_content(doc: &mut Value, page_id: &str, html: String, now: u64) -
     Ok(())
 }
 
+/// Effective prose for one page (JP-201): the live Y.Doc fragment when the doc
+/// is resident and the page has live content, else the JSON projection. Errors
+/// (page not found) only when neither source has it.
+fn resolve_prose_content(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    doc: &Value,
+    page_id: &str,
+) -> Result<String, String> {
+    if let Some(handle) = ctx.registry.get(&ctx.workspace_id, doc_id) {
+        if let Some(html) = handle.prose_html(page_id) {
+            return Ok(html);
+        }
+    }
+    read_prose_content(doc, page_id)
+}
+
+/// Effective prose pages (JP-201): the JSON `richTextPages` list with each
+/// page's `content` overlaid from the live Y.Doc when the doc is resident.
+/// Content is authoritative from the live fragment; `name`/`order` come from
+/// JSON (that page metadata isn't CRDT-synced). A live-only page (fragment with
+/// no JSON entry) is appended with a default name. `(id, name, order, content)`
+/// in JSON `pageOrder` order, live-only pages after.
+fn resolve_prose_pages(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    doc: &Value,
+) -> Vec<(String, Value, Value, String)> {
+    let empty = json!({});
+    let rtp = doc.get("richTextPages");
+    let pages_obj = rtp.and_then(|r| r.get("pages")).unwrap_or(&empty);
+    let order: Vec<String> = rtp
+        .and_then(|r| r.get("pageOrder"))
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+
+    let mut pages: Vec<(String, Value, Value, String)> = order
+        .iter()
+        .filter_map(|id| {
+            let page = pages_obj.get(id)?;
+            Some((
+                id.clone(),
+                page.get("name").cloned().unwrap_or(json!("")),
+                page.get("order").cloned().unwrap_or(json!(0)),
+                page.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string(),
+            ))
+        })
+        .collect();
+
+    if let Some(handle) = ctx.registry.get(&ctx.workspace_id, doc_id) {
+        for (id, html) in handle.prose_pages() {
+            match pages.iter_mut().find(|e| e.0 == id) {
+                Some(entry) => entry.3 = html,
+                None => {
+                    let order_idx = pages.len() as i64;
+                    pages.push((id, json!("Untitled"), json!(order_idx), html));
+                }
+            }
+        }
+    }
+    pages
+}
+
 /// Summarise an outline's sections as `[{index, level, title}]`.
 fn outline_summary(outline: &Outline) -> Vec<Value> {
     outline
@@ -1035,7 +1089,7 @@ fn get_outline(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: GetOutlineArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
-    let content = read_prose_content(&doc, &parsed.page_id)?;
+    let content = resolve_prose_content(ctx, &parsed.doc_id, &doc, &parsed.page_id)?;
     let outline = Outline::parse(&content);
     Ok(ToolOutcome {
         result: json!({"outline": outline_summary(&outline), "source": source}),

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -18,7 +18,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde_json::{Map as JsonMap, Value};
+use serde_json::{json, Map as JsonMap, Value};
 use yrs::types::ToJson;
 use yrs::{Any, Doc, Transact};
 
@@ -92,6 +92,58 @@ fn metadata_title_and_updated(meta_any: &Any) -> (Option<String>, Option<u64>) {
         _ => None,
     };
     (title, updated)
+}
+
+/// Project live prose pages (`(page_id, html)`, from the Y.Doc `prose:*`
+/// fragments) into `json["richTextPages"]` (JP-201 Slice 3). A **read
+/// projection only**: it overlays each live page's `content` (creating the
+/// `richTextPages` structure + a default entry for a live-only page) and
+/// preserves any existing `name`/`order` (that metadata isn't CRDT-synced).
+/// Hydration never reads `richTextPages`, so this never re-seeds the Y.Doc;
+/// prose *restore* stays binary-sidecar based, preserving CRDT identity.
+///
+/// No-op when there's no live prose, so a shape-only flatten leaves any
+/// existing (e.g. MCP-authored) `richTextPages` untouched.
+pub fn project_prose_into(pages: &[(String, String)], json: &mut Value) {
+    if pages.is_empty() {
+        return;
+    }
+    let now = now_ms();
+    let Some(obj) = json.as_object_mut() else {
+        return;
+    };
+    let rtp = obj
+        .entry("richTextPages")
+        .or_insert_with(|| json!({"pages": {}, "pageOrder": []}));
+    let Some(rtp) = rtp.as_object_mut() else {
+        return;
+    };
+
+    // Content overlay (create a default entry for a live-only page).
+    let pages_map = rtp.entry("pages").or_insert_with(|| json!({}));
+    if let Some(pages_map) = pages_map.as_object_mut() {
+        for (i, (id, html)) in pages.iter().enumerate() {
+            let page = pages_map
+                .entry(id.clone())
+                .or_insert_with(|| json!({"id": id, "name": "Untitled", "order": i, "createdAt": now}));
+            if let Some(page) = page.as_object_mut() {
+                page.entry("id").or_insert_with(|| Value::String(id.clone()));
+                page.insert("content".to_string(), Value::String(html.clone()));
+                page.insert("modifiedAt".to_string(), Value::from(now));
+            }
+        }
+    }
+
+    // Ensure each live page id appears in `pageOrder` (append unknowns; keep the
+    // existing order — names/order are owned by the client, best-effort here).
+    let order = rtp.entry("pageOrder").or_insert_with(|| json!([]));
+    if let Some(order) = order.as_array_mut() {
+        for (id, _) in pages {
+            if !order.iter().any(|v| v.as_str() == Some(id.as_str())) {
+                order.push(Value::String(id.clone()));
+            }
+        }
+    }
 }
 
 /// Convert a yrs `Any` into a `serde_json::Value` — the inverse of
@@ -227,5 +279,39 @@ mod tests {
         assert!(!flatten_into(&doc, "does-not-exist", &mut json));
         // Nothing written.
         assert_eq!(json["pages"]["p1"]["shapeOrder"], json!(["s1"]));
+    }
+
+    #[test]
+    fn projects_prose_content_preserving_metadata() {
+        let mut json = json!({
+            "id": "d",
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"id": "rt1", "name": "Page 1", "order": 0, "content": "<p></p>"}}
+            }
+        });
+        project_prose_into(&[("rt1".to_string(), "<p>typed</p>".to_string())], &mut json);
+        assert_eq!(json["richTextPages"]["pages"]["rt1"]["content"], "<p>typed</p>");
+        assert_eq!(json["richTextPages"]["pages"]["rt1"]["name"], "Page 1", "name preserved");
+        assert_eq!(json["richTextPages"]["pageOrder"], json!(["rt1"]));
+    }
+
+    #[test]
+    fn projects_live_only_page_with_defaults() {
+        let mut json = json!({"id": "d"}); // no richTextPages at all
+        project_prose_into(&[("rtX".to_string(), "<p>new</p>".to_string())], &mut json);
+        assert_eq!(json["richTextPages"]["pages"]["rtX"]["content"], "<p>new</p>");
+        assert_eq!(json["richTextPages"]["pages"]["rtX"]["name"], "Untitled");
+        assert_eq!(json["richTextPages"]["pageOrder"], json!(["rtX"]));
+    }
+
+    #[test]
+    fn empty_prose_is_a_noop() {
+        let mut json = json!({
+            "id": "d",
+            "richTextPages": {"pageOrder": ["rt1"], "pages": {"rt1": {"content": "<p>keep</p>"}}}
+        });
+        project_prose_into(&[], &mut json);
+        assert_eq!(json["richTextPages"]["pages"]["rt1"]["content"], "<p>keep</p>");
     }
 }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -20,6 +20,7 @@
 mod binary;
 mod flatten;
 mod hydration;
+mod prose_html;
 mod protocol;
 
 pub use hydration::active_page_shape_count;
@@ -195,6 +196,48 @@ impl DocHandle {
         doc_prose_count(&self.doc)
     }
 
+    /// Serialize the live `prose:<page_id>` fragment to HTML (JP-201 resident
+    /// read). `None` when the page has no prose root or it's empty — the caller
+    /// then falls back to the JSON projection. Mirrors the editor's
+    /// `editor.getHTML()` for the same page.
+    pub fn prose_html(&self, page_id: &str) -> Option<String> {
+        let name = format!("prose:{page_id}");
+        // Grab the fragment handle before opening a txn (`get_or_insert_*`
+        // transacts; nesting deadlocks), then read under a fresh txn.
+        let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+        let txn = self.doc.transact();
+        if frag.len(&txn) == 0 {
+            return None;
+        }
+        Some(prose_html::fragment_to_html(&frag, &txn))
+    }
+
+    /// Every non-empty prose page in the live Y.Doc as `(page_id, html)`, the id
+    /// parsed from each `prose:<id>` root. Order is unspecified — the caller
+    /// merges name/order from the JSON snapshot (that metadata isn't CRDT-synced).
+    pub fn prose_pages(&self) -> Vec<(String, String)> {
+        let names: Vec<String> = {
+            let txn = self.doc.transact();
+            txn.root_refs()
+                .map(|(name, _)| name)
+                .filter(|name| name.starts_with("prose:"))
+                .map(String::from)
+                .collect()
+        };
+        let mut pages = Vec::new();
+        for name in names {
+            let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+            let txn = self.doc.transact();
+            if frag.len(&txn) == 0 {
+                continue;
+            }
+            let html = prose_html::fragment_to_html(&frag, &txn);
+            let page_id = name.strip_prefix("prose:").unwrap_or(&name).to_string();
+            pages.push((page_id, html));
+        }
+        pages
+    }
+
     /// Encode the live `Y.Doc` as a binary sidecar blob tagged with
     /// `server_version` (JP-108). Captures the whole doc — every shared type,
     /// incl. prose — not just the active-page shapes the JSON flatten writes.
@@ -239,10 +282,18 @@ impl DocHandle {
     /// `false` (writing nothing) if this doc has no page id or the page is
     /// absent in `json`.
     pub fn flatten_into(&self, json: &mut Value) -> bool {
-        match &self.page_id {
-            Some(page_id) => flatten::flatten_into(&self.doc, page_id, json),
-            None => false,
+        let Some(page_id) = &self.page_id else {
+            return false;
+        };
+        if !flatten::flatten_into(&self.doc, page_id, json) {
+            return false;
         }
+        // JP-201 Slice 3: also project the live prose pages into
+        // `richTextPages` so MCP/preview/cold readers see prose (which the
+        // shape-only flatten above never wrote). Read projection only — restore
+        // stays binary-sidecar based.
+        flatten::project_prose_into(&self.prose_pages(), json);
+        true
     }
 
     // ---- MCP authoritative write surface (JP-35) ----
@@ -461,6 +512,32 @@ mod tests {
         let txn = handle.doc.transact();
         assert!(shapes.contains_key(&txn, "s1"), "JSON shapes hydrated");
         assert_eq!(prose.get_string(&txn), "", "stale binary prose ignored");
+    }
+
+    #[test]
+    fn prose_html_serializes_live_fragment() {
+        use yrs::{XmlElementPrelim, XmlFragment, XmlTextPrelim};
+        // A binary sidecar whose `prose:p1` is a real XmlFragment (paragraph +
+        // text) — the shape y-prosemirror produces, unlike the plain-text
+        // `binary_with_prose` helper.
+        let bin = {
+            let doc = Doc::new();
+            let frag = doc.get_or_insert_xml_fragment("prose:p1");
+            {
+                let mut txn = doc.transact_mut();
+                let p = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+                p.push_back(&mut txn, XmlTextPrelim::new("Live prose"));
+            }
+            binary::encode_snapshot(9, &doc)
+        };
+        // JSON at a lower version → hydration uses the binary sidecar.
+        let handle = DocHandle::hydrate(&empty_json_body(1), Some(&bin), false);
+        assert_eq!(handle.prose_html("p1").as_deref(), Some("<p>Live prose</p>"));
+        assert!(handle.prose_html("absent").is_none(), "no fragment → None (caller uses JSON)");
+        assert_eq!(
+            handle.prose_pages(),
+            vec![("p1".to_string(), "<p>Live prose</p>".to_string())]
+        );
     }
 
     #[test]

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -1,0 +1,400 @@
+//! Serialize a `prose:<pageId>` `Y.XmlFragment` to HTML — the relay-side analog
+//! of the editor's `editor.getHTML()` (JP-201).
+//!
+//! Editor prose binds to Tiptap's `Collaboration` extension as a
+//! `Y.XmlFragment` per page (`prose:<pageId>`), where y-prosemirror encodes:
+//! - PM **block nodes** as `Y.XmlElement`s whose tag is the PM node *type name*
+//!   (`paragraph`, `heading`, `bulletList`, …) — NOT the HTML tag;
+//! - PM **text + marks** as `Y.XmlText` runs, where each mark is a *formatting
+//!   attribute* on the run (`bold`, `italic`, `link`, …), surfaced via
+//!   [`Text::diff`].
+//!
+//! We walk that tree and emit HTML. The node/mark tables below mirror the
+//! editor's extension set — **the source of truth is the collaborative editor's
+//! extensions** (`src/ui/CollaborativeProseEditor.tsx`: history-disabled
+//! `StarterKit` + `sharedProseExtensions` in `src/ui/TiptapEditor.tsx` + the
+//! `Collaboration` binding). Unknown node types degrade to their children
+//! (wrapper dropped, text preserved); unknown marks pass through unwrapped — so
+//! schema drift never drops content, it only loses styling on the unmapped bit.
+//!
+//! This is a **read projection only** (MCP reads + the JSON flatten, JP-36).
+//! There is no inverse (HTML → fragment): prose restore stays binary-sidecar
+//! based, preserving CRDT identity.
+
+use std::fmt::Write as _;
+
+use yrs::types::Attrs;
+use yrs::{Any, Out, ReadTxn, Text, Xml, XmlElementRef, XmlFragment, XmlFragmentRef, XmlOut, XmlTextRef};
+
+/// Serialize every top-level block of `frag` to an HTML string.
+pub fn fragment_to_html<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> String {
+    let mut out = String::new();
+    write_children(frag, txn, &mut out);
+    out
+}
+
+fn write_children<F, T>(frag: &F, txn: &T, out: &mut String)
+where
+    F: XmlFragment,
+    T: ReadTxn,
+{
+    for node in frag.children(txn) {
+        write_node(&node, txn, out);
+    }
+}
+
+fn write_node<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String) {
+    match node {
+        XmlOut::Element(el) => write_element(el, txn, out),
+        XmlOut::Text(t) => write_text(t, txn, out),
+        // PM doesn't nest bare fragments, but if one appears, recurse so no
+        // content is lost.
+        XmlOut::Fragment(f) => write_children(f, txn, out),
+    }
+}
+
+/// How a PM block node maps to HTML.
+enum Block {
+    /// Wrap children in `open`…`close`.
+    Wrap { open: String, close: &'static str },
+    /// Self-closing, no children (`<br>`, `<hr>`, `<img …>`).
+    Void(String),
+    /// Unknown type: emit children with no wrapper (preserve text).
+    Transparent,
+}
+
+fn write_element<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String) {
+    match block_for(el, txn) {
+        Block::Wrap { open, close } => {
+            out.push_str(&open);
+            write_children(el, txn, out);
+            out.push_str(close);
+        }
+        Block::Void(html) => out.push_str(&html),
+        Block::Transparent => write_children(el, txn, out),
+    }
+}
+
+/// Map a PM node type name → HTML block. Mirrors the collaborative editor's
+/// node set (StarterKit + table/task-list/etc.); unmapped types degrade to
+/// [`Block::Transparent`].
+fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
+    let wrap = |tag: &'static str| Block::Wrap {
+        open: format!("<{tag}>"),
+        close: leading_close(tag),
+    };
+    match el.tag().as_ref() {
+        "paragraph" => wrap("p"),
+        "heading" => {
+            let level = el
+                .get_attribute(txn, "level")
+                .and_then(out_to_u8)
+                .filter(|l| (1..=6).contains(l))
+                .unwrap_or(1);
+            Block::Wrap {
+                open: format!("<h{level}>"),
+                close: match level {
+                    1 => "</h1>",
+                    2 => "</h2>",
+                    3 => "</h3>",
+                    4 => "</h4>",
+                    5 => "</h5>",
+                    _ => "</h6>",
+                },
+            }
+        }
+        "bulletList" | "taskList" => wrap("ul"),
+        "orderedList" => wrap("ol"),
+        "listItem" | "taskItem" => wrap("li"),
+        "blockquote" => wrap("blockquote"),
+        "codeBlock" => Block::Wrap {
+            open: "<pre><code>".to_string(),
+            close: "</code></pre>",
+        },
+        "table" => wrap("table"),
+        "tableRow" => wrap("tr"),
+        "tableCell" => wrap("td"),
+        "tableHeader" => wrap("th"),
+        "horizontalRule" => Block::Void("<hr>".to_string()),
+        "hardBreak" => Block::Void("<br>".to_string()),
+        "image" => Block::Void(image_html(el, txn)),
+        _ => Block::Transparent,
+    }
+}
+
+/// Closing tag for a simple `<tag>` (static lifetime for the common set).
+fn leading_close(tag: &str) -> &'static str {
+    match tag {
+        "p" => "</p>",
+        "ul" => "</ul>",
+        "ol" => "</ol>",
+        "li" => "</li>",
+        "blockquote" => "</blockquote>",
+        "table" => "</table>",
+        "tr" => "</tr>",
+        "td" => "</td>",
+        "th" => "</th>",
+        // Unreachable for the set above; safe fallback.
+        _ => "",
+    }
+}
+
+fn image_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let attr = |k: &str| {
+        el.get_attribute(txn, k)
+            .and_then(|o| match o {
+                Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+    };
+    let mut s = String::from("<img");
+    if let Some(src) = attr("src") {
+        let _ = write!(s, " src=\"{}\"", escape_attr(&src));
+    }
+    if let Some(alt) = attr("alt") {
+        let _ = write!(s, " alt=\"{}\"", escape_attr(&alt));
+    }
+    if let Some(title) = attr("title") {
+        let _ = write!(s, " title=\"{}\"", escape_attr(&title));
+    }
+    s.push('>');
+    s
+}
+
+fn write_text<T: ReadTxn>(t: &XmlTextRef, txn: &T, out: &mut String) {
+    for run in t.diff(txn, |_| ()) {
+        let Out::Any(Any::String(text)) = &run.insert else {
+            // Non-text embeds (rare) — skip rather than emit garbage.
+            continue;
+        };
+        let (opens, closes) = inline_marks(run.attributes.as_deref());
+        out.push_str(&opens);
+        push_escaped(out, text);
+        out.push_str(&closes);
+    }
+}
+
+/// Marks in a fixed outer→inner order so stacked marks nest deterministically.
+/// Each entry: the PM mark name + its open/close. `link` needs the run's attrs
+/// for `href`, so it's handled specially below.
+const MARK_ORDER: &[(&str, &str, &str)] = &[
+    ("highlight", "<mark>", "</mark>"),
+    ("bold", "<strong>", "</strong>"),
+    ("italic", "<em>", "</em>"),
+    ("underline", "<u>", "</u>"),
+    ("strike", "<s>", "</s>"),
+    ("superscript", "<sup>", "</sup>"),
+    ("subscript", "<sub>", "</sub>"),
+    ("code", "<code>", "</code>"),
+];
+
+/// Build (opening tags, closing tags) for a text run's marks. `link` wraps
+/// outermost; unmapped marks pass through unwrapped (text preserved).
+fn inline_marks(attrs: Option<&Attrs>) -> (String, String) {
+    let Some(attrs) = attrs else {
+        return (String::new(), String::new());
+    };
+    let mut opens = String::new();
+    let mut closes_rev: Vec<&str> = Vec::new();
+
+    // Link outermost so inline emphasis nests inside the anchor.
+    if let Some(href) = attrs.get("link").and_then(link_href) {
+        let _ = write!(opens, "<a href=\"{}\">", escape_attr(&href));
+        closes_rev.push("</a>");
+    }
+    for (name, open, close) in MARK_ORDER {
+        if attrs.contains_key(*name) {
+            opens.push_str(open);
+            closes_rev.push(close);
+        }
+    }
+    let closes: String = closes_rev.into_iter().rev().collect();
+    (opens, closes)
+}
+
+/// Extract `href` from a `link` mark's value (`{ href, target, … }`), or treat
+/// a bare string value as the href.
+fn link_href(v: &Any) -> Option<String> {
+    match v {
+        Any::Map(m) => match m.get("href") {
+            Some(Any::String(s)) => Some(s.to_string()),
+            _ => None,
+        },
+        Any::String(s) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+fn out_to_u8(o: Out) -> Option<u8> {
+    match o {
+        Out::Any(Any::Number(n)) if n.is_finite() && n >= 0.0 => Some(n as u8),
+        Out::Any(Any::BigInt(i)) if (0..=255).contains(&i) => Some(i as u8),
+        Out::Any(Any::String(s)) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+fn push_escaped(out: &mut String, s: &str) {
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            c => out.push(c),
+        }
+    }
+}
+
+fn escape_attr(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use yrs::{Doc, Text, Transact, Xml, XmlElementPrelim, XmlFragment, XmlTextPrelim};
+
+    /// Render a fragment built by `build` (run inside a write txn).
+    fn render(build: impl FnOnce(&Doc, &yrs::XmlFragmentRef, &mut yrs::TransactionMut)) -> String {
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("prose:p1");
+        {
+            let mut txn = doc.transact_mut();
+            build(&doc, &frag, &mut txn);
+        }
+        let txn = doc.transact();
+        fragment_to_html(&frag, &txn)
+    }
+
+    fn mark(name: &str) -> Attrs {
+        HashMap::from([(Arc::from(name), Any::Bool(true))])
+    }
+
+    #[test]
+    fn paragraph_with_inline_marks() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            let t = p.push_back(txn, XmlTextPrelim::new("Hello world"));
+            t.format(txn, 6, 5, mark("bold")); // bold "world"
+        });
+        assert_eq!(html, "<p>Hello <strong>world</strong></p>");
+    }
+
+    #[test]
+    fn stacked_marks_nest_deterministically() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            let t = p.push_back(txn, XmlTextPrelim::new("x"));
+            t.format(
+                txn,
+                0,
+                1,
+                HashMap::from([
+                    (Arc::from("bold"), Any::Bool(true)),
+                    (Arc::from("italic"), Any::Bool(true)),
+                ]),
+            );
+        });
+        // Fixed order: bold outside italic, regardless of HashMap iteration.
+        assert_eq!(html, "<p><strong><em>x</em></strong></p>");
+    }
+
+    #[test]
+    fn link_wraps_outermost_with_href() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            let t = p.push_back(txn, XmlTextPrelim::new("click"));
+            let link = HashMap::from([(
+                Arc::from("link"),
+                Any::Map(Arc::new(HashMap::from([(
+                    "href".to_string(),
+                    Any::String("https://x.test/a?b=1".into()),
+                )]))),
+            )]);
+            t.format(txn, 0, 5, link);
+        });
+        assert_eq!(html, "<p><a href=\"https://x.test/a?b=1\">click</a></p>");
+    }
+
+    #[test]
+    fn heading_uses_level_attribute() {
+        let html = render(|_doc, frag, txn| {
+            let h = frag.push_back(txn, XmlElementPrelim::empty("heading"));
+            h.insert_attribute(txn, "level", "3");
+            h.push_back(txn, XmlTextPrelim::new("Title"));
+        });
+        assert_eq!(html, "<h3>Title</h3>");
+    }
+
+    #[test]
+    fn nested_bullet_list() {
+        let html = render(|_doc, frag, txn| {
+            let ul = frag.push_back(txn, XmlElementPrelim::empty("bulletList"));
+            for label in ["a", "b"] {
+                let li = ul.push_back(txn, XmlElementPrelim::empty("listItem"));
+                let p = li.push_back(txn, XmlElementPrelim::empty("paragraph"));
+                p.push_back(txn, XmlTextPrelim::new(label));
+            }
+        });
+        assert_eq!(html, "<ul><li><p>a</p></li><li><p>b</p></li></ul>");
+    }
+
+    #[test]
+    fn code_block_wraps_pre_code() {
+        let html = render(|_doc, frag, txn| {
+            let cb = frag.push_back(txn, XmlElementPrelim::empty("codeBlock"));
+            cb.push_back(txn, XmlTextPrelim::new("let x = 1;"));
+        });
+        assert_eq!(html, "<pre><code>let x = 1;</code></pre>");
+    }
+
+    #[test]
+    fn void_nodes_self_close() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("a"));
+            p.push_back(txn, XmlElementPrelim::empty("hardBreak"));
+            p.push_back(txn, XmlTextPrelim::new("b"));
+            frag.push_back(txn, XmlElementPrelim::empty("horizontalRule"));
+        });
+        assert_eq!(html, "<p>a<br>b</p><hr>");
+    }
+
+    #[test]
+    fn unknown_node_degrades_to_children() {
+        let html = render(|_doc, frag, txn| {
+            let weird = frag.push_back(txn, XmlElementPrelim::empty("mysteryBlock"));
+            let p = weird.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("kept"));
+        });
+        // Wrapper dropped, content preserved.
+        assert_eq!(html, "<p>kept</p>");
+    }
+
+    #[test]
+    fn text_is_html_escaped() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("a < b & c > d"));
+        });
+        assert_eq!(html, "<p>a &lt; b &amp; c &gt; d</p>");
+    }
+
+    #[test]
+    fn empty_fragment_is_empty_string() {
+        let html = render(|_doc, _frag, _txn| {});
+        assert_eq!(html, "");
+    }
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -35,6 +35,7 @@ use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
 use yrs::{
     Any, Array, ArrayRef, Doc, GetString, Map, MapRef, ReadTxn, StateVector, Text, Transact, Update,
+    XmlElementPrelim, XmlFragment, XmlTextPrelim,
 };
 
 // ----------------------------------------------------------------------
@@ -231,6 +232,22 @@ impl LocalDoc {
     fn prose_text(&self, page: &str) -> String {
         let prose = self.doc.get_or_insert_text(format!("prose:{page}"));
         prose.get_string(&self.doc.transact())
+    }
+
+    /// Insert a paragraph into a page's `prose:<page>` fragment as a real
+    /// `XmlFragment` (paragraph element + text) — the shape y-prosemirror
+    /// produces — so the relay can serialize it to HTML (JP-201). Returns the
+    /// `Update` frame a client would send.
+    fn insert_prose_paragraph(&self, page: &str, text: &str) -> Vec<u8> {
+        let before = self.doc.transact().state_vector();
+        let frag = self.doc.get_or_insert_xml_fragment(format!("prose:{page}"));
+        {
+            let mut txn = self.doc.transact_mut();
+            let p = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(&mut txn, XmlTextPrelim::new(text));
+        }
+        let update = self.doc.transact().encode_state_as_update_v1(&before);
+        SyncMessage::Update(update).encode_v1()
     }
 
     fn has_shape(&self, id: &str) -> bool {
@@ -624,6 +641,132 @@ async fn mcp_add_shape(mcp_base: &str, token: &str, doc_id: &str, page_id: &str)
         .as_str()
         .unwrap_or_else(|| panic!("no shape id in MCP result: {res}"))
         .to_string()
+}
+
+/// Call `docushark.get_prose` over MCP and return the `structuredContent`.
+async fn mcp_get_prose(mcp_base: &str, token: &str, doc_id: &str) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.get_prose", "arguments": {"docId": doc_id}}
+    });
+    let res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    res["result"]["structuredContent"].clone()
+}
+
+/// JP-201: an MCP `get_prose` of a resident doc reflects prose a connected
+/// editor just typed into the live Y.Doc — *before* any snapshot flatten —
+/// where the JSON store still shows the old (empty) content.
+#[tokio::test]
+async fn jp201_mcp_get_prose_reads_live_prose_fragment() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    // Seed a doc whose JSON prose page `rt1` is empty.
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-prose", "name": "Prose", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"name": "Page 1", "order": 0, "content": "<p></p>"}}
+            }
+        }),
+    )
+    .await;
+
+    // Cold read (no client connected) → the JSON projection: empty.
+    let cold = mcp_get_prose(&mcp_base, &token, "doc-prose").await;
+    assert_eq!(cold["pages"][0]["content"], "<p></p>", "cold read serves JSON");
+
+    // An editor connects + joins → doc becomes resident, then types prose into
+    // `rt1`'s fragment (a live Y.Doc update, never a REST save).
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-prose").await;
+    editor
+        .send_sync(&local.insert_prose_paragraph("rt1", "Hello live"))
+        .await;
+
+    // Resident read reflects the live fragment within one snapshot interval
+    // (default 10s; we poll well under it, so no flatten has run).
+    let mut content = String::new();
+    for _ in 0..25 {
+        let res = mcp_get_prose(&mcp_base, &token, "doc-prose").await;
+        content = res["pages"][0]["content"].as_str().unwrap_or("").to_string();
+        if content.contains("Hello live") {
+            // Page metadata still comes from JSON (not CRDT-synced).
+            assert_eq!(res["pages"][0]["name"], "Page 1", "name preserved from JSON");
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(content, "<p>Hello live</p>", "resident read serves the live Y.Doc prose");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-201 Slice 3: the snapshot flatten projects live prose into the JSON
+/// `richTextPages`, so a cold reader (REST / non-resident MCP) sees prose the
+/// shape-only flatten never wrote — without re-seeding the Y.Doc (restore stays
+/// binary-sidecar based).
+#[tokio::test]
+async fn jp201_flatten_projects_prose_into_json_on_evict() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "flat-prose", "name": "Flat", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"id": "rt1", "name": "Page 1", "order": 0, "content": "<p></p>"}}
+            }
+        }),
+    )
+    .await;
+
+    // A client types prose, then leaves (last participant → evict-flush).
+    let mut a = WsClient::connect(&relay.ws_base).await;
+    a.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut a, &local, "flat-prose").await;
+    a.send_sync(&local.insert_prose_paragraph("rt1", "Durable prose"))
+        .await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    drop(a);
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // Cold REST read now carries the prose (projected by the flatten).
+    let doc = get_doc(&relay.http, &token, "flat-prose").await;
+    assert_eq!(
+        doc["richTextPages"]["pages"]["rt1"]["content"], "<p>Durable prose</p>",
+        "flatten projected live prose into JSON: {doc}"
+    );
+    assert_eq!(
+        doc["richTextPages"]["pages"]["rt1"]["name"], "Page 1",
+        "JSON page name preserved"
+    );
+
+    relay.server.stop().await.expect("stop");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Promote JP-201 (#102) to `staging` so the `:edge` relay image rebuilds with the
live-prose serializer + resident-read + flatten projection. Carries only the
JP-201 change.

After this merges: `relay-image.yml` rebuilds `:edge`, then `dsk-relay-staging-yyz`
is redeployed onto the new image to verify the live `get_prose` read end-to-end.

Assisted-by: Opus 4.8