### PR TITLE
Deploy: JP-238 live MCP prose writes to staging

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -119,10 +119,27 @@ All tools are namespaced `docushark.*`.
 
 ## Concurrency
 
-All write tools persist through an **optimistic-concurrency check** on the
-document's `serverVersion`: a write reads the current version, applies its
-mutation, and saves only if the version still matches, retrying on conflict.
-A concurrent editor's live change is therefore never silently clobbered.
+**Live docs (a client is connected/editing).** When a document is resident on
+the relay, writes apply to the **authoritative Y.Doc** and broadcast a CRDT
+delta, so connected editors see the change immediately (they merge it — no
+reload):
+
+- **Shape** tools (`add_shape`/`add_shapes`/`connect`/`update_shape`) write the
+  live shape map when the doc is resident *and* the target page is the active
+  page.
+- **Prose** tools (`set_prose`/`add_prose_page`/`insert_section`/
+  `restructure_outline`) rebuild the page's live `prose:<pageId>` fragment
+  (whole-page replace) when the doc is resident — so an agent's prose appears in
+  a connected editor live, and an MCP read reflects an editor's un-snapshotted
+  prose. (A new `add_prose_page` page's *tab* may lag until the prose page list
+  syncs; its content lands immediately.)
+
+**Cold docs (no client connected).** Writes persist through an
+**optimistic-concurrency check** on the document's `serverVersion`: read the
+current version, apply, save only if it still matches, retrying on conflict — so
+a concurrent editor's change is never silently clobbered. The relay's snapshot
+flatten later projects live edits back into this JSON, so cold reads stay
+current.
 
 ## Limits & current constraints
 

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -883,6 +883,15 @@ fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
         Ok(page_id)
     })?;
 
