### PR TITLE
JP-232: per-workspace blob ledger survives volume loss

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -321,6 +321,7 @@ async fn usage_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     let effective = state.resolve_limits(limits);
     let counts = state.workspace_conn_for(&ws).await;
     (
@@ -357,6 +358,7 @@ async fn blob_upload_url_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     if !is_valid_blob_hash(&hash) {
         return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
     }
@@ -433,6 +435,7 @@ async fn blob_finalize_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     if !is_valid_blob_hash(&hash) {
         return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
     }
@@ -522,6 +525,7 @@ async fn blob_download_url_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     if !is_valid_blob_hash(&hash) {
         return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
     }
@@ -671,6 +675,7 @@ async fn save_doc_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
 
     // The doc body's `id` must match the path id — REST clients can't
     // forge a different doc id via the body.
@@ -778,6 +783,7 @@ async fn delete_doc_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
 
     if let Err(e) = check_delete_permission(
         state.doc_store(),
@@ -1032,6 +1038,7 @@ async fn blob_ingest_from_url_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
 
     let allow: Vec<String> = state.blob_ingest_allowed_hosts().to_vec();
     if allow.is_empty() {

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -131,6 +131,16 @@ impl S3Backend {
         format!("{}docs/{}/index.json", self.config.key_prefix, ws.as_str())
     }
 
+    /// Object key for a workspace's **blob ledger** (JP-232):
+    /// `{prefix}docs/{ws}/blob_ledger.json`. Durable per-workspace projection of
+    /// the blob bookkeeping (ACLs + per-doc refs + size/mime) so a recycled
+    /// machine — whose on-volume sidecars are gone — restores reads, GC refcounts,
+    /// and quota without re-walking the doc corpus. Sits beside the doc index in
+    /// the same paired bucket so a region migration carries it along.
+    pub fn blob_ledger_key(&self, ws: &WorkspaceId) -> String {
+        format!("{}docs/{}/blob_ledger.json", self.config.key_prefix, ws.as_str())
+    }
+
     /// Canonical request URI (path-style): `/{bucket}/{uri-encoded-key}`, with
     /// `/` preserved inside the key. This exact string is both signed and used
     /// as the request path, so they can never disagree.
@@ -219,6 +229,18 @@ impl S3Backend {
     /// `Err` on any other failure. Used by finalize to read the authoritative
     /// size after a direct client upload.
     pub async fn head_object(&self, ws: &WorkspaceId, hash: &str) -> Result<Option<u64>, String> {
+        Ok(self.head_object_typed(ws, hash).await?.map(|(size, _ct)| size))
+    }
+
+    /// HEAD the object, returning both the authoritative `size` and the stored
+    /// `Content-Type` (`None` if the object carries no content-type header).
+    /// `Ok(None)` on 404. Used by JP-232 blob-bookkeeping reconstruction so a
+    /// restored blob recovers its true mime, not a placeholder.
+    pub async fn head_object_typed(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+    ) -> Result<Option<(u64, Option<String>)>, String> {
         let key = self.object_key(ws, hash);
         let resp = self
             .send_signed("HEAD", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
@@ -229,13 +251,18 @@ impl S3Backend {
         if !resp.status().is_success() {
             return Err(format!("R2 HEAD {} -> {}", key, resp.status()));
         }
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.to_string());
         let size = resp
             .headers()
             .get(reqwest::header::CONTENT_LENGTH)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse::<u64>().ok());
         match size {
-            Some(s) => Ok(Some(s)),
+            Some(s) => Ok(Some((s, content_type))),
             None => Err(format!("R2 HEAD {} missing content-length", key)),
         }
     }
@@ -766,6 +793,104 @@ mod tests {
             DocObjectStore::get_doc_object(&backend, &ws, &doc, "json").await.unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn blob_ledger_key_sits_beside_the_doc_index() {
+        let backend = S3Backend::new(S3Config {
+            endpoint: "https://acct.r2.cloudflarestorage.com".to_string(),
+            bucket: "blobs".to_string(),
+            region: "auto".to_string(),
+            access_key_id: "AKID".to_string(),
+            secret_access_key: "secret".to_string(),
+            key_prefix: String::new(),
+            put_ttl_secs: 900,
+            get_ttl_secs: 900,
+        });
+        let ws = WorkspaceId::single_tenant();
+        assert_eq!(
+            backend.blob_ledger_key(&ws),
+            format!("docs/{}/blob_ledger.json", ws.as_str())
+        );
+    }
+
+    /// JP-232 R2 surface against a live S3 server: the `head_object_typed`
+    /// content-type read (used by reconstruct) and the blob-ledger key
+    /// put/get round-trip. Skipped unless `RELAY_TEST_S3_*` is set.
+    #[tokio::test]
+    async fn s3_ledger_and_typed_head_roundtrip_against_live_endpoint() {
+        let Some(backend) = test_backend_from_env() else {
+            eprintln!("skipping s3 ledger roundtrip: RELAY_TEST_S3_ENDPOINT unset");
+            return;
+        };
+        let ws = WorkspaceId::single_tenant();
+        let hash = "c".repeat(64);
+        let body = b"typed-head blob bytes".to_vec();
+
+        // Proxy PUT pins a content-type; the typed HEAD must read it back.
+        backend.put_object(&ws, &hash, body.clone(), "image/png").await.unwrap();
+        let (size, ct) = backend.head_object_typed(&ws, &hash).await.unwrap().unwrap();
+        assert_eq!(size, body.len() as u64);
+        assert_eq!(ct.as_deref(), Some("image/png"));
+        backend.delete_object(&ws, &hash).await.unwrap();
+        assert_eq!(backend.head_object_typed(&ws, &hash).await.unwrap(), None);
+
+        // Ledger object round-trips at its dedicated key.
+        let key = backend.blob_ledger_key(&ws);
+        let ledger = br#"{"acls":["abc"],"docRefs":[],"blobs":[]}"#.to_vec();
+        backend.put_object_at(&key, ledger.clone(), "application/json").await.unwrap();
+        assert_eq!(backend.get_object_at(&key).await.unwrap().as_deref(), Some(ledger.as_slice()));
+        backend.delete_object_at(&key).await.unwrap();
+        assert_eq!(backend.get_object_at(&key).await.unwrap(), None);
+    }
+
+    /// JP-232 end-to-end durability through live R2: drive the *real* mechanism
+    /// — build a workspace's bookkeeping, serialize its ledger, PUT it to R2,
+    /// simulate volume loss (a fresh `BlobStore`), GET + `install_ledger`, and
+    /// assert reads/quota survive and the GC does not reclaim a still-referenced
+    /// shared blob. Skipped unless `RELAY_TEST_S3_*` is set.
+    #[tokio::test]
+    async fn jp232_blob_ledger_survives_volume_loss_against_live_endpoint() {
+        use crate::server::blobs::{BlobStore, WorkspaceBlobLedger};
+        let Some(backend) = test_backend_from_env() else {
+            eprintln!("skipping JP-232 ledger durability: RELAY_TEST_S3_ENDPOINT unset");
+            return;
+        };
+        let ws = WorkspaceId::from_configured("jp232ws").unwrap();
+        let a = b"shared blob A bytes";
+        let ha = BlobStore::compute_hash(a);
+        let b = b"docA-only blob B bytes";
+        let hb = BlobStore::compute_hash(b);
+
+        // Live pod: bookkeeping built, ledger serialized + PUT to R2.
+        let dir = tempfile::tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.save_blob(&ws, &ha, a, "image/png", "u1").unwrap();
+        store.save_blob(&ws, &hb, b, "application/pdf", "u1").unwrap();
+        store.sync_doc_refs(&ws, "docA", [ha.clone(), hb.clone()].into_iter().collect()).unwrap();
+        store.sync_doc_refs(&ws, "docB", [ha.clone()].into_iter().collect()).unwrap();
+        let expected_size = store.get_workspace_size(&ws);
+
+        let key = backend.blob_ledger_key(&ws);
+        let bytes = serde_json::to_vec(&store.ledger_for_workspace(&ws)).unwrap();
+        backend.put_object_at(&key, bytes, "application/json").await.unwrap();
+
+        // Recycled machine: fresh volume, restore the ledger from R2.
+        let dir2 = tempfile::tempdir().unwrap();
+        let restored = BlobStore::new(dir2.path().to_path_buf());
+        let got = backend.get_object_at(&key).await.unwrap().expect("ledger present in R2");
+        let ledger: WorkspaceBlobLedger = serde_json::from_slice(&got).unwrap();
+        restored.install_ledger(&ws, ledger).unwrap();
+
+        // Reads + quota survive; GC keeps the shared blob, reclaims the docA-only one.
+        assert!(restored.exists(&ws, &ha));
+        assert_eq!(restored.get_workspace_size(&ws), expected_size);
+        assert_eq!(restored.sweep_unreferenced(), 0, "full ref graph → nothing to reclaim");
+        restored.release_doc_refs(&ws, "docA").unwrap();
+        assert!(restored.exists(&ws, &ha), "shared blob still referenced by docB");
+        assert!(!restored.exists(&ws, &hb), "docA-only blob reclaimed");
+
+        backend.delete_object_at(&key).await.unwrap();
     }
 
     #[test]

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -83,6 +83,38 @@ pub struct BlobProvenanceRow {
     pub sources: Vec<String>,
 }
 
+/// Per-workspace durable projection of the blob bookkeeping (JP-232), mirrored
+/// to R2 as `docs/<ws>/blob_ledger.json`. On a recycled machine whose on-volume
+/// sidecars are gone, restoring this rehydrates a workspace's ACLs, per-document
+/// refcounts, and size/mime — so reads, GC, and quota survive volume loss
+/// without re-walking the doc corpus. Written from live in-memory state, so it
+/// is **independent of the (best-effort) R2 document index**: a doc missing from
+/// the index still has its blob refs preserved here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceBlobLedger {
+    /// Blob hashes this workspace holds an ACL grant for.
+    pub acls: Vec<String>,
+    /// Per-document blob references — the refcount source. (`DocRefRow.workspace`
+    /// is redundant in a per-ws ledger; install trusts the ws it restores into.)
+    pub doc_refs: Vec<DocRefRow>,
+    /// Index metadata for every hash the workspace references.
+    pub blobs: Vec<LedgerBlob>,
+}
+
+/// One blob's index metadata as carried in a [`WorkspaceBlobLedger`] — enough to
+/// reconstruct a [`BlobMetadata`] exactly (the ledger is built from the live
+/// index, so `created_at`/`uploaded_by` round-trip at full fidelity).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LedgerBlob {
+    pub hash: String,
+    pub size: u64,
+    pub mime_type: String,
+    pub created_at: u64,
+    pub uploaded_by: String,
+}
+
 /// Failure modes of [`BlobStore::save_blob_with_quota`]. The HTTP layer
 /// maps `QuotaExceeded` to **507 Insufficient Storage** (JP-81), a hash
 /// mismatch to 400, and IO to 500.
@@ -164,6 +196,11 @@ pub struct BlobStore {
     /// labels), recorded at ingest for audit + cleanup. Additive; advisory
     /// only (never affects GC). Persisted to `blob_provenance.json`.
     provenance: RwLock<HashMap<(WorkspaceId, String), BTreeSet<String>>>,
+    /// JP-232 ledger-mirror sink. `Some` in object-storage mode: when a
+    /// workspace's bookkeeping changes, its id is sent here for a background
+    /// worker to serialize [`Self::ledger_for_workspace`] and PUT to R2. `None`
+    /// is the filesystem mode (the on-volume sidecars are the only durable copy).
+    ledger_mirror_tx: Option<UnboundedSender<WorkspaceId>>,
 }
 
 impl BlobStore {
@@ -196,6 +233,7 @@ impl BlobStore {
             object_delete_tx: None,
             orphaned_objects_at: RwLock::new(HashMap::new()),
             provenance: RwLock::new(HashMap::new()),
+            ledger_mirror_tx: None,
         };
 
         // Load existing index + ACLs + per-doc references + provenance.
@@ -625,6 +663,9 @@ impl BlobStore {
         if acl_changed {
             self.save_acls().map_err(SaveBlobError::Io)?;
         }
+        if metadata_changed || acl_changed {
+            self.mark_ledger_dirty(ws);
+        }
 
         // Return the canonical (possibly pre-existing) metadata.
         let final_meta = self
@@ -698,6 +739,9 @@ impl BlobStore {
         }
         if acl_changed {
             self.save_acls()?;
+        }
+        if metadata_changed || acl_changed {
+            self.mark_ledger_dirty(ws);
         }
 
         Ok(self.get_metadata_unchecked(hash).unwrap_or(metadata))
@@ -827,16 +871,22 @@ impl BlobStore {
         doc_id: &str,
         hashes: HashSet<String>,
     ) -> Result<(), String> {
-        let dropped: Vec<String> = {
+        let (dropped, changed): (Vec<String>, bool) = {
             let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
             let old = refs
                 .insert((ws.clone(), doc_id.to_string()), hashes.clone())
                 .unwrap_or_default();
-            old.difference(&hashes).cloned().collect()
+            let changed = old != hashes;
+            (old.difference(&hashes).cloned().collect(), changed)
         };
         self.save_doc_refs()?;
         for h in dropped {
             self.release_acl_if_unreferenced(ws, &h)?;
+        }
+        // JP-232: a changed ref set alters the workspace ledger (added hashes
+        // won't have fired a release signal). Coalesced by the mirror worker.
+        if changed {
+            self.mark_ledger_dirty(ws);
         }
         Ok(())
     }
@@ -844,15 +894,21 @@ impl BlobStore {
     /// Drop all of a document's blob references (called on doc delete) and
     /// release/GC anything the workspace no longer references.
     pub fn release_doc_refs(&self, ws: &WorkspaceId, doc_id: &str) -> Result<(), String> {
-        let dropped: Vec<String> = {
+        let (dropped, existed): (Vec<String>, bool) = {
             let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
-            refs.remove(&(ws.clone(), doc_id.to_string()))
-                .map(|s| s.into_iter().collect())
-                .unwrap_or_default()
+            match refs.remove(&(ws.clone(), doc_id.to_string())) {
+                Some(s) => (s.into_iter().collect(), true),
+                None => (Vec::new(), false),
+            }
         };
         self.save_doc_refs()?;
         for h in dropped {
             self.release_acl_if_unreferenced(ws, &h)?;
+        }
+        // JP-232: the doc-ref row is gone — reflect it in the ledger even if no
+        // ACL was released (another doc may still reference the same hashes).
+        if existed {
+            self.mark_ledger_dirty(ws);
         }
         Ok(())
     }
@@ -950,6 +1006,7 @@ impl BlobStore {
         };
         if removed {
             self.save_acls()?;
+            self.mark_ledger_dirty(ws);
             log::info!("released blob ACL {}/{}", ws.as_str(), hash);
             if self.per_workspace_objects() {
                 // s3: this workspace's object is its own — reclaim it now,
@@ -975,6 +1032,24 @@ impl BlobStore {
     /// store is shared, when `[storage] backend = "s3"`.
     pub fn set_object_delete_sink(&mut self, tx: UnboundedSender<(WorkspaceId, String)>) {
         self.object_delete_tx = Some(tx);
+    }
+
+    /// Install the JP-232 ledger-mirror sink (object-storage mode). A workspace
+    /// whose bookkeeping changes is sent here for a background worker to PUT its
+    /// `blob_ledger.json` to R2. Called once at startup, before the store is
+    /// shared.
+    pub fn set_ledger_mirror_sink(&mut self, tx: UnboundedSender<WorkspaceId>) {
+        self.ledger_mirror_tx = Some(tx);
+    }
+
+    /// Signal that `ws`'s blob bookkeeping changed and its R2 ledger should be
+    /// re-written. Best-effort: a closed channel (worker gone) is dropped. No-op
+    /// in filesystem mode. Multiple signals coalesce — the worker re-reads live
+    /// state via [`Self::ledger_for_workspace`] at process time.
+    pub(crate) fn mark_ledger_dirty(&self, ws: &WorkspaceId) {
+        if let Some(tx) = &self.ledger_mirror_tx {
+            let _ = tx.send(ws.clone());
+        }
     }
 
     /// Whether the store reclaims bytes per workspace (s3 object mode) vs. the
@@ -1132,6 +1207,157 @@ impl BlobStore {
             log::info!("blob {} orphaned; deferring GC by {}s", hash, grace);
         }
         Ok(())
+    }
+
+    // ---- JP-232: per-workspace durable blob ledger ----
+
+    /// Whether `ws` already has any in-memory bookkeeping (an ACL grant or a
+    /// per-doc reference). On a healthy restart the on-volume sidecars populate
+    /// these at boot, so a `true` here means recovery can be skipped; an empty
+    /// `false` means the workspace is cold on this pod and should be recovered
+    /// from R2 (JP-232).
+    pub fn has_workspace_bookkeeping(&self, ws: &WorkspaceId) -> bool {
+        if self
+            .acls
+            .read()
+            .map(|a| a.iter().any(|(w, _)| w == ws))
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        self.doc_refs
+            .read()
+            .map(|r| r.keys().any(|(w, _)| w == ws))
+            .unwrap_or(false)
+    }
+
+    /// Serialize `ws`'s slice of the bookkeeping into a [`WorkspaceBlobLedger`]
+    /// (read-only; no mutation). The blob set is every hash the workspace holds
+    /// an ACL for — exactly what [`Self::get_workspace_size`] meters.
+    pub fn ledger_for_workspace(&self, ws: &WorkspaceId) -> WorkspaceBlobLedger {
+        let acls: Vec<String> = self
+            .acls
+            .read()
+            .map(|a| a.iter().filter(|(w, _)| w == ws).map(|(_, h)| h.clone()).collect())
+            .unwrap_or_default();
+        let doc_refs: Vec<DocRefRow> = self
+            .doc_refs
+            .read()
+            .map(|r| {
+                r.iter()
+                    .filter(|((w, _), _)| w == ws)
+                    .map(|((w, doc_id), hashes)| DocRefRow {
+                        workspace: w.clone(),
+                        doc_id: doc_id.clone(),
+                        hashes: hashes.iter().cloned().collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let blobs: Vec<LedgerBlob> = {
+            let index = match self.index.read() {
+                Ok(g) => g,
+                Err(_) => return WorkspaceBlobLedger { acls, doc_refs, blobs: Vec::new() },
+            };
+            acls.iter()
+                .filter_map(|hash| {
+                    index.get(hash).map(|m| LedgerBlob {
+                        hash: m.hash.clone(),
+                        size: m.size,
+                        mime_type: m.mime_type.clone(),
+                        created_at: m.created_at,
+                        uploaded_by: m.uploaded_by.clone(),
+                    })
+                })
+                .collect()
+        };
+        WorkspaceBlobLedger { acls, doc_refs, blobs }
+    }
+
+    /// Merge a restored [`WorkspaceBlobLedger`] into the live maps and persist
+    /// the on-volume sidecars (JP-232 cold recovery). **Additive** — never
+    /// removes another workspace's state, and never overwrites an existing index
+    /// entry (a live blob's metadata wins over the ledger's). The orphan-grace
+    /// maps are intentionally untouched: recovery starts with no pending
+    /// deferrals. Does **not** signal a ledger re-write (we just loaded it).
+    pub fn install_ledger(&self, ws: &WorkspaceId, ledger: WorkspaceBlobLedger) -> Result<(), String> {
+        {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            for b in &ledger.blobs {
+                index.entry(b.hash.clone()).or_insert_with(|| BlobMetadata {
+                    hash: b.hash.clone(),
+                    size: b.size,
+                    mime_type: b.mime_type.clone(),
+                    created_at: b.created_at,
+                    uploaded_by: b.uploaded_by.clone(),
+                });
+            }
+        }
+        {
+            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            for hash in &ledger.acls {
+                acls.insert((ws.clone(), hash.clone()));
+            }
+        }
+        {
+            let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
+            for row in &ledger.doc_refs {
+                refs.insert(
+                    (ws.clone(), row.doc_id.clone()),
+                    row.hashes.iter().cloned().collect(),
+                );
+            }
+        }
+        self.save_index()?;
+        self.save_acls()?;
+        self.save_doc_refs()?;
+        log::info!(
+            "JP-232 restored blob ledger for {}: {} acl(s), {} doc-ref row(s)",
+            ws.as_str(),
+            ledger.acls.len(),
+            ledger.doc_refs.len()
+        );
+        Ok(())
+    }
+
+    /// Reconstruct one document's blob bookkeeping from its `blobReferences`
+    /// (JP-232 disaster fallback, used when no R2 ledger exists). `blobs` is the
+    /// per-hash `(size, mime)` read from the object store's HEAD. **Release-free**
+    /// — it only grants ACLs, records index metadata, and seeds the doc-ref set
+    /// (via [`Self::seed_doc_refs`]); it never runs the GC path. The caller
+    /// requests a single ledger write after the whole workspace is rebuilt.
+    pub fn reconstruct_doc_blobs(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &str,
+        blobs: Vec<(String, u64, String)>,
+    ) -> Result<(), String> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let hashes: HashSet<String> = blobs.iter().map(|(h, _, _)| h.clone()).collect();
+        {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            for (hash, size, mime) in &blobs {
+                index.entry(hash.clone()).or_insert_with(|| BlobMetadata {
+                    hash: hash.clone(),
+                    size: *size,
+                    mime_type: mime.clone(),
+                    created_at: now,
+                    uploaded_by: String::new(),
+                });
+            }
+        }
+        {
+            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            for (hash, _, _) in &blobs {
+                acls.insert((ws.clone(), hash.clone()));
+            }
+        }
+        self.save_index()?;
+        self.save_acls()?;
+        self.seed_doc_refs(ws, doc_id, hashes)
     }
 }
 
@@ -1739,5 +1965,84 @@ mod tests {
             assert_eq!(store.sweep_unreferenced(), 0);
             assert!(store.exists(&ws, &h));
         }
+    }
+
+    // ---- JP-232: per-workspace ledger round-trip + reconstruct fallback ----
+
+    // The core volume-loss case, modeled without R2: build a workspace's
+    // bookkeeping, snapshot it to a ledger, then `install_ledger` into a *fresh*
+    // store (the recycled volume). Reads, refcounts, and quota must all survive,
+    // and the GC must not reclaim a blob still referenced by an un-touched doc.
+    #[test]
+    fn ledger_round_trips_acls_refs_quota_and_survives_gc() {
+        let ws = WorkspaceId::from_configured("alpha").unwrap();
+        let a = b"shared file A"; // referenced by docA + docB
+        let ha = BlobStore::compute_hash(a);
+        let b = b"file B only in docA";
+        let hb = BlobStore::compute_hash(b);
+
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.save_blob(&ws, &ha, a, "image/png", "u1").unwrap();
+        store.save_blob(&ws, &hb, b, "text/plain", "u1").unwrap();
+        store.sync_doc_refs(&ws, "docA", refs(&[ha.as_str(), hb.as_str()])).unwrap();
+        store.sync_doc_refs(&ws, "docB", refs(&[ha.as_str()])).unwrap();
+        let expected_size = store.get_workspace_size(&ws);
+
+        let ledger = store.ledger_for_workspace(&ws);
+        assert_eq!(ledger.acls.len(), 2);
+        assert_eq!(ledger.blobs.len(), 2);
+        assert_eq!(ledger.doc_refs.len(), 2);
+
+        // Recycled machine: fresh volume, restore the ledger.
+        let dir2 = tempdir().unwrap();
+        let restored = BlobStore::new(dir2.path().to_path_buf());
+        restored.install_ledger(&ws, ledger).unwrap();
+
+        // Reads + quota survive (mime/size round-trip at full fidelity).
+        assert!(restored.exists(&ws, &ha));
+        assert!(restored.exists(&ws, &hb));
+        assert_eq!(restored.get_workspace_size(&ws), expected_size);
+        assert_eq!(restored.get_metadata(&ws, &ha).unwrap().mime_type, "image/png");
+
+        // A sweep right after recovery must reclaim nothing (full ref graph).
+        assert_eq!(restored.sweep_unreferenced(), 0);
+        assert!(restored.exists(&ws, &ha));
+
+        // Acceptance: dropping docA must NOT reclaim `ha` (docB still refs it),
+        // but `hb` (docA-only) is correctly released.
+        restored.release_doc_refs(&ws, "docA").unwrap();
+        assert!(restored.exists(&ws, &ha), "shared blob still referenced by docB");
+        assert!(!restored.exists(&ws, &hb), "docA-only blob correctly reclaimed");
+        assert_eq!(restored.get_workspace_size(&ws), a.len() as u64);
+    }
+
+    // The disaster fallback (no ledger): rebuild a doc's bookkeeping directly
+    // from its hashes + HEAD sizes/mimes. Release-free; quota + reads correct.
+    #[test]
+    fn reconstruct_doc_blobs_seeds_refs_acls_and_quota() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::from_configured("beta").unwrap();
+        let h1 = "a".repeat(64);
+        let h2 = "b".repeat(64);
+
+        store
+            .reconstruct_doc_blobs(
+                &ws,
+                "doc1",
+                vec![
+                    (h1.clone(), 100, "image/png".to_string()),
+                    (h2.clone(), 200, "application/pdf".to_string()),
+                ],
+            )
+            .unwrap();
+
+        assert!(store.exists(&ws, &h1));
+        assert!(store.exists(&ws, &h2));
+        assert_eq!(store.get_workspace_size(&ws), 300);
+        assert_eq!(store.get_metadata(&ws, &h1).unwrap().mime_type, "image/png");
+        // Release-free: the freshly-seeded refs keep both blobs through a sweep.
+        assert_eq!(store.sweep_unreferenced(), 0);
     }
 }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -108,6 +108,48 @@ async fn run_blob_delete_worker(
     }
 }
 
+/// Default MIME for a blob whose stored content-type can't be read during the
+/// JP-232 reconstruct fallback. Display-only; never affects GC or quota.
+fn default_blob_mime() -> String {
+    "application/octet-stream".to_string()
+}
+
+/// Background worker that mirrors per-workspace **blob ledgers** to R2 (JP-232).
+/// Each bookkeeping change sends the workspace id here; the worker coalesces a
+/// burst (drains the backlog into a dedup set — e.g. a startup sweep releasing
+/// many ACLs) and PUTs each workspace's current `blob_ledger.json` once,
+/// re-reading live state via [`BlobStore::ledger_for_workspace`] at processing
+/// time. Best-effort: a failed PUT is logged and dropped — the next change
+/// re-enqueues and reconstruct-from-docs is the disaster backstop. Exits when
+/// the sink is dropped (server shutdown).
+async fn run_blob_ledger_worker(
+    mut rx: mpsc::UnboundedReceiver<WorkspaceId>,
+    blob_store: Arc<BlobStore>,
+    s3: Arc<S3Backend>,
+) {
+    while let Some(ws) = rx.recv().await {
+        let mut dirty: HashSet<WorkspaceId> = HashSet::new();
+        dirty.insert(ws);
+        while let Ok(more) = rx.try_recv() {
+            dirty.insert(more);
+        }
+        for ws in dirty {
+            let ledger = blob_store.ledger_for_workspace(&ws);
+            let bytes = match serde_json::to_vec(&ledger) {
+                Ok(b) => b,
+                Err(e) => {
+                    log::warn!("blob ledger serialize failed for {}: {}", ws.as_str(), e);
+                    continue;
+                }
+            };
+            let key = s3.blob_ledger_key(&ws);
+            if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                log::warn!("R2 blob ledger PUT failed for {}: {}", key, e);
+            }
+        }
+    }
+}
+
 /// Background worker that mirrors workspace **documents** to R2 (JP-200). The
 /// synchronous write paths enqueue a [`MirrorOp`] after each local write; this
 /// drains them in FIFO order and performs the async R2 PUT/DELETE, re-reading the
@@ -438,6 +480,14 @@ pub struct ServerState {
     /// of release builds. Phase 21.2.
     #[cfg(debug_assertions)]
     panic_tenant_trigger: Option<WorkspaceId>,
+    /// JP-232 cold-recovery once-gate. `blob_recovery_done` records the
+    /// workspaces whose blob bookkeeping has been restored/rebuilt this process;
+    /// `blob_recovery_locks` holds a per-workspace async mutex so concurrent
+    /// first-touches serialize *per workspace* (and a save can't race a half-done
+    /// recovery) while different workspaces recover in parallel. Both guard
+    /// short critical sections only — never held across an `.await`.
+    blob_recovery_done: std::sync::Mutex<HashSet<WorkspaceId>>,
+    blob_recovery_locks: std::sync::Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl ServerState {
@@ -464,15 +514,28 @@ impl ServerState {
             // transient reference-drop can be corrected without losing bytes.
             let mut bs = BlobStore::new(app_data_dir.clone());
             bs.set_gc_grace_secs(tenancy.limits.blob_gc_grace_secs);
-            // s3 mode: route reclaimed per-workspace objects to a background
-            // worker that DELETEs them from R2, keeping the sync GC chain sync.
-            if let Some(s3) = &s3 {
-                let (tx, rx) = mpsc::unbounded_channel();
-                bs.set_object_delete_sink(tx);
-                let s3 = s3.clone();
-                tokio::spawn(async move { run_blob_delete_worker(rx, s3).await });
+            // s3 mode: install the per-workspace object-delete (JP-127) and
+            // ledger-mirror (JP-232) sinks *before* sharing the store, then spawn
+            // their workers against the shared Arc — the ledger worker re-reads
+            // live state through a store handle, so the Arc must exist first.
+            let channels = if s3.is_some() {
+                let (del_tx, del_rx) = mpsc::unbounded_channel();
+                let (led_tx, led_rx) = mpsc::unbounded_channel();
+                bs.set_object_delete_sink(del_tx);
+                bs.set_ledger_mirror_sink(led_tx);
+                Some((del_rx, led_rx))
+            } else {
+                None
+            };
+            let bs = Arc::new(bs);
+            if let (Some(s3), Some((del_rx, led_rx))) = (s3.as_ref(), channels) {
+                let s3d = s3.clone();
+                tokio::spawn(async move { run_blob_delete_worker(del_rx, s3d).await });
+                let s3l = s3.clone();
+                let bsl = bs.clone();
+                tokio::spawn(async move { run_blob_ledger_worker(led_rx, bsl, s3l).await });
             }
-            Arc::new(bs)
+            bs
         };
         // JP-200: build the document store, wiring the R2 mirror sink + a
         // background worker when the s3 backend is active. The sender is also
@@ -520,6 +583,8 @@ impl ServerState {
             poison_guard,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
+            blob_recovery_done: std::sync::Mutex::new(HashSet::new()),
+            blob_recovery_locks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -583,13 +648,192 @@ impl ServerState {
     /// returning `false` on the filesystem backend (caller falls through to its
     /// normal not-found handling).
     pub(crate) async fn ensure_doc_local(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        // JP-232: recover this workspace's blob bookkeeping before any restore.
+        // No-op (O(1)) on a healthy/already-recovered pod.
+        self.ensure_blob_bookkeeping(ws).await;
         if self.doc_store.get_metadata(ws, doc_id).is_some() {
             return true;
         }
-        match &self.s3 {
-            Some(s3) => self.doc_store.restore_doc_from(s3.as_ref(), ws, doc_id).await,
-            None => false,
+        let s3 = match &self.s3 {
+            Some(s3) => s3,
+            None => return false,
+        };
+        let restored = self.doc_store.restore_doc_from(s3.as_ref(), ws, doc_id).await;
+        if restored {
+            // JP-232: `install_restored_doc` bypasses the blob store, so re-seed
+            // this doc's blob references from the restored body. This keeps the
+            // refcount/quota correct and self-heals any ledger lag for this doc
+            // (the durable body is authoritative over a stale ledger).
+            if let Ok(doc) = self.doc_store.get_document(ws, doc_id) {
+                let hashes = crate::api::blob_refs_from_doc(&doc);
+                if !hashes.is_empty() {
+                    if let Err(e) = self.blob_store.seed_doc_refs(ws, doc_id.as_str(), hashes) {
+                        log::warn!(
+                            "JP-232 post-restore ref seed failed for {}/{}: {}",
+                            ws.as_str(),
+                            doc_id.as_str(),
+                            e
+                        );
+                    }
+                }
+            }
         }
+        restored
+    }
+
+    /// JP-232 cold-recovery: ensure `ws`'s blob bookkeeping (ACLs, per-doc
+    /// refcounts, size/mime) is present in memory before the workspace is served.
+    /// Idempotent + once-per-process per workspace, gated by a per-ws async mutex
+    /// so concurrent first-touches serialize (a save can't race a half-done
+    /// recovery) while different workspaces recover in parallel.
+    ///
+    /// Must be `await`ed at the top of every handler that **releases a blob ACL**
+    /// (doc save/delete) or **serves a blob** — `resolve_workspace` is sync and
+    /// the save path does not pass through `ensure_doc_local`, so this is the
+    /// explicit gate that makes blocking recovery safe.
+    ///
+    /// Recovery is **ledger-first**: restore `blob_ledger.json` from R2 directly
+    /// (fast, independent of the best-effort doc index); only when the ledger is
+    /// absent/corrupt does it fall back to walking the R2 doc corpus and rebuild
+    /// from each body's `blobReferences`. Filesystem mode and workspaces already
+    /// resident on this pod are no-ops.
+    pub(crate) async fn ensure_blob_bookkeeping(&self, ws: &WorkspaceId) {
+        // Fast path — already recovered/known this process.
+        if self.blob_recovery_done.lock().unwrap().contains(ws) {
+            return;
+        }
+        // Per-workspace gate: serialize recovery for *this* ws, parallel across ws.
+        let gate = {
+            let mut locks = self.blob_recovery_locks.lock().unwrap();
+            locks
+                .entry(ws.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        let _guard = gate.lock().await;
+        // Re-check under the gate — a concurrent first-touch may have finished.
+        if self.blob_recovery_done.lock().unwrap().contains(ws) {
+            return;
+        }
+
+        let s3 = match &self.s3 {
+            // Filesystem mode: bookkeeping lives only on the volume; nothing to
+            // recover from. Mark done so we never re-check.
+            None => {
+                self.blob_recovery_done.lock().unwrap().insert(ws.clone());
+                return;
+            }
+            Some(s3) => s3.clone(),
+        };
+        // Volume intact for this ws → the on-volume sidecars are authoritative;
+        // never walk R2. Either signal proves intactness: in-memory bookkeeping
+        // (sidecars loaded at boot), or any local document (the index + blob
+        // sidecars share the volume, so present docs ⇒ present sidecars; covers a
+        // blob-less workspace too, and JP-231-evicted docs keep their index row).
+        if self.blob_store.has_workspace_bookkeeping(ws)
+            || !self.doc_store.list_documents(ws).is_empty()
+        {
+            self.blob_recovery_done.lock().unwrap().insert(ws.clone());
+            return;
+        }
+
+        // Ledger-first.
+        match s3.get_object_at(&s3.blob_ledger_key(ws)).await {
+            Ok(Some(bytes)) => {
+                match serde_json::from_slice::<crate::server::blobs::WorkspaceBlobLedger>(&bytes) {
+                    Ok(ledger) => {
+                        if let Err(e) = self.blob_store.install_ledger(ws, ledger) {
+                            log::warn!("JP-232 ledger install failed for {}: {}", ws.as_str(), e);
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "JP-232 ledger for {} corrupt ({}); rebuilding from docs",
+                            ws.as_str(),
+                            e
+                        );
+                        self.reconstruct_blob_bookkeeping_from_docs(ws, &s3).await;
+                    }
+                }
+            }
+            Ok(None) => {
+                // No ledger — disaster fallback (or a workspace new to this pod
+                // that never wrote one). Rebuild from the durable doc corpus.
+                self.reconstruct_blob_bookkeeping_from_docs(ws, &s3).await;
+            }
+            Err(e) => {
+                // R2 unreachable: don't poison the done-set — leave the ws
+                // un-recovered so a later touch retries. (Readiness gating on R2
+                // is a separate follow-up.)
+                log::warn!("JP-232 ledger GET failed for {}: {} — will retry", ws.as_str(), e);
+                return;
+            }
+        }
+        self.blob_recovery_done.lock().unwrap().insert(ws.clone());
+    }
+
+    /// JP-232 disaster fallback: rebuild `ws`'s blob bookkeeping by walking its
+    /// R2 document corpus (no ledger). Restores the workspace index, then for
+    /// each doc reads the body from R2, extracts `blobReferences`, HEADs each
+    /// blob for size + content-type, and reconstructs ACLs/refs/index
+    /// release-free. Writes a fresh ledger at the end so the next cold boot
+    /// fast-paths. Best-effort per doc/blob — a single failure is logged, not
+    /// fatal.
+    async fn reconstruct_blob_bookkeeping_from_docs(&self, ws: &WorkspaceId, s3: &Arc<S3Backend>) {
+        self.doc_store.restore_workspace_index_from(s3.as_ref(), ws).await;
+        for meta in self.doc_store.list_documents(ws) {
+            let key = s3.doc_object_key(ws, &meta.id, "json");
+            let bytes = match s3.get_object_at(&key).await {
+                Ok(Some(b)) => b,
+                Ok(None) => continue,
+                Err(e) => {
+                    log::warn!("JP-232 reconstruct: R2 get {} failed: {}", key, e);
+                    continue;
+                }
+            };
+            let doc: serde_json::Value = match serde_json::from_slice(&bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!("JP-232 reconstruct: parse {} failed: {}", key, e);
+                    continue;
+                }
+            };
+            let hashes = crate::api::blob_refs_from_doc(&doc);
+            let mut blobs: Vec<(String, u64, String)> = Vec::with_capacity(hashes.len());
+            for h in hashes {
+                let (size, mime) = match s3.head_object_typed(ws, &h).await {
+                    Ok(Some((size, ct))) => (size, ct.unwrap_or_else(default_blob_mime)),
+                    // Bytes missing/unreadable in R2: still record the ref + ACL
+                    // (size 0) so GC never treats a referenced blob as orphaned;
+                    // size self-corrects on the next upload/finalize of that hash.
+                    Ok(None) => {
+                        log::warn!(
+                            "JP-232 reconstruct: blob {}/{} absent in R2; recording ref with size 0",
+                            ws.as_str(),
+                            h
+                        );
+                        (0, default_blob_mime())
+                    }
+                    Err(e) => {
+                        log::warn!("JP-232 reconstruct: HEAD {}/{} failed: {}", ws.as_str(), h, e);
+                        (0, default_blob_mime())
+                    }
+                };
+                blobs.push((h, size, mime));
+            }
+            if let Err(e) = self.blob_store.reconstruct_doc_blobs(ws, meta.id.as_str(), blobs) {
+                log::warn!(
+                    "JP-232 reconstruct: rebuild {}/{} failed: {}",
+                    ws.as_str(),
+                    meta.id.as_str(),
+                    e
+                );
+            }
+        }
+        // Persist the freshly-rebuilt bookkeeping as a ledger so subsequent cold
+        // boots take the fast path (and a blob-less ws converges to an empty one).
+        self.blob_store.mark_ledger_dirty(ws);
+        log::info!("JP-232 rebuilt blob bookkeeping for {} from doc corpus", ws.as_str());
     }
 
     /// JP-200: ensure a workspace's document index is locally populated,
@@ -597,6 +841,8 @@ impl ServerState {
     /// in-memory index (only restores when the workspace has nothing in memory),
     /// so it's safe to call before a listing.
     pub(crate) async fn ensure_workspace_index_local(&self, ws: &WorkspaceId) {
+        // JP-232: recover blob bookkeeping before serving a cold workspace listing.
+        self.ensure_blob_bookkeeping(ws).await;
         if !self.doc_store.list_documents(ws).is_empty() {
             return;
         }


### PR DESCRIPTION
## What & why

Closes **JP-232**. The relay's blob bookkeeping — `blob_index.json` (size/mime → quota), `blob_acl.json` (`(ws,hash)` read grants + GC gate), `blob_refs.json` (per-doc refcount) — was **volume-only**. After a machine recycle onto a fresh Fly volume (or a workspace migrating to a new pod), it was gone even though doc bodies + blob bytes are durable in R2 (JP-200). Consequences:

- **Reads 404** — `load_blob`/`exists` gate on `has_acl`; bytes in R2 but the relay refused to serve them.
- **GC mis-reclaim** — a partially-restored workspace could release a shared blob's ACL + DELETE its R2 object while another un-opened doc still referenced it.
- **Quota reset** — `get_workspace_size` summed an empty index → 0.

## Approach — per-workspace blob ledger (ledger-first, reconstruct-on-miss)

A durable per-workspace projection mirrored to R2 at `docs/<ws>/blob_ledger.json`. Written from **live** in-memory state, so it's **index-independent** — it sidesteps the JP-230 stale-doc-index gap that pure reconstruct-from-docs would inherit.

- **`BlobStore`**: `WorkspaceBlobLedger` (acls + per-doc refs + size/mime), `ledger_for_workspace` / `install_ledger` (additive merge) / `reconstruct_doc_blobs` (release-free fallback), and a change-gated ledger-mirror sink fired from each bookkeeping mutation.
- **`run_blob_ledger_worker`** (s3 mode): coalesces a burst and PUTs the current ledger, reusing the JP-200 mirror pattern; spawned against the shared `Arc<BlobStore>`.
- **`ensure_blob_bookkeeping(ws)`**: per-workspace once-gate (async mutex → concurrent first-touches serialize, a save can't race a half-done recovery; different workspaces recover in parallel). On a cold pod: restore the R2 ledger directly; only walk the R2 doc corpus when no ledger exists. `await`ed at every handler that releases an ACL or serves/meters a blob (save, delete, blob upload/finalize/download, usage), plus JOIN/REST doc paths via `ensure_doc_local`/`ensure_workspace_index_local` — `resolve_workspace` is sync and the save path doesn't pass through `ensure_doc_local`.
- **`ensure_doc_local`**: re-seed a restored doc's blob refs (`install_restored_doc` bypassed the blob store), self-healing ledger lag from the durable body.
- **`s3`**: `blob_ledger_key`; `head_object_typed` recovers a blob's true mime in the fallback.

**Detection is per-workspace** — a ws with local docs or in-memory bookkeeping is intact ⇒ no R2 walk — so healthy restarts pay nothing.

## Verification

- Unit (no R2): ledger round-trip + reconstruct — the core acceptance (**dropping docA does not reclaim a blob docB still references; quota correct**).
- Env-gated against **live MinIO** (`RELAY_TEST_S3_*`): typed HEAD content-type, ledger key, and a full **volume-loss durability round-trip** (serialize ledger → PUT R2 → fresh `BlobStore` → GET → `install_ledger` → GC-safe + quota correct). All green locally.
- `cargo test --lib` 295 passed; `cargo clippy` no new warnings; OSS leak grep clean.

## Notes

- **Known limitation:** the ledger can lag the last few saves before a crash; durable doc bodies stay authoritative (save-time + post-restore ref seeding self-heal), reconstruct-from-docs is the deep fallback.
- **Deferred to a follow-up** (will file): graceful R2 **readiness gating** (liveness never gated; readiness degrades only on sustained R2 failure; s3-mode only; Fly check wiring in docushark-web).
- Estimate bumped 3 → 5; the full authenticated relay-restart E2E is the staging deploy test.

Assisted-by: Opus 4.8