### PR TITLE
JP-255: Accent color + Motion preference (Appearance)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -258,3 +258,59 @@ body {
 [data-theme="dark"] body {
   background-color: var(--navy-1000);
 }
+
+/* ===========================================================================
+ * Accent color (Settings → Appearance → Accent color)
+ * ---------------------------------------------------------------------------
+ * Swaps the unified `--color-primary*` tokens (links, active borders, focus
+ * rings, primary buttons, selected controls, the active layout chip — anything
+ * that consumes them). `data-accent="default"` adds no override, so the theme's
+ * own accent stands (navy in light, gold in dark). The CTA gold (`--color-cta*`)
+ * is intentionally left untouched. Per-accent hues are tuned for contrast on
+ * the warm-paper (light) and navy (dark) surfaces respectively.
+ * ======================================================================== */
+
+[data-accent='teal'] {
+  --color-primary: #0f766e;
+  --color-primary-dark: #115e59;
+}
+[data-accent='violet'] {
+  --color-primary: #6d28d9;
+  --color-primary-dark: #5b21b6;
+}
+[data-accent='amber'] {
+  --color-primary: #b45309;
+  --color-primary-dark: #92400e;
+}
+[data-accent='rose'] {
+  --color-primary: #be123c;
+  --color-primary-dark: #9f1239;
+}
+
+[data-theme='dark'][data-accent='teal'] {
+  --color-primary: #5eead4;
+  --color-primary-dark: #2dd4bf;
+}
+[data-theme='dark'][data-accent='violet'] {
+  --color-primary: #c4b5fd;
+  --color-primary-dark: #a78bfa;
+}
+[data-theme='dark'][data-accent='amber'] {
+  --color-primary: #fcd34d;
+  --color-primary-dark: #fbbf24;
+}
+[data-theme='dark'][data-accent='rose'] {
+  --color-primary: #fda4af;
+  --color-primary-dark: #fb7185;
+}
+
+/* Derive the soft wash + focus-ring tints from the chosen hue so they stay in
+   sync without hand-tuning each accent (only non-default accents; the theme
+   defaults keep their hand-tuned values). */
+[data-accent='teal'],
+[data-accent='violet'],
+[data-accent='amber'],
+[data-accent='rose'] {
+  --color-primary-light: color-mix(in srgb, var(--color-primary) 14%, transparent);
+  --color-primary-alpha: color-mix(in srgb, var(--color-primary) 32%, transparent);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,9 @@ import './index.css';
 // + reduced-motion root attribute via the CSS module's sibling import below.
 import './ui/adaptive-motion.css';
 import './platform/adaptiveBudget';
+// Mirror the persisted appearance prefs (accent + motion) onto the document at
+// boot, before first paint — see applyAppearance (Abstraction A).
+import './ui/appearance/applyAppearance';
 
 function mountApp(): void {
   const root = document.getElementById('root');

--- a/src/platform/adaptiveBudget.test.ts
+++ b/src/platform/adaptiveBudget.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { refreshAdaptiveBudget } from './adaptiveBudget';
+import { refreshAdaptiveBudget, setMotionPreference } from './adaptiveBudget';
 
 interface DeviceEnv {
   coarsePointer?: boolean;
@@ -76,5 +76,39 @@ describe('adaptiveBudget', () => {
     expect(budget.reduceMotion).toBe(true);
     expect(budget.cursorBroadcastMs).toBe(120);
     expect(document.documentElement.dataset['reducedMotion']).toBe('true');
+  });
+});
+
+describe('adaptiveBudget — user motion preference', () => {
+  // Module state persists between cases; reset to the default after each.
+  afterEach(() => {
+    setMotionPreference('system');
+  });
+
+  it("'reduced' forces reduceMotion + the attribute, even when the OS does not", () => {
+    setupDevice({ reduceMotion: false });
+    const budget = setMotionPreference('reduced');
+    expect(budget.reduceMotion).toBe(true);
+    expect(document.documentElement.dataset['reducedMotion']).toBe('true');
+  });
+
+  it("'full' overrides the OS reduce-motion setting (no reduction, no attribute)", () => {
+    setupDevice({ reduceMotion: true });
+    const budget = setMotionPreference('full');
+    expect(budget.reduceMotion).toBe(false);
+    expect(document.documentElement.dataset['reducedMotion']).toBeUndefined();
+  });
+
+  it("'full' overrides the low-power heuristic too", () => {
+    setupDevice({ cores: 2, memory: 2 });
+    const budget = setMotionPreference('full');
+    expect(budget.reduceMotion).toBe(false);
+  });
+
+  it("'system' follows the OS setting", () => {
+    setupDevice({ reduceMotion: true });
+    expect(setMotionPreference('system').reduceMotion).toBe(true);
+    setupDevice({ reduceMotion: false });
+    expect(refreshAdaptiveBudget().reduceMotion).toBe(false);
   });
 });

--- a/src/platform/adaptiveBudget.ts
+++ b/src/platform/adaptiveBudget.ts
@@ -9,17 +9,30 @@
  *
  * Detection is **boot-time**: touch and power are sampled once at module load
  * (they effectively never change mid-session), so the snapshot is memoized.
- * The one exception is motion — the OS "reduce motion" toggle is live, so we
- * listen for `prefers-reduced-motion` changes and re-derive on the fly. CSS
- * can express the media-query half directly, but not the `isLowPower` half, so
- * we mirror the resolved `reduceMotion` onto a `data-reduced-motion` root
- * attribute that `adaptive-motion.css` keys off.
+ * The one exception is motion — both the OS "reduce motion" toggle and the
+ * user's in-app Motion preference are live, so we re-derive on either change.
+ * `data-reduced-motion` on the root is the *single* authority that
+ * `adaptive-motion.css` keys off (this module is its only writer); the CSS no
+ * longer also reads `@media (prefers-reduced-motion)` directly, so an explicit
+ * "Full" preference can override the OS everywhere.
  *
  * Browser-native only (reads `device`, which uses `matchMedia` / `navigator`),
  * so this tree-shakes identically into both the Tauri and PWA shells.
  */
 
 import { device } from './device';
+
+/**
+ * User-facing motion preference (Settings → Appearance → Motion):
+ *  - `system`  — follow the OS reduce-motion setting (and low-power heuristic).
+ *  - `reduced` — always minimize motion, regardless of OS.
+ *  - `full`    — always animate, overriding the OS setting and the low-power
+ *               heuristic (an explicit opt-in).
+ *
+ * Fed in via `setMotionPreference` by the appearance applier so this module
+ * stays the single authority over `data-reduced-motion`.
+ */
+export type MotionPreference = 'system' | 'reduced' | 'full';
 
 export interface AdaptiveBudget {
   /** Skip non-essential animation (OS reduce-motion or a low-power device). */
@@ -37,9 +50,20 @@ const DEFAULT_CURSOR_MS = 33;
 /** Grab-zone enlargement on coarse pointers (handles, snap, drag threshold). */
 const TOUCH_HIT_TARGET_SCALE = 1.6;
 
+/** The live user preference; updated via `setMotionPreference`. */
+let motionPreference: MotionPreference = 'system';
+
+/** Resolve the effective reduce-motion flag from the preference + device. */
+function resolveReduceMotion(): boolean {
+  if (motionPreference === 'reduced') return true;
+  if (motionPreference === 'full') return false;
+  // 'system': honor the OS toggle and the low-power heuristic.
+  return device.prefersReducedMotion() || device.isLowPower();
+}
+
 function deriveBudget(): AdaptiveBudget {
   return {
-    reduceMotion: device.prefersReducedMotion() || device.isLowPower(),
+    reduceMotion: resolveReduceMotion(),
     cursorBroadcastMs: device.isLowPower() ? CONSTRAINED_CURSOR_MS : DEFAULT_CURSOR_MS,
     hitTargetScale: device.isTouch() ? TOUCH_HIT_TARGET_SCALE : 1,
   };
@@ -70,6 +94,15 @@ export function refreshAdaptiveBudget(): AdaptiveBudget {
   budget = deriveBudget();
   applyReducedMotionAttr(budget.reduceMotion);
   return budget;
+}
+
+/**
+ * Set the user's motion preference and re-derive. Called by the appearance
+ * applier on hydration and whenever the Motion setting changes.
+ */
+export function setMotionPreference(pref: MotionPreference): AdaptiveBudget {
+  motionPreference = pref;
+  return refreshAdaptiveBudget();
 }
 
 // Live motion: the OS reduce-motion setting can flip mid-session. Re-derive

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -238,4 +238,50 @@ describe('uiPreferencesStore — migration', () => {
     expect(layout.customChrome).toBe(true);
     expect(layout.modeOverrides.technician.properties?.dock).toBe('left');
   });
+
+  it('v3 → v4 defaults the new appearance slice without disturbing layout', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          expandedSections: {},
+          propertyPanelWidth: 240,
+          documentBrowserView: 'list',
+          documentBrowserSort: 'modified-desc',
+          documentBrowserGroupBy: 'none',
+          documentBrowserCollapsed: {},
+          layout: { defaultMode: 'power', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          // No appearancePrefs — predates the v4 slice.
+        },
+        version: 3,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    const state = useUIPreferencesStore.getState();
+    expect(state.appearancePrefs).toEqual({ accent: 'default', motion: 'system' });
+    // Layout from the older payload is untouched.
+    expect(state.layout.defaultMode).toBe('power');
+  });
+});
+
+describe('uiPreferencesStore — appearance slice', () => {
+  it("defaults to the theme's own accent and follow-system motion", () => {
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      accent: 'default',
+      motion: 'system',
+    });
+  });
+
+  it('setAccent / setMotion update the slice (new object reference each time)', () => {
+    const s = useUIPreferencesStore.getState();
+    const before = s.appearancePrefs;
+    s.setAccent('teal');
+    s.setMotion('reduced');
+    const after = useUIPreferencesStore.getState().appearancePrefs;
+    expect(after).toEqual({ accent: 'teal', motion: 'reduced' });
+    // Reference changes so the applier's identity check fires.
+    expect(after).not.toBe(before);
+  });
 });

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -15,6 +15,7 @@ import type {
 } from '../ui/layout/types';
 import { LAYOUT_MODES } from '../ui/layout/types';
 import { LAYOUT_PRESETS } from '../ui/layout/modes';
