### PR TITLE
JP-248: prose-pipeline DoS hardening — depth caps + content-size limit

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -167,6 +167,11 @@ current.
 - **Prose is HTML.** Markdown in is rendered (GFM tables / strikethrough /
   task-lists on); HTML pass-through is re-parsed by the editor against its
   schema on load, which drops anything unmodelled.
+- **Prose write limits.** A single prose write's content is capped at **~1 MiB**
+  (`set_prose`/`add_prose_page`/`insert_section`; over it → `ERR_PROSE_TOO_LARGE`,
+  advertised as `maxLength`). Nesting deeper than **64** levels is truncated
+  (real prose nests <~10) — a safety bound so pathological input can't exhaust
+  the server.
 - **Outlines are flat.** A section is a heading plus the content up to the
   next heading; nesting is conveyed by `level`, not containment. `move` moves a
   single section, not its descendants.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -172,7 +172,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "properties": {
                     "docId": {"type": "string"},
                     "name": {"type": "string", "description": "Page title. Defaults to \"Page N\"."},
-                    "content": {"type": "string", "description": "Initial body. Markdown unless format is \"html\". Optional (blank page if omitted)."},
+                    "content": {"type": "string", "maxLength": MAX_PROSE_CONTENT_BYTES, "description": "Initial body. Markdown unless format is \"html\". Optional (blank page if omitted). Capped at ~1 MiB."},
                     "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."}
                 },
                 "required": ["docId"],
@@ -188,7 +188,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "properties": {
                     "docId": {"type": "string"},
                     "pageId": {"type": "string"},
-                    "content": {"type": "string", "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\"."},
+                    "content": {"type": "string", "maxLength": MAX_PROSE_CONTENT_BYTES, "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\". Capped at ~1 MiB."},
                     "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."},
                     "anchor": {"type": "string", "description": "Optional. The current text of the block to replace (a targeted edit). Must match exactly one top-level block; whitespace is normalized and styling/marks are ignored. Omit to replace the whole page."},
                     "anchorUntil": {"type": "string", "description": "Optional. With 'anchor', replace the inclusive span of blocks from 'anchor' through the block matching this text."}
@@ -852,6 +852,26 @@ fn markdown_to_html(md: &str) -> String {
     out
 }
 
+/// Hard cap on a single prose write's content size, in bytes (JP-248). A safety
+/// bound on the public `/mcp` surface so one `set_prose`/`add_prose_page`/
+/// `insert_section` can't build a huge fragment + broadcast delta. Advertised as
+/// `maxLength` on the prose-write tools so agents self-limit. A const (not a
+/// config knob) to stay lean — no `ToolContext` threading; promote to config if
+/// per-deployment tuning is ever needed.
+const MAX_PROSE_CONTENT_BYTES: usize = 1_048_576; // 1 MiB
+
+/// Reject prose content over [`MAX_PROSE_CONTENT_BYTES`] with `ERR_PROSE_TOO_LARGE`.
+fn check_prose_size(content: &str) -> Result<(), String> {
+    if content.len() > MAX_PROSE_CONTENT_BYTES {
+        return Err(format!(
+            "ERR_PROSE_TOO_LARGE: content is {} bytes; the limit is {} bytes",
+            content.len(),
+            MAX_PROSE_CONTENT_BYTES
+        ));
+    }
+    Ok(())
+}
+
 /// Turn agent-supplied content into the HTML stored on a prose page.
 /// Markdown is the default (agents produce it reliably); `html` is a
 /// pass-through escape hatch. The editor re-parses this HTML against the
@@ -941,7 +961,10 @@ fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
     // Render once, outside the retry loop — deterministic and lets a bad
     // format fail fast before we touch the store.
     let html = match &parsed.content {
-        Some(c) => content_to_html(c, parsed.format.as_deref())?,
+        Some(c) => {
+            check_prose_size(c)?;
+            content_to_html(c, parsed.format.as_deref())?
+        }
         None => String::new(),
     };
 
