### PR TITLE
JP-280: dedupe offline badge, hide relay URL, fix download indicator

### DIFF
--- a/src/storage/blobResolver.ts
+++ b/src/storage/blobResolver.ts
@@ -76,9 +76,20 @@ function ensureDownloaded(hash: string): Promise<boolean> {
     .catch(() => false)
     .finally(() => {
       downloadsInFlight.delete(hash);
+      notifyBlobLoad(); // download finished — refresh the sync-activity indicator
     });
   downloadsInFlight.set(hash, p);
+  notifyBlobLoad(); // download started — surface it in the sync-activity indicator
   return p;
+}
+
+/**
+ * Number of blob downloads currently in flight. Drives the sync-activity
+ * indicator's "downloading…" state — subscribe via {@link onBlobLoad}, which
+ * fires when a download starts and finishes.
+ */
+export function inFlightDownloadCount(): number {
+  return downloadsInFlight.size;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -18,8 +18,6 @@ import {
   Trash2,
   Upload,
   Users,
-  Wifi,
-  WifiOff,
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
 import type { DocumentRecord, Permission } from '../types/DocumentRegistry';
@@ -373,26 +371,8 @@ export function DocumentCard({
             {getTypeLabel(record.type)}
           </span>
 
-          {/* Relay badge (which relay this doc belongs to + connection state) */}
-          {relay && (
-            <span
-              className={`document-card__relay document-card__relay--${relay.status}`}
-              title={
-                relay.status === 'connected'
-                  ? `Relay ${relay.host} — connected`
-                  : `Relay ${relay.host} — disconnected`
-              }
-            >
-              {relay.status === 'connected' ? (
-                <Wifi size={12} aria-hidden="true" />
-              ) : (
-                <WifiOff size={12} aria-hidden="true" />
-              )}
-              {relay.host}
-            </span>
-          )}
-
-          {/* Sync status */}
+          {/* Sync status. The connection/offline state lives here only — a
+              separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
 
           {/* Modified time */}
@@ -402,14 +382,6 @@ export function DocumentCard({
         {/* Expandable details panel */}
         {showDetails && isExpanded && (
           <dl className="document-card__details" onClick={(e) => e.stopPropagation()}>
-            {relay && (
-              <div className="document-card__detail">
-                <dt>Relay</dt>
-                <dd>
-                  {relay.host} · {relay.status === 'connected' ? 'Connected' : 'Disconnected'}
-                </dd>
-              </div>
-            )}
             {record.type === 'remote' && (
               <>
                 <div className="document-card__detail">

--- a/src/ui/UploadIndicator.tsx
+++ b/src/ui/UploadIndicator.tsx
@@ -1,18 +1,34 @@
+import { useEffect, useState } from 'react';
 import { useUploadStatusStore } from '../store/uploadStatusStore';
+import { inFlightDownloadCount, onBlobLoad } from '../storage/blobResolver';
 
 /**
- * Minimal upload-progress indicator (JP-126). Visible while a save uploads
- * referenced assets to the relay blob store; file-count granularity. Styling is
- * intentionally bare — the comprehensive design is owned separately.
+ * Sync-activity indicator. Visible while assets **upload** to the relay blob
+ * store on save (JP-126) or **download** into local cache on demand (JP-129).
+ * File-count granularity — per-byte progress within a file is a follow-up (needs
+ * an XHR upload transport; `fetch` has no upload-progress events).
+ *
+ * Uploads come from `uploadStatusStore`; downloads resolve lazily through the
+ * blob resolver (not in that store), which signals start/finish via `onBlobLoad`
+ * — so the indicator subscribes to that for the live download count. (Previously
+ * this only rendered the `uploading` phase, so an active download never showed.)
  */
 export function UploadIndicator() {
-  const active = useUploadStatusStore((s) => s.active);
+  const uploadActive = useUploadStatusStore((s) => s.active);
   const phase = useUploadStatusStore((s) => s.phase);
   const current = useUploadStatusStore((s) => s.current);
   const total = useUploadStatusStore((s) => s.total);
 
-  if (!active || phase !== 'uploading' || total === 0) return null;
-  const pct = Math.min(100, Math.round((current / total) * 100));
+  const [downloads, setDownloads] = useState(0);
+  useEffect(() => onBlobLoad(() => setDownloads(inFlightDownloadCount())), []);
+
+  const uploading = uploadActive && phase === 'uploading' && total > 0;
+  if (!uploading && downloads === 0) return null;
+
+  const label = uploading
+    ? `Uploading assets… ${current} of ${total}`
+    : `Downloading files… ${downloads}`;
+  const pct = uploading ? Math.min(100, Math.round((current / total) * 100)) : null;
 
   return (
     <div
@@ -32,14 +48,14 @@ export function UploadIndicator() {
         fontFamily: 'sans-serif',
       }}
     >
-      <div>
-        Uploading assets… {current} of {total}
-      </div>
-      <div style={{ height: 4, marginTop: 6, borderRadius: 2, background: '#444' }}>
-        <div
-          style={{ width: `${pct}%`, height: '100%', borderRadius: 2, background: '#4ea1ff' }}
-        />
-      </div>
+      <div>{label}</div>
+      {pct !== null && (
+        <div style={{ height: 4, marginTop: 6, borderRadius: 2, background: '#444' }}>
+          <div
+            style={{ width: `${pct}%`, height: '100%', borderRadius: 2, background: '#4ea1ff' }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -60,6 +60,16 @@ const UNGROUPED_KEY = '__ungrouped__';
 const LOCAL_RELAY_KEY = '__local__';
 const UNKNOWN_RELAY_KEY = 'unknown';
 
+/**
+ * Retired-option guard (Storage Manager Phase 1): "By relay" grouping is gone
+ * (its section headers exposed the relay host). A value persisted before the
+ * option was removed degrades to ungrouped. The explicit return type keeps
+ * `groupBy` the full union so the legacy `relaySections` guards still compile.
+ */
+function sanitizeGroupBy(g: DocumentBrowserGroupBy): DocumentBrowserGroupBy {
+  return g === 'relay' ? 'none' : g;
+}
+
 /** Bucket key for a record under "By relay" grouping. */
 export function relayKeyForRecord(record: DocumentRecord): string {
   if (record.type === 'local') return LOCAL_RELAY_KEY;
@@ -163,7 +173,13 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   // UI preferences
   const view = useUIPreferencesStore((s) => s.documentBrowserView);
   const sort = useUIPreferencesStore((s) => s.documentBrowserSort);
-  const groupBy = useUIPreferencesStore((s) => s.documentBrowserGroupBy);
+  // "By relay" grouping is retired — its section headers exposed the relay host
+  // (an implementation detail users shouldn't see). The picker option is removed
+  // below; `sanitizeGroupBy` degrades any persisted 'relay' to ungrouped rather
+  // than rendering relay-address sections. (Relay grouping returns as workspace /
+  // collection grouping later; the now-unreachable `relaySections` path can be
+  // deleted then.)
+  const groupBy = sanitizeGroupBy(useUIPreferencesStore((s) => s.documentBrowserGroupBy));
   const collapsedMap = useUIPreferencesStore((s) => s.documentBrowserCollapsed);
   const setView = useUIPreferencesStore((s) => s.setDocumentBrowserView);
   const setSort = useUIPreferencesStore((s) => s.setDocumentBrowserSort);
@@ -826,7 +842,6 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               options={[
                 { value: 'none', label: 'No grouping' },
                 { value: 'group', label: 'By group' },
-                { value: 'relay', label: 'By relay' },
               ]}
             />
             <div className="document-browser__view-toggle" role="group" aria-label="View mode">


### PR DESCRIPTION
**Storage Manager visibility — Phase 1** (under settings-rework epic **JP-211** / **JP-280**). Small fixes so users can tell what's happening with their docs/files.

### Fixes
1. **Duplicate offline status** — `DocumentCard` showed both the `SyncStatusBadge` (`offline` → CloudOff) *and* a per-card relay badge (WifiOff "disconnected"). Removed the relay badge; the sync badge is the single connection/offline indicator.
2. **Relay URL leak** — the relay badge rendered the relay **host:port**, and "By relay" section headers used the relay address as their title. Removed the per-card badge + the "Relay: host" details row, and retired the "By relay" `groupBy` option (`sanitizeGroupBy` degrades any persisted value to ungrouped).
3. **Download indicator never showed** — `UploadIndicator` returned null unless `phase === 'uploading'`, so an active **download** (resolved lazily through `blobResolver`, outside the upload store) never appeared. Added `blobResolver.inFlightDownloadCount()` (notifies on start/finish via `onBlobLoad`) and a live "Downloading files… N" state.

### Deferred (with collections)
Workspace-grouping of the all-docs view — needs a per-doc workspace id the client doesn't have yet (only `relayId`). Punted with workspace identification/slugs to the collections work. The now-unreachable `relaySections` code is left for deletion at that point.

### Verify
`bun run typecheck` clean; full suite **1904 passed**. (Client-only; verify live after a PWA deploy: cards show one connection badge + no relay host; loading a doc with not-yet-cached files shows "Downloading files… N".)

Assisted-by: Opus 4.8