### PR TITLE
Generic blob ingest-from-URL endpoint + SSRF guard + provenance (JP-264)

### DIFF
--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -300,6 +300,76 @@ paths:
         '507':
           description: Projected per-workspace storage quota exceeded.
 
+  /api/v1/blobs/ingest-from-url:
+    post:
+      tags: [blobs]
+      summary: Ingest a blob from a URL (server-side fetch)
+      description: |
+        Fetch bytes from `url` (sending `authorization` verbatim as the
+        `Authorization` header), store them content-addressed for the caller's
+        workspace, and return the SHA-256 hash. Lets a trusted backend hand the
+        relay a reference instead of streaming the bytes through itself.
+
+        **Disabled by default:** returns 403 unless the operator configures a
+        host allowlist (`[tenancy.limits] blob_ingest_allowed_hosts` /
+        `RELAY_BLOB_INGEST_ALLOWED_HOSTS`). The allowlist (exact host or
+        `*.suffix` wildcard) is enforced on the initial URL **and every redirect
+        hop**; only `https` is allowed and private/loopback IP-literal hosts are
+        rejected (SSRF protection). `source`/`tags` are opaque provenance
+        strings recorded for audit; the relay does not interpret them.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url, authorization]
+              properties:
+                url:
+                  type: string
+                  description: https URL on the configured allowlist.
+                authorization:
+                  type: string
+                  description: Verbatim value for the Authorization header sent to `url`.
+                mimeType:
+                  type: string
+                  description: Overrides the source response's Content-Type when set.
+                source:
+                  type: string
+                  description: Opaque provenance tag recorded with the blob (audit only).
+                tags:
+                  type: array
+                  items:
+                    type: string
+                  description: Additional opaque provenance tags (audit only).
+      responses:
+        '200':
+          description: Stored (or deduplicated) blob.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+                  size:
+                    type: integer
+                    format: int64
+                  mimeType:
+                    type: string
+        '400':
+          description: Malformed request URL.
+        '403':
+          description: Endpoint not configured, or URL host not on the allowlist.
+        '413':
+          description: Fetched blob exceeds the per-blob size limit.
+        '502':
+          description: The source fetch failed or returned a non-success status.
+        '507':
+          description: Per-workspace storage quota exceeded.
+
   /api/v1/blobs/{hash}/finalize:
     parameters:
       - name: hash

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -10,6 +10,7 @@
 //! See `routes()` for the full surface.
 
 use std::collections::HashSet;
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use axum::{
@@ -29,6 +30,7 @@ use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
     PermissionError,
 };
+use crate::server::blobs::{BlobStore, SaveBlobError};
 use crate::server::protocol::{ClaimLimits, DocEventType, DocId, WorkspaceId};
 use crate::server::ServerState;
 
@@ -125,6 +127,10 @@ pub fn routes() -> Router<Arc<ServerState>> {
         .route(
             "/api/v1/blobs/:hash/download-url",
             post(blob_download_url_handler),
+        )
+        .route(
+            "/api/v1/blobs/ingest-from-url",
+            post(blob_ingest_from_url_handler),
         )
         .route("/api/docs", get(list_docs_handler))
         .route("/api/docs/:id", get(get_doc_handler))
@@ -928,6 +934,286 @@ async fn require_auth(
     })
 }
 
