### PR TITLE
JP-235: harden public MCP pod — workspace-routed DocEvent + force local-access off

### DIFF
--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -391,12 +391,15 @@ async fn run_serve(
 /// `DocEvent::Updated` so a running editor refreshes after an MCP write.
 /// (The real-time CRDT merge rides the separate `on_doc_update` sink; this is
 /// the coarse "something changed" nudge.)
-fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<dyn Fn(DocId) + Send + Sync> {
+fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<docushark_relay::mcp::DocChangedSink> {
     let server_for_mcp = server.clone();
-    Arc::new(move |doc_id: DocId| {
+    Arc::new(move |workspace: &WorkspaceId, doc_id: DocId| {
         let server = server_for_mcp.clone();
+        // JP-235: broadcast to the workspace that actually wrote (the request's
+        // authenticated workspace), not a hard-coded `single_tenant()` — so the
+        // reload nudge reaches the right editors on a multi-tenant public pod.
+        let ws = workspace.clone();
         tokio::spawn(async move {
-            let ws = WorkspaceId::single_tenant();
             server
                 .broadcast_doc_event(&ws, &doc_id, DocEventType::Updated, None)
                 .await;

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -26,10 +26,17 @@ use tokio::sync::RwLock;
 
 use crate::auth::OidcAuthState;
 use crate::server::documents::DocumentStore;
-use crate::server::protocol::DocId;
+use crate::server::protocol::{DocId, WorkspaceId};
 use crate::server::WorkspaceWriteLimiter;
 use crate::sync::DocRegistry;
 use tools::OnDocUpdate;
+
+/// The post-write "doc list changed" sink. Invoked after a successful MCP write
+/// with the **writing workspace** and the changed doc id, so the caller can
+/// broadcast a coarse `DocEvent::Updated` to exactly the clients in that
+/// workspace. Carrying the workspace (rather than assuming `single_tenant()`)
+/// is what makes the nudge correct on a multi-tenant public pod — JP-235.
+pub type DocChangedSink = dyn Fn(&WorkspaceId, DocId) + Send + Sync;
 use config::McpFeatureConfigStore;
 use local_mirror::LocalDocumentMirror;
 use token::TokenStore;
@@ -65,7 +72,7 @@ pub struct McpServer {
     doc_store: Arc<DocumentStore>,
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
-    on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    on_doc_changed: Arc<DocChangedSink>,
     /// Shared panic counter — same atomic as `ServerState.panic_count`
     /// so the WS `/metrics` endpoint reflects MCP-side panics too.
     /// Phase 21.2.
@@ -102,7 +109,7 @@ pub struct PublicMount {
     token: Arc<TokenStore>,
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
-    on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    on_doc_changed: Arc<DocChangedSink>,
 }
 
 /// The server-owned handles a [`PublicMount`] needs to build its router. The
@@ -127,7 +134,7 @@ impl PublicMount {
     /// successful write so the caller can broadcast a `DocEvent`.
     pub fn new(
         app_data_dir: PathBuf,
-        on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+        on_doc_changed: Arc<DocChangedSink>,
     ) -> Result<Self, String> {
         Ok(Self {
             token: Arc::new(TokenStore::load_or_create(&app_data_dir)?),
@@ -162,6 +169,12 @@ impl PublicMount {
             sync_registry: shared.sync_registry,
             on_doc_update: shared.on_doc_update,
             allow_static_token: false,
+            // A public pod never serves local (renderer-owned) documents: the
+            // local mirror is only ever populated by a desktop renderer, never
+            // on a headless relay, so this is belt-and-suspenders — but it keeps
+            // the catch-all `single_tenant` local layout unreachable over the
+            // network regardless of `feature_config`. JP-235.
+            allow_local: false,
         };
         transport::public_router(state)
     }
@@ -177,7 +190,7 @@ impl McpServer {
     #[allow(clippy::too_many_arguments)] // shared handles wired from main.rs
     pub fn new(
         app_data_dir: PathBuf,
-        on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+        on_doc_changed: Arc<DocChangedSink>,
         panic_counter: Arc<AtomicU64>,
         rate_limit_rejections: Arc<AtomicU64>,
         write_limiter: Arc<WorkspaceWriteLimiter>,
@@ -289,6 +302,9 @@ impl McpServer {
             on_doc_update: self.on_doc_update.clone(),
             // Loopback listener: the static token gates a single-tenant store.
             allow_static_token: true,
+            // Desktop / self-host: the local mirror is the whole point — it lets
+            // the renderer expose personal documents read-only to MCP. JP-235.
+            allow_local: true,
         };
         let app = transport::router(state);
 

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1397,6 +1397,15 @@ struct AddShapeArgs {
 /// every mutating tool enforces the same contract — see AGENTS.md "MCP
 /// Integration" for the rationale.
 fn reject_if_local(ctx: &ToolContext, doc_id: &DocId) -> Result<(), String> {
+    // The `local_enabled` short-circuit looks like it *weakens* the guard when
+    // local access is off (e.g. a public mount, JP-235) — it doesn't. The guard
+    // exists to stop a write from clobbering a renderer-owned doc that's mirrored
+    // read-only. That mirror is only ever populated by a desktop renderer, so on
+    // a headless/public pod `ctx.local.contains(...)` is always false and this
+    // was already a no-op. With the mirror unreadable, a "local" id simply isn't
+    // found in the team store and the write fails not-found — no local doc is
+    // ever read or mutated. Do not "simplify" by dropping the `local_enabled`
+    // term: on the loopback listener it's what makes the mirror reachable.
     if ctx.local_enabled
         && ctx.local.contains(&ctx.workspace_id, doc_id.as_str())
         && ctx.team.get_document(&ctx.workspace_id, doc_id).is_err()

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -31,7 +31,7 @@ use serde_json::{json, Value};
 
 use crate::auth::OidcAuthState;
 use crate::server::documents::DocumentStore;
-use crate::server::protocol::{DocId, WorkspaceId};
+use crate::server::protocol::WorkspaceId;
 use crate::server::WorkspaceWriteLimiter;
 
 use super::config::McpFeatureConfigStore;
@@ -50,8 +50,10 @@ pub struct McpAppState {
     pub local_mirror: Arc<LocalDocumentMirror>,
     pub feature_config: Arc<McpFeatureConfigStore>,
     pub token: Arc<TokenStore>,
-    /// Called after a successful write so the running app can refresh.
-    pub on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    /// Called after a successful write so the running app can refresh. Carries
+    /// the writing workspace so the coarse `DocEvent` reaches the right clients
+    /// on a multi-tenant public pod (JP-235).
+    pub on_doc_changed: Arc<super::DocChangedSink>,
     /// Shared with `ServerState.panic_count` so MCP tool panics
     /// surface at the WS `/metrics` counter. Phase 21.2.
     pub panic_counter: Arc<AtomicU64>,
@@ -86,6 +88,13 @@ pub struct McpAppState {
     /// `single_tenant` workspace — callers there present a JWT whose `wsp`
     /// claim scopes them to a real workspace.
     pub allow_static_token: bool,
+    /// Whether local (renderer-owned) documents are reachable via MCP. `true`
+    /// on the loopback listener (desktop / self-host, where the local mirror is
+    /// the point). `false` when folded onto the public surface (JP-235): a
+    /// headless public pod never populates the mirror, and its only local layout
+    /// would be the catch-all `single_tenant` one — so local access is forced off
+    /// for defense-in-depth, independent of `feature_config`.
+    pub allow_local: bool,
 }
 
 /// Build the Axum router for the MCP endpoint.
@@ -373,7 +382,9 @@ fn handle_tools_call(
     let ctx = ToolContext {
         team: &state.doc_store,
         local: &state.local_mirror,
-        local_enabled: state.feature_config.local_access_enabled(),
+        // JP-235: a public mount hard-disables local access (`allow_local =
+        // false`) regardless of the persisted feature flag.
+        local_enabled: state.allow_local && state.feature_config.local_access_enabled(),
         workspace_id: workspace.clone(),
         registry: &state.sync_registry,
         on_doc_update: state.on_doc_update.as_ref(),
@@ -437,7 +448,10 @@ fn handle_tools_call(
     match outcome {
         Ok(outcome) => {
             if let Some(doc_id) = outcome.changed_doc_id {
-                (state.on_doc_changed)(doc_id);
+                // JP-235: route the coarse reload nudge to the *writing*
+                // workspace (the request's authenticated workspace), not the
+                // hard-coded `single_tenant()` — correct on a public pod.
+                (state.on_doc_changed)(workspace, doc_id);
             }
             let text = serde_json::to_string_pretty(&outcome.result).unwrap_or_else(|_| "{}".into());
             Json(rpc_result(
@@ -511,7 +525,7 @@ mod tests {
             local_mirror: local,
             feature_config: cfg,
             token,
-            on_doc_changed: Arc::new(|_| {}),
+            on_doc_changed: Arc::new(|_, _| {}),
             panic_counter: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             write_limiter: Arc::new(crate::server::build_workspace_limiter(1000, 1000)),
@@ -520,6 +534,7 @@ mod tests {
             sync_registry: Arc::new(crate::sync::DocRegistry::new()),
             on_doc_update: Arc::new(|_, _, _| {}),
             allow_static_token: true,
+            allow_local: true,
         };
         (state, token_str)
     }

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -136,7 +136,7 @@ impl Harness {
         let panic_counter = self.server.panic_counter_handle();
         let rate_limit_rejections = self.server.rate_limit_rejections_handle();
         let write_limiter = self.server.build_write_limiter().await;
-        let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+        let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
         // This harness deliberately hands MCP a *standalone* Y.Doc registry +
         // noop broadcaster (not the server's): a separate registry never resolves
         // a live handle, so MCP writes take the JSON path, which already enforces

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -47,7 +47,7 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
         .get_doc_store()
         .await
         .expect("doc store available after start");
-    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
     let on_doc_update: Arc<dyn Fn(&WorkspaceId, &DocId, Vec<u8>) + Send + Sync> =
         Arc::new(|_, _, _| {});
     let mcp = Arc::new(

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -5,11 +5,11 @@
 //! the public-pod hardening that the static token is refused (a `wsp`-scoped
 //! JWT is required).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::mcp::PublicMount;
-use docushark_relay::server::protocol::DocId;
+use docushark_relay::server::protocol::WorkspaceId;
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
 use docushark_relay::test_support::OidcTestIssuer;
 use serde_json::json;
@@ -32,7 +32,15 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         .expect("set_config");
 
     // JP-210: fold MCP onto the public listener before start().
-    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    // JP-235: capture the workspace the coarse reload nudge is routed to, so we
+    // can assert a write authenticated as `ws-public` broadcasts to *that*
+    // workspace and not the hard-coded `single_tenant()`.
+    let routed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let routed_sink = routed.clone();
+    let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> =
+        Arc::new(move |ws: &WorkspaceId, _doc| {
+            routed_sink.lock().unwrap().push(ws.as_str().to_string());
+        });
     let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed).expect("mount");
     let static_token = mount.token();
     server.set_mcp_public_mount(mount).await;
@@ -108,6 +116,44 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         .filter_map(|t| t["name"].as_str())
         .collect();
     assert!(names.contains(&"docushark.create_document"), "{names:?}");
+
+    // JP-235 (1): a write authenticated as `ws-public` routes the coarse reload
+    // nudge to *that* workspace, not the catch-all `single_tenant()`.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "docushark.create_document", "arguments": {"name": "JP-235"}}
+        }))
+        .send()
+        .await
+        .expect("create_document post");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        routed.lock().unwrap().as_slice(),
+        ["ws-public"],
+        "the doc-changed nudge must broadcast to the writing workspace"
+    );
+
+    // JP-235 (2): a public mount forces local access off — `list_documents`
+    // reports it disabled regardless of the persisted feature flag (default on).
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "docushark.list_documents", "arguments": {}}
+        }))
+        .send()
+        .await
+        .expect("list_documents post");
+    let body: serde_json::Value = resp.json().await.expect("list json");
+    assert_eq!(
+        body["result"]["structuredContent"]["localAccessEnabled"],
+        json!(false),
+        "public mount must hard-disable local access: {body}"
+    );
 
     // The sync/REST surface still answers on the same listener.
     let health = client

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -50,7 +50,7 @@ impl Harness {
         let panic_counter = server.panic_counter_handle();
         let rate_limit_rejections = server.rate_limit_rejections_handle();
         let write_limiter = server.build_write_limiter().await;
-        let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+        let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
 
         // Start the server first so MCP can share its single `DocumentStore`
         // (JP-230). The write limiter is already built + cached above, so this

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -600,7 +600,7 @@ async fn snapshot_skips_when_active_page_diverged() {
 /// broadcast channel as the running relay — the exact wiring `main.rs` does
 /// post-`start()`. Returns the server handle + its `http://host:port` base.
 async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
-    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
     let panic_counter = relay.server.panic_counter_handle();
     let rate_limit_rejections = relay.server.rate_limit_rejections_handle();
     let write_limiter = relay.server.build_write_limiter().await;


### PR DESCRIPTION
Closes JP-235. Two multi-tenant niceties from the JP-210 public-MCP review. Neither is a data-loss/security bug — live edits ride the separate `on_doc_update` sink (correctly scoped) — but both matter once the MCP endpoint is network-reachable.

### 1. Route the coarse `DocEvent` to the writing workspace
`on_doc_changed` (the post-write "doc list changed" reload nudge) hard-coded `WorkspaceId::single_tenant()`. On an `expose = "public"` pod a browser editor in the real workspace never got the nudge after an agent's MCP write.

- New `DocChangedSink = Fn(&WorkspaceId, DocId)` type alias replaces the workspace-less `Fn(DocId)` across `McpServer` / `PublicMount` / `McpAppState`.
- The request's authenticated `workspace` is already in scope at the transport call site → passed straight through (cleaner than threading it through `ToolOutcome`).
- `make_doc_changed` broadcasts to that workspace. Loopback still passes `single_tenant()` (static token), so its behavior is unchanged.

### 2. Force local-access off on a public mount (defense-in-depth)
`McpFeatureConfigStore` defaults the local-doc mirror **on**. A headless public relay never populates the mirror (only a desktop renderer does), and its only local layout would be the catch-all `single_tenant` one — so a public pod hard-disables it.

- New `allow_local` flag on `McpAppState`, mirroring `allow_static_token`; AND-ed into `ToolContext.local_enabled` (gates `reject_if_local`, local reads, and the `localAccessEnabled` field).
- `false` in `PublicMount::into_public_router`, `true` on the loopback listener.

### Verification
- `tests/public_mcp.rs` extended to assert both through the public path: a `create_document` as `ws-public` routes the nudge to `ws-public` (not `single_tenant`), and `list_documents` reports `localAccessEnabled=false`.
- Full relay suite green (0 failures), clippy clean on the changed surface, OSS-leak grep clean.

Assisted-by: Opus 4.8