### PR TITLE
JP-86: drawio import adapter (Phase 1 — primitives + bound edges)

### DIFF
--- a/src/shapes/import/adapters/__fixtures__/small-flowchart.drawio
+++ b/src/shapes/import/adapters/__fixtures__/small-flowchart.drawio
@@ -1,0 +1,61 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="Page-1" id="K6E8O5Y1DAfZg3Gjbj2_">
+    <mxGraphModel dx="1048" dy="711" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-3" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-2" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-17" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=classic;startFill=1;endArrow=none;endFill=0;" target="sJ5Oo2qX5d5MOfgK30kJ-16" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#b1ddf0;strokeColor=#10739e;" value="Process 1" vertex="1">
+          <mxGeometry height="60" width="120" x="380" y="340" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-5" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-4" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-7" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-6" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-2" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#60a917;fontColor=#ffffff;strokeColor=#2D7600;" value="Process 2" vertex="1">
+          <mxGeometry height="60" width="120" x="570" y="340" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-9" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-8" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-11" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-10" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-4" parent="1" style="rhombus;whiteSpace=wrap;html=1;rounded=0;fillColor=#6a00ff;fontColor=#ffffff;strokeColor=#3700CC;" value="Decision 1" vertex="1">
+          <mxGeometry height="80" width="80" x="590" y="190" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-13" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-12" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-15" edge="1" parent="1" source="sJ5Oo2qX5d5MOfgK30kJ-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="sJ5Oo2qX5d5MOfgK30kJ-14" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-6" parent="1" style="rhombus;whiteSpace=wrap;html=1;fillColor=#0050ef;strokeColor=#001DBC;rounded=0;fontColor=#ffffff;" value="Decis&lt;span style=&quot;background-color: transparent; color: light-dark(rgb(255, 255, 255), rgb(18, 18, 18));&quot;&gt;ion 2&lt;/span&gt;" vertex="1">
+          <mxGeometry height="80" width="80" x="590" y="470" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-8" parent="1" style="whiteSpace=wrap;html=1;fillColor=#0050ef;strokeColor=#001DBC;fontColor=#ffffff;rounded=0;" value="Process 3" vertex="1">
+          <mxGeometry height="60" width="120" x="570" y="40" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-10" parent="1" style="whiteSpace=wrap;html=1;fillColor=#6a00ff;strokeColor=#3700CC;fontColor=#ffffff;rounded=0;" value="Process 4" vertex="1">
+          <mxGeometry height="60" width="120" x="730" y="200" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-12" parent="1" style="whiteSpace=wrap;html=1;fillColor=#6a00ff;strokeColor=#3700CC;fontColor=#ffffff;rounded=0;" value="Process 5" vertex="1">
+          <mxGeometry height="60" width="120" x="570" y="640" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-14" parent="1" style="whiteSpace=wrap;html=1;fillColor=#0050ef;strokeColor=#001DBC;fontColor=#ffffff;rounded=0;" value="Process 6" vertex="1">
+          <mxGeometry height="60" width="120" x="730" y="480" as="geometry" />
+        </mxCell>
+        <mxCell id="sJ5Oo2qX5d5MOfgK30kJ-16" parent="1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#b1ddf0;strokeColor=#10739e;rounded=0;" value="Initial State" vertex="1">
+          <mxGeometry height="80" width="80" x="200" y="330" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/src/shapes/import/adapters/drawioAdapter.test.ts
+++ b/src/shapes/import/adapters/drawioAdapter.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { drawioAdapter } from './drawioAdapter';
+import type { Shape } from '../../Shape';
+
+// jsdom makes import.meta.url an http: URL, so resolve from the project cwd
+// (vitest runs at the repo root) rather than a file: URL.
+const SMALL_FLOWCHART = readFileSync(
+  resolve(process.cwd(), 'src/shapes/import/adapters/__fixtures__/small-flowchart.drawio'),
+  'utf8'
+);
+
+const byType = (shapes: Shape[], type: string) => shapes.filter((s) => s.type === type);
+
+describe('drawioAdapter', () => {
+  it('canImport recognizes drawio/mxGraph XML only', () => {
+    expect(drawioAdapter.canImport(SMALL_FLOWCHART)).toBe(true);
+    expect(drawioAdapter.canImport('<mxGraphModel><root></root></mxGraphModel>')).toBe(true);
+    expect(drawioAdapter.canImport('{"type":"excalidraw"}')).toBe(false);
+    expect(drawioAdapter.canImport('not xml')).toBe(false);
+  });
+
+  it('maps the small flowchart to primitives + connectors', async () => {
+    const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
+    // 9 vertices: 6 rectangles (Process 1-6) + 2 diamonds (Decision 1-2) +
+    // 1 ellipse (Initial State); 8 bound edges.
+    expect(byType(shapes, 'rectangle')).toHaveLength(6);
+    expect(byType(shapes, 'diamond')).toHaveLength(2);
+    expect(byType(shapes, 'ellipse')).toHaveLength(1);
+    expect(byType(shapes, 'connector')).toHaveLength(8);
+  });
+
+  it('recentres top-left geometry and carries fill/label', async () => {
+    const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
+    // Process 1: x=380 y=340 w=120 h=60 → centre (440, 370), fill #b1ddf0.
+    const p1 = shapes.find((s) => (s as { label?: string }).label === 'Process 1')!;
+    expect(p1.x).toBe(440);
+    expect(p1.y).toBe(370);
+    expect((p1 as { fill: string | null }).fill).toBe('#b1ddf0');
+  });
+
+  it('strips HTML from labels', async () => {
+    const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
+    // "Decis<span ...>ion 2</span>" → "Decision 2".
+    const labels = shapes.map((s) => (s as { label?: string }).label);
+    expect(labels).toContain('Decision 2');
+  });
+
+  it('hitches bound edges to edge anchors, not the shape centre (JP-196 reuse)', async () => {
+    const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
+    const connectors = byType(shapes, 'connector') as Array<{
+      startShapeId?: string;
+      endShapeId?: string;
+      startAnchor?: string;
+      endAnchor?: string;
+    }>;
+    // Every connector in the sample is bound at both ends.
+    for (const c of connectors) {
+      expect(c.startShapeId).toBeTruthy();
+      expect(c.endShapeId).toBeTruthy();
+      expect(['top', 'right', 'bottom', 'left']).toContain(c.startAnchor);
+      expect(['top', 'right', 'bottom', 'left']).toContain(c.endAnchor);
+      expect(c.startAnchor).not.toBe('center');
+      expect(c.endAnchor).not.toBe('center');
+    }
+  });
+
+  it('honours drawio arrow style (start arrow + no end arrow)', async () => {
+    const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
+    // Edge -17 has startArrow=classic;endArrow=none → exactly one such connector.
+    const connectors = byType(shapes, 'connector') as Array<{ startArrow: boolean; endArrow: boolean }>;
+    const startArrowed = connectors.filter((c) => c.startArrow && !c.endArrow);
+    expect(startArrowed).toHaveLength(1);
+  });
+
+  it('reports compressed payloads instead of failing', async () => {
+    const compressed =
+      '<mxfile host="app.diagrams.net"><diagram name="Page-1">7Vpdc5s4FP01ftw=</diagram></mxfile>';
+    const { shapes, warnings } = await drawioAdapter.import(compressed);
+    expect(shapes).toHaveLength(0);
+    expect(warnings?.some((w) => w.kind === 'unsupported-compressed')).toBe(true);
+  });
+});

