### PR TITLE
Fix two transfer data bugs: prose duplication (to-Cloud) + blob loss (to-Personal)

### DIFF
--- a/src/services/DocumentTransferService.test.ts
+++ b/src/services/DocumentTransferService.test.ts
@@ -257,6 +257,59 @@ describe('DocumentTransferService', () => {
     });
   });
 
+  // Data-loss guard: a relay→personal move must download the doc's blobs locally
+  // before deleting the relay copy. Otherwise the personal doc keeps blob:// refs
+  // whose bytes lived only on the relay → irreversibly broken file refs.
+  describe('Move-to-Personal blob safety', () => {
+    let teamDoc: DiagramDocument;
+
+    beforeEach(() => {
+      teamDoc = createTestDocument({ isRelayDocument: true, ownerId: 'user-1' });
+      deps.loadDocument = vi.fn((id: string) => (id === teamDoc.id ? teamDoc : null));
+      deps.saveDocument = vi.fn((doc: DiagramDocument) => {
+        teamDoc = doc;
+      });
+    });
+
+    it('aborts without deleting the relay copy when blobs cannot be secured', async () => {
+      deps.ensureBlobsAvailableLocally = vi.fn().mockResolvedValue(false);
+
+      const result = await service.transferToPersonal(teamDoc.id);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/files/i);
+      expect(deps.deleteFromHost).not.toHaveBeenCalled();
+      // The doc is left untouched as a relay doc — nothing lost.
+      expect(teamDoc.isRelayDocument).toBe(true);
+    });
+
+    it('proceeds once blobs are secured locally', async () => {
+      deps.ensureBlobsAvailableLocally = vi.fn().mockResolvedValue(true);
+
+      const result = await service.transferToPersonal(teamDoc.id);
+
+      expect(deps.ensureBlobsAvailableLocally).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.document?.isRelayDocument).toBe(false);
+      expect(deps.deleteFromHost).toHaveBeenCalledTimes(1);
+    });
+
+    it('secures blobs BEFORE deleting the relay copy', async () => {
+      const order: string[] = [];
+      deps.ensureBlobsAvailableLocally = vi.fn(async () => {
+        order.push('ensure-blobs');
+        return true;
+      });
+      deps.deleteFromHost = vi.fn(async () => {
+        order.push('delete-from-host');
+      });
+
+      await service.transferToPersonal(teamDoc.id);
+
+      expect(order).toEqual(['ensure-blobs', 'delete-from-host']);
+    });
+  });
+
   // JP-83 regression: a relay doc moved back to personal must remain visible in
   // the document browser. `DocumentBrowser.handleMoveToPersonal` re-registers the
   // converted doc as Local after the transfer — without that step the doc is

--- a/src/services/DocumentTransferService.ts
+++ b/src/services/DocumentTransferService.ts
@@ -92,6 +92,13 @@ export interface TransferServiceDeps {
   isAuthenticated: () => boolean;
   /** Update metadata in store */
   updateMetadata: (docId: string, metadata: DocumentMetadata) => void;
+  /**
+   * Ensure every blob the document references is present in local storage
+   * (downloading any missing). Resolves true only when all are local. Gates the
+   * relay→personal delete so the move never orphans blobs that lived only on the
+   * relay. Optional: when absent the check is skipped (e.g. tests / no blob sync).
+   */
+  ensureBlobsAvailableLocally?: (doc: DiagramDocument) => Promise<boolean>;
 }
 
 // ============ Constants ============
