### PR TITLE
Deploy to staging: transfer fixes + offline mgr + relay orphan GC (#134–#138)

### DIFF
--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -1026,6 +1026,12 @@ impl BlobStore {
         self.gc_grace_secs.store(secs, Ordering::Relaxed);
     }
 
+    /// The configured orphan-reclaim grace (seconds). `0` disables deferral.
+    /// Lets the periodic sweeper decide whether to run a reclaim pass.
+    pub fn gc_grace_secs(&self) -> u64 {
+        self.gc_grace_secs.load(Ordering::Relaxed)
+    }
+
     /// Switch the store into **per-workspace object mode** by installing the
     /// object-delete sink (the s3/R2 backend). Released objects are sent here
     /// for a background worker to `DELETE`. Called once at startup, before the
@@ -1411,6 +1417,17 @@ mod tests {
         assert!(deleted);
         assert!(!store.exists(&ws, &hash));
         assert_eq!(store.get_blob_count(), 0);
+    }
+
+    // The periodic sweeper reads `gc_grace_secs()` to decide whether to run a
+    // reclaim pass, so it must reflect what `set_gc_grace_secs` stored.
+    #[test]
+    fn gc_grace_secs_getter_round_trips() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        assert_eq!(store.gc_grace_secs(), 0, "defaults to immediate reclaim");
+        store.set_gc_grace_secs(900);
+        assert_eq!(store.gc_grace_secs(), 900);
     }
 
     // JP-127: with a grace, dropping the last reference must NOT reclaim the

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1754,15 +1754,22 @@ impl WebSocketServer {
         // + shutdown flushes still run). Aborted on `stop()` after a final flush.
         let snapshot_interval_secs = self.sync_config.read().await.snapshot_interval_secs;
         let doc_cache_max_bytes = self.sync_config.read().await.doc_cache_max_bytes;
-        // Run the sweeper if snapshots OR JP-231 eviction is enabled. When
-        // snapshots are off (interval 0) but eviction is on, tick on a default
-        // cadence so the cache is still bounded.
-        const DEFAULT_EVICTION_INTERVAL_SECS: u64 = 30;
-        if snapshot_interval_secs > 0 || doc_cache_max_bytes > 0 {
+        // Whether deferred blob-GC (JP-127) is on. If so the sweeper must run so
+        // grace-elapsed orphans get reclaimed on a cadence — otherwise
+        // `reclaim_expired_orphans` only fires on the next incidental blob op or a
+        // restart, so orphans from the *last* op (a doc delete / move-to-personal,
+        // or an abandoned to-Cloud transfer that uploaded blobs but never
+        // committed a doc-ref) linger indefinitely.
+        let gc_grace_secs = server_state.blob_store.gc_grace_secs();
+        // Run the sweeper if snapshots OR JP-231 eviction OR deferred GC is on.
+        // When snapshots are off (interval 0) tick on a default cadence so the
+        // cache stays bounded and orphans still get reclaimed.
+        const DEFAULT_SWEEP_INTERVAL_SECS: u64 = 30;
+        if snapshot_interval_secs > 0 || doc_cache_max_bytes > 0 || gc_grace_secs > 0 {
             let tick_secs = if snapshot_interval_secs > 0 {
                 snapshot_interval_secs
             } else {
-                DEFAULT_EVICTION_INTERVAL_SECS
+                DEFAULT_SWEEP_INTERVAL_SECS
             };
             let sweeper_state = server_state.clone();
             let handle = tokio::spawn(async move {
@@ -1778,6 +1785,12 @@ impl WebSocketServer {
                         sweeper_state.snapshot_all();
                     }
                     sweeper_state.evict_cold_docs_if_over_budget(doc_cache_max_bytes);
+                    // JP-127 follow-up: reclaim deferred orphans whose grace has
+                    // elapsed (no-op when grace is 0 or nothing is pending).
+                    let reclaimed = sweeper_state.blob_store.reclaim_expired_orphans();
+                    if reclaimed > 0 {
+                        log::info!("sweeper reclaimed {} expired orphan blob(s)", reclaimed);
+                    }
                 }
             });
             *self.snapshot_task.write().await = Some(handle);

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -44,16 +44,22 @@ vi.mock('./UnifiedSyncProvider', () => ({
   })),
 }));
 
+// Stable mock object so spies (clearRelayDocuments / setProvider) persist across
+// getState() calls — lets us assert switchDocument doesn't wipe the doc list.
+const hoisted = vi.hoisted(() => ({
+  relayDocStore: {
+    setHostConnected: vi.fn(),
+    setError: vi.fn(),
+    setAuthenticated: vi.fn(),
+    handleDocumentEvent: vi.fn(),
+    setProvider: vi.fn(),
+    clearRelayDocuments: vi.fn(),
+  },
+}));
+
 vi.mock('../store/relayDocumentStore', () => ({
   useRelayDocumentStore: {
-    getState: vi.fn(() => ({
-      setHostConnected: vi.fn(),
-      setError: vi.fn(),
-      setAuthenticated: vi.fn(),
-      handleDocumentEvent: vi.fn(),
-      setProvider: vi.fn(),
-      clearRelayDocuments: vi.fn(),
-    })),
+    getState: vi.fn(() => hoisted.relayDocStore),
   },
 }));
 
@@ -360,6 +366,32 @@ describe('collaborationStore', () => {
         useCollaborationStore.getState().switchDocument('doc-2');
       }).not.toThrow();
       expect(useCollaborationStore.getState().isActive).toBe(false);
+    });
+
+    it('preserves the relay document list + provider across a switch', () => {
+      // Regression: switchDocument used stopSession, which clears the relay doc
+      // list (remote AND cached entries). Online that was masked by a follow-up
+      // refetch, but offline the cached docs vanished when opening one. A switch
+      // must leave the list/provider intact (preserveAuth).
+      const config = createTestConfig({ documentId: 'doc-1', token: 'tok' });
+      useCollaborationStore.getState().startSession(config);
+      hoisted.relayDocStore.clearRelayDocuments.mockClear();
+
+      useCollaborationStore.getState().switchDocument('doc-2');
+
+      // The doc list must survive the switch. (startSession re-establishes the
+      // REST provider via setProvider; that's expected — only the *clear* is the bug.)
+      expect(hoisted.relayDocStore.clearRelayDocuments).not.toHaveBeenCalled();
+    });
+
+    it('stopSession (full sign-out) still clears the relay document list', () => {
+      const config = createTestConfig({ documentId: 'doc-1', token: 'tok' });
+      useCollaborationStore.getState().startSession(config);
+      hoisted.relayDocStore.clearRelayDocuments.mockClear();
+
+      useCollaborationStore.getState().stopSession();
+
+      expect(hoisted.relayDocStore.clearRelayDocuments).toHaveBeenCalled();
     });
   });
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -663,12 +663,17 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       const token = conn.token ?? config.token;
       const tokenExpiresAt = conn.tokenExpiresAt;
 
-      get().stopSession();
+      // Leave the current doc but KEEP the relay identity, provider, and
+      // document list across the switch (preserveAuth). A full `stopSession`
+      // here cleared the relay doc list — `clearRelayDocuments` drops remote
+      // *and* cached entries — which online was masked by the follow-up
+      // `startSession`→`fetchDocumentList`, but offline there's nothing to
+      // refetch, so every other cached doc vanished when opening one.
+      get().leaveDocument();
 
-      // `stopSession` resets the connection store (token → null). Re-assert the
-      // identity BEFORE the new `startSession` so its REST-client seed + token
-      // monitor pick it up — otherwise an authenticated collaborator would drop
-      // to unauthenticated across a doc switch.
+      // `leaveDocument` preserves the token; re-assert the freshest one (auth /
+      // refresh updates connectionStore) before `startSession` so its REST-client
+      // seed + token monitor pick it up across the switch.
       if (token) {
         useConnectionStore.getState().setToken(token, tokenExpiresAt);
       }

--- a/src/services/DocumentTransferService.test.ts
+++ b/src/services/DocumentTransferService.test.ts
@@ -257,6 +257,59 @@ describe('DocumentTransferService', () => {
     });
   });
 
