### PR TITLE
JP-292: route local delete to Trash + permanent-delete (bypass)

### DIFF
--- a/src/store/persistenceStore.trashDelete.test.ts
+++ b/src/store/persistenceStore.trashDelete.test.ts
@@ -1,0 +1,64 @@
+/**
+ * JP-292 — local delete routing.
+ *
+ *  - `deleteDocument` is a *soft* delete: the doc moves to the Trash and its
+ *    blobs are NOT released (they stay reffed via the trash mark-set).
+ *  - `permanentlyDeleteDocument` bypasses the Trash: hard removal + blob release.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { usePersistenceStore, saveDocumentToStorage } from './persistenceStore';
+import { isInTrash, getTrashItem, emptyTrash } from '../storage/TrashStorage';
+import { blobStorage } from '../storage/BlobStorage';
+import { getDocumentMetadata, type DiagramDocument } from '../types/Document';
+
+function makeDoc(id: string): DiagramDocument {
+  return {
+    id,
+    name: id,
+    pages: {},
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 1,
+    blobReferences: ['b1'],
+  };
+}
+
+describe('persistenceStore delete routing (JP-292)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    emptyTrash();
+    vi.restoreAllMocks();
+    // Keep currentDocumentId off the doc under test so deleting it doesn't
+    // trigger newDocument() (which would spin up the page store).
+    usePersistenceStore.setState({ currentDocumentId: 'other', documents: {} });
+  });
+
+  it('deleteDocument soft-deletes to the Trash without releasing blobs', () => {
+    const dec = vi.spyOn(blobStorage, 'decrementUsageCount').mockResolvedValue(undefined);
+    const doc = makeDoc('d1');
+    saveDocumentToStorage(doc);
+    usePersistenceStore.setState((s) => ({ documents: { ...s.documents, d1: getDocumentMetadata(doc) } }));
+
+    usePersistenceStore.getState().deleteDocument('d1');
+
+    expect(isInTrash('d1')).toBe(true);
+    expect(getTrashItem('d1')?.kind).toBe('local');
+    expect(usePersistenceStore.getState().documents.d1).toBeUndefined();
+    expect(dec).not.toHaveBeenCalled();
+  });
+
+  it('permanentlyDeleteDocument hard-removes and releases blobs', () => {
+    const dec = vi.spyOn(blobStorage, 'decrementUsageCount').mockResolvedValue(undefined);
+    const doc = makeDoc('d2');
+    saveDocumentToStorage(doc);
+    usePersistenceStore.setState((s) => ({ documents: { ...s.documents, d2: getDocumentMetadata(doc) } }));
+
+    usePersistenceStore.getState().permanentlyDeleteDocument('d2');
+
+    expect(isInTrash('d2')).toBe(false);
+    expect(usePersistenceStore.getState().documents.d2).toBeUndefined();
+    expect(dec).toHaveBeenCalledWith('b1');
+  });
+});

--- a/src/store/persistenceStore.trashDelete.test.ts
+++ b/src/store/persistenceStore.trashDelete.test.ts
@@ -45,7 +45,7 @@ describe('persistenceStore delete routing (JP-292)', () => {
 
     expect(isInTrash('d1')).toBe(true);
     expect(getTrashItem('d1')?.kind).toBe('local');
-    expect(usePersistenceStore.getState().documents.d1).toBeUndefined();
+    expect(usePersistenceStore.getState().documents['d1']).toBeUndefined();
     expect(dec).not.toHaveBeenCalled();
   });
 
@@ -58,7 +58,7 @@ describe('persistenceStore delete routing (JP-292)', () => {
     usePersistenceStore.getState().permanentlyDeleteDocument('d2');
 
     expect(isInTrash('d2')).toBe(false);
-    expect(usePersistenceStore.getState().documents.d2).toBeUndefined();
+    expect(usePersistenceStore.getState().documents['d2']).toBeUndefined();
     expect(dec).toHaveBeenCalledWith('b1');
   });
 });

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -28,6 +28,7 @@ import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { useSessionStore } from './sessionStore';
 import { useHistoryStore } from './historyStore';
 import { useDocumentRegistry } from './documentRegistry';
+import { useTrashStore } from './trashStore';
 import { isRemoteDocument, isCachedDocument } from '../types/DocumentRegistry';
 import { isCollabContentDoc, ensureCollabSessionForDoc, useCollaborationStore } from '../collaboration';
 import { useWhiteboardStore } from './whiteboardStore';
@@ -279,8 +280,10 @@ export interface PersistenceActions {
   saveDocumentAs: (name: string) => void;
   /** Load a document by ID */
   loadDocument: (id: string) => boolean;
