### PR TITLE
JP-256: Density + Interface size (Appearance)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "docushark",
       "dependencies": {
         "@radix-ui/react-radio-group": "^1.4.0",
+        "@radix-ui/react-slider": "^1.4.0",
         "@radix-ui/react-switch": "^1.3.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-fs": "^2.5.0",
@@ -378,6 +379,8 @@
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
+    "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
+
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.9", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-slot": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ=="],
@@ -397,6 +400,8 @@
     "@radix-ui/react-radio-group": ["@radix-ui/react-radio-group@1.4.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-roving-focus": "1.1.12", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ=="],
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg=="],
+
+    "@radix-ui/react-slider": ["@radix-ui/react-slider@1.4.0", "", { "dependencies": { "@radix-ui/number": "1.1.2", "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-layout-effect": "1.1.2", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-RHcPlLOThRJM51DSIC33ZnpDEBYhyEFroVWkd2P54PGGjkmAt14RboYUU9E1MFst666zFHM0tGtWvMjSOtU1pw=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@radix-ui/react-radio-group": "^1.4.0",
+    "@radix-ui/react-slider": "^1.4.0",
     "@radix-ui/react-switch": "^1.3.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-fs": "^2.5.0",

--- a/src/index.css
+++ b/src/index.css
@@ -107,9 +107,12 @@
   /* ======================================================================
      Dimensional scale (JP-153) — canonical spacing / radius / type / control
      tokens. Mode-independent, so defined once here (no dark override). Values
-     are rem at the default 16px root (nothing sets `html { font-size }`), so
-     they map 1:1 onto the px the chrome used before this scale landed. Consume
-     these instead of hardcoding px; the long tail still migrates onto them.
+     are rem; the root font-size is scaled by `--ui-scale` (Appearance →
+     Interface size), so consuming these makes the chrome grow/shrink with that
+     control. Spacing + control heights are additionally scaled by
+     `--density-mult` (Appearance → Density). The canvas is flex/px-sized and
+     uses its own Camera, so neither affects it. Consume these instead of
+     hardcoding px; the long tail still migrates onto them.
      ====================================================================== */
 
   /* Font families */
@@ -118,17 +121,22 @@
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
     'Liberation Mono', monospace;
 
-  /* Spacing — 4px grid (rem /16) */
+  /* Density multiplier (Appearance → Density). 1 = Normal; the [data-density]
+     rules at the end of this file override it. Baked into spacing + control
+     tokens so density flows app-wide through the cascade — no per-rule sweep. */
+  --density-mult: 1;
+
+  /* Spacing — 4px grid (rem /16), scaled by --density-mult */
   --space-0: 0;
-  --space-0-5: 0.125rem;  /* 2px */
-  --space-1: 0.25rem;     /* 4px */
-  --space-1-5: 0.375rem;  /* 6px */
-  --space-2: 0.5rem;      /* 8px */
-  --space-3: 0.75rem;     /* 12px */
-  --space-4: 1rem;        /* 16px */
-  --space-5: 1.25rem;     /* 20px */
-  --space-6: 1.5rem;      /* 24px */
-  --space-8: 2rem;        /* 32px */
+  --space-0-5: calc(0.125rem * var(--density-mult));  /* 2px */
+  --space-1: calc(0.25rem * var(--density-mult));     /* 4px */
+  --space-1-5: calc(0.375rem * var(--density-mult));  /* 6px */
+  --space-2: calc(0.5rem * var(--density-mult));      /* 8px */
+  --space-3: calc(0.75rem * var(--density-mult));     /* 12px */
+  --space-4: calc(1rem * var(--density-mult));        /* 16px */
+  --space-5: calc(1.25rem * var(--density-mult));     /* 20px */
+  --space-6: calc(1.5rem * var(--density-mult));      /* 24px */
+  --space-8: calc(2rem * var(--density-mult));        /* 32px */
 
   /* Border radius */
   --radius-sm: 0.25rem;   /* 4px */
@@ -161,12 +169,12 @@
   --line-height-normal: 1.4;
   --line-height-relaxed: 1.5;
 
-  /* Control heights — buttons / inputs / selects (rem /16) */
-  --control-height-xs: 1.25rem;  /* 20px */
-  --control-height-sm: 1.5rem;   /* 24px */
-  --control-height-md: 1.75rem;  /* 28px */
-  --control-height-lg: 2rem;     /* 32px */
-  --control-height-xl: 2.25rem;  /* 36px */
+  /* Control heights — buttons / inputs / selects (rem /16), scaled by --density-mult */
+  --control-height-xs: calc(1.25rem * var(--density-mult));  /* 20px */
+  --control-height-sm: calc(1.5rem * var(--density-mult));   /* 24px */
+  --control-height-md: calc(1.75rem * var(--density-mult));  /* 28px */
+  --control-height-lg: calc(2rem * var(--density-mult));     /* 32px */
+  --control-height-xl: calc(2.25rem * var(--density-mult));  /* 36px */
 }
 
 /* --- Semantic: DARK (navy-native; elevation = lighter navy, not black) --- */
@@ -313,4 +321,25 @@ body {
 [data-accent='rose'] {
   --color-primary-light: color-mix(in srgb, var(--color-primary) 14%, transparent);
   --color-primary-alpha: color-mix(in srgb, var(--color-primary) 32%, transparent);
+}
+
+/* ===========================================================================
+ * Interface size + Density (Settings → Appearance)
+ * ---------------------------------------------------------------------------
+ * Interface size scales the rem root, so all rem-based chrome (spacing, control
+ * heights, type tokens) grows/shrinks together. Density adjusts only spacing +
+ * control heights via --density-mult. Both ride the rem token system; the
+ * canvas is flex/px-sized and maps input through its own Camera, so it is never
+ * affected (no zoom on the canvas or any of its ancestors).
+ * ======================================================================== */
+
+html {
+  font-size: calc(100% * var(--ui-scale, 1));
+}
+
+[data-density='compact'] {
+  --density-mult: 0.85;
+}
+[data-density='spacious'] {
+  --density-mult: 1.15;
 }

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -260,28 +260,68 @@ describe('uiPreferencesStore — migration', () => {
     await useUIPreferencesStore.persist.rehydrate();
 
     const state = useUIPreferencesStore.getState();
-    expect(state.appearancePrefs).toEqual({ accent: 'default', motion: 'system' });
+    expect(state.appearancePrefs).toEqual({
+      accent: 'default',
+      motion: 'system',
+      density: 'normal',
+      uiScale: 1,
+    });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
+  });
+
+  it('v4 → v5 fills density + uiScale onto an accent/motion-only slice', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          appearancePrefs: { accent: 'teal', motion: 'reduced' }, // v4 shape
+        },
+        version: 4,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    // Existing accent/motion preserved; new fields defaulted.
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      accent: 'teal',
+      motion: 'reduced',
+      density: 'normal',
+      uiScale: 1,
+    });
   });
 });
 
 describe('uiPreferencesStore — appearance slice', () => {
-  it("defaults to the theme's own accent and follow-system motion", () => {
+  it('defaults to the theme accent, system motion, normal density, scale 1', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
       accent: 'default',
       motion: 'system',
+      density: 'normal',
+      uiScale: 1,
     });
   });
 
-  it('setAccent / setMotion update the slice (new object reference each time)', () => {
+  it('setAccent / setMotion / setDensity update the slice (new ref each time)', () => {
     const s = useUIPreferencesStore.getState();
     const before = s.appearancePrefs;
     s.setAccent('teal');
     s.setMotion('reduced');
+    s.setDensity('compact');
     const after = useUIPreferencesStore.getState().appearancePrefs;
-    expect(after).toEqual({ accent: 'teal', motion: 'reduced' });
-    // Reference changes so the applier's identity check fires.
+    expect(after).toEqual({ accent: 'teal', motion: 'reduced', density: 'compact', uiScale: 1 });
     expect(after).not.toBe(before);
+  });
+
+  it('setUiScale clamps to the supported range', () => {
+    const s = useUIPreferencesStore.getState();
+    s.setUiScale(5);
+    expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(1.25);
+    s.setUiScale(0.1);
+    expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(0.9);
+    s.setUiScale(1.1);
+    expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(1.1);
   });
 });

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -16,6 +16,7 @@ import type {
 import { LAYOUT_MODES } from '../ui/layout/types';
 import { LAYOUT_PRESETS } from '../ui/layout/modes';
 import type { MotionPreference } from '../platform/adaptiveBudget';
+import { device } from '../platform/device';
 
 export type DocumentBrowserView = 'list' | 'grid';
 export type DocumentBrowserSort =
@@ -32,11 +33,22 @@ export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
  */
 export type AccentColor = 'default' | 'teal' | 'violet' | 'amber' | 'rose';
 
+/** Chrome spacing density — tightens/loosens spacing + control heights. */
+export type Density = 'compact' | 'normal' | 'spacious';
+
+/** Bounds for the interface-size (UI scale) multiplier. */
+export const UI_SCALE_MIN = 0.9;
+export const UI_SCALE_MAX = 1.25;
+
 /** App-wide appearance preferences. (Theme lives in its own `themeStore`.) */
 export interface AppearancePrefs {
   accent: AccentColor;
   /** Interface-motion preference; fed into the adaptive motion budget. */
   motion: MotionPreference;
+  /** Spacing density (chrome only). */
+  density: Density;
+  /** Interface size multiplier (rem root scale); clamped to [0.9, 1.25]. */
+  uiScale: number;
 }
 
 /**
@@ -119,6 +131,10 @@ export interface UIPreferencesActions {
   setAccent: (accent: AccentColor) => void;
   /** Set the interface motion preference. */
   setMotion: (motion: MotionPreference) => void;
+  /** Set the spacing density. */
+  setDensity: (density: Density) => void;
+  /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
+  setUiScale: (uiScale: number) => void;
 
   /** Reset to initial state */
   reset: () => void;
@@ -154,11 +170,23 @@ const initialLayoutState: LayoutState = {
   customChrome: false,
 };
 
-/** Initial appearance prefs — theme's own accent, follow-system motion. */
+/**
+ * Initial appearance prefs — theme's own accent, follow-system motion, scale 1.
+ * Density seeds from the input type on first run (touch gets roomier hit
+ * targets); a persisted choice always wins via the persist merge.
+ */
 const initialAppearancePrefs: AppearancePrefs = {
   accent: 'default',
   motion: 'system',
+  density: device.isTouch() ? 'spacious' : 'normal',
+  uiScale: 1,
 };
+
+/** Clamp a UI-scale value into the supported range. */
+function clampUiScale(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, value));
+}
 
 /**
  * Initial state.
@@ -372,13 +400,21 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ appearancePrefs: { ...get().appearancePrefs, motion } });
       },
 
+      setDensity: (density) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, density } });
+      },
+
+      setUiScale: (uiScale) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, uiScale: clampUiScale(uiScale) } });
+      },
+
       reset: () => {
         set(initialState);
       },
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 4,
+      version: 5,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
@@ -455,6 +491,14 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // motion); the `merge` below also backstops this.
         if (fromVersion < 4) {
           next['appearancePrefs'] = next['appearancePrefs'] ?? { ...initialAppearancePrefs };
+        }
+        // v4 → v5: the appearance slice gained density + uiScale. Fill any
+        // missing fields from the defaults without clobbering accent/motion.
+        if (fromVersion < 5) {
+          next['appearancePrefs'] = {
+            ...initialAppearancePrefs,
+            ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
+          };
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -26,6 +26,17 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
   })) as unknown as typeof window.matchMedia;
 }
 
+// jsdom does not implement `ResizeObserver`; Radix primitives (e.g. Slider)
+// observe their elements. A no-op stub is sufficient for the test environment.
+if (typeof (globalThis as { ResizeObserver?: unknown }).ResizeObserver === 'undefined') {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub;
+}
+
 if (typeof (globalThis as { Path2D?: unknown }).Path2D === 'undefined') {
   class Path2DStub implements PathMethods {
     [method: string]: (...args: number[]) => void;

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -12,8 +12,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  useUIPreferencesStore.getState().setAccent('default');
-  useUIPreferencesStore.getState().setMotion('system');
+  const s = useUIPreferencesStore.getState();
+  s.setAccent('default');
+  s.setMotion('system');
+  s.setDensity('normal');
+  s.setUiScale(1);
 });
 
 describe('appearance applier (Abstraction A)', () => {
@@ -28,27 +31,57 @@ describe('appearance applier (Abstraction A)', () => {
     useUIPreferencesStore.getState().setMotion('full');
     expect(document.documentElement.dataset['reducedMotion']).toBeUndefined();
   });
+
+  it('mirrors density + UI scale onto the document root', () => {
+    useUIPreferencesStore.getState().setDensity('compact');
+    useUIPreferencesStore.getState().setUiScale(1.2);
+    expect(document.documentElement.dataset['density']).toBe('compact');
+    expect(document.documentElement.style.getPropertyValue('--ui-scale')).toBe('1.2');
+  });
 });
 
 describe('appearance snapshot seam (Abstraction B)', () => {
-  it('captures theme + accent + motion', () => {
+  it('captures the full appearance config', () => {
     useThemeStore.getState().setPreference('dark');
-    useUIPreferencesStore.getState().setAccent('amber');
-    useUIPreferencesStore.getState().setMotion('reduced');
-    expect(getAppearanceSnapshot()).toEqual({ theme: 'dark', accent: 'amber', motion: 'reduced' });
+    const s = useUIPreferencesStore.getState();
+    s.setAccent('amber');
+    s.setMotion('reduced');
+    s.setDensity('spacious');
+    s.setUiScale(1.15);
+    expect(getAppearanceSnapshot()).toEqual({
+      theme: 'dark',
+      accent: 'amber',
+      motion: 'reduced',
+      density: 'spacious',
+      uiScale: 1.15,
+    });
   });
 
   it('applies a config across both stores', () => {
-    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full' });
+    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full', density: 'compact', uiScale: 1.1 });
     expect(useThemeStore.getState().preference).toBe('light');
-    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({ accent: 'rose', motion: 'full' });
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      accent: 'rose',
+      motion: 'full',
+      density: 'compact',
+      uiScale: 1.1,
+    });
   });
 
   it('resetAppearance restores every default', () => {
     useThemeStore.getState().setPreference('dark');
-    useUIPreferencesStore.getState().setAccent('teal');
-    useUIPreferencesStore.getState().setMotion('reduced');
+    const s = useUIPreferencesStore.getState();
+    s.setAccent('teal');
+    s.setMotion('reduced');
+    s.setDensity('compact');
+    s.setUiScale(1.2);
     resetAppearance();
-    expect(getAppearanceSnapshot()).toEqual({ theme: 'system', accent: 'default', motion: 'system' });
+    expect(getAppearanceSnapshot()).toEqual({
+      theme: 'system',
+      accent: 'default',
+      motion: 'system',
+      density: 'normal',
+      uiScale: 1,
+    });
   });
 });

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -8,25 +8,33 @@
  */
 
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
-import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
+import {
+  useUIPreferencesStore,
+  type AccentColor,
+  type Density,
+} from '../../store/uiPreferencesStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
 
 export interface AppearanceConfig {
   theme: ThemePreference;
   accent: AccentColor;
   motion: MotionPreference;
+  density: Density;
+  uiScale: number;
 }
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
   theme: 'system',
   accent: 'default',
   motion: 'system',
