### PR TITLE
Deploy to staging: JP-232 blob ledger + catch up to master

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "docushark",
       "dependencies": {
         "@radix-ui/react-radio-group": "^1.4.0",
+        "@radix-ui/react-slider": "^1.4.0",
         "@radix-ui/react-switch": "^1.3.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-fs": "^2.5.0",
@@ -378,6 +379,8 @@
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
+    "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
+
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
 
     "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.9", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-slot": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ=="],
@@ -397,6 +400,8 @@
     "@radix-ui/react-radio-group": ["@radix-ui/react-radio-group@1.4.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-roving-focus": "1.1.12", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ=="],
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg=="],
+
+    "@radix-ui/react-slider": ["@radix-ui/react-slider@1.4.0", "", { "dependencies": { "@radix-ui/number": "1.1.2", "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-layout-effect": "1.1.2", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-RHcPlLOThRJM51DSIC33ZnpDEBYhyEFroVWkd2P54PGGjkmAt14RboYUU9E1MFst666zFHM0tGtWvMjSOtU1pw=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "pdfjs-dist": "^5.6.205",
         "rbush": "^3.0.1",
         "react": "^18.2.0",
+        "react-colorful": "^5.7.0",
         "react-dom": "^18.2.0",
         "simple-icons": "^16.9.0",
         "xlsx": "^0.18.5",
@@ -1164,6 +1165,8 @@
     "rbush": ["rbush@3.0.1", "", { "dependencies": { "quickselect": "^2.0.0" } }, "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-colorful": ["react-colorful@5.7.0", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "docushark",
       "dependencies": {
+        "@radix-ui/react-radio-group": "^1.4.0",
+        "@radix-ui/react-switch": "^1.3.0",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-http": "^2.5.9",
@@ -375,6 +377,42 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.9", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-slot": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg=="],
+
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.6", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.5", "", { "dependencies": { "@radix-ui/react-slot": "1.2.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA=="],
+
+    "@radix-ui/react-radio-group": ["@radix-ui/react-radio-group@1.4.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-roving-focus": "1.1.12", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ=="],
+
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-collection": "1.1.9", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
+
+    "@radix-ui/react-switch": ["@radix-ui/react-switch@1.3.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-primitive": "2.1.5", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-previous": "1.1.2", "@radix-ui/react-use-size": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-GP1EZwhoZO/GGnhM1P5/2Vpm8iN8EnngyU0oezn2l78kN8tj25pyrvjIaT7azBhK615KSt+P2w39y57YV5jVkA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.3", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w=="],
 
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#2196f3" />
+    <!-- Default matches the light --bg-primary surface; themeStore updates this
+         at runtime to track the active theme (see applyThemeColorMeta). -->
+    <meta name="theme-color" content="#f9f6ee" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="DocuShark" />

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "pdfjs-dist": "^5.6.205",
     "rbush": "^3.0.1",
     "react": "^18.2.0",
+    "react-colorful": "^5.7.0",
     "react-dom": "^18.2.0",
     "simple-icons": "^16.9.0",
     "xlsx": "^0.18.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@radix-ui/react-radio-group": "^1.4.0",
+    "@radix-ui/react-switch": "^1.3.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-http": "^2.5.9",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@radix-ui/react-radio-group": "^1.4.0",
+    "@radix-ui/react-slider": "^1.4.0",
     "@radix-ui/react-switch": "^1.3.0",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-fs": "^2.5.0",

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -300,6 +300,76 @@ paths:
         '507':
           description: Projected per-workspace storage quota exceeded.
 
+  /api/v1/blobs/ingest-from-url:
+    post:
+      tags: [blobs]
+      summary: Ingest a blob from a URL (server-side fetch)
+      description: |
+        Fetch bytes from `url` (sending `authorization` verbatim as the
+        `Authorization` header), store them content-addressed for the caller's
+        workspace, and return the SHA-256 hash. Lets a trusted backend hand the
+        relay a reference instead of streaming the bytes through itself.
+
+        **Disabled by default:** returns 403 unless the operator configures a
+        host allowlist (`[tenancy.limits] blob_ingest_allowed_hosts` /
+        `RELAY_BLOB_INGEST_ALLOWED_HOSTS`). The allowlist (exact host or
+        `*.suffix` wildcard) is enforced on the initial URL **and every redirect
+        hop**; only `https` is allowed and private/loopback IP-literal hosts are
+        rejected (SSRF protection). `source`/`tags` are opaque provenance
+        strings recorded for audit; the relay does not interpret them.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url, authorization]
+              properties:
+                url:
+                  type: string
+                  description: https URL on the configured allowlist.
+                authorization:
+                  type: string
+                  description: Verbatim value for the Authorization header sent to `url`.
+                mimeType:
+                  type: string
+                  description: Overrides the source response's Content-Type when set.
+                source:
+                  type: string
+                  description: Opaque provenance tag recorded with the blob (audit only).
+                tags:
+                  type: array
+                  items:
+                    type: string
+                  description: Additional opaque provenance tags (audit only).
+      responses:
+        '200':
+          description: Stored (or deduplicated) blob.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hash:
+                    type: string
+                  size:
+                    type: integer
+                    format: int64
+                  mimeType:
+                    type: string
+        '400':
+          description: Malformed request URL.
+        '403':
+          description: Endpoint not configured, or URL host not on the allowlist.
+        '413':
+          description: Fetched blob exceeds the per-blob size limit.
+        '502':
+          description: The source fetch failed or returned a non-success status.
+        '507':
+          description: Per-workspace storage quota exceeded.
+
   /api/v1/blobs/{hash}/finalize:
     parameters:
       - name: hash

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -167,6 +167,11 @@ current.
 - **Prose is HTML.** Markdown in is rendered (GFM tables / strikethrough /
   task-lists on); HTML pass-through is re-parsed by the editor against its
   schema on load, which drops anything unmodelled.
+- **Prose write limits.** A single prose write's content is capped at **~1 MiB**
+  (`set_prose`/`add_prose_page`/`insert_section`; over it → `ERR_PROSE_TOO_LARGE`,
+  advertised as `maxLength`). Nesting deeper than **64** levels is truncated
+  (real prose nests <~10) — a safety bound so pathological input can't exhaust
+  the server.
 - **Outlines are flat.** A section is a heading plus the content up to the
   next heading; nesting is conveyed by `level`, not containment. `move` moves a
   single section, not its descendants.

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -173,6 +173,11 @@ current.
 - **`generate_diagram` layout is relay-side and approximate** — a layered or
   grid placement, not the editor's full auto-layout. The editor can re-layout
   on open. Node caps: 500 nodes / 1000 edges per call.
+- **Rate limits (per workspace).** Writes draw from the shared write bucket
+  (`[tenancy.limits] writes_per_sec`/`writes_burst`, shared with WS sync); reads
+  draw from a **separate** bucket (`reads_per_sec`/`reads_burst`, `0` =
+  unlimited). Over the bucket → HTTP `429` with `ERR_RATE_LIMIT`. Tunable via
+  `RELAY_*` env on Cloud pods.
 - **No open-in-editor link yet.** `create_document` returns the document `id`;
   a deep link back into the editor is not yet wired.
 

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -124,8 +124,10 @@ All tools are namespaced `docushark.*`.
 | -- | -- |
 | `delete_shape` | Delete a shape by id. **Cascade-removes** any connectors attached to it (start or end), so no dangling connectors are left; returns the ids actually deleted. |
 | `delete_prose_page` | Delete a prose page by id. Refuses to delete the **last** remaining prose page. In a connected editor the page's *tab* may persist until reload (the prose page list isn't yet live-synced); its content is cleared immediately. |
+| `reorder_shapes` | Set a page's z-order. `order` must be a permutation of the page's current shape ids (later ids render on top). |
+| `reorder_prose_pages` | Set the order of a document's prose pages. `order` must be a permutation of the current prose page ids. Tab order may update on reload (page list not yet live-synced). |
 
-(Renames: `rename_prose_page`. Reorder of shapes / prose pages is planned.)
+(Renames: `rename_prose_page`.)
 
 ## Concurrency
 

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -321,6 +321,7 @@ async fn usage_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     let effective = state.resolve_limits(limits);
     let counts = state.workspace_conn_for(&ws).await;
     (
@@ -357,6 +358,7 @@ async fn blob_upload_url_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     if !is_valid_blob_hash(&hash) {
         return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
     }
@@ -433,6 +435,7 @@ async fn blob_finalize_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     if !is_valid_blob_hash(&hash) {
         return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
     }
@@ -522,6 +525,7 @@ async fn blob_download_url_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
     if !is_valid_blob_hash(&hash) {
         return (StatusCode::BAD_REQUEST, ApiError::body("invalid blob hash")).into_response();
     }
@@ -671,6 +675,7 @@ async fn save_doc_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
 
     // The doc body's `id` must match the path id — REST clients can't
     // forge a different doc id via the body.
@@ -778,6 +783,7 @@ async fn delete_doc_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
 
     if let Err(e) = check_delete_permission(
         state.doc_store(),
@@ -1032,6 +1038,7 @@ async fn blob_ingest_from_url_handler(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    state.ensure_blob_bookkeeping(&ws).await;
 
     let allow: Vec<String> = state.blob_ingest_allowed_hosts().to_vec();
     if allow.is_empty() {

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -10,6 +10,7 @@
 //! See `routes()` for the full surface.
 
 use std::collections::HashSet;
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use axum::{
@@ -29,6 +30,7 @@ use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
     PermissionError,
 };
+use crate::server::blobs::{BlobStore, SaveBlobError};
 use crate::server::protocol::{ClaimLimits, DocEventType, DocId, WorkspaceId};
 use crate::server::ServerState;
 
@@ -125,6 +127,10 @@ pub fn routes() -> Router<Arc<ServerState>> {
         .route(
             "/api/v1/blobs/:hash/download-url",
             post(blob_download_url_handler),
+        )
+        .route(
+            "/api/v1/blobs/ingest-from-url",
+            post(blob_ingest_from_url_handler),
         )
         .route("/api/docs", get(list_docs_handler))
         .route("/api/docs/:id", get(get_doc_handler))
@@ -928,6 +934,286 @@ async fn require_auth(
     })
 }
 
+// ============ Generic blob ingest-from-URL (JP-264) ============
+
+/// Body of `POST /api/v1/blobs/ingest-from-url`. The relay fetches `url`
+/// (sending `authorization` verbatim as the `Authorization` header), stores the
+/// bytes content-addressed, and returns the hash. `source`/`tags` are **opaque**
+/// provenance strings recorded for audit — the relay never interprets them.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IngestFromUrlRequest {
+    url: String,
+    /// Verbatim value for the `Authorization` header sent to `url`.
+    authorization: String,
+    #[serde(default)]
+    mime_type: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+/// Match a host against one allowlist entry: exact, or a `*.suffix` wildcard
+/// that matches the bare suffix and any subdomain. Case/trailing-dot insensitive.
+fn ingest_host_matches(host: &str, pattern: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    let pat = pattern.trim().trim_end_matches('.').to_ascii_lowercase();
+    if let Some(suffix) = pat.strip_prefix("*.") {
+        !suffix.is_empty() && (host == suffix || host.ends_with(&format!(".{suffix}")))
+    } else {
+        !pat.is_empty() && host == pat
+    }
+}
+
+fn ingest_host_allowed(host: &str, allow: &[String]) -> bool {
+    !host.is_empty() && allow.iter().any(|p| ingest_host_matches(host, p))
+}
+
+/// Reject IP-literal hosts that point at private/loopback/link-local/unspecified
+/// space (defense-in-depth atop the allowlist; covers IPv4-mapped IPv6 too).
+fn ingest_ip_blocked(host: &str) -> bool {
+    let h = host.trim_start_matches('[').trim_end_matches(']');
+    match h.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+        }
+        Ok(IpAddr::V6(ip)) => {
+            if let Some(v4) = ip.to_ipv4_mapped() {
+                return v4.is_private()
+                    || v4.is_loopback()
+                    || v4.is_link_local()
+                    || v4.is_unspecified()
+                    || v4.is_broadcast();
+            }
+            if ip.is_loopback() || ip.is_unspecified() {
+                return true;
+            }
+            let seg = ip.segments();
+            let unique_local = (seg[0] & 0xfe00) == 0xfc00; // fc00::/7
+            let link_local = (seg[0] & 0xffc0) == 0xfe80; // fe80::/10
+            unique_local || link_local
+        }
+        Err(_) => false, // not an IP literal → a DNS host, governed by the allowlist
+    }
+}
+
+/// SSRF gate: https only, host on the allowlist, not a blocked IP literal.
+/// Enforced on the initial URL and (via the redirect policy) every hop.
+fn ingest_url_ok(url: &reqwest::Url, allow: &[String]) -> bool {
+    if url.scheme() != "https" {
+        return false;
+    }
+    match url.host_str() {
+        Some(host) => !ingest_ip_blocked(host) && ingest_host_allowed(host, allow),
+        None => false,
+    }
+}
+
+/// `POST /api/v1/blobs/ingest-from-url` — fetch a blob from an allowlisted URL
+/// and store it content-addressed for the caller's workspace. Generic: the
+/// relay has no knowledge of any specific integration; the `source`/`tags` are
+/// opaque. Disabled (403) unless `[tenancy.limits] blob_ingest_allowed_hosts`
+/// is configured — the relay is never an open fetch proxy by default.
+async fn blob_ingest_from_url_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Json(req): Json<IngestFromUrlRequest>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    let allow: Vec<String> = state.blob_ingest_allowed_hosts().to_vec();
+    if allow.is_empty() {
+        return (
+            StatusCode::FORBIDDEN,
+            ApiError::body("ingest_not_configured"),
+        )
+            .into_response();
+    }
+
+    let url = match reqwest::Url::parse(&req.url) {
+        Ok(u) => u,
+        Err(_) => return (StatusCode::BAD_REQUEST, ApiError::body("invalid url")).into_response(),
+    };
+    if !ingest_url_ok(&url, &allow) {
+        return (StatusCode::FORBIDDEN, ApiError::body("url_not_allowed")).into_response();
+    }
+
+    let max = state.max_blob_bytes();
+
+    // Validate every redirect hop against the same allowlist (an open redirect
+    // to an internal host is the classic SSRF escape).
+    let policy_allow = allow.clone();
+    let client = match reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() > 5 {
+                return attempt.error("too many redirects");
+            }
+            if ingest_url_ok(attempt.url(), &policy_allow) {
+                attempt.follow()
+            } else {
+                attempt.stop()
+            }
+        }))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("ingest client build failed: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body("client_error"))
+                .into_response();
+        }
+    };
+
+    let resp = match client
+        .get(url)
+        .header(reqwest::header::AUTHORIZATION, &req.authorization)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::info!("ingest fetch failed for ws {}: {e}", ws.as_str());
+            return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
+        }
+    };
+    if !resp.status().is_success() {
+        return (
+            StatusCode::BAD_GATEWAY,
+            ApiError::body(format!("source returned {}", resp.status())),
+        )
+            .into_response();
+    }
+
+    // Early reject on a declared length over the ceiling.
+    if let Some(len) = resp.content_length() {
+        if len > max as u64 {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                ApiError::body("blob exceeds max size"),
+            )
+                .into_response();
+        }
+    }
+
+    let mime = req
+        .mime_type
+        .clone()
+        .or_else(|| {
+            resp.headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    let body = match resp.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            log::info!("ingest body read failed for ws {}: {e}", ws.as_str());
+            return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
+        }
+    };
+    // Authoritative size check (the host may ignore/omit Content-Length).
+    if body.len() > max {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            ApiError::body("blob exceeds max size"),
+        )
+            .into_response();
+    }
+
+    let hash = BlobStore::compute_hash(&body);
+    let quota = state.resolve_limits(limits).quota_bytes;
+
+    // Persist, mirroring the proxy upload's s3-vs-filesystem split.
+    let (size, hash) = if let Some(s3) = state.s3_backend() {
+        if state.blob_store().exists(&ws, &hash) {
+            let size = state
+                .blob_store()
+                .get_metadata(&ws, &hash)
+                .map(|m| m.size)
+                .unwrap_or(body.len() as u64);
+            (size, hash)
+        } else {
+            if let Some(q) = quota {
+                if state
+                    .blob_store()
+                    .get_workspace_size(&ws)
+                    .saturating_add(body.len() as u64)
+                    > q
+                {
+                    return (
+                        StatusCode::INSUFFICIENT_STORAGE,
+                        ApiError::body("storage quota exceeded"),
+                    )
+                        .into_response();
+                }
+            }
+            if let Err(e) = s3.put_object(&ws, &hash, body.to_vec(), &mime).await {
+                log::warn!("ingest s3 put failed {}/{}: {e}", ws.as_str(), hash);
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    ApiError::body("blob store unavailable"),
+                )
+                    .into_response();
+            }
+            match state
+                .blob_store()
+                .record_finalized_blob(&ws, &hash, body.len() as u64, &mime, &claims.sub)
+            {
+                Ok(m) => (m.size, m.hash),
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response()
+                }
+            }
+        }
+    } else {
+        match state
+            .blob_store()
+            .save_blob_with_quota(&ws, &hash, &body, &mime, &claims.sub, quota)
+        {
+            Ok(m) => (m.size, m.hash),
+            Err(e @ SaveBlobError::QuotaExceeded { .. }) => {
+                return (StatusCode::INSUFFICIENT_STORAGE, ApiError::body(e.to_string()))
+                    .into_response()
+            }
+            Err(e) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e.to_string()))
+                    .into_response()
+            }
+        }
+    };
+
+    // Record opaque provenance (source + tags), additive; advisory only.
+    let mut tags = req.tags.clone();
+    if let Some(s) = req.source.clone() {
+        tags.push(s);
+    }
+    if let Err(e) = state.blob_store().record_provenance(&ws, &hash, &tags) {
+        log::warn!("provenance record failed {}/{}: {e}", ws.as_str(), hash);
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({ "hash": hash, "size": size, "mimeType": mime })),
+    )
+        .into_response()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -946,5 +1232,55 @@ mod tests {
         assert!(!is_valid_blob_hash(&"A".repeat(64))); // uppercase not allowed
         assert!(!is_valid_blob_hash(&"g".repeat(64))); // non-hex
         assert!(!is_valid_blob_hash("")); // empty
+    }
+
+    #[test]
+    fn ingest_host_matching_exact_and_wildcard() {
+        let allow = vec!["api.example.com".to_string(), "*.example.net".to_string()];
+        // exact
+        assert!(ingest_host_allowed("api.example.com", &allow));
+        // wildcard matches subdomain + the bare suffix
+        assert!(ingest_host_allowed("acme.example.net", &allow));
+        assert!(ingest_host_allowed("example.net", &allow));
+        assert!(ingest_host_allowed("API.Example.COM", &allow)); // case-insensitive
+        // misses
+        assert!(!ingest_host_allowed("evil.com", &allow));
+        assert!(!ingest_host_allowed("example.net.evil.com", &allow)); // suffix trick
+        assert!(!ingest_host_allowed("notexample.net", &allow)); // not a dot-boundary
+        assert!(!ingest_host_allowed("", &allow));
+        assert!(!ingest_host_allowed("api.example.com", &[])); // empty allowlist = nothing
+    }
+
+    #[test]
+    fn ingest_blocks_private_and_loopback_ip_literals() {
+        assert!(ingest_ip_blocked("127.0.0.1"));
+        assert!(ingest_ip_blocked("10.0.0.5"));
+        assert!(ingest_ip_blocked("192.168.1.1"));
+        assert!(ingest_ip_blocked("169.254.1.1")); // link-local
+        assert!(ingest_ip_blocked("0.0.0.0"));
+        assert!(ingest_ip_blocked("[::1]")); // ipv6 loopback w/ brackets
+        assert!(ingest_ip_blocked("fc00::1")); // ULA
+        assert!(ingest_ip_blocked("fe80::1")); // link-local
+        assert!(ingest_ip_blocked("[::ffff:127.0.0.1]")); // ipv4-mapped loopback
+        // public literals are not blocked here (the allowlist is the gate)
+        assert!(!ingest_ip_blocked("8.8.8.8"));
+        assert!(!ingest_ip_blocked("example.com")); // not an IP literal
+    }
+
+    #[test]
+    fn ingest_url_ok_enforces_https_allowlist_and_ip_block() {
+        let allow = vec!["*.example.net".to_string(), "8.8.8.8".to_string()];
+        let ok = reqwest::Url::parse("https://acme.example.net/x").unwrap();
+        assert!(ingest_url_ok(&ok, &allow));
+        // http rejected even if host allowed
+        let http = reqwest::Url::parse("http://acme.example.net/x").unwrap();
+        assert!(!ingest_url_ok(&http, &allow));
+        // off-allowlist host
+        let off = reqwest::Url::parse("https://evil.com/x").unwrap();
+        assert!(!ingest_url_ok(&off, &allow));
+        // a private IP literal is blocked even if it were somehow allowlisted
+        let priv_allow = vec!["127.0.0.1".to_string()];
+        let loop_url = reqwest::Url::parse("https://127.0.0.1/x").unwrap();
+        assert!(!ingest_url_ok(&loop_url, &priv_allow));
     }
 }

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -42,6 +42,12 @@ pub const DEFAULT_AUDIENCE: &str = "docushark-relay";
 pub const DEFAULT_WRITES_PER_SEC: u32 = 40;
 /// Default burst size for the per-workspace write bucket.
 pub const DEFAULT_WRITES_BURST: u32 = 80;
+/// Default token-bucket refill rate (MCP reads / sec) per workspace (JP-249).
+/// Reads are cheap, so this is generous — a public-pod backstop against a
+/// read-storm, not a throttle on normal agent use. `0` = unlimited.
+pub const DEFAULT_READS_PER_SEC: u32 = 100;
+/// Default burst size for the per-workspace MCP read bucket.
+pub const DEFAULT_READS_BURST: u32 = 200;
 /// Default cap on concurrent authenticated WS connections per workspace.
 pub const DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE: u32 = 25;
 /// Default cap on a single WS frame's payload size (bytes). Pathological