@@ -1028,6 +1051,7 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: SetProseArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     reject_if_local(ctx, &parsed.doc_id)?;
+    check_prose_size(&parsed.content)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
 
     match &parsed.anchor {
@@ -1260,7 +1284,10 @@ fn insert_section(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
     let inner_html = escape_html(&title);
     // Render the body once, up front, so a bad format fails before any write.
     let body_html = match &parsed.body {
-        Some(b) => content_to_html(b, parsed.format.as_deref())?,
+        Some(b) => {
+            check_prose_size(b)?;
+            content_to_html(b, parsed.format.as_deref())?
+        }
         None => String::new(),
     };
 
@@ -3102,6 +3129,32 @@ mod tests {
         )
         .unwrap_err();
         assert!(missing.contains("not found"));
+    }
+
+    #[test]
+    fn prose_writes_reject_oversized_content() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let big = "a".repeat(MAX_PROSE_CONTENT_BYTES + 1);
+
+        // The size check fires before page lookup, so the page need not exist.
+        for (tool, args) in [
+            ("docushark.set_prose", json!({"docId": "doc1", "pageId": "p", "content": big.clone()})),
+            ("docushark.add_prose_page", json!({"docId": "doc1", "content": big.clone()})),
+        ] {
+            let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();
+            assert!(err.contains("ERR_PROSE_TOO_LARGE"), "{tool}: {err}");
+        }
+
+        // Just under the cap passes the size gate (fails later for a real reason).
+        let ok_size = "a".repeat(MAX_PROSE_CONTENT_BYTES);
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.set_prose",
+            &json!({"docId": "doc1", "pageId": "nope", "content": ok_size}),
+        )
+        .unwrap_err();
+        assert!(!err.contains("ERR_PROSE_TOO_LARGE"), "under-cap must pass the size gate: {err}");
     }
 
     #[test]

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -34,27 +34,27 @@ use super::prose_schema;
 /// Serialize every top-level block of `frag` to an HTML string.
 pub fn fragment_to_html<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> String {
     let mut out = String::new();
-    write_children(frag, txn, &mut out);
+    write_children(frag, txn, &mut out, 0);
     out
 }
 
-fn write_children<F, T>(frag: &F, txn: &T, out: &mut String)
+fn write_children<F, T>(frag: &F, txn: &T, out: &mut String, depth: usize)
 where
     F: XmlFragment,
     T: ReadTxn,
 {
     for node in frag.children(txn) {
-        write_node(&node, txn, out);
+        write_node(&node, txn, out, depth);
     }
 }
 
-fn write_node<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String) {
+fn write_node<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String, depth: usize) {
     match node {
-        XmlOut::Element(el) => write_element(el, txn, out),
+        XmlOut::Element(el) => write_element(el, txn, out, depth),
         XmlOut::Text(t) => write_text(t, txn, out),
         // PM doesn't nest bare fragments, but if one appears, recurse so no
         // content is lost.
-        XmlOut::Fragment(f) => write_children(f, txn, out),
+        XmlOut::Fragment(f) => write_children(f, txn, out, depth),
     }
 }
 
@@ -68,15 +68,22 @@ enum Block {
     Transparent,
 }
 
-fn write_element<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String) {
+fn write_element<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String, depth: usize) {
+    // Depth guard (JP-248): a live `prose:` fragment can be built arbitrarily
+    // deep via the raw WS sync path (bypassing the parser's cap), so cap the
+    // serialize recursion independently. Beyond the cap, stop descending — the
+    // deep remainder is omitted; real prose never approaches it.
+    if depth >= prose_schema::MAX_PROSE_DEPTH {
+        return;
+    }
     match block_for(el, txn) {
         Block::Wrap { open, close } => {
             out.push_str(&open);
-            write_children(el, txn, out);
+            write_children(el, txn, out, depth + 1);
             out.push_str(close);
         }
         Block::Void(html) => out.push_str(&html),
-        Block::Transparent => write_children(el, txn, out),
+        Block::Transparent => write_children(el, txn, out, depth + 1),
     }
 }
 
@@ -390,5 +397,21 @@ mod tests {
     fn empty_fragment_is_empty_string() {
         let html = render(|_doc, _frag, _txn| {});
         assert_eq!(html, "");
+    }
+
+    #[test]
+    fn deeply_nested_fragment_serializes_without_overflow() {
+        // A live fragment can be built arbitrarily deep via the raw WS sync path
+        // (bypassing the parser cap), so serialize must be depth-bounded too
+        // (JP-248). 10k nested blockquotes would overflow an uncapped serialize;
+        // this test *completing* is the proof.
+        let html = render(|_doc, frag, txn| {
+            let mut parent = frag.push_back(txn, XmlElementPrelim::empty("blockquote"));
+            for _ in 0..10_000 {
+                parent = parent.push_back(txn, XmlElementPrelim::empty("blockquote"));
+            }
+            parent.push_back(txn, XmlTextPrelim::new("deep"));
+        });
+        assert!(html.starts_with("<blockquote>"), "bounded output produced: {}", &html[..html.len().min(40)]);
     }
 }

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -250,7 +250,18 @@ fn build_tree(tokens: &[Token]) -> Vec<HtmlNode> {
                 &mut roots,
                 HtmlNode::Element { tag: tag.clone(), attrs: attrs.clone(), children: Vec::new() },
             ),
