### PR TITLE
JP-293: Trash view UI + Storage-Manager "In Trash" badge

### DIFF
--- a/src/store/trashStore.ts
+++ b/src/store/trashStore.ts
@@ -31,6 +31,7 @@ import { blobStorage } from '../storage/BlobStorage';
 import { BlobGarbageCollector } from '../storage/BlobGarbageCollector';
 import {
   getTrashItems,
+  getTrashedBlobReferences,
   moveToTrash,
   recoverFromTrash,
   permanentlyDeleteFromTrash,
@@ -39,7 +40,7 @@ import {
   type TrashItem,
   type TrashOrigin,
 } from '../storage/TrashStorage';
-import { usePersistenceStore } from './persistenceStore';
+import { usePersistenceStore, loadDocumentFromStorage } from './persistenceStore';
 
 /** Reused so the incremental ref cache survives across reclaim passes. */
 const gc = new BlobGarbageCollector(blobStorage);
@@ -55,6 +56,29 @@ async function reclaimOrphanedBlobs(): Promise<void> {
   } catch (error) {
     console.warn('[trashStore] blob reclaim failed (will retry next sweep):', error);
   }
+}
+
+/**
+ * Bytes that emptying the Trash would reclaim: blobs referenced *only* by
+ * trashed documents (not by any active document). Used by the Trash view's
+ * "Empty Trash" affordance to show what the fire button frees (JP-293).
+ */
+export async function getTrashReclaimableBytes(): Promise<number> {
+  const trashRefs = getTrashedBlobReferences();
+  if (trashRefs.size === 0) return 0;
+
+  // Blob hashes still referenced by an active (non-trashed) document.
+  const activeRefs = new Set<string>();
+  for (const meta of usePersistenceStore.getState().getDocumentList()) {
+    const doc = loadDocumentFromStorage(meta.id);
+    doc?.blobReferences?.forEach((h) => activeRefs.add(h));
+  }
+
+  const reclaimable = [...trashRefs].filter((h) => !activeRefs.has(h));
+  if (reclaimable.length === 0) return 0;
+
+  const sizeByHash = new Map((await blobStorage.listAllBlobs()).map((b) => [b.id, b.size]));
+  return reclaimable.reduce((sum, h) => sum + (sizeByHash.get(h) ?? 0), 0);
 }
 
 interface TrashState {

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -552,3 +552,162 @@
     transition: none;
   }
 }