+  // Data-loss guard: a relay→personal move must download the doc's blobs locally
+  // before deleting the relay copy. Otherwise the personal doc keeps blob:// refs
+  // whose bytes lived only on the relay → irreversibly broken file refs.
+  describe('Move-to-Personal blob safety', () => {
+    let teamDoc: DiagramDocument;
+
+    beforeEach(() => {
+      teamDoc = createTestDocument({ isRelayDocument: true, ownerId: 'user-1' });
+      deps.loadDocument = vi.fn((id: string) => (id === teamDoc.id ? teamDoc : null));
+      deps.saveDocument = vi.fn((doc: DiagramDocument) => {
+        teamDoc = doc;
+      });
+    });
+
+    it('aborts without deleting the relay copy when blobs cannot be secured', async () => {
+      deps.ensureBlobsAvailableLocally = vi.fn().mockResolvedValue(false);
+
+      const result = await service.transferToPersonal(teamDoc.id);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/files/i);
+      expect(deps.deleteFromHost).not.toHaveBeenCalled();
+      // The doc is left untouched as a relay doc — nothing lost.
+      expect(teamDoc.isRelayDocument).toBe(true);
+    });
+
+    it('proceeds once blobs are secured locally', async () => {
+      deps.ensureBlobsAvailableLocally = vi.fn().mockResolvedValue(true);
+
+      const result = await service.transferToPersonal(teamDoc.id);
+
+      expect(deps.ensureBlobsAvailableLocally).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.document?.isRelayDocument).toBe(false);
+      expect(deps.deleteFromHost).toHaveBeenCalledTimes(1);
+    });
+
+    it('secures blobs BEFORE deleting the relay copy', async () => {
+      const order: string[] = [];
+      deps.ensureBlobsAvailableLocally = vi.fn(async () => {
+        order.push('ensure-blobs');
+        return true;
+      });
+      deps.deleteFromHost = vi.fn(async () => {
+        order.push('delete-from-host');
+      });
+
+      await service.transferToPersonal(teamDoc.id);
+
+      expect(order).toEqual(['ensure-blobs', 'delete-from-host']);
+    });
+  });
+
   // JP-83 regression: a relay doc moved back to personal must remain visible in
   // the document browser. `DocumentBrowser.handleMoveToPersonal` re-registers the
   // converted doc as Local after the transfer — without that step the doc is

--- a/src/services/DocumentTransferService.ts
+++ b/src/services/DocumentTransferService.ts
@@ -92,6 +92,13 @@ export interface TransferServiceDeps {
   isAuthenticated: () => boolean;
   /** Update metadata in store */
   updateMetadata: (docId: string, metadata: DocumentMetadata) => void;
+  /**
+   * Ensure every blob the document references is present in local storage
+   * (downloading any missing). Resolves true only when all are local. Gates the
+   * relay→personal delete so the move never orphans blobs that lived only on the
+   * relay. Optional: when absent the check is skipped (e.g. tests / no blob sync).
+   */
+  ensureBlobsAvailableLocally?: (doc: DiagramDocument) => Promise<boolean>;
 }
 
 // ============ Constants ============
