### PR TITLE
JP-239 (part 1): anchored, block-level MCP prose writes

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -97,7 +97,7 @@ All tools are namespaced `docushark.*`.
 | Tool | Purpose |
 | -- | -- |
 | `add_prose_page` | Append a prose page. Markdown by default. |
-| `set_prose` | Replace a prose page's entire body. Markdown by default. |
+| `set_prose` | Write a prose page. Replaces the whole body by default; pass `anchor` (the current text of a block) to replace **only that block** — a targeted edit. Markdown by default. |
 | `rename_prose_page` | Rename a prose page. |
 
 ### Structure (write)
@@ -133,6 +133,14 @@ reload):
   a connected editor live, and an MCP read reflects an editor's un-snapshotted
   prose. (A new `add_prose_page` page's *tab* may lag until the prose page list
   syncs; its content lands immediately.)
+- **Anchored prose edits** (`set_prose` with `anchor`) are the *targeted* path:
+  the block whose text matches the anchor is the only one rewritten, so the CRDT
+  delta touches just that block and a concurrent edit elsewhere on the page is
+  preserved. The anchor doubles as a **block-level compare-and-swap** — it must
+  match exactly one block (matched against the live fragment when resident, the
+  JSON content when cold), so a stale anchor is refused (`ERR_ANCHOR_*`) rather
+  than clobbering drifted content. (Full PM-tree diff-merge for *whole-page*
+  writes is future work.)
 
 **Cold docs (no client connected).** Writes persist through an
 **optimistic-concurrency check** on the document's `serverVersion`: read the

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -163,14 +163,16 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.set_prose",
             description:
-                "Replace the entire content of a prose page. Content is Markdown by default (set format:\"html\" to pass HTML through). Refuses local (renderer-owned) documents.",
+                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "docId": {"type": "string"},
                     "pageId": {"type": "string"},
-                    "content": {"type": "string", "description": "New full body. Markdown unless format is \"html\"."},
-                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."}
+                    "content": {"type": "string", "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\"."},
+                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."},
+                    "anchor": {"type": "string", "description": "Optional. The current text of the block to replace (a targeted edit). Must match exactly one top-level block; whitespace is normalized and styling/marks are ignored. Omit to replace the whole page."},
+                    "anchorUntil": {"type": "string", "description": "Optional. With 'anchor', replace the inclusive span of blocks from 'anchor' through the block matching this text."}
                 },
                 "required": ["docId", "pageId", "content"],
                 "additionalProperties": false
@@ -907,6 +909,15 @@ struct SetProseArgs {
     page_id: String,
     content: String,
     format: Option<String>,
+    /// JP-239: when present, `content` replaces only the block matching this
+    /// text (a targeted edit) instead of the whole page. The block's current
+    /// text — the anchor doubles as a write-confirmation lock (must match
+    /// exactly one block).
+    anchor: Option<String>,
+    /// JP-239: with `anchor`, replace the inclusive span of blocks from `anchor`
+    /// through the block matching this text.
+    #[serde(rename = "anchorUntil")]
+    anchor_until: Option<String>,
 }
 
 fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
@@ -915,22 +926,33 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     reject_if_local(ctx, &parsed.doc_id)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
 
