### PR TITLE
JP-243: seed live prose fragments from richTextPages on JSON hydration

### DIFF
--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -99,8 +99,10 @@ fn metadata_title_and_updated(meta_any: &Any) -> (Option<String>, Option<u64>) {
 /// projection only**: it overlays each live page's `content` (creating the
 /// `richTextPages` structure + a default entry for a live-only page) and
 /// preserves any existing `name`/`order` (that metadata isn't CRDT-synced).
-/// Hydration never reads `richTextPages`, so this never re-seeds the Y.Doc;
-/// prose *restore* stays binary-sidecar based, preserving CRDT identity.
+/// This write projection pairs with [`super::hydration::json_prose_to_ydoc`],
+/// which seeds the Y.Doc *from* `richTextPages` on a JSON rebuild — so prose
+/// survives a full evict/rehydrate cycle even without a binary sidecar (the
+/// sidecar is still preferred when present, preserving CRDT identity).
 ///
 /// No-op when there's no live prose, so a shape-only flatten leaves any
 /// existing (e.g. MCP-authored) `richTextPages` untouched.

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -64,6 +64,70 @@ pub fn json_to_ydoc(doc_json: &Value, doc: &Doc) {
     }
 }
 
+/// Seed the live `prose:<id>` `Y.XmlFragment`s from a persisted document's
+/// `richTextPages[*].content` HTML (JP-239 follow-up).
+///
+/// [`json_to_ydoc`] hydrates only the shape surface — prose lives in its own
+/// per-page fragments. A document whose prose exists **only in JSON** (e.g. one
+/// an MCP agent authored cold and never opened in an editor) therefore hydrated
+/// with empty fragments, and a joining editor — which trusts the relay's
+/// authoritative `Y.Doc` (JP-34) — rendered blank even though `richTextPages`
+/// held the text. Seeding here folds that cold-authored prose into the
+/// authoritative state the editor syncs on join.
+///
+/// **Only the JSON-rebuild hydration path calls this.** When a binary sidecar is
+/// used it already carries authoritative prose (with CRDT identity preserved), so
+/// double-seeding would duplicate content. The relay is the single hydrator
+/// (JP-34), so the fresh CRDT identity minted here can't diverge across seeders;
+/// the next snapshot writes a binary sidecar that becomes authoritative
+/// thereafter. Uses the same HTML→PM builder as the MCP prose write (JP-238), so
+/// the seeded fragment matches what a `set_prose` would have produced.
+pub fn json_prose_to_ydoc(doc_json: &Value, doc: &Doc) {
+    let Some(pages) = doc_json
+        .get("richTextPages")
+        .and_then(|r| r.get("pages"))
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    for (id, page) in pages {
+        let content = page.get("content").and_then(Value::as_str).unwrap_or("");
+        if content.trim().is_empty() {
+            continue;
+        }
+        let blocks = super::prose_parse::html_to_blocks(content);
+        // An "empty" page serializes to the placeholder `<p></p>` (the editor's
+        // never-truly-empty invariant). Seeding that would leave a spurious empty
+        // paragraph that the editor's first real edit then appends after — an
+        // empty page must hydrate to an **empty fragment**, matching what a live
+        // editor holds. So skip content with no text and no embeds.
+        if !blocks.iter().any(block_has_substance) {
+            continue;
+        }
+        // Grab the fragment handle before opening the txn (`get_or_insert_*`
+        // transacts; nesting deadlocks).
+        let frag = doc.get_or_insert_xml_fragment(format!("prose:{id}").as_str());
+        let mut txn = doc.transact_mut();
+        for node in &blocks {
+            super::build_prose_node(&frag, &mut txn, node);
+        }
+    }
+}
+
+/// Whether a parsed prose block carries real content — any non-whitespace text,
+/// or an embed (image / horizontal rule). A bare/empty paragraph (the empty-page
+/// placeholder) has none, so it isn't seeded.
+fn block_has_substance(node: &super::prose_parse::PmNode) -> bool {
+    use super::prose_parse::PmChild;
+    if matches!(node.node_type.as_str(), "image" | "horizontalRule") {
+        return true;
+    }
+    node.children.iter().any(|child| match child {
+        PmChild::Text { text, .. } => !text.trim().is_empty(),
+        PmChild::Node(inner) => block_has_substance(inner),
+    })
+}
+
 /// Count the shapes on a persisted document's **active page** — the same flat
 /// surface [`json_to_ydoc`] hydrates into the `shapes` map, so it's directly
 /// comparable with a `Y.Doc`'s `shapes.len()` (JP-180 poison detection).
