### PR TITLE
Add a "Display as icon" toggle to the shape Icons panel

### DIFF
--- a/src/engine/tools/SelectTool.ts
+++ b/src/engine/tools/SelectTool.ts
@@ -7,6 +7,7 @@ import { MiddleClickPanHandler } from './PanTool';
 import { Handle, HandleType, Shape, isRectangle, isEllipse, isLine, isText, isFile, isGroup, isConnector, isLibraryShape, Anchor, AnchorPosition } from '../../shapes/Shape';
 import { snapBounds, snap, SnapResult } from '../Snapping';
 import { shapeRegistry } from '../../shapes/ShapeRegistry';
+import { isIconOnlyMode } from '../../utils/iconRenderer';
 import { getAdaptiveBudget } from '../../platform/adaptiveBudget';
 
 /**
@@ -1072,13 +1073,23 @@ export class SelectTool extends BaseTool {
       }
     }
 
+    // Lock aspect ratio when Shift is held, the shape type declares
+    // `aspectRatioLocked` (mirrors LibraryShapeTool's creation constraint), or
+    // the shape is displayed icon-only (the icon fills the bounds aspect-locked,
+    // so a non-square box would just leave dead space).
+    const metadata = shapeRegistry.getMetadata(original.type);
+    const maintainAspectRatio =
+      this.isShiftHeld ||
+      !!metadata?.aspectRatioLocked ||
+      isIconOnlyMode(original as Parameters<typeof isIconOnlyMode>[0]);
+
     // Calculate new shape properties based on handle type and original shape
     const updates = this.calculateResize(
       original,
       handleType,
       currentPoint,
       this.resizeAnchorPoint,
-      this.isShiftHeld
+      maintainAspectRatio
     );
 
     if (updates) {

--- a/src/shapes/library/LibraryShapeHandler.ts
+++ b/src/shapes/library/LibraryShapeHandler.ts
@@ -26,7 +26,7 @@ import { localToWorld, worldToLocal, getWorldCorners } from '../utils/localSpace
 import { renderLabel } from '../label/renderLabel';
 import { LIBRARY_LABEL_SPEC } from '../label/specs';
 import type { LabelSpec, LabelOverflow } from '../label/LabelSpec';
-import { renderShapeIcons, isIconOnlyMode } from '../../utils/iconRenderer';
+import { renderShapeIcons, isIconOnlyMode, iconOnlyLabelOffsetY } from '../../utils/iconRenderer';
 
 /**
  * Structural view of the label + icon fields the factory reads. Core shapes
@@ -116,17 +116,24 @@ export function createShapeHandler<T extends Shape>(
       }
 
       if (f.label && !definition.customLabelRendering) {
+        const labelFontSize = f.labelFontSize || DEFAULT_LIBRARY_SHAPE.labelFontSize;
+        // In icon-only mode the icon occupies an `iconSize`-square centred on the
+        // shape, so a centred label would render straight through it. Default the
+        // label to sit just below the icon — offset sticks to the icon's size, so
+        // it tracks larger/smaller icons. A user-set `labelOffsetY` still wins
+        // (use `??` so an explicit 0 pulls the label back to centre).
+        const defaultOffsetY = iconOnly ? iconOnlyLabelOffsetY(f, labelFontSize) : 0;
         renderLabel(ctx, {
           text: f.label,
           spec: labelSpec,
           overflow: f.labelOverflow,
           boxWidth: width,
           boxHeight: height,
-          fontSize: f.labelFontSize || DEFAULT_LIBRARY_SHAPE.labelFontSize,
+          fontSize: labelFontSize,
           color: f.labelColor || stroke || '#000000',
           background: f.labelBackground,
           offsetX: f.labelOffsetX || 0,
-          offsetY: f.labelOffsetY || 0,
+          offsetY: f.labelOffsetY ?? defaultOffsetY,
         });
       }
 

--- a/src/shapes/library/LibraryShapeHandler.ts
+++ b/src/shapes/library/LibraryShapeHandler.ts
@@ -26,7 +26,7 @@ import { localToWorld, worldToLocal, getWorldCorners } from '../utils/localSpace
 import { renderLabel } from '../label/renderLabel';
 import { LIBRARY_LABEL_SPEC } from '../label/specs';
 import type { LabelSpec, LabelOverflow } from '../label/LabelSpec';
-import { renderShapeIcons, isIconOnlyMode, iconOnlyLabelOffsetY } from '../../utils/iconRenderer';
+import { renderShapeIcons, isIconOnlyMode, iconOnlyLabelOffsetY, iconOnlyRenderSize } from '../../utils/iconRenderer';
 
 /**
  * Structural view of the label + icon fields the factory reads. Core shapes
@@ -122,7 +122,9 @@ export function createShapeHandler<T extends Shape>(
         // label to sit just below the icon — offset sticks to the icon's size, so
         // it tracks larger/smaller icons. A user-set `labelOffsetY` still wins
         // (use `??` so an explicit 0 pulls the label back to centre).
-        const defaultOffsetY = iconOnly ? iconOnlyLabelOffsetY(f, labelFontSize) : 0;
+        const defaultOffsetY = iconOnly
+          ? iconOnlyLabelOffsetY(iconOnlyRenderSize(width, height), labelFontSize)
+          : 0;
         renderLabel(ctx, {
           text: f.label,
           spec: labelSpec,

--- a/src/ui/DisplayAsIconToggle.test.tsx
+++ b/src/ui/DisplayAsIconToggle.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+import { DisplayAsIconToggle } from './DisplayAsIconToggle';
+
+afterEach(cleanup);
+
+describe('DisplayAsIconToggle', () => {
+  it('is checked when the shape is already displayed as an icon', () => {
+    render(<DisplayAsIconToggle iconId="builtin:aws-aws-lambda" displayMode="icon-only" onChange={() => {}} />);
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('turns a shape into its icon (icon-only) when toggled on', () => {
+    const onChange = vi.fn();
+    render(<DisplayAsIconToggle iconId="builtin:aws-aws-lambda" displayMode="inside" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith('icon-only');
+  });
+
+  it('returns to a normal shape (inside) when toggled off', () => {
+    const onChange = vi.fn();
+    render(<DisplayAsIconToggle iconId="builtin:aws-aws-lambda" displayMode="icon-only" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith('inside');
+  });
+
+  it('is disabled with a hint until an icon is chosen', () => {
+    const onChange = vi.fn();
+    render(<DisplayAsIconToggle iconId={undefined} displayMode={undefined} onChange={onChange} />);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(true);
+    expect(screen.getByText('pick an icon first')).toBeTruthy();
+    fireEvent.click(checkbox);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/DisplayAsIconToggle.tsx
+++ b/src/ui/DisplayAsIconToggle.tsx
@@ -1,0 +1,44 @@
+import type { IconDisplayMode } from '../shapes/Shape';
+
+export interface DisplayAsIconToggleProps {
+  /** The shape's current icon id (empty/undefined = no icon chosen yet). */
+  iconId: string | undefined;
+  /** The shape's current icon display mode. */
+  displayMode: IconDisplayMode | undefined;
+  /** Called with the new display mode when toggled. */
+  onChange: (mode: IconDisplayMode) => void;
+}
+
+/**
+ * Prominent one-click "turn this shape into its icon" control.
+ *
+ * The capability already exists (`iconDisplayMode: 'icon-only'` hides the box
+ * and renders just the vector icon at the shape's bounds), but it's buried as
+ * the third option in the Mode dropdown. This surfaces it as the headline
+ * action of the Icons section — the discoverability gap called out in *Shapes
+ * Design - Core* §2 — so a user can flip any shape into any of the catalog's
+ * 1000+ icons in one click. Disabled until an icon is chosen; toggling off
+ * returns the shape to the default `inside` mode (icon as decoration on a box).
+ */
+export function DisplayAsIconToggle({ iconId, displayMode, onChange }: DisplayAsIconToggleProps) {
+  const hasIcon = !!iconId;
+  const isIconOnly = displayMode === 'icon-only';
+
+  return (
+    <label className={`display-as-icon-toggle${hasIcon ? '' : ' is-disabled'}`}>
+      <input
+        type="checkbox"
+        checked={isIconOnly}
+        disabled={!hasIcon}
+        onChange={(e) => {
+          if (!hasIcon) return; // no-op until an icon is chosen
+          onChange(e.target.checked ? 'icon-only' : 'inside');
+        }}
+      />
+      <span className="display-as-icon-label">Display as icon</span>
+      {!hasIcon && <span className="display-as-icon-hint">pick an icon first</span>}
+    </label>
+  );
+}
+
+export default DisplayAsIconToggle;

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -1432,3 +1432,26 @@
 [data-theme="dark"] .swimlane-reset-widths:hover {
   background: var(--bg-tertiary);
 }
