### PR TITLE
JP-257: Theme builder — user-built custom themes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "pdfjs-dist": "^5.6.205",
         "rbush": "^3.0.1",
         "react": "^18.2.0",
+        "react-colorful": "^5.7.0",
         "react-dom": "^18.2.0",
         "simple-icons": "^16.9.0",
         "xlsx": "^0.18.5",
@@ -1164,6 +1165,8 @@
     "rbush": ["rbush@3.0.1", "", { "dependencies": { "quickselect": "^2.0.0" } }, "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-colorful": ["react-colorful@5.7.0", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "pdfjs-dist": "^5.6.205",
     "rbush": "^3.0.1",
     "react": "^18.2.0",
+    "react-colorful": "^5.7.0",
     "react-dom": "^18.2.0",
     "simple-icons": "^16.9.0",
     "xlsx": "^0.18.5",

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,7 @@
   --color-primary-dark: #0e1c30;  /* hover / pressed */
   --color-primary-light: #e9edf3; /* soft navy wash — active backgrounds */
   --color-primary-alpha: rgba(31, 51, 84, 0.18); /* focus ring */
+  --color-on-primary: #f6f4ec;    /* text/icons on a solid primary fill (paper on navy) */
 
   /* Semantic status (fills + readable text) */
   --success: #2d8f63;
@@ -204,6 +205,7 @@
   --color-primary-dark: #c9a262;  /* solid gold (hover / pressed) */
   --color-primary-light: rgba(224, 198, 144, 0.14);
   --color-primary-alpha: rgba(224, 198, 140, 0.30);
+  --color-on-primary: #0a1525;    /* ink on the gold primary fill */
 
   /* Semantic status — fills stay solid; text is lightened for navy */
   --success: #2d8f63;
@@ -265,62 +267,6 @@ body {
 /* Deepest layer of the dark elevation ladder sits behind every surface. */
 [data-theme="dark"] body {
   background-color: var(--navy-1000);
-}
-
-/* ===========================================================================
- * Accent color (Settings → Appearance → Accent color)
- * ---------------------------------------------------------------------------
- * Swaps the unified `--color-primary*` tokens (links, active borders, focus
- * rings, primary buttons, selected controls, the active layout chip — anything
- * that consumes them). `data-accent="default"` adds no override, so the theme's
- * own accent stands (navy in light, gold in dark). The CTA gold (`--color-cta*`)
- * is intentionally left untouched. Per-accent hues are tuned for contrast on
- * the warm-paper (light) and navy (dark) surfaces respectively.
- * ======================================================================== */
-
-[data-accent='teal'] {
-  --color-primary: #0f766e;
-  --color-primary-dark: #115e59;
-}
-[data-accent='violet'] {
-  --color-primary: #6d28d9;
-  --color-primary-dark: #5b21b6;
-}
-[data-accent='amber'] {
-  --color-primary: #b45309;
-  --color-primary-dark: #92400e;
-}
-[data-accent='rose'] {
-  --color-primary: #be123c;
-  --color-primary-dark: #9f1239;
-}
-
-[data-theme='dark'][data-accent='teal'] {
-  --color-primary: #5eead4;
-  --color-primary-dark: #2dd4bf;
-}
-[data-theme='dark'][data-accent='violet'] {
-  --color-primary: #c4b5fd;
-  --color-primary-dark: #a78bfa;
-}
-[data-theme='dark'][data-accent='amber'] {
-  --color-primary: #fcd34d;
-  --color-primary-dark: #fbbf24;
-}
-[data-theme='dark'][data-accent='rose'] {
-  --color-primary: #fda4af;
-  --color-primary-dark: #fb7185;
-}
-
-/* Derive the soft wash + focus-ring tints from the chosen hue so they stay in
-   sync without hand-tuning each accent (only non-default accents; the theme
-   defaults keep their hand-tuned values). */
-[data-accent='teal'],
-[data-accent='violet'],
-[data-accent='amber'],
-[data-accent='rose'] {
-  --color-primary-light: color-mix(in srgb, var(--color-primary) 14%, transparent);
-  --color-primary-alpha: color-mix(in srgb, var(--color-primary) 32%, transparent);
 }
 
 /* ===========================================================================

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -261,7 +261,7 @@ describe('uiPreferencesStore — migration', () => {
 
     const state = useUIPreferencesStore.getState();
     expect(state.appearancePrefs).toEqual({
-      accent: 'default',
+      themeInputs: { light: {}, dark: {} },
       motion: 'system',
       density: 'normal',
       uiScale: 1,
@@ -270,13 +270,13 @@ describe('uiPreferencesStore — migration', () => {
     expect(state.layout.defaultMode).toBe('power');
   });
 
-  it('v4 → v5 fills density + uiScale onto an accent/motion-only slice', async () => {
+  it('v4 → v6 migrates accent → custom Primary and fills density/uiScale', async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
         state: {
           layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
-          appearancePrefs: { accent: 'teal', motion: 'reduced' }, // v4 shape
+          appearancePrefs: { accent: 'teal', motion: 'reduced' }, // v4 shape (accent enum)
         },
         version: 4,
       })
@@ -284,34 +284,67 @@ describe('uiPreferencesStore — migration', () => {
 
     await useUIPreferencesStore.persist.rehydrate();
 
-    // Existing accent/motion preserved; new fields defaulted.
+    // accent → primary (both bases, JP-255 teal hexes); motion preserved; rest defaulted.
     expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
-      accent: 'teal',
+      themeInputs: { light: { primary: '#0f766e' }, dark: { primary: '#5eead4' } },
       motion: 'reduced',
       density: 'normal',
       uiScale: 1,
     });
   });
+
+  it("v5 → v6 with accent 'default' yields empty custom-theme inputs", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          appearancePrefs: { accent: 'default', motion: 'system', density: 'compact', uiScale: 1.1 }, // v5 shape
+        },
+        version: 5,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      themeInputs: { light: {}, dark: {} },
+      motion: 'system',
+      density: 'compact',
+      uiScale: 1.1,
+    });
+  });
 });
 
 describe('uiPreferencesStore — appearance slice', () => {
-  it('defaults to the theme accent, system motion, normal density, scale 1', () => {
+  it('defaults to the base theme (no overrides), system motion, normal density, scale 1', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
-      accent: 'default',
+      themeInputs: { light: {}, dark: {} },
       motion: 'system',
       density: 'normal',
       uiScale: 1,
     });
   });
 
-  it('setAccent / setMotion / setDensity update the slice (new ref each time)', () => {
+  it('setThemeInput sets/clears a slot per base without touching the other base', () => {
+    const s = useUIPreferencesStore.getState();
+    s.setThemeInput('light', 'primary', '#123456');
+    expect(useUIPreferencesStore.getState().appearancePrefs.themeInputs).toEqual({
+      light: { primary: '#123456' },
+      dark: {},
+    });
+    s.setThemeInput('light', 'primary', undefined);
+    expect(useUIPreferencesStore.getState().appearancePrefs.themeInputs.light).toEqual({});
+  });
+
+  it('setMotion / setDensity update the slice (new ref each time)', () => {
     const s = useUIPreferencesStore.getState();
     const before = s.appearancePrefs;
-    s.setAccent('teal');
     s.setMotion('reduced');
     s.setDensity('compact');
     const after = useUIPreferencesStore.getState().appearancePrefs;
-    expect(after).toEqual({ accent: 'teal', motion: 'reduced', density: 'compact', uiScale: 1 });
+    expect(after.motion).toBe('reduced');
+    expect(after.density).toBe('compact');
     expect(after).not.toBe(before);
   });
 

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -265,6 +265,7 @@ describe('uiPreferencesStore — migration', () => {
       motion: 'system',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -290,6 +291,7 @@ describe('uiPreferencesStore — migration', () => {
       motion: 'reduced',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
   });
 
@@ -312,6 +314,7 @@ describe('uiPreferencesStore — migration', () => {
       motion: 'system',
       density: 'compact',
       uiScale: 1.1,
+      proseBackground: 'default',
     });
   });
 });
@@ -323,6 +326,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       motion: 'system',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
   });
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -53,6 +53,9 @@ export interface ThemeBuild {
 /** Chrome spacing density — tightens/loosens spacing + control heights. */
 export type Density = 'compact' | 'normal' | 'spacious';
 
+/** Prose editor background preset (token-based gradients; `default` = base behavior). */
+export type ProseBackground = 'default' | 'flat' | 'glow' | 'aurora';
+
 /** Bounds for the interface-size (UI scale) multiplier. */
 export const UI_SCALE_MIN = 0.9;
 export const UI_SCALE_MAX = 1.25;
@@ -67,6 +70,8 @@ export interface AppearancePrefs {
   density: Density;
   /** Interface size multiplier (rem root scale); clamped to [0.9, 1.25]. */
   uiScale: number;
+  /** Prose editor background preset. */
+  proseBackground: ProseBackground;
 }
 
 /**
@@ -157,6 +162,8 @@ export interface UIPreferencesActions {
   setDensity: (density: Density) => void;
   /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
   setUiScale: (uiScale: number) => void;
+  /** Set the prose editor background preset. */
+  setProseBackground: (proseBackground: ProseBackground) => void;
 
   /** Reset to initial state */
   reset: () => void;
@@ -214,6 +221,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   motion: 'system',
   density: device.isTouch() ? 'spacious' : 'normal',
   uiScale: 1,
+  proseBackground: 'default',
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -468,6 +476,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setUiScale: (uiScale) => {
         set({ appearancePrefs: { ...get().appearancePrefs, uiScale: clampUiScale(uiScale) } });
+      },
+
+      setProseBackground: (proseBackground) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, proseBackground } });
       },
 
       reset: () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -31,7 +31,24 @@ export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
  * Accent hue driving the `--color-primary*` tokens. `'default'` keeps the
  * theme's own accent (navy in light, gold in dark) by adding no override.
  */
