### PR TITLE
Fix SVG render: sniff MIME for untyped blobs in the resolver

### DIFF
--- a/src/storage/blobResolver.test.ts
+++ b/src/storage/blobResolver.test.ts
@@ -11,6 +11,7 @@ import {
   isBlobMissing,
   blobHashFromRef,
   onBlobLoad,
+  sniffMimeFromBytes,
 } from './blobResolver';
 
 const HASH_A = 'a'.repeat(64);
@@ -19,6 +20,28 @@ const HASH_B = 'b'.repeat(64);
 function pngBlob(bytes = 4): Blob {
   return new Blob([new Uint8Array(bytes)], { type: 'image/png' });
 }
+
+describe('sniffMimeFromBytes', () => {
+  const bytesOf = (s: string) => new TextEncoder().encode(s);
+
+  it('detects SVG so an untyped object URL renders (browsers do not sniff SVG)', () => {
+    expect(sniffMimeFromBytes(bytesOf('<svg xmlns="http://www.w3.org/2000/svg"></svg>'))).toBe('image/svg+xml');
+    expect(sniffMimeFromBytes(bytesOf('<?xml version="1.0"?>\n<svg></svg>'))).toBe('image/svg+xml');
+    expect(sniffMimeFromBytes(bytesOf('  \n  <SVG></SVG>'))).toBe('image/svg+xml'); // leading ws + case
+    expect(sniffMimeFromBytes(bytesOf('﻿<svg></svg>'))).toBe('image/svg+xml'); // BOM
+  });
+
+  it('detects common binary types by magic number', () => {
+    expect(sniffMimeFromBytes(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).toBe('image/png');
+    expect(sniffMimeFromBytes(new Uint8Array([0xff, 0xd8, 0xff]))).toBe('image/jpeg');
+    expect(sniffMimeFromBytes(new Uint8Array([0x25, 0x50, 0x44, 0x46]))).toBe('application/pdf');
+  });
+
+  it('returns null for unrecognized / empty content (blob left as-is)', () => {
+    expect(sniffMimeFromBytes(bytesOf('just some text'))).toBeNull();
+    expect(sniffMimeFromBytes(new Uint8Array(0))).toBeNull();
+  });
+});
 
 describe('blobResolver', () => {
   let loadBlobSpy: MockInstance<[id: string], Promise<Blob | null>>;

--- a/src/storage/blobResolver.ts
+++ b/src/storage/blobResolver.ts
@@ -173,6 +173,51 @@ function store(hash: string, blob: Blob, pinned: boolean): string {
   return objectUrl;
 }
 
+/**
+ * Sniff a blob's real MIME from its leading bytes. The local content-addressed
+ * store keeps bytes untyped (`application/octet-stream`), and while browsers
+ * content-sniff raster images in an `<img>`, they deliberately do **not** sniff
+ * SVG (a security rule) — so an untyped object URL renders a PNG fine but leaves
+ * an SVG blank. Re-typing the object URL from a sniff fixes SVG and makes the
+ * raster/PDF cases correct for non-sniffing consumers (downloads) too. Returns
+ * `null` when unrecognized (leaves the blob as-is). Only called when the stored
+ * type is missing/generic.
+ */
+export function sniffMimeFromBytes(b: Uint8Array): string | null {
+  if (b.length === 0) return null;
+  // Binary magic numbers.
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'image/png';
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'image/jpeg';
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) return 'image/gif';
+  if (b[0] === 0x25 && b[1] === 0x50 && b[2] === 0x44 && b[3] === 0x46) return 'application/pdf';
+  if (
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  // SVG is XML text — skip a BOM + leading whitespace, then look for an `<svg`
+  // root (optionally behind an `<?xml …?>` / comment prolog).
+  const text = new TextDecoder('utf-8', { fatal: false })
+    .decode(b)
+    .replace(/^﻿/, '')
+    .trimStart()
+    .toLowerCase();
+  if (text.startsWith('<svg') || ((text.startsWith('<?xml') || text.startsWith('<!--')) && text.includes('<svg'))) {
+    return 'image/svg+xml';
+  }
+  return null;
+}
+
+async function sniffBlobType(blob: Blob): Promise<string | null> {
+  return sniffMimeFromBytes(new Uint8Array(await blob.slice(0, 512).arrayBuffer()));
+}
+
+/** True when a blob carries no usable MIME (so the object URL must be sniffed). */
+function hasGenericType(blob: Blob): boolean {
+  return !blob.type || blob.type === 'application/octet-stream';
+}
+
 // ---------------------------------------------------------------------------
 // Public resolve surface
 // ---------------------------------------------------------------------------
@@ -228,6 +273,12 @@ export function resolveBlobObjectUrl(
       if (!blob) {
         markBlobMissing(hash);
         return null;
+      }
+      // Re-type the object URL when the stored blob is untyped — otherwise an
+      // SVG (which browsers won't content-sniff) renders blank.
+      if (hasGenericType(blob)) {
+        const sniffed = await sniffBlobType(blob);
+        if (sniffed) blob = blob.slice(0, blob.size, sniffed);
       }
       const url = store(hash, blob, pinned);
       markBlobAvailable(hash);


### PR DESCRIPTION
## Problem
Embedded SVGs rendered blank on the canvas / in rich text, while PNG/JPEG/PDF were fine. R2 serves the SVG correctly as `image/svg+xml` (verified) — so it's client-side: the local content-addressed store keeps bytes **untyped** (`application/octet-stream`), and browsers **content-sniff raster images but deliberately refuse to sniff SVG**, so an untyped object URL renders a PNG but leaves an SVG blank.

## Fix
In `blobResolver`, when a resolved blob has no usable type, sniff the leading bytes and re-type the object URL via `Blob.slice(0, size, mime)`:
- SVG XML root (`<svg`, or `<?xml`/`<!--` prolog then `<svg`; tolerant of BOM, leading whitespace, case)
- common binary magics (PNG/JPEG/GIF/PDF/WebP) — so raster/PDF object URLs are correctly typed for non-sniffing consumers (downloads) too

Universal (works for FileShapes **and** rich-text images, no MIME threading through callers), and only runs when the stored type is generic.

## Tests
Pure `sniffMimeFromBytes` unit-tested (SVG variants, binary magics, null/unknown). `bun run typecheck` clean; full suite **1904 passed**.

## Note (separate, deferred)
The "page-embedded images unavailable offline in collab docs" finding is **not** a small patch and is intentionally **not** in this PR. The download-on-miss path already persists to IndexedDB (`BlobSyncService.saveBlob`), so caching works — but it's **view-driven** (only rendered images download). Closing that is a *proactive offline-prefetch* feature (now feasible since JP-278 gives collab docs real `blobReferences`) with a real design choice (prefetch eagerly vs. on an explicit "make available offline"). Worth its own issue.

Assisted-by: Opus 4.8