### PR TITLE
Relay: reclaim grace-expired orphan blobs on the periodic sweeper

### DIFF
--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -1026,6 +1026,12 @@ impl BlobStore {
         self.gc_grace_secs.store(secs, Ordering::Relaxed);
     }
 
+    /// The configured orphan-reclaim grace (seconds). `0` disables deferral.
+    /// Lets the periodic sweeper decide whether to run a reclaim pass.
+    pub fn gc_grace_secs(&self) -> u64 {
+        self.gc_grace_secs.load(Ordering::Relaxed)
+    }
+
     /// Switch the store into **per-workspace object mode** by installing the
     /// object-delete sink (the s3/R2 backend). Released objects are sent here
     /// for a background worker to `DELETE`. Called once at startup, before the
@@ -1411,6 +1417,17 @@ mod tests {
         assert!(deleted);
         assert!(!store.exists(&ws, &hash));
         assert_eq!(store.get_blob_count(), 0);
+    }
+
+    // The periodic sweeper reads `gc_grace_secs()` to decide whether to run a
+    // reclaim pass, so it must reflect what `set_gc_grace_secs` stored.
+    #[test]
+    fn gc_grace_secs_getter_round_trips() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        assert_eq!(store.gc_grace_secs(), 0, "defaults to immediate reclaim");
+        store.set_gc_grace_secs(900);
+        assert_eq!(store.gc_grace_secs(), 900);
     }
 
     // JP-127: with a grace, dropping the last reference must NOT reclaim the

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1754,15 +1754,22 @@ impl WebSocketServer {
         // + shutdown flushes still run). Aborted on `stop()` after a final flush.
         let snapshot_interval_secs = self.sync_config.read().await.snapshot_interval_secs;
         let doc_cache_max_bytes = self.sync_config.read().await.doc_cache_max_bytes;
-        // Run the sweeper if snapshots OR JP-231 eviction is enabled. When
-        // snapshots are off (interval 0) but eviction is on, tick on a default
-        // cadence so the cache is still bounded.
-        const DEFAULT_EVICTION_INTERVAL_SECS: u64 = 30;
-        if snapshot_interval_secs > 0 || doc_cache_max_bytes > 0 {
+        // Whether deferred blob-GC (JP-127) is on. If so the sweeper must run so
+        // grace-elapsed orphans get reclaimed on a cadence — otherwise
+        // `reclaim_expired_orphans` only fires on the next incidental blob op or a
+        // restart, so orphans from the *last* op (a doc delete / move-to-personal,
+        // or an abandoned to-Cloud transfer that uploaded blobs but never
+        // committed a doc-ref) linger indefinitely.
+        let gc_grace_secs = server_state.blob_store.gc_grace_secs();
+        // Run the sweeper if snapshots OR JP-231 eviction OR deferred GC is on.
+        // When snapshots are off (interval 0) tick on a default cadence so the
+        // cache stays bounded and orphans still get reclaimed.
+        const DEFAULT_SWEEP_INTERVAL_SECS: u64 = 30;
+        if snapshot_interval_secs > 0 || doc_cache_max_bytes > 0 || gc_grace_secs > 0 {
             let tick_secs = if snapshot_interval_secs > 0 {
                 snapshot_interval_secs
             } else {
-                DEFAULT_EVICTION_INTERVAL_SECS
+                DEFAULT_SWEEP_INTERVAL_SECS
             };
             let sweeper_state = server_state.clone();
             let handle = tokio::spawn(async move {
@@ -1778,6 +1785,12 @@ impl WebSocketServer {
                         sweeper_state.snapshot_all();
                     }
                     sweeper_state.evict_cold_docs_if_over_budget(doc_cache_max_bytes);
+                    // JP-127 follow-up: reclaim deferred orphans whose grace has
+                    // elapsed (no-op when grace is 0 or nothing is pending).
+                    let reclaimed = sweeper_state.blob_store.reclaim_expired_orphans();
+                    if reclaimed > 0 {
+                        log::info!("sweeper reclaimed {} expired orphan blob(s)", reclaimed);
+                    }
                 }
             });
             *self.snapshot_task.write().await = Some(handle);


### PR DESCRIPTION
Fixes the orphaned-blob reports from the transfer testing (move-to-Personal leaves blobs behind; abandoned to-Cloud transfers leak uploaded blobs).

## Root cause
The relay's blob GC is otherwise complete — REST save → `sync_doc_refs`, REST delete → `release_doc_refs`, grace-deferred `reclaim_expired_orphans` (JP-127), R2-delete worker, ledger mirror. But **`reclaim_expired_orphans` only ran on incidental blob uploads + the startup sweep**, never on a timer. The periodic sweeper loop (`server/mod.rs`) only flattened snapshots (JP-36) and evicted cold docs (JP-231).

So orphans created by the **last** operation lingered until a later blob op or a restart:
- **move-to-Personal:** the doc DELETE releases the doc's blob refs (`release_doc_refs`) → ACL released, bytes deferred by the grace → but nothing fires the grace-elapsed reclaim, so the bytes sit in the workspace, dropped from the ledger refs and unreferenced (exactly the reported symptom).
- **abandoned/failed to-Cloud transfer:** blobs uploaded but no committed doc-ref → unreferenced, same lingering.

## Fix
- Call `reclaim_expired_orphans()` in the sweeper loop (no-op when grace is 0 or nothing is pending; logs when it reclaims).
- Spawn the sweeper when **deferred GC is enabled** (`gc_grace_secs > 0`) even if snapshots + eviction are both off, so reclaim always has a cadence. Added a `gc_grace_secs()` getter for that decision.

On Cloud (snapshots on, ~10s) orphans are now reclaimed within `grace + one tick`.

## Testing
- `cargo check` clean; relay blob tests pass; added a `gc_grace_secs()` getter round-trip test.
- The reclaim logic itself is already covered (grace defer/cancel, sweep-unreferenced, ledger round-trip). End-to-end (move a doc, confirm relay bytes reclaimed after grace) needs a deploy.

Pairs with #136 (client blob-safety on move) — that secures blobs locally before delete; this reclaims the now-orphaned relay copies.

Assisted-by: Opus 4.8