### PR TITLE
JP-175: react to deleted relay docs — strand to Trash / demote open doc

### DIFF
--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -478,13 +478,26 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
           // id). Mark it as not-syncing and tell the user their edits are
           // local-only, rather than letting them edit into the void.
           if (isUnknownDocError(error) && docId) {
-            useDocumentRegistry.getState().setSyncState(docId, 'error');
-            useNotificationStore
-              .getState()
-              .warning(
-                'This document isn’t syncing — the relay has no record of it. ' +
-                  'Your changes are saved locally only.',
-              );
+            const record = useDocumentRegistry.getState().getRecord(docId);
+            if (record && (record.type === 'remote' || record.type === 'cached')) {
+              // The relay has no record of a doc we believed was relay-backed —
+              // it was deleted, possibly while we were offline. Converge on the
+              // same strand/demote path as a live Deleted event (JP-175) so the
+              // user keeps their copy instead of editing a ghost into the void.
+              // No deleter id (this is our own rejected JOIN), so it's treated
+              // as a foreign deletion (never self-skipped).
+              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+            } else {
+              // Diverged / never-promoted local id — not a deletion. Keep the
+              // gentler "saved locally only" hint.
+              useDocumentRegistry.getState().setSyncState(docId, 'error');
+              useNotificationStore
+                .getState()
+                .warning(
+                  'This document isn’t syncing — the relay has no record of it. ' +
+                    'Your changes are saved locally only.',
+                );
+            }
           }
         },
         shouldJoinDocument: (docId: string) => {

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -287,6 +287,14 @@ export interface PersistenceActions {
    * Strips relay-only fields so the restored copy is local-only.
    */
   adoptDocument: (doc: DiagramDocument) => void;
+  /**
+   * Demote the currently-open relay document to a local-only document in place
+   * (JP-175). Used when the relay deletes the doc out from under an open editor:
+   * the user keeps their work and keeps editing — saves now go local. Network-
+   * free (no relay delete; the relay already removed it). No-op if there's no
+   * open doc or it isn't a relay document.
+   */
+  demoteCurrentDocumentToLocal: () => void;
   /** Rename the current document */
   renameDocument: (name: string) => void;
   /** Export current document as JSON string */
@@ -908,6 +916,37 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         }));
 
         useDocumentRegistry.getState().registerLocal(metadata);
+      },
+
+      demoteCurrentDocumentToLocal: () => {
+        const docId = get().currentDocumentId;
+        if (!docId) return;
+
+        // The open relay doc is mirrored to localStorage by loadRemoteDocument,
+        // so it's loadable here. Flip it local in place (mirrors transferToPersonal's
+        // field clear, minus the network delete — the relay already removed it).
+        const doc = loadDocumentFromStorage(docId);
+        if (!doc || !doc.isRelayDocument) return;
+
+        doc.isRelayDocument = false;
+        delete doc.ownerId;
+        delete doc.ownerName;
+        delete doc.lockedBy;
+        delete doc.lockedByName;
+        delete doc.lockedAt;
+        delete doc.sharedWith;
+        delete doc.lastModifiedBy;
+        delete doc.lastModifiedByName;
+        delete doc.serverVersion;
+        doc.modifiedAt = Date.now();
+
+        saveDocumentToStorage(doc);
+        const metadata = getDocumentMetadata(doc);
+        set((state) => ({ documents: { ...state.documents, [docId]: metadata } }));
+
+        const registry = useDocumentRegistry.getState();
+        registry.registerLocal(metadata);
+        registry.setActiveDocument(docId);
       },
 
       // Rename the current document

