### PR TITLE
JP-249: rate-limit MCP reads on the public surface

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -173,6 +173,11 @@ current.
 - **`generate_diagram` layout is relay-side and approximate** — a layered or
   grid placement, not the editor's full auto-layout. The editor can re-layout
   on open. Node caps: 500 nodes / 1000 edges per call.
+- **Rate limits (per workspace).** Writes draw from the shared write bucket
+  (`[tenancy.limits] writes_per_sec`/`writes_burst`, shared with WS sync); reads
+  draw from a **separate** bucket (`reads_per_sec`/`reads_burst`, `0` =
+  unlimited). Over the bucket → HTTP `429` with `ERR_RATE_LIMIT`. Tunable via
+  `RELAY_*` env on Cloud pods.
 - **No open-in-editor link yet.** `create_document` returns the document `id`;
   a deep link back into the editor is not yet wired.
 

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -42,6 +42,12 @@ pub const DEFAULT_AUDIENCE: &str = "docushark-relay";
 pub const DEFAULT_WRITES_PER_SEC: u32 = 40;
 /// Default burst size for the per-workspace write bucket.
 pub const DEFAULT_WRITES_BURST: u32 = 80;
+/// Default token-bucket refill rate (MCP reads / sec) per workspace (JP-249).
+/// Reads are cheap, so this is generous — a public-pod backstop against a
+/// read-storm, not a throttle on normal agent use. `0` = unlimited.
+pub const DEFAULT_READS_PER_SEC: u32 = 100;
+/// Default burst size for the per-workspace MCP read bucket.
+pub const DEFAULT_READS_BURST: u32 = 200;
 /// Default cap on concurrent authenticated WS connections per workspace.
 pub const DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE: u32 = 25;
 /// Default cap on a single WS frame's payload size (bytes). Pathological
