### PR TITLE
Deploy to staging: JP-279 doc body-presence restore + SVG MIME fix

### DIFF
--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -1251,6 +1251,17 @@ impl DocumentStore {
         self.index.read().ok()?.get(ws)?.get(doc_id.as_str()).cloned()
     }
 
+    /// Whether the document's JSON **body** is present on the local volume
+    /// (JP-279). The index can list a doc whose body isn't local — after a
+    /// JP-200 R2 `index.json` restore (index eager, bodies lazy-by-id) or a
+    /// JP-231 eviction (index entry kept, body removed) — so body presence, not
+    /// index/metadata presence, is the correct "is it local" signal for
+    /// restore-on-miss. Using metadata instead would short-circuit the restore
+    /// and ENOENT on the subsequent `get_document` read.
+    pub fn has_local_body(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        self.doc_path(ws, doc_id).exists()
+    }
+
     /// Update document lock status
     pub fn set_lock(
         &self,
@@ -1909,6 +1920,35 @@ mod tests {
         // Eviction must not feed the mirror back.
         drop(store);
         assert!(rx.try_recv().is_err(), "eviction enqueued a mirror op");
+    }
+
+    // JP-279: the "is it local" signal must follow the **body file**, not the
+    // index. A doc whose body was evicted (or whose index was restored from R2
+    // ahead of its body) is still listed in the index — using metadata presence
+    // as the gate short-circuits restore-on-miss and ENOENTs the read.
+    #[test]
+    fn has_local_body_tracks_the_body_not_the_index() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("body-doc".into()).unwrap();
+
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({"id": "body-doc", "name": "B", "serverVersion": 1}),
+            )
+            .unwrap();
+        assert!(store.has_local_body(&ws, &doc_id), "body present after save");
+
+        store.evict_doc_files(&ws, &doc_id);
+        // Index entry kept (listable) but the body is gone — the exact state that
+        // ENOENT'd: `get_metadata` is Some while `has_local_body` is false.
+        assert!(store.get_metadata(&ws, &doc_id).is_some(), "still indexed");
+        assert!(
+            !store.has_local_body(&ws, &doc_id),
+            "body gone — must trigger restore-on-miss, not report 'local'"
+        );
     }
 
     #[tokio::test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -651,7 +651,12 @@ impl ServerState {
         // JP-232: recover this workspace's blob bookkeeping before any restore.
         // No-op (O(1)) on a healthy/already-recovered pod.
         self.ensure_blob_bookkeeping(ws).await;
