### PR TITLE
ci: rename relay-image workflow to 'Relay Image Build & Gated Publish'

### DIFF
--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -1,4 +1,4 @@
-name: Relay image
+name: Relay Image Build & Gated Publish
 
 # Internal/testing channel for the relay container image. Pushes to `staging`
 # build + publish to GHCR (`:edge` tracks `staging`, plus `:sha-<short>`) — this


### PR DESCRIPTION
Renames the `relay-image.yml` workflow from `Relay image` to **`Relay Image Build & Gated Publish`**.

The workflow builds the relay container image on both triggers, but only *publishes* (`:edge` → GHCR) on `staging` pushes; `master` PRs get a build-check with no publish. The new name reflects both halves — the build and the staging-gated publish — instead of the terse, ambiguous old name.

No behavior change; `name:` only.

Assisted-by: Opus 4.8