@@ -346,6 +352,12 @@ pub struct LimitsConfig {
     pub writes_per_sec: u32,
     /// Burst capacity for the per-workspace write bucket.
     pub writes_burst: u32,
+    /// Token-bucket refill rate (MCP reads / second) per workspace (JP-249).
+    /// `0` = unlimited (loopback/self-host). Separate from the write bucket so a
+    /// read-storm never contends with live WS editing.
+    pub reads_per_sec: u32,
+    /// Burst capacity for the per-workspace MCP read bucket.
+    pub reads_burst: u32,
     /// Cap on concurrent authenticated WS connections per workspace.
     pub max_ws_connections_per_workspace: u32,
     /// Cap on a single WS frame's payload size (bytes).
@@ -374,6 +386,8 @@ impl Default for LimitsConfig {
         Self {
             writes_per_sec: DEFAULT_WRITES_PER_SEC,
             writes_burst: DEFAULT_WRITES_BURST,
+            reads_per_sec: DEFAULT_READS_PER_SEC,
+            reads_burst: DEFAULT_READS_BURST,
             max_ws_connections_per_workspace: DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE,
             max_ws_payload_bytes: DEFAULT_MAX_WS_PAYLOAD_BYTES,
             max_blob_bytes: DEFAULT_MAX_BLOB_BYTES,

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -379,6 +379,16 @@ pub struct LimitsConfig {
     /// reference-drop (e.g. a bad reconnect save) can be corrected without
     /// irreversible byte loss; the released ACL means it's already unmetered.
     pub blob_gc_grace_secs: u64,
+    /// Host allowlist for the generic blob ingest-from-URL endpoint
+    /// (`POST /api/v1/blobs/ingest-from-url`). Each entry is an exact host
+    /// (`api.example.com`) or a `*.`-prefixed suffix wildcard (`*.example.com`,
+    /// which also matches the bare suffix). **Empty disables the endpoint**
+    /// (403) — the relay is never an open fetch proxy by default; an operator
+    /// opts in by listing the hosts an integration may pull bytes from.
+    /// Enforced on the initial URL *and every redirect hop*, alongside a
+    /// private/loopback IP-literal block.
+    #[serde(default)]
+    pub blob_ingest_allowed_hosts: Vec<String>,
 }
 
 impl Default for LimitsConfig {
@@ -394,6 +404,7 @@ impl Default for LimitsConfig {
             storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
             max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
             blob_gc_grace_secs: DEFAULT_BLOB_GC_GRACE_SECS,
+            blob_ingest_allowed_hosts: Vec::new(),
         }
     }
 }
@@ -626,6 +637,13 @@ impl RelayConfig {
             self.tenancy.limits.blob_gc_grace_secs = v
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_BLOB_GC_GRACE_SECS must be a u64 (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_BLOB_INGEST_ALLOWED_HOSTS") {
+            self.tenancy.limits.blob_ingest_allowed_hosts = v
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
         }
         if let Some(v) = get("RELAY_SNAPSHOT_INTERVAL_SECS") {
             self.sync.snapshot_interval_secs = v.parse().map_err(|_| {

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -272,9 +272,18 @@ async fn run_serve(
     // state *before* start so it folds `/mcp` + the RFC 9728 discovery doc onto
     // the main public listener (one origin, one TLS story). The loopback
     // `McpServer` below is then skipped — a public pod runs no second listener.
+    // JP-249: per-workspace MCP read limiter (None = unlimited when
+    // reads_per_sec == 0). Separate from the WS/write bucket so a read-storm on a
+    // public pod can't contend with live editing.
+    let mcp_read_limiter = build_mcp_read_limiter(&config.tenancy.limits);
+
     if config.mcp.enabled && config.mcp.expose == McpExpose::Public {
-        let mount = PublicMount::new(config.storage.path.clone(), make_doc_changed(&server))
-            .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
+        let mount = PublicMount::new(
+            config.storage.path.clone(),
+            make_doc_changed(&server),
+            mcp_read_limiter.clone(),
+        )
+        .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
         // Logged for local diagnostics only; public pods reject the static
         // token and require a `wsp`-scoped JWT.
         log::info!(
@@ -328,6 +337,7 @@ async fn run_serve(
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
+                mcp_read_limiter.clone(),
                 auth.clone(),
                 region.clone(),
                 sync_registry,
@@ -391,6 +401,21 @@ async fn run_serve(
 /// `DocEvent::Updated` so a running editor refreshes after an MCP write.
 /// (The real-time CRDT merge rides the separate `on_doc_update` sink; this is
 /// the coarse "something changed" nudge.)
+/// Build the per-workspace MCP read limiter from config (JP-249). `None` when
+/// `reads_per_sec == 0` (unlimited — loopback/self-host default escape hatch).
+fn build_mcp_read_limiter(
+    limits: &docushark_relay::config::LimitsConfig,
+) -> Option<Arc<docushark_relay::server::WorkspaceWriteLimiter>> {
+    if limits.reads_per_sec == 0 {
+        None
+    } else {
+        Some(Arc::new(docushark_relay::server::build_workspace_limiter(
+            limits.reads_per_sec,
+            limits.reads_burst,
+        )))
+    }
+}
+
 fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<docushark_relay::mcp::DocChangedSink> {
     let server_for_mcp = server.clone();
     Arc::new(move |workspace: &WorkspaceId, doc_id: DocId| {

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -84,6 +84,8 @@ pub struct McpServer {
     /// Per-workspace write limiter shared with the WS subsystem.
     /// Phase 21.3.
     write_limiter: Arc<WorkspaceWriteLimiter>,
+    /// Separate per-workspace MCP **read** limiter (JP-249). `None` = unlimited.
+    read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     /// OIDC validator + JWKS cache + revocation set, shared with the
     /// WS subsystem so MCP and WS accept the same relay-issued tokens.
     /// JP-77 + Phase 21.6.
@@ -110,6 +112,9 @@ pub struct PublicMount {
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
     on_doc_changed: Arc<DocChangedSink>,
+    /// Per-workspace MCP read limiter (JP-249). `None` = unlimited. MCP-local,
+    /// so it's carried on the mount rather than `McpSharedHandles`.
+    read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
 }
 
 /// The server-owned handles a [`PublicMount`] needs to build its router. The
@@ -135,12 +140,14 @@ impl PublicMount {
     pub fn new(
         app_data_dir: PathBuf,
         on_doc_changed: Arc<DocChangedSink>,
+        read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     ) -> Result<Self, String> {
         Ok(Self {
             token: Arc::new(TokenStore::load_or_create(&app_data_dir)?),
             local_mirror: Arc::new(LocalDocumentMirror::new(app_data_dir.clone())),
             feature_config: Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir)),
             on_doc_changed,
+            read_limiter,
         })
     }
 
@@ -168,6 +175,7 @@ impl PublicMount {
             relay_region: shared.relay_region,
             sync_registry: shared.sync_registry,
             on_doc_update: shared.on_doc_update,
+            read_limiter: self.read_limiter,
             allow_static_token: false,
             // A public pod never serves local (renderer-owned) documents: the
             // local mirror is only ever populated by a desktop renderer, never
@@ -194,6 +202,7 @@ impl McpServer {
         panic_counter: Arc<AtomicU64>,
         rate_limit_rejections: Arc<AtomicU64>,
         write_limiter: Arc<WorkspaceWriteLimiter>,
+        read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
         auth: OidcAuthState,
         relay_region: String,
         sync_registry: Arc<DocRegistry>,
@@ -220,6 +229,7 @@ impl McpServer {
             panic_counter,
             rate_limit_rejections,
             write_limiter,
+            read_limiter,
             auth,
             relay_region,
             sync_registry,
@@ -300,6 +310,7 @@ impl McpServer {
             relay_region: self.relay_region.clone(),
             sync_registry: self.sync_registry.clone(),
             on_doc_update: self.on_doc_update.clone(),
+            read_limiter: self.read_limiter.clone(),
             // Loopback listener: the static token gates a single-tenant store.
             allow_static_token: true,
             // Desktop / self-host: the local mirror is the whole point — it lets

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -172,7 +172,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "properties": {
                     "docId": {"type": "string"},
                     "name": {"type": "string", "description": "Page title. Defaults to \"Page N\"."},
-                    "content": {"type": "string", "description": "Initial body. Markdown unless format is \"html\". Optional (blank page if omitted)."},
+                    "content": {"type": "string", "maxLength": MAX_PROSE_CONTENT_BYTES, "description": "Initial body. Markdown unless format is \"html\". Optional (blank page if omitted). Capped at ~1 MiB."},
                     "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."}
                 },
                 "required": ["docId"],
@@ -188,7 +188,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "properties": {
                     "docId": {"type": "string"},
                     "pageId": {"type": "string"},
-                    "content": {"type": "string", "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\"."},
+                    "content": {"type": "string", "maxLength": MAX_PROSE_CONTENT_BYTES, "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\". Capped at ~1 MiB."},
                     "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."},
                     "anchor": {"type": "string", "description": "Optional. The current text of the block to replace (a targeted edit). Must match exactly one top-level block; whitespace is normalized and styling/marks are ignored. Omit to replace the whole page."},
                     "anchorUntil": {"type": "string", "description": "Optional. With 'anchor', replace the inclusive span of blocks from 'anchor' through the block matching this text."}
@@ -852,6 +852,26 @@ fn markdown_to_html(md: &str) -> String {
     out
 }
 
+/// Hard cap on a single prose write's content size, in bytes (JP-248). A safety
+/// bound on the public `/mcp` surface so one `set_prose`/`add_prose_page`/
+/// `insert_section` can't build a huge fragment + broadcast delta. Advertised as
+/// `maxLength` on the prose-write tools so agents self-limit. A const (not a
+/// config knob) to stay lean — no `ToolContext` threading; promote to config if
+/// per-deployment tuning is ever needed.
+const MAX_PROSE_CONTENT_BYTES: usize = 1_048_576; // 1 MiB
+
+/// Reject prose content over [`MAX_PROSE_CONTENT_BYTES`] with `ERR_PROSE_TOO_LARGE`.
+fn check_prose_size(content: &str) -> Result<(), String> {
+    if content.len() > MAX_PROSE_CONTENT_BYTES {
+        return Err(format!(
+            "ERR_PROSE_TOO_LARGE: content is {} bytes; the limit is {} bytes",
+            content.len(),
+            MAX_PROSE_CONTENT_BYTES
+        ));
+    }
+    Ok(())
+}
+
 /// Turn agent-supplied content into the HTML stored on a prose page.
 /// Markdown is the default (agents produce it reliably); `html` is a
 /// pass-through escape hatch. The editor re-parses this HTML against the
@@ -941,7 +961,10 @@ fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
     // Render once, outside the retry loop — deterministic and lets a bad
     // format fail fast before we touch the store.
     let html = match &parsed.content {
-        Some(c) => content_to_html(c, parsed.format.as_deref())?,
+        Some(c) => {
+            check_prose_size(c)?;
+            content_to_html(c, parsed.format.as_deref())?
+        }
         None => String::new(),
     };
 
@@ -1028,6 +1051,7 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: SetProseArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     reject_if_local(ctx, &parsed.doc_id)?;
+    check_prose_size(&parsed.content)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
 
     match &parsed.anchor {
@@ -1260,7 +1284,10 @@ fn insert_section(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
     let inner_html = escape_html(&title);
     // Render the body once, up front, so a bad format fails before any write.
     let body_html = match &parsed.body {
-        Some(b) => content_to_html(b, parsed.format.as_deref())?,
+        Some(b) => {
+            check_prose_size(b)?;
+            content_to_html(b, parsed.format.as_deref())?
+        }
         None => String::new(),
     };
 
@@ -3102,6 +3129,32 @@ mod tests {
         )
         .unwrap_err();
         assert!(missing.contains("not found"));
+    }
+
+    #[test]
+    fn prose_writes_reject_oversized_content() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let big = "a".repeat(MAX_PROSE_CONTENT_BYTES + 1);
+
+        // The size check fires before page lookup, so the page need not exist.
+        for (tool, args) in [
+            ("docushark.set_prose", json!({"docId": "doc1", "pageId": "p", "content": big.clone()})),
+            ("docushark.add_prose_page", json!({"docId": "doc1", "content": big.clone()})),
+        ] {
+            let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();
+            assert!(err.contains("ERR_PROSE_TOO_LARGE"), "{tool}: {err}");
+        }
+
+        // Just under the cap passes the size gate (fails later for a real reason).
+        let ok_size = "a".repeat(MAX_PROSE_CONTENT_BYTES);
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.set_prose",
+            &json!({"docId": "doc1", "pageId": "nope", "content": ok_size}),
+        )
+        .unwrap_err();
+        assert!(!err.contains("ERR_PROSE_TOO_LARGE"), "under-cap must pass the size gate: {err}");
     }
 
     #[test]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1668,6 +1668,35 @@ fn live_handle(ctx: &ToolContext, doc_id: &DocId, page_id: &str) -> Option<Arc<D
     }
 }
 
+/// Shared shape-write dispatch (JP-250). Applies to the live Y.Doc when the doc
+/// is resident on its active page — broadcasting the CRDT delta, no `DocEvent`
+/// (clients merge — JP-35) — else to the JSON store under optimistic concurrency,
+/// with a `DocEvent` (`changed_doc_id`) so a running app reloads. Each shape tool
+/// supplies just its two effects (each returning the result JSON): the `live`
+/// op (→ framed delta + result) and the `cold` op. Centralizing the gate, the
+/// broadcast, and the `changed_doc_id` convention here keeps the cold path from
+/// silently drifting from the live one.
+fn write_shape_live_or_json(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    page_id: &str,
+    live: impl FnOnce(&DocHandle) -> Result<(Vec<u8>, Value), String>,
+    cold: impl FnMut(&mut Value) -> Result<Value, String>,
+) -> Result<ToolOutcome, String> {
+    if let Some(handle) = live_handle(ctx, doc_id, page_id) {
+        let (framed, result) = live(handle.as_ref())?;
+        ctx.broadcast_update(doc_id, framed);
+        Ok(ToolOutcome { result, changed_doc_id: None, change_detail: None })
+    } else {
+        let result = mutate_with_retry(ctx, doc_id, cold)?;
+        Ok(ToolOutcome {
+            result,
+            changed_doc_id: Some(doc_id.clone()),
+            change_detail: None,
+        })
+    }
+}
+
 /// The live Y.Doc handle for a doc that's **resident** in the registry (clients
 /// connected → it's hydrated). Unlike [`live_handle`] there's no active-page
 /// check: prose lives in `prose:<pageId>` fragments regardless of the canvas
@@ -1835,33 +1864,23 @@ fn add_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
 
     reject_if_local(ctx, &parsed.doc_id)?;
 
-    // JP-35: when the doc is live + on its active page, apply to the
-    // authoritative Y.Doc and broadcast the CRDT delta (clients merge, no
-    // reload). The JP-36 snapshot sweeper persists it — no JSON write here.
-    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
-        let id = shape_id_or_gen(&parsed.shape);
-        let shape = build_shape_json(&parsed.shape, &id);
-        let framed = handle.insert_shapes(&[(id.clone(), shape)])?;
-        ctx.broadcast_update(&parsed.doc_id, framed);
-        return Ok(ToolOutcome {
-            result: json!({"id": id, "warning": Value::Null}),
-            changed_doc_id: None,
-            change_detail: None,
-        });
-    }
-
-    let (id, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        let warning = lock_warning(doc);
-        let id = append_shape_in_place(doc, &parsed.page_id, &parsed.shape)?;
-        stamp_modified(doc, &parsed.page_id);
-        Ok((id, warning))
-    })?;
-
-    Ok(ToolOutcome {
-        result: json!({"id": id, "warning": warning}),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            let id = shape_id_or_gen(&parsed.shape);
+            let shape = build_shape_json(&parsed.shape, &id);
+            let framed = handle.insert_shapes(&[(id.clone(), shape)])?;
+            Ok((framed, json!({"id": id, "warning": Value::Null})))
+        },
+        |doc| {
+            let warning = lock_warning(doc);
+            let id = append_shape_in_place(doc, &parsed.page_id, &parsed.shape)?;
+            stamp_modified(doc, &parsed.page_id);
+            Ok(json!({"id": id, "warning": warning}))
+        },
+    )
 }
 
 fn stamp_modified(doc: &mut Value, page_id: &str) {
@@ -1894,46 +1913,38 @@ fn add_shapes(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
 
     reject_if_local(ctx, &parsed.doc_id)?;
 
-    // JP-35: live Y.Doc path — every shape inserted in one transaction with a
-    // single broadcast (atomic, unlike the JSON loop's incremental append).
-    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
-        let items: Vec<(String, Value)> = parsed
-            .shapes
-            .iter()
-            .map(|s| {
-                let id = shape_id_or_gen(s);
-                let shape = build_shape_json(s, &id);
-                (id, shape)
-            })
-            .collect();
-        let ids: Vec<String> = items.iter().map(|(id, _)| id.clone()).collect();
-        let framed = handle.insert_shapes(&items)?;
-        ctx.broadcast_update(&parsed.doc_id, framed);
-        return Ok(ToolOutcome {
-            result: json!({"ids": ids, "warning": Value::Null}),
-            changed_doc_id: None,
-            change_detail: None,
-        });
-    }
-
-    let (ids, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        let warning = lock_warning(doc);
-        let mut ids = Vec::with_capacity(parsed.shapes.len());
-        for (idx, shape) in parsed.shapes.iter().enumerate() {
-            match append_shape_in_place(doc, &parsed.page_id, shape) {
-                Ok(id) => ids.push(id),
-                Err(e) => return Err(format!("shape[{}]: {}", idx, e)),
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            // One transaction, single broadcast (atomic, unlike the JSON loop).
+            let items: Vec<(String, Value)> = parsed
+                .shapes
+                .iter()
+                .map(|s| {
+                    let id = shape_id_or_gen(s);
+                    let shape = build_shape_json(s, &id);
+                    (id, shape)
+                })
+                .collect();
+            let ids: Vec<String> = items.iter().map(|(id, _)| id.clone()).collect();
+            let framed = handle.insert_shapes(&items)?;
+            Ok((framed, json!({"ids": ids, "warning": Value::Null})))
+        },
+        |doc| {
+            let warning = lock_warning(doc);
+            let mut ids = Vec::with_capacity(parsed.shapes.len());
+            for (idx, shape) in parsed.shapes.iter().enumerate() {
+                match append_shape_in_place(doc, &parsed.page_id, shape) {
+                    Ok(id) => ids.push(id),
+                    Err(e) => return Err(format!("shape[{}]: {}", idx, e)),
+                }
             }
-        }
-        stamp_modified(doc, &parsed.page_id);
-        Ok((ids, warning))
-    })?;
-
-    Ok(ToolOutcome {
-        result: json!({"ids": ids, "warning": warning}),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+            stamp_modified(doc, &parsed.page_id);
+            Ok(json!({"ids": ids, "warning": warning}))
+        },
+    )
 }
 
 #[derive(Deserialize)]
@@ -1976,63 +1987,55 @@ fn connect(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         end_arrow_style: None,
     };
 
-    // JP-35: live Y.Doc path — validate endpoints against the live shapes,
-    // then insert the connector + broadcast.
-    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
-        if !handle.has_shape(&parsed.from_id) {
-            return Err(format!(
-                "fromId '{}' does not exist on page '{}'",
-                parsed.from_id, parsed.page_id
-            ));
-        }
-        if !handle.has_shape(&parsed.to_id) {
-            return Err(format!(
-                "toId '{}' does not exist on page '{}'",
-                parsed.to_id, parsed.page_id
-            ));
-        }
-        let id = shape_id_or_gen(&dsl);
-        let shape = build_shape_json(&dsl, &id);
-        let framed = handle.insert_shapes(&[(id.clone(), shape)])?;
-        ctx.broadcast_update(&parsed.doc_id, framed);
-        return Ok(ToolOutcome {
-            result: json!({"id": id, "warning": Value::Null}),
-            changed_doc_id: None,
-            change_detail: None,
-        });
-    }
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            // Validate both endpoints exist on the live page before inserting.
+            if !handle.has_shape(&parsed.from_id) {
+                return Err(format!(
+                    "fromId '{}' does not exist on page '{}'",
+                    parsed.from_id, parsed.page_id
+                ));
+            }
+            if !handle.has_shape(&parsed.to_id) {
+                return Err(format!(
+                    "toId '{}' does not exist on page '{}'",
+                    parsed.to_id, parsed.page_id
+                ));
+            }
+            let id = shape_id_or_gen(&dsl);
+            let shape = build_shape_json(&dsl, &id);
+            let framed = handle.insert_shapes(&[(id.clone(), shape)])?;
+            Ok((framed, json!({"id": id, "warning": Value::Null})))
+        },
+        |doc| {
+            // Validate the endpoints actually exist on the page before we mutate.
+            let page = doc
+                .get("pages")
+                .and_then(|p| p.get(&parsed.page_id))
+                .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
+            let shapes = page.get("shapes").ok_or("Page has no shapes")?;
+            if shapes.get(&parsed.from_id).is_none() {
+                return Err(format!(
+                    "fromId '{}' does not exist on page '{}'",
+                    parsed.from_id, parsed.page_id
+                ));
+            }
+            if shapes.get(&parsed.to_id).is_none() {
+                return Err(format!(
+                    "toId '{}' does not exist on page '{}'",
+                    parsed.to_id, parsed.page_id
+                ));
+            }
 
-    let (id, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        // Validate the endpoints actually exist on the page before we mutate.
-        let page = doc
-            .get("pages")
-            .and_then(|p| p.get(&parsed.page_id))
-            .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
-        let shapes = page.get("shapes").ok_or("Page has no shapes")?;
-        if shapes.get(&parsed.from_id).is_none() {
-            return Err(format!(
-                "fromId '{}' does not exist on page '{}'",
-                parsed.from_id, parsed.page_id
-            ));
-        }
-        if shapes.get(&parsed.to_id).is_none() {
-            return Err(format!(
-                "toId '{}' does not exist on page '{}'",
-                parsed.to_id, parsed.page_id
-            ));
-        }
-
-        let warning = lock_warning(doc);
-        let id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
-        stamp_modified(doc, &parsed.page_id);
-        Ok((id, warning))
-    })?;
-
-    Ok(ToolOutcome {
-        result: json!({"id": id, "warning": warning}),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+            let warning = lock_warning(doc);
+            let id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
+            stamp_modified(doc, &parsed.page_id);
+            Ok(json!({"id": id, "warning": warning}))
+        },
+    )
 }
 
 #[derive(Deserialize)]
@@ -2051,61 +2054,53 @@ fn update_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
 
     reject_if_local(ctx, &parsed.doc_id)?;
 
-    // JP-35: live Y.Doc path — read the live shape, merge the patch, overwrite
-    // + broadcast. Read-then-write across two short txns; field-level
-    // last-write-wins, inherent to a concurrent edit on the same shape.
-    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
-        let mut shape = handle
-            .get_shape_json(&parsed.id)
-            .ok_or_else(|| format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id))?;
-        let changed = apply_dsl_patch(&mut shape, &parsed.patch);
-        if changed.is_empty() {
-            return Err("Patch did not specify any updatable fields".into());
-        }
-        stamp_provenance(&mut shape);
-        let framed = handle.overwrite_shape(&parsed.id, shape)?;
-        ctx.broadcast_update(&parsed.doc_id, framed);
-        return Ok(ToolOutcome {
-            result: json!({"id": parsed.id, "changed": changed, "warning": Value::Null}),
-            changed_doc_id: None,
-            change_detail: None,
-        });
-    }
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            // Read the live shape, merge the patch, overwrite + broadcast.
+            // Read-then-write across two short txns; field-level last-write-wins,
+            // inherent to a concurrent edit on the same shape.
+            let mut shape = handle.get_shape_json(&parsed.id).ok_or_else(|| {
+                format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id)
+            })?;
+            let changed = apply_dsl_patch(&mut shape, &parsed.patch);
+            if changed.is_empty() {
+                return Err("Patch did not specify any updatable fields".into());
+            }
+            stamp_provenance(&mut shape);
+            let framed = handle.overwrite_shape(&parsed.id, shape)?;
+            Ok((framed, json!({"id": parsed.id, "changed": changed, "warning": Value::Null})))
+        },
+        |doc| {
+            let warning = lock_warning(doc);
+            let pages = doc
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .ok_or("Document missing 'pages'")?;
+            let page = pages
+                .get_mut(&parsed.page_id)
+                .and_then(|v| v.as_object_mut())
+                .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
+            let shapes = page
+                .get_mut("shapes")
+                .and_then(|v| v.as_object_mut())
+                .ok_or("Page 'shapes' is not an object")?;
+            let shape = shapes.get_mut(&parsed.id).ok_or_else(|| {
+                format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id)
+            })?;
 
-    let (changed, warning) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        let warning = lock_warning(doc);
+            let changed = apply_dsl_patch(shape, &parsed.patch);
+            if changed.is_empty() {
+                return Err("Patch did not specify any updatable fields".into());
+            }
+            stamp_provenance(shape);
 
-        let pages = doc
-            .get_mut("pages")
-            .and_then(|v| v.as_object_mut())
-            .ok_or("Document missing 'pages'")?;
-        let page = pages
-            .get_mut(&parsed.page_id)
-            .and_then(|v| v.as_object_mut())
-            .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
-        let shapes = page
-            .get_mut("shapes")
-            .and_then(|v| v.as_object_mut())
-            .ok_or("Page 'shapes' is not an object")?;
-        let shape = shapes
-            .get_mut(&parsed.id)
-            .ok_or_else(|| format!("Shape '{}' not found on page '{}'", parsed.id, parsed.page_id))?;
-
-        let changed = apply_dsl_patch(shape, &parsed.patch);
-        if changed.is_empty() {
-            return Err("Patch did not specify any updatable fields".into());
-        }
-        stamp_provenance(shape);
-
-        stamp_modified(doc, &parsed.page_id);
-        Ok((changed, warning))
-    })?;
-
-    Ok(ToolOutcome {
-        result: json!({"id": parsed.id, "changed": changed, "warning": warning}),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+            stamp_modified(doc, &parsed.page_id);
+            Ok(json!({"id": parsed.id, "changed": changed, "warning": warning}))
+        },
+    )
 }
 
 /// All ids to remove when deleting `target`: the shape itself plus every
@@ -2142,60 +2137,52 @@ fn delete_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     reject_if_local(ctx, &parsed.doc_id)?;
 
-    // Live path: cascade against the live shapes, delete + broadcast.
-    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
-        if !handle.has_shape(&parsed.id) {
-            return Err(format!(
-                "Shape '{}' not found on page '{}'",
-                parsed.id, parsed.page_id
-            ));
-        }
-        let ids = cascade_delete_ids(&handle.shapes_json(), &parsed.id);
-        let framed = handle.delete_shapes(&ids)?;
-        ctx.broadcast_update(&parsed.doc_id, framed);
-        return Ok(ToolOutcome {
-            result: json!({"deleted": ids}),
-            changed_doc_id: None,
-            change_detail: None,
-        });
-    }
-
-    // Cold path.
-    let deleted = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        let page = doc
-            .get_mut("pages")
-            .and_then(|v| v.as_object_mut())
-            .and_then(|pages| pages.get_mut(&parsed.page_id))
-            .and_then(|p| p.as_object_mut())
-            .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
-        let shapes = page
-            .get("shapes")
-            .and_then(|v| v.as_object())
-            .ok_or("Page 'shapes' is not an object")?;
-        if !shapes.contains_key(&parsed.id) {
-            return Err(format!(
-                "Shape '{}' not found on page '{}'",
-                parsed.id, parsed.page_id
-            ));
-        }
-        let ids = cascade_delete_ids(shapes, &parsed.id);
-        if let Some(shapes_mut) = page.get_mut("shapes").and_then(|v| v.as_object_mut()) {
-            for did in &ids {
-                shapes_mut.remove(did);
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            // Cascade against the live shapes, delete + broadcast.
+            if !handle.has_shape(&parsed.id) {
+                return Err(format!(
+                    "Shape '{}' not found on page '{}'",
+                    parsed.id, parsed.page_id
+                ));
             }
-        }
-        if let Some(order) = page.get_mut("shapeOrder").and_then(|v| v.as_array_mut()) {
-            order.retain(|v| v.as_str().is_none_or(|s| !ids.iter().any(|d| d == s)));
-        }
-        stamp_modified(doc, &parsed.page_id);
-        Ok(ids)
-    })?;
-
-    Ok(ToolOutcome {
-        result: json!({"deleted": deleted}),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+            let ids = cascade_delete_ids(&handle.shapes_json(), &parsed.id);
+            let framed = handle.delete_shapes(&ids)?;
+            Ok((framed, json!({"deleted": ids})))
+        },
+        |doc| {
+            let page = doc
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|pages| pages.get_mut(&parsed.page_id))
+                .and_then(|p| p.as_object_mut())
+                .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
+            let shapes = page
+                .get("shapes")
+                .and_then(|v| v.as_object())
+                .ok_or("Page 'shapes' is not an object")?;
+            if !shapes.contains_key(&parsed.id) {
+                return Err(format!(
+                    "Shape '{}' not found on page '{}'",
+                    parsed.id, parsed.page_id
+                ));
+            }
+            let ids = cascade_delete_ids(shapes, &parsed.id);
+            if let Some(shapes_mut) = page.get_mut("shapes").and_then(|v| v.as_object_mut()) {
+                for did in &ids {
+                    shapes_mut.remove(did);
+                }
+            }
+            if let Some(order) = page.get_mut("shapeOrder").and_then(|v| v.as_array_mut()) {
+                order.retain(|v| v.as_str().is_none_or(|s| !ids.iter().any(|d| d == s)));
+            }
+            stamp_modified(doc, &parsed.page_id);
+            Ok(json!({"deleted": ids}))
+        },
+    )
 }
 
 #[derive(Deserialize)]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -620,6 +620,12 @@ fn get_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
     let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
 
+    // JP-251: when resident, the active page's live shape count can be ahead of
+    // the JSON snapshot — report the live count for that page (the Y.Doc is
+    // active-page-only, JP-34, so only that page is enriched).
+    let resident = resident_handle(ctx, &parsed.doc_id);
+    let live_page = resident.as_ref().and_then(|h| h.page_id().map(String::from));
+
     let pages: Vec<Value> = doc
         .get("pageOrder")
         .and_then(|v| v.as_array())
@@ -629,11 +635,14 @@ fn get_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
                 .filter_map(|id| id.as_str())
                 .filter_map(|id| {
                     let page = doc.get("pages")?.get(id)?;
-                    let shape_count = page
-                        .get("shapeOrder")
-                        .and_then(|v| v.as_array())
-                        .map(|a| a.len())
-                        .unwrap_or(0);
+                    let shape_count = if Some(id) == live_page.as_deref() {
+                        resident.as_ref().map_or(0, |h| h.shape_count())
+                    } else {
+                        page.get("shapeOrder")
+                            .and_then(|v| v.as_array())
+                            .map(|a| a.len())
+                            .unwrap_or(0)
+                    };
                     Some(json!({
                         "id": id,
                         "name": page.get("name").cloned().unwrap_or(json!("")),
@@ -701,6 +710,26 @@ struct GetPageArgs {
 fn get_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: GetPageArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    // JP-251: resident-accurate when the doc is hot on this (active) page —
+    // reads the live Y.Doc the write path mutates (JP-35), so a write-then-read
+    // round-trip is consistent. Else (non-active page or non-resident) the JSON
+    // snapshot. Mirrors the prose resident-read (JP-201) + `get_shape`.
+    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
+        let shapes_map = handle.shapes_json();
+        let shapes: Vec<Value> = handle
+            .shape_order()
+            .iter()
+            .filter_map(|id| shapes_map.get(id))
+            .map(shape_to_dsl_or_generic)
+            .collect();
+        return Ok(ToolOutcome {
+            result: json!({"shapes": shapes, "source": "team"}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
     let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
     let page = doc
         .get("pages")
@@ -718,19 +747,7 @@ fn get_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let shapes: Vec<Value> = order
         .iter()
         .filter_map(|id| shapes_obj.get(id))
-        .map(|shape| {
-            shape_json_to_dsl(shape).unwrap_or_else(|| {
-                // Fallback: pass through a minimal generic descriptor for
-                // shape kinds the foundation adapter doesn't model yet.
-                json!({
-                    "id": shape.get("id"),
-                    "kind": shape.get("type"),
-                    "x": shape.get("x"),
-                    "y": shape.get("y"),
-                    "_unmapped": true,
-                })
-            })
-        })
+        .map(shape_to_dsl_or_generic)
         .collect();
 
     Ok(ToolOutcome {
@@ -2624,6 +2641,51 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn get_page_and_get_document_read_live_shapes_when_resident() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let _handle = f.make_resident("doc1");
+        // Live add — goes to the Y.Doc, not the JSON store (JP-35).
+        dispatch(
+            &f.ctx(true),
+            "docushark.add_shape",
+            &json!({"docId": "doc1", "pageId": "p1",
+                    "shape": {"kind": "rectangle", "id": "s1", "x": 1.0, "y": 2.0}}),
+        )
+        .unwrap();
+
+        // get_page reflects the live shape (JP-251)...
+        let page = dispatch(
+            &f.ctx(true),
+            "docushark.get_page",
+            &json!({"docId": "doc1", "pageId": "p1"}),
+        )
+        .unwrap();
+        let shapes = page.result["shapes"].as_array().unwrap();
+        assert_eq!(shapes.len(), 1);
+        assert_eq!(shapes[0]["id"], "s1");
+
+        // ...while the JSON store is genuinely empty — proving the live read.
+        let ws = WorkspaceId::single_tenant();
+        let json = f
+            .team
+            .get_document(&ws, &DocId::from_http_path("doc1".to_string()).unwrap())
+            .unwrap();
+        assert_eq!(json["pages"]["p1"]["shapes"].as_object().unwrap().len(), 0);
+
+        // get_document's active-page shapeCount is the live count too.
+        let docout = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": "doc1"}))
+            .unwrap();
+        let p1 = docout.result["pages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["id"] == "p1")
+            .unwrap();
+        assert_eq!(p1["shapeCount"], 1);
     }
 
     #[test]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -7,7 +7,8 @@
 //!                 generate_diagram
 //! Prose writes:   add_prose_page, set_prose, rename_prose_page,
 //!                 insert_section, restructure_outline
-//! Manage (JP-246): delete_shape (cascade connectors), delete_prose_page
+//! Manage (JP-246/247): delete_shape (cascade connectors), delete_prose_page,
+//!                 reorder_shapes, reorder_prose_pages
 //!
 //! A "document" carries both a diagram canvas (`pages` → shapes) and a
 //! written body (`richTextPages`, multi-page TipTap prose stored as HTML).
@@ -405,6 +406,43 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "additionalProperties": false
             }),
         },
+        ToolDescriptor {
+            name: "docushark.reorder_shapes",
+            description:
+                "Set the z-order (front-to-back stacking) of a page's shapes. 'order' must be a permutation of the page's current shape ids — every id present, none added or duplicated (read get_page first). Later ids render on top. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "order": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "All of the page's shape ids in the new z-order (back to front)."
+                    }
+                },
+                "required": ["docId", "pageId", "order"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.reorder_prose_pages",
+            description:
+                "Set the order of a document's prose pages. 'order' must be a permutation of the current prose page ids (read get_prose first). Note: in a connected editor the tab order may update only on reload (the prose page list isn't yet live-synced). Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "order": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "All of the document's prose page ids in the new order."
+                    }
+                },
+                "required": ["docId", "order"],
+                "additionalProperties": false
+            }),
+        },
     ]
 }
 
@@ -512,6 +550,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.update_shape" => update_shape(ctx, args),
         "docushark.delete_shape" => delete_shape(ctx, args),
         "docushark.delete_prose_page" => delete_prose_page(ctx, args),
+        "docushark.reorder_shapes" => reorder_shapes(ctx, args),
+        "docushark.reorder_prose_pages" => reorder_prose_pages(ctx, args),
         _ => Err(format!("Unknown tool: {}", name)),
     }
 }
@@ -2201,6 +2241,119 @@ fn delete_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Str
     })
 }
 
+/// Validate that `requested` is a permutation of `current` — same ids, none
+/// missing, added, or duplicated. Shared by `reorder_shapes`/`reorder_prose_pages`.
+fn validate_order(current: &[String], requested: &[String], what: &str) -> Result<(), String> {
+    let mut a = current.to_vec();
+    a.sort();
+    let mut b = requested.to_vec();
+    b.sort();
+    if a == b {
+        Ok(())
+    } else {
+        Err(format!(
+            "order must be a permutation of the current {what} ids ({} ids); got {} — check for \
+             missing, extra, or duplicate ids",
+            current.len(),
+            requested.len()
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+struct ReorderShapesArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    order: Vec<String>,
+}
+
+fn reorder_shapes(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: ReorderShapesArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    // Live path: validate against the live z-order, then apply + broadcast.
+    if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
+        validate_order(&handle.shape_order(), &parsed.order, "shape")?;
+        let framed = handle.set_shape_order(&parsed.order);
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        return Ok(ToolOutcome {
+            result: json!({"pageId": parsed.page_id, "ok": true}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    // Cold path.
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let page = doc
+            .get_mut("pages")
+            .and_then(|v| v.as_object_mut())
+            .and_then(|pages| pages.get_mut(&parsed.page_id))
+            .and_then(|p| p.as_object_mut())
+            .ok_or_else(|| format!("Page '{}' not found", parsed.page_id))?;
+        let current: Vec<String> = page
+            .get("shapeOrder")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+        validate_order(&current, &parsed.order, "shape")?;
+        page.insert("shapeOrder".into(), json!(parsed.order));
+        stamp_modified(doc, &parsed.page_id);
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "ok": true}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct ReorderProsePagesArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    order: Vec<String>,
+}
+
+fn reorder_prose_pages(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: ReorderProsePagesArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    // The prose page list is JSON-only (not CRDT-synced, JP-171), so this is
+    // always a JSON write; a connected editor's tab order updates on reload.
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let rtp = rich_text_pages_mut(doc)?;
+        let current: Vec<String> = rtp
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+        validate_order(&current, &parsed.order, "prose page")?;
+        rtp.insert("pageOrder".into(), json!(parsed.order));
+        // Keep each page's numeric `order` field consistent with the new index.
+        if let Some(pages) = rtp.get_mut("pages").and_then(|v| v.as_object_mut()) {
+            for (i, id) in parsed.order.iter().enumerate() {
+                if let Some(page) = pages.get_mut(id).and_then(|v| v.as_object_mut()) {
+                    page.insert("order".into(), json!(i));
+                }
+            }
+        }
+        stamp_doc_modified(doc, now_ms());
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"order": parsed.order, "ok": true}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2502,6 +2655,108 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("last prose page"), "{err}");
+    }
+
+    // ---- JP-247: reorder ----
+
+    #[test]
+    fn validate_order_accepts_permutation_rejects_otherwise() {
+        let cur = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert!(validate_order(&cur, &["c".into(), "a".into(), "b".into()], "shape").is_ok());
+        // missing one
+        assert!(validate_order(&cur, &["a".into(), "b".into()], "shape").is_err());
+        // extra id
+        assert!(validate_order(&cur, &["a".into(), "b".into(), "c".into(), "d".into()], "shape").is_err());
+        // duplicate (same length, wrong multiset)
+        assert!(validate_order(&cur, &["a".into(), "a".into(), "b".into()], "shape").is_err());
+    }
+
+    #[test]
+    fn reorder_shapes_live_sets_zorder_and_broadcasts() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let handle = f.make_resident("doc1");
+        dispatch(
+            &f.ctx(true),
+            "docushark.add_shapes",
+            &json!({"docId": "doc1", "pageId": "p1", "shapes": [
+                {"kind": "rectangle", "id": "s1", "x": 0.0, "y": 0.0},
+                {"kind": "rectangle", "id": "s2", "x": 10.0, "y": 0.0},
+                {"kind": "rectangle", "id": "s3", "x": 20.0, "y": 0.0}
+            ]}),
+        )
+        .unwrap();
+        assert_eq!(handle.shape_order(), vec!["s1", "s2", "s3"]);
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.reorder_shapes",
+            &json!({"docId": "doc1", "pageId": "p1", "order": ["s3", "s1", "s2"]}),
+        )
+        .unwrap();
+        assert_eq!(out.result["ok"], true);
+        assert_eq!(handle.shape_order(), vec!["s3", "s1", "s2"]);
+        assert!(out.changed_doc_id.is_none(), "live path");
+        assert_eq!(f.broadcasts().len(), 2, "add_shapes + reorder");
+
+        // A non-permutation is refused (and applies nothing).
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.reorder_shapes",
+            &json!({"docId": "doc1", "pageId": "p1", "order": ["s3", "s1"]}),
+        )
+        .unwrap_err();
+        assert!(err.contains("permutation"), "{err}");
+        assert_eq!(handle.shape_order(), vec!["s3", "s1", "s2"], "unchanged on error");
+    }
+
+    #[test]
+    fn reorder_prose_pages_reorders_and_renumbers() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        f.team
+            .save_document(
+                &ws,
+                json!({
+                    "id": "docp", "name": "P", "version": 1, "createdAt": 1u64, "modifiedAt": 1u64,
+                    "activePageId": "c1", "pageOrder": ["c1"],
+                    "pages": {"c1": {"id": "c1", "shapes": {}, "shapeOrder": []}},
+                    "richTextPages": {"activePageId": "rt1", "pageOrder": ["rt1", "rt2", "rt3"], "pages": {
+                        "rt1": {"id": "rt1", "name": "One", "content": "<p>a</p>", "order": 0},
+                        "rt2": {"id": "rt2", "name": "Two", "content": "<p>b</p>", "order": 1},
+                        "rt3": {"id": "rt3", "name": "Three", "content": "<p>c</p>", "order": 2}
+                    }}
+                }),
+            )
+            .unwrap();
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.reorder_prose_pages",
+            &json!({"docId": "docp", "order": ["rt3", "rt1", "rt2"]}),
+        )
+        .unwrap();
+        assert_eq!(out.result["ok"], true);
+
+        let doc = f
+            .team
+            .get_document(&ws, &DocId::from_http_path("docp".to_string()).unwrap())
+            .unwrap();
+        assert_eq!(doc["richTextPages"]["pageOrder"], json!(["rt3", "rt1", "rt2"]));
+        // Numeric order fields renumbered to match.
+        assert_eq!(doc["richTextPages"]["pages"]["rt3"]["order"], 0);
+        assert_eq!(doc["richTextPages"]["pages"]["rt1"]["order"], 1);
+        assert_eq!(doc["richTextPages"]["pages"]["rt2"]["order"], 2);
+
+        // Non-permutation refused.
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.reorder_prose_pages",
+            &json!({"docId": "docp", "order": ["rt3", "rt1"]}),
+        )
+        .unwrap_err();
+        assert!(err.contains("permutation"), "{err}");
     }
 
     #[test]
@@ -2945,6 +3200,14 @@ mod tests {
             (
                 "docushark.delete_prose_page",
                 json!({"docId":"local1","pageId":"rt1"}),
+            ),
+            (
+                "docushark.reorder_shapes",
+                json!({"docId":"local1","pageId":"p1","order":["a","b"]}),
+            ),
+            (
+                "docushark.reorder_prose_pages",
+                json!({"docId":"local1","order":["rt1","rt2"]}),
             ),
         ] {
             let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -366,6 +366,8 @@ fn is_mcp_write_tool(name: &str) -> bool {
             | "docushark.update_shape"
             | "docushark.delete_shape"
             | "docushark.delete_prose_page"
+            | "docushark.reorder_shapes"
+            | "docushark.reorder_prose_pages"
     )
 }
 
@@ -681,7 +683,9 @@ mod tests {
         assert!(names.contains(&"docushark.get_shape"));
         assert!(names.contains(&"docushark.delete_shape"));
         assert!(names.contains(&"docushark.delete_prose_page"));
-        assert_eq!(tools.len(), 19);
+        assert!(names.contains(&"docushark.reorder_shapes"));
+        assert!(names.contains(&"docushark.reorder_prose_pages"));
+        assert_eq!(tools.len(), 21);
     }
 
     #[tokio::test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -61,6 +61,11 @@ pub struct McpAppState {
     /// draw from the same per-workspace token bucket as WS sync
     /// frames. Phase 21.3.
     pub write_limiter: Arc<WorkspaceWriteLimiter>,
+    /// Separate per-workspace bucket for MCP **reads** (JP-249) so a read-storm
+    /// on the public pod can't burn CPU/IO unbounded without contending with the
+    /// write/WS bucket. `None` = unlimited (loopback/self-host, or
+    /// `reads_per_sec = 0`).
+    pub read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     /// Shared with `ServerState.rate_limit_rejections` so MCP write
     /// throttles surface at the same `/metrics` counter as WS throttles.
     pub rate_limit_rejections: Arc<AtomicU64>,
@@ -392,33 +397,39 @@ fn handle_tools_call(
         on_doc_update: state.on_doc_update.as_ref(),
     };
 