--- a/src/store/relayDocumentStore.staleEviction.test.ts
+++ b/src/store/relayDocumentStore.staleEviction.test.ts
@@ -1,11 +1,12 @@
 /**
- * Coverage for `refreshStaleCachedDocuments`'s eviction behavior.
+ * Coverage for `refreshStaleCachedDocuments`'s reconciliation behavior.
  *
  * The cache is host-scoped: every entry remembers which relay it came
  * from. The staleness sweep must only look at entries from the
  * currently-connected relay, and entries that are no longer on that
- * relay must be evicted (deleted, wiped, or share revoked → drop the
- * orphan) rather than re-logged on every reconnect forever.
+ * relay are reconciled via the JP-175 strand path — the local copy is
+ * preserved in Trash (or demoted if open) and the cache entry removed —
+ * rather than being silently dropped on reconnect.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -17,6 +18,9 @@ const cacheMock = vi.hoisted(() => ({
   getCachedIds: vi.fn<[], string[]>(() => []),
   getMeta: vi.fn<[string], { cachedAt: number; relayId: string } | null>(() => null),
   remove: vi.fn<[string], Promise<void>>(async () => {}),
+  // The strand path reads the cached bytes before removing. Default: no bytes
+  // (nothing to preserve → the entry is just cleaned up).
+  get: vi.fn<[string], Promise<unknown>>(async () => null),
 }));
 
 vi.mock('../storage/RelayDocumentCache', () => ({
@@ -65,6 +69,8 @@ describe('refreshStaleCachedDocuments — host-scoped eviction', () => {
     cacheMock.getMeta.mockReset();
     cacheMock.remove.mockReset();
     cacheMock.remove.mockResolvedValue(undefined);
+    cacheMock.get.mockReset();
+    cacheMock.get.mockResolvedValue(null);
     syncManagerMock.hasPendingChanges.mockReset();
     syncManagerMock.hasPendingChanges.mockReturnValue(false);
 
@@ -75,16 +81,19 @@ describe('refreshStaleCachedDocuments — host-scoped eviction', () => {
     });
   });
 
-  it('evicts cached docs that this host no longer has', async () => {
+  it('reconciles cached docs that this host no longer has (strand + clean up)', async () => {
     cacheMock.getCachedIdsForHost.mockReturnValue(['ghost-A', 'ghost-B']);
     // Server returned an empty doc list — both cache entries are orphans.
 
     await useRelayDocumentStore.getState().refreshStaleCachedDocuments();
 
     expect(cacheMock.getCachedIdsForHost).toHaveBeenCalledWith('localhost:9876');
-    expect(cacheMock.remove).toHaveBeenCalledWith('ghost-A');
-    expect(cacheMock.remove).toHaveBeenCalledWith('ghost-B');
-    expect(cacheMock.remove).toHaveBeenCalledTimes(2);
+    // Removal happens after the strand path reads the bytes (async), so wait
+    // for the deferred cleanup to land.
+    await vi.waitFor(() => {
+      expect(cacheMock.remove).toHaveBeenCalledWith('ghost-A');
+      expect(cacheMock.remove).toHaveBeenCalledWith('ghost-B');
+    });
   });
 
   it('leaves docs the server still has alone', async () => {
@@ -125,10 +134,21 @@ describe('refreshStaleCachedDocuments — host-scoped eviction', () => {
     expect(cacheMock.remove).not.toHaveBeenCalled();
   });
 
-  it('clears any in-memory shadow of the evicted doc', async () => {
+  it('clears any in-memory shadow of the stranded doc', async () => {
     cacheMock.getCachedIdsForHost.mockReturnValue(['orphan']);
     useRelayDocumentStore.setState({
-      documentCache: { orphan: { id: 'orphan' } as never },
+      documentCache: {
+        orphan: {
+          id: 'orphan',
+          name: 'orphan',
+          pages: {},
+          pageOrder: ['p1'],
+          activePageId: 'p1',
+          createdAt: 0,
+          modifiedAt: 0,
+          version: 1,
+        } as never,
+      },
     });
 
     await useRelayDocumentStore.getState().refreshStaleCachedDocuments();

--- a/src/store/relayDocumentStore.strand.test.ts
+++ b/src/store/relayDocumentStore.strand.test.ts
@@ -1,0 +1,131 @@
+/**
+ * JP-175 — clients react to a deleted relay document by preserving the user's
+ * copy instead of silently dropping it. `strandOrDemoteDeletedDoc` decides:
+ *   - open doc        → demote to local + stop relay sync (don't strand)
+ *   - other doc, copy → strand into Trash
+ *   - self-initiated  → nothing to preserve
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable harness state the mocks read, so each test can vary "what's open".
+const h = vi.hoisted(() => ({
+  currentDocumentId: null as string | null,
+  currentUserId: 'me' as string | undefined,
+  demote: vi.fn(),
+  leaveDocument: vi.fn(),
+  trashStranded: vi.fn(),
+  removeDocument: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+  cacheGet: vi.fn(async () => null as unknown),
+  cacheRemove: vi.fn(async () => {}),
+}));
+
+vi.mock('./persistenceStore', () => ({
+  usePersistenceStore: {
+    getState: () => ({
+      currentDocumentId: h.currentDocumentId,
+      demoteCurrentDocumentToLocal: h.demote,
+    }),
+  },
+}));
+vi.mock('./notificationStore', () => ({
+  useNotificationStore: { getState: () => ({ warning: h.warning, info: h.info }) },
+}));
+vi.mock('./trashStore', () => ({
+  useTrashStore: { getState: () => ({ trashStranded: h.trashStranded }) },
+}));
+vi.mock('../store/userStore', () => ({
+  useUserStore: { getState: () => ({ currentUser: { id: h.currentUserId, role: 'user' } }) },
+}));
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: { getState: () => ({ host: { address: 'relay-1' } }) },
+  useIsRelayAuthenticated: () => false,
+}));
+vi.mock('../collaboration/collaborationStore', () => ({
+  isCollabContentDoc: () => false,
+  useCollaborationStore: { getState: () => ({ leaveDocument: h.leaveDocument }) },
+}));
+vi.mock('./documentRegistry', () => ({
+  useDocumentRegistry: {
+    getState: () => ({
+      getDocumentContent: () => undefined,
+      removeDocument: h.removeDocument,
+      registerRemote: vi.fn(),
+    }),
+  },
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({
+  RelayDocumentCache: { get: h.cacheGet, remove: h.cacheRemove },
+}));
+
+import { useRelayDocumentStore } from './relayDocumentStore';
+import type { DiagramDocument } from '../types/Document';
+
+const DOC_ID = 'doc-1';
+const makeDoc = (): DiagramDocument =>
+  ({ id: DOC_ID, name: 'My Doc', pages: {}, pageOrder: [] }) as unknown as DiagramDocument;
+
+function seedRelayDoc() {
+  useRelayDocumentStore.setState({
+    documentCache: { [DOC_ID]: makeDoc() },
+    relayDocuments: {
+      [DOC_ID]: { id: DOC_ID, name: 'My Doc', createdAt: 0, modifiedAt: 5, pageCount: 1, ownerId: 'owner-1' },
+    },
+  });
+}
+
+describe('strandOrDemoteDeletedDoc (JP-175)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.currentDocumentId = null;
+    h.currentUserId = 'me';
+    h.cacheGet.mockResolvedValue(null);
+    seedRelayDoc();
+  });
+
+  it('strands a non-open doc into Trash and clears relay state', () => {
+    useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(DOC_ID, 'someone-else');
+
+    expect(h.trashStranded).toHaveBeenCalledTimes(1);
+    const [doc, origin] = h.trashStranded.mock.calls[0]!;
+    expect((doc as DiagramDocument).id).toBe(DOC_ID);
+    expect(origin).toEqual({ relayId: 'relay-1', ownerId: 'owner-1', lastSyncedAt: 5 });
+
+    expect(h.removeDocument).toHaveBeenCalledWith(DOC_ID);
+    expect(h.demote).not.toHaveBeenCalled();
+    expect(useRelayDocumentStore.getState().relayDocuments[DOC_ID]).toBeUndefined();
+    expect(useRelayDocumentStore.getState().documentCache[DOC_ID]).toBeUndefined();
+  });
+
+  it('demotes the OPEN doc to local instead of stranding it', () => {
+    h.currentDocumentId = DOC_ID;
+
+    useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(DOC_ID, 'someone-else');
+
+    expect(h.demote).toHaveBeenCalledTimes(1);
+    expect(h.leaveDocument).toHaveBeenCalledTimes(1);
+    expect(h.warning).toHaveBeenCalledTimes(1);
+    expect(h.trashStranded).not.toHaveBeenCalled();
+    // The (now-local) registry entry is preserved — don't remove it.
+    expect(h.removeDocument).not.toHaveBeenCalled();
+    expect(useRelayDocumentStore.getState().relayDocuments[DOC_ID]).toBeUndefined();
+  });
+
+  it('preserves nothing when WE initiated the deletion', () => {
+    useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(DOC_ID, 'me');
+
+    expect(h.trashStranded).not.toHaveBeenCalled();
+    expect(h.demote).not.toHaveBeenCalled();
+    expect(h.removeDocument).toHaveBeenCalledWith(DOC_ID);
+  });
+
+  it('routes a Deleted DocEvent through the strand path', () => {
+    useRelayDocumentStore.getState().handleDocumentEvent({
+      eventType: 'deleted',
+      docId: DOC_ID,
+      userId: 'someone-else',
+    });
+    expect(h.trashStranded).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -879,7 +879,7 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       // Get document list to check versions
       const teamDocs = get().relayDocuments;
       let refreshed = 0;
-      let evicted = 0;
+      let stranded = 0;
 
       for (const docId of cachedIds) {
         // JP-108: never stale-refresh the doc in an active collab session — its
@@ -906,20 +906,19 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
             );
             continue;
           }
+          // The relay lists it no longer, but we hold a cached copy — it was
+          // deleted (or access revoked) while we were away. Don't silently drop
+          // it: route through the same reaction as a live Deleted event (JP-175)
+          // so the copy is preserved in Trash (or, if it's the open doc, demoted
+          // to local) instead of vanishing on reconnect. strandOrDemoteDeletedDoc
+          // reads the cached/in-memory copy, trashes it, and clears the relay
+          // bookkeeping + offline cache. No deleter id → treated as foreign.
           try {
-            await RelayDocumentCache.remove(docId);
-            // Also drop any in-memory shadow.
-            set((state) => {
-              if (!(docId in state.documentCache)) return state;
-              const documentCache = { ...state.documentCache };
-              delete documentCache[docId];
-              return { documentCache };
-            });
-            useDocumentRegistry.getState().invalidateContent(docId);
-            evicted++;
+            get().strandOrDemoteDeletedDoc(docId);
+            stranded++;
           } catch (error) {
             console.warn(
-              `[relayDocumentStore] Failed to evict orphaned cache entry ${docId}:`,
+              `[relayDocumentStore] Failed to strand orphaned cache entry ${docId}:`,
               error,
             );
           }
@@ -955,9 +954,9 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       if (refreshed > 0) {
         console.log(`[relayDocumentStore] Refreshed ${refreshed} stale cached documents`);
       }
-      if (evicted > 0) {
+      if (stranded > 0) {
         console.log(
-          `[relayDocumentStore] Evicted ${evicted} orphaned cache entries no longer on the relay`,
+          `[relayDocumentStore] Stranded ${stranded} cached document(s) no longer on the relay into Trash`,
         );
       }
     },

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -29,7 +29,11 @@ import {
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
 import { registerBlobDownloader } from '../storage/blobResolver';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
-import { isCollabContentDoc } from '../collaboration/collaborationStore';
+import { isCollabContentDoc, useCollaborationStore } from '../collaboration/collaborationStore';
+import { usePersistenceStore } from './persistenceStore';
+import { useNotificationStore } from './notificationStore';
+import { useTrashStore } from './trashStore';
+import type { TrashOrigin } from '../storage/TrashStorage';
 import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
 import type { RelayUsage } from '../api/relayClient';
 import { useUploadStatusStore } from './uploadStatusStore';
@@ -192,6 +196,18 @@ interface RelayDocumentActions {
 
   /** Handle document events from host */
   handleDocumentEvent: (event: DocEvent) => void;
