### PR TITLE
Deploy: JP-239 anchored prose writes to staging

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -97,7 +97,7 @@ All tools are namespaced `docushark.*`.
 | Tool | Purpose |
 | -- | -- |
 | `add_prose_page` | Append a prose page. Markdown by default. |
-| `set_prose` | Replace a prose page's entire body. Markdown by default. |
+| `set_prose` | Write a prose page. Replaces the whole body by default; pass `anchor` (the current text of a block) to replace **only that block** — a targeted edit. Markdown by default. |
 | `rename_prose_page` | Rename a prose page. |
 
 ### Structure (write)
@@ -133,6 +133,14 @@ reload):
   a connected editor live, and an MCP read reflects an editor's un-snapshotted
   prose. (A new `add_prose_page` page's *tab* may lag until the prose page list
   syncs; its content lands immediately.)
+- **Anchored prose edits** (`set_prose` with `anchor`) are the *targeted* path:
+  the block whose text matches the anchor is the only one rewritten, so the CRDT
+  delta touches just that block and a concurrent edit elsewhere on the page is
+  preserved. The anchor doubles as a **block-level compare-and-swap** — it must
+  match exactly one block (matched against the live fragment when resident, the
+  JSON content when cold), so a stale anchor is refused (`ERR_ANCHOR_*`) rather
+  than clobbering drifted content. (Full PM-tree diff-merge for *whole-page*
+  writes is future work.)
 
 **Cold docs (no client connected).** Writes persist through an
 **optimistic-concurrency check** on the document's `serverVersion`: read the

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -391,12 +391,15 @@ async fn run_serve(
 /// `DocEvent::Updated` so a running editor refreshes after an MCP write.
 /// (The real-time CRDT merge rides the separate `on_doc_update` sink; this is
 /// the coarse "something changed" nudge.)
-fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<dyn Fn(DocId) + Send + Sync> {
+fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<docushark_relay::mcp::DocChangedSink> {
     let server_for_mcp = server.clone();
-    Arc::new(move |doc_id: DocId| {
+    Arc::new(move |workspace: &WorkspaceId, doc_id: DocId| {
         let server = server_for_mcp.clone();
+        // JP-235: broadcast to the workspace that actually wrote (the request's
+        // authenticated workspace), not a hard-coded `single_tenant()` — so the
+        // reload nudge reaches the right editors on a multi-tenant public pod.
+        let ws = workspace.clone();
         tokio::spawn(async move {
-            let ws = WorkspaceId::single_tenant();
             server
                 .broadcast_doc_event(&ws, &doc_id, DocEventType::Updated, None)
                 .await;

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -26,10 +26,17 @@ use tokio::sync::RwLock;
 
 use crate::auth::OidcAuthState;
 use crate::server::documents::DocumentStore;
-use crate::server::protocol::DocId;
+use crate::server::protocol::{DocId, WorkspaceId};
 use crate::server::WorkspaceWriteLimiter;
 use crate::sync::DocRegistry;
 use tools::OnDocUpdate;
+
+/// The post-write "doc list changed" sink. Invoked after a successful MCP write
+/// with the **writing workspace** and the changed doc id, so the caller can
+/// broadcast a coarse `DocEvent::Updated` to exactly the clients in that
+/// workspace. Carrying the workspace (rather than assuming `single_tenant()`)
+/// is what makes the nudge correct on a multi-tenant public pod — JP-235.
+pub type DocChangedSink = dyn Fn(&WorkspaceId, DocId) + Send + Sync;
 use config::McpFeatureConfigStore;
 use local_mirror::LocalDocumentMirror;
 use token::TokenStore;
@@ -65,7 +72,7 @@ pub struct McpServer {
     doc_store: Arc<DocumentStore>,
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
-    on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    on_doc_changed: Arc<DocChangedSink>,
     /// Shared panic counter — same atomic as `ServerState.panic_count`
     /// so the WS `/metrics` endpoint reflects MCP-side panics too.
     /// Phase 21.2.
@@ -102,7 +109,7 @@ pub struct PublicMount {
     token: Arc<TokenStore>,
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
-    on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    on_doc_changed: Arc<DocChangedSink>,
 }
 
 /// The server-owned handles a [`PublicMount`] needs to build its router. The
@@ -127,7 +134,7 @@ impl PublicMount {
     /// successful write so the caller can broadcast a `DocEvent`.
     pub fn new(
         app_data_dir: PathBuf,
-        on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+        on_doc_changed: Arc<DocChangedSink>,
     ) -> Result<Self, String> {
         Ok(Self {
             token: Arc::new(TokenStore::load_or_create(&app_data_dir)?),
@@ -162,6 +169,12 @@ impl PublicMount {
             sync_registry: shared.sync_registry,
             on_doc_update: shared.on_doc_update,
             allow_static_token: false,
+            // A public pod never serves local (renderer-owned) documents: the
+            // local mirror is only ever populated by a desktop renderer, never
+            // on a headless relay, so this is belt-and-suspenders — but it keeps
+            // the catch-all `single_tenant` local layout unreachable over the
+            // network regardless of `feature_config`. JP-235.
+            allow_local: false,
         };
         transport::public_router(state)
     }
@@ -177,7 +190,7 @@ impl McpServer {
     #[allow(clippy::too_many_arguments)] // shared handles wired from main.rs
     pub fn new(
         app_data_dir: PathBuf,
-        on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+        on_doc_changed: Arc<DocChangedSink>,
         panic_counter: Arc<AtomicU64>,
         rate_limit_rejections: Arc<AtomicU64>,
         write_limiter: Arc<WorkspaceWriteLimiter>,
@@ -289,6 +302,9 @@ impl McpServer {
             on_doc_update: self.on_doc_update.clone(),
             // Loopback listener: the static token gates a single-tenant store.
             allow_static_token: true,
+            // Desktop / self-host: the local mirror is the whole point — it lets
+            // the renderer expose personal documents read-only to MCP. JP-235.
+            allow_local: true,
         };
         let app = transport::router(state);
 

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1397,6 +1397,15 @@ struct AddShapeArgs {
 /// every mutating tool enforces the same contract — see AGENTS.md "MCP
 /// Integration" for the rationale.
 fn reject_if_local(ctx: &ToolContext, doc_id: &DocId) -> Result<(), String> {
+    // The `local_enabled` short-circuit looks like it *weakens* the guard when
+    // local access is off (e.g. a public mount, JP-235) — it doesn't. The guard
+    // exists to stop a write from clobbering a renderer-owned doc that's mirrored
+    // read-only. That mirror is only ever populated by a desktop renderer, so on
+    // a headless/public pod `ctx.local.contains(...)` is always false and this
+    // was already a no-op. With the mirror unreadable, a "local" id simply isn't
+    // found in the team store and the write fails not-found — no local doc is
+    // ever read or mutated. Do not "simplify" by dropping the `local_enabled`
+    // term: on the loopback listener it's what makes the mirror reachable.
     if ctx.local_enabled
         && ctx.local.contains(&ctx.workspace_id, doc_id.as_str())
         && ctx.team.get_document(&ctx.workspace_id, doc_id).is_err()

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -163,14 +163,16 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.set_prose",
             description:
-                "Replace the entire content of a prose page. Content is Markdown by default (set format:\"html\" to pass HTML through). Refuses local (renderer-owned) documents.",
+                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "docId": {"type": "string"},
                     "pageId": {"type": "string"},
-                    "content": {"type": "string", "description": "New full body. Markdown unless format is \"html\"."},
-                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."}
+                    "content": {"type": "string", "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\"."},
+                    "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."},
+                    "anchor": {"type": "string", "description": "Optional. The current text of the block to replace (a targeted edit). Must match exactly one top-level block; whitespace is normalized and styling/marks are ignored. Omit to replace the whole page."},
+                    "anchorUntil": {"type": "string", "description": "Optional. With 'anchor', replace the inclusive span of blocks from 'anchor' through the block matching this text."}
                 },
                 "required": ["docId", "pageId", "content"],
                 "additionalProperties": false
@@ -907,6 +909,15 @@ struct SetProseArgs {
     page_id: String,
     content: String,
     format: Option<String>,
+    /// JP-239: when present, `content` replaces only the block matching this
+    /// text (a targeted edit) instead of the whole page. The block's current
+    /// text — the anchor doubles as a write-confirmation lock (must match
+    /// exactly one block).
+    anchor: Option<String>,
+    /// JP-239: with `anchor`, replace the inclusive span of blocks from `anchor`
+    /// through the block matching this text.
+    #[serde(rename = "anchorUntil")]
+    anchor_until: Option<String>,
 }
 
 fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
@@ -915,22 +926,33 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     reject_if_local(ctx, &parsed.doc_id)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
 
-    // JP-238: live to the Y.Doc fragment when resident (connected editors see it
-    // immediately), else JSON.
-    write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &html, |doc| {
-        let now = now_ms();
-        let rtp = rich_text_pages_mut(doc)?;
-        let page = rtp
-            .get_mut("pages")
-            .and_then(|v| v.as_object_mut())
-            .and_then(|pages| pages.get_mut(&parsed.page_id))
-            .and_then(|p| p.as_object_mut())
-            .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
-        page.insert("content".into(), json!(html));
-        page.insert("modifiedAt".into(), json!(now));
-        stamp_doc_modified(doc, now);
-        Ok(())
-    })?;
+    match &parsed.anchor {
+        // JP-239: anchored, block-level replace — only the matched block(s) change.
+        Some(anchor) => write_prose_block_live_or_json(
+            ctx,
+            &parsed.doc_id,
+            &parsed.page_id,
+            anchor,
+            parsed.anchor_until.as_deref(),
+            &html,
+        )?,
+        // JP-238: whole-page replace — live to the Y.Doc fragment when resident
+        // (connected editors see it immediately), else JSON.
+        None => write_prose_page_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &html, |doc| {
+            let now = now_ms();
+            let rtp = rich_text_pages_mut(doc)?;
+            let page = rtp
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|pages| pages.get_mut(&parsed.page_id))
+                .and_then(|p| p.as_object_mut())
+                .ok_or_else(|| format!("Prose page '{}' not found", parsed.page_id))?;
+            page.insert("content".into(), json!(html));
+            page.insert("modifiedAt".into(), json!(now));
+            stamp_doc_modified(doc, now);
+            Ok(())
+        })?,
+    }
 
     Ok(ToolOutcome {
         result: json!({"pageId": parsed.page_id, "ok": true}),
@@ -1502,6 +1524,47 @@ fn write_prose_page_live_or_json(
         Ok(())
     } else {
         mutate_with_retry(ctx, doc_id, json_fallback).map(|_| ())
+    }
+}
+
+/// Anchored, block-level prose write (JP-239): replace only the block(s) matching
+/// `anchor` with `html`. Mirrors [`write_prose_page_live_or_json`] — live to the
+/// resident Y.Doc fragment (minimal delta, broadcast so connected editors merge
+/// it), else apply the same block surgery on the page's JSON `content` under
+/// optimistic concurrency. The anchor is matched against authoritative state
+/// (the live fragment when resident; the JSON content when cold), so a stale
+/// anchor is refused with `ERR_ANCHOR_*` in both modes.
+fn write_prose_block_live_or_json(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    page_id: &str,
+    anchor: &str,
+    anchor_until: Option<&str>,
+    html: &str,
+) -> Result<(), String> {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
+        let framed = handle.replace_prose_block(page_id, anchor, anchor_until, html)?;
+        ctx.broadcast_update(doc_id, framed);
+        Ok(())
+    } else {
+        mutate_with_retry(ctx, doc_id, |doc| {
+            let now = now_ms();
+            let current = read_prose_content(doc, page_id)?;
+            let new_html =
+                crate::sync::replace_block_in_html(&current, anchor, anchor_until, html)?;
+            let rtp = rich_text_pages_mut(doc)?;
+            let page = rtp
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|pages| pages.get_mut(page_id))
+                .and_then(|p| p.as_object_mut())
+                .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
+            page.insert("content".into(), json!(new_html));
+            page.insert("modifiedAt".into(), json!(now));
+            stamp_doc_modified(doc, now);
+            Ok(())
+        })
+        .map(|_| ())
     }
 }
 

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -31,7 +31,7 @@ use serde_json::{json, Value};
 
 use crate::auth::OidcAuthState;
 use crate::server::documents::DocumentStore;
-use crate::server::protocol::{DocId, WorkspaceId};
+use crate::server::protocol::WorkspaceId;
 use crate::server::WorkspaceWriteLimiter;
 
 use super::config::McpFeatureConfigStore;
@@ -50,8 +50,10 @@ pub struct McpAppState {
     pub local_mirror: Arc<LocalDocumentMirror>,
     pub feature_config: Arc<McpFeatureConfigStore>,
     pub token: Arc<TokenStore>,
-    /// Called after a successful write so the running app can refresh.
-    pub on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync>,
+    /// Called after a successful write so the running app can refresh. Carries
+    /// the writing workspace so the coarse `DocEvent` reaches the right clients
+    /// on a multi-tenant public pod (JP-235).
+    pub on_doc_changed: Arc<super::DocChangedSink>,
     /// Shared with `ServerState.panic_count` so MCP tool panics
     /// surface at the WS `/metrics` counter. Phase 21.2.
     pub panic_counter: Arc<AtomicU64>,
@@ -86,6 +88,13 @@ pub struct McpAppState {
     /// `single_tenant` workspace — callers there present a JWT whose `wsp`
     /// claim scopes them to a real workspace.
     pub allow_static_token: bool,
+    /// Whether local (renderer-owned) documents are reachable via MCP. `true`
+    /// on the loopback listener (desktop / self-host, where the local mirror is
+    /// the point). `false` when folded onto the public surface (JP-235): a
+    /// headless public pod never populates the mirror, and its only local layout
+    /// would be the catch-all `single_tenant` one — so local access is forced off
+    /// for defense-in-depth, independent of `feature_config`.
+    pub allow_local: bool,
 }
 
 /// Build the Axum router for the MCP endpoint.
@@ -373,7 +382,9 @@ fn handle_tools_call(
     let ctx = ToolContext {
         team: &state.doc_store,
         local: &state.local_mirror,
-        local_enabled: state.feature_config.local_access_enabled(),
+        // JP-235: a public mount hard-disables local access (`allow_local =
+        // false`) regardless of the persisted feature flag.
+        local_enabled: state.allow_local && state.feature_config.local_access_enabled(),
         workspace_id: workspace.clone(),
         registry: &state.sync_registry,
         on_doc_update: state.on_doc_update.as_ref(),
@@ -437,7 +448,10 @@ fn handle_tools_call(
     match outcome {
         Ok(outcome) => {
             if let Some(doc_id) = outcome.changed_doc_id {
-                (state.on_doc_changed)(doc_id);
+                // JP-235: route the coarse reload nudge to the *writing*
+                // workspace (the request's authenticated workspace), not the
+                // hard-coded `single_tenant()` — correct on a public pod.
+                (state.on_doc_changed)(workspace, doc_id);
             }
             let text = serde_json::to_string_pretty(&outcome.result).unwrap_or_else(|_| "{}".into());
             Json(rpc_result(
@@ -511,7 +525,7 @@ mod tests {
             local_mirror: local,
             feature_config: cfg,
             token,
-            on_doc_changed: Arc::new(|_| {}),
+            on_doc_changed: Arc::new(|_, _| {}),
             panic_counter: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             write_limiter: Arc::new(crate::server::build_workspace_limiter(1000, 1000)),
@@ -520,6 +534,7 @@ mod tests {
             sync_registry: Arc::new(crate::sync::DocRegistry::new()),
             on_doc_update: Arc::new(|_, _, _| {}),
             allow_static_token: true,
+            allow_local: true,
         };
         (state, token_str)
     }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -20,10 +20,15 @@
 mod binary;
 mod flatten;
 mod hydration;
+mod prose_block;
 mod prose_html;
 mod prose_parse;
 mod prose_schema;
 mod protocol;
+
+/// Apply an anchored, block-level prose edit to a page's HTML off the live path
+/// (the MCP cold path for a non-resident document). See [`prose_block`].
+pub use prose_block::replace_block_in_html;
 
 pub use hydration::active_page_shape_count;
 pub use protocol::{SyncError, SyncOutcome};
@@ -406,6 +411,30 @@ impl DocHandle {
         for node in &blocks {
             build_prose_node(&frag, &mut txn, node);
         }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        Ok(protocol::frame_update(update))
+    }
+
+    /// Anchored, block-level prose write (JP-239): replace only the top-level
+    /// block(s) matching `anchor` (through `anchor_until`, if given) with
+    /// `html`, in one transaction. Returns the framed CRDT delta to broadcast;
+    /// marks dirty. An `Err` (no match / ambiguous / bad range) leaves the live
+    /// fragment untouched — the delta touches only the changed blocks, so a
+    /// concurrent edit elsewhere on the page is preserved. See [`prose_block`].
+    pub fn replace_prose_block(
+        &self,
+        page_id: &str,
+        anchor: &str,
+        anchor_until: Option<&str>,
+        html: &str,
+    ) -> Result<Vec<u8>, String> {
+        let name = format!("prose:{page_id}");
+        let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        prose_block::replace_block_in_fragment(&frag, &mut txn, anchor, anchor_until, html)?;
         let update = txn.encode_state_as_update_v1(&before);
         drop(txn);
         self.dirty.store(true, Ordering::Relaxed);

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -1,0 +1,336 @@
+//! Anchored, block-level prose writes (JP-239 part 1).
+//!
+//! The whole-page replace ([`super::DocHandle::replace_prose`], JP-238) rebuilds
+//! the entire `prose:<page>` fragment. That's the right default, but a localized
+//! edit ("reword this paragraph") shouldn't touch the rest of the page — both to
+//! keep the CRDT delta minimal and to narrow the concurrency blast radius.
+//!
+//! The mechanism is a **block-level compare-and-swap**: the agent passes the
+//! current *text* of the block it intends to change (the `anchor`), and the relay
+//! replaces that block only if the anchor matches **exactly one** top-level block.
+//! If the block drifted (a concurrent edit changed its text), the anchor no
+//! longer matches and the write is refused — the anchor *is* the write
+//! confirmation. An optional `anchor_until` extends the target to the inclusive
+//! span of blocks from `anchor` through `anchor_until`.
+//!
+//! Matching is on **normalized plain text** (trim + collapse whitespace), so the
+//! anchor can be supplied as the block's text *or* as the HTML `get_prose`
+//! returned for it — tags are stripped to text either way. Marks/styling don't
+//! participate in matching.
+//!
+//! Both the live path ([`super::DocHandle::replace_prose_block`]) and the cold
+//! JSON path ([`replace_block_in_html`]) funnel through
+//! [`replace_block_in_fragment`], so they can't diverge: the cold path applies
+//! the exact same fragment surgery on a throwaway `Doc` and re-serializes via
+//! [`super::prose_html`].
+
+use yrs::{
+    Any, Doc, Out, ReadTxn, Text, Transact, TransactionMut, Xml, XmlElementPrelim, XmlFragment,
+    XmlOut,
+};
+
+use super::prose_parse::{self, PmChild, PmNode};
+use super::{build_prose_children, build_prose_node, prose_html};
+
+/// Replace the top-level block(s) matching `anchor` (through `anchor_until`, if
+/// given) with the blocks parsed from `new_html`, in a single transaction.
+///
+/// Anchor resolution happens before any mutation, so an `Err` (no match /
+/// ambiguous / bad range) leaves the fragment untouched. An edit that would empty
+/// the fragment re-seeds a single empty paragraph (the editor's "a page is never
+/// truly empty" invariant, matching [`super::DocHandle::replace_prose`]).
+pub fn replace_block_in_fragment<F: XmlFragment>(
+    frag: &F,
+    txn: &mut TransactionMut,
+    anchor: &str,
+    anchor_until: Option<&str>,
+    new_html: &str,
+) -> Result<(), String> {
+    // Snapshot each top-level block's normalized text up front (owned, so the
+    // read-borrow is released before we mutate below).
+    let block_texts: Vec<String> = {
+        let mut v = Vec::new();
+        for node in frag.children(&*txn) {
+            v.push(normalize(&xml_block_text(&node, &*txn)));
+        }
+        v
+    };
+
+    let start = resolve_anchor(&block_texts, anchor, "anchor")?;
+    let end = match anchor_until {
+        None => start,
+        Some(until) => {
+            let e = resolve_anchor(&block_texts, until, "anchorUntil")?;
+            if e < start {
+                return Err(
+                    "ERR_ANCHOR_RANGE: anchorUntil matches a block before anchor".into(),
+                );
+            }
+            e
+        }
+    };
+    let count = (end - start + 1) as u32;
+
+    let new_blocks = prose_parse::html_to_blocks(new_html);
+
+    frag.remove_range(txn, start as u32, count);
+    for (i, node) in new_blocks.iter().enumerate() {
+        build_prose_node_at(frag, txn, start as u32 + i as u32, node);
+    }
+    if frag.len(txn) == 0 {
+        build_prose_node(frag, txn, &empty_paragraph());
+    }
+    Ok(())
+}
+
+/// Apply [`replace_block_in_fragment`] to a page's HTML without a live `Doc`:
+/// build a throwaway fragment from `current_html`, run the same surgery, and
+/// re-serialize. Used by the MCP cold path (a non-resident document edits its
+/// JSON `richTextPages[*].content`).
+pub fn replace_block_in_html(
+    current_html: &str,
+    anchor: &str,
+    anchor_until: Option<&str>,
+    new_html: &str,
+) -> Result<String, String> {
+    let doc = Doc::new();
+    let frag = doc.get_or_insert_xml_fragment("prose:scratch");
+    {
+        let mut txn = doc.transact_mut();
+        for node in &prose_parse::html_to_blocks(current_html) {
+            build_prose_node(&frag, &mut txn, node);
+        }
+        replace_block_in_fragment(&frag, &mut txn, anchor, anchor_until, new_html)?;
+    }
+    let txn = doc.transact();
+    Ok(prose_html::fragment_to_html(&frag, &txn))
+}
+
+/// Find the single block whose normalized text equals the anchor's normalized
+/// text. `field` names the offending argument in the error.
+fn resolve_anchor(block_texts: &[String], raw: &str, field: &str) -> Result<usize, String> {
+    let needle = normalize(&anchor_to_text(raw));
+    if needle.is_empty() {
+        return Err(format!("ERR_ANCHOR_EMPTY: {field} has no text content"));
+    }
+    let hits: Vec<usize> = block_texts
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| t.as_str() == needle)
+        .map(|(i, _)| i)
+        .collect();
+    match hits.len() {
+        0 => Err(format!(
+            "ERR_ANCHOR_NOT_FOUND: no prose block matches {field}={raw:?} — its text may have \
+             changed, or you must pass the block's full text"
+        )),
+        1 => Ok(hits[0]),
+        n => Err(format!(
+            "ERR_ANCHOR_AMBIGUOUS: {n} prose blocks match {field}={raw:?} — include more of the \
+             block's text to identify exactly one"
+        )),
+    }
+}
+
+/// Insert one PM node (and subtree) at `index` among `parent`'s children. The
+/// positional analog of [`super::build_prose_node`] (which appends); children are
+/// still appended into the freshly-inserted element.
+fn build_prose_node_at<P: XmlFragment>(
+    parent: &P,
+    txn: &mut TransactionMut,
+    index: u32,
+    node: &PmNode,
+) {
+    let el = parent.insert(txn, index, XmlElementPrelim::empty(node.node_type.as_str()));
+    for (k, v) in &node.attrs {
+        el.insert_attribute(txn, k.as_str(), v.clone());
+    }
+    build_prose_children(&el, txn, &node.children);
+}
+
+/// Normalize text for anchor comparison: trim and collapse internal whitespace
+/// runs to a single space — so a write isn't foiled by re-wrapped HTML or
+/// markdown vs. editor whitespace.
+fn normalize(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Plain text of an anchor argument. The anchor may be raw text or an HTML block
+/// (what `get_prose` returns) — parse it leniently and flatten the text so either
+/// form matches.
+fn anchor_to_text(raw: &str) -> String {
+    let mut out = String::new();
+    for node in &prose_parse::html_to_blocks(raw) {
+        pm_node_text(node, &mut out);
+    }
+    out
+}
+
+fn pm_node_text(node: &PmNode, out: &mut String) {
+    for child in &node.children {
+        match child {
+            PmChild::Text { text, .. } => out.push_str(text),
+            PmChild::Node(n) => pm_node_text(n, out),
+        }
+    }
+}
+
+/// All descendant text of one top-level fragment block, concatenated.
+fn xml_block_text<T: ReadTxn>(node: &XmlOut, txn: &T) -> String {
+    let mut out = String::new();
+    collect_xml_text(node, txn, &mut out);
+    out
+}
+
+fn collect_xml_text<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String) {
+    match node {
+        XmlOut::Element(el) => {
+            for child in el.children(txn) {
+                collect_xml_text(&child, txn, out);
+            }
+        }
+        XmlOut::Text(t) => {
+            for run in t.diff(txn, |_| ()) {
+                if let Out::Any(Any::String(s)) = &run.insert {
+                    out.push_str(s);
+                }
+            }
+        }
+        XmlOut::Fragment(f) => {
+            for child in f.children(txn) {
+                collect_xml_text(&child, txn, out);
+            }
+        }
+    }
+}
+
+fn empty_paragraph() -> PmNode {
+    PmNode {
+        node_type: "paragraph".to_string(),
+        attrs: Vec::new(),
+        children: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fragment from HTML, apply a block replace, return the new HTML.
+    fn apply(current: &str, anchor: &str, until: Option<&str>, new: &str) -> Result<String, String> {
+        replace_block_in_html(current, anchor, until, new)
+    }
+
+    #[test]
+    fn replaces_single_matched_paragraph() {
+        let out = apply(
+            "<p>Intro.</p><p>Replace me.</p><p>Outro.</p>",
+            "Replace me.",
+            None,
+            "<p>Fresh text.</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>Intro.</p><p>Fresh text.</p><p>Outro.</p>");
+    }
+
+    #[test]
+    fn anchor_accepts_the_blocks_html() {
+        // Agent pastes back the HTML get_prose returned for the block.
+        let out = apply(
+            "<p>keep</p><p>old</p>",
+            "<p>old</p>",
+            None,
+            "<p>new</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>keep</p><p>new</p>");
+    }
+
+    #[test]
+    fn replacement_can_expand_to_multiple_blocks() {
+        let out = apply(
+            "<h1>Title</h1><p>stub</p>",
+            "stub",
+            None,
+            "<p>one</p><p>two</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<h1>Title</h1><p>one</p><p>two</p>");
+    }
+
+    #[test]
+    fn range_replaces_inclusive_span() {
+        let out = apply(
+            "<p>a</p><p>b</p><p>c</p><p>d</p>",
+            "b",
+            Some("c"),
+            "<p>merged</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>a</p><p>merged</p><p>d</p>");
+    }
+
+    #[test]
+    fn whitespace_is_normalized_for_matching() {
+        let out = apply(
+            "<p>hello   world</p>",
+            "hello world",
+            None,
+            "<p>done</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>done</p>");
+    }
+
+    #[test]
+    fn marks_dont_block_a_text_match() {
+        let out = apply(
+            "<p>see <strong>this</strong> now</p>",
+            "see this now",
+            None,
+            "<p>gone</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>gone</p>");
+    }
+
+    #[test]
+    fn not_found_is_an_error() {
+        let err = apply("<p>a</p>", "missing", None, "<p>x</p>").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_NOT_FOUND"), "{err}");
+    }
+
+    #[test]
+    fn ambiguous_is_an_error() {
+        let err = apply("<p>dup</p><p>dup</p>", "dup", None, "<p>x</p>").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_AMBIGUOUS"), "{err}");
+    }
+
+    #[test]
+    fn reversed_range_is_an_error() {
+        let err = apply("<p>a</p><p>b</p>", "b", Some("a"), "<p>x</p>").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_RANGE"), "{err}");
+    }
+
+    #[test]
+    fn emptying_the_page_reseeds_a_paragraph() {
+        // Replacing the only block with empty content leaves one empty paragraph.
+        let out = apply("<p>only</p>", "only", None, "").unwrap();
+        assert_eq!(out, "<p></p>");
+    }
+
+    #[test]
+    fn untouched_blocks_are_preserved_verbatim() {
+        let out = apply(
+            "<h2>Goals</h2><ul><li><p>one</p></li></ul><p>target</p>",
+            "target",
+            None,
+            "<p>replaced</p>",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "<h2>Goals</h2><ul><li><p>one</p></li></ul><p>replaced</p>"
+        );
+    }
+}

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -136,7 +136,7 @@ impl Harness {
         let panic_counter = self.server.panic_counter_handle();
         let rate_limit_rejections = self.server.rate_limit_rejections_handle();
         let write_limiter = self.server.build_write_limiter().await;
-        let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+        let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
         // This harness deliberately hands MCP a *standalone* Y.Doc registry +
         // noop broadcaster (not the server's): a separate registry never resolves
         // a live handle, so MCP writes take the JSON path, which already enforces

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -47,7 +47,7 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
         .get_doc_store()
         .await
         .expect("doc store available after start");
-    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
     let on_doc_update: Arc<dyn Fn(&WorkspaceId, &DocId, Vec<u8>) + Send + Sync> =
         Arc::new(|_, _, _| {});
     let mcp = Arc::new(

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -5,11 +5,11 @@
 //! the public-pod hardening that the static token is refused (a `wsp`-scoped
 //! JWT is required).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::mcp::PublicMount;
-use docushark_relay::server::protocol::DocId;
+use docushark_relay::server::protocol::WorkspaceId;
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
 use docushark_relay::test_support::OidcTestIssuer;
 use serde_json::json;
@@ -32,7 +32,15 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         .expect("set_config");
 
     // JP-210: fold MCP onto the public listener before start().
-    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    // JP-235: capture the workspace the coarse reload nudge is routed to, so we
+    // can assert a write authenticated as `ws-public` broadcasts to *that*
+    // workspace and not the hard-coded `single_tenant()`.
+    let routed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let routed_sink = routed.clone();
+    let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> =
+        Arc::new(move |ws: &WorkspaceId, _doc| {
+            routed_sink.lock().unwrap().push(ws.as_str().to_string());
+        });
     let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed).expect("mount");
     let static_token = mount.token();
     server.set_mcp_public_mount(mount).await;
@@ -108,6 +116,44 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         .filter_map(|t| t["name"].as_str())
         .collect();
     assert!(names.contains(&"docushark.create_document"), "{names:?}");
+
+    // JP-235 (1): a write authenticated as `ws-public` routes the coarse reload
+    // nudge to *that* workspace, not the catch-all `single_tenant()`.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "docushark.create_document", "arguments": {"name": "JP-235"}}
+        }))
+        .send()
+        .await
+        .expect("create_document post");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        routed.lock().unwrap().as_slice(),
+        ["ws-public"],
+        "the doc-changed nudge must broadcast to the writing workspace"
+    );
+
+    // JP-235 (2): a public mount forces local access off — `list_documents`
+    // reports it disabled regardless of the persisted feature flag (default on).
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "docushark.list_documents", "arguments": {}}
+        }))
+        .send()
+        .await
+        .expect("list_documents post");
+    let body: serde_json::Value = resp.json().await.expect("list json");
+    assert_eq!(
+        body["result"]["structuredContent"]["localAccessEnabled"],
+        json!(false),
+        "public mount must hard-disable local access: {body}"
+    );
 
     // The sync/REST surface still answers on the same listener.
     let health = client

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -50,7 +50,7 @@ impl Harness {
         let panic_counter = server.panic_counter_handle();
         let rate_limit_rejections = server.rate_limit_rejections_handle();
         let write_limiter = server.build_write_limiter().await;
-        let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+        let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
 
         // Start the server first so MCP can share its single `DocumentStore`
         // (JP-230). The write limiter is already built + cached above, so this

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -21,7 +21,7 @@ use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::config::{TenancyConfig, TenancyMode};
 use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer};
 use docushark_relay::server::protocol::{
-    encode_message, DocId, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
+    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
     PROTOCOL_VERSION,
 };
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
@@ -811,6 +811,119 @@ async fn jp238_mcp_set_prose_reaches_connected_editor() {
     assert!(
         prose["pages"][0]["content"].as_str().unwrap_or("").contains("Agent wrote this"),
         "get_prose did not reflect the write: {prose}"
+    );
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+async fn mcp_set_prose_anchored(
+    mcp_base: &str,
+    token: &str,
+    doc_id: &str,
+    page_id: &str,
+    anchor: &str,
+    content: &str,
+) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.set_prose", "arguments": {
+            "docId": doc_id, "pageId": page_id, "content": content,
+            "format": "html", "anchor": anchor
+        }}
+    });
+    reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json")
+}
+
+/// JP-239: an anchored `set_prose` on a **resident** doc replaces only the block
+/// matching the anchor, leaving the other blocks untouched — and broadcasts the
+/// minimal delta so a connected editor merges just that change. A stale anchor is
+/// refused.
+#[tokio::test]
+async fn jp239_mcp_anchored_set_prose_replaces_only_matched_block() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-anchor", "name": "Anchor", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"name": "Page 1", "order": 0, "content": "<p></p>"}}
+            }
+        }),
+    )
+    .await;
+
+    // Editor joins → doc resident, then types two paragraphs into the live
+    // fragment so there's something to anchor against.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-anchor").await;
+    editor.send_sync(&local.insert_prose_paragraph("rt1", "First block")).await;
+    editor.send_sync(&local.insert_prose_paragraph("rt1", "Second block")).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Agent rewrites ONLY the first block, anchored by its text.
+    let res = mcp_set_prose_anchored(
+        &mcp_base,
+        &token,
+        "doc-anchor",
+        "rt1",
+        "First block",
+        "<p>Rewritten first</p>",
+    )
+    .await;
+    assert_eq!(res["result"]["structuredContent"]["ok"], true, "anchored set_prose failed: {res}");
+
+    // The editor receives the targeted delta; the matched block changed and the
+    // other block is preserved verbatim.
+    let mut ok = false;
+    for _ in 0..25 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        let s = local.prose_fragment_string("rt1");
+        if s.contains("Rewritten first") && s.contains("Second block") {
+            ok = true;
+            break;
+        }
+    }
+    let s = local.prose_fragment_string("rt1");
+    assert!(ok, "editor never got the anchored block replace: {s:?}");
+    assert!(!s.contains("First block"), "the old block text should be gone: {s:?}");
+
+    // A stale anchor (no such block) is refused with ERR_ANCHOR_NOT_FOUND.
+    let res = mcp_set_prose_anchored(
+        &mcp_base,
+        &token,
+        "doc-anchor",
+        "rt1",
+        "Nonexistent block",
+        "<p>nope</p>",
+    )
+    .await;
+    let text = res["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        res["result"]["isError"] == json!(true) && text.contains("ERR_ANCHOR_NOT_FOUND"),
+        "stale anchor should be refused: {res}"
     );
 
     mcp.stop().await.ok();

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -600,7 +600,7 @@ async fn snapshot_skips_when_active_page_diverged() {
 /// broadcast channel as the running relay — the exact wiring `main.rs` does
 /// post-`start()`. Returns the server handle + its `http://host:port` base.
 async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
-    let on_doc_changed: Arc<dyn Fn(DocId) + Send + Sync> = Arc::new(|_| {});
+    let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
     let panic_counter = relay.server.panic_counter_handle();
     let rate_limit_rejections = relay.server.rate_limit_rejections_handle();
     let write_limiter = relay.server.build_write_limiter().await;


### PR DESCRIPTION
Promote master → staging to deploy JP-239 part 1 (PR #107): anchored/block-level MCP prose writes (`set_prose` `anchor`/`anchorUntil`).

Rebuilds the `:edge` relay image; `dsk-relay-staging-yyz` redeployed for a live anchored-edit check on the scratch doc.

Assisted-by: Opus 4.8