-            Token::Open(tag, attrs) => stack.push((tag.clone(), attrs.clone(), Vec::new())),
+            Token::Open(tag, attrs) => {
+                // Depth guard (JP-248): refuse to nest past MAX_PROSE_DEPTH. This
+                // bounds the produced tree — so map_blocks/collect_inline and the
+                // downstream build_prose_* recursion can't overflow the stack —
+                // and caps the O(stack-depth) `rposition` scan below. Beyond the
+                // cap the open is dropped: later text attaches to the current
+                // (depth-capped) parent and the unmatched close is ignored
+                // leniently, so text is preserved. Real prose never nears 64.
+                if stack.len() < prose_schema::MAX_PROSE_DEPTH {
+                    stack.push((tag.clone(), attrs.clone(), Vec::new()));
+                }
+            }
             Token::Close(tag) => {
                 // Pop until we match the tag (lenient: tolerate stray/misnested
                 // closes by closing the nearest matching open).
@@ -495,5 +506,29 @@ mod tests {
         let PmChild::Text { marks, .. } = &b[0].children[0] else { panic!() };
         let names: Vec<&str> = marks.iter().map(|m| m.name.as_str()).collect();
         assert_eq!(names, vec!["bold", "italic"]);
+    }
+
+    #[test]
+    fn pathologically_deep_input_is_bounded_not_overflow() {
+        // 100k nested tags would overflow an uncapped recursive parse. The
+        // build_tree depth guard bounds the tree (JP-248); this test merely
+        // *completing* proves the stack is bounded — and text is preserved.
+        let depth = 100_000;
+        let html = format!("{}content{}", "<div>".repeat(depth), "</div>".repeat(depth));
+        let blocks = html_to_blocks(&html);
+
+        fn text_of(n: &PmNode, out: &mut String) {
+            for c in &n.children {
+                match c {
+                    PmChild::Text { text, .. } => out.push_str(text),
+                    PmChild::Node(inner) => text_of(inner, out),
+                }
+            }
+        }
+        let mut text = String::new();
+        for b in &blocks {
+            text_of(b, &mut text);
+        }
+        assert!(text.contains("content"), "text survives the depth cap");
     }
 }

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -8,6 +8,14 @@
 //! void nodes (`<br>`/`<hr>`/`<img>`), and the `link` mark (`href`) — are
 //! handled explicitly by each side; everything here is the symmetric core.
 
+/// Max prose nesting depth honored by the parser ([`super::prose_parse`]) and
+/// the serializer ([`super::prose_html`]) — a safety bound, **not** a content
+/// limit (JP-248). Real prose nests <~10 deep; 64 is generous headroom while
+/// keeping recursion (and the parser's lenient-close scan) bounded so a
+/// pathologically deep input on the public `/mcp` surface can't overflow the
+/// stack and abort the process. Beyond it, nesting is truncated (never panics).
+pub const MAX_PROSE_DEPTH: usize = 64;
+
 /// Simple block nodes whose PM type ↔ HTML wrapper tag round-trips 1:1 (children
 /// recurse inside). Read maps PM→HTML; write maps HTML→PM.
 pub const SIMPLE_BLOCKS: &[(&str, &str)] = &[


### PR DESCRIPTION
First slice of the relay public-surface hardening pass. **Closes a live cross-tenant DoS** on the now-public `/mcp` (JP-210/235).

### The hole
Prose **parse** (`prose_parse`), **build** (`build_prose_*`), and **serialize** (`prose_html::write_*`) recurse on nesting depth with **no cap**. Deeply-nested input (`<div>`×100k — *under* the 2 MiB body limit) overflows the stack and **aborts the process** — and Phase 21.2's `catch_unwind` **can't catch a stack overflow**, so one crafted write takes down *every tenant on the pod*. Reachable via `set_prose`, a raw WS-crafted deep `prose:` fragment, or deep prose JSON at hydrate.

### The fix (lean)
- **`MAX_PROSE_DEPTH = 64`** in `prose_schema` (shared). Guard `build_tree`'s stack push (`prose_parse`): over-deep opens are dropped (text preserved via the lenient close), which **bounds the tree** → transitively bounds `map_blocks`/`collect_inline` + `build_prose_*` recursion, *and* caps the O(stack-depth) `rposition` scan (a secondary CPU blowup). **Independent** depth cap threaded through `prose_html::write_*` — the live fragment can be built deep via the raw WS path, bypassing the parser, so reads/flatten of it must not overflow either. Beyond the cap: truncate (real prose nests <~10).
- **`MAX_PROSE_CONTENT_BYTES = 1 MiB`** (const — lean, no `ToolContext` threading): `check_prose_size` in `set_prose`/`add_prose_page`/`insert_section` → `ERR_PROSE_TOO_LARGE`, **advertised as `maxLength`** on the prose-write schemas so agents self-limit.

### Out of scope (Phase 21)
Bounding the WS *write* path's in-memory Y.Doc size/depth — the serialize cap here protects *reads* of such a doc.

### Verification
- Deep-input unit tests — 100k-nested parse (`html_to_blocks`) and 10k-nested fragment serialize (`fragment_to_html`) that **complete** = overflow bounded, with text preserved.
- Size-cap unit (`set_prose`/`add_prose_page` over cap → `ERR_PROSE_TOO_LARGE`; under-cap passes the gate).
- Full relay suite green (0 failures), changed code clippy-clean, leak grep clean. README limits documented.

JP-249 (rate-limit MCP reads) is the fast-follow.

Assisted-by: Opus 4.8