+// ============ Generic blob ingest-from-URL (JP-264) ============
+
+/// Body of `POST /api/v1/blobs/ingest-from-url`. The relay fetches `url`
+/// (sending `authorization` verbatim as the `Authorization` header), stores the
+/// bytes content-addressed, and returns the hash. `source`/`tags` are **opaque**
+/// provenance strings recorded for audit — the relay never interprets them.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IngestFromUrlRequest {
+    url: String,
+    /// Verbatim value for the `Authorization` header sent to `url`.
+    authorization: String,
+    #[serde(default)]
+    mime_type: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+/// Match a host against one allowlist entry: exact, or a `*.suffix` wildcard
+/// that matches the bare suffix and any subdomain. Case/trailing-dot insensitive.
+fn ingest_host_matches(host: &str, pattern: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    let pat = pattern.trim().trim_end_matches('.').to_ascii_lowercase();
+    if let Some(suffix) = pat.strip_prefix("*.") {
+        !suffix.is_empty() && (host == suffix || host.ends_with(&format!(".{suffix}")))
+    } else {
+        !pat.is_empty() && host == pat
+    }
+}
+
+fn ingest_host_allowed(host: &str, allow: &[String]) -> bool {
+    !host.is_empty() && allow.iter().any(|p| ingest_host_matches(host, p))
+}
+
+/// Reject IP-literal hosts that point at private/loopback/link-local/unspecified
+/// space (defense-in-depth atop the allowlist; covers IPv4-mapped IPv6 too).
+fn ingest_ip_blocked(host: &str) -> bool {
+    let h = host.trim_start_matches('[').trim_end_matches(']');
+    match h.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+        }
+        Ok(IpAddr::V6(ip)) => {
+            if let Some(v4) = ip.to_ipv4_mapped() {
+                return v4.is_private()
+                    || v4.is_loopback()
+                    || v4.is_link_local()
+                    || v4.is_unspecified()
+                    || v4.is_broadcast();
+            }
+            if ip.is_loopback() || ip.is_unspecified() {
+                return true;
+            }
+            let seg = ip.segments();
+            let unique_local = (seg[0] & 0xfe00) == 0xfc00; // fc00::/7
+            let link_local = (seg[0] & 0xffc0) == 0xfe80; // fe80::/10
+            unique_local || link_local
+        }
+        Err(_) => false, // not an IP literal → a DNS host, governed by the allowlist
+    }
+}
+
+/// SSRF gate: https only, host on the allowlist, not a blocked IP literal.
+/// Enforced on the initial URL and (via the redirect policy) every hop.
+fn ingest_url_ok(url: &reqwest::Url, allow: &[String]) -> bool {
+    if url.scheme() != "https" {
+        return false;
+    }
+    match url.host_str() {
+        Some(host) => !ingest_ip_blocked(host) && ingest_host_allowed(host, allow),
+        None => false,
+    }
+}
+
+/// `POST /api/v1/blobs/ingest-from-url` — fetch a blob from an allowlisted URL
+/// and store it content-addressed for the caller's workspace. Generic: the
+/// relay has no knowledge of any specific integration; the `source`/`tags` are
+/// opaque. Disabled (403) unless `[tenancy.limits] blob_ingest_allowed_hosts`
+/// is configured — the relay is never an open fetch proxy by default.
+async fn blob_ingest_from_url_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Json(req): Json<IngestFromUrlRequest>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    let allow: Vec<String> = state.blob_ingest_allowed_hosts().to_vec();
+    if allow.is_empty() {
+        return (
+            StatusCode::FORBIDDEN,
+            ApiError::body("ingest_not_configured"),
+        )
+            .into_response();
+    }
+
+    let url = match reqwest::Url::parse(&req.url) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, ApiError::body("invalid url")).into_response(),
+    };
+    if !ingest_url_ok(&url, &allow) {
+        return (StatusCode::FORBIDDEN, ApiError::body("url_not_allowed")).into_response();
+    }
+
+    let max = state.max_blob_bytes();
+
+    // Validate every redirect hop against the same allowlist (an open redirect
+    // to an internal host is the classic SSRF escape).
+    let policy_allow = allow.clone();
+    let client = match reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() > 5 {
+                return attempt.error("too many redirects");
+            }
+            if ingest_url_ok(attempt.url(), &policy_allow) {
+                attempt.follow()
+            } else {
+                attempt.stop()
+            }
+        }))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("ingest client build failed: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body("client_error"))
+                .into_response();
+        }
+    };
+
+    let resp = match client
+        .get(url)
+        .header(reqwest::header::AUTHORIZATION, &req.authorization)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::info!("ingest fetch failed for ws {}: {e}", ws.as_str());
+            return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
+        }
+    };
+    if !resp.status().is_success() {
+        return (
+            StatusCode::BAD_GATEWAY,
+            ApiError::body(format!("source returned {}", resp.status())),
+        )
+            .into_response();
+    }
+
+    // Early reject on a declared length over the ceiling.
+    if let Some(len) = resp.content_length() {
+        if len > max as u64 {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                ApiError::body("blob exceeds max size"),
+            )
+                .into_response();
+        }
+    }
+
+    let mime = req
+        .mime_type
+        .clone()
+        .or_else(|| {
+            resp.headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    let body = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            log::info!("ingest body read failed for ws {}: {e}", ws.as_str());
+            return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
+        }
+    };
+    // Authoritative size check (the host may ignore/omit Content-Length).
+    if body.len() > max {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            ApiError::body("blob exceeds max size"),
+        )
+            .into_response();
+    }
+
+    let hash = BlobStore::compute_hash(&body);
+    let quota = state.resolve_limits(limits).quota_bytes;
+
+    // Persist, mirroring the proxy upload's s3-vs-filesystem split.
+    let (size, hash) = if let Some(s3) = state.s3_backend() {
+        if state.blob_store().exists(&ws, &hash) {
+            let size = state
+                .blob_store()
+                .get_metadata(&ws, &hash)
+                .map(|m| m.size)
+                .unwrap_or(body.len() as u64);
+            (size, hash)
+        } else {
+            if let Some(q) = quota {
+                if state
+                    .blob_store()
+                    .get_workspace_size(&ws)
+                    .saturating_add(body.len() as u64)
+                    > q
+                {
+                    return (
+                        StatusCode::INSUFFICIENT_STORAGE,
+                        ApiError::body("storage quota exceeded"),
+                    )
+                        .into_response();
+                }
+            }
+            if let Err(e) = s3.put_object(&ws, &hash, body.to_vec(), &mime).await {
+                log::warn!("ingest s3 put failed {}/{}: {e}", ws.as_str(), hash);
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    ApiError::body("blob store unavailable"),
+                )
+                    .into_response();
+            }
+            match state
+                .blob_store()
+                .record_finalized_blob(&ws, &hash, body.len() as u64, &mime, &claims.sub)
+            {
+                Ok(m) => (m.size, m.hash),
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response()
+                }
+            }
+        }
+    } else {
+        match state
+            .blob_store()
+            .save_blob_with_quota(&ws, &hash, &body, &mime, &claims.sub, quota)
+        {
+            Ok(m) => (m.size, m.hash),
+            Err(e @ SaveBlobError::QuotaExceeded { .. }) => {
+                return (StatusCode::INSUFFICIENT_STORAGE, ApiError::body(e.to_string()))
+                    .into_response()
+            }
+            Err(e) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e.to_string()))
+                    .into_response()
+            }
+        }
+    };
+
+    // Record opaque provenance (source + tags), additive; advisory only.
+    let mut tags = req.tags.clone();
+    if let Some(s) = req.source.clone() {
+        tags.push(s);
+    }
+    if let Err(e) = state.blob_store().record_provenance(&ws, &hash, &tags) {
+        log::warn!("provenance record failed {}/{}: {e}", ws.as_str(), hash);
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({ "hash": hash, "size": size, "mimeType": mime })),
+    )
+        .into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -946,5 +1232,55 @@ mod tests {
         assert!(!is_valid_blob_hash(&"A".repeat(64))); // uppercase not allowed
         assert!(!is_valid_blob_hash(&"g".repeat(64))); // non-hex
         assert!(!is_valid_blob_hash("")); // empty
+    }
+
+    #[test]
+    fn ingest_host_matching_exact_and_wildcard() {
+        let allow = vec!["api.example.com".to_string(), "*.example.net".to_string()];
+        // exact
+        assert!(ingest_host_allowed("api.example.com", &allow));
+        // wildcard matches subdomain + the bare suffix
+        assert!(ingest_host_allowed("acme.example.net", &allow));
+        assert!(ingest_host_allowed("example.net", &allow));
+        assert!(ingest_host_allowed("API.Example.COM", &allow)); // case-insensitive
+        // misses
+        assert!(!ingest_host_allowed("evil.com", &allow));
+        assert!(!ingest_host_allowed("example.net.evil.com", &allow)); // suffix trick
+        assert!(!ingest_host_allowed("notexample.net", &allow)); // not a dot-boundary
+        assert!(!ingest_host_allowed("", &allow));
+        assert!(!ingest_host_allowed("api.example.com", &[])); // empty allowlist = nothing
+    }
+
+    #[test]
+    fn ingest_blocks_private_and_loopback_ip_literals() {
+        assert!(ingest_ip_blocked("127.0.0.1"));
+        assert!(ingest_ip_blocked("10.0.0.5"));
+        assert!(ingest_ip_blocked("192.168.1.1"));
+        assert!(ingest_ip_blocked("169.254.1.1")); // link-local
+        assert!(ingest_ip_blocked("0.0.0.0"));
+        assert!(ingest_ip_blocked("[::1]")); // ipv6 loopback w/ brackets
+        assert!(ingest_ip_blocked("fc00::1")); // ULA
+        assert!(ingest_ip_blocked("fe80::1")); // link-local
+        assert!(ingest_ip_blocked("[::ffff:127.0.0.1]")); // ipv4-mapped loopback
+        // public literals are not blocked here (the allowlist is the gate)
+        assert!(!ingest_ip_blocked("8.8.8.8"));
+        assert!(!ingest_ip_blocked("example.com")); // not an IP literal
+    }
+
+    #[test]
+    fn ingest_url_ok_enforces_https_allowlist_and_ip_block() {
+        let allow = vec!["*.example.net".to_string(), "8.8.8.8".to_string()];
+        let ok = reqwest::Url::parse("https://acme.example.net/x").unwrap();
+        assert!(ingest_url_ok(&ok, &allow));
+        // http rejected even if host allowed
+        let http = reqwest::Url::parse("http://acme.example.net/x").unwrap();
+        assert!(!ingest_url_ok(&http, &allow));
+        // off-allowlist host
+        let off = reqwest::Url::parse("https://evil.com/x").unwrap();
+        assert!(!ingest_url_ok(&off, &allow));
+        // a private IP literal is blocked even if it were somehow allowlisted
+        let priv_allow = vec!["127.0.0.1".to_string()];
+        let loop_url = reqwest::Url::parse("https://127.0.0.1/x").unwrap();
+        assert!(!ingest_url_ok(&loop_url, &priv_allow));
     }
 }

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -379,6 +379,16 @@ pub struct LimitsConfig {
     /// reference-drop (e.g. a bad reconnect save) can be corrected without
     /// irreversible byte loss; the released ACL means it's already unmetered.
     pub blob_gc_grace_secs: u64,
+    /// Host allowlist for the generic blob ingest-from-URL endpoint
+    /// (`POST /api/v1/blobs/ingest-from-url`). Each entry is an exact host
+    /// (`api.example.com`) or a `*.`-prefixed suffix wildcard (`*.example.com`,
+    /// which also matches the bare suffix). **Empty disables the endpoint**
+    /// (403) — the relay is never an open fetch proxy by default; an operator
+    /// opts in by listing the hosts an integration may pull bytes from.
+    /// Enforced on the initial URL *and every redirect hop*, alongside a
+    /// private/loopback IP-literal block.
+    #[serde(default)]
+    pub blob_ingest_allowed_hosts: Vec<String>,
 }
 
 impl Default for LimitsConfig {
@@ -394,6 +404,7 @@ impl Default for LimitsConfig {
             storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
             max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
             blob_gc_grace_secs: DEFAULT_BLOB_GC_GRACE_SECS,
+            blob_ingest_allowed_hosts: Vec::new(),
         }
     }
 }
