### PR TITLE
JP-254 + JP-107: Appearance settings tab + theme persistence

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "docushark",
       "dependencies": {
+        "@radix-ui/react-radio-group": "^1.4.0",
+        "@radix-ui/react-switch": "^1.3.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-http": "^2.5.9",
@@ -375,6 +377,42 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.9", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-slot": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.5", "", { "dependencies": { "@radix-ui/react-slot": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA=="],
+
+    "@radix-ui/react-radio-group": ["@radix-ui/react-radio-group@1.4.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-roving-focus": "1.1.12", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ=="],
+
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
+
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.3.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-GP1EZwhoZO/GGnhM1P5/2Vpm8iN8EnngyU0oezn2l78kN8tj25pyrvjIaT7azBhK615KSt+P2w39y57YV5jVkA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w=="],
 
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#2196f3" />
+    <!-- Default matches the light --bg-primary surface; themeStore updates this
+         at runtime to track the active theme (see applyThemeColorMeta). -->
+    <meta name="theme-color" content="#f9f6ee" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="DocuShark" />

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@radix-ui/react-radio-group": "^1.4.0",
+    "@radix-ui/react-switch": "^1.3.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-http": "^2.5.9",

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,9 @@
   --color-cta-text: var(--navy-1000);
   --color-cta-hover: var(--brand-gold-deep);
 
+  /* Native form controls / scrollbars follow the active theme. */
+  color-scheme: light;
+
   /* --- Semantic: LIGHT (warm paper + navy accent) --- */
   /* Backgrounds */
   --bg-primary: #f9f6ee;          /* surface — cards, panels, inputs (soft warm white) */
@@ -168,6 +171,7 @@
 
 /* --- Semantic: DARK (navy-native; elevation = lighter navy, not black) --- */
 [data-theme="dark"] {
+  color-scheme: dark;
   /* Backgrounds — elevation ladder: app(body) #060c17 < page #0a1525 <
      surface #0e1c30 < raised #16273f */
   --bg-primary: #0e1c30;          /* surface — cards, panels, inputs */

--- a/src/store/themeStore.test.ts
+++ b/src/store/themeStore.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useThemeStore } from './themeStore';
+
+const KEY = 'docushark-theme';
+
+describe('themeStore persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset to the default preference between tests (derived fields recomputed
+    // via setPreference).
+    useThemeStore.getState().setPreference('system');
+  });
+
+  it('persists the user preference to localStorage', () => {
+    useThemeStore.getState().setPreference('dark');
+    const raw = localStorage.getItem(KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).state.preference).toBe('dark');
+  });
+
+  it('applies the resolved theme to the document on change', () => {
+    useThemeStore.getState().setPreference('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(useThemeStore.getState().resolvedTheme).toBe('dark');
+    expect(useThemeStore.getState().colors.backgroundColor).toBe('#1e1e1e');
+  });
+
+  it('recomputes derived theme from a persisted preference on rehydrate', async () => {
+    // Simulate a prior session that saved a Dark preference.
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ state: { preference: 'dark' }, version: 0 })
+    );
+    await useThemeStore.persist.rehydrate();
+
+    const state = useThemeStore.getState();
+    expect(state.preference).toBe('dark');
+    // The merge must recompute resolvedTheme + colors, not leave the pre-hydration default.
+    expect(state.resolvedTheme).toBe('dark');
+    expect(state.colors.backgroundColor).toBe('#1e1e1e');
+  });
+
+  it('keeps theme-color meta in sync with the active theme', () => {
+    useThemeStore.getState().setPreference('dark');
+    const meta = document.querySelector('meta[name="theme-color"]');
+    expect(meta).toBeTruthy();
+    // jsdom returns empty for the CSS custom property, so the fallback applies.
+    expect(meta?.getAttribute('content')).toBe('#0e1c30');
+  });
+});

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 /**
  * Theme preference options.
@@ -101,11 +102,42 @@ function getColorsForTheme(theme: ResolvedTheme): ThemeColors {
 }
 
 /**
- * Apply theme to document (sets data-theme attribute).
+ * Fallbacks for the PWA `theme-color` meta — kept in sync with `--bg-primary`
+ * in `index.css` (light warm-paper surface / dark navy surface). Used only when
+ * the computed token can't be read yet (e.g. before stylesheet application).
+ */
+const THEME_COLOR_FALLBACK: Record<ResolvedTheme, string> = {
+  light: '#f9f6ee',
+  dark: '#0e1c30',
+};
+
+/**
+ * Update (or create) the `<meta name="theme-color">` element so an installed
+ * PWA's mobile browser/status-bar chrome matches the active theme. Prefers the
+ * live `--bg-primary` token so it tracks the brand palette without drift.
+ */
+function applyThemeColorMeta(theme: ResolvedTheme): void {
+  if (typeof document === 'undefined') return;
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = 'theme-color';
+    document.head.appendChild(meta);
+  }
+  const computed = getComputedStyle(document.documentElement)
+    .getPropertyValue('--bg-primary')
+    .trim();
+  meta.content = computed || THEME_COLOR_FALLBACK[theme];
+}
+
+/**
+ * Apply theme to document: sets the `data-theme` attribute (which drives every
+ * semantic token + `color-scheme` in `index.css`) and the PWA theme-color meta.
  */
 function applyThemeToDocument(theme: ResolvedTheme): void {
   if (typeof document !== 'undefined') {
     document.documentElement.setAttribute('data-theme', theme);
+    applyThemeColorMeta(theme);
   }
 }
 
