### PR TITLE
JP-85: Mermaid flowchart import adapter + shared graph layout

### DIFF
--- a/src/services/importPipeline.ts
+++ b/src/services/importPipeline.ts
@@ -86,6 +86,10 @@ export function applyImportResult(
   // distinct `programmatic` write rather than masquerading as a user edit.
   mutateDocument('programmatic', () => {
     useDocumentStore.getState().addShapes(shapes);
+    // Connectors hitch to the right anchors, but their routed waypoints aren't
+    // computed until a route rebuild — run one now so any imported diagram
+    // renders cleanly immediately instead of looking off until the first edit.
+    useDocumentStore.getState().rebuildAllConnectorRoutes();
   });
 
   const ids = shapes.map((s) => s.id);

--- a/src/shapes/import/adapters/__fixtures__/example-pipeline.mermaid
+++ b/src/shapes/import/adapters/__fixtures__/example-pipeline.mermaid
@@ -1,0 +1,56 @@
+flowchart TD
+    Start([User uploads document]) --> Validate{Valid file type?}
+    Validate -->|No| Reject[Return error to user]
+    Reject --> End1([End])
+    Validate -->|Yes| Classify[Classify document type]
+
+    subgraph Ingestion["Ingestion Layer"]
+        Classify --> Type{Document type?}
+        Type -->|PDF| PdfPath[Extract text + OCR fallback]
+        Type -->|DOCX| DocxPath[Parse XML structure]
+        Type -->|Image| ImgPath[Run OCR engine]
+        Type -->|Unknown| Quarantine[Quarantine for review]
+    end
+
+    PdfPath --> Normalize[Normalize to canonical format]
+    DocxPath --> Normalize
+    ImgPath --> Confidence{OCR confidence > 85%?}
+    Confidence -->|No| Quarantine
+    Confidence -->|Yes| Normalize
+    Quarantine --> HumanReview[Manual review queue]
+    HumanReview --> Normalize
+
+    subgraph Processing["Processing Layer"]
+        direction LR
+        Normalize --> Chunk[Chunk into segments]
+        Chunk --> Embed[Generate embeddings]
+        Chunk --> Extract[Extract entities & metadata]
+        Embed --> Store1[(Vector DB)]
+        Extract --> Store2[(Metadata DB)]
+    end
+
+    Store1 --> Index{Indexing complete?}
+    Store2 --> Index
+    Index -->|No| Retry[Retry with backoff]
+    Retry --> Index
+    Index -->|Yes| Notify[Notify downstream services]
+
+    subgraph Delivery["Delivery Layer"]
+        Notify --> Search[Searchable in app]
+        Notify --> Webhook[Fire webhooks]
+        Notify --> Audit[Write audit log]
+    end
+
+    Search --> Done([Document ready])
+    Webhook --> Done
+    Audit --> Done
+
+    Retry -.->|Max retries exceeded| Alert[Alert ops team]
+    Alert --> DLQ[(Dead-letter queue)]
+
+    classDef errorNode fill:#7a1f1f,stroke:#ff6b6b,color:#fff
+    classDef successNode fill:#1f4d2e,stroke:#4ade80,color:#fff
+    classDef storeNode fill:#1e3a5f,stroke:#60a5fa,color:#fff
+    class Reject,Quarantine,Alert,DLQ errorNode
+    class Done,Search successNode
+    class Store1,Store2 storeNode

--- a/src/shapes/import/adapters/mermaidAdapter.test.ts
+++ b/src/shapes/import/adapters/mermaidAdapter.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { mermaidAdapter } from './mermaidAdapter';
+import type { Shape } from '../../Shape';
+
+const PIPELINE = readFileSync(
+  resolve(process.cwd(), 'src/shapes/import/adapters/__fixtures__/example-pipeline.mermaid'),
+  'utf8'
+);
+
+const byType = (shapes: Shape[], type: string) => shapes.filter((s) => s.type === type);
+const labelled = (shapes: Shape[], label: string) =>
+  shapes.find((s) => (s as { label?: string }).label === label);
+
+describe('mermaidAdapter', () => {
+  it('recognises Mermaid headers only', () => {
+    expect(mermaidAdapter.canImport('flowchart TD\n  A --> B')).toBe(true);
+    expect(mermaidAdapter.canImport('graph LR; A-->B')).toBe(true);
+    expect(mermaidAdapter.canImport('```mermaid\nflowchart TD\nA-->B\n```')).toBe(true);
+    expect(mermaidAdapter.canImport('{"type":"excalidraw"}')).toBe(false);
+    expect(mermaidAdapter.canImport('<mxGraphModel>')).toBe(false);
+  });
+
+  it('maps node bracket syntax to the right shapes', async () => {
+    const src = `flowchart TD
+      A([Start]) --> B{Decide}
+      B --> C[Process]
+      C --> D[(Store)]
+      D --> E[/Input/]`;
+    const { shapes } = await mermaidAdapter.import(src);
+    expect((labelled(shapes, 'Start') as Shape).type).toBe('terminator');
+    expect((labelled(shapes, 'Decide') as Shape).type).toBe('diamond');
+    expect((labelled(shapes, 'Process') as Shape).type).toBe('rectangle');
+    expect((labelled(shapes, 'Input') as Shape).type).toBe('data');
+  });
+
+  it('creates connectors with edge labels, arrows and dashed style', async () => {
+    const src = `flowchart TD
+      A[A] -->|yes| B[B]
+      A -.->|retry| C[C]`;
+    const { shapes } = await mermaidAdapter.import(src);
+    const conns = byType(shapes, 'connector') as Array<{
+      label?: string; endArrow: boolean; lineStyle: string;
+      startShapeId?: string; endShapeId?: string; startAnchor?: string; endAnchor?: string;
+    }>;
+    expect(conns).toHaveLength(2);
+    expect(conns.map((c) => c.label).sort()).toEqual(['retry', 'yes']);
+    // All bound + hitched to an edge anchor (never centre).
+    for (const c of conns) {
+      expect(c.startShapeId).toBeTruthy();
+      expect(c.endShapeId).toBeTruthy();
+      expect(['top', 'right', 'bottom', 'left']).toContain(c.startAnchor);
+      expect(c.endArrow).toBe(true);
+    }
+    expect(conns.find((c) => c.label === 'retry')!.lineStyle).toBe('dashed');
+  });
+
+  it('applies classDef styling to assigned nodes', async () => {
+    const src = `flowchart TD
+      A[A] --> B[B]
+      classDef err fill:#7a1f1f,stroke:#ff6b6b,color:#fff
+      class B err`;
+    const { shapes } = await mermaidAdapter.import(src);
+    const b = labelled(shapes, 'B') as { fill: string | null; stroke: string | null; labelColor?: string };
+    expect(b.fill).toBe('#7a1f1f');
+    expect(b.stroke).toBe('#ff6b6b');
+    expect(b.labelColor).toBe('#fff');
+  });
+
+  it('reports non-flowchart diagrams instead of failing', async () => {
+    const { shapes, warnings } = await mermaidAdapter.import('sequenceDiagram\n  A->>B: hi');
+    expect(shapes).toHaveLength(0);
+    expect(warnings?.some((w) => w.kind === 'unsupported-diagram')).toBe(true);
+  });
+
+  it('imports the example pipeline end-to-end', async () => {
+    const { shapes, warnings } = await mermaidAdapter.import(PIPELINE);
+    // Nodes laid out + edges connected; subgraphs flattened + reported.
+    expect(byType(shapes, 'connector').length).toBeGreaterThan(20);
+    expect(byType(shapes, 'diamond').length).toBeGreaterThanOrEqual(4); // Validate/Type/Confidence/Index
+    expect(labelled(shapes, 'User uploads document')!.type).toBe('terminator');
+    expect(warnings?.some((w) => w.kind === 'subgraph')).toBe(true);
+    // Error-class nodes picked up their fill.
+    const reject = labelled(shapes, 'Return error to user') as { fill: string | null };
+    expect(reject.fill).toBe('#7a1f1f');
+    // No two nodes share an exact position (layout actually spread them).
+    const nodeShapes = shapes.filter((s) => s.type !== 'connector');
+    const coords = new Set(nodeShapes.map((s) => `${Math.round(s.x)},${Math.round(s.y)}`));
+    expect(coords.size).toBe(nodeShapes.length);
+  });
+});

--- a/src/shapes/import/adapters/mermaidAdapter.ts
+++ b/src/shapes/import/adapters/mermaidAdapter.ts
@@ -1,0 +1,373 @@
+/**
+ * Mermaid import adapter (JP-85) — flowchart Phase 1.
+ *
+ * Mermaid is a coordinate-less text DSL, so this hand-rolls a focused parser
+ * for the `flowchart`/`graph` grammar (no heavyweight `mermaid` dependency —
+ * project ethos favours light, hand-rolled parsing), maps nodes/edges to
+ * existing DocuShark shapes, assigns geometry via the shared `layoutGraph`
+ * helper, and hitches edge connectors to the boundary anchor facing the other
+ * node via the shared `connectorBinding` helper (JP-196).
+ *
+ * Phase 1 scope: flowcharts (the dominant Mermaid use). `classDef`/`class`
+ * styling is applied; `subgraph`s are flattened (grouping not preserved) and
+ * reported; sequence/class/state/ER diagrams are recognised but reported as
+ * not-yet-supported rather than failing. Never silent loss.
+ */
+
+import { nanoid } from 'nanoid';
+import type { ImportAdapter, ImportResult, ImportWarning } from '../ImportAdapter';
+import type { Shape } from '../../Shape';
+import {
+  DEFAULT_RECTANGLE,
+  DEFAULT_ELLIPSE,
+  DEFAULT_CONNECTOR,
+  DEFAULT_LIBRARY_SHAPE,
+} from '../../Shape';
+import { layoutGraph, type GraphDirection } from '../layoutGraph';
+import { nearestEdgeAnchor, type AnchorBox } from '../connectorBinding';
+
+/** Node shape kinds we map from Mermaid bracket syntax. */
+type MerShape =
+  | 'rectangle'
+  | 'rounded'
+  | 'ellipse'
+  | 'terminator'
+  | 'diamond'
+  | 'data'
+  | 'predefined-process';
+
+interface MerNode {
+  id: string;
+  label: string;
+  shape: MerShape;
+  className?: string;
+  defined: boolean; // got an explicit shape/label vs. auto-created from an edge
+}
+
+interface MerEdge {
+  from: string;
+  to: string;
+  label?: string;
+  dashed: boolean;
+  thick: boolean;
+  arrow: boolean;
+}
+
+/** Mermaid bracket pairs → shape kind, longest opener first so `([` beats `(`. */
+const NODE_BRACKETS: Array<{ open: string; close: string; shape: MerShape }> = [
+  { open: '([', close: '])', shape: 'terminator' },
+  { open: '[[', close: ']]', shape: 'predefined-process' },
+  { open: '[(', close: ')]', shape: 'rectangle' }, // cylinder/db — no cylinder shape yet
+  { open: '((', close: '))', shape: 'ellipse' },
+  { open: '{{', close: '}}', shape: 'rectangle' }, // hexagon — no hexagon shape yet
+  { open: '[/', close: '/]', shape: 'data' },
+  { open: '[\\', close: '\\]', shape: 'data' },
+  { open: '{', close: '}', shape: 'diamond' },
+  { open: '[', close: ']', shape: 'rectangle' },
+  { open: '(', close: ')', shape: 'rounded' },
+];
+
+/** Clean a Mermaid label: strip wrapping quotes, turn <br> into newlines, drop tags. */
+function cleanLabel(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .trim();
+}
+
+interface NodeMatch {
+  id: string;
+  shape?: MerShape;
+  label?: string;
+  end: number;
+}
+
+/** Match `id` + optional shape bracket at `line[i]`. */
+function matchNode(line: string, i: number): NodeMatch | null {
+  const idMatch = /^[A-Za-z0-9_]+/.exec(line.slice(i));
+  if (!idMatch) return null;
+  const id = idMatch[0];
+  let j = i + id.length;
+
+  for (const b of NODE_BRACKETS) {
+    if (line.startsWith(b.open, j)) {
+      const closeIdx = line.indexOf(b.close, j + b.open.length);
+      if (closeIdx !== -1) {
+        const inner = line.slice(j + b.open.length, closeIdx);
+        return { id, shape: b.shape, label: cleanLabel(inner), end: closeIdx + b.close.length };
+      }
+    }
+  }
+  return { id, end: j }; // bare reference
+}
+
+interface EdgeMatch {
+  label?: string;
+  dashed: boolean;
+  thick: boolean;
+  arrow: boolean;
+  end: number;
+}
+
+/** Match an edge operator (+ optional `|label|`) at `line[i]`. */
+function matchEdge(line: string, i: number): EdgeMatch | null {
+  const rest = line.slice(i);
+  const op = /^\s*(<?[-.=]{2,}>?)/.exec(rest);
+  if (!op) return null;
+  const token = op[1]!;
+  let end = i + op[0].length;
+
+  let label: string | undefined;
+  const lbl = /^\s*\|([^|]*)\|/.exec(line.slice(end));
+  if (lbl) {
+    label = cleanLabel(lbl[1]!);
+    end += lbl[0].length;
+  }
+
+  return {
+    ...(label !== undefined ? { label } : {}),
+    dashed: token.includes('.'),
+    thick: token.includes('='),
+    arrow: token.endsWith('>') || token.startsWith('<'),
+    end,
+  };
+}
+
+interface ClassStyle {
+  fill?: string;
+  stroke?: string;
+  labelColor?: string;
+}
+
+/** Parse a `classDef` style list (`fill:#x,stroke:#y,color:#z`). */
+function parseClassStyle(styleStr: string): ClassStyle {
+  const style: ClassStyle = {};
+  for (const part of styleStr.split(',')) {
+    const [k, v] = part.split(':').map((s) => s.trim());
+    if (!k || !v) continue;
+    if (k === 'fill') style.fill = v;
+    else if (k === 'stroke') style.stroke = v;
+    else if (k === 'color') style.labelColor = v;
+  }
+  return style;
+}
+
+const FENCE = /^```(?:mermaid)?\s*|\s*```$/g;
+
+function importMermaid(raw: string): ImportResult {
+  const warnings: ImportWarning[] = [];
+  const text = raw.replace(FENCE, '').trim();
+  const rawLines = text.split('\n');
+
+  // Strip comments + blanks; keep the rest in order.
+  const lines = rawLines
+    .map((l) => l.replace(/%%\{.*?\}%%/g, '').trim())
+    .filter((l) => l.length > 0 && !l.startsWith('%%'));
+
+  const header = lines[0] ?? '';
+  const fc = /^(?:flowchart|graph)\s+(TB|TD|BT|LR|RL)?/i.exec(header);
+  if (!fc) {
+    const other = /^(sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|gantt|pie|journey|mindmap|gitGraph)/i.exec(header);
+    const detail = other
+      ? `Mermaid ${other[1]} is not supported yet (flowchart only for now)`
+      : 'not a recognised Mermaid flowchart';
+    return { shapes: [], warnings: [{ kind: other ? 'unsupported-diagram' : 'parse', detail }] };
+  }
+
+  const dirToken = (fc[1] ?? 'TB').toUpperCase();
+  const direction: GraphDirection = dirToken === 'TD' ? 'TB' : (dirToken as GraphDirection);
+
+  const nodes = new Map<string, MerNode>();
+  const edges: MerEdge[] = [];
+  const classStyles = new Map<string, ClassStyle>();
+  let subgraphDepth = 0;
+  let subgraphCount = 0;
+
+  const ensureNode = (id: string, shape?: MerShape, label?: string): MerNode => {
+    let node = nodes.get(id);
+    if (!node) {
+      node = { id, label: label ?? id, shape: shape ?? 'rectangle', defined: !!shape };
+      nodes.set(id, node);
+    } else if (shape) {
+      node.shape = shape;
+      if (label !== undefined) node.label = label;
+      node.defined = true;
+    }
+    return node;
+  };
+
+  for (const line of lines.slice(1)) {
+    if (/^subgraph\b/i.test(line)) {
+      subgraphDepth++;
+      subgraphCount++;
+      continue;
+    }
+    if (/^end$/i.test(line)) {
+      if (subgraphDepth > 0) subgraphDepth--;
+      continue;
+    }
+    if (/^direction\b/i.test(line)) continue; // per-subgraph direction (flattened)
+
+    const classDef = /^classDef\s+(\w+)\s+(.+)$/i.exec(line);
+    if (classDef) {
+      classStyles.set(classDef[1]!, parseClassStyle(classDef[2]!));
+      continue;
+    }
+    const classAssign = /^class\s+([\w,\s]+?)\s+(\w+)$/i.exec(line);
+    if (classAssign) {
+      const className = classAssign[2]!;
+      for (const id of classAssign[1]!.split(',').map((s) => s.trim()).filter(Boolean)) {
+        ensureNode(id).className = className;
+      }
+      continue;
+    }
+    if (/^(style|linkStyle)\b/i.test(line)) continue; // direct styling — Phase 1 skip
+
+    // Otherwise a node/edge chain: parse node (edge node)*.
+    let i = 0;
+    let prevId: string | null = null;
+    let pending: EdgeMatch | null = null;
+    while (i < line.length) {
+      while (i < line.length && line[i] === ' ') i++;
+      if (i >= line.length) break;
+
+      const nodeM = matchNode(line, i);
+      if (nodeM) {
+        const node = ensureNode(nodeM.id, nodeM.shape, nodeM.label);
+        if (pending && prevId) {
+          edges.push({
+            from: prevId,
+            to: node.id,
+            ...(pending.label !== undefined ? { label: pending.label } : {}),
+            dashed: pending.dashed,
+            thick: pending.thick,
+            arrow: pending.arrow,
+          });
+          pending = null;
+        }
+        prevId = node.id;
+        i = nodeM.end;
+        continue;
+      }
+
+      const edgeM = prevId ? matchEdge(line, i) : null;
+      if (edgeM) {
+        pending = edgeM;
+        i = edgeM.end;
+        continue;
+      }
+      break; // unparseable remainder
+    }
+  }
+
+  if (subgraphCount > 0) {
+    warnings.push({
+      kind: 'subgraph',
+      detail: `${subgraphCount} subgraph(s) flattened (grouping not preserved yet)`,
+      count: subgraphCount,
+    });
+  }
+  if (nodes.size === 0) {
+    return { shapes: [], warnings: [...warnings, { kind: 'parse', detail: 'no flowchart nodes found' }] };
+  }
+
+  // Size each node from its label, then lay the graph out.
+  const sizeOf = (node: MerNode): { width: number; height: number } => {
+    const labelLines = node.label.split('\n');
+    const longest = Math.max(1, ...labelLines.map((l) => l.length));
+    let width = Math.min(260, Math.max(96, longest * 8 + 32));
+    let height = Math.max(48, labelLines.length * 22 + 24);
+    if (node.shape === 'diamond') { width += 28; height += 16; }
+    if (node.shape === 'ellipse' || node.shape === 'terminator') width += 12;
+    return { width, height };
+  };
+
+  const sizes = new Map<string, { width: number; height: number }>();
+  for (const node of nodes.values()) sizes.set(node.id, sizeOf(node));
+
+  const positions = layoutGraph(
+    Array.from(nodes.values()).map((n) => ({ id: n.id, ...sizes.get(n.id)! })),
+    edges.map((e) => ({ from: e.from, to: e.to })),
+    { direction }
+  );
+
+  const shapes: Shape[] = [];
+  const idMap = new Map<string, string>(); // mermaid id → DocuShark shape id
+
+  for (const node of nodes.values()) {
+    const size = sizes.get(node.id)!;
+    const pos = positions.get(node.id) ?? { x: 0, y: 0 };
+    const style = node.className ? classStyles.get(node.className) : undefined;
+    const id = nanoid();
+    idMap.set(node.id, id);
+
+    const base = { id, x: pos.x, y: pos.y, rotation: 0, opacity: 1, locked: false, visible: true };
+    const styleProps = {
+      ...(style?.fill ? { fill: style.fill } : {}),
+      ...(style?.stroke ? { stroke: style.stroke } : {}),
+      ...(style?.labelColor ? { labelColor: style.labelColor } : {}),
+    };
+
+    if (node.shape === 'ellipse') {
+      shapes.push({
+        ...DEFAULT_ELLIPSE, ...base, type: 'ellipse',
+        radiusX: size.width / 2, radiusY: size.height / 2, label: node.label, ...styleProps,
+      } as Shape);
+    } else if (node.shape === 'rectangle' || node.shape === 'rounded') {
+      shapes.push({
+        ...DEFAULT_RECTANGLE, ...base, type: 'rectangle',
+        width: size.width, height: size.height,
+        cornerRadius: node.shape === 'rounded' ? 12 : 0, label: node.label, ...styleProps,
+      } as Shape);
+    } else {
+      // Flowchart library shapes: terminator / diamond / data / predefined-process.
+      shapes.push({
+        ...DEFAULT_LIBRARY_SHAPE, ...base, type: node.shape,
+        width: size.width, height: size.height, label: node.label, ...styleProps,
+      } as Shape);
+    }
+  }
+
+  // Edges → connectors, hitched to the boundary anchor facing the other node.
+  for (const edge of edges) {
+    const startId = idMap.get(edge.from);
+    const endId = idMap.get(edge.to);
+    const startPos = positions.get(edge.from);
+    const endPos = positions.get(edge.to);
+    if (!startId || !endId || !startPos || !endPos) continue;
+
+    const startBox: AnchorBox = { cx: startPos.x, cy: startPos.y, ...sizes.get(edge.from)! };
+    const endBox: AnchorBox = { cx: endPos.x, cy: endPos.y, ...sizes.get(edge.to)! };
+
+    shapes.push({
+      ...DEFAULT_CONNECTOR,
+      id: nanoid(),
+      type: 'connector',
+      x: startPos.x, y: startPos.y, x2: endPos.x, y2: endPos.y,
+      rotation: 0, opacity: 1, locked: false, visible: true,
+      strokeWidth: edge.thick ? 3 : DEFAULT_CONNECTOR.strokeWidth,
+      lineStyle: edge.dashed ? 'dashed' : 'solid',
+      startArrow: false,
+      endArrow: edge.arrow,
+      startShapeId: startId,
+      startAnchor: nearestEdgeAnchor(startBox, endPos),
+      endShapeId: endId,
+      endAnchor: nearestEdgeAnchor(endBox, startPos),
+      ...(edge.label ? { label: edge.label } : {}),
+    } as Shape);
+  }
+
+  return { shapes, warnings };
+}
+
+const MERMAID_HEADER =
+  /^\s*(?:```(?:mermaid)?\s*)?(?:%%\{.*?\}%%\s*)?(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|gantt|pie|journey|mindmap|gitGraph)\b/i;
+
+export const mermaidAdapter: ImportAdapter = {
+  id: 'mermaid',
+  label: 'Mermaid',
+  canImport: (raw) => MERMAID_HEADER.test(raw),
+  import: async (raw) => importMermaid(raw),
+};

--- a/src/shapes/import/layoutGraph.test.ts
+++ b/src/shapes/import/layoutGraph.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { layoutGraph } from './layoutGraph';
+
+const N = (id: string, width = 100, height = 60) => ({ id, width, height });
+
+describe('layoutGraph', () => {
+  it('stacks a chain into successive ranks (TB: increasing y)', () => {
+    const pos = layoutGraph([N('a'), N('b'), N('c')], [{ from: 'a', to: 'b' }, { from: 'b', to: 'c' }]);
+    expect(pos.get('a')!.y).toBeLessThan(pos.get('b')!.y);
+    expect(pos.get('b')!.y).toBeLessThan(pos.get('c')!.y);
+  });
+
+  it('places siblings of one rank on the same row, spread on x', () => {
+    // a → b, a → c : b and c share rank 1.
+    const pos = layoutGraph([N('a'), N('b'), N('c')], [{ from: 'a', to: 'b' }, { from: 'a', to: 'c' }]);
+    expect(pos.get('b')!.y).toBe(pos.get('c')!.y);
+    expect(pos.get('b')!.x).not.toBe(pos.get('c')!.x);
+  });
+
+  it('LR flows along x instead of y', () => {
+    const pos = layoutGraph([N('a'), N('b')], [{ from: 'a', to: 'b' }], { direction: 'LR' });
+    expect(pos.get('a')!.x).toBeLessThan(pos.get('b')!.x);
+    expect(pos.get('a')!.y).toBe(pos.get('b')!.y);
+  });
+
+  it('BT reverses the flow axis', () => {
+    const pos = layoutGraph([N('a'), N('b')], [{ from: 'a', to: 'b' }], { direction: 'BT' });
+    expect(pos.get('a')!.y).toBeGreaterThan(pos.get('b')!.y);
+  });
+
+  it('terminates on cycles (bounded relaxation)', () => {
+    const pos = layoutGraph(
+      [N('a'), N('b'), N('c')],
+      [{ from: 'a', to: 'b' }, { from: 'b', to: 'c' }, { from: 'c', to: 'a' }]
+    );
+    expect(pos.size).toBe(3);
+    expect(Number.isFinite(pos.get('a')!.y)).toBe(true);
+  });
+
+  it('is deterministic across runs', () => {
+    const nodes = [N('a'), N('b'), N('c')];
+    const edges = [{ from: 'a', to: 'b' }, { from: 'a', to: 'c' }];
+    expect(JSON.stringify([...layoutGraph(nodes, edges)])).toBe(
+      JSON.stringify([...layoutGraph(nodes, edges)])
+    );
+  });
+});

--- a/src/shapes/import/layoutGraph.ts
+++ b/src/shapes/import/layoutGraph.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared layered-graph layout for coordinate-less import adapters (JP-164 /
+ * JP-85). Mermaid, PlantUML and friends describe a node/edge graph with no
+ * geometry, so we assign positions here.
+ *
+ * This is the **light, editor-side** layout: longest-path layering (Sugiyama
+ * without crossing minimisation) + per-rank packing using each node's real
+ * size. It is deterministic (stable on re-run, tie-broken by input order) and
+ * dependency-free — the heavyweight, crossing-minimised, obstacle-routed
+ * version is the relay-side JP-245 work; this one just needs to produce a
+ * readable diagram a human is happy to open and then tidy.
+ *
+ * Returns **centre** positions (DocuShark box shapes are centre-anchored).
+ */
+
+export interface GraphLayoutNode {
+  id: string;
+  /** Real rendered size — text/library shapes vary, so layout must read them. */
+  width: number;
+  height: number;
+}
+
+export interface GraphLayoutEdge {
+  from: string;
+  to: string;
+}
+
+/** Flow direction: Top-Bottom, Bottom-Top, Left-Right, Right-Left. */
+export type GraphDirection = 'TB' | 'BT' | 'LR' | 'RL';
+
+export interface GraphLayoutOptions {
+  direction?: GraphDirection;
+  /** Gap between sibling nodes within a rank (cross axis). */
+  nodeGap?: number;
+  /** Gap between ranks (flow axis). */
+  rankGap?: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Assign ranks by longest path from the roots. Cycles are bounded: the relax
+ * loop runs at most `n` passes, so a back-edge can't spin forever — it just
+ * settles at a finite rank.
+ */
+function assignRanks(
+  ids: string[],
+  edges: GraphLayoutEdge[],
+  has: (id: string) => boolean
+): Map<string, number> {
+  const rank = new Map<string, number>(ids.map((id) => [id, 0]));
+  for (let pass = 0; pass < ids.length; pass++) {
+    let changed = false;
+    for (const e of edges) {
+      if (e.from === e.to || !has(e.from) || !has(e.to)) continue;
+      const next = rank.get(e.from)! + 1;
+      if (next > rank.get(e.to)!) {
+        rank.set(e.to, next);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return rank;
+}
+
+export function layoutGraph(
+  nodes: GraphLayoutNode[],
+  edges: GraphLayoutEdge[],
+  options: GraphLayoutOptions = {}
+): Map<string, Point> {
+  const direction = options.direction ?? 'TB';
+  const nodeGap = options.nodeGap ?? 48;
+  const rankGap = options.rankGap ?? 72;
+
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const ids = nodes.map((n) => n.id);
+  const rank = assignRanks(ids, edges, (id) => byId.has(id));
+
+  // Group nodes by rank, preserving input order within each rank.
+  const ranks = new Map<number, GraphLayoutNode[]>();
+  let maxRank = 0;
+  for (const node of nodes) {
+    const r = rank.get(node.id)!;
+    maxRank = Math.max(maxRank, r);
+    (ranks.get(r) ?? ranks.set(r, []).get(r)!).push(node);
+  }
+
+  const horizontal = direction === 'LR' || direction === 'RL';
+  // Flow-axis size = the dimension ranks advance along; cross-axis = the other.
+  const flowSize = (n: GraphLayoutNode) => (horizontal ? n.width : n.height);
+  const crossSize = (n: GraphLayoutNode) => (horizontal ? n.height : n.width);
+
+  const positions = new Map<string, Point>();
+
+  // Walk ranks in flow order, accumulating the flow-axis offset by the tallest
+  // node in each rank. BT/RL just reverse the rank order.
+  const order: number[] = [];
+  for (let r = 0; r <= maxRank; r++) order.push(r);
+  if (direction === 'BT' || direction === 'RL') order.reverse();
+
+  let flowCursor = 0;
+  for (const r of order) {
+    const rankNodes = ranks.get(r) ?? [];
+    const rankExtent = rankNodes.reduce((m, n) => Math.max(m, flowSize(n)), 0);
+    const flowCenter = flowCursor + rankExtent / 2;
+
+    // Pack the rank along the cross axis, centred on 0.
+    const totalCross =
+      rankNodes.reduce((s, n) => s + crossSize(n), 0) + Math.max(0, rankNodes.length - 1) * nodeGap;
+    let crossCursor = -totalCross / 2;
+    for (const n of rankNodes) {
+      const crossCenter = crossCursor + crossSize(n) / 2;
+      positions.set(
+        n.id,
+        horizontal ? { x: flowCenter, y: crossCenter } : { x: crossCenter, y: flowCenter }
+      );
+      crossCursor += crossSize(n) + nodeGap;
+    }
+
+    flowCursor += rankExtent + rankGap;
+  }
+
+  return positions;
+}

--- a/src/shapes/import/registerImportAdapters.ts
+++ b/src/shapes/import/registerImportAdapters.ts
@@ -7,10 +7,14 @@
 import { registerImportAdapter, getImportAdapter } from './ImportAdapter';
 import { excalidrawAdapter } from './adapters/excalidrawAdapter';
 import { drawioAdapter } from './adapters/drawioAdapter';
+import { mermaidAdapter } from './adapters/mermaidAdapter';
 
 if (!getImportAdapter(excalidrawAdapter.id)) {
   registerImportAdapter(excalidrawAdapter);
 }
 if (!getImportAdapter(drawioAdapter.id)) {
   registerImportAdapter(drawioAdapter);
+}
+if (!getImportAdapter(mermaidAdapter.id)) {
+  registerImportAdapter(mermaidAdapter);
 }


### PR DESCRIPTION
First **coordinate-less** import on-ramp — Mermaid flowcharts. Designed in *Shapes Design - Adapters*.

## Two new pieces

**`layoutGraph.ts`** — the shared, dependency-free **layered-graph layout** (JP-164's missing piece). Longest-path layering + per-rank packing using real node sizes, direction-aware (TB/BT/LR/RL), deterministic, cycle-bounded. Returns centre positions. Reusable by PlantUML (JP-166) next.

**`mermaidAdapter.ts`** — a **hand-rolled flowchart parser** (no heavyweight `mermaid` dep — project ethos favours light parsing):
- Node bracket syntax → shapes: `([])`→terminator, `{}`→diamond, `[/]`→data, `[[]]`→predefined-process, `(())`→ellipse, `[]`→rectangle, `()`→rounded.
- Edges → connectors **hitched to edge anchors** via the shared `connectorBinding` helper (JP-196) — toward the laid-out position of the other node. Edge labels, arrows, and dashed (`-.->`) / thick (`==>`) styling.
- `classDef` / `class` → fill/stroke/label-color.
- Subgraphs flattened + reported; sequence/class/state/ER recognised but reported as not-yet-supported. **Never silent loss.**

## Bonus (requested): rebuild connectors after every import

`applyImportResult` now runs `rebuildAllConnectorRoutes()` after insert, so imported connectors render with their routed waypoints **immediately** instead of looking off until the first edit — benefits drawio/Excalidraw/Mermaid alike.

## Tests

Golden-tested against the `Example-Pipeline.mermaid` asset (vendored): node-shape mapping, labelled/dashed connectors hitched to anchors, `classDef` styling, the unsupported-diagram report, and a full end-to-end pass (20+ connectors; layout spreads every node to a unique position). Plus `layoutGraph` unit tests (ranks / siblings / LR / BT / cycles / determinism). Full suite green (1997), typecheck clean.

## Scope

Phase 1 = **flowchart** (the dominant Mermaid use + the test asset). Sequence/class/state/ER are follow-up slices (recognised + reported today).

Assisted-by: Opus 4.8