@@ -626,6 +637,13 @@ impl RelayConfig {
             self.tenancy.limits.blob_gc_grace_secs = v
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_BLOB_GC_GRACE_SECS must be a u64 (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_BLOB_INGEST_ALLOWED_HOSTS") {
+            self.tenancy.limits.blob_ingest_allowed_hosts = v
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
         }
         if let Some(v) = get("RELAY_SNAPSHOT_INTERVAL_SECS") {
             self.sync.snapshot_interval_secs = v.parse().map_err(|_| {

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -67,6 +67,20 @@ pub struct DocRefRow {
     pub workspace: WorkspaceId,
     pub doc_id: String,
     pub hashes: Vec<String>,
+}
+
+/// One persisted row of the per-`(workspace, hash)` provenance set: opaque
+/// caller-supplied source/tag strings recorded at ingest (e.g. an importer
+/// name), for audit + cleanup. **Additive** — a content-addressed blob
+/// shared by several sources accumulates all their tags. Purely **advisory**
+/// metadata: GC is still driven by ACLs/refcounts (JP-120), never by these tags.
+/// On-disk shape in `blob_provenance.json` (a flat `Vec`, mirroring `BlobAcl`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobProvenanceRow {
+    pub workspace: WorkspaceId,
+    pub hash: String,
+    pub sources: Vec<String>,
 }
 
 /// Failure modes of [`BlobStore::save_blob_with_quota`]. The HTTP layer
@@ -146,6 +160,10 @@ pub struct BlobStore {
     /// delete is deferred and recorded here, mirroring `orphaned_at` but keyed
     /// per workspace since each workspace owns a distinct object.
     orphaned_objects_at: RwLock<HashMap<(WorkspaceId, String), Instant>>,
+    /// Opaque per-`(workspace, hash)` provenance tags (caller-supplied source
+    /// labels), recorded at ingest for audit + cleanup. Additive; advisory
+    /// only (never affects GC). Persisted to `blob_provenance.json`.
+    provenance: RwLock<HashMap<(WorkspaceId, String), BTreeSet<String>>>,
 }
 
 impl BlobStore {
@@ -177,12 +195,14 @@ impl BlobStore {
             gc_grace_secs: AtomicU64::new(0),
             object_delete_tx: None,
             orphaned_objects_at: RwLock::new(HashMap::new()),
+            provenance: RwLock::new(HashMap::new()),
         };
 
-        // Load existing index + ACLs + per-doc references.
+        // Load existing index + ACLs + per-doc references + provenance.
         store.load_index();
         store.load_acls_or_backfill();
         store.load_doc_refs();
+        store.load_provenance();
 
         store
     }
@@ -200,6 +220,11 @@ impl BlobStore {
     /// Path to the per-document blob-reference sidecar (JP-120).
     fn refs_path(&self) -> PathBuf {
         self.meta_dir.join("blob_refs.json")
+    }
+
+    /// Path to the per-`(workspace, hash)` provenance sidecar.
+    fn provenance_path(&self) -> PathBuf {
+        self.meta_dir.join("blob_provenance.json")
     }
 
     /// Load the metadata index from disk
@@ -306,6 +331,85 @@ impl BlobStore {
         std::fs::write(self.acl_path(), json)
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
+    }
+
+    /// Load the provenance sidecar from disk (absent = empty map).
+    fn load_provenance(&self) {
+        let path = self.provenance_path();
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            if let Ok(rows) = serde_json::from_str::<Vec<BlobProvenanceRow>>(&data) {
+                if let Ok(mut current) = self.provenance.write() {
+                    current.clear();
+                    for row in rows {
+                        current.insert((row.workspace, row.hash), row.sources.into_iter().collect());
+                    }
+                    log::info!("Loaded blob provenance with {} entries", current.len());
+                }
+            }
+        }
+    }
+
+    /// Persist the provenance sidecar to disk.
+    fn save_provenance(&self) -> Result<(), String> {
+        let snapshot: Vec<BlobProvenanceRow> = {
+            let prov = self.provenance.read().map_err(|e| e.to_string())?;
+            prov.iter()
+                .map(|((ws, hash), sources)| BlobProvenanceRow {
+                    workspace: ws.clone(),
+                    hash: hash.clone(),
+                    sources: sources.iter().cloned().collect(),
+                })
+                .collect()
+        };
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| format!("Serialize error: {}", e))?;
+        std::fs::write(self.provenance_path(), json)
+            .map_err(|e| format!("Write error: {}", e))?;
+        Ok(())
+    }
+
+    /// Record opaque provenance tags for a `(workspace, hash)` grant — additive
+    /// (a shared blob accumulates every source's tags). No-op when `tags` is
+    /// empty after trimming. Advisory metadata only; never affects GC.
+    pub fn record_provenance(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+        tags: &[String],
+    ) -> Result<(), String> {
+        let cleaned: Vec<String> = tags
+            .iter()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if cleaned.is_empty() {
+            return Ok(());
+        }
+        let changed = {
+            let mut prov = self.provenance.write().map_err(|e| e.to_string())?;
+            let set = prov.entry((ws.clone(), hash.to_string())).or_default();
+            let before = set.len();
+            for t in cleaned {
+                set.insert(t);
+            }
+            set.len() != before
+        };
+        if changed {
+            self.save_provenance()?;
+        }
+        Ok(())
+    }
+
+    /// All provenance tags recorded for a `(workspace, hash)` (sorted; audit/tests).
+    pub fn provenance_for(&self, ws: &WorkspaceId, hash: &str) -> Vec<String> {
+        self.provenance
+            .read()
+            .ok()
+            .and_then(|p| {
+                p.get(&(ws.clone(), hash.to_string()))
+                    .map(|s| s.iter().cloned().collect())
+            })
+            .unwrap_or_default()
     }
 
     /// Load the per-document blob-reference map from disk (JP-120). Absent

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -739,6 +739,12 @@ impl ServerState {
         self.tenancy.limits.max_blob_bytes
     }
 
+    /// Host allowlist for the generic blob ingest-from-URL endpoint
+    /// (`[tenancy.limits] blob_ingest_allowed_hosts`). Empty = endpoint disabled.
+    pub(crate) fn blob_ingest_allowed_hosts(&self) -> &[String] {
+        &self.tenancy.limits.blob_ingest_allowed_hosts
+    }
+
     /// Snapshot of per-workspace live connection counts (editor/viewer
     /// split), for the metering debug log.
     pub(crate) async fn workspace_conn_snapshot(&self) -> HashMap<WorkspaceId, WorkspaceConnCounts> {


### PR DESCRIPTION
Slice 2 of the inbound-integration build (JP-261). A **generic, Confluence-agnostic** relay capability: hand the relay a `{url, authorization}` reference and it fetches + stores the bytes itself, so byte-heavy work lands on the blob store rather than transiting the (proprietary) control-plane workers. The relay never learns what external service the bytes came from.

## Endpoint
`POST /api/v1/blobs/ingest-from-url` → fetches `url` (with the caller-supplied `Authorization` header), stores content-addressed for the caller's workspace, returns `{ hash, size, mimeType }`.

## Security (the main new attack surface)
- **Disabled by default (403)** — only active when `[tenancy.limits] blob_ingest_allowed_hosts` (env: `RELAY_BLOB_INGEST_ALLOWED_HOSTS`) is configured. The OSS relay is never an open fetch proxy.
- **SSRF guard:** https-only; host allowlist (exact or `*.suffix`) enforced on the initial URL **and every redirect hop** (custom redirect policy); private/loopback/link-local IP-literal hosts rejected, including IPv4-mapped IPv6.
- Per-blob size ceiling (declared Content-Length + actual bytes) and per-workspace storage quota enforced; content-hash dedup.

## Provenance (audit + cleanup)
Additive per-`(workspace, hash)` opaque `source`/`tags` sidecar (`blob_provenance.json`). **Advisory only** — content-addressed dedup means one blob can carry several sources; reclamation still flows through the JP-120 refcount GC, so tags never delete bytes.

## Reuse / wire
Saves via the existing proxy-upload path (s3 `put_object` + `record_finalized_blob`, or filesystem `save_blob_with_quota`). OpenAPI updated in the same commit per the wire-contract rule.

## Verification
`cargo check --tests` clean; new `api::tests` (allowlist matching incl. suffix-trick/case, private-IP blocking v4/v6/v4-mapped, the https+allowlist+IP gate) + `server::blobs` tests pass. Generic by design — no integration name appears anywhere in the relay tree.

Assisted-by: Opus 4.8