@@ -137,43 +169,68 @@ const initialResolved = resolveTheme(initialPreference);
  * setPreference('system');
  * ```
  */
-export const useThemeStore = create<ThemeState & ThemeActions>()((set, get) => ({
-  // State
-  preference: initialPreference,
-  resolvedTheme: initialResolved,
-  colors: getColorsForTheme(initialResolved),
+export const useThemeStore = create<ThemeState & ThemeActions>()(
+  persist(
+    (set, get) => ({
+      // State
+      preference: initialPreference,
+      resolvedTheme: initialResolved,
+      colors: getColorsForTheme(initialResolved),
 
-  // Actions
-  setPreference: (preference: ThemePreference) => {
-    const resolvedTheme = resolveTheme(preference);
-    const colors = getColorsForTheme(resolvedTheme);
-    applyThemeToDocument(resolvedTheme);
-    set({ preference, resolvedTheme, colors });
-  },
+      // Actions
+      setPreference: (preference: ThemePreference) => {
+        const resolvedTheme = resolveTheme(preference);
+        const colors = getColorsForTheme(resolvedTheme);
+        applyThemeToDocument(resolvedTheme);
+        set({ preference, resolvedTheme, colors });
+      },
 
-  updateFromSystem: () => {
-    const { preference } = get();
-    if (preference === 'system') {
-      const resolvedTheme = getSystemTheme();
-      const colors = getColorsForTheme(resolvedTheme);
-      applyThemeToDocument(resolvedTheme);
-      set({ resolvedTheme, colors });
+      updateFromSystem: () => {
+        const { preference } = get();
+        if (preference === 'system') {
+          const resolvedTheme = getSystemTheme();
+          const colors = getColorsForTheme(resolvedTheme);
+          applyThemeToDocument(resolvedTheme);
+          set({ resolvedTheme, colors });
+        }
+      },
+
+      getOppositeTheme: (): ResolvedTheme => {
+        return get().resolvedTheme === 'light' ? 'dark' : 'light';
+      },
+
+      toggle: () => {
+        const opposite = get().getOppositeTheme();
+        get().setPreference(opposite);
+      },
+    }),
+    {
+      name: 'docushark-theme',
+      // Only the user's choice is durable; `resolvedTheme`/`colors` are derived.
+      partialize: (state) => ({ preference: state.preference }),
+      // localStorage hydrates synchronously during `create`, so recompute the
+      // derived fields from the persisted preference here — that way the
+      // module-load apply below reads the correct theme and there's no FOUC.
+      merge: (persisted, current) => {
+        const preference =
+          (persisted as { preference?: ThemePreference } | undefined)?.preference ??
+          current.preference;
+        const resolvedTheme = resolveTheme(preference);
+        return {
+          ...current,
+          preference,
+          resolvedTheme,
+          colors: getColorsForTheme(resolvedTheme),
+        };
+      },
     }
-  },
+  )
+);
 
-  getOppositeTheme: (): ResolvedTheme => {
-    return get().resolvedTheme === 'light' ? 'dark' : 'light';
-  },
-
-  toggle: () => {
-    const opposite = get().getOppositeTheme();
-    get().setPreference(opposite);
-  },
-}));
-
-// Apply initial theme on load
+// Apply the (already-hydrated) theme on load — reads the persisted preference,
+// not the pre-hydration default, so a saved Dark choice paints dark immediately.
 if (typeof document !== 'undefined') {
-  applyThemeToDocument(initialResolved);
+  applyThemeToDocument(useThemeStore.getState().resolvedTheme);
 }
 
 // Listen for system theme changes

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -10,6 +10,22 @@
 
 type PathMethods = Record<string, (...args: number[]) => void>;
 
+// jsdom does not implement `matchMedia`. Stores read it at module load
+// (theme `prefers-color-scheme`, device adaptive hints), so provide a minimal
+// always-"no-match" stub with the full MediaQueryList event surface.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
 if (typeof (globalThis as { Path2D?: unknown }).Path2D === 'undefined') {
   class Path2DStub implements PathMethods {
     [method: string]: (...args: number[]) => void;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -69,7 +69,7 @@ function App() {
 
   // Settings modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'documents' | 'layout'>('documents');
+  const [settingsInitialTab, setSettingsInitialTab] = useState<'documents' | 'appearance'>('documents');
 
   // Command palette state (Cmd/Ctrl+K)
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -81,13 +81,14 @@ function App() {
   const rebuildAllConnectorRoutes = useDocumentStore((state) => state.rebuildAllConnectorRoutes);
 
   // Custom chrome opt-in — drives both the in-app TitleBar render and the
-  // Tauri native-decoration toggle synced below. Force-disabled on macOS:
-  // the traffic-light controls and unified titlebar are too tightly coupled
-  // to native decorations for the cross-platform in-app TitleBar to be a
-  // credible swap, and a synced/migrated `true` from another OS would
-  // otherwise strip the native frame on Mac.
+  // Tauri native-decoration toggle synced below. Gated to the desktop shell:
+  // `windowControls.isSupported()` is false on the PWA, so a persisted (or
+  // legacy, pre-JP-107) `true` never renders a controls-less in-app TitleBar
+  // on web. Force-disabled on macOS too: the traffic-light controls and
+  // unified titlebar are too tightly coupled to native decorations for the
+  // cross-platform in-app TitleBar to be a credible swap.
   const customChromePref = useUIPreferencesStore((s) => s.layout.customChrome);
-  const customChrome = customChromePref && !isMacOS();
+  const customChrome = customChromePref && windowControls.isSupported() && !isMacOS();
 
   // Layout-driven panel visibility. The store is the source of truth; switching
   // layouts (Step 4) or moving panels (Step 6) flows through here.
@@ -179,7 +180,7 @@ function App() {
   }, []);
 
   const handleOpenLayoutSettings = useCallback(() => {
-    setSettingsInitialTab('layout');
+    setSettingsInitialTab('appearance');
     setIsSettingsOpen(true);
   }, []);
 

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -4,7 +4,8 @@
  * Features:
  * - Tab infrastructure for multiple settings sections
  * - Documents management (new, open, save, import/export)
- * - General settings (connector defaults, style profile defaults, display options, theme)
+ * - General settings (connector defaults, style profile defaults, display options)
+ * - Appearance (theme, canvas grid, layout customization, window chrome)
  * - Storage management (images and icons)
  * - Style Profile settings
  * - Shape Libraries management
@@ -19,7 +20,7 @@ import {
   Package,
   Palette,
   Library,
-  Layout,
+  SwatchBook,
   Maximize2,
   Minimize2,
 } from 'lucide-react';
@@ -31,13 +32,13 @@ import { StorageSettings } from './settings/StorageSettings';
 import { StyleProfileSettings } from './settings/StyleProfileSettings';
 import { RelaySettings } from './settings/RelaySettings';
 import { BackupSettings } from './settings/BackupSettings';
-import { LayoutSettings } from './settings/LayoutSettings';
+import { AppearanceSettings } from './settings/AppearanceSettings';
 import './SettingsModal.css';
 
 /**
  * Available settings tabs.
  */
-type SettingsTab = 'documents' | 'general' | 'layout' | 'relay' | 'storage' | 'backup' | 'style-profiles' | 'shape-libraries';
+type SettingsTab = 'documents' | 'general' | 'appearance' | 'relay' | 'storage' | 'backup' | 'style-profiles' | 'shape-libraries';
 
 /**
  * Tab configuration.
@@ -54,7 +55,7 @@ interface TabConfig {
 const TABS: TabConfig[] = [
   { id: 'documents', label: 'Documents', icon: FileText },
   { id: 'general', label: 'General', icon: Settings },
-  { id: 'layout', label: 'Layout', icon: Layout },
+  { id: 'appearance', label: 'Appearance', icon: SwatchBook },
   { id: 'relay', label: 'Relay', icon: Cloud },
   { id: 'storage', label: 'Storage', icon: Database },
   { id: 'backup', label: 'Backup & Restore', icon: Package },
@@ -174,7 +175,7 @@ export function SettingsModal({ isOpen, onClose, initialTab = 'documents' }: Set
           <div className="settings-modal-content">
             {activeTab === 'documents' && <DocumentBrowser />}
             {activeTab === 'general' && <GeneralSettings />}
-            {activeTab === 'layout' && <LayoutSettings />}
+            {activeTab === 'appearance' && <AppearanceSettings />}
             {activeTab === 'relay' && <RelaySettings />}
             {activeTab === 'storage' && <StorageSettings />}
             {activeTab === 'backup' && <BackupSettings />}

--- a/src/ui/components/SegmentedControl.css
+++ b/src/ui/components/SegmentedControl.css
@@ -1,0 +1,64 @@
+/* SegmentedControl — brand-tokened segmented button group (Radix RadioGroup). */
+
+.segmented-control {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color, var(--bg-active));
+  border-radius: 8px;
+}
+
+.segmented-control__item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.segmented-control__item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.segmented-control__item[data-state='checked'] {
+  background: var(--bg-primary);
+  color: var(--color-primary);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(14, 28, 48, 0.12));
+}
+
+.segmented-control__item:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 1px;
+}
+
+.segmented-control__item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.segmented-control__icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Honor reduced-motion explicitly (CSS @media here is fine; the JS-driven
+   `data-motion` override seam lands with the Accent/Motion slice). */
+@media (prefers-reduced-motion: reduce) {
+  .segmented-control__item {
+    transition: none;
+  }
+}

--- a/src/ui/components/SegmentedControl.test.tsx
+++ b/src/ui/components/SegmentedControl.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SegmentedControl } from './SegmentedControl';
+
+const OPTIONS = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+] as const;
+
+describe('SegmentedControl', () => {
+  it('renders every option', () => {
+    render(
+      <SegmentedControl ariaLabel="Color theme" value="system" onValueChange={() => {}} options={OPTIONS} />
+    );
+    expect(screen.getByText('System')).toBeTruthy();
+    expect(screen.getByText('Light')).toBeTruthy();
+    expect(screen.getByText('Dark')).toBeTruthy();
+  });
+
+  it('marks the selected option as checked', () => {
+    render(
+      <SegmentedControl ariaLabel="Color theme" value="light" onValueChange={() => {}} options={OPTIONS} />
+    );
+    const light = screen.getByRole('radio', { name: 'Light' });
+    expect(light.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('calls onValueChange with the clicked option value', () => {
+    const onValueChange = vi.fn();
+    render(
+      <SegmentedControl ariaLabel="Color theme" value="system" onValueChange={onValueChange} options={OPTIONS} />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }));
+    expect(onValueChange).toHaveBeenCalledWith('dark');
+  });
+});

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -1,0 +1,70 @@
+/**
+ * SegmentedControl — a horizontal single-select control styled as a segmented
+ * button group, built on Radix `RadioGroup` (roving-tabindex keyboard nav,
+ * arrow keys, WAI-ARIA radiogroup semantics for free).
+ *
+ * Thin local wrapper so the rest of the app consumes *our* component, not Radix
+ * directly — the dependency is swappable and the styling stays brand-tokened.
+ */
+
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import type { ReactNode } from 'react';
+import './SegmentedControl.css';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+  /** Optional leading icon (e.g. a lucide glyph). */
+  icon?: ReactNode;
+  /** Native title / tooltip. */
+  title?: string;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  value: T;
+  onValueChange: (value: T) => void;
+  options: ReadonlyArray<SegmentedOption<T>>;
+  /** Accessible label for the group (required — there's no visible legend). */
+  ariaLabel: string;
+  /** Optional form name. */
+  name?: string;
+  disabled?: boolean;
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  onValueChange,
+  options,
+  ariaLabel,
+  name,
+  disabled,
+}: SegmentedControlProps<T>) {
+  return (
+    <RadioGroup.Root
+      className="segmented-control"
+      value={value}
+      onValueChange={(v) => onValueChange(v as T)}
+      aria-label={ariaLabel}
+      orientation="horizontal"
+      loop
+      {...(name !== undefined ? { name } : {})}
+      {...(disabled !== undefined ? { disabled } : {})}
+    >
+      {options.map((opt) => (
+        <RadioGroup.Item
+          key={opt.value}
+          className="segmented-control__item"
+          value={opt.value}
+          {...(opt.title !== undefined ? { title: opt.title } : {})}
+        >
+          {opt.icon != null && (
+            <span className="segmented-control__icon" aria-hidden="true">
+              {opt.icon}
+            </span>
+          )}
+          <span className="segmented-control__label">{opt.label}</span>
+        </RadioGroup.Item>
+      ))}
+    </RadioGroup.Root>
+  );
+}

--- a/src/ui/components/Switch.css
+++ b/src/ui/components/Switch.css
@@ -1,0 +1,56 @@
+/* Switch — brand-tokened toggle (Radix Switch). */
+
+.switch {
+  --switch-w: 38px;
+  --switch-h: 22px;
+  --switch-pad: 2px;
+  --thumb: calc(var(--switch-h) - var(--switch-pad) * 2);
+  flex: 0 0 auto;
+  width: var(--switch-w);
+  height: var(--switch-h);
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--bg-active);
+  cursor: pointer;
+  position: relative;
+  transition: background-color 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.switch[data-state='checked'] {
+  background: var(--color-primary);
+}
+
+.switch:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+.switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.switch__thumb {
+  display: block;
+  width: var(--thumb);
+  height: var(--thumb);
+  border-radius: 50%;
+  background: var(--bg-primary);
+  box-shadow: 0 1px 2px rgba(14, 28, 48, 0.3);
+  transform: translateX(var(--switch-pad));
+  transition: transform 0.15s ease;
+  will-change: transform;
+}
+
+.switch[data-state='checked'] .switch__thumb {
+  transform: translateX(calc(var(--switch-w) - var(--thumb) - var(--switch-pad)));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch,
+  .switch__thumb {
+    transition: none;
+  }
+}

--- a/src/ui/components/Switch.tsx
+++ b/src/ui/components/Switch.tsx
@@ -1,0 +1,30 @@
+/**
+ * Switch — a brand-tokened toggle built on Radix `Switch` (keyboard + ARIA
+ * switch semantics). Thin local wrapper so the dependency stays swappable.
+ */
+
+import * as RadixSwitch from '@radix-ui/react-switch';
+import './Switch.css';
+
+export interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  id?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+}
+
+export function Switch({ checked, onCheckedChange, id, ariaLabel, disabled }: SwitchProps) {
+  return (
+    <RadixSwitch.Root
+      className="switch"
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      {...(id !== undefined ? { id } : {})}
+      {...(ariaLabel !== undefined ? { 'aria-label': ariaLabel } : {})}
+      {...(disabled !== undefined ? { disabled } : {})}
+    >
+      <RadixSwitch.Thumb className="switch__thumb" />
+    </RadixSwitch.Root>
+  );
+}

--- a/src/ui/layout/LayoutSelector.tsx
+++ b/src/ui/layout/LayoutSelector.tsx
@@ -4,17 +4,12 @@
  * Lives in `UnifiedToolbar`, never in the titlebar. The toolbar is always our
  * own UI regardless of chrome choice, so this control is guaranteed to render.
  *
- * The dropdown footer hosts the custom-chrome opt-in and a "Customize layout"
- * link into Settings.
+ * The dropdown footer hosts a "Customize layout…" link into Settings. The
+ * custom-chrome opt-in lives in Settings → Appearance → Window (gated to the
+ * desktop shell), not here.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
-import { usePersistenceStore } from '../../store/persistenceStore';
-import { useNotificationStore } from '../../store/notificationStore';
-import { isTauri } from '../../platform/runtime';
-import { opener } from '../../platform/opener';
-import { isMacOS } from '../../utils/platform';
 import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS } from './modes';
 import { useActiveLayoutMode, useLayoutActions } from './useLayout';
 import { LAYOUT_MODES, type LayoutMode } from './types';
@@ -29,8 +24,6 @@ export interface LayoutSelectorProps {
 export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
   const activeMode = useActiveLayoutMode();
   const { setActiveLayout } = useLayoutActions();
-  const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
-  const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
 
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -62,56 +55,6 @@ export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
   const handleCustomize = () => {
     close();
     onOpenLayoutSettings?.();
-  };
-
-  const handleChromeToggle = () => {
-    const next = !customChrome;
-    const inTauri = isTauri();
-    const verb = inTauri
-      ? import.meta.env.DEV
-        ? 'The flag will be saved (manual `tauri:dev` restart required)'
-        : 'The app will restart'
-      : 'The window will reload';
-    const confirmed = window.confirm(
-      next
-        ? `Use custom window chrome? ${verb} to apply.`
-        : `Revert to system window decorations? ${verb} to apply.`
-    );
-    if (!confirmed) return;
-    setCustomChrome(next);
-    // Flush any pending auto-save so the beforeunload handler in useAutoSave
-    // doesn't fire its "unsaved changes" prompt during the reload path. (In
-    // Tauri we skip the JS reload entirely, but doing this unconditionally
-    // also handles the web PWA path.)
-    try {
-      usePersistenceStore.getState().saveDocument();
-    } catch {
-      // Best-effort flush; the user already confirmed they want to reload.
-    }
-    if (isTauri()) {
-      // Desktop: persist the flag, then either restart (prod) or just
-      // warn the developer (dev). The restart path is required on Linux
-      // WMs that ignore runtime setDecorations.
-      //
-      // Dev-mode caveat: `app.restart()` under `tauri dev` kills the
-      // cargo-spawned binary without re-spawning it (and the dev-server
-      // bridge wouldn't reattach cleanly anyway), so we persist the
-      // flag without restarting and tell the developer to bounce
-      // `bun run tauri:dev` themselves. Production bundles are fine.
-      if (import.meta.env.DEV) {
-        void opener.persistCustomChrome(next);
-        useNotificationStore.getState().warning(
-          'Custom chrome flag saved. In dev mode you must stop and restart `bun run tauri:dev` manually for it to take effect.',
-          { duration: 10000 }
-        );
-      } else {
-        void opener.applyCustomChrome(next);
-      }
-    } else {
-      // Web/PWA: no native chrome to swap, but a reload re-mounts so the
-      // optional in-app TitleBar appears/disappears consistently.
-      window.location.reload();
-    }
   };
 
   return (
@@ -162,20 +105,6 @@ export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
             >
               Customize layout…
             </button>
-            {/* Custom chrome is not offered on macOS — the platform's
-                traffic-light controls and unified titlebar are too tightly
-                coupled to native window decorations for our cross-platform
-                in-app TitleBar to be a credible replacement. */}
-            {!isMacOS() && (
-              <label className="layout-selector-footer-item layout-selector-toggle">
-                <input
-                  type="checkbox"
-                  checked={customChrome}
-                  onChange={handleChromeToggle}
-                />
-                <span>Use custom window chrome</span>
-              </label>
-            )}
           </div>
         </div>
       )}

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -1,0 +1,41 @@
+/* Settings → Appearance.
+ *
+ * Reuses the shared `.settings-*` group/row/label/hint/slider classes defined
+ * in GeneralSettings.css (co-loaded with the settings module graph). Only the
+ * Appearance-specific additions live here. (The settings-menu rework — JP-211 —
+ * is expected to consolidate these shared classes into one place.) */
+
+.appearance-settings {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Switch row: label + thumb on one line, hint beneath (mirrors the checkbox
+   row pattern but for the Radix-based Switch). */
+.appearance-settings .settings-row-switch {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.appearance-settings .settings-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.appearance-settings .settings-switch-text {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+/* The embedded LayoutSettings drops its standalone top margin so it reads as a
+   section within the panel rather than a separate page. */
+.appearance-settings .layout-settings {
+  margin-top: 0;
+}
+
+.appearance-settings .layout-settings-header p {
+  margin-top: 2px;
+}

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppearanceSettings } from './AppearanceSettings';
+
+describe('AppearanceSettings', () => {
+  it('renders the theme control', () => {
+    render(<AppearanceSettings />);
+    expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
+  });
+
+  // JP-107 regression: the custom-window-chrome control is desktop-only. In the
+  // test (web) environment `windowControls.isSupported()` is false (IS_TAURI is
+  // false), so the entire Window section — header included — must be absent.
+  it('does not render the window-chrome section on web', () => {
+    render(<AppearanceSettings />);
+    expect(screen.queryByText(/custom window chrome/i)).toBeNull();
+    expect(screen.queryByText('Window')).toBeNull();
+  });
+});

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,0 +1,160 @@
+/**
+ * Settings → Appearance — the consolidated home for visual/UX configuration.
+ *
+ * Sections: Theme, Canvas, Layout (the panel-arrangement editor, embedded), and
+ * Window chrome (desktop-only). Accent / Motion / Density + UI-scale knobs land
+ * in later slices of the Appearance epic; this panel is the structural backbone.
+ *
+ * Kept self-contained (no coupling to `SettingsModal` internals) so it survives
+ * the planned settings-menu rework.
+ */
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useSettingsStore } from '../../store/settingsStore';
+import { useThemeStore, type ThemePreference } from '../../store/themeStore';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { usePersistenceStore } from '../../store/persistenceStore';
+import { useNotificationStore } from '../../store/notificationStore';
+import { windowControls } from '../../platform/window';
+import { opener } from '../../platform/opener';
+import { isMacOS } from '../../utils/platform';
+import { SegmentedControl } from '../components/SegmentedControl';
+import { Switch } from '../components/Switch';
+import { LayoutSettings } from './LayoutSettings';
+import './AppearanceSettings.css';
+
+const THEME_OPTIONS = [
+  { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your OS appearance' },
+  { value: 'light' as const, label: 'Light', icon: <Sun size={15} />, title: 'Light theme' },
+  { value: 'dark' as const, label: 'Dark', icon: <Moon size={15} />, title: 'Dark theme' },
+];
+
+export function AppearanceSettings() {
+  const themePreference = useThemeStore((s) => s.preference);
+  const setThemePreference = useThemeStore((s) => s.setPreference);
+  const gridOpacity = useSettingsStore((s) => s.gridOpacity);
+  const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
+
+  return (
+    <div className="appearance-settings">
+      <h3 className="settings-section-title">Appearance</h3>
+
+      {/* Theme */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Theme</h4>
+        <div className="settings-row">
+          <span className="settings-label">Color theme</span>
+          <SegmentedControl
+            ariaLabel="Color theme"
+            value={themePreference}
+            onValueChange={(v: ThemePreference) => setThemePreference(v)}
+            options={THEME_OPTIONS}
+          />
+          <span className="settings-hint">
+            Choose your preferred color theme. Your choice is remembered across sessions.
+          </span>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Canvas</h4>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="grid-opacity">
+            Grid Opacity
+          </label>
+          <div className="settings-slider-row">
+            <input
+              id="grid-opacity"
+              type="range"
+              className="styled-slider"
+              min={0}
+              max={100}
+              value={gridOpacity}
+              onChange={(e) => setGridOpacity(Number(e.target.value))}
+            />
+            <span className="settings-slider-value">{gridOpacity}%</span>
+          </div>
+          <span className="settings-hint">
+            Adjust the visibility of the canvas grid (0 = hidden)
+          </span>
+        </div>
+      </div>
+
+      {/* Layout — the panel-arrangement editor, embedded as a section. */}
+      <LayoutSettings embedded />
+
+      {/* Window chrome — desktop-only; renders nothing on the PWA. */}
+      <WindowChromeSection />
+    </div>
+  );
+}
+
+/**
+ * Custom-window-chrome opt-in. Gated to the desktop shell that actually owns a
+ * native title bar — `windowControls.isSupported()` is false on the PWA (and we
+ * exclude macOS, whose traffic-light controls can't be credibly replaced), so
+ * the whole section is absent on web (closes JP-107: the toggle no longer leaks
+ * onto the PWA, where it had no effect).
+ */
+function WindowChromeSection() {
+  const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
+  const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
+
+  if (!windowControls.isSupported() || isMacOS()) return null;
+
+  const handleToggle = (next: boolean) => {
+    const verb = import.meta.env.DEV
+      ? 'The flag will be saved (manual `tauri:dev` restart required)'
+      : 'The app will restart';
+    const confirmed = window.confirm(
+      next
+        ? `Use custom window chrome? ${verb} to apply.`
+        : `Revert to system window decorations? ${verb} to apply.`
+    );
+    if (!confirmed) return;
+    setCustomChrome(next);
+    // Flush any pending auto-save so the restart path doesn't trip the
+    // "unsaved changes" beforeunload prompt.
+    try {
+      usePersistenceStore.getState().saveDocument();
+    } catch {
+      // Best-effort flush; the user already confirmed the restart.
+    }
+    // Dev-mode caveat: `app.restart()` under `tauri dev` kills the cargo-spawned
+    // binary without re-spawning, so persist the flag and tell the developer to
+    // bounce `tauri:dev`. Production bundles restart cleanly.
+    if (import.meta.env.DEV) {
+      void opener.persistCustomChrome(next);
+      useNotificationStore.getState().warning(
+        'Custom chrome flag saved. In dev mode you must stop and restart `bun run tauri:dev` manually for it to take effect.',
+        { duration: 10000 }
+      );
+    } else {
+      void opener.applyCustomChrome(next);
+    }
+  };
+
+  return (
+    <div className="settings-group">
+      <h4 className="settings-group-title">Window</h4>
+      <div className="settings-row settings-row-switch">
+        <label className="settings-switch-label" htmlFor="custom-chrome">
+          <Switch
+            id="custom-chrome"
+            checked={customChrome}
+            onCheckedChange={handleToggle}
+            ariaLabel="Use custom window chrome"
+          />
+          <span className="settings-switch-text">Use custom window chrome</span>
+        </label>
+        <span className="settings-hint">
+          Replace the native title bar with DocuShark's in-app window chrome.
+          {import.meta.env.DEV
+            ? ' In dev, restart tauri:dev to apply.'
+            : ' The app restarts to apply.'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/settings/GeneralSettings.tsx
+++ b/src/ui/settings/GeneralSettings.tsx
@@ -11,7 +11,6 @@
 
 import { useSettingsStore, ConnectorRoutingMode } from '../../store/settingsStore';
 import { useStyleProfileStore } from '../../store/styleProfileStore';
-import { useThemeStore, ThemePreference } from '../../store/themeStore';
 import './GeneralSettings.css';
 
 export function GeneralSettings() {
@@ -27,15 +26,9 @@ export function GeneralSettings() {
   const setShowMinimap = useSettingsStore((state) => state.setShowMinimap);
   const layerClickFocusShape = useSettingsStore((state) => state.layerClickFocusShape);
   const setLayerClickFocusShape = useSettingsStore((state) => state.setLayerClickFocusShape);
-  const gridOpacity = useSettingsStore((state) => state.gridOpacity);
-  const setGridOpacity = useSettingsStore((state) => state.setGridOpacity);
   const resetSettings = useSettingsStore((state) => state.resetSettings);
 
   const profiles = useStyleProfileStore((state) => state.profiles);
-
-  // Theme state
-  const themePreference = useThemeStore((state) => state.preference);
-  const setThemePreference = useThemeStore((state) => state.setPreference);
 
   const handleConnectorTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setDefaultConnectorType(e.target.value as ConnectorRoutingMode);
@@ -46,58 +39,9 @@ export function GeneralSettings() {
     setDefaultStyleProfileId(value === '' ? null : value);
   };
 
-  const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setThemePreference(e.target.value as ThemePreference);
-  };
-
   return (
     <div className="general-settings">
       <h3 className="settings-section-title">General Settings</h3>
-
-      {/* Appearance Settings */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Appearance</h4>
-
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="theme-mode">
-            Theme
-          </label>
-          <select
-            id="theme-mode"
-            className="settings-select"
-            value={themePreference}
-            onChange={handleThemeChange}
-          >
-            <option value="system">System (Auto)</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-          <span className="settings-hint">
-            Choose your preferred color theme
-          </span>
-        </div>
-
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="grid-opacity">
-            Grid Opacity
-          </label>
-          <div className="settings-slider-row">
-            <input
-              id="grid-opacity"
-              type="range"
-              className="styled-slider"
-              min={0}
-              max={100}
-              value={gridOpacity}
-              onChange={(e) => setGridOpacity(Number(e.target.value))}
-            />
-            <span className="settings-slider-value">{gridOpacity}%</span>
-          </div>
-          <span className="settings-hint">
-            Adjust the visibility of the canvas grid (0 = hidden)
-          </span>
-        </div>
-      </div>
 
       {/* Connector Settings */}
       <div className="settings-group">

--- a/src/ui/settings/LayoutSettings.tsx
+++ b/src/ui/settings/LayoutSettings.tsx
@@ -27,7 +27,16 @@ const DOCK_LABELS: Record<DockSide, string> = {
   right: 'Right',
 };
 
-export function LayoutSettings() {
+export interface LayoutSettingsProps {
+  /**
+   * Render as a section within a larger settings panel (Appearance) — uses an
+   * `h4` section heading instead of the standalone `h3`, so heading levels
+   * stay sane when nested. Defaults to standalone.
+   */
+  embedded?: boolean;
+}
+
+export function LayoutSettings({ embedded = false }: LayoutSettingsProps = {}) {
   const layout = useUIPreferencesStore((s) => s.layout);
   const setDefaultLayout = useUIPreferencesStore((s) => s.setDefaultLayout);
   const setPanelDockFor = useUIPreferencesStore((s) => s.setPanelDockFor);
@@ -45,7 +54,7 @@ export function LayoutSettings() {
   return (
     <div className="layout-settings">
       <header className="layout-settings-header">
-        <h3>Layout</h3>
+        {embedded ? <h4 className="settings-group-title">Layout</h4> : <h3>Layout</h3>}
         <p>
           Customize how each layout arranges its panels. Changes are scoped to
           the layout you're editing — switching to another layout never carries


### PR DESCRIPTION
Stacks **JP-254** (Appearance tab + theme persistence) and **JP-107** (window-chrome PWA leak) — the first slice of the **JP-253** UX-flex epic. The bug fix is subsumed by relocating the chrome toggle, so they ship together.

## What changed

- **Renamed Settings `Layout` tab → `Appearance`** (`SwatchBook` icon) and added `AppearanceSettings` — the consolidated home for visual/UX config. Sections: **Theme · Canvas · Layout · Window chrome**. `LayoutSettings` embeds as a section (`embedded` prop → `h4` heading).
- **Moved Theme + Grid Opacity** out of General into Appearance. General keeps the granular connector/shape/display settings.
- **Theme persistence (latent bug fix):** the theme preference was *not persisted* — Light/Dark silently reset to `system` on every reload. Now persisted to `docushark-theme`, FOUC-safe (a recomputing persist `merge` derives `resolvedTheme`/`colors` from the stored preference, applied at module load). Added `color-scheme` per theme + PWA `<meta name="theme-color">` sync (replaces the stale `#2196f3` default).
- **JP-107:** custom window chrome is now gated behind the `src/platform/` seam. The opt-in moved into Appearance → Window (rendered only when `windowControls.isSupported()` and not macOS), and `App.tsx` gates the in-app `TitleBar` render on `windowControls.isSupported()` too — so a persisted/legacy `true` no longer renders a controls-less title bar on the PWA.
- **New reusable primitives** `src/ui/components/{SegmentedControl,Switch}` on Radix (`react-radio-group`, `react-switch`) — headless, brand-tokened, a swap-friendly seam for the future settings-menu rework (JP-211). ~15–20 KB gz.

## Verification

- `bun run typecheck` ✅  ·  `bun run test:run` ✅ (1872 tests, +9 new)  ·  `bun run build` ✅
- New tests: theme persistence/rehydrate/theme-color, `SegmentedControl`, `AppearanceSettings` (incl. a JP-107 web regression asserting the Window section is absent when `IS_TAURI` is false). Added a `matchMedia` test shim.
- OSS-leak grep on touched files: clean.

## Notes

- Accent/Motion (JP-255) and Density + UI scale (JP-256) build on this backbone in follow-up PRs; the `AppearanceConfig` snapshot seam lands with JP-255 alongside the `appearancePrefs` slice.

Fixes JP-107

Assisted-by: Opus 4.8