@@ -239,7 +246,9 @@ export class DocumentTransferService {
     try {
       const executeResult = await this.execute(record, skipServerSync, timeout);
       if (!executeResult.success) {
-        // Attempt rollback
+        // Carry the reason into the record so rollback surfaces *why* (e.g. blobs
+        // couldn't be secured) instead of a generic failure.
+        if (executeResult.error !== undefined) record.error = executeResult.error;
         onProgress?.('rolling-back');
         return this.rollback(record);
       }
@@ -373,6 +382,29 @@ export class DocumentTransferService {
     skipServerSync: boolean,
     timeout: number
   ): Promise<TransferResult> {
+    // Secure the document's blobs locally BEFORE deleting the relay copy.
+    // Otherwise the personal doc keeps blob:// refs whose bytes live only on the
+    // relay, and the delete orphans them irreversibly. If they can't all be
+    // downloaded, abort the move (no delete) so nothing is lost — the caller
+    // surfaces the failure and the relay copy stays intact.
+    if (!skipServerSync && this.deps.ensureBlobsAvailableLocally) {
+      let blobsSecured = false;
+      try {
+        blobsSecured = await this.deps.ensureBlobsAvailableLocally(doc);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to download files';
+        return { success: false, error: `Could not download all files locally: ${message}` };
+      }
+      if (!blobsSecured) {
+        return {
+          success: false,
+          error:
+            'Could not download all of this document’s files for offline use. ' +
+            'Move cancelled so nothing is lost — try again while online.',
+        };
+      }
+    }
+
     // Delete from server first (if authenticated)
     if (!skipServerSync && this.deps.isAuthenticated()) {
       try {
@@ -465,7 +497,7 @@ export class DocumentTransferService {
 
       return {
         success: false,
-        error: record.error ?? 'Transfer failed and was rolled back',
+        error: `${record.error ?? 'Transfer failed'} (rolled back)`,
         document: record.originalDocument,
         rolledBack: true,
       };

--- a/src/storage/BlobStorage.ts
+++ b/src/storage/BlobStorage.ts
@@ -240,6 +240,18 @@ export class BlobStorage {
   }
 
   /**
+   * Whether a blob's bytes are present in local storage. Checks the metadata
+   * index only (no blob data read), so it's cheap to call across many hashes —
+   * e.g. computing a document's offline-ready status (JP-281).
+   *
+   * @param id - Blob ID (content hash)
+   * @returns true when the blob is stored locally
+   */
+  async hasBlob(id: string): Promise<boolean> {
+    return (await this.getBlobMetadata(id)) !== null;
+  }
+
+  /**
    * List all blob metadata.
    * Does not load blob data (efficient for large collections).
    *

--- a/src/storage/blobResolver.ts
+++ b/src/storage/blobResolver.ts
@@ -76,9 +76,20 @@ function ensureDownloaded(hash: string): Promise<boolean> {
     .catch(() => false)
     .finally(() => {
       downloadsInFlight.delete(hash);
+      notifyBlobLoad(); // download finished — refresh the sync-activity indicator
     });
   downloadsInFlight.set(hash, p);
+  notifyBlobLoad(); // download started — surface it in the sync-activity indicator
   return p;
+}
+
+/**
+ * Number of blob downloads currently in flight. Drives the sync-activity
+ * indicator's "downloading…" state — subscribe via {@link onBlobLoad}, which
+ * fires when a download starts and finishes.
+ */
+export function inFlightDownloadCount(): number {
+  return downloadsInFlight.size;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/store/offlineAvailability.test.ts
+++ b/src/store/offlineAvailability.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DiagramDocument } from '../types/Document';
+import type { DocumentRecord } from '../types/DocumentRegistry';
+
+// --- module mocks --------------------------------------------------------
+vi.mock('../storage/AssetBundler', () => ({
+  collectBlobReferences: vi.fn(() => [] as string[]),
+}));
+vi.mock('../storage/BlobStorage', () => ({
+  blobStorage: { hasBlob: vi.fn(async () => false) },
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({
+  RelayDocumentCache: { get: vi.fn(async () => null) },
+}));
+vi.mock('./documentRegistry', () => ({
+  useDocumentRegistry: {
+    getState: vi.fn(() => ({ getDocumentContent: vi.fn(() => undefined) })),
+  },
+}));
+vi.mock('./relayDocumentStore', () => ({
+  useRelayDocumentStore: {
+    getState: vi.fn(() => ({
+      getCachedDocument: vi.fn(() => undefined),
+      loadRelayDocument: vi.fn(),
+    })),
+  },
+  getDocProvider: vi.fn(() => null),
+}));
+
+import {
+  computeOfflineStatus,
+  deriveOfflineState,
+  makeAvailableOffline,
+} from './offlineAvailability';
+import { collectBlobReferences } from '../storage/AssetBundler';
+import { blobStorage } from '../storage/BlobStorage';
+import { useDocumentRegistry } from './documentRegistry';
+import { useRelayDocumentStore, getDocProvider } from './relayDocumentStore';
+
+const mockCollect = vi.mocked(collectBlobReferences);
+const mockHasBlob = vi.mocked(blobStorage.hasBlob);
+const mockRegistryState = vi.mocked(useDocumentRegistry.getState);
+const mockRelayState = vi.mocked(useRelayDocumentStore.getState);
+const mockGetProvider = vi.mocked(getDocProvider);
+
+function record(type: DocumentRecord['type'], id = 'doc-1'): DocumentRecord {
+  return { id, type, name: 'Doc' } as unknown as DocumentRecord;
+}
+
+const emptyDoc = { id: 'doc-1' } as unknown as DiagramDocument;
+
+/** Wire the relay/registry/storage caches for a given body + present-blob set. */
+function setCaches(opts: {
+  cachedBody?: DiagramDocument | null;
+  refs?: string[];
+  present?: Set<string>;
+}) {
+  const { cachedBody = null, refs = [], present = new Set<string>() } = opts;
+  mockCollect.mockReturnValue(refs);
+  mockHasBlob.mockImplementation(async (h: string) => present.has(h));
+  mockRelayState.mockReturnValue({
+    getCachedDocument: vi.fn(() => cachedBody ?? undefined),
+    loadRelayDocument: vi.fn(async () => cachedBody ?? emptyDoc),
+  } as never);
+  mockRegistryState.mockReturnValue({
+    getDocumentContent: vi.fn(() => undefined),
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProvider.mockReturnValue(null);
+});
+
+describe('deriveOfflineState', () => {
+  it('is online-only when the body is not cached', () => {
+    expect(deriveOfflineState(false, 0, 0)).toBe('online-only');
+    expect(deriveOfflineState(false, 5, 5)).toBe('online-only');
+  });
+
+  it('is ready when body cached and no blobs or all present', () => {
+    expect(deriveOfflineState(true, 0, 0)).toBe('ready');
+    expect(deriveOfflineState(true, 3, 3)).toBe('ready');
+    expect(deriveOfflineState(true, 4, 3)).toBe('ready'); // present can exceed in edge cases
+  });
+
+  it('is partial when body cached but some blobs missing', () => {
+    expect(deriveOfflineState(true, 0, 2)).toBe('partial');
+    expect(deriveOfflineState(true, 1, 2)).toBe('partial');
+  });
+});
+
+describe('computeOfflineStatus', () => {
+  it('treats local documents as inherently ready', async () => {
+    setCaches({});
+    const status = await computeOfflineStatus(record('local'));
+    expect(status).toEqual({ state: 'ready', present: 0, total: 0, bodyCached: true });
+    // No blob/body lookups needed for local docs.
+    expect(mockHasBlob).not.toHaveBeenCalled();
+  });
+
+  it('is online-only when no body is cached anywhere', async () => {
+    setCaches({ cachedBody: null });
+    const status = await computeOfflineStatus(record('remote'));
+    expect(status).toEqual({ state: 'online-only', present: 0, total: 0, bodyCached: false });
+  });
+
+  it('is ready when body cached and every blob present', async () => {
+    setCaches({
+      cachedBody: emptyDoc,
+      refs: ['a', 'b'],
+      present: new Set(['a', 'b']),
+    });
+    const status = await computeOfflineStatus(record('remote'));
+    expect(status).toEqual({ state: 'ready', present: 2, total: 2, bodyCached: true });
+  });
+
+  it('is partial with counts when some blobs are missing', async () => {
+    setCaches({
+      cachedBody: emptyDoc,
+      refs: ['a', 'b', 'c'],
+      present: new Set(['a']),
+    });
+    const status = await computeOfflineStatus(record('remote'));
+    expect(status).toEqual({ state: 'partial', present: 1, total: 3, bodyCached: true });
+  });
+});
+
+describe('makeAvailableOffline', () => {
+  it('is a no-op for local documents', async () => {
+    setCaches({});
+    const status = await makeAvailableOffline(record('local'));
+    expect(status.state).toBe('ready');
+    expect(mockGetProvider).not.toHaveBeenCalled();
+  });
+
+  it('downloads missing blobs, reports progress, and ends ready', async () => {
+    const present = new Set<string>(); // start with nothing cached
+    setCaches({ cachedBody: emptyDoc, refs: ['a', 'b', 'c'], present });
+    // The provider's downloadBlobs writes bytes into local storage.
+    const downloadBlobs = vi.fn(async (hashes: string[]) => {
+      for (const h of hashes) present.add(h);
+      return { total: hashes.length, success: hashes.length, uploaded: hashes.length, failed: 0, skipped: 0, errors: [] };
+    });
+    mockGetProvider.mockReturnValue({ downloadBlobs } as never);
+
+    const progress: Array<{ done: number; total: number }> = [];
+    const status = await makeAvailableOffline(record('remote'), (p) => progress.push({ ...p }));
+
+    // Every missing blob was fetched (one call per hash).
+    expect(downloadBlobs).toHaveBeenCalledTimes(3);
+    // Progress starts at 0/3 and ends at 3/3.
+    expect(progress[0]).toEqual({ done: 0, total: 3 });
+    expect(progress[progress.length - 1]).toEqual({ done: 3, total: 3 });
+    // Final recompute sees all three present.
+    expect(status).toEqual({ state: 'ready', present: 3, total: 3, bodyCached: true });
+  });
+
+  it('leaves the doc partial when a blob download fails', async () => {
+    const present = new Set<string>(['a']);
+    setCaches({ cachedBody: emptyDoc, refs: ['a', 'b'], present });
+    const downloadBlobs = vi.fn(async () => {
+      throw new Error('network');
+    });
+    mockGetProvider.mockReturnValue({ downloadBlobs } as never);
+
+    const status = await makeAvailableOffline(record('remote'));
+    expect(downloadBlobs).toHaveBeenCalledTimes(1); // only 'b' was missing
+    expect(status).toEqual({ state: 'partial', present: 1, total: 2, bodyCached: true });
+  });
+});

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -165,3 +165,38 @@ export async function makeAvailableOffline(
 
   return computeOfflineStatus(record);
 }
+
+/**
+ * Ensure every blob an already-loaded document references is present in local
+ * storage, downloading any that are missing. Resolves to `true` only when *all*
+ * referenced blobs are local afterwards.
+ *
+ * This is the data-safety gate for a relay→personal move: the relay copy (and
+ * its blobs) must not be deleted until the bytes are safely local, or the
+ * personal doc is left with `blob://` refs whose bytes existed only on the relay
+ * — an irreversible loss (the blobResolver can never fetch them again).
+ */
+export async function ensureDocBlobsLocal(doc: DiagramDocument): Promise<boolean> {
+  const refs = collectBlobReferences(doc);
+  if (refs.length === 0) return true;
+
+  const presence = await Promise.all(refs.map((h) => blobStorage.hasBlob(h)));
+  const missing = refs.filter((_, i) => !presence[i]);
+
+  if (missing.length > 0) {
+    const provider = getDocProvider();
+    if (provider?.downloadBlobs) {
+      const downloadBlobs = provider.downloadBlobs.bind(provider);
+      await runWithConcurrency(missing, OFFLINE_PREFETCH_CONCURRENCY, async (hash) => {
+        try {
+          await downloadBlobs([hash]);
+        } catch {
+          // Best-effort — the final presence check below decides success.
+        }
+      });
+    }
+  }
+
+  const finalPresence = await Promise.all(refs.map((h) => blobStorage.hasBlob(h)));
+  return finalPresence.every(Boolean);
+}

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -1,0 +1,167 @@
+/**
+ * offlineAvailability — per-document "is this safe offline?" status plus the
+ * "Make available offline" prefetch action (JP-281).
+ *
+ * Blob caching is otherwise *view-driven*: only assets the user actually renders
+ * get pulled down (blobResolver's download-on-miss), so an unviewed file in a
+ * relay/collab document is missing when offline. This module computes a
+ * document's offline-ready status (body cached + every referenced blob present)
+ * and lets the user proactively pull a whole document's asset set into the local
+ * IndexedDB cache. Enumeration is reliable because the relay snapshot now
+ * derives `blobReferences` (JP-278), so `collectBlobReferences` sees the full
+ * asset set client-side.
+ *
+ * Status computation is offline-safe — it reads only local caches and never
+ * hits the network — so it's cheap to call passively for every visible card.
+ */
+
+import { collectBlobReferences } from '../storage/AssetBundler';
+import { blobStorage } from '../storage/BlobStorage';
+import { RelayDocumentCache } from '../storage/RelayDocumentCache';
+import type { DiagramDocument } from '../types/Document';
+import type { DocumentRecord } from '../types/DocumentRegistry';
+import { useDocumentRegistry } from './documentRegistry';
+import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+
+/** Max blob downloads in flight at once during a prefetch. */
+const OFFLINE_PREFETCH_CONCURRENCY = 4;
+
+export type OfflineState = 'ready' | 'partial' | 'online-only';
+
+export interface OfflineStatus {
+  state: OfflineState;
+  /** Referenced blobs whose bytes are present in local storage. */
+  present: number;
+  /** Total blobs the document references. */
+  total: number;
+  /** Whether the document body itself is cached locally. */
+  bodyCached: boolean;
+}
+
+/** Progress of an in-flight {@link makeAvailableOffline} prefetch. */
+export interface OfflineProgress {
+  done: number;
+  total: number;
+}
+
+/**
+ * Pure mapping from cache facts to an offline state. Exported for testing.
+ * - body not cached → the doc can't open offline at all ('online-only')
+ * - body cached, no blobs or all present → 'ready'
+ * - body cached but some blobs missing → 'partial'
+ */
+export function deriveOfflineState(
+  bodyCached: boolean,
+  present: number,
+  total: number,
+): OfflineState {
+  if (!bodyCached) return 'online-only';
+  if (total === 0 || present >= total) return 'ready';
+  return 'partial';
+}
+
+/**
+ * Resolve a relay/cached document's body from offline-safe caches only (no
+ * network): in-memory store cache → registry content → the persistent offline
+ * cache. Returns null when the body isn't cached anywhere locally.
+ */
+async function loadCachedBody(record: DocumentRecord): Promise<DiagramDocument | null> {
+  const relay = useRelayDocumentStore.getState();
+  const inMemory = relay.getCachedDocument(record.id);
+  if (inMemory) return inMemory;
+  const registryDoc = useDocumentRegistry.getState().getDocumentContent(record.id);
+  if (registryDoc) return registryDoc;
+  return RelayDocumentCache.get(record.id);
+}
+
+/** Count how many of `hashes` have their bytes present in local storage. */
+async function countPresent(hashes: string[]): Promise<number> {
+  const presence = await Promise.all(hashes.map((h) => blobStorage.hasBlob(h)));
+  return presence.filter(Boolean).length;
+}
+
+/**
+ * Compute a document's offline-ready status from local caches only. Local
+ * documents are inherently offline-ready (body + blobs already live in local
+ * storage); relay/cached documents are inspected for body + blob presence.
+ */
+export async function computeOfflineStatus(record: DocumentRecord): Promise<OfflineStatus> {
+  if (record.type === 'local') {
+    return { state: 'ready', present: 0, total: 0, bodyCached: true };
+  }
+
+  const body = await loadCachedBody(record);
+  if (!body) {
+    return { state: 'online-only', present: 0, total: 0, bodyCached: false };
+  }
+
+  const refs = collectBlobReferences(body);
+  const present = await countPresent(refs);
+  return {
+    state: deriveOfflineState(true, present, refs.length),
+    present,
+    total: refs.length,
+    bodyCached: true,
+  };
+}
+
+/** Run `task` over `items` with at most `limit` in flight at a time. */
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      await task(items[index]!);
+    }
+  });
+  await Promise.all(workers);
+}
+
+/**
+ * Proactively cache a relay/cached document for offline use: ensure its body is
+ * in the offline cache, then download every referenced blob missing locally.
+ * Reports progress as blobs are processed and resolves to the final offline
+ * status. No-op for local documents (already offline-ready). Best-effort: a blob
+ * that fails to download just leaves the document 'partial'.
+ */
+export async function makeAvailableOffline(
+  record: DocumentRecord,
+  onProgress?: (progress: OfflineProgress) => void,
+): Promise<OfflineStatus> {
+  if (record.type === 'local') {
+    return { state: 'ready', present: 0, total: 0, bodyCached: true };
+  }
+
+  // loadRelayDocument serves (or fetches) the body and writes it to the
+  // persistent offline cache as a side effect — that satisfies "body cached".
+  const body = await useRelayDocumentStore.getState().loadRelayDocument(record.id);
+  const refs = collectBlobReferences(body);
+  const total = refs.length;
+
+  const presence = await Promise.all(refs.map((h) => blobStorage.hasBlob(h)));
+  const missing = refs.filter((_, i) => !presence[i]);
+
+  let done = total - missing.length;
+  onProgress?.({ done, total });
+
+  const provider = getDocProvider();
+  if (missing.length > 0 && provider?.downloadBlobs) {
+    const downloadBlobs = provider.downloadBlobs.bind(provider);
+    await runWithConcurrency(missing, OFFLINE_PREFETCH_CONCURRENCY, async (hash) => {
+      try {
+        await downloadBlobs([hash]);
+      } catch {
+        // Best-effort — a failed blob leaves the doc 'partial' on recompute.
+      } finally {
+        done += 1;
+        onProgress?.({ done, total });
+      }
+    });
+  }
+
+  return computeOfflineStatus(record);
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,6 +35,7 @@ import { initializePersistence, usePersistenceStore } from '../store/persistence
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { ensureDocBlobsLocal } from '../store/offlineAvailability';
 import { useUserStore } from '../store/userStore';
 import { useConnectionStore } from '../store/connectionStore';
 import { opener } from '../platform/opener';
@@ -311,6 +312,7 @@ function App() {
         await useRelayDocumentStore.getState().saveToHost(doc);
       },
       deleteFromHost: (id) => useRelayDocumentStore.getState().deleteFromHost(id),
+      ensureBlobsAvailableLocally: (doc) => ensureDocBlobsLocal(doc),
       isAuthenticated: () =>
         useConnectionStore.getState().status === 'authenticated' &&
         useRelayDocumentStore.getState().authenticated,

--- a/src/ui/CollaborativeProseEditor.seed.test.ts
+++ b/src/ui/CollaborativeProseEditor.seed.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { shouldSeedFragment } from './CollaborativeProseEditor';
+
+/** Give a prose fragment one child so it reads as non-empty. */
+function fillFragment(doc: Y.Doc, field: string): void {
+  doc.getXmlFragment(field).insert(0, [new Y.XmlElement('paragraph')]);
+}
+
+describe('shouldSeedFragment', () => {
+  it('seeds an empty, never-seeded fragment once the relay confirms state', () => {
+    const doc = new Y.Doc();
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(true);
+  });
+
+  it('does not seed before the relay confirms state (offline)', () => {
+    const doc = new Y.Doc();
+    expect(shouldSeedFragment(doc, 'prose:p1', false)).toBe(false);
+  });
+
+  it('does NOT seed when the fragment already has content (relay already seeded)', () => {
+    // The promote-to-Cloud dup: the relay seeds the fragment from richTextPages
+    // (json_prose_to_ydoc) without setting the client proseSeeded flag. The
+    // client must adopt that content, not re-seed on top of it.
+    const doc = new Y.Doc();
+    fillFragment(doc, 'prose:p1');
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(false);
+  });
+
+  it('does not re-seed a fragment this client already seeded', () => {
+    const doc = new Y.Doc();
+    doc.getMap<boolean>('proseSeeded').set('prose:p1', true);
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(false);
+  });
+
+  it('keys seeding per fragment field', () => {
+    const doc = new Y.Doc();
+    fillFragment(doc, 'prose:p1');
+    expect(shouldSeedFragment(doc, 'prose:p1', true)).toBe(false);
+    expect(shouldSeedFragment(doc, 'prose:p2', true)).toBe(true);
+  });
+});

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -32,6 +32,25 @@ import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import './TiptapEditor.css';
 
+/**
+ * Whether this client should seed the prose fragment from `seedHtml`.
+ *
+ * True only when the fragment is **empty**, never client-seeded before
+ * (`proseSeeded` flag), and the relay has confirmed the doc's state (`isSynced`).
+ *
+ * The emptiness check is load-bearing: the relay *also* seeds prose from
+ * `richTextPages` on a JSON-rebuild hydration (`json_prose_to_ydoc`) WITHOUT
+ * setting the client-side `proseSeeded` flag. Without the emptiness guard the
+ * client would re-seed on top of the relay-seeded content and duplicate every
+ * page — seen on promote-to-Cloud, where a local doc's `richTextPages` seeds the
+ * relay fragment, then the editor binds to the already-populated fragment.
+ */
+export function shouldSeedFragment(ydoc: YDoc, field: string, isSynced: boolean): boolean {
+  if (!isSynced) return false;
+  if (ydoc.getMap<boolean>('proseSeeded').get(field) === true) return false;
+  return ydoc.getXmlFragment(field).length === 0;
+}
+
 export interface CollaborativeProseEditorProps {
   /** Shared collaboration Y.Doc (from `collaborationStore.getYjsDocument()`). */
   ydoc: YDoc;
@@ -68,10 +87,12 @@ export function CollaborativeProseEditor({
   onEditorReady,
 }: CollaborativeProseEditorProps) {
   const proseSeeded = ydoc.getMap<boolean>('proseSeeded');
-  // Seed only a never-seeded fragment, and only once the relay confirms the
-  // doc's state. The panel won't even mount us for an empty fragment offline
-  // (it shows a read-only preview instead), so this is also the safety gate.
-  const shouldSeed = proseSeeded.get(field) !== true && isSynced;
+  // Seed only an EMPTY, never-seeded fragment, once the relay confirms state.
+  // The emptiness check prevents double-seeding when the relay already seeded the
+  // fragment from richTextPages (see shouldSeedFragment). The panel won't mount
+  // us for an empty fragment offline (read-only preview instead), so isSynced is
+  // also the offline safety gate.
+  const shouldSeed = shouldSeedFragment(ydoc, field, isSynced);
 
   const editor = useEditor(
     {

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -116,6 +116,40 @@
   color: var(--text-muted);
 }
 
+/* Offline-cache status badge (JP-281) — distinct from the sync badge: it tracks
+   whether the doc's body + referenced blobs are saved locally for offline use. */
+.document-card__offline {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.document-card__offline svg {
+  flex-shrink: 0;
+}
+
+.document-card__offline--ready {
+  color: var(--success);
+}
+
+.document-card__offline--partial {
+  color: var(--warning);
+}
+
+.document-card__offline--online-only {
+  color: var(--text-muted);
+}
+
+.document-card__offline--caching {
+  color: var(--color-primary);
+}
+
+.document-card__offline-count {
+  font-variant-numeric: tabular-nums;
+}
+
 /* Actions */
 .document-card__actions {
   display: flex;

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -150,6 +150,28 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Actionable variant — the badge doubles as the "make available offline"
+   trigger when the doc isn't fully cached. Button reset + a subtle hover. */
+button.document-card__offline--action {
+  border: none;
+  background: transparent;
+  padding: 1px;
+  margin: 0;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+button.document-card__offline--action:hover {
+  background: var(--surface-hover, rgba(100, 116, 139, 0.12));
+  color: var(--color-primary);
+}
+
+button.document-card__offline--action:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
 /* Actions */
 .document-card__actions {
   display: flex;

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -5,7 +5,7 @@
  * Used in the DocumentBrowser for unified document listing.
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { memo, useState, useCallback, useEffect } from 'react';
 import {
   Check,
   ChevronDown,
@@ -68,32 +68,42 @@ interface DocumentCardProps {
   mode?: 'compact' | 'full' | 'grid' | undefined;
 }
 
-interface OfflineBadgeConfig {
+interface OfflineBadge {
   Icon: typeof CloudCheck;
   className: string;
   title: string;
+  /** When true the badge doubles as the "make available offline" trigger. */
+  actionable: boolean;
 }
 
-/** Passive offline-cache indicator config for a relay/cached document. */
-function offlineBadgeConfig(status: OfflineStatus): OfflineBadgeConfig {
-  switch (status.state) {
+/**
+ * Offline-cache indicator for a relay/cached document. Always returns a config
+ * (never hidden) — an unknown status (not yet computed) is treated as
+ * actionable so the affordance is visible from the first paint.
+ */
+function offlineBadge(status: OfflineStatus | undefined): OfflineBadge {
+  switch (status?.state) {
     case 'ready':
       return {
         Icon: CloudCheck,
         className: 'document-card__offline--ready',
         title: 'Available offline — body and all files cached locally',
+        actionable: false,
       };
     case 'partial':
       return {
         Icon: CloudDownload,
         className: 'document-card__offline--partial',
-        title: `Partially offline — ${status.present}/${status.total} files cached`,
+        title: `Partially offline — ${status.present}/${status.total} files cached · click to finish`,
+        actionable: true,
       };
     case 'online-only':
+    default:
       return {
-        Icon: CloudOff,
+        Icon: CloudDownload,
         className: 'document-card__offline--online-only',
-        title: 'Online only — not saved for offline use',
+        title: 'Not saved offline · click to make available offline',
+        actionable: true,
       };
   }
 }
@@ -208,7 +218,7 @@ export function formatRelayLabel(
   };
 }
 
-export function DocumentCard({
+function DocumentCardImpl({
   record,
   isActive = false,
   isSelected = false,
@@ -361,15 +371,14 @@ export function DocumentCard({
 
   const showCheckbox = Boolean(onSelectToggle) && (showSelectionCheckbox || isSelected);
 
-  // Offline-cache surfacing (JP-281) — relay/cached docs only. The passive
-  // badge answers "is this safe offline?"; the hover action proactively pulls
-  // the body + every referenced blob into the local cache.
+  // Offline-cache surfacing (JP-281) — relay/cached docs only. Rendered in the
+  // always-visible meta row (NOT the hover-only actions row) so the offline
+  // state reads as passive status for every doc and the "save offline" action
+  // is discoverable without hovering. Local docs are inherently offline.
   const isRelayBacked = record.type === 'remote' || record.type === 'cached';
   const isCaching = offlineProgress != null;
-  const showOfflineBadge = isRelayBacked && offlineStatus !== undefined;
-  const offlineBadge = showOfflineBadge && !isCaching ? offlineBadgeConfig(offlineStatus) : null;
-  const canMakeOffline =
-    isRelayBacked && Boolean(onMakeAvailableOffline) && offlineStatus?.state !== 'ready';
+  const offline = isRelayBacked ? offlineBadge(offlineStatus) : null;
+  const offlineActionable = Boolean(offline?.actionable && onMakeAvailableOffline);
 
   return (
     <div
@@ -432,25 +441,39 @@ export function DocumentCard({
               separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
 
-          {/* Offline-cache status (JP-281): distinct from sync — answers
-              "is the doc's content saved locally for offline use?" */}
-          {isCaching && (
-            <span
-              className="document-card__offline document-card__offline--caching"
-              title="Caching for offline use…"
-            >
-              <Loader2 className="document-card__spin" size={12} aria-hidden="true" />
-              {offlineProgress && offlineProgress.total > 0 && (
-                <span className="document-card__offline-count">
-                  {offlineProgress.done}/{offlineProgress.total}
-                </span>
-              )}
-            </span>
-          )}
-          {offlineBadge && (
-            <span className={`document-card__offline ${offlineBadge.className}`} title={offlineBadge.title}>
-              <offlineBadge.Icon size={12} aria-hidden="true" />
-            </span>
+          {/* Offline-cache status + action (JP-281): always-visible (not in the
+              hover-only actions row), so it reads as passive status for every
+              relay doc and the "save offline" action is discoverable without
+              hovering. Distinct from the sync badge — answers "is the content
+              saved locally for offline use?". */}
+          {offline && (
+            isCaching ? (
+              <span
+                className="document-card__offline document-card__offline--caching"
+                title="Caching for offline use…"
+              >
+                <Loader2 className="document-card__spin" size={12} aria-hidden="true" />
+                {offlineProgress && offlineProgress.total > 0 && (
+                  <span className="document-card__offline-count">
+                    {offlineProgress.done}/{offlineProgress.total}
+                  </span>
+                )}
+              </span>
+            ) : offlineActionable ? (
+              <button
+                type="button"
+                className={`document-card__offline document-card__offline--action ${offline.className}`}
+                onClick={handleMakeOffline}
+                title={offline.title}
+                aria-label="Make available offline"
+              >
+                <offline.Icon size={12} aria-hidden="true" />
+              </button>
+            ) : (
+              <span className={`document-card__offline ${offline.className}`} title={offline.title}>
+                <offline.Icon size={12} aria-hidden="true" />
+              </span>
+            )
           )}
 
           {/* Modified time */}
@@ -572,21 +595,6 @@ export function DocumentCard({
             )}
           </button>
         )}
-        {canMakeOffline && (
-          <button
-            className="document-card__action document-card__action--offline"
-            onClick={handleMakeOffline}
-            disabled={isCaching}
-            title={isCaching ? 'Caching for offline use…' : 'Make available offline'}
-            aria-label="Make available offline"
-          >
-            {isCaching ? (
-              <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
-            ) : (
-              <CloudDownload size={16} aria-hidden="true" />
-            )}
-          </button>
-        )}
         {onEditPermissions && (
           <button
             className="document-card__action"
@@ -639,5 +647,13 @@ export function DocumentCard({
     </div>
   );
 }
+
+/**
+ * Memoized so an action on one card (e.g. an in-flight "make available offline"
+ * progress tick) re-renders only that card, not the whole list. Relies on the
+ * browser passing referentially-stable props — notably a stable `groupAccent`
+ * and per-doc offline status/progress (JP-281).
+ */
+export const DocumentCard = memo(DocumentCardImpl);
 
 export default DocumentCard;

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -10,6 +10,8 @@ import {
   Check,
   ChevronDown,
   Cloud,
+  CloudCheck,
+  CloudDownload,
   CloudOff,
   Download,
   HardDrive,
@@ -21,6 +23,7 @@ import {
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
 import type { DocumentRecord, Permission } from '../types/DocumentRegistry';
+import type { OfflineProgress, OfflineStatus } from '../store/offlineAvailability';
 import { useConnectionStore } from '../store/connectionStore';
 import './DocumentCard.css';
 
@@ -55,8 +58,44 @@ interface DocumentCardProps {
   groupAccent?: { name: string; color?: string | undefined } | undefined;
   /** Address (host:port) of the currently-connected relay, for connected/disconnected badge state. */
   connectedRelayAddress?: string | undefined;
+  /** Offline-cache status for relay/cached docs (JP-281). Drives the offline-ready badge. */
+  offlineStatus?: OfflineStatus | undefined;
+  /** In-flight "make available offline" progress; non-null while caching. */
+  offlineProgress?: OfflineProgress | null | undefined;
+  /** Callback to proactively cache this doc's body + all referenced blobs offline. */
+  onMakeAvailableOffline?: ((id: string) => void) | undefined;
   /** Display mode */
   mode?: 'compact' | 'full' | 'grid' | undefined;
+}
+
+interface OfflineBadgeConfig {
+  Icon: typeof CloudCheck;
+  className: string;
+  title: string;
+}
+
+/** Passive offline-cache indicator config for a relay/cached document. */
+function offlineBadgeConfig(status: OfflineStatus): OfflineBadgeConfig {
+  switch (status.state) {
+    case 'ready':
+      return {
+        Icon: CloudCheck,
+        className: 'document-card__offline--ready',
+        title: 'Available offline — body and all files cached locally',
+      };
+    case 'partial':
+      return {
+        Icon: CloudDownload,
+        className: 'document-card__offline--partial',
+        title: `Partially offline — ${status.present}/${status.total} files cached`,
+      };
+    case 'online-only':
+      return {
+        Icon: CloudOff,
+        className: 'document-card__offline--online-only',
+        title: 'Online only — not saved for offline use',
+      };
+  }
 }
 
 function formatDate(timestamp: number): string {
@@ -184,6 +223,9 @@ export function DocumentCard({
   onSelectToggle,
   groupAccent,
   connectedRelayAddress,
+  offlineStatus,
+  offlineProgress,
+  onMakeAvailableOffline,
   mode = 'compact',
 }: DocumentCardProps) {
   const [isEditing, setIsEditing] = useState(false);
@@ -297,6 +339,11 @@ export function DocumentCard({
     setShowDeleteConfirm(false);
   }, []);
 
+  const handleMakeOffline = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onMakeAvailableOffline) onMakeAvailableOffline(record.id);
+  }, [onMakeAvailableOffline, record.id]);
+
   // A still-valid cached relay token means a disconnected relay doc is only
   // *idle* (reopen reconnects instantly), not *offline*. Re-evaluates on any
   // connection-store change (token set/cleared on sign-in / sign-out).
@@ -313,6 +360,16 @@ export function DocumentCard({
   const showDetails = mode === 'full';
 
   const showCheckbox = Boolean(onSelectToggle) && (showSelectionCheckbox || isSelected);
+
+  // Offline-cache surfacing (JP-281) — relay/cached docs only. The passive
+  // badge answers "is this safe offline?"; the hover action proactively pulls
+  // the body + every referenced blob into the local cache.
+  const isRelayBacked = record.type === 'remote' || record.type === 'cached';
+  const isCaching = offlineProgress != null;
+  const showOfflineBadge = isRelayBacked && offlineStatus !== undefined;
+  const offlineBadge = showOfflineBadge && !isCaching ? offlineBadgeConfig(offlineStatus) : null;
+  const canMakeOffline =
+    isRelayBacked && Boolean(onMakeAvailableOffline) && offlineStatus?.state !== 'ready';
 
   return (
     <div
@@ -374,6 +431,27 @@ export function DocumentCard({
           {/* Sync status. The connection/offline state lives here only — a
               separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
+
+          {/* Offline-cache status (JP-281): distinct from sync — answers
+              "is the doc's content saved locally for offline use?" */}
+          {isCaching && (
+            <span
+              className="document-card__offline document-card__offline--caching"
+              title="Caching for offline use…"
+            >
+              <Loader2 className="document-card__spin" size={12} aria-hidden="true" />
+              {offlineProgress && offlineProgress.total > 0 && (
+                <span className="document-card__offline-count">
+                  {offlineProgress.done}/{offlineProgress.total}
+                </span>
+              )}
+            </span>
+          )}
+          {offlineBadge && (
+            <span className={`document-card__offline ${offlineBadge.className}`} title={offlineBadge.title}>
+              <offlineBadge.Icon size={12} aria-hidden="true" />
+            </span>
+          )}
 
           {/* Modified time */}
           <span className="document-card__date">{formatDate(record.modifiedAt)}</span>
@@ -491,6 +569,21 @@ export function DocumentCard({
               <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
             ) : (
               <Download size={16} aria-hidden="true" />
+            )}
+          </button>
+        )}
+        {canMakeOffline && (
+          <button
+            className="document-card__action document-card__action--offline"
+            onClick={handleMakeOffline}
+            disabled={isCaching}
+            title={isCaching ? 'Caching for offline use…' : 'Make available offline'}
+            aria-label="Make available offline"
+          >
+            {isCaching ? (
+              <Loader2 className="document-card__spin" size={16} aria-hidden="true" />
+            ) : (
+              <CloudDownload size={16} aria-hidden="true" />
             )}
           </button>
         )}

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -18,8 +18,6 @@ import {
   Trash2,
   Upload,
   Users,
-  Wifi,
-  WifiOff,
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
 import type { DocumentRecord, Permission } from '../types/DocumentRegistry';
@@ -373,26 +371,8 @@ export function DocumentCard({
             {getTypeLabel(record.type)}
           </span>
 
-          {/* Relay badge (which relay this doc belongs to + connection state) */}
-          {relay && (
-            <span
-              className={`document-card__relay document-card__relay--${relay.status}`}
-              title={
-                relay.status === 'connected'
-                  ? `Relay ${relay.host} — connected`
-                  : `Relay ${relay.host} — disconnected`
-              }
-            >
-              {relay.status === 'connected' ? (
-                <Wifi size={12} aria-hidden="true" />
-              ) : (
-                <WifiOff size={12} aria-hidden="true" />
-              )}
-              {relay.host}
-            </span>
-          )}
-
-          {/* Sync status */}
+          {/* Sync status. The connection/offline state lives here only — a
+              separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
 
           {/* Modified time */}
@@ -402,14 +382,6 @@ export function DocumentCard({
         {/* Expandable details panel */}
         {showDetails && isExpanded && (
           <dl className="document-card__details" onClick={(e) => e.stopPropagation()}>
-            {relay && (
-              <div className="document-card__detail">
-                <dt>Relay</dt>
-                <dd>
-                  {relay.host} · {relay.status === 'connected' ? 'Connected' : 'Disconnected'}
-                </dd>
-              </div>
-            )}
             {record.type === 'remote' && (
               <>
                 <div className="document-card__detail">

--- a/src/ui/UploadIndicator.tsx
+++ b/src/ui/UploadIndicator.tsx
@@ -1,18 +1,34 @@
+import { useEffect, useState } from 'react';
 import { useUploadStatusStore } from '../store/uploadStatusStore';
+import { inFlightDownloadCount, onBlobLoad } from '../storage/blobResolver';
 
 /**
- * Minimal upload-progress indicator (JP-126). Visible while a save uploads
- * referenced assets to the relay blob store; file-count granularity. Styling is
- * intentionally bare — the comprehensive design is owned separately.
+ * Sync-activity indicator. Visible while assets **upload** to the relay blob
+ * store on save (JP-126) or **download** into local cache on demand (JP-129).
+ * File-count granularity — per-byte progress within a file is a follow-up (needs
+ * an XHR upload transport; `fetch` has no upload-progress events).
+ *
+ * Uploads come from `uploadStatusStore`; downloads resolve lazily through the
+ * blob resolver (not in that store), which signals start/finish via `onBlobLoad`
+ * — so the indicator subscribes to that for the live download count. (Previously
+ * this only rendered the `uploading` phase, so an active download never showed.)
  */
 export function UploadIndicator() {
-  const active = useUploadStatusStore((s) => s.active);
+  const uploadActive = useUploadStatusStore((s) => s.active);
   const phase = useUploadStatusStore((s) => s.phase);
   const current = useUploadStatusStore((s) => s.current);
   const total = useUploadStatusStore((s) => s.total);
 
-  if (!active || phase !== 'uploading' || total === 0) return null;
-  const pct = Math.min(100, Math.round((current / total) * 100));
+  const [downloads, setDownloads] = useState(0);
+  useEffect(() => onBlobLoad(() => setDownloads(inFlightDownloadCount())), []);
+
+  const uploading = uploadActive && phase === 'uploading' && total > 0;
+  if (!uploading && downloads === 0) return null;
+
+  const label = uploading
+    ? `Uploading assets… ${current} of ${total}`
+    : `Downloading files… ${downloads}`;
+  const pct = uploading ? Math.min(100, Math.round((current / total) * 100)) : null;
 
   return (
     <div
@@ -32,14 +48,14 @@ export function UploadIndicator() {
         fontFamily: 'sans-serif',
       }}
     >
-      <div>
-        Uploading assets… {current} of {total}
-      </div>
-      <div style={{ height: 4, marginTop: 6, borderRadius: 2, background: '#444' }}>
-        <div
-          style={{ width: `${pct}%`, height: '100%', borderRadius: 2, background: '#4ea1ff' }}
-        />
-      </div>
+      <div>{label}</div>
+      {pct !== null && (
+        <div style={{ height: 4, marginTop: 6, borderRadius: 2, background: '#444' }}>
+          <div
+            style={{ width: `${pct}%`, height: '100%', borderRadius: 2, background: '#4ea1ff' }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -697,6 +697,27 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
 
   return (
     <div className={`document-browser ${compact ? 'document-browser--compact' : ''}`}>
+      {/* JP-212: at-a-glance library summary (total + Personal/Team/Offline). */}
+      <div
+        className="document-browser__summary"
+        role="status"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '4px 14px',
+          padding: '4px 2px 8px',
+          fontSize: 13,
+          opacity: 0.85,
+        }}
+      >
+        <span>
+          <strong>{documentCounts.total}</strong> document{documentCounts.total === 1 ? '' : 's'}
+        </span>
+        {documentCounts.local > 0 && <span>{documentCounts.local} personal</span>}
+        {documentCounts.team > 0 && <span>{documentCounts.team} team</span>}
+        {documentCounts.cached > 0 && <span>{documentCounts.cached} offline</span>}
+      </div>
+
       {/* Quick Actions */}
       <div className="document-browser__actions">
         <button

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -253,10 +253,22 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       setOfflineStatuses((prev) => (prev.size === 0 ? prev : new Map()));
       return;
     }
-    void Promise.all(
-      records.map(async (r) => [r.id, await computeOfflineStatus(r)] as const),
-    ).then((pairs) => {
-      if (!cancelled) setOfflineStatuses(new Map(pairs));
+    // allSettled (not all): one doc whose status can't be computed must not wipe
+    // every other doc's badge. Merge results so unaffected entries keep their
+    // refs, and prune statuses for docs that left the list.
+    const liveIds = new Set(records.map((r) => r.id));
+    void Promise.allSettled(records.map((r) => computeOfflineStatus(r))).then((results) => {
+      if (cancelled) return;
+      setOfflineStatuses((prev) => {
+        const next = new Map(prev);
+        results.forEach((res, i) => {
+          if (res.status === 'fulfilled') next.set(records[i]!.id, res.value);
+        });
+        for (const id of next.keys()) {
+          if (!liveIds.has(id)) next.delete(id);
+        }
+        return next;
+      });
     });
     return () => {
       cancelled = true;
@@ -688,16 +700,27 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const cardMode: 'compact' | 'full' | 'grid' =
     view === 'grid' ? 'grid' : compact ? 'compact' : 'full';
 
+  // Stable per-doc group accent so DocumentCard's memo can skip cards unaffected
+  // by an action elsewhere (e.g. an offline-prefetch progress tick on another
+  // card no longer re-renders the whole list).
+  const accentByDoc = useMemo(() => {
+    const map = new Map<string, { name: string; color?: string }>();
+    if (groupBy === 'group') return map; // membership shown via section headers instead
+    for (const docId of Object.keys(assignments)) {
+      const gid = assignments[docId];
+      const group = gid ? groupsMap[gid] : undefined;
+      if (!group) continue;
+      map.set(
+        docId,
+        group.color !== undefined ? { name: group.name, color: group.color } : { name: group.name },
+      );
+    }
+    return map;
+  }, [assignments, groupsMap, groupBy]);
+
   const renderCard = useCallback(
     (record: DocumentRecord) => {
-      const gid = assignments[record.id];
-      const group = gid ? groupsMap[gid] : undefined;
-      const accent =
-        group && groupBy !== 'group'
-          ? group.color !== undefined
-            ? { name: group.name, color: group.color }
-            : { name: group.name }
-          : undefined;
+      const accent = accentByDoc.get(record.id);
       return (
         <DocumentCard
           key={record.id}
@@ -727,9 +750,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       );
     },
     [
-      assignments,
-      groupsMap,
-      groupBy,
+      accentByDoc,
       connectedRelayAddress,
       currentDocumentId,
       selectedIds,

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -158,6 +158,17 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const deleteFromHost = useRelayDocumentStore((s) => s.deleteFromHost);
   const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
 
+  // Whether we have a usable relay session for *transfers*. Gates the
+  // publish/move affordances on a VALID CACHED TOKEN, not the live WS — opening
+  // a local doc tears down the per-doc WS (ensureCollabSession → leaveDocument),
+  // which flips `isRelayLive`/`hostConnected` false even though the token + REST
+  // provider survive (preserveAuth). Transfers run over the REST provider, so
+  // they must stay available while signed in; otherwise being on a local doc
+  // confusingly hides the "Move to Relay" action (JP-211 transfer-gating bug).
+  const relaySessionUsable = useConnectionStore(
+    (s) => s.token !== null && (s.tokenExpiresAt === null || Date.now() < s.tokenExpiresAt),
+  );
+
   // Currently-connected relay address (host:port) — drives per-card relay
   // badges and the "By relay" section ordering. "Connected" must mean *actually
   // connected*, not merely that a relay address is configured: opening a doc
@@ -738,8 +749,8 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               ? setPermissionsDocId
               : undefined
           }
-          onPublishToTeam={canPublishToTeam(record, isInTeamMode, authenticated) ? handlePublishToTeam : undefined}
-          onMoveToPersonal={canMoveToPersonal(record, authenticated, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
+          onPublishToTeam={canPublishToTeam(record, relaySessionUsable) ? handlePublishToTeam : undefined}
+          onMoveToPersonal={canMoveToPersonal(record, relaySessionUsable, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
           groupAccent={accent}
           connectedRelayAddress={connectedRelayAddress}
           offlineStatus={offlineStatuses.get(record.id)}
@@ -765,7 +776,7 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       handleDelete,
       handleRename,
       isInTeamMode,
-      authenticated,
+      relaySessionUsable,
       handlePublishToTeam,
       handleMoveToPersonal,
       cardMode,
@@ -1324,25 +1335,27 @@ function canManagePermissions(
   return false;
 }
 
-/** Check if user can publish a document to the team */
-function canPublishToTeam(
-  record: DocumentRecord,
-  isInTeamMode: boolean,
-  isAuthenticated: boolean
-): boolean {
-  if (!isInTeamMode || !isAuthenticated) return false;
+/**
+ * Check if user can publish a document to the team. Gated on a usable relay
+ * session (valid cached token), NOT a live WS — transfers run over the REST
+ * provider, which survives leaving a doc, so being on a local doc must not hide
+ * the action (JP-211 transfer-gating bug).
+ */
+function canPublishToTeam(record: DocumentRecord, relayUsable: boolean): boolean {
+  if (!relayUsable) return false;
   return record.type === 'local';
 }
 
-/** Check if user can move a relay document back to personal */
+/** Check if user can move a relay document back to personal. Gated on a usable
+ *  relay session (valid cached token), not the live WS (see canPublishToTeam). */
 function canMoveToPersonal(
   record: DocumentRecord,
-  isAuthenticated: boolean,
+  relayUsable: boolean,
   userId?: string,
   userRole?: string
 ): boolean {
   if (record.type !== 'remote') return false;
-  if (!isAuthenticated) return false;
+  if (!relayUsable) return false;
   return record.permission === 'owner' || record.ownerId === userId || userRole === 'admin';
 }
 

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -60,6 +60,16 @@ const UNGROUPED_KEY = '__ungrouped__';
 const LOCAL_RELAY_KEY = '__local__';
 const UNKNOWN_RELAY_KEY = 'unknown';
 
+/**
+ * Retired-option guard (Storage Manager Phase 1): "By relay" grouping is gone
+ * (its section headers exposed the relay host). A value persisted before the
+ * option was removed degrades to ungrouped. The explicit return type keeps
+ * `groupBy` the full union so the legacy `relaySections` guards still compile.
+ */
+function sanitizeGroupBy(g: DocumentBrowserGroupBy): DocumentBrowserGroupBy {
+  return g === 'relay' ? 'none' : g;
+}
+
 /** Bucket key for a record under "By relay" grouping. */
 export function relayKeyForRecord(record: DocumentRecord): string {
   if (record.type === 'local') return LOCAL_RELAY_KEY;
@@ -163,7 +173,13 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   // UI preferences
   const view = useUIPreferencesStore((s) => s.documentBrowserView);
   const sort = useUIPreferencesStore((s) => s.documentBrowserSort);
-  const groupBy = useUIPreferencesStore((s) => s.documentBrowserGroupBy);
+  // "By relay" grouping is retired — its section headers exposed the relay host
+  // (an implementation detail users shouldn't see). The picker option is removed
+  // below; `sanitizeGroupBy` degrades any persisted 'relay' to ungrouped rather
+  // than rendering relay-address sections. (Relay grouping returns as workspace /
+  // collection grouping later; the now-unreachable `relaySections` path can be
+  // deleted then.)
+  const groupBy = sanitizeGroupBy(useUIPreferencesStore((s) => s.documentBrowserGroupBy));
   const collapsedMap = useUIPreferencesStore((s) => s.documentBrowserCollapsed);
   const setView = useUIPreferencesStore((s) => s.setDocumentBrowserView);
   const setSort = useUIPreferencesStore((s) => s.setDocumentBrowserSort);
@@ -826,7 +842,6 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               options={[
                 { value: 'none', label: 'No grouping' },
                 { value: 'group', label: 'By group' },
-                { value: 'relay', label: 'By relay' },
               ]}
             />
             <div className="document-browser__view-toggle" role="group" aria-label="View mode">

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -26,6 +26,12 @@ import { useDocumentRegistry } from '../../store/documentRegistry';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
 import { useRelayDocumentStore } from '../../store/relayDocumentStore';
+import {
+  computeOfflineStatus,
+  makeAvailableOffline,
+  type OfflineProgress,
+  type OfflineStatus,
+} from '../../store/offlineAvailability';
 import { useUserStore } from '../../store/userStore';
 import {
   useUIPreferencesStore,
@@ -209,6 +215,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
   const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
   const [assignMenuOpen, setAssignMenuOpen] = useState(false);
   const [activeGroupMenu, setActiveGroupMenu] = useState<string | null>(null);
+  // Offline-cache surfacing (JP-281): passive per-doc status + in-flight prefetch progress.
+  const [offlineStatuses, setOfflineStatuses] = useState<Map<string, OfflineStatus>>(new Map());
+  const [offlineProgress, setOfflineProgress] = useState<Map<string, OfflineProgress>>(new Map());
 
   const isInTeamMode = isRelayLive;
   const isConnectedToHost = isRelayLive && authenticated;
@@ -233,6 +242,47 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
 
     return [...filtered].sort((a, b) => compareRecords(a, b, sort));
   }, [entries, getFilteredDocuments, filterMode, searchQuery, sort]);
+
+  // JP-281: compute each relay-backed doc's offline-ready status from local
+  // caches (network-free). Recomputes when the list or registry changes so the
+  // badge reflects view-driven caching that lands in the background.
+  useEffect(() => {
+    let cancelled = false;
+    const records = documentList.filter((d) => d.type !== 'local');
+    if (records.length === 0) {
+      setOfflineStatuses((prev) => (prev.size === 0 ? prev : new Map()));
+      return;
+    }
+    void Promise.all(
+      records.map(async (r) => [r.id, await computeOfflineStatus(r)] as const),
+    ).then((pairs) => {
+      if (!cancelled) setOfflineStatuses(new Map(pairs));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [documentList]);
+
+  // JP-281: proactively cache a doc's body + all referenced blobs for offline use.
+  const handleMakeAvailableOffline = useCallback(async (id: string) => {
+    const record = useDocumentRegistry.getState().getRecord(id);
+    if (!record) return;
+    setOfflineProgress((m) => new Map(m).set(id, { done: 0, total: 0 }));
+    try {
+      const status = await makeAvailableOffline(record, (p) => {
+        setOfflineProgress((m) => new Map(m).set(id, p));
+      });
+      setOfflineStatuses((m) => new Map(m).set(id, status));
+    } catch (e) {
+      console.warn('[DocumentBrowser] Make available offline failed:', id, e);
+    } finally {
+      setOfflineProgress((m) => {
+        const next = new Map(m);
+        next.delete(id);
+        return next;
+      });
+    }
+  }, []);
 
   // Bucket documents by group when group-by is enabled.
   const groupedSections = useMemo(() => {
@@ -669,6 +719,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
           onMoveToPersonal={canMoveToPersonal(record, authenticated, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
           groupAccent={accent}
           connectedRelayAddress={connectedRelayAddress}
+          offlineStatus={offlineStatuses.get(record.id)}
+          offlineProgress={offlineProgress.get(record.id) ?? null}
+          onMakeAvailableOffline={record.type !== 'local' ? handleMakeAvailableOffline : undefined}
           mode={cardMode}
         />
       );
@@ -682,6 +735,9 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       selectedIds,
       showSelectionAffordance,
       isAvailableOffline,
+      offlineStatuses,
+      offlineProgress,
+      handleMakeAvailableOffline,
       handleOpen,
       handleSelectToggle,
       currentUser,

--- a/src/ui/settings/StorageSettings.tsx
+++ b/src/ui/settings/StorageSettings.tsx
@@ -22,9 +22,34 @@ import type { IconMetadata } from '../../storage/IconTypes';
 import { formatFileSize } from '../../utils/imageUtils';
 import { usePersistenceStore, loadDocumentFromStorage } from '../../store/persistenceStore';
 import { extractRichTextBlobIds, extractShapeBlobIds } from '../../utils/richTextBlobExtractor';
+import { useDocumentRegistry } from '../../store/documentRegistry';
+import { isRemoteDocument, type DocumentRecord } from '../../types/DocumentRegistry';
+import { SyncStatusBadge, type ExtendedSyncState } from '../SyncStatusBadge';
 import './StorageSettings.css';
 
 type TabId = 'images' | 'icons';
+
+/** A blob's owning documents + the sync state derived from them (JP-212). */
+interface BlobOwnership {
+  owners: { id: string; name: string }[];
+  sync: ExtendedSyncState;
+}
+
+/**
+ * Derive a blob's sync state from the documents that reference it (JP-212): a
+ * blob is "synced" (pushed to the relay) when any owning doc is a synced relay
+ * document; "local" when only personal docs own it. A non-synced relay state
+ * surfaces an asset still in flight.
+ */
+function deriveBlobSyncState(owners: DocumentRecord[]): ExtendedSyncState {
+  const remoteStates = owners.filter(isRemoteDocument).map((r) => r.syncState);
+  if (remoteStates.length === 0) return 'local';
+  if (remoteStates.includes('synced')) return 'synced';
+  if (remoteStates.includes('error')) return 'error';
+  if (remoteStates.includes('syncing')) return 'syncing';
+  if (remoteStates.includes('pending')) return 'pending';
+  return 'synced';
+}
 
 export function StorageSettings() {
   const [activeTab, setActiveTab] = useState<TabId>('images');
@@ -36,6 +61,8 @@ export function StorageSettings() {
   const [isRecalculating, setIsRecalculating] = useState(false);
   const [gcResult, setGcResult] = useState<GCStats | null>(null);
   const [showCleanupConfirm, setShowCleanupConfirm] = useState(false);
+  // JP-212: per-blob owning documents + derived sync state.
+  const [ownership, setOwnership] = useState<Record<string, BlobOwnership>>({});
 
   // Icon state
   const [icons, setIcons] = useState<IconMetadata[]>([]);
@@ -67,6 +94,31 @@ export function StorageSettings() {
       setStats(storageStats);
       const safeOrphans = orphaned.filter((b) => b.usageCount === 0);
       setOrphanedBlobs(safeOrphans);
+
+      // JP-212: map each blob to the documents that reference it, then derive a
+      // per-blob sync state from those docs' registry records. Scans the same
+      // locally-loadable docs the usage count is built from.
+      const registry = useDocumentRegistry.getState();
+      const owners: Record<string, { id: string; name: string }[]> = {};
+      for (const docMeta of getDocumentList()) {
+        const doc = loadDocumentFromStorage(docMeta.id);
+        if (!doc) continue;
+        const ids = new Set([
+          ...extractRichTextBlobIds(doc.richTextContent),
+          ...extractShapeBlobIds(doc.pages ?? {}),
+        ]);
+        for (const blobId of ids) {
+          (owners[blobId] ??= []).push({ id: docMeta.id, name: docMeta.name });
+        }
+      }
+      const info: Record<string, BlobOwnership> = {};
+      for (const [blobId, docs] of Object.entries(owners)) {
+        const records = docs
+          .map((d) => registry.getRecord(d.id))
+          .filter((r): r is DocumentRecord => Boolean(r));
+        info[blobId] = { owners: docs, sync: deriveBlobSyncState(records) };
+      }
+      setOwnership(info);
     } catch (error) {
       console.error('Failed to load storage data:', error);
     } finally {
@@ -348,12 +400,14 @@ export function StorageSettings() {
                   <span className="storage-col-name">Name</span>
                   <span className="storage-col-type">Type</span>
                   <span className="storage-col-size">Size</span>
-                  <span className="storage-col-usage">Usage</span>
+                  <span className="storage-col-usage">Used by</span>
                   <span className="storage-col-date">Created</span>
                   <span className="storage-col-actions">Actions</span>
                 </div>
                 {blobs.map((blob) => {
                   const isIcon = blob.type === 'image/svg+xml';
+                  const own = ownership[blob.id];
+                  const owners = own?.owners ?? [];
                   return (
                     <div key={blob.id} className="storage-list-item">
                       <span className="storage-col-name" title={blob.name}>
@@ -368,7 +422,22 @@ export function StorageSettings() {
                             {isIcon ? 'Protected' : 'Orphaned'}
                           </span>
                         ) : (
-                          `${blob.usageCount}x`
+                          <span
+                            className="storage-usage-cell"
+                            style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                            title={
+                              owners.length
+                                ? `Used by: ${owners.map((o) => o.name).join(', ')}`
+                                : `${blob.usageCount} document(s)`
+                            }
+                          >
+                            <SyncStatusBadge state={own?.sync ?? 'local'} size="small" />
+                            <span className="storage-usage-docs">
+                              {owners.length === 1
+                                ? (owners[0]?.name ?? '1 doc')
+                                : `${blob.usageCount} docs`}
+                            </span>
+                          </span>
                         )}
                       </span>
                       <span className="storage-col-date" title={formatDate(blob.createdAt)}>


### PR DESCRIPTION
Catch staging up to master to redeploy the staging relay (and PWA) with the recent fixes — primarily to observe the new orphan-blob reclaim live.

## Included (since last staging deploy at #131 / JP-279)
- **#138** — relay reclaims grace-expired orphan blobs on the periodic sweeper (the one we want to watch — should clean up the blobs left orphaned by earlier move-to-Personal testing).
- **#137** — transfer actions no longer hidden on a local doc with a live/cached relay session (gate on cached token, not live WS).
- **#136** — transfer data fixes: prose-dup guard (partial — see JP-282) + blob-loss-on-move guard (download blobs before relay delete).
- **#135** — offline doc-switch no longer wipes cached docs.
- **#134** — JP-281 "Make available offline" (per-doc prefetch + offline-ready status).
- **#133 / #132** — Storage Manager visibility (per-file sync status, doc-browser polish).

## After merge
Rebuild publishes the relay `:edge` image (GHCR); redeploy the Fly machine `dsk-relay-staging-yyz` to pull it, then watch the sweeper reclaim the orphaned blobs (log line: `sweeper reclaimed N expired orphan blob(s)`).

Assisted-by: Opus 4.8