@@ -239,7 +246,9 @@ export class DocumentTransferService {
     try {
       const executeResult = await this.execute(record, skipServerSync, timeout);
       if (!executeResult.success) {
-        // Attempt rollback
+        // Carry the reason into the record so rollback surfaces *why* (e.g. blobs
+        // couldn't be secured) instead of a generic failure.
+        if (executeResult.error !== undefined) record.error = executeResult.error;
         onProgress?.('rolling-back');
         return this.rollback(record);
       }
@@ -373,6 +382,29 @@ export class DocumentTransferService {
     skipServerSync: boolean,
     timeout: number
   ): Promise<TransferResult> {
+    // Secure the document's blobs locally BEFORE deleting the relay copy.
+    // Otherwise the personal doc keeps blob:// refs whose bytes live only on the
+    // relay, and the delete orphans them irreversibly. If they can't all be
+    // downloaded, abort the move (no delete) so nothing is lost — the caller
+    // surfaces the failure and the relay copy stays intact.
+    if (!skipServerSync && this.deps.ensureBlobsAvailableLocally) {
+      let blobsSecured = false;
+      try {
+        blobsSecured = await this.deps.ensureBlobsAvailableLocally(doc);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to download files';
+        return { success: false, error: `Could not download all files locally: ${message}` };
+      }
+      if (!blobsSecured) {
+        return {
+          success: false,
+          error:
+            'Could not download all of this document’s files for offline use. ' +
+            'Move cancelled so nothing is lost — try again while online.',
+        };
+      }
+    }
+
     // Delete from server first (if authenticated)
     if (!skipServerSync && this.deps.isAuthenticated()) {
       try {
@@ -465,7 +497,7 @@ export class DocumentTransferService {
 
       return {
         success: false,
-        error: record.error ?? 'Transfer failed and was rolled back',
+        error: `${record.error ?? 'Transfer failed'} (rolled back)`,
         document: record.originalDocument,
         rolledBack: true,
       };

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -165,3 +165,38 @@ export async function makeAvailableOffline(
 
   return computeOfflineStatus(record);
 }
+
+/**
+ * Ensure every blob an already-loaded document references is present in local
+ * storage, downloading any that are missing. Resolves to `true` only when *all*
+ * referenced blobs are local afterwards.
+ *
+ * This is the data-safety gate for a relay→personal move: the relay copy (and
+ * its blobs) must not be deleted until the bytes are safely local, or the
+ * personal doc is left with `blob://` refs whose bytes existed only on the relay
+ * — an irreversible loss (the blobResolver can never fetch them again).
+ */
+export async function ensureDocBlobsLocal(doc: DiagramDocument): Promise<boolean> {
+  const refs = collectBlobReferences(doc);
+  if (refs.length === 0) return true;
+
+  const presence = await Promise.all(refs.map((h) => blobStorage.hasBlob(h)));
+  const missing = refs.filter((_, i) => !presence[i]);
+
+  if (missing.length > 0) {
+    const provider = getDocProvider();
+    if (provider?.downloadBlobs) {
+      const downloadBlobs = provider.downloadBlobs.bind(provider);
+      await runWithConcurrency(missing, OFFLINE_PREFETCH_CONCURRENCY, async (hash) => {
+        try {
+          await downloadBlobs([hash]);
+        } catch {
+          // Best-effort — the final presence check below decides success.
+        }
+      });
+    }
+  }
+
+  const finalPresence = await Promise.all(refs.map((h) => blobStorage.hasBlob(h)));
+  return finalPresence.every(Boolean);
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,6 +35,7 @@ import { initializePersistence, usePersistenceStore } from '../store/persistence
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { ensureDocBlobsLocal } from '../store/offlineAvailability';
 import { useUserStore } from '../store/userStore';
 import { useConnectionStore } from '../store/connectionStore';
 import { opener } from '../platform/opener';
@@ -311,6 +312,7 @@ function App() {
         await useRelayDocumentStore.getState().saveToHost(doc);
       },
       deleteFromHost: (id) => useRelayDocumentStore.getState().deleteFromHost(id),
+      ensureBlobsAvailableLocally: (doc) => ensureDocBlobsLocal(doc),
       isAuthenticated: () =>
         useConnectionStore.getState().status === 'authenticated' &&
         useRelayDocumentStore.getState().authenticated,

--- a/src/ui/CollaborativeProseEditor.seed.test.ts
+++ b/src/ui/CollaborativeProseEditor.seed.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { shouldSeedFragment } from './CollaborativeProseEditor';
+
+/** Give a prose fragment one child so it reads as non-empty. */
+function fillFragment(doc: Y.Doc, field: string): void {
+  doc.getXmlFragment(field).insert(0, [new Y.XmlElement('paragraph')]);
+}
+
+describe('shouldSeedFragment', () => {
+  it('seeds an empty, never-seeded fragment once the relay confirms state', () => {
+    const doc = new Y.Doc();
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(true);
+  });
+
+  it('does not seed before the relay confirms state (offline)', () => {
+    const doc = new Y.Doc();
+    expect(shouldSeedFragment(doc, 'prose:p1', false)).toBe(false);
+  });
+
+  it('does NOT seed when the fragment already has content (relay already seeded)', () => {
+    // The promote-to-Cloud dup: the relay seeds the fragment from richTextPages
+    // (json_prose_to_ydoc) without setting the client proseSeeded flag. The
+    // client must adopt that content, not re-seed on top of it.
+    const doc = new Y.Doc();
+    fillFragment(doc, 'prose:p1');
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(false);
+  });
+
+  it('does not re-seed a fragment this client already seeded', () => {
+    const doc = new Y.Doc();
+    doc.getMap<boolean>('proseSeeded').set('prose:p1', true);
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(false);
+  });
+
+  it('keys seeding per fragment field', () => {
+    const doc = new Y.Doc();
+    fillFragment(doc, 'prose:p1');
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(false);
+    expect(shouldSeedFragment(doc, 'prose:p2', true)).toBe(true);
+  });
+});

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -32,6 +32,25 @@ import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import './TiptapEditor.css';
 
+/**
+ * Whether this client should seed the prose fragment from `seedHtml`.
+ *
+ * True only when the fragment is **empty**, never client-seeded before
+ * (`proseSeeded` flag), and the relay has confirmed the doc's state (`isSynced`).
+ *
+ * The emptiness check is load-bearing: the relay *also* seeds prose from
+ * `richTextPages` on a JSON-rebuild hydration (`json_prose_to_ydoc`) WITHOUT
+ * setting the client-side `proseSeeded` flag. Without the emptiness guard the
+ * client would re-seed on top of the relay-seeded content and duplicate every
+ * page — seen on promote-to-Cloud, where a local doc's `richTextPages` seeds the
+ * relay fragment, then the editor binds to the already-populated fragment.
+ */
+export function shouldSeedFragment(ydoc: YDoc, field: string, isSynced: boolean): boolean {
+  if (!isSynced) return false;
+  if (ydoc.getMap<boolean>('proseSeeded').get(field) === true) return false;
+  return ydoc.getXmlFragment(field).length === 0;
+}
+
 export interface CollaborativeProseEditorProps {
   /** Shared collaboration Y.Doc (from `collaborationStore.getYjsDocument()`). */
   ydoc: YDoc;
@@ -68,10 +87,12 @@ export function CollaborativeProseEditor({
   onEditorReady,
 }: CollaborativeProseEditorProps) {
   const proseSeeded = ydoc.getMap<boolean>('proseSeeded');
-  // Seed only a never-seeded fragment, and only once the relay confirms the
-  // doc's state. The panel won't even mount us for an empty fragment offline
-  // (it shows a read-only preview instead), so this is also the safety gate.
-  const shouldSeed = proseSeeded.get(field) !== true && isSynced;
+  // Seed only an EMPTY, never-seeded fragment, once the relay confirms state.
+  // The emptiness check prevents double-seeding when the relay already seeded the
+  // fragment from richTextPages (see shouldSeedFragment). The panel won't mount
+  // us for an empty fragment offline (read-only preview instead), so isSynced is
+  // also the offline safety gate.
+  const shouldSeed = shouldSeedFragment(ydoc, field, isSynced);
 
   const editor = useEditor(
     {


### PR DESCRIPTION
Two data-integrity bugs in document transfers, found during testing.

## Bug 1 — prose duplicates per page when promoting to Cloud
`CollaborativeProseEditor` seeded the prose `Y.XmlFragment` whenever the client-side `proseSeeded` flag was unset and the relay had confirmed state — **without checking the fragment was empty**. But the relay *also* seeds prose from `richTextPages` on a JSON-rebuild hydration (`json_prose_to_ydoc`) and does **not** set that client flag. So on promote: relay seeds the fragment → editor binds and re-seeds on top → every page duplicated.

**Fix:** seeding now also requires the fragment to be empty (extracted as a testable `shouldSeedFragment`). When the relay already seeded it, the client adopts that content instead of duplicating it.

## Bug 2 — moving Cloud→Personal lost blobs irreversibly
`executeToPersonal` called `deleteFromHost` **before** the doc's blobs were downloaded locally. The personal doc was left with `blob://` refs whose bytes existed only on the just-deleted relay copy — the resolver can never fetch them again, so the file refs are permanently broken.

**Fix:** the transfer now secures every referenced blob locally **before** the relay delete, via a new optional `ensureBlobsAvailableLocally` dep (wired to `ensureDocBlobsLocal`, reusing the JP-281 download path with a final presence check). If any blob can't be secured, the move **aborts with no delete** — the relay copy stays intact — and the reason is surfaced (rollback now carries the execute error; the timeout path still reads "rolled back").

## Testing
- `shouldSeedFragment` (5 tests): empty/seeded/synced matrix, incl. the relay-already-seeded dup case and per-field keying.
- Transfer blob-safety (3 tests): aborts without deleting when blobs can't be secured, proceeds when they can, and secures-blobs-before-delete ordering.
- `bun run typecheck` clean; full suite **1924 passed**.
- End-to-end (real promote/move round-trips) needs a deploy to confirm.

## Known follow-up (not in this PR)
After a Cloud→Personal move, the relay-side blobs are left orphaned (present in the workspace but dropped from the ledger and unreferenced — not GC'd). Relay-storage cleanliness issue, not client data loss — parked for a separate relay-side fix.

Assisted-by: Opus 4.8