+    // JP-238: the page list (name/order) is JSON-only (not CRDT-synced), so the
+    // metadata write above always runs. Additionally seed the live `prose:<id>`
+    // fragment when the doc is resident, so the content is in the Y.Doc for when
+    // the tab surfaces (its live appearance awaits prose page-list sync, JP-171).
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let framed = handle.replace_prose(&id, &html)?;
+        ctx.broadcast_update(&parsed.doc_id, framed);
+    }
+
     Ok(ToolOutcome {
         result: json!({"id": id}),
         changed_doc_id: Some(parsed.doc_id),
@@ -906,7 +915,9 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     reject_if_local(ctx, &parsed.doc_id)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
 
-    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+    // JP-238: live to the Y.Doc fragment when resident (connected editors see it
+    // immediately), else JSON.
+    write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &html, |doc| {
         let now = now_ms();
         let rtp = rich_text_pages_mut(doc)?;
         let page = rtp
@@ -915,7 +926,7 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
             .and_then(|pages| pages.get_mut(&parsed.page_id))
             .and_then(|p| p.as_object_mut())
             .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
-        page.insert("content".into(), json!(html.clone()));
+        page.insert("content".into(), json!(html));
         page.insert("modifiedAt".into(), json!(now));
         stamp_doc_modified(doc, now);
         Ok(())
@@ -1012,7 +1023,7 @@ fn resolve_prose_content(
     doc: &Value,
     page_id: &str,
 ) -> Result<String, String> {
-    if let Some(handle) = ctx.registry.get(&ctx.workspace_id, doc_id) {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
         if let Some(html) = handle.prose_html(page_id) {
             return Ok(html);
         }
@@ -1053,7 +1064,7 @@ fn resolve_prose_pages(
         })
         .collect();
 
-    if let Some(handle) = ctx.registry.get(&ctx.workspace_id, doc_id) {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
         for (id, html) in handle.prose_pages() {
             match pages.iter_mut().find(|e| e.0 == id) {
                 Some(entry) => entry.3 = html,
@@ -1127,28 +1138,24 @@ fn insert_section(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
         None => String::new(),
     };
 
-    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        let now = now_ms();
-        let content = read_prose_content(doc, &parsed.page_id)?;
-        let mut outline = Outline::parse(&content);
-        let len = outline.sections.len();
-        let pos = match parsed.after_index {
-            Some(ai) => (ai + 1).min(len),
-            None => match parsed.position.as_deref() {
-                Some("start") => 0,
-                _ => len,
-            },
-        };
-        outline.sections.insert(
-            pos,
-            Section {
-                level,
-                inner_html: inner_html.clone(),
-                title: title.clone(),
-                body_html: body_html.clone(),
-            },
-        );
-        write_prose_content(doc, &parsed.page_id, outline.to_html(), now)
+    // Read the current page content (live if resident, else JSON), apply the
+    // insert, then write the whole page back live-or-JSON (JP-238).
+    let (doc_json, _) = fetch_doc(ctx, &parsed.doc_id)?;
+    let current = resolve_prose_content(ctx, &parsed.doc_id, &doc_json, &parsed.page_id)?;
+    let mut outline = Outline::parse(&current);
+    let len = outline.sections.len();
+    let pos = match parsed.after_index {
+        Some(ai) => (ai + 1).min(len),
+        None => match parsed.position.as_deref() {
+            Some("start") => 0,
+            _ => len,
+        },
+    };
+    outline.sections.insert(pos, Section { level, inner_html, title, body_html });
+    let new_html = outline.to_html();
+
+    write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &new_html, |doc| {
+        write_prose_content(doc, &parsed.page_id, new_html.clone(), now_ms())
     })?;
 
     Ok(ToolOutcome {
@@ -1175,43 +1182,44 @@ fn restructure_outline(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, S
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     reject_if_local(ctx, &parsed.doc_id)?;
 
-    let summary = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        let now = now_ms();
-        let content = read_prose_content(doc, &parsed.page_id)?;
-        let mut outline = Outline::parse(&content);
-        let n = outline.sections.len();
-        if parsed.index >= n {
+    // Read current content (live if resident, else JSON), apply the op, then
+    // write the whole page back live-or-JSON (JP-238).
+    let (doc_json, _) = fetch_doc(ctx, &parsed.doc_id)?;
+    let current = resolve_prose_content(ctx, &parsed.doc_id, &doc_json, &parsed.page_id)?;
+    let mut outline = Outline::parse(&current);
+    let n = outline.sections.len();
+    if parsed.index >= n {
+        return Err(format!(
+            "No section at index {} — the page has {} heading(s)",
+            parsed.index, n
+        ));
+    }
+    match parsed.op.as_str() {
+        "promote" => {
+            let lvl = outline.sections[parsed.index].level as i64;
+            outline.sections[parsed.index].level = clamp_level(lvl - 1);
+        }
+        "demote" => {
+            let lvl = outline.sections[parsed.index].level as i64;
+            outline.sections[parsed.index].level = clamp_level(lvl + 1);
+        }
+        "move" => {
+            let to = parsed.to_index.ok_or("op 'move' requires 'toIndex'")?.min(n - 1);
+            let section = outline.sections.remove(parsed.index);
+            outline.sections.insert(to, section);
+        }
+        other => {
             return Err(format!(
-                "No section at index {} — the page has {} heading(s)",
-                parsed.index, n
-            ));
+                "Unknown op '{}'; expected 'promote', 'demote', or 'move'",
+                other
+            ))
         }
-        match parsed.op.as_str() {
-            "promote" => {
-                let lvl = outline.sections[parsed.index].level as i64;
-                outline.sections[parsed.index].level = clamp_level(lvl - 1);
-            }
-            "demote" => {
-                let lvl = outline.sections[parsed.index].level as i64;
-                outline.sections[parsed.index].level = clamp_level(lvl + 1);
-            }
-            "move" => {
-                let to = parsed
-                    .to_index
-                    .ok_or("op 'move' requires 'toIndex'")?
-                    .min(n - 1);
-                let section = outline.sections.remove(parsed.index);
-                outline.sections.insert(to, section);
-            }
-            other => {
-                return Err(format!(
-                    "Unknown op '{}'; expected 'promote', 'demote', or 'move'",
-                    other
-                ))
-            }
-        }
-        write_prose_content(doc, &parsed.page_id, outline.to_html(), now)?;
-        Ok(outline_summary(&outline))
+    }
+    let summary = outline_summary(&outline);
+    let new_html = outline.to_html();
+
+    write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &new_html, |doc| {
+        write_prose_content(doc, &parsed.page_id, new_html.clone(), now_ms())
     })?;
 
     Ok(ToolOutcome {
@@ -1455,6 +1463,36 @@ fn live_handle(ctx: &ToolContext, doc_id: &DocId, page_id: &str) -> Option<Arc<D
         Some(handle)
     } else {
         None
+    }
+}
+
+/// The live Y.Doc handle for a doc that's **resident** in the registry (clients
+/// connected → it's hydrated). Unlike [`live_handle`] there's no active-page
+/// check: prose lives in `prose:<pageId>` fragments regardless of the canvas
+/// active page. Shared by the JP-201 prose read resolvers and the JP-238 prose
+/// write path.
+fn resident_handle(ctx: &ToolContext, doc_id: &DocId) -> Option<Arc<DocHandle>> {
+    ctx.registry.get(&ctx.workspace_id, doc_id)
+}
+
+/// Write a prose page's full HTML to the **live** Y.Doc fragment when the doc is
+/// resident — broadcasting the CRDT delta so connected editors update live
+/// (JP-238, whole-page replace) — else fall back to the JSON path. The live path
+/// leaves durability to the JP-36/JP-201 snapshot flatten (which projects prose
+/// into the JSON), exactly like the JP-35 shape write path.
+fn write_prose_page_live_or_json(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    page_id: &str,
+    html: &str,
+    json_fallback: impl FnMut(&mut Value) -> Result<(), String>,
+) -> Result<(), String> {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
+        let framed = handle.replace_prose(page_id, html)?;
+        ctx.broadcast_update(doc_id, framed);
+        Ok(())
+    } else {
+        mutate_with_retry(ctx, doc_id, json_fallback).map(|_| ())
     }
 }
 

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -21,6 +21,8 @@ mod binary;
 mod flatten;
 mod hydration;
 mod prose_html;
+mod prose_parse;
+mod prose_schema;
 mod protocol;
 
 pub use hydration::active_page_shape_count;
@@ -31,7 +33,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
-use yrs::{Any, Array, Doc, Map, ReadTxn, Transact, XmlFragment};
+use yrs::types::Attrs;
+use yrs::{
+    Any, Array, Doc, Map, ReadTxn, Text, Transact, TransactionMut, Xml, XmlElementPrelim,
+    XmlFragment, XmlTextPrelim,
+};
 
 use crate::server::protocol::{DocId, WorkspaceId};
 
@@ -365,6 +371,99 @@ impl DocHandle {
         self.dirty.store(true, Ordering::Relaxed);
         Ok(protocol::frame_update(update))
     }
+
+    /// Replace a page's prose by rebuilding its `prose:<page_id>` fragment from
+    /// `html` in a single transaction (JP-238). Whole-page replace: clear the
+    /// fragment, parse the HTML to PM nodes ([`prose_parse`]), and rebuild —
+    /// returns the framed CRDT delta to broadcast; marks dirty. The inverse of
+    /// the [`prose_html`] read serializer (shared [`prose_schema`] mapping).
+    ///
+    /// One atomic txn ⇒ peers apply it as a single change (no transient-empty
+    /// render) and the JP-189 prose-zeroing guard only sees the final state.
+    /// Empty/whitespace `html` rebuilds a single empty paragraph — the editor's
+    /// "a page is never truly empty" invariant.
+    pub fn replace_prose(&self, page_id: &str, html: &str) -> Result<Vec<u8>, String> {
+        let name = format!("prose:{page_id}");
+        // Grab the fragment handle before opening the txn (`get_or_insert_*`
+        // transacts; nesting deadlocks).
+        let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+
+        let mut blocks = prose_parse::html_to_blocks(html);
+        if blocks.is_empty() {
+            blocks.push(prose_parse::PmNode {
+                node_type: "paragraph".to_string(),
+                attrs: Vec::new(),
+                children: Vec::new(),
+            });
+        }
+
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        let len = frag.len(&txn);
+        if len > 0 {
+            frag.remove_range(&mut txn, 0, len);
+        }
+        for node in &blocks {
+            build_prose_node(&frag, &mut txn, node);
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        Ok(protocol::frame_update(update))
+    }
+}
+
+/// Append one PM node (and its subtree) to `parent`. Generic over the parent
+/// kind (`XmlFragmentRef` at the root, `XmlElementRef` when recursing).
+fn build_prose_node<P: XmlFragment>(parent: &P, txn: &mut TransactionMut, node: &prose_parse::PmNode) {
+    let el = parent.push_back(txn, XmlElementPrelim::empty(node.node_type.as_str()));
+    for (k, v) in &node.attrs {
+        el.insert_attribute(txn, k.as_str(), v.clone());
+    }
+    build_prose_children(&el, txn, &node.children);
+}
+
+fn build_prose_children<P: XmlFragment>(
+    parent: &P,
+    txn: &mut TransactionMut,
+    children: &[prose_parse::PmChild],
+) {
+    for child in children {
+        match child {
+            prose_parse::PmChild::Text { text, marks } => {
+                if text.is_empty() {
+                    continue;
+                }
+                let xtext = parent.push_back(txn, XmlTextPrelim::new(text.as_str()));
+                if !marks.is_empty() {
+                    // Format the whole inserted run at once — `len()` is in the
+                    // doc's offset unit, so we never miscompute multibyte ranges.
+                    let run_len = xtext.len(&*txn);
+                    if run_len > 0 {
+                        xtext.format(txn, 0, run_len, marks_to_attrs(marks));
+                    }
+                }
+            }
+            prose_parse::PmChild::Node(node) => build_prose_node(parent, txn, node),
+        }
+    }
+}
+
+/// All of a run's marks as one Yjs formatting attribute set: boolean marks →
+/// `true`, `link` → `{ href }` (matching the read side's `link_href`).
+fn marks_to_attrs(marks: &[prose_parse::PmMark]) -> Attrs {
+    let mut attrs = Attrs::new();
+    for m in marks {
+        let value = match &m.href {
+            Some(href) => Any::Map(Arc::new(std::collections::HashMap::from([(
+                "href".to_string(),
+                Any::String(href.as_str().into()),
+            )]))),
+            None => Any::Bool(true),
+        };
+        attrs.insert(Arc::from(m.name.as_str()), value);
+    }
+    attrs
 }
 
 /// In-memory registry of active-document Y.Docs, keyed by `(workspace, doc)`.
@@ -538,6 +637,44 @@ mod tests {
             handle.prose_pages(),
             vec![("p1".to_string(), "<p>Live prose</p>".to_string())]
         );
+    }
+
+    #[test]
+    fn replace_prose_round_trips_through_the_serializer() {
+        // html → replace_prose (parse + rebuild fragment) → prose_html (read).
+        // The write parser + read serializer share `prose_schema`, so the common
+        // subset is stable.
+        let cases = [
+            "<p>Hello <strong>world</strong></p>",
+            "<h2>Title</h2><p>body</p>",
+            "<ul><li><p>a</p></li><li><p>b</p></li></ul>",
+            "<pre><code>let x = 1;</code></pre>",
+            r#"<p><a href="https://x.test/a?b=1">go</a></p>"#,
+            "<p>a<br>b</p>",
+            "<p><strong><em>both</em></strong></p>",
+            "<p>a &lt; b &amp; c</p>",
+        ];
+        for html in cases {
+            let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+            let framed = handle.replace_prose("p1", html).expect("replace_prose");
+            assert!(!framed.is_empty(), "a framed delta is returned to broadcast");
+            assert_eq!(handle.prose_html("p1").as_deref(), Some(html), "round-trip: {html}");
+        }
+    }
+
+    #[test]
+    fn replace_prose_empty_yields_single_paragraph() {
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        handle.replace_prose("p1", "   ").expect("replace_prose");
+        assert_eq!(handle.prose_html("p1").as_deref(), Some("<p></p>"));
+    }
+
+    #[test]
+    fn replace_prose_clears_prior_content() {
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        handle.replace_prose("p1", "<p>first</p><p>second</p>").unwrap();
+        handle.replace_prose("p1", "<p>only</p>").unwrap();
+        assert_eq!(handle.prose_html("p1").as_deref(), Some("<p>only</p>"));
     }
 
     #[test]

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -26,6 +26,8 @@ use std::fmt::Write as _;
 use yrs::types::Attrs;
 use yrs::{Any, Out, ReadTxn, Text, Xml, XmlElementRef, XmlFragment, XmlFragmentRef, XmlOut, XmlTextRef};
 
+use super::prose_schema;
+
 /// Serialize every top-level block of `frag` to an HTML string.
 pub fn fragment_to_html<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> String {
     let mut out = String::new();
@@ -103,22 +105,23 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
                 },
             }
         }
-        "bulletList" | "taskList" => wrap("ul"),
-        "orderedList" => wrap("ol"),
-        "listItem" | "taskItem" => wrap("li"),
-        "blockquote" => wrap("blockquote"),
         "codeBlock" => Block::Wrap {
             open: "<pre><code>".to_string(),
             close: "</code></pre>",
         },
-        "table" => wrap("table"),
-        "tableRow" => wrap("tr"),
-        "tableCell" => wrap("td"),
-        "tableHeader" => wrap("th"),
         "horizontalRule" => Block::Void("<hr>".to_string()),
         "hardBreak" => Block::Void("<br>".to_string()),
         "image" => Block::Void(image_html(el, txn)),
-        _ => Block::Transparent,
+        // Task list/item are read-only aliases of ul/li (not in the shared
+        // round-trip table — a write never re-emits these PM types).
+        "taskList" => wrap("ul"),
+        "taskItem" => wrap("li"),
+        // Everything else round-trips 1:1 via the shared schema (paragraph,
+        // lists, blockquote, tables); unmapped types degrade to their children.
+        other => match prose_schema::simple_block_html(other) {
+            Some(html) => wrap(html),
+            None => Block::Transparent,
+        },
     }
 }
 
@@ -174,38 +177,26 @@ fn write_text<T: ReadTxn>(t: &XmlTextRef, txn: &T, out: &mut String) {
     }
 }
 