-  /** Delete a document by ID */
+  /** Delete a document by ID (soft delete → moves it to the Trash). */
   deleteDocument: (id: string) => void;
+  /** Permanently delete a document, bypassing the Trash and releasing blobs. */
+  permanentlyDeleteDocument: (id: string) => void;
   /**
    * Adopt an existing document object into local storage as a personal
    * document — used by the Trash to restore a trashed/stranded doc (JP-291).
@@ -859,8 +862,40 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         return true;
       },
 
-      // Delete a document by ID
+      // Delete a document by ID — soft delete: move it to the Trash so it's
+      // recoverable (JP-292). Blobs are NOT released here; they stay referenced
+      // via the trash mark-set until the entry is purged/emptied/expired
+      // (JP-291). Hard removal is `permanentlyDeleteDocument`.
       deleteDocument: (id: string) => {
+        const state = get();
+
+        const doc = loadDocumentFromStorage(id);
+        if (doc) {
+          // Snapshot into the trash, then drop the active copy. (No blob
+          // decrement — the trashed copy still references them.)
+          useTrashStore.getState().trashLocal(doc);
+        }
+
+        // Drop the active localStorage copy + index entry. The trash keeps its
+        // own copy under a separate key.
+        deleteDocumentFromStorage(id);
+        set((state) => {
+          const newDocuments = { ...state.documents };
+          delete newDocuments[id];
+          return { documents: newDocuments };
+        });
+        useDocumentRegistry.getState().removeDocument(id);
+
+        // If we deleted the current document, create a new one
+        if (state.currentDocumentId === id) {
+          get().newDocument();
+        }
+      },
+
+      // Permanently delete a document, bypassing the Trash (JP-292). Releases
+      // its blob references immediately. Use for "Delete permanently" and for
+      // purging from the Trash.
+      permanentlyDeleteDocument: (id: string) => {
         const state = get();
 
         // Load document to get blob references

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -181,6 +181,16 @@ interface RelayDocumentActions {
   /** Delete a relay document from host */
   deleteFromHost: (docId: string) => Promise<void>;
 
+  /**
+   * "Delete" a relay document (non-permanent): hard-delete it on the relay
+   * (there's no relay-side soft-delete yet — that's JP-294) but keep the
+   * deleter a recoverable copy in their own Trash as a stranded entry (JP-292).
+   * Other connected editors strand it via the broadcast `Deleted` event; the
+   * self-broadcast back to us is skipped by the self-initiated guard, so this
+   * is the single place the deleter's own copy is preserved.
+   */
+  trashRelayDocument: (docId: string) => Promise<void>;
+
   /** Update document sharing permissions */
   updateDocumentShares: (
     docId: string,
@@ -626,6 +636,37 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         const error = e instanceof Error ? e.message : 'Failed to delete document';
         set({ error });
         throw e;
+      }
+    },
+
+    trashRelayDocument: async (docId) => {
+      const registry = useDocumentRegistry.getState();
+      const connection = useConnectionStore.getState();
+      const meta = get().relayDocuments[docId];
+
+      // Capture a copy to keep recoverable in the deleter's Trash. Prefer what's
+      // already in memory; otherwise pull it from the relay before deleting.
+      let copy = get().documentCache[docId] ?? registry.getDocumentContent(docId);
+      if (!copy) {
+        try {
+          copy = await get().loadRelayDocument(docId);
+        } catch {
+          // No copy reachable — proceed with the delete anyway; we just can't
+          // offer a local recovery copy.
+        }
+      }
+
+      const origin: TrashOrigin = { relayId: connection.host?.address ?? 'unknown' };
+      if (meta?.ownerId) origin.ownerId = meta.ownerId;
+      if (meta?.modifiedAt) origin.lastSyncedAt = meta.modifiedAt;
+
+      // Hard-delete on the relay (clears our relay maps + offline cache + the
+      // Deleted broadcast). The self-broadcast back here is skipped by the
+      // self-initiated guard in strandOrDemoteDeletedDoc.
+      await get().deleteFromHost(docId);
+
+      if (copy) {
+        useTrashStore.getState().trashStranded(copy, origin);
       }
     },
 

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -262,13 +262,24 @@ button.document-card__offline--action:focus-visible {
   transition: all 0.15s ease;
 }
 
