### PR TITLE
JP-282: fix prose duplicating per page on re-promote to Cloud

### DIFF
--- a/src/collaboration/ensureCollabSession.ts
+++ b/src/collaboration/ensureCollabSession.ts
@@ -54,6 +54,42 @@ const PLACEHOLDER_USER = { id: 'pending', name: 'You', color: '#4a90d9' };
  * Callers must only pass relay-backed doc ids; local-only docs are
  * renderer-owned and never get an engine (guarded here as a safety net).
  */
+/**
+ * Purge a document's local prose CRDT room (the `host:docId` y-indexeddb DB) so a
+ * subsequent (re)join adopts the relay's authoritative state instead of merging a
+ * stale copy.
+ *
+ * Used on the **promote-to-Cloud boundary**: a doc previously moved Cloud→Personal
+ * keeps its room on disk (leaveDocument/stopSession close the connection but leave
+ * the data — it's the durability store), so on re-promote the client reloads that
+ * stale prose while the relay re-seeds the same prose fresh from `richTextPages`
+ * (`json_prose_to_ydoc`) — a different CRDT lineage. The two merge and duplicate
+ * every page (JP-282). Purging first makes the client start empty and adopt.
+ *
+ * Safe: `richTextPages` is the durable prose source (the relay re-seeds from it),
+ * and a local doc has no live engine, so its room isn't open. No-op when there's
+ * no relay configured or the room doesn't exist. Best-effort on error/blocked.
+ */
+export async function purgeLocalDocRoom(docId: string): Promise<void> {
+  if (!docId || typeof indexedDB === 'undefined') return;
+  const conn = await loadConnection();
+  if (!conn?.relayUrl) return;
+  let host: string;
+  try {
+    // The y-indexeddb room key is `${wsUrlHost}:${docId}`; the WS host equals the
+    // REST host (restUrlToWsUrl only swaps the scheme), so derive it from relayUrl.
+    host = new URL(conn.relayUrl).host;
+  } catch {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase(`${host}:${docId}`);
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
+}
+
 export async function ensureCollabSessionForDoc(docId: string): Promise<void> {
   if (!docId) return;
 

--- a/src/collaboration/index.ts
+++ b/src/collaboration/index.ts
@@ -29,7 +29,7 @@ export type { CollaborationConfig, RemoteUser } from './collaborationStore';
 export { useCollaborationSync, isRemoteSyncInProgress } from './useCollaborationSync';
 
 // Offline-first engine activation (JP-108 step 3, Stage 2)
-export { ensureCollabSessionForDoc } from './ensureCollabSession';
+export { ensureCollabSessionForDoc, purgeLocalDocRoom } from './ensureCollabSession';
 export { isOfflineFirstEngineEnabled } from './offlineFirstEngine';
 
 // Protocol types and helpers

--- a/src/collaboration/proseReseedDuplication.test.ts
+++ b/src/collaboration/proseReseedDuplication.test.ts
@@ -1,0 +1,56 @@
+/**
+ * JP-282 root-cause probe: two *independent* seedings of the same prose into the
+ * same `prose:<pageId>` fragment merge into DUPLICATED content.
+ *
+ * This is the promote-to-Cloud dup mechanism: the client reloads a stale prose
+ * CRDT from y-indexeddb (lineage from a prior relay session, kept on disk
+ * because leaveDocument/stopSession don't purge it) while the relay re-hydrates
+ * the same doc fresh and re-seeds prose from richTextPages (json_prose_to_ydoc) —
+ * a *different* CRDT lineage. On join the two fragments sync and concatenate.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+
+/** Append one `<p>text</p>` paragraph to a prose fragment (independent items). */
+function seedParagraph(doc: Y.Doc, field: string, text: string): void {
+  const frag = doc.getXmlFragment(field);
+  const p = new Y.XmlElement('paragraph');
+  const t = new Y.XmlText();
+  t.insert(0, text);
+  p.insert(0, [t]);
+  frag.insert(frag.length, [p]);
+}
+
+describe('JP-282: independent prose seedings merge to duplicates', () => {
+  it('doubles when a stale client fragment syncs with a fresh relay seed', () => {
+    // Stale local CRDT (y-indexeddb survivor from a previous relay session).
+    const client = new Y.Doc();
+    seedParagraph(client, 'prose:p1', 'hello world');
+
+    // Relay re-hydrates the (now fresh) doc and re-seeds the same prose — its own
+    // lineage, no shared item identity with the client's stale copy.
+    const relay = new Y.Doc();
+    seedParagraph(relay, 'prose:p1', 'hello world');
+
+    // Join: exchange state both ways (the Yjs sync handshake).
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(relay));
+    Y.applyUpdate(relay, Y.encodeStateAsUpdate(client));
+
+    // Both ends now hold the paragraph TWICE — the reported per-page dup.
+    expect(client.getXmlFragment('prose:p1').length).toBe(2);
+    expect(relay.getXmlFragment('prose:p1').length).toBe(2);
+  });
+
+  it('does NOT double when the client starts empty and adopts the relay seed', () => {
+    // The fix: client purges its stale room → empty fragment → pure adopt.
+    const client = new Y.Doc(); // empty (room purged on the transfer boundary)
+    const relay = new Y.Doc();
+    seedParagraph(relay, 'prose:p1', 'hello world');
+
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(relay));
+    Y.applyUpdate(relay, Y.encodeStateAsUpdate(client));
+
+    expect(client.getXmlFragment('prose:p1').length).toBe(1);
+    expect(relay.getXmlFragment('prose:p1').length).toBe(1);
+  });
+});

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -56,7 +56,7 @@ const PDFExportDialog = lazy(() =>
 import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
 import { getTransferService } from '../../services/DocumentTransferService';
 import { useTransferStore, isTransferRunning, transferPhaseLabel } from '../../store/transferStore';
-import { useCollaborationStore } from '../../collaboration';
+import { useCollaborationStore, purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
 import './DocumentBrowser.css';
@@ -479,6 +479,15 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
         return;
       }
       useDocumentRegistry.getState().removeDocument(docId);
+
+      // Purge any stale local prose CRDT room BEFORE the doc re-joins as a relay
+      // doc. A doc previously moved Cloud→Personal keeps its `host:docId`
+      // y-indexeddb room on disk; without this, re-promote reloads that stale
+      // prose and merges it with the relay's fresh re-seed from richTextPages —
+      // duplicating every page (JP-282). richTextPages (just saved to the relay)
+      // is the source of truth, so the client adopts the relay copy cleanly.
+      await purgeLocalDocRoom(docId);
+
       await fetchDocumentList();
 
       // If the promoted doc is the one open in the editor and we have an


### PR DESCRIPTION
Closes JP-282 (the dup #136 didn't resolve).

## Root cause (probe-confirmed)
A doc moved **Cloud→Personal keeps its `host:docId` y-indexeddb prose CRDT room** on disk — `leaveDocument`/`stopSession` close the connection but deliberately leave the data (it's the durability store). On a later **promote back to Cloud**:
1. `switchDocument` → `startSession` re-creates `IndexeddbPersistence(host:docId)` and **reloads the stale prose**, while
2. the relay re-hydrates the now-fresh doc and **re-seeds the same prose from `richTextPages`** (`json_prose_to_ydoc`) — a *different* CRDT lineage,
3. so on join the two fragments **merge and every page duplicates**.

`src/collaboration/proseReseedDuplication.test.ts` proves the mechanism headlessly: two independent same-content seedings of a `prose:*` fragment sync to **length 2**; an empty client adopting the relay seed stays **length 1**.

This is why #136 missed — that fixed the client `seedHtml` path; this dup is stale-y-indexeddb + relay re-seed.

## Fix
Purge the doc's local CRDT room on the **promote boundary** (`handlePublishToTeam`, before the doc re-joins) via a new `purgeLocalDocRoom(docId)` helper in `ensureCollabSession.ts`. The client then starts empty and **adopts** the relay's authoritative re-seed.

Safe: `richTextPages` (just saved to the relay) is the durable prose source; a local doc has no live engine so the room isn't open; no-op on a first-ever promote (no room exists).

## Validation
- Headless probe (mechanism + fix invariant).
- `bun run typecheck` clean; full suite **1926 passed**.
- End-to-end (promote → move to personal → re-promote, confirm single copy) needs a deploy. Note: my analysis says a **first-ever** promote was already clean; this targets the **re-promote / cycled-doc** case (which matches the repeated-transfer testing). If a brand-new doc's first promote ever dups, there's a separate timing bug — but the probe + code strongly point here.

Assisted-by: Opus 4.8