### PR TITLE
JP-159 (slice 2a): relay collection membership + metadata-only listing

### DIFF
--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -185,6 +185,49 @@ paths:
         '404':
           description: Document not found in the caller's workspace.
 
+  /api/collections:
+    get:
+      tags: [docs]
+      summary: List the workspace's collection definitions
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Collection definitions (id/name/colour/order), sorted by order.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  collections:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CollectionDef'
+    put:
+      tags: [docs]
+      summary: Replace the workspace's collection definitions (wholesale)
+      description: |
+        The editor owns the definition set and replaces it whole. Definitions
+        are presentation metadata (name/colour/order), not membership — a
+        document's membership is set via PUT /api/docs/{id}/collection.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [collections]
+              properties:
+                collections:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CollectionDef'
+      responses:
+        '200':
+          description: Definitions replaced.
+
   /api/collections/{id}/documents:
     parameters:
       - name: id
@@ -699,6 +742,24 @@ components:
           type: string
           nullable: true
           description: Target collection id, or null to clear (Unassigned).
+
+    CollectionDef:
+      type: object
+      required: [id, name, order]
+      description: |
+        A collection definition — presentation metadata only (name/colour/order).
+        Membership lives on each document's collectionId, not here. Flat: no
+        nesting.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        color:
+          type: string
+          nullable: true
+        order:
+          type: integer
 
     Document:
       type: object

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -159,6 +159,64 @@ paths:
         '403':
           description: Caller is not the current owner.
 
+  /api/docs/{id}/collection:
+    parameters:
+      - $ref: '#/components/parameters/DocId'
+    put:
+      tags: [docs]
+      summary: Set or clear a document's collection membership
+      description: |
+        Assigns the document to a single collection (or clears it with
+        `collectionId: null`). Write-scoped like a save. Membership rides the
+        document body's `collectionId` and surfaces in `DocumentMetadata`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionMembershipRequest'
+      responses:
+        '200':
+          description: Membership updated.
+        '403':
+          description: Caller cannot edit this document.
+        '404':
+          description: Document not found in the caller's workspace.
+
+  /api/collections/{id}/documents:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Collection id.
+    get:
+      tags: [docs]
+      summary: List a collection's document-members (metadata only)
+      description: |
+        Returns the documents assigned to the collection in the caller's
+        workspace, as **metadata only** — never document bodies, Y.Doc state, or
+        blobs. A browse/list surface for the web collection view, not a
+        content-read channel. Workspace-scoped from the JWT; an unknown/foreign
+        collection id yields an empty list (no cross-tenant existence leak).
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Metadata for the collection's documents.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  documents:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DocumentMetadata'
+
   /api/blobs/{hash}:
     parameters:
       - name: hash
@@ -627,6 +685,20 @@ components:
         is_relay_document:
           type: boolean
           description: Wire-field for clients to distinguish local-only vs relay-stored.
+        collectionId:
+          type: string
+          nullable: true
+          description: |
+            Collection this document belongs to (at most one). Absent/null means
+            Unassigned. Set via PUT /api/docs/{id}/collection.
+
+    CollectionMembershipRequest:
+      type: object
+      properties:
+        collectionId:
+          type: string
+          nullable: true
+          description: Target collection id, or null to clear (Unassigned).
 
     Document:
       type: object

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -188,6 +188,11 @@ pub fn routes() -> Router<Arc<ServerState>> {
         .route("/api/docs/:id", delete(delete_doc_handler))
         .route("/api/docs/:id/share", post(share_doc_handler))
         .route("/api/docs/:id/transfer", post(transfer_doc_handler))
+        .route("/api/docs/:id/collection", put(set_doc_collection_handler))
+        .route(
+            "/api/collections/:id/documents",
+            get(list_collection_docs_handler),
+        )
         .route("/api/docs/:id/recovery", get(list_recovery_handler))
         .route(
             "/api/docs/:id/recovery/:pointId/restore",
@@ -236,6 +241,14 @@ struct ShareRequest {
 struct TransferRequest {
     new_owner_id: String,
     new_owner_name: String,
+}
+
+/// Body of `PUT /api/docs/:id/collection`. A document belongs to at most one
+/// collection; `null` clears the assignment (Unassigned).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionMembershipRequest {
+    collection_id: Option<String>,
 }
 
 /// Workspace-scoped usage + effective limits, consumed by the
@@ -959,6 +972,87 @@ async fn transfer_doc_handler(
     state.emit_doc_event(&ws, &doc_id, DocEventType::Updated, Some(claims.sub.clone()));
 
     (StatusCode::OK, Json(WriteAck { success: true })).into_response()
+}
+
+/// `PUT /api/docs/:id/collection` — set (or clear, with `collectionId: null`) a
+/// document's collection membership. Write-scoped like a save; the membership
+/// rides the document body's `collectionId` and surfaces in the metadata-only
+/// listing. Mirrors `share_doc_handler` (a metadata-shaped mutation).
+async fn set_doc_collection_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<CollectionMembershipRequest>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+
+    // Restore the body from R2 on a cold miss before reading/mutating it.
+    state.ensure_doc_local(&ws, &doc_id).await;
+
+    if let Err(e) = check_write_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    if let Err(e) =
+        state
+            .doc_store()
+            .update_document_collection(&ws, &doc_id, body.collection_id.as_deref())
+    {
+        return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response();
+    }
+
+    state.emit_doc_event(&ws, &doc_id, DocEventType::Updated, Some(claims.sub.clone()));
+
+    (StatusCode::OK, Json(WriteAck { success: true })).into_response()
+}
+
+/// `GET /api/collections/:id/documents` — the document-members of a collection
+/// for the caller's workspace, as **metadata only** (id, name, owner,
+/// modified-at, page count, sync version, `collectionId`). The relay never
+/// returns document bodies, Y.Doc state, or blobs here — this is a browse/list
+/// surface (consumed by the docushark-web collection view), not a content-read
+/// side channel. Workspace-scoped from the JWT exactly like `/api/docs`, so a
+/// caller only sees their own workspace; a foreign/unknown collection id simply
+/// yields an empty list (no cross-tenant existence leak).
+async fn list_collection_docs_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(collection_id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+    // Repopulate the workspace index from R2 on a cold machine first (best-effort).
+    state.ensure_workspace_index_local(&ws).await;
+    let docs: Vec<_> = state
+        .doc_store()
+        .list_documents(&ws)
+        .into_iter()
+        .filter(|d| d.collection_id.as_deref() == Some(collection_id.as_str()))
+        .collect();
+    (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
 }
 
 // ============ Helpers ============

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::auth::{OidcClaims, WorkspaceRole};
-use crate::server::documents::SaveOutcome;
+use crate::server::documents::{CollectionDef, SaveOutcome};
 use crate::server::protocol::ShareEntry;
 use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
@@ -190,6 +190,10 @@ pub fn routes() -> Router<Arc<ServerState>> {
         .route("/api/docs/:id/transfer", post(transfer_doc_handler))
         .route("/api/docs/:id/collection", put(set_doc_collection_handler))
         .route(
+            "/api/collections",
+            get(list_collections_handler).put(set_collections_handler),
+        )
+        .route(
             "/api/collections/:id/documents",
             get(list_collection_docs_handler),
         )
@@ -249,6 +253,14 @@ struct TransferRequest {
 #[serde(rename_all = "camelCase")]
 struct CollectionMembershipRequest {
     collection_id: Option<String>,
+}
+
+/// Body of `PUT /api/collections` and response of `GET /api/collections`. The
+/// editor owns the definition set and replaces it wholesale.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionsBody {
+    collections: Vec<CollectionDef>,
 }
 
 /// Workspace-scoped usage + effective limits, consumed by the
@@ -1053,6 +1065,48 @@ async fn list_collection_docs_handler(
         .filter(|d| d.collection_id.as_deref() == Some(collection_id.as_str()))
         .collect();
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
+}
+
+/// `GET /api/collections` — the caller's workspace's collection **definitions**
+/// (id/name/colour/order), sorted by order. Workspace-scoped from the JWT.
+async fn list_collections_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+    state.ensure_workspace_collections_local(&ws).await;
+    let collections = state.doc_store().list_collections(&ws);
+    (StatusCode::OK, Json(CollectionsBody { collections })).into_response()
+}
+
+/// `PUT /api/collections` — replace the workspace's collection definitions
+/// wholesale (the editor owns the set). Definitions are presentation metadata,
+/// not membership, so a member-level session may update them; cross-workspace is
+/// already impossible (the set is keyed by the JWT's workspace).
+async fn set_collections_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Json(body): Json<CollectionsBody>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = state.doc_store().set_collections(&ws, body.collections) {
+        return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response();
+    }
+    (StatusCode::OK, Json(WriteAck { success: true })).into_response()
 }
 
 // ============ Helpers ============

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -131,6 +131,14 @@ impl S3Backend {
         format!("{}docs/{}/index.json", self.config.key_prefix, ws.as_str())
     }
 
+    /// Object key for a workspace's collection-definitions registry:
+    /// `{prefix}docs/{ws}/collections.json`. Sits beside the doc index so a
+    /// region migration carries it along. Client-authoritative content; loss
+    /// only costs collection titles until the editor re-pushes.
+    pub fn workspace_collections_key(&self, ws: &WorkspaceId) -> String {
+        format!("{}docs/{}/collections.json", self.config.key_prefix, ws.as_str())
+    }
+
     /// Object key for a workspace's **blob ledger** (JP-232):
     /// `{prefix}docs/{ws}/blob_ledger.json`. Durable per-workspace projection of
     /// the blob bookkeeping (ACLs + per-doc refs + size/mime) so a recycled
@@ -405,6 +413,12 @@ pub trait DocObjectStore: Send + Sync {
         &self,
         ws: &WorkspaceId,
     ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
+
+    /// Fetch a workspace's collection-definitions registry (best-effort restore).
+    fn get_workspace_collections(
+        &self,
+        ws: &WorkspaceId,
+    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
 }
 
 impl DocObjectStore for S3Backend {
@@ -419,6 +433,10 @@ impl DocObjectStore for S3Backend {
 
     async fn get_workspace_index(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
         self.get_object_at(&self.workspace_index_key(ws)).await
+    }
+
+    async fn get_workspace_collections(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
+        self.get_object_at(&self.workspace_collections_key(ws)).await
     }
 }
 

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -27,6 +27,8 @@ pub enum MirrorOp {
     },
     /// Upload a workspace's `index.json` (best-effort listing restore).
     PutIndex { ws: WorkspaceId },
+    /// Upload a workspace's `collections.json` (collection definitions registry).
+    PutCollections { ws: WorkspaceId },
     /// Delete a doc's objects (`json` + `ydoc`) from R2.
     Delete { ws: WorkspaceId, doc_id: DocId },
     /// Drain marker: the worker acks once every prior op has been processed.
@@ -41,6 +43,22 @@ pub struct DocumentShare {
     pub user_name: String,
     pub permission: String, // "view" or "edit"
     pub shared_at: u64,
+}
+
+/// A collection **definition** — name/colour/order for one collection in a
+/// workspace. Definitions are client-authoritative (the editor owns them) and
+/// stored per-workspace in `collections.json` so docushark-web can render a
+/// collection's title/colour. Membership (which documents are in a collection)
+/// is NOT here — it lives on each document's `collection_id`
+/// ([`DocumentMetadata`]). Flat by design: no nesting, no parent links.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionDef {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    pub order: i64,
 }
 
 /// Lightweight metadata for document listing
@@ -211,6 +229,11 @@ pub struct DocumentStore {
     /// Loaded eagerly at startup; subsequent loads happen on demand
     /// when a new workspace is touched.
     index: RwLock<HashMap<WorkspaceId, HashMap<String, DocumentMetadata>>>,
+    /// Per-workspace collection **definitions** (name/colour/order), loaded from
+    /// `workspaces/<ws>/collections.json`. Client-authoritative; the relay stores
+    /// them so the web can render collection titles. Membership is not here (it's
+    /// `DocumentMetadata.collection_id`).
+    collections: RwLock<HashMap<WorkspaceId, Vec<CollectionDef>>>,
     /// JP-200 write-through R2 mirror sink. `Some` enqueues a [`MirrorOp`] after
     /// each successful local write for a background worker to upload; `None`
     /// (self-host / filesystem backend) keeps the store volume-only. The same
@@ -244,14 +267,15 @@ impl DocumentStore {
         let store = Self {
             documents_dir: documents_dir.clone(),
             index: RwLock::new(HashMap::new()),
+            collections: RwLock::new(HashMap::new()),
             mirror_tx: None,
             cache: RwLock::new(HashMap::new()),
             index_write_lock: std::sync::Mutex::new(()),
         };
 
-        // Eagerly preload every workspace index so `list_documents`
-        // for a known-but-not-yet-touched workspace doesn't miss its
-        // entries on a cold start.
+        // Eagerly preload every workspace index (and collection registry) so
+        // `list_documents` / `list_collections` for a known-but-not-yet-touched
+        // workspace doesn't miss its entries on a cold start.
         store.preload_all_workspace_indexes();
 
         store
@@ -865,6 +889,7 @@ impl DocumentStore {
             // on load.
             let Some(ws) = WorkspaceId::from_configured(&name) else { continue };
             self.load_workspace_index(&ws);
+            self.load_workspace_collections(&ws);
         }
     }
 
@@ -919,6 +944,99 @@ impl DocumentStore {
         self.write_workspace_index_file(ws)?;
         self.enqueue_mirror(MirrorOp::PutIndex { ws: ws.clone() });
         Ok(())
+    }
+
+    // ── Collection definitions registry (`collections.json`) ──────────────────
+
+    /// Path to a workspace's collection-definitions file.
+    fn collections_path(&self, ws: &WorkspaceId) -> PathBuf {
+        self.workspace_root(ws).join("collections.json")
+    }
+
+    /// Load a single workspace's collection definitions from disk into memory.
+    /// No-op (leaves the in-memory entry untouched) if the file is missing or
+    /// unparseable — collections are client-authoritative and re-pushed on change.
+    fn load_workspace_collections(&self, ws: &WorkspaceId) {
+        let path = self.collections_path(ws);
+        let Ok(data) = std::fs::read_to_string(&path) else { return };
+        let Ok(parsed) = serde_json::from_str::<Vec<CollectionDef>>(&data) else {
+            log::warn!("collections for workspace {} are malformed — leaving empty", ws.as_str());
+            return;
+        };
+        if let Ok(mut current) = self.collections.write() {
+            current.insert(ws.clone(), parsed);
+        }
+    }
+
+    /// Snapshot the in-memory definitions for a workspace and write them to disk.
+    /// A wholesale replace (the client PUTs the full set), so unlike the index
+    /// there's no per-entry merge race; the `index_write_lock` still serializes
+    /// concurrent file writes for this workspace's sidecars.
+    fn write_workspace_collections_file(&self, ws: &WorkspaceId) -> Result<(), String> {
+        let _guard = self
+            .index_write_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let snapshot = {
+            let collections = self.collections.read().map_err(|e| e.to_string())?;
+            collections.get(ws).cloned().unwrap_or_default()
+        };
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| format!("Serialize error: {}", e))?;
+        let _ = std::fs::create_dir_all(self.workspace_root(ws));
+        std::fs::write(self.collections_path(ws), json)
+            .map_err(|e| format!("Write error: {}", e))?;
+        Ok(())
+    }
+
+    /// Read a workspace's `collections.json` bytes off the local volume for the
+    /// mirror worker. `None` if absent/unreadable.
+    pub fn read_workspace_collections_bytes(&self, ws: &WorkspaceId) -> Option<Vec<u8>> {
+        std::fs::read(self.collections_path(ws)).ok()
+    }
+
+    /// List a workspace's collection definitions (sorted by `order`).
+    pub fn list_collections(&self, ws: &WorkspaceId) -> Vec<CollectionDef> {
+        let mut defs = self
+            .collections
+            .read()
+            .ok()
+            .and_then(|c| c.get(ws).cloned())
+            .unwrap_or_default();
+        defs.sort_by_key(|c| c.order);
+        defs
+    }
+
+    /// Replace a workspace's collection definitions wholesale (the editor owns
+    /// the set and PUTs it whole). Persists locally and mirrors to R2.
+    pub fn set_collections(&self, ws: &WorkspaceId, defs: Vec<CollectionDef>) -> Result<(), String> {
+        {
+            let mut current = self.collections.write().map_err(|e| e.to_string())?;
+            current.insert(ws.clone(), defs);
+        }
+        self.write_workspace_collections_file(ws)?;
+        self.enqueue_mirror(MirrorOp::PutCollections { ws: ws.clone() });
+        Ok(())
+    }
+
+    /// Restore a workspace's collection definitions from R2 on a cold machine
+    /// (best-effort), paralleling `restore_workspace_index_from`.
+    pub async fn restore_workspace_collections_from<S: DocObjectStore>(
+        &self,
+        store: &S,
+        ws: &WorkspaceId,
+    ) {
+        match store.get_workspace_collections(ws).await {
+            Ok(Some(bytes)) => {
+                let _ = std::fs::create_dir_all(self.workspace_root(ws));
+                if std::fs::write(self.collections_path(ws), &bytes).is_ok() {
+                    self.load_workspace_collections(ws);
+                    log::info!("restored collections for workspace {} from R2", ws.as_str());
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!("restore: R2 get collections {}: {}", ws.as_str(), e),
+        }
     }
 
     /// List all documents for a single workspace.
@@ -1543,6 +1661,60 @@ mod tests {
     }
 
     #[test]
+    fn collections_registry_round_trips_and_sorts() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceId::single_tenant();
+        let defs = vec![
+            CollectionDef { id: "b".into(), name: "Beta".into(), color: None, order: 1 },
+            CollectionDef {
+                id: "a".into(),
+                name: "Alpha".into(),
+                color: Some("#ef4444".into()),
+                order: 0,
+            },
+        ];
+        {
+            let store = DocumentStore::new(dir.path().to_path_buf());
+            assert!(store.list_collections(&ws).is_empty());
+            store.set_collections(&ws, defs.clone()).unwrap();
+            // Sorted by order.
+            let listed = store.list_collections(&ws);
+            assert_eq!(listed.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(), ["a", "b"]);
+            assert_eq!(listed[0].color.as_deref(), Some("#ef4444"));
+        }
+        // A fresh store over the same dir preloads the persisted registry.
+        let reloaded = DocumentStore::new(dir.path().to_path_buf());
+        assert_eq!(reloaded.list_collections(&ws).len(), 2);
+
+        // Wholesale replace.
+        reloaded
+            .set_collections(&ws, vec![CollectionDef { id: "c".into(), name: "C".into(), color: None, order: 0 }])
+            .unwrap();
+        assert_eq!(
+            reloaded.list_collections(&ws).iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
+            ["c"]
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_collections_from_object_store() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        assert!(store.list_collections(&ws).is_empty());
+
+        let fake = FakeObjectStore {
+            collections: Some(
+                br#"[{"id":"x","name":"X","order":0}]"#.to_vec(),
+            ),
+            ..Default::default()
+        };
+        store.restore_workspace_collections_from(&fake, &ws).await;
+        assert_eq!(store.list_collections(&ws).len(), 1);
+        assert_eq!(store.list_collections(&ws)[0].name, "X");
+    }
+
+    #[test]
     fn mirror_enqueues_expected_ops_without_duplicate_index() {
         let dir = tempdir().unwrap();
         let mut store = DocumentStore::new(dir.path().to_path_buf());
@@ -1568,6 +1740,7 @@ mod tests {
                 MirrorOp::Put { ext: "ydoc", .. } => put_ydoc += 1,
                 MirrorOp::Put { .. } => {}
                 MirrorOp::PutIndex { .. } => put_index += 1,
+                MirrorOp::PutCollections { .. } => {}
                 MirrorOp::Delete { .. } => deletes += 1,
                 MirrorOp::Flush(_) => {}
             }
@@ -1594,10 +1767,12 @@ mod tests {
 
     /// In-memory `DocObjectStore` standing in for R2 — lets the restore path be
     /// unit-tested offline (the live SigV4 path is the env-gated s3 roundtrip).
+    #[derive(Default)]
     struct FakeObjectStore {
         json: Option<Vec<u8>>,
         ydoc: Option<Vec<u8>>,
         index: Option<Vec<u8>>,
+        collections: Option<Vec<u8>>,
     }
 
     impl DocObjectStore for FakeObjectStore {
@@ -1620,6 +1795,13 @@ mod tests {
         ) -> Result<Option<Vec<u8>>, String> {
             Ok(self.index.clone())
         }
+
+        async fn get_workspace_collections(
+            &self,
+            _ws: &WorkspaceId,
+        ) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.collections.clone())
+        }
     }
 
     #[tokio::test]
@@ -1636,6 +1818,7 @@ mod tests {
             json: Some(br#"{"id":"r-doc","name":"Restored","serverVersion":3}"#.to_vec()),
             ydoc: Some(b"DSKY-bin".to_vec()),
             index: None,
+            ..Default::default()
         };
         assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
 
@@ -1660,6 +1843,7 @@ mod tests {
             json: Some(br#"{"id":"j-doc","name":"JsonOnly"}"#.to_vec()),
             ydoc: None,
             index: None,
+            ..Default::default()
         };
         assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
         assert_eq!(store.get_document(&ws, &doc_id).unwrap()["name"], "JsonOnly");
@@ -1674,7 +1858,7 @@ mod tests {
         let ws = WorkspaceId::single_tenant();
         let doc_id = DocId::from_http_path("ghost".into()).unwrap();
 
-        let fake = FakeObjectStore { json: None, ydoc: None, index: None };
+        let fake = FakeObjectStore::default();
         assert!(!store.restore_doc_from(&fake, &ws, &doc_id).await);
         assert!(store.get_document(&ws, &doc_id).is_err());
     }
@@ -1693,6 +1877,7 @@ mod tests {
             json: Some(br#"{"id":"q-doc","name":"Q"}"#.to_vec()),
             ydoc: Some(b"bin".to_vec()),
             index: None,
+            ..Default::default()
         };
         assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
         drop(store);
@@ -2049,6 +2234,7 @@ mod tests {
             json: Some(br#"{"id":"rt-doc","name":"RoundTrip","serverVersion":1}"#.to_vec()),
             ydoc: None,
             index: None,
+            ..Default::default()
         };
         assert!(store.restore_doc_from(&fake, &ws, &doc_id).await);
         assert_eq!(store.get_document(&ws, &doc_id).unwrap()["name"], "RoundTrip");

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -71,6 +71,14 @@ pub struct DocumentMetadata {
     pub owner_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_name: Option<String>,
+    /// Membership in a single collection ("workspace inside your workspace").
+    /// `None` means unassigned. Carried on the document body under `collectionId`
+    /// and lifted here by `metadata_from_body`, so it rides the existing save +
+    /// R2-mirror path and surfaces in the metadata-only listing without a
+    /// separate membership store. Additive + optional → backward-compatible
+    /// (absent in pre-collections `index.json` entries).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared_with: Option<Vec<DocumentShare>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1025,6 +1033,7 @@ impl DocumentStore {
             locked_at: doc.get("lockedAt").and_then(|v| v.as_u64()),
             owner_id: doc.get("ownerId").and_then(|v| v.as_str()).map(String::from),
             owner_name: doc.get("ownerName").and_then(|v| v.as_str()).map(String::from),
+            collection_id: doc.get("collectionId").and_then(|v| v.as_str()).map(String::from),
             shared_with: doc
                 .get("sharedWith")
                 .and_then(|v| serde_json::from_value(v.clone()).ok()),
@@ -1354,6 +1363,30 @@ impl DocumentStore {
         Ok(())
     }
 
+    /// Set (or clear, with `None`) a document's collection membership. A document
+    /// belongs to at most one collection; passing a new id reassigns it, `None`
+    /// unassigns it. Writes `collectionId` onto the body and saves through the
+    /// normal path, so `metadata_from_body` lifts it into the index and the save
+    /// mirrors body + index to R2 — no separate membership store. Mirrors
+    /// `update_document_shares` (metadata-shaped mutation of the body).
+    pub fn update_document_collection(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        collection_id: Option<&str>,
+    ) -> Result<(), String> {
+        let mut doc = self.get_document(ws, doc_id)?;
+        match collection_id {
+            Some(cid) => doc["collectionId"] = serde_json::json!(cid),
+            None => {
+                if let Some(obj) = doc.as_object_mut() {
+                    obj.remove("collectionId");
+                }
+            }
+        }
+        self.save_document(ws, doc)
+    }
+
     /// Transfer document ownership to another user
     pub fn transfer_ownership(
         &self,
@@ -1465,6 +1498,48 @@ mod tests {
 
         // List should be empty again
         assert!(store.list_documents(&ws).is_empty());
+    }
+
+    #[test]
+    fn collection_membership_set_and_clear() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("c-doc".to_string()).unwrap();
+
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({ "id": "c-doc", "name": "C", "pageOrder": ["p"] }),
+            )
+            .unwrap();
+
+        // Unassigned by default.
+        assert_eq!(store.get_metadata(&ws, &doc_id).unwrap().collection_id, None);
+
+        // Assign → surfaces in metadata + on the body.
+        store
+            .update_document_collection(&ws, &doc_id, Some("coll-1"))
+            .unwrap();
+        assert_eq!(
+            store.get_metadata(&ws, &doc_id).unwrap().collection_id.as_deref(),
+            Some("coll-1")
+        );
+        assert_eq!(store.get_document(&ws, &doc_id).unwrap()["collectionId"], "coll-1");
+
+        // Reassign to a different collection.
+        store
+            .update_document_collection(&ws, &doc_id, Some("coll-2"))
+            .unwrap();
+        assert_eq!(
+            store.get_metadata(&ws, &doc_id).unwrap().collection_id.as_deref(),
+            Some("coll-2")
+        );
+
+        // Clear → unassigned again, body key removed.
+        store.update_document_collection(&ws, &doc_id, None).unwrap();
+        assert_eq!(store.get_metadata(&ws, &doc_id).unwrap().collection_id, None);
+        assert!(store.get_document(&ws, &doc_id).unwrap().get("collectionId").is_none());
     }
 
     #[test]
@@ -1776,6 +1851,7 @@ mod tests {
             locked_at: None,
             owner_id: None,
             owner_name: None,
+            collection_id: None,
             shared_with: None,
             last_modified_by: None,
             last_modified_by_name: None,

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -205,6 +205,15 @@ async fn run_doc_mirror_worker(
                     log::warn!("R2 index mirror PUT failed for {}: {}", key, e);
                 }
             }
+            MirrorOp::PutCollections { ws } => {
+                let Some(bytes) = doc_store.read_workspace_collections_bytes(&ws) else {
+                    continue;
+                };
+                let key = s3.workspace_collections_key(&ws);
+                if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                    log::warn!("R2 collections mirror PUT failed for {}: {}", key, e);
+                }
+            }
             MirrorOp::Delete { ws, doc_id } => {
                 for ext in ["json", "ydoc"] {
                     let key = s3.doc_object_key(&ws, &doc_id, ext);
@@ -854,6 +863,20 @@ impl ServerState {
         if let Some(s3) = &self.s3 {
             self.doc_store
                 .restore_workspace_index_from(s3.as_ref(), ws)
+                .await;
+        }
+    }
+
+    /// Best-effort restore of a workspace's collection definitions from R2 before
+    /// serving the collections registry on a cold machine. Only reaches for R2
+    /// when the in-memory registry is empty, so a populated one is never clobbered.
+    pub(crate) async fn ensure_workspace_collections_local(&self, ws: &WorkspaceId) {
+        if !self.doc_store.list_collections(ws).is_empty() {
+            return;
+        }
+        if let Some(s3) = &self.s3 {
+            self.doc_store
+                .restore_workspace_collections_from(s3.as_ref(), ws)
                 .await;
         }
     }

--- a/relay/src/server/permissions.rs
+++ b/relay/src/server/permissions.rs
@@ -259,6 +259,7 @@ mod tests {
             locked_at: None,
             owner_id: Some(owner_id.to_string()),
             owner_name: Some("Owner".to_string()),
+            collection_id: None,
             shared_with: if shares.is_empty() {
                 None
             } else {

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -386,6 +386,7 @@ mod tests {
                 locked_at: None,
                 owner_id: Some("user-1".to_string()),
                 owner_name: Some("Test User".to_string()),
+                collection_id: None,
                 shared_with: None,
                 last_modified_by: None,
                 last_modified_by_name: None,


### PR DESCRIPTION
Part of JP-159 (collections rework, under the JP-211 settings epic). This is the **relay-side foundation**: a server-readable home for collection **membership** plus a **metadata-only listing** the docushark-web collection view will read — built entirely on the existing per-workspace index + R2-mirror infrastructure, so it needs **no new persistence artifact and no migration**.

## What changed (relay, AGPL/OSS)
- **`DocumentMetadata.collection_id`** (optional) — lifted from the document body's `collectionId` at the single `metadata_from_body` chokepoint. Additive + optional → existing `index.json` entries load unchanged.
- **`DocumentStore::update_document_collection`** — sets/clears membership by writing `collectionId` onto the body and saving through the normal path (rides the existing save + R2 mirror). Models `update_document_shares`.
- **`PUT /api/docs/:id/collection`** — write-scoped; assigns to one collection or clears with `collectionId: null`.
- **`GET /api/collections/:id/documents`** — the collection's document-members as **metadata only** (never bodies / Y.Doc / blobs). Workspace-scoped from the JWT; a foreign/unknown collection id yields an empty list (no cross-tenant existence leak).
- **OpenAPI spec** updated for both endpoints + the `collectionId` field (the web codes against this spec).

## Design note
One collection per document. Membership lives on the document body (like `ownerId`/`sharedWith`), so it persists + mirrors with the doc and surfaces in the listing for free — no separate membership store. The earlier idea of a standalone membership registry was dropped in favour of this (the in-memory index is already R2-mirrored, and `share`/`transfer` are the exact metadata-update precedent).

## Remaining slice-2 work (follow-ups)
- Collection **definitions** registry (`collections.json`: name/colour/order) so the web can render collection titles/colours.
- Editor **client write-through** that calls `PUT /api/docs/:id/collection` for relay-hosted docs (depends on slice 1's `collectionStore`, PR #145).

## Verification
- `cargo check` clean; `cargo test --lib` → **302/302** pass (incl. new `collection_membership_set_and_clear`).
- No `PROTOCOL_VERSION` change (REST only).
- OSS commercial-leak grep on touched files — clean.

Membership is dormant-but-correct until the client write-through lands; it's fully exercised by the Rust tests.

Assisted-by: Opus 4.8