+/* "Trash" — the recoverable soft delete: neutral, not alarming. */
 .document-card__confirm-yes {
+  background: var(--accent, var(--bg-tertiary));
+  color: var(--accent-contrast, var(--text-primary));
+}
+
+.document-card__confirm-yes:hover {
+  filter: brightness(1.05);
+}
+
+/* "Forever" — the destructive bypass: danger red. */
+.document-card__confirm-forever {
   background: var(--danger);
   color: white;
 }
 
-.document-card__confirm-yes:hover {
-  background: var(--danger);
+.document-card__confirm-forever:hover {
+  filter: brightness(1.05);
 }
 
 .document-card__confirm-no {

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -40,8 +40,10 @@ interface DocumentCardProps {
   showSelectionCheckbox?: boolean | undefined;
   /** Callback when document is clicked (to open) */
   onOpen?: ((id: string) => void | Promise<void>) | undefined;
-  /** Callback when delete is requested */
+  /** Callback when delete is requested (soft delete → Trash) */
   onDelete?: ((id: string) => void | Promise<void>) | undefined;
+  /** Callback when permanent delete is requested (bypasses Trash) */
+  onPermanentDelete?: ((id: string) => void | Promise<void>) | undefined;
   /** Callback when rename is requested */
   onRename?: ((id: string, newName: string) => void) | undefined;
   /** Callback to edit permissions (ownership/access) */
@@ -226,6 +228,7 @@ function DocumentCardImpl({
   isOfflineAvailable = false,
   onOpen,
   onDelete,
+  onPermanentDelete,
   onRename,
   onEditPermissions,
   onPublishToTeam,
@@ -343,6 +346,13 @@ function DocumentCardImpl({
     }
     setShowDeleteConfirm(false);
   }, [onDelete, record.id]);
+
+  const handlePermanentDeleteConfirm = useCallback(() => {
+    if (onPermanentDelete) {
+      onPermanentDelete(record.id);
+    }
+    setShowDeleteConfirm(false);
+  }, [onPermanentDelete, record.id]);
 
   const handleDeleteCancel = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -635,11 +645,24 @@ function DocumentCardImpl({
         {showDeleteConfirm && (
           <div className="document-card__confirm" onClick={(e) => e.stopPropagation()}>
             <span className="document-card__confirm-text">Delete?</span>
-            <button className="document-card__confirm-btn document-card__confirm-yes" onClick={handleDeleteConfirm}>
-              Yes
+            <button
+              className="document-card__confirm-btn document-card__confirm-yes"
+              onClick={handleDeleteConfirm}
+              title="Move to Trash (recoverable)"
+            >
+              Trash
             </button>
+            {onPermanentDelete && (
+              <button
+                className="document-card__confirm-btn document-card__confirm-forever"
+                onClick={handlePermanentDeleteConfirm}
+                title="Delete permanently — bypasses the Trash"
+              >
+                Forever
+              </button>
+            )}
             <button className="document-card__confirm-btn document-card__confirm-no" onClick={handleDeleteCancel}>
-              No
+              Cancel
             </button>
           </div>
         )}

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -59,6 +59,7 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
     handleSelectToggle,
     currentUser,
     handleDelete,
+    handlePermanentDelete,
     handleRename,
     setPermissionsDocId,
     isInTeamMode,
@@ -88,6 +89,9 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
         onOpen={onOpen}
         onSelectToggle={handleSelectToggle}
         onDelete={canDelete(record, currentUser?.id, currentUser?.role) ? handleDelete : undefined}
+        onPermanentDelete={
+          canDelete(record, currentUser?.id, currentUser?.role) ? handlePermanentDelete : undefined
+        }
         onRename={canEdit(record, currentUser?.id, currentUser?.role) ? handleRename : undefined}
         onEditPermissions={
           canManagePermissions(record, isInTeamMode, currentUser?.id, currentUser?.role)

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -156,6 +156,7 @@ export interface DocumentBrowserModel {
   handleExport: () => void;
   handleOpen: (docId: string) => Promise<void>;
   handleDelete: (docId: string) => Promise<void>;
+  handlePermanentDelete: (docId: string) => Promise<void>;
   handleRename: (docId: string, newName: string) => void;
   handlePublishToTeam: (docId: string) => Promise<void>;
   handleMoveToPersonal: (docId: string) => Promise<void>;
@@ -186,6 +187,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const saveDocument = usePersistenceStore((s) => s.saveDocument);
   const loadDocument = usePersistenceStore((s) => s.loadDocument);
   const deleteDocument = usePersistenceStore((s) => s.deleteDocument);
+  const permanentlyDeleteDocument = usePersistenceStore((s) => s.permanentlyDeleteDocument);
   const renameDocument = usePersistenceStore((s) => s.renameDocument);
 
   // Relay stores
@@ -196,6 +198,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const fetchDocumentList = useRelayDocumentStore((s) => s.fetchDocumentList);
   const loadRelayDocument = useRelayDocumentStore((s) => s.loadRelayDocument);
   const deleteFromHost = useRelayDocumentStore((s) => s.deleteFromHost);
+  const trashRelayDocument = useRelayDocumentStore((s) => s.trashRelayDocument);
   const isAvailableOffline = useRelayDocumentStore((s) => s.isAvailableOffline);
 
   // Whether we have a usable relay session for *transfers*. Gates the
@@ -421,6 +424,9 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     [currentDocumentId, entries, loadRelayDocument, loadDocument]
   );
 
+  // Soft delete → Trash. Relay docs hard-delete on the relay (no relay-side
+  // soft-delete yet — JP-294) but the deleter keeps a recoverable stranded copy
+  // in their own Trash. Local/cached docs move to the local Trash.
   const handleDelete = useCallback(
     async (docId: string) => {
       const entry = entries[docId];
@@ -428,7 +434,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       const record = entry.record;
       if (record.type === 'remote') {
         try {
-          await deleteFromHost(docId);
+          await trashRelayDocument(docId);
         } catch (error) {
           console.error('Failed to delete relay document:', error);
         }
@@ -441,7 +447,29 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
         deleteDocument(docId);
       }
     },
-    [entries, deleteFromHost, deleteDocument]
+    [entries, trashRelayDocument, deleteDocument]
+  );
+
+  // Permanent delete → bypass the Trash. Relay docs hard-delete on the relay
+  // and keep NO local copy (other editors still strand it). Local/cached docs
+  // are hard-removed and their blobs released.
+  const handlePermanentDelete = useCallback(
+    async (docId: string) => {
+      const entry = entries[docId];
+      if (!entry) return;
+      const record = entry.record;
+      if (record.type === 'remote') {
+        try {
+          await deleteFromHost(docId);
+        } catch (error) {
+          console.error('Failed to permanently delete relay document:', error);
+        }
+        await purgeLocalDocRoom(docId);
+      } else {
+        permanentlyDeleteDocument(docId);
+      }
+    },
+    [entries, deleteFromHost, permanentlyDeleteDocument]
   );
 
   const handleRename = useCallback(
@@ -796,6 +824,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     handleExport,
     handleOpen,
     handleDelete,
+    handlePermanentDelete,
     handleRename,
     handlePublishToTeam,
     handleMoveToPersonal,


### PR DESCRIPTION
**Stacked on #153 (JP-175), which is stacked on #152 (JP-291).** Merge bottom-up.

Makes "Delete" recoverable by default and adds an explicit permanent-delete that bypasses the Trash.

## Behaviour
| Action | Local / cached doc | Relay doc |
|---|---|---|
| **Delete** | soft delete → local Trash (blobs kept) | hard-delete on relay, deleter keeps a recoverable **stranded** copy in their Trash; other editors strand it too |
| **Delete permanently** | hard remove + release blobs | hard-delete on relay, **no** local copy kept; other editors still strand it |

## Changes
- **`persistenceStore`** — `deleteDocument` is now a soft delete (snapshots into the Trash via `trashStore.trashLocal`, drops the active copy, **does not** release blobs — they stay reffed via the JP-291 mark-set). The old hard-delete body moved verbatim to **`permanentlyDeleteDocument`**.
- **`relayDocumentStore.trashRelayDocument`** — relay "Delete": `deleteFromHost` + keep the deleter a stranded copy. The self-broadcast `Deleted` is skipped by JP-175's self-initiated guard (no double-strand).
- **`useDocumentBrowserModel`** — `handleDelete` (→ Trash) + new `handlePermanentDelete` (→ bypass), dispatched by record type. Bulk delete rides `handleDelete`. Permission gate unchanged (`canDelete`).
- **`DocumentCard`** — the delete confirm now offers **Trash** (recoverable, neutral) and, when permitted, **Forever** (danger) + **Cancel**.

## Tests
Soft-delete lands in Trash without releasing blobs; permanent delete hard-removes + releases. Full suite green (1952).

Closes JP-292.

Assisted-by: Opus 4.8