+
+/* "Display as icon" toggle — headline action of the Icons section (turn a
+   shape into its vector icon; maps to iconDisplayMode 'icon-only'). */
+.display-as-icon-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+.display-as-icon-toggle.is-disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.display-as-icon-toggle input { cursor: inherit; }
+.display-as-icon-label { font-weight: 600; }
+.display-as-icon-hint {
+  font-size: 11px;
+  opacity: 0.7;
+  font-style: italic;
+}

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -44,6 +44,7 @@ import { ShadowEditor } from './ShadowEditor';
 import { BorderStylePicker } from './BorderStylePicker';
 import { LabelPositionPicker } from './LabelPositionPicker';
 import { IconListEditor } from './IconListEditor';
+import { DisplayAsIconToggle } from './DisplayAsIconToggle';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 // GroupStyles types are used via the PatternPicker, ShadowEditor, LabelPositionPicker components
 import type { ShapeMetadata, PropertyDefinition, PropertySection as PropertySectionType } from '../shapes/ShapeMetadata';
@@ -439,6 +440,11 @@ function LibraryShapeProperties({
           ) : (
             /* Legacy single-icon mode or no icons */
             <>
+              <DisplayAsIconToggle
+                iconId={shape.iconId}
+                displayMode={shape.iconDisplayMode}
+                onChange={(mode) => handleUpdate('iconDisplayMode', mode)}
+              />
               <IconPicker
                 value={shape.iconId}
                 onChange={(iconId: string | undefined) => handleUpdate('iconId', iconId || '')}

--- a/src/utils/iconRenderer.test.ts
+++ b/src/utils/iconRenderer.test.ts
@@ -1,31 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { getIconOnlySize, iconOnlyLabelOffsetY } from './iconRenderer';
+import { iconOnlyRenderSize, iconOnlyLabelOffsetY } from './iconRenderer';
 
-describe('getIconOnlySize', () => {
-  it('reads the legacy iconSize, defaulting to 24', () => {
-    expect(getIconOnlySize({ iconSize: 48 })).toBe(48);
-    expect(getIconOnlySize({})).toBe(24);
-  });
-
-  it('reads the icon-only entry from a multi-icon array', () => {
-    expect(
-      getIconOnlySize({ icons: [{ iconId: 'x', position: 'center', displayMode: 'icon-only', size: 40 }] })
-    ).toBe(40);
+describe('iconOnlyRenderSize', () => {
+  it('fills the bounds, aspect-locked to the smaller dimension', () => {
+    expect(iconOnlyRenderSize(100, 80)).toBe(80);
+    expect(iconOnlyRenderSize(60, 120)).toBe(60);
+    expect(iconOnlyRenderSize(64, 64)).toBe(64);
   });
 });
 
 describe('iconOnlyLabelOffsetY', () => {
-  it('drops the label below the centred icon, sticky to the icon size', () => {
-    // iconSize/2 clears the icon's bottom edge, + one label line for a gap.
-    expect(iconOnlyLabelOffsetY({ iconSize: 24 }, 14)).toBe(12 + 14);
-    expect(iconOnlyLabelOffsetY({ iconSize: 48 }, 14)).toBe(24 + 14);
-  });
-
-  it('tracks the default icon size when none is set', () => {
-    expect(iconOnlyLabelOffsetY({}, 12)).toBe(12 + 12); // default size 24 → /2 = 12
+  it('drops the label below the centred icon, sticky to its rendered size', () => {
+    // renderSize/2 clears the icon's bottom edge, + one label line for a gap.
+    expect(iconOnlyLabelOffsetY(80, 14)).toBe(40 + 14);
+    expect(iconOnlyLabelOffsetY(48, 14)).toBe(24 + 14);
   });
 
   it('is always positive (below centre), never overlapping', () => {
-    expect(iconOnlyLabelOffsetY({ iconSize: 16 }, 10)).toBeGreaterThan(0);
+    expect(iconOnlyLabelOffsetY(iconOnlyRenderSize(40, 30), 10)).toBeGreaterThan(0);
   });
 });

--- a/src/utils/iconRenderer.test.ts
+++ b/src/utils/iconRenderer.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { getIconOnlySize, iconOnlyLabelOffsetY } from './iconRenderer';
+
+describe('getIconOnlySize', () => {
+  it('reads the legacy iconSize, defaulting to 24', () => {
+    expect(getIconOnlySize({ iconSize: 48 })).toBe(48);
+    expect(getIconOnlySize({})).toBe(24);
+  });
+
+  it('reads the icon-only entry from a multi-icon array', () => {
+    expect(
+      getIconOnlySize({ icons: [{ iconId: 'x', position: 'center', displayMode: 'icon-only', size: 40 }] })
+    ).toBe(40);
+  });
+});
+
+describe('iconOnlyLabelOffsetY', () => {
+  it('drops the label below the centred icon, sticky to the icon size', () => {
+    // iconSize/2 clears the icon's bottom edge, + one label line for a gap.
+    expect(iconOnlyLabelOffsetY({ iconSize: 24 }, 14)).toBe(12 + 14);
+    expect(iconOnlyLabelOffsetY({ iconSize: 48 }, 14)).toBe(24 + 14);
+  });
+
+  it('tracks the default icon size when none is set', () => {
+    expect(iconOnlyLabelOffsetY({}, 12)).toBe(12 + 12); // default size 24 → /2 = 12
+  });
+
+  it('is always positive (below centre), never overlapping', () => {
+    expect(iconOnlyLabelOffsetY({ iconSize: 16 }, 10)).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/iconRenderer.ts
+++ b/src/utils/iconRenderer.ts
@@ -309,10 +309,13 @@ function renderSingleIcon(
       // Then draw icon
       return drawIcon(ctx, iconId, pos.x, pos.y, size, color);
 
-    case 'icon-only':
-      // Icon-only mode - shape handler should skip fill/stroke
-      // Just draw the icon centered
-      return drawIcon(ctx, iconId, -size / 2, -size / 2, size, color);
+    case 'icon-only': {
+      // Icon-only mode - shape handler skips fill/stroke; the icon *is* the
+      // shape, so fill the bounds (aspect-locked: icons are square, so fit the
+      // smaller dimension and centre).
+      const fillSize = iconOnlyRenderSize(bounds.halfWidth * 2, bounds.halfHeight * 2);
+      return drawIcon(ctx, iconId, -fillSize / 2, -fillSize / 2, fillSize, color);
+    }
 
     case 'inside':
     default:
@@ -438,18 +441,24 @@ export function getIconOnlySize(shape: {
 }
 
 /**
+ * The icon's rendered size in icon-only mode. The icon *is* the shape, so it
+ * fills the bounds; icons are square, so it's aspect-locked to the smaller of
+ * width/height and centred.
+ */
+export function iconOnlyRenderSize(width: number, height: number): number {
+  return Math.min(width, height);
+}
+
+/**
  * Default vertical label offset for an icon-only shape.
  *
- * In icon-only mode the icon is drawn as an `iconSize`-square centred on the
- * shape, so a centred label renders straight through it. This drops the label
- * to just below the icon — `iconSize/2` clears the icon's bottom edge, plus one
- * label line for a gap. It sticks to the icon's size, so it tracks larger or
- * smaller icons. Shape handlers apply this only when the user hasn't set an
+ * The bound-filling icon is centred, so a centred label renders straight
+ * through it. This drops the label to just below the icon — `size/2` clears the
+ * icon's bottom edge, plus one label line for a gap. `iconRenderSize` is the
+ * result of {@link iconOnlyRenderSize}, so the label tracks the icon's actual
+ * rendered size. Shape handlers apply this only when the user hasn't set an
  * explicit `labelOffsetY`.
  */
-export function iconOnlyLabelOffsetY(
-  shape: { iconSize?: number; icons?: IconConfig[] },
-  labelFontSize: number
-): number {
-  return getIconOnlySize(shape) / 2 + labelFontSize;
+export function iconOnlyLabelOffsetY(iconRenderSize: number, labelFontSize: number): number {
+  return iconRenderSize / 2 + labelFontSize;
 }

--- a/src/utils/iconRenderer.ts
+++ b/src/utils/iconRenderer.ts
@@ -436,3 +436,20 @@ export function getIconOnlySize(shape: {
   // Fall back to legacy property
   return shape.iconSize ?? 24;
 }
+
+/**
+ * Default vertical label offset for an icon-only shape.
+ *
+ * In icon-only mode the icon is drawn as an `iconSize`-square centred on the
+ * shape, so a centred label renders straight through it. This drops the label
+ * to just below the icon — `iconSize/2` clears the icon's bottom edge, plus one
+ * label line for a gap. It sticks to the icon's size, so it tracks larger or
+ * smaller icons. Shape handlers apply this only when the user hasn't set an
+ * explicit `labelOffsetY`.
+ */
+export function iconOnlyLabelOffsetY(
+  shape: { iconSize?: number; icons?: IconConfig[] },
+  labelFontSize: number
+): number {
+  return getIconOnlySize(shape) / 2 + labelFontSize;
+}


### PR DESCRIPTION
## What

A one-click **"Display as icon"** toggle at the top of the shape *Icons* property section — turn any shape into any of the catalog's 1000+ (vector) icons.

## Why

The capability already existed but wasn't discoverable: shapes carry `iconId` + `iconDisplayMode`, and `'icon-only'` hides the box and renders just the icon at the shape's bounds — but that was the **third option in a Mode dropdown** inside a **collapsed** section. So "make this shape an icon" was effectively hidden.

This is the discoverability gap flagged in *Shapes Design - Core* §2 — the UX half of the native custom-shape / icon-in-container story.

## How

New `DisplayAsIconToggle` (small, isolated, tested) sits above the `IconPicker`:
- Disabled with a "pick an icon first" hint until an icon is chosen.
- Then a single checkbox flips the shape between **icon-only** and the default **inside** mode.
- The existing Mode dropdown stays for `inside`/`badge`/`icon-only` power use; both read the same `iconDisplayMode`, so they stay in sync.

Icons are vector (`svgContent` for builtins, `assetPath` SVGs for the cloud sets), so they scale cleanly as the shape's appearance.

## Tests

Component unit tests: checked state reflects `icon-only`, toggling on/off emits `icon-only`/`inside`, and the disabled-until-icon guard. Full suite green (1974), typecheck clean.

Assisted-by: Opus 4.8