-export type AccentColor = 'default' | 'teal' | 'violet' | 'amber' | 'rose';
+/** The light/dark base a custom theme builds on (mirrors themeStore's resolved theme). */
+export type ThemeBase = 'light' | 'dark';
+
+/** The user-controllable color slots of a custom theme. */
+export type ThemeColorSlot = 'primary' | 'cta' | 'surface' | 'text';
+
+/**
+ * A sparse set of color overrides (hex). Only the slots the user set are
+ * present; everything else falls through to the base token set in index.css —
+ * which is how coverage stays complete (no token can be "missing").
+ */
+export type ThemeInputs = Partial<Record<ThemeColorSlot, string>>;
+
+/** Per-base custom-theme inputs, so light + dark are customized independently. */
+export interface ThemeBuild {
+  light: ThemeInputs;
+  dark: ThemeInputs;
+}
 
 /** Chrome spacing density — tightens/loosens spacing + control heights. */
 export type Density = 'compact' | 'normal' | 'spacious';
@@ -40,9 +57,10 @@ export type Density = 'compact' | 'normal' | 'spacious';
 export const UI_SCALE_MIN = 0.9;
 export const UI_SCALE_MAX = 1.25;
 
-/** App-wide appearance preferences. (Theme lives in its own `themeStore`.) */
+/** App-wide appearance preferences. (Theme light/dark base lives in `themeStore`.) */
 export interface AppearancePrefs {
-  accent: AccentColor;
+  /** Custom-theme color overrides per base; empty objects = the base defaults. */
+  themeInputs: ThemeBuild;
   /** Interface-motion preference; fed into the adaptive motion budget. */
   motion: MotionPreference;
   /** Spacing density (chrome only). */
@@ -127,8 +145,12 @@ export interface UIPreferencesActions {
   resetLayoutCustomization: () => void;
 
   // ── Appearance actions
-  /** Set the accent hue. */
-  setAccent: (accent: AccentColor) => void;
+  /** Set (or clear, with `undefined`) one color slot of a base's custom theme. */
+  setThemeInput: (base: ThemeBase, slot: ThemeColorSlot, value: string | undefined) => void;
+  /** Replace one base's inputs wholesale (presets, "Surprise me", import). */
+  setThemeInputs: (base: ThemeBase, inputs: ThemeInputs) => void;
+  /** Clear all custom-theme inputs (both bases → base defaults). */
+  resetThemeBuild: () => void;
   /** Set the interface motion preference. */
   setMotion: (motion: MotionPreference) => void;
   /** Set the spacing density. */
@@ -171,12 +193,24 @@ const initialLayoutState: LayoutState = {
 };
 
 /**
- * Initial appearance prefs — theme's own accent, follow-system motion, scale 1.
- * Density seeds from the input type on first run (touch gets roomier hit
- * targets); a persisted choice always wins via the persist merge.
+ * Hex values of the legacy accent enum (JP-255), per base — used by the v5→v6
+ * migration to carry a user's accent choice forward as a custom Primary. Mirrors
+ * the old `[data-accent]` rules removed from index.css. `default` → no override.
+ */
+const LEGACY_ACCENT_HEX: Record<string, { light: string; dark: string }> = {
+  teal: { light: '#0f766e', dark: '#5eead4' },
+  violet: { light: '#6d28d9', dark: '#c4b5fd' },
+  amber: { light: '#b45309', dark: '#fcd34d' },
+  rose: { light: '#be123c', dark: '#fda4af' },
+};
+
+/**
+ * Initial appearance prefs — base theme (no color overrides), follow-system
+ * motion, scale 1. Density seeds from the input type on first run (touch gets
+ * roomier hit targets); a persisted choice always wins via the persist merge.
  */
 const initialAppearancePrefs: AppearancePrefs = {
-  accent: 'default',
+  themeInputs: { light: {}, dark: {} },
   motion: 'system',
   density: device.isTouch() ? 'spacious' : 'normal',
   uiScale: 1,
@@ -392,8 +426,36 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         });
       },
 
-      setAccent: (accent) => {
-        set({ appearancePrefs: { ...get().appearancePrefs, accent } });
+      setThemeInput: (base, slot, value) => {
+        const { appearancePrefs } = get();
+        const baseInputs = { ...appearancePrefs.themeInputs[base] };
+        if (value === undefined) {
+          delete baseInputs[slot];
+        } else {
+          baseInputs[slot] = value;
+        }
+        set({
+          appearancePrefs: {
+            ...appearancePrefs,
+            themeInputs: { ...appearancePrefs.themeInputs, [base]: baseInputs },
+          },
+        });
+      },
+
+      setThemeInputs: (base, inputs) => {
+        const { appearancePrefs } = get();
+        set({
+          appearancePrefs: {
+            ...appearancePrefs,
+            themeInputs: { ...appearancePrefs.themeInputs, [base]: { ...inputs } },
+          },
+        });
+      },
+
+      resetThemeBuild: () => {
+        set({
+          appearancePrefs: { ...get().appearancePrefs, themeInputs: { light: {}, dark: {} } },
+        });
       },
 
       setMotion: (motion) => {
@@ -414,7 +476,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 5,
+      version: 6,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
@@ -500,6 +562,19 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
           };
         }
+        // v5 → v6: accent enum → custom-theme Primary (both bases). The old
+        // `[data-accent]` rules are gone; a user's accent choice is preserved as
+        // a Primary override so their look survives. `default` → no override.
+        if (fromVersion < 6) {
+          const ap = (next['appearancePrefs'] as Record<string, unknown> | undefined) ?? {};
+          const accent = typeof ap['accent'] === 'string' ? (ap['accent'] as string) : 'default';
+          const hex = LEGACY_ACCENT_HEX[accent];
+          const themeInputs: ThemeBuild = hex
+            ? { light: { primary: hex.light }, dark: { primary: hex.dark } }
+            : { light: {}, dark: {} };
+          delete ap['accent'];
+          next['appearancePrefs'] = { ...ap, themeInputs };
+        }
         return next as unknown as UIPreferencesState;
       },
       merge: (persisted, current) => {
@@ -514,9 +589,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...(p.layout?.modeOverrides ?? {}),
           },
         };
+        const persistedAp = (p.appearancePrefs ?? {}) as Partial<AppearancePrefs>;
         const appearancePrefs: AppearancePrefs = {
           ...initialAppearancePrefs,
-          ...(p.appearancePrefs ?? {}),
+          ...persistedAp,
+          // Always materialize both bases so the applier can index safely.
+          themeInputs: {
+            light: { ...(persistedAp.themeInputs?.light ?? {}) },
+            dark: { ...(persistedAp.themeInputs?.dark ?? {}) },
+          },
         };
         return { ...current, ...p, layout, appearancePrefs };
       },

--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -3,20 +3,20 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  background-color: var(--bg-primary);
+  /* `--prose-bg` is set by the Appearance "Prose background" preset; when unset
+   * (the Default preset) it falls back to the built-in per-base behavior: a flat
+   * surface in light, the soft glow below in dark. The prose surface
+   * (.tiptap-editor) is transparent so this backdrop shows through. */
+  background: var(--prose-bg, var(--bg-primary));
 }
 