@@ -195,6 +259,53 @@ mod tests {
         let txn = doc.transact();
         assert_eq!(shapes.len(&txn), 0);
         assert_eq!(order.len(&txn), 0);
+    }
+
+    #[test]
+    fn json_prose_to_ydoc_seeds_fragments_from_richtextpages() {
+        use yrs::XmlFragment;
+        let doc = Doc::new();
+        super::json_prose_to_ydoc(
+            &json!({
+                "id": "d",
+                "richTextPages": {
+                    "pageOrder": ["rt1", "rt2", "rt3"],
+                    "pages": {
+                        "rt1": {"content": "<p>hello</p><p>world</p>"},
+                        "rt2": {"content": ""},
+                        "rt3": {"content": "<p></p>"}
+                    }
+                }
+            }),
+            &doc,
+        );
+        let f1 = doc.get_or_insert_xml_fragment("prose:rt1");
+        let f2 = doc.get_or_insert_xml_fragment("prose:rt2");
+        let f3 = doc.get_or_insert_xml_fragment("prose:rt3");
+        let txn = doc.transact();
+        // Seeded fragment round-trips to the source HTML via the read serializer.
+        assert_eq!(
+            super::super::prose_html::fragment_to_html(&f1, &txn),
+            "<p>hello</p><p>world</p>"
+        );
+        // Empty content is not seeded (no spurious empty fragment).
+        assert_eq!(f2.len(&txn), 0);
+        // The empty-page placeholder `<p></p>` is not seeded either — an empty
+        // page must hydrate to an empty fragment, not a stray paragraph.
+        assert_eq!(f3.len(&txn), 0);
+    }
+
+    #[test]
+    fn json_prose_to_ydoc_noop_without_richtextpages() {
+        use yrs::ReadTxn;
+        let doc = Doc::new();
+        super::json_prose_to_ydoc(&json!({"id": "d", "name": "x"}), &doc);
+        // No prose roots created.
+        let txn = doc.transact();
+        assert_eq!(
+            txn.root_refs().filter(|(n, _)| n.starts_with("prose:")).count(),
+            0
+        );
     }
 
     #[test]

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -190,6 +190,11 @@ impl DocHandle {
         }
         let doc = Doc::new();
         hydration::json_to_ydoc(doc_json, &doc);
+        // JP-239 follow-up: the binary sidecar (above) carries prose with CRDT
+        // identity; the JSON rebuild doesn't, so seed the live prose fragments
+        // from `richTextPages` here. Without this, cold-authored prose (MCP, never
+        // opened in an editor) hydrates empty and a joining editor renders blank.
+        hydration::json_prose_to_ydoc(doc_json, &doc);
         (doc, poison_healed)
     }
 

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -17,9 +17,12 @@
 //! (wrapper dropped, text preserved); unknown marks pass through unwrapped — so
 //! schema drift never drops content, it only loses styling on the unmapped bit.
 //!
-//! This is a **read projection only** (MCP reads + the JSON flatten, JP-36).
-//! There is no inverse (HTML → fragment): prose restore stays binary-sidecar
-//! based, preserving CRDT identity.
+//! This is the **read** direction (MCP reads + the JSON flatten, JP-36). The
+//! inverse (HTML → fragment) lives in [`super::prose_parse`] + the builder in
+//! [`super`]: it backs MCP prose writes (JP-238) and seeding the live fragments
+//! from `richTextPages` on a JSON rebuild ([`super::hydration::json_prose_to_ydoc`]).
+//! A binary sidecar is still preferred on rehydrate when present, preserving CRDT
+//! identity; the HTML round-trip is the fallback when there's no sidecar.
 
 use std::fmt::Write as _;
 

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -930,6 +930,61 @@ async fn jp239_mcp_anchored_set_prose_replaces_only_matched_block() {
     relay.server.stop().await.expect("stop");
 }
 