-    // JP-238: live to the Y.Doc fragment when resident (connected editors see it
-    // immediately), else JSON.
-    write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &html, |doc| {
-        let now = now_ms();
-        let rtp = rich_text_pages_mut(doc)?;
-        let page = rtp
-            .get_mut("pages")
-            .and_then(|v| v.as_object_mut())
-            .and_then(|pages| pages.get_mut(&parsed.page_id))
-            .and_then(|p| p.as_object_mut())
-            .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
-        page.insert("content".into(), json!(html));
-        page.insert("modifiedAt".into(), json!(now));
-        stamp_doc_modified(doc, now);
-        Ok(())
-    })?;
+    match &parsed.anchor {
+        // JP-239: anchored, block-level replace — only the matched block(s) change.
+        Some(anchor) => write_prose_block_live_or_json(
+            ctx,
+            &parsed.doc_id,
+            &parsed.page_id,
+            anchor,
+            parsed.anchor_until.as_deref(),
+            &html,
+        )?,
+        // JP-238: whole-page replace — live to the Y.Doc fragment when resident
+        // (connected editors see it immediately), else JSON.
+        None => write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &html, |doc| {
+            let now = now_ms();
+            let rtp = rich_text_pages_mut(doc)?;
+            let page = rtp
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|pages| pages.get_mut(&parsed.page_id))
+                .and_then(|p| p.as_object_mut())
+                .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
+            page.insert("content".into(), json!(html));
+            page.insert("modifiedAt".into(), json!(now));
+            stamp_doc_modified(doc, now);
+            Ok(())
+        })?,
+    }
 
     Ok(ToolOutcome {
         result: json!({"pageId": parsed.page_id, "ok": true}),
@@ -1502,6 +1524,47 @@ fn write_prose_page_live_or_json(
         Ok(())
     } else {
         mutate_with_retry(ctx, doc_id, json_fallback).map(|_| ())
+    }
+}
+
+/// Anchored, block-level prose write (JP-239): replace only the block(s) matching
+/// `anchor` with `html`. Mirrors [`write_prose_page_live_or_json`] — live to the
+/// resident Y.Doc fragment (minimal delta, broadcast so connected editors merge
+/// it), else apply the same block surgery on the page's JSON `content` under
+/// optimistic concurrency. The anchor is matched against authoritative state
+/// (the live fragment when resident; the JSON content when cold), so a stale
+/// anchor is refused with `ERR_ANCHOR_*` in both modes.
+fn write_prose_block_live_or_json(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    page_id: &str,
+    anchor: &str,
+    anchor_until: Option<&str>,
+    html: &str,
+) -> Result<(), String> {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
+        let framed = handle.replace_prose_block(page_id, anchor, anchor_until, html)?;
+        ctx.broadcast_update(doc_id, framed);
+        Ok(())
+    } else {
+        mutate_with_retry(ctx, doc_id, |doc| {
+            let now = now_ms();
+            let current = read_prose_content(doc, page_id)?;
+            let new_html =
+                crate::sync::replace_block_in_html(&current, anchor, anchor_until, html)?;
+            let rtp = rich_text_pages_mut(doc)?;
+            let page = rtp
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|pages| pages.get_mut(page_id))
+                .and_then(|p| p.as_object_mut())
+                .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
+            page.insert("content".into(), json!(new_html));
+            page.insert("modifiedAt".into(), json!(now));
+            stamp_doc_modified(doc, now);
+            Ok(())
+        })
+        .map(|_| ())
     }
 }
 

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -20,10 +20,15 @@
 mod binary;
 mod flatten;
 mod hydration;
+mod prose_block;
 mod prose_html;
 mod prose_parse;
 mod prose_schema;
 mod protocol;
+
+/// Apply an anchored, block-level prose edit to a page's HTML off the live path
+/// (the MCP cold path for a non-resident document). See [`prose_block`].
+pub use prose_block::replace_block_in_html;
 
 pub use hydration::active_page_shape_count;
 pub use protocol::{SyncError, SyncOutcome};
