### PR TITLE
JP-89 slice 1: per-document reference library (data model + store)

### DIFF
--- a/src/store/persistenceStore.references.test.ts
+++ b/src/store/persistenceStore.references.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Persistence wiring for the per-document reference library (JP-89 slice 1).
+ *
+ * Drives the real public `loadDocument` path (which calls the private
+ * `loadDocumentToPageStore`) to prove that `DiagramDocument.references`:
+ *   - loads into `referenceStore` when present,
+ *   - resets the store to empty when absent (back-compat for pre-JP-89 docs),
+ *   - never bleeds a prior document's references into one that has none.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  put: vi.fn(async () => {}),
+  getMeta: vi.fn(() => null),
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+
+const syncManagerMock = vi.hoisted(() => ({
+  queueSave: vi.fn(() => ({ id: 'op-1' })),
+  hasPendingChanges: vi.fn(() => false),
+  processQueueForHost: vi.fn(async () => []),
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => syncManagerMock,
+}));
+
+import { usePersistenceStore } from './persistenceStore';
+import { useReferenceStore } from './referenceStore';
+import { createDocument, STORAGE_KEYS, type DiagramDocument } from '../types/Document';
+import type { CSLItem, ReferenceLibrary } from '../types/Citation';
+
+function item(id: string): CSLItem {
+  return { id, type: 'article-journal', title: `Title ${id}` };
+}
+
+function library(...ids: string[]): ReferenceLibrary {
+  const items: Record<string, CSLItem> = {};
+  for (const id of ids) items[id] = item(id);
+  return { items, itemOrder: [...ids] };
+}
+
+/** Write a DiagramDocument into localStorage where `loadDocument` reads it. */
+function seedDoc(id: string, references?: ReferenceLibrary): void {
+  const doc: DiagramDocument = createDocument(`Doc ${id}`, id, `${id}-p1`);
+  if (references) doc.references = references;
+  localStorage.setItem(`${STORAGE_KEYS.DOCUMENT_PREFIX}${id}`, JSON.stringify(doc));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useReferenceStore.getState().clear();
+  vi.restoreAllMocks();
+});
+
+describe('persistenceStore reference-library wiring', () => {
+  it('loads references from a document that has them', () => {
+    seedDoc('doc-a', library('a', 'b'));
+
+    const ok = usePersistenceStore.getState().loadDocument('doc-a');
+    expect(ok).toBe(true);
+
+    expect(useReferenceStore.getState().listReferences().map((r) => r.id)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('resets to empty for a pre-JP-89 document with no references field', () => {
+    // Simulate stale in-memory state from a previously-open document.
+    useReferenceStore.getState().addReference(item('stale'));
+    seedDoc('doc-old'); // no references field
+
+    usePersistenceStore.getState().loadDocument('doc-old');
+
+    expect(useReferenceStore.getState().listReferences()).toEqual([]);
+  });
+
+  it('does not bleed references across documents', () => {
+    seedDoc('doc-a', library('a', 'b'));
+    seedDoc('doc-b'); // no references
+
+    usePersistenceStore.getState().loadDocument('doc-a');
+    expect(useReferenceStore.getState().itemOrder).toEqual(['a', 'b']);
+
+    usePersistenceStore.getState().loadDocument('doc-b');
+    expect(useReferenceStore.getState().listReferences()).toEqual([]);
+  });
+});

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -20,6 +20,7 @@ import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
+import { useReferenceStore } from './referenceStore';
 import { useUserStore } from './userStore';
 import { isRelayAuthenticated, useConnectionStore } from './connectionStore';
 import { useRelayDocumentStore } from './relayDocumentStore';
@@ -501,6 +502,7 @@ function createDocumentFromPageStore(
   }
   const richTextContent = useRichTextStore.getState().getContent();
   const richTextPages = useRichTextPagesStore.getState().serialize();
+  const references = useReferenceStore.getState().serialize();
   const whiteboardSnapshot = useWhiteboardStore.getState().getSnapshot();
 
   const doc: DiagramDocument = {
@@ -514,6 +516,7 @@ function createDocumentFromPageStore(
     version: 1,
     richTextContent,
     richTextPages,
+    references,
     whiteboard: whiteboardSnapshot,
   };
 
@@ -590,6 +593,15 @@ function loadDocumentToPageStore(doc: DiagramDocument): void {
       useRichTextPagesStore.getState().initializeDefaultPage();
     }
 
+    // Load reference library (JP-89) — clear when absent so a prior document's
+    // references never bleed into one that has none (back-compat for pre-JP-89
+    // documents). `loadReferences` defensively normalizes malformed input.
+    if (doc.references) {
+      useReferenceStore.getState().loadReferences(doc.references);
+    } else {
+      useReferenceStore.getState().clear();
+    }
+
     // Load whiteboard state (or initialize with defaults if not present)
     if (doc.whiteboard) {
       useWhiteboardStore.getState().loadSnapshot(doc.whiteboard);
@@ -639,6 +651,9 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         // Reset rich text pages and initialize with default page
         useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
         useRichTextPagesStore.getState().initializeDefaultPage();
+
+        // Reset the reference library (JP-89) for the new empty document
+        useReferenceStore.getState().clear();
 
         // Clear selection and history
         useSessionStore.getState().clearSelection();

--- a/src/store/referenceStore.test.ts
+++ b/src/store/referenceStore.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for referenceStore (JP-89 slice 1).
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useReferenceStore } from './referenceStore';
+import type { CSLItem, ReferenceLibrary } from '../types/Citation';
+
+function item(id: string, title = `Title ${id}`): CSLItem {
+  return { id, type: 'article-journal', title };
+}
+
+beforeEach(() => {
+  useReferenceStore.getState().clear();
+});
+
+describe('referenceStore CRUD', () => {
+  it('adds references and preserves insertion order', () => {
+    const s = useReferenceStore.getState();
+    s.addReference(item('a'));
+    s.addReference(item('b'));
+    s.addReference(item('c'));
+
+    expect(useReferenceStore.getState().listReferences().map((r) => r.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('generates an id when an item arrives without a citekey', () => {
+    const id = useReferenceStore.getState().addReference({ id: '', type: 'book' });
+    expect(id).toMatch(/^ref-/);
+    expect(useReferenceStore.getState().getReference(id)?.type).toBe('book');
+  });
+
+  it('upserts by id without duplicating the order entry', () => {
+    const s = useReferenceStore.getState();
+    s.addReference(item('a', 'first'));
+    s.upsertReference(item('a', 'second'));
+
+    const state = useReferenceStore.getState();
+    expect(state.itemOrder).toEqual(['a']);
+    expect(state.getReference('a')?.title).toBe('second');
+  });
+
+  it('updates a reference via shallow merge, never re-keying it', () => {
+    const s = useReferenceStore.getState();
+    s.addReference(item('a'));
+    s.updateReference('a', { title: 'patched', DOI: '10.1/x' });
+
+    const ref = useReferenceStore.getState().getReference('a');
+    expect(ref?.id).toBe('a');
+    expect(ref?.title).toBe('patched');
+    expect(ref?.DOI).toBe('10.1/x');
+  });
+
+  it('updateReference is a no-op for an unknown id', () => {
+    useReferenceStore.getState().updateReference('missing', { title: 'x' });
+    expect(useReferenceStore.getState().getReference('missing')).toBeUndefined();
+  });
+
+  it('removes a reference from both items and order', () => {
+    const s = useReferenceStore.getState();
+    s.addReference(item('a'));
+    s.addReference(item('b'));
+    s.removeReference('a');
+
+    const state = useReferenceStore.getState();
+    expect(state.getReference('a')).toBeUndefined();
+    expect(state.itemOrder).toEqual(['b']);
+  });
+
+  it('clear() empties the library', () => {
+    const s = useReferenceStore.getState();
+    s.addReference(item('a'));
+    s.clear();
+
+    const state = useReferenceStore.getState();
+    expect(state.itemOrder).toEqual([]);
+    expect(state.listReferences()).toEqual([]);
+  });
+});
+
+describe('referenceStore serialize / load round-trip', () => {
+  it('round-trips serialize() -> loadReferences()', () => {
+    const s = useReferenceStore.getState();
+    s.addReference(item('a'));
+    s.addReference(item('b'));
+    const serialized = useReferenceStore.getState().serialize();
+
+    s.clear();
+    expect(useReferenceStore.getState().itemOrder).toEqual([]);
+
+    useReferenceStore.getState().loadReferences(serialized);
+    expect(useReferenceStore.getState().serialize()).toEqual(serialized);
+  });
+
+  it('degrades malformed input to an empty library without throwing', () => {
+    useReferenceStore.getState().addReference(item('a'));
+    // Deliberately malformed shape.
+    useReferenceStore
+      .getState()
+      .loadReferences({ itemOrder: 'nope' } as unknown as ReferenceLibrary);
+
+    const state = useReferenceStore.getState();
+    expect(state.items).toEqual({});
+    expect(state.itemOrder).toEqual([]);
+  });
+
+  it('normalizes inconsistent order vs items on load', () => {
+    const lib: ReferenceLibrary = {
+      items: { a: item('a'), b: item('b') },
+      // order references a ghost id and omits a real one.
+      itemOrder: ['a', 'ghost'],
+    };
+    useReferenceStore.getState().loadReferences(lib);
+
+    const state = useReferenceStore.getState();
+    expect(state.itemOrder).toContain('a');
+    expect(state.itemOrder).toContain('b');
+    expect(state.itemOrder).not.toContain('ghost');
+    expect(state.itemOrder).toHaveLength(2);
+  });
+});

--- a/src/store/referenceStore.ts
+++ b/src/store/referenceStore.ts
@@ -1,0 +1,154 @@
+/**
+ * referenceStore - Per-document reference library (JP-89, slice 1).
+ *
+ * Holds the active document's CSL-JSON references (the backing store for inline
+ * citations + the bibliography block in later slices). Modelled on
+ * `richTextPagesStore`: a pure id-map + order-array data store, serialized into
+ * `DiagramDocument.references` on save and reloaded / cleared on document
+ * switch by `persistenceStore`.
+ *
+ * This is a **data store only** — no formatting, ingest, or DOI lookup (those
+ * are JP-89 slices 2/3). Keep it free of network and `@citation-js` imports so
+ * it stays light and synchronous.
+ */
+
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import type { CSLItem, ReferenceLibrary } from '../types/Citation';
+import { isReferenceLibrary } from '../types/Citation';
+
+/**
+ * State for the reference store.
+ */
+interface ReferenceState {
+  /** CSL items keyed by id. */
+  items: Record<string, CSLItem>;
+  /** Display order of item ids. */
+  itemOrder: string[];
+}
+
+/**
+ * Actions for the reference store.
+ */
+interface ReferenceActions {
+  /** Insert a new reference. If its id collides, it is treated as an upsert. */
+  addReference: (item: CSLItem) => string;
+  /** Insert or replace a reference by id (id generated if absent). */
+  upsertReference: (item: CSLItem) => string;
+  /** Shallow-merge a patch into an existing reference. No-op if id unknown. */
+  updateReference: (id: string, patch: Partial<CSLItem>) => void;
+  /** Remove a reference by id. */
+  removeReference: (id: string) => void;
+  /** Get a reference by id. */
+  getReference: (id: string) => CSLItem | undefined;
+  /** All references in display order. */
+  listReferences: () => CSLItem[];
+  /** Reset to an empty library (document switch / new document). */
+  clear: () => void;
+  /** Load a serialized library, defensively normalizing malformed input. */
+  loadReferences: (data: ReferenceLibrary) => void;
+  /** Serialize for persistence into `DiagramDocument.references`. */
+  serialize: () => ReferenceLibrary;
+}
+
+/**
+ * Generate a unique reference id when an item arrives without a citekey.
+ * Mirrors the id-generation idiom in `richTextPagesStore`. Ids are scoped per
+ * document, so the timestamp+random suffix is collision-free in practice.
+ */
+function generateReferenceId(): string {
+  return `ref-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export const useReferenceStore = create<ReferenceState & ReferenceActions>()(
+  immer((set, get) => ({
+    items: {},
+    itemOrder: [],
+
+    upsertReference: (item: CSLItem) => {
+      const id = item.id && item.id.trim() ? item.id : generateReferenceId();
+      set((draft) => {
+        const stored: CSLItem = { ...item, id };
+        if (!draft.items[id]) {
+          draft.itemOrder.push(id);
+        }
+        draft.items[id] = stored;
+      });
+      return id;
+    },
+
+    addReference: (item: CSLItem) => {
+      // Insert semantics with id-collision tolerance == upsert.
+      return get().upsertReference(item);
+    },
+
+    updateReference: (id: string, patch: Partial<CSLItem>) => {
+      set((draft) => {
+        const existing = draft.items[id];
+        if (!existing) return;
+        // Preserve the canonical id; a patch must not silently re-key an item.
+        draft.items[id] = { ...existing, ...patch, id };
+      });
+    },
+
+    removeReference: (id: string) => {
+      set((draft) => {
+        if (!draft.items[id]) return;
+        delete draft.items[id];
+        const index = draft.itemOrder.indexOf(id);
+        if (index !== -1) {
+          draft.itemOrder.splice(index, 1);
+        }
+      });
+    },
+
+    getReference: (id: string) => {
+      return get().items[id];
+    },
+
+    listReferences: () => {
+      const state = get();
+      return state.itemOrder
+        .map((id) => state.items[id])
+        .filter((item): item is CSLItem => item !== undefined);
+    },
+
+    clear: () => {
+      set((draft) => {
+        draft.items = {};
+        draft.itemOrder = [];
+      });
+    },
+
+    loadReferences: (data: ReferenceLibrary) => {
+      set((draft) => {
+        if (!isReferenceLibrary(data)) {
+          // Malformed input degrades to an empty library — never throw.
+          draft.items = {};
+          draft.itemOrder = [];
+          return;
+        }
+        // Drop order entries with no backing item, and append any items missing
+        // from the order, so the two collections stay consistent after an
+        // imperfect import.
+        const items = data.items;
+        const order = data.itemOrder.filter((id) => items[id] !== undefined);
+        for (const id of Object.keys(items)) {
+          if (!order.includes(id)) {
+            order.push(id);
+          }
+        }
+        draft.items = items;
+        draft.itemOrder = order;
+      });
+    },
+
+    serialize: () => {
+      const state = get();
+      return {
+        items: state.items,
+        itemOrder: state.itemOrder,
+      };
+    },
+  }))
+);

--- a/src/types/Citation.ts
+++ b/src/types/Citation.ts
@@ -1,0 +1,98 @@
+/**
+ * Citation / reference types for the per-document reference library (JP-89).
+ *
+ * The canonical interchange shape is **CSL-JSON** (Citation Style Language) —
+ * the same structure `@citation-js` and DOI content-negotiation
+ * (`application/vnd.citationstyles.csl+json`) both emit and consume. Storing
+ * references as CSL-JSON now means later slices (BibTeX/DOI ingest, CSL
+ * formatting, the Tiptap inline-cite + bibliography nodes, the MCP surface)
+ * feed straight in with no re-modelling.
+ *
+ * This file is the data model only — no formatting, ingest, or network logic
+ * (those land in subsequent JP-89 slices).
+ */
+
+/**
+ * A CSL name (author / editor / etc.). Either a structured `family`/`given`
+ * pair or a `literal` for institutional / unparsed names.
+ */
+export interface CSLName {
+  family?: string;
+  given?: string;
+  /** Whole-name fallback (organisations, "et al.", unparsed names). */
+  literal?: string;
+}
+
+/**
+ * A CSL date. CSL encodes dates as nested `date-parts` (`[[year, month, day]]`,
+ * each part optional from the right) with a `raw` string fallback for dates
+ * that don't parse into parts.
+ */
+export interface CSLDate {
+  'date-parts'?: number[][];
+  raw?: string;
+}
+
+/**
+ * A single CSL-JSON bibliographic item.
+ *
+ * The commonly-used fields are modelled explicitly; the `[key: string]: unknown`
+ * index signature carries the long tail of the CSL spec (~50 fields) without
+ * resorting to `any`. Accessing an explicit field uses dot notation; accessing
+ * an extra CSL field uses bracket notation (per `noPropertyAccessFromIndexSignature`).
+ */
+export interface CSLItem {
+  /** Citekey / unique id within the document's library. Required. */
+  id: string;
+  /** CSL item type, e.g. `article-journal`, `book`, `webpage`. */
+  type: string;
+  title?: string;
+  author?: CSLName[];
+  editor?: CSLName[];
+  issued?: CSLDate;
+  DOI?: string;
+  URL?: string;
+  ISBN?: string;
+  'container-title'?: string;
+  publisher?: string;
+  page?: string;
+  volume?: string;
+  issue?: string;
+  abstract?: string;
+  /** Long tail of CSL fields not modelled explicitly. */
+  [key: string]: unknown;
+}
+
+/**
+ * A document's reference library: CSL items keyed by id, plus an explicit
+ * display order. Mirrors the id-map + order-array shape of `Page` / `RichTextPage`.
+ */
+export interface ReferenceLibrary {
+  items: Record<string, CSLItem>;
+  itemOrder: string[];
+}
+
+/**
+ * Create an empty reference library.
+ */
+export function createEmptyReferenceLibrary(): ReferenceLibrary {
+  return { items: {}, itemOrder: [] };
+}
+
+/**
+ * Runtime guard: is `x` a structurally-valid {@link ReferenceLibrary}?
+ *
+ * Used to defensively normalize untrusted input (e.g. an imported document or
+ * a partial snapshot) before loading it into the store — a malformed value
+ * should degrade to an empty library, never throw.
+ */
+export function isReferenceLibrary(x: unknown): x is ReferenceLibrary {
+  if (!x || typeof x !== 'object') return false;
+  const lib = x as Record<string, unknown>;
+  return (
+    typeof lib['items'] === 'object' &&
+    lib['items'] !== null &&
+    !Array.isArray(lib['items']) &&
+    Array.isArray(lib['itemOrder'])
+  );
+}

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -7,6 +7,7 @@ import { RichTextContent } from './RichText';
 import type { RichTextPage } from '../store/richTextPagesStore';
 import type { WhiteboardState } from './Whiteboard';
 import type { PDFSettings } from './PDFExport';
+import type { ReferenceLibrary } from './Citation';
 
 /**
  * A single page within a document.
@@ -57,6 +58,17 @@ export interface DiagramDocument {
   };
   /** Blob IDs referenced by this document (for garbage collection) */
   blobReferences?: string[];
+
+  // Citations (JP-89)
+  /**
+   * Per-document reference library (CSL-JSON), the backing store for inline
+   * citations + the bibliography block. Optional for backwards compatibility:
+   * an older document simply has no `references` key and loads as an empty
+   * library (mirrors how `richTextPages` was introduced — additive, no
+   * `DOCUMENT_VERSION` bump). Plain JSON, so it rides the normal save/load and
+   * relay-flatten paths with no special handling.
+   */
+  references?: ReferenceLibrary;
 
   // Team document fields (Phase 14.1)
   /** Whether this is a relay document (stored on host, synced via CRDT) */


### PR DESCRIPTION
First slice of **JP-89 — Citations management with MCP surface**. JP-89 is an 8-point feature shipping as 6 ordered slices; this is the foundation every later slice hangs off.

## What this slice does
The per-document **reference library** (CSL-JSON) — the backing store for inline citations, the bibliography block, and the MCP surface in later slices. **Data model only**: no formatting, ingest, DOI lookup, UI, or MCP yet.

- **`types/Citation.ts`** — CSL-JSON model (`CSLItem` / `CSLName` / `CSLDate` / `ReferenceLibrary`) + `createEmptyReferenceLibrary()` and an `isReferenceLibrary()` guard. CSL-JSON is the shape `@citation-js` and DOI content-negotiation both emit/consume, so slices 2–4 feed straight in with no re-modelling.
- **`DiagramDocument.references?`** — additive optional field modelled on `richTextPages` (no `DOCUMENT_VERSION` bump; an older doc simply has no key and loads as an empty library).
- **`referenceStore.ts`** — Zustand+Immer data store mirroring `richTextPagesStore` (`add/upsert/update/remove/get/list/clear/loadReferences/serialize`), with defensive normalization of malformed / order-inconsistent input on load.
- **`persistenceStore` wiring** at all three `richTextPages` chokepoints — serialize in `createDocumentFromPageStore` (all save paths incl. relay save), load in `loadDocumentToPageStore` (all load paths incl. relay-doc open), clear in `newDocument` — so a prior document's references never bleed across documents.

## Durability / scope notes
- **Relay/Cloud docs need no relay changes:** `flatten_into` merges into the stored JSON and leaves unknown top-level fields untouched, so a `references` field saved via REST survives every flatten cycle.
- **Deferred:** real-time concurrent multi-editor sync of references (they're not a Y.Doc shared type) — same last-write-wins exposure prose page metadata has today. Slated for a later slice.

## Slice roadmap
1. **Data model + store + wiring** ← this PR
2. Ingest: BibTeX / CSL-JSON parse + DOI lookup (Crossref/DataCite)
3. CSL formatting engine (`@citation-js`, lazy-loaded)
4. Tiptap inline-citation node + bibliography block node
5. UI: reference manager panel + citation picker + style selector
6. Relay MCP tools (`citations.add/resolve_doi/format/list`)

## Verification
- `bun run typecheck` — clean.
- `referenceStore.test.ts` (10) + `persistenceStore.references.test.ts` (3, incl. back-compat + cross-doc-bleed guard) — green.
- 99 related store tests pass; OSS commercial-leak grep clean.

Assisted-by: Opus 4.8