+import type { MotionPreference } from '../platform/adaptiveBudget';
 
 export type DocumentBrowserView = 'list' | 'grid';
 export type DocumentBrowserSort =
@@ -24,6 +25,19 @@ export type DocumentBrowserSort =
   | 'name-desc'
   | 'created-desc';
 export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
+
+/**
+ * Accent hue driving the `--color-primary*` tokens. `'default'` keeps the
+ * theme's own accent (navy in light, gold in dark) by adding no override.
+ */
+export type AccentColor = 'default' | 'teal' | 'violet' | 'amber' | 'rose';
+
+/** App-wide appearance preferences. (Theme lives in its own `themeStore`.) */
+export interface AppearancePrefs {
+  accent: AccentColor;
+  /** Interface-motion preference; fed into the adaptive motion budget. */
+  motion: MotionPreference;
+}
 
 /**
  * UI preferences state.
@@ -53,6 +67,8 @@ export interface UIPreferencesState {
   storageInfoToastSeen: boolean;
   /** Layout manager slice — modes, per-doc memory, per-mode overrides, chrome. */
   layout: LayoutState;
+  /** Appearance slice — accent + motion (theme is in `themeStore`). */
+  appearancePrefs: AppearancePrefs;
 }
 
 /**
@@ -98,6 +114,12 @@ export interface UIPreferencesActions {
   /** Drop all per-layout customization, preserving defaultMode + customChrome. */
   resetLayoutCustomization: () => void;
 
