### PR TITLE
JP-196: hitch imported bound arrows to edge anchors, not shape centre

### DIFF
--- a/src/shapes/import/adapters/excalidrawAdapter.test.ts
+++ b/src/shapes/import/adapters/excalidrawAdapter.test.ts
@@ -62,6 +62,17 @@ describe('excalidrawAdapter', () => {
     expect(conn.endShapeId).toBe(ell.id);
   });
 
+  it('hitches bound arrows to edge anchors, not the shape centre (JP-196)', async () => {
+    const { shapes } = await excalidrawAdapter.import(JSON.stringify(scene));
+    const conn = find(shapes, 'connector') as { startAnchor?: string; endAnchor?: string };
+    // r1 centre (60,40), arrow runs right toward e1 → leaves r1 on the right;
+    // e1 centre (240,30), arrow arrives from the left → enters e1 on the left.
+    expect(conn.startAnchor).toBe('right');
+    expect(conn.endAnchor).toBe('left');
+    expect(conn.startAnchor).not.toBe('center');
+    expect(conn.endAnchor).not.toBe('center');
+  });
+
   it('skips freedraw and reports it', async () => {
     const { shapes, warnings } = await excalidrawAdapter.import(JSON.stringify(scene));
     expect(find(shapes, 'freedraw')).toBeUndefined();

--- a/src/shapes/import/adapters/excalidrawAdapter.ts
+++ b/src/shapes/import/adapters/excalidrawAdapter.ts
@@ -23,6 +23,7 @@ import {
 } from '../../Shape';
 import { blobStorage } from '../../../storage/BlobStorage';
 import { AUTO_COLOR } from '../../../engine/ContrastResolver';
+import { nearestEdgeAnchor, boxFromTopLeft } from '../connectorBinding';
 
 /** Excalidraw's default stroke — theme-inverted by Excalidraw at render time. */
 const EXCALIDRAW_DEFAULT_STROKE = '#1e1e1e';
@@ -124,6 +125,7 @@ async function importExcalidraw(raw: string): Promise<ImportResult> {
   }
 
   const elements = scene.elements.filter((el) => !el.isDeleted);
+  const elById = new Map(elements.map((el) => [el.id, el])); // excalidraw id → element
   const idMap = new Map<string, string>(); // excalidraw id → DocuShark shape id
   const boundText = new Map<string, ExElement>(); // containerId → text element
   const labelById = new Map<string, string>(); // DocuShark shape id → label text
@@ -277,16 +279,33 @@ async function importExcalidraw(raw: string): Promise<ImportResult> {
     const pts = el.points ?? [[0, 0], [el.width, el.height]];
     const a = pts[0] ?? [0, 0];
     const b = pts[pts.length - 1] ?? [el.width, el.height];
-    const startId = el.startBinding?.elementId ? idMap.get(el.startBinding.elementId) : undefined;
-    const endId = el.endBinding?.elementId ? idMap.get(el.endBinding.elementId) : undefined;
+    const startPoint = { x: el.x + a[0], y: el.y + a[1] };
+    const endPoint = { x: el.x + b[0], y: el.y + b[1] };
+
+    const startEl = el.startBinding?.elementId ? elById.get(el.startBinding.elementId) : undefined;
+    const endEl = el.endBinding?.elementId ? elById.get(el.endBinding.elementId) : undefined;
+    const startId = startEl ? idMap.get(startEl.id) : undefined;
+    const endId = endEl ? idMap.get(endEl.id) : undefined;
+
+    // Resolve each bound endpoint to the boundary anchor facing the OTHER end,
+    // so the arrow hitches at the shape's edge instead of its centre (JP-196).
+    const startAnchor =
+      startId && startEl
+        ? nearestEdgeAnchor(boxFromTopLeft(startEl.x, startEl.y, startEl.width, startEl.height, startEl.angle ?? 0), endPoint)
+        : undefined;
+    const endAnchor =
+      endId && endEl
+        ? nearestEdgeAnchor(boxFromTopLeft(endEl.x, endEl.y, endEl.width, endEl.height, endEl.angle ?? 0), startPoint)
+        : undefined;
+
     shapes.push({
       ...DEFAULT_CONNECTOR,
       id: nanoid(),
       type: 'connector',
-      x: el.x + a[0],
-      y: el.y + a[1],
-      x2: el.x + b[0],
-      y2: el.y + b[1],
+      x: startPoint.x,
+      y: startPoint.y,
+      x2: endPoint.x,
+      y2: endPoint.y,
       rotation: 0,
       opacity: opacityOf(el),
       locked: false,
@@ -296,7 +315,9 @@ async function importExcalidraw(raw: string): Promise<ImportResult> {
       startArrow: false,
       endArrow: true,
       ...(startId ? { startShapeId: startId } : {}),
+      ...(startAnchor ? { startAnchor } : {}),
       ...(endId ? { endShapeId: endId } : {}),
+      ...(endAnchor ? { endAnchor } : {}),
     });
   }
 

--- a/src/shapes/import/connectorBinding.test.ts
+++ b/src/shapes/import/connectorBinding.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { nearestEdgeAnchor, boxFromTopLeft, type AnchorBox } from './connectorBinding';
+
+const UNIT: AnchorBox = { cx: 0, cy: 0, width: 100, height: 100 };
+
+describe('nearestEdgeAnchor', () => {
+  it('picks the cardinal side facing the toward-point', () => {
+    expect(nearestEdgeAnchor(UNIT, { x: 500, y: 0 })).toBe('right');
+    expect(nearestEdgeAnchor(UNIT, { x: -500, y: 0 })).toBe('left');
+    expect(nearestEdgeAnchor(UNIT, { x: 0, y: 500 })).toBe('bottom');
+    expect(nearestEdgeAnchor(UNIT, { x: 0, y: -500 })).toBe('top');
+  });
+
+  it('never resolves to the centre (the JP-196 bug)', () => {
+    // Even a point essentially at the centre yields an edge, not 'center'.
+    const side = nearestEdgeAnchor(UNIT, { x: 0, y: 0 });
+    expect(['top', 'right', 'bottom', 'left']).toContain(side);
+  });
+
+  it('respects aspect ratio — same raw point, opposite side per box shape', () => {
+    // The point (50,50) is a 45° tie on a square, but half-extent normalisation
+    // makes the *short* axis dominate: a wide (short) box sends it to bottom,
+    // a tall (narrow) box sends it to right.
+    const wide: AnchorBox = { cx: 0, cy: 0, width: 400, height: 40 };
+    const tall: AnchorBox = { cx: 0, cy: 0, width: 40, height: 400 };
+    expect(nearestEdgeAnchor(wide, { x: 50, y: 50 })).toBe('bottom');
+    expect(nearestEdgeAnchor(tall, { x: 50, y: 50 })).toBe('right');
+  });
+
+  it('undoes box rotation before choosing the side', () => {
+    // Box rotated 90° clockwise; a point to the world-right approaches what is
+    // locally the top edge.
+    const rotated: AnchorBox = { cx: 0, cy: 0, width: 100, height: 100, rotation: Math.PI / 2 };
+    expect(nearestEdgeAnchor(rotated, { x: 500, y: 0 })).toBe('top');
+  });
+
+  it('boxFromTopLeft centres a top-left rect', () => {
+    const box = boxFromTopLeft(10, 20, 100, 40);
+    expect(box).toEqual({ cx: 60, cy: 40, width: 100, height: 40, rotation: 0 });
+  });
+});

--- a/src/shapes/import/connectorBinding.ts
+++ b/src/shapes/import/connectorBinding.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared connector-binding helpers for import adapters (JP-196).
+ *
+ * Every import on-ramp (Excalidraw, drawio, Mermaid, PlantUML, …) faces the
+ * same problem: a source format binds an arrow to a node, and we must decide
+ * *where on the node's boundary* the connector hitches. Binding only the shape
+ * id leaves the endpoint at the shape **centre** (DocuShark's connector model
+ * resolves an unset anchor to the `'center'` anchor at local 0,0), so the line
+ * visibly runs into the middle of the box. This module centralises the
+ * "nearest hitch" rule so it's identical across adapters.
+ */
+
+import type { AnchorPosition } from '../Shape';
+
+/**
+ * A target shape's bounding box, in whatever coordinate space the adapter is
+ * working in (source-scene coords are fine — the rule is scale/space-agnostic
+ * as long as `box` and the `toward` point share a space).
+ */
+export interface AnchorBox {
+  /** Centre of the box. */
+  cx: number;
+  cy: number;
+  /** Full width / height of the box. */
+  width: number;
+  height: number;
+  /** Rotation in radians, clockwise. Defaults to 0. */
+  rotation?: number;
+}
+
+/** Build an {@link AnchorBox} from a top-left-anchored rect (the common case). */
+export function boxFromTopLeft(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  rotation = 0
+): AnchorBox {
+  return { cx: x + width / 2, cy: y + height / 2, width, height, rotation };
+}
+
+/**
+ * Pick the boundary anchor (`top` / `right` / `bottom` / `left`) of `box` that
+ * faces the point `toward` — the side an imported connector should hitch to
+ * instead of the shape centre.
+ *
+ * `toward` is normally the connector's **other** endpoint, so the binding lands
+ * on the side the rest of the connector runs to (the user's "project along the
+ * line from the connector's other end to the boundary" rule). The direction is
+ * normalised by the box's half-extents, so aspect ratio is respected — a wide
+ * box attaches on left/right far more readily than top/bottom — and the box's
+ * rotation is undone first so a rotated node still hitches on the visually
+ * correct face.
+ *
+ * The four returned sides are exactly the mid-edge anchors every box shape
+ * exposes via `createStandardAnchors`, so the connector resolves to that edge
+ * at render time (`getConnectorStartPoint` / `getConnectorEndPoint`).
+ */
+export function nearestEdgeAnchor(
+  box: AnchorBox,
+  toward: { x: number; y: number }
+): AnchorPosition {
+  let dx = toward.x - box.cx;
+  let dy = toward.y - box.cy;
+
+  const angle = box.rotation ?? 0;
+  if (angle) {
+    const cos = Math.cos(-angle);
+    const sin = Math.sin(-angle);
+    [dx, dy] = [dx * cos - dy * sin, dx * sin + dy * cos];
+  }
+
+  const nx = dx / Math.max(box.width / 2, 1e-6);
+  const ny = dy / Math.max(box.height / 2, 1e-6);
+
+  if (Math.abs(nx) >= Math.abs(ny)) return nx >= 0 ? 'right' : 'left';
+  return ny >= 0 ? 'bottom' : 'top';
+}


### PR DESCRIPTION
## The bug

Importing an Excalidraw file, a connector/arrow bound to a shape landed its endpoint at the **centre** of the target shape — the line visibly ran into the middle of the box instead of terminating at its border.

## Root cause

The adapter bound arrows with `startShapeId`/`endShapeId` but never set an anchor, so `DEFAULT_CONNECTOR.startAnchor`/`endAnchor` (`'center'`) won. The connector model resolves the `'center'` anchor to local `(0,0)` → the shape centre (`getConnectorStartPoint`/`getConnectorEndPoint` in `Connector.ts`). It was an endpoint-resolution fidelity bug, not a missing-binding bug.

## Fix

New shared helper `src/shapes/import/connectorBinding.ts`:

- `nearestEdgeAnchor(box, toward)` — picks the `top`/`right`/`bottom`/`left` mid-edge anchor facing `toward` (the connector's *other* endpoint, per the issue's "project along the line from the other end to the boundary" rule). Normalised by the box's half-extents so aspect ratio is respected, and de-rotates the box first so rotated nodes hitch on the visually correct face. The four sides map 1:1 to `createStandardAnchors`, so the connector resolves to that edge at render.
- `boxFromTopLeft(...)` convenience for the common top-left-anchored rect.

**Coordinate-space-agnostic and adapter-agnostic on purpose** — the other import on-ramps (drawio JP-86, Mermaid JP-85, PlantUML) reuse the identical nearest-hitch rule rather than each re-deriving it. The Excalidraw adapter just adapts its element to the box and sets `startAnchor`/`endAnchor`.

## Tests

- `connectorBinding.test.ts` — cardinals, never-centre, aspect-ratio (same raw point → opposite side per box shape), rotation, `boxFromTopLeft`.
- `excalidrawAdapter.test.ts` — the sample bound arrow now hitches `right`→`left`, not `center`.

Full suite green (1963), typecheck clean.

Assisted-by: Opus 4.8