+
+  /**
+   * React to a relay document that's gone from the workspace (JP-175) — either
+   * a `DocEvent::Deleted` broadcast or a JOIN_DOC `ERR_UNKNOWN_DOC` rejection.
+   * The client never silently drops it:
+   *  - if it's the **open** doc → demote it to a local document so the user
+   *    keeps editing (saves go local), stop relay sync, and notify;
+   *  - otherwise, if we hold a copy → **strand** it into Trash (recoverable);
+   *  - clean up the relay bookkeeping either way.
+   * Skips preservation when *we* initiated the deletion (`deletedByUserId` is us).
+   */
+  strandOrDemoteDeletedDoc: (docId: string, deletedByUserId?: string) => void;
 
   /** Set host connection status */
   setHostConnected: (connected: boolean) => void;
@@ -657,6 +673,12 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       const userId = userState.currentUser?.id;
       const userRole = userState.currentUser?.role;
 
+      // A deletion isn't a silent drop — preserve the user's copy (JP-175).
+      if (event.eventType === 'deleted') {
+        get().strandOrDemoteDeletedDoc(event.docId, event.userId);
+        return;
+      }
+
       set((state) => {
         const relayDocuments = { ...state.relayDocuments };
         const documentCache = { ...state.documentCache };
@@ -677,16 +699,90 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
               registry.invalidateContent(event.docId);
             }
             break;
-
-          case 'deleted':
-            delete relayDocuments[event.docId];
-            delete documentCache[event.docId];
-            // Remove from registry
-            registry.removeDocument(event.docId);
-            break;
         }
 
         return { relayDocuments, documentCache };
