### PR TITLE
JP-279: ensure_doc_local must gate on body presence, not index presence

### DIFF
--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -1251,6 +1251,17 @@ impl DocumentStore {
         self.index.read().ok()?.get(ws)?.get(doc_id.as_str()).cloned()
     }
 
+    /// Whether the document's JSON **body** is present on the local volume
+    /// (JP-279). The index can list a doc whose body isn't local — after a
+    /// JP-200 R2 `index.json` restore (index eager, bodies lazy-by-id) or a
+    /// JP-231 eviction (index entry kept, body removed) — so body presence, not
+    /// index/metadata presence, is the correct "is it local" signal for
+    /// restore-on-miss. Using metadata instead would short-circuit the restore
+    /// and ENOENT on the subsequent `get_document` read.
+    pub fn has_local_body(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        self.doc_path(ws, doc_id).exists()
+    }
+
     /// Update document lock status
     pub fn set_lock(
         &self,
@@ -1909,6 +1920,35 @@ mod tests {
         // Eviction must not feed the mirror back.
         drop(store);
         assert!(rx.try_recv().is_err(), "eviction enqueued a mirror op");
+    }
+
+    // JP-279: the "is it local" signal must follow the **body file**, not the
+    // index. A doc whose body was evicted (or whose index was restored from R2
+    // ahead of its body) is still listed in the index — using metadata presence
+    // as the gate short-circuits restore-on-miss and ENOENTs the read.
+    #[test]
+    fn has_local_body_tracks_the_body_not_the_index() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("body-doc".into()).unwrap();
+
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({"id": "body-doc", "name": "B", "serverVersion": 1}),
+            )
+            .unwrap();
+        assert!(store.has_local_body(&ws, &doc_id), "body present after save");
+
+        store.evict_doc_files(&ws, &doc_id);
+        // Index entry kept (listable) but the body is gone — the exact state that
+        // ENOENT'd: `get_metadata` is Some while `has_local_body` is false.
+        assert!(store.get_metadata(&ws, &doc_id).is_some(), "still indexed");
+        assert!(
+            !store.has_local_body(&ws, &doc_id),
+            "body gone — must trigger restore-on-miss, not report 'local'"
+        );
     }
 
     #[tokio::test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -651,7 +651,12 @@ impl ServerState {
         // JP-232: recover this workspace's blob bookkeeping before any restore.
         // No-op (O(1)) on a healthy/already-recovered pod.
         self.ensure_blob_bookkeeping(ws).await;
-        if self.doc_store.get_metadata(ws, doc_id).is_some() {
+        // JP-279: gate on **body presence**, not index/metadata presence. After a
+        // JP-200 index restore (index eager, bodies lazy-by-id) or a JP-231
+        // eviction, a doc is listed in the index but its body isn't on the volume
+        // — using `get_metadata().is_some()` here short-circuited the restore and
+        // ENOENT'd the subsequent read.
+        if self.doc_store.has_local_body(ws, doc_id) {
             return true;
         }
         let s3 = match &self.s3 {


### PR DESCRIPTION
Closes **JP-279**. Found on staging right after the JP-232 volume-wipe test: every doc **except the one open during recovery** failed to open with *"Failed to read document: No such file or directory (os error 2)."*

## Root cause
`ensure_doc_local` (mod.rs) short-circuited "already local" on `get_metadata().is_some()`, but `get_metadata` reads the **in-memory index only** — not whether the body file is on the volume. After a volume loss, JP-200 restores the workspace `index.json` from R2 eagerly (every doc listed) while **bodies** restore lazily by id on access. So once the index was back, `ensure_doc_local` returned `true` for every doc **without restoring the body**, and the subsequent `get_document` `fs::read` ENOENT'd.

The active doc survived only because it was auto-joined *before* the index finished restoring (metadata briefly absent → body restored). The `doc-` prefix / "only doc with an image" were red herrings — the axis is **early-auto-joined vs. clicked-later**. Same index-vs-body confusion latently breaks **JP-231** eviction-restore.

## Fix
Add `DocumentStore::has_local_body` (checks `doc_path(...).exists()`) and gate `ensure_doc_local` on **body presence**, restoring from R2 by id whenever the body is absent — regardless of metadata. `restore_doc_from` is already by-id, so the metadata gate was never needed to reach R2.

## Tests
A doc evicted (index entry kept, body removed) reports `get_metadata` Some but `has_local_body` false — the exact ENOENT state. `cargo test --lib` 298 passed; clippy clean.

## Verify
Wipe volume → restore index → open a *non-active* doc → it restores its body from R2 and opens (no ENOENT). Staging deploy to follow.

Assisted-by: Opus 4.8