@@ -406,6 +411,30 @@ impl DocHandle {
         for node in &blocks {
             build_prose_node(&frag, &mut txn, node);
         }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        Ok(protocol::frame_update(update))
+    }
+
+    /// Anchored, block-level prose write (JP-239): replace only the top-level
+    /// block(s) matching `anchor` (through `anchor_until`, if given) with
+    /// `html`, in one transaction. Returns the framed CRDT delta to broadcast;
+    /// marks dirty. An `Err` (no match / ambiguous / bad range) leaves the live
+    /// fragment untouched — the delta touches only the changed blocks, so a
+    /// concurrent edit elsewhere on the page is preserved. See [`prose_block`].
+    pub fn replace_prose_block(
+        &self,
+        page_id: &str,
+        anchor: &str,
+        anchor_until: Option<&str>,
+        html: &str,
+    ) -> Result<Vec<u8>, String> {
+        let name = format!("prose:{page_id}");
+        let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        prose_block::replace_block_in_fragment(&frag, &mut txn, anchor, anchor_until, html)?;
         let update = txn.encode_state_as_update_v1(&before);
         drop(txn);
         self.dirty.store(true, Ordering::Relaxed);

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -1,0 +1,336 @@
+//! Anchored, block-level prose writes (JP-239 part 1).
+//!
+//! The whole-page replace ([`super::DocHandle::replace_prose`], JP-238) rebuilds
+//! the entire `prose:<page>` fragment. That's the right default, but a localized
+//! edit ("reword this paragraph") shouldn't touch the rest of the page — both to
+//! keep the CRDT delta minimal and to narrow the concurrency blast radius.
+//!
+//! The mechanism is a **block-level compare-and-swap**: the agent passes the
+//! current *text* of the block it intends to change (the `anchor`), and the relay
+//! replaces that block only if the anchor matches **exactly one** top-level block.
+//! If the block drifted (a concurrent edit changed its text), the anchor no
+//! longer matches and the write is refused — the anchor *is* the write
+//! confirmation. An optional `anchor_until` extends the target to the inclusive
+//! span of blocks from `anchor` through `anchor_until`.
+//!
+//! Matching is on **normalized plain text** (trim + collapse whitespace), so the
+//! anchor can be supplied as the block's text *or* as the HTML `get_prose`
+//! returned for it — tags are stripped to text either way. Marks/styling don't
+//! participate in matching.
+//!
+//! Both the live path ([`super::DocHandle::replace_prose_block`]) and the cold
+//! JSON path ([`replace_block_in_html`]) funnel through
+//! [`replace_block_in_fragment`], so they can't diverge: the cold path applies
+//! the exact same fragment surgery on a throwaway `Doc` and re-serializes via
+//! [`super::prose_html`].
+
+use yrs::{
+    Any, Doc, Out, ReadTxn, Text, Transact, TransactionMut, Xml, XmlElementPrelim, XmlFragment,
+    XmlOut,
+};
+
+use super::prose_parse::{self, PmChild, PmNode};
+use super::{build_prose_children, build_prose_node, prose_html};
+
+/// Replace the top-level block(s) matching `anchor` (through `anchor_until`, if
+/// given) with the blocks parsed from `new_html`, in a single transaction.
+///
+/// Anchor resolution happens before any mutation, so an `Err` (no match /
+/// ambiguous / bad range) leaves the fragment untouched. An edit that would empty
+/// the fragment re-seeds a single empty paragraph (the editor's "a page is never
+/// truly empty" invariant, matching [`super::DocHandle::replace_prose`]).
+pub fn replace_block_in_fragment<F: XmlFragment>(
+    frag: &F,
+    txn: &mut TransactionMut,
+    anchor: &str,
+    anchor_until: Option<&str>,
+    new_html: &str,
+) -> Result<(), String> {
+    // Snapshot each top-level block's normalized text up front (owned, so the
+    // read-borrow is released before we mutate below).
+    let block_texts: Vec<String> = {
+        let mut v = Vec::new();
+        for node in frag.children(&*txn) {
+            v.push(normalize(&xml_block_text(&node, &*txn)));
+        }
+        v
+    };
+
+    let start = resolve_anchor(&block_texts, anchor, "anchor")?;
+    let end = match anchor_until {
+        None => start,
+        Some(until) => {
+            let e = resolve_anchor(&block_texts, until, "anchorUntil")?;
+            if e < start {
+                return Err(
+                    "ERR_ANCHOR_RANGE: anchorUntil matches a block before anchor".into(),
+                );
+            }
+            e
+        }
+    };
+    let count = (end - start + 1) as u32;
+
+    let new_blocks = prose_parse::html_to_blocks(new_html);
+
+    frag.remove_range(txn, start as u32, count);
+    for (i, node) in new_blocks.iter().enumerate() {
+        build_prose_node_at(frag, txn, start as u32 + i as u32, node);
+    }
+    if frag.len(txn) == 0 {
+        build_prose_node(frag, txn, &empty_paragraph());
+    }
+    Ok(())
+}
+
+/// Apply [`replace_block_in_fragment`] to a page's HTML without a live `Doc`:
+/// build a throwaway fragment from `current_html`, run the same surgery, and
+/// re-serialize. Used by the MCP cold path (a non-resident document edits its
+/// JSON `richTextPages[*].content`).
+pub fn replace_block_in_html(
+    current_html: &str,
+    anchor: &str,
+    anchor_until: Option<&str>,
+    new_html: &str,
+) -> Result<String, String> {
+    let doc = Doc::new();
+    let frag = doc.get_or_insert_xml_fragment("prose:scratch");
+    {
+        let mut txn = doc.transact_mut();
+        for node in &prose_parse::html_to_blocks(current_html) {
+            build_prose_node(&frag, &mut txn, node);
+        }
+        replace_block_in_fragment(&frag, &mut txn, anchor, anchor_until, new_html)?;
+    }
+    let txn = doc.transact();
+    Ok(prose_html::fragment_to_html(&frag, &txn))
+}
+
+/// Find the single block whose normalized text equals the anchor's normalized
+/// text. `field` names the offending argument in the error.
+fn resolve_anchor(block_texts: &[String], raw: &str, field: &str) -> Result<usize, String> {
+    let needle = normalize(&anchor_to_text(raw));
+    if needle.is_empty() {
+        return Err(format!("ERR_ANCHOR_EMPTY: {field} has no text content"));
+    }
+    let hits: Vec<usize> = block_texts
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| t.as_str() == needle)
+        .map(|(i, _)| i)
+        .collect();
+    match hits.len() {
+        0 => Err(format!(
+            "ERR_ANCHOR_NOT_FOUND: no prose block matches {field}={raw:?} — its text may have \
+             changed, or you must pass the block's full text"
+        )),
+        1 => Ok(hits[0]),
+        n => Err(format!(
+            "ERR_ANCHOR_AMBIGUOUS: {n} prose blocks match {field}={raw:?} — include more of the \
+             block's text to identify exactly one"
+        )),
+    }
+}
+
+/// Insert one PM node (and subtree) at `index` among `parent`'s children. The
+/// positional analog of [`super::build_prose_node`] (which appends); children are
+/// still appended into the freshly-inserted element.
+fn build_prose_node_at<P: XmlFragment>(
+    parent: &P,
+    txn: &mut TransactionMut,
+    index: u32,
+    node: &PmNode,
+) {
+    let el = parent.insert(txn, index, XmlElementPrelim::empty(node.node_type.as_str()));
+    for (k, v) in &node.attrs {
+        el.insert_attribute(txn, k.as_str(), v.clone());
+    }
+    build_prose_children(&el, txn, &node.children);
+}
+
+/// Normalize text for anchor comparison: trim and collapse internal whitespace
+/// runs to a single space — so a write isn't foiled by re-wrapped HTML or
+/// markdown vs. editor whitespace.
+fn normalize(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Plain text of an anchor argument. The anchor may be raw text or an HTML block
+/// (what `get_prose` returns) — parse it leniently and flatten the text so either
+/// form matches.
+fn anchor_to_text(raw: &str) -> String {
+    let mut out = String::new();
+    for node in &prose_parse::html_to_blocks(raw) {
+        pm_node_text(node, &mut out);
+    }
+    out
+}
+
+fn pm_node_text(node: &PmNode, out: &mut String) {
+    for child in &node.children {
+        match child {
+            PmChild::Text { text, .. } => out.push_str(text),
+            PmChild::Node(n) => pm_node_text(n, out),
+        }
+    }
+}
+
+/// All descendant text of one top-level fragment block, concatenated.
+fn xml_block_text<T: ReadTxn>(node: &XmlOut, txn: &T) -> String {
+    let mut out = String::new();
+    collect_xml_text(node, txn, &mut out);
+    out
+}
+
+fn collect_xml_text<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String) {
+    match node {
+        XmlOut::Element(el) => {
+            for child in el.children(txn) {
+                collect_xml_text(&child, txn, out);
+            }
+        }
+        XmlOut::Text(t) => {
+            for run in t.diff(txn, |_| ()) {
+                if let Out::Any(Any::String(s)) = &run.insert {
+                    out.push_str(s);
+                }
+            }
+        }
+        XmlOut::Fragment(f) => {
+            for child in f.children(txn) {
+                collect_xml_text(&child, txn, out);
+            }
+        }
+    }
+}
+
+fn empty_paragraph() -> PmNode {
+    PmNode {
+        node_type: "paragraph".to_string(),
+        attrs: Vec::new(),
+        children: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fragment from HTML, apply a block replace, return the new HTML.
+    fn apply(current: &str, anchor: &str, until: Option<&str>, new: &str) -> Result<String, String> {
+        replace_block_in_html(current, anchor, until, new)
+    }
+
+    #[test]
+    fn replaces_single_matched_paragraph() {
+        let out = apply(
+            "<p>Intro.</p><p>Replace me.</p><p>Outro.</p>",
+            "Replace me.",
+            None,
+            "<p>Fresh text.</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>Intro.</p><p>Fresh text.</p><p>Outro.</p>");
+    }
+
+    #[test]
+    fn anchor_accepts_the_blocks_html() {
+        // Agent pastes back the HTML get_prose returned for the block.
+        let out = apply(
+            "<p>keep</p><p>old</p>",
+            "<p>old</p>",
+            None,
+            "<p>new</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>keep</p><p>new</p>");
+    }
+
+    #[test]
+    fn replacement_can_expand_to_multiple_blocks() {
+        let out = apply(
+            "<h1>Title</h1><p>stub</p>",
+            "stub",
+            None,
+            "<p>one</p><p>two</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<h1>Title</h1><p>one</p><p>two</p>");
+    }
+
+    #[test]
+    fn range_replaces_inclusive_span() {
+        let out = apply(
+            "<p>a</p><p>b</p><p>c</p><p>d</p>",
+            "b",
+            Some("c"),
+            "<p>merged</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>a</p><p>merged</p><p>d</p>");
+    }
+
+    #[test]
+    fn whitespace_is_normalized_for_matching() {
+        let out = apply(
+            "<p>hello   world</p>",
+            "hello world",
+            None,
+            "<p>done</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>done</p>");
+    }
+
+    #[test]
+    fn marks_dont_block_a_text_match() {
+        let out = apply(
+            "<p>see <strong>this</strong> now</p>",
+            "see this now",
+            None,
+            "<p>gone</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>gone</p>");
+    }
+
+    #[test]
+    fn not_found_is_an_error() {
+        let err = apply("<p>a</p>", "missing", None, "<p>x</p>").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_NOT_FOUND"), "{err}");
+    }
+
+    #[test]
+    fn ambiguous_is_an_error() {
+        let err = apply("<p>dup</p><p>dup</p>", "dup", None, "<p>x</p>").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_AMBIGUOUS"), "{err}");
+    }
+
+    #[test]
+    fn reversed_range_is_an_error() {
+        let err = apply("<p>a</p><p>b</p>", "b", Some("a"), "<p>x</p>").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_RANGE"), "{err}");
+    }
+
+    #[test]
+    fn emptying_the_page_reseeds_a_paragraph() {
+        // Replacing the only block with empty content leaves one empty paragraph.
+        let out = apply("<p>only</p>", "only", None, "").unwrap();
+        assert_eq!(out, "<p></p>");
+    }
+
+    #[test]
+    fn untouched_blocks_are_preserved_verbatim() {
+        let out = apply(
+            "<h2>Goals</h2><ul><li><p>one</p></li></ul><p>target</p>",
+            "target",
+            None,
+            "<p>replaced</p>",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "<h2>Goals</h2><ul><li><p>one</p></li></ul><p>replaced</p>"
+        );
+    }
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -21,7 +21,7 @@ use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::config::{TenancyConfig, TenancyMode};
 use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer};
 use docushark_relay::server::protocol::{
-    encode_message, DocId, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
+    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
     PROTOCOL_VERSION,
 };
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
@@ -811,6 +811,119 @@ async fn jp238_mcp_set_prose_reaches_connected_editor() {
     assert!(
         prose["pages"][0]["content"].as_str().unwrap_or("").contains("Agent wrote this"),
         "get_prose did not reflect the write: {prose}"
+    );
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+async fn mcp_set_prose_anchored(
+    mcp_base: &str,
+    token: &str,
+    doc_id: &str,
+    page_id: &str,
+    anchor: &str,
+    content: &str,
+) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.set_prose", "arguments": {
+            "docId": doc_id, "pageId": page_id, "content": content,
+            "format": "html", "anchor": anchor
+        }}
+    });
+    reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json")
+}
+
+/// JP-239: an anchored `set_prose` on a **resident** doc replaces only the block
+/// matching the anchor, leaving the other blocks untouched — and broadcasts the
+/// minimal delta so a connected editor merges just that change. A stale anchor is
+/// refused.
+#[tokio::test]
+async fn jp239_mcp_anchored_set_prose_replaces_only_matched_block() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-anchor", "name": "Anchor", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"name": "Page 1", "order": 0, "content": "<p></p>"}}
+            }
+        }),
+    )
+    .await;
+
+    // Editor joins → doc resident, then types two paragraphs into the live
+    // fragment so there's something to anchor against.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-anchor").await;
+    editor.send_sync(&local.insert_prose_paragraph("rt1", "First block")).await;
+    editor.send_sync(&local.insert_prose_paragraph("rt1", "Second block")).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Agent rewrites ONLY the first block, anchored by its text.
+    let res = mcp_set_prose_anchored(
+        &mcp_base,
+        &token,
+        "doc-anchor",
+        "rt1",
+        "First block",
+        "<p>Rewritten first</p>",
+    )
+    .await;
+    assert_eq!(res["result"]["structuredContent"]["ok"], true, "anchored set_prose failed: {res}");
+
+    // The editor receives the targeted delta; the matched block changed and the
+    // other block is preserved verbatim.
+    let mut ok = false;
+    for _ in 0..25 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        let s = local.prose_fragment_string("rt1");
+        if s.contains("Rewritten first") && s.contains("Second block") {
+            ok = true;
+            break;
+        }
+    }
+    let s = local.prose_fragment_string("rt1");
+    assert!(ok, "editor never got the anchored block replace: {s:?}");
+    assert!(!s.contains("First block"), "the old block text should be gone: {s:?}");
+
+    // A stale anchor (no such block) is refused with ERR_ANCHOR_NOT_FOUND.
+    let res = mcp_set_prose_anchored(
+        &mcp_base,
+        &token,
+        "doc-anchor",
+        "rt1",
+        "Nonexistent block",
+        "<p>nope</p>",
+    )
+    .await;
+    let text = res["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        res["result"]["isError"] == json!(true) && text.contains("ERR_ANCHOR_NOT_FOUND"),
+        "stale anchor should be refused: {res}"
     );
 
     mcp.stop().await.ok();


