### PR TITLE
Fix: transfer actions hidden on a local doc with a live/cached relay session

### DIFF
--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -158,6 +158,17 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const deleteFromHost = useRelayDocumentStore((s) => s.deleteFromHost);
   const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
 
+  // Whether we have a usable relay session for *transfers*. Gates the
+  // publish/move affordances on a VALID CACHED TOKEN, not the live WS — opening
+  // a local doc tears down the per-doc WS (ensureCollabSession → leaveDocument),
+  // which flips `isRelayLive`/`hostConnected` false even though the token + REST
+  // provider survive (preserveAuth). Transfers run over the REST provider, so
+  // they must stay available while signed in; otherwise being on a local doc
+  // confusingly hides the "Move to Relay" action (JP-211 transfer-gating bug).
+  const relaySessionUsable = useConnectionStore(
+    (s) => s.token !== null && (s.tokenExpiresAt === null || Date.now() < s.tokenExpiresAt),
+  );
+
   // Currently-connected relay address (host:port) — drives per-card relay
   // badges and the "By relay" section ordering. "Connected" must mean *actually
   // connected*, not merely that a relay address is configured: opening a doc
@@ -738,8 +749,8 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               ? setPermissionsDocId
               : undefined
           }
-          onPublishToTeam={canPublishToTeam(record, isInTeamMode, authenticated) ? handlePublishToTeam : undefined}
-          onMoveToPersonal={canMoveToPersonal(record, authenticated, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
+          onPublishToTeam={canPublishToTeam(record, relaySessionUsable) ? handlePublishToTeam : undefined}
+          onMoveToPersonal={canMoveToPersonal(record, relaySessionUsable, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
           groupAccent={accent}
           connectedRelayAddress={connectedRelayAddress}
           offlineStatus={offlineStatuses.get(record.id)}
@@ -765,7 +776,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       handleDelete,
       handleRename,
       isInTeamMode,
-      authenticated,
+      relaySessionUsable,
       handlePublishToTeam,
       handleMoveToPersonal,
       cardMode,
@@ -1324,25 +1335,27 @@ function canManagePermissions(
   return false;
 }
 
-/** Check if user can publish a document to the team */
-function canPublishToTeam(
-  record: DocumentRecord,
-  isInTeamMode: boolean,
-  isAuthenticated: boolean
-): boolean {
-  if (!isInTeamMode || !isAuthenticated) return false;
+/**
+ * Check if user can publish a document to the team. Gated on a usable relay
+ * session (valid cached token), NOT a live WS — transfers run over the REST
+ * provider, which survives leaving a doc, so being on a local doc must not hide
+ * the action (JP-211 transfer-gating bug).
+ */
+function canPublishToTeam(record: DocumentRecord, relayUsable: boolean): boolean {
+  if (!relayUsable) return false;
   return record.type === 'local';
 }
 
-/** Check if user can move a relay document back to personal */
+/** Check if user can move a relay document back to personal. Gated on a usable
+ *  relay session (valid cached token), not the live WS (see canPublishToTeam). */
 function canMoveToPersonal(
   record: DocumentRecord,
-  isAuthenticated: boolean,
+  relayUsable: boolean,
   userId?: string,
   userRole?: string
 ): boolean {
   if (record.type !== 'remote') return false;
-  if (!isAuthenticated) return false;
+  if (!relayUsable) return false;
   return record.permission === 'owner' || record.ownerId === userId || userRole === 'admin';
 }
 


### PR DESCRIPTION
Bug 3 from the transfer round (JP-211 area).

## Symptom
On a local document while signed in with a live/cached relay session, the transfer actions ("Move to Relay", and move-to-Personal for relay docs) disappear — confusing, since you *are* signed in.

## Root cause
Opening a local doc runs `ensureCollabSession` → `leaveDocument()`, which tears down the per-doc WS and flips `isRelayLive` / `hostConnected` to **disconnected** — even though the relay **token + REST provider survive** (preserveAuth). The publish/move gates (`canPublishToTeam` / `canMoveToPersonal`) keyed off that live-WS signal (`isInTeamMode` / `authenticated`), so they hid the actions.

## Fix
Gate transfers on a **usable relay session** — a valid cached token (`relaySessionUsable`) — not the live WS. Transfers run over the REST provider (kept across `leaveDocument`), so they work while signed in even when the per-doc socket is down; a genuinely offline attempt still fails gracefully via `saveToHost`. Other gates (manage-permissions, the post-promote live join) keep using the live-connection signal intentionally.

## On "fully uploaded before transferring"
Already enforced and tested — `relayDocumentStore.blobSync.test.ts` asserts blob uploads are ordered **before** the doc save and that the save **aborts if any upload fails**. No change needed; called out here for the record.

## Testing
- `bun run typecheck` clean; full suite **1916 passed**.
- The gating is a UI-visibility change — manual E2E (open a local doc with a live session → "Move to Relay" stays available) confirms it.

Orphan-blob reclaim (unfinished transfers + move-to-personal) is a separate relay-side PR.

Assisted-by: Opus 4.8