-/* Dark mode: replace the flat navy slab with a soft top-center glow that
- * settles into the deep page navy — adds depth without an aggressive blue
- * block. Stays within the navy elevation ladder (raised -> surface -> page).
- * Applied to the panel so the toolbar + prose share one continuous backdrop;
- * the prose surface (.tiptap-editor) is transparent in dark mode to show it. */
+/* Dark mode default: a soft top-center glow that settles into the deep page
+ * navy — depth without an aggressive blue block, within the navy elevation
+ * ladder (raised -> surface -> page). A chosen preset (--prose-bg) overrides it. */
 [data-theme="dark"] .document-editor-panel {
-  background: radial-gradient(
-    140% 90% at 50% 0%,
-    #16273f 0%,
-    #0e1c30 42%,
-    #0a1525 100%
+  background: var(
+    --prose-bg,
+    radial-gradient(140% 90% at 50% 0%, #16273f 0%, #0e1c30 42%, #0a1525 100%)
   );
 }
 

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -323,7 +323,7 @@
 
 [data-theme="dark"] .export-format-btn.active {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .export-select,
@@ -371,7 +371,7 @@
 
 [data-theme="dark"] .export-btn-primary {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .export-btn-primary:hover:not(:disabled) {

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -324,7 +324,7 @@
 
 [data-theme="dark"] .save-to-library-create-btn {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .save-to-library-cancel-btn {
@@ -359,7 +359,7 @@
 
 [data-theme="dark"] .save-to-library-btn-primary {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .save-to-library-btn-primary:hover:not(:disabled) {

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -446,7 +446,7 @@
 
 [data-theme="dark"] .shape-library-create-btn {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .shape-library-cancel-btn {
@@ -464,7 +464,7 @@
 
 [data-theme="dark"] .shape-library-item.selected {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .shape-library-edit-input {

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -1,12 +1,8 @@
 .tiptap-editor {
   flex: 1;
   overflow-y: auto;
-  background-color: var(--bg-primary);
-}
-
-/* Dark mode: let the panel's gradient backdrop show through the prose surface
- * so the two don't paint competing flat fills (see DocumentEditorPanel.css). */
-[data-theme="dark"] .tiptap-editor {
+  /* Transparent so the panel's background (flat or a chosen prose-background
+   * gradient) shows through in both modes — see DocumentEditorPanel.css. */
   background-color: transparent;
 }
 

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -1,28 +1,39 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
 import { useThemeStore } from '../../store/themeStore';
-// Importing the applier boots its module-level store subscription.
+// Importing the applier boots its module-level store subscriptions.
 import './applyAppearance';
 import { getAppearanceSnapshot, applyAppearanceSnapshot, resetAppearance } from './appearanceConfig';
 
 beforeEach(() => {
   localStorage.clear();
   useUIPreferencesStore.getState().reset();
-  useThemeStore.getState().setPreference('system');
+  useThemeStore.getState().setPreference('light'); // deterministic active base
 });
 
 afterEach(() => {
   const s = useUIPreferencesStore.getState();
-  s.setAccent('default');
+  s.resetThemeBuild();
   s.setMotion('system');
   s.setDensity('normal');
   s.setUiScale(1);
 });
 
 describe('appearance applier (Abstraction A)', () => {
-  it('mirrors the accent onto the document root', () => {
-    useUIPreferencesStore.getState().setAccent('violet');
-    expect(document.documentElement.dataset['accent']).toBe('violet');
+  it('writes resolved theme overrides for the active base onto the root', () => {
+    useUIPreferencesStore.getState().setThemeInput('light', 'primary', '#3366cc');
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--color-primary')).toBe('#3366cc');
+    // Derived relatives are written too (no missing tokens for a set slot).
+    expect(style.getPropertyValue('--color-on-primary')).not.toBe('');
+    expect(style.getPropertyValue('--color-primary-alpha')).not.toBe('');
+  });
+
+  it('reverts the inline override when a slot is cleared', () => {
+    const s = useUIPreferencesStore.getState();
+    s.setThemeInput('light', 'primary', '#3366cc');
+    s.setThemeInput('light', 'primary', undefined);
+    expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('');
   });
 
   it('routes motion through the adaptive budget (data-reduced-motion)', () => {
@@ -44,13 +55,13 @@ describe('appearance snapshot seam (Abstraction B)', () => {
   it('captures the full appearance config', () => {
     useThemeStore.getState().setPreference('dark');
     const s = useUIPreferencesStore.getState();
-    s.setAccent('amber');
+    s.setThemeInput('dark', 'primary', '#abcdef');
     s.setMotion('reduced');
     s.setDensity('spacious');
     s.setUiScale(1.15);
     expect(getAppearanceSnapshot()).toEqual({
       theme: 'dark',
-      accent: 'amber',
+      themeInputs: { light: {}, dark: { primary: '#abcdef' } },
       motion: 'reduced',
       density: 'spacious',
       uiScale: 1.15,
@@ -58,27 +69,28 @@ describe('appearance snapshot seam (Abstraction B)', () => {
   });
 
   it('applies a config across both stores', () => {
-    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full', density: 'compact', uiScale: 1.1 });
-    expect(useThemeStore.getState().preference).toBe('light');
-    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
-      accent: 'rose',
+    applyAppearanceSnapshot({
+      theme: 'light',
+      themeInputs: { light: { primary: '#112233' }, dark: {} },
       motion: 'full',
       density: 'compact',
       uiScale: 1.1,
     });
+    expect(useThemeStore.getState().preference).toBe('light');
+    const ap = useUIPreferencesStore.getState().appearancePrefs;
+    expect(ap.themeInputs).toEqual({ light: { primary: '#112233' }, dark: {} });
+    expect(ap.motion).toBe('full');
   });
 
   it('resetAppearance restores every default', () => {
     useThemeStore.getState().setPreference('dark');
     const s = useUIPreferencesStore.getState();
-    s.setAccent('teal');
+    s.setThemeInput('dark', 'primary', '#ff0000');
     s.setMotion('reduced');
-    s.setDensity('compact');
-    s.setUiScale(1.2);
     resetAppearance();
     expect(getAppearanceSnapshot()).toEqual({
       theme: 'system',
-      accent: 'default',
+      themeInputs: { light: {}, dark: {} },
       motion: 'system',
       density: 'normal',
       uiScale: 1,

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
   s.setMotion('system');
   s.setDensity('normal');
   s.setUiScale(1);
+  s.setProseBackground('default');
 });
 
 describe('appearance applier (Abstraction A)', () => {
@@ -49,6 +50,13 @@ describe('appearance applier (Abstraction A)', () => {
     expect(document.documentElement.dataset['density']).toBe('compact');
     expect(document.documentElement.style.getPropertyValue('--ui-scale')).toBe('1.2');
   });
+
+  it('sets --prose-bg for a preset and removes it for default', () => {
+    useUIPreferencesStore.getState().setProseBackground('glow');
+    expect(document.documentElement.style.getPropertyValue('--prose-bg')).toContain('gradient');
+    useUIPreferencesStore.getState().setProseBackground('default');
+    expect(document.documentElement.style.getPropertyValue('--prose-bg')).toBe('');
+  });
 });
 
 describe('appearance snapshot seam (Abstraction B)', () => {
@@ -59,12 +67,14 @@ describe('appearance snapshot seam (Abstraction B)', () => {
     s.setMotion('reduced');
     s.setDensity('spacious');
     s.setUiScale(1.15);
+    s.setProseBackground('glow');
     expect(getAppearanceSnapshot()).toEqual({
       theme: 'dark',
       themeInputs: { light: {}, dark: { primary: '#abcdef' } },
       motion: 'reduced',
       density: 'spacious',
       uiScale: 1.15,
+      proseBackground: 'glow',
     });
   });
 
@@ -94,6 +104,7 @@ describe('appearance snapshot seam (Abstraction B)', () => {
       motion: 'system',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
   });
 });

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -1,23 +1,22 @@
 /**
  * Appearance snapshot seam (Abstraction B) — a single read/write surface across
- * the two stores that own appearance state (theme preference in `themeStore`,
- * accent + motion in `uiPreferencesStore`). Designed now so the future
- * "Workspaces" presets + shareable-config features capture/apply a whole look
- * in one call, without reaching into each store. Not yet wired to UI beyond the
- * "Reset appearance" action.
+ * the two stores that own appearance state (theme light/dark base in `themeStore`,
+ * custom-theme inputs + motion/density/scale in `uiPreferencesStore`). Designed
+ * so the future "Workspaces" presets + shareable-config / export-import features
+ * capture and apply a whole look in one call, without reaching into each store.
  */
 
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
-  type AccentColor,
   type Density,
+  type ThemeBuild,
 } from '../../store/uiPreferencesStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
 
 export interface AppearanceConfig {
   theme: ThemePreference;
-  accent: AccentColor;
+  themeInputs: ThemeBuild;
   motion: MotionPreference;
   density: Density;
   uiScale: number;
@@ -25,7 +24,7 @@ export interface AppearanceConfig {
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
   theme: 'system',
-  accent: 'default',
+  themeInputs: { light: {}, dark: {} },
   motion: 'system',
   density: 'normal',
   uiScale: 1,
@@ -33,22 +32,26 @@ export const DEFAULT_APPEARANCE: AppearanceConfig = {
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { accent, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, accent, motion, density, uiScale };
+  const { themeInputs, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale };
 }
 
 /** Apply a (partial) appearance config across both stores. */
 export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
+  const ui = useUIPreferencesStore.getState();
   if (cfg.theme !== undefined) useThemeStore.getState().setPreference(cfg.theme);
-  if (cfg.accent !== undefined) useUIPreferencesStore.getState().setAccent(cfg.accent);
-  if (cfg.motion !== undefined) useUIPreferencesStore.getState().setMotion(cfg.motion);
-  if (cfg.density !== undefined) useUIPreferencesStore.getState().setDensity(cfg.density);
-  if (cfg.uiScale !== undefined) useUIPreferencesStore.getState().setUiScale(cfg.uiScale);
+  if (cfg.themeInputs !== undefined) {
+    ui.setThemeInputs('light', cfg.themeInputs.light);
+    ui.setThemeInputs('dark', cfg.themeInputs.dark);
+  }
+  if (cfg.motion !== undefined) ui.setMotion(cfg.motion);
+  if (cfg.density !== undefined) ui.setDensity(cfg.density);
+  if (cfg.uiScale !== undefined) ui.setUiScale(cfg.uiScale);
 }
 
 /**
- * Reset every appearance choice to its default — theme, accent, motion, and the
- * per-layout customization deltas.
+ * Reset every appearance choice to its default — theme, custom-theme inputs,
+ * motion, density, UI scale, and the per-layout customization deltas.
  */
 export function resetAppearance(): void {
   applyAppearanceSnapshot(DEFAULT_APPEARANCE);

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -10,6 +10,7 @@ import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
   type Density,
+  type ProseBackground,
   type ThemeBuild,
 } from '../../store/uiPreferencesStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
@@ -20,6 +21,7 @@ export interface AppearanceConfig {
   motion: MotionPreference;
   density: Density;
   uiScale: number;
+  proseBackground: ProseBackground;
 }
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
@@ -28,12 +30,14 @@ export const DEFAULT_APPEARANCE: AppearanceConfig = {
   motion: 'system',
   density: 'normal',
   uiScale: 1,
+  proseBackground: 'default',
 };
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { themeInputs, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale };
+  const { themeInputs, motion, density, uiScale, proseBackground } =
+    useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale, proseBackground };
 }
 
 /** Apply a (partial) appearance config across both stores. */
@@ -47,6 +51,7 @@ export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
   if (cfg.motion !== undefined) ui.setMotion(cfg.motion);
   if (cfg.density !== undefined) ui.setDensity(cfg.density);
   if (cfg.uiScale !== undefined) ui.setUiScale(cfg.uiScale);
+  if (cfg.proseBackground !== undefined) ui.setProseBackground(cfg.proseBackground);
 }
 
 /**

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -22,7 +22,7 @@
 import { useUIPreferencesStore, type AppearancePrefs } from '../../store/uiPreferencesStore';
 import { useThemeStore } from '../../store/themeStore';
 import { setMotionPreference } from '../../platform/adaptiveBudget';
-import { resolveThemeOverrides, THEME_CONTROLLED_TOKENS } from './themeEngine';
+import { PROSE_BACKGROUNDS, resolveThemeOverrides, THEME_CONTROLLED_TOKENS } from './themeEngine';
 
 /** Apply the resolved custom-theme overrides for the *active* base. */
 function applyThemeColors(prefs: AppearancePrefs): void {
@@ -46,6 +46,14 @@ function applyNonColor(prefs: AppearancePrefs): void {
     const root = document.documentElement;
     root.dataset['density'] = prefs.density;
     root.style.setProperty('--ui-scale', String(prefs.uiScale));
+    // Prose editor background: set the override, or remove it so the panel keeps
+    // its built-in per-base behavior (the `default` preset).
+    const prose = PROSE_BACKGROUNDS[prefs.proseBackground]?.value ?? null;
+    if (prose) {
+      root.style.setProperty('--prose-bg', prose);
+    } else {
+      root.style.removeProperty('--prose-bg');
+    }
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -1,45 +1,79 @@
 /**
  * Appearance applier (Abstraction A) — the single place that mirrors appearance
- * preferences onto the document. Runs at module load via a vanilla
+ * preferences onto the document. Runs at module load via vanilla
  * `store.subscribe` (NOT a React effect), so it applies the hydrated values
  * before first paint (localStorage hydrates synchronously on store creation) —
  * no flash — and keeps tracking changes from anywhere, inside or outside React.
  *
- * Accent  → `data-accent` root attribute (CSS swaps `--color-primary*`).
- * Density → `data-density` root attribute (CSS scales `--density-mult`).
- * UI size → `--ui-scale` root var (CSS scales the rem root font-size).
- * Motion  → handed to `adaptiveBudget`, the sole authority over the
- *           `data-reduced-motion` attribute.
+ * Theme colors → resolved from the active base's custom inputs and written as
+ *   inline `--color-*`/`--bg-*`/`--text-*` overrides (which beat the stylesheet
+ *   base in index.css). The full controlled-token set is iterated every apply:
+ *   set for overridden tokens, removed otherwise — so a Light customization can
+ *   never bleed onto Dark, and clearing a slot reverts cleanly to the base.
+ * Density → `data-density` root attribute.
+ * UI size → `--ui-scale` root var (rem root font-size).
+ * Motion → handed to `adaptiveBudget`, the sole authority over `data-reduced-motion`.
  *
- * Density + UI size are chrome-only by construction: they ride the rem token
- * system, while the canvas is flex/px-sized and maps coordinates through its
- * own Camera — so it is never affected.
- *
- * (Theme is applied by `themeStore` itself; this module owns the rest.)
+ * Theme colors + density + UI size are chrome-only by construction (they ride
+ * the CSS token system); the canvas is flex/px-sized and maps input through its
+ * own Camera, so it is never affected.
  */
 
 import { useUIPreferencesStore, type AppearancePrefs } from '../../store/uiPreferencesStore';
+import { useThemeStore } from '../../store/themeStore';
 import { setMotionPreference } from '../../platform/adaptiveBudget';
+import { resolveThemeOverrides, THEME_CONTROLLED_TOKENS } from './themeEngine';
 
-function applyAppearance(prefs: AppearancePrefs): void {
+/** Apply the resolved custom-theme overrides for the *active* base. */
+function applyThemeColors(prefs: AppearancePrefs): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  const base = useThemeStore.getState().resolvedTheme; // 'light' | 'dark'
+  const overrides = resolveThemeOverrides(base, prefs.themeInputs[base] ?? {});
+  for (const token of THEME_CONTROLLED_TOKENS) {
+    const value = overrides[token];
+    if (value != null) {
+      root.style.setProperty(token, value);
+    } else {
+      root.style.removeProperty(token);
+    }
+  }
+}
+
+/** Apply the non-color appearance prefs (density, UI scale, motion). */
+function applyNonColor(prefs: AppearancePrefs): void {
   if (typeof document !== 'undefined') {
     const root = document.documentElement;
-    root.dataset['accent'] = prefs.accent;
     root.dataset['density'] = prefs.density;
     root.style.setProperty('--ui-scale', String(prefs.uiScale));
   }
   setMotionPreference(prefs.motion);
 }
 
-// Apply the already-hydrated preferences immediately.
+function applyAll(prefs: AppearancePrefs): void {
+  applyNonColor(prefs);
+  applyThemeColors(prefs);
+}
+
+// Apply the already-hydrated preferences immediately, before first paint.
 let applied = useUIPreferencesStore.getState().appearancePrefs;
-applyAppearance(applied);
+applyAll(applied);
 
 // Re-apply only when the appearance slice actually changes (the setters produce
 // a new object reference), so unrelated UI-pref updates don't churn.
 useUIPreferencesStore.subscribe((state) => {
   if (state.appearancePrefs !== applied) {
     applied = state.appearancePrefs;
-    applyAppearance(applied);
+    applyAll(applied);
+  }
+});
+
+// Re-resolve theme colors when the base flips (explicit Light/Dark or a `system`
+// OS change) — the active base's overrides differ.
+let appliedBase = useThemeStore.getState().resolvedTheme;
+useThemeStore.subscribe((state) => {
+  if (state.resolvedTheme !== appliedBase) {
+    appliedBase = state.resolvedTheme;
+    applyThemeColors(applied);
   }
 });

--- a/src/ui/appearance/themeEngine.test.ts
+++ b/src/ui/appearance/themeEngine.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  resolveThemeOverrides,
+  surpriseTheme,
+  onColor,
+  THEME_CONTROLLED_TOKENS,
+  THEME_PRESETS,
+  THEME_INK,
+  THEME_PAPER,
+  BASE_SWATCHES,
+} from './themeEngine';
+import { contrastRatio } from '../../utils/color';
+import type { ThemeBase } from '../../store/uiPreferencesStore';
+
+const BASES: ThemeBase[] = ['light', 'dark'];
+const CONTROLLED = new Set<string>(THEME_CONTROLLED_TOKENS);
+/** Accept hex or rgb()/rgba() — the only forms the engine emits. */
+const VALID = /^#[0-9a-f]{6}$|^rgba?\(/i;
+
+function randHex(): string {
+  return '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
+}
+
+describe('themeEngine — completeness', () => {
+  it('empty inputs produce no overrides (base is untouched)', () => {
+    for (const base of BASES) {
+      expect(resolveThemeOverrides(base, {})).toEqual({});
+    }
+  });
+
+  it('a set Primary writes its whole token family', () => {
+    const out = resolveThemeOverrides('light', { primary: '#3366cc' });
+    for (const t of ['--color-primary', '--color-primary-dark', '--color-primary-light', '--color-primary-alpha', '--color-on-primary']) {
+      expect(out[t as keyof typeof out]).toBeTruthy();
+    }
+  });
+
+  it('every emitted token is controlled and a valid color, across presets + fuzz', () => {
+    const cases = [
+      ...THEME_PRESETS.flatMap((p) => [
+        { base: 'light' as const, inputs: p.light },
+        { base: 'dark' as const, inputs: p.dark },
+      ]),
+      ...Array.from({ length: 200 }, () => ({
+        base: (Math.random() < 0.5 ? 'light' : 'dark') as ThemeBase,
+        inputs: { primary: randHex(), cta: randHex(), surface: randHex(), text: randHex() },
+      })),
+    ];
+    for (const { base, inputs } of cases) {
+      const out = resolveThemeOverrides(base, inputs);
+      for (const [token, value] of Object.entries(out)) {
+        expect(CONTROLLED.has(token)).toBe(true);
+        expect(value).toMatch(VALID);
+      }
+    }
+  });
+
+  it('on-fill text always picks the more legible of ink/paper', () => {
+    for (let i = 0; i < 200; i++) {
+      const primary = randHex();
+      const chosen = onColor(primary);
+      const other = chosen === THEME_PAPER ? THEME_INK : THEME_PAPER;
+      // The engine never leaves a more-readable option on the table.
+      expect(contrastRatio(chosen, primary)).toBeGreaterThanOrEqual(contrastRatio(other, primary));
+    }
+  });
+
+  it('curated presets keep on-Primary text AA-legible', () => {
+    for (const preset of THEME_PRESETS) {
+      for (const base of BASES) {
+        const primary = preset[base].primary;
+        if (!primary) continue;
+        expect(contrastRatio(onColor(primary), primary)).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});
+
+describe('themeEngine — drift guard', () => {
+  it('every controlled token is defined in index.css (no engine typo / drift)', () => {
+    const css = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
+    for (const token of THEME_CONTROLLED_TOKENS) {
+      expect(css.includes(`${token}:`)).toBe(true);
+    }
+  });
+
+  it('base swatches cover every base + slot', () => {
+    for (const base of BASES) {
+      for (const slot of ['primary', 'cta', 'surface', 'text'] as const) {
+        expect(BASE_SWATCHES[base][slot]).toMatch(/^#[0-9a-f]{6}$/i);
+      }
+    }
+  });
+});
+
+describe('themeEngine — surprise me', () => {
+  it('generates a legible primary for the base', () => {
+    for (const base of BASES) {
+      for (let i = 0; i < 50; i++) {
+        const inputs = surpriseTheme(base);
+        const out = resolveThemeOverrides(base, inputs);
+        expect(contrastRatio(out['--color-on-primary'] as string, inputs.primary as string)).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});

--- a/src/ui/appearance/themeEngine.ts
+++ b/src/ui/appearance/themeEngine.ts
@@ -22,7 +22,12 @@ import {
   rgbToHex,
   withAlpha,
 } from '../../utils/color';
-import type { ThemeBase, ThemeColorSlot, ThemeInputs } from '../../store/uiPreferencesStore';
+import type {
+  ProseBackground,
+  ThemeBase,
+  ThemeColorSlot,
+  ThemeInputs,
+} from '../../store/uiPreferencesStore';
 
 /**
  * Every semantic token the engine may override. Order is irrelevant; the
@@ -167,6 +172,26 @@ export function surpriseTheme(base: ThemeBase): ThemeInputs {
 export const BASE_SWATCHES: Record<ThemeBase, Record<ThemeColorSlot, string>> = {
   light: { primary: '#1f3354', cta: '#c9a262', surface: '#f9f6ee', text: '#0a1525' },
   dark: { primary: '#e0c690', cta: '#c9a262', surface: '#0e1c30', text: '#f6f4ec' },
+};
+
+/**
+ * Prose editor background presets. Values are token-referencing CSS `background`
+ * strings, so each adapts to the active theme *and* a custom Surface for free.
+ * `default` has `value: null` → no `--prose-bg` override, so the panel keeps its
+ * built-in per-base behavior (flat in light, the dark glow in dark).
+ */
+export const PROSE_BACKGROUNDS: Record<ProseBackground, { label: string; value: string | null }> = {
+  default: { label: 'Default', value: null },
+  flat: { label: 'Flat', value: 'var(--bg-primary)' },
+  glow: {
+    label: 'Glow',
+    value:
+      'radial-gradient(140% 90% at 50% 0%, var(--bg-tertiary) 0%, var(--bg-primary) 45%, var(--bg-secondary) 100%)',
+  },
+  aurora: {
+    label: 'Aurora',
+    value: 'linear-gradient(180deg, var(--color-primary-light) 0%, var(--bg-primary) 45%)',
+  },
 };
 
 /** Slots in display order, with plain labels for the builder UI. */

--- a/src/ui/appearance/themeEngine.ts
+++ b/src/ui/appearance/themeEngine.ts
@@ -1,0 +1,178 @@
+/**
+ * Theme engine — pure derivation from a sparse set of user color inputs to the
+ * full set of semantic token *overrides* (JP-58).
+ *
+ * Bulletproof-by-construction: the complete light/dark token sets live in
+ * `index.css`. This engine only produces overrides for the slots the user set;
+ * everything else falls through to that base, so no token can ever be missing.
+ * `resolveThemeOverrides(base, {})` returns `{}` → the app looks exactly as it
+ * does with no customization.
+ *
+ * Coverage is enforced by tests: `THEME_CONTROLLED_TOKENS` must be a subset of
+ * the tokens defined in `index.css` (drift guard), and every set slot must
+ * resolve every relative it owns to a parseable color (completeness).
+ */
+
+import {
+  contrastRatio,
+  darken,
+  hslToRgb,
+  lighten,
+  mix,
+  rgbToHex,
+  withAlpha,
+} from '../../utils/color';
+import type { ThemeBase, ThemeColorSlot, ThemeInputs } from '../../store/uiPreferencesStore';
+
+/**
+ * Every semantic token the engine may override. Order is irrelevant; the
+ * applier iterates this set and set/removes each so reverting is total.
+ */
+export const THEME_CONTROLLED_TOKENS = [
+  '--color-primary',
+  '--color-primary-dark',
+  '--color-primary-light',
+  '--color-primary-alpha',
+  '--color-on-primary',
+  '--color-cta',
+  '--color-cta-hover',
+  '--color-cta-text',
+  '--bg-primary',
+  '--bg-secondary',
+  '--bg-tertiary',
+  '--bg-hover',
+  '--bg-active',
+  '--border-color',
+  '--border-color-light',
+  '--border-color-input',
+  '--text-primary',
+  '--text-secondary',
+  '--text-muted',
+  '--text-faint',
+] as const;
+
+export type ControlledToken = (typeof THEME_CONTROLLED_TOKENS)[number];
+
+/** Brand ink/paper anchors used for contrast picks + text fallbacks. */
+export const THEME_INK = '#0a1525';
+export const THEME_PAPER = '#f6f4ec';
+/** Default base surfaces (match index.css) — fallback for text-toward-surface mixing. */
+const BASE_SURFACE: Record<ThemeBase, string> = { light: '#f9f6ee', dark: '#0e1c30' };
+
+/** Pick ink or paper for the most readable text/icon on a filled color. */
+export function onColor(fill: string): string {
+  return contrastRatio(THEME_PAPER, fill) >= contrastRatio(THEME_INK, fill) ? THEME_PAPER : THEME_INK;
+}
+
+/**
+ * Resolve the token overrides for one base from the user's sparse inputs.
+ * Only set slots contribute; each set slot writes its whole token family.
+ */
+export function resolveThemeOverrides(
+  base: ThemeBase,
+  inputs: ThemeInputs
+): Partial<Record<ControlledToken, string>> {
+  const out: Partial<Record<ControlledToken, string>> = {};
+  const { primary, cta, surface, text } = inputs;
+
+  // Resolve text first (surface tints + borders key off it). When the user set a
+  // surface but no text, derive a readable text color from the surface.
+  const resolvedText = text ?? (surface ? onColor(surface) : undefined);
+
+  if (primary) {
+    out['--color-primary'] = primary;
+    out['--color-primary-dark'] = darken(primary, 10);
+    out['--color-primary-light'] = withAlpha(primary, base === 'dark' ? 0.14 : 0.12);
+    out['--color-primary-alpha'] = withAlpha(primary, 0.3);
+    out['--color-on-primary'] = onColor(primary);
+  }
+
+  if (cta) {
+    out['--color-cta'] = cta;
+    out['--color-cta-hover'] = darken(cta, 10);
+    out['--color-cta-text'] = onColor(cta);
+  }
+
+  if (surface) {
+    const tint = resolvedText ?? (base === 'dark' ? THEME_PAPER : THEME_INK);
+    out['--bg-primary'] = surface;
+    out['--bg-secondary'] = base === 'dark' ? darken(surface, 4) : darken(surface, 2);
+    out['--bg-tertiary'] = base === 'dark' ? lighten(surface, 5) : darken(surface, 5);
+    out['--bg-hover'] = withAlpha(tint, 0.06);
+    out['--bg-active'] = withAlpha(tint, 0.1);
+    out['--border-color'] = withAlpha(tint, 0.12);
+    out['--border-color-light'] = withAlpha(tint, 0.06);
+    out['--border-color-input'] = withAlpha(tint, 0.2);
+  }
+
+  if (resolvedText) {
+    const toward = surface ?? BASE_SURFACE[base];
+    out['--text-primary'] = resolvedText;
+    out['--text-secondary'] = mix(resolvedText, toward, 0.2);
+    out['--text-muted'] = mix(resolvedText, toward, 0.45);
+    out['--text-faint'] = mix(resolvedText, toward, 0.6);
+  }
+
+  return out;
+}
+
+/** A curated, on-white-safe preset (per base). `inputs` are sparse. */
+export interface ThemePreset {
+  id: string;
+  label: string;
+  light: ThemeInputs;
+  dark: ThemeInputs;
+}
+
+/**
+ * Safe starter presets. `default` is empty (the hand-tuned base). Values are
+ * intentionally conservative — tuned over time; the point is the mechanism.
+ */
+export const THEME_PRESETS: ThemePreset[] = [
+  { id: 'default', label: 'Default', light: {}, dark: {} },
+  { id: 'ocean', label: 'Ocean', light: { primary: '#0f6fa8' }, dark: { primary: '#7cc6ec' } },
+  { id: 'forest', label: 'Forest', light: { primary: '#0f766e' }, dark: { primary: '#5eead4' } },
+  { id: 'plum', label: 'Plum', light: { primary: '#7e22ce' }, dark: { primary: '#d8b4fe' } },
+  { id: 'ember', label: 'Ember', light: { primary: '#b4530a' }, dark: { primary: '#fcd34d' } },
+];
+
+/**
+ * Generate a tasteful, contrast-safe random theme for a base ("Surprise me").
+ * Lightness is constrained per base so the derived on-color and Primary↔Surface
+ * contrast stay legible; hue/sat are free for variety.
+ */
+export function surpriseTheme(base: ThemeBase): ThemeInputs {
+  const sat = 45 + Math.floor(Math.random() * 25); // 45–70%
+  // Build a hue at a lightness guaranteed to give an AA-legible on-color, by
+  // pushing lightness away from the mid "dead zone" (where neither ink nor paper
+  // reaches AA) until it does — perceptual luminance varies by hue, so we check.
+  const safeFill = (hue: number): string => {
+    let l = base === 'dark' ? 70 : 38;
+    const step = base === 'dark' ? 3 : -3;
+    for (let i = 0; i < 14; i++) {
+      const hex = rgbToHex(hslToRgb({ h: hue, s: sat, l }));
+      if (contrastRatio(onColor(hex), hex) >= 4.6) return hex;
+      l = Math.max(4, Math.min(96, l + step));
+    }
+    return rgbToHex(hslToRgb({ h: hue, s: sat, l }));
+  };
+  const hue = Math.floor(Math.random() * 360);
+  return { primary: safeFill(hue), cta: safeFill((hue + 150) % 360) };
+}
+
+/**
+ * Representative base-default color per slot per base (mirrors index.css), shown
+ * in the builder when a slot is *not* overridden so the swatch reflects reality.
+ */
+export const BASE_SWATCHES: Record<ThemeBase, Record<ThemeColorSlot, string>> = {
+  light: { primary: '#1f3354', cta: '#c9a262', surface: '#f9f6ee', text: '#0a1525' },
+  dark: { primary: '#e0c690', cta: '#c9a262', surface: '#0e1c30', text: '#f6f4ec' },
+};
+
+/** Slots in display order, with plain labels for the builder UI. */
+export const THEME_SLOTS: ReadonlyArray<{ slot: ThemeColorSlot; label: string; hint: string }> = [
+  { slot: 'primary', label: 'Primary', hint: 'Links, active states, primary buttons' },
+  { slot: 'cta', label: 'Call-to-action', hint: 'Prominent action buttons' },
+  { slot: 'surface', label: 'Surface', hint: 'Page and panel backgrounds' },
+  { slot: 'text', label: 'Text', hint: 'Body text colour' },
+];

--- a/src/ui/components/ColorField.css
+++ b/src/ui/components/ColorField.css
@@ -1,0 +1,118 @@
+/* ColorField — theme-builder color slot (swatch + react-colorful popover). */
+
+.color-field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.color-field__head {
+  display: flex;
+  flex-direction: column;
+}
+
+.color-field__label {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.color-field__hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.color-field__control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.color-field__swatch {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-color-input);
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+}
+
+.color-field__swatch:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+.color-field__value {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.color-field__warning {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--warning);
+}
+
+.color-field__popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+}
+
+.color-field__popover .react-colorful {
+  width: 200px;
+  height: 160px;
+}
+
+.color-field__popover-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.color-field__hash {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.color-field__hex {
+  width: 84px;
+  padding: 4px 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 6px;
+}
+
+.color-field__default-btn {
+  margin-left: auto;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.color-field__default-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/ui/components/ColorField.tsx
+++ b/src/ui/components/ColorField.tsx
@@ -1,0 +1,110 @@
+/**
+ * ColorField — one color slot in the theme builder: a swatch that opens a
+ * popover with a react-colorful picker + hex input, plus "Use default" to clear
+ * the override (fall back to the base token). Shows an optional contrast warning.
+ *
+ * `value === undefined` means "not overridden" — the swatch shows `defaultSwatch`
+ * (the base's representative color) and the field reads as Default.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { HexColorPicker, HexColorInput } from 'react-colorful';
+import { AlertTriangle } from 'lucide-react';
+import './ColorField.css';
+
+export interface ColorFieldProps {
+  label: string;
+  hint?: string;
+  /** Current override, or undefined when the base default applies. */
+  value: string | undefined;
+  /** Representative swatch shown when unset. */
+  defaultSwatch: string;
+  onChange: (value: string | undefined) => void;
+  /** Inline contrast warning text, if any. */
+  warning?: string;
+}
+
+export function ColorField({ label, hint, value, defaultSwatch, onChange, warning }: ColorFieldProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const swatch = value ?? defaultSwatch;
+  const isDefault = value === undefined;
+
+  // Normalize to a leading-# hex before storing — HexColorInput can emit the
+  // bare hex, which is not a valid CSS color value.
+  const handlePick = useCallback(
+    (c: string) => onChange(c ? (c.startsWith('#') ? c : `#${c}`) : undefined),
+    [onChange]
+  );
+
+  const close = useCallback(() => setOpen(false), []);
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (t && !wrapRef.current?.contains(t)) close();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('pointerdown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, close]);
+
+  return (
+    <div className="color-field" ref={wrapRef}>
+      <div className="color-field__head">
+        <span className="color-field__label">{label}</span>
+        {hint && <span className="color-field__hint">{hint}</span>}
+      </div>
+
+      <div className="color-field__control">
+        <button
+          type="button"
+          className="color-field__swatch"
+          style={{ background: swatch }}
+          aria-label={`${label}: ${isDefault ? 'Default' : swatch}. Click to change.`}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        />
+        <span className="color-field__value">{isDefault ? 'Default' : swatch}</span>
+        {warning && (
+          <span className="color-field__warning" role="status" title={warning}>
+            <AlertTriangle size={13} aria-hidden="true" /> {warning}
+          </span>
+        )}
+      </div>
+
+      {open && (
+        <div className="color-field__popover" role="dialog" aria-label={`${label} color`}>
+          <HexColorPicker color={swatch} onChange={handlePick} />
+          <div className="color-field__popover-row">
+            <span className="color-field__hash">#</span>
+            <HexColorInput
+              className="color-field__hex"
+              color={swatch}
+              onChange={handlePick}
+              aria-label={`${label} hex value`}
+            />
+            <button
+              type="button"
+              className="color-field__default-btn"
+              disabled={isDefault}
+              onClick={() => {
+                onChange(undefined);
+                close();
+              }}
+            >
+              Use default
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -40,49 +40,67 @@
   margin-top: 2px;
 }
 
-/* Accent color swatches (Radix RadioGroup of color circles). */
-.accent-picker {
-  display: inline-flex;
-  gap: 10px;
+/* Theme builder — preset row, color-slot grid, per-base reset. */
+.theme-preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.accent-picker__swatch {
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  border: none;
-  border-radius: 50%;
-  background: var(--swatch);
-  box-shadow: 0 0 0 1px var(--bg-active) inset;
+.theme-preset {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: 6px;
+  padding: 5px 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
   cursor: pointer;
-  transition: transform 0.1s ease, box-shadow 0.1s ease;
 }
 
-.accent-picker__swatch:hover {
-  transform: scale(1.08);
+.theme-preset:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
-.accent-picker__swatch:focus-visible {
+.theme-preset.is-active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.theme-preset:focus-visible {
   outline: 2px solid var(--color-primary-alpha);
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
-/* Selected: a ring in the panel color around the swatch + a white check. */
-.accent-picker__swatch[data-state='checked'] {
-  box-shadow:
-    0 0 0 2px var(--bg-primary),
-    0 0 0 4px var(--swatch);
+.theme-preset__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--border-color-input) inset;
 }
 
-.accent-picker__check {
-  color: #fff;
-  opacity: 0;
-  transition: opacity 0.1s ease;
+.theme-slots {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 4px 0 10px;
 }
 
-.accent-picker__swatch[data-state='checked'] .accent-picker__check {
-  opacity: 1;
+.theme-reset-base {
+  padding: 5px 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.theme-reset-base:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -104,3 +104,46 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Prose background presets — chip with a live gradient preview. */
+.prose-bg-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.prose-bg-option {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.prose-bg-option:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.prose-bg-option.is-active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.prose-bg-option:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 1px;
+}
+
+.prose-bg-preview {
+  width: 64px;
+  height: 40px;
+  border-radius: 5px;
+  box-shadow: 0 0 0 1px var(--border-color-input) inset;
+}

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -13,6 +13,9 @@ describe('AppearanceSettings', () => {
     expect(screen.getByText('Primary')).toBeTruthy();
     expect(screen.getByText('Surface')).toBeTruthy();
     expect(screen.getByText('Surprise me')).toBeTruthy();
+    // Prose background presets render.
+    expect(screen.getByText('Prose background')).toBeTruthy();
+    expect(screen.getByText('Glow')).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -3,13 +3,16 @@ import { render, screen } from '@testing-library/react';
 import { AppearanceSettings } from './AppearanceSettings';
 
 describe('AppearanceSettings', () => {
-  it('renders the theme, accent, motion, density, and interface-size controls', () => {
+  it('renders the theme builder + comfort controls', () => {
     render(<AppearanceSettings />);
-    expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
-    expect(screen.getByRole('radiogroup', { name: 'Accent color' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Theme base' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Interface animations' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Spacing density' })).toBeTruthy();
     expect(screen.getByRole('slider', { name: 'Interface size' })).toBeTruthy();
+    // Theme color slots + the Surprise-me generator are present.
+    expect(screen.getByText('Primary')).toBeTruthy();
+    expect(screen.getByText('Surface')).toBeTruthy();
+    expect(screen.getByText('Surprise me')).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,21 +1,21 @@
 /**
  * Settings → Appearance — the consolidated home for visual/UX configuration.
  *
- * Sections: Theme, Accent color, Motion, Canvas, Layout (the panel-arrangement
- * editor, embedded), and Title bar (desktop-only). Density + UI-scale land in a
- * later slice. Kept self-contained (no coupling to `SettingsModal` internals)
+ * Sections: Theme builder (base + presets + Primary/CTA/Surface/Text + Surprise
+ * me), Motion, Density, Interface size, Canvas, Layout (embedded), and Title bar
+ * (desktop-only). Kept self-contained (no coupling to `SettingsModal` internals)
  * so it survives the planned settings-menu rework.
  */
 
-import type { CSSProperties } from 'react';
-import * as RadioGroup from '@radix-ui/react-radio-group';
-import { Check, Monitor, Moon, Sun } from 'lucide-react';
+import { Monitor, Moon, Sun, Wand2 } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
-  type AccentColor,
   type Density,
+  type ThemeBase,
+  type ThemeColorSlot,
+  type ThemeInputs,
   UI_SCALE_MIN,
   UI_SCALE_MAX,
 } from '../../store/uiPreferencesStore';
@@ -25,9 +25,17 @@ import type { MotionPreference } from '../../platform/adaptiveBudget';
 import { windowControls } from '../../platform/window';
 import { opener } from '../../platform/opener';
 import { isMacOS } from '../../utils/platform';
+import { contrastRatio } from '../../utils/color';
+import {
+  BASE_SWATCHES,
+  THEME_PRESETS,
+  THEME_SLOTS,
+  surpriseTheme,
+} from '../appearance/themeEngine';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { Slider } from '../components/Slider';
 import { Switch } from '../components/Switch';
+import { ColorField } from '../components/ColorField';
 import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
 import './AppearanceSettings.css';
@@ -36,16 +44,6 @@ const THEME_OPTIONS = [
   { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your device appearance' },
   { value: 'light' as const, label: 'Light', icon: <Sun size={15} />, title: 'Light theme' },
   { value: 'dark' as const, label: 'Dark', icon: <Moon size={15} />, title: 'Dark theme' },
-];
-
-// Representative swatch colors (the light-theme hue). 'default' shows the brand
-// navy and adds no override — the theme keeps its own accent (navy / gold).
-const ACCENT_OPTIONS: ReadonlyArray<{ value: AccentColor; label: string; swatch: string }> = [
-  { value: 'default', label: 'Default', swatch: '#1f3354' },
-  { value: 'teal', label: 'Teal', swatch: '#0f766e' },
-  { value: 'violet', label: 'Violet', swatch: '#6d28d9' },
-  { value: 'amber', label: 'Amber', swatch: '#b45309' },
-  { value: 'rose', label: 'Rose', swatch: '#be123c' },
 ];
 
 const MOTION_OPTIONS = [
@@ -60,11 +58,20 @@ const DENSITY_OPTIONS = [
   { value: 'spacious' as const, label: 'Spacious', title: 'Roomier spacing and larger targets' },
 ];
 
+/** WCAG thresholds for the inline contrast warnings. */
+const AA_TEXT = 4.5;
+const UI_MIN = 3;
+
 export function AppearanceSettings() {
   const themePreference = useThemeStore((s) => s.preference);
   const setThemePreference = useThemeStore((s) => s.setPreference);
-  const accent = useUIPreferencesStore((s) => s.appearancePrefs.accent);
-  const setAccent = useUIPreferencesStore((s) => s.setAccent);
+  // The base being edited follows the resolved (active) theme.
+  const activeBase = useThemeStore((s) => s.resolvedTheme) as ThemeBase;
+
+  const themeInputs = useUIPreferencesStore((s) => s.appearancePrefs.themeInputs[activeBase]);
+  const setThemeInput = useUIPreferencesStore((s) => s.setThemeInput);
+  const setThemeInputs = useUIPreferencesStore((s) => s.setThemeInputs);
+
   const motion = useUIPreferencesStore((s) => s.appearancePrefs.motion);
   const setMotion = useUIPreferencesStore((s) => s.setMotion);
   const density = useUIPreferencesStore((s) => s.appearancePrefs.density);
@@ -75,9 +82,24 @@ export function AppearanceSettings() {
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
   const uiScalePercent = Math.round(uiScale * 100);
+  const baseSwatch = BASE_SWATCHES[activeBase];
+
+  // Resolved surface for contrast checks (override or base default).
+  const resolvedSurface = themeInputs.surface ?? baseSwatch.surface;
+  const warnFor = (slot: ThemeColorSlot): string | undefined => {
+    const v = themeInputs[slot];
+    if (!v) return undefined; // unset → engine derives safely
+    if (slot === 'text' && contrastRatio(v, resolvedSurface) < AA_TEXT) return 'Low contrast';
+    if (slot === 'primary' && contrastRatio(v, resolvedSurface) < UI_MIN) return 'Low contrast on this surface';
+    return undefined;
+  };
+
+  const activePresetId = THEME_PRESETS.find(
+    (p) => JSON.stringify(p[activeBase]) === JSON.stringify(themeInputs)
+  )?.id;
 
   const handleReset = () => {
-    if (window.confirm('Reset theme, accent color, motion, and layout customization to their defaults?')) {
+    if (window.confirm('Reset theme, motion, density, interface size, and layout customization to their defaults?')) {
       resetAppearance();
     }
   };
@@ -86,32 +108,77 @@ export function AppearanceSettings() {
     <div className="appearance-settings">
       <h3 className="settings-section-title">Appearance</h3>
 
-      {/* Theme */}
+      {/* Theme builder */}
       <div className="settings-group">
         <h4 className="settings-group-title">Theme</h4>
+
         <div className="settings-row">
-          <span className="settings-label">Color theme</span>
+          <span className="settings-label">Base</span>
           <SegmentedControl
-            ariaLabel="Color theme"
+            ariaLabel="Theme base"
             value={themePreference}
             onValueChange={(v: ThemePreference) => setThemePreference(v)}
             options={THEME_OPTIONS}
           />
           <span className="settings-hint">
-            Choose your preferred color theme. Your choice is remembered across sessions.
+            Light or dark foundation. You're editing your <strong>{activeBase}</strong> theme;
+            switch base to customize the other independently.
           </span>
         </div>
-      </div>
 
-      {/* Accent color */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Accent color</h4>
         <div className="settings-row">
-          <span className="settings-label">Accent</span>
-          <AccentPicker value={accent} onValueChange={setAccent} />
-          <span className="settings-hint">
-            Tints buttons, links, highlights, and selected controls across the app.
-          </span>
+          <span className="settings-label">Presets</span>
+          <div className="theme-preset-row">
+            {THEME_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                className={`theme-preset${activePresetId === preset.id ? ' is-active' : ''}`}
+                onClick={() => setThemeInputs(activeBase, preset[activeBase])}
+              >
+                <span
+                  className="theme-preset__dot"
+                  style={{ background: preset[activeBase].primary ?? baseSwatch.primary }}
+                  aria-hidden="true"
+                />
+                {preset.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="theme-preset theme-preset--surprise"
+              onClick={() => setThemeInputs(activeBase, surpriseTheme(activeBase))}
+              title="Generate a random, legible theme"
+            >
+              <Wand2 size={14} aria-hidden="true" /> Surprise me
+            </button>
+          </div>
+          <span className="settings-hint">Start from a preset, then fine-tune the colors below.</span>
+        </div>
+
+        <div className="theme-slots">
+          {THEME_SLOTS.map(({ slot, label, hint }) => (
+            <ColorField
+              key={slot}
+              label={label}
+              hint={hint}
+              value={themeInputs[slot]}
+              defaultSwatch={baseSwatch[slot]}
+              onChange={(value) => setThemeInput(activeBase, slot, value)}
+              {...(warnFor(slot) !== undefined ? { warning: warnFor(slot) as string } : {})}
+            />
+          ))}
+        </div>
+
+        <div className="settings-row">
+          <button
+            type="button"
+            className="theme-reset-base"
+            disabled={Object.keys(themeInputs as ThemeInputs).length === 0}
+            onClick={() => setThemeInputs(activeBase, {})}
+          >
+            Reset {activeBase} theme to default
+          </button>
         </div>
       </div>
 
@@ -218,44 +285,10 @@ export function AppearanceSettings() {
   );
 }
 
-function AccentPicker({
-  value,
-  onValueChange,
-}: {
-  value: AccentColor;
-  onValueChange: (value: AccentColor) => void;
-}) {
-  return (
-    <RadioGroup.Root
-      className="accent-picker"
-      value={value}
-      onValueChange={(v) => onValueChange(v as AccentColor)}
-      aria-label="Accent color"
-      orientation="horizontal"
-      loop
-    >
-      {ACCENT_OPTIONS.map((opt) => (
-        <RadioGroup.Item
-          key={opt.value}
-          className="accent-picker__swatch"
-          value={opt.value}
-          aria-label={opt.label}
-          title={opt.label}
-          style={{ '--swatch': opt.swatch } as CSSProperties}
-        >
-          <Check className="accent-picker__check" size={14} strokeWidth={3} aria-hidden="true" />
-        </RadioGroup.Item>
-      ))}
-    </RadioGroup.Root>
-  );
-}
-
 /**
- * DocuShark title bar opt-in. Gated to the desktop shell that actually owns a
- * native title bar — `windowControls.isSupported()` is false on the web app
- * (and we exclude macOS, whose window controls can't be credibly replaced) — so
- * the whole section is absent there (JP-107: the option no longer appears where
- * it has no effect).
+ * DocuShark title bar opt-in. Gated to the desktop shell that owns a native
+ * title bar — `windowControls.isSupported()` is false on the web app (and we
+ * exclude macOS) — so the whole section is absent there (JP-107).
  */
 function TitleBarSection() {
   const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
@@ -271,15 +304,12 @@ function TitleBarSection() {
     );
     if (!confirmed) return;
     setCustomChrome(next);
-    // Flush any pending auto-save so the restart doesn't trip the unsaved-changes prompt.
     try {
       usePersistenceStore.getState().saveDocument();
     } catch {
       // Best-effort flush; the user already confirmed the restart.
     }
     if (import.meta.env.DEV) {
-      // Under `tauri dev` the app can't relaunch itself, so persist the flag and
-      // let the developer relaunch. (Dev-only path; customers get the restart.)
       void opener.persistCustomChrome(next);
       useNotificationStore.getState().info('Title bar preference saved — restart the app to see it.', {
         duration: 6000,

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -13,6 +13,7 @@ import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
   type Density,
+  type ProseBackground,
   type ThemeBase,
   type ThemeColorSlot,
   type ThemeInputs,
@@ -28,6 +29,7 @@ import { isMacOS } from '../../utils/platform';
 import { contrastRatio } from '../../utils/color';
 import {
   BASE_SWATCHES,
+  PROSE_BACKGROUNDS,
   THEME_PRESETS,
   THEME_SLOTS,
   surpriseTheme,
@@ -78,6 +80,8 @@ export function AppearanceSettings() {
   const setDensity = useUIPreferencesStore((s) => s.setDensity);
   const uiScale = useUIPreferencesStore((s) => s.appearancePrefs.uiScale);
   const setUiScale = useUIPreferencesStore((s) => s.setUiScale);
+  const proseBackground = useUIPreferencesStore((s) => s.appearancePrefs.proseBackground);
+  const setProseBackground = useUIPreferencesStore((s) => s.setProseBackground);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -179,6 +183,35 @@ export function AppearanceSettings() {
           >
             Reset {activeBase} theme to default
           </button>
+        </div>
+      </div>
+
+      {/* Prose background */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Prose background</h4>
+        <div className="settings-row">
+          <span className="settings-label">Editor backdrop</span>
+          <div className="prose-bg-row">
+            {(Object.keys(PROSE_BACKGROUNDS) as ProseBackground[]).map((id) => (
+              <button
+                key={id}
+                type="button"
+                className={`prose-bg-option${proseBackground === id ? ' is-active' : ''}`}
+                onClick={() => setProseBackground(id)}
+                aria-pressed={proseBackground === id}
+              >
+                <span
+                  className="prose-bg-preview"
+                  style={{ background: PROSE_BACKGROUNDS[id].value ?? 'var(--bg-primary)' }}
+                  aria-hidden="true"
+                />
+                {PROSE_BACKGROUNDS[id].label}
+              </button>
+            ))}
+          </div>
+          <span className="settings-hint">
+            The backdrop behind the writing area. Presets follow your theme colors.
+          </span>
         </div>
       </div>
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -266,3 +266,66 @@ export function isLightColor(hex: string): boolean {
 export function getContrastColor(backgroundColor: string): string {
   return isLightColor(backgroundColor) ? '#000000' : '#ffffff';
 }
+
+/**
+ * WCAG relative luminance of an sRGB color (0 = black, 1 = white).
+ */
+function relativeLuminance(rgb: RGB): number {
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+}
+
+/**
+ * WCAG contrast ratio between two colors (1:1 .. 21:1). Order-independent.
+ * Invalid input yields 1 (worst case) so callers fail safe.
+ *
+ * @param a - Hex color string
+ * @param b - Hex color string
+ */
+export function contrastRatio(a: string, b: string): number {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  if (!ra || !rb) return 1;
+  const la = relativeLuminance(ra);
+  const lb = relativeLuminance(rb);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Linearly interpolate between two hex colors in sRGB space.
+ *
+ * @param a - Start hex color
+ * @param b - End hex color
+ * @param t - Amount toward `b` (0..1)
+ * @returns Mixed hex color (#RRGGBB); returns `a` unchanged on invalid input
+ */
+export function mix(a: string, b: string, t: number): string {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  if (!ra || !rb) return a;
+  const m = Math.max(0, Math.min(1, t));
+  return rgbToHex({
+    r: ra.r + (rb.r - ra.r) * m,
+    g: ra.g + (rb.g - ra.g) * m,
+    b: ra.b + (rb.b - ra.b) * m,
+  });
+}
+
+/**
+ * Build an `rgba()` string from a hex color and an alpha (0..1).
+ *
+ * @param hex - Hex color string
+ * @param alpha - Opacity 0..1
+ * @returns `rgba(r, g, b, a)`; returns `hex` unchanged on invalid input
+ */
+export function withAlpha(hex: string, alpha: number): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+  const a = Math.max(0, Math.min(1, alpha));
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
+}


### PR DESCRIPTION
PR 1 of **JP-58** (Theme Builder), the next step of the UX-flex epic (JP-253). Supersedes the JP-255 accent picker.

Pick a **Light or Dark base**, then set **Primary, CTA, Surface, Text** from presets or a custom color picker — everything else (hover/active/wash/focus-ring/borders/muted text + on-fill text) **derives**.

## Bulletproof by construction

The complete hand-tuned light/dark token sets stay in `index.css` (the base). The engine writes only inline **overrides** for the slots a user set (inline custom props beat the stylesheet), so anything untouched falls through to the base — **no token can be missing**, and empty inputs are **pixel-identical to today**.

Three enforced layers (tests): **completeness** (presets + 200-case fuzz — every emitted token is controlled + a valid color), **drift guard** (`THEME_CONTROLLED_TOKENS` ⊆ tokens defined in `index.css`), and on-color **optimality + AA** (presets + "Surprise me" guaranteed legible).

## The real coverage threat, handled

`--color-primary` is used as a **fill in ~98 places** with **no on-color token** — a light custom Primary would break readability there. Added **`--color-on-primary`** (contrast-derived), and migrated the visible dark primary-fill buttons (Export / SaveToLibrary / ShapeLibrary) off a hardcoded `#1e1e1e` onto it (which was *already* a latent contrast issue). Presets are curated on-legible; the remaining fills are ratcheted in **JP-258**.

## Mechanics

- `themeEngine.ts` — pure `resolveThemeOverrides(base, inputs)`; derivation via `src/utils/color.ts` (added `contrastRatio`/`mix`/`withAlpha`); presets + contrast-safe **Surprise me** (lightness pushed out of the dead zone until AA holds).
- `uiPreferencesStore` — `themeInputs { light, dark }` replaces the `accent` enum; **v5→v6 migration** maps a user's accent → custom Primary (both bases) so nothing is lost; `merge` materializes both bases.
- `applyAppearance` — set/remove the **full** controlled-token set each apply (Light can't bleed onto Dark); keys off `resolvedTheme`, subscribes to `themeStore` for base flips; FOUC-proof.
- `react-colorful` (~2.8 KB) + `ColorField` (preset swatches + Custom… popover + inline **AA contrast warnings**, aria-live). Snapshot seam carries `themeInputs` (future shareable/export themes + Workspaces).

## Verification

- `bun run typecheck` ✅ · `bun run test:run` ✅ (1900 tests, +19) · `bun run build` ✅ · OSS-leak grep clean.
- Manual: build a theme for Light *and* Dark, reload (persists per base), switch base (no bleed), confirm **Default = exact current look**, a light custom Primary keeps button text legible, low-contrast Text shows ⚠, Surprise me always legible, canvas unaffected.

## Next (JP-258)

Coverage ratchet (file-allowlist the 63 current offenders; fail new ones) + migrate the remaining hardcoded hex / primary-fill on-text.

Assisted-by: Opus 4.8