-    // Phase 21.3: per-workspace write rate limit. Only mutating tools
-    // count against the bucket — reads pass through. The workspace
-    // here is the single-tenant default until MCP grows a workspace
-    // claim of its own (deferred follow-up). Even so, MCP and WS
-    // share the bucket, so a chatty MCP client and a chatty browser
-    // editor on the same workspace see fair accounting.
-    if is_mcp_write_tool(name) {
-        if state.write_limiter.check_key(&ctx.workspace_id).is_err() {
-            state.rate_limit_rejections.fetch_add(1, Ordering::Relaxed);
-            log::debug!(
-                "mcp tool rate-limited tool={} workspace_id={}",
-                name,
-                ctx.workspace_id.as_str()
-            );
-            return (
-                axum::http::StatusCode::TOO_MANY_REQUESTS,
-                [(axum::http::header::RETRY_AFTER, "1")],
-                Json(rpc_result(
-                    id,
-                    json!({
-                        "content": [{"type": "text", "text": "ERR_RATE_LIMIT"}],
-                        "isError": true,
-                    }),
-                )),
-            )
-                .into_response();
-        }
+    // Per-workspace rate limit. Writes draw from the shared write bucket (same
+    // bucket as WS sync frames, Phase 21.3); reads draw from a **separate** MCP
+    // read bucket (JP-249) so a read-storm on the public pod can't burn CPU/IO
+    // unbounded — yet never contends with live WS editing or writes. The read
+    // limiter is `None` (unlimited) on loopback/self-host or when
+    // `reads_per_sec = 0`.
+    let throttled = if is_mcp_write_tool(name) {
+        state.write_limiter.check_key(&ctx.workspace_id).is_err()
+    } else {
+        state
+            .read_limiter
+            .as_ref()
+            .is_some_and(|rl| rl.check_key(&ctx.workspace_id).is_err())
+    };
+    if throttled {
+        state.rate_limit_rejections.fetch_add(1, Ordering::Relaxed);
+        log::debug!(
+            "mcp tool rate-limited tool={} workspace_id={}",
+            name,
+            ctx.workspace_id.as_str()
+        );
+        return (
+            axum::http::StatusCode::TOO_MANY_REQUESTS,
+            [(axum::http::header::RETRY_AFTER, "1")],
+            Json(rpc_result(
+                id,
+                json!({
+                    "content": [{"type": "text", "text": "ERR_RATE_LIMIT"}],
+                    "isError": true,
+                }),
+            )),
+        )
+            .into_response();
     }
 
     // Phase 21.2: catch tool panics so one bad tool call can't take
@@ -531,6 +542,7 @@ mod tests {
             panic_counter: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             write_limiter: Arc::new(crate::server::build_workspace_limiter(1000, 1000)),
+            read_limiter: None,
             auth: test_auth_state(),
             relay_region: "default".to_string(),
             sync_registry: Arc::new(crate::sync::DocRegistry::new()),

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -131,6 +131,16 @@ impl S3Backend {
         format!("{}docs/{}/index.json", self.config.key_prefix, ws.as_str())
     }
 
+    /// Object key for a workspace's **blob ledger** (JP-232):
+    /// `{prefix}docs/{ws}/blob_ledger.json`. Durable per-workspace projection of
+    /// the blob bookkeeping (ACLs + per-doc refs + size/mime) so a recycled
+    /// machine — whose on-volume sidecars are gone — restores reads, GC refcounts,
+    /// and quota without re-walking the doc corpus. Sits beside the doc index in
+    /// the same paired bucket so a region migration carries it along.
+    pub fn blob_ledger_key(&self, ws: &WorkspaceId) -> String {
+        format!("{}docs/{}/blob_ledger.json", self.config.key_prefix, ws.as_str())
+    }
+
     /// Canonical request URI (path-style): `/{bucket}/{uri-encoded-key}`, with
     /// `/` preserved inside the key. This exact string is both signed and used
     /// as the request path, so they can never disagree.
@@ -219,6 +229,18 @@ impl S3Backend {
     /// `Err` on any other failure. Used by finalize to read the authoritative
     /// size after a direct client upload.
     pub async fn head_object(&self, ws: &WorkspaceId, hash: &str) -> Result<Option<u64>, String> {
+        Ok(self.head_object_typed(ws, hash).await?.map(|(size, _ct)| size))
+    }
+
+    /// HEAD the object, returning both the authoritative `size` and the stored
+    /// `Content-Type` (`None` if the object carries no content-type header).
+    /// `Ok(None)` on 404. Used by JP-232 blob-bookkeeping reconstruction so a
+    /// restored blob recovers its true mime, not a placeholder.
+    pub async fn head_object_typed(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+    ) -> Result<Option<(u64, Option<String>)>, String> {
         let key = self.object_key(ws, hash);
         let resp = self
             .send_signed("HEAD", &key, reqwest::Body::from(Vec::new()), EMPTY_SHA256, &[])
@@ -229,13 +251,18 @@ impl S3Backend {
         if !resp.status().is_success() {
             return Err(format!("R2 HEAD {} -> {}", key, resp.status()));
         }
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.to_string());
         let size = resp
             .headers()
             .get(reqwest::header::CONTENT_LENGTH)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse::<u64>().ok());
         match size {
-            Some(s) => Ok(Some(s)),
+            Some(s) => Ok(Some((s, content_type))),
             None => Err(format!("R2 HEAD {} missing content-length", key)),
         }
     }
@@ -766,6 +793,104 @@ mod tests {
             DocObjectStore::get_doc_object(&backend, &ws, &doc, "json").await.unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn blob_ledger_key_sits_beside_the_doc_index() {
+        let backend = S3Backend::new(S3Config {
+            endpoint: "https://acct.r2.cloudflarestorage.com".to_string(),
+            bucket: "blobs".to_string(),
+            region: "auto".to_string(),
+            access_key_id: "AKID".to_string(),
+            secret_access_key: "secret".to_string(),
+            key_prefix: String::new(),
+            put_ttl_secs: 900,
+            get_ttl_secs: 900,
+        });
+        let ws = WorkspaceId::single_tenant();
+        assert_eq!(
+            backend.blob_ledger_key(&ws),
+            format!("docs/{}/blob_ledger.json", ws.as_str())
+        );
+    }
+
+    /// JP-232 R2 surface against a live S3 server: the `head_object_typed`
+    /// content-type read (used by reconstruct) and the blob-ledger key
+    /// put/get round-trip. Skipped unless `RELAY_TEST_S3_*` is set.
+    #[tokio::test]
+    async fn s3_ledger_and_typed_head_roundtrip_against_live_endpoint() {
+        let Some(backend) = test_backend_from_env() else {
+            eprintln!("skipping s3 ledger roundtrip: RELAY_TEST_S3_ENDPOINT unset");
+            return;
+        };
+        let ws = WorkspaceId::single_tenant();
+        let hash = "c".repeat(64);
+        let body = b"typed-head blob bytes".to_vec();
+
+        // Proxy PUT pins a content-type; the typed HEAD must read it back.
+        backend.put_object(&ws, &hash, body.clone(), "image/png").await.unwrap();
+        let (size, ct) = backend.head_object_typed(&ws, &hash).await.unwrap().unwrap();
+        assert_eq!(size, body.len() as u64);
+        assert_eq!(ct.as_deref(), Some("image/png"));
+        backend.delete_object(&ws, &hash).await.unwrap();
+        assert_eq!(backend.head_object_typed(&ws, &hash).await.unwrap(), None);
+
+        // Ledger object round-trips at its dedicated key.
+        let key = backend.blob_ledger_key(&ws);
+        let ledger = br#"{"acls":["abc"],"docRefs":[],"blobs":[]}"#.to_vec();
+        backend.put_object_at(&key, ledger.clone(), "application/json").await.unwrap();
+        assert_eq!(backend.get_object_at(&key).await.unwrap().as_deref(), Some(ledger.as_slice()));
+        backend.delete_object_at(&key).await.unwrap();
+        assert_eq!(backend.get_object_at(&key).await.unwrap(), None);
+    }
+
+    /// JP-232 end-to-end durability through live R2: drive the *real* mechanism
+    /// — build a workspace's bookkeeping, serialize its ledger, PUT it to R2,
+    /// simulate volume loss (a fresh `BlobStore`), GET + `install_ledger`, and
+    /// assert reads/quota survive and the GC does not reclaim a still-referenced
+    /// shared blob. Skipped unless `RELAY_TEST_S3_*` is set.
+    #[tokio::test]
+    async fn jp232_blob_ledger_survives_volume_loss_against_live_endpoint() {
+        use crate::server::blobs::{BlobStore, WorkspaceBlobLedger};
+        let Some(backend) = test_backend_from_env() else {
+            eprintln!("skipping JP-232 ledger durability: RELAY_TEST_S3_ENDPOINT unset");
+            return;
+        };
+        let ws = WorkspaceId::from_configured("jp232ws").unwrap();
+        let a = b"shared blob A bytes";
+        let ha = BlobStore::compute_hash(a);
+        let b = b"docA-only blob B bytes";
+        let hb = BlobStore::compute_hash(b);
+
+        // Live pod: bookkeeping built, ledger serialized + PUT to R2.
+        let dir = tempfile::tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.save_blob(&ws, &ha, a, "image/png", "u1").unwrap();
+        store.save_blob(&ws, &hb, b, "application/pdf", "u1").unwrap();
+        store.sync_doc_refs(&ws, "docA", [ha.clone(), hb.clone()].into_iter().collect()).unwrap();
+        store.sync_doc_refs(&ws, "docB", [ha.clone()].into_iter().collect()).unwrap();
+        let expected_size = store.get_workspace_size(&ws);
+
+        let key = backend.blob_ledger_key(&ws);
+        let bytes = serde_json::to_vec(&store.ledger_for_workspace(&ws)).unwrap();
+        backend.put_object_at(&key, bytes, "application/json").await.unwrap();
+
+        // Recycled machine: fresh volume, restore the ledger from R2.
+        let dir2 = tempfile::tempdir().unwrap();
+        let restored = BlobStore::new(dir2.path().to_path_buf());
+        let got = backend.get_object_at(&key).await.unwrap().expect("ledger present in R2");
+        let ledger: WorkspaceBlobLedger = serde_json::from_slice(&got).unwrap();
+        restored.install_ledger(&ws, ledger).unwrap();
+
+        // Reads + quota survive; GC keeps the shared blob, reclaims the docA-only one.
+        assert!(restored.exists(&ws, &ha));
+        assert_eq!(restored.get_workspace_size(&ws), expected_size);
+        assert_eq!(restored.sweep_unreferenced(), 0, "full ref graph → nothing to reclaim");
+        restored.release_doc_refs(&ws, "docA").unwrap();
+        assert!(restored.exists(&ws, &ha), "shared blob still referenced by docB");
+        assert!(!restored.exists(&ws, &hb), "docA-only blob reclaimed");
+
+        backend.delete_object_at(&key).await.unwrap();
     }
 
     #[test]

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -67,6 +67,20 @@ pub struct DocRefRow {
     pub workspace: WorkspaceId,
     pub doc_id: String,
     pub hashes: Vec<String>,
+}
+
+/// One persisted row of the per-`(workspace, hash)` provenance set: opaque
+/// caller-supplied source/tag strings recorded at ingest (e.g. an importer
+/// name), for audit + cleanup. **Additive** — a content-addressed blob
+/// shared by several sources accumulates all their tags. Purely **advisory**
+/// metadata: GC is still driven by ACLs/refcounts (JP-120), never by these tags.
+/// On-disk shape in `blob_provenance.json` (a flat `Vec`, mirroring `BlobAcl`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobProvenanceRow {
+    pub workspace: WorkspaceId,
+    pub hash: String,
+    pub sources: Vec<String>,
 }
 
 /// Failure modes of [`BlobStore::save_blob_with_quota`]. The HTTP layer
@@ -146,6 +160,10 @@ pub struct BlobStore {
     /// delete is deferred and recorded here, mirroring `orphaned_at` but keyed
     /// per workspace since each workspace owns a distinct object.
     orphaned_objects_at: RwLock<HashMap<(WorkspaceId, String), Instant>>,
+    /// Opaque per-`(workspace, hash)` provenance tags (caller-supplied source
+    /// labels), recorded at ingest for audit + cleanup. Additive; advisory
+    /// only (never affects GC). Persisted to `blob_provenance.json`.
+    provenance: RwLock<HashMap<(WorkspaceId, String), BTreeSet<String>>>,
 }
 
 impl BlobStore {
@@ -177,12 +195,14 @@ impl BlobStore {
             gc_grace_secs: AtomicU64::new(0),
             object_delete_tx: None,
             orphaned_objects_at: RwLock::new(HashMap::new()),
+            provenance: RwLock::new(HashMap::new()),
         };
 
-        // Load existing index + ACLs + per-doc references.
+        // Load existing index + ACLs + per-doc references + provenance.
         store.load_index();
         store.load_acls_or_backfill();
         store.load_doc_refs();
+        store.load_provenance();
 
         store
     }
@@ -200,6 +220,11 @@ impl BlobStore {
     /// Path to the per-document blob-reference sidecar (JP-120).
     fn refs_path(&self) -> PathBuf {
         self.meta_dir.join("blob_refs.json")
+    }
+
+    /// Path to the per-`(workspace, hash)` provenance sidecar.
+    fn provenance_path(&self) -> PathBuf {
+        self.meta_dir.join("blob_provenance.json")
     }
 
     /// Load the metadata index from disk
@@ -306,6 +331,85 @@ impl BlobStore {
         std::fs::write(self.acl_path(), json)
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
+    }
+
+    /// Load the provenance sidecar from disk (absent = empty map).
+    fn load_provenance(&self) {
+        let path = self.provenance_path();
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            if let Ok(rows) = serde_json::from_str::<Vec<BlobProvenanceRow>>(&data) {
+                if let Ok(mut current) = self.provenance.write() {
+                    current.clear();
+                    for row in rows {
+                        current.insert((row.workspace, row.hash), row.sources.into_iter().collect());
+                    }
+                    log::info!("Loaded blob provenance with {} entries", current.len());
+                }
+            }
+        }
+    }
+
+    /// Persist the provenance sidecar to disk.
+    fn save_provenance(&self) -> Result<(), String> {
+        let snapshot: Vec<BlobProvenanceRow> = {
+            let prov = self.provenance.read().map_err(|e| e.to_string())?;
+            prov.iter()
+                .map(|((ws, hash), sources)| BlobProvenanceRow {
+                    workspace: ws.clone(),
+                    hash: hash.clone(),
+                    sources: sources.iter().cloned().collect(),
+                })
+                .collect()
+        };
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| format!("Serialize error: {}", e))?;
+        std::fs::write(self.provenance_path(), json)
+            .map_err(|e| format!("Write error: {}", e))?;
+        Ok(())
+    }
+
+    /// Record opaque provenance tags for a `(workspace, hash)` grant — additive
+    /// (a shared blob accumulates every source's tags). No-op when `tags` is
+    /// empty after trimming. Advisory metadata only; never affects GC.
+    pub fn record_provenance(
+        &self,
+        ws: &WorkspaceId,
+        hash: &str,
+        tags: &[String],
+    ) -> Result<(), String> {
+        let cleaned: Vec<String> = tags
+            .iter()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if cleaned.is_empty() {
+            return Ok(());
+        }
+        let changed = {
+            let mut prov = self.provenance.write().map_err(|e| e.to_string())?;
+            let set = prov.entry((ws.clone(), hash.to_string())).or_default();
+            let before = set.len();
+            for t in cleaned {
+                set.insert(t);
+            }
+            set.len() != before
+        };
+        if changed {
+            self.save_provenance()?;
+        }
+        Ok(())
+    }
+
+    /// All provenance tags recorded for a `(workspace, hash)` (sorted; audit/tests).
+    pub fn provenance_for(&self, ws: &WorkspaceId, hash: &str) -> Vec<String> {
+        self.provenance
+            .read()
+            .ok()
+            .and_then(|p| {
+                p.get(&(ws.clone(), hash.to_string()))
+                    .map(|s| s.iter().cloned().collect())
+            })
+            .unwrap_or_default()
     }
 
     /// Load the per-document blob-reference map from disk (JP-120). Absent

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -83,6 +83,38 @@ pub struct BlobProvenanceRow {
     pub sources: Vec<String>,
 }
 
+/// Per-workspace durable projection of the blob bookkeeping (JP-232), mirrored
+/// to R2 as `docs/<ws>/blob_ledger.json`. On a recycled machine whose on-volume
+/// sidecars are gone, restoring this rehydrates a workspace's ACLs, per-document
+/// refcounts, and size/mime — so reads, GC, and quota survive volume loss
+/// without re-walking the doc corpus. Written from live in-memory state, so it
+/// is **independent of the (best-effort) R2 document index**: a doc missing from
+/// the index still has its blob refs preserved here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceBlobLedger {
+    /// Blob hashes this workspace holds an ACL grant for.
+    pub acls: Vec<String>,
+    /// Per-document blob references — the refcount source. (`DocRefRow.workspace`
+    /// is redundant in a per-ws ledger; install trusts the ws it restores into.)
+    pub doc_refs: Vec<DocRefRow>,
+    /// Index metadata for every hash the workspace references.
+    pub blobs: Vec<LedgerBlob>,
+}
+
+/// One blob's index metadata as carried in a [`WorkspaceBlobLedger`] — enough to
+/// reconstruct a [`BlobMetadata`] exactly (the ledger is built from the live
+/// index, so `created_at`/`uploaded_by` round-trip at full fidelity).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LedgerBlob {
+    pub hash: String,
+    pub size: u64,
+    pub mime_type: String,
+    pub created_at: u64,
+    pub uploaded_by: String,
+}
+
 /// Failure modes of [`BlobStore::save_blob_with_quota`]. The HTTP layer
 /// maps `QuotaExceeded` to **507 Insufficient Storage** (JP-81), a hash
 /// mismatch to 400, and IO to 500.