+      });
+    },
+
+    strandOrDemoteDeletedDoc: (docId, deletedByUserId) => {
+      const registry = useDocumentRegistry.getState();
+      const connection = useConnectionStore.getState();
+      const persistence = usePersistenceStore.getState();
+      const userId = useUserStore.getState().currentUser?.id;
+
+      const meta = get().relayDocuments[docId];
+      const origin: TrashOrigin = { relayId: connection.host?.address ?? 'unknown' };
+      if (meta?.ownerId) origin.ownerId = meta.ownerId;
+      if (meta?.modifiedAt) origin.lastSyncedAt = meta.modifiedAt;
+
+      // A self-initiated delete (we asked for it) is intentional — nothing to
+      // preserve, just drop our bookkeeping below.
+      const selfInitiated =
+        deletedByUserId != null && userId != null && deletedByUserId === userId;
+      const isOpen = persistence.currentDocumentId === docId;
+
+      // Clear the in-memory relay maps for this doc (the registry + offline
+      // cache are handled per-branch below).
+      const clearRelayMaps = () => {
+        set((state) => {
+          const relayDocuments = { ...state.relayDocuments };
+          const documentCache = { ...state.documentCache };
+          delete relayDocuments[docId];
+          delete documentCache[docId];
+          return { relayDocuments, documentCache };
+        });
+      };
+
+      // Open doc → keep the user editing: demote in place to a local document
+      // (its registry entry becomes local), stop relay sync, and tell them.
+      if (isOpen && !selfInitiated) {
+        persistence.demoteCurrentDocumentToLocal();
+        useCollaborationStore.getState().leaveDocument();
+        useNotificationStore
+          .getState()
+          .warning(
+            'This document was deleted from the relay. Your copy is now a local document.',
+          );
+        // Keep the (now-local) registry entry demote just created; only clear
+        // the relay-side maps + offline cache.
+        clearRelayMaps();
+        void RelayDocumentCache.remove(docId);
+        return;
+      }
+
+      // Capture an in-memory copy before we drop it.
+      const copy = get().documentCache[docId] ?? registry.getDocumentContent(docId);
+
+      clearRelayMaps();
+      registry.removeDocument(docId);
+
+      if (selfInitiated) {
+        void RelayDocumentCache.remove(docId); // we deleted it on purpose
+        return;
+      }
+
+      if (copy) {
+        // trashStranded snapshots the bytes into the trash, so the offline
+        // cache entry is now safe to drop.
+        useTrashStore.getState().trashStranded(copy, origin);
+        void RelayDocumentCache.remove(docId);
+        useNotificationStore
+          .getState()
+          .info(`“${copy.name}” was deleted from the relay and moved to Trash.`);
+        return;
+      }
+
+      // No in-memory copy, but a persistent offline copy may exist — strand it
+      // (read it BEFORE removing) best-effort.
+      void RelayDocumentCache.get(docId).then((cached) => {
+        if (cached) {
+          useTrashStore.getState().trashStranded(cached, origin);
+          useNotificationStore
+            .getState()
+            .info(`“${cached.name}” was deleted from the relay and moved to Trash.`);
+        }
+        void RelayDocumentCache.remove(docId);
       });
     },
 