+
+/* ── Trash view (JP-293) ───────────────────────────────────────────────── */
+.trash-sub {
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.trash-empty-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.trash-empty-btn:hover:not(:disabled) {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.trash-empty-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.trash-empty-bytes {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.trash-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.trash-confirm-yes,
+.trash-confirm-no {
+  padding: 5px 12px;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.trash-confirm-yes {
+  background: var(--danger);
+  color: #fff;
+}
+.trash-confirm-no {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.trash-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 64px 16px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+.trash-empty-state p {
+  margin: 4px 0 0;
+  font-size: 15px;
+  color: var(--text-primary);
+}
+.trash-empty-state span {
+  font-size: 13px;
+  max-width: 360px;
+}
+
+.trash-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.trash-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+}
+.trash-kind {
+  display: inline-flex;
+  color: var(--text-secondary);
+}
+.trash-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.trash-name {
+  font-size: 14px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.trash-detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.trash-tag {
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+.trash-tag--stranded {
+  background: rgba(31, 51, 84, 0.12);
+  color: var(--color-primary, var(--text-primary));
+}
+.trash-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.trash-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.trash-action:hover {
+  background: var(--bg-tertiary);
+}
+.trash-action--danger:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+}

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -37,6 +37,8 @@ import { useDocumentBrowserModel, SORT_LABELS } from '../settings/useDocumentBro
 import { DocumentList, SelectionBar } from '../settings/DocumentList';
 import { StorageSettings } from '../settings/StorageSettings';
 import { RelaySettings } from '../settings/RelaySettings';
+import { TrashView } from './TrashView';
+import { useTrashStore } from '../../store/trashStore';
 import { useThemeStore } from '../../store/themeStore';
 import { getDocProvider } from '../../store/relayDocumentStore';
 import type { RelayUsage } from '../../api/relayClient';
@@ -98,7 +100,9 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
   const [nav, setNav] = useState<NavId>('all');
   // Which destination the main area shows. Storage (JP-215) and Cloud (JP-213)
   // are first-class views inside the surface, not Settings tabs.
-  const [mainView, setMainView] = useState<'documents' | 'storage' | 'cloud'>('documents');
+  const [mainView, setMainView] = useState<'documents' | 'storage' | 'cloud' | 'trash'>('documents');
+  const trashCount = useTrashStore((s) => s.items.length);
+  const refreshTrash = useTrashStore((s) => s.refresh);
 
   const selectNav = (id: NavId) => {
     setNav(id);
@@ -195,6 +199,11 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
     void opener.openExternalUrl(`${cloudBaseUrl.replace(/\/+$/, '')}/account`);
   };
 
+  // Keep the Trash nav count accurate on open (other surfaces mutate the bin).
+  useEffect(() => {
+    refreshTrash();
+  }, [refreshTrash]);
+
   // "Continue working" strip: the most recent docs, shown on All without a query.
   const recents = useMemo(() => documentList.slice(0, 3), [documentList]);
   const showRecents = nav === 'all' && collectionFilter === null && !searchQuery && recents.length > 0;
@@ -286,11 +295,14 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
             </>
           )}
 
-          {/* Trash lights up once relay deletion signals (JP-175) land. */}
-          <button className="dh-nav-item dh-nav-item--disabled" disabled title="Coming soon">
+          <button
+            className={`dh-nav-item${mainView === 'trash' ? ' dh-nav-item--on' : ''}`}
+            onClick={() => setMainView('trash')}
+            title="Trash"
+          >
             <Trash2 size={17} aria-hidden="true" />
             <span className="dh-nav-label">Trash</span>
-            <span className="dh-nav-soon">soon</span>
+            {trashCount > 0 && <span className="dh-nav-count">{trashCount}</span>}
           </button>
         </nav>
 
@@ -380,6 +392,8 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
               <RelaySettings />
             </div>
           </>
+        ) : mainView === 'trash' ? (
+          <TrashView onBack={() => setMainView('documents')} />
         ) : (
           <>
         <header className="dh-top">

--- a/src/ui/home/TrashView.tsx
+++ b/src/ui/home/TrashView.tsx
@@ -1,0 +1,179 @@
+/**
+ * TrashView — the Documents "Trash" bin (JP-293).
+ *
+ * Lists soft-deleted documents the user can recover or purge. Two kinds today
+ * (a future relay-soft-delete kind, JP-294, slots in via `trashStore`):
+ *  - **Local**    — a personal document the user deleted.
+ *  - **Stranded** — a relay document hard-deleted on the relay; we kept the
+ *    last local copy here rather than wiping it.
+ *
+ * Per item: Restore (both kinds come back as a *local* document) and Delete
+ * permanently. A header "Empty Trash" (the fire button) purges everything and
+ * reclaims the blob bytes only the Trash was keeping alive.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, Flame, RotateCcw, Trash2, Cloud, HardDrive } from 'lucide-react';
+import { useTrashStore, getTrashReclaimableBytes } from '../../store/trashStore';
+import type { TrashItem } from '../../storage/TrashStorage';
+import { formatFileSize } from '../../utils/imageUtils';
+
+export interface TrashViewProps {
+  /** Back to the documents list. */
+  onBack: () => void;
+}
+
+/** "in 3 days" / "in 5 hours" / "soon" for an expiry timestamp. */
+function formatExpiry(expiresAt: number): string {
+  const ms = expiresAt - Date.now();
+  if (ms <= 0) return 'any moment now';
+  const days = Math.floor(ms / 86_400_000);
+  if (days >= 1) return `in ${days} day${days === 1 ? '' : 's'}`;
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours >= 1) return `in ${hours} hour${hours === 1 ? '' : 's'}`;
+  return 'soon';
+}
+
+function kindLabel(item: TrashItem): { label: string; Icon: typeof Cloud } {
+  return item.kind === 'stranded'
+    ? { label: 'Stranded', Icon: Cloud }
+    : { label: 'Local', Icon: HardDrive };
+}
+
+export function TrashView({ onBack }: TrashViewProps) {
+  const items = useTrashStore((s) => s.items);
+  const refresh = useTrashStore((s) => s.refresh);
+  const restore = useTrashStore((s) => s.restore);
+  const purge = useTrashStore((s) => s.purge);
+  const emptyAll = useTrashStore((s) => s.emptyAll);
+
+  const [confirmEmpty, setConfirmEmpty] = useState(false);
+  const [reclaimable, setReclaimable] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Reload from storage on open (other surfaces may have changed it).
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Recompute reclaimable bytes whenever the list changes.
+  useEffect(() => {
+    let cancelled = false;
+    if (items.length === 0) {
+      setReclaimable(0);
+      return;
+    }
+    void getTrashReclaimableBytes().then((b) => {
+      if (!cancelled) setReclaimable(b);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [items]);
+
+  const sorted = useMemo(() => [...items].sort((a, b) => b.deletedAt - a.deletedAt), [items]);
+
+  const onEmpty = async () => {
+    setBusy(true);
+    try {
+      await emptyAll();
+    } finally {
+      setBusy(false);
+      setConfirmEmpty(false);
+    }
+  };
+
+  return (
+    <>
+      <header className="dh-top">
+        <button className="dh-back" onClick={onBack} title="Back to documents">
+          <ChevronLeft size={18} aria-hidden="true" />
+          <span>Documents</span>
+        </button>
+        <div className="dh-crumb">
+          <strong>Trash</strong>
+          <span className="trash-sub">{items.length} item{items.length === 1 ? '' : 's'}</span>
+        </div>
+        <div className="dh-top-actions">
+          {!confirmEmpty ? (
+            <button
+              className="trash-empty-btn"
+              onClick={() => setConfirmEmpty(true)}
+              disabled={items.length === 0 || busy}
+              title="Permanently delete everything in the Trash"
+            >
+              <Flame size={16} aria-hidden="true" />
+              <span>Empty Trash</span>
+              {reclaimable != null && reclaimable > 0 && (
+                <span className="trash-empty-bytes">frees {formatFileSize(reclaimable)}</span>
+              )}
+            </button>
+          ) : (
+            <div className="trash-confirm">
+              <span>Delete all {items.length} permanently?</span>
+              <button className="trash-confirm-yes" onClick={onEmpty} disabled={busy}>
+                Empty
+              </button>
+              <button className="trash-confirm-no" onClick={() => setConfirmEmpty(false)} disabled={busy}>
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className="dh-content">
+        {sorted.length === 0 ? (
+          <div className="trash-empty-state">
+            <Trash2 size={32} aria-hidden="true" />
+            <p>Trash is empty.</p>
+            <span>Deleted documents land here and are removed automatically after a while.</span>
+          </div>
+        ) : (
+          <ul className="trash-list">
+            {sorted.map((item) => {
+              const { label, Icon } = kindLabel(item);
+              return (
+                <li key={item.id} className="trash-row">
+                  <span className="trash-kind" title={label}>
+                    <Icon size={16} aria-hidden="true" />
+                  </span>
+                  <span className="trash-meta">
+                    <span className="trash-name">{item.name}</span>
+                    <span className="trash-detail">
+                      <span className={`trash-tag trash-tag--${item.kind ?? 'local'}`}>{label}</span>
+                      <span className="trash-expiry">Removed {formatExpiry(item.expiresAt)}</span>
+                    </span>
+                  </span>
+                  <span className="trash-actions">
+                    <button
+                      className="trash-action"
+                      onClick={() => void restore(item.id)}
+                      title={
+                        item.kind === 'stranded'
+                          ? 'Keep as a local document (the relay copy is gone)'
+                          : 'Restore this document'
+                      }
+                    >
+                      <RotateCcw size={15} aria-hidden="true" />
+                      <span>{item.kind === 'stranded' ? 'Keep local' : 'Restore'}</span>
+                    </button>
+                    <button
+                      className="trash-action trash-action--danger"
+                      onClick={() => void purge(item.id)}
+                      title="Delete permanently"
+                    >
+                      <Trash2 size={15} aria-hidden="true" />
+                    </button>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default TrashView;

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -209,6 +209,12 @@
   background: rgba(31, 51, 84, 0.1);
 }
 
+/* Blob kept alive only by the Trash (JP-293). */
+.storage-orphan-badge.storage-trash-badge {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
 /* Icon tag in blob list */
 .storage-icon-tag {
   margin-left: 6px;

--- a/src/ui/settings/StorageSettings.tsx
+++ b/src/ui/settings/StorageSettings.tsx
@@ -15,6 +15,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { blobStorage } from '../../storage/BlobStorage';
+import { getTrashItems } from '../../storage/TrashStorage';
 import { BlobGarbageCollector } from '../../storage/BlobGarbageCollector';
 import type { BlobMetadata, StorageStats, GCStats } from '../../storage/BlobTypes';
 import { useIconLibraryStore, initializeIconLibrary } from '../../store/iconLibraryStore';
@@ -32,6 +33,8 @@ type TabId = 'images' | 'icons';
 /** A blob's owning documents + the sync state derived from them (JP-212). */
 interface BlobOwnership {
   owners: { id: string; name: string }[];
+  /** Trashed documents that reference this blob (JP-293). */
+  trashedOwners: { id: string; name: string }[];
   sync: ExtendedSyncState;
 }
 
@@ -111,12 +114,28 @@ export function StorageSettings() {
           (owners[blobId] ??= []).push({ id: docMeta.id, name: docMeta.name });
         }
       }
+
+      // JP-293: blobs are also kept alive by *trashed* documents. Tag those so
+      // the UI can show a blob is only reachable through the Trash (and would be
+      // freed by emptying it). Trash items carry a snapshotted blobReferences list.
+      const trashedOwners: Record<string, { id: string; name: string }[]> = {};
+      for (const item of getTrashItems()) {
+        for (const blobId of item.blobReferences ?? []) {
+          (trashedOwners[blobId] ??= []).push({ id: item.id, name: item.name });
+        }
+      }
+
       const info: Record<string, BlobOwnership> = {};
-      for (const [blobId, docs] of Object.entries(owners)) {
+      for (const blobId of new Set([...Object.keys(owners), ...Object.keys(trashedOwners)])) {
+        const docs = owners[blobId] ?? [];
         const records = docs
           .map((d) => registry.getRecord(d.id))
           .filter((r): r is DocumentRecord => Boolean(r));
-        info[blobId] = { owners: docs, sync: deriveBlobSyncState(records) };
+        info[blobId] = {
+          owners: docs,
+          trashedOwners: trashedOwners[blobId] ?? [],
+          sync: deriveBlobSyncState(records),
+        };
       }
       setOwnership(info);
     } catch (error) {
@@ -408,6 +427,9 @@ export function StorageSettings() {
                   const isIcon = blob.type === 'image/svg+xml';
                   const own = ownership[blob.id];
                   const owners = own?.owners ?? [];
+                  const trashedOwners = own?.trashedOwners ?? [];
+                  // Held alive only by the Trash → reclaimable by emptying it.
+                  const trashOnly = owners.length === 0 && trashedOwners.length > 0;
                   return (
                     <div key={blob.id} className="storage-list-item">
                       <span className="storage-col-name" title={blob.name}>
@@ -420,6 +442,15 @@ export function StorageSettings() {
                         {blob.usageCount === 0 ? (
                           <span className={`storage-orphan-badge ${isIcon ? 'protected' : ''}`}>
                             {isIcon ? 'Protected' : 'Orphaned'}
+                          </span>
+                        ) : trashOnly ? (
+                          <span
+                            className="storage-orphan-badge storage-trash-badge"
+                            title={`Only referenced from the Trash: ${trashedOwners
+                              .map((o) => o.name)
+                              .join(', ')}. Emptying the Trash frees this.`}
+                          >
+                            In Trash
                           </span>
                         ) : (
                           <span


### PR DESCRIPTION
**Top of the stack** — `master → #152 → #153 → #154 → this`. Merge bottom-up.

Lights up the previously-disabled "Trash" nav button in the Documents browser and surfaces trash-held blobs in the Storage Manager — the user-facing payoff of the trash work.

## Changes
- **`TrashView`** (new) — lists `trashStore` entries with a kind badge (**Local** / **Stranded**), per-item **Restore** (a stranded entry restores as *"Keep local"*, since the relay copy is gone) + **Delete permanently**, a header **Empty Trash** (`Flame`) with a confirm + **"frees N MB"**, and a "Removed in N days" TTL countdown. Clean empty state.
- **`DocumentsHome`** — the Trash nav button is now active (with a count badge) and routes to a `'trash'` main view; the count refreshes on open.
- **`trashStore.getTrashReclaimableBytes`** — bytes referenced *only* by trashed docs (active∪trash − active) → what the fire button frees.
- **`StorageSettings`** — the JP-212 per-blob ownership scan now also tags trashed-doc owners; a blob held *only* by the Trash shows an **"In Trash"** badge (the "trashed flag on each reference" idea — it falls out of the same partition the GC already needs).

## Verification
typecheck + full suite (1952) green; leak-grep clean. UI is non-rendered-in-tests; recommend a manual pass on the stack once merged (delete → appears in Trash → restore / empty-frees-bytes; "In Trash" badge in Storage Manager).

Closes JP-293.

Assisted-by: Opus 4.8