### PR TITLE
Fix inline shape label resetting while typing

### DIFF
--- a/src/ui/TextEditor.inputReset.test.tsx
+++ b/src/ui/TextEditor.inputReset.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Regression guard for the "shape label resets while typing" bug.
+ *
+ * Root cause (now fixed): the inline label editor used an UNCONTROLLED textarea
+ * whose "focus on edit start" effect re-derived `textarea.value` from the shape
+ * on EVERY render. Because `<TextEditor>` is not memoized and `useAutoSave()`
+ * sits at the app root force-re-rendering the whole tree on each autosave status
+ * pulse (pending→saving→saved→idle) and on `isDirty`/`lastSavedAt` changes, any
+ * save/cache cycle that landed while the user was typing re-ran that effect and
+ * wiped the draft. The trigger was NOT a `documentStore.shapes` write — an
+ * ancestor re-render with no shapes change was enough.
+ *
+ * The fix (`useInlineLabelEditor`) seeds the draft exactly once per edit
+ * session, keyed on `editingTextId` alone, so re-renders can no longer clobber
+ * in-progress keystrokes. These tests reproduce the three ways the editor gets
+ * re-rendered mid-type and assert the draft survives each.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import { TextEditor } from './TextEditor';
+import { Camera } from '../engine/Camera';
+import { useSessionStore } from '../store/sessionStore';
+import { useDocumentStore } from '../store/documentStore';
+import { rectangleHandler } from '../shapes/Rectangle';
+import { Vec2 } from '../math/Vec2';
+import type { RectangleShape } from '../shapes/Shape';
+
+function makeRect(id: string, label: string): RectangleShape {
+  const shape = rectangleHandler.create(new Vec2(100, 100), id) as RectangleShape;
+  return { ...shape, label } as RectangleShape;
+}
+
+function resetStores() {
+  useDocumentStore.setState({ shapes: {}, shapeOrder: [] });
+  useSessionStore.getState().stopTextEdit();
+}
+
+const camera = () => new Camera({ x: 0, y: 0, zoom: 1 });
+
+/** Wrapper exposing a bump() that re-renders <TextEditor> WITHOUT any store
+ *  change — exactly what an autosave status pulse does via the root re-render. */
+let bumpAncestor: () => void = () => {};
+function Harness() {
+  const [, setN] = useState(0);
+  bumpAncestor = () => setN((n) => n + 1);
+  return <TextEditor camera={camera()} />;
+}
+
+describe('TextEditor — inline label survives re-renders while typing', () => {
+  beforeEach(resetStores);
+  afterEach(() => {
+    cleanup();
+    resetStores();
+  });
+
+  it('characterizes the historical root cause: getEditTarget returns a new object each call', () => {
+    const rect = makeRect('rect-1', 'Stored');
+    const a = rectangleHandler.getLabelEditTarget!(rect);
+    const b = rectangleHandler.getLabelEditTarget!(rect);
+    // Structurally equal, different identity — putting this in an effect dep
+    // array is what made the focus effect re-run (and re-seed) every render.
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps in-progress typing across an ANCESTOR re-render (autosave status pulse)', () => {
+    const edited = makeRect('rect-edited', 'Stored');
+    act(() => {
+      useDocumentStore.setState({ shapes: { [edited.id]: edited }, shapeOrder: [edited.id] });
+      useSessionStore.getState().startTextEdit(edited.id);
+    });
+
+    const { container } = render(<Harness />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+
+    // User types. fireEvent keeps React's view of the uncontrolled value honest.
+    fireEvent.change(textarea, { target: { value: 'User is typing…' } });
+
+    // The whole tree re-renders (no shapes change) — what useAutoSave's force()
+    // does on every pending/saving/saved/idle transition.
+    act(() => bumpAncestor());
+
+    expect(textarea.value).toBe('User is typing…');
+  });
+
+  it('keeps in-progress typing when an UNRELATED shape updates (store write)', () => {
+    const edited = makeRect('rect-edited', 'Stored');
+    const other = makeRect('rect-other', 'Other');
+    act(() => {
+      useDocumentStore.setState({
+        shapes: { [edited.id]: edited, [other.id]: other },
+        shapeOrder: [edited.id, other.id],
+      });
+      useSessionStore.getState().startTextEdit(edited.id);
+    });
+
+    const { container } = render(<TextEditor camera={camera()} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Half-typed' } });
+
+    act(() => {
+      useDocumentStore.getState().updateShape('rect-other', { x: 200 });
+    });
+
+    expect(textarea.value).toBe('Half-typed');
+  });
+
+  it('keeps in-progress typing when the edited shape gets a remote position update', () => {
+    const edited = makeRect('rect-edited', 'Stored');
+    act(() => {
+      useDocumentStore.setState({ shapes: { [edited.id]: edited }, shapeOrder: [edited.id] });
+      useSessionStore.getState().startTextEdit(edited.id);
+    });
+
+    const { container } = render(<TextEditor camera={camera()} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Half-typed label' } });
+
+    // Remote sync moves the shape; the label field is untouched.
+    act(() => {
+      useDocumentStore.getState().updateShape('rect-edited', { x: 350 });
+    });
+
+    expect(textarea.value).toBe('Half-typed label');
+  });
+
+  it('still commits the typed label to the shape on blur (save path intact)', () => {
+    const edited = makeRect('rect-edited', 'Stored');
+    act(() => {
+      useDocumentStore.setState({ shapes: { [edited.id]: edited }, shapeOrder: [edited.id] });
+      useSessionStore.getState().startTextEdit(edited.id);
+    });
+
+    const { container } = render(<TextEditor camera={camera()} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Committed label' } });
+
+    act(() => {
+      fireEvent.blur(textarea);
+    });
+
+    const saved = useDocumentStore.getState().shapes['rect-edited'] as RectangleShape;
+    expect(saved.label).toBe('Committed label');
+    expect(useSessionStore.getState().editingTextId).toBeNull();
+  });
+});

--- a/src/ui/TextEditor.tsx
+++ b/src/ui/TextEditor.tsx
@@ -1,36 +1,12 @@
-import { useEffect, useRef, useCallback } from 'react';
-import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
-import { pushHistory } from '../store/historyStore';
-import { isText, Shape } from '../shapes/Shape';
-import { shapeRegistry, type LabelEditTarget } from '../shapes/ShapeRegistry';
+import { isText } from '../shapes/Shape';
 import { Vec2 } from '../math/Vec2';
 import { Camera } from '../engine/Camera';
+import { useInlineLabelEditor, getEditTarget, readField } from './useInlineLabelEditor';
 import './TextEditor.css';
 
 export interface TextEditorProps {
   camera: Camera | null;
-}
-
-/**
- * Read the editable text for a shape from the target field.
- * Text shapes store `text`; all other label-bearing shapes store `label`.
- */
-function readField(shape: Shape, field: 'label' | 'text'): string {
-  if (field === 'text') {
-    return isText(shape) ? shape.text : '';
-  }
-  return (shape as { label?: string }).label ?? '';
-}
-
-/**
- * Resolve the in-place edit target for a shape via its handler capability.
- * Returns null when the shape has no editable label (JP-102 capability check).
- */
-function getEditTarget(shape: Shape | null | undefined): LabelEditTarget | null {
-  if (!shape) return null;
-  const handler = shapeRegistry.getHandler(shape.type);
-  return handler.getLabelEditTarget?.(shape) ?? null;
 }
 
 /**
@@ -42,64 +18,22 @@ function getEditTarget(shape: Shape | null | undefined): LabelEditTarget | null 
  * shapes keep their bespoke top-left anchoring; every other shape is positioned
  * from the target's world rect.
  *
- * Saves changes on blur or Enter (Shift+Enter inserts a newline).
+ * The *edit session* (the in-progress draft, focus, save-on-blur/Enter) is owned
+ * by {@link useInlineLabelEditor}, which seeds the textarea exactly once per
+ * session. This component is responsible only for *positioning* the overlay,
+ * which intentionally stays reactive so the box follows the shape as it moves.
+ * Keeping those two concerns apart is what stops unrelated re-renders (autosave
+ * status pulses, cache writes, CRDT sync) from wiping a draft mid-type.
  */
 export function TextEditor({ camera }: TextEditorProps) {
-  const editingTextId = useSessionStore((state) => state.editingTextId);
-  const stopTextEdit = useSessionStore((state) => state.stopTextEdit);
+  const { editingTextId, textareaRef, handleSave, handleKeyDown } =
+    useInlineLabelEditor();
+  // Subscribed for positioning only — the draft value is owned by the hook.
   const shapes = useDocumentStore((state) => state.shapes);
-  const updateShape = useDocumentStore((state) => state.updateShape);
-
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const originalTextRef = useRef<string>('');
 
   const shape = editingTextId ? shapes[editingTextId] : null;
   const target = getEditTarget(shape);
   const canEdit = !!shape && target !== null;
-
-  // Focus the textarea when editing starts.
-  useEffect(() => {
-    if (canEdit && shape && target && textareaRef.current) {
-      const text = readField(shape, target.field);
-      originalTextRef.current = text;
-      textareaRef.current.value = text;
-      requestAnimationFrame(() => {
-        if (textareaRef.current) {
-          textareaRef.current.focus();
-          textareaRef.current.select();
-        }
-      });
-    }
-  }, [canEdit, shape, target, editingTextId]);
-
-  const handleSave = useCallback(() => {
-    if (!editingTextId || !textareaRef.current || !shape || !target) return;
-
-    const newText = textareaRef.current.value;
-    if (newText !== originalTextRef.current) {
-      pushHistory(target.field === 'text' ? 'Edit text' : 'Edit label');
-      updateShape(editingTextId, { [target.field]: newText } as Partial<Shape>);
-    }
-    stopTextEdit();
-  }, [editingTextId, shape, target, updateShape, stopTextEdit]);
-
-  const handleCancel = useCallback(() => {
-    stopTextEdit();
-  }, [stopTextEdit]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        handleCancel();
-      } else if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        handleSave();
-      }
-      // Shift+Enter allows newlines
-    },
-    [handleSave, handleCancel]
-  );
 
   if (!canEdit || !shape || !target || !camera) {
     return null;

--- a/src/ui/useInlineLabelEditor.ts
+++ b/src/ui/useInlineLabelEditor.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSessionStore } from '../store/sessionStore';
+import { useDocumentStore } from '../store/documentStore';
+import { pushHistory } from '../store/historyStore';
+import { isText, Shape } from '../shapes/Shape';
+import { shapeRegistry, type LabelEditTarget } from '../shapes/ShapeRegistry';
+
+/**
+ * Read the editable text for a shape from the target field.
+ * Text shapes store `text`; all other label-bearing shapes store `label`.
+ */
+export function readField(shape: Shape, field: 'label' | 'text'): string {
+  if (field === 'text') {
+    return isText(shape) ? shape.text : '';
+  }
+  return (shape as { label?: string }).label ?? '';
+}
+
+/**
+ * Resolve the in-place edit target for a shape via its handler capability.
+ * Returns null when the shape has no editable label (JP-102 capability check).
+ *
+ * NOTE: handlers return a FRESH object each call, so the result is never
+ * referentially stable across renders — never put it in a hook dependency
+ * array (that was the root of the "label resets while typing" bug).
+ */
+export function getEditTarget(shape: Shape | null | undefined): LabelEditTarget | null {
+  if (!shape) return null;
+  const handler = shapeRegistry.getHandler(shape.type);
+  return handler.getLabelEditTarget?.(shape) ?? null;
+}
+
+export interface InlineLabelEditor {
+  /** The id of the shape currently being edited, or null. */
+  editingTextId: string | null;
+  /** Ref to attach to the editing `<textarea>`. */
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  /** Commit the draft to the shape (on blur / Enter) and end the session. */
+  handleSave: () => void;
+  /** Discard the draft (on Escape) and end the session. */
+  handleCancel: () => void;
+  /** Keydown handler implementing Enter=save, Shift+Enter=newline, Esc=cancel. */
+  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+}
+
+/**
+ * Owns the lifecycle of an inline label-edit *session*, decoupled from the
+ * shape's persisted label.
+ *
+ * The crux: the textarea is uncontrolled and its value (the in-progress draft)
+ * is **seeded exactly once per session**, keyed on `editingTextId` alone. It is
+ * deliberately NOT re-derived from the shape on every render. That is what makes
+ * the editor robust to the store churn that happens right after a document opens
+ * or as edits are autosaved/cached/synced — those re-renders previously re-ran a
+ * `textarea.value = <stored label>` assignment and wiped whatever the user had
+ * typed.
+ *
+ * The shape/target are read fresh from the stores at session start and at save
+ * time via `getState()` — never captured into a dependency array (the target
+ * object is a fresh reference every call; see `getEditTarget`).
+ */
+export function useInlineLabelEditor(): InlineLabelEditor {
+  const editingTextId = useSessionStore((state) => state.editingTextId);
+  const stopTextEdit = useSessionStore((state) => state.stopTextEdit);
+  const updateShape = useDocumentStore((state) => state.updateShape);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const originalTextRef = useRef<string>('');
+
+  // Seed the draft and focus EXACTLY ONCE per edit session. Depending only on
+  // `editingTextId` (not on `shape`/`target`, whose references change every
+  // render) means an unrelated store write — autosave, cache round-trip, CRDT
+  // sync — re-renders the editor without re-seeding the textarea, so it can no
+  // longer clobber in-progress keystrokes.
+  useEffect(() => {
+    if (!editingTextId) return;
+    const shape = useDocumentStore.getState().shapes[editingTextId];
+    const target = getEditTarget(shape);
+    const textarea = textareaRef.current;
+    if (!shape || !target || !textarea) return;
+
+    const text = readField(shape, target.field);
+    originalTextRef.current = text;
+    textarea.value = text;
+
+    const raf = requestAnimationFrame(() => {
+      if (textareaRef.current) {
+        textareaRef.current.focus();
+        textareaRef.current.select();
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [editingTextId]);
+
+  const handleSave = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!editingTextId || !textarea) return;
+
+    // Read the target fresh — the shape may have moved/changed during the
+    // session, but its edit field (label vs text) is stable per type.
+    const shape = useDocumentStore.getState().shapes[editingTextId];
+    const target = getEditTarget(shape);
+    if (!shape || !target) {
+      stopTextEdit();
+      return;
+    }
+
+    const newText = textarea.value;
+    if (newText !== originalTextRef.current) {
+      pushHistory(target.field === 'text' ? 'Edit text' : 'Edit label');
+      updateShape(editingTextId, { [target.field]: newText } as Partial<Shape>);
+    }
+    stopTextEdit();
+  }, [editingTextId, updateShape, stopTextEdit]);
+
+  const handleCancel = useCallback(() => {
+    stopTextEdit();
+  }, [stopTextEdit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+      } else if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSave();
+      }
+      // Shift+Enter allows newlines
+    },
+    [handleSave, handleCancel]
+  );
+
+  return { editingTextId, textareaRef, handleSave, handleCancel, handleKeyDown };
+}


### PR DESCRIPTION
## The bug

For the first ~10-20s after opening a document — and any time you make a
follow-up label edit right after another — typing into a shape's inline label
gets wiped every few seconds. Reproduces on **both collab and local** documents.

## Root cause

The inline label editor used an **uncontrolled** textarea whose "focus on edit
start" effect re-derived `textarea.value` from the shape on **every render**.
Two things made it fire mid-type:

- the effect's `target` dependency is a fresh object each render (handlers build
  `getLabelEditTarget` results inline, so the reference is never stable), and
- `<TextEditor>` is not memoized, so any ancestor re-render re-ran the effect.

The trigger in practice is `useAutoSave()` at the app root: it force-re-renders
the whole tree on every autosave status pulse (`pending→saving→saved→idle`) and
on `isDirty`/`lastSavedAt` changes. So each save/cache cycle that landed while
the user was typing overwrote the draft — worst right after open, when the doc
is settling and saves fire repeatedly.

## Fix

Fix at the editor, where the draft belongs. Extract `useInlineLabelEditor`,
which owns the edit session and seeds the textarea **exactly once per session**
(keyed on `editingTextId` alone). `<TextEditor>` keeps only the reactive
positioning, so the overlay still follows the shape as it moves. Re-renders can
no longer clobber the draft, regardless of their source.

## Tests

`TextEditor.inputReset.test.tsx` covers the three re-render paths (ancestor
re-render with no shapes change, unrelated store write, edited-shape update),
the save-on-blur path, and the unstable-`target` root cause. Full suite green
(1943 passing), typecheck clean.

> Not on the board — surfaced and fixed directly. A follow-up optimization for
> the root-level autosave over-rendering is filed separately.

Assisted-by: Opus 4.8