### PR TITLE
JP-291: trash-bin foundation — client trashStore + blob-safe purge + GC mark-set

### DIFF
--- a/src/storage/BlobGarbageCollector.trash.test.ts
+++ b/src/storage/BlobGarbageCollector.trash.test.ts
@@ -1,0 +1,105 @@
+/**
+ * JP-291 — the blob GC must treat trashed documents as live referencers.
+ *
+ * The collector is scan-based off the *active* document index, so without
+ * unioning the trash mark-set, a document's blobs would be reclaimed the moment
+ * it left the active index for the trash. This guards that: a blob referenced
+ * only by a trashed doc survives, and is reclaimable again once the trash is
+ * emptied.
+ *
+ * IndexedDB-free: a fake `BlobStorage` is injected and the persistence module
+ * (active-doc source) is mocked; the trash side uses the real `TrashStorage`
+ * over a mocked localStorage.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the active-document source the GC scans. The trash side stays real.
+vi.mock('../store/persistenceStore', () => ({
+  usePersistenceStore: {
+    getState: () => ({
+      getDocumentList: () => [{ id: 'active-doc', modifiedAt: 1, name: 'Active' }],
+    }),
+  },
+  loadDocumentFromStorage: (id: string) =>
+    id === 'active-doc' ? { id, blobReferences: ['active-blob'] } : null,
+}));
+
+import { BlobGarbageCollector } from './BlobGarbageCollector';
+import type { BlobStorage } from './BlobStorage';
+import type { BlobMetadata } from './BlobTypes';
+import { moveToTrash, emptyTrash } from './TrashStorage';
+import type { DiagramDocument, DocumentMetadata } from '../types/Document';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+function blob(id: string): BlobMetadata {
+  return { id, size: 10, type: 'image/png', createdAt: 0, usageCount: 1 } as BlobMetadata;
+}
+
+/** Fake content-addressed store holding three blobs; records deletions. */
+function makeFakeStorage(deleted: Set<string>): BlobStorage {
+  const all = [blob('active-blob'), blob('trash-blob'), blob('orphan-blob')];
+  return {
+    listAllBlobs: async () => all.filter((b) => !deleted.has(b.id)),
+    deleteBlob: async (id: string) => { deleted.add(id); },
+  } as unknown as BlobStorage;
+}
+
+const doc = (id: string): DiagramDocument => ({
+  id,
+  name: id,
+  pages: {},
+  pageOrder: ['p1'],
+  activePageId: 'p1',
+  createdAt: 0,
+  modifiedAt: 0,
+  version: 1,
+});
+const meta = (id: string): DocumentMetadata => ({ id, name: id, createdAt: 0, modifiedAt: 0, pageCount: 1 });
+
+describe('BlobGarbageCollector + trash (JP-291)', () => {
+  beforeEach(() => localStorageMock.clear());
+
+  it('keeps a blob referenced only by a trashed doc, and reclaims it after empty', async () => {
+    moveToTrash(doc('trashed-doc'), meta('trashed-doc'), undefined, { blobReferences: ['trash-blob'] });
+
+    const deleted = new Set<string>();
+    const gc = new BlobGarbageCollector(makeFakeStorage(deleted));
+
+    // While trashed: only the truly-unreferenced blob is an orphan.
+    let orphans = (await gc.getOrphanedBlobs()).map((b) => b.id);
+    expect(orphans).toEqual(['orphan-blob']);
+
+    await gc.collectGarbage();
+    expect(deleted.has('trash-blob')).toBe(false); // survived
+    expect(deleted.has('active-blob')).toBe(false);
+    expect(deleted.has('orphan-blob')).toBe(true);
+
+    // Empty the trash → the trashed doc's blob is now reclaimable.
+    emptyTrash();
+    orphans = (await gc.getOrphanedBlobs()).map((b) => b.id);
+    expect(orphans).toContain('trash-blob');
+  });
+
+  it('incremental collection also honours the trash mark-set', async () => {
+    moveToTrash(doc('trashed-doc'), meta('trashed-doc'), undefined, { blobReferences: ['trash-blob'] });
+
+    const deleted = new Set<string>();
+    const gc = new BlobGarbageCollector(makeFakeStorage(deleted));
+
+    await gc.collectGarbageIncremental();
+    expect(deleted.has('trash-blob')).toBe(false);
+    expect(deleted.has('orphan-blob')).toBe(true);
+  });
+});