+  density: 'normal',
+  uiScale: 1,
 };
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { accent, motion } = useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, accent, motion };
+  const { accent, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, accent, motion, density, uiScale };
 }
 
 /** Apply a (partial) appearance config across both stores. */
@@ -34,6 +42,8 @@ export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
   if (cfg.theme !== undefined) useThemeStore.getState().setPreference(cfg.theme);
   if (cfg.accent !== undefined) useUIPreferencesStore.getState().setAccent(cfg.accent);
   if (cfg.motion !== undefined) useUIPreferencesStore.getState().setMotion(cfg.motion);
+  if (cfg.density !== undefined) useUIPreferencesStore.getState().setDensity(cfg.density);
+  if (cfg.uiScale !== undefined) useUIPreferencesStore.getState().setUiScale(cfg.uiScale);
 }
 
 /**

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -5,9 +5,15 @@
  * before first paint (localStorage hydrates synchronously on store creation) —
  * no flash — and keeps tracking changes from anywhere, inside or outside React.
  *
- * Accent → `data-accent` root attribute (CSS swaps `--color-primary*`).
- * Motion → handed to `adaptiveBudget`, the sole authority over the
- *          `data-reduced-motion` attribute.
+ * Accent  → `data-accent` root attribute (CSS swaps `--color-primary*`).
+ * Density → `data-density` root attribute (CSS scales `--density-mult`).
+ * UI size → `--ui-scale` root var (CSS scales the rem root font-size).
+ * Motion  → handed to `adaptiveBudget`, the sole authority over the
+ *           `data-reduced-motion` attribute.
+ *
+ * Density + UI size are chrome-only by construction: they ride the rem token
+ * system, while the canvas is flex/px-sized and maps coordinates through its
+ * own Camera — so it is never affected.
  *
  * (Theme is applied by `themeStore` itself; this module owns the rest.)
  */