### PR DESCRIPTION
Part 1 of JP-239 — the **ranged/anchored** prose write. (The heavier whole-page PM-tree diff-merge stays as the follow-up; see Linear realign below.)

### What it does
`set_prose` gains an optional `anchor` (the current text of a block). With it, `content` replaces **only that block** — a targeted edit that leaves the rest of the page untouched. Without it, behavior is unchanged (whole-page replace, JP-238).

The anchor is a **block-level compare-and-swap**:
- Matched on **normalized plain text** (trim + collapse whitespace), so the agent can pass the block's text *or* the HTML `get_prose` returned for it; styling/marks are ignored.
- `0` matches → `ERR_ANCHOR_NOT_FOUND`, `≥2` → `ERR_ANCHOR_AMBIGUOUS`. So a **stale anchor** (content drifted since the agent read it) is refused rather than clobbering — the anchor *is* the write confirmation.
- Optional `anchorUntil` extends to the inclusive span of blocks.
- Minimal CRDT delta ⇒ a concurrent edit elsewhere on the page is preserved.

### Shape
- **`relay/src/sync/prose_block.rs`** (new) — `replace_block_in_fragment` (the shared surgery), `replace_block_in_html` (cold path: same surgery on a throwaway `Doc`, re-serialized via `prose_html` so live/cold can't diverge), `build_prose_node_at` (positional insert). 11 unit tests.
- **`DocHandle::replace_prose_block`** — live path, framed delta, one atomic txn (the anchor resolves *before* any mutation, so an error leaves the fragment untouched).
- **`tools.rs`** — `set_prose` routes to `write_prose_block_live_or_json`: resident → live fragment + broadcast; cold → block surgery on the JSON `content` under optimistic concurrency. Descriptor + README updated.

### Verification
- 11 `prose_block` unit tests (single/range/multi-block replacement, not-found, ambiguous, reversed-range, whitespace-normalize, marks-ignored, anchor-as-HTML, empty→reseed, untouched-blocks-preserved).
- Integration: anchored `set_prose` on a resident doc replaces only the matched block, the connected editor merges the minimal delta, the other block survives verbatim, and a stale anchor is refused.
- Full relay suite green (0 failures, no warnings), new code clippy-clean, OSS-leak grep clean.
- Also drops a stray unused `DocId` import left in `yjs_authority.rs` by the JP-235 merge.

Assisted-by: Opus 4.8