### PR TITLE
Fix: doc switch wiped the relay doc list offline (cached docs vanished)

### DIFF
--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -44,16 +44,22 @@ vi.mock('./UnifiedSyncProvider', () => ({
   })),
 }));
 
+// Stable mock object so spies (clearRelayDocuments / setProvider) persist across
+// getState() calls — lets us assert switchDocument doesn't wipe the doc list.
+const hoisted = vi.hoisted(() => ({
+  relayDocStore: {
+    setHostConnected: vi.fn(),
+    setError: vi.fn(),
+    setAuthenticated: vi.fn(),
+    handleDocumentEvent: vi.fn(),
+    setProvider: vi.fn(),
+    clearRelayDocuments: vi.fn(),
+  },
+}));
+
 vi.mock('../store/relayDocumentStore', () => ({
   useRelayDocumentStore: {
-    getState: vi.fn(() => ({
-      setHostConnected: vi.fn(),
-      setError: vi.fn(),
-      setAuthenticated: vi.fn(),
-      handleDocumentEvent: vi.fn(),
-      setProvider: vi.fn(),
-      clearRelayDocuments: vi.fn(),
-    })),
+    getState: vi.fn(() => hoisted.relayDocStore),
   },
 }));
 
@@ -360,6 +366,32 @@ describe('collaborationStore', () => {
         useCollaborationStore.getState().switchDocument('doc-2');
       }).not.toThrow();
       expect(useCollaborationStore.getState().isActive).toBe(false);
+    });
+
+    it('preserves the relay document list + provider across a switch', () => {
+      // Regression: switchDocument used stopSession, which clears the relay doc
+      // list (remote AND cached entries). Online that was masked by a follow-up
+      // refetch, but offline the cached docs vanished when opening one. A switch
+      // must leave the list/provider intact (preserveAuth).
+      const config = createTestConfig({ documentId: 'doc-1', token: 'tok' });
+      useCollaborationStore.getState().startSession(config);
+      hoisted.relayDocStore.clearRelayDocuments.mockClear();
+
+      useCollaborationStore.getState().switchDocument('doc-2');
+
+      // The doc list must survive the switch. (startSession re-establishes the
+      // REST provider via setProvider; that's expected — only the *clear* is the bug.)
+      expect(hoisted.relayDocStore.clearRelayDocuments).not.toHaveBeenCalled();
+    });
+
+    it('stopSession (full sign-out) still clears the relay document list', () => {
+      const config = createTestConfig({ documentId: 'doc-1', token: 'tok' });
+      useCollaborationStore.getState().startSession(config);
+      hoisted.relayDocStore.clearRelayDocuments.mockClear();
+
+      useCollaborationStore.getState().stopSession();
+
+      expect(hoisted.relayDocStore.clearRelayDocuments).toHaveBeenCalled();
     });
   });
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -663,12 +663,17 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       const token = conn.token ?? config.token;
       const tokenExpiresAt = conn.tokenExpiresAt;
 
-      get().stopSession();
+      // Leave the current doc but KEEP the relay identity, provider, and
+      // document list across the switch (preserveAuth). A full `stopSession`
+      // here cleared the relay doc list — `clearRelayDocuments` drops remote
+      // *and* cached entries — which online was masked by the follow-up
+      // `startSession`→`fetchDocumentList`, but offline there's nothing to
+      // refetch, so every other cached doc vanished when opening one.
+      get().leaveDocument();
 
-      // `stopSession` resets the connection store (token → null). Re-assert the
-      // identity BEFORE the new `startSession` so its REST-client seed + token
-      // monitor pick it up — otherwise an authenticated collaborator would drop
-      // to unauthenticated across a doc switch.
+      // `leaveDocument` preserves the token; re-assert the freshest one (auth /
+      // refresh updates connectionStore) before `startSession` so its REST-client
+      // seed + token monitor pick it up across the switch.
       if (token) {
         useConnectionStore.getState().setToken(token, tokenExpiresAt);
       }


### PR DESCRIPTION
## Bug
In **offline mode**, opening one cached relay doc made every *other* cached doc disappear from the document browser. ("Made available offline" didn't help — the bytes survive in `RelayDocumentCache`; only the in-memory registry list was cleared.)

## Root cause
`collaborationStore.switchDocument()` tore the old session down via **`stopSession()`** = `teardownSession({ preserveAuth: false })`, which calls `clearRelayDocuments()` → `registry.clearRemoteDocuments(host)`. That helper deletes **both `remote` and `cached`** entries for the relay.

- **Online:** the follow-up `startSession()` → `fetchDocumentList()` repopulated the list, masking the wipe.
- **Offline:** no provider/connection → nothing to refetch → the cleared cached docs never came back.

Trigger: open a doc → `ensureCollabSession` / `DocumentBrowser.handleOpen` → `switchDocument()` → `stopSession()` → `clearRelayDocuments()`.

## Fix
Switch now tears down with **`preserveAuth` (`leaveDocument()`)**, keeping the relay identity, provider, and document list across the switch. The per-doc WS provider + Y.Doc are still destroyed and a fresh session starts for the new doc (JP-190 already relies on this path keeping the provider/list). Full sign-out (disconnect button → `stopSession`) still clears the list, as intended.

## Testing
- New regression tests: `switchDocument` no longer calls `clearRelayDocuments`; `stopSession` still does.
- `bun run typecheck` clean; full suite **1916 passed**.
- Offline end-to-end (open a cached doc, others stay) needs a deploy to confirm.

Follow-up surfaced during JP-281 offline testing.

Assisted-by: Opus 4.8