### PR DESCRIPTION
**Stacked on #152 (JP-291).** Review/merge that first — the base will retarget to `master` automatically once it lands.

Fixes the JP-175 ghost-doc bug: a relay document deleted out from under a client was silently dropped (or kept editable as a ghost). Now `DocEvent::Deleted` **and** the JOIN_DOC `ERR_UNKNOWN_DOC` rejection converge on one reaction via `strandOrDemoteDeletedDoc`:

| Situation | Behaviour |
|---|---|
| The deleted doc is **open** in the editor | Demote it to a **local** document in place, stop relay sync, notify. The user keeps their work and keeps editing — saves go local. |
| We hold a copy of a **non-open** doc | **Strand** it into Trash (recoverable, GC'd after the trash TTL), with its relay origin recorded. |
| **We** initiated the deletion | Nothing to preserve — just drop the relay bookkeeping. |

## Changes
- **`relayDocumentStore`** — new `strandOrDemoteDeletedDoc`; `handleDocumentEvent` `'deleted'` routes through it instead of silently removing from the registry/cache. In-memory copy is captured before removal; a persistent-only offline copy is read *before* its cache entry is dropped, then stranded best-effort.
- **`persistenceStore.demoteCurrentDocumentToLocal`** — network-free local flip of the open relay doc (the relay already removed it; mirrors `transferToPersonal`'s field-clear minus the delete).
- **`collaborationStore`** — `ERR_UNKNOWN_DOC` on a `remote`/`cached` record converges on the same path; a diverged/never-promoted **local** id keeps the gentler "saved locally only" hint (avoids false-positive stranding).

Stranded copies use JP-291's trash substrate (`trashStranded`), so their blobs stay referenced until the entry is purged/emptied.

## Design note
Open doc → **demote to local** (not strand) so we don't create a dual identity (a doc that's both an active-local entry and a trash entry under the same id). Non-open → strand to Trash. Both honour "never silently lose the user's copy."

## Tests
Branching (open→demote, other→strand, self→nothing) + `DocEvent` routing. Full suite green (1950).

Closes JP-175.

Assisted-by: Opus 4.8