@@ -17,7 +23,10 @@ import { setMotionPreference } from '../../platform/adaptiveBudget';
 
 function applyAppearance(prefs: AppearancePrefs): void {
   if (typeof document !== 'undefined') {
-    document.documentElement.dataset['accent'] = prefs.accent;
+    const root = document.documentElement;
+    root.dataset['accent'] = prefs.accent;
+    root.dataset['density'] = prefs.density;
+    root.style.setProperty('--ui-scale', String(prefs.uiScale));
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/components/Slider.css
+++ b/src/ui/components/Slider.css
@@ -1,0 +1,50 @@
+/* Slider — brand-tokened single-value slider (Radix Slider). */
+
+.ds-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 160px;
+  height: 20px;
+  -webkit-user-select: none;
+  user-select: none;
+  touch-action: none;
+}
+
+.ds-slider__track {
+  position: relative;
+  flex-grow: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--bg-active);
+}
+
+.ds-slider__range {
+  position: absolute;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--color-primary);
+}
+
+.ds-slider__thumb {
+  display: block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bg-primary);
+  box-shadow: 0 1px 3px rgba(14, 28, 48, 0.35), 0 0 0 1px var(--color-primary) inset;
+  cursor: pointer;
+}
+
+.ds-slider__thumb:hover {
+  box-shadow: 0 1px 3px rgba(14, 28, 48, 0.4), 0 0 0 2px var(--color-primary) inset;
+}
+
+.ds-slider__thumb:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+.ds-slider[data-disabled] {
+  opacity: 0.5;
+}