-        if self.doc_store.get_metadata(ws, doc_id).is_some() {
+        // JP-279: gate on **body presence**, not index/metadata presence. After a
+        // JP-200 index restore (index eager, bodies lazy-by-id) or a JP-231
+        // eviction, a doc is listed in the index but its body isn't on the volume
+        // — using `get_metadata().is_some()` here short-circuited the restore and
+        // ENOENT'd the subsequent read.
+        if self.doc_store.has_local_body(ws, doc_id) {
             return true;
         }
         let s3 = match &self.s3 {

--- a/src/storage/blobResolver.test.ts
+++ b/src/storage/blobResolver.test.ts
@@ -11,6 +11,7 @@ import {
   isBlobMissing,
   blobHashFromRef,
   onBlobLoad,
+  sniffMimeFromBytes,
 } from './blobResolver';
 
 const HASH_A = 'a'.repeat(64);
@@ -19,6 +20,28 @@ const HASH_B = 'b'.repeat(64);
 function pngBlob(bytes = 4): Blob {
   return new Blob([new Uint8Array(bytes)], { type: 'image/png' });
 }
+
+describe('sniffMimeFromBytes', () => {
+  const bytesOf = (s: string) => new TextEncoder().encode(s);
+
+  it('detects SVG so an untyped object URL renders (browsers do not sniff SVG)', () => {
+    expect(sniffMimeFromBytes(bytesOf('<svg xmlns="http://www.w3.org/2000/svg"></svg>'))).toBe('image/svg+xml');
+    expect(sniffMimeFromBytes(bytesOf('<?xml version="1.0"?>\n<svg></svg>'))).toBe('image/svg+xml');
+    expect(sniffMimeFromBytes(bytesOf('  \n  <SVG></SVG>'))).toBe('image/svg+xml'); // leading ws + case
+    expect(sniffMimeFromBytes(bytesOf('﻿<svg></svg>'))).toBe('image/svg+xml'); // BOM
+  });
+
+  it('detects common binary types by magic number', () => {
+    expect(sniffMimeFromBytes(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).toBe('image/png');
+    expect(sniffMimeFromBytes(new Uint8Array([0xff, 0xd8, 0xff]))).toBe('image/jpeg');
+    expect(sniffMimeFromBytes(new Uint8Array([0x25, 0x50, 0x44, 0x46]))).toBe('application/pdf');
+  });
+
+  it('returns null for unrecognized / empty content (blob left as-is)', () => {
+    expect(sniffMimeFromBytes(bytesOf('just some text'))).toBeNull();
+    expect(sniffMimeFromBytes(new Uint8Array(0))).toBeNull();
+  });
+});
 
 describe('blobResolver', () => {
   let loadBlobSpy: MockInstance<[id: string], Promise<Blob | null>>;

--- a/src/storage/blobResolver.ts
+++ b/src/storage/blobResolver.ts
@@ -173,6 +173,51 @@ function store(hash: string, blob: Blob, pinned: boolean): string {
   return objectUrl;
 }
 
+/**
+ * Sniff a blob's real MIME from its leading bytes. The local content-addressed
+ * store keeps bytes untyped (`application/octet-stream`), and while browsers
+ * content-sniff raster images in an `<img>`, they deliberately do **not** sniff
+ * SVG (a security rule) — so an untyped object URL renders a PNG fine but leaves
+ * an SVG blank. Re-typing the object URL from a sniff fixes SVG and makes the
+ * raster/PDF cases correct for non-sniffing consumers (downloads) too. Returns
+ * `null` when unrecognized (leaves the blob as-is). Only called when the stored
+ * type is missing/generic.
+ */
+export function sniffMimeFromBytes(b: Uint8Array): string | null {
+  if (b.length === 0) return null;
+  // Binary magic numbers.
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return 'image/png';
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return 'image/jpeg';
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) return 'image/gif';
+  if (b[0] === 0x25 && b[1] === 0x50 && b[2] === 0x44 && b[3] === 0x46) return 'application/pdf';
+  if (
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  // SVG is XML text — skip a BOM + leading whitespace, then look for an `<svg`
+  // root (optionally behind an `<?xml …?>` / comment prolog).
+  const text = new TextDecoder('utf-8', { fatal: false })
+    .decode(b)
+    .replace(/^﻿/, '')
+    .trimStart()
+    .toLowerCase();
+  if (text.startsWith('<svg') || ((text.startsWith('<?xml') || text.startsWith('<!--')) && text.includes('<svg'))) {
+    return 'image/svg+xml';
+  }
+  return null;
+}
+
+async function sniffBlobType(blob: Blob): Promise<string | null> {
+  return sniffMimeFromBytes(new Uint8Array(await blob.slice(0, 512).arrayBuffer()));
+}
+
+/** True when a blob carries no usable MIME (so the object URL must be sniffed). */
+function hasGenericType(blob: Blob): boolean {
+  return !blob.type || blob.type === 'application/octet-stream';
+}
+
 // ---------------------------------------------------------------------------
 // Public resolve surface
 // ---------------------------------------------------------------------------
@@ -228,6 +273,12 @@ export function resolveBlobObjectUrl(
       if (!blob) {
         markBlobMissing(hash);
         return null;
+      }
+      // Re-type the object URL when the stored blob is untyped — otherwise an
+      // SVG (which browsers won't content-sniff) renders blank.
+      if (hasGenericType(blob)) {
+        const sniffed = await sniffBlobType(blob);
+        if (sniffed) blob = blob.slice(0, blob.size, sniffed);
       }
       const url = store(hash, blob, pinned);
       markBlobAvailable(hash);


### PR DESCRIPTION
Catch-up deploy:
- **JP-279** (relay) — `ensure_doc_local` gates on body presence → fixes "Failed to read document (ENOENT)" for non-active docs after a cold/wipe restore. Rebuilds `:edge`.
- **#129** (client) — SVG MIME sniff in the blob resolver (deploys via the PWA).

Verifies the volume-loss recovery is fully correct: every doc restores its body from R2 on open.

Assisted-by: Opus 4.8