@@ -346,6 +352,12 @@ pub struct LimitsConfig {
     pub writes_per_sec: u32,
     /// Burst capacity for the per-workspace write bucket.
     pub writes_burst: u32,
+    /// Token-bucket refill rate (MCP reads / second) per workspace (JP-249).
+    /// `0` = unlimited (loopback/self-host). Separate from the write bucket so a
+    /// read-storm never contends with live WS editing.
+    pub reads_per_sec: u32,
+    /// Burst capacity for the per-workspace MCP read bucket.
+    pub reads_burst: u32,
     /// Cap on concurrent authenticated WS connections per workspace.
     pub max_ws_connections_per_workspace: u32,
     /// Cap on a single WS frame's payload size (bytes).
@@ -374,6 +386,8 @@ impl Default for LimitsConfig {
         Self {
             writes_per_sec: DEFAULT_WRITES_PER_SEC,
             writes_burst: DEFAULT_WRITES_BURST,
+            reads_per_sec: DEFAULT_READS_PER_SEC,
+            reads_burst: DEFAULT_READS_BURST,
             max_ws_connections_per_workspace: DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE,
             max_ws_payload_bytes: DEFAULT_MAX_WS_PAYLOAD_BYTES,
             max_blob_bytes: DEFAULT_MAX_BLOB_BYTES,

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -272,9 +272,18 @@ async fn run_serve(
     // state *before* start so it folds `/mcp` + the RFC 9728 discovery doc onto
     // the main public listener (one origin, one TLS story). The loopback
     // `McpServer` below is then skipped — a public pod runs no second listener.
+    // JP-249: per-workspace MCP read limiter (None = unlimited when
+    // reads_per_sec == 0). Separate from the WS/write bucket so a read-storm on a
+    // public pod can't contend with live editing.
+    let mcp_read_limiter = build_mcp_read_limiter(&config.tenancy.limits);
+
     if config.mcp.enabled && config.mcp.expose == McpExpose::Public {
-        let mount = PublicMount::new(config.storage.path.clone(), make_doc_changed(&server))
-            .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
+        let mount = PublicMount::new(
+            config.storage.path.clone(),
+            make_doc_changed(&server),
+            mcp_read_limiter.clone(),
+        )
+        .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
         // Logged for local diagnostics only; public pods reject the static
         // token and require a `wsp`-scoped JWT.
         log::info!(
@@ -328,6 +337,7 @@ async fn run_serve(
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
+                mcp_read_limiter.clone(),
                 auth.clone(),
                 region.clone(),
                 sync_registry,
@@ -391,6 +401,21 @@ async fn run_serve(
 /// `DocEvent::Updated` so a running editor refreshes after an MCP write.
 /// (The real-time CRDT merge rides the separate `on_doc_update` sink; this is
 /// the coarse "something changed" nudge.)
+/// Build the per-workspace MCP read limiter from config (JP-249). `None` when
+/// `reads_per_sec == 0` (unlimited — loopback/self-host default escape hatch).
+fn build_mcp_read_limiter(
+    limits: &docushark_relay::config::LimitsConfig,
+) -> Option<Arc<docushark_relay::server::WorkspaceWriteLimiter>> {
+    if limits.reads_per_sec == 0 {
+        None
+    } else {
+        Some(Arc::new(docushark_relay::server::build_workspace_limiter(
+            limits.reads_per_sec,
+            limits.reads_burst,
+        )))
+    }
+}
+
 fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<docushark_relay::mcp::DocChangedSink> {
     let server_for_mcp = server.clone();
     Arc::new(move |workspace: &WorkspaceId, doc_id: DocId| {

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -84,6 +84,8 @@ pub struct McpServer {
     /// Per-workspace write limiter shared with the WS subsystem.
     /// Phase 21.3.
     write_limiter: Arc<WorkspaceWriteLimiter>,
+    /// Separate per-workspace MCP **read** limiter (JP-249). `None` = unlimited.
+    read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     /// OIDC validator + JWKS cache + revocation set, shared with the
     /// WS subsystem so MCP and WS accept the same relay-issued tokens.
     /// JP-77 + Phase 21.6.
@@ -110,6 +112,9 @@ pub struct PublicMount {
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
     on_doc_changed: Arc<DocChangedSink>,
+    /// Per-workspace MCP read limiter (JP-249). `None` = unlimited. MCP-local,
+    /// so it's carried on the mount rather than `McpSharedHandles`.
+    read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
 }
 
 /// The server-owned handles a [`PublicMount`] needs to build its router. The
@@ -135,12 +140,14 @@ impl PublicMount {
     pub fn new(
         app_data_dir: PathBuf,
         on_doc_changed: Arc<DocChangedSink>,
+        read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     ) -> Result<Self, String> {
         Ok(Self {
             token: Arc::new(TokenStore::load_or_create(&app_data_dir)?),
             local_mirror: Arc::new(LocalDocumentMirror::new(app_data_dir.clone())),
             feature_config: Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir)),
             on_doc_changed,
+            read_limiter,
         })
     }
 
@@ -168,6 +175,7 @@ impl PublicMount {
             relay_region: shared.relay_region,
             sync_registry: shared.sync_registry,
             on_doc_update: shared.on_doc_update,
+            read_limiter: self.read_limiter,
             allow_static_token: false,
             // A public pod never serves local (renderer-owned) documents: the
             // local mirror is only ever populated by a desktop renderer, never
@@ -194,6 +202,7 @@ impl McpServer {
         panic_counter: Arc<AtomicU64>,
         rate_limit_rejections: Arc<AtomicU64>,
         write_limiter: Arc<WorkspaceWriteLimiter>,
+        read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
         auth: OidcAuthState,
         relay_region: String,
         sync_registry: Arc<DocRegistry>,
@@ -220,6 +229,7 @@ impl McpServer {
             panic_counter,
             rate_limit_rejections,
             write_limiter,
+            read_limiter,
             auth,
             relay_region,
             sync_registry,
@@ -300,6 +310,7 @@ impl McpServer {
             relay_region: self.relay_region.clone(),
             sync_registry: self.sync_registry.clone(),
             on_doc_update: self.on_doc_update.clone(),
+            read_limiter: self.read_limiter.clone(),
             // Loopback listener: the static token gates a single-tenant store.
             allow_static_token: true,
             // Desktop / self-host: the local mirror is the whole point — it lets

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -61,6 +61,11 @@ pub struct McpAppState {
     /// draw from the same per-workspace token bucket as WS sync
     /// frames. Phase 21.3.
     pub write_limiter: Arc<WorkspaceWriteLimiter>,
+    /// Separate per-workspace bucket for MCP **reads** (JP-249) so a read-storm
+    /// on the public pod can't burn CPU/IO unbounded without contending with the
+    /// write/WS bucket. `None` = unlimited (loopback/self-host, or
+    /// `reads_per_sec = 0`).
+    pub read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     /// Shared with `ServerState.rate_limit_rejections` so MCP write
     /// throttles surface at the same `/metrics` counter as WS throttles.
     pub rate_limit_rejections: Arc<AtomicU64>,
@@ -392,33 +397,39 @@ fn handle_tools_call(
         on_doc_update: state.on_doc_update.as_ref(),
     };
 
-    // Phase 21.3: per-workspace write rate limit. Only mutating tools
-    // count against the bucket — reads pass through. The workspace
-    // here is the single-tenant default until MCP grows a workspace
-    // claim of its own (deferred follow-up). Even so, MCP and WS
-    // share the bucket, so a chatty MCP client and a chatty browser
-    // editor on the same workspace see fair accounting.
-    if is_mcp_write_tool(name) {
-        if state.write_limiter.check_key(&ctx.workspace_id).is_err() {
-            state.rate_limit_rejections.fetch_add(1, Ordering::Relaxed);
-            log::debug!(
-                "mcp tool rate-limited tool={} workspace_id={}",
-                name,
-                ctx.workspace_id.as_str()
-            );
-            return (
-                axum::http::StatusCode::TOO_MANY_REQUESTS,
-                [(axum::http::header::RETRY_AFTER, "1")],
-                Json(rpc_result(
-                    id,
-                    json!({
-                        "content": [{"type": "text", "text": "ERR_RATE_LIMIT"}],
-                        "isError": true,
-                    }),
-                )),
-            )
-                .into_response();
-        }
+    // Per-workspace rate limit. Writes draw from the shared write bucket (same
+    // bucket as WS sync frames, Phase 21.3); reads draw from a **separate** MCP
+    // read bucket (JP-249) so a read-storm on the public pod can't burn CPU/IO
+    // unbounded — yet never contends with live WS editing or writes. The read
+    // limiter is `None` (unlimited) on loopback/self-host or when
+    // `reads_per_sec = 0`.
+    let throttled = if is_mcp_write_tool(name) {
+        state.write_limiter.check_key(&ctx.workspace_id).is_err()
+    } else {
+        state
+            .read_limiter
+            .as_ref()
+            .is_some_and(|rl| rl.check_key(&ctx.workspace_id).is_err())
+    };
+    if throttled {
+        state.rate_limit_rejections.fetch_add(1, Ordering::Relaxed);
+        log::debug!(
+            "mcp tool rate-limited tool={} workspace_id={}",
+            name,
+            ctx.workspace_id.as_str()
+        );
+        return (
+            axum::http::StatusCode::TOO_MANY_REQUESTS,
+            [(axum::http::header::RETRY_AFTER, "1")],
+            Json(rpc_result(
+                id,
+                json!({
+                    "content": [{"type": "text", "text": "ERR_RATE_LIMIT"}],
+                    "isError": true,
+                }),
+            )),
+        )
+            .into_response();
     }
 
     // Phase 21.2: catch tool panics so one bad tool call can't take
@@ -531,6 +542,7 @@ mod tests {
             panic_counter: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             write_limiter: Arc::new(crate::server::build_workspace_limiter(1000, 1000)),
+            read_limiter: None,
             auth: test_auth_state(),
             relay_region: "default".to_string(),
             sync_registry: Arc::new(crate::sync::DocRegistry::new()),

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -159,6 +159,7 @@ impl Harness {
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
+                None, // JP-249: MCP read limiter (unlimited in this test)
                 self.issuer.auth_state(),
                 "default".to_string(),
                 sync_registry,

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -57,6 +57,7 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
             server.panic_counter_handle(),
             server.rate_limit_rejections_handle(),
             server.build_write_limiter().await,
+            None, // JP-249: MCP read limiter (unlimited in this test)
             issuer.auth_state(),
             "default".to_string(),
             server.sync_registry_handle().await,

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -41,7 +41,7 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         Arc::new(move |ws: &WorkspaceId, _doc| {
             routed_sink.lock().unwrap().push(ws.as_str().to_string());
         });
-    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed).expect("mount");
+    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed, None).expect("mount");
     let static_token = mount.token();
     server.set_mcp_public_mount(mount).await;
 

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -37,6 +37,16 @@ impl Harness {
         let server = Arc::new(WebSocketServer::new());
         server.set_app_data_dir(data_dir.clone()).await;
         server.set_auth(issuer.auth_state()).await;
+        // JP-249: build the MCP read limiter from the tenancy limits before
+        // `tenancy` is moved into `set_tenancy` (mirrors main.rs).
+        let mcp_read_limiter = if tenancy.limits.reads_per_sec == 0 {
+            None
+        } else {
+            Some(Arc::new(docushark_relay::server::build_workspace_limiter(
+                tenancy.limits.reads_per_sec,
+                tenancy.limits.reads_burst,
+            )))
+        };
         server.set_tenancy(tenancy).await;
         server
             .set_config(ServerConfig {
@@ -80,6 +90,7 @@ impl Harness {
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
+                mcp_read_limiter,
                 issuer.auth_state(),
                 "default".to_string(),
                 sync_registry,
@@ -183,6 +194,22 @@ impl Harness {
             .status()
     }
 
+    /// Fire one MCP `list_documents` read. Returns the HTTP status.
+    async fn mcp_list_documents(&self) -> reqwest::StatusCode {
+        let body = json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "docushark.list_documents", "arguments": {}}
+        });
+        reqwest::Client::new()
+            .post(format!("{}/mcp", self.mcp_base))
+            .bearer_auth(&self.mcp_token)
+            .json(&body)
+            .send()
+            .await
+            .expect("POST /mcp")
+            .status()
+    }
+
     async fn stop(self) {
         self.mcp.stop().await.expect("mcp stop");
         self.server.stop().await.expect("server stop");
@@ -238,6 +265,44 @@ async fn mcp_writes_burst_then_rate_limit_with_429() {
     assert_eq!(
         rejections, limited_count as u64,
         "relay_rate_limit_rejections_total ({rejections}) should match the 429 count ({limited_count})"
+    );
+
+    h.stop().await;
+}
+
+/// JP-249: MCP reads are clamped by a **separate** per-workspace bucket — a
+/// read-storm gets 429s without draining the write bucket (writes still pass).
+#[tokio::test]
+async fn mcp_reads_burst_then_rate_limit_independent_of_writes() {
+    let limits = LimitsConfig {
+        reads_per_sec: 1,
+        reads_burst: 2,
+        // Generous writes so the write path is never the bottleneck here.
+        ..LimitsConfig::default()
+    };
+    let tenancy = TenancyConfig {
+        mode: TenancyMode::Dedicated,
+        workspace_id: None,
+        limits,
+    };
+    let h = Harness::start(tenancy).await;
+    h.seed_doc_via_store("doc-1", "p1").await;
+
+    let mut statuses = Vec::new();
+    for _ in 0..6 {
+        statuses.push(h.mcp_list_documents().await);
+    }
+    let ok = statuses.iter().filter(|s| s.as_u16() == 200).count();
+    let limited = statuses.iter().filter(|s| s.as_u16() == 429).count();
+    assert!(ok >= 2, "read burst should pass >=2; statuses={statuses:?}");
+    assert!(limited >= 1, "reads past burst must 429; statuses={statuses:?}");
+
+    // Independence: the write bucket is untouched, so a write still passes even
+    // after the read bucket is drained.
+    assert_eq!(
+        h.mcp_add_shape("doc-1", "p1").await.as_u16(),
+        200,
+        "writes must be unaffected by a read-storm (separate bucket)"
     );
 
     h.stop().await;

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -619,6 +619,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             panic_counter,
             rate_limit_rejections,
             write_limiter,
+            None, // JP-249: MCP read limiter (unlimited in this test)
             relay.issuer.auth_state(),
             "default".to_string(),
             sync_registry,


### PR DESCRIPTION
Second slice of the relay public-surface hardening pass. Closes the read-storm gap on the now-public `/mcp` (JP-210/235).

### The gap
Only **writes** were gated against the per-workspace bucket (`is_mcp_write_tool`); **reads** (`get_prose`/`get_page`/`list_documents`/`get_outline`/`get_shape`) bypassed it — an authed tenant could read-storm a public pod (CPU/IO + serialization burn).

### The fix
A **separate** per-workspace MCP read limiter — so a read-storm is clamped *without* draining the write/WS bucket (a chatty agent's bulk reads never throttle live editing):
- `LimitsConfig.reads_per_sec`/`reads_burst` (defaults **100/200**; **`0` = unlimited**), `RELAY_*` tunable.
- `read_limiter: Option<Arc<WorkspaceWriteLimiter>>` on `McpAppState`, threaded through `McpServer::new` + `PublicMount::new`/`into_public_router` — **MCP-local** (not on `ServerState`; WS has no "reads"); built from config in `main.rs` (`None` when `reads_per_sec==0` → loopback/self-host unaffected).
- `handle_tools_call`: writes → write bucket (unchanged); reads → read bucket; over-quota → `429` + `ERR_RATE_LIMIT` + `rate_limit_rejections` (surfaces on `/metrics`).

### Out of scope (edge-handled)
Unauthenticated discovery-endpoint flooding + a global pod limiter (CF/Fly edge + the JP-244 scaling alerts).

### Verification
- New `rate_limits.rs` test: reads past burst → `429`, and a write **still passes** after the read bucket is drained (independent buckets).
- Full relay suite green (0 failures), changed code clippy-clean, leak grep clean. README + `RELAY_*` knobs documented.

Fast-follow to JP-248 (#116). Together they complete the chosen security + rate-limit hardening pass.

Assisted-by: Opus 4.8