@@ -164,6 +196,11 @@ pub struct BlobStore {
     /// labels), recorded at ingest for audit + cleanup. Additive; advisory
     /// only (never affects GC). Persisted to `blob_provenance.json`.
     provenance: RwLock<HashMap<(WorkspaceId, String), BTreeSet<String>>>,
+    /// JP-232 ledger-mirror sink. `Some` in object-storage mode: when a
+    /// workspace's bookkeeping changes, its id is sent here for a background
+    /// worker to serialize [`Self::ledger_for_workspace`] and PUT to R2. `None`
+    /// is the filesystem mode (the on-volume sidecars are the only durable copy).
+    ledger_mirror_tx: Option<UnboundedSender<WorkspaceId>>,
 }
 
 impl BlobStore {
@@ -196,6 +233,7 @@ impl BlobStore {
             object_delete_tx: None,
             orphaned_objects_at: RwLock::new(HashMap::new()),
             provenance: RwLock::new(HashMap::new()),
+            ledger_mirror_tx: None,
         };
 
         // Load existing index + ACLs + per-doc references + provenance.
@@ -625,6 +663,9 @@ impl BlobStore {
         if acl_changed {
             self.save_acls().map_err(SaveBlobError::Io)?;
         }
+        if metadata_changed || acl_changed {
+            self.mark_ledger_dirty(ws);
+        }
 
         // Return the canonical (possibly pre-existing) metadata.
         let final_meta = self
@@ -698,6 +739,9 @@ impl BlobStore {
         }
         if acl_changed {
             self.save_acls()?;
+        }
+        if metadata_changed || acl_changed {
+            self.mark_ledger_dirty(ws);
         }
 
         Ok(self.get_metadata_unchecked(hash).unwrap_or(metadata))
@@ -827,16 +871,22 @@ impl BlobStore {
         doc_id: &str,
         hashes: HashSet<String>,
     ) -> Result<(), String> {
-        let dropped: Vec<String> = {
+        let (dropped, changed): (Vec<String>, bool) = {
             let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
             let old = refs
                 .insert((ws.clone(), doc_id.to_string()), hashes.clone())
                 .unwrap_or_default();
-            old.difference(&hashes).cloned().collect()
+            let changed = old != hashes;
+            (old.difference(&hashes).cloned().collect(), changed)
         };
         self.save_doc_refs()?;
         for h in dropped {
             self.release_acl_if_unreferenced(ws, &h)?;
+        }
+        // JP-232: a changed ref set alters the workspace ledger (added hashes
+        // won't have fired a release signal). Coalesced by the mirror worker.
+        if changed {
+            self.mark_ledger_dirty(ws);
         }
         Ok(())
     }
@@ -844,15 +894,21 @@ impl BlobStore {
     /// Drop all of a document's blob references (called on doc delete) and
     /// release/GC anything the workspace no longer references.
     pub fn release_doc_refs(&self, ws: &WorkspaceId, doc_id: &str) -> Result<(), String> {
-        let dropped: Vec<String> = {
+        let (dropped, existed): (Vec<String>, bool) = {
             let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
-            refs.remove(&(ws.clone(), doc_id.to_string()))
-                .map(|s| s.into_iter().collect())
-                .unwrap_or_default()
+            match refs.remove(&(ws.clone(), doc_id.to_string())) {
+                Some(s) => (s.into_iter().collect(), true),
+                None => (Vec::new(), false),
+            }
         };
         self.save_doc_refs()?;
         for h in dropped {
             self.release_acl_if_unreferenced(ws, &h)?;
+        }
+        // JP-232: the doc-ref row is gone — reflect it in the ledger even if no
+        // ACL was released (another doc may still reference the same hashes).
+        if existed {
+            self.mark_ledger_dirty(ws);
         }
         Ok(())
     }
@@ -950,6 +1006,7 @@ impl BlobStore {
         };
         if removed {
             self.save_acls()?;
+            self.mark_ledger_dirty(ws);
             log::info!("released blob ACL {}/{}", ws.as_str(), hash);
             if self.per_workspace_objects() {
                 // s3: this workspace's object is its own — reclaim it now,
@@ -975,6 +1032,24 @@ impl BlobStore {
     /// store is shared, when `[storage] backend = "s3"`.
     pub fn set_object_delete_sink(&mut self, tx: UnboundedSender<(WorkspaceId, String)>) {
         self.object_delete_tx = Some(tx);
+    }
+
+    /// Install the JP-232 ledger-mirror sink (object-storage mode). A workspace
+    /// whose bookkeeping changes is sent here for a background worker to PUT its
+    /// `blob_ledger.json` to R2. Called once at startup, before the store is
+    /// shared.
+    pub fn set_ledger_mirror_sink(&mut self, tx: UnboundedSender<WorkspaceId>) {
+        self.ledger_mirror_tx = Some(tx);
+    }
+
+    /// Signal that `ws`'s blob bookkeeping changed and its R2 ledger should be
+    /// re-written. Best-effort: a closed channel (worker gone) is dropped. No-op
+    /// in filesystem mode. Multiple signals coalesce — the worker re-reads live
+    /// state via [`Self::ledger_for_workspace`] at process time.
+    pub(crate) fn mark_ledger_dirty(&self, ws: &WorkspaceId) {
+        if let Some(tx) = &self.ledger_mirror_tx {
+            let _ = tx.send(ws.clone());
+        }
     }
 
     /// Whether the store reclaims bytes per workspace (s3 object mode) vs. the
@@ -1132,6 +1207,157 @@ impl BlobStore {
             log::info!("blob {} orphaned; deferring GC by {}s", hash, grace);
         }
         Ok(())
+    }
+
+    // ---- JP-232: per-workspace durable blob ledger ----
+
+    /// Whether `ws` already has any in-memory bookkeeping (an ACL grant or a
+    /// per-doc reference). On a healthy restart the on-volume sidecars populate
+    /// these at boot, so a `true` here means recovery can be skipped; an empty
+    /// `false` means the workspace is cold on this pod and should be recovered
+    /// from R2 (JP-232).
+    pub fn has_workspace_bookkeeping(&self, ws: &WorkspaceId) -> bool {
+        if self
+            .acls
+            .read()
+            .map(|a| a.iter().any(|(w, _)| w == ws))
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        self.doc_refs
+            .read()
+            .map(|r| r.keys().any(|(w, _)| w == ws))
+            .unwrap_or(false)
+    }
+
+    /// Serialize `ws`'s slice of the bookkeeping into a [`WorkspaceBlobLedger`]
+    /// (read-only; no mutation). The blob set is every hash the workspace holds
+    /// an ACL for — exactly what [`Self::get_workspace_size`] meters.
+    pub fn ledger_for_workspace(&self, ws: &WorkspaceId) -> WorkspaceBlobLedger {
+        let acls: Vec<String> = self
+            .acls
+            .read()
+            .map(|a| a.iter().filter(|(w, _)| w == ws).map(|(_, h)| h.clone()).collect())
+            .unwrap_or_default();
+        let doc_refs: Vec<DocRefRow> = self
+            .doc_refs
+            .read()
+            .map(|r| {
+                r.iter()
+                    .filter(|((w, _), _)| w == ws)
+                    .map(|((w, doc_id), hashes)| DocRefRow {
+                        workspace: w.clone(),
+                        doc_id: doc_id.clone(),
+                        hashes: hashes.iter().cloned().collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let blobs: Vec<LedgerBlob> = {
+            let index = match self.index.read() {
+                Ok(g) => g,
+                Err(_) => return WorkspaceBlobLedger { acls, doc_refs, blobs: Vec::new() },
+            };
+            acls.iter()
+                .filter_map(|hash| {
+                    index.get(hash).map(|m| LedgerBlob {
+                        hash: m.hash.clone(),
+                        size: m.size,
+                        mime_type: m.mime_type.clone(),
+                        created_at: m.created_at,
+                        uploaded_by: m.uploaded_by.clone(),
+                    })
+                })
+                .collect()
+        };
+        WorkspaceBlobLedger { acls, doc_refs, blobs }
+    }
+
+    /// Merge a restored [`WorkspaceBlobLedger`] into the live maps and persist
+    /// the on-volume sidecars (JP-232 cold recovery). **Additive** — never
+    /// removes another workspace's state, and never overwrites an existing index
+    /// entry (a live blob's metadata wins over the ledger's). The orphan-grace
+    /// maps are intentionally untouched: recovery starts with no pending
+    /// deferrals. Does **not** signal a ledger re-write (we just loaded it).
+    pub fn install_ledger(&self, ws: &WorkspaceId, ledger: WorkspaceBlobLedger) -> Result<(), String> {
+        {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            for b in &ledger.blobs {
+                index.entry(b.hash.clone()).or_insert_with(|| BlobMetadata {
+                    hash: b.hash.clone(),
+                    size: b.size,
+                    mime_type: b.mime_type.clone(),
+                    created_at: b.created_at,
+                    uploaded_by: b.uploaded_by.clone(),
+                });
+            }
+        }
+        {
+            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            for hash in &ledger.acls {
+                acls.insert((ws.clone(), hash.clone()));
+            }
+        }
+        {
+            let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
+            for row in &ledger.doc_refs {
+                refs.insert(
+                    (ws.clone(), row.doc_id.clone()),
+                    row.hashes.iter().cloned().collect(),
+                );
+            }
+        }
+        self.save_index()?;
+        self.save_acls()?;
+        self.save_doc_refs()?;
+        log::info!(
+            "JP-232 restored blob ledger for {}: {} acl(s), {} doc-ref row(s)",
+            ws.as_str(),
+            ledger.acls.len(),
+            ledger.doc_refs.len()
+        );
+        Ok(())
+    }
+
+    /// Reconstruct one document's blob bookkeeping from its `blobReferences`
+    /// (JP-232 disaster fallback, used when no R2 ledger exists). `blobs` is the
+    /// per-hash `(size, mime)` read from the object store's HEAD. **Release-free**
+    /// — it only grants ACLs, records index metadata, and seeds the doc-ref set
+    /// (via [`Self::seed_doc_refs`]); it never runs the GC path. The caller
+    /// requests a single ledger write after the whole workspace is rebuilt.
+    pub fn reconstruct_doc_blobs(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &str,
+        blobs: Vec<(String, u64, String)>,
+    ) -> Result<(), String> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let hashes: HashSet<String> = blobs.iter().map(|(h, _, _)| h.clone()).collect();
+        {
+            let mut index = self.index.write().map_err(|e| e.to_string())?;
+            for (hash, size, mime) in &blobs {
+                index.entry(hash.clone()).or_insert_with(|| BlobMetadata {
+                    hash: hash.clone(),
+                    size: *size,
+                    mime_type: mime.clone(),
+                    created_at: now,
+                    uploaded_by: String::new(),
+                });
+            }
+        }
+        {
+            let mut acls = self.acls.write().map_err(|e| e.to_string())?;
+            for (hash, _, _) in &blobs {
+                acls.insert((ws.clone(), hash.clone()));
+            }
+        }
+        self.save_index()?;
+        self.save_acls()?;
+        self.seed_doc_refs(ws, doc_id, hashes)
     }
 }
 
@@ -1739,5 +1965,84 @@ mod tests {
             assert_eq!(store.sweep_unreferenced(), 0);
             assert!(store.exists(&ws, &h));
         }
+    }
+
+    // ---- JP-232: per-workspace ledger round-trip + reconstruct fallback ----
+
+    // The core volume-loss case, modeled without R2: build a workspace's
+    // bookkeeping, snapshot it to a ledger, then `install_ledger` into a *fresh*
+    // store (the recycled volume). Reads, refcounts, and quota must all survive,
+    // and the GC must not reclaim a blob still referenced by an un-touched doc.
+    #[test]
+    fn ledger_round_trips_acls_refs_quota_and_survives_gc() {
+        let ws = WorkspaceId::from_configured("alpha").unwrap();
+        let a = b"shared file A"; // referenced by docA + docB
+        let ha = BlobStore::compute_hash(a);
+        let b = b"file B only in docA";
+        let hb = BlobStore::compute_hash(b);
+
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.save_blob(&ws, &ha, a, "image/png", "u1").unwrap();
+        store.save_blob(&ws, &hb, b, "text/plain", "u1").unwrap();
+        store.sync_doc_refs(&ws, "docA", refs(&[ha.as_str(), hb.as_str()])).unwrap();
+        store.sync_doc_refs(&ws, "docB", refs(&[ha.as_str()])).unwrap();
+        let expected_size = store.get_workspace_size(&ws);
+
+        let ledger = store.ledger_for_workspace(&ws);
+        assert_eq!(ledger.acls.len(), 2);
+        assert_eq!(ledger.blobs.len(), 2);
+        assert_eq!(ledger.doc_refs.len(), 2);
+
+        // Recycled machine: fresh volume, restore the ledger.
+        let dir2 = tempdir().unwrap();
+        let restored = BlobStore::new(dir2.path().to_path_buf());
+        restored.install_ledger(&ws, ledger).unwrap();
+
+        // Reads + quota survive (mime/size round-trip at full fidelity).
+        assert!(restored.exists(&ws, &ha));
+        assert!(restored.exists(&ws, &hb));
+        assert_eq!(restored.get_workspace_size(&ws), expected_size);
+        assert_eq!(restored.get_metadata(&ws, &ha).unwrap().mime_type, "image/png");
+
+        // A sweep right after recovery must reclaim nothing (full ref graph).
+        assert_eq!(restored.sweep_unreferenced(), 0);
+        assert!(restored.exists(&ws, &ha));
+
+        // Acceptance: dropping docA must NOT reclaim `ha` (docB still refs it),
+        // but `hb` (docA-only) is correctly released.
+        restored.release_doc_refs(&ws, "docA").unwrap();
+        assert!(restored.exists(&ws, &ha), "shared blob still referenced by docB");
+        assert!(!restored.exists(&ws, &hb), "docA-only blob correctly reclaimed");
+        assert_eq!(restored.get_workspace_size(&ws), a.len() as u64);
+    }
+
+    // The disaster fallback (no ledger): rebuild a doc's bookkeeping directly
+    // from its hashes + HEAD sizes/mimes. Release-free; quota + reads correct.
+    #[test]
+    fn reconstruct_doc_blobs_seeds_refs_acls_and_quota() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::from_configured("beta").unwrap();
+        let h1 = "a".repeat(64);
+        let h2 = "b".repeat(64);
+
+        store
+            .reconstruct_doc_blobs(
+                &ws,
+                "doc1",
+                vec![
+                    (h1.clone(), 100, "image/png".to_string()),
+                    (h2.clone(), 200, "application/pdf".to_string()),
+                ],
+            )
+            .unwrap();
+
+        assert!(store.exists(&ws, &h1));
+        assert!(store.exists(&ws, &h2));
+        assert_eq!(store.get_workspace_size(&ws), 300);
+        assert_eq!(store.get_metadata(&ws, &h1).unwrap().mime_type, "image/png");
+        // Release-free: the freshly-seeded refs keep both blobs through a sweep.
+        assert_eq!(store.sweep_unreferenced(), 0);
     }
 }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -739,6 +739,12 @@ impl ServerState {
         self.tenancy.limits.max_blob_bytes
     }
 
+    /// Host allowlist for the generic blob ingest-from-URL endpoint
+    /// (`[tenancy.limits] blob_ingest_allowed_hosts`). Empty = endpoint disabled.
+    pub(crate) fn blob_ingest_allowed_hosts(&self) -> &[String] {
+        &self.tenancy.limits.blob_ingest_allowed_hosts
+    }
+
     /// Snapshot of per-workspace live connection counts (editor/viewer
     /// split), for the metering debug log.
     pub(crate) async fn workspace_conn_snapshot(&self) -> HashMap<WorkspaceId, WorkspaceConnCounts> {

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -108,6 +108,48 @@ async fn run_blob_delete_worker(
     }
 }
 
+/// Default MIME for a blob whose stored content-type can't be read during the
+/// JP-232 reconstruct fallback. Display-only; never affects GC or quota.
+fn default_blob_mime() -> String {
+    "application/octet-stream".to_string()
+}
+
+/// Background worker that mirrors per-workspace **blob ledgers** to R2 (JP-232).
+/// Each bookkeeping change sends the workspace id here; the worker coalesces a
+/// burst (drains the backlog into a dedup set — e.g. a startup sweep releasing
+/// many ACLs) and PUTs each workspace's current `blob_ledger.json` once,
+/// re-reading live state via [`BlobStore::ledger_for_workspace`] at processing
+/// time. Best-effort: a failed PUT is logged and dropped — the next change
+/// re-enqueues and reconstruct-from-docs is the disaster backstop. Exits when
+/// the sink is dropped (server shutdown).
+async fn run_blob_ledger_worker(
+    mut rx: mpsc::UnboundedReceiver<WorkspaceId>,
+    blob_store: Arc<BlobStore>,
+    s3: Arc<S3Backend>,
+) {
+    while let Some(ws) = rx.recv().await {
+        let mut dirty: HashSet<WorkspaceId> = HashSet::new();
+        dirty.insert(ws);
+        while let Ok(more) = rx.try_recv() {
+            dirty.insert(more);
+        }
+        for ws in dirty {
+            let ledger = blob_store.ledger_for_workspace(&ws);
+            let bytes = match serde_json::to_vec(&ledger) {
+                Ok(b) => b,
+                Err(e) => {
+                    log::warn!("blob ledger serialize failed for {}: {}", ws.as_str(), e);
+                    continue;
+                }
+            };
+            let key = s3.blob_ledger_key(&ws);
+            if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                log::warn!("R2 blob ledger PUT failed for {}: {}", key, e);
+            }
+        }
+    }
+}
+
 /// Background worker that mirrors workspace **documents** to R2 (JP-200). The
 /// synchronous write paths enqueue a [`MirrorOp`] after each local write; this
 /// drains them in FIFO order and performs the async R2 PUT/DELETE, re-reading the
@@ -438,6 +480,14 @@ pub struct ServerState {
     /// of release builds. Phase 21.2.
     #[cfg(debug_assertions)]
     panic_tenant_trigger: Option<WorkspaceId>,
+    /// JP-232 cold-recovery once-gate. `blob_recovery_done` records the
+    /// workspaces whose blob bookkeeping has been restored/rebuilt this process;
+    /// `blob_recovery_locks` holds a per-workspace async mutex so concurrent
+    /// first-touches serialize *per workspace* (and a save can't race a half-done
+    /// recovery) while different workspaces recover in parallel. Both guard
+    /// short critical sections only — never held across an `.await`.
+    blob_recovery_done: std::sync::Mutex<HashSet<WorkspaceId>>,
+    blob_recovery_locks: std::sync::Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl ServerState {
@@ -464,15 +514,28 @@ impl ServerState {
             // transient reference-drop can be corrected without losing bytes.
             let mut bs = BlobStore::new(app_data_dir.clone());
             bs.set_gc_grace_secs(tenancy.limits.blob_gc_grace_secs);
-            // s3 mode: route reclaimed per-workspace objects to a background
-            // worker that DELETEs them from R2, keeping the sync GC chain sync.
-            if let Some(s3) = &s3 {
-                let (tx, rx) = mpsc::unbounded_channel();
-                bs.set_object_delete_sink(tx);
-                let s3 = s3.clone();
-                tokio::spawn(async move { run_blob_delete_worker(rx, s3).await });
+            // s3 mode: install the per-workspace object-delete (JP-127) and
+            // ledger-mirror (JP-232) sinks *before* sharing the store, then spawn
+            // their workers against the shared Arc — the ledger worker re-reads
+            // live state through a store handle, so the Arc must exist first.
+            let channels = if s3.is_some() {
+                let (del_tx, del_rx) = mpsc::unbounded_channel();
+                let (led_tx, led_rx) = mpsc::unbounded_channel();
+                bs.set_object_delete_sink(del_tx);
+                bs.set_ledger_mirror_sink(led_tx);
+                Some((del_rx, led_rx))
+            } else {
+                None
+            };
+            let bs = Arc::new(bs);
+            if let (Some(s3), Some((del_rx, led_rx))) = (s3.as_ref(), channels) {
+                let s3d = s3.clone();
+                tokio::spawn(async move { run_blob_delete_worker(del_rx, s3d).await });
+                let s3l = s3.clone();
+                let bsl = bs.clone();
+                tokio::spawn(async move { run_blob_ledger_worker(led_rx, bsl, s3l).await });
             }
-            Arc::new(bs)
+            bs
         };
         // JP-200: build the document store, wiring the R2 mirror sink + a
         // background worker when the s3 backend is active. The sender is also
@@ -520,6 +583,8 @@ impl ServerState {
             poison_guard,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
+            blob_recovery_done: std::sync::Mutex::new(HashSet::new()),
+            blob_recovery_locks: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -583,13 +648,192 @@ impl ServerState {
     /// returning `false` on the filesystem backend (caller falls through to its
     /// normal not-found handling).
     pub(crate) async fn ensure_doc_local(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        // JP-232: recover this workspace's blob bookkeeping before any restore.
+        // No-op (O(1)) on a healthy/already-recovered pod.
+        self.ensure_blob_bookkeeping(ws).await;
         if self.doc_store.get_metadata(ws, doc_id).is_some() {
             return true;
         }
-        match &self.s3 {
-            Some(s3) => self.doc_store.restore_doc_from(s3.as_ref(), ws, doc_id).await,
-            None => false,
+        let s3 = match &self.s3 {
+            Some(s3) => s3,
+            None => return false,
+        };
+        let restored = self.doc_store.restore_doc_from(s3.as_ref(), ws, doc_id).await;
+        if restored {
+            // JP-232: `install_restored_doc` bypasses the blob store, so re-seed
+            // this doc's blob references from the restored body. This keeps the
+            // refcount/quota correct and self-heals any ledger lag for this doc
+            // (the durable body is authoritative over a stale ledger).
+            if let Ok(doc) = self.doc_store.get_document(ws, doc_id) {
+                let hashes = crate::api::blob_refs_from_doc(&doc);
+                if !hashes.is_empty() {
+                    if let Err(e) = self.blob_store.seed_doc_refs(ws, doc_id.as_str(), hashes) {
+                        log::warn!(
+                            "JP-232 post-restore ref seed failed for {}/{}: {}",
+                            ws.as_str(),
+                            doc_id.as_str(),
+                            e
+                        );
+                    }
+                }
+            }
         }
+        restored
+    }
+
+    /// JP-232 cold-recovery: ensure `ws`'s blob bookkeeping (ACLs, per-doc
+    /// refcounts, size/mime) is present in memory before the workspace is served.
+    /// Idempotent + once-per-process per workspace, gated by a per-ws async mutex
+    /// so concurrent first-touches serialize (a save can't race a half-done
+    /// recovery) while different workspaces recover in parallel.
+    ///
+    /// Must be `await`ed at the top of every handler that **releases a blob ACL**
+    /// (doc save/delete) or **serves a blob** — `resolve_workspace` is sync and
+    /// the save path does not pass through `ensure_doc_local`, so this is the
+    /// explicit gate that makes blocking recovery safe.
+    ///
+    /// Recovery is **ledger-first**: restore `blob_ledger.json` from R2 directly
+    /// (fast, independent of the best-effort doc index); only when the ledger is
+    /// absent/corrupt does it fall back to walking the R2 doc corpus and rebuild
+    /// from each body's `blobReferences`. Filesystem mode and workspaces already
+    /// resident on this pod are no-ops.
+    pub(crate) async fn ensure_blob_bookkeeping(&self, ws: &WorkspaceId) {
+        // Fast path — already recovered/known this process.
+        if self.blob_recovery_done.lock().unwrap().contains(ws) {
+            return;
+        }
+        // Per-workspace gate: serialize recovery for *this* ws, parallel across ws.
+        let gate = {
+            let mut locks = self.blob_recovery_locks.lock().unwrap();
+            locks
+                .entry(ws.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .clone()
+        };
+        let _guard = gate.lock().await;
+        // Re-check under the gate — a concurrent first-touch may have finished.
+        if self.blob_recovery_done.lock().unwrap().contains(ws) {
+            return;
+        }
+
+        let s3 = match &self.s3 {
+            // Filesystem mode: bookkeeping lives only on the volume; nothing to
+            // recover from. Mark done so we never re-check.
+            None => {
+                self.blob_recovery_done.lock().unwrap().insert(ws.clone());
+                return;
+            }
+            Some(s3) => s3.clone(),
+        };
+        // Volume intact for this ws → the on-volume sidecars are authoritative;
+        // never walk R2. Either signal proves intactness: in-memory bookkeeping
+        // (sidecars loaded at boot), or any local document (the index + blob
+        // sidecars share the volume, so present docs ⇒ present sidecars; covers a
+        // blob-less workspace too, and JP-231-evicted docs keep their index row).
+        if self.blob_store.has_workspace_bookkeeping(ws)
+            || !self.doc_store.list_documents(ws).is_empty()
+        {
+            self.blob_recovery_done.lock().unwrap().insert(ws.clone());
+            return;
+        }
+
+        // Ledger-first.
+        match s3.get_object_at(&s3.blob_ledger_key(ws)).await {
+            Ok(Some(bytes)) => {
+                match serde_json::from_slice::<crate::server::blobs::WorkspaceBlobLedger>(&bytes) {
+                    Ok(ledger) => {
+                        if let Err(e) = self.blob_store.install_ledger(ws, ledger) {
+                            log::warn!("JP-232 ledger install failed for {}: {}", ws.as_str(), e);
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "JP-232 ledger for {} corrupt ({}); rebuilding from docs",
+                            ws.as_str(),
+                            e
+                        );
+                        self.reconstruct_blob_bookkeeping_from_docs(ws, &s3).await;
+                    }
+                }
+            }
+            Ok(None) => {
+                // No ledger — disaster fallback (or a workspace new to this pod
+                // that never wrote one). Rebuild from the durable doc corpus.
+                self.reconstruct_blob_bookkeeping_from_docs(ws, &s3).await;
+            }
+            Err(e) => {
+                // R2 unreachable: don't poison the done-set — leave the ws
+                // un-recovered so a later touch retries. (Readiness gating on R2
+                // is a separate follow-up.)
+                log::warn!("JP-232 ledger GET failed for {}: {} — will retry", ws.as_str(), e);
+                return;
+            }
+        }
+        self.blob_recovery_done.lock().unwrap().insert(ws.clone());
+    }
+
+    /// JP-232 disaster fallback: rebuild `ws`'s blob bookkeeping by walking its
+    /// R2 document corpus (no ledger). Restores the workspace index, then for
+    /// each doc reads the body from R2, extracts `blobReferences`, HEADs each
+    /// blob for size + content-type, and reconstructs ACLs/refs/index
+    /// release-free. Writes a fresh ledger at the end so the next cold boot
+    /// fast-paths. Best-effort per doc/blob — a single failure is logged, not
+    /// fatal.
+    async fn reconstruct_blob_bookkeeping_from_docs(&self, ws: &WorkspaceId, s3: &Arc<S3Backend>) {
+        self.doc_store.restore_workspace_index_from(s3.as_ref(), ws).await;
+        for meta in self.doc_store.list_documents(ws) {
+            let key = s3.doc_object_key(ws, &meta.id, "json");
+            let bytes = match s3.get_object_at(&key).await {
+                Ok(Some(b)) => b,
+                Ok(None) => continue,
+                Err(e) => {
+                    log::warn!("JP-232 reconstruct: R2 get {} failed: {}", key, e);
+                    continue;
+                }
+            };
+            let doc: serde_json::Value = match serde_json::from_slice(&bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!("JP-232 reconstruct: parse {} failed: {}", key, e);
+                    continue;
+                }
+            };
+            let hashes = crate::api::blob_refs_from_doc(&doc);
+            let mut blobs: Vec<(String, u64, String)> = Vec::with_capacity(hashes.len());
+            for h in hashes {
+                let (size, mime) = match s3.head_object_typed(ws, &h).await {
+                    Ok(Some((size, ct))) => (size, ct.unwrap_or_else(default_blob_mime)),
+                    // Bytes missing/unreadable in R2: still record the ref + ACL
+                    // (size 0) so GC never treats a referenced blob as orphaned;
+                    // size self-corrects on the next upload/finalize of that hash.
+                    Ok(None) => {
+                        log::warn!(
+                            "JP-232 reconstruct: blob {}/{} absent in R2; recording ref with size 0",
+                            ws.as_str(),
+                            h
+                        );
+                        (0, default_blob_mime())
+                    }
+                    Err(e) => {
+                        log::warn!("JP-232 reconstruct: HEAD {}/{} failed: {}", ws.as_str(), h, e);
+                        (0, default_blob_mime())
+                    }
+                };
+                blobs.push((h, size, mime));
+            }
+            if let Err(e) = self.blob_store.reconstruct_doc_blobs(ws, meta.id.as_str(), blobs) {
+                log::warn!(
+                    "JP-232 reconstruct: rebuild {}/{} failed: {}",
+                    ws.as_str(),
+                    meta.id.as_str(),
+                    e
+                );
+            }
+        }
+        // Persist the freshly-rebuilt bookkeeping as a ledger so subsequent cold
+        // boots take the fast path (and a blob-less ws converges to an empty one).
+        self.blob_store.mark_ledger_dirty(ws);
+        log::info!("JP-232 rebuilt blob bookkeeping for {} from doc corpus", ws.as_str());
     }
 
     /// JP-200: ensure a workspace's document index is locally populated,
@@ -597,6 +841,8 @@ impl ServerState {
     /// in-memory index (only restores when the workspace has nothing in memory),
     /// so it's safe to call before a listing.
     pub(crate) async fn ensure_workspace_index_local(&self, ws: &WorkspaceId) {
+        // JP-232: recover blob bookkeeping before serving a cold workspace listing.
+        self.ensure_blob_bookkeeping(ws).await;
         if !self.doc_store.list_documents(ws).is_empty() {
             return;
         }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -450,6 +450,42 @@ impl DocHandle {
         protocol::frame_update(update)
     }
 
+    /// The active-page z-order (`shapeOrder`) as a list of shape ids. Used by the
+    /// MCP `reorder_shapes` tool to validate a requested order is a permutation
+    /// of the current one before applying it.
+    pub fn shape_order(&self) -> Vec<String> {
+        let order = self.doc.get_or_insert_array("shapeOrder");
+        let txn = self.doc.transact();
+        order
+            .iter(&txn)
+            .filter_map(|o| match o {
+                yrs::Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Replace `shapeOrder` with `order` (clear + repush, one txn). The caller is
+    /// responsible for validating `order` is a permutation of the current ids
+    /// (see the MCP `reorder_shapes` tool) — this just applies it. Returns the
+    /// framed delta to broadcast; marks dirty.
+    pub fn set_shape_order(&self, order: &[String]) -> Vec<u8> {
+        let arr = self.doc.get_or_insert_array("shapeOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        let len = arr.len(&txn);
+        if len > 0 {
+            arr.remove_range(&mut txn, 0, len);
+        }
+        for id in order {
+            arr.push_back(&mut txn, Any::String(id.as_str().into()));
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
+    }
+
     /// Replace a page's prose by rebuilding its `prose:<page_id>` fragment from
     /// `html` in a single transaction (JP-238). Whole-page replace: clear the
     /// fragment, parse the HTML to PM nodes ([`prose_parse`]), and rebuild —

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -34,27 +34,27 @@ use super::prose_schema;
 /// Serialize every top-level block of `frag` to an HTML string.
 pub fn fragment_to_html<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> String {
     let mut out = String::new();
-    write_children(frag, txn, &mut out);
+    write_children(frag, txn, &mut out, 0);
     out
 }
 
-fn write_children<F, T>(frag: &F, txn: &T, out: &mut String)
+fn write_children<F, T>(frag: &F, txn: &T, out: &mut String, depth: usize)
 where
     F: XmlFragment,
     T: ReadTxn,
 {
     for node in frag.children(txn) {
-        write_node(&node, txn, out);
+        write_node(&node, txn, out, depth);
     }
 }
 
-fn write_node<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String) {
+fn write_node<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String, depth: usize) {
     match node {
-        XmlOut::Element(el) => write_element(el, txn, out),
+        XmlOut::Element(el) => write_element(el, txn, out, depth),
         XmlOut::Text(t) => write_text(t, txn, out),
         // PM doesn't nest bare fragments, but if one appears, recurse so no
         // content is lost.
-        XmlOut::Fragment(f) => write_children(f, txn, out),
+        XmlOut::Fragment(f) => write_children(f, txn, out, depth),
     }
 }
 
@@ -68,15 +68,22 @@ enum Block {
     Transparent,
 }
 
-fn write_element<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String) {
+fn write_element<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String, depth: usize) {
+    // Depth guard (JP-248): a live `prose:` fragment can be built arbitrarily
+    // deep via the raw WS sync path (bypassing the parser's cap), so cap the
+    // serialize recursion independently. Beyond the cap, stop descending — the
+    // deep remainder is omitted; real prose never approaches it.
+    if depth >= prose_schema::MAX_PROSE_DEPTH {
+        return;
+    }
     match block_for(el, txn) {
         Block::Wrap { open, close } => {
             out.push_str(&open);
-            write_children(el, txn, out);
+            write_children(el, txn, out, depth + 1);
             out.push_str(close);
         }
         Block::Void(html) => out.push_str(&html),
-        Block::Transparent => write_children(el, txn, out),
+        Block::Transparent => write_children(el, txn, out, depth + 1),
     }
 }
 
@@ -390,5 +397,21 @@ mod tests {
     fn empty_fragment_is_empty_string() {
         let html = render(|_doc, _frag, _txn| {});
         assert_eq!(html, "");
+    }
+
+    #[test]
+    fn deeply_nested_fragment_serializes_without_overflow() {
+        // A live fragment can be built arbitrarily deep via the raw WS sync path
+        // (bypassing the parser cap), so serialize must be depth-bounded too
+        // (JP-248). 10k nested blockquotes would overflow an uncapped serialize;
+        // this test *completing* is the proof.
+        let html = render(|_doc, frag, txn| {
+            let mut parent = frag.push_back(txn, XmlElementPrelim::empty("blockquote"));
+            for _ in 0..10_000 {
+                parent = parent.push_back(txn, XmlElementPrelim::empty("blockquote"));
+            }
+            parent.push_back(txn, XmlTextPrelim::new("deep"));
+        });
+        assert!(html.starts_with("<blockquote>"), "bounded output produced: {}", &html[..html.len().min(40)]);
     }
 }

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -250,7 +250,18 @@ fn build_tree(tokens: &[Token]) -> Vec<HtmlNode> {
                 &mut roots,
                 HtmlNode::Element { tag: tag.clone(), attrs: attrs.clone(), children: Vec::new() },
             ),
-            Token::Open(tag, attrs) => stack.push((tag.clone(), attrs.clone(), Vec::new())),
+            Token::Open(tag, attrs) => {
+                // Depth guard (JP-248): refuse to nest past MAX_PROSE_DEPTH. This
+                // bounds the produced tree — so map_blocks/collect_inline and the
+                // downstream build_prose_* recursion can't overflow the stack —
+                // and caps the O(stack-depth) `rposition` scan below. Beyond the
+                // cap the open is dropped: later text attaches to the current
+                // (depth-capped) parent and the unmatched close is ignored
+                // leniently, so text is preserved. Real prose never nears 64.
+                if stack.len() < prose_schema::MAX_PROSE_DEPTH {
+                    stack.push((tag.clone(), attrs.clone(), Vec::new()));
+                }
+            }
             Token::Close(tag) => {
                 // Pop until we match the tag (lenient: tolerate stray/misnested
                 // closes by closing the nearest matching open).
@@ -495,5 +506,29 @@ mod tests {
         let PmChild::Text { marks, .. } = &b[0].children[0] else { panic!() };
         let names: Vec<&str> = marks.iter().map(|m| m.name.as_str()).collect();
         assert_eq!(names, vec!["bold", "italic"]);
+    }
+
+    #[test]
+    fn pathologically_deep_input_is_bounded_not_overflow() {
+        // 100k nested tags would overflow an uncapped recursive parse. The
+        // build_tree depth guard bounds the tree (JP-248); this test merely
+        // *completing* proves the stack is bounded — and text is preserved.
+        let depth = 100_000;
+        let html = format!("{}content{}", "<div>".repeat(depth), "</div>".repeat(depth));
+        let blocks = html_to_blocks(&html);
+
+        fn text_of(n: &PmNode, out: &mut String) {
+            for c in &n.children {
+                match c {
+                    PmChild::Text { text, .. } => out.push_str(text),
+                    PmChild::Node(inner) => text_of(inner, out),
+                }
+            }
+        }
+        let mut text = String::new();
+        for b in &blocks {
+            text_of(b, &mut text);
+        }
+        assert!(text.contains("content"), "text survives the depth cap");
     }
 }

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -8,6 +8,14 @@
 //! void nodes (`<br>`/`<hr>`/`<img>`), and the `link` mark (`href`) — are
 //! handled explicitly by each side; everything here is the symmetric core.
 
+/// Max prose nesting depth honored by the parser ([`super::prose_parse`]) and
+/// the serializer ([`super::prose_html`]) — a safety bound, **not** a content
+/// limit (JP-248). Real prose nests <~10 deep; 64 is generous headroom while
+/// keeping recursion (and the parser's lenient-close scan) bounded so a
+/// pathologically deep input on the public `/mcp` surface can't overflow the
+/// stack and abort the process. Beyond it, nesting is truncated (never panics).
+pub const MAX_PROSE_DEPTH: usize = 64;
+
 /// Simple block nodes whose PM type ↔ HTML wrapper tag round-trips 1:1 (children
 /// recurse inside). Read maps PM→HTML; write maps HTML→PM.
 pub const SIMPLE_BLOCKS: &[(&str, &str)] = &[

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -159,6 +159,7 @@ impl Harness {
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
+                None, // JP-249: MCP read limiter (unlimited in this test)
                 self.issuer.auth_state(),
                 "default".to_string(),
                 sync_registry,

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -57,6 +57,7 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
             server.panic_counter_handle(),
             server.rate_limit_rejections_handle(),
             server.build_write_limiter().await,
+            None, // JP-249: MCP read limiter (unlimited in this test)
             issuer.auth_state(),
             "default".to_string(),
             server.sync_registry_handle().await,

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -41,7 +41,7 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         Arc::new(move |ws: &WorkspaceId, _doc| {
             routed_sink.lock().unwrap().push(ws.as_str().to_string());
         });
-    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed).expect("mount");
+    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed, None).expect("mount");
     let static_token = mount.token();
     server.set_mcp_public_mount(mount).await;
 

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -37,6 +37,16 @@ impl Harness {
         let server = Arc::new(WebSocketServer::new());
         server.set_app_data_dir(data_dir.clone()).await;
         server.set_auth(issuer.auth_state()).await;
+        // JP-249: build the MCP read limiter from the tenancy limits before
+        // `tenancy` is moved into `set_tenancy` (mirrors main.rs).
+        let mcp_read_limiter = if tenancy.limits.reads_per_sec == 0 {
+            None
+        } else {
+            Some(Arc::new(docushark_relay::server::build_workspace_limiter(
+                tenancy.limits.reads_per_sec,
+                tenancy.limits.reads_burst,
+            )))
+        };
         server.set_tenancy(tenancy).await;
         server
             .set_config(ServerConfig {
@@ -80,6 +90,7 @@ impl Harness {
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
+                mcp_read_limiter,
                 issuer.auth_state(),
                 "default".to_string(),
                 sync_registry,
@@ -183,6 +194,22 @@ impl Harness {
             .status()
     }
 
+    /// Fire one MCP `list_documents` read. Returns the HTTP status.
+    async fn mcp_list_documents(&self) -> reqwest::StatusCode {
+        let body = json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "docushark.list_documents", "arguments": {}}
+        });
+        reqwest::Client::new()
+            .post(format!("{}/mcp", self.mcp_base))
+            .bearer_auth(&self.mcp_token)
+            .json(&body)
+            .send()
+            .await
+            .expect("POST /mcp")
+            .status()
+    }
+
     async fn stop(self) {
         self.mcp.stop().await.expect("mcp stop");
         self.server.stop().await.expect("server stop");
@@ -238,6 +265,44 @@ async fn mcp_writes_burst_then_rate_limit_with_429() {
     assert_eq!(
         rejections, limited_count as u64,
         "relay_rate_limit_rejections_total ({rejections}) should match the 429 count ({limited_count})"
+    );
+
+    h.stop().await;
+}
+
+/// JP-249: MCP reads are clamped by a **separate** per-workspace bucket — a
+/// read-storm gets 429s without draining the write bucket (writes still pass).
+#[tokio::test]
+async fn mcp_reads_burst_then_rate_limit_independent_of_writes() {
+    let limits = LimitsConfig {
+        reads_per_sec: 1,
+        reads_burst: 2,
+        // Generous writes so the write path is never the bottleneck here.
+        ..LimitsConfig::default()
+    };
+    let tenancy = TenancyConfig {
+        mode: TenancyMode::Dedicated,
+        workspace_id: None,
+        limits,
+    };
+    let h = Harness::start(tenancy).await;
+    h.seed_doc_via_store("doc-1", "p1").await;
+
+    let mut statuses = Vec::new();
+    for _ in 0..6 {
+        statuses.push(h.mcp_list_documents().await);
+    }
+    let ok = statuses.iter().filter(|s| s.as_u16() == 200).count();
+    let limited = statuses.iter().filter(|s| s.as_u16() == 429).count();
+    assert!(ok >= 2, "read burst should pass >=2; statuses={statuses:?}");
+    assert!(limited >= 1, "reads past burst must 429; statuses={statuses:?}");
+
+    // Independence: the write bucket is untouched, so a write still passes even
+    // after the read bucket is drained.
+    assert_eq!(
+        h.mcp_add_shape("doc-1", "p1").await.as_u16(),
+        200,
+        "writes must be unaffected by a read-storm (separate bucket)"
     );
 
     h.stop().await;

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -619,6 +619,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             panic_counter,
             rate_limit_rejections,
             write_limiter,
+            None, // JP-249: MCP read limiter (unlimited in this test)
             relay.issuer.auth_state(),
             "default".to_string(),
             sync_registry,

--- a/src/index.css
+++ b/src/index.css
@@ -107,9 +107,12 @@
   /* ======================================================================
      Dimensional scale (JP-153) — canonical spacing / radius / type / control
      tokens. Mode-independent, so defined once here (no dark override). Values
-     are rem at the default 16px root (nothing sets `html { font-size }`), so
-     they map 1:1 onto the px the chrome used before this scale landed. Consume
-     these instead of hardcoding px; the long tail still migrates onto them.
+     are rem; the root font-size is scaled by `--ui-scale` (Appearance →
+     Interface size), so consuming these makes the chrome grow/shrink with that
+     control. Spacing + control heights are additionally scaled by
+     `--density-mult` (Appearance → Density). The canvas is flex/px-sized and
+     uses its own Camera, so neither affects it. Consume these instead of
+     hardcoding px; the long tail still migrates onto them.
      ====================================================================== */
 
   /* Font families */
@@ -118,17 +121,22 @@
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
     'Liberation Mono', monospace;
 
-  /* Spacing — 4px grid (rem /16) */
+  /* Density multiplier (Appearance → Density). 1 = Normal; the [data-density]
+     rules at the end of this file override it. Baked into spacing + control
+     tokens so density flows app-wide through the cascade — no per-rule sweep. */
+  --density-mult: 1;
+
+  /* Spacing — 4px grid (rem /16), scaled by --density-mult */
   --space-0: 0;
-  --space-0-5: 0.125rem;  /* 2px */
-  --space-1: 0.25rem;     /* 4px */
-  --space-1-5: 0.375rem;  /* 6px */
-  --space-2: 0.5rem;      /* 8px */
-  --space-3: 0.75rem;     /* 12px */
-  --space-4: 1rem;        /* 16px */
-  --space-5: 1.25rem;     /* 20px */
-  --space-6: 1.5rem;      /* 24px */
-  --space-8: 2rem;        /* 32px */
+  --space-0-5: calc(0.125rem * var(--density-mult));  /* 2px */
+  --space-1: calc(0.25rem * var(--density-mult));     /* 4px */
+  --space-1-5: calc(0.375rem * var(--density-mult));  /* 6px */
+  --space-2: calc(0.5rem * var(--density-mult));      /* 8px */
+  --space-3: calc(0.75rem * var(--density-mult));     /* 12px */
+  --space-4: calc(1rem * var(--density-mult));        /* 16px */
+  --space-5: calc(1.25rem * var(--density-mult));     /* 20px */
+  --space-6: calc(1.5rem * var(--density-mult));      /* 24px */
+  --space-8: calc(2rem * var(--density-mult));        /* 32px */
 
   /* Border radius */
   --radius-sm: 0.25rem;   /* 4px */
@@ -161,12 +169,12 @@
   --line-height-normal: 1.4;
   --line-height-relaxed: 1.5;
 
-  /* Control heights — buttons / inputs / selects (rem /16) */
-  --control-height-xs: 1.25rem;  /* 20px */
-  --control-height-sm: 1.5rem;   /* 24px */
-  --control-height-md: 1.75rem;  /* 28px */
-  --control-height-lg: 2rem;     /* 32px */
-  --control-height-xl: 2.25rem;  /* 36px */
+  /* Control heights — buttons / inputs / selects (rem /16), scaled by --density-mult */
+  --control-height-xs: calc(1.25rem * var(--density-mult));  /* 20px */
+  --control-height-sm: calc(1.5rem * var(--density-mult));   /* 24px */
+  --control-height-md: calc(1.75rem * var(--density-mult));  /* 28px */
+  --control-height-lg: calc(2rem * var(--density-mult));     /* 32px */
+  --control-height-xl: calc(2.25rem * var(--density-mult));  /* 36px */
 }
 
 /* --- Semantic: DARK (navy-native; elevation = lighter navy, not black) --- */
@@ -313,4 +321,25 @@ body {
 [data-accent='rose'] {
   --color-primary-light: color-mix(in srgb, var(--color-primary) 14%, transparent);
   --color-primary-alpha: color-mix(in srgb, var(--color-primary) 32%, transparent);
+}
+
+/* ===========================================================================
+ * Interface size + Density (Settings → Appearance)
+ * ---------------------------------------------------------------------------
+ * Interface size scales the rem root, so all rem-based chrome (spacing, control
+ * heights, type tokens) grows/shrinks together. Density adjusts only spacing +
+ * control heights via --density-mult. Both ride the rem token system; the
+ * canvas is flex/px-sized and maps input through its own Camera, so it is never
+ * affected (no zoom on the canvas or any of its ancestors).
+ * ======================================================================== */
+
+html {
+  font-size: calc(100% * var(--ui-scale, 1));
+}
+
+[data-density='compact'] {
+  --density-mult: 0.85;
+}
+[data-density='spacious'] {
+  --density-mult: 1.15;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,7 @@
   --color-primary-dark: #0e1c30;  /* hover / pressed */
   --color-primary-light: #e9edf3; /* soft navy wash — active backgrounds */
   --color-primary-alpha: rgba(31, 51, 84, 0.18); /* focus ring */
+  --color-on-primary: #f6f4ec;    /* text/icons on a solid primary fill (paper on navy) */
 
   /* Semantic status (fills + readable text) */
   --success: #2d8f63;
@@ -204,6 +205,7 @@
   --color-primary-dark: #c9a262;  /* solid gold (hover / pressed) */
   --color-primary-light: rgba(224, 198, 144, 0.14);
   --color-primary-alpha: rgba(224, 198, 140, 0.30);
+  --color-on-primary: #0a1525;    /* ink on the gold primary fill */
 
   /* Semantic status — fills stay solid; text is lightened for navy */
   --success: #2d8f63;
@@ -265,62 +267,6 @@ body {
 /* Deepest layer of the dark elevation ladder sits behind every surface. */
 [data-theme="dark"] body {
   background-color: var(--navy-1000);
-}
-
-/* ===========================================================================
- * Accent color (Settings → Appearance → Accent color)
- * ---------------------------------------------------------------------------
- * Swaps the unified `--color-primary*` tokens (links, active borders, focus
- * rings, primary buttons, selected controls, the active layout chip — anything
- * that consumes them). `data-accent="default"` adds no override, so the theme's
- * own accent stands (navy in light, gold in dark). The CTA gold (`--color-cta*`)
- * is intentionally left untouched. Per-accent hues are tuned for contrast on
- * the warm-paper (light) and navy (dark) surfaces respectively.
- * ======================================================================== */
-
-[data-accent='teal'] {
-  --color-primary: #0f766e;
-  --color-primary-dark: #115e59;
-}
-[data-accent='violet'] {
-  --color-primary: #6d28d9;
-  --color-primary-dark: #5b21b6;
-}
-[data-accent='amber'] {
-  --color-primary: #b45309;
-  --color-primary-dark: #92400e;
-}
-[data-accent='rose'] {
-  --color-primary: #be123c;
-  --color-primary-dark: #9f1239;
-}
-
-[data-theme='dark'][data-accent='teal'] {
-  --color-primary: #5eead4;
-  --color-primary-dark: #2dd4bf;
-}
-[data-theme='dark'][data-accent='violet'] {
-  --color-primary: #c4b5fd;
-  --color-primary-dark: #a78bfa;
-}
-[data-theme='dark'][data-accent='amber'] {
-  --color-primary: #fcd34d;
-  --color-primary-dark: #fbbf24;
-}
-[data-theme='dark'][data-accent='rose'] {
-  --color-primary: #fda4af;
-  --color-primary-dark: #fb7185;
-}
-
-/* Derive the soft wash + focus-ring tints from the chosen hue so they stay in
-   sync without hand-tuning each accent (only non-default accents; the theme
-   defaults keep their hand-tuned values). */
-[data-accent='teal'],
-[data-accent='violet'],
-[data-accent='amber'],
-[data-accent='rose'] {
-  --color-primary-light: color-mix(in srgb, var(--color-primary) 14%, transparent);
-  --color-primary-alpha: color-mix(in srgb, var(--color-primary) 32%, transparent);
 }
 
 /* ===========================================================================

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,9 @@
   --color-cta-text: var(--navy-1000);
   --color-cta-hover: var(--brand-gold-deep);
 
+  /* Native form controls / scrollbars follow the active theme. */
+  color-scheme: light;
+
   /* --- Semantic: LIGHT (warm paper + navy accent) --- */
   /* Backgrounds */
   --bg-primary: #f9f6ee;          /* surface — cards, panels, inputs (soft warm white) */
@@ -168,6 +171,7 @@
 
 /* --- Semantic: DARK (navy-native; elevation = lighter navy, not black) --- */
 [data-theme="dark"] {
+  color-scheme: dark;
   /* Backgrounds — elevation ladder: app(body) #060c17 < page #0a1525 <
      surface #0e1c30 < raised #16273f */
   --bg-primary: #0e1c30;          /* surface — cards, panels, inputs */

--- a/src/index.css
+++ b/src/index.css
@@ -258,3 +258,59 @@ body {
 [data-theme="dark"] body {
   background-color: var(--navy-1000);
 }
+
+/* ===========================================================================
+ * Accent color (Settings → Appearance → Accent color)
+ * ---------------------------------------------------------------------------
+ * Swaps the unified `--color-primary*` tokens (links, active borders, focus
+ * rings, primary buttons, selected controls, the active layout chip — anything
+ * that consumes them). `data-accent="default"` adds no override, so the theme's
+ * own accent stands (navy in light, gold in dark). The CTA gold (`--color-cta*`)
+ * is intentionally left untouched. Per-accent hues are tuned for contrast on
+ * the warm-paper (light) and navy (dark) surfaces respectively.
+ * ======================================================================== */
+
+[data-accent='teal'] {
+  --color-primary: #0f766e;
+  --color-primary-dark: #115e59;
+}
+[data-accent='violet'] {
+  --color-primary: #6d28d9;
+  --color-primary-dark: #5b21b6;
+}
+[data-accent='amber'] {
+  --color-primary: #b45309;
+  --color-primary-dark: #92400e;
+}
+[data-accent='rose'] {
+  --color-primary: #be123c;
+  --color-primary-dark: #9f1239;
+}
+
+[data-theme='dark'][data-accent='teal'] {
+  --color-primary: #5eead4;
+  --color-primary-dark: #2dd4bf;
+}
+[data-theme='dark'][data-accent='violet'] {
+  --color-primary: #c4b5fd;
+  --color-primary-dark: #a78bfa;
+}
+[data-theme='dark'][data-accent='amber'] {
+  --color-primary: #fcd34d;
+  --color-primary-dark: #fbbf24;
+}
+[data-theme='dark'][data-accent='rose'] {
+  --color-primary: #fda4af;
+  --color-primary-dark: #fb7185;
+}
+
+/* Derive the soft wash + focus-ring tints from the chosen hue so they stay in
+   sync without hand-tuning each accent (only non-default accents; the theme
+   defaults keep their hand-tuned values). */
+[data-accent='teal'],
+[data-accent='violet'],
+[data-accent='amber'],
+[data-accent='rose'] {
+  --color-primary-light: color-mix(in srgb, var(--color-primary) 14%, transparent);
+  --color-primary-alpha: color-mix(in srgb, var(--color-primary) 32%, transparent);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,9 @@ import './index.css';
 // + reduced-motion root attribute via the CSS module's sibling import below.
 import './ui/adaptive-motion.css';
 import './platform/adaptiveBudget';
+// Mirror the persisted appearance prefs (accent + motion) onto the document at
+// boot, before first paint — see applyAppearance (Abstraction A).
+import './ui/appearance/applyAppearance';
 
 function mountApp(): void {
   const root = document.getElementById('root');

--- a/src/platform/adaptiveBudget.test.ts
+++ b/src/platform/adaptiveBudget.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { refreshAdaptiveBudget } from './adaptiveBudget';
+import { refreshAdaptiveBudget, setMotionPreference } from './adaptiveBudget';
 
 interface DeviceEnv {
   coarsePointer?: boolean;
@@ -76,5 +76,39 @@ describe('adaptiveBudget', () => {
     expect(budget.reduceMotion).toBe(true);
     expect(budget.cursorBroadcastMs).toBe(120);
     expect(document.documentElement.dataset['reducedMotion']).toBe('true');
+  });
+});
+
+describe('adaptiveBudget — user motion preference', () => {
+  // Module state persists between cases; reset to the default after each.
+  afterEach(() => {
+    setMotionPreference('system');
+  });
+
+  it("'reduced' forces reduceMotion + the attribute, even when the OS does not", () => {
+    setupDevice({ reduceMotion: false });
+    const budget = setMotionPreference('reduced');
+    expect(budget.reduceMotion).toBe(true);
+    expect(document.documentElement.dataset['reducedMotion']).toBe('true');
+  });
+
+  it("'full' overrides the OS reduce-motion setting (no reduction, no attribute)", () => {
+    setupDevice({ reduceMotion: true });
+    const budget = setMotionPreference('full');
+    expect(budget.reduceMotion).toBe(false);
+    expect(document.documentElement.dataset['reducedMotion']).toBeUndefined();
+  });
+
+  it("'full' overrides the low-power heuristic too", () => {
+    setupDevice({ cores: 2, memory: 2 });
+    const budget = setMotionPreference('full');
+    expect(budget.reduceMotion).toBe(false);
+  });
+
+  it("'system' follows the OS setting", () => {
+    setupDevice({ reduceMotion: true });
+    expect(setMotionPreference('system').reduceMotion).toBe(true);
+    setupDevice({ reduceMotion: false });
+    expect(refreshAdaptiveBudget().reduceMotion).toBe(false);
   });
 });

--- a/src/platform/adaptiveBudget.ts
+++ b/src/platform/adaptiveBudget.ts
@@ -9,17 +9,30 @@
  *
  * Detection is **boot-time**: touch and power are sampled once at module load
  * (they effectively never change mid-session), so the snapshot is memoized.
- * The one exception is motion — the OS "reduce motion" toggle is live, so we
- * listen for `prefers-reduced-motion` changes and re-derive on the fly. CSS
- * can express the media-query half directly, but not the `isLowPower` half, so
- * we mirror the resolved `reduceMotion` onto a `data-reduced-motion` root
- * attribute that `adaptive-motion.css` keys off.
+ * The one exception is motion — both the OS "reduce motion" toggle and the
+ * user's in-app Motion preference are live, so we re-derive on either change.
+ * `data-reduced-motion` on the root is the *single* authority that
+ * `adaptive-motion.css` keys off (this module is its only writer); the CSS no
+ * longer also reads `@media (prefers-reduced-motion)` directly, so an explicit
+ * "Full" preference can override the OS everywhere.
  *
  * Browser-native only (reads `device`, which uses `matchMedia` / `navigator`),
  * so this tree-shakes identically into both the Tauri and PWA shells.
  */
 
 import { device } from './device';
+
+/**
+ * User-facing motion preference (Settings → Appearance → Motion):
+ *  - `system`  — follow the OS reduce-motion setting (and low-power heuristic).
+ *  - `reduced` — always minimize motion, regardless of OS.
+ *  - `full`    — always animate, overriding the OS setting and the low-power
+ *               heuristic (an explicit opt-in).
+ *
+ * Fed in via `setMotionPreference` by the appearance applier so this module
+ * stays the single authority over `data-reduced-motion`.
+ */
+export type MotionPreference = 'system' | 'reduced' | 'full';
 
 export interface AdaptiveBudget {
   /** Skip non-essential animation (OS reduce-motion or a low-power device). */
@@ -37,9 +50,20 @@ const DEFAULT_CURSOR_MS = 33;
 /** Grab-zone enlargement on coarse pointers (handles, snap, drag threshold). */
 const TOUCH_HIT_TARGET_SCALE = 1.6;
 
+/** The live user preference; updated via `setMotionPreference`. */
+let motionPreference: MotionPreference = 'system';
+
+/** Resolve the effective reduce-motion flag from the preference + device. */
+function resolveReduceMotion(): boolean {
+  if (motionPreference === 'reduced') return true;
+  if (motionPreference === 'full') return false;
+  // 'system': honor the OS toggle and the low-power heuristic.
+  return device.prefersReducedMotion() || device.isLowPower();
+}
+
 function deriveBudget(): AdaptiveBudget {
   return {
-    reduceMotion: device.prefersReducedMotion() || device.isLowPower(),
+    reduceMotion: resolveReduceMotion(),
     cursorBroadcastMs: device.isLowPower() ? CONSTRAINED_CURSOR_MS : DEFAULT_CURSOR_MS,
     hitTargetScale: device.isTouch() ? TOUCH_HIT_TARGET_SCALE : 1,
   };
@@ -70,6 +94,15 @@ export function refreshAdaptiveBudget(): AdaptiveBudget {
   budget = deriveBudget();
   applyReducedMotionAttr(budget.reduceMotion);
   return budget;
+}
+
+/**
+ * Set the user's motion preference and re-derive. Called by the appearance
+ * applier on hydration and whenever the Motion setting changes.
+ */
+export function setMotionPreference(pref: MotionPreference): AdaptiveBudget {
+  motionPreference = pref;
+  return refreshAdaptiveBudget();
 }
 
 // Live motion: the OS reduce-motion setting can flip mid-session. Re-derive

--- a/src/store/themeStore.test.ts
+++ b/src/store/themeStore.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useThemeStore } from './themeStore';
+
+const KEY = 'docushark-theme';
+
+describe('themeStore persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset to the default preference between tests (derived fields recomputed
+    // via setPreference).
+    useThemeStore.getState().setPreference('system');
+  });
+
+  it('persists the user preference to localStorage', () => {
+    useThemeStore.getState().setPreference('dark');
+    const raw = localStorage.getItem(KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).state.preference).toBe('dark');
+  });
+
+  it('applies the resolved theme to the document on change', () => {
+    useThemeStore.getState().setPreference('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(useThemeStore.getState().resolvedTheme).toBe('dark');
+    expect(useThemeStore.getState().colors.backgroundColor).toBe('#1e1e1e');
+  });
+
+  it('recomputes derived theme from a persisted preference on rehydrate', async () => {
+    // Simulate a prior session that saved a Dark preference.
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ state: { preference: 'dark' }, version: 0 })
+    );
+    await useThemeStore.persist.rehydrate();
+
+    const state = useThemeStore.getState();
+    expect(state.preference).toBe('dark');
+    // The merge must recompute resolvedTheme + colors, not leave the pre-hydration default.
+    expect(state.resolvedTheme).toBe('dark');
+    expect(state.colors.backgroundColor).toBe('#1e1e1e');
+  });
+
+  it('keeps theme-color meta in sync with the active theme', () => {
+    useThemeStore.getState().setPreference('dark');
+    const meta = document.querySelector('meta[name="theme-color"]');
+    expect(meta).toBeTruthy();
+    // jsdom returns empty for the CSS custom property, so the fallback applies.
+    expect(meta?.getAttribute('content')).toBe('#0e1c30');
+  });
+});

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 /**
  * Theme preference options.
@@ -101,11 +102,42 @@ function getColorsForTheme(theme: ResolvedTheme): ThemeColors {
 }
 
 /**
- * Apply theme to document (sets data-theme attribute).
+ * Fallbacks for the PWA `theme-color` meta — kept in sync with `--bg-primary`
+ * in `index.css` (light warm-paper surface / dark navy surface). Used only when
+ * the computed token can't be read yet (e.g. before stylesheet application).
+ */
+const THEME_COLOR_FALLBACK: Record<ResolvedTheme, string> = {
+  light: '#f9f6ee',
+  dark: '#0e1c30',
+};
+
+/**
+ * Update (or create) the `<meta name="theme-color">` element so an installed
+ * PWA's mobile browser/status-bar chrome matches the active theme. Prefers the
+ * live `--bg-primary` token so it tracks the brand palette without drift.
+ */
+function applyThemeColorMeta(theme: ResolvedTheme): void {
+  if (typeof document === 'undefined') return;
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = 'theme-color';
+    document.head.appendChild(meta);
+  }
+  const computed = getComputedStyle(document.documentElement)
+    .getPropertyValue('--bg-primary')
+    .trim();
+  meta.content = computed || THEME_COLOR_FALLBACK[theme];
+}
+
+/**
+ * Apply theme to document: sets the `data-theme` attribute (which drives every
+ * semantic token + `color-scheme` in `index.css`) and the PWA theme-color meta.
  */
 function applyThemeToDocument(theme: ResolvedTheme): void {
   if (typeof document !== 'undefined') {
     document.documentElement.setAttribute('data-theme', theme);
+    applyThemeColorMeta(theme);
   }
 }
 
@@ -137,43 +169,68 @@ const initialResolved = resolveTheme(initialPreference);
  * setPreference('system');
  * ```
  */
-export const useThemeStore = create<ThemeState & ThemeActions>()((set, get) => ({
-  // State
-  preference: initialPreference,
-  resolvedTheme: initialResolved,
-  colors: getColorsForTheme(initialResolved),
+export const useThemeStore = create<ThemeState & ThemeActions>()(
+  persist(
+    (set, get) => ({
+      // State
+      preference: initialPreference,
+      resolvedTheme: initialResolved,
+      colors: getColorsForTheme(initialResolved),
 
-  // Actions
-  setPreference: (preference: ThemePreference) => {
-    const resolvedTheme = resolveTheme(preference);
-    const colors = getColorsForTheme(resolvedTheme);
-    applyThemeToDocument(resolvedTheme);
-    set({ preference, resolvedTheme, colors });
-  },
+      // Actions
+      setPreference: (preference: ThemePreference) => {
+        const resolvedTheme = resolveTheme(preference);
+        const colors = getColorsForTheme(resolvedTheme);
+        applyThemeToDocument(resolvedTheme);
+        set({ preference, resolvedTheme, colors });
+      },
 
-  updateFromSystem: () => {
-    const { preference } = get();
-    if (preference === 'system') {
-      const resolvedTheme = getSystemTheme();
-      const colors = getColorsForTheme(resolvedTheme);
-      applyThemeToDocument(resolvedTheme);
-      set({ resolvedTheme, colors });
+      updateFromSystem: () => {
+        const { preference } = get();
+        if (preference === 'system') {
+          const resolvedTheme = getSystemTheme();
+          const colors = getColorsForTheme(resolvedTheme);
+          applyThemeToDocument(resolvedTheme);
+          set({ resolvedTheme, colors });
+        }
+      },
+
+      getOppositeTheme: (): ResolvedTheme => {
+        return get().resolvedTheme === 'light' ? 'dark' : 'light';
+      },
+
+      toggle: () => {
+        const opposite = get().getOppositeTheme();
+        get().setPreference(opposite);
+      },
+    }),
+    {
+      name: 'docushark-theme',
+      // Only the user's choice is durable; `resolvedTheme`/`colors` are derived.
+      partialize: (state) => ({ preference: state.preference }),
+      // localStorage hydrates synchronously during `create`, so recompute the
+      // derived fields from the persisted preference here — that way the
+      // module-load apply below reads the correct theme and there's no FOUC.
+      merge: (persisted, current) => {
+        const preference =
+          (persisted as { preference?: ThemePreference } | undefined)?.preference ??
+          current.preference;
+        const resolvedTheme = resolveTheme(preference);
+        return {
+          ...current,
+          preference,
+          resolvedTheme,
+          colors: getColorsForTheme(resolvedTheme),
+        };
+      },
     }
-  },
+  )
+);
 
-  getOppositeTheme: (): ResolvedTheme => {
-    return get().resolvedTheme === 'light' ? 'dark' : 'light';
-  },
-
-  toggle: () => {
-    const opposite = get().getOppositeTheme();
-    get().setPreference(opposite);
-  },
-}));
-
-// Apply initial theme on load
+// Apply the (already-hydrated) theme on load — reads the persisted preference,
+// not the pre-hydration default, so a saved Dark choice paints dark immediately.
 if (typeof document !== 'undefined') {
-  applyThemeToDocument(initialResolved);
+  applyThemeToDocument(useThemeStore.getState().resolvedTheme);
 }
 
 // Listen for system theme changes

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -261,7 +261,7 @@ describe('uiPreferencesStore — migration', () => {
 
     const state = useUIPreferencesStore.getState();
     expect(state.appearancePrefs).toEqual({
-      accent: 'default',
+      themeInputs: { light: {}, dark: {} },
       motion: 'system',
       density: 'normal',
       uiScale: 1,
@@ -270,13 +270,13 @@ describe('uiPreferencesStore — migration', () => {
     expect(state.layout.defaultMode).toBe('power');
   });
 
-  it('v4 → v5 fills density + uiScale onto an accent/motion-only slice', async () => {
+  it('v4 → v6 migrates accent → custom Primary and fills density/uiScale', async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
         state: {
           layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
-          appearancePrefs: { accent: 'teal', motion: 'reduced' }, // v4 shape
+          appearancePrefs: { accent: 'teal', motion: 'reduced' }, // v4 shape (accent enum)
         },
         version: 4,
       })
@@ -284,34 +284,67 @@ describe('uiPreferencesStore — migration', () => {
 
     await useUIPreferencesStore.persist.rehydrate();
 
-    // Existing accent/motion preserved; new fields defaulted.
+    // accent → primary (both bases, JP-255 teal hexes); motion preserved; rest defaulted.
     expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
-      accent: 'teal',
+      themeInputs: { light: { primary: '#0f766e' }, dark: { primary: '#5eead4' } },
       motion: 'reduced',
       density: 'normal',
       uiScale: 1,
     });
   });
+
+  it("v5 → v6 with accent 'default' yields empty custom-theme inputs", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          appearancePrefs: { accent: 'default', motion: 'system', density: 'compact', uiScale: 1.1 }, // v5 shape
+        },
+        version: 5,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      themeInputs: { light: {}, dark: {} },
+      motion: 'system',
+      density: 'compact',
+      uiScale: 1.1,
+    });
+  });
 });
 
 describe('uiPreferencesStore — appearance slice', () => {
-  it('defaults to the theme accent, system motion, normal density, scale 1', () => {
+  it('defaults to the base theme (no overrides), system motion, normal density, scale 1', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
-      accent: 'default',
+      themeInputs: { light: {}, dark: {} },
       motion: 'system',
       density: 'normal',
       uiScale: 1,
     });
   });
 
-  it('setAccent / setMotion / setDensity update the slice (new ref each time)', () => {
+  it('setThemeInput sets/clears a slot per base without touching the other base', () => {
+    const s = useUIPreferencesStore.getState();
+    s.setThemeInput('light', 'primary', '#123456');
+    expect(useUIPreferencesStore.getState().appearancePrefs.themeInputs).toEqual({
+      light: { primary: '#123456' },
+      dark: {},
+    });
+    s.setThemeInput('light', 'primary', undefined);
+    expect(useUIPreferencesStore.getState().appearancePrefs.themeInputs.light).toEqual({});
+  });
+
+  it('setMotion / setDensity update the slice (new ref each time)', () => {
     const s = useUIPreferencesStore.getState();
     const before = s.appearancePrefs;
-    s.setAccent('teal');
     s.setMotion('reduced');
     s.setDensity('compact');
     const after = useUIPreferencesStore.getState().appearancePrefs;
-    expect(after).toEqual({ accent: 'teal', motion: 'reduced', density: 'compact', uiScale: 1 });
+    expect(after.motion).toBe('reduced');
+    expect(after.density).toBe('compact');
     expect(after).not.toBe(before);
   });
 

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -265,6 +265,7 @@ describe('uiPreferencesStore — migration', () => {
       motion: 'system',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -290,6 +291,7 @@ describe('uiPreferencesStore — migration', () => {
       motion: 'reduced',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
   });
 
@@ -312,6 +314,7 @@ describe('uiPreferencesStore — migration', () => {
       motion: 'system',
       density: 'compact',
       uiScale: 1.1,
+      proseBackground: 'default',
     });
   });
 });
@@ -323,6 +326,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       motion: 'system',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
   });
 

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -238,4 +238,50 @@ describe('uiPreferencesStore — migration', () => {
     expect(layout.customChrome).toBe(true);
     expect(layout.modeOverrides.technician.properties?.dock).toBe('left');
   });
+
+  it('v3 → v4 defaults the new appearance slice without disturbing layout', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          expandedSections: {},
+          propertyPanelWidth: 240,
+          documentBrowserView: 'list',
+          documentBrowserSort: 'modified-desc',
+          documentBrowserGroupBy: 'none',
+          documentBrowserCollapsed: {},
+          layout: { defaultMode: 'power', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          // No appearancePrefs — predates the v4 slice.
+        },
+        version: 3,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    const state = useUIPreferencesStore.getState();
+    expect(state.appearancePrefs).toEqual({ accent: 'default', motion: 'system' });
+    // Layout from the older payload is untouched.
+    expect(state.layout.defaultMode).toBe('power');
+  });
+});
+
+describe('uiPreferencesStore — appearance slice', () => {
+  it("defaults to the theme's own accent and follow-system motion", () => {
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      accent: 'default',
+      motion: 'system',
+    });
+  });
+
+  it('setAccent / setMotion update the slice (new object reference each time)', () => {
+    const s = useUIPreferencesStore.getState();
+    const before = s.appearancePrefs;
+    s.setAccent('teal');
+    s.setMotion('reduced');
+    const after = useUIPreferencesStore.getState().appearancePrefs;
+    expect(after).toEqual({ accent: 'teal', motion: 'reduced' });
+    // Reference changes so the applier's identity check fires.
+    expect(after).not.toBe(before);
+  });
 });

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -260,28 +260,68 @@ describe('uiPreferencesStore — migration', () => {
     await useUIPreferencesStore.persist.rehydrate();
 
     const state = useUIPreferencesStore.getState();
-    expect(state.appearancePrefs).toEqual({ accent: 'default', motion: 'system' });
+    expect(state.appearancePrefs).toEqual({
+      accent: 'default',
+      motion: 'system',
+      density: 'normal',
+      uiScale: 1,
+    });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
+  });
+
+  it('v4 → v5 fills density + uiScale onto an accent/motion-only slice', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          appearancePrefs: { accent: 'teal', motion: 'reduced' }, // v4 shape
+        },
+        version: 4,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    // Existing accent/motion preserved; new fields defaulted.
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      accent: 'teal',
+      motion: 'reduced',
+      density: 'normal',
+      uiScale: 1,
+    });
   });
 });
 
 describe('uiPreferencesStore — appearance slice', () => {
-  it("defaults to the theme's own accent and follow-system motion", () => {
+  it('defaults to the theme accent, system motion, normal density, scale 1', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
       accent: 'default',
       motion: 'system',
+      density: 'normal',
+      uiScale: 1,
     });
   });
 
-  it('setAccent / setMotion update the slice (new object reference each time)', () => {
+  it('setAccent / setMotion / setDensity update the slice (new ref each time)', () => {
     const s = useUIPreferencesStore.getState();
     const before = s.appearancePrefs;
     s.setAccent('teal');
     s.setMotion('reduced');
+    s.setDensity('compact');
     const after = useUIPreferencesStore.getState().appearancePrefs;
-    expect(after).toEqual({ accent: 'teal', motion: 'reduced' });
-    // Reference changes so the applier's identity check fires.
+    expect(after).toEqual({ accent: 'teal', motion: 'reduced', density: 'compact', uiScale: 1 });
     expect(after).not.toBe(before);
+  });
+
+  it('setUiScale clamps to the supported range', () => {
+    const s = useUIPreferencesStore.getState();
+    s.setUiScale(5);
+    expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(1.25);
+    s.setUiScale(0.1);
+    expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(0.9);
+    s.setUiScale(1.1);
+    expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(1.1);
   });
 });

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -15,6 +15,7 @@ import type {
 } from '../ui/layout/types';
 import { LAYOUT_MODES } from '../ui/layout/types';
 import { LAYOUT_PRESETS } from '../ui/layout/modes';
+import type { MotionPreference } from '../platform/adaptiveBudget';
 
 export type DocumentBrowserView = 'list' | 'grid';
 export type DocumentBrowserSort =
@@ -24,6 +25,19 @@ export type DocumentBrowserSort =
   | 'name-desc'
   | 'created-desc';
 export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
+
+/**
+ * Accent hue driving the `--color-primary*` tokens. `'default'` keeps the
+ * theme's own accent (navy in light, gold in dark) by adding no override.
+ */
+export type AccentColor = 'default' | 'teal' | 'violet' | 'amber' | 'rose';
+
+/** App-wide appearance preferences. (Theme lives in its own `themeStore`.) */
+export interface AppearancePrefs {
+  accent: AccentColor;
+  /** Interface-motion preference; fed into the adaptive motion budget. */
+  motion: MotionPreference;
+}
 
 /**
  * UI preferences state.
@@ -53,6 +67,8 @@ export interface UIPreferencesState {
   storageInfoToastSeen: boolean;
   /** Layout manager slice — modes, per-doc memory, per-mode overrides, chrome. */
   layout: LayoutState;
+  /** Appearance slice — accent + motion (theme is in `themeStore`). */
+  appearancePrefs: AppearancePrefs;
 }
 
 /**
@@ -98,6 +114,12 @@ export interface UIPreferencesActions {
   /** Drop all per-layout customization, preserving defaultMode + customChrome. */
   resetLayoutCustomization: () => void;
 
+  // ── Appearance actions
+  /** Set the accent hue. */
+  setAccent: (accent: AccentColor) => void;
+  /** Set the interface motion preference. */
+  setMotion: (motion: MotionPreference) => void;
+
   /** Reset to initial state */
   reset: () => void;
 }
@@ -132,6 +154,12 @@ const initialLayoutState: LayoutState = {
   customChrome: false,
 };
 
+/** Initial appearance prefs — theme's own accent, follow-system motion. */
+const initialAppearancePrefs: AppearancePrefs = {
+  accent: 'default',
+  motion: 'system',
+};
+
 /**
  * Initial state.
  */
@@ -145,6 +173,7 @@ const initialState: UIPreferencesState = {
   documentBrowserCollapsed: {},
   storageInfoToastSeen: false,
   layout: initialLayoutState,
+  appearancePrefs: { ...initialAppearancePrefs },
 };
 
 /**
@@ -335,13 +364,21 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         });
       },
 
+      setAccent: (accent) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, accent } });
+      },
+
+      setMotion: (motion) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, motion } });
+      },
+
       reset: () => {
         set(initialState);
       },
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 3,
+      version: 4,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
@@ -352,6 +389,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         documentBrowserCollapsed: state.documentBrowserCollapsed,
         storageInfoToastSeen: state.storageInfoToastSeen,
         layout: state.layout,
+        appearancePrefs: state.appearancePrefs,
       }),
       migrate: (persisted, fromVersion) => {
         // Cast away the loose persisted-state typing — older payloads carry
@@ -412,6 +450,12 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
           layout = rest as LayoutState;
         }
         next['layout'] = layout;
+        // v3 → v4: added the appearance slice (accent + motion). Default it so
+        // existing behavior is preserved (theme's own accent, follow-system
+        // motion); the `merge` below also backstops this.
+        if (fromVersion < 4) {
+          next['appearancePrefs'] = next['appearancePrefs'] ?? { ...initialAppearancePrefs };
+        }
         return next as unknown as UIPreferencesState;
       },
       merge: (persisted, current) => {
@@ -426,7 +470,11 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...(p.layout?.modeOverrides ?? {}),
           },
         };
-        return { ...current, ...p, layout };
+        const appearancePrefs: AppearancePrefs = {
+          ...initialAppearancePrefs,
+          ...(p.appearancePrefs ?? {}),
+        };
+        return { ...current, ...p, layout, appearancePrefs };
       },
     }
   )

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -53,6 +53,9 @@ export interface ThemeBuild {
 /** Chrome spacing density — tightens/loosens spacing + control heights. */
 export type Density = 'compact' | 'normal' | 'spacious';
 
+/** Prose editor background preset (token-based gradients; `default` = base behavior). */
+export type ProseBackground = 'default' | 'flat' | 'glow' | 'aurora';
+
 /** Bounds for the interface-size (UI scale) multiplier. */
 export const UI_SCALE_MIN = 0.9;
 export const UI_SCALE_MAX = 1.25;
@@ -67,6 +70,8 @@ export interface AppearancePrefs {
   density: Density;
   /** Interface size multiplier (rem root scale); clamped to [0.9, 1.25]. */
   uiScale: number;
+  /** Prose editor background preset. */
+  proseBackground: ProseBackground;
 }
 
 /**
@@ -157,6 +162,8 @@ export interface UIPreferencesActions {
   setDensity: (density: Density) => void;
   /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
   setUiScale: (uiScale: number) => void;
+  /** Set the prose editor background preset. */
+  setProseBackground: (proseBackground: ProseBackground) => void;
 
   /** Reset to initial state */
   reset: () => void;
@@ -214,6 +221,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   motion: 'system',
   density: device.isTouch() ? 'spacious' : 'normal',
   uiScale: 1,
+  proseBackground: 'default',
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -468,6 +476,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setUiScale: (uiScale) => {
         set({ appearancePrefs: { ...get().appearancePrefs, uiScale: clampUiScale(uiScale) } });
+      },
+
+      setProseBackground: (proseBackground) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, proseBackground } });
       },
 
       reset: () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -31,7 +31,24 @@ export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
  * Accent hue driving the `--color-primary*` tokens. `'default'` keeps the
  * theme's own accent (navy in light, gold in dark) by adding no override.
  */
-export type AccentColor = 'default' | 'teal' | 'violet' | 'amber' | 'rose';
+/** The light/dark base a custom theme builds on (mirrors themeStore's resolved theme). */
+export type ThemeBase = 'light' | 'dark';
+
+/** The user-controllable color slots of a custom theme. */
+export type ThemeColorSlot = 'primary' | 'cta' | 'surface' | 'text';
+
+/**
+ * A sparse set of color overrides (hex). Only the slots the user set are
+ * present; everything else falls through to the base token set in index.css —
+ * which is how coverage stays complete (no token can be "missing").
+ */
+export type ThemeInputs = Partial<Record<ThemeColorSlot, string>>;
+
+/** Per-base custom-theme inputs, so light + dark are customized independently. */
+export interface ThemeBuild {
+  light: ThemeInputs;
+  dark: ThemeInputs;
+}
 
 /** Chrome spacing density — tightens/loosens spacing + control heights. */
 export type Density = 'compact' | 'normal' | 'spacious';
@@ -40,9 +57,10 @@ export type Density = 'compact' | 'normal' | 'spacious';
 export const UI_SCALE_MIN = 0.9;
 export const UI_SCALE_MAX = 1.25;
 
-/** App-wide appearance preferences. (Theme lives in its own `themeStore`.) */
+/** App-wide appearance preferences. (Theme light/dark base lives in `themeStore`.) */
 export interface AppearancePrefs {
-  accent: AccentColor;
+  /** Custom-theme color overrides per base; empty objects = the base defaults. */
+  themeInputs: ThemeBuild;
   /** Interface-motion preference; fed into the adaptive motion budget. */
   motion: MotionPreference;
   /** Spacing density (chrome only). */
@@ -127,8 +145,12 @@ export interface UIPreferencesActions {
   resetLayoutCustomization: () => void;
 
   // ── Appearance actions
-  /** Set the accent hue. */
-  setAccent: (accent: AccentColor) => void;
+  /** Set (or clear, with `undefined`) one color slot of a base's custom theme. */
+  setThemeInput: (base: ThemeBase, slot: ThemeColorSlot, value: string | undefined) => void;
+  /** Replace one base's inputs wholesale (presets, "Surprise me", import). */
+  setThemeInputs: (base: ThemeBase, inputs: ThemeInputs) => void;
+  /** Clear all custom-theme inputs (both bases → base defaults). */
+  resetThemeBuild: () => void;
   /** Set the interface motion preference. */
   setMotion: (motion: MotionPreference) => void;
   /** Set the spacing density. */
@@ -171,12 +193,24 @@ const initialLayoutState: LayoutState = {
 };
 
 /**
- * Initial appearance prefs — theme's own accent, follow-system motion, scale 1.
- * Density seeds from the input type on first run (touch gets roomier hit
- * targets); a persisted choice always wins via the persist merge.
+ * Hex values of the legacy accent enum (JP-255), per base — used by the v5→v6
+ * migration to carry a user's accent choice forward as a custom Primary. Mirrors
+ * the old `[data-accent]` rules removed from index.css. `default` → no override.
+ */
+const LEGACY_ACCENT_HEX: Record<string, { light: string; dark: string }> = {
+  teal: { light: '#0f766e', dark: '#5eead4' },
+  violet: { light: '#6d28d9', dark: '#c4b5fd' },
+  amber: { light: '#b45309', dark: '#fcd34d' },
+  rose: { light: '#be123c', dark: '#fda4af' },
+};
+
+/**
+ * Initial appearance prefs — base theme (no color overrides), follow-system
+ * motion, scale 1. Density seeds from the input type on first run (touch gets
+ * roomier hit targets); a persisted choice always wins via the persist merge.
  */
 const initialAppearancePrefs: AppearancePrefs = {
-  accent: 'default',
+  themeInputs: { light: {}, dark: {} },
   motion: 'system',
   density: device.isTouch() ? 'spacious' : 'normal',
   uiScale: 1,
@@ -392,8 +426,36 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         });
       },
 
-      setAccent: (accent) => {
-        set({ appearancePrefs: { ...get().appearancePrefs, accent } });
+      setThemeInput: (base, slot, value) => {
+        const { appearancePrefs } = get();
+        const baseInputs = { ...appearancePrefs.themeInputs[base] };
+        if (value === undefined) {
+          delete baseInputs[slot];
+        } else {
+          baseInputs[slot] = value;
+        }
+        set({
+          appearancePrefs: {
+            ...appearancePrefs,
+            themeInputs: { ...appearancePrefs.themeInputs, [base]: baseInputs },
+          },
+        });
+      },
+
+      setThemeInputs: (base, inputs) => {
+        const { appearancePrefs } = get();
+        set({
+          appearancePrefs: {
+            ...appearancePrefs,
+            themeInputs: { ...appearancePrefs.themeInputs, [base]: { ...inputs } },
+          },
+        });
+      },
+
+      resetThemeBuild: () => {
+        set({
+          appearancePrefs: { ...get().appearancePrefs, themeInputs: { light: {}, dark: {} } },
+        });
       },
 
       setMotion: (motion) => {
@@ -414,7 +476,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 5,
+      version: 6,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
@@ -500,6 +562,19 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
           };
         }
+        // v5 → v6: accent enum → custom-theme Primary (both bases). The old
+        // `[data-accent]` rules are gone; a user's accent choice is preserved as
+        // a Primary override so their look survives. `default` → no override.
+        if (fromVersion < 6) {
+          const ap = (next['appearancePrefs'] as Record<string, unknown> | undefined) ?? {};
+          const accent = typeof ap['accent'] === 'string' ? (ap['accent'] as string) : 'default';
+          const hex = LEGACY_ACCENT_HEX[accent];
+          const themeInputs: ThemeBuild = hex
+            ? { light: { primary: hex.light }, dark: { primary: hex.dark } }
+            : { light: {}, dark: {} };
+          delete ap['accent'];
+          next['appearancePrefs'] = { ...ap, themeInputs };
+        }
         return next as unknown as UIPreferencesState;
       },
       merge: (persisted, current) => {
@@ -514,9 +589,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...(p.layout?.modeOverrides ?? {}),
           },
         };
+        const persistedAp = (p.appearancePrefs ?? {}) as Partial<AppearancePrefs>;
         const appearancePrefs: AppearancePrefs = {
           ...initialAppearancePrefs,
-          ...(p.appearancePrefs ?? {}),
+          ...persistedAp,
+          // Always materialize both bases so the applier can index safely.
+          themeInputs: {
+            light: { ...(persistedAp.themeInputs?.light ?? {}) },
+            dark: { ...(persistedAp.themeInputs?.dark ?? {}) },
+          },
         };
         return { ...current, ...p, layout, appearancePrefs };
       },

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -16,6 +16,7 @@ import type {
 import { LAYOUT_MODES } from '../ui/layout/types';
 import { LAYOUT_PRESETS } from '../ui/layout/modes';
 import type { MotionPreference } from '../platform/adaptiveBudget';
+import { device } from '../platform/device';
 
 export type DocumentBrowserView = 'list' | 'grid';
 export type DocumentBrowserSort =
@@ -32,11 +33,22 @@ export type DocumentBrowserGroupBy = 'none' | 'group' | 'relay';
  */
 export type AccentColor = 'default' | 'teal' | 'violet' | 'amber' | 'rose';
 
+/** Chrome spacing density — tightens/loosens spacing + control heights. */
+export type Density = 'compact' | 'normal' | 'spacious';
+
+/** Bounds for the interface-size (UI scale) multiplier. */
+export const UI_SCALE_MIN = 0.9;
+export const UI_SCALE_MAX = 1.25;
+
 /** App-wide appearance preferences. (Theme lives in its own `themeStore`.) */
 export interface AppearancePrefs {
   accent: AccentColor;
   /** Interface-motion preference; fed into the adaptive motion budget. */
   motion: MotionPreference;
+  /** Spacing density (chrome only). */
+  density: Density;
+  /** Interface size multiplier (rem root scale); clamped to [0.9, 1.25]. */
+  uiScale: number;
 }
 
 /**
@@ -119,6 +131,10 @@ export interface UIPreferencesActions {
   setAccent: (accent: AccentColor) => void;
   /** Set the interface motion preference. */
   setMotion: (motion: MotionPreference) => void;
+  /** Set the spacing density. */
+  setDensity: (density: Density) => void;
+  /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
+  setUiScale: (uiScale: number) => void;
 
   /** Reset to initial state */
   reset: () => void;
@@ -154,11 +170,23 @@ const initialLayoutState: LayoutState = {
   customChrome: false,
 };
 
-/** Initial appearance prefs — theme's own accent, follow-system motion. */
+/**
+ * Initial appearance prefs — theme's own accent, follow-system motion, scale 1.
+ * Density seeds from the input type on first run (touch gets roomier hit
+ * targets); a persisted choice always wins via the persist merge.
+ */
 const initialAppearancePrefs: AppearancePrefs = {
   accent: 'default',
   motion: 'system',
+  density: device.isTouch() ? 'spacious' : 'normal',
+  uiScale: 1,
 };
+
+/** Clamp a UI-scale value into the supported range. */
+function clampUiScale(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, value));
+}
 
 /**
  * Initial state.
@@ -372,13 +400,21 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ appearancePrefs: { ...get().appearancePrefs, motion } });
       },
 
+      setDensity: (density) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, density } });
+      },
+
+      setUiScale: (uiScale) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, uiScale: clampUiScale(uiScale) } });
+      },
+
       reset: () => {
         set(initialState);
       },
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 4,
+      version: 5,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         propertyPanelWidth: state.propertyPanelWidth,
@@ -455,6 +491,14 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // motion); the `merge` below also backstops this.
         if (fromVersion < 4) {
           next['appearancePrefs'] = next['appearancePrefs'] ?? { ...initialAppearancePrefs };
+        }
+        // v4 → v5: the appearance slice gained density + uiScale. Fill any
+        // missing fields from the defaults without clobbering accent/motion.
+        if (fromVersion < 5) {
+          next['appearancePrefs'] = {
+            ...initialAppearancePrefs,
+            ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
+          };
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -26,6 +26,17 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
   })) as unknown as typeof window.matchMedia;
 }
 
+// jsdom does not implement `ResizeObserver`; Radix primitives (e.g. Slider)
+// observe their elements. A no-op stub is sufficient for the test environment.
+if (typeof (globalThis as { ResizeObserver?: unknown }).ResizeObserver === 'undefined') {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub;
+}
+
 if (typeof (globalThis as { Path2D?: unknown }).Path2D === 'undefined') {
   class Path2DStub implements PathMethods {
     [method: string]: (...args: number[]) => void;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -10,6 +10,22 @@
 
 type PathMethods = Record<string, (...args: number[]) => void>;
 
+// jsdom does not implement `matchMedia`. Stores read it at module load
+// (theme `prefers-color-scheme`, device adaptive hints), so provide a minimal
+// always-"no-match" stub with the full MediaQueryList event surface.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
 if (typeof (globalThis as { Path2D?: unknown }).Path2D === 'undefined') {
   class Path2DStub implements PathMethods {
     [method: string]: (...args: number[]) => void;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -69,7 +69,7 @@ function App() {
 
   // Settings modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'documents' | 'layout'>('documents');
+  const [settingsInitialTab, setSettingsInitialTab] = useState<'documents' | 'appearance'>('documents');
 
   // Command palette state (Cmd/Ctrl+K)
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -81,13 +81,14 @@ function App() {
   const rebuildAllConnectorRoutes = useDocumentStore((state) => state.rebuildAllConnectorRoutes);
 
   // Custom chrome opt-in — drives both the in-app TitleBar render and the
-  // Tauri native-decoration toggle synced below. Force-disabled on macOS:
-  // the traffic-light controls and unified titlebar are too tightly coupled
-  // to native decorations for the cross-platform in-app TitleBar to be a
-  // credible swap, and a synced/migrated `true` from another OS would
-  // otherwise strip the native frame on Mac.
+  // Tauri native-decoration toggle synced below. Gated to the desktop shell:
+  // `windowControls.isSupported()` is false on the PWA, so a persisted (or
+  // legacy, pre-JP-107) `true` never renders a controls-less in-app TitleBar
+  // on web. Force-disabled on macOS too: the traffic-light controls and
+  // unified titlebar are too tightly coupled to native decorations for the
+  // cross-platform in-app TitleBar to be a credible swap.
   const customChromePref = useUIPreferencesStore((s) => s.layout.customChrome);
-  const customChrome = customChromePref && !isMacOS();
+  const customChrome = customChromePref && windowControls.isSupported() && !isMacOS();
 
   // Layout-driven panel visibility. The store is the source of truth; switching
   // layouts (Step 4) or moving panels (Step 6) flows through here.
@@ -179,7 +180,7 @@ function App() {
   }, []);
 
   const handleOpenLayoutSettings = useCallback(() => {
-    setSettingsInitialTab('layout');
+    setSettingsInitialTab('appearance');
     setIsSettingsOpen(true);
   }, []);
 

--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -3,20 +3,20 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  background-color: var(--bg-primary);
+  /* `--prose-bg` is set by the Appearance "Prose background" preset; when unset
+   * (the Default preset) it falls back to the built-in per-base behavior: a flat
+   * surface in light, the soft glow below in dark. The prose surface
+   * (.tiptap-editor) is transparent so this backdrop shows through. */
+  background: var(--prose-bg, var(--bg-primary));
 }
 
-/* Dark mode: replace the flat navy slab with a soft top-center glow that
- * settles into the deep page navy — adds depth without an aggressive blue
- * block. Stays within the navy elevation ladder (raised -> surface -> page).
- * Applied to the panel so the toolbar + prose share one continuous backdrop;
- * the prose surface (.tiptap-editor) is transparent in dark mode to show it. */
+/* Dark mode default: a soft top-center glow that settles into the deep page
+ * navy — depth without an aggressive blue block, within the navy elevation
+ * ladder (raised -> surface -> page). A chosen preset (--prose-bg) overrides it. */
 [data-theme="dark"] .document-editor-panel {
-  background: radial-gradient(
-    140% 90% at 50% 0%,
-    #16273f 0%,
-    #0e1c30 42%,
-    #0a1525 100%
+  background: var(
+    --prose-bg,
+    radial-gradient(140% 90% at 50% 0%, #16273f 0%, #0e1c30 42%, #0a1525 100%)
   );
 }
 

--- a/src/ui/ExportDialog.css
+++ b/src/ui/ExportDialog.css
@@ -323,7 +323,7 @@
 
 [data-theme="dark"] .export-format-btn.active {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .export-select,
@@ -371,7 +371,7 @@
 
 [data-theme="dark"] .export-btn-primary {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .export-btn-primary:hover:not(:disabled) {

--- a/src/ui/SaveToLibraryDialog.css
+++ b/src/ui/SaveToLibraryDialog.css
@@ -324,7 +324,7 @@
 
 [data-theme="dark"] .save-to-library-create-btn {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .save-to-library-cancel-btn {
@@ -359,7 +359,7 @@
 
 [data-theme="dark"] .save-to-library-btn-primary {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .save-to-library-btn-primary:hover:not(:disabled) {

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -4,7 +4,8 @@
  * Features:
  * - Tab infrastructure for multiple settings sections
  * - Documents management (new, open, save, import/export)
- * - General settings (connector defaults, style profile defaults, display options, theme)
+ * - General settings (connector defaults, style profile defaults, display options)
+ * - Appearance (theme, canvas grid, layout customization, window chrome)
  * - Storage management (images and icons)
  * - Style Profile settings
  * - Shape Libraries management
@@ -19,7 +20,7 @@ import {
   Package,
   Palette,
   Library,
-  Layout,
+  SwatchBook,
   Maximize2,
   Minimize2,
 } from 'lucide-react';
@@ -31,13 +32,13 @@ import { StorageSettings } from './settings/StorageSettings';
 import { StyleProfileSettings } from './settings/StyleProfileSettings';
 import { RelaySettings } from './settings/RelaySettings';
 import { BackupSettings } from './settings/BackupSettings';
-import { LayoutSettings } from './settings/LayoutSettings';
+import { AppearanceSettings } from './settings/AppearanceSettings';
 import './SettingsModal.css';
 
 /**
  * Available settings tabs.
  */
-type SettingsTab = 'documents' | 'general' | 'layout' | 'relay' | 'storage' | 'backup' | 'style-profiles' | 'shape-libraries';
+type SettingsTab = 'documents' | 'general' | 'appearance' | 'relay' | 'storage' | 'backup' | 'style-profiles' | 'shape-libraries';
 
 /**
  * Tab configuration.
@@ -54,7 +55,7 @@ interface TabConfig {
 const TABS: TabConfig[] = [
   { id: 'documents', label: 'Documents', icon: FileText },
   { id: 'general', label: 'General', icon: Settings },
-  { id: 'layout', label: 'Layout', icon: Layout },
+  { id: 'appearance', label: 'Appearance', icon: SwatchBook },
   { id: 'relay', label: 'Relay', icon: Cloud },
   { id: 'storage', label: 'Storage', icon: Database },
   { id: 'backup', label: 'Backup & Restore', icon: Package },
@@ -174,7 +175,7 @@ export function SettingsModal({ isOpen, onClose, initialTab = 'documents' }: Set
           <div className="settings-modal-content">
             {activeTab === 'documents' && <DocumentBrowser />}
             {activeTab === 'general' && <GeneralSettings />}
-            {activeTab === 'layout' && <LayoutSettings />}
+            {activeTab === 'appearance' && <AppearanceSettings />}
             {activeTab === 'relay' && <RelaySettings />}
             {activeTab === 'storage' && <StorageSettings />}
             {activeTab === 'backup' && <BackupSettings />}

--- a/src/ui/ShapeLibraryManager.css
+++ b/src/ui/ShapeLibraryManager.css
@@ -446,7 +446,7 @@
 
 [data-theme="dark"] .shape-library-create-btn {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .shape-library-cancel-btn {
@@ -464,7 +464,7 @@
 
 [data-theme="dark"] .shape-library-item.selected {
   background: var(--color-primary);
-  color: #1e1e1e;
+  color: var(--color-on-primary);
 }
 
 [data-theme="dark"] .shape-library-edit-input {

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -1,12 +1,8 @@
 .tiptap-editor {
   flex: 1;
   overflow-y: auto;
-  background-color: var(--bg-primary);
-}
-
-/* Dark mode: let the panel's gradient backdrop show through the prose surface
- * so the two don't paint competing flat fills (see DocumentEditorPanel.css). */
-[data-theme="dark"] .tiptap-editor {
+  /* Transparent so the panel's background (flat or a chosen prose-background
+   * gradient) shows through in both modes — see DocumentEditorPanel.css. */
   background-color: transparent;
 }
 

--- a/src/ui/adaptive-motion.css
+++ b/src/ui/adaptive-motion.css
@@ -1,26 +1,18 @@
 /*
  * Adaptive motion budget (JP-101). Neutralizes non-essential animation when
- * the device reports constrained conditions, per Final OSS App Design §5.
+ * motion should be reduced, per Final OSS App Design §5.
  *
- * Two triggers, same treatment:
- *   1. The native `prefers-reduced-motion: reduce` media query (OS setting).
- *   2. `:root[data-reduced-motion="true"]`, set by adaptiveBudget.ts — this
- *      covers the low-power-device case, which CSS alone cannot detect.
+ * Single trigger: `:root[data-reduced-motion="true"]`, set by adaptiveBudget.ts.
+ * That module is the sole authority — it folds together the OS
+ * `prefers-reduced-motion` setting, the low-power-device heuristic (which CSS
+ * alone cannot detect), and the user's in-app Motion preference. We deliberately
+ * do NOT also read `@media (prefers-reduced-motion: reduce)` here: that would
+ * fire independently and stop an explicit "Full" preference from overriding the
+ * OS. The attribute already reflects the OS setting (the module reads it).
  *
  * We don't hard-zero durations (that can break transitionend listeners);
  * collapsing to ~0.01ms keeps callbacks firing while removing the motion.
  */
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-}
 
 :root[data-reduced-motion='true'] *,
 :root[data-reduced-motion='true'] *::before,

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -1,28 +1,39 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
 import { useThemeStore } from '../../store/themeStore';
-// Importing the applier boots its module-level store subscription.
+// Importing the applier boots its module-level store subscriptions.
 import './applyAppearance';
 import { getAppearanceSnapshot, applyAppearanceSnapshot, resetAppearance } from './appearanceConfig';
 
 beforeEach(() => {
   localStorage.clear();
   useUIPreferencesStore.getState().reset();
-  useThemeStore.getState().setPreference('system');
+  useThemeStore.getState().setPreference('light'); // deterministic active base
 });
 
 afterEach(() => {
   const s = useUIPreferencesStore.getState();
-  s.setAccent('default');
+  s.resetThemeBuild();
   s.setMotion('system');
   s.setDensity('normal');
   s.setUiScale(1);
 });
 
 describe('appearance applier (Abstraction A)', () => {
-  it('mirrors the accent onto the document root', () => {
-    useUIPreferencesStore.getState().setAccent('violet');
-    expect(document.documentElement.dataset['accent']).toBe('violet');
+  it('writes resolved theme overrides for the active base onto the root', () => {
+    useUIPreferencesStore.getState().setThemeInput('light', 'primary', '#3366cc');
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--color-primary')).toBe('#3366cc');
+    // Derived relatives are written too (no missing tokens for a set slot).
+    expect(style.getPropertyValue('--color-on-primary')).not.toBe('');
+    expect(style.getPropertyValue('--color-primary-alpha')).not.toBe('');
+  });
+
+  it('reverts the inline override when a slot is cleared', () => {
+    const s = useUIPreferencesStore.getState();
+    s.setThemeInput('light', 'primary', '#3366cc');
+    s.setThemeInput('light', 'primary', undefined);
+    expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe('');
   });
 
   it('routes motion through the adaptive budget (data-reduced-motion)', () => {
@@ -44,13 +55,13 @@ describe('appearance snapshot seam (Abstraction B)', () => {
   it('captures the full appearance config', () => {
     useThemeStore.getState().setPreference('dark');
     const s = useUIPreferencesStore.getState();
-    s.setAccent('amber');
+    s.setThemeInput('dark', 'primary', '#abcdef');
     s.setMotion('reduced');
     s.setDensity('spacious');
     s.setUiScale(1.15);
     expect(getAppearanceSnapshot()).toEqual({
       theme: 'dark',
-      accent: 'amber',
+      themeInputs: { light: {}, dark: { primary: '#abcdef' } },
       motion: 'reduced',
       density: 'spacious',
       uiScale: 1.15,
@@ -58,27 +69,28 @@ describe('appearance snapshot seam (Abstraction B)', () => {
   });
 
   it('applies a config across both stores', () => {
-    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full', density: 'compact', uiScale: 1.1 });
-    expect(useThemeStore.getState().preference).toBe('light');
-    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
-      accent: 'rose',
+    applyAppearanceSnapshot({
+      theme: 'light',
+      themeInputs: { light: { primary: '#112233' }, dark: {} },
       motion: 'full',
       density: 'compact',
       uiScale: 1.1,
     });
+    expect(useThemeStore.getState().preference).toBe('light');
+    const ap = useUIPreferencesStore.getState().appearancePrefs;
+    expect(ap.themeInputs).toEqual({ light: { primary: '#112233' }, dark: {} });
+    expect(ap.motion).toBe('full');
   });
 
   it('resetAppearance restores every default', () => {
     useThemeStore.getState().setPreference('dark');
     const s = useUIPreferencesStore.getState();
-    s.setAccent('teal');
+    s.setThemeInput('dark', 'primary', '#ff0000');
     s.setMotion('reduced');
-    s.setDensity('compact');
-    s.setUiScale(1.2);
     resetAppearance();
     expect(getAppearanceSnapshot()).toEqual({
       theme: 'system',
-      accent: 'default',
+      themeInputs: { light: {}, dark: {} },
       motion: 'system',
       density: 'normal',
       uiScale: 1,

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { useThemeStore } from '../../store/themeStore';
+// Importing the applier boots its module-level store subscription.
+import './applyAppearance';
+import { getAppearanceSnapshot, applyAppearanceSnapshot, resetAppearance } from './appearanceConfig';
+
+beforeEach(() => {
+  localStorage.clear();
+  useUIPreferencesStore.getState().reset();
+  useThemeStore.getState().setPreference('system');
+});
+
+afterEach(() => {
+  useUIPreferencesStore.getState().setAccent('default');
+  useUIPreferencesStore.getState().setMotion('system');
+});
+
+describe('appearance applier (Abstraction A)', () => {
+  it('mirrors the accent onto the document root', () => {
+    useUIPreferencesStore.getState().setAccent('violet');
+    expect(document.documentElement.dataset['accent']).toBe('violet');
+  });
+
+  it('routes motion through the adaptive budget (data-reduced-motion)', () => {
+    useUIPreferencesStore.getState().setMotion('reduced');
+    expect(document.documentElement.dataset['reducedMotion']).toBe('true');
+    useUIPreferencesStore.getState().setMotion('full');
+    expect(document.documentElement.dataset['reducedMotion']).toBeUndefined();
+  });
+});
+
+describe('appearance snapshot seam (Abstraction B)', () => {
+  it('captures theme + accent + motion', () => {
+    useThemeStore.getState().setPreference('dark');
+    useUIPreferencesStore.getState().setAccent('amber');
+    useUIPreferencesStore.getState().setMotion('reduced');
+    expect(getAppearanceSnapshot()).toEqual({ theme: 'dark', accent: 'amber', motion: 'reduced' });
+  });
+
+  it('applies a config across both stores', () => {
+    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full' });
+    expect(useThemeStore.getState().preference).toBe('light');
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({ accent: 'rose', motion: 'full' });
+  });
+
+  it('resetAppearance restores every default', () => {
+    useThemeStore.getState().setPreference('dark');
+    useUIPreferencesStore.getState().setAccent('teal');
+    useUIPreferencesStore.getState().setMotion('reduced');
+    resetAppearance();
+    expect(getAppearanceSnapshot()).toEqual({ theme: 'system', accent: 'default', motion: 'system' });
+  });
+});

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
   s.setMotion('system');
   s.setDensity('normal');
   s.setUiScale(1);
+  s.setProseBackground('default');
 });
 
 describe('appearance applier (Abstraction A)', () => {
@@ -49,6 +50,13 @@ describe('appearance applier (Abstraction A)', () => {
     expect(document.documentElement.dataset['density']).toBe('compact');
     expect(document.documentElement.style.getPropertyValue('--ui-scale')).toBe('1.2');
   });
+
+  it('sets --prose-bg for a preset and removes it for default', () => {
+    useUIPreferencesStore.getState().setProseBackground('glow');
+    expect(document.documentElement.style.getPropertyValue('--prose-bg')).toContain('gradient');
+    useUIPreferencesStore.getState().setProseBackground('default');
+    expect(document.documentElement.style.getPropertyValue('--prose-bg')).toBe('');
+  });
 });
 
 describe('appearance snapshot seam (Abstraction B)', () => {
@@ -59,12 +67,14 @@ describe('appearance snapshot seam (Abstraction B)', () => {
     s.setMotion('reduced');
     s.setDensity('spacious');
     s.setUiScale(1.15);
+    s.setProseBackground('glow');
     expect(getAppearanceSnapshot()).toEqual({
       theme: 'dark',
       themeInputs: { light: {}, dark: { primary: '#abcdef' } },
       motion: 'reduced',
       density: 'spacious',
       uiScale: 1.15,
+      proseBackground: 'glow',
     });
   });
 
@@ -94,6 +104,7 @@ describe('appearance snapshot seam (Abstraction B)', () => {
       motion: 'system',
       density: 'normal',
       uiScale: 1,
+      proseBackground: 'default',
     });
   });
 });

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -12,8 +12,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  useUIPreferencesStore.getState().setAccent('default');
-  useUIPreferencesStore.getState().setMotion('system');
+  const s = useUIPreferencesStore.getState();
+  s.setAccent('default');
+  s.setMotion('system');
+  s.setDensity('normal');
+  s.setUiScale(1);
 });
 
 describe('appearance applier (Abstraction A)', () => {
@@ -28,27 +31,57 @@ describe('appearance applier (Abstraction A)', () => {
     useUIPreferencesStore.getState().setMotion('full');
     expect(document.documentElement.dataset['reducedMotion']).toBeUndefined();
   });
+
+  it('mirrors density + UI scale onto the document root', () => {
+    useUIPreferencesStore.getState().setDensity('compact');
+    useUIPreferencesStore.getState().setUiScale(1.2);
+    expect(document.documentElement.dataset['density']).toBe('compact');
+    expect(document.documentElement.style.getPropertyValue('--ui-scale')).toBe('1.2');
+  });
 });
 
 describe('appearance snapshot seam (Abstraction B)', () => {
-  it('captures theme + accent + motion', () => {
+  it('captures the full appearance config', () => {
     useThemeStore.getState().setPreference('dark');
-    useUIPreferencesStore.getState().setAccent('amber');
-    useUIPreferencesStore.getState().setMotion('reduced');
-    expect(getAppearanceSnapshot()).toEqual({ theme: 'dark', accent: 'amber', motion: 'reduced' });
+    const s = useUIPreferencesStore.getState();
+    s.setAccent('amber');
+    s.setMotion('reduced');
+    s.setDensity('spacious');
+    s.setUiScale(1.15);
+    expect(getAppearanceSnapshot()).toEqual({
+      theme: 'dark',
+      accent: 'amber',
+      motion: 'reduced',
+      density: 'spacious',
+      uiScale: 1.15,
+    });
   });
 
   it('applies a config across both stores', () => {
-    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full' });
+    applyAppearanceSnapshot({ theme: 'light', accent: 'rose', motion: 'full', density: 'compact', uiScale: 1.1 });
     expect(useThemeStore.getState().preference).toBe('light');
-    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({ accent: 'rose', motion: 'full' });
+    expect(useUIPreferencesStore.getState().appearancePrefs).toEqual({
+      accent: 'rose',
+      motion: 'full',
+      density: 'compact',
+      uiScale: 1.1,
+    });
   });
 
   it('resetAppearance restores every default', () => {
     useThemeStore.getState().setPreference('dark');
-    useUIPreferencesStore.getState().setAccent('teal');
-    useUIPreferencesStore.getState().setMotion('reduced');
+    const s = useUIPreferencesStore.getState();
+    s.setAccent('teal');
+    s.setMotion('reduced');
+    s.setDensity('compact');
+    s.setUiScale(1.2);
     resetAppearance();
-    expect(getAppearanceSnapshot()).toEqual({ theme: 'system', accent: 'default', motion: 'system' });
+    expect(getAppearanceSnapshot()).toEqual({
+      theme: 'system',
+      accent: 'default',
+      motion: 'system',
+      density: 'normal',
+      uiScale: 1,
+    });
   });
 });

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -1,0 +1,46 @@
+/**
+ * Appearance snapshot seam (Abstraction B) — a single read/write surface across
+ * the two stores that own appearance state (theme preference in `themeStore`,
+ * accent + motion in `uiPreferencesStore`). Designed now so the future
+ * "Workspaces" presets + shareable-config features capture/apply a whole look
+ * in one call, without reaching into each store. Not yet wired to UI beyond the
+ * "Reset appearance" action.
+ */
+
+import { useThemeStore, type ThemePreference } from '../../store/themeStore';
+import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
+import type { MotionPreference } from '../../platform/adaptiveBudget';
+
+export interface AppearanceConfig {
+  theme: ThemePreference;
+  accent: AccentColor;
+  motion: MotionPreference;
+}
+
+export const DEFAULT_APPEARANCE: AppearanceConfig = {
+  theme: 'system',
+  accent: 'default',
+  motion: 'system',
+};
+
+/** Capture the current appearance as a portable config object. */
+export function getAppearanceSnapshot(): AppearanceConfig {
+  const { accent, motion } = useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, accent, motion };
+}
+
+/** Apply a (partial) appearance config across both stores. */
+export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
+  if (cfg.theme !== undefined) useThemeStore.getState().setPreference(cfg.theme);
+  if (cfg.accent !== undefined) useUIPreferencesStore.getState().setAccent(cfg.accent);
+  if (cfg.motion !== undefined) useUIPreferencesStore.getState().setMotion(cfg.motion);
+}
+
+/**
+ * Reset every appearance choice to its default — theme, accent, motion, and the
+ * per-layout customization deltas.
+ */
+export function resetAppearance(): void {
+  applyAppearanceSnapshot(DEFAULT_APPEARANCE);
+  useUIPreferencesStore.getState().resetLayoutCustomization();
+}

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -1,23 +1,22 @@
 /**
  * Appearance snapshot seam (Abstraction B) — a single read/write surface across
- * the two stores that own appearance state (theme preference in `themeStore`,
- * accent + motion in `uiPreferencesStore`). Designed now so the future
- * "Workspaces" presets + shareable-config features capture/apply a whole look
- * in one call, without reaching into each store. Not yet wired to UI beyond the
- * "Reset appearance" action.
+ * the two stores that own appearance state (theme light/dark base in `themeStore`,
+ * custom-theme inputs + motion/density/scale in `uiPreferencesStore`). Designed
+ * so the future "Workspaces" presets + shareable-config / export-import features
+ * capture and apply a whole look in one call, without reaching into each store.
  */
 
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
-  type AccentColor,
   type Density,
+  type ThemeBuild,
 } from '../../store/uiPreferencesStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
 
 export interface AppearanceConfig {
   theme: ThemePreference;
-  accent: AccentColor;
+  themeInputs: ThemeBuild;
   motion: MotionPreference;
   density: Density;
   uiScale: number;
@@ -25,7 +24,7 @@ export interface AppearanceConfig {
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
   theme: 'system',
-  accent: 'default',
+  themeInputs: { light: {}, dark: {} },
   motion: 'system',
   density: 'normal',
   uiScale: 1,
@@ -33,22 +32,26 @@ export const DEFAULT_APPEARANCE: AppearanceConfig = {
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { accent, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, accent, motion, density, uiScale };
+  const { themeInputs, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale };
 }
 
 /** Apply a (partial) appearance config across both stores. */
 export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
+  const ui = useUIPreferencesStore.getState();
   if (cfg.theme !== undefined) useThemeStore.getState().setPreference(cfg.theme);
-  if (cfg.accent !== undefined) useUIPreferencesStore.getState().setAccent(cfg.accent);
-  if (cfg.motion !== undefined) useUIPreferencesStore.getState().setMotion(cfg.motion);
-  if (cfg.density !== undefined) useUIPreferencesStore.getState().setDensity(cfg.density);
-  if (cfg.uiScale !== undefined) useUIPreferencesStore.getState().setUiScale(cfg.uiScale);
+  if (cfg.themeInputs !== undefined) {
+    ui.setThemeInputs('light', cfg.themeInputs.light);
+    ui.setThemeInputs('dark', cfg.themeInputs.dark);
+  }
+  if (cfg.motion !== undefined) ui.setMotion(cfg.motion);
+  if (cfg.density !== undefined) ui.setDensity(cfg.density);
+  if (cfg.uiScale !== undefined) ui.setUiScale(cfg.uiScale);
 }
 
 /**
- * Reset every appearance choice to its default — theme, accent, motion, and the
- * per-layout customization deltas.
+ * Reset every appearance choice to its default — theme, custom-theme inputs,
+ * motion, density, UI scale, and the per-layout customization deltas.
  */
 export function resetAppearance(): void {
   applyAppearanceSnapshot(DEFAULT_APPEARANCE);

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -8,25 +8,33 @@
  */
 
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
-import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
+import {
+  useUIPreferencesStore,
+  type AccentColor,
+  type Density,
+} from '../../store/uiPreferencesStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
 
 export interface AppearanceConfig {
   theme: ThemePreference;
   accent: AccentColor;
   motion: MotionPreference;
+  density: Density;
+  uiScale: number;
 }
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
   theme: 'system',
   accent: 'default',
   motion: 'system',
+  density: 'normal',
+  uiScale: 1,
 };
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { accent, motion } = useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, accent, motion };
+  const { accent, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, accent, motion, density, uiScale };
 }
 
 /** Apply a (partial) appearance config across both stores. */
@@ -34,6 +42,8 @@ export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
   if (cfg.theme !== undefined) useThemeStore.getState().setPreference(cfg.theme);
   if (cfg.accent !== undefined) useUIPreferencesStore.getState().setAccent(cfg.accent);
   if (cfg.motion !== undefined) useUIPreferencesStore.getState().setMotion(cfg.motion);
+  if (cfg.density !== undefined) useUIPreferencesStore.getState().setDensity(cfg.density);
+  if (cfg.uiScale !== undefined) useUIPreferencesStore.getState().setUiScale(cfg.uiScale);
 }
 
 /**

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -10,6 +10,7 @@ import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
   type Density,
+  type ProseBackground,
   type ThemeBuild,
 } from '../../store/uiPreferencesStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
@@ -20,6 +21,7 @@ export interface AppearanceConfig {
   motion: MotionPreference;
   density: Density;
   uiScale: number;
+  proseBackground: ProseBackground;
 }
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
@@ -28,12 +30,14 @@ export const DEFAULT_APPEARANCE: AppearanceConfig = {
   motion: 'system',
   density: 'normal',
   uiScale: 1,
+  proseBackground: 'default',
 };
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { themeInputs, motion, density, uiScale } = useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale };
+  const { themeInputs, motion, density, uiScale, proseBackground } =
+    useUIPreferencesStore.getState().appearancePrefs;
+  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale, proseBackground };
 }
 
 /** Apply a (partial) appearance config across both stores. */
@@ -47,6 +51,7 @@ export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
   if (cfg.motion !== undefined) ui.setMotion(cfg.motion);
   if (cfg.density !== undefined) ui.setDensity(cfg.density);
   if (cfg.uiScale !== undefined) ui.setUiScale(cfg.uiScale);
+  if (cfg.proseBackground !== undefined) ui.setProseBackground(cfg.proseBackground);
 }
 
 /**

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -1,0 +1,36 @@
+/**
+ * Appearance applier (Abstraction A) — the single place that mirrors appearance
+ * preferences onto the document. Runs at module load via a vanilla
+ * `store.subscribe` (NOT a React effect), so it applies the hydrated values
+ * before first paint (localStorage hydrates synchronously on store creation) —
+ * no flash — and keeps tracking changes from anywhere, inside or outside React.
+ *
+ * Accent → `data-accent` root attribute (CSS swaps `--color-primary*`).
+ * Motion → handed to `adaptiveBudget`, the sole authority over the
+ *          `data-reduced-motion` attribute.
+ *
+ * (Theme is applied by `themeStore` itself; this module owns the rest.)
+ */
+
+import { useUIPreferencesStore, type AppearancePrefs } from '../../store/uiPreferencesStore';
+import { setMotionPreference } from '../../platform/adaptiveBudget';
+
+function applyAppearance(prefs: AppearancePrefs): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset['accent'] = prefs.accent;
+  }
+  setMotionPreference(prefs.motion);
+}
+
+// Apply the already-hydrated preferences immediately.
+let applied = useUIPreferencesStore.getState().appearancePrefs;
+applyAppearance(applied);
+
+// Re-apply only when the appearance slice actually changes (the setters produce
+// a new object reference), so unrelated UI-pref updates don't churn.
+useUIPreferencesStore.subscribe((state) => {
+  if (state.appearancePrefs !== applied) {
+    applied = state.appearancePrefs;
+    applyAppearance(applied);
+  }
+});

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -5,9 +5,15 @@
  * before first paint (localStorage hydrates synchronously on store creation) —
  * no flash — and keeps tracking changes from anywhere, inside or outside React.
  *
- * Accent → `data-accent` root attribute (CSS swaps `--color-primary*`).
- * Motion → handed to `adaptiveBudget`, the sole authority over the
- *          `data-reduced-motion` attribute.
+ * Accent  → `data-accent` root attribute (CSS swaps `--color-primary*`).
+ * Density → `data-density` root attribute (CSS scales `--density-mult`).
+ * UI size → `--ui-scale` root var (CSS scales the rem root font-size).
+ * Motion  → handed to `adaptiveBudget`, the sole authority over the
+ *           `data-reduced-motion` attribute.
+ *
+ * Density + UI size are chrome-only by construction: they ride the rem token
+ * system, while the canvas is flex/px-sized and maps coordinates through its
+ * own Camera — so it is never affected.
  *
  * (Theme is applied by `themeStore` itself; this module owns the rest.)
  */
@@ -17,7 +23,10 @@ import { setMotionPreference } from '../../platform/adaptiveBudget';
 
 function applyAppearance(prefs: AppearancePrefs): void {
   if (typeof document !== 'undefined') {
-    document.documentElement.dataset['accent'] = prefs.accent;
+    const root = document.documentElement;
+    root.dataset['accent'] = prefs.accent;
+    root.dataset['density'] = prefs.density;
+    root.style.setProperty('--ui-scale', String(prefs.uiScale));
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -22,7 +22,7 @@
 import { useUIPreferencesStore, type AppearancePrefs } from '../../store/uiPreferencesStore';
 import { useThemeStore } from '../../store/themeStore';
 import { setMotionPreference } from '../../platform/adaptiveBudget';
-import { resolveThemeOverrides, THEME_CONTROLLED_TOKENS } from './themeEngine';
+import { PROSE_BACKGROUNDS, resolveThemeOverrides, THEME_CONTROLLED_TOKENS } from './themeEngine';
 
 /** Apply the resolved custom-theme overrides for the *active* base. */
 function applyThemeColors(prefs: AppearancePrefs): void {
@@ -46,6 +46,14 @@ function applyNonColor(prefs: AppearancePrefs): void {
     const root = document.documentElement;
     root.dataset['density'] = prefs.density;
     root.style.setProperty('--ui-scale', String(prefs.uiScale));
+    // Prose editor background: set the override, or remove it so the panel keeps
+    // its built-in per-base behavior (the `default` preset).
+    const prose = PROSE_BACKGROUNDS[prefs.proseBackground]?.value ?? null;
+    if (prose) {
+      root.style.setProperty('--prose-bg', prose);
+    } else {
+      root.style.removeProperty('--prose-bg');
+    }
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -1,45 +1,79 @@
 /**
  * Appearance applier (Abstraction A) — the single place that mirrors appearance
- * preferences onto the document. Runs at module load via a vanilla
+ * preferences onto the document. Runs at module load via vanilla
  * `store.subscribe` (NOT a React effect), so it applies the hydrated values
  * before first paint (localStorage hydrates synchronously on store creation) —
  * no flash — and keeps tracking changes from anywhere, inside or outside React.
  *
- * Accent  → `data-accent` root attribute (CSS swaps `--color-primary*`).
- * Density → `data-density` root attribute (CSS scales `--density-mult`).
- * UI size → `--ui-scale` root var (CSS scales the rem root font-size).
- * Motion  → handed to `adaptiveBudget`, the sole authority over the
- *           `data-reduced-motion` attribute.
+ * Theme colors → resolved from the active base's custom inputs and written as
+ *   inline `--color-*`/`--bg-*`/`--text-*` overrides (which beat the stylesheet
+ *   base in index.css). The full controlled-token set is iterated every apply:
+ *   set for overridden tokens, removed otherwise — so a Light customization can
+ *   never bleed onto Dark, and clearing a slot reverts cleanly to the base.
+ * Density → `data-density` root attribute.
+ * UI size → `--ui-scale` root var (rem root font-size).
+ * Motion → handed to `adaptiveBudget`, the sole authority over `data-reduced-motion`.
  *
- * Density + UI size are chrome-only by construction: they ride the rem token
- * system, while the canvas is flex/px-sized and maps coordinates through its
- * own Camera — so it is never affected.
- *
- * (Theme is applied by `themeStore` itself; this module owns the rest.)
+ * Theme colors + density + UI size are chrome-only by construction (they ride
+ * the CSS token system); the canvas is flex/px-sized and maps input through its
+ * own Camera, so it is never affected.
  */
 
 import { useUIPreferencesStore, type AppearancePrefs } from '../../store/uiPreferencesStore';
+import { useThemeStore } from '../../store/themeStore';
 import { setMotionPreference } from '../../platform/adaptiveBudget';
+import { resolveThemeOverrides, THEME_CONTROLLED_TOKENS } from './themeEngine';
 
-function applyAppearance(prefs: AppearancePrefs): void {
+/** Apply the resolved custom-theme overrides for the *active* base. */
+function applyThemeColors(prefs: AppearancePrefs): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  const base = useThemeStore.getState().resolvedTheme; // 'light' | 'dark'
+  const overrides = resolveThemeOverrides(base, prefs.themeInputs[base] ?? {});
+  for (const token of THEME_CONTROLLED_TOKENS) {
+    const value = overrides[token];
+    if (value != null) {
+      root.style.setProperty(token, value);
+    } else {
+      root.style.removeProperty(token);
+    }
+  }
+}
+
+/** Apply the non-color appearance prefs (density, UI scale, motion). */
+function applyNonColor(prefs: AppearancePrefs): void {
   if (typeof document !== 'undefined') {
     const root = document.documentElement;
-    root.dataset['accent'] = prefs.accent;
     root.dataset['density'] = prefs.density;
     root.style.setProperty('--ui-scale', String(prefs.uiScale));
   }
   setMotionPreference(prefs.motion);
 }
 
-// Apply the already-hydrated preferences immediately.
+function applyAll(prefs: AppearancePrefs): void {
+  applyNonColor(prefs);
+  applyThemeColors(prefs);
+}
+
+// Apply the already-hydrated preferences immediately, before first paint.
 let applied = useUIPreferencesStore.getState().appearancePrefs;
-applyAppearance(applied);
+applyAll(applied);
 
 // Re-apply only when the appearance slice actually changes (the setters produce
 // a new object reference), so unrelated UI-pref updates don't churn.
 useUIPreferencesStore.subscribe((state) => {
   if (state.appearancePrefs !== applied) {
     applied = state.appearancePrefs;
-    applyAppearance(applied);
+    applyAll(applied);
+  }
+});
+
+// Re-resolve theme colors when the base flips (explicit Light/Dark or a `system`
+// OS change) — the active base's overrides differ.
+let appliedBase = useThemeStore.getState().resolvedTheme;
+useThemeStore.subscribe((state) => {
+  if (state.resolvedTheme !== appliedBase) {
+    appliedBase = state.resolvedTheme;
+    applyThemeColors(applied);
   }
 });

--- a/src/ui/appearance/themeEngine.test.ts
+++ b/src/ui/appearance/themeEngine.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  resolveThemeOverrides,
+  surpriseTheme,
+  onColor,
+  THEME_CONTROLLED_TOKENS,
+  THEME_PRESETS,
+  THEME_INK,
+  THEME_PAPER,
+  BASE_SWATCHES,
+} from './themeEngine';
+import { contrastRatio } from '../../utils/color';
+import type { ThemeBase } from '../../store/uiPreferencesStore';
+
+const BASES: ThemeBase[] = ['light', 'dark'];
+const CONTROLLED = new Set<string>(THEME_CONTROLLED_TOKENS);
+/** Accept hex or rgb()/rgba() — the only forms the engine emits. */
+const VALID = /^#[0-9a-f]{6}$|^rgba?\(/i;
+
+function randHex(): string {
+  return '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
+}
+
+describe('themeEngine — completeness', () => {
+  it('empty inputs produce no overrides (base is untouched)', () => {
+    for (const base of BASES) {
+      expect(resolveThemeOverrides(base, {})).toEqual({});
+    }
+  });
+
+  it('a set Primary writes its whole token family', () => {
+    const out = resolveThemeOverrides('light', { primary: '#3366cc' });
+    for (const t of ['--color-primary', '--color-primary-dark', '--color-primary-light', '--color-primary-alpha', '--color-on-primary']) {
+      expect(out[t as keyof typeof out]).toBeTruthy();
+    }
+  });
+
+  it('every emitted token is controlled and a valid color, across presets + fuzz', () => {
+    const cases = [
+      ...THEME_PRESETS.flatMap((p) => [
+        { base: 'light' as const, inputs: p.light },
+        { base: 'dark' as const, inputs: p.dark },
+      ]),
+      ...Array.from({ length: 200 }, () => ({
+        base: (Math.random() < 0.5 ? 'light' : 'dark') as ThemeBase,
+        inputs: { primary: randHex(), cta: randHex(), surface: randHex(), text: randHex() },
+      })),
+    ];
+    for (const { base, inputs } of cases) {
+      const out = resolveThemeOverrides(base, inputs);
+      for (const [token, value] of Object.entries(out)) {
+        expect(CONTROLLED.has(token)).toBe(true);
+        expect(value).toMatch(VALID);
+      }
+    }
+  });
+
+  it('on-fill text always picks the more legible of ink/paper', () => {
+    for (let i = 0; i < 200; i++) {
+      const primary = randHex();
+      const chosen = onColor(primary);
+      const other = chosen === THEME_PAPER ? THEME_INK : THEME_PAPER;
+      // The engine never leaves a more-readable option on the table.
+      expect(contrastRatio(chosen, primary)).toBeGreaterThanOrEqual(contrastRatio(other, primary));
+    }
+  });
+
+  it('curated presets keep on-Primary text AA-legible', () => {
+    for (const preset of THEME_PRESETS) {
+      for (const base of BASES) {
+        const primary = preset[base].primary;
+        if (!primary) continue;
+        expect(contrastRatio(onColor(primary), primary)).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});
+
+describe('themeEngine — drift guard', () => {
+  it('every controlled token is defined in index.css (no engine typo / drift)', () => {
+    const css = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
+    for (const token of THEME_CONTROLLED_TOKENS) {
+      expect(css.includes(`${token}:`)).toBe(true);
+    }
+  });
+
+  it('base swatches cover every base + slot', () => {
+    for (const base of BASES) {
+      for (const slot of ['primary', 'cta', 'surface', 'text'] as const) {
+        expect(BASE_SWATCHES[base][slot]).toMatch(/^#[0-9a-f]{6}$/i);
+      }
+    }
+  });
+});
+
+describe('themeEngine — surprise me', () => {
+  it('generates a legible primary for the base', () => {
+    for (const base of BASES) {
+      for (let i = 0; i < 50; i++) {
+        const inputs = surpriseTheme(base);
+        const out = resolveThemeOverrides(base, inputs);
+        expect(contrastRatio(out['--color-on-primary'] as string, inputs.primary as string)).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+});

--- a/src/ui/appearance/themeEngine.ts
+++ b/src/ui/appearance/themeEngine.ts
@@ -22,7 +22,12 @@ import {
   rgbToHex,
   withAlpha,
 } from '../../utils/color';
-import type { ThemeBase, ThemeColorSlot, ThemeInputs } from '../../store/uiPreferencesStore';
+import type {
+  ProseBackground,
+  ThemeBase,
+  ThemeColorSlot,
+  ThemeInputs,
+} from '../../store/uiPreferencesStore';
 
 /**
  * Every semantic token the engine may override. Order is irrelevant; the
@@ -167,6 +172,26 @@ export function surpriseTheme(base: ThemeBase): ThemeInputs {
 export const BASE_SWATCHES: Record<ThemeBase, Record<ThemeColorSlot, string>> = {
   light: { primary: '#1f3354', cta: '#c9a262', surface: '#f9f6ee', text: '#0a1525' },
   dark: { primary: '#e0c690', cta: '#c9a262', surface: '#0e1c30', text: '#f6f4ec' },
+};
+
+/**
+ * Prose editor background presets. Values are token-referencing CSS `background`
+ * strings, so each adapts to the active theme *and* a custom Surface for free.
+ * `default` has `value: null` → no `--prose-bg` override, so the panel keeps its
+ * built-in per-base behavior (flat in light, the dark glow in dark).
+ */
+export const PROSE_BACKGROUNDS: Record<ProseBackground, { label: string; value: string | null }> = {
+  default: { label: 'Default', value: null },
+  flat: { label: 'Flat', value: 'var(--bg-primary)' },
+  glow: {
+    label: 'Glow',
+    value:
+      'radial-gradient(140% 90% at 50% 0%, var(--bg-tertiary) 0%, var(--bg-primary) 45%, var(--bg-secondary) 100%)',
+  },
+  aurora: {
+    label: 'Aurora',
+    value: 'linear-gradient(180deg, var(--color-primary-light) 0%, var(--bg-primary) 45%)',
+  },
 };
 
 /** Slots in display order, with plain labels for the builder UI. */

--- a/src/ui/appearance/themeEngine.ts
+++ b/src/ui/appearance/themeEngine.ts
@@ -1,0 +1,178 @@
+/**
+ * Theme engine — pure derivation from a sparse set of user color inputs to the
+ * full set of semantic token *overrides* (JP-58).
+ *
+ * Bulletproof-by-construction: the complete light/dark token sets live in
+ * `index.css`. This engine only produces overrides for the slots the user set;
+ * everything else falls through to that base, so no token can ever be missing.
+ * `resolveThemeOverrides(base, {})` returns `{}` → the app looks exactly as it
+ * does with no customization.
+ *
+ * Coverage is enforced by tests: `THEME_CONTROLLED_TOKENS` must be a subset of
+ * the tokens defined in `index.css` (drift guard), and every set slot must
+ * resolve every relative it owns to a parseable color (completeness).
+ */
+
+import {
+  contrastRatio,
+  darken,
+  hslToRgb,
+  lighten,
+  mix,
+  rgbToHex,
+  withAlpha,
+} from '../../utils/color';
+import type { ThemeBase, ThemeColorSlot, ThemeInputs } from '../../store/uiPreferencesStore';
+
+/**
+ * Every semantic token the engine may override. Order is irrelevant; the
+ * applier iterates this set and set/removes each so reverting is total.
+ */
+export const THEME_CONTROLLED_TOKENS = [
+  '--color-primary',
+  '--color-primary-dark',
+  '--color-primary-light',
+  '--color-primary-alpha',
+  '--color-on-primary',
+  '--color-cta',
+  '--color-cta-hover',
+  '--color-cta-text',
+  '--bg-primary',
+  '--bg-secondary',
+  '--bg-tertiary',
+  '--bg-hover',
+  '--bg-active',
+  '--border-color',
+  '--border-color-light',
+  '--border-color-input',
+  '--text-primary',
+  '--text-secondary',
+  '--text-muted',
+  '--text-faint',
+] as const;
+
+export type ControlledToken = (typeof THEME_CONTROLLED_TOKENS)[number];
+
+/** Brand ink/paper anchors used for contrast picks + text fallbacks. */
+export const THEME_INK = '#0a1525';
+export const THEME_PAPER = '#f6f4ec';
+/** Default base surfaces (match index.css) — fallback for text-toward-surface mixing. */
+const BASE_SURFACE: Record<ThemeBase, string> = { light: '#f9f6ee', dark: '#0e1c30' };
+
+/** Pick ink or paper for the most readable text/icon on a filled color. */
+export function onColor(fill: string): string {
+  return contrastRatio(THEME_PAPER, fill) >= contrastRatio(THEME_INK, fill) ? THEME_PAPER : THEME_INK;
+}
+
+/**
+ * Resolve the token overrides for one base from the user's sparse inputs.
+ * Only set slots contribute; each set slot writes its whole token family.
+ */
+export function resolveThemeOverrides(
+  base: ThemeBase,
+  inputs: ThemeInputs
+): Partial<Record<ControlledToken, string>> {
+  const out: Partial<Record<ControlledToken, string>> = {};
+  const { primary, cta, surface, text } = inputs;
+
+  // Resolve text first (surface tints + borders key off it). When the user set a
+  // surface but no text, derive a readable text color from the surface.
+  const resolvedText = text ?? (surface ? onColor(surface) : undefined);
+
+  if (primary) {
+    out['--color-primary'] = primary;
+    out['--color-primary-dark'] = darken(primary, 10);
+    out['--color-primary-light'] = withAlpha(primary, base === 'dark' ? 0.14 : 0.12);
+    out['--color-primary-alpha'] = withAlpha(primary, 0.3);
+    out['--color-on-primary'] = onColor(primary);
+  }
+
+  if (cta) {
+    out['--color-cta'] = cta;
+    out['--color-cta-hover'] = darken(cta, 10);
+    out['--color-cta-text'] = onColor(cta);
+  }
+
+  if (surface) {
+    const tint = resolvedText ?? (base === 'dark' ? THEME_PAPER : THEME_INK);
+    out['--bg-primary'] = surface;
+    out['--bg-secondary'] = base === 'dark' ? darken(surface, 4) : darken(surface, 2);
+    out['--bg-tertiary'] = base === 'dark' ? lighten(surface, 5) : darken(surface, 5);
+    out['--bg-hover'] = withAlpha(tint, 0.06);
+    out['--bg-active'] = withAlpha(tint, 0.1);
+    out['--border-color'] = withAlpha(tint, 0.12);
+    out['--border-color-light'] = withAlpha(tint, 0.06);
+    out['--border-color-input'] = withAlpha(tint, 0.2);
+  }
+
+  if (resolvedText) {
+    const toward = surface ?? BASE_SURFACE[base];
+    out['--text-primary'] = resolvedText;
+    out['--text-secondary'] = mix(resolvedText, toward, 0.2);
+    out['--text-muted'] = mix(resolvedText, toward, 0.45);
+    out['--text-faint'] = mix(resolvedText, toward, 0.6);
+  }
+
+  return out;
+}
+
+/** A curated, on-white-safe preset (per base). `inputs` are sparse. */
+export interface ThemePreset {
+  id: string;
+  label: string;
+  light: ThemeInputs;
+  dark: ThemeInputs;
+}
+
+/**
+ * Safe starter presets. `default` is empty (the hand-tuned base). Values are
+ * intentionally conservative — tuned over time; the point is the mechanism.
+ */
+export const THEME_PRESETS: ThemePreset[] = [
+  { id: 'default', label: 'Default', light: {}, dark: {} },
+  { id: 'ocean', label: 'Ocean', light: { primary: '#0f6fa8' }, dark: { primary: '#7cc6ec' } },
+  { id: 'forest', label: 'Forest', light: { primary: '#0f766e' }, dark: { primary: '#5eead4' } },
+  { id: 'plum', label: 'Plum', light: { primary: '#7e22ce' }, dark: { primary: '#d8b4fe' } },
+  { id: 'ember', label: 'Ember', light: { primary: '#b4530a' }, dark: { primary: '#fcd34d' } },
+];
+
+/**
+ * Generate a tasteful, contrast-safe random theme for a base ("Surprise me").
+ * Lightness is constrained per base so the derived on-color and Primary↔Surface
+ * contrast stay legible; hue/sat are free for variety.
+ */
+export function surpriseTheme(base: ThemeBase): ThemeInputs {
+  const sat = 45 + Math.floor(Math.random() * 25); // 45–70%
+  // Build a hue at a lightness guaranteed to give an AA-legible on-color, by
+  // pushing lightness away from the mid "dead zone" (where neither ink nor paper
+  // reaches AA) until it does — perceptual luminance varies by hue, so we check.
+  const safeFill = (hue: number): string => {
+    let l = base === 'dark' ? 70 : 38;
+    const step = base === 'dark' ? 3 : -3;
+    for (let i = 0; i < 14; i++) {
+      const hex = rgbToHex(hslToRgb({ h: hue, s: sat, l }));
+      if (contrastRatio(onColor(hex), hex) >= 4.6) return hex;
+      l = Math.max(4, Math.min(96, l + step));
+    }
+    return rgbToHex(hslToRgb({ h: hue, s: sat, l }));
+  };
+  const hue = Math.floor(Math.random() * 360);
+  return { primary: safeFill(hue), cta: safeFill((hue + 150) % 360) };
+}
+
+/**
+ * Representative base-default color per slot per base (mirrors index.css), shown
+ * in the builder when a slot is *not* overridden so the swatch reflects reality.
+ */
+export const BASE_SWATCHES: Record<ThemeBase, Record<ThemeColorSlot, string>> = {
+  light: { primary: '#1f3354', cta: '#c9a262', surface: '#f9f6ee', text: '#0a1525' },
+  dark: { primary: '#e0c690', cta: '#c9a262', surface: '#0e1c30', text: '#f6f4ec' },
+};
+
+/** Slots in display order, with plain labels for the builder UI. */
+export const THEME_SLOTS: ReadonlyArray<{ slot: ThemeColorSlot; label: string; hint: string }> = [
+  { slot: 'primary', label: 'Primary', hint: 'Links, active states, primary buttons' },
+  { slot: 'cta', label: 'Call-to-action', hint: 'Prominent action buttons' },
+  { slot: 'surface', label: 'Surface', hint: 'Page and panel backgrounds' },
+  { slot: 'text', label: 'Text', hint: 'Body text colour' },
+];

--- a/src/ui/components/ColorField.css
+++ b/src/ui/components/ColorField.css
@@ -1,0 +1,118 @@
+/* ColorField — theme-builder color slot (swatch + react-colorful popover). */
+
+.color-field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.color-field__head {
+  display: flex;
+  flex-direction: column;
+}
+
+.color-field__label {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.color-field__hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.color-field__control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.color-field__swatch {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-color-input);
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+}
+
+.color-field__swatch:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+.color-field__value {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.color-field__warning {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--warning);
+}
+
+.color-field__popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+}
+
+.color-field__popover .react-colorful {
+  width: 200px;
+  height: 160px;
+}
+
+.color-field__popover-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.color-field__hash {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.color-field__hex {
+  width: 84px;
+  padding: 4px 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 6px;
+}
+
+.color-field__default-btn {
+  margin-left: auto;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.color-field__default-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/ui/components/ColorField.tsx
+++ b/src/ui/components/ColorField.tsx
@@ -1,0 +1,110 @@
+/**
+ * ColorField — one color slot in the theme builder: a swatch that opens a
+ * popover with a react-colorful picker + hex input, plus "Use default" to clear
+ * the override (fall back to the base token). Shows an optional contrast warning.
+ *
+ * `value === undefined` means "not overridden" — the swatch shows `defaultSwatch`
+ * (the base's representative color) and the field reads as Default.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { HexColorPicker, HexColorInput } from 'react-colorful';
+import { AlertTriangle } from 'lucide-react';
+import './ColorField.css';
+
+export interface ColorFieldProps {
+  label: string;
+  hint?: string;
+  /** Current override, or undefined when the base default applies. */
+  value: string | undefined;
+  /** Representative swatch shown when unset. */
+  defaultSwatch: string;
+  onChange: (value: string | undefined) => void;
+  /** Inline contrast warning text, if any. */
+  warning?: string;
+}
+
+export function ColorField({ label, hint, value, defaultSwatch, onChange, warning }: ColorFieldProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const swatch = value ?? defaultSwatch;
+  const isDefault = value === undefined;
+
+  // Normalize to a leading-# hex before storing — HexColorInput can emit the
+  // bare hex, which is not a valid CSS color value.
+  const handlePick = useCallback(
+    (c: string) => onChange(c ? (c.startsWith('#') ? c : `#${c}`) : undefined),
+    [onChange]
+  );
+
+  const close = useCallback(() => setOpen(false), []);
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (t && !wrapRef.current?.contains(t)) close();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('pointerdown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, close]);
+
+  return (
+    <div className="color-field" ref={wrapRef}>
+      <div className="color-field__head">
+        <span className="color-field__label">{label}</span>
+        {hint && <span className="color-field__hint">{hint}</span>}
+      </div>
+
+      <div className="color-field__control">
+        <button
+          type="button"
+          className="color-field__swatch"
+          style={{ background: swatch }}
+          aria-label={`${label}: ${isDefault ? 'Default' : swatch}. Click to change.`}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        />
+        <span className="color-field__value">{isDefault ? 'Default' : swatch}</span>
+        {warning && (
+          <span className="color-field__warning" role="status" title={warning}>
+            <AlertTriangle size={13} aria-hidden="true" /> {warning}
+          </span>
+        )}
+      </div>
+
+      {open && (
+        <div className="color-field__popover" role="dialog" aria-label={`${label} color`}>
+          <HexColorPicker color={swatch} onChange={handlePick} />
+          <div className="color-field__popover-row">
+            <span className="color-field__hash">#</span>
+            <HexColorInput
+              className="color-field__hex"
+              color={swatch}
+              onChange={handlePick}
+              aria-label={`${label} hex value`}
+            />
+            <button
+              type="button"
+              className="color-field__default-btn"
+              disabled={isDefault}
+              onClick={() => {
+                onChange(undefined);
+                close();
+              }}
+            >
+              Use default
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/SegmentedControl.css
+++ b/src/ui/components/SegmentedControl.css
@@ -55,10 +55,5 @@
   align-items: center;
 }
 
-/* Honor reduced-motion explicitly (CSS @media here is fine; the JS-driven
-   `data-motion` override seam lands with the Accent/Motion slice). */
-@media (prefers-reduced-motion: reduce) {
-  .segmented-control__item {
-    transition: none;
-  }
-}
+/* Reduced-motion is handled globally by adaptive-motion.css via
+   :root[data-reduced-motion='true'] — no per-component @media needed. */

--- a/src/ui/components/SegmentedControl.css
+++ b/src/ui/components/SegmentedControl.css
@@ -1,0 +1,64 @@
+/* SegmentedControl — brand-tokened segmented button group (Radix RadioGroup). */
+
+.segmented-control {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color, var(--bg-active));
+  border-radius: 8px;
+}
+
+.segmented-control__item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.segmented-control__item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.segmented-control__item[data-state='checked'] {
+  background: var(--bg-primary);
+  color: var(--color-primary);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(14, 28, 48, 0.12));
+}
+
+.segmented-control__item:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 1px;
+}
+
+.segmented-control__item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.segmented-control__icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Honor reduced-motion explicitly (CSS @media here is fine; the JS-driven
+   `data-motion` override seam lands with the Accent/Motion slice). */
+@media (prefers-reduced-motion: reduce) {
+  .segmented-control__item {
+    transition: none;
+  }
+}

--- a/src/ui/components/SegmentedControl.test.tsx
+++ b/src/ui/components/SegmentedControl.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SegmentedControl } from './SegmentedControl';
+
+const OPTIONS = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+] as const;
+
+describe('SegmentedControl', () => {
+  it('renders every option', () => {
+    render(
+      <SegmentedControl ariaLabel="Color theme" value="system" onValueChange={() => {}} options={OPTIONS} />
+    );
+    expect(screen.getByText('System')).toBeTruthy();
+    expect(screen.getByText('Light')).toBeTruthy();
+    expect(screen.getByText('Dark')).toBeTruthy();
+  });
+
+  it('marks the selected option as checked', () => {
+    render(
+      <SegmentedControl ariaLabel="Color theme" value="light" onValueChange={() => {}} options={OPTIONS} />
+    );
+    const light = screen.getByRole('radio', { name: 'Light' });
+    expect(light.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('calls onValueChange with the clicked option value', () => {
+    const onValueChange = vi.fn();
+    render(
+      <SegmentedControl ariaLabel="Color theme" value="system" onValueChange={onValueChange} options={OPTIONS} />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }));
+    expect(onValueChange).toHaveBeenCalledWith('dark');
+  });
+});

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -1,0 +1,70 @@
+/**
+ * SegmentedControl — a horizontal single-select control styled as a segmented
+ * button group, built on Radix `RadioGroup` (roving-tabindex keyboard nav,
+ * arrow keys, WAI-ARIA radiogroup semantics for free).
+ *
+ * Thin local wrapper so the rest of the app consumes *our* component, not Radix
+ * directly — the dependency is swappable and the styling stays brand-tokened.
+ */
+
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import type { ReactNode } from 'react';
+import './SegmentedControl.css';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+  /** Optional leading icon (e.g. a lucide glyph). */
+  icon?: ReactNode;
+  /** Native title / tooltip. */
+  title?: string;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  value: T;
+  onValueChange: (value: T) => void;
+  options: ReadonlyArray<SegmentedOption<T>>;
+  /** Accessible label for the group (required — there's no visible legend). */
+  ariaLabel: string;
+  /** Optional form name. */
+  name?: string;
+  disabled?: boolean;
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  onValueChange,
+  options,
+  ariaLabel,
+  name,
+  disabled,
+}: SegmentedControlProps<T>) {
+  return (
+    <RadioGroup.Root
+      className="segmented-control"
+      value={value}
+      onValueChange={(v) => onValueChange(v as T)}
+      aria-label={ariaLabel}
+      orientation="horizontal"
+      loop
+      {...(name !== undefined ? { name } : {})}
+      {...(disabled !== undefined ? { disabled } : {})}
+    >
+      {options.map((opt) => (
+        <RadioGroup.Item
+          key={opt.value}
+          className="segmented-control__item"
+          value={opt.value}
+          {...(opt.title !== undefined ? { title: opt.title } : {})}
+        >
+          {opt.icon != null && (
+            <span className="segmented-control__icon" aria-hidden="true">
+              {opt.icon}
+            </span>
+          )}
+          <span className="segmented-control__label">{opt.label}</span>
+        </RadioGroup.Item>
+      ))}
+    </RadioGroup.Root>
+  );
+}

--- a/src/ui/components/Slider.css
+++ b/src/ui/components/Slider.css
@@ -1,0 +1,50 @@
+/* Slider — brand-tokened single-value slider (Radix Slider). */
+
+.ds-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 160px;
+  height: 20px;
+  -webkit-user-select: none;
+  user-select: none;
+  touch-action: none;
+}
+
+.ds-slider__track {
+  position: relative;
+  flex-grow: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--bg-active);
+}
+
+.ds-slider__range {
+  position: absolute;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--color-primary);
+}
+
+.ds-slider__thumb {
+  display: block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bg-primary);
+  box-shadow: 0 1px 3px rgba(14, 28, 48, 0.35), 0 0 0 1px var(--color-primary) inset;
+  cursor: pointer;
+}
+
+.ds-slider__thumb:hover {
+  box-shadow: 0 1px 3px rgba(14, 28, 48, 0.4), 0 0 0 2px var(--color-primary) inset;
+}
+
+.ds-slider__thumb:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+.ds-slider[data-disabled] {
+  opacity: 0.5;
+}

--- a/src/ui/components/Slider.test.tsx
+++ b/src/ui/components/Slider.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Slider } from './Slider';
+
+describe('Slider', () => {
+  it('exposes an accessible slider with the current value', () => {
+    render(<Slider ariaLabel="Interface size" value={110} onValueChange={() => {}} min={90} max={125} step={5} />);
+    const slider = screen.getByRole('slider', { name: 'Interface size' });
+    expect(slider.getAttribute('aria-valuenow')).toBe('110');
+  });
+
+  it('moves on keyboard input and reports the new value', () => {
+    const onValueChange = vi.fn();
+    render(<Slider ariaLabel="Interface size" value={100} onValueChange={onValueChange} min={90} max={125} step={5} />);
+    const slider = screen.getByRole('slider', { name: 'Interface size' });
+    slider.focus();
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(onValueChange).toHaveBeenCalledWith(105);
+  });
+});

--- a/src/ui/components/Slider.tsx
+++ b/src/ui/components/Slider.tsx
@@ -1,0 +1,37 @@
+/**
+ * Slider — a brand-tokened single-value slider built on Radix `Slider`
+ * (keyboard + ARIA). Thin local wrapper so the dependency stays swappable.
+ */
+
+import * as RadixSlider from '@radix-ui/react-slider';
+import './Slider.css';
+
+export interface SliderProps {
+  value: number;
+  onValueChange: (value: number) => void;
+  min: number;
+  max: number;
+  step: number;
+  ariaLabel: string;
+  disabled?: boolean;
+}
+
+export function Slider({ value, onValueChange, min, max, step, ariaLabel, disabled }: SliderProps) {
+  return (
+    <RadixSlider.Root
+      className="ds-slider"
+      value={[value]}
+      onValueChange={(values) => onValueChange(values[0] ?? value)}
+      min={min}
+      max={max}
+      step={step}
+      aria-label={ariaLabel}
+      {...(disabled !== undefined ? { disabled } : {})}
+    >
+      <RadixSlider.Track className="ds-slider__track">
+        <RadixSlider.Range className="ds-slider__range" />
+      </RadixSlider.Track>
+      <RadixSlider.Thumb className="ds-slider__thumb" aria-label={ariaLabel} />
+    </RadixSlider.Root>
+  );
+}

--- a/src/ui/components/Switch.css
+++ b/src/ui/components/Switch.css
@@ -1,0 +1,56 @@
+/* Switch — brand-tokened toggle (Radix Switch). */
+
+.switch {
+  --switch-w: 38px;
+  --switch-h: 22px;
+  --switch-pad: 2px;
+  --thumb: calc(var(--switch-h) - var(--switch-pad) * 2);
+  flex: 0 0 auto;
+  width: var(--switch-w);
+  height: var(--switch-h);
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--bg-active);
+  cursor: pointer;
+  position: relative;
+  transition: background-color 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.switch[data-state='checked'] {
+  background: var(--color-primary);
+}
+
+.switch:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+.switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.switch__thumb {
+  display: block;
+  width: var(--thumb);
+  height: var(--thumb);
+  border-radius: 50%;
+  background: var(--bg-primary);
+  box-shadow: 0 1px 2px rgba(14, 28, 48, 0.3);
+  transform: translateX(var(--switch-pad));
+  transition: transform 0.15s ease;
+  will-change: transform;
+}
+
+.switch[data-state='checked'] .switch__thumb {
+  transform: translateX(calc(var(--switch-w) - var(--thumb) - var(--switch-pad)));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch,
+  .switch__thumb {
+    transition: none;
+  }
+}

--- a/src/ui/components/Switch.css
+++ b/src/ui/components/Switch.css
@@ -48,9 +48,4 @@
   transform: translateX(calc(var(--switch-w) - var(--thumb) - var(--switch-pad)));
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .switch,
-  .switch__thumb {
-    transition: none;
-  }
-}
+/* Reduced-motion handled globally by adaptive-motion.css. */

--- a/src/ui/components/Switch.tsx
+++ b/src/ui/components/Switch.tsx
@@ -1,0 +1,30 @@
+/**
+ * Switch — a brand-tokened toggle built on Radix `Switch` (keyboard + ARIA
+ * switch semantics). Thin local wrapper so the dependency stays swappable.
+ */
+
+import * as RadixSwitch from '@radix-ui/react-switch';
+import './Switch.css';
+
+export interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  id?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+}
+
+export function Switch({ checked, onCheckedChange, id, ariaLabel, disabled }: SwitchProps) {
+  return (
+    <RadixSwitch.Root
+      className="switch"
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      {...(id !== undefined ? { id } : {})}
+      {...(ariaLabel !== undefined ? { 'aria-label': ariaLabel } : {})}
+      {...(disabled !== undefined ? { disabled } : {})}
+    >
+      <RadixSwitch.Thumb className="switch__thumb" />
+    </RadixSwitch.Root>
+  );
+}

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -93,10 +93,12 @@
   z-index: 6;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .flyout-panel-body {
-    animation: flyout-panel-slide 140ms ease-out;
-  }
+/* Slide-in is declared unconditionally; the global
+   `:root[data-reduced-motion='true']` rule in adaptive-motion.css collapses it
+   when motion is reduced (OS, low-power, or the user's Motion preference), and
+   an explicit "Full" preference keeps it even when the OS asks to reduce. */
+.flyout-panel-body {
+  animation: flyout-panel-slide 140ms ease-out;
 }
 
 .flyout-panel-side-right .flyout-panel-body {

--- a/src/ui/layout/LayoutSelector.tsx
+++ b/src/ui/layout/LayoutSelector.tsx
@@ -4,17 +4,12 @@
  * Lives in `UnifiedToolbar`, never in the titlebar. The toolbar is always our
  * own UI regardless of chrome choice, so this control is guaranteed to render.
  *
- * The dropdown footer hosts the custom-chrome opt-in and a "Customize layout"
- * link into Settings.
+ * The dropdown footer hosts a "Customize layout…" link into Settings. The
+ * custom-chrome opt-in lives in Settings → Appearance → Window (gated to the
+ * desktop shell), not here.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
-import { usePersistenceStore } from '../../store/persistenceStore';
-import { useNotificationStore } from '../../store/notificationStore';
-import { isTauri } from '../../platform/runtime';
-import { opener } from '../../platform/opener';
-import { isMacOS } from '../../utils/platform';
 import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS } from './modes';
 import { useActiveLayoutMode, useLayoutActions } from './useLayout';
 import { LAYOUT_MODES, type LayoutMode } from './types';
@@ -29,8 +24,6 @@ export interface LayoutSelectorProps {
 export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
   const activeMode = useActiveLayoutMode();
   const { setActiveLayout } = useLayoutActions();
-  const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
-  const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
 
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -62,56 +55,6 @@ export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
   const handleCustomize = () => {
     close();
     onOpenLayoutSettings?.();
-  };
-
-  const handleChromeToggle = () => {
-    const next = !customChrome;
-    const inTauri = isTauri();
-    const verb = inTauri
-      ? import.meta.env.DEV
-        ? 'The flag will be saved (manual `tauri:dev` restart required)'
-        : 'The app will restart'
-      : 'The window will reload';
-    const confirmed = window.confirm(
-      next
-        ? `Use custom window chrome? ${verb} to apply.`
-        : `Revert to system window decorations? ${verb} to apply.`
-    );
-    if (!confirmed) return;
-    setCustomChrome(next);
-    // Flush any pending auto-save so the beforeunload handler in useAutoSave
-    // doesn't fire its "unsaved changes" prompt during the reload path. (In
-    // Tauri we skip the JS reload entirely, but doing this unconditionally
-    // also handles the web PWA path.)
-    try {
-      usePersistenceStore.getState().saveDocument();
-    } catch {
-      // Best-effort flush; the user already confirmed they want to reload.
-    }
-    if (isTauri()) {
-      // Desktop: persist the flag, then either restart (prod) or just
-      // warn the developer (dev). The restart path is required on Linux
-      // WMs that ignore runtime setDecorations.
-      //
-      // Dev-mode caveat: `app.restart()` under `tauri dev` kills the
-      // cargo-spawned binary without re-spawning it (and the dev-server
-      // bridge wouldn't reattach cleanly anyway), so we persist the
-      // flag without restarting and tell the developer to bounce
-      // `bun run tauri:dev` themselves. Production bundles are fine.
-      if (import.meta.env.DEV) {
-        void opener.persistCustomChrome(next);
-        useNotificationStore.getState().warning(
-          'Custom chrome flag saved. In dev mode you must stop and restart `bun run tauri:dev` manually for it to take effect.',
-          { duration: 10000 }
-        );
-      } else {
-        void opener.applyCustomChrome(next);
-      }
-    } else {
-      // Web/PWA: no native chrome to swap, but a reload re-mounts so the
-      // optional in-app TitleBar appears/disappears consistently.
-      window.location.reload();
-    }
   };
 
   return (
@@ -162,20 +105,6 @@ export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
             >
               Customize layout…
             </button>
-            {/* Custom chrome is not offered on macOS — the platform's
-                traffic-light controls and unified titlebar are too tightly
-                coupled to native window decorations for our cross-platform
-                in-app TitleBar to be a credible replacement. */}
-            {!isMacOS() && (
-              <label className="layout-selector-footer-item layout-selector-toggle">
-                <input
-                  type="checkbox"
-                  checked={customChrome}
-                  onChange={handleChromeToggle}
-                />
-                <span>Use custom window chrome</span>
-              </label>
-            )}
           </div>
         </div>
       )}

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -40,49 +40,67 @@
   margin-top: 2px;
 }
 
-/* Accent color swatches (Radix RadioGroup of color circles). */
-.accent-picker {
-  display: inline-flex;
-  gap: 10px;
+/* Theme builder — preset row, color-slot grid, per-base reset. */
+.theme-preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.accent-picker__swatch {
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  border: none;
-  border-radius: 50%;
-  background: var(--swatch);
-  box-shadow: 0 0 0 1px var(--bg-active) inset;
+.theme-preset {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: 6px;
+  padding: 5px 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
   cursor: pointer;
-  transition: transform 0.1s ease, box-shadow 0.1s ease;
 }
 
-.accent-picker__swatch:hover {
-  transform: scale(1.08);
+.theme-preset:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
-.accent-picker__swatch:focus-visible {
+.theme-preset.is-active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.theme-preset:focus-visible {
   outline: 2px solid var(--color-primary-alpha);
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
-/* Selected: a ring in the panel color around the swatch + a white check. */
-.accent-picker__swatch[data-state='checked'] {
-  box-shadow:
-    0 0 0 2px var(--bg-primary),
-    0 0 0 4px var(--swatch);
+.theme-preset__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--border-color-input) inset;
 }
 
-.accent-picker__check {
-  color: #fff;
-  opacity: 0;
-  transition: opacity 0.1s ease;
+.theme-slots {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 4px 0 10px;
 }
 
-.accent-picker__swatch[data-state='checked'] .accent-picker__check {
-  opacity: 1;
+.theme-reset-base {
+  padding: 5px 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.theme-reset-base:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -104,3 +104,46 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Prose background presets — chip with a live gradient preview. */
+.prose-bg-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.prose-bg-option {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.prose-bg-option:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.prose-bg-option.is-active {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.prose-bg-option:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 1px;
+}
+
+.prose-bg-preview {
+  width: 64px;
+  height: 40px;
+  border-radius: 5px;
+  box-shadow: 0 0 0 1px var(--border-color-input) inset;
+}

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -1,0 +1,41 @@
+/* Settings → Appearance.
+ *
+ * Reuses the shared `.settings-*` group/row/label/hint/slider classes defined
+ * in GeneralSettings.css (co-loaded with the settings module graph). Only the
+ * Appearance-specific additions live here. (The settings-menu rework — JP-211 —
+ * is expected to consolidate these shared classes into one place.) */
+
+.appearance-settings {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Switch row: label + thumb on one line, hint beneath (mirrors the checkbox
+   row pattern but for the Radix-based Switch). */
+.appearance-settings .settings-row-switch {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.appearance-settings .settings-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.appearance-settings .settings-switch-text {
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+/* The embedded LayoutSettings drops its standalone top margin so it reads as a
+   section within the panel rather than a separate page. */
+.appearance-settings .layout-settings {
+  margin-top: 0;
+}
+
+.appearance-settings .layout-settings-header p {
+  margin-top: 2px;
+}

--- a/src/ui/settings/AppearanceSettings.css
+++ b/src/ui/settings/AppearanceSettings.css
@@ -39,3 +39,50 @@
 .appearance-settings .layout-settings-header p {
   margin-top: 2px;
 }
+
+/* Accent color swatches (Radix RadioGroup of color circles). */
+.accent-picker {
+  display: inline-flex;
+  gap: 10px;
+}
+
+.accent-picker__swatch {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--swatch);
+  box-shadow: 0 0 0 1px var(--bg-active) inset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.accent-picker__swatch:hover {
+  transform: scale(1.08);
+}
+
+.accent-picker__swatch:focus-visible {
+  outline: 2px solid var(--color-primary-alpha);
+  outline-offset: 2px;
+}
+
+/* Selected: a ring in the panel color around the swatch + a white check. */
+.accent-picker__swatch[data-state='checked'] {
+  box-shadow:
+    0 0 0 2px var(--bg-primary),
+    0 0 0 4px var(--swatch);
+}
+
+.accent-picker__check {
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.accent-picker__swatch[data-state='checked'] .accent-picker__check {
+  opacity: 1;
+}

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -3,11 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { AppearanceSettings } from './AppearanceSettings';
 
 describe('AppearanceSettings', () => {
-  it('renders the theme, accent, and motion controls', () => {
+  it('renders the theme, accent, motion, density, and interface-size controls', () => {
     render(<AppearanceSettings />);
     expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Accent color' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Interface animations' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Spacing density' })).toBeTruthy();
+    expect(screen.getByRole('slider', { name: 'Interface size' })).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -3,17 +3,19 @@ import { render, screen } from '@testing-library/react';
 import { AppearanceSettings } from './AppearanceSettings';
 
 describe('AppearanceSettings', () => {
-  it('renders the theme control', () => {
+  it('renders the theme, accent, and motion controls', () => {
     render(<AppearanceSettings />);
     expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Accent color' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Interface animations' })).toBeTruthy();
   });
 
-  // JP-107 regression: the custom-window-chrome control is desktop-only. In the
+  // JP-107 regression: the DocuShark title-bar control is desktop-only. In the
   // test (web) environment `windowControls.isSupported()` is false (IS_TAURI is
-  // false), so the entire Window section — header included — must be absent.
-  it('does not render the window-chrome section on web', () => {
+  // false), so the entire Title bar section — header included — must be absent.
+  it('does not render the title-bar section on the web app', () => {
     render(<AppearanceSettings />);
-    expect(screen.queryByText(/custom window chrome/i)).toBeNull();
-    expect(screen.queryByText('Window')).toBeNull();
+    expect(screen.queryByText(/use docushark's title bar/i)).toBeNull();
+    expect(screen.queryByText('Title bar')).toBeNull();
   });
 });

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -13,6 +13,9 @@ describe('AppearanceSettings', () => {
     expect(screen.getByText('Primary')).toBeTruthy();
     expect(screen.getByText('Surface')).toBeTruthy();
     expect(screen.getByText('Surprise me')).toBeTruthy();
+    // Prose background presets render.
+    expect(screen.getByText('Prose background')).toBeTruthy();
+    expect(screen.getByText('Glow')).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -3,13 +3,16 @@ import { render, screen } from '@testing-library/react';
 import { AppearanceSettings } from './AppearanceSettings';
 
 describe('AppearanceSettings', () => {
-  it('renders the theme, accent, motion, density, and interface-size controls', () => {
+  it('renders the theme builder + comfort controls', () => {
     render(<AppearanceSettings />);
-    expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
-    expect(screen.getByRole('radiogroup', { name: 'Accent color' })).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: 'Theme base' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Interface animations' })).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: 'Spacing density' })).toBeTruthy();
     expect(screen.getByRole('slider', { name: 'Interface size' })).toBeTruthy();
+    // Theme color slots + the Surprise-me generator are present.
+    expect(screen.getByText('Primary')).toBeTruthy();
+    expect(screen.getByText('Surface')).toBeTruthy();
+    expect(screen.getByText('Surprise me')).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppearanceSettings } from './AppearanceSettings';
+
+describe('AppearanceSettings', () => {
+  it('renders the theme control', () => {
+    render(<AppearanceSettings />);
+    expect(screen.getByRole('radiogroup', { name: 'Color theme' })).toBeTruthy();
+  });
+
+  // JP-107 regression: the custom-window-chrome control is desktop-only. In the
+  // test (web) environment `windowControls.isSupported()` is false (IS_TAURI is
+  // false), so the entire Window section — header included — must be absent.
+  it('does not render the window-chrome section on web', () => {
+    render(<AppearanceSettings />);
+    expect(screen.queryByText(/custom window chrome/i)).toBeNull();
+    expect(screen.queryByText('Window')).toBeNull();
+  });
+});

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -12,7 +12,13 @@ import * as RadioGroup from '@radix-ui/react-radio-group';
 import { Check, Monitor, Moon, Sun } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
-import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
+import {
+  useUIPreferencesStore,
+  type AccentColor,
+  type Density,
+  UI_SCALE_MIN,
+  UI_SCALE_MAX,
+} from '../../store/uiPreferencesStore';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
 import type { MotionPreference } from '../../platform/adaptiveBudget';
@@ -20,6 +26,7 @@ import { windowControls } from '../../platform/window';
 import { opener } from '../../platform/opener';
 import { isMacOS } from '../../utils/platform';
 import { SegmentedControl } from '../components/SegmentedControl';
+import { Slider } from '../components/Slider';
 import { Switch } from '../components/Switch';
 import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
@@ -47,6 +54,12 @@ const MOTION_OPTIONS = [
   { value: 'full' as const, label: 'Full', title: 'Always show interface animations' },
 ];
 
+const DENSITY_OPTIONS = [
+  { value: 'compact' as const, label: 'Compact', title: 'Tighter spacing — fit more on screen' },
+  { value: 'normal' as const, label: 'Normal', title: 'Default spacing' },
+  { value: 'spacious' as const, label: 'Spacious', title: 'Roomier spacing and larger targets' },
+];
+
 export function AppearanceSettings() {
   const themePreference = useThemeStore((s) => s.preference);
   const setThemePreference = useThemeStore((s) => s.setPreference);
@@ -54,8 +67,14 @@ export function AppearanceSettings() {
   const setAccent = useUIPreferencesStore((s) => s.setAccent);
   const motion = useUIPreferencesStore((s) => s.appearancePrefs.motion);
   const setMotion = useUIPreferencesStore((s) => s.setMotion);
+  const density = useUIPreferencesStore((s) => s.appearancePrefs.density);
+  const setDensity = useUIPreferencesStore((s) => s.setDensity);
+  const uiScale = useUIPreferencesStore((s) => s.appearancePrefs.uiScale);
+  const setUiScale = useUIPreferencesStore((s) => s.setUiScale);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
+
+  const uiScalePercent = Math.round(uiScale * 100);
 
   const handleReset = () => {
     if (window.confirm('Reset theme, accent color, motion, and layout customization to their defaults?')) {
@@ -110,6 +129,49 @@ export function AppearanceSettings() {
           <span className="settings-hint">
             Reduce or turn off interface animations. "System" follows your device's
             accessibility setting.
+          </span>
+        </div>
+      </div>
+
+      {/* Density */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Density</h4>
+        <div className="settings-row">
+          <span className="settings-label">Spacing</span>
+          <SegmentedControl
+            ariaLabel="Spacing density"
+            value={density}
+            onValueChange={(v: Density) => setDensity(v)}
+            options={DENSITY_OPTIONS}
+          />
+          <span className="settings-hint">
+            Tighten or loosen spacing throughout the app. Compact fits more on screen;
+            Spacious gives larger, easier targets.
+          </span>
+        </div>
+      </div>
+
+      {/* Interface size */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Interface size</h4>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="ui-scale">
+            Size
+          </label>
+          <div className="settings-slider-row">
+            <Slider
+              ariaLabel="Interface size"
+              value={uiScalePercent}
+              onValueChange={(pct) => setUiScale(pct / 100)}
+              min={Math.round(UI_SCALE_MIN * 100)}
+              max={Math.round(UI_SCALE_MAX * 100)}
+              step={5}
+            />
+            <span className="settings-slider-value">{uiScalePercent}%</span>
+          </div>
+          <span className="settings-hint">
+            Scale the whole interface up or down. The canvas and your diagrams are
+            not affected.
           </span>
         </div>
       </div>

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,21 +1,21 @@
 /**
  * Settings → Appearance — the consolidated home for visual/UX configuration.
  *
- * Sections: Theme, Accent color, Motion, Canvas, Layout (the panel-arrangement
- * editor, embedded), and Title bar (desktop-only). Density + UI-scale land in a
- * later slice. Kept self-contained (no coupling to `SettingsModal` internals)
+ * Sections: Theme builder (base + presets + Primary/CTA/Surface/Text + Surprise
+ * me), Motion, Density, Interface size, Canvas, Layout (embedded), and Title bar
+ * (desktop-only). Kept self-contained (no coupling to `SettingsModal` internals)
  * so it survives the planned settings-menu rework.
  */
 
-import type { CSSProperties } from 'react';
-import * as RadioGroup from '@radix-ui/react-radio-group';
-import { Check, Monitor, Moon, Sun } from 'lucide-react';
+import { Monitor, Moon, Sun, Wand2 } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
-  type AccentColor,
   type Density,
+  type ThemeBase,
+  type ThemeColorSlot,
+  type ThemeInputs,
   UI_SCALE_MIN,
   UI_SCALE_MAX,
 } from '../../store/uiPreferencesStore';
@@ -25,9 +25,17 @@ import type { MotionPreference } from '../../platform/adaptiveBudget';
 import { windowControls } from '../../platform/window';
 import { opener } from '../../platform/opener';
 import { isMacOS } from '../../utils/platform';
+import { contrastRatio } from '../../utils/color';
+import {
+  BASE_SWATCHES,
+  THEME_PRESETS,
+  THEME_SLOTS,
+  surpriseTheme,
+} from '../appearance/themeEngine';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { Slider } from '../components/Slider';
 import { Switch } from '../components/Switch';
+import { ColorField } from '../components/ColorField';
 import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
 import './AppearanceSettings.css';
@@ -36,16 +44,6 @@ const THEME_OPTIONS = [
   { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your device appearance' },
   { value: 'light' as const, label: 'Light', icon: <Sun size={15} />, title: 'Light theme' },
   { value: 'dark' as const, label: 'Dark', icon: <Moon size={15} />, title: 'Dark theme' },
-];
-
-// Representative swatch colors (the light-theme hue). 'default' shows the brand
-// navy and adds no override — the theme keeps its own accent (navy / gold).
-const ACCENT_OPTIONS: ReadonlyArray<{ value: AccentColor; label: string; swatch: string }> = [
-  { value: 'default', label: 'Default', swatch: '#1f3354' },
-  { value: 'teal', label: 'Teal', swatch: '#0f766e' },
-  { value: 'violet', label: 'Violet', swatch: '#6d28d9' },
-  { value: 'amber', label: 'Amber', swatch: '#b45309' },
-  { value: 'rose', label: 'Rose', swatch: '#be123c' },
 ];
 
 const MOTION_OPTIONS = [
@@ -60,11 +58,20 @@ const DENSITY_OPTIONS = [
   { value: 'spacious' as const, label: 'Spacious', title: 'Roomier spacing and larger targets' },
 ];
 
+/** WCAG thresholds for the inline contrast warnings. */
+const AA_TEXT = 4.5;
+const UI_MIN = 3;
+
 export function AppearanceSettings() {
   const themePreference = useThemeStore((s) => s.preference);
   const setThemePreference = useThemeStore((s) => s.setPreference);
-  const accent = useUIPreferencesStore((s) => s.appearancePrefs.accent);
-  const setAccent = useUIPreferencesStore((s) => s.setAccent);
+  // The base being edited follows the resolved (active) theme.
+  const activeBase = useThemeStore((s) => s.resolvedTheme) as ThemeBase;
+
+  const themeInputs = useUIPreferencesStore((s) => s.appearancePrefs.themeInputs[activeBase]);
+  const setThemeInput = useUIPreferencesStore((s) => s.setThemeInput);
+  const setThemeInputs = useUIPreferencesStore((s) => s.setThemeInputs);
+
   const motion = useUIPreferencesStore((s) => s.appearancePrefs.motion);
   const setMotion = useUIPreferencesStore((s) => s.setMotion);
   const density = useUIPreferencesStore((s) => s.appearancePrefs.density);
@@ -75,9 +82,24 @@ export function AppearanceSettings() {
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
   const uiScalePercent = Math.round(uiScale * 100);
+  const baseSwatch = BASE_SWATCHES[activeBase];
+
+  // Resolved surface for contrast checks (override or base default).
+  const resolvedSurface = themeInputs.surface ?? baseSwatch.surface;
+  const warnFor = (slot: ThemeColorSlot): string | undefined => {
+    const v = themeInputs[slot];
+    if (!v) return undefined; // unset → engine derives safely
+    if (slot === 'text' && contrastRatio(v, resolvedSurface) < AA_TEXT) return 'Low contrast';
+    if (slot === 'primary' && contrastRatio(v, resolvedSurface) < UI_MIN) return 'Low contrast on this surface';
+    return undefined;
+  };
+
+  const activePresetId = THEME_PRESETS.find(
+    (p) => JSON.stringify(p[activeBase]) === JSON.stringify(themeInputs)
+  )?.id;
 
   const handleReset = () => {
-    if (window.confirm('Reset theme, accent color, motion, and layout customization to their defaults?')) {
+    if (window.confirm('Reset theme, motion, density, interface size, and layout customization to their defaults?')) {
       resetAppearance();
     }
   };
@@ -86,32 +108,77 @@ export function AppearanceSettings() {
     <div className="appearance-settings">
       <h3 className="settings-section-title">Appearance</h3>
 
-      {/* Theme */}
+      {/* Theme builder */}
       <div className="settings-group">
         <h4 className="settings-group-title">Theme</h4>
+
         <div className="settings-row">
-          <span className="settings-label">Color theme</span>
+          <span className="settings-label">Base</span>
           <SegmentedControl
-            ariaLabel="Color theme"
+            ariaLabel="Theme base"
             value={themePreference}
             onValueChange={(v: ThemePreference) => setThemePreference(v)}
             options={THEME_OPTIONS}
           />
           <span className="settings-hint">
-            Choose your preferred color theme. Your choice is remembered across sessions.
+            Light or dark foundation. You're editing your <strong>{activeBase}</strong> theme;
+            switch base to customize the other independently.
           </span>
         </div>
-      </div>
 
-      {/* Accent color */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Accent color</h4>
         <div className="settings-row">
-          <span className="settings-label">Accent</span>
-          <AccentPicker value={accent} onValueChange={setAccent} />
-          <span className="settings-hint">
-            Tints buttons, links, highlights, and selected controls across the app.
-          </span>
+          <span className="settings-label">Presets</span>
+          <div className="theme-preset-row">
+            {THEME_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                className={`theme-preset${activePresetId === preset.id ? ' is-active' : ''}`}
+                onClick={() => setThemeInputs(activeBase, preset[activeBase])}
+              >
+                <span
+                  className="theme-preset__dot"
+                  style={{ background: preset[activeBase].primary ?? baseSwatch.primary }}
+                  aria-hidden="true"
+                />
+                {preset.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="theme-preset theme-preset--surprise"
+              onClick={() => setThemeInputs(activeBase, surpriseTheme(activeBase))}
+              title="Generate a random, legible theme"
+            >
+              <Wand2 size={14} aria-hidden="true" /> Surprise me
+            </button>
+          </div>
+          <span className="settings-hint">Start from a preset, then fine-tune the colors below.</span>
+        </div>
+
+        <div className="theme-slots">
+          {THEME_SLOTS.map(({ slot, label, hint }) => (
+            <ColorField
+              key={slot}
+              label={label}
+              hint={hint}
+              value={themeInputs[slot]}
+              defaultSwatch={baseSwatch[slot]}
+              onChange={(value) => setThemeInput(activeBase, slot, value)}
+              {...(warnFor(slot) !== undefined ? { warning: warnFor(slot) as string } : {})}
+            />
+          ))}
+        </div>
+
+        <div className="settings-row">
+          <button
+            type="button"
+            className="theme-reset-base"
+            disabled={Object.keys(themeInputs as ThemeInputs).length === 0}
+            onClick={() => setThemeInputs(activeBase, {})}
+          >
+            Reset {activeBase} theme to default
+          </button>
         </div>
       </div>
 
@@ -218,44 +285,10 @@ export function AppearanceSettings() {
   );
 }
 
-function AccentPicker({
-  value,
-  onValueChange,
-}: {
-  value: AccentColor;
-  onValueChange: (value: AccentColor) => void;
-}) {
-  return (
-    <RadioGroup.Root
-      className="accent-picker"
-      value={value}
-      onValueChange={(v) => onValueChange(v as AccentColor)}
-      aria-label="Accent color"
-      orientation="horizontal"
-      loop
-    >
-      {ACCENT_OPTIONS.map((opt) => (
-        <RadioGroup.Item
-          key={opt.value}
-          className="accent-picker__swatch"
-          value={opt.value}
-          aria-label={opt.label}
-          title={opt.label}
-          style={{ '--swatch': opt.swatch } as CSSProperties}
-        >
-          <Check className="accent-picker__check" size={14} strokeWidth={3} aria-hidden="true" />
-        </RadioGroup.Item>
-      ))}
-    </RadioGroup.Root>
-  );
-}
-
 /**
- * DocuShark title bar opt-in. Gated to the desktop shell that actually owns a
- * native title bar — `windowControls.isSupported()` is false on the web app
- * (and we exclude macOS, whose window controls can't be credibly replaced) — so
- * the whole section is absent there (JP-107: the option no longer appears where
- * it has no effect).
+ * DocuShark title bar opt-in. Gated to the desktop shell that owns a native
+ * title bar — `windowControls.isSupported()` is false on the web app (and we
+ * exclude macOS) — so the whole section is absent there (JP-107).
  */
 function TitleBarSection() {
   const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
@@ -271,15 +304,12 @@ function TitleBarSection() {
     );
     if (!confirmed) return;
     setCustomChrome(next);
-    // Flush any pending auto-save so the restart doesn't trip the unsaved-changes prompt.
     try {
       usePersistenceStore.getState().saveDocument();
     } catch {
       // Best-effort flush; the user already confirmed the restart.
     }
     if (import.meta.env.DEV) {
-      // Under `tauri dev` the app can't relaunch itself, so persist the flag and
-      // let the developer relaunch. (Dev-only path; customers get the restart.)
       void opener.persistCustomChrome(next);
       useNotificationStore.getState().info('Title bar preference saved — restart the app to see it.', {
         duration: 6000,

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -13,6 +13,7 @@ import { useThemeStore, type ThemePreference } from '../../store/themeStore';
 import {
   useUIPreferencesStore,
   type Density,
+  type ProseBackground,
   type ThemeBase,
   type ThemeColorSlot,
   type ThemeInputs,
@@ -28,6 +29,7 @@ import { isMacOS } from '../../utils/platform';
 import { contrastRatio } from '../../utils/color';
 import {
   BASE_SWATCHES,
+  PROSE_BACKGROUNDS,
   THEME_PRESETS,
   THEME_SLOTS,
   surpriseTheme,
@@ -78,6 +80,8 @@ export function AppearanceSettings() {
   const setDensity = useUIPreferencesStore((s) => s.setDensity);
   const uiScale = useUIPreferencesStore((s) => s.appearancePrefs.uiScale);
   const setUiScale = useUIPreferencesStore((s) => s.setUiScale);
+  const proseBackground = useUIPreferencesStore((s) => s.appearancePrefs.proseBackground);
+  const setProseBackground = useUIPreferencesStore((s) => s.setProseBackground);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -179,6 +183,35 @@ export function AppearanceSettings() {
           >
             Reset {activeBase} theme to default
           </button>
+        </div>
+      </div>
+
+      {/* Prose background */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Prose background</h4>
+        <div className="settings-row">
+          <span className="settings-label">Editor backdrop</span>
+          <div className="prose-bg-row">
+            {(Object.keys(PROSE_BACKGROUNDS) as ProseBackground[]).map((id) => (
+              <button
+                key={id}
+                type="button"
+                className={`prose-bg-option${proseBackground === id ? ' is-active' : ''}`}
+                onClick={() => setProseBackground(id)}
+                aria-pressed={proseBackground === id}
+              >
+                <span
+                  className="prose-bg-preview"
+                  style={{ background: PROSE_BACKGROUNDS[id].value ?? 'var(--bg-primary)' }}
+                  aria-hidden="true"
+                />
+                {PROSE_BACKGROUNDS[id].label}
+              </button>
+            ))}
+          </div>
+          <span className="settings-hint">
+            The backdrop behind the writing area. Presets follow your theme colors.
+          </span>
         </div>
       </div>
 

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,39 +1,67 @@
 /**
  * Settings → Appearance — the consolidated home for visual/UX configuration.
  *
- * Sections: Theme, Canvas, Layout (the panel-arrangement editor, embedded), and
- * Window chrome (desktop-only). Accent / Motion / Density + UI-scale knobs land
- * in later slices of the Appearance epic; this panel is the structural backbone.
- *
- * Kept self-contained (no coupling to `SettingsModal` internals) so it survives
- * the planned settings-menu rework.
+ * Sections: Theme, Accent color, Motion, Canvas, Layout (the panel-arrangement
+ * editor, embedded), and Title bar (desktop-only). Density + UI-scale land in a
+ * later slice. Kept self-contained (no coupling to `SettingsModal` internals)
+ * so it survives the planned settings-menu rework.
  */
 
-import { Monitor, Moon, Sun } from 'lucide-react';
+import type { CSSProperties } from 'react';
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import { Check, Monitor, Moon, Sun } from 'lucide-react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useThemeStore, type ThemePreference } from '../../store/themeStore';
-import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { useUIPreferencesStore, type AccentColor } from '../../store/uiPreferencesStore';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
+import type { MotionPreference } from '../../platform/adaptiveBudget';
 import { windowControls } from '../../platform/window';
 import { opener } from '../../platform/opener';
 import { isMacOS } from '../../utils/platform';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { Switch } from '../components/Switch';
+import { resetAppearance } from '../appearance/appearanceConfig';
 import { LayoutSettings } from './LayoutSettings';
 import './AppearanceSettings.css';
 
 const THEME_OPTIONS = [
-  { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your OS appearance' },
+  { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your device appearance' },
   { value: 'light' as const, label: 'Light', icon: <Sun size={15} />, title: 'Light theme' },
   { value: 'dark' as const, label: 'Dark', icon: <Moon size={15} />, title: 'Dark theme' },
+];
+
+// Representative swatch colors (the light-theme hue). 'default' shows the brand
+// navy and adds no override — the theme keeps its own accent (navy / gold).
+const ACCENT_OPTIONS: ReadonlyArray<{ value: AccentColor; label: string; swatch: string }> = [
+  { value: 'default', label: 'Default', swatch: '#1f3354' },
+  { value: 'teal', label: 'Teal', swatch: '#0f766e' },
+  { value: 'violet', label: 'Violet', swatch: '#6d28d9' },
+  { value: 'amber', label: 'Amber', swatch: '#b45309' },
+  { value: 'rose', label: 'Rose', swatch: '#be123c' },
+];
+
+const MOTION_OPTIONS = [
+  { value: 'system' as const, label: 'System', title: 'Follow your device accessibility setting' },
+  { value: 'reduced' as const, label: 'Reduced', title: 'Minimize interface animations' },
+  { value: 'full' as const, label: 'Full', title: 'Always show interface animations' },
 ];
 
 export function AppearanceSettings() {
   const themePreference = useThemeStore((s) => s.preference);
   const setThemePreference = useThemeStore((s) => s.setPreference);
+  const accent = useUIPreferencesStore((s) => s.appearancePrefs.accent);
+  const setAccent = useUIPreferencesStore((s) => s.setAccent);
+  const motion = useUIPreferencesStore((s) => s.appearancePrefs.motion);
+  const setMotion = useUIPreferencesStore((s) => s.setMotion);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
+
+  const handleReset = () => {
+    if (window.confirm('Reset theme, accent color, motion, and layout customization to their defaults?')) {
+      resetAppearance();
+    }
+  };
 
   return (
     <div className="appearance-settings">
@@ -56,12 +84,42 @@ export function AppearanceSettings() {
         </div>
       </div>
 
+      {/* Accent color */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Accent color</h4>
+        <div className="settings-row">
+          <span className="settings-label">Accent</span>
+          <AccentPicker value={accent} onValueChange={setAccent} />
+          <span className="settings-hint">
+            Tints buttons, links, highlights, and selected controls across the app.
+          </span>
+        </div>
+      </div>
+
+      {/* Motion */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Motion</h4>
+        <div className="settings-row">
+          <span className="settings-label">Interface animations</span>
+          <SegmentedControl
+            ariaLabel="Interface animations"
+            value={motion}
+            onValueChange={(v: MotionPreference) => setMotion(v)}
+            options={MOTION_OPTIONS}
+          />
+          <span className="settings-hint">
+            Reduce or turn off interface animations. "System" follows your device's
+            accessibility setting.
+          </span>
+        </div>
+      </div>
+
       {/* Canvas */}
       <div className="settings-group">
         <h4 className="settings-group-title">Canvas</h4>
         <div className="settings-row">
           <label className="settings-label" htmlFor="grid-opacity">
-            Grid Opacity
+            Grid opacity
           </label>
           <div className="settings-slider-row">
             <input
@@ -76,7 +134,7 @@ export function AppearanceSettings() {
             <span className="settings-slider-value">{gridOpacity}%</span>
           </div>
           <span className="settings-hint">
-            Adjust the visibility of the canvas grid (0 = hidden)
+            Adjust how visible the canvas grid is (0 = hidden).
           </span>
         </div>
       </div>
@@ -84,52 +142,86 @@ export function AppearanceSettings() {
       {/* Layout — the panel-arrangement editor, embedded as a section. */}
       <LayoutSettings embedded />
 
-      {/* Window chrome — desktop-only; renders nothing on the PWA. */}
-      <WindowChromeSection />
+      {/* Title bar — desktop-only; renders nothing on the web app. */}
+      <TitleBarSection />
+
+      {/* Reset */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Reset</h4>
+        <button type="button" className="settings-reset-btn" onClick={handleReset}>
+          Reset appearance to defaults
+        </button>
+      </div>
     </div>
   );
 }
 
+function AccentPicker({
+  value,
+  onValueChange,
+}: {
+  value: AccentColor;
+  onValueChange: (value: AccentColor) => void;
+}) {
+  return (
+    <RadioGroup.Root
+      className="accent-picker"
+      value={value}
+      onValueChange={(v) => onValueChange(v as AccentColor)}
+      aria-label="Accent color"
+      orientation="horizontal"
+      loop
+    >
+      {ACCENT_OPTIONS.map((opt) => (
+        <RadioGroup.Item
+          key={opt.value}
+          className="accent-picker__swatch"
+          value={opt.value}
+          aria-label={opt.label}
+          title={opt.label}
+          style={{ '--swatch': opt.swatch } as CSSProperties}
+        >
+          <Check className="accent-picker__check" size={14} strokeWidth={3} aria-hidden="true" />
+        </RadioGroup.Item>
+      ))}
+    </RadioGroup.Root>
+  );
+}
+
 /**
- * Custom-window-chrome opt-in. Gated to the desktop shell that actually owns a
- * native title bar — `windowControls.isSupported()` is false on the PWA (and we
- * exclude macOS, whose traffic-light controls can't be credibly replaced), so
- * the whole section is absent on web (closes JP-107: the toggle no longer leaks
- * onto the PWA, where it had no effect).
+ * DocuShark title bar opt-in. Gated to the desktop shell that actually owns a
+ * native title bar — `windowControls.isSupported()` is false on the web app
+ * (and we exclude macOS, whose window controls can't be credibly replaced) — so
+ * the whole section is absent there (JP-107: the option no longer appears where
+ * it has no effect).
  */
-function WindowChromeSection() {
+function TitleBarSection() {
   const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
   const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
 
   if (!windowControls.isSupported() || isMacOS()) return null;
 
   const handleToggle = (next: boolean) => {
-    const verb = import.meta.env.DEV
-      ? 'The flag will be saved (manual `tauri:dev` restart required)'
-      : 'The app will restart';
     const confirmed = window.confirm(
       next
-        ? `Use custom window chrome? ${verb} to apply.`
-        : `Revert to system window decorations? ${verb} to apply.`
+        ? "Use DocuShark's title bar? The app will restart to apply."
+        : "Switch back to your system's title bar? The app will restart to apply."
     );
     if (!confirmed) return;
     setCustomChrome(next);
-    // Flush any pending auto-save so the restart path doesn't trip the
-    // "unsaved changes" beforeunload prompt.
+    // Flush any pending auto-save so the restart doesn't trip the unsaved-changes prompt.
     try {
       usePersistenceStore.getState().saveDocument();
     } catch {
       // Best-effort flush; the user already confirmed the restart.
     }
-    // Dev-mode caveat: `app.restart()` under `tauri dev` kills the cargo-spawned
-    // binary without re-spawning, so persist the flag and tell the developer to
-    // bounce `tauri:dev`. Production bundles restart cleanly.
     if (import.meta.env.DEV) {
+      // Under `tauri dev` the app can't relaunch itself, so persist the flag and
+      // let the developer relaunch. (Dev-only path; customers get the restart.)
       void opener.persistCustomChrome(next);
-      useNotificationStore.getState().warning(
-        'Custom chrome flag saved. In dev mode you must stop and restart `bun run tauri:dev` manually for it to take effect.',
-        { duration: 10000 }
-      );
+      useNotificationStore.getState().info('Title bar preference saved — restart the app to see it.', {
+        duration: 6000,
+      });
     } else {
       void opener.applyCustomChrome(next);
     }
@@ -137,22 +229,20 @@ function WindowChromeSection() {
 
   return (
     <div className="settings-group">
-      <h4 className="settings-group-title">Window</h4>
+      <h4 className="settings-group-title">Title bar</h4>
       <div className="settings-row settings-row-switch">
-        <label className="settings-switch-label" htmlFor="custom-chrome">
+        <label className="settings-switch-label" htmlFor="docushark-title-bar">
           <Switch
-            id="custom-chrome"
+            id="docushark-title-bar"
             checked={customChrome}
             onCheckedChange={handleToggle}
-            ariaLabel="Use custom window chrome"
+            ariaLabel="Use DocuShark's title bar"
           />
-          <span className="settings-switch-text">Use custom window chrome</span>
+          <span className="settings-switch-text">Use DocuShark's title bar</span>
         </label>
         <span className="settings-hint">
-          Replace the native title bar with DocuShark's in-app window chrome.
-          {import.meta.env.DEV
-            ? ' In dev, restart tauri:dev to apply.'
-            : ' The app restarts to apply.'}
+          Replace your operating system's window title bar with DocuShark's own for a
+          more unified look. The app restarts to apply.
         </span>
       </div>
     </div>

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -1,0 +1,160 @@
+/**
+ * Settings → Appearance — the consolidated home for visual/UX configuration.
+ *
+ * Sections: Theme, Canvas, Layout (the panel-arrangement editor, embedded), and
+ * Window chrome (desktop-only). Accent / Motion / Density + UI-scale knobs land
+ * in later slices of the Appearance epic; this panel is the structural backbone.
+ *
+ * Kept self-contained (no coupling to `SettingsModal` internals) so it survives
+ * the planned settings-menu rework.
+ */
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useSettingsStore } from '../../store/settingsStore';
+import { useThemeStore, type ThemePreference } from '../../store/themeStore';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { usePersistenceStore } from '../../store/persistenceStore';
+import { useNotificationStore } from '../../store/notificationStore';
+import { windowControls } from '../../platform/window';
+import { opener } from '../../platform/opener';
+import { isMacOS } from '../../utils/platform';
+import { SegmentedControl } from '../components/SegmentedControl';
+import { Switch } from '../components/Switch';
+import { LayoutSettings } from './LayoutSettings';
+import './AppearanceSettings.css';
+
+const THEME_OPTIONS = [
+  { value: 'system' as const, label: 'System', icon: <Monitor size={15} />, title: 'Follow your OS appearance' },
+  { value: 'light' as const, label: 'Light', icon: <Sun size={15} />, title: 'Light theme' },
+  { value: 'dark' as const, label: 'Dark', icon: <Moon size={15} />, title: 'Dark theme' },
+];
+
+export function AppearanceSettings() {
+  const themePreference = useThemeStore((s) => s.preference);
+  const setThemePreference = useThemeStore((s) => s.setPreference);
+  const gridOpacity = useSettingsStore((s) => s.gridOpacity);
+  const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
+
+  return (
+    <div className="appearance-settings">
+      <h3 className="settings-section-title">Appearance</h3>
+
+      {/* Theme */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Theme</h4>
+        <div className="settings-row">
+          <span className="settings-label">Color theme</span>
+          <SegmentedControl
+            ariaLabel="Color theme"
+            value={themePreference}
+            onValueChange={(v: ThemePreference) => setThemePreference(v)}
+            options={THEME_OPTIONS}
+          />
+          <span className="settings-hint">
+            Choose your preferred color theme. Your choice is remembered across sessions.
+          </span>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Canvas</h4>
+        <div className="settings-row">
+          <label className="settings-label" htmlFor="grid-opacity">
+            Grid Opacity
+          </label>
+          <div className="settings-slider-row">
+            <input
+              id="grid-opacity"
+              type="range"
+              className="styled-slider"
+              min={0}
+              max={100}
+              value={gridOpacity}
+              onChange={(e) => setGridOpacity(Number(e.target.value))}
+            />
+            <span className="settings-slider-value">{gridOpacity}%</span>
+          </div>
+          <span className="settings-hint">
+            Adjust the visibility of the canvas grid (0 = hidden)
+          </span>
+        </div>
+      </div>
+
+      {/* Layout — the panel-arrangement editor, embedded as a section. */}
+      <LayoutSettings embedded />
+
+      {/* Window chrome — desktop-only; renders nothing on the PWA. */}
+      <WindowChromeSection />
+    </div>
+  );
+}
+
+/**
+ * Custom-window-chrome opt-in. Gated to the desktop shell that actually owns a
+ * native title bar — `windowControls.isSupported()` is false on the PWA (and we
+ * exclude macOS, whose traffic-light controls can't be credibly replaced), so
+ * the whole section is absent on web (closes JP-107: the toggle no longer leaks
+ * onto the PWA, where it had no effect).
+ */
+function WindowChromeSection() {
+  const customChrome = useUIPreferencesStore((s) => s.layout.customChrome);
+  const setCustomChrome = useUIPreferencesStore((s) => s.setCustomChrome);
+
+  if (!windowControls.isSupported() || isMacOS()) return null;
+
+  const handleToggle = (next: boolean) => {
+    const verb = import.meta.env.DEV
+      ? 'The flag will be saved (manual `tauri:dev` restart required)'
+      : 'The app will restart';
+    const confirmed = window.confirm(
+      next
+        ? `Use custom window chrome? ${verb} to apply.`
+        : `Revert to system window decorations? ${verb} to apply.`
+    );
+    if (!confirmed) return;
+    setCustomChrome(next);
+    // Flush any pending auto-save so the restart path doesn't trip the
+    // "unsaved changes" beforeunload prompt.
+    try {
+      usePersistenceStore.getState().saveDocument();
+    } catch {
+      // Best-effort flush; the user already confirmed the restart.
+    }
+    // Dev-mode caveat: `app.restart()` under `tauri dev` kills the cargo-spawned
+    // binary without re-spawning, so persist the flag and tell the developer to
+    // bounce `tauri:dev`. Production bundles restart cleanly.
+    if (import.meta.env.DEV) {
+      void opener.persistCustomChrome(next);
+      useNotificationStore.getState().warning(
+        'Custom chrome flag saved. In dev mode you must stop and restart `bun run tauri:dev` manually for it to take effect.',
+        { duration: 10000 }
+      );
+    } else {
+      void opener.applyCustomChrome(next);
+    }
+  };
+
+  return (
+    <div className="settings-group">
+      <h4 className="settings-group-title">Window</h4>
+      <div className="settings-row settings-row-switch">
+        <label className="settings-switch-label" htmlFor="custom-chrome">
+          <Switch
+            id="custom-chrome"
+            checked={customChrome}
+            onCheckedChange={handleToggle}
+            ariaLabel="Use custom window chrome"
+          />
+          <span className="settings-switch-text">Use custom window chrome</span>
+        </label>
+        <span className="settings-hint">
+          Replace the native title bar with DocuShark's in-app window chrome.
+          {import.meta.env.DEV
+            ? ' In dev, restart tauri:dev to apply.'
+            : ' The app restarts to apply.'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/settings/GeneralSettings.tsx
+++ b/src/ui/settings/GeneralSettings.tsx
@@ -11,7 +11,6 @@
 
 import { useSettingsStore, ConnectorRoutingMode } from '../../store/settingsStore';
 import { useStyleProfileStore } from '../../store/styleProfileStore';
-import { useThemeStore, ThemePreference } from '../../store/themeStore';
 import './GeneralSettings.css';
 
 export function GeneralSettings() {
@@ -27,15 +26,9 @@ export function GeneralSettings() {
   const setShowMinimap = useSettingsStore((state) => state.setShowMinimap);
   const layerClickFocusShape = useSettingsStore((state) => state.layerClickFocusShape);
   const setLayerClickFocusShape = useSettingsStore((state) => state.setLayerClickFocusShape);
-  const gridOpacity = useSettingsStore((state) => state.gridOpacity);
-  const setGridOpacity = useSettingsStore((state) => state.setGridOpacity);
   const resetSettings = useSettingsStore((state) => state.resetSettings);
 
   const profiles = useStyleProfileStore((state) => state.profiles);
-
-  // Theme state
-  const themePreference = useThemeStore((state) => state.preference);
-  const setThemePreference = useThemeStore((state) => state.setPreference);
 
   const handleConnectorTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setDefaultConnectorType(e.target.value as ConnectorRoutingMode);
@@ -46,58 +39,9 @@ export function GeneralSettings() {
     setDefaultStyleProfileId(value === '' ? null : value);
   };
 
-  const handleThemeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setThemePreference(e.target.value as ThemePreference);
-  };
-
   return (
     <div className="general-settings">
       <h3 className="settings-section-title">General Settings</h3>
-
-      {/* Appearance Settings */}
-      <div className="settings-group">
-        <h4 className="settings-group-title">Appearance</h4>
-
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="theme-mode">
-            Theme
-          </label>
-          <select
-            id="theme-mode"
-            className="settings-select"
-            value={themePreference}
-            onChange={handleThemeChange}
-          >
-            <option value="system">System (Auto)</option>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-          <span className="settings-hint">
-            Choose your preferred color theme
-          </span>
-        </div>
-
-        <div className="settings-row">
-          <label className="settings-label" htmlFor="grid-opacity">
-            Grid Opacity
-          </label>
-          <div className="settings-slider-row">
-            <input
-              id="grid-opacity"
-              type="range"
-              className="styled-slider"
-              min={0}
-              max={100}
-              value={gridOpacity}
-              onChange={(e) => setGridOpacity(Number(e.target.value))}
-            />
-            <span className="settings-slider-value">{gridOpacity}%</span>
-          </div>
-          <span className="settings-hint">
-            Adjust the visibility of the canvas grid (0 = hidden)
-          </span>
-        </div>
-      </div>
 
       {/* Connector Settings */}
       <div className="settings-group">

--- a/src/ui/settings/LayoutSettings.tsx
+++ b/src/ui/settings/LayoutSettings.tsx
@@ -27,7 +27,16 @@ const DOCK_LABELS: Record<DockSide, string> = {
   right: 'Right',
 };
 
-export function LayoutSettings() {
+export interface LayoutSettingsProps {
+  /**
+   * Render as a section within a larger settings panel (Appearance) — uses an
+   * `h4` section heading instead of the standalone `h3`, so heading levels
+   * stay sane when nested. Defaults to standalone.
+   */
+  embedded?: boolean;
+}
+
+export function LayoutSettings({ embedded = false }: LayoutSettingsProps = {}) {
   const layout = useUIPreferencesStore((s) => s.layout);
   const setDefaultLayout = useUIPreferencesStore((s) => s.setDefaultLayout);
   const setPanelDockFor = useUIPreferencesStore((s) => s.setPanelDockFor);
@@ -45,7 +54,7 @@ export function LayoutSettings() {
   return (
     <div className="layout-settings">
       <header className="layout-settings-header">
-        <h3>Layout</h3>
+        {embedded ? <h4 className="settings-group-title">Layout</h4> : <h3>Layout</h3>}
         <p>
           Customize how each layout arranges its panels. Changes are scoped to
           the layout you're editing — switching to another layout never carries

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -266,3 +266,66 @@ export function isLightColor(hex: string): boolean {
 export function getContrastColor(backgroundColor: string): string {
   return isLightColor(backgroundColor) ? '#000000' : '#ffffff';
 }
+
+/**
+ * WCAG relative luminance of an sRGB color (0 = black, 1 = white).
+ */
+function relativeLuminance(rgb: RGB): number {
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+}
+
+/**
+ * WCAG contrast ratio between two colors (1:1 .. 21:1). Order-independent.
+ * Invalid input yields 1 (worst case) so callers fail safe.
+ *
+ * @param a - Hex color string
+ * @param b - Hex color string
+ */
+export function contrastRatio(a: string, b: string): number {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  if (!ra || !rb) return 1;
+  const la = relativeLuminance(ra);
+  const lb = relativeLuminance(rb);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Linearly interpolate between two hex colors in sRGB space.
+ *
+ * @param a - Start hex color
+ * @param b - End hex color
+ * @param t - Amount toward `b` (0..1)
+ * @returns Mixed hex color (#RRGGBB); returns `a` unchanged on invalid input
+ */
+export function mix(a: string, b: string, t: number): string {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  if (!ra || !rb) return a;
+  const m = Math.max(0, Math.min(1, t));
+  return rgbToHex({
+    r: ra.r + (rb.r - ra.r) * m,
+    g: ra.g + (rb.g - ra.g) * m,
+    b: ra.b + (rb.b - ra.b) * m,
+  });
+}
+
+/**
+ * Build an `rgba()` string from a hex color and an alpha (0..1).
+ *
+ * @param hex - Hex color string
+ * @param alpha - Opacity 0..1
+ * @returns `rgba(r, g, b, a)`; returns `hex` unchanged on invalid input
+ */
+export function withAlpha(hex: string, alpha: number): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+  const a = Math.max(0, Math.min(1, alpha));
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
+}


### PR DESCRIPTION
Catch-up deploy of `master` → `staging` (staging was stuck at JP-243). Rebuilds the relay `:edge` image + redeploys the staging relay/PWA.

## Headline: JP-232 — per-workspace blob ledger
Blob bookkeeping (acl/refs/index) now survives volume loss / pod migration via a durable per-workspace ledger in R2 (`docs/<ws>/blob_ledger.json`), with reconstruct-from-docs fallback. Unit + live-MinIO verified; this deploy is for the staging E2E.

## Also rolling up (master ahead of staging by 12 commits)
- **JP-264** generic blob ingest-from-URL (SSRF guard + provenance)
- **JP-254–257** UX-flex / Appearance: settings tab + theme persistence, accent/motion, density/UI-scale, theme builder + prose bg presets
- **JP-247–251** MCP hardening: reorder tools, prose-pipeline DoS caps, read rate-limit, live-or-cold dispatch consolidation, resident-enriched shape reads

## Post-merge
Rebuilds `:edge`; staging relay (`dsk-relay-staging-yyz`) needs to pull the new image. Blob-ledger E2E (volume-loss recovery) to follow per the deploy plan in-thread.

Assisted-by: Opus 4.8