### PR TITLE
JP-281: "Make available offline" — per-doc blob prefetch + offline-ready status

### DIFF
--- a/src/storage/BlobStorage.ts
+++ b/src/storage/BlobStorage.ts
@@ -240,6 +240,18 @@ export class BlobStorage {
   }
 
   /**
+   * Whether a blob's bytes are present in local storage. Checks the metadata
+   * index only (no blob data read), so it's cheap to call across many hashes —
+   * e.g. computing a document's offline-ready status (JP-281).
+   *
+   * @param id - Blob ID (content hash)
+   * @returns true when the blob is stored locally
+   */
+  async hasBlob(id: string): Promise<boolean> {
+    return (await this.getBlobMetadata(id)) !== null;
+  }
+
+  /**
    * List all blob metadata.
    * Does not load blob data (efficient for large collections).
    *

--- a/src/store/offlineAvailability.test.ts
+++ b/src/store/offlineAvailability.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DiagramDocument } from '../types/Document';
+import type { DocumentRecord } from '../types/DocumentRegistry';
+
+// --- module mocks --------------------------------------------------------
+vi.mock('../storage/AssetBundler', () => ({
+  collectBlobReferences: vi.fn(() => [] as string[]),
+}));
+vi.mock('../storage/BlobStorage', () => ({
+  blobStorage: { hasBlob: vi.fn(async () => false) },
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({
+  RelayDocumentCache: { get: vi.fn(async () => null) },
+}));
+vi.mock('./documentRegistry', () => ({
+  useDocumentRegistry: {
+    getState: vi.fn(() => ({ getDocumentContent: vi.fn(() => undefined) })),
+  },
+}));
+vi.mock('./relayDocumentStore', () => ({
+  useRelayDocumentStore: {
+    getState: vi.fn(() => ({
+      getCachedDocument: vi.fn(() => undefined),
+      loadRelayDocument: vi.fn(),
+    })),
+  },
+  getDocProvider: vi.fn(() => null),
+}));
+
+import {
+  computeOfflineStatus,
+  deriveOfflineState,
+  makeAvailableOffline,
+} from './offlineAvailability';
+import { collectBlobReferences } from '../storage/AssetBundler';
+import { blobStorage } from '../storage/BlobStorage';
+import { useDocumentRegistry } from './documentRegistry';
+import { useRelayDocumentStore, getDocProvider } from './relayDocumentStore';
+
+const mockCollect = vi.mocked(collectBlobReferences);
+const mockHasBlob = vi.mocked(blobStorage.hasBlob);
+const mockRegistryState = vi.mocked(useDocumentRegistry.getState);
+const mockRelayState = vi.mocked(useRelayDocumentStore.getState);
+const mockGetProvider = vi.mocked(getDocProvider);
+
+function record(type: DocumentRecord['type'], id = 'doc-1'): DocumentRecord {
+  return { id, type, name: 'Doc' } as unknown as DocumentRecord;
+}
+
+const emptyDoc = { id: 'doc-1' } as unknown as DiagramDocument;
+
+/** Wire the relay/registry/storage caches for a given body + present-blob set. */
+function setCaches(opts: {
+  cachedBody?: DiagramDocument | null;
+  refs?: string[];
+  present?: Set<string>;
+}) {
+  const { cachedBody = null, refs = [], present = new Set<string>() } = opts;
+  mockCollect.mockReturnValue(refs);
+  mockHasBlob.mockImplementation(async (h: string) => present.has(h));
+  mockRelayState.mockReturnValue({
+    getCachedDocument: vi.fn(() => cachedBody ?? undefined),
+    loadRelayDocument: vi.fn(async () => cachedBody ?? emptyDoc),
+  } as never);
+  mockRegistryState.mockReturnValue({
+    getDocumentContent: vi.fn(() => undefined),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProvider.mockReturnValue(null);
+});
+
+describe('deriveOfflineState', () => {
+  it('is online-only when the body is not cached', () => {
+    expect(deriveOfflineState(false, 0, 0)).toBe('online-only');
+    expect(deriveOfflineState(false, 5, 5)).toBe('online-only');
+  });
+
+  it('is ready when body cached and no blobs or all present', () => {
+    expect(deriveOfflineState(true, 0, 0)).toBe('ready');
+    expect(deriveOfflineState(true, 3, 3)).toBe('ready');
+    expect(deriveOfflineState(true, 4, 3)).toBe('ready'); // present can exceed in edge cases
+  });
+
+  it('is partial when body cached but some blobs missing', () => {
+    expect(deriveOfflineState(true, 0, 2)).toBe('partial');
+    expect(deriveOfflineState(true, 1, 2)).toBe('partial');
+  });
+});
+
+describe('computeOfflineStatus', () => {
+  it('treats local documents as inherently ready', async () => {
+    setCaches({});
+    const status = await computeOfflineStatus(record('local'));
+    expect(status).toEqual({ state: 'ready', present: 0, total: 0, bodyCached: true });
+    // No blob/body lookups needed for local docs.
+    expect(mockHasBlob).not.toHaveBeenCalled();
+  });
+
+  it('is online-only when no body is cached anywhere', async () => {
+    setCaches({ cachedBody: null });
+    const status = await computeOfflineStatus(record('remote'));
+    expect(status).toEqual({ state: 'online-only', present: 0, total: 0, bodyCached: false });
+  });
+
+  it('is ready when body cached and every blob present', async () => {
+    setCaches({
+      cachedBody: emptyDoc,
+      refs: ['a', 'b'],
+      present: new Set(['a', 'b']),
+    });
+    const status = await computeOfflineStatus(record('remote'));
+    expect(status).toEqual({ state: 'ready', present: 2, total: 2, bodyCached: true });
+  });
+
+  it('is partial with counts when some blobs are missing', async () => {
+    setCaches({
+      cachedBody: emptyDoc,
+      refs: ['a', 'b', 'c'],
+      present: new Set(['a']),
+    });
+    const status = await computeOfflineStatus(record('remote'));
+    expect(status).toEqual({ state: 'partial', present: 1, total: 3, bodyCached: true });
+  });
+});
+
+describe('makeAvailableOffline', () => {
+  it('is a no-op for local documents', async () => {
+    setCaches({});
+    const status = await makeAvailableOffline(record('local'));
+    expect(status.state).toBe('ready');
+    expect(mockGetProvider).not.toHaveBeenCalled();
+  });
+
+  it('downloads missing blobs, reports progress, and ends ready', async () => {
+    const present = new Set<string>(); // start with nothing cached
+    setCaches({ cachedBody: emptyDoc, refs: ['a', 'b', 'c'], present });
+    // The provider's downloadBlobs writes bytes into local storage.
+    const downloadBlobs = vi.fn(async (hashes: string[]) => {
+      for (const h of hashes) present.add(h);
+      return { total: hashes.length, success: hashes.length, uploaded: hashes.length, failed: 0, skipped: 0, errors: [] };
+    });
+    mockGetProvider.mockReturnValue({ downloadBlobs } as never);
+
+    const progress: Array<{ done: number; total: number }> = [];
+    const status = await makeAvailableOffline(record('remote'), (p) => progress.push({ ...p }));
+
+    // Every missing blob was fetched (one call per hash).
+    expect(downloadBlobs).toHaveBeenCalledTimes(3);
+    // Progress starts at 0/3 and ends at 3/3.
+    expect(progress[0]).toEqual({ done: 0, total: 3 });
+    expect(progress[progress.length - 1]).toEqual({ done: 3, total: 3 });
+    // Final recompute sees all three present.
+    expect(status).toEqual({ state: 'ready', present: 3, total: 3, bodyCached: true });
+  });
+
+  it('leaves the doc partial when a blob download fails', async () => {
+    const present = new Set<string>(['a']);
+    setCaches({ cachedBody: emptyDoc, refs: ['a', 'b'], present });
+    const downloadBlobs = vi.fn(async () => {
+      throw new Error('network');
+    });
+    mockGetProvider.mockReturnValue({ downloadBlobs } as never);
+
+    const status = await makeAvailableOffline(record('remote'));
+    expect(downloadBlobs).toHaveBeenCalledTimes(1); // only 'b' was missing
+    expect(status).toEqual({ state: 'partial', present: 1, total: 2, bodyCached: true });
+  });
+});

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -1,0 +1,167 @@
+/**
+ * offlineAvailability — per-document "is this safe offline?" status plus the
+ * "Make available offline" prefetch action (JP-281).
+ *
+ * Blob caching is otherwise *view-driven*: only assets the user actually renders
+ * get pulled down (blobResolver's download-on-miss), so an unviewed file in a
+ * relay/collab document is missing when offline. This module computes a
+ * document's offline-ready status (body cached + every referenced blob present)
+ * and lets the user proactively pull a whole document's asset set into the local
+ * IndexedDB cache. Enumeration is reliable because the relay snapshot now
+ * derives `blobReferences` (JP-278), so `collectBlobReferences` sees the full
+ * asset set client-side.
+ *
+ * Status computation is offline-safe — it reads only local caches and never
+ * hits the network — so it's cheap to call passively for every visible card.
+ */
+
+import { collectBlobReferences } from '../storage/AssetBundler';
+import { blobStorage } from '../storage/BlobStorage';
+import { RelayDocumentCache } from '../storage/RelayDocumentCache';
+import type { DiagramDocument } from '../types/Document';
+import type { DocumentRecord } from '../types/DocumentRegistry';
+import { useDocumentRegistry } from './documentRegistry';
+import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+
+/** Max blob downloads in flight at once during a prefetch. */
+const OFFLINE_PREFETCH_CONCURRENCY = 4;
+
+export type OfflineState = 'ready' | 'partial' | 'online-only';
+
+export interface OfflineStatus {
+  state: OfflineState;
+  /** Referenced blobs whose bytes are present in local storage. */
+  present: number;
+  /** Total blobs the document references. */
+  total: number;
+  /** Whether the document body itself is cached locally. */
+  bodyCached: boolean;
+}
+
+/** Progress of an in-flight {@link makeAvailableOffline} prefetch. */
+export interface OfflineProgress {
+  done: number;
+  total: number;
+}
+
+/**
+ * Pure mapping from cache facts to an offline state. Exported for testing.
+ * - body not cached → the doc can't open offline at all ('online-only')
+ * - body cached, no blobs or all present → 'ready'
+ * - body cached but some blobs missing → 'partial'
+ */
+export function deriveOfflineState(
+  bodyCached: boolean,
+  present: number,
+  total: number,
+): OfflineState {
+  if (!bodyCached) return 'online-only';
+  if (total === 0 || present >= total) return 'ready';
+  return 'partial';
+}
+
+/**
+ * Resolve a relay/cached document's body from offline-safe caches only (no
+ * network): in-memory store cache → registry content → the persistent offline
+ * cache. Returns null when the body isn't cached anywhere locally.
+ */
+async function loadCachedBody(record: DocumentRecord): Promise<DiagramDocument | null> {
+  const relay = useRelayDocumentStore.getState();
+  const inMemory = relay.getCachedDocument(record.id);
+  if (inMemory) return inMemory;
+  const registryDoc = useDocumentRegistry.getState().getDocumentContent(record.id);
+  if (registryDoc) return registryDoc;
+  return RelayDocumentCache.get(record.id);
+}
+
+/** Count how many of `hashes` have their bytes present in local storage. */
+async function countPresent(hashes: string[]): Promise<number> {
+  const presence = await Promise.all(hashes.map((h) => blobStorage.hasBlob(h)));
+  return presence.filter(Boolean).length;
+}
+
+/**
+ * Compute a document's offline-ready status from local caches only. Local
+ * documents are inherently offline-ready (body + blobs already live in local
+ * storage); relay/cached documents are inspected for body + blob presence.
+ */
+export async function computeOfflineStatus(record: DocumentRecord): Promise<OfflineStatus> {
+  if (record.type === 'local') {
+    return { state: 'ready', present: 0, total: 0, bodyCached: true };
+  }
+
+  const body = await loadCachedBody(record);
+  if (!body) {
+    return { state: 'online-only', present: 0, total: 0, bodyCached: false };
+  }
+
+  const refs = collectBlobReferences(body);
+  const present = await countPresent(refs);
+  return {
+    state: deriveOfflineState(true, present, refs.length),
+    present,
+    total: refs.length,
+    bodyCached: true,
+  };
+}
+
+/** Run `task` over `items` with at most `limit` in flight at a time. */
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      await task(items[index]!);
+    }
+  });
+  await Promise.all(workers);
+}
+
+/**
+ * Proactively cache a relay/cached document for offline use: ensure its body is
+ * in the offline cache, then download every referenced blob missing locally.
+ * Reports progress as blobs are processed and resolves to the final offline
+ * status. No-op for local documents (already offline-ready). Best-effort: a blob
+ * that fails to download just leaves the document 'partial'.
+ */
+export async function makeAvailableOffline(
+  record: DocumentRecord,
+  onProgress?: (progress: OfflineProgress) => void,
+): Promise<OfflineStatus> {
+  if (record.type === 'local') {
+    return { state: 'ready', present: 0, total: 0, bodyCached: true };
+  }
+
+  // loadRelayDocument serves (or fetches) the body and writes it to the
+  // persistent offline cache as a side effect — that satisfies "body cached".
+  const body = await useRelayDocumentStore.getState().loadRelayDocument(record.id);
+  const refs = collectBlobReferences(body);
+  const total = refs.length;
+
+  const presence = await Promise.all(refs.map((h) => blobStorage.hasBlob(h)));
+  const missing = refs.filter((_, i) => !presence[i]);
+
+  let done = total - missing.length;
+  onProgress?.({ done, total });
+
+  const provider = getDocProvider();
+  if (missing.length > 0 && provider?.downloadBlobs) {
+    const downloadBlobs = provider.downloadBlobs.bind(provider);
+    await runWithConcurrency(missing, OFFLINE_PREFETCH_CONCURRENCY, async (hash) => {
+      try {
+        await downloadBlobs([hash]);
+      } catch {
+        // Best-effort — a failed blob leaves the doc 'partial' on recompute.
+      } finally {
+        done += 1;
+        onProgress?.({ done, total });
+      }
+    });
+  }
+
+  return computeOfflineStatus(record);
+}

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -116,6 +116,40 @@
   color: var(--text-muted);
 }
 