+/// JP-239 follow-up: prose that exists only in a doc's JSON `richTextPages`
+/// (authored cold via MCP, never opened in an editor) is seeded into the live
+/// `prose:` fragment on hydration — so a joining editor receives it via the
+/// authoritative SyncStep1 instead of rendering blank.
+#[tokio::test]
+async fn jp239_cold_authored_prose_seeds_into_joining_editor() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    // A doc whose prose lives only in JSON — no live session ever ran, so there
+    // is no binary sidecar; hydration must rebuild from JSON.
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "cold-prose", "name": "Cold", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"id": "rt1", "name": "Page 1", "order": 0,
+                    "content": "<p>Authored by an agent, never opened.</p>"}}
+            }
+        }),
+    )
+    .await;
+
+    // Editor joins → relay hydrates from JSON (no sidecar) and seeds the prose.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "cold-prose").await;
+
+    let mut seen = local.prose_fragment_string("rt1").contains("Authored by an agent");
+    for _ in 0..15 {
+        if seen {
+            break;
+        }
+        if let Some((ty, bytes)) = editor.recv_within(150).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        seen = local.prose_fragment_string("rt1").contains("Authored by an agent");
+    }
+    assert!(
+        seen,
+        "cold-authored JSON prose should hydrate into the live fragment and reach \
+         the joining editor: {:?}",
+        local.prose_fragment_string("rt1")
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
 /// JP-201 Slice 3: the snapshot flatten projects live prose into the JSON
 /// `richTextPages`, so a cold reader (REST / non-resident MCP) sees prose the
 /// shape-only flatten never wrote — without re-seeding the Y.Doc (restore stays


### PR DESCRIPTION
Fixes the bug found during JP-239 live testing: an MCP agent creates a doc and writes prose to it **cold** (no editor connected), then opening it in the editor shows **blank prose** — even though `get_prose` and the JSON `richTextPages` hold the text.

### Root cause
`hydration::json_to_ydoc` hydrates only the shape surface (`shapes`/`shapeOrder`/`metadata`) — never prose. A cold-authored doc has **no binary sidecar**, so it rebuilds from JSON with empty `prose:<id>` fragments. A joining editor trusts the relay's authoritative `Y.Doc` (JP-34) and renders the empty fragments; the JSON prose is stranded as a read-only projection.

### Fix (relay-side)
New `hydration::json_prose_to_ydoc` seeds the live `prose:<id>` fragments from `richTextPages[*].content` on the **JSON-rebuild hydration path only**:
- The binary sidecar already carries authoritative prose (CRDT identity preserved) → never double-seeded.
- The relay is the sole hydrator (JP-34) → the fresh CRDT identity can't diverge across seeders; the next snapshot writes a sidecar that's authoritative thereafter.
- Reuses the JP-238 HTML→PM builder, so a seeded fragment matches what `set_prose` would produce.
- **Skips the empty-page placeholder** (`<p></p>`): an empty page must hydrate to an empty fragment, matching a live editor (otherwise the editor's first edit appends after a stray paragraph — caught by the JP-201 tests).
- The staleness gate already routes a *cold-write-after-sidecar* through the JSON rebuild, so that case is covered too.

### Not a data-loss bug
The symptom looked scary, but `prose_pages()` skips empty fragments, so the JP-201 flatten never overwrites JSON prose with an empty live fragment. Confirmed.

### Known narrow limitation (acceptable, pre-GA)
A doc opened *before* this fix that had JSON-only prose, nobody touched prose, then evicted — would have a *current* empty-prose sidecar that wins over JSON on rehydrate. The fix prevents this forming for any new doc; only that pre-existing sequence is unaffected.

### Verification
- Unit: `json_prose_to_ydoc` seeds real content (round-trips via `prose_html`), skips empty + `<p></p>` placeholder; no-op without `richTextPages`.
- Integration: cold-authored JSON prose hydrates into the live fragment and reaches a joining editor via SyncStep1.
- Full relay suite green (0 failures, no warnings), new code clippy-clean, leak grep clean.
- Refreshes the now-stale "hydration never reads richTextPages" notes in `flatten.rs` + `prose_html.rs`.

Assisted-by: Opus 4.8