### PR TITLE
Purge a doc's local CRDT room on delete (stop y-indexeddb room leak)

### DIFF
--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -432,6 +432,11 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
         } catch (error) {
           console.error('Failed to delete relay document:', error);
         }
+        // Purge the doc's local prose CRDT room so its y-indexeddb DB doesn't
+        // linger forever (leaveDocument keeps room data on disk; nothing else
+        // cleans it on delete) and can't stale-merge if the id is ever reused.
+        // Best-effort: a no-op if the doc is currently open (its room is locked).
+        await purgeLocalDocRoom(docId);
       } else {
         deleteDocument(docId);
       }


### PR DESCRIPTION
Quick-win cleanup found during the JP-282 dig (reuses #140's `purgeLocalDocRoom` helper, now on master).

## Problem
`leaveDocument`/`stopSession` keep a doc's `host:docId` prose CRDT room on disk (it's the durability store), and **nothing purged it on delete**. So every relay doc you ever opened and then deleted leaves a y-indexeddb database behind forever — unbounded client-side storage growth, plus a latent stale-merge vector (same family as JP-282) if a doc id is reused.

## Fix
`handleDelete` calls `purgeLocalDocRoom(docId)` after a relay-doc delete. Best-effort: a no-op if the doc is currently open (room DB locked) — no worse than today; the common delete-a-non-open-doc case is now cleaned.

## Testing
- `bun run typecheck` clean; full suite **1926 passed**.
- E2E (delete a relay doc → its IndexedDB DB is gone) needs the app.

Follow-up (minor, deferred): the active-doc-delete edge needs the collab teardown to purge on delete.

Assisted-by: Opus 4.8