+  // ── Appearance actions
+  /** Set the accent hue. */
+  setAccent: (accent: AccentColor) => void;
+  /** Set the interface motion preference. */
+  setMotion: (motion: MotionPreference) => void;
+
   /** Reset to initial state */
   reset: () => void;
 }
@@ -132,6 +154,12 @@ const initialLayoutState: LayoutState = {
   customChrome: false,
 };
 
+/** Initial appearance prefs — theme's own accent, follow-system motion. */
+const initialAppearancePrefs: AppearancePrefs = {
+  accent: 'default',
+  motion: 'system',
+};
+
 /**
  * Initial state.
  */
@@ -145,6 +173,7 @@ const initialState: UIPreferencesState = {
   documentBrowserCollapsed: {},
   storageInfoToastSeen: false,
   layout: initialLayoutState,
+  appearancePrefs: { ...initialAppearancePrefs },
 };
 
 /**
@@ -335,13 +364,21 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         });
       },
 
+      setAccent: (accent) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, accent } });
+      },
+
+      setMotion: (motion) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, motion } });
+      },
+
       reset: () => {
         set(initialState);
       },
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 3,
+      version: 4,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
@@ -352,6 +389,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         documentBrowserCollapsed: state.documentBrowserCollapsed,
         storageInfoToastSeen: state.storageInfoToastSeen,
         layout: state.layout,
+        appearancePrefs: state.appearancePrefs,
       }),
       migrate: (persisted, fromVersion) => {
         // Cast away the loose persisted-state typing — older payloads carry
@@ -412,6 +450,12 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
           layout = rest as LayoutState;
         }
         next['layout'] = layout;
+        // v3 → v4: added the appearance slice (accent + motion). Default it so
+        // existing behavior is preserved (theme's own accent, follow-system
+        // motion); the `merge` below also backstops this.
+        if (fromVersion < 4) {
+          next['appearancePrefs'] = next['appearancePrefs'] ?? { ...initialAppearancePrefs };
+        }
         return next as unknown as UIPreferencesState;
       },
       merge: (persisted, current) => {
@@ -426,7 +470,11 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...(p.layout?.modeOverrides ?? {}),
           },
         };
-        return { ...current, ...p, layout };
+        const appearancePrefs: AppearancePrefs = {
+          ...initialAppearancePrefs,
+          ...(p.appearancePrefs ?? {}),
+        };
+        return { ...current, ...p, layout, appearancePrefs };
       },
     }
   )

--- a/src/ui/adaptive-motion.css
+++ b/src/ui/adaptive-motion.css
@@ -1,26 +1,18 @@
 /*
  * Adaptive motion budget (JP-101). Neutralizes non-essential animation when
- * the device reports constrained conditions, per Final OSS App Design §5.
+ * motion should be reduced, per Final OSS App Design §5.
  *
- * Two triggers, same treatment:
- *   1. The native `prefers-reduced-motion: reduce` media query (OS setting).
- *   2. `:root[data-reduced-motion="true"]`, set by adaptiveBudget.ts — this
- *      covers the low-power-device case, which CSS alone cannot detect.
+ * Single trigger: `:root[data-reduced-motion="true"]`, set by adaptiveBudget.ts.
+ * That module is the sole authority — it folds together the OS
+ * `prefers-reduced-motion` setting, the low-power-device heuristic (which CSS
+ * alone cannot detect), and the user's in-app Motion preference. We deliberately
+ * do NOT also read `@media (prefers-reduced-motion: reduce)` here: that would
+ * fire independently and stop an explicit "Full" preference from overriding the
+ * OS. The attribute already reflects the OS setting (the module reads it).
  *
  * We don't hard-zero durations (that can break transitionend listeners);
  * collapsing to ~0.01ms keeps callbacks firing while removing the motion.
  */
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
 
 :root[data-reduced-motion='true'] *,
 :root[data-reduced-motion='true'] *::before,

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { useThemeStore } from '../../store/themeStore';
+// Importing the applier boots its module-level store subscription.
+import './applyAppearance';
+import { getAppearanceSnapshot, applyAppearanceSnapshot, resetAppearance } from './appearanceConfig';
+
+beforeEach(() => {
+  localStorage.clear();
+  useUIPreferencesStore.getState().reset();
+  useThemeStore.getState().setPreference('system');
+});
+
+afterEach(() => {
+  useUIPreferencesStore.getState().setAccent('default');
+  useUIPreferencesStore.getState().setMotion('system');
+});
+
+describe('appearance applier (Abstraction A)', () => {
+  it('mirrors the accent onto the document root', () => {
+    useUIPreferencesStore.getState().setAccent('violet');
+    expect(document.documentElement.dataset['accent']).toBe('violet');
+  });
+
+  it('routes motion through the adaptive budget (data-reduced-motion)', () => {
+    useUIPreferencesStore.getState().setMotion('reduced');
+    expect(document.documentElement.dataset['reducedMotion']).toBe('true');
+    useUIPreferencesStore.getState().setMotion('full');
+    expect(document.documentElement.dataset['reducedMotion']).toBeUndefined();
+  });
+});
+
+describe('appearance snapshot seam (Abstraction B)', () => {
+  it('captures theme + accent + motion', () => {
+    useThemeStore.getState().setPreference('dark');
+    useUIPreferencesStore.getState().setAccent('amber');
+    useUIPreferencesStore.getState().setMotion('reduced');
+    expect(getAppearanceSnapshot()).toEqual({ theme: 'dark', accent: 'amber', motion: 'reduced' });
+  });
+
+  it('applies a config across both stores', () => {
+    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full' });
+    expect(useThemeStore.getState().preference).toBe('light');
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({ accent: 'rose', motion: 'full' });
+  });
+
+  it('resetAppearance restores every default', () => {
+    useThemeStore.getState().setPreference('dark');
+    useUIPreferencesStore.getState().setAccent('teal');
+    useUIPreferencesStore.getState().setMotion('reduced');
+    resetAppearance();
+    expect(getAppearanceSnapshot()).toEqual({ theme: 'system', accent: 'default', motion: 'system' });
+  });
+});

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -1,0 +1,46 @@
+/**
+ * Appearance snapshot seam (Abstraction B) — a single read/write surface across
+ * the two stores that own appearance state (theme preference in `themeStore`,
+ * accent + motion in `uiPreferencesStore`). Designed now so the future
+ * "Workspaces" presets + shareable-config features capture/apply a whole look
+ * in one call, without reaching into each store. Not yet wired to UI beyond the
+ * "Reset appearance" action.
+ */
+
+import { useThemeStore, type ThemePreference } from '../../store/themeStore';
+import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
+import type { MotionPreference } from '../../platform/adaptiveBudget';
+
+export interface AppearanceConfig {
+  theme: ThemePreference;
+  accent: AccentColor;
+  motion: MotionPreference;
+}
+
+export const DEFAULT_APPEARANCE: AppearanceConfig = {
+  theme: 'system',
+  accent: 'default',
+  motion: 'system',
+};
+
+/** Capture the current appearance as a portable config object. */
+export function getAppearanceSnapshot(): AppearanceConfig {
+  const { accent, motion } = useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, accent, motion };
+}
+
+/** Apply a (partial) appearance config across both stores. */
+export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
+  if (cfg.theme !== undefined) useThemeStore.getState().setPreference(cfg.theme);
+  if (cfg.accent !== undefined) useUIPreferencesStore.getState().setAccent(cfg.accent);
+  if (cfg.motion !== undefined) useUIPreferencesStore.getState().setMotion(cfg.motion);
+}
+
+/**
+ * Reset every appearance choice to its default — theme, accent, motion, and the
+ * per-layout customization deltas.
+ */
+export function resetAppearance(): void {
+  applyAppearanceSnapshot(DEFAULT_APPEARANCE);
+  useUIPreferencesStore.getState().resetLayoutCustomization();
+}

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -1,0 +1,36 @@
+/**
+ * Appearance applier (Abstraction A) — the single place that mirrors appearance
+ * preferences onto the document. Runs at module load via a vanilla
+ * `store.subscribe` (NOT a React effect), so it applies the hydrated values
+ * before first paint (localStorage hydrates synchronously on store creation) —
+ * no flash — and keeps tracking changes from anywhere, inside or outside React.
+ *
+ * Accent → `data-accent` root attribute (CSS swaps `--color-primary*`).
+ * Motion → handed to `adaptiveBudget`, the sole authority over the
+ *          `data-reduced-motion` attribute.
+ *
+ * (Theme is applied by `themeStore` itself; this module owns the rest.)
+ */
+
+import { useUIPreferencesStore, type AppearancePrefs } from '../../store/uiPreferencesStore';
+import { setMotionPreference } from '../../platform/adaptiveBudget';
+
+function applyAppearance(prefs: AppearancePrefs): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset['accent'] = prefs.accent;
+  }
+  setMotionPreference(prefs.motion);
+}
+
+// Apply the already-hydrated preferences immediately.
+let applied = useUIPreferencesStore.getState().appearancePrefs;
+applyAppearance(applied);
+
+// Re-apply only when the appearance slice actually changes (the setters produce
+// a new object reference), so unrelated UI-pref updates don't churn.
+useUIPreferencesStore.subscribe((state) => {
+  if (state.appearancePrefs !== applied) {
+    applied = state.appearancePrefs;
+    applyAppearance(applied);
+  }
+});