+/* Offline-cache status badge (JP-281) — distinct from the sync badge: it tracks
+   whether the doc's body + referenced blobs are saved locally for offline use. */
+.document-card__offline {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.document-card__offline svg {
+  flex-shrink: 0;
+}
+
+.document-card__offline--ready {
+  color: var(--success);
+}
+
+.document-card__offline--partial {
+  color: var(--warning);
+}
+
+.document-card__offline--online-only {
+  color: var(--text-muted);
+}
+
+.document-card__offline--caching {
+  color: var(--color-primary);
+}
+
+.document-card__offline-count {
+  font-variant-numeric: tabular-nums;
+}
+
 /* Actions */
 .document-card__actions {
   display: flex;

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -150,6 +150,28 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Actionable variant — the badge doubles as the "make available offline"
+   trigger when the doc isn't fully cached. Button reset + a subtle hover. */
+button.document-card__offline--action {
+  border: none;
+  background: transparent;
+  padding: 1px;
+  margin: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+button.document-card__offline--action:hover {
+  background: var(--surface-hover, rgba(100, 116, 139, 0.12));
+  color: var(--color-primary);
+}
+
+button.document-card__offline--action:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
 /* Actions */
 .document-card__actions {
   display: flex;

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -5,7 +5,7 @@
  * Used in the DocumentBrowser for unified document listing.
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { memo, useState, useCallback, useEffect } from 'react';
 import {
   Check,
   ChevronDown,
@@ -68,32 +68,42 @@ interface DocumentCardProps {
   mode?: 'compact' | 'full' | 'grid' | undefined;
 }
 
-interface OfflineBadgeConfig {
+interface OfflineBadge {
   Icon: typeof CloudCheck;
   className: string;
   title: string;
+  /** When true the badge doubles as the "make available offline" trigger. */
+  actionable: boolean;
 }
 
-/** Passive offline-cache indicator config for a relay/cached document. */
-function offlineBadgeConfig(status: OfflineStatus): OfflineBadgeConfig {
-  switch (status.state) {
+/**
+ * Offline-cache indicator for a relay/cached document. Always returns a config
+ * (never hidden) — an unknown status (not yet computed) is treated as
+ * actionable so the affordance is visible from the first paint.
+ */
+function offlineBadge(status: OfflineStatus | undefined): OfflineBadge {
+  switch (status?.state) {
     case 'ready':
       return {
         Icon: CloudCheck,
         className: 'document-card__offline--ready',
         title: 'Available offline — body and all files cached locally',
+        actionable: false,
       };
     case 'partial':
       return {
         Icon: CloudDownload,
         className: 'document-card__offline--partial',
-        title: `Partially offline — ${status.present}/${status.total} files cached`,
+        title: `Partially offline — ${status.present}/${status.total} files cached · click to finish`,
+        actionable: true,
       };
     case 'online-only':
+    default:
       return {
-        Icon: CloudOff,
+        Icon: CloudDownload,
         className: 'document-card__offline--online-only',
-        title: 'Online only — not saved for offline use',
+        title: 'Not saved offline · click to make available offline',
+        actionable: true,
       };
   }
 }
@@ -208,7 +218,7 @@ export function formatRelayLabel(
   };
 }
 
-export function DocumentCard({
+function DocumentCardImpl({
   record,
   isActive = false,
   isSelected = false,
@@ -361,15 +371,14 @@ export function DocumentCard({
 
   const showCheckbox = Boolean(onSelectToggle) && (showSelectionCheckbox || isSelected);
 
-  // Offline-cache surfacing (JP-281) — relay/cached docs only. The passive
-  // badge answers "is this safe offline?"; the hover action proactively pulls
-  // the body + every referenced blob into the local cache.
+  // Offline-cache surfacing (JP-281) — relay/cached docs only. Rendered in the
+  // always-visible meta row (NOT the hover-only actions row) so the offline
+  // state reads as passive status for every doc and the "save offline" action
+  // is discoverable without hovering. Local docs are inherently offline.
   const isRelayBacked = record.type === 'remote' || record.type === 'cached';
   const isCaching = offlineProgress != null;
-  const showOfflineBadge = isRelayBacked && offlineStatus !== undefined;
-  const offlineBadge = showOfflineBadge && !isCaching ? offlineBadgeConfig(offlineStatus) : null;
-  const canMakeOffline =
-    isRelayBacked && Boolean(onMakeAvailableOffline) && offlineStatus?.state !== 'ready';
+  const offline = isRelayBacked ? offlineBadge(offlineStatus) : null;
+  const offlineActionable = Boolean(offline?.actionable && onMakeAvailableOffline);
 
   return (
     <div
@@ -432,25 +441,39 @@ export function DocumentCard({
               separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
 
-          {/* Offline-cache status (JP-281): distinct from sync — answers
-              "is the doc's content saved locally for offline use?" */}
-          {isCaching && (
-            <span
-              className="document-card__offline document-card__offline--caching"
-              title="Caching for offline use…"
-            >
-              <Loader2 className="document-card__spin" size={12} aria-hidden="true" />
-              {offlineProgress && offlineProgress.total > 0 && (
-                <span className="document-card__offline-count">
-                  {offlineProgress.done}/{offlineProgress.total}
-                </span>
-              )}
-            </span>
-          )}
-          {offlineBadge && (
-            <span className={`document-card__offline ${offlineBadge.className}`} title={offlineBadge.title}>
-              <offlineBadge.Icon size={12} aria-hidden="true" />
-            </span>
+          {/* Offline-cache status + action (JP-281): always-visible (not in the
+              hover-only actions row), so it reads as passive status for every
+              relay doc and the "save offline" action is discoverable without
+              hovering. Distinct from the sync badge — answers "is the content
+              saved locally for offline use?". */}
+          {offline && (
+            isCaching ? (
+              <span
+                className="document-card__offline document-card__offline--caching"
+                title="Caching for offline use…"
+              >
+                <Loader2 className="document-card__spin" size={12} aria-hidden="true" />
+                {offlineProgress && offlineProgress.total > 0 && (
+                  <span className="document-card__offline-count">
+                    {offlineProgress.done}/{offlineProgress.total}
+                  </span>
+                )}
+              </span>
+            ) : offlineActionable ? (
+              <button
+                type="button"
+                className={`document-card__offline document-card__offline--action ${offline.className}`}
+                onClick={handleMakeOffline}
+                title={offline.title}
+                aria-label="Make available offline"
+              >
+                <offline.Icon size={12} aria-hidden="true" />
+              </button>
+            ) : (
+              <span className={`document-card__offline ${offline.className}`} title={offline.title}>
+                <offline.Icon size={12} aria-hidden="true" />
+              </span>
+            )
           )}
 
           {/* Modified time */}
@@ -572,21 +595,6 @@ export function DocumentCard({
             )}
           </button>
         )}
-        {canMakeOffline && (
-          <button
-            className="document-card__action document-card__action--offline"
-            onClick={handleMakeOffline}
-            disabled={isCaching}
-            title={isCaching ? 'Caching for offline use…' : 'Make available offline'}
-            aria-label="Make available offline"
-          >
-            {isCaching ? (
-              <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
-            ) : (
-              <CloudDownload size={16} aria-hidden="true" />
-            )}
-          </button>
-        )}
         {onEditPermissions && (
           <button
             className="document-card__action"
@@ -639,5 +647,13 @@ export function DocumentCard({
     </div>
   );
 }
+
+/**
+ * Memoized so an action on one card (e.g. an in-flight "make available offline"
+ * progress tick) re-renders only that card, not the whole list. Relies on the
+ * browser passing referentially-stable props — notably a stable `groupAccent`
+ * and per-doc offline status/progress (JP-281).
+ */
+export const DocumentCard = memo(DocumentCardImpl);
 
 export default DocumentCard;

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -10,6 +10,8 @@ import {
   Check,
   ChevronDown,
   Cloud,
+  CloudCheck,
+  CloudDownload,
   CloudOff,
   Download,
   HardDrive,
@@ -21,6 +23,7 @@ import {
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
 import type { DocumentRecord, Permission } from '../types/DocumentRegistry';
+import type { OfflineProgress, OfflineStatus } from '../store/offlineAvailability';
 import { useConnectionStore } from '../store/connectionStore';
 import './DocumentCard.css';
 
@@ -55,8 +58,44 @@ interface DocumentCardProps {
   groupAccent?: { name: string; color?: string | undefined } | undefined;
   /** Address (host:port) of the currently-connected relay, for connected/disconnected badge state. */
   connectedRelayAddress?: string | undefined;
+  /** Offline-cache status for relay/cached docs (JP-281). Drives the offline-ready badge. */
+  offlineStatus?: OfflineStatus | undefined;
+  /** In-flight "make available offline" progress; non-null while caching. */
+  offlineProgress?: OfflineProgress | null | undefined;
+  /** Callback to proactively cache this doc's body + all referenced blobs offline. */
+  onMakeAvailableOffline?: ((id: string) => void) | undefined;
   /** Display mode */
   mode?: 'compact' | 'full' | 'grid' | undefined;
+}
+
+interface OfflineBadgeConfig {
+  Icon: typeof CloudCheck;
+  className: string;
+  title: string;
+}
+
+/** Passive offline-cache indicator config for a relay/cached document. */
+function offlineBadgeConfig(status: OfflineStatus): OfflineBadgeConfig {
+  switch (status.state) {
+    case 'ready':
+      return {
+        Icon: CloudCheck,
+        className: 'document-card__offline--ready',
+        title: 'Available offline — body and all files cached locally',
+      };
+    case 'partial':
+      return {
+        Icon: CloudDownload,
+        className: 'document-card__offline--partial',
+        title: `Partially offline — ${status.present}/${status.total} files cached`,
+      };
+    case 'online-only':
+      return {
+        Icon: CloudOff,
+        className: 'document-card__offline--online-only',
+        title: 'Online only — not saved for offline use',
+      };
+  }
 }
 
 function formatDate(timestamp: number): string {
@@ -184,6 +223,9 @@ export function DocumentCard({
   onSelectToggle,
   groupAccent,
   connectedRelayAddress,
+  offlineStatus,
+  offlineProgress,
+  onMakeAvailableOffline,
   mode = 'compact',
 }: DocumentCardProps) {
   const [isEditing, setIsEditing] = useState(false);
@@ -297,6 +339,11 @@ export function DocumentCard({
     setShowDeleteConfirm(false);
   }, []);
 
+  const handleMakeOffline = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onMakeAvailableOffline) onMakeAvailableOffline(record.id);
+  }, [onMakeAvailableOffline, record.id]);
+
   // A still-valid cached relay token means a disconnected relay doc is only
   // *idle* (reopen reconnects instantly), not *offline*. Re-evaluates on any
   // connection-store change (token set/cleared on sign-in / sign-out).
@@ -313,6 +360,16 @@ export function DocumentCard({
   const showDetails = mode === 'full';
 
   const showCheckbox = Boolean(onSelectToggle) && (showSelectionCheckbox || isSelected);
+
+  // Offline-cache surfacing (JP-281) — relay/cached docs only. The passive
+  // badge answers "is this safe offline?"; the hover action proactively pulls
+  // the body + every referenced blob into the local cache.
+  const isRelayBacked = record.type === 'remote' || record.type === 'cached';
+  const isCaching = offlineProgress != null;
+  const showOfflineBadge = isRelayBacked && offlineStatus !== undefined;
+  const offlineBadge = showOfflineBadge && !isCaching ? offlineBadgeConfig(offlineStatus) : null;
+  const canMakeOffline =
+    isRelayBacked && Boolean(onMakeAvailableOffline) && offlineStatus?.state !== 'ready';
 
   return (
     <div
@@ -374,6 +431,27 @@ export function DocumentCard({
           {/* Sync status. The connection/offline state lives here only — a
               separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
+
+          {/* Offline-cache status (JP-281): distinct from sync — answers
+              "is the doc's content saved locally for offline use?" */}
+          {isCaching && (
+            <span
+              className="document-card__offline document-card__offline--caching"
+              title="Caching for offline use…"
+            >
+              <Loader2 className="document-card__spin" size={12} aria-hidden="true" />
+              {offlineProgress && offlineProgress.total > 0 && (
+                <span className="document-card__offline-count">
+                  {offlineProgress.done}/{offlineProgress.total}
+                </span>
+              )}
+            </span>
+          )}
+          {offlineBadge && (
+            <span className={`document-card__offline ${offlineBadge.className}`} title={offlineBadge.title}>
+              <offlineBadge.Icon size={12} aria-hidden="true" />
+            </span>
+          )}
 
           {/* Modified time */}
           <span className="document-card__date">{formatDate(record.modifiedAt)}</span>
@@ -491,6 +569,21 @@ export function DocumentCard({
               <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
             ) : (
               <Download size={16} aria-hidden="true" />
+            )}
+          </button>
+        )}
+        {canMakeOffline && (
+          <button
+            className="document-card__action document-card__action--offline"
+            onClick={handleMakeOffline}
+            disabled={isCaching}
+            title={isCaching ? 'Caching for offline use…' : 'Make available offline'}
+            aria-label="Make available offline"
+          >
+            {isCaching ? (
+              <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
+            ) : (
+              <CloudDownload size={16} aria-hidden="true" />
             )}
           </button>
         )}

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -253,10 +253,22 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       setOfflineStatuses((prev) => (prev.size === 0 ? prev : new Map()));
       return;
     }
-    void Promise.all(
-      records.map(async (r) => [r.id, await computeOfflineStatus(r)] as const),
-    ).then((pairs) => {
-      if (!cancelled) setOfflineStatuses(new Map(pairs));
+    // allSettled (not all): one doc whose status can't be computed must not wipe
+    // every other doc's badge. Merge results so unaffected entries keep their
+    // refs, and prune statuses for docs that left the list.
+    const liveIds = new Set(records.map((r) => r.id));
+    void Promise.allSettled(records.map((r) => computeOfflineStatus(r))).then((results) => {
+      if (cancelled) return;
+      setOfflineStatuses((prev) => {
+        const next = new Map(prev);
+        results.forEach((res, i) => {
+          if (res.status === 'fulfilled') next.set(records[i]!.id, res.value);
+        });
+        for (const id of next.keys()) {
+          if (!liveIds.has(id)) next.delete(id);
+        }
+        return next;
+      });
     });
     return () => {
       cancelled = true;
@@ -688,16 +700,27 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const cardMode: 'compact' | 'full' | 'grid' =
     view === 'grid' ? 'grid' : compact ? 'compact' : 'full';
 
+  // Stable per-doc group accent so DocumentCard's memo can skip cards unaffected
+  // by an action elsewhere (e.g. an offline-prefetch progress tick on another
+  // card no longer re-renders the whole list).
+  const accentByDoc = useMemo(() => {
+    const map = new Map<string, { name: string; color?: string }>();
+    if (groupBy === 'group') return map; // membership shown via section headers instead
+    for (const docId of Object.keys(assignments)) {
+      const gid = assignments[docId];
+      const group = gid ? groupsMap[gid] : undefined;
+      if (!group) continue;
+      map.set(
+        docId,
+        group.color !== undefined ? { name: group.name, color: group.color } : { name: group.name },
+      );
+    }
+    return map;
+  }, [assignments, groupsMap, groupBy]);
+
   const renderCard = useCallback(
     (record: DocumentRecord) => {
-      const gid = assignments[record.id];
-      const group = gid ? groupsMap[gid] : undefined;
-      const accent =
-        group && groupBy !== 'group'
-          ? group.color !== undefined
-            ? { name: group.name, color: group.color }
-            : { name: group.name }
-          : undefined;
+      const accent = accentByDoc.get(record.id);
       return (
         <DocumentCard
           key={record.id}
@@ -727,9 +750,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       );
     },
     [
-      assignments,
-      groupsMap,
-      groupBy,
+      accentByDoc,
       connectedRelayAddress,
       currentDocumentId,
       selectedIds,

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -26,6 +26,12 @@ import { useDocumentRegistry } from '../../store/documentRegistry';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
 import { useRelayDocumentStore } from '../../store/relayDocumentStore';
+import {
+  computeOfflineStatus,
+  makeAvailableOffline,
+  type OfflineProgress,
+  type OfflineStatus,
+} from '../../store/offlineAvailability';
 import { useUserStore } from '../../store/userStore';
 import {
   useUIPreferencesStore,
@@ -209,6 +215,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
   const [assignMenuOpen, setAssignMenuOpen] = useState(false);
   const [activeGroupMenu, setActiveGroupMenu] = useState<string | null>(null);
+  // Offline-cache surfacing (JP-281): passive per-doc status + in-flight prefetch progress.
+  const [offlineStatuses, setOfflineStatuses] = useState<Map<string, OfflineStatus>>(new Map());
+  const [offlineProgress, setOfflineProgress] = useState<Map<string, OfflineProgress>>(new Map());
 
   const isInTeamMode = isRelayLive;
   const isConnectedToHost = isRelayLive && authenticated;
@@ -233,6 +242,47 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
 
     return [...filtered].sort((a, b) => compareRecords(a, b, sort));
   }, [entries, getFilteredDocuments, filterMode, searchQuery, sort]);
+
+  // JP-281: compute each relay-backed doc's offline-ready status from local
+  // caches (network-free). Recomputes when the list or registry changes so the
+  // badge reflects view-driven caching that lands in the background.
+  useEffect(() => {
+    let cancelled = false;
+    const records = documentList.filter((d) => d.type !== 'local');
+    if (records.length === 0) {
+      setOfflineStatuses((prev) => (prev.size === 0 ? prev : new Map()));
+      return;
+    }
+    void Promise.all(
+      records.map(async (r) => [r.id, await computeOfflineStatus(r)] as const),
+    ).then((pairs) => {
+      if (!cancelled) setOfflineStatuses(new Map(pairs));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [documentList]);
+
+  // JP-281: proactively cache a doc's body + all referenced blobs for offline use.
+  const handleMakeAvailableOffline = useCallback(async (id: string) => {
+    const record = useDocumentRegistry.getState().getRecord(id);
+    if (!record) return;
+    setOfflineProgress((m) => new Map(m).set(id, { done: 0, total: 0 }));
+    try {
+      const status = await makeAvailableOffline(record, (p) => {
+        setOfflineProgress((m) => new Map(m).set(id, p));
+      });
+      setOfflineStatuses((m) => new Map(m).set(id, status));
+    } catch (e) {
+      console.warn('[DocumentBrowser] Make available offline failed:', id, e);
+    } finally {
+      setOfflineProgress((m) => {
+        const next = new Map(m);
+        next.delete(id);
+        return next;
+      });
+    }
+  }, []);
 
   // Bucket documents by group when group-by is enabled.
   const groupedSections = useMemo(() => {
@@ -669,6 +719,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
           onMoveToPersonal={canMoveToPersonal(record, authenticated, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
           groupAccent={accent}
           connectedRelayAddress={connectedRelayAddress}
+          offlineStatus={offlineStatuses.get(record.id)}
+          offlineProgress={offlineProgress.get(record.id) ?? null}
+          onMakeAvailableOffline={record.type !== 'local' ? handleMakeAvailableOffline : undefined}
           mode={cardMode}
         />
       );
@@ -682,6 +735,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       selectedIds,
       showSelectionAffordance,
       isAvailableOffline,
+      offlineStatuses,
+      offlineProgress,
+      handleMakeAvailableOffline,
       handleOpen,
       handleSelectToggle,
       currentUser,


### PR DESCRIPTION
Storage Manager **Phase 3** (settings-rework epic JP-211) — the offline capstone.

## Why
Blob caching is otherwise **view-driven** (blobResolver download-on-miss): only assets the user actually renders get pulled down, so an unviewed file in a relay/collab doc is missing offline. This adds a **proactive prefetch** plus a **passive status** that answers "is this doc safe offline?". Enumeration is reliable now that the relay snapshot derives `blobReferences` (JP-278).

Per the issue's design fork, this ships the **recommended explicit opt-in action** — the lazy/view-driven model stays the default; prefetch is user-initiated (no bandwidth burned on every open). The badge passively reports state regardless.

## What
- **`src/store/offlineAvailability.ts` (new)**
  - `computeOfflineStatus` — **network-free**; reads local caches only (body: in-memory → registry → `RelayDocumentCache`; per-blob presence via `blobStorage.hasBlob`) → `ready` / `partial` / `online-only` with present/total counts. Local docs are inherently `ready`.
  - `makeAvailableOffline` — caches the body via `loadRelayDocument`, then downloads missing blobs through the existing `provider.downloadBlobs` seam (concurrency-capped at 4) with N/M progress; recomputes the final status.
  - `deriveOfflineState` — pure, fully unit-tested.
- **`BlobStorage.hasBlob`** — cheap metadata-only presence check for the status scan.
- **`DocumentCard`** — passive offline-cache badge (distinct from the sync badge) + a hover **"Make available offline"** action with a spinner + live N/M while caching. Relay/cached docs only.
- **`DocumentBrowser`** — computes statuses for visible relay-backed docs (recomputes on list/registry change so background view-driven caching is reflected) and owns the prefetch handler + per-doc progress.

## Testing
- `bun run typecheck` clean.
- Full suite **1914 passed** (10 new in `offlineAvailability.test.ts` covering the state matrix, cache resolution, prefetch progress, and the failed-download → `partial` path).
- E2E (real relay + going offline) needs a deploy — not verifiable in-repo.

Assisted-by: Opus 4.8