-/// Marks in a fixed outer→inner order so stacked marks nest deterministically.
-/// Each entry: the PM mark name + its open/close. `link` needs the run's attrs
-/// for `href`, so it's handled specially below.
-const MARK_ORDER: &[(&str, &str, &str)] = &[
-    ("highlight", "<mark>", "</mark>"),
-    ("bold", "<strong>", "</strong>"),
-    ("italic", "<em>", "</em>"),
-    ("underline", "<u>", "</u>"),
-    ("strike", "<s>", "</s>"),
-    ("superscript", "<sup>", "</sup>"),
-    ("subscript", "<sub>", "</sub>"),
-    ("code", "<code>", "</code>"),
-];
-
-/// Build (opening tags, closing tags) for a text run's marks. `link` wraps
-/// outermost; unmapped marks pass through unwrapped (text preserved).
+/// Build (opening tags, closing tags) for a text run's marks, in the shared
+/// outer→inner order ([`prose_schema::MARKS`]) so stacked marks nest
+/// deterministically. `link` wraps outermost; unmapped marks pass through
+/// unwrapped (text preserved).
 fn inline_marks(attrs: Option<&Attrs>) -> (String, String) {
     let Some(attrs) = attrs else {
         return (String::new(), String::new());
     };
     let mut opens = String::new();
-    let mut closes_rev: Vec<&str> = Vec::new();
+    let mut closes_rev: Vec<String> = Vec::new();
 
     // Link outermost so inline emphasis nests inside the anchor.
     if let Some(href) = attrs.get("link").and_then(link_href) {
         let _ = write!(opens, "<a href=\"{}\">", escape_attr(&href));
-        closes_rev.push("</a>");
+        closes_rev.push("</a>".to_string());
     }
-    for (name, open, close) in MARK_ORDER {
+    for (name, tag) in prose_schema::MARKS {
         if attrs.contains_key(*name) {
-            opens.push_str(open);
-            closes_rev.push(close);
+            let _ = write!(opens, "<{tag}>");
+            closes_rev.push(format!("</{tag}>"));
         }
     }
     let closes: String = closes_rev.into_iter().rev().collect();

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -1,0 +1,499 @@
+//! Parse the constrained prose HTML the relay handles into a ProseMirror node
+//! model the writer turns into a `prose:<page>` `Y.XmlFragment` (JP-238). The
+//! inverse of [`super::prose_html`]; the two share [`super::prose_schema`] so
+//! the tag mapping can't drift.
+//!
+//! The HTML is **machine-generated** — `pulldown-cmark` (the MCP markdown path),
+//! the editor's `editor.getHTML()`, and our own `prose_html` output — so this is
+//! a small lenient tokenizer for well-formed markup, **not** a spec HTML5
+//! parser. Anything it doesn't recognize degrades to its children (text is never
+//! dropped), mirroring the read-side degrade.
+
+use super::prose_schema;
+
+/// A ProseMirror node (block): a type name + attrs + ordered children.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PmNode {
+    pub node_type: String,
+    pub attrs: Vec<(String, String)>,
+    pub children: Vec<PmChild>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PmChild {
+    Node(PmNode),
+    /// A run of text carrying its marks (the writer merges consecutive runs into
+    /// one `Y.XmlText` with per-range formatting).
+    Text { text: String, marks: Vec<PmMark> },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PmMark {
+    pub name: String,
+    /// `href` for a `link` mark; `None` for the boolean marks.
+    pub href: Option<String>,
+}
+
+/// Parse prose HTML into top-level PM block nodes.
+pub fn html_to_blocks(html: &str) -> Vec<PmNode> {
+    let tokens = tokenize(html);
+    let tree = build_tree(&tokens);
+    map_blocks(&tree)
+}
+
+// ---- tokenizer ------------------------------------------------------------
+
+#[derive(Debug)]
+enum Token {
+    Open(String, Vec<(String, String)>),
+    Close(String),
+    Void(String, Vec<(String, String)>),
+    Text(String),
+}
+
+/// Tags that never have children / closing tags in our subset.
+fn is_void(tag: &str) -> bool {
+    matches!(tag, "br" | "hr" | "img")
+}
+
+fn tokenize(html: &str) -> Vec<Token> {
+    let bytes = html.as_bytes();
+    let mut i = 0;
+    let mut tokens = Vec::new();
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            // Skip comments `<!-- ... -->` / doctype `<! ... >`.
+            if html[i..].starts_with("<!--") {
+                if let Some(end) = html[i..].find("-->") {
+                    i += end + 3;
+                    continue;
+                }
+                break;
+            }
+            let Some(close_rel) = html[i..].find('>') else {
+                break; // malformed tail — stop
+            };
+            let inner = &html[i + 1..i + close_rel]; // between < and >
+            i += close_rel + 1;
+            let inner = inner.trim();
+            if let Some(name) = inner.strip_prefix('/') {
+                tokens.push(Token::Close(name.trim().to_ascii_lowercase()));
+            } else {
+                let self_close = inner.ends_with('/');
+                let inner = inner.trim_end_matches('/').trim();
+                let (tag, attrs) = parse_tag(inner);
+                if self_close || is_void(&tag) {
+                    tokens.push(Token::Void(tag, attrs));
+                } else {
+                    tokens.push(Token::Open(tag, attrs));
+                }
+            }
+        } else {
+            let next = html[i..].find('<').map(|r| i + r).unwrap_or(bytes.len());
+            let raw = &html[i..next];
+            tokens.push(Token::Text(decode_entities(raw)));
+            i = next;
+        }
+    }
+    tokens
+}
+
+/// Split a tag's inner text (`a href="x"`) into a lowercased name + attrs.
+fn parse_tag(inner: &str) -> (String, Vec<(String, String)>) {
+    let mut chars = inner.char_indices();
+    // tag name = up to first whitespace
+    let mut name_end = inner.len();
+    for (idx, c) in chars.by_ref() {
+        if c.is_whitespace() {
+            name_end = idx;
+            break;
+        }
+    }
+    let tag = inner[..name_end].to_ascii_lowercase();
+    let attrs = parse_attrs(&inner[name_end..]);
+    (tag, attrs)
+}
+
+fn parse_attrs(s: &str) -> Vec<(String, String)> {
+    let mut attrs = Vec::new();
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        // skip whitespace
+        while i < b.len() && b[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        // read name
+        let start = i;
+        while i < b.len() && b[i] != b'=' && !b[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i == start {
+            break;
+        }
+        let name = s[start..i].to_ascii_lowercase();
+        // skip whitespace before '='
+        while i < b.len() && b[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i < b.len() && b[i] == b'=' {
+            i += 1;
+            while i < b.len() && b[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            let value = if i < b.len() && (b[i] == b'"' || b[i] == b'\'') {
+                let quote = b[i];
+                i += 1;
+                let vstart = i;
+                while i < b.len() && b[i] != quote {
+                    i += 1;
+                }
+                let v = &s[vstart..i];
+                if i < b.len() {
+                    i += 1; // closing quote
+                }
+                decode_entities(v)
+            } else {
+                let vstart = i;
+                while i < b.len() && !b[i].is_ascii_whitespace() {
+                    i += 1;
+                }
+                decode_entities(&s[vstart..i])
+            };
+            attrs.push((name, value));
+        } else {
+            attrs.push((name, String::new())); // bare attribute
+        }
+    }
+    attrs
+}
+
+fn decode_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        rest = &rest[amp..];
+        let Some(semi) = rest.find(';') else {
+            out.push('&');
+            rest = &rest[1..];
+            continue;
+        };
+        let entity = &rest[1..semi];
+        let decoded = match entity {
+            "amp" => Some('&'),
+            "lt" => Some('<'),
+            "gt" => Some('>'),
+            "quot" => Some('"'),
+            "apos" | "#39" => Some('\''),
+            "nbsp" => Some('\u{00a0}'),
+            _ => entity
+                .strip_prefix('#')
+                .and_then(|n| {
+                    if let Some(hex) = n.strip_prefix(['x', 'X']) {
+                        u32::from_str_radix(hex, 16).ok()
+                    } else {
+                        n.parse::<u32>().ok()
+                    }
+                })
+                .and_then(char::from_u32),
+        };
+        match decoded {
+            Some(c) => {
+                out.push(c);
+                rest = &rest[semi + 1..];
+            }
+            None => {
+                out.push('&');
+                rest = &rest[1..];
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+// ---- HTML tree ------------------------------------------------------------
+
+#[derive(Debug)]
+enum HtmlNode {
+    Element {
+        tag: String,
+        attrs: Vec<(String, String)>,
+        children: Vec<HtmlNode>,
+    },
+    Text(String),
+}
+
+fn build_tree(tokens: &[Token]) -> Vec<HtmlNode> {
+    // Stack of (tag, attrs, accumulated children).
+    let mut stack: Vec<(String, Vec<(String, String)>, Vec<HtmlNode>)> = Vec::new();
+    let mut roots: Vec<HtmlNode> = Vec::new();
+
+    let push_child = |stack: &mut Vec<(String, Vec<(String, String)>, Vec<HtmlNode>)>,
+                      roots: &mut Vec<HtmlNode>,
+                      node: HtmlNode| {
+        match stack.last_mut() {
+            Some((_, _, kids)) => kids.push(node),
+            None => roots.push(node),
+        }
+    };
+
+    for tok in tokens {
+        match tok {
+            Token::Text(s) => push_child(&mut stack, &mut roots, HtmlNode::Text(s.clone())),
+            Token::Void(tag, attrs) => push_child(
+                &mut stack,
+                &mut roots,
+                HtmlNode::Element { tag: tag.clone(), attrs: attrs.clone(), children: Vec::new() },
+            ),
+            Token::Open(tag, attrs) => stack.push((tag.clone(), attrs.clone(), Vec::new())),
+            Token::Close(tag) => {
+                // Pop until we match the tag (lenient: tolerate stray/misnested
+                // closes by closing the nearest matching open).
+                if let Some(pos) = stack.iter().rposition(|(t, _, _)| t == tag) {
+                    while stack.len() > pos {
+                        let (t, a, kids) = stack.pop().unwrap();
+                        push_child(
+                            &mut stack,
+                            &mut roots,
+                            HtmlNode::Element { tag: t, attrs: a, children: kids },
+                        );
+                    }
+                }
+                // Unmatched close → ignore.
+            }
+        }
+    }
+    // Unclosed opens at EOF → close them in order.
+    while let Some((t, a, kids)) = stack.pop() {
+        push_child(&mut stack, &mut roots, HtmlNode::Element { tag: t, attrs: a, children: kids });
+    }
+    roots
+}
+
+// ---- HTML tree → PM nodes -------------------------------------------------
+
+fn map_blocks(nodes: &[HtmlNode]) -> Vec<PmNode> {
+    let mut out = Vec::new();
+    for n in nodes {
+        match n {
+            HtmlNode::Text(s) if s.trim().is_empty() => {} // whitespace between blocks
+            HtmlNode::Text(_) => {
+                // Stray top-level/inline text in block context → wrap in a paragraph.
+                if let Some(p) = paragraph_from_inline(std::slice::from_ref(n)) {
+                    out.push(p);
+                }
+            }
+            HtmlNode::Element { tag, attrs, children } => {
+                if let Some(node) = map_block_element(tag, attrs, children) {
+                    out.push(node);
+                } else if prose_schema::mark_pm(tag).is_some() || tag == "a" {
+                    // Inline mark at block level → wrap in a paragraph.
+                    if let Some(p) = paragraph_from_inline(std::slice::from_ref(n)) {
+                        out.push(p);
+                    }
+                } else {
+                    // Unknown block tag → unwrap its children (never drop text).
+                    out.extend(map_blocks(children));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Map a known block-level HTML element to a PM node, else `None`.
+fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode]) -> Option<PmNode> {
+    // Heading h1..h6.
+    if tag.len() == 2 && tag.as_bytes()[0] == b'h' && tag.as_bytes()[1].is_ascii_digit() {
+        let level = (tag.as_bytes()[1] - b'0').clamp(1, 6);
+        return Some(PmNode {
+            node_type: "heading".to_string(),
+            attrs: vec![("level".to_string(), level.to_string())],
+            children: collect_inline(children, &[]),
+        });
+    }
+    match tag {
+        "p" => Some(PmNode {
+            node_type: "paragraph".to_string(),
+            attrs: vec![],
+            children: collect_inline(children, &[]),
+        }),
+        "pre" => Some(PmNode {
+            node_type: "codeBlock".to_string(),
+            attrs: vec![],
+            // Code block content is plain text (unwrap any inner <code>).
+            children: vec![PmChild::Text { text: text_content(children), marks: vec![] }],
+        }),
+        "hr" => Some(PmNode { node_type: "horizontalRule".to_string(), attrs: vec![], children: vec![] }),
+        "img" => Some(PmNode {
+            node_type: "image".to_string(),
+            attrs: attrs
+                .iter()
+                .filter(|(k, _)| matches!(k.as_str(), "src" | "alt" | "title"))
+                .cloned()
+                .collect(),
+            children: vec![],
+        }),
+        // Block containers — children are blocks (map_blocks wraps stray inline
+        // into paragraphs, so a loose `<li>text` still works).
+        _ => prose_schema::simple_block_pm(tag).map(|pm| PmNode {
+            node_type: pm.to_string(),
+            attrs: vec![],
+            children: map_blocks(children).into_iter().map(PmChild::Node).collect(),
+        }),
+    }
+}
+
+/// Collect inline content (text + marks, plus `<br>` hard breaks) under the
+/// given active marks.
+fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
+    let mut out = Vec::new();
+    for n in nodes {
+        match n {
+            HtmlNode::Text(s) => out.push(PmChild::Text { text: s.clone(), marks: marks.to_vec() }),
+            HtmlNode::Element { tag, attrs, children } => {
+                if tag == "br" {
+                    out.push(PmChild::Node(PmNode {
+                        node_type: "hardBreak".to_string(),
+                        attrs: vec![],
+                        children: vec![],
+                    }));
+                } else if tag == "a" {
+                    let href = attrs.iter().find(|(k, _)| k == "href").map(|(_, v)| v.clone());
+                    let mut m = marks.to_vec();
+                    m.push(PmMark { name: "link".to_string(), href });
+                    out.extend(collect_inline(children, &m));
+                } else if let Some(mark) = prose_schema::mark_pm(tag) {
+                    let mut m = marks.to_vec();
+                    m.push(PmMark { name: mark.to_string(), href: None });
+                    out.extend(collect_inline(children, &m));
+                } else {
+                    // Unknown inline tag → unwrap (keep text + current marks).
+                    out.extend(collect_inline(children, marks));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn paragraph_from_inline(nodes: &[HtmlNode]) -> Option<PmNode> {
+    let children = collect_inline(nodes, &[]);
+    if children.is_empty() {
+        return None;
+    }
+    Some(PmNode { node_type: "paragraph".to_string(), attrs: vec![], children })
+}
+
+/// Flatten all descendant text (used for code blocks).
+fn text_content(nodes: &[HtmlNode]) -> String {
+    let mut s = String::new();
+    for n in nodes {
+        match n {
+            HtmlNode::Text(t) => s.push_str(t),
+            HtmlNode::Element { children, .. } => s.push_str(&text_content(children)),
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(t: &str) -> PmChild {
+        PmChild::Text { text: t.to_string(), marks: vec![] }
+    }
+    fn marked(t: &str, marks: &[&str]) -> PmChild {
+        PmChild::Text {
+            text: t.to_string(),
+            marks: marks.iter().map(|m| PmMark { name: m.to_string(), href: None }).collect(),
+        }
+    }
+
+    #[test]
+    fn paragraph_with_bold() {
+        let b = html_to_blocks("<p>Hello <strong>world</strong></p>");
+        assert_eq!(
+            b,
+            vec![PmNode {
+                node_type: "paragraph".into(),
+                attrs: vec![],
+                children: vec![text("Hello "), marked("world", &["bold"])],
+            }]
+        );
+    }
+
+    #[test]
+    fn heading_level_and_entities() {
+        let b = html_to_blocks("<h3>A &amp; B &lt;x&gt;</h3>");
+        assert_eq!(b[0].node_type, "heading");
+        assert_eq!(b[0].attrs, vec![("level".to_string(), "3".to_string())]);
+        assert_eq!(b[0].children, vec![text("A & B <x>")]);
+    }
+
+    #[test]
+    fn link_carries_href() {
+        let b = html_to_blocks(r#"<p><a href="https://x.test">go</a></p>"#);
+        let PmChild::Text { marks, .. } = &b[0].children[0] else { panic!() };
+        assert_eq!(marks[0].name, "link");
+        assert_eq!(marks[0].href.as_deref(), Some("https://x.test"));
+    }
+
+    #[test]
+    fn nested_list() {
+        let b = html_to_blocks("<ul><li><p>a</p></li><li><p>b</p></li></ul>");
+        assert_eq!(b[0].node_type, "bulletList");
+        assert_eq!(b[0].children.len(), 2);
+        let PmChild::Node(li) = &b[0].children[0] else { panic!() };
+        assert_eq!(li.node_type, "listItem");
+        let PmChild::Node(p) = &li.children[0] else { panic!() };
+        assert_eq!(p.node_type, "paragraph");
+    }
+
+    #[test]
+    fn loose_list_item_wraps_text_in_paragraph() {
+        let b = html_to_blocks("<ul><li>bare</li></ul>");
+        let PmChild::Node(li) = &b[0].children[0] else { panic!() };
+        let PmChild::Node(p) = &li.children[0] else { panic!() };
+        assert_eq!(p.node_type, "paragraph");
+        assert_eq!(p.children, vec![text("bare")]);
+    }
+
+    #[test]
+    fn code_block_unwraps_inner_code() {
+        let b = html_to_blocks("<pre><code>let x = 1;</code></pre>");
+        assert_eq!(b[0].node_type, "codeBlock");
+        assert_eq!(b[0].children, vec![text("let x = 1;")]);
+    }
+
+    #[test]
+    fn hard_break_is_a_node() {
+        let b = html_to_blocks("<p>a<br>b</p>");
+        assert_eq!(b[0].children.len(), 3);
+        assert_eq!(b[0].children[0], text("a"));
+        let PmChild::Node(br) = &b[0].children[1] else { panic!() };
+        assert_eq!(br.node_type, "hardBreak");
+        assert_eq!(b[0].children[2], text("b"));
+    }
+
+    #[test]
+    fn unknown_block_tag_unwraps_children() {
+        let b = html_to_blocks("<section><p>kept</p></section>");
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].node_type, "paragraph");
+    }
+
+    #[test]
+    fn stacked_marks() {
+        let b = html_to_blocks("<p><strong><em>x</em></strong></p>");
+        let PmChild::Text { marks, .. } = &b[0].children[0] else { panic!() };
+        let names: Vec<&str> = marks.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["bold", "italic"]);
+    }
+}

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -1,0 +1,52 @@
+//! Canonical PM-node / mark ↔ HTML-tag mapping, shared by the prose **read**
+//! serializer (`prose_html`) and the **write** parser (`prose_parse`) so the
+//! two directions can't drift (JP-238 / JP-201).
+//!
+//! Mirrors the collaborative editor's extension set (`StarterKit` +
+//! `sharedProseExtensions` — `src/ui/TiptapEditor.tsx`). The cases that aren't a
+//! plain `<tag>` wrapper — heading (`level` attr), `codeBlock` (`<pre><code>`),
+//! void nodes (`<br>`/`<hr>`/`<img>`), and the `link` mark (`href`) — are
+//! handled explicitly by each side; everything here is the symmetric core.
+
+/// Simple block nodes whose PM type ↔ HTML wrapper tag round-trips 1:1 (children
+/// recurse inside). Read maps PM→HTML; write maps HTML→PM.
+pub const SIMPLE_BLOCKS: &[(&str, &str)] = &[
+    ("paragraph", "p"),
+    ("bulletList", "ul"),
+    ("orderedList", "ol"),
+    ("listItem", "li"),
+    ("blockquote", "blockquote"),
+    ("table", "table"),
+    ("tableRow", "tr"),
+    ("tableCell", "td"),
+    ("tableHeader", "th"),
+];
+
+/// Inline marks: PM mark name ↔ HTML tag, in **outer→inner** nesting order so
+/// both directions are deterministic for stacked marks. (`link` is handled
+/// separately — it carries an `href`.)
+pub const MARKS: &[(&str, &str)] = &[
+    ("highlight", "mark"),
+    ("bold", "strong"),
+    ("italic", "em"),
+    ("underline", "u"),
+    ("strike", "s"),
+    ("superscript", "sup"),
+    ("subscript", "sub"),
+    ("code", "code"),
+];
+
+/// HTML wrapper tag for a simple block PM node (read side).
+pub fn simple_block_html(pm_type: &str) -> Option<&'static str> {
+    SIMPLE_BLOCKS.iter().find(|(p, _)| *p == pm_type).map(|(_, h)| *h)
+}
+
+/// PM node type for a simple block HTML tag (write side).
+pub fn simple_block_pm(html_tag: &str) -> Option<&'static str> {
+    SIMPLE_BLOCKS.iter().find(|(_, h)| *h == html_tag).map(|(p, _)| *p)
+}
+
+/// Mark name for an inline HTML tag (write side).
+pub fn mark_pm(html_tag: &str) -> Option<&'static str> {
+    MARKS.iter().find(|(_, h)| *h == html_tag).map(|(m, _)| *m)
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -35,7 +35,7 @@ use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
 use yrs::{
     Any, Array, ArrayRef, Doc, GetString, Map, MapRef, ReadTxn, StateVector, Text, Transact, Update,
-    XmlElementPrelim, XmlFragment, XmlTextPrelim,
+    XmlElementPrelim, XmlFragment, XmlOut, XmlTextPrelim,
 };
 
 // ----------------------------------------------------------------------
@@ -232,6 +232,23 @@ impl LocalDoc {
     fn prose_text(&self, page: &str) -> String {
         let prose = self.doc.get_or_insert_text(format!("prose:{page}"));
         prose.get_string(&self.doc.transact())
+    }
+
+    /// Render the page's `prose:<page>` XmlFragment to a flat string (the PM-XML
+    /// shape, e.g. `<paragraph>text</paragraph>`) — enough to assert content
+    /// arrived live from a relay-side write.
+    fn prose_fragment_string(&self, page: &str) -> String {
+        let frag = self.doc.get_or_insert_xml_fragment(format!("prose:{page}"));
+        let txn = self.doc.transact();
+        let mut s = String::new();
+        for node in frag.children(&txn) {
+            match node {
+                XmlOut::Element(el) => s.push_str(&el.get_string(&txn)),
+                XmlOut::Text(t) => s.push_str(&t.get_string(&txn)),
+                XmlOut::Fragment(_) => {}
+            }
+        }
+        s
     }
 
     /// Insert a paragraph into a page's `prose:<page>` fragment as a real
@@ -715,6 +732,86 @@ async fn jp201_mcp_get_prose_reads_live_prose_fragment() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     assert_eq!(content, "<p>Hello live</p>", "resident read serves the live Y.Doc prose");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// Call `docushark.set_prose` over MCP (markdown content).
+async fn mcp_set_prose(mcp_base: &str, token: &str, doc_id: &str, page_id: &str, content: &str) {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.set_prose", "arguments": {
+            "docId": doc_id, "pageId": page_id, "content": content, "format": "markdown"
+        }}
+    });
+    let res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    assert_eq!(res["result"]["structuredContent"]["ok"], true, "set_prose failed: {res}");
+}
+
+/// JP-238: an MCP `set_prose` on a **resident** doc rebuilds the live `prose:`
+/// fragment and broadcasts the delta — a connected WS editor receives it live
+/// (the write-side mirror of the JP-201 read test).
+#[tokio::test]
+async fn jp238_mcp_set_prose_reaches_connected_editor() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-write", "name": "Write", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"name": "Page 1", "order": 0, "content": "<p></p>"}}
+            }
+        }),
+    )
+    .await;
+
+    // Editor joins → doc resident.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-write").await;
+
+    // MCP agent writes prose.
+    mcp_set_prose(&mcp_base, &token, "doc-write", "rt1", "Agent wrote this").await;
+
+    // The editor receives the prose delta live (merges, no reload).
+    let mut delivered = false;
+    for _ in 0..25 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.prose_fragment_string("rt1").contains("Agent wrote this") {
+            delivered = true;
+            break;
+        }
+    }
+    assert!(delivered, "editor never received the MCP prose via the live broadcast path");
+
+    // And an MCP read reflects it too.
+    let prose = mcp_get_prose(&mcp_base, &token, "doc-write").await;
+    assert!(
+        prose["pages"][0]["content"].as_str().unwrap_or("").contains("Agent wrote this"),
+        "get_prose did not reflect the write: {prose}"
+    );
 
     mcp.stop().await.ok();
     relay.server.stop().await.expect("stop");


### PR DESCRIPTION
Promote master → staging to deploy JP-238 (PR #104): MCP prose writes hit the live relay Y.Doc (whole-page replace), mirroring JP-35 for shapes and JP-201 for reads.

Deploy target: rebuilds the `:edge` relay image; `dsk-relay-staging-yyz` redeployed off it for live E2E (agent `set_prose` → connected editor sees prose live).

Assisted-by: Opus 4.8