--- a/src/storage/BlobGarbageCollector.ts
+++ b/src/storage/BlobGarbageCollector.ts
@@ -2,6 +2,7 @@ import type { BlobStorage } from './BlobStorage';
 import type { BlobMetadata, GCStats } from './BlobTypes';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { loadDocumentFromStorage } from '../store/persistenceStore';
+import { getTrashedBlobReferences } from './TrashStorage';
 
 /**
  * Options for garbage collection.
@@ -271,6 +272,10 @@ export class BlobGarbageCollector {
           // Continue with other documents
         }
       }
+
+      // Trashed documents still hold their blobs (JP-291). Union them into the
+      // mark-set so the sweep doesn't reclaim blobs out from under the trash.
+      getTrashedBlobReferences().forEach((id) => references.add(id));
     } catch (error) {
       console.error('Failed to get document references:', error);
     }
@@ -336,6 +341,11 @@ export class BlobGarbageCollector {
           this.refCache.delete(cachedId);
         }
       }
+
+      // Trashed documents still hold their blobs (JP-291). Unioned in fresh each
+      // run (trash is bounded + reads snapshotted refs, so no per-doc caching
+      // needed) so the sweep never reclaims blobs a trashed doc still references.
+      getTrashedBlobReferences().forEach((id) => references.add(id));
     } catch (error) {
       console.error('Failed to get document references:', error);
     }

--- a/src/storage/TrashStorage.test.ts
+++ b/src/storage/TrashStorage.test.ts
@@ -9,6 +9,8 @@ import {
   getTrashItem,
   isInTrash,
   getTrashCount,
+  getTrashedBlobReferences,
+  getStoredTrashDocument,
   type TrashItem,
 } from './TrashStorage';
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
@@ -253,6 +255,86 @@ describe('TrashStorage', () => {
 
     it('returns false for non-trashed documents', () => {
       expect(isInTrash('doc-1')).toBe(false);
+    });
+  });
+
+  describe('kind / origin / blobReferences (JP-291)', () => {
+    it('defaults to local kind and snapshots blobReferences from the doc', () => {
+      const doc = { ...createTestDocument('doc-1', 'Test Doc'), blobReferences: ['blob-a', 'blob-b'] };
+      moveToTrash(doc, createTestMetadata('doc-1', 'Test Doc'));
+
+      const item = getTrashItem('doc-1');
+      expect(item?.kind).toBe('local');
+      expect(item?.blobReferences).toEqual(['blob-a', 'blob-b']);
+      expect(item?.origin).toBeUndefined();
+    });
+
+    it('records stranded kind + origin + explicit blobReferences', () => {
+      const doc = createTestDocument('doc-2', 'Stranded Doc');
+      moveToTrash(doc, createTestMetadata('doc-2', 'Stranded Doc'), undefined, {
+        kind: 'stranded',
+        origin: { relayId: 'relay-1', ownerId: 'user-1', lastSyncedAt: 123 },
+        blobReferences: ['blob-c'],
+      });
+
+      const item = getTrashItem('doc-2');
+      expect(item?.kind).toBe('stranded');
+      expect(item?.origin).toEqual({ relayId: 'relay-1', ownerId: 'user-1', lastSyncedAt: 123 });
+      expect(item?.blobReferences).toEqual(['blob-c']);
+    });
+
+    it('getStoredTrashDocument reads bytes without recovering', () => {
+      const doc = createTestDocument('doc-3', 'Test Doc');
+      moveToTrash(doc, createTestMetadata('doc-3', 'Test Doc'));
+
+      expect(getStoredTrashDocument('doc-3')?.id).toBe('doc-3');
+      expect(isInTrash('doc-3')).toBe(true); // still in trash
+      expect(getStoredTrashDocument('missing')).toBeNull();
+    });
+  });
+
+  describe('getTrashedBlobReferences (GC mark-set source)', () => {
+    it('unions blob refs across all non-expired trashed docs', () => {
+      moveToTrash(createTestDocument('doc-1', 'A'), createTestMetadata('doc-1', 'A'), undefined, {
+        blobReferences: ['blob-a', 'blob-shared'],
+      });
+      moveToTrash(createTestDocument('doc-2', 'B'), createTestMetadata('doc-2', 'B'), undefined, {
+        blobReferences: ['blob-b', 'blob-shared'],
+      });
+
+      const refs = getTrashedBlobReferences();
+      expect(refs).toEqual(new Set(['blob-a', 'blob-b', 'blob-shared']));
+    });
+
+    it('drops a doc\'s refs once it is purged (so the GC can reclaim)', () => {
+      moveToTrash(createTestDocument('doc-1', 'A'), createTestMetadata('doc-1', 'A'), undefined, {
+        blobReferences: ['blob-a'],
+      });
+      expect(getTrashedBlobReferences().has('blob-a')).toBe(true);
+
+      permanentlyDeleteFromTrash('doc-1');
+      expect(getTrashedBlobReferences().has('blob-a')).toBe(false);
+    });
+
+    it('falls back to the stored document for legacy items without blobReferences', () => {
+      // Simulate a pre-JP-291 trash entry: list item lacks blobReferences, but
+      // the stored document carries them.
+      const items: TrashItem[] = [
+        {
+          id: 'legacy-1',
+          name: 'Legacy',
+          deletedAt: Date.now(),
+          expiresAt: Date.now() + 100000,
+          originalMetadata: createTestMetadata('legacy-1', 'Legacy'),
+        },
+      ];
+      localStorageMock.setItem('docushark-trash', JSON.stringify(items));
+      localStorageMock.setItem(
+        'docushark-trash-doc-legacy-1',
+        JSON.stringify({ ...createTestDocument('legacy-1', 'Legacy'), blobReferences: ['legacy-blob'] })
+      );
+
+      expect(getTrashedBlobReferences().has('legacy-blob')).toBe(true);
     });
   });
 

--- a/src/storage/TrashStorage.ts
+++ b/src/storage/TrashStorage.ts
@@ -27,6 +27,30 @@ const MAX_TRASH_ITEMS = 50;
 // ============ Types ============
 
 /**
+ * Why a document is in the trash.
+ *
+ * - `local`    — a personal document the user soft-deleted (category 2).
+ * - `stranded` — a relay document hard-deleted out from under us; we kept the
+ *   last local copy here rather than wiping it (category 3, JP-175).
+ *
+ * A future `relay-soft` kind (category 1, a relay-side soft-delete that's still
+ * restorable on the server) is intentionally NOT stored here — it lives on the
+ * relay and is unioned into the trash view by its own source. See JP-294.
+ */
+export type TrashKind = 'local' | 'stranded';
+
+/**
+ * Provenance for a stranded relay document, so the trash UI can show where it
+ * came from (and a future restore-to-relay path has what it needs).
+ */
+export interface TrashOrigin {
+  relayId: string;
+  ownerId?: string;
+  /** Last time we were in sync with the relay before it was deleted. */
+  lastSyncedAt?: number;
+}
+
+/**
  * Metadata for a trashed document.
  */
 export interface TrashItem {
@@ -40,6 +64,32 @@ export interface TrashItem {
   expiresAt: number;
   /** Original document metadata */
   originalMetadata: DocumentMetadata;
+  /**
+   * Why this document is in the trash. Optional for backward-compat with items
+   * written before JP-291; absent is treated as `'local'`.
+   */
+  kind?: TrashKind;
+  /** Origin of a stranded relay document (kind === 'stranded'). */
+  origin?: TrashOrigin;
+  /**
+   * Blob hashes this document references, snapshotted at trash time. Lets the
+   * blob GC keep these blobs alive while the doc sits in trash WITHOUT loading
+   * the full document on every sweep (JP-291). Optional for backward-compat;
+   * absent falls back to reading the stored document.
+   */
+  blobReferences?: string[];
+}
+
+/** Options for {@link moveToTrash} beyond the legacy `retentionMs` positional. */
+export interface MoveToTrashOptions {
+  kind?: TrashKind;
+  origin?: TrashOrigin;
+  /**
+   * Blob hashes the document references. When omitted, falls back to the
+   * document's own `blobReferences` array. Callers that have the canonical
+   * whole-document walk (`collectBlobReferences`) should pass it explicitly.
+   */
+  blobReferences?: string[];
 }
 
 /**
@@ -108,7 +158,8 @@ function saveTrashItems(items: TrashItem[]): void {
 export function moveToTrash(
   doc: DiagramDocument,
   metadata: DocumentMetadata,
-  retentionMs: number = DEFAULT_RETENTION_MS
+  retentionMs: number = DEFAULT_RETENTION_MS,
+  options: MoveToTrashOptions = {}
 ): boolean {
   try {
     const now = Date.now();
@@ -124,7 +175,10 @@ export function moveToTrash(
       deletedAt: now,
       expiresAt: now + retentionMs,
       originalMetadata: metadata,
+      kind: options.kind ?? 'local',
+      blobReferences: options.blobReferences ?? doc.blobReferences ?? [],
     };
+    if (options.origin) trashItem.origin = options.origin;
 
     // Add to trash list
     const items = getTrashItems();
@@ -268,6 +322,46 @@ export function isInTrash(id: string): boolean {
  */
 export function getTrashCount(): number {
   return getTrashItems().length;
+}
+
+/**
+ * Read the full stored document for a trashed item, without recovering it
+ * (leaves it in trash). Returns null if the bytes aren't present.
+ */
+export function getStoredTrashDocument(id: string): DiagramDocument | null {
+  try {
+    const json = localStorage.getItem(`${TRASH_PREFIX}${id}`);
+    return json ? (JSON.parse(json) as DiagramDocument) : null;
+  } catch (error) {
+    console.error('[Trash] Failed to read stored trash document:', error);
+    return null;
+  }
+}
+
+/**
+ * Collect every blob hash referenced by the documents currently in trash.
+ *
+ * This is the trash half of the blob GC mark-set (JP-291): the
+ * `BlobGarbageCollector` is scan-based off the *active* document index, so a
+ * trashed document would otherwise lose its blobs on the next sweep. Unioning
+ * this into the mark-set keeps a trashed doc's blobs alive until it's purged,
+ * emptied, or expires — at which point it leaves this set and the next sweep
+ * reclaims them.
+ *
+ * Reads each item's snapshotted `blobReferences` (cheap); only falls back to
+ * loading the stored document for legacy items written before JP-291.
+ */
+export function getTrashedBlobReferences(): Set<string> {
+  const refs = new Set<string>();
+  for (const item of getTrashItems()) {
+    if (item.blobReferences) {
+      item.blobReferences.forEach((hash) => refs.add(hash));
+    } else {
+      const doc = getStoredTrashDocument(item.id);
+      doc?.blobReferences?.forEach((hash) => refs.add(hash));
+    }
+  }
+  return refs;
 }
 
 // ============ Internal Helpers ============

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -281,6 +281,12 @@ export interface PersistenceActions {
   loadDocument: (id: string) => boolean;
   /** Delete a document by ID */
   deleteDocument: (id: string) => void;
+  /**
+   * Adopt an existing document object into local storage as a personal
+   * document — used by the Trash to restore a trashed/stranded doc (JP-291).
+   * Strips relay-only fields so the restored copy is local-only.
+   */
+  adoptDocument: (doc: DiagramDocument) => void;
   /** Rename the current document */
   renameDocument: (name: string) => void;
   /** Export current document as JSON string */
@@ -877,6 +883,31 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         if (state.currentDocumentId === id) {
           get().newDocument();
         }
+      },
+
+      adoptDocument: (doc: DiagramDocument) => {
+        // Restore into the personal/local space: drop relay-only fields so the
+        // copy is local-only (a stranded relay doc can't go back to a relay
+        // that deleted it — see JP-175). Blob bytes stay in IndexedDB and are
+        // already kept alive via the trash mark-set, so refcounts are untouched.
+        const {
+          isRelayDocument: _isRelay,
+          serverVersion: _sv,
+          lockedBy: _lb,
+          lockedByName: _lbn,
+          lockedAt: _la,
+          ...rest
+        } = doc;
+        const localDoc: DiagramDocument = { ...rest, isRelayDocument: false };
+
+        saveDocumentToStorage(localDoc);
+        const metadata = getDocumentMetadata(localDoc);
+
+        set((state) => ({
+          documents: { ...state.documents, [localDoc.id]: metadata },
+        }));
+
+        useDocumentRegistry.getState().registerLocal(metadata);
       },
 
       // Rename the current document

--- a/src/store/trashStore.ts
+++ b/src/store/trashStore.ts
@@ -1,0 +1,151 @@
+/**
+ * Trash store (JP-291)
+ *
+ * The client-side substrate behind the Documents "Trash" bin. It aggregates the
+ * trashed documents the user can recover or purge, and orchestrates the *async*
+ * blob reclaim around the otherwise-synchronous `TrashStorage` calls.
+ *
+ * Three kinds of document end up in the trash (see the parent ask, JP-175):
+ *
+ *  - **local**    — a personal document the user soft-deleted.
+ *  - **stranded** — a relay document hard-deleted out from under us; we kept the
+ *    last local copy rather than wiping it.
+ *  - (future) **relay-soft** — a relay-side soft-delete still restorable on the
+ *    server (JP-294). It lives on the relay, not here; when that lands it gets
+ *    its own source and is unioned into the view — this store's shape leaves
+ *    room for it without a reshape.
+ *
+ * **Blob lifetime.** Trashing never releases a document's blobs; they're kept
+ * alive while the doc sits in trash because `BlobGarbageCollector` unions the
+ * trash mark-set in. Purging / emptying / expiring an entry removes it from that
+ * set, so a GC pass right after reclaims the now-unreferenced bytes. Restore
+ * puts the document back into the active index, so its blobs stay referenced and
+ * are never collected.
+ */
+
+import { create } from 'zustand';
+import type { DiagramDocument } from '../types/Document';
+import { getDocumentMetadata } from '../types/Document';
+import { collectBlobReferences } from '../storage/AssetBundler';
+import { blobStorage } from '../storage/BlobStorage';
+import { BlobGarbageCollector } from '../storage/BlobGarbageCollector';
+import {
+  getTrashItems,
+  moveToTrash,
+  recoverFromTrash,
+  permanentlyDeleteFromTrash,
+  emptyTrash,
+  cleanupExpiredTrash,
+  type TrashItem,
+  type TrashOrigin,
+} from '../storage/TrashStorage';
+import { usePersistenceStore } from './persistenceStore';
+
+/** Reused so the incremental ref cache survives across reclaim passes. */
+const gc = new BlobGarbageCollector(blobStorage);
+
+/**
+ * Reclaim blobs no longer referenced by any active OR trashed document. Called
+ * after an entry leaves the trash (purge/empty/expire). Best-effort — a failure
+ * just leaves the bytes for the next sweep; it must never break the trash op.
+ */
+async function reclaimOrphanedBlobs(): Promise<void> {
+  try {
+    await gc.collectGarbageIncremental();
+  } catch (error) {
+    console.warn('[trashStore] blob reclaim failed (will retry next sweep):', error);
+  }
+}
+
+interface TrashState {
+  /** Trashed documents, newest first. Mirror of `TrashStorage.getTrashItems()`. */
+  items: TrashItem[];
+}
+
+interface TrashActions {
+  /** Reload the in-memory list from storage. */
+  refresh: () => void;
+
+  /** Soft-delete a personal document into the trash (category 2). */
+  trashLocal: (doc: DiagramDocument) => void;
+
+  /**
+   * Strand a relay document into the trash (category 3): it was hard-deleted on
+   * the relay, but we keep our last local copy here rather than wiping it.
+   */
+  trashStranded: (doc: DiagramDocument, origin: TrashOrigin) => void;
+
+  /**
+   * Restore a trashed document. Both kinds come back as a *local* document — a
+   * stranded relay doc can't return to a relay that deleted it. Returns false
+   * if the bytes couldn't be read.
+   */
+  restore: (id: string) => Promise<boolean>;
+
+  /** Permanently delete one entry and reclaim its blobs. */
+  purge: (id: string) => Promise<void>;
+
+  /** Empty the entire trash and reclaim freed blobs. Returns items removed. */
+  emptyAll: () => Promise<number>;
+
+  /**
+   * Remove expired entries and reclaim their blobs. Safe to call on app start.
+   * Returns the number of entries swept.
+   */
+  expireSweep: () => Promise<number>;
+}
+
+export const useTrashStore = create<TrashState & TrashActions>((set, get) => ({
+  items: [],
+
+  refresh: () => set({ items: getTrashItems() }),
+
+  trashLocal: (doc) => {
+    moveToTrash(doc, getDocumentMetadata(doc), undefined, {
+      kind: 'local',
+      blobReferences: collectBlobReferences(doc),
+    });
+    get().refresh();
+  },
+
+  trashStranded: (doc, origin) => {
+    moveToTrash(doc, getDocumentMetadata(doc), undefined, {
+      kind: 'stranded',
+      origin,
+      blobReferences: collectBlobReferences(doc),
+    });
+    get().refresh();
+  },
+
+  restore: async (id) => {
+    const result = recoverFromTrash(id);
+    if (!result.success || !result.document) return false;
+    usePersistenceStore.getState().adoptDocument(result.document);
+    get().refresh();
+    return true;
+  },
+
+  purge: async (id) => {
+    permanentlyDeleteFromTrash(id);
+    get().refresh();
+    await reclaimOrphanedBlobs();
+  },
+
+  emptyAll: async () => {
+    const removed = emptyTrash();
+    get().refresh();
+    await reclaimOrphanedBlobs();
+    return removed;
+  },
+
+  expireSweep: async () => {
+    const swept = cleanupExpiredTrash();
+    if (swept > 0) {
+      get().refresh();
+      await reclaimOrphanedBlobs();
+    }
+    return swept;
+  },
+}));
+
+export default useTrashStore;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -36,6 +36,7 @@ import { initializePersistence, usePersistenceStore } from '../store/persistence
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { useTrashStore } from '../store/trashStore';
 import { ensureDocBlobsLocal } from '../store/offlineAvailability';
 import { useUserStore } from '../store/userStore';
 import { useConnectionStore } from '../store/connectionStore';
@@ -288,6 +289,10 @@ function App() {
 
     // Warmup relay document cache from IndexedDB (async, non-blocking)
     useRelayDocumentStore.getState().warmupCache().catch(console.error);
+
+    // Sweep expired trash + reclaim its blobs, then surface what remains in the
+    // bin for the Documents Trash view (JP-291). Non-blocking.
+    void useTrashStore.getState().expireSweep().then(() => useTrashStore.getState().refresh());
 
     // Ask the browser to make our storage persistent so it won't evict the
     // offline sync queue / relay cache under storage pressure (PWA durability;


### PR DESCRIPTION
Foundation slice for the Documents **Trash bin** (parent ask JP-175). Builds the client-side substrate the editor reaction (JP-175), the local-delete/permanent-delete wiring (JP-292), and the Trash view UI (JP-293) all sit on.

No delete path routes to trash yet, so this is **inert until those land** — but it's fully verifiable on its own.

## What's here
- **`TrashStorage`** — `TrashItem` gains `kind` (`'local' | 'stranded'`), `origin`, and a snapshotted `blobReferences` (all optional → back-compat with pre-JP-291 items). `moveToTrash` gets a 4th `options` arg (the legacy `retentionMs` stays the 3rd positional). New `getTrashedBlobReferences()` + `getStoredTrashDocument()`.
- **`BlobGarbageCollector`** — unions the **trash mark-set** into both the full and incremental reference scans. The GC is scan-based off the *active* doc index, so without this a doc would lose its blobs the moment it left the index for the trash. **This is the spine of "blobs stay reffed from trash."**
- **`trashStore`** (new) — aggregates trashed docs and orchestrates the *async* blob reclaim around the sync `TrashStorage` calls: `trashLocal` / `trashStranded` / `restore` / `purge` / `emptyAll` / `expireSweep`. Purge/empty/expire run a GC pass so freed bytes show immediately; restore re-adopts as a local doc.
- **`persistenceStore.adoptDocument`** — restore a doc into local storage, stripping relay-only fields (a stranded relay doc can't return to the relay that deleted it).
- **App startup** — sweep expired trash + reclaim.

## Design note
Both trash kinds share a single backing (`TrashStorage` / localStorage) rather than keeping stranded docs in `RelayDocumentCache` + a separate index. Relay docs reference blobs externally (`blob://`), so their JSON is small, and this removes the LRU-eviction hazard of relying on the cache to *preserve* a stranded doc. The `trashStore` still leaves room for a future relay-soft-delete source (JP-294) without a reshape.

## Tests
- `TrashStorage`: kind/origin/blobReferences round-trip + mark-set source (incl. legacy fallback).
- IndexedDB-free **GC regression**: a blob referenced only by a trashed doc survives a sweep and becomes reclaimable after empty (full + incremental).
- Full suite green (1946 tests).

Closes JP-291.

Assisted-by: Opus 4.8