--- a/src/ui/components/SegmentedControl.css
+++ b/src/ui/components/SegmentedControl.css
@@ -55,10 +55,5 @@
   align-items: center;
 }
 
-/* Honor reduced-motion explicitly (CSS @media here is fine; the JS-driven
-   `data-motion` override seam lands with the Accent/Motion slice). */
-@media (prefers-reduced-motion: reduce) {
-  .segmented-control__item {
-    transition: none;
-  }
-}
+/* Reduced-motion is handled globally by adaptive-motion.css via
+   :root[data-reduced-motion='true'] — no per-component @media needed. */

--- a/src/ui/components/Switch.css
+++ b/src/ui/components/Switch.css
@@ -48,9 +48,4 @@
   transform: translateX(calc(var(--switch-w) - var(--thumb) - var(--switch-pad)));
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .switch,
-  .switch__thumb {
-    transition: none;
-  }
-}
+/* Reduced-motion handled globally by adaptive-motion.css. */

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -93,10 +93,12 @@
   z-index: 6;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .flyout-panel-body {
-    animation: flyout-panel-slide 140ms ease-out;
-  }
+/* Slide-in is declared unconditionally; the global
+   `:root[data-reduced-motion='true']` rule in adaptive-motion.css collapses it
+   when motion is reduced (OS, low-power, or the user's Motion preference), and
+   an explicit "Full" preference keeps it even when the OS asks to reduce. */
+.flyout-panel-body {
+  animation: flyout-panel-slide 140ms ease-out;
 }
 
 .flyout-panel-side-right .flyout-panel-body {

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -39,3 +39,50 @@
 .appearance-settings .layout-settings-header p {
   margin-top: 2px;
 }
+
+/* Accent color swatches (Radix RadioGroup of color circles). */
+.accent-picker {
+  display: inline-flex;
+  gap: 10px;
+}
+
+.accent-picker__swatch {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--swatch);
+  box-shadow: 0 0 0 1px var(--bg-active) inset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.accent-picker__swatch:hover {
+  transform: scale(1.08);
+}
+
+.accent-picker__swatch:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+/* Selected: a ring in the panel color around the swatch + a white check. */
+.accent-picker__swatch[data-state='checked'] {
+  box-shadow:
+    0 0 0 2px var(--bg-primary),
+    0 0 0 4px var(--swatch);
+}
+
+.accent-picker__check {
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.accent-picker__swatch[data-state='checked'] .accent-picker__check {
+  opacity: 1;
+}

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -3,17 +3,19 @@ import { render, screen } from '@testing-library/react';
 import { AppearanceSettings } from './AppearanceSettings';
 
 describe('AppearanceSettings', () => {
-  it('renders the theme control', () => {
+  it('renders the theme, accent, and motion controls', () => {
     render(<AppearanceSettings />);
     expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Accent color' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Interface animations' })).toBeTruthy();
   });
 
-  // JP-107 regression: the custom-window-chrome control is desktop-only. In the
+  // JP-107 regression: the DocuShark title-bar control is desktop-only. In the
   // test (web) environment `windowControls.isSupported()` is false (IS_TAURI is
-  // false), so the entire Window section — header included — must be absent.
-  it('does not render the window-chrome section on web', () => {
+  // false), so the entire Title bar section — header included — must be absent.
+  it('does not render the title-bar section on the web app', () => {
     render(<AppearanceSettings />);
-    expect(screen.queryByText(/custom window chrome/i)).toBeNull();
-    expect(screen.queryByText('Window')).toBeNull();
+    expect(screen.queryByText(/use docushark's title bar/i)).toBeNull();
+    expect(screen.queryByText('Title bar')).toBeNull();
   });
 });

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,39 +1,67 @@
 /**
  * Settings → Appearance — the consolidated home for visual/UX configuration.
  *
- * Sections: Theme, Canvas, Layout (the panel-arrangement editor, embedded), and
- * Window chrome (desktop-only). Accent / Motion / Density + UI-scale knobs land
- * in later slices of the Appearance epic; this panel is the structural backbone.
- *
- * Kept self-contained (no coupling to `SettingsModal` internals) so it survives
- * the planned settings-menu rework.
+ * Sections: Theme, Accent color, Motion, Canvas, Layout (the panel-arrangement
+ * editor, embedded), and Title bar (desktop-only). Density + UI-scale land in a
+ * later slice. Kept self-contained (no coupling to `SettingsModal` internals)
+ * so it survives the planned settings-menu rework.
  */
 
-import { Monitor, Moon, Sun } from 'lucide-react';
+import type { CSSProperties } from 'react';
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import { Check, Monitor, Moon, Sun } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
-import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
+import type { MotionPreference } from '../../platform/adaptiveBudget';
 import { windowControls } from '../../platform/window';
 import { opener } from '../../platform/opener';
 import { isMacOS } from '../../utils/platform';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { Switch } from '../components/Switch';
+import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
 import './AppearanceSettings.css';
 
 const THEME_OPTIONS = [
-  { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your OS appearance' },
+  { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your device appearance' },
   { value: 'light' as const, label: 'Light', icon: <Sun size={15} />, title: 'Light theme' },
   { value: 'dark' as const, label: 'Dark', icon: <Moon size={15} />, title: 'Dark theme' },
+];
+
+// Representative swatch colors (the light-theme hue). 'default' shows the brand
+// navy and adds no override — the theme keeps its own accent (navy / gold).
+const ACCENT_OPTIONS: ReadonlyArray<{ value: AccentColor; label: string; swatch: string }> = [
+  { value: 'default', label: 'Default', swatch: '#1f3354' },
+  { value: 'teal', label: 'Teal', swatch: '#0f766e' },
+  { value: 'violet', label: 'Violet', swatch: '#6d28d9' },
+  { value: 'amber', label: 'Amber', swatch: '#b45309' },
+  { value: 'rose', label: 'Rose', swatch: '#be123c' },
+];
+
+const MOTION_OPTIONS = [
+  { value: 'system' as const, label: 'System', title: 'Follow your device accessibility setting' },
+  { value: 'reduced' as const, label: 'Reduced', title: 'Minimize interface animations' },
+  { value: 'full' as const, label: 'Full', title: 'Always show interface animations' },
 ];
 
 export function AppearanceSettings() {
   const themePreference = useThemeStore((s) => s.preference);
   const setThemePreference = useThemeStore((s) => s.setPreference);
+  const accent = useUIPreferencesStore((s) => s.appearancePrefs.accent);
+  const setAccent = useUIPreferencesStore((s) => s.setAccent);
+  const motion = useUIPreferencesStore((s) => s.appearancePrefs.motion);
+  const setMotion = useUIPreferencesStore((s) => s.setMotion);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
+
+  const handleReset = () => {
+    if (window.confirm('Reset theme, accent color, motion, and layout customization to their defaults?')) {
+      resetAppearance();
+    }
+  };
 
   return (
     <div className="appearance-settings">
@@ -56,12 +84,42 @@ export function AppearanceSettings() {
         </div>
       </div>
 
+      {/* Accent color */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Accent color</h4>
+        <div className="settings-row">
+          <span className="settings-label">Accent</span>
+          <AccentPicker value={accent} onValueChange={setAccent} />
+          <span className="settings-hint">
+            Tints buttons, links, highlights, and selected controls across the app.
+          </span>
+        </div>
+      </div>
+
+      {/* Motion */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Motion</h4>
+        <div className="settings-row">
+          <span className="settings-label">Interface animations</span>
+          <SegmentedControl
+            ariaLabel="Interface animations"
+            value={motion}
+            onValueChange={(v: MotionPreference) => setMotion(v)}
+            options={MOTION_OPTIONS}
+          />
+          <span className="settings-hint">
+            Reduce or turn off interface animations. "System" follows your device's
+            accessibility setting.
+          </span>
+        </div>
+      </div>
+
       {/* Canvas */}
       <div className="settings-group">
         <h4 className="settings-group-title">Canvas</h4>
         <div className="settings-row">
           <label className="settings-label" htmlFor="grid-opacity">
-            Grid Opacity
+            Grid opacity
           </label>
           <div className="settings-slider-row">
             <input
@@ -76,7 +134,7 @@ export function AppearanceSettings() {
             <span className="settings-slider-value">{gridOpacity}%</span>
           </div>
           <span className="settings-hint">
-            Adjust the visibility of the canvas grid (0 = hidden)
+            Adjust how visible the canvas grid is (0 = hidden).
           </span>
         </div>
       </div>
@@ -84,52 +142,86 @@ export function AppearanceSettings() {
       {/* Layout — the panel-arrangement editor, embedded as a section. */}
       <LayoutSettings embedded />
 
-      {/* Window chrome — desktop-only; renders nothing on the PWA. */}
-      <WindowChromeSection />
+      {/* Title bar — desktop-only; renders nothing on the web app. */}
+      <TitleBarSection />
+
+      {/* Reset */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Reset</h4>
+        <button type="button" className="settings-reset-btn" onClick={handleReset}>
+          Reset appearance to defaults
+        </button>
+      </div>
     </div>
   );
 }
 
+function AccentPicker({
+  value,
+  onValueChange,
+}: {
+  value: AccentColor;
+  onValueChange: (value: AccentColor) => void;
+}) {
+  return (
+    <RadioGroup.Root
+      className="accent-picker"
+      value={value}
+      onValueChange={(v) => onValueChange(v as AccentColor)}
+      aria-label="Accent color"
+      orientation="horizontal"
+      loop
+    >
+      {ACCENT_OPTIONS.map((opt) => (
+        <RadioGroup.Item
+          key={opt.value}
+          className="accent-picker__swatch"
+          value={opt.value}
+          aria-label={opt.label}
+          title={opt.label}
+          style={{ '--swatch': opt.swatch } as CSSProperties}
+        >
+          <Check className="accent-picker__check" size={14} strokeWidth={3} aria-hidden="true" />
+        </RadioGroup.Item>
+      ))}
+    </RadioGroup.Root>
+  );
+}
+
 /**
- * Custom-window-chrome opt-in. Gated to the desktop shell that actually owns a
- * native title bar — `windowControls.isSupported()` is false on the PWA (and we
- * exclude macOS, whose traffic-light controls can't be credibly replaced), so
- * the whole section is absent on web (closes JP-107: the toggle no longer leaks
- * onto the PWA, where it had no effect).
+ * DocuShark title bar opt-in. Gated to the desktop shell that actually owns a
+ * native title bar — `windowControls.isSupported()` is false on the web app
+ * (and we exclude macOS, whose window controls can't be credibly replaced) — so
+ * the whole section is absent there (JP-107: the option no longer appears where
+ * it has no effect).
  */
-function WindowChromeSection() {
+function TitleBarSection() {
   const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
   const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
 
   if (!windowControls.isSupported() || isMacOS()) return null;
 
   const handleToggle = (next: boolean) => {
-    const verb = import.meta.env.DEV
-      ? 'The flag will be saved (manual `tauri:dev` restart required)'
-      : 'The app will restart';
     const confirmed = window.confirm(
       next
-        ? `Use custom window chrome? ${verb} to apply.`
-        : `Revert to system window decorations? ${verb} to apply.`
+        ? "Use DocuShark's title bar? The app will restart to apply."
+        : "Switch back to your system's title bar? The app will restart to apply."
     );
     if (!confirmed) return;
     setCustomChrome(next);
-    // Flush any pending auto-save so the restart path doesn't trip the
-    // "unsaved changes" beforeunload prompt.
+    // Flush any pending auto-save so the restart doesn't trip the unsaved-changes prompt.
     try {
       usePersistenceStore.getState().saveDocument();
     } catch {
       // Best-effort flush; the user already confirmed the restart.
     }
-    // Dev-mode caveat: `app.restart()` under `tauri dev` kills the cargo-spawned
-    // binary without re-spawning, so persist the flag and tell the developer to
-    // bounce `tauri:dev`. Production bundles restart cleanly.
     if (import.meta.env.DEV) {
+      // Under `tauri dev` the app can't relaunch itself, so persist the flag and
+      // let the developer relaunch. (Dev-only path; customers get the restart.)
       void opener.persistCustomChrome(next);
-      useNotificationStore.getState().warning(
-        'Custom chrome flag saved. In dev mode you must stop and restart `bun run tauri:dev` manually for it to take effect.',
-        { duration: 10000 }
-      );
+      useNotificationStore.getState().info('Title bar preference saved — restart the app to see it.', {
+        duration: 6000,
+      });
     } else {
       void opener.applyCustomChrome(next);
     }
@@ -137,22 +229,20 @@ function WindowChromeSection() {
 
   return (
     <div className="settings-group">
-      <h4 className="settings-group-title">Window</h4>
+      <h4 className="settings-group-title">Title bar</h4>
       <div className="settings-row settings-row-switch">
-        <label className="settings-switch-label" htmlFor="custom-chrome">
+        <label className="settings-switch-label" htmlFor="docushark-title-bar">
           <Switch
-            id="custom-chrome"
+            id="docushark-title-bar"
             checked={customChrome}
             onCheckedChange={handleToggle}
-            ariaLabel="Use custom window chrome"
+            ariaLabel="Use DocuShark's title bar"
           />
-          <span className="settings-switch-text">Use custom window chrome</span>
+          <span className="settings-switch-text">Use DocuShark's title bar</span>
         </label>
         <span className="settings-hint">
-          Replace the native title bar with DocuShark's in-app window chrome.
-          {import.meta.env.DEV
-            ? ' In dev, restart tauri:dev to apply.'
-            : ' The app restarts to apply.'}
+          Replace your operating system's window title bar with DocuShark's own for a
+          more unified look. The app restarts to apply.
         </span>
       </div>
     </div>


### PR DESCRIPTION
Second slice of the **JP-253** UX-flex epic, building on the merged Appearance backbone (#120).

## What changed

- **Accent color** (Settings → Appearance → Accent color): a swatch picker (Radix `RadioGroup`) with `default / teal / violet / amber / rose`. Swaps the unified `--color-primary*` tokens, so it tints buttons, links, focus rings, selected controls, and the active layout chip **app-wide** — not just one element. `default` adds no override (keeps the theme's own navy/gold). Soft-wash + focus-ring tints are derived from the hue via `color-mix`. CTA gold is intentionally untouched.
- **Motion preference** (System / Reduced / Full): feeds the **existing** `adaptiveBudget` seam (`setMotionPreference`) rather than a parallel attribute, keeping `data-reduced-motion` the single authority. `adaptive-motion.css` drops its standalone `@media (prefers-reduced-motion)` block so the attribute is authoritative — an explicit **Full** now overrides the OS everywhere (CSS *and* the canvas/JS `reduceMotion` consumers). FlyoutPanel declares its slide unconditionally and relies on the global reduced-motion override.
- **`appearancePrefs` slice** on `uiPreferencesStore` (accent + motion) with an additive **v3→v4** migration + merge default. **One FOUC-proof applier** (`applyAppearance`) mirrors prefs onto the root via a vanilla `store.subscribe` at boot. **`AppearanceConfig` snapshot seam** (`get`/`apply`/`reset`) seeds the future presets + shareable-config work.
- **Plainer, customer-facing copy** (per review): the desktop-only option is now **"Use DocuShark's title bar"** (was "custom window chrome"), and the dev-only `tauri:dev` wording is gone from the UI. Added a **"Reset appearance"** action.

## Verification

- `bun run typecheck` ✅ · `bun run test:run` ✅ (1884 tests, +15 new) · `bun run build` ✅
- New tests: motion-preference derivation (incl. **Full** overriding both the OS and the low-power heuristic), v3→v4 migration defaulting the slice, the applier + snapshot seam, and the AppearanceSettings controls. OSS-leak grep clean.

## Notes

- Next: **JP-256** (Density + UI text scale) — the heaviest slice (the `zoom`-vs-token decision + canvas-coordinate isolation), its own PR.

Assisted-by: Opus 4.8