--- a/src/shapes/import/adapters/drawioAdapter.ts
+++ b/src/shapes/import/adapters/drawioAdapter.ts
@@ -1,0 +1,305 @@
+/**
+ * drawio / diagrams.net (`.drawio`, mxGraph XML) import adapter (JP-86).
+ *
+ * Parses the uncompressed `mxGraphModel`: `<mxCell vertex="1">` → primitives,
+ * `<mxCell edge="1" source=… target=…>` → connectors. A cell's `style` is a
+ * `;`-delimited string whose leading bare token (if any) is the shape *kind*
+ * (`rhombus`, `ellipse`, …; absent ⇒ rectangle); the rest are `key=value`.
+ * Geometry `x,y` is the TOP-LEFT corner — DocuShark box shapes are
+ * centre-anchored, so they're recentred (as in the Excalidraw adapter).
+ *
+ * Bound edges carry no explicit endpoint geometry, so each end hitches to the
+ * boundary anchor facing the *other* bound node's centre, via the shared
+ * `connectorBinding` helper (JP-196) — no more centre-to-centre arrows.
+ *
+ * Phase 1 scope: the core flowchart/box primitives + bound edges of a single
+ * page. Deliberately reported (never silently dropped), pending follow-up
+ * slices: stencil → icon resolution (`shape=mxgraph.*` currently becomes a
+ * labelled box), multi-page → grouping (only the first page is imported), and
+ * compressed (deflate) diagram payloads.
+ */
+
+import { nanoid } from 'nanoid';
+import type { ImportAdapter, ImportResult, ImportWarning } from '../ImportAdapter';
+import type { Shape } from '../../Shape';
+import {
+  DEFAULT_RECTANGLE,
+  DEFAULT_ELLIPSE,
+  DEFAULT_TEXT,
+  DEFAULT_CONNECTOR,
+  DEFAULT_LIBRARY_SHAPE,
+} from '../../Shape';
+import { nearestEdgeAnchor, boxFromTopLeft } from '../connectorBinding';
+
+/** A drawio cell flattened to the fields we read (handles `<object>` wrappers). */
+interface DioCell {
+  id: string;
+  value: string;
+  style: string;
+  vertex: boolean;
+  edge: boolean;
+  source: string | null;
+  target: string | null;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface ParsedStyle {
+  /** Leading bare token (no `=`), e.g. `rhombus` / `ellipse` — the shape kind. */
+  kind: string | null;
+  props: Record<string, string>;
+}
+
+/** Parse an mxGraph `style` string into its leading kind + `key=value` props. */
+function parseStyle(style: string): ParsedStyle {
+  let kind: string | null = null;
+  const props: Record<string, string> = {};
+  for (const token of style.split(';')) {
+    if (!token) continue;
+    const eq = token.indexOf('=');
+    if (eq === -1) {
+      if (kind === null) kind = token; // first bare flag = the shape kind
+    } else {
+      props[token.slice(0, eq)] = token.slice(eq + 1);
+    }
+  }
+  return { kind, props };
+}
+
+/** drawio `none`/empty colour → no fill/stroke; otherwise pass the value through. */
+function colorOrNull(c: string | undefined): string | null {
+  return !c || c === 'none' ? null : c;
+}
+
+/**
+ * Decode an mxGraph label to plain text: the value is HTML (`Decis<span…>ion
+ * 2</span>` after XML entity-decoding), so render it and read `textContent`.
+ */
+function stripHtmlLabel(value: string): string {
+  if (!value) return '';
+  if (typeof DOMParser === 'undefined') return value.replace(/<[^>]*>/g, '').trim();
+  const doc = new DOMParser().parseFromString(value, 'text/html');
+  return (doc.body.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+const num = (v: string | null, fallback = 0): number => {
+  const n = v === null ? NaN : parseFloat(v);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+/** Flatten `<mxCell>` and `<object>`/`<UserObject>`-wrapped cells under `root`. */
+function collectCells(root: Element): DioCell[] {
+  const cells: DioCell[] = [];
+  for (const child of Array.from(root.children)) {
+    const tag = child.tagName.toLowerCase();
+    let id: string | null;
+    let value: string;
+    let mxc: Element | null;
+    if (tag === 'mxcell') {
+      id = child.getAttribute('id');
+      value = child.getAttribute('value') ?? '';
+      mxc = child;
+    } else if (tag === 'object' || tag === 'userobject') {
+      // Wrapper carries the id + label; the inner mxCell carries style/geometry.
+      id = child.getAttribute('id');
+      value = child.getAttribute('label') ?? '';
+      mxc = child.querySelector('mxCell');
+    } else {
+      continue;
+    }
+    if (!id || !mxc) continue;
+
+    const geom = mxc.querySelector('mxGeometry');
+    cells.push({
+      id,
+      value,
+      style: mxc.getAttribute('style') ?? '',
+      vertex: mxc.getAttribute('vertex') === '1',
+      edge: mxc.getAttribute('edge') === '1',
+      source: mxc.getAttribute('source'),
+      target: mxc.getAttribute('target'),
+      x: num(geom?.getAttribute('x') ?? null),
+      y: num(geom?.getAttribute('y') ?? null),
+      width: num(geom?.getAttribute('width') ?? null),
+      height: num(geom?.getAttribute('height') ?? null),
+    });
+  }
+  return cells;
+}
+
+/** Common centre-anchored base shared by box primitives. */
+function boxBase(cell: DioCell) {
+  return {
+    id: nanoid(),
+    x: cell.x + cell.width / 2,
+    y: cell.y + cell.height / 2,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+  };
+}
+
+async function importDrawio(raw: string): Promise<ImportResult> {
+  const shapes: Shape[] = [];
+  const warnings: ImportWarning[] = [];
+
+  if (typeof DOMParser === 'undefined') {
+    return { shapes, warnings: [{ kind: 'parse', detail: 'XML parsing unavailable in this environment' }] };
+  }
+  const doc = new DOMParser().parseFromString(raw, 'application/xml');
+  if (doc.querySelector('parsererror')) {
+    return { shapes, warnings: [{ kind: 'parse', detail: 'not a valid drawio/XML document' }] };
+  }
+
+  const model = doc.querySelector('mxGraphModel');
+  const root = model?.querySelector('root');
+  if (!root) {
+    // No inline model usually means a compressed (deflate+base64) <diagram> body.
+    const compressed = doc.querySelector('diagram');
+    const detail = compressed
+      ? 'compressed drawio payload not yet supported — re-export with "Uncompressed" in drawio'
+      : 'no <mxGraphModel> found';
+    return { shapes, warnings: [{ kind: 'unsupported-compressed', detail }] };
+  }
+
+  const pageCount = doc.querySelectorAll('diagram').length;
+  if (pageCount > 1) {
+    warnings.push({
+      kind: 'multi-page',
+      detail: `only the first of ${pageCount} pages imported (multi-page grouping is a follow-up)`,
+      count: pageCount - 1,
+    });
+  }
+
+  const cells = collectCells(root);
+  const idMap = new Map<string, string>(); // drawio cell id → DocuShark shape id
+  const cellById = new Map(cells.map((c) => [c.id, c]));
+  const unsupported = new Map<string, number>();
+
+  // Pass A: vertices → primitives.
+  for (const cell of cells) {
+    if (!cell.vertex) continue;
+    const { kind, props } = parseStyle(cell.style);
+    const fill = colorOrNull(props['fillColor']);
+    const stroke = props['strokeColor'] ? colorOrNull(props['strokeColor']) : DEFAULT_RECTANGLE.stroke;
+    const labelColor = props['fontColor'];
+    const label = stripHtmlLabel(cell.value);
+    const base = boxBase(cell);
+
+    // A stencil (`shape=mxgraph.*`) or any kind we don't model yet still imports
+    // as a labelled box so nothing is lost — icon resolution is a follow-up.
+    const isStencil = kind?.startsWith('mxgraph.') || !!props['shape'];
+
+    if (kind === 'ellipse') {
+      idMap.set(cell.id, base.id);
+      shapes.push({
+        ...DEFAULT_ELLIPSE, ...base, type: 'ellipse',
+        radiusX: cell.width / 2, radiusY: cell.height / 2,
+        fill, stroke, ...(labelColor ? { labelColor } : {}), label,
+      } as Shape);
+    } else if (kind === 'rhombus') {
+      idMap.set(cell.id, base.id);
+      shapes.push({
+        ...DEFAULT_LIBRARY_SHAPE, ...base, type: 'diamond',
+        width: cell.width, height: cell.height,
+        fill, stroke, ...(labelColor ? { labelColor } : {}), label,
+      } as Shape);
+    } else if (kind === 'text') {
+      idMap.set(cell.id, base.id);
+      shapes.push({
+        ...DEFAULT_TEXT, ...base, type: 'text',
+        width: cell.width, height: cell.height,
+        text: label, ...(labelColor ? { fill: labelColor } : {}),
+      } as Shape);
+    } else {
+      // Default + stencil fallback: rectangle (rounded honours `rounded=1`).
+      if (isStencil) unsupported.set('stencil', (unsupported.get('stencil') ?? 0) + 1);
+      else if (kind) unsupported.set(kind, (unsupported.get(kind) ?? 0) + 1);
+      idMap.set(cell.id, base.id);
+      shapes.push({
+        ...DEFAULT_RECTANGLE, ...base, type: 'rectangle',
+        width: cell.width, height: cell.height,
+        cornerRadius: props['rounded'] === '1' ? 12 : 0,
+        fill, stroke, ...(labelColor ? { labelColor } : {}), label,
+      } as Shape);
+    }
+  }
+
+  // Pass B: edges → connectors, hitched to edge anchors via the shared helper.
+  for (const cell of cells) {
+    if (!cell.edge) continue;
+    const { props } = parseStyle(cell.style);
+    const startEl = cell.source ? cellById.get(cell.source) : undefined;
+    const endEl = cell.target ? cellById.get(cell.target) : undefined;
+    const startId = startEl ? idMap.get(startEl.id) : undefined;
+    const endId = endEl ? idMap.get(endEl.id) : undefined;
+
+    const startCenter = startEl ? { x: startEl.x + startEl.width / 2, y: startEl.y + startEl.height / 2 } : undefined;
+    const endCenter = endEl ? { x: endEl.x + endEl.width / 2, y: endEl.y + endEl.height / 2 } : undefined;
+
+    // No explicit edge points in drawio: hitch toward the other node's centre.
+    const startAnchor =
+      startId && startEl && endCenter
+        ? nearestEdgeAnchor(boxFromTopLeft(startEl.x, startEl.y, startEl.width, startEl.height), endCenter)
+        : undefined;
+    const endAnchor =
+      endId && endEl && startCenter
+        ? nearestEdgeAnchor(boxFromTopLeft(endEl.x, endEl.y, endEl.width, endEl.height), startCenter)
+        : undefined;
+
+    if (!startId && !endId && !startCenter && !endCenter) {
+      // Fully dangling edge (no bindings, no geometry) — nothing to anchor to.
+      unsupported.set('dangling-edge', (unsupported.get('dangling-edge') ?? 0) + 1);
+      continue;
+    }
+
+    // drawio's default edge has an end arrow and no start arrow.
+    const hasStartArrow = !!props['startArrow'] && props['startArrow'] !== 'none';
+    const hasEndArrow = props['endArrow'] !== 'none';
+
+    shapes.push({
+      ...DEFAULT_CONNECTOR,
+      id: nanoid(),
+      type: 'connector',
+      x: startCenter?.x ?? 0,
+      y: startCenter?.y ?? 0,
+      x2: endCenter?.x ?? 0,
+      y2: endCenter?.y ?? 0,
+      rotation: 0,
+      opacity: 1,
+      locked: false,
+      visible: true,
+      stroke: colorOrNull(props['strokeColor']) ?? DEFAULT_CONNECTOR.stroke,
+      strokeWidth: num(props['strokeWidth'] ?? null, DEFAULT_CONNECTOR.strokeWidth),
+      startArrow: hasStartArrow,
+      endArrow: hasEndArrow,
+      ...(stripHtmlLabel(cell.value) ? { label: stripHtmlLabel(cell.value) } : {}),
+      ...(startId ? { startShapeId: startId } : {}),
+      ...(startAnchor ? { startAnchor } : {}),
+      ...(endId ? { endShapeId: endId } : {}),
+      ...(endAnchor ? { endAnchor } : {}),
+    } as Shape);
+  }
+
+  for (const [kind, count] of unsupported) {
+    const detail =
+      kind === 'stencil'
+        ? `${count} stencil shape(s) imported as labelled boxes (icon mapping is a follow-up)`
+        : kind === 'dangling-edge'
+          ? `${count} edge(s) with no endpoints skipped`
+          : `${count} unsupported "${kind}" shape(s) imported as boxes`;
+    warnings.push({ kind, detail, count });
+  }
+
+  return { shapes, warnings };
+}
+
+export const drawioAdapter: ImportAdapter = {
+  id: 'drawio',
+  label: 'drawio',
+  canImport: (raw) => /<mxGraphModel|<mxfile|host="app\.diagrams\.net"/.test(raw),
+  import: importDrawio,
+};

--- a/src/shapes/import/registerImportAdapters.ts
+++ b/src/shapes/import/registerImportAdapters.ts
@@ -6,7 +6,11 @@
 
 import { registerImportAdapter, getImportAdapter } from './ImportAdapter';
 import { excalidrawAdapter } from './adapters/excalidrawAdapter';
+import { drawioAdapter } from './adapters/drawioAdapter';
 
 if (!getImportAdapter(excalidrawAdapter.id)) {
   registerImportAdapter(excalidrawAdapter);
+}
+if (!getImportAdapter(drawioAdapter.id)) {
+  registerImportAdapter(drawioAdapter);
 }


### PR DESCRIPTION
First drawio (mxGraph XML) on-ramp. Designed in *Shapes Design - Adapters*.

## What it does

Parses the **uncompressed** `mxGraphModel`:

- **Vertices** (`<mxCell vertex="1">`) → primitives. `style` is split into its leading bare shape token + `key=value` props: `rhombus`→diamond, `ellipse`→ellipse, default→rectangle (`rounded=1`→cornerRadius), `text`→text. Top-left geometry is recentred to our centre anchor. `fillColor`/`strokeColor`/`fontColor` → `fill`/`stroke`/`labelColor`; HTML labels (`Decis<span…>ion 2</span>`) are stripped to plain text. `<object>`/`<UserObject>` wrappers are flattened.
- **Edges** (`<mxCell edge="1" source= target=>`) → connectors. drawio edges carry no explicit endpoint geometry, so each end **hitches to the boundary anchor facing the other node's centre** via the shared `connectorBinding` helper (JP-196) — reusing exactly the abstraction that fix introduced (no centre-to-centre arrows). Arrow direction from `start/endArrow`.

## Safe-parse, never drop

Stencils (`shape=mxgraph.*`) import as labelled boxes; compressed payloads, extra pages, and dangling edges are reported as `ImportWarning`s, not dropped.

## Tests

Golden-tested against `test-assets/Small-Flowchart.drawio` (vendored as a fixture): 9 vertices (6 rect / 2 diamond / 1 ellipse) + 8 bound edges, all connectors hitched to **edge anchors** (not centre), HTML label stripping, recentre + fill, arrow style, and the compressed-payload warning. Full suite green (1970), typecheck clean.

## Follow-up slices (per the design doc)

- stencil → icon resolution (`resolveIcon` against the existing ~1,140-icon catalog)
- multi-page → grouping ("group the pages")
- compressed (deflate) `.drawio` payloads
- guided importer

Assisted-by: Opus 4.8