--- a/src/ui/components/Slider.test.tsx
+++ b/src/ui/components/Slider.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Slider } from './Slider';
+
+describe('Slider', () => {
+  it('exposes an accessible slider with the current value', () => {
+    render(<Slider ariaLabel="Interface size" value={110} onValueChange={() => {}} min={90} max={125} step={5} />);
+    const slider = screen.getByRole('slider', { name: 'Interface size' });
+    expect(slider.getAttribute('aria-valuenow')).toBe('110');
+  });
+
+  it('moves on keyboard input and reports the new value', () => {
+    const onValueChange = vi.fn();
+    render(<Slider ariaLabel="Interface size" value={100} onValueChange={onValueChange} min={90} max={125} step={5} />);
+    const slider = screen.getByRole('slider', { name: 'Interface size' });
+    slider.focus();
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(onValueChange).toHaveBeenCalledWith(105);
+  });
+});

--- a/src/ui/components/Slider.tsx
+++ b/src/ui/components/Slider.tsx
@@ -1,0 +1,37 @@
+/**
+ * Slider — a brand-tokened single-value slider built on Radix `Slider`
+ * (keyboard + ARIA). Thin local wrapper so the dependency stays swappable.
+ */
+
+import * as RadixSlider from '@radix-ui/react-slider';
+import './Slider.css';
+
+export interface SliderProps {
+  value: number;
+  onValueChange: (value: number) => void;
+  min: number;
+  max: number;
+  step: number;
+  ariaLabel: string;
+  disabled?: boolean;
+}
+
+export function Slider({ value, onValueChange, min, max, step, ariaLabel, disabled }: SliderProps) {
+  return (
+    <RadixSlider.Root
+      className="ds-slider"
+      value={[value]}
+      onValueChange={(values) => onValueChange(values[0] ?? value)}
+      min={min}
+      max={max}
+      step={step}
+      aria-label={ariaLabel}
+      {...(disabled !== undefined ? { disabled } : {})}
+    >
+      <RadixSlider.Track className="ds-slider__track">
+        <RadixSlider.Range className="ds-slider__range" />
+      </RadixSlider.Track>
+      <RadixSlider.Thumb className="ds-slider__thumb" aria-label={ariaLabel} />
+    </RadixSlider.Root>
+  );
+}

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -3,11 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { AppearanceSettings } from './AppearanceSettings';
 
 describe('AppearanceSettings', () => {
-  it('renders the theme, accent, and motion controls', () => {
+  it('renders the theme, accent, motion, density, and interface-size controls', () => {
     render(<AppearanceSettings />);
     expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Accent color' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Interface animations' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Spacing density' })).toBeTruthy();
+    expect(screen.getByRole('slider', { name: 'Interface size' })).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -12,7 +12,13 @@ import * as RadioGroup from '@radix-ui/react-radio-group';
 import { Check, Monitor, Moon, Sun } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
-import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
+import {
+  useUIPreferencesStore,
+  type AccentColor,
+  type Density,
+  UI_SCALE_MIN,
+  UI_SCALE_MAX,
+} from '../../store/uiPreferencesStore';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
@@ -20,6 +26,7 @@ import { windowControls } from '../../platform/window';
 import { opener } from '../../platform/opener';
 import { isMacOS } from '../../utils/platform';
 import { SegmentedControl } from '../components/SegmentedControl';
+import { Slider } from '../components/Slider';
 import { Switch } from '../components/Switch';
 import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
@@ -47,6 +54,12 @@ const MOTION_OPTIONS = [
   { value: 'full' as const, label: 'Full', title: 'Always show interface animations' },
 ];
 
+const DENSITY_OPTIONS = [
+  { value: 'compact' as const, label: 'Compact', title: 'Tighter spacing — fit more on screen' },
+  { value: 'normal' as const, label: 'Normal', title: 'Default spacing' },
+  { value: 'spacious' as const, label: 'Spacious', title: 'Roomier spacing and larger targets' },
+];
+
 export function AppearanceSettings() {
   const themePreference = useThemeStore((s) => s.preference);
   const setThemePreference = useThemeStore((s) => s.setPreference);
@@ -54,8 +67,14 @@ export function AppearanceSettings() {
   const setAccent = useUIPreferencesStore((s) => s.setAccent);
   const motion = useUIPreferencesStore((s) => s.appearancePrefs.motion);
   const setMotion = useUIPreferencesStore((s) => s.setMotion);
+  const density = useUIPreferencesStore((s) => s.appearancePrefs.density);
+  const setDensity = useUIPreferencesStore((s) => s.setDensity);
+  const uiScale = useUIPreferencesStore((s) => s.appearancePrefs.uiScale);
+  const setUiScale = useUIPreferencesStore((s) => s.setUiScale);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
+
+  const uiScalePercent = Math.round(uiScale * 100);
 
   const handleReset = () => {
     if (window.confirm('Reset theme, accent color, motion, and layout customization to their defaults?')) {
@@ -110,6 +129,49 @@ export function AppearanceSettings() {
           <span className="settings-hint">
             Reduce or turn off interface animations. "System" follows your device's
             accessibility setting.
+          </span>
+        </div>
+      </div>
+
+      {/* Density */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Density</h4>
+        <div className="settings-row">
+          <span className="settings-label">Spacing</span>
+          <SegmentedControl
+            ariaLabel="Spacing density"
+            value={density}
+            onValueChange={(v: Density) => setDensity(v)}
+            options={DENSITY_OPTIONS}
+          />
+          <span className="settings-hint">
+            Tighten or loosen spacing throughout the app. Compact fits more on screen;
+            Spacious gives larger, easier targets.
+          </span>
+        </div>
+      </div>
+
+      {/* Interface size */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Interface size</h4>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="ui-scale">
+            Size
+          </label>
+          <div className="settings-slider-row">
+            <Slider
+              ariaLabel="Interface size"
+              value={uiScalePercent}
+              onValueChange={(pct) => setUiScale(pct / 100)}
+              min={Math.round(UI_SCALE_MIN * 100)}
+              max={Math.round(UI_SCALE_MAX * 100)}
+              step={5}
+            />
+            <span className="settings-slider-value">{uiScalePercent}%</span>
+          </div>
+          <span className="settings-hint">
+            Scale the whole interface up or down. The canvas and your diagrams are
+            not affected.
           </span>
         </div>
       </div>


### PR DESCRIPTION
Final MVP slice of the **JP-253** UX-flex epic — the display-foundation knobs.

## Approach (the de-risking)

The chrome already uses a **rem-based token system** (`--space-*`, `--control-height-*`, `--font-size-*` — 393 `var(--space-*)` uses across 20 files). So both knobs work **through the cascade with zero zoom and zero canvas-coordinate risk**, rather than the riskier `zoom`-per-region path:

- **Interface size (90–125%)** scales the **rem root font-size** via `--ui-scale`, so all rem-based chrome (spacing, control heights, type tokens) grows/shrinks together.
- **Density (Compact/Normal/Spacious)** bakes a `--density-mult` into the `--space-*` and `--control-height-*` token *definitions* — so density flows app-wide through the existing 393 token uses, **no per-rule sweep**.

**Canvas isolation (the acceptance gate) holds by construction:** the canvas is `flex`/px-sized and maps pointers via `getBoundingClientRect` + `clientX` + `devicePixelRatio` (none rem/font-size dependent), and neither the canvas nor any ancestor is zoomed. The existing InputHandler coordinate tests stay green. At defaults (`uiScale 1`, `Normal`) the tokens are byte-identical to before — **zero visual change**.

## What changed

- `density` + `uiScale` added to the `appearancePrefs` slice; additive **v4→v5** migration + merge default them. `uiScale` clamped to `[0.9, 1.25]`. Density **seeds from input type** on first run (touch → Spacious); a saved choice always wins.
- The FOUC-proof applier mirrors `data-density` + `--ui-scale` onto the root; `AppearanceConfig` snapshot carries both (future presets/shareable config).
- New reusable **Slider** wrapper (Radix `react-slider`); Density uses the existing `SegmentedControl`. Plain copy ("Tighten or loosen spacing…", "The canvas and your diagrams are not affected").
- Test shim for `ResizeObserver` (Radix Slider needs it).

## Verification

- `bun run typecheck` ✅ · `bun run test:run` ✅ (1889 tests, +10) · `bun run build` ✅ · OSS-leak grep clean.

## Notes / follow-ups

- ui-scale's text effect grows as the long-tail px→rem migration proceeds (aligned with JP-150/151); spacing + control heights + token-based fonts already scale today.
- Canvas-region overlays (CanvasToolbar/LayerPanel) intentionally track the canvas, not ui-scale, since they live inside the canvas wrapper.

This completes the JP-253 MVP (Appearance home + theme persistence + accent + motion + density + scale). Campaign-horizon items (first-run picker, ambient popover, shareable config, presets) remain in the campaign doc.

Assisted-by: Opus 4.8