### PR TITLE
JP-218 (slice 1): first-class Documents surface + headless browser model

### DIFF
--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -112,6 +112,16 @@ export function getAllCommands(): Command[] {
       execute: () => window.dispatchEvent(new CustomEvent('docushark:import-diagram')),
     },
 
+    // --- Documents surface (JP-218) ---
+    {
+      id: 'view.documents',
+      label: 'Go to Documents',
+      category: 'File',
+      shortcut: 'Ctrl+Shift+O',
+      // The palette can't reach React state; App listens for this event.
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:open-documents')),
+    },
+
     // --- Editing ---
     {
       id: 'edit.undo', label: 'Undo', category: 'Editing', shortcut: 'Ctrl+Z',

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -18,6 +18,7 @@ import { useSessionStore } from '../store/sessionStore';
 import { isMacOS } from '../utils/platform';
 import { TitleBar } from './chrome/TitleBar';
 import { SettingsModal } from './SettingsModal';
+import { DocumentsHome } from './home/DocumentsHome';
 import { UnifiedToolbar } from './UnifiedToolbar';
 import { CanvasToolbar } from './CanvasToolbar';
 import { StatusBar } from './StatusBar';
@@ -70,7 +71,15 @@ function App() {
 
   // Settings modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<'documents' | 'appearance'>('documents');
+  const [settingsInitialTab, setSettingsInitialTab] = useState<
+    'documents' | 'appearance' | 'relay' | 'storage'
+  >('documents');
+
+  // Top-level app surface. The Documents "home" (JP-218) is a first-class
+  // peer to the editor — full-bleed, reachable any time, and left by opening a
+  // document. Not a modal: the editor stays mounted underneath so its state
+  // survives the round trip.
+  const [appView, setAppView] = useState<'editor' | 'documents'>('editor');
 
   // Command palette state (Cmd/Ctrl+K)
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -175,10 +184,20 @@ function App() {
   useCollaborationSync();
 
   // Open settings callback
+  const handleOpenSettingsTab = useCallback(
+    (tab: 'documents' | 'appearance' | 'relay' | 'storage' = 'documents') => {
+      setSettingsInitialTab(tab);
+      setIsSettingsOpen(true);
+    },
+    []
+  );
   const handleOpenSettings = useCallback(() => {
-    setSettingsInitialTab('documents');
-    setIsSettingsOpen(true);
-  }, []);
+    handleOpenSettingsTab('documents');
+  }, [handleOpenSettingsTab]);
+
+  // Documents surface (JP-218) entry / exit.
+  const handleOpenDocuments = useCallback(() => setAppView('documents'), []);
+  const handleLeaveToEditor = useCallback(() => setAppView('editor'), []);
 
   const handleOpenLayoutSettings = useCallback(() => {
     setSettingsInitialTab('appearance');
@@ -225,6 +244,13 @@ function App() {
         return;
       }
 
+      // Ctrl/Cmd+Shift+O — Documents surface (JP-218)
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'o' || e.key === 'O')) {
+        e.preventDefault();
+        setAppView('documents');
+        return;
+      }
+
       // Ctrl/Cmd+Shift+1..4 — Switch layout
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && /^[1-4]$/.test(e.key)) {
         e.preventDefault();
@@ -253,6 +279,14 @@ function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // The command palette can't reach React state directly; "Go to Documents"
+  // dispatches an event (mirrors the import-diagram command). Listen for it.
+  useEffect(() => {
+    const open = () => setAppView('documents');
+    window.addEventListener('docushark:open-documents', open);
+    return () => window.removeEventListener('docushark:open-documents', open);
   }, []);
 
   // Initialize persistence on mount
@@ -368,6 +402,7 @@ function App() {
         <UnifiedToolbar
           onOpenSettings={handleOpenSettings}
           onOpenLayoutSettings={handleOpenLayoutSettings}
+          onOpenDocuments={handleOpenDocuments}
         />
         <main className="app-main">
           {/* Document on left. In Relaxed the editor is the primary reading
@@ -511,6 +546,15 @@ function App() {
         <div className="app-presence">
           <PresenceIndicators size="small" />
         </div>
+
+        {/* Documents surface (JP-218) — full-bleed peer to the editor. Mounted
+            over everything; the editor stays alive underneath. */}
+        {appView === 'documents' && (
+          <DocumentsHome
+            onLeaveToEditor={handleLeaveToEditor}
+            onOpenSettings={handleOpenSettingsTab}
+          />
+        )}
 
         {/* Settings Modal (includes Documents, Storage, etc.) */}
         <SettingsModal

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -598,8 +598,9 @@
   height: 16px;
 }
 
-/* Full-size settings button */
-.toolbar-settings-btn {
+/* Full-size settings + documents buttons */
+.toolbar-settings-btn,
+.toolbar-documents-btn {
   display: flex;
   align-items: center;
   gap: var(--space-1-5);
@@ -614,21 +615,29 @@
   transition: all 0.15s ease;
 }
 
-.toolbar-settings-btn:hover {
+.toolbar-settings-btn:hover,
+.toolbar-documents-btn:hover {
   background: var(--bg-hover);
   border-color: var(--color-primary, var(--color-primary));
   color: var(--color-primary, var(--color-primary));
 }
 
-.toolbar-settings-btn:focus {
+.toolbar-settings-btn:focus,
+.toolbar-documents-btn:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
-.toolbar-settings-btn svg {
+.toolbar-settings-btn svg,
+.toolbar-documents-btn svg {
   width: 14px;
   height: 14px;
   flex-shrink: 0;
+}
+
+/* The Documents launcher sits at the far left, ahead of the doc identity. */
+.toolbar-documents-btn {
+  margin-right: var(--space-2);
 }
 
 /* Dark Mode */
@@ -808,14 +817,16 @@
   color: var(--color-primary);
 }
 
-/* Dark mode for settings button */
-[data-theme="dark"] .toolbar-settings-btn {
+/* Dark mode for settings + documents buttons */
+[data-theme="dark"] .toolbar-settings-btn,
+[data-theme="dark"] .toolbar-documents-btn {
   color: var(--text-primary);
   background: var(--bg-secondary);
   border-color: var(--border-color);
 }
 
-[data-theme="dark"] .toolbar-settings-btn:hover {
+[data-theme="dark"] .toolbar-settings-btn:hover,
+[data-theme="dark"] .toolbar-documents-btn:hover {
   background: var(--bg-hover);
   color: var(--color-primary);
   border-color: var(--color-primary);

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StickyNote, CircleHelp, Settings, Import } from 'lucide-react';
+import { StickyNote, CircleHelp, Settings, Import, FolderOpen } from 'lucide-react';
 import { Icon } from './icons';
 import { ToolbarGroup } from './ToolbarGroup';
 import { usePersistenceStore } from '../store/persistenceStore';
@@ -128,6 +128,8 @@ function SavedIcon() {
 interface UnifiedToolbarProps {
   onOpenSettings?: () => void;
   onOpenLayoutSettings?: () => void;
+  /** Open the first-class Documents surface (JP-218). */
+  onOpenDocuments?: () => void;
 }
 
 /**
@@ -142,13 +144,28 @@ async function openDocsHandler() {
 /**
  * UnifiedToolbar component — the global app bar.
  */
-export function UnifiedToolbar({ onOpenSettings, onOpenLayoutSettings }: UnifiedToolbarProps) {
+export function UnifiedToolbar({
+  onOpenSettings,
+  onOpenLayoutSettings,
+  onOpenDocuments,
+}: UnifiedToolbarProps) {
   const activeLayout = useActiveLayoutMode();
 
   return (
     <div className="unified-toolbar">
-      {/* Left: document identity */}
+      {/* Left: Documents launcher + document identity */}
       <div className="unified-toolbar-left">
+        {onOpenDocuments && (
+          <button
+            className="toolbar-documents-btn"
+            onClick={onOpenDocuments}
+            title="Documents (Ctrl+Shift+O)"
+            aria-label="Documents"
+          >
+            <Icon icon={FolderOpen} size={14} />
+            <span>Documents</span>
+          </button>
+        )}
         <DocumentInfo />
       </div>
 

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -1,0 +1,489 @@
+/* DocumentsHome — first-class Documents surface (JP-218).
+   Brand kit visual language via the semantic tokens in index.css. */
+
+.documents-home {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  overflow: hidden;
+}
+
+/* ── Sidebar ── */
+.dh-side {
+  flex: 0 0 264px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-primary);
+  border-right: 1px solid var(--border-color);
+}
+
+.dh-identity {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  padding: 12px 12px 10px;
+  border-bottom: 1px solid var(--border-color-light);
+}
+
+.dh-workspace {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--bg-tertiary);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.dh-workspace:hover {
+  border-color: var(--border-color-input);
+  background: var(--bg-hover);
+}
+.dh-workspace-avatar {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: var(--brand-navy);
+  color: var(--brand-gold-soft);
+}
+.dh-workspace-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.dh-workspace-name {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-workspace-meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+.dh-manage {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.dh-manage:hover {
+  background: var(--bg-hover);
+}
+
+.dh-nav {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.dh-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+.dh-nav-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.dh-nav-item--on {
+  background: var(--color-primary-light);
+  color: var(--text-primary);
+  font-weight: var(--font-weight-medium);
+}
+.dh-nav-item--disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.dh-nav-item--disabled:hover {
+  background: transparent;
+  color: var(--text-secondary);
+}
+.dh-nav-label {
+  flex: 1 1 auto;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-nav-count {
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.dh-nav-soon {
+  flex: 0 0 auto;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-faint);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-pill);
+  padding: 1px 6px;
+}
+.dh-nav-section {
+  padding: 14px 10px 4px;
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-faint);
+}
+.dh-collection-dot {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--text-faint);
+}
+
+.dh-side-foot {
+  flex: 0 0 auto;
+  padding: 10px;
+  border-top: 1px solid var(--border-color-light);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.dh-storage {
+  display: block;
+  width: 100%;
+  padding: 9px 11px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--bg-tertiary);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease;
+}
+.dh-storage:hover {
+  background: var(--bg-hover);
+}
+.dh-storage-top {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+}
+.dh-storage-manage {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  color: var(--brand-gold-deep);
+}
+.dh-storage-bar {
+  height: 5px;
+  margin: 7px 0 5px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-active);
+  overflow: hidden;
+}
+.dh-storage-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--brand-gold);
+  transition: width 0.3s ease;
+}
+.dh-storage-meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dh-user {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 4px 2px;
+}
+.dh-user-avatar {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-full);
+  background: var(--brand-navy);
+  color: var(--brand-gold-soft);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+}
+.dh-user-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.dh-user-name {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-user-meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+.dh-user-theme {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.dh-user-theme:hover {
+  background: var(--bg-hover);
+}
+
+/* ── Main ── */
+.dh-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.dh-top {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+.dh-back {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 6px 10px 6px 7px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: var(--font-size-md);
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.dh-back:hover {
+  background: var(--bg-hover);
+}
+.dh-crumb {
+  flex: 0 0 auto;
+  font-size: var(--font-size-lg);
+}
+.dh-crumb strong {
+  font-weight: var(--font-weight-semibold);
+}
+.dh-search {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 460px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-lg);
+  background: var(--bg-primary);
+  color: var(--text-muted);
+}
+.dh-search input {
+  flex: 1 1 auto;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+  outline: none;
+}
+.dh-top-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.dh-sort {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+.dh-sort select {
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.dh-view-toggle {
+  display: flex;
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.dh-view-toggle button {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: var(--bg-primary);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.dh-view-toggle button.on {
+  background: var(--color-primary-light);
+  color: var(--text-primary);
+}
+.dh-new {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-cta);
+  color: var(--color-cta-text);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.dh-new:hover {
+  background: var(--color-cta-hover);
+}
+
+.dh-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 22px;
+}
+.dh-section {
+  margin-bottom: 26px;
+}
+.dh-section--list {
+  margin-bottom: 0;
+}
+.dh-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.dh-section-count {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-normal);
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-faint);
+}
+
+.dh-recents {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+.dh-rcard {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  background: var(--bg-primary);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+}
+.dh-rcard:hover {
+  border-color: var(--border-color-input);
+  box-shadow: var(--shadow-sm);
+}
+.dh-rcard-ico {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-lg);
+  background: var(--bg-tertiary);
+  color: var(--brand-gold-deep);
+}
+.dh-rcard-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.dh-rcard-title {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-rcard-sub {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+/* The shared DocumentList renders the editor's existing `.document-browser__*`
+   list markup; it inherits global styling. Nothing to override here in Slice 1. */
+
+@media (prefers-reduced-motion: reduce) {
+  .dh-storage-fill,
+  .dh-rcard,
+  .dh-workspace,
+  .dh-nav-item {
+    transition: none;
+  }
+}

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -1,0 +1,399 @@
+/**
+ * DocumentsHome — the first-class "Documents" surface (JP-218).
+ *
+ * Promotes document browsing out of the Settings modal into a full-bleed app
+ * surface: a sidebar (identity, nav rail, collections, local storage, user) and
+ * a main area (header, "Continue working" strip, document list). It wraps the
+ * shared `useDocumentBrowserModel` engine — all document logic lives there; this
+ * file is the chrome.
+ *
+ * Visual language follows the DocuShark brand kit (warm-paper / navy surfaces,
+ * gold accents) via the tokens in `index.css`. The kit's web-only concepts
+ * (multi-workspace switching, share links, collaborators) are intentionally
+ * absent — this surfaces the editor's real model: local + cloud documents,
+ * collections, and local storage.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft,
+  Clock,
+  Cloud,
+  Database,
+  FilePlus2,
+  FolderOpen,
+  HardDrive,
+  Layers,
+  LayoutGrid,
+  List,
+  Moon,
+  Search,
+  Settings as SettingsIcon,
+  Sun,
+  Trash2,
+} from 'lucide-react';
+import { useDocumentBrowserModel, SORT_LABELS } from '../settings/useDocumentBrowserModel';
+import { DocumentList, SelectionBar } from '../settings/DocumentList';
+import { useThemeStore } from '../../store/themeStore';
+import { blobStorage } from '../../storage/BlobStorage';
+import type { StorageStats } from '../../storage/BlobTypes';
+import { formatFileSize } from '../../utils/imageUtils';
+import type { DocumentBrowserSort, DocumentBrowserView } from '../../store/uiPreferencesStore';
+import './DocumentsHome.css';
+
+export interface DocumentsHomeProps {
+  /** Switch the app shell back to the editor (after opening/creating a doc, or "back"). */
+  onLeaveToEditor: () => void;
+  /** Open the Settings modal, optionally on a specific tab (cloud/storage management). */
+  onOpenSettings?: (tab?: 'relay' | 'storage') => void;
+}
+
+type NavId = 'all' | 'recents' | 'local' | 'cloud' | 'cached';
+
+const NAV_LABELS: Record<NavId, string> = {
+  all: 'All documents',
+  recents: 'Recents',
+  local: 'Local',
+  cloud: 'Cloud',
+  cached: 'Offline',
+};
+
+export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHomeProps) {
+  const model = useDocumentBrowserModel();
+  const {
+    documentList,
+    documentCounts,
+    collections,
+    assignments,
+    collectionFilter,
+    setCollectionFilter,
+    setFilterMode,
+    searchQuery,
+    setSearchQuery,
+    view,
+    setView,
+    sort,
+    setSort,
+    isInTeamMode,
+    isConnectedToHost,
+    relaySessionUsable,
+    currentUser,
+    currentDocumentId,
+    hasSelection,
+    handleNewDocument,
+  } = model;
+
+  const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
+  const toggleTheme = useThemeStore((s) => s.toggle);
+
+  // Active nav rail entry. Collection selection is tracked by the model
+  // (`collectionFilter`); the type-axis entries map to `filterMode`.
+  const [nav, setNav] = useState<NavId>('all');
+
+  const selectNav = (id: NavId) => {
+    setNav(id);
+    setCollectionFilter(null);
+    if (id === 'recents') {
+      setFilterMode('all');
+      setSort('modified-desc');
+    } else if (id === 'all') {
+      setFilterMode('all');
+    } else if (id === 'local') {
+      setFilterMode('local');
+    } else if (id === 'cloud') {
+      setFilterMode('team');
+    } else if (id === 'cached') {
+      setFilterMode('cached');
+    }
+  };
+
+  const selectCollection = (id: string) => {
+    setFilterMode('all');
+    setCollectionFilter(id);
+  };
+
+  // Per-collection counts (network-free, from the local assignment map).
+  const collectionCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const cid of Object.values(assignments)) {
+      if (cid) counts[cid] = (counts[cid] ?? 0) + 1;
+    }
+    return counts;
+  }, [assignments]);
+
+  // Local IndexedDB storage usage for the sidebar foot. navigator.storage
+  // .estimate() returns 0 quota on WebKitGTK/Linux desktop — degrade to
+  // "used only" rather than showing a misleading 0%/full bar.
+  const [storage, setStorage] = useState<StorageStats | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    blobStorage
+      .getStorageStats()
+      .then((s) => {
+        if (!cancelled) setStorage(s);
+      })
+      .catch(() => {
+        /* best-effort; foot just hides the bar */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const quotaKnown = storage !== null && storage.available > 0;
+
+  // "Continue working" strip: the most recent docs, shown on All without a query.
+  const recents = useMemo(() => documentList.slice(0, 3), [documentList]);
+  const showRecents = nav === 'all' && collectionFilter === null && !searchQuery && recents.length > 0;
+
+  const activeLabel = collectionFilter
+    ? (collections.find((c) => c.id === collectionFilter)?.name ?? 'Collection')
+    : NAV_LABELS[nav];
+
+  const navItems: { id: NavId; label: string; icon: typeof FolderOpen; count: number | null }[] = [
+    { id: 'all', label: NAV_LABELS.all, icon: FolderOpen, count: documentCounts.total },
+    { id: 'recents', label: NAV_LABELS.recents, icon: Clock, count: null },
+    { id: 'local', label: NAV_LABELS.local, icon: HardDrive, count: documentCounts.local },
+  ];
+  if (isInTeamMode) {
+    navItems.push({ id: 'cloud', label: NAV_LABELS.cloud, icon: Cloud, count: documentCounts.team });
+    if (documentCounts.cached > 0) {
+      navItems.push({ id: 'cached', label: NAV_LABELS.cached, icon: Database, count: documentCounts.cached });
+    }
+  }
+
+  const onNew = () => {
+    handleNewDocument();
+    onLeaveToEditor();
+  };
+
+  const signedIn = isConnectedToHost || relaySessionUsable;
+
+  return (
+    <div className="documents-home" data-theme={resolvedTheme}>
+      {/* ── Sidebar ── */}
+      <aside className="dh-side">
+        <div className="dh-identity">
+          <button
+            className="dh-workspace"
+            onClick={() => onOpenSettings?.('relay')}
+            title={signedIn ? 'Manage cloud connection' : 'Sign in to DocuShark Cloud'}
+          >
+            <span className="dh-workspace-avatar">
+              {signedIn ? <Cloud size={18} aria-hidden="true" /> : <HardDrive size={18} aria-hidden="true" />}
+            </span>
+            <span className="dh-workspace-info">
+              <span className="dh-workspace-name">
+                {signedIn ? (currentUser?.displayName ?? 'Cloud workspace') : 'Local workspace'}
+              </span>
+              <span className="dh-workspace-meta">
+                {signedIn ? (isConnectedToHost ? 'Connected' : 'Signed in') : 'Sign in to sync'}
+              </span>
+            </span>
+          </button>
+          <button
+            className="dh-manage"
+            onClick={() => onOpenSettings?.()}
+            title="Settings"
+            aria-label="Settings"
+          >
+            <SettingsIcon size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        <nav className="dh-nav">
+          {navItems.map((n) => {
+            const Icon = n.icon;
+            const active = collectionFilter === null && nav === n.id;
+            return (
+              <button
+                key={n.id}
+                className={`dh-nav-item${active ? ' dh-nav-item--on' : ''}`}
+                onClick={() => selectNav(n.id)}
+              >
+                <Icon size={17} aria-hidden="true" />
+                <span className="dh-nav-label">{n.label}</span>
+                {n.count != null && <span className="dh-nav-count">{n.count}</span>}
+              </button>
+            );
+          })}
+
+          {collections.length > 0 && (
+            <>
+              <div className="dh-nav-section">Collections</div>
+              {collections.map((c) => (
+                <button
+                  key={c.id}
+                  className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
+                  onClick={() => selectCollection(c.id)}
+                >
+                  <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
+                  <span className="dh-nav-label">{c.name}</span>
+                  <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
+                </button>
+              ))}
+            </>
+          )}
+
+          {/* Trash lights up once relay deletion signals (JP-175) land. */}
+          <button className="dh-nav-item dh-nav-item--disabled" disabled title="Coming soon">
+            <Trash2 size={17} aria-hidden="true" />
+            <span className="dh-nav-label">Trash</span>
+            <span className="dh-nav-soon">soon</span>
+          </button>
+        </nav>
+
+        <div className="dh-side-foot">
+          <button className="dh-storage" onClick={() => onOpenSettings?.('storage')} title="Manage storage">
+            <div className="dh-storage-top">
+              <Database size={14} aria-hidden="true" />
+              <span>Storage</span>
+              <span className="dh-storage-manage">Manage</span>
+            </div>
+            {quotaKnown ? (
+              <>
+                <div className="dh-storage-bar">
+                  <div
+                    className="dh-storage-fill"
+                    style={{ width: `${Math.min(100, storage!.percentUsed)}%` }}
+                  />
+                </div>
+                <div className="dh-storage-meta">
+                  {formatFileSize(storage!.used)} / {formatFileSize(storage!.available)} ·{' '}
+                  {Math.round(storage!.percentUsed)}%
+                </div>
+              </>
+            ) : (
+              <div className="dh-storage-meta">
+                {storage ? `${formatFileSize(storage.used)} used` : 'Calculating…'}
+              </div>
+            )}
+          </button>
+
+          <div className="dh-user">
+            <span className="dh-user-avatar">
+              {(currentUser?.displayName ?? 'You').slice(0, 1).toUpperCase()}
+            </span>
+            <span className="dh-user-info">
+              <span className="dh-user-name">{currentUser?.displayName ?? 'You'}</span>
+              <span className="dh-user-meta">{signedIn ? 'DocuShark Cloud' : 'Local only'}</span>
+            </span>
+            <button
+              className="dh-user-theme"
+              onClick={toggleTheme}
+              title={resolvedTheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+              aria-label={resolvedTheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            >
+              {resolvedTheme === 'dark' ? <Sun size={16} aria-hidden="true" /> : <Moon size={16} aria-hidden="true" />}
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      {/* ── Main ── */}
+      <div className="dh-main">
+        <header className="dh-top">
+          {currentDocumentId && (
+            <button className="dh-back" onClick={onLeaveToEditor} title="Back to editor">
+              <ChevronLeft size={18} aria-hidden="true" />
+              <span>Editor</span>
+            </button>
+          )}
+          <div className="dh-crumb">
+            <strong>{activeLabel}</strong>
+          </div>
+          <div className="dh-search">
+            <Search size={16} aria-hidden="true" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={`Search ${activeLabel.toLowerCase()}…`}
+            />
+          </div>
+          <div className="dh-top-actions">
+            <label className="dh-sort">
+              <span className="dh-sort-label">Sort</span>
+              <select value={sort} onChange={(e) => setSort(e.target.value as DocumentBrowserSort)}>
+                {Object.entries(SORT_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="dh-view-toggle" role="group" aria-label="View mode">
+              <button
+                className={view === 'list' ? 'on' : ''}
+                onClick={() => setView('list' as DocumentBrowserView)}
+                title="List view"
+                aria-label="List view"
+                aria-pressed={view === 'list'}
+              >
+                <List size={16} aria-hidden="true" />
+              </button>
+              <button
+                className={view === 'grid' ? 'on' : ''}
+                onClick={() => setView('grid' as DocumentBrowserView)}
+                title="Grid view"
+                aria-label="Grid view"
+                aria-pressed={view === 'grid'}
+              >
+                <LayoutGrid size={16} aria-hidden="true" />
+              </button>
+            </div>
+            <button className="dh-new" onClick={onNew} title="New document">
+              <FilePlus2 size={16} aria-hidden="true" />
+              <span>New</span>
+            </button>
+          </div>
+        </header>
+
+        <div className="dh-content">
+          {showRecents && (
+            <section className="dh-section">
+              <h2 className="dh-section-title">
+                <Clock size={15} aria-hidden="true" /> Continue working
+              </h2>
+              <div className="dh-recents">
+                {recents.map((r) => (
+                  <button
+                    key={r.id}
+                    className="dh-rcard"
+                    onClick={async () => {
+                      await model.handleOpen(r.id);
+                      onLeaveToEditor();
+                    }}
+                  >
+                    <span className="dh-rcard-ico">
+                      <Layers size={18} aria-hidden="true" />
+                    </span>
+                    <span className="dh-rcard-meta">
+                      <span className="dh-rcard-title">{r.name}</span>
+                      <span className="dh-rcard-sub">
+                        {r.type === 'local' ? 'Local' : r.type === 'cached' ? 'Offline' : 'Cloud'}
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {hasSelection && <SelectionBar model={model} />}
+
+          <section className="dh-section dh-section--list">
+            <h2 className="dh-section-title">
+              {searchQuery ? 'Results' : activeLabel}
+              <span className="dh-section-count">
+                {documentList.length} {documentList.length === 1 ? 'item' : 'items'}
+              </span>
+            </h2>
+            <DocumentList model={model} onOpened={onLeaveToEditor} />
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DocumentsHome;

--- a/src/ui/settings/DocumentBrowser.tsx
+++ b/src/ui/settings/DocumentBrowser.tsx
@@ -2,734 +2,80 @@
  * DocumentBrowser component
  *
  * Unified document browser that combines local and remote document management.
+ * This is the legacy Settings-tab chrome around the shared
+ * `useDocumentBrowserModel` engine; the first-class `DocumentsHome` surface
+ * (JP-218) wraps the same model with its own chrome. All document logic lives
+ * in the model + `DocumentList`; this file is presentation only.
  *
  * Phase 14.1.6 UI Consolidation, Phase 20: collections, grid view, multi-select.
  */
 
-import { useState, useCallback, useMemo, useRef, useEffect, lazy, Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import {
-  ChevronDown,
   Download,
   FileText,
   LayoutGrid,
   List,
-  MoreHorizontal,
   Plus,
   RefreshCw,
   Save,
   Upload,
-  X,
 } from 'lucide-react';
-import { useDocumentRegistry } from '../../store/documentRegistry';
-import { usePersistenceStore } from '../../store/persistenceStore';
-import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
-import { useRelayDocumentStore } from '../../store/relayDocumentStore';
 import {
-  computeOfflineStatus,
-  makeAvailableOffline,
-  type OfflineProgress,
-  type OfflineStatus,
-} from '../../store/offlineAvailability';
-import { useUserStore } from '../../store/userStore';
-import {
-  useUIPreferencesStore,
   type DocumentBrowserSort,
   type DocumentBrowserGroupBy,
   type DocumentBrowserView,
 } from '../../store/uiPreferencesStore';
-import {
-  useCollectionStore,
-  COLLECTION_SWATCHES,
-  type Collection,
-} from '../../store/collectionStore';
-import { DocumentCard } from '../DocumentCard';
 import { SyncStatusBadge } from '../SyncStatusBadge';
 import { DocumentPermissionsDialog } from '../DocumentPermissionsDialog';
+import { useDocumentBrowserModel, SORT_LABELS } from './useDocumentBrowserModel';
+import { DocumentList, SelectionBar } from './DocumentList';
 
 // Lazy: the PDF export dialog pulls jspdf + html2canvas + tiptap extensions —
 // load that chunk only when the dialog is opened.
 const PDFExportDialog = lazy(() =>
   import('../PDFExportDialog').then((m) => ({ default: m.PDFExportDialog })),
 );
-import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
-import { getTransferService } from '../../services/DocumentTransferService';
-import { useTransferStore, isTransferRunning, transferPhaseLabel } from '../../store/transferStore';
-import { useCollaborationStore, purgeLocalDocRoom } from '../../collaboration';
-import { getDocumentMetadata } from '../../types/Document';
-import type { DocumentRecord } from '../../types/DocumentRegistry';
-import './DocumentBrowser.css';
-
-type FilterMode = 'all' | 'local' | 'team' | 'cached';
-const UNASSIGNED_KEY = '__unassigned__';
+import { isTransferRunning, transferPhaseLabel } from '../../store/transferStore';
 
 interface DocumentBrowserProps {
   /** Compact mode for sidebar usage */
   compact?: boolean;
 }
 
-function compareRecords(a: DocumentRecord, b: DocumentRecord, sort: DocumentBrowserSort): number {
-  switch (sort) {
-    case 'modified-desc':
-      return b.modifiedAt - a.modifiedAt;
-    case 'modified-asc':
-      return a.modifiedAt - b.modifiedAt;
-    case 'name-asc':
-      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
-    case 'name-desc':
-      return b.name.localeCompare(a.name, undefined, { sensitivity: 'base' });
-    case 'created-desc':
-      return b.createdAt - a.createdAt;
-  }
-}
-
-/**
- * Map raw transfer error messages (often surfaced verbatim from the relay
- * REST layer) onto something a non-engineer can act on. Falls back to the
- * raw message when nothing matches so we never swallow a useful detail.
- */
-function friendlyTransferError(raw: string | undefined): string {
-  if (!raw) return 'Unknown error';
-  const lower = raw.toLowerCase();
-  if (lower.includes('401') || lower.includes('unauthorized') || lower.includes('token'))
-    return 'Relay session expired — please sign in again.';
-  if (lower.includes('403') || lower.includes('forbidden') || lower.includes('not owner'))
-    return 'Only the document owner can do that.';
-  if (lower.includes('413') || lower.includes('too large') || lower.includes('payload'))
-    return 'Document is too large for the relay.';
-  if (lower.includes('409') || lower.includes('version conflict'))
-    return 'The relay copy was changed since you opened it. Please reload and try again.';
-  if (lower.includes('network') || lower.includes('fetch') || lower.includes('timed out'))
-    return "Couldn't reach the relay. Check your connection and try again.";
-  return raw;
-}
-
-const SORT_LABELS: Record<DocumentBrowserSort, string> = {
-  'modified-desc': 'Recently modified',
-  'modified-asc': 'Least recently modified',
-  'name-asc': 'Name (A–Z)',
-  'name-desc': 'Name (Z–A)',
-  'created-desc': 'Recently created',
-};
-
 export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
-  // Registry store
-  const entries = useDocumentRegistry((s) => s.entries);
-  const isFetchingRemote = useDocumentRegistry((s) => s.isFetchingRemote);
-  const registryError = useDocumentRegistry((s) => s.error);
-  const getFilteredDocuments = useDocumentRegistry((s) => s.getFilteredDocuments);
-  const setFilter = useDocumentRegistry((s) => s.setFilter);
-
-  // Persistence store
-  const currentDocumentId = usePersistenceStore((s) => s.currentDocumentId);
-  const newDocument = usePersistenceStore((s) => s.newDocument);
-  const saveDocument = usePersistenceStore((s) => s.saveDocument);
-  const loadDocument = usePersistenceStore((s) => s.loadDocument);
-  const deleteDocument = usePersistenceStore((s) => s.deleteDocument);
-  const renameDocument = usePersistenceStore((s) => s.renameDocument);
-
-  // Relay stores
-  const isRelayLive = useIsRelayAuthenticated();
-  const authenticated = useRelayDocumentStore((s) => s.authenticated);
-  const isLoadingList = useRelayDocumentStore((s) => s.isLoadingList);
-  const teamStoreError = useRelayDocumentStore((s) => s.error);
-  const fetchDocumentList = useRelayDocumentStore((s) => s.fetchDocumentList);
-  const loadRelayDocument = useRelayDocumentStore((s) => s.loadRelayDocument);
-  const deleteFromHost = useRelayDocumentStore((s) => s.deleteFromHost);
-  const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
-
-  // Whether we have a usable relay session for *transfers*. Gates the
-  // publish/move affordances on a VALID CACHED TOKEN, not the live WS — opening
-  // a local doc tears down the per-doc WS (ensureCollabSession → leaveDocument),
-  // which flips `isRelayLive`/`hostConnected` false even though the token + REST
-  // provider survive (preserveAuth). Transfers run over the REST provider, so
-  // they must stay available while signed in; otherwise being on a local doc
-  // confusingly hides the "Move to Relay" action (JP-211 transfer-gating bug).
-  const relaySessionUsable = useConnectionStore(
-    (s) => s.token !== null && (s.tokenExpiresAt === null || Date.now() < s.tokenExpiresAt),
-  );
-
-  // Currently-connected relay address (host:port) — drives per-card relay
-  // badges and the "By relay" section ordering. "Connected" must mean *actually
-  // connected*, not merely that a relay address is configured: opening a doc
-  // calls `connectionStore.setHost(address)` (engine start) even while offline,
-  // so keying off `host?.address` alone falsely flips every card to
-  // connected/synced. Gate on the real WS-connected signal (`hostConnected`,
-  // which only goes true on an authenticated connection).
-  const relayHostAddress = useConnectionStore((s) => s.host?.address);
-  const hostConnected = useRelayDocumentStore((s) => s.hostConnected);
-  const connectedRelayAddress = hostConnected ? relayHostAddress : undefined;
-
-  // User store
-  const currentUser = useUserStore((s) => s.currentUser);
-
-  // Transfer progress (Local ↔ Cloud)
-  const transferPhase = useTransferStore((s) => s.phase);
-  const transferDirection = useTransferStore((s) => s.direction);
-
-  // UI preferences
-  const view = useUIPreferencesStore((s) => s.documentBrowserView);
-  const sort = useUIPreferencesStore((s) => s.documentBrowserSort);
-  const groupBy = useUIPreferencesStore((s) => s.documentBrowserGroupBy);
-  const collapsedMap = useUIPreferencesStore((s) => s.documentBrowserCollapsed);
-  const setView = useUIPreferencesStore((s) => s.setDocumentBrowserView);
-  const setSort = useUIPreferencesStore((s) => s.setDocumentBrowserSort);
-  const setGroupBy = useUIPreferencesStore((s) => s.setDocumentBrowserGroupBy);
-  const toggleCollapsed = useUIPreferencesStore((s) => s.toggleDocumentBrowserGroupCollapsed);
-
-  // Collection store
-  const collectionsMap = useCollectionStore((s) => s.collections);
-  const assignments = useCollectionStore((s) => s.assignments);
-  const createCollection = useCollectionStore((s) => s.createCollection);
-  const renameCollectionAction = useCollectionStore((s) => s.renameCollection);
-  const recolorCollectionAction = useCollectionStore((s) => s.recolorCollection);
-  const deleteCollectionAction = useCollectionStore((s) => s.deleteCollection);
-  const assignMany = useCollectionStore((s) => s.assignMany);
-
-  const collections = useMemo<Collection[]>(
-    () => Object.values(collectionsMap).sort((a, b) => a.order - b.order),
-    [collectionsMap]
-  );
-
-  // Local state
-  const [filterMode, setFilterMode] = useState<FilterMode>('all');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [pdfExportOpen, setPdfExportOpen] = useState(false);
-  const [permissionsDocId, setPermissionsDocId] = useState<string | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
-  const [assignMenuOpen, setAssignMenuOpen] = useState(false);
-  const [activeCollectionMenu, setActiveCollectionMenu] = useState<string | null>(null);
-  // Offline-cache surfacing (JP-281): passive per-doc status + in-flight prefetch progress.
-  const [offlineStatuses, setOfflineStatuses] = useState<Map<string, OfflineStatus>>(new Map());
-  const [offlineProgress, setOfflineProgress] = useState<Map<string, OfflineProgress>>(new Map());
-
-  const isInTeamMode = isRelayLive;
-  const isConnectedToHost = isRelayLive && authenticated;
-  const isHost = false;
-
-  // Filtered + sorted documents (flat list — the same list used to drive grouping).
-  const documentList = useMemo(() => {
-    const allDocs = getFilteredDocuments();
-    let filtered = allDocs;
-    if (filterMode === 'local') {
-      filtered = allDocs.filter((d) => d.type === 'local');
-    } else if (filterMode === 'team') {
-      filtered = allDocs.filter((d) => d.type === 'remote');
-    } else if (filterMode === 'cached') {
-      filtered = allDocs.filter((d) => d.type === 'cached');
-    }
-
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter((d) => d.name.toLowerCase().includes(query));
-    }
-
-    return [...filtered].sort((a, b) => compareRecords(a, b, sort));
-  }, [entries, getFilteredDocuments, filterMode, searchQuery, sort]);
-
-  // JP-281: compute each relay-backed doc's offline-ready status from local
-  // caches (network-free). Recomputes when the list or registry changes so the
-  // badge reflects view-driven caching that lands in the background.
-  useEffect(() => {
-    let cancelled = false;
-    const records = documentList.filter((d) => d.type !== 'local');
-    if (records.length === 0) {
-      setOfflineStatuses((prev) => (prev.size === 0 ? prev : new Map()));
-      return;
-    }
-    // allSettled (not all): one doc whose status can't be computed must not wipe
-    // every other doc's badge. Merge results so unaffected entries keep their
-    // refs, and prune statuses for docs that left the list.
-    const liveIds = new Set(records.map((r) => r.id));
-    void Promise.allSettled(records.map((r) => computeOfflineStatus(r))).then((results) => {
-      if (cancelled) return;
-      setOfflineStatuses((prev) => {
-        const next = new Map(prev);
-        results.forEach((res, i) => {
-          if (res.status === 'fulfilled') next.set(records[i]!.id, res.value);
-        });
-        for (const id of next.keys()) {
-          if (!liveIds.has(id)) next.delete(id);
-        }
-        return next;
-      });
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [documentList]);
-
-  // JP-281: proactively cache a doc's body + all referenced blobs for offline use.
-  const handleMakeAvailableOffline = useCallback(async (id: string) => {
-    const record = useDocumentRegistry.getState().getRecord(id);
-    if (!record) return;
-    setOfflineProgress((m) => new Map(m).set(id, { done: 0, total: 0 }));
-    try {
-      const status = await makeAvailableOffline(record, (p) => {
-        setOfflineProgress((m) => new Map(m).set(id, p));
-      });
-      setOfflineStatuses((m) => new Map(m).set(id, status));
-    } catch (e) {
-      console.warn('[DocumentBrowser] Make available offline failed:', id, e);
-    } finally {
-      setOfflineProgress((m) => {
-        const next = new Map(m);
-        next.delete(id);
-        return next;
-      });
-    }
-  }, []);
-
-  // Bucket documents by collection when grouping is enabled.
-  const groupedSections = useMemo(() => {
-    if (groupBy !== 'collection') return null;
-    const buckets = new Map<string, DocumentRecord[]>();
-    for (const doc of documentList) {
-      const cid = assignments[doc.id];
-      const key = cid && collectionsMap[cid] ? cid : UNASSIGNED_KEY;
-      const arr = buckets.get(key);
-      if (arr) arr.push(doc);
-      else buckets.set(key, [doc]);
-    }
-    const sections: { key: string; collection: Collection | null; docs: DocumentRecord[] }[] = [];
-    for (const c of collections) {
-      sections.push({ key: c.id, collection: c, docs: buckets.get(c.id) ?? [] });
-    }
-    sections.push({
-      key: UNASSIGNED_KEY,
-      collection: null,
-      docs: buckets.get(UNASSIGNED_KEY) ?? [],
-    });
-    return sections;
-  }, [groupBy, documentList, assignments, collectionsMap, collections]);
-
-  // Count documents by type
-  const documentCounts = useMemo(() => {
-    const allDocs = Object.values(entries).map((e) => e.record);
-    return {
-      total: allDocs.length,
-      local: allDocs.filter((d) => d.type === 'local').length,
-      team: allDocs.filter((d) => d.type === 'remote').length,
-      cached: allDocs.filter((d) => d.type === 'cached').length,
-    };
-  }, [entries]);
-
-  // Clear selection when the visible list changes meaningfully.
-  useEffect(() => {
-    setSelectedIds((prev) => {
-      if (prev.size === 0) return prev;
-      const visible = new Set(documentList.map((d) => d.id));
-      const next = new Set<string>();
-      for (const id of prev) if (visible.has(id)) next.add(id);
-      return next.size === prev.size ? prev : next;
-    });
-  }, [documentList]);
-
-  // Handlers
-  const handleNewDocument = useCallback(() => newDocument(), [newDocument]);
-  const handleSave = useCallback(() => saveDocument(), [saveDocument]);
-
-  const handleRefresh = useCallback(() => {
-    if (isConnectedToHost || isHost) fetchDocumentList();
-  }, [fetchDocumentList, isConnectedToHost, isHost]);
-
-  const handleOpen = useCallback(
-    async (docId: string) => {
-      if (docId === currentDocumentId) return;
-      const entry = entries[docId];
-      if (!entry) return;
-      const record = entry.record;
-      if (record.type === 'remote' || record.type === 'cached') {
-        try {
-          const doc = await loadRelayDocument(docId);
-          usePersistenceStore.getState().loadRemoteDocument(doc);
-        } catch (error) {
-          console.error('Failed to load relay document:', error);
-        }
-      } else {
-        loadDocument(docId);
-      }
-    },
-    [currentDocumentId, entries, loadRelayDocument, loadDocument]
-  );
-
-  const handleDelete = useCallback(
-    async (docId: string) => {
-      const entry = entries[docId];
-      if (!entry) return;
-      const record = entry.record;
-      if (record.type === 'remote') {
-        try {
-          await deleteFromHost(docId);
-        } catch (error) {
-          console.error('Failed to delete relay document:', error);
-        }
-        // Purge the doc's local prose CRDT room so its y-indexeddb DB doesn't
-        // linger forever (leaveDocument keeps room data on disk; nothing else
-        // cleans it on delete) and can't stale-merge if the id is ever reused.
-        // Best-effort: a no-op if the doc is currently open (its room is locked).
-        await purgeLocalDocRoom(docId);
-      } else {
-        deleteDocument(docId);
-      }
-    },
-    [entries, deleteFromHost, deleteDocument]
-  );
-
-  const handleRename = useCallback(
-    (docId: string, newName: string) => {
-      if (docId === currentDocumentId) renameDocument(newName);
-    },
-    [currentDocumentId, renameDocument]
-  );
-
-  const handlePublishToTeam = useCallback(
-    async (docId: string) => {
-      if (!currentUser?.id) return;
-      if (isTransferRunning(useTransferStore.getState().phase)) {
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore.getState().warning('A document transfer is already in progress.');
-        return;
-      }
-      const service = getTransferService();
-      if (!service) {
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore.getState().error('Transfer service not ready');
-        return;
-      }
-
-      // Persist any unsaved edits before snapshotting for transfer.
-      if (docId === currentDocumentId) {
-        saveDocument();
-      }
-
-      useTransferStore.getState().begin(docId, 'to-relay');
-      const result = await service.transferToTeam(docId, {
-        onProgress: (phase) => useTransferStore.getState().setPhase(phase),
-      });
-      if (!result.success) {
-        useTransferStore.getState().fail(friendlyTransferError(result.error));
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore
-          .getState()
-          .error(`Move to Relay failed: ${friendlyTransferError(result.error)}`);
-        return;
-      }
-      useDocumentRegistry.getState().removeDocument(docId);
-
-      // Purge any stale local prose CRDT room BEFORE the doc re-joins as a relay
-      // doc. A doc previously moved Cloud→Personal keeps its `host:docId`
-      // y-indexeddb room on disk; without this, re-promote reloads that stale
-      // prose and merges it with the relay's fresh re-seed from richTextPages —
-      // duplicating every page (JP-282). richTextPages (just saved to the relay)
-      // is the source of truth, so the client adopts the relay copy cleanly.
-      await purgeLocalDocRoom(docId);
-
-      await fetchDocumentList();
-
-      // If the promoted doc is the one open in the editor and we have an
-      // authenticated relay session, join it on the relay so edits sync
-      // immediately (convert-in-place keeps the same id). This is what turns
-      // the post-sign-in "JOIN_DOC for unknown doc" rejection into a real
-      // synced session.
-      if (docId === currentDocumentId && isConnectedToHost) {
-        useCollaborationStore.getState().switchDocument(docId);
-      }
-      useTransferStore.getState().reset();
-    },
-    [currentDocumentId, saveDocument, fetchDocumentList, currentUser, isConnectedToHost]
-  );
-
-  const handleMoveToPersonal = useCallback(
-    async (docId: string) => {
-      const entry = entries[docId];
-      if (!entry) return;
-      const record = entry.record;
-      if (record.type !== 'remote') return;
-      if (isTransferRunning(useTransferStore.getState().phase)) {
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore.getState().warning('A document transfer is already in progress.');
-        return;
-      }
-      const service = getTransferService();
-      if (!service) {
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore.getState().error('Transfer service not ready');
-        return;
-      }
-      try {
-        // Pull the latest snapshot from the relay into localStorage so the
-        // transfer service can read it as the source-of-truth before
-        // mutating its relay-side fields.
-        const doc = await loadRelayDocument(docId);
-        usePersistenceStore.getState().loadRemoteDocument(doc);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Failed to fetch relay document';
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore
-          .getState()
-          .error(`Move to Personal failed: ${friendlyTransferError(message)}`);
-        return;
-      }
-
-      useTransferStore.getState().begin(docId, 'to-personal');
-      const result = await service.transferToPersonal(docId, {
-        onProgress: (phase) => useTransferStore.getState().setPhase(phase),
-      });
-      if (!result.success) {
-        useTransferStore.getState().fail(friendlyTransferError(result.error));
-        const { useNotificationStore } = await import('../../store/notificationStore');
-        useNotificationStore
-          .getState()
-          .error(`Move to Personal failed: ${friendlyTransferError(result.error)}`);
-        return;
-      }
-      // The doc was just DELETEd from the relay, so refresh the remote list
-      // (it'll be absent from it now) and then re-register the converted doc as
-      // Local. fetchDocumentList only ever registers *remote* docs, so without
-      // this registerLocal the now-personal doc would vanish from the browser
-      // even though its data is safely in localStorage.
-      await fetchDocumentList();
-      if (result.document) {
-        useDocumentRegistry.getState().registerLocal(getDocumentMetadata(result.document));
-      }
-      useTransferStore.getState().reset();
-    },
-    [entries, loadRelayDocument, fetchDocumentList]
-  );
-
-  const handleExport = useCallback(() => {
-    if (!currentDocumentId) return;
-    saveDocument();
-    exportAndDownloadDocumentArchive(currentDocumentId).catch((err) => {
-      console.error('Failed to export document archive:', err);
-    });
-  }, [currentDocumentId, saveDocument]);
-
-  const handleImport = useCallback(() => {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.docushark';
-    input.onchange = (e) => {
-      const file = (e.target as HTMLInputElement).files?.[0];
-      if (file) {
-        importDocumentArchive(file).catch((err) => {
-          console.error('Failed to import document archive:', err);
-        });
-      }
-    };
-    input.click();
-  }, []);
-
-  const handleFilterChange = useCallback(
-    (mode: FilterMode) => {
-      setFilterMode(mode);
-      const types: ('local' | 'remote' | 'cached')[] =
-        mode === 'all'
-          ? ['local', 'remote', 'cached']
-          : mode === 'local'
-            ? ['local']
-            : mode === 'team'
-              ? ['remote']
-              : ['cached'];
-      setFilter({ types });
-    },
-    [setFilter]
-  );
-
-  // Multi-select handlers
-  const handleSelectToggle = useCallback(
-    (id: string, mods: { shift: boolean; meta: boolean }) => {
-      setSelectedIds((prev) => {
-        const next = new Set(prev);
-        if (mods.shift && lastSelectedId && lastSelectedId !== id) {
-          const ids = documentList.map((d) => d.id);
-          const a = ids.indexOf(lastSelectedId);
-          const b = ids.indexOf(id);
-          if (a !== -1 && b !== -1) {
-            const [start, end] = a < b ? [a, b] : [b, a];
-            for (let i = start; i <= end; i++) {
-              const v = ids[i];
-              if (v !== undefined) next.add(v);
-            }
-            return next;
-          }
-        }
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        return next;
-      });
-      setLastSelectedId(id);
-    },
-    [documentList, lastSelectedId]
-  );
-
-  const clearSelection = useCallback(() => {
-    setSelectedIds(new Set());
-    setLastSelectedId(null);
-  }, []);
-
-  // Clear selection when filters / sort / grouping change.
-  useEffect(() => {
-    clearSelection();
-  }, [filterMode, sort, groupBy, clearSelection]);
-
-  const handleBulkAssign = useCallback(
-    (collectionId: string | null) => {
-      assignMany(Array.from(selectedIds), collectionId);
-      setAssignMenuOpen(false);
-    },
-    [assignMany, selectedIds]
-  );
-
-  const handleBulkAssignNewCollection = useCallback(() => {
-    const name = window.prompt('New collection name');
-    if (!name || !name.trim()) return;
-    const id = createCollection(name);
-    if (id) assignMany(Array.from(selectedIds), id);
-    setAssignMenuOpen(false);
-  }, [assignMany, createCollection, selectedIds]);
-
-  const handleBulkDelete = useCallback(async () => {
-    const ids = Array.from(selectedIds);
-    const deletable = ids.filter((id) => {
-      const entry = entries[id];
-      if (!entry) return false;
-      return canDelete(entry.record, currentUser?.id, currentUser?.role);
-    });
-    if (deletable.length === 0) return;
-    if (!window.confirm(`Delete ${deletable.length} document(s)? This cannot be undone.`)) return;
-    for (const id of deletable) {
-      await handleDelete(id);
-    }
-    clearSelection();
-  }, [selectedIds, entries, currentUser, handleDelete, clearSelection]);
-
-  const handleBulkExport = useCallback(async () => {
-    const ids = Array.from(selectedIds);
-    for (const id of ids) {
-      try {
-        await exportAndDownloadDocumentArchive(id);
-      } catch (err) {
-        console.error('Failed to export', id, err);
-      }
-    }
-  }, [selectedIds]);
-
-  // Collection management
-  const handleCreateCollection = useCallback(() => {
-    const name = window.prompt('New collection name');
-    if (!name || !name.trim()) return;
-    createCollection(name);
-  }, [createCollection]);
-
-  const handleRenameCollection = useCallback(
-    (collection: Collection) => {
-      const name = window.prompt('Rename collection', collection.name);
-      if (!name) return;
-      renameCollectionAction(collection.id, name);
-      setActiveCollectionMenu(null);
-    },
-    [renameCollectionAction]
-  );
-
-  const handleDeleteCollection = useCallback(
-    (collection: Collection) => {
-      if (!window.confirm(`Delete collection "${collection.name}"? Documents in it will become Unassigned.`)) return;
-      deleteCollectionAction(collection.id);
-      setActiveCollectionMenu(null);
-    },
-    [deleteCollectionAction]
-  );
-
-  const handleRecolor = useCallback(
-    (collection: Collection, color: string | undefined) => {
-      recolorCollectionAction(collection.id, color);
-    },
-    [recolorCollectionAction]
-  );
-
-  const error = registryError || teamStoreError;
-  const isLoading = isFetchingRemote || isLoadingList;
-  const hasSelection = selectedIds.size > 0;
-  const showSelectionAffordance = hasSelection;
-
-  const cardMode: 'compact' | 'full' | 'grid' =
-    view === 'grid' ? 'grid' : compact ? 'compact' : 'full';
-
-  // Stable per-doc collection accent so DocumentCard's memo can skip cards
-  // unaffected by an action elsewhere (e.g. an offline-prefetch progress tick on
-  // another card no longer re-renders the whole list).
-  const accentByDoc = useMemo(() => {
-    const map = new Map<string, { name: string; color?: string }>();
-    if (groupBy === 'collection') return map; // membership shown via section headers instead
-    for (const docId of Object.keys(assignments)) {
-      const cid = assignments[docId];
-      const collection = cid ? collectionsMap[cid] : undefined;
-      if (!collection) continue;
-      map.set(
-        docId,
-        collection.color !== undefined
-          ? { name: collection.name, color: collection.color }
-          : { name: collection.name },
-      );
-    }
-    return map;
-  }, [assignments, collectionsMap, groupBy]);
-
-  const renderCard = useCallback(
-    (record: DocumentRecord) => {
-      const accent = accentByDoc.get(record.id);
-      return (
-        <DocumentCard
-          key={record.id}
-          record={record}
-          isActive={record.id === currentDocumentId}
-          isSelected={selectedIds.has(record.id)}
-          showSelectionCheckbox={showSelectionAffordance}
-          isOfflineAvailable={record.type === 'remote' && isAvailableOffline(record.id)}
-          onOpen={handleOpen}
-          onSelectToggle={handleSelectToggle}
-          onDelete={canDelete(record, currentUser?.id, currentUser?.role) ? handleDelete : undefined}
-          onRename={canEdit(record, currentUser?.id, currentUser?.role) ? handleRename : undefined}
-          onEditPermissions={
-            canManagePermissions(record, isInTeamMode, currentUser?.id, currentUser?.role)
-              ? setPermissionsDocId
-              : undefined
-          }
-          onPublishToTeam={canPublishToTeam(record, relaySessionUsable) ? handlePublishToTeam : undefined}
-          onMoveToPersonal={canMoveToPersonal(record, relaySessionUsable, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
-          collectionAccent={accent}
-          connectedRelayAddress={connectedRelayAddress}
-          offlineStatus={offlineStatuses.get(record.id)}
-          offlineProgress={offlineProgress.get(record.id) ?? null}
-          onMakeAvailableOffline={record.type !== 'local' ? handleMakeAvailableOffline : undefined}
-          mode={cardMode}
-        />
-      );
-    },
-    [
-      accentByDoc,
-      connectedRelayAddress,
-      currentDocumentId,
-      selectedIds,
-      showSelectionAffordance,
-      isAvailableOffline,
-      offlineStatuses,
-      offlineProgress,
-      handleMakeAvailableOffline,
-      handleOpen,
-      handleSelectToggle,
-      currentUser,
-      handleDelete,
-      handleRename,
-      isInTeamMode,
-      relaySessionUsable,
-      handlePublishToTeam,
-      handleMoveToPersonal,
-      cardMode,
-    ]
-  );
+  const model = useDocumentBrowserModel();
+  const {
+    documentCounts,
+    filterMode,
+    setFilterMode,
+    searchQuery,
+    setSearchQuery,
+    view,
+    sort,
+    groupBy,
+    setView,
+    setSort,
+    setGroupBy,
+    hasSelection,
+    pdfExportOpen,
+    setPdfExportOpen,
+    permissionsDocId,
+    setPermissionsDocId,
+    isInTeamMode,
+    isConnectedToHost,
+    isHost,
+    error,
+    isLoading,
+    transferPhase,
+    transferDirection,
+    handleNewDocument,
+    handleSave,
+    handleRefresh,
+    handleImport,
+    handleExport,
+    handleCreateCollection,
+  } = model;
 
   return (
     <div className={`document-browser ${compact ? 'document-browser--compact' : ''}`}>
@@ -855,13 +201,13 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
           <div className="document-browser__filter">
             <button
               className={`document-browser__filter-btn ${filterMode === 'all' ? 'document-browser__filter-btn--active' : ''}`}
-              onClick={() => handleFilterChange('all')}
+              onClick={() => setFilterMode('all')}
             >
               All ({documentCounts.total})
             </button>
             <button
               className={`document-browser__filter-btn ${filterMode === 'local' ? 'document-browser__filter-btn--active' : ''}`}
-              onClick={() => handleFilterChange('local')}
+              onClick={() => setFilterMode('local')}
             >
               Personal ({documentCounts.local})
             </button>
@@ -869,14 +215,14 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
               <>
                 <button
                   className={`document-browser__filter-btn ${filterMode === 'team' ? 'document-browser__filter-btn--active' : ''}`}
-                  onClick={() => handleFilterChange('team')}
+                  onClick={() => setFilterMode('team')}
                 >
                   Team ({documentCounts.team})
                 </button>
                 {documentCounts.cached > 0 && (
                   <button
                     className={`document-browser__filter-btn ${filterMode === 'cached' ? 'document-browser__filter-btn--active' : ''}`}
-                    onClick={() => handleFilterChange('cached')}
+                    onClick={() => setFilterMode('cached')}
                   >
                     Offline ({documentCounts.cached})
                   </button>
@@ -934,107 +280,10 @@ export function DocumentBrowser({ compact = false }: DocumentBrowserProps) {
       </div>
 
       {/* Selection bar */}
-      {hasSelection && (
-        <div className="document-browser__selection-bar">
-          <span className="document-browser__selection-count">
-            {selectedIds.size} selected
-          </span>
-          <div className="document-browser__selection-actions">
-            <div className="document-browser__assign-wrap">
-              <button
-                className="document-browser__bulk-btn"
-                onClick={() => setAssignMenuOpen((v) => !v)}
-              >
-                Assign to collection ▾
-              </button>
-              {assignMenuOpen && (
-                <div className="document-browser__assign-menu" role="menu">
-                  <button
-                    className="document-browser__assign-item"
-                    onClick={() => handleBulkAssign(null)}
-                  >
-                    Remove from collection
-                  </button>
-                  {collections.length > 0 && <div className="document-browser__assign-sep" />}
-                  {collections.map((c) => (
-                    <button
-                      key={c.id}
-                      className="document-browser__assign-item"
-                      onClick={() => handleBulkAssign(c.id)}
-                    >
-                      <span
-                        className="document-browser__assign-swatch"
-                        style={c.color ? { background: c.color } : undefined}
-                      />
-                      {c.name}
-                    </button>
-                  ))}
-                  <div className="document-browser__assign-sep" />
-                  <button
-                    className="document-browser__assign-item document-browser__assign-item--new"
-                    onClick={handleBulkAssignNewCollection}
-                  >
-                    + New collection…
-                  </button>
-                </div>
-              )}
-            </div>
-            <button className="document-browser__bulk-btn" onClick={handleBulkExport}>
-              Export
-            </button>
-            <button
-              className="document-browser__bulk-btn document-browser__bulk-btn--danger"
-              onClick={handleBulkDelete}
-            >
-              Delete
-            </button>
-            <button className="document-browser__bulk-btn" onClick={clearSelection}>
-              Clear
-            </button>
-          </div>
-        </div>
-      )}
+      {hasSelection && <SelectionBar model={model} />}
 
       {/* Document List */}
-      <div
-        className={`document-browser__list ${view === 'grid' ? 'document-browser__list--grid' : ''}`}
-      >
-        {documentList.length === 0 ? (
-          <div className="document-browser__empty">
-            {searchQuery ? (
-              <p>No documents match your search.</p>
-            ) : filterMode !== 'all' ? (
-              <p>No {filterMode === 'local' ? 'personal' : filterMode} documents.</p>
-            ) : (
-              <p>No documents yet. Create a new one to get started!</p>
-            )}
-          </div>
-        ) : groupedSections ? (
-          groupedSections.map(({ key, collection, docs }) => {
-            if (docs.length === 0 && collection === null) return null;
-            const collapsed = collapsedMap[key] === true;
-            return (
-              <CollectionSection
-                key={key}
-                collection={collection}
-                docs={docs}
-                collapsed={collapsed}
-                onToggle={() => toggleCollapsed(key)}
-                view={view}
-                renderCard={renderCard}
-                isMenuOpen={activeCollectionMenu === key}
-                onOpenMenu={() => setActiveCollectionMenu(activeCollectionMenu === key ? null : key)}
-                onCloseMenu={() => setActiveCollectionMenu(null)}
-                onRename={handleRenameCollection}
-                onDelete={handleDeleteCollection}
-                onRecolor={handleRecolor}
-              />
-            );
-          })
-        ) : (
-          documentList.map((record) => renderCard(record))
-        )}
-      </div>
+      <DocumentList model={model} compact={compact} />
 
       {/* PDF Export Dialog — lazy; only mounted (and its chunk fetched) when open */}
       {pdfExportOpen && (
@@ -1078,199 +327,6 @@ function SelectControl({ label, value, options, onChange }: SelectControlProps) 
       </select>
     </label>
   );
-}
-
-interface CollectionSectionProps {
-  collection: Collection | null;
-  docs: DocumentRecord[];
-  collapsed: boolean;
-  view: DocumentBrowserView;
-  onToggle: () => void;
-  renderCard: (record: DocumentRecord) => React.ReactNode;
-  // Collection menu props — only supplied for user-defined collection sections.
-  isMenuOpen?: boolean | undefined;
-  onOpenMenu?: (() => void) | undefined;
-  onCloseMenu?: (() => void) | undefined;
-  onRename?: ((collection: Collection) => void) | undefined;
-  onDelete?: ((collection: Collection) => void) | undefined;
-  onRecolor?: ((collection: Collection, color: string | undefined) => void) | undefined;
-}
-
-function CollectionSection({
-  collection,
-  docs,
-  collapsed,
-  view,
-  onToggle,
-  renderCard,
-  isMenuOpen,
-  onOpenMenu,
-  onCloseMenu,
-  onRename,
-  onDelete,
-  onRecolor,
-}: CollectionSectionProps) {
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!isMenuOpen || !onCloseMenu) return;
-    const onDoc = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onCloseMenu();
-      }
-    };
-    document.addEventListener('mousedown', onDoc);
-    return () => document.removeEventListener('mousedown', onDoc);
-  }, [isMenuOpen, onCloseMenu]);
-
-  const isUnassigned = collection === null;
-  // Show the collection-actions menu + swatch only for real user-defined
-  // collections, never for the unassigned section.
-  const showMenu = collection !== null;
-  const showSwatch = !isUnassigned;
-  const title = collection !== null ? collection.name : 'Unassigned';
-  return (
-    <div className="document-browser__section">
-      <div className="document-browser__section-header">
-        <button
-          className="document-browser__section-toggle"
-          onClick={onToggle}
-          aria-expanded={!collapsed}
-        >
-          <ChevronDown
-            className={`document-browser__caret ${collapsed ? 'document-browser__caret--collapsed' : ''}`}
-            size={14}
-            aria-hidden="true"
-          />
-          {showSwatch && (
-            <span
-              className="document-browser__section-swatch"
-              style={collection?.color ? { background: collection.color } : undefined}
-            />
-          )}
-          <span className="document-browser__section-title">{title}</span>
-          <span className="document-browser__section-count">{docs.length}</span>
-        </button>
-        {showMenu && collection && (
-          <div className="document-browser__section-menu-wrap" ref={menuRef}>
-            <button
-              className="document-browser__section-menu-btn"
-              onClick={onOpenMenu}
-              title="Collection actions"
-              aria-label="Collection actions"
-              aria-haspopup="menu"
-            >
-              <MoreHorizontal size={16} aria-hidden="true" />
-            </button>
-            {isMenuOpen && (
-              <div className="document-browser__section-menu" role="menu">
-                <button
-                  className="document-browser__assign-item"
-                  onClick={() => onRename?.(collection)}
-                >
-                  Rename…
-                </button>
-                <div className="document-browser__assign-sep" />
-                <div className="document-browser__swatch-row">
-                  {COLLECTION_SWATCHES.map((color) => (
-                    <button
-                      key={color}
-                      className="document-browser__swatch"
-                      style={{ background: color }}
-                      onClick={() => onRecolor?.(collection, color)}
-                      title={color}
-                    />
-                  ))}
-                  <button
-                    className="document-browser__swatch document-browser__swatch--clear"
-                    onClick={() => onRecolor?.(collection, undefined)}
-                    title="Clear colour"
-                    aria-label="Clear colour"
-                  >
-                    <X size={12} aria-hidden="true" />
-                  </button>
-                </div>
-                <div className="document-browser__assign-sep" />
-                <button
-                  className="document-browser__assign-item document-browser__assign-item--danger"
-                  onClick={() => onDelete?.(collection)}
-                >
-                  Delete collection
-                </button>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-      {!collapsed && (
-        <div
-          className={`document-browser__section-body ${view === 'grid' ? 'document-browser__section-body--grid' : ''}`}
-        >
-          {docs.length === 0 ? (
-            <div className="document-browser__section-empty">No documents in this collection.</div>
-          ) : (
-            docs.map((d) => renderCard(d))
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/** Check if user can delete a document */
-function canDelete(record: DocumentRecord, _userId?: string, userRole?: string): boolean {
-  if (record.type === 'local') return true;
-  if (record.type === 'remote' && record.permission === 'owner') return true;
-  if (record.type === 'remote' && userRole === 'admin') return true;
-  if (record.type === 'cached') return true;
-  return false;
-}
-
-/** Check if user can edit a document */
-function canEdit(record: DocumentRecord, _userId?: string, userRole?: string): boolean {
-  if (record.type === 'local') return true;
-  if (record.type === 'remote' && (record.permission === 'owner' || record.permission === 'editor')) return true;
-  if (record.type === 'remote' && userRole === 'admin') return true;
-  if (record.type === 'cached') return true;
-  return false;
-}
-
-/** Check if user can manage permissions on a document */
-function canManagePermissions(
-  record: DocumentRecord,
-  isInTeamMode: boolean,
-  _userId?: string,
-  userRole?: string
-): boolean {
-  if (!isInTeamMode) return false;
-  if (record.type !== 'remote') return false;
-  if (record.permission === 'owner') return true;
-  if (userRole === 'admin') return true;
-  return false;
-}
-
-/**
- * Check if user can publish a document to the team. Gated on a usable relay
- * session (valid cached token), NOT a live WS — transfers run over the REST
- * provider, which survives leaving a doc, so being on a local doc must not hide
- * the action (JP-211 transfer-gating bug).
- */
-function canPublishToTeam(record: DocumentRecord, relayUsable: boolean): boolean {
-  if (!relayUsable) return false;
-  return record.type === 'local';
-}
-
-/** Check if user can move a relay document back to personal. Gated on a usable
- *  relay session (valid cached token), not the live WS (see canPublishToTeam). */
-function canMoveToPersonal(
-  record: DocumentRecord,
-  relayUsable: boolean,
-  userId?: string,
-  userRole?: string
-): boolean {
-  if (record.type !== 'remote') return false;
-  if (!relayUsable) return false;
-  return record.permission === 'owner' || record.ownerId === userId || userRole === 'admin';
 }
 
 export default DocumentBrowser;

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -1,0 +1,353 @@
+/**
+ * DocumentList — presentational document grid/list fed by `useDocumentBrowserModel`.
+ *
+ * Renders the card area (flat list, collection-grouped sections, or empty
+ * state) plus the multi-select `SelectionBar`. No document logic of its own —
+ * every action comes from the model. Shared by the legacy Settings-tab
+ * `DocumentBrowser` chrome and the first-class `DocumentsHome` surface (JP-218).
+ */
+
+import { useRef, useEffect } from 'react';
+import { ChevronDown, MoreHorizontal, X } from 'lucide-react';
+import { DocumentCard } from '../DocumentCard';
+import { COLLECTION_SWATCHES, type Collection } from '../../store/collectionStore';
+import type { DocumentBrowserView } from '../../store/uiPreferencesStore';
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+import {
+  canDelete,
+  canEdit,
+  canManagePermissions,
+  canPublishToTeam,
+  canMoveToPersonal,
+  type DocumentBrowserModel,
+} from './useDocumentBrowserModel';
+
+interface DocumentListProps {
+  model: DocumentBrowserModel;
+  /** Compact card layout for narrow sidebar usage. */
+  compact?: boolean;
+  /** Called after a document is opened (e.g. so a host surface can leave the browser). */
+  onOpened?: (id: string) => void;
+}
+
+export function DocumentList({ model, compact = false, onOpened }: DocumentListProps) {
+  const {
+    documentList,
+    groupedSections,
+    view,
+    searchQuery,
+    filterMode,
+    collapsedMap,
+    toggleCollapsed,
+    activeCollectionMenu,
+    setActiveCollectionMenu,
+    handleRenameCollection,
+    handleDeleteCollection,
+    handleRecolor,
+    accentByDoc,
+    currentDocumentId,
+    selectedIds,
+    hasSelection,
+    isAvailableOffline,
+    offlineStatuses,
+    offlineProgress,
+    handleMakeAvailableOffline,
+    handleOpen,
+    handleSelectToggle,
+    currentUser,
+    handleDelete,
+    handleRename,
+    setPermissionsDocId,
+    isInTeamMode,
+    relaySessionUsable,
+    handlePublishToTeam,
+    handleMoveToPersonal,
+  } = model;
+
+  const cardMode: 'compact' | 'full' | 'grid' =
+    view === 'grid' ? 'grid' : compact ? 'compact' : 'full';
+
+  const onOpen = async (id: string) => {
+    await handleOpen(id);
+    onOpened?.(id);
+  };
+
+  const renderCard = (record: DocumentRecord) => {
+    const accent = accentByDoc.get(record.id);
+    return (
+      <DocumentCard
+        key={record.id}
+        record={record}
+        isActive={record.id === currentDocumentId}
+        isSelected={selectedIds.has(record.id)}
+        showSelectionCheckbox={hasSelection}
+        isOfflineAvailable={record.type === 'remote' && isAvailableOffline(record.id)}
+        onOpen={onOpen}
+        onSelectToggle={handleSelectToggle}
+        onDelete={canDelete(record, currentUser?.id, currentUser?.role) ? handleDelete : undefined}
+        onRename={canEdit(record, currentUser?.id, currentUser?.role) ? handleRename : undefined}
+        onEditPermissions={
+          canManagePermissions(record, isInTeamMode, currentUser?.id, currentUser?.role)
+            ? setPermissionsDocId
+            : undefined
+        }
+        onPublishToTeam={canPublishToTeam(record, relaySessionUsable) ? handlePublishToTeam : undefined}
+        onMoveToPersonal={canMoveToPersonal(record, relaySessionUsable, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
+        collectionAccent={accent}
+        connectedRelayAddress={model.connectedRelayAddress}
+        offlineStatus={offlineStatuses.get(record.id)}
+        offlineProgress={offlineProgress.get(record.id) ?? null}
+        onMakeAvailableOffline={record.type !== 'local' ? handleMakeAvailableOffline : undefined}
+        mode={cardMode}
+      />
+    );
+  };
+
+  return (
+    <div className={`document-browser__list ${view === 'grid' ? 'document-browser__list--grid' : ''}`}>
+      {documentList.length === 0 ? (
+        <div className="document-browser__empty">
+          {searchQuery ? (
+            <p>No documents match your search.</p>
+          ) : filterMode !== 'all' ? (
+            <p>No {filterMode === 'local' ? 'personal' : filterMode} documents.</p>
+          ) : (
+            <p>No documents yet. Create a new one to get started!</p>
+          )}
+        </div>
+      ) : groupedSections ? (
+        groupedSections.map(({ key, collection, docs }) => {
+          if (docs.length === 0 && collection === null) return null;
+          const collapsed = collapsedMap[key] === true;
+          return (
+            <CollectionSection
+              key={key}
+              collection={collection}
+              docs={docs}
+              collapsed={collapsed}
+              onToggle={() => toggleCollapsed(key)}
+              view={view}
+              renderCard={renderCard}
+              isMenuOpen={activeCollectionMenu === key}
+              onOpenMenu={() => setActiveCollectionMenu(activeCollectionMenu === key ? null : key)}
+              onCloseMenu={() => setActiveCollectionMenu(null)}
+              onRename={handleRenameCollection}
+              onDelete={handleDeleteCollection}
+              onRecolor={handleRecolor}
+            />
+          );
+        })
+      ) : (
+        documentList.map((record) => renderCard(record))
+      )}
+    </div>
+  );
+}
+
+/**
+ * SelectionBar — bulk-action affordance shown when documents are multi-selected.
+ * Extracted so both browser chromes reuse it.
+ */
+export function SelectionBar({ model }: { model: DocumentBrowserModel }) {
+  const {
+    selectedIds,
+    collections,
+    assignMenuOpen,
+    setAssignMenuOpen,
+    handleBulkAssign,
+    handleBulkAssignNewCollection,
+    handleBulkExport,
+    handleBulkDelete,
+    clearSelection,
+  } = model;
+
+  return (
+    <div className="document-browser__selection-bar">
+      <span className="document-browser__selection-count">{selectedIds.size} selected</span>
+      <div className="document-browser__selection-actions">
+        <div className="document-browser__assign-wrap">
+          <button
+            className="document-browser__bulk-btn"
+            onClick={() => setAssignMenuOpen((v) => !v)}
+          >
+            Assign to collection ▾
+          </button>
+          {assignMenuOpen && (
+            <div className="document-browser__assign-menu" role="menu">
+              <button className="document-browser__assign-item" onClick={() => handleBulkAssign(null)}>
+                Remove from collection
+              </button>
+              {collections.length > 0 && <div className="document-browser__assign-sep" />}
+              {collections.map((c) => (
+                <button
+                  key={c.id}
+                  className="document-browser__assign-item"
+                  onClick={() => handleBulkAssign(c.id)}
+                >
+                  <span
+                    className="document-browser__assign-swatch"
+                    style={c.color ? { background: c.color } : undefined}
+                  />
+                  {c.name}
+                </button>
+              ))}
+              <div className="document-browser__assign-sep" />
+              <button
+                className="document-browser__assign-item document-browser__assign-item--new"
+                onClick={handleBulkAssignNewCollection}
+              >
+                + New collection…
+              </button>
+            </div>
+          )}
+        </div>
+        <button className="document-browser__bulk-btn" onClick={handleBulkExport}>
+          Export
+        </button>
+        <button
+          className="document-browser__bulk-btn document-browser__bulk-btn--danger"
+          onClick={handleBulkDelete}
+        >
+          Delete
+        </button>
+        <button className="document-browser__bulk-btn" onClick={clearSelection}>
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface CollectionSectionProps {
+  collection: Collection | null;
+  docs: DocumentRecord[];
+  collapsed: boolean;
+  view: DocumentBrowserView;
+  onToggle: () => void;
+  renderCard: (record: DocumentRecord) => React.ReactNode;
+  // Collection menu props — only supplied for user-defined collection sections.
+  isMenuOpen?: boolean | undefined;
+  onOpenMenu?: (() => void) | undefined;
+  onCloseMenu?: (() => void) | undefined;
+  onRename?: ((collection: Collection) => void) | undefined;
+  onDelete?: ((collection: Collection) => void) | undefined;
+  onRecolor?: ((collection: Collection, color: string | undefined) => void) | undefined;
+}
+
+function CollectionSection({
+  collection,
+  docs,
+  collapsed,
+  view,
+  onToggle,
+  renderCard,
+  isMenuOpen,
+  onOpenMenu,
+  onCloseMenu,
+  onRename,
+  onDelete,
+  onRecolor,
+}: CollectionSectionProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isMenuOpen || !onCloseMenu) return;
+    const onDoc = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onCloseMenu();
+      }
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [isMenuOpen, onCloseMenu]);
+
+  const isUnassigned = collection === null;
+  // Show the collection-actions menu + swatch only for real user-defined
+  // collections, never for the unassigned section.
+  const showMenu = collection !== null;
+  const showSwatch = !isUnassigned;
+  const title = collection !== null ? collection.name : 'Unassigned';
+  return (
+    <div className="document-browser__section">
+      <div className="document-browser__section-header">
+        <button
+          className="document-browser__section-toggle"
+          onClick={onToggle}
+          aria-expanded={!collapsed}
+        >
+          <ChevronDown
+            className={`document-browser__caret ${collapsed ? 'document-browser__caret--collapsed' : ''}`}
+            size={14}
+            aria-hidden="true"
+          />
+          {showSwatch && (
+            <span
+              className="document-browser__section-swatch"
+              style={collection?.color ? { background: collection.color } : undefined}
+            />
+          )}
+          <span className="document-browser__section-title">{title}</span>
+          <span className="document-browser__section-count">{docs.length}</span>
+        </button>
+        {showMenu && collection && (
+          <div className="document-browser__section-menu-wrap" ref={menuRef}>
+            <button
+              className="document-browser__section-menu-btn"
+              onClick={onOpenMenu}
+              title="Collection actions"
+              aria-label="Collection actions"
+              aria-haspopup="menu"
+            >
+              <MoreHorizontal size={16} aria-hidden="true" />
+            </button>
+            {isMenuOpen && (
+              <div className="document-browser__section-menu" role="menu">
+                <button className="document-browser__assign-item" onClick={() => onRename?.(collection)}>
+                  Rename…
+                </button>
+                <div className="document-browser__assign-sep" />
+                <div className="document-browser__swatch-row">
+                  {COLLECTION_SWATCHES.map((color) => (
+                    <button
+                      key={color}
+                      className="document-browser__swatch"
+                      style={{ background: color }}
+                      onClick={() => onRecolor?.(collection, color)}
+                      title={color}
+                    />
+                  ))}
+                  <button
+                    className="document-browser__swatch document-browser__swatch--clear"
+                    onClick={() => onRecolor?.(collection, undefined)}
+                    title="Clear colour"
+                    aria-label="Clear colour"
+                  >
+                    <X size={12} aria-hidden="true" />
+                  </button>
+                </div>
+                <div className="document-browser__assign-sep" />
+                <button
+                  className="document-browser__assign-item document-browser__assign-item--danger"
+                  onClick={() => onDelete?.(collection)}
+                >
+                  Delete collection
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      {!collapsed && (
+        <div
+          className={`document-browser__section-body ${view === 'grid' ? 'document-browser__section-body--grid' : ''}`}
+        >
+          {docs.length === 0 ? (
+            <div className="document-browser__section-empty">No documents in this collection.</div>
+          ) : (
+            docs.map((d) => renderCard(d))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/settings/useDocumentBrowserModel.test.ts
+++ b/src/ui/settings/useDocumentBrowserModel.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure-logic coverage for the document-browser model (JP-218 extraction).
+ *
+ * The hook itself wires many zustand stores together (covered by manual /
+ * integration testing), but the sort comparator, permission gates, and
+ * transfer-error mapping it exports are pure and worth pinning — they decide
+ * ordering and which per-card affordances appear.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  compareRecords,
+  friendlyTransferError,
+  canDelete,
+  canEdit,
+  canManagePermissions,
+  canPublishToTeam,
+  canMoveToPersonal,
+} from './useDocumentBrowserModel';
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+
+/** Minimal record shape — the helpers only read these fields. */
+function rec(partial: Partial<DocumentRecord>): DocumentRecord {
+  return {
+    id: 'd',
+    name: 'Doc',
+    type: 'local',
+    createdAt: 0,
+    modifiedAt: 0,
+    ...partial,
+  } as DocumentRecord;
+}
+
+describe('compareRecords', () => {
+  const older = rec({ id: 'a', name: 'Alpha', createdAt: 100, modifiedAt: 100 });
+  const newer = rec({ id: 'b', name: 'Bravo', createdAt: 200, modifiedAt: 200 });
+
+  it('modified-desc puts most-recently-modified first', () => {
+    expect(compareRecords(older, newer, 'modified-desc')).toBeGreaterThan(0);
+    expect(compareRecords(newer, older, 'modified-desc')).toBeLessThan(0);
+  });
+
+  it('modified-asc reverses that', () => {
+    expect(compareRecords(older, newer, 'modified-asc')).toBeLessThan(0);
+  });
+
+  it('created-desc orders by createdAt', () => {
+    expect(compareRecords(older, newer, 'created-desc')).toBeGreaterThan(0);
+  });
+
+  it('name-asc / name-desc order case-insensitively', () => {
+    const lower = rec({ name: 'apple' });
+    const upper = rec({ name: 'Banana' });
+    expect(compareRecords(lower, upper, 'name-asc')).toBeLessThan(0);
+    expect(compareRecords(lower, upper, 'name-desc')).toBeGreaterThan(0);
+  });
+
+  it('sorts a list deterministically by modified-desc', () => {
+    const list = [older, newer];
+    const sorted = [...list].sort((x, y) => compareRecords(x, y, 'modified-desc'));
+    expect(sorted.map((r) => r.id)).toEqual(['b', 'a']);
+  });
+});
+
+describe('friendlyTransferError', () => {
+  it('maps known status families to actionable copy', () => {
+    expect(friendlyTransferError('HTTP 401 unauthorized')).toMatch(/sign in again/i);
+    expect(friendlyTransferError('403 forbidden')).toMatch(/owner/i);
+    expect(friendlyTransferError('413 payload too large')).toMatch(/too large/i);
+    expect(friendlyTransferError('409 version conflict')).toMatch(/changed since/i);
+    expect(friendlyTransferError('network fetch failed')).toMatch(/connection/i);
+  });
+
+  it('falls back to the raw message and handles undefined', () => {
+    expect(friendlyTransferError('weird relay glitch 555')).toBe('weird relay glitch 555');
+    expect(friendlyTransferError(undefined)).toBe('Unknown error');
+  });
+});
+
+describe('permission gates', () => {
+  it('canDelete: local + cached always; remote only owner/admin', () => {
+    expect(canDelete(rec({ type: 'local' }))).toBe(true);
+    expect(canDelete(rec({ type: 'cached' }))).toBe(true);
+    expect(canDelete(rec({ type: 'remote', permission: 'owner' }))).toBe(true);
+    expect(canDelete(rec({ type: 'remote', permission: 'editor' }))).toBe(false);
+    expect(canDelete(rec({ type: 'remote', permission: 'editor' }), 'u', 'admin')).toBe(true);
+  });
+
+  it('canEdit: editors can edit remote, viewers cannot', () => {
+    expect(canEdit(rec({ type: 'remote', permission: 'editor' }))).toBe(true);
+    expect(canEdit(rec({ type: 'remote', permission: 'viewer' }))).toBe(false);
+    expect(canEdit(rec({ type: 'remote', permission: 'viewer' }), 'u', 'admin')).toBe(true);
+  });
+
+  it('canManagePermissions: only remote owner/admin while in team mode', () => {
+    expect(canManagePermissions(rec({ type: 'remote', permission: 'owner' }), true)).toBe(true);
+    expect(canManagePermissions(rec({ type: 'remote', permission: 'owner' }), false)).toBe(false);
+    expect(canManagePermissions(rec({ type: 'local' }), true)).toBe(false);
+  });
+
+  it('canPublishToTeam: local docs only, and only with a usable relay session', () => {
+    expect(canPublishToTeam(rec({ type: 'local' }), true)).toBe(true);
+    expect(canPublishToTeam(rec({ type: 'local' }), false)).toBe(false);
+    expect(canPublishToTeam(rec({ type: 'remote' }), true)).toBe(false);
+  });
+
+  it('canMoveToPersonal: remote owner/admin/self with a usable relay session', () => {
+    expect(canMoveToPersonal(rec({ type: 'remote', permission: 'owner' }), true)).toBe(true);
+    expect(canMoveToPersonal(rec({ type: 'remote', permission: 'owner' }), false)).toBe(false);
+    expect(canMoveToPersonal(rec({ type: 'remote', permission: 'editor', ownerId: 'u' }), true, 'u')).toBe(true);
+    expect(canMoveToPersonal(rec({ type: 'remote', permission: 'editor', ownerId: 'x' }), true, 'u')).toBe(false);
+    expect(canMoveToPersonal(rec({ type: 'local' }), true)).toBe(false);
+  });
+});

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -1,0 +1,870 @@
+/**
+ * useDocumentBrowserModel — the headless engine behind the document browser.
+ *
+ * All the filtering / sorting / grouping / selection / transfer / collection
+ * logic that used to live inside `DocumentBrowser.tsx` lives here, so it can be
+ * driven by more than one chrome: the (legacy) Settings tab and the first-class
+ * `DocumentsHome` surface (JP-218). The component(s) render the model; they own
+ * no document logic of their own.
+ *
+ * Nothing here is presentational — it returns plain data + callbacks. The card
+ * rendering lives in `DocumentList`, which consumes this model.
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useDocumentRegistry } from '../../store/documentRegistry';
+import { usePersistenceStore } from '../../store/persistenceStore';
+import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
+import { useRelayDocumentStore } from '../../store/relayDocumentStore';
+import {
+  computeOfflineStatus,
+  makeAvailableOffline,
+  type OfflineProgress,
+  type OfflineStatus,
+} from '../../store/offlineAvailability';
+import { useUserStore } from '../../store/userStore';
+import {
+  useUIPreferencesStore,
+  type DocumentBrowserSort,
+} from '../../store/uiPreferencesStore';
+import { useCollectionStore, type Collection } from '../../store/collectionStore';
+import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
+import { getTransferService } from '../../services/DocumentTransferService';
+import { useTransferStore, isTransferRunning } from '../../store/transferStore';
+import { useCollaborationStore, purgeLocalDocRoom } from '../../collaboration';
+import { getDocumentMetadata } from '../../types/Document';
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+
+/** Document type axis the nav rail / filter row toggles. */
+export type FilterMode = 'all' | 'local' | 'team' | 'cached';
+
+/** Section key for documents that belong to no collection. */
+export const UNASSIGNED_KEY = '__unassigned__';
+
+export function compareRecords(a: DocumentRecord, b: DocumentRecord, sort: DocumentBrowserSort): number {
+  switch (sort) {
+    case 'modified-desc':
+      return b.modifiedAt - a.modifiedAt;
+    case 'modified-asc':
+      return a.modifiedAt - b.modifiedAt;
+    case 'name-asc':
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    case 'name-desc':
+      return b.name.localeCompare(a.name, undefined, { sensitivity: 'base' });
+    case 'created-desc':
+      return b.createdAt - a.createdAt;
+  }
+}
+
+/**
+ * Map raw transfer error messages (often surfaced verbatim from the relay
+ * REST layer) onto something a non-engineer can act on. Falls back to the
+ * raw message when nothing matches so we never swallow a useful detail.
+ */
+export function friendlyTransferError(raw: string | undefined): string {
+  if (!raw) return 'Unknown error';
+  const lower = raw.toLowerCase();
+  if (lower.includes('401') || lower.includes('unauthorized') || lower.includes('token'))
+    return 'Relay session expired — please sign in again.';
+  if (lower.includes('403') || lower.includes('forbidden') || lower.includes('not owner'))
+    return 'Only the document owner can do that.';
+  if (lower.includes('413') || lower.includes('too large') || lower.includes('payload'))
+    return 'Document is too large for the relay.';
+  if (lower.includes('409') || lower.includes('version conflict'))
+    return 'The relay copy was changed since you opened it. Please reload and try again.';
+  if (lower.includes('network') || lower.includes('fetch') || lower.includes('timed out'))
+    return "Couldn't reach the relay. Check your connection and try again.";
+  return raw;
+}
+
+export const SORT_LABELS: Record<DocumentBrowserSort, string> = {
+  'modified-desc': 'Recently modified',
+  'modified-asc': 'Least recently modified',
+  'name-asc': 'Name (A–Z)',
+  'name-desc': 'Name (Z–A)',
+  'created-desc': 'Recently created',
+};
+
+/** A grouping bucket: a collection (or the synthetic "Unassigned") + its docs. */
+export interface GroupedSection {
+  key: string;
+  collection: Collection | null;
+  docs: DocumentRecord[];
+}
+
+export interface DocumentBrowserModel {
+  // Filtered data
+  documentList: DocumentRecord[];
+  groupedSections: GroupedSection[] | null;
+  documentCounts: { total: number; local: number; team: number; cached: number };
+  // Collections
+  collections: Collection[];
+  collectionsMap: Record<string, Collection>;
+  assignments: Record<string, string>;
+  accentByDoc: Map<string, { name: string; color?: string }>;
+  // Axis / view state
+  filterMode: FilterMode;
+  setFilterMode: (mode: FilterMode) => void;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  /** Nav-rail single-collection filter (null = no collection filter). */
+  collectionFilter: string | null;
+  setCollectionFilter: (id: string | null) => void;
+  view: ReturnType<typeof useUIPreferencesStore.getState>['documentBrowserView'];
+  sort: DocumentBrowserSort;
+  groupBy: ReturnType<typeof useUIPreferencesStore.getState>['documentBrowserGroupBy'];
+  setView: (v: ReturnType<typeof useUIPreferencesStore.getState>['documentBrowserView']) => void;
+  setSort: (s: DocumentBrowserSort) => void;
+  setGroupBy: (g: ReturnType<typeof useUIPreferencesStore.getState>['documentBrowserGroupBy']) => void;
+  collapsedMap: Record<string, boolean>;
+  toggleCollapsed: (key: string) => void;
+  // Selection
+  selectedIds: Set<string>;
+  hasSelection: boolean;
+  handleSelectToggle: (id: string, mods: { shift: boolean; meta: boolean }) => void;
+  clearSelection: () => void;
+  assignMenuOpen: boolean;
+  setAssignMenuOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+  activeCollectionMenu: string | null;
+  setActiveCollectionMenu: (v: string | null) => void;
+  // Dialog state
+  pdfExportOpen: boolean;
+  setPdfExportOpen: (v: boolean) => void;
+  permissionsDocId: string | null;
+  setPermissionsDocId: (v: string | null) => void;
+  // Offline cache surfacing (JP-281)
+  offlineStatuses: Map<string, OfflineStatus>;
+  offlineProgress: Map<string, OfflineProgress>;
+  // Flags / identity
+  isInTeamMode: boolean;
+  isConnectedToHost: boolean;
+  isHost: boolean;
+  relaySessionUsable: boolean;
+  connectedRelayAddress: string | undefined;
+  isAvailableOffline: (id: string) => boolean;
+  currentDocumentId: string | null;
+  currentUser: ReturnType<typeof useUserStore.getState>['currentUser'];
+  error: string | null;
+  isLoading: boolean;
+  transferPhase: ReturnType<typeof useTransferStore.getState>['phase'];
+  transferDirection: ReturnType<typeof useTransferStore.getState>['direction'];
+  // Document-level actions
+  handleNewDocument: () => void;
+  handleSave: () => void;
+  handleRefresh: () => void;
+  handleImport: () => void;
+  handleExport: () => void;
+  handleOpen: (docId: string) => Promise<void>;
+  handleDelete: (docId: string) => Promise<void>;
+  handleRename: (docId: string, newName: string) => void;
+  handlePublishToTeam: (docId: string) => Promise<void>;
+  handleMoveToPersonal: (docId: string) => Promise<void>;
+  handleMakeAvailableOffline: (id: string) => Promise<void>;
+  // Bulk actions
+  handleBulkAssign: (collectionId: string | null) => void;
+  handleBulkAssignNewCollection: () => void;
+  handleBulkDelete: () => Promise<void>;
+  handleBulkExport: () => Promise<void>;
+  // Collection management
+  handleCreateCollection: () => void;
+  handleRenameCollection: (collection: Collection) => void;
+  handleDeleteCollection: (collection: Collection) => void;
+  handleRecolor: (collection: Collection, color: string | undefined) => void;
+}
+
+export function useDocumentBrowserModel(): DocumentBrowserModel {
+  // Registry store
+  const entries = useDocumentRegistry((s) => s.entries);
+  const isFetchingRemote = useDocumentRegistry((s) => s.isFetchingRemote);
+  const registryError = useDocumentRegistry((s) => s.error);
+  const getFilteredDocuments = useDocumentRegistry((s) => s.getFilteredDocuments);
+  const setFilter = useDocumentRegistry((s) => s.setFilter);
+
+  // Persistence store
+  const currentDocumentId = usePersistenceStore((s) => s.currentDocumentId);
+  const newDocument = usePersistenceStore((s) => s.newDocument);
+  const saveDocument = usePersistenceStore((s) => s.saveDocument);
+  const loadDocument = usePersistenceStore((s) => s.loadDocument);
+  const deleteDocument = usePersistenceStore((s) => s.deleteDocument);
+  const renameDocument = usePersistenceStore((s) => s.renameDocument);
+
+  // Relay stores
+  const isRelayLive = useIsRelayAuthenticated();
+  const authenticated = useRelayDocumentStore((s) => s.authenticated);
+  const isLoadingList = useRelayDocumentStore((s) => s.isLoadingList);
+  const teamStoreError = useRelayDocumentStore((s) => s.error);
+  const fetchDocumentList = useRelayDocumentStore((s) => s.fetchDocumentList);
+  const loadRelayDocument = useRelayDocumentStore((s) => s.loadRelayDocument);
+  const deleteFromHost = useRelayDocumentStore((s) => s.deleteFromHost);
+  const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
+
+  // Whether we have a usable relay session for *transfers*. Gates the
+  // publish/move affordances on a VALID CACHED TOKEN, not the live WS — opening
+  // a local doc tears down the per-doc WS (ensureCollabSession → leaveDocument),
+  // which flips `isRelayLive`/`hostConnected` false even though the token + REST
+  // provider survive (preserveAuth). Transfers run over the REST provider, so
+  // they must stay available while signed in; otherwise being on a local doc
+  // confusingly hides the "Move to Relay" action (JP-211 transfer-gating bug).
+  const relaySessionUsable = useConnectionStore(
+    (s) => s.token !== null && (s.tokenExpiresAt === null || Date.now() < s.tokenExpiresAt),
+  );
+
+  // Currently-connected relay address (host:port) — drives per-card relay
+  // badges and the "By relay" section ordering. "Connected" must mean *actually
+  // connected*, not merely that a relay address is configured: opening a doc
+  // calls `connectionStore.setHost(address)` (engine start) even while offline,
+  // so keying off `host?.address` alone falsely flips every card to
+  // connected/synced. Gate on the real WS-connected signal (`hostConnected`,
+  // which only goes true on an authenticated connection).
+  const relayHostAddress = useConnectionStore((s) => s.host?.address);
+  const hostConnected = useRelayDocumentStore((s) => s.hostConnected);
+  const connectedRelayAddress = hostConnected ? relayHostAddress : undefined;
+
+  // User store
+  const currentUser = useUserStore((s) => s.currentUser);
+
+  // Transfer progress (Local ↔ Cloud)
+  const transferPhase = useTransferStore((s) => s.phase);
+  const transferDirection = useTransferStore((s) => s.direction);
+
+  // UI preferences
+  const view = useUIPreferencesStore((s) => s.documentBrowserView);
+  const sort = useUIPreferencesStore((s) => s.documentBrowserSort);
+  const groupBy = useUIPreferencesStore((s) => s.documentBrowserGroupBy);
+  const collapsedMap = useUIPreferencesStore((s) => s.documentBrowserCollapsed);
+  const setView = useUIPreferencesStore((s) => s.setDocumentBrowserView);
+  const setSort = useUIPreferencesStore((s) => s.setDocumentBrowserSort);
+  const setGroupBy = useUIPreferencesStore((s) => s.setDocumentBrowserGroupBy);
+  const toggleCollapsed = useUIPreferencesStore((s) => s.toggleDocumentBrowserGroupCollapsed);
+
+  // Collection store
+  const collectionsMap = useCollectionStore((s) => s.collections);
+  const assignments = useCollectionStore((s) => s.assignments);
+  const createCollection = useCollectionStore((s) => s.createCollection);
+  const renameCollectionAction = useCollectionStore((s) => s.renameCollection);
+  const recolorCollectionAction = useCollectionStore((s) => s.recolorCollection);
+  const deleteCollectionAction = useCollectionStore((s) => s.deleteCollection);
+  const assignMany = useCollectionStore((s) => s.assignMany);
+
+  const collections = useMemo<Collection[]>(
+    () => Object.values(collectionsMap).sort((a, b) => a.order - b.order),
+    [collectionsMap]
+  );
+
+  // Local state
+  const [filterMode, setFilterModeState] = useState<FilterMode>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [collectionFilter, setCollectionFilter] = useState<string | null>(null);
+  const [pdfExportOpen, setPdfExportOpen] = useState(false);
+  const [permissionsDocId, setPermissionsDocId] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
+  const [assignMenuOpen, setAssignMenuOpen] = useState(false);
+  const [activeCollectionMenu, setActiveCollectionMenu] = useState<string | null>(null);
+  // Offline-cache surfacing (JP-281): passive per-doc status + in-flight prefetch progress.
+  const [offlineStatuses, setOfflineStatuses] = useState<Map<string, OfflineStatus>>(new Map());
+  const [offlineProgress, setOfflineProgress] = useState<Map<string, OfflineProgress>>(new Map());
+
+  const isInTeamMode = isRelayLive;
+  const isConnectedToHost = isRelayLive && authenticated;
+  const isHost = false;
+
+  // Filtered + sorted documents (flat list — the same list used to drive grouping).
+  const documentList = useMemo(() => {
+    const allDocs = getFilteredDocuments();
+    let filtered = allDocs;
+    if (filterMode === 'local') {
+      filtered = allDocs.filter((d) => d.type === 'local');
+    } else if (filterMode === 'team') {
+      filtered = allDocs.filter((d) => d.type === 'remote');
+    } else if (filterMode === 'cached') {
+      filtered = allDocs.filter((d) => d.type === 'cached');
+    }
+
+    // Nav-rail single-collection filter (DocumentsHome). Independent of the
+    // type axis above so "Local + Collection X" composes naturally.
+    if (collectionFilter !== null) {
+      filtered = filtered.filter((d) => assignments[d.id] === collectionFilter);
+    }
+
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter((d) => d.name.toLowerCase().includes(query));
+    }
+
+    return [...filtered].sort((a, b) => compareRecords(a, b, sort));
+  }, [entries, getFilteredDocuments, filterMode, collectionFilter, assignments, searchQuery, sort]);
+
+  // JP-281: compute each relay-backed doc's offline-ready status from local
+  // caches (network-free). Recomputes when the list or registry changes so the
+  // badge reflects view-driven caching that lands in the background.
+  useEffect(() => {
+    let cancelled = false;
+    const records = documentList.filter((d) => d.type !== 'local');
+    if (records.length === 0) {
+      setOfflineStatuses((prev) => (prev.size === 0 ? prev : new Map()));
+      return;
+    }
+    // allSettled (not all): one doc whose status can't be computed must not wipe
+    // every other doc's badge. Merge results so unaffected entries keep their
+    // refs, and prune statuses for docs that left the list.
+    const liveIds = new Set(records.map((r) => r.id));
+    void Promise.allSettled(records.map((r) => computeOfflineStatus(r))).then((results) => {
+      if (cancelled) return;
+      setOfflineStatuses((prev) => {
+        const next = new Map(prev);
+        results.forEach((res, i) => {
+          if (res.status === 'fulfilled') next.set(records[i]!.id, res.value);
+        });
+        for (const id of next.keys()) {
+          if (!liveIds.has(id)) next.delete(id);
+        }
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [documentList]);
+
+  // JP-281: proactively cache a doc's body + all referenced blobs for offline use.
+  const handleMakeAvailableOffline = useCallback(async (id: string) => {
+    const record = useDocumentRegistry.getState().getRecord(id);
+    if (!record) return;
+    setOfflineProgress((m) => new Map(m).set(id, { done: 0, total: 0 }));
+    try {
+      const status = await makeAvailableOffline(record, (p) => {
+        setOfflineProgress((m) => new Map(m).set(id, p));
+      });
+      setOfflineStatuses((m) => new Map(m).set(id, status));
+    } catch (e) {
+      console.warn('[DocumentBrowser] Make available offline failed:', id, e);
+    } finally {
+      setOfflineProgress((m) => {
+        const next = new Map(m);
+        next.delete(id);
+        return next;
+      });
+    }
+  }, []);
+
+  // Bucket documents by collection when grouping is enabled.
+  const groupedSections = useMemo<GroupedSection[] | null>(() => {
+    if (groupBy !== 'collection') return null;
+    const buckets = new Map<string, DocumentRecord[]>();
+    for (const doc of documentList) {
+      const cid = assignments[doc.id];
+      const key = cid && collectionsMap[cid] ? cid : UNASSIGNED_KEY;
+      const arr = buckets.get(key);
+      if (arr) arr.push(doc);
+      else buckets.set(key, [doc]);
+    }
+    const sections: GroupedSection[] = [];
+    for (const c of collections) {
+      sections.push({ key: c.id, collection: c, docs: buckets.get(c.id) ?? [] });
+    }
+    sections.push({
+      key: UNASSIGNED_KEY,
+      collection: null,
+      docs: buckets.get(UNASSIGNED_KEY) ?? [],
+    });
+    return sections;
+  }, [groupBy, documentList, assignments, collectionsMap, collections]);
+
+  // Count documents by type
+  const documentCounts = useMemo(() => {
+    const allDocs = Object.values(entries).map((e) => e.record);
+    return {
+      total: allDocs.length,
+      local: allDocs.filter((d) => d.type === 'local').length,
+      team: allDocs.filter((d) => d.type === 'remote').length,
+      cached: allDocs.filter((d) => d.type === 'cached').length,
+    };
+  }, [entries]);
+
+  // Clear selection when the visible list changes meaningfully.
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev;
+      const visible = new Set(documentList.map((d) => d.id));
+      const next = new Set<string>();
+      for (const id of prev) if (visible.has(id)) next.add(id);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [documentList]);
+
+  // Handlers
+  const handleNewDocument = useCallback(() => newDocument(), [newDocument]);
+  const handleSave = useCallback(() => saveDocument(), [saveDocument]);
+
+  const handleRefresh = useCallback(() => {
+    if (isConnectedToHost || isHost) fetchDocumentList();
+  }, [fetchDocumentList, isConnectedToHost, isHost]);
+
+  const handleOpen = useCallback(
+    async (docId: string) => {
+      if (docId === currentDocumentId) return;
+      const entry = entries[docId];
+      if (!entry) return;
+      const record = entry.record;
+      if (record.type === 'remote' || record.type === 'cached') {
+        try {
+          const doc = await loadRelayDocument(docId);
+          usePersistenceStore.getState().loadRemoteDocument(doc);
+        } catch (error) {
+          console.error('Failed to load relay document:', error);
+        }
+      } else {
+        loadDocument(docId);
+      }
+    },
+    [currentDocumentId, entries, loadRelayDocument, loadDocument]
+  );
+
+  const handleDelete = useCallback(
+    async (docId: string) => {
+      const entry = entries[docId];
+      if (!entry) return;
+      const record = entry.record;
+      if (record.type === 'remote') {
+        try {
+          await deleteFromHost(docId);
+        } catch (error) {
+          console.error('Failed to delete relay document:', error);
+        }
+        // Purge the doc's local prose CRDT room so its y-indexeddb DB doesn't
+        // linger forever (leaveDocument keeps room data on disk; nothing else
+        // cleans it on delete) and can't stale-merge if the id is ever reused.
+        // Best-effort: a no-op if the doc is currently open (its room is locked).
+        await purgeLocalDocRoom(docId);
+      } else {
+        deleteDocument(docId);
+      }
+    },
+    [entries, deleteFromHost, deleteDocument]
+  );
+
+  const handleRename = useCallback(
+    (docId: string, newName: string) => {
+      if (docId === currentDocumentId) renameDocument(newName);
+    },
+    [currentDocumentId, renameDocument]
+  );
+
+  const handlePublishToTeam = useCallback(
+    async (docId: string) => {
+      if (!currentUser?.id) return;
+      if (isTransferRunning(useTransferStore.getState().phase)) {
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore.getState().warning('A document transfer is already in progress.');
+        return;
+      }
+      const service = getTransferService();
+      if (!service) {
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore.getState().error('Transfer service not ready');
+        return;
+      }
+
+      // Persist any unsaved edits before snapshotting for transfer.
+      if (docId === currentDocumentId) {
+        saveDocument();
+      }
+
+      useTransferStore.getState().begin(docId, 'to-relay');
+      const result = await service.transferToTeam(docId, {
+        onProgress: (phase) => useTransferStore.getState().setPhase(phase),
+      });
+      if (!result.success) {
+        useTransferStore.getState().fail(friendlyTransferError(result.error));
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore
+          .getState()
+          .error(`Move to Relay failed: ${friendlyTransferError(result.error)}`);
+        return;
+      }
+      useDocumentRegistry.getState().removeDocument(docId);
+
+      // Purge any stale local prose CRDT room BEFORE the doc re-joins as a relay
+      // doc. A doc previously moved Cloud→Personal keeps its `host:docId`
+      // y-indexeddb room on disk; without this, re-promote reloads that stale
+      // prose and merges it with the relay's fresh re-seed from richTextPages —
+      // duplicating every page (JP-282). richTextPages (just saved to the relay)
+      // is the source of truth, so the client adopts the relay copy cleanly.
+      await purgeLocalDocRoom(docId);
+
+      await fetchDocumentList();
+
+      // If the promoted doc is the one open in the editor and we have an
+      // authenticated relay session, join it on the relay so edits sync
+      // immediately (convert-in-place keeps the same id). This is what turns
+      // the post-sign-in "JOIN_DOC for unknown doc" rejection into a real
+      // synced session.
+      if (docId === currentDocumentId && isConnectedToHost) {
+        useCollaborationStore.getState().switchDocument(docId);
+      }
+      useTransferStore.getState().reset();
+    },
+    [currentDocumentId, saveDocument, fetchDocumentList, currentUser, isConnectedToHost]
+  );
+
+  const handleMoveToPersonal = useCallback(
+    async (docId: string) => {
+      const entry = entries[docId];
+      if (!entry) return;
+      const record = entry.record;
+      if (record.type !== 'remote') return;
+      if (isTransferRunning(useTransferStore.getState().phase)) {
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore.getState().warning('A document transfer is already in progress.');
+        return;
+      }
+      const service = getTransferService();
+      if (!service) {
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore.getState().error('Transfer service not ready');
+        return;
+      }
+      try {
+        // Pull the latest snapshot from the relay into localStorage so the
+        // transfer service can read it as the source-of-truth before
+        // mutating its relay-side fields.
+        const doc = await loadRelayDocument(docId);
+        usePersistenceStore.getState().loadRemoteDocument(doc);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to fetch relay document';
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore
+          .getState()
+          .error(`Move to Personal failed: ${friendlyTransferError(message)}`);
+        return;
+      }
+
+      useTransferStore.getState().begin(docId, 'to-personal');
+      const result = await service.transferToPersonal(docId, {
+        onProgress: (phase) => useTransferStore.getState().setPhase(phase),
+      });
+      if (!result.success) {
+        useTransferStore.getState().fail(friendlyTransferError(result.error));
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore
+          .getState()
+          .error(`Move to Personal failed: ${friendlyTransferError(result.error)}`);
+        return;
+      }
+      // The doc was just DELETEd from the relay, so refresh the remote list
+      // (it'll be absent from it now) and then re-register the converted doc as
+      // Local. fetchDocumentList only ever registers *remote* docs, so without
+      // this registerLocal the now-personal doc would vanish from the browser
+      // even though its data is safely in localStorage.
+      await fetchDocumentList();
+      if (result.document) {
+        useDocumentRegistry.getState().registerLocal(getDocumentMetadata(result.document));
+      }
+      useTransferStore.getState().reset();
+    },
+    [entries, loadRelayDocument, fetchDocumentList]
+  );
+
+  const handleExport = useCallback(() => {
+    if (!currentDocumentId) return;
+    saveDocument();
+    exportAndDownloadDocumentArchive(currentDocumentId).catch((err) => {
+      console.error('Failed to export document archive:', err);
+    });
+  }, [currentDocumentId, saveDocument]);
+
+  const handleImport = useCallback(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.docushark';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) {
+        importDocumentArchive(file).catch((err) => {
+          console.error('Failed to import document archive:', err);
+        });
+      }
+    };
+    input.click();
+  }, []);
+
+  const setFilterMode = useCallback(
+    (mode: FilterMode) => {
+      setFilterModeState(mode);
+      const types: ('local' | 'remote' | 'cached')[] =
+        mode === 'all'
+          ? ['local', 'remote', 'cached']
+          : mode === 'local'
+            ? ['local']
+            : mode === 'team'
+              ? ['remote']
+              : ['cached'];
+      setFilter({ types });
+    },
+    [setFilter]
+  );
+
+  // Multi-select handlers
+  const handleSelectToggle = useCallback(
+    (id: string, mods: { shift: boolean; meta: boolean }) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (mods.shift && lastSelectedId && lastSelectedId !== id) {
+          const ids = documentList.map((d) => d.id);
+          const a = ids.indexOf(lastSelectedId);
+          const b = ids.indexOf(id);
+          if (a !== -1 && b !== -1) {
+            const [start, end] = a < b ? [a, b] : [b, a];
+            for (let i = start; i <= end; i++) {
+              const v = ids[i];
+              if (v !== undefined) next.add(v);
+            }
+            return next;
+          }
+        }
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+      setLastSelectedId(id);
+    },
+    [documentList, lastSelectedId]
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    setLastSelectedId(null);
+  }, []);
+
+  // Clear selection when filters / sort / grouping change.
+  useEffect(() => {
+    clearSelection();
+  }, [filterMode, collectionFilter, sort, groupBy, clearSelection]);
+
+  const handleBulkAssign = useCallback(
+    (collectionId: string | null) => {
+      assignMany(Array.from(selectedIds), collectionId);
+      setAssignMenuOpen(false);
+    },
+    [assignMany, selectedIds]
+  );
+
+  const handleBulkAssignNewCollection = useCallback(() => {
+    const name = window.prompt('New collection name');
+    if (!name || !name.trim()) return;
+    const id = createCollection(name);
+    if (id) assignMany(Array.from(selectedIds), id);
+    setAssignMenuOpen(false);
+  }, [assignMany, createCollection, selectedIds]);
+
+  const handleBulkDelete = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    const deletable = ids.filter((id) => {
+      const entry = entries[id];
+      if (!entry) return false;
+      return canDelete(entry.record, currentUser?.id, currentUser?.role);
+    });
+    if (deletable.length === 0) return;
+    if (!window.confirm(`Delete ${deletable.length} document(s)? This cannot be undone.`)) return;
+    for (const id of deletable) {
+      await handleDelete(id);
+    }
+    clearSelection();
+  }, [selectedIds, entries, currentUser, handleDelete, clearSelection]);
+
+  const handleBulkExport = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    for (const id of ids) {
+      try {
+        await exportAndDownloadDocumentArchive(id);
+      } catch (err) {
+        console.error('Failed to export', id, err);
+      }
+    }
+  }, [selectedIds]);
+
+  // Collection management
+  const handleCreateCollection = useCallback(() => {
+    const name = window.prompt('New collection name');
+    if (!name || !name.trim()) return;
+    createCollection(name);
+  }, [createCollection]);
+
+  const handleRenameCollection = useCallback(
+    (collection: Collection) => {
+      const name = window.prompt('Rename collection', collection.name);
+      if (!name) return;
+      renameCollectionAction(collection.id, name);
+      setActiveCollectionMenu(null);
+    },
+    [renameCollectionAction]
+  );
+
+  const handleDeleteCollection = useCallback(
+    (collection: Collection) => {
+      if (!window.confirm(`Delete collection "${collection.name}"? Documents in it will become Unassigned.`)) return;
+      deleteCollectionAction(collection.id);
+      setActiveCollectionMenu(null);
+    },
+    [deleteCollectionAction]
+  );
+
+  const handleRecolor = useCallback(
+    (collection: Collection, color: string | undefined) => {
+      recolorCollectionAction(collection.id, color);
+    },
+    [recolorCollectionAction]
+  );
+
+  const error = registryError || teamStoreError;
+  const isLoading = isFetchingRemote || isLoadingList;
+  const hasSelection = selectedIds.size > 0;
+
+  // Stable per-doc collection accent so DocumentCard's memo can skip cards
+  // unaffected by an action elsewhere (e.g. an offline-prefetch progress tick on
+  // another card no longer re-renders the whole list).
+  const accentByDoc = useMemo(() => {
+    const map = new Map<string, { name: string; color?: string }>();
+    if (groupBy === 'collection') return map; // membership shown via section headers instead
+    for (const docId of Object.keys(assignments)) {
+      const cid = assignments[docId];
+      const collection = cid ? collectionsMap[cid] : undefined;
+      if (!collection) continue;
+      map.set(
+        docId,
+        collection.color !== undefined
+          ? { name: collection.name, color: collection.color }
+          : { name: collection.name },
+      );
+    }
+    return map;
+  }, [assignments, collectionsMap, groupBy]);
+
+  return {
+    documentList,
+    groupedSections,
+    documentCounts,
+    collections,
+    collectionsMap,
+    assignments,
+    accentByDoc,
+    filterMode,
+    setFilterMode,
+    searchQuery,
+    setSearchQuery,
+    collectionFilter,
+    setCollectionFilter,
+    view,
+    sort,
+    groupBy,
+    setView,
+    setSort,
+    setGroupBy,
+    collapsedMap,
+    toggleCollapsed,
+    selectedIds,
+    hasSelection,
+    handleSelectToggle,
+    clearSelection,
+    assignMenuOpen,
+    setAssignMenuOpen,
+    activeCollectionMenu,
+    setActiveCollectionMenu,
+    pdfExportOpen,
+    setPdfExportOpen,
+    permissionsDocId,
+    setPermissionsDocId,
+    offlineStatuses,
+    offlineProgress,
+    isInTeamMode,
+    isConnectedToHost,
+    isHost,
+    relaySessionUsable,
+    connectedRelayAddress,
+    isAvailableOffline,
+    currentDocumentId,
+    currentUser,
+    error,
+    isLoading,
+    transferPhase,
+    transferDirection,
+    handleNewDocument,
+    handleSave,
+    handleRefresh,
+    handleImport,
+    handleExport,
+    handleOpen,
+    handleDelete,
+    handleRename,
+    handlePublishToTeam,
+    handleMoveToPersonal,
+    handleMakeAvailableOffline,
+    handleBulkAssign,
+    handleBulkAssignNewCollection,
+    handleBulkDelete,
+    handleBulkExport,
+    handleCreateCollection,
+    handleRenameCollection,
+    handleDeleteCollection,
+    handleRecolor,
+  };
+}
+
+/* ── Permission helpers (pure; shared by the list renderer) ─────────────────── */
+
+/** Check if user can delete a document */
+export function canDelete(record: DocumentRecord, _userId?: string, userRole?: string): boolean {
+  if (record.type === 'local') return true;
+  if (record.type === 'remote' && record.permission === 'owner') return true;
+  if (record.type === 'remote' && userRole === 'admin') return true;
+  if (record.type === 'cached') return true;
+  return false;
+}
+
+/** Check if user can edit a document */
+export function canEdit(record: DocumentRecord, _userId?: string, userRole?: string): boolean {
+  if (record.type === 'local') return true;
+  if (record.type === 'remote' && (record.permission === 'owner' || record.permission === 'editor')) return true;
+  if (record.type === 'remote' && userRole === 'admin') return true;
+  if (record.type === 'cached') return true;
+  return false;
+}
+
+/** Check if user can manage permissions on a document */
+export function canManagePermissions(
+  record: DocumentRecord,
+  isInTeamMode: boolean,
+  _userId?: string,
+  userRole?: string
+): boolean {
+  if (!isInTeamMode) return false;
+  if (record.type !== 'remote') return false;
+  if (record.permission === 'owner') return true;
+  if (userRole === 'admin') return true;
+  return false;
+}
+
+/**
+ * Check if user can publish a document to the team. Gated on a usable relay
+ * session (valid cached token), NOT a live WS — transfers run over the REST
+ * provider, which survives leaving a doc, so being on a local doc must not hide
+ * the action (JP-211 transfer-gating bug).
+ */
+export function canPublishToTeam(record: DocumentRecord, relayUsable: boolean): boolean {
+  if (!relayUsable) return false;
+  return record.type === 'local';
+}
+
+/** Check if user can move a relay document back to personal. Gated on a usable
+ *  relay session (valid cached token), not the live WS (see canPublishToTeam). */
+export function canMoveToPersonal(
+  record: DocumentRecord,
+  relayUsable: boolean,
+  userId?: string,
+  userRole?: string
+): boolean {
+  if (record.type !== 'remote') return false;
+  if (!relayUsable) return false;
+  return record.permission === 'owner' || record.ownerId === userId || userRole === 'admin';
+}


### PR DESCRIPTION
First slice of the **Documents area** rework — promotes document browsing out of the Settings modal into a first-class, full-bleed **Documents** surface (the IA problem JP-218 was filed for). Part of the JP-211 settings-rework epic; the brand kit was used as **styling inspiration only** (web-only concepts like multi-workspace switching / share links / collaborators intentionally dropped — this surfaces the editor's real model).

## Surface model
A top-level app *mode* (`appView: 'editor' | 'documents'`), not a modal. The editor stays mounted underneath so its state survives the round trip; you leave Documents by opening/creating a doc or the **Editor** back button.

## Reuse over rebuild
- **`useDocumentBrowserModel`** — headless hook holding all the filter/sort/group/selection/transfer/collection/offline logic previously locked inside the 1276-line `DocumentBrowser`. Adds a nav-rail single-collection filter.
- **`DocumentList` + `SelectionBar`** — presentational card area, shared by both chromes.
- **`DocumentBrowser`** — now thin Settings-tab chrome over the model (render preserved; Settings tab unchanged this slice).
- **`DocumentsHome`** — the new surface: sidebar (identity, nav rail All/Recents/Local/Cloud/Offline, Collections, a disabled **Trash** placeholder pending relay deletion signals / JP-175, local-storage foot, user + theme toggle) + main (header with search/sort/view/New, "Continue working" strip, shared list). Brand tokens from `index.css`.

## Entry points
"Documents" toolbar button · `Ctrl/Cmd+Shift+O` · "Go to Documents" in the command palette (dispatches `docushark:open-documents`, mirroring the import-diagram command).

## Scope / follow-up slices
- Storage foot shows **local** IndexedDB usage (graceful when WebKitGTK returns 0 quota). "Manage" + the cloud identity card route to the existing Settings tabs for now.
- **JP-215** (storage fold-in), **JP-213** (cloud/connection surface), brand polish, and **Settings slim-down** (removing the Documents/Storage/Relay tabs) are the remaining slices.

## Verification
- `bun run typecheck` clean.
- `bun run test --run` → **1937 passed** (incl. 12 new pure-logic tests for the sort comparator, permission gates, and transfer-error mapping). `DocumentBrowser` had no component test, so the extraction's net is typecheck + verbatim logic movement + the suite.
- The surface itself needs a manual `bun run dev` (and a relay for cloud docs) to E2E — not in-repo verifiable.

Assisted-by: Opus 4.8