### PR TITLE
JP-89 slice 2: reference ingest (BibTeX / CSL-JSON parse + DOI lookup)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "docushark",
       "dependencies": {
+        "@citation-js/core": "^0.7.21",
+        "@citation-js/plugin-bibtex": "^0.7.21",
         "@radix-ui/react-radio-group": "^1.4.0",
         "@radix-ui/react-slider": "^1.4.0",
         "@radix-ui/react-switch": "^1.3.0",
@@ -269,6 +271,14 @@
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@citation-js/core": ["@citation-js/core@0.7.21", "", { "dependencies": { "@citation-js/date": "^0.5.0", "@citation-js/name": "^0.4.2", "fetch-ponyfill": "^7.1.0", "sync-fetch": "^0.4.1" } }, "sha512-Vobv2/Yfnn6C6BVO/pvj7madQ7Mfzl83/jAWwixbemGF6ZThhGMz8++FD9hWHyHXDMYuLGa6fK68c2VsolZmTA=="],
+
+    "@citation-js/date": ["@citation-js/date@0.5.1", "", {}, "sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw=="],
+
+    "@citation-js/name": ["@citation-js/name@0.4.2", "", {}, "sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ=="],
+
+    "@citation-js/plugin-bibtex": ["@citation-js/plugin-bibtex@0.7.21", "", { "dependencies": { "@citation-js/date": "^0.5.0", "@citation-js/name": "^0.4.2", "moo": "^0.5.1" }, "peerDependencies": { "@citation-js/core": "^0.7.0" } }, "sha512-O008pSsJgiYKn4+7gAWrbNpNdUH++aMeYmZaJ2oFQ8X1tcY5jNBxJcr0zZojNtUi5CVOaXXHQ0yIifoUhuF2Vg=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -698,6 +708,8 @@
 
     "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.3", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-8QdH6czo+G7uBsNo0GiUfouPN1lRzKdJTGnKXwe12gkFbnnOUaUKGN55dMkfy+mnxmvjwl9zcI4VncczcVXDhA=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
@@ -709,6 +721,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "btoa": ["btoa@1.2.1", "", { "bin": { "btoa": "bin/btoa.js" } }, "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -838,6 +852,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-ponyfill": ["fetch-ponyfill@7.1.0", "", { "dependencies": { "node-fetch": "~2.6.1" } }, "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw=="],
+
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
@@ -913,6 +929,8 @@
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
@@ -1056,11 +1074,15 @@
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
 
+    "moo": ["moo@0.5.3", "", {}, "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+
+    "node-fetch": ["node-fetch@2.6.13", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA=="],
 
     "node-readable-to-web-readable-stream": ["node-readable-to-web-readable-stream@0.4.2", "", {}, "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ=="],
 
@@ -1285,6 +1307,8 @@
     "svg-pathdata": ["svg-pathdata@6.0.3", "", {}, "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "sync-fetch": ["sync-fetch@0.4.5", "", { "dependencies": { "buffer": "^5.7.1", "node-fetch": "^2.6.1" } }, "sha512-esiWJ7ixSKGpd9DJPBTC4ckChqdOjIwJfYhVHkcQ2Gnm41323p1TRmEI+esTQ9ppD+b5opps2OTEGTCGX5kF+g=="],
 
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 
@@ -1674,6 +1698,8 @@
 
     "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -1685,6 +1711,8 @@
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "sync-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "tempy/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -1894,9 +1922,15 @@
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "source-map/whatwg-url/tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
     "source-map/whatwg-url/webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
+    "sync-fetch/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
@@ -1971,6 +2005,10 @@
     "@babel/plugin-transform-object-rest-spread/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "sync-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "sync-fetch/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "@babel/plugin-transform-modules-amd/@babel/helper-module-transforms/@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@citation-js/core": "^0.7.21",
+    "@citation-js/plugin-bibtex": "^0.7.21",
     "@radix-ui/react-radio-group": "^1.4.0",
     "@radix-ui/react-slider": "^1.4.0",
     "@radix-ui/react-switch": "^1.3.0",

--- a/src/services/citations/ingest.test.ts
+++ b/src/services/citations/ingest.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for reference ingest (JP-89 slice 2).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  detectFormat,
+  normalizeDoi,
+  normalizeItem,
+  parseReferences,
+  resolveDoi,
+} from './ingest';
+
+/** Minimal Response-like stub for the injected fetch. */
+function jsonResponse(body: unknown, init: { status?: number; ok?: boolean } = {}): Response {
+  const status = init.status ?? 200;
+  return {
+    ok: init.ok ?? (status >= 200 && status < 300),
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('detectFormat', () => {
+  it('detects csl-json (array or object)', () => {
+    expect(detectFormat('[{"id":"a"}]')).toBe('csl-json');
+    expect(detectFormat('  {"id":"a"}')).toBe('csl-json');
+  });
+  it('detects bibtex', () => {
+    expect(detectFormat('@article{key, title={X}}')).toBe('bibtex');
+    expect(detectFormat('@book{ k ,')).toBe('bibtex');
+  });
+  it('returns null for unrecognized / empty', () => {
+    expect(detectFormat('just some prose')).toBeNull();
+    expect(detectFormat('   ')).toBeNull();
+  });
+});
+
+describe('normalizeItem', () => {
+  it('guarantees id and type', () => {
+    expect(normalizeItem({ title: 'X' }, 'fb')).toEqual({ title: 'X', id: 'fb', type: 'document' });
+    expect(normalizeItem({ id: 'real', type: 'book' }, 'fb')?.id).toBe('real');
+  });
+  it('rejects non-objects', () => {
+    expect(normalizeItem('x', 'fb')).toBeNull();
+    expect(normalizeItem(['a'], 'fb')).toBeNull();
+    expect(normalizeItem(null, 'fb')).toBeNull();
+  });
+});
+
+describe('parseReferences — CSL-JSON', () => {
+  it('parses an array of items', async () => {
+    const { items, report } = await parseReferences('[{"id":"a","type":"book"},{"id":"b","type":"article-journal"}]');
+    expect(report.source).toBe('csl-json');
+    expect(report.count).toBe(2);
+    expect(items.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+  it('parses a single object', async () => {
+    const { items } = await parseReferences('{"id":"single","type":"webpage"}', 'csl-json');
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe('single');
+  });
+  it('reports invalid JSON without throwing', async () => {
+    const { items, report } = await parseReferences('{not json', 'csl-json');
+    expect(items).toEqual([]);
+    expect(report.errors[0]).toContain('Invalid JSON');
+  });
+  it('skips non-object entries with a warning', async () => {
+    const { items, report } = await parseReferences('[{"id":"a"}, 42]', 'csl-json');
+    expect(items).toHaveLength(1);
+    expect(report.warnings.length).toBe(1);
+  });
+});
+
+describe('parseReferences — BibTeX (lazy citation-js)', () => {
+  it('parses a journal article into CSL-JSON', async () => {
+    const bibtex = `@article{smith2020,
+      title = {On Things},
+      author = {Smith, Jane and Doe, John},
+      journal = {Journal of Things},
+      year = {2020}
+    }`;
+    const { items, report } = await parseReferences(bibtex);
+    expect(report.source).toBe('bibtex');
+    expect(items).toHaveLength(1);
+    const item = items[0]!;
+    expect(item.id).toBeTruthy();
+    expect(item.title).toBe('On Things');
+    expect(item.type).toBe('article-journal');
+    expect(item.author?.[0]?.family).toBe('Smith');
+  });
+  it('handles malformed BibTeX gracefully (no throw, empty + reported)', async () => {
+    const { items, report } = await parseReferences('@', 'bibtex');
+    expect(items).toEqual([]);
+    expect(report.source).toBe('bibtex');
+    expect(report.errors.length + report.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe('normalizeDoi', () => {
+  it('strips common prefixes', () => {
+    expect(normalizeDoi('https://doi.org/10.1/abc')).toBe('10.1/abc');
+    expect(normalizeDoi('doi:10.1/abc')).toBe('10.1/abc');
+    expect(normalizeDoi('  10.1/abc  ')).toBe('10.1/abc');
+  });
+});
+
+describe('resolveDoi (injected fetch)', () => {
+  const csl = { DOI: '10.1000/xyz', type: 'article-journal', title: 'Resolved' };
+
+  it('resolves a DOI to a CSL item', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(csl));
+    const { items, report } = await resolveDoi('10.1000/xyz', { fetch: fetchMock as unknown as typeof fetch });
+    expect(report.source).toBe('doi');
+    expect(items).toHaveLength(1);
+    expect(items[0]?.title).toBe('Resolved');
+    // id keyed off the DOI when the payload has none.
+    expect(items[0]?.id).toBe('10.1000/xyz');
+    // requested CSL-JSON via content negotiation against doi.org.
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://doi.org/10.1000/xyz');
+    expect(init?.headers).toMatchObject({
+      Accept: 'application/vnd.citationstyles.csl+json',
+    });
+  });
+
+  it('accepts a full doi.org URL input', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(csl));
+    await resolveDoi('https://doi.org/10.1000/xyz', { fetch: fetchMock as unknown as typeof fetch });
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://doi.org/10.1000/xyz');
+  });
+
+  it('rejects a malformed DOI before fetching', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(csl));
+    const { items, report } = await resolveDoi('not-a-doi', { fetch: fetchMock as unknown as typeof fetch });
+    expect(items).toEqual([]);
+    expect(report.errors[0]).toContain('Not a valid DOI');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a 404 as "not found"', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({}, { status: 404 }));
+    const { report } = await resolveDoi('10.1000/missing', { fetch: fetchMock as unknown as typeof fetch });
+    expect(report.errors[0]).toContain('DOI not found');
+  });
+
+  it('reports a network failure without throwing', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('offline');
+    });
+    const { report } = await resolveDoi('10.1000/xyz', { fetch: fetchMock as unknown as typeof fetch });
+    expect(report.errors[0]).toContain('DOI lookup failed');
+    expect(report.errors[0]).toContain('offline');
+  });
+});

--- a/src/services/citations/ingest.ts
+++ b/src/services/citations/ingest.ts
@@ -1,0 +1,197 @@
+/**
+ * Reference ingest (JP-89 slice 2).
+ *
+ * Turns external bibliographic input into normalized CSL-JSON {@link CSLItem}s:
+ *   - `parseReferences` — BibTeX (via lazy-loaded `@citation-js`) or CSL-JSON
+ *     (native `JSON.parse`), format auto-detected or forced.
+ *   - `resolveDoi` — a single DOI resolved to CSL-JSON via content negotiation
+ *     against `doi.org`, which transparently routes to the registration agency
+ *     (Crossref **or** DataCite), so one path covers both.
+ *
+ * Everything here is **safe-parse**: functions never throw on bad input — they
+ * return whatever parsed plus an {@link IngestReport} of errors/warnings. The
+ * `@citation-js` import is dynamic so the (heavy) library stays out of the core
+ * PWA bundle; the network transport is injectable so callers/tests control it.
+ */
+
+import type { CSLItem } from '../../types/Citation';
+
+/** Recognized local input formats. `'doi'` is network-resolved, not parsed. */
+export type IngestFormat = 'bibtex' | 'csl-json';
+export type IngestSource = IngestFormat | 'doi';
+
+export interface IngestReport {
+  source: IngestSource;
+  /** Number of items successfully produced. */
+  count: number;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface IngestResult {
+  items: CSLItem[];
+  report: IngestReport;
+}
+
+/** Injectable dependencies for {@link resolveDoi} (tests pass a mock fetch). */
+export interface DoiDeps {
+  fetch?: typeof fetch;
+}
+
+const CSL_JSON_DOI_ACCEPT = 'application/vnd.citationstyles.csl+json';
+
+/**
+ * Best-effort format detection for pasted/dropped text. Returns `null` when the
+ * text matches neither shape (caller can surface "unrecognized format").
+ */
+export function detectFormat(text: string): IngestFormat | null {
+  const trimmed = text.trimStart();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('[') || trimmed.startsWith('{')) return 'csl-json';
+  // BibTeX entries open with `@type{key,` (also @string/@preamble/@comment).
+  if (/^@[a-zA-Z]+\s*[{(]/.test(trimmed)) return 'bibtex';
+  return null;
+}
+
+/**
+ * Coerce an untrusted parsed object into a {@link CSLItem}, guaranteeing a
+ * non-empty `id` and `type`. Returns `null` if it isn't an object at all.
+ */
+export function normalizeItem(raw: unknown, fallbackId: string): CSLItem | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const id = typeof obj['id'] === 'string' && obj['id'].trim() ? (obj['id'] as string) : fallbackId;
+  const type = typeof obj['type'] === 'string' && obj['type'].trim() ? (obj['type'] as string) : 'document';
+  return { ...obj, id, type };
+}
+
+/**
+ * Parse a block of reference text. `format` forces the parser; omit it to
+ * auto-detect. Never throws.
+ */
+export async function parseReferences(text: string, format?: IngestFormat): Promise<IngestResult> {
+  const resolved = format ?? detectFormat(text);
+  if (resolved === null) {
+    return {
+      items: [],
+      report: { source: 'csl-json', count: 0, errors: ['Unrecognized reference format'], warnings: [] },
+    };
+  }
+  return resolved === 'bibtex' ? parseBibTeX(text) : parseCslJson(text);
+}
+
+async function parseBibTeX(text: string): Promise<IngestResult> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let items: CSLItem[] = [];
+  try {
+    // Lazy-load citation-js (heavy) only when BibTeX is actually ingested.
+    const { Cite } = await import('@citation-js/core');
+    await import('@citation-js/plugin-bibtex');
+    const cite = new Cite(text, { forceType: '@bibtex/text' });
+    items = cite.data
+      .map((entry, i) => normalizeItem(entry, `ref-bibtex-${i}`))
+      .filter((item): item is CSLItem => item !== null);
+    if (items.length === 0) {
+      warnings.push('No BibTeX entries found');
+    }
+  } catch (err) {
+    errors.push(`BibTeX parse failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return { items, report: { source: 'bibtex', count: items.length, errors, warnings } };
+}
+
+function parseCslJson(text: string): IngestResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const items: CSLItem[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    return {
+      items: [],
+      report: {
+        source: 'csl-json',
+        count: 0,
+        errors: [`Invalid JSON: ${err instanceof Error ? err.message : String(err)}`],
+        warnings: [],
+      },
+    };
+  }
+  const rawItems = Array.isArray(parsed) ? parsed : [parsed];
+  rawItems.forEach((raw, i) => {
+    const item = normalizeItem(raw, `ref-csl-${i}`);
+    if (item) {
+      items.push(item);
+    } else {
+      warnings.push(`Skipped non-object entry at index ${i}`);
+    }
+  });
+  return { items, report: { source: 'csl-json', count: items.length, errors, warnings } };
+}
+
+/**
+ * Strip common DOI prefixes/wrappers to a bare DOI (`10.xxxx/yyyy`).
+ */
+export function normalizeDoi(input: string): string {
+  return input
+    .trim()
+    .replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')
+    .replace(/^doi:\s*/i, '')
+    .replace(/^info:doi\//i, '')
+    .trim();
+}
+
+/**
+ * Resolve a single DOI to a CSL-JSON {@link CSLItem} via `doi.org` content
+ * negotiation. The fetch transport is injectable (defaults to global `fetch`)
+ * so tests run offline and desktop can swap in a non-CORS transport later.
+ * Never throws.
+ */
+export async function resolveDoi(doi: string, deps: DoiDeps = {}): Promise<IngestResult> {
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const bare = normalizeDoi(doi);
+  const errors: string[] = [];
+  const emptyReport = (msg: string): IngestResult => ({
+    items: [],
+    report: { source: 'doi', count: 0, errors: [msg], warnings: [] },
+  });
+
+  if (!bare || !/^10\.\d{4,9}\//.test(bare)) {
+    return emptyReport(`Not a valid DOI: "${doi}"`);
+  }
+  if (typeof fetchImpl !== 'function') {
+    return emptyReport('No fetch implementation available for DOI lookup');
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`https://doi.org/${bare}`, {
+      headers: { Accept: CSL_JSON_DOI_ACCEPT },
+      redirect: 'follow',
+    });
+  } catch (err) {
+    return emptyReport(`DOI lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (res.status === 404) return emptyReport(`DOI not found: ${bare}`);
+  if (!res.ok) return emptyReport(`DOI lookup failed (HTTP ${res.status})`);
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return emptyReport(`DOI response was not JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // CSL-JSON from doi.org carries `DOI` but usually no `id`; key it off the DOI.
+  const fallbackId =
+    typeof (body as Record<string, unknown>)?.['DOI'] === 'string'
+      ? ((body as Record<string, unknown>)['DOI'] as string)
+      : bare;
+  const item = normalizeItem(body, fallbackId);
+  if (!item) return emptyReport('DOI response was not a CSL item');
+
+  return { items: [item], report: { source: 'doi', count: 1, errors, warnings: [] } };
+}

--- a/src/services/citations/referenceImport.test.ts
+++ b/src/services/citations/referenceImport.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for reference import + dedup (JP-89 slice 2).
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { dedupeReferences, importReferences } from './referenceImport';
+import { useReferenceStore } from '../../store/referenceStore';
+import type { CSLItem } from '../../types/Citation';
+
+function item(id: string, extra: Partial<CSLItem> = {}): CSLItem {
+  return { id, type: 'article-journal', title: `Title ${id}`, ...extra };
+}
+
+describe('dedupeReferences', () => {
+  it('treats a shared id as a duplicate', () => {
+    const { unique, duplicates } = dedupeReferences([item('a')], [item('a'), item('b')]);
+    expect(unique.map((i) => i.id)).toEqual(['b']);
+    expect(duplicates.map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('treats a shared DOI (case-insensitive, different id) as a duplicate', () => {
+    const existing = [item('a', { DOI: '10.1/X' })];
+    const incoming = [item('b', { DOI: '10.1/x' })];
+    const { unique, duplicates } = dedupeReferences(existing, incoming);
+    expect(unique).toEqual([]);
+    expect(duplicates.map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('dedups within the incoming batch itself', () => {
+    const incoming = [item('a', { DOI: '10.1/x' }), item('b', { DOI: '10.1/x' })];
+    const { unique, duplicates } = dedupeReferences([], incoming);
+    expect(unique.map((i) => i.id)).toEqual(['a']);
+    expect(duplicates.map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('keeps items with no DOI distinct when ids differ', () => {
+    const { unique } = dedupeReferences([item('a')], [item('b'), item('c')]);
+    expect(unique.map((i) => i.id)).toEqual(['b', 'c']);
+  });
+});
+
+describe('importReferences', () => {
+  beforeEach(() => {
+    useReferenceStore.getState().clear();
+  });
+
+  it('adds new references to the store', () => {
+    const result = importReferences([item('a'), item('b')]);
+    expect(result).toEqual({ added: 2, duplicates: 0 });
+    expect(useReferenceStore.getState().listReferences().map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('skips items already in the library', () => {
+    importReferences([item('a', { DOI: '10.1/x' })]);
+    const result = importReferences([item('a-again', { DOI: '10.1/x' }), item('c')]);
+    expect(result).toEqual({ added: 1, duplicates: 1 });
+    expect(useReferenceStore.getState().listReferences().map((r) => r.id)).toEqual(['a', 'c']);
+  });
+});

--- a/src/services/citations/referenceImport.ts
+++ b/src/services/citations/referenceImport.ts
@@ -1,0 +1,71 @@
+/**
+ * Reference import + dedup (JP-89 slice 2).
+ *
+ * Bridges {@link ingest} output into the per-document reference library
+ * (`referenceStore`): drop items that already exist (by DOI, then by id), then
+ * upsert the rest. Kept separate from `ingest.ts` so the parsers stay pure and
+ * store-free; the pure `dedupeReferences` is exported for direct testing.
+ */
+
+import type { CSLItem } from '../../types/Citation';
+import { useReferenceStore } from '../../store/referenceStore';
+
+export interface DedupeResult {
+  /** Incoming items not already present in `existing`. */
+  unique: CSLItem[];
+  /** Incoming items that duplicate an existing reference. */
+  duplicates: CSLItem[];
+}
+
+export interface ImportResult {
+  added: number;
+  duplicates: number;
+}
+
+/** Lower-cased DOI, or `null` when absent — DOIs are case-insensitive. */
+function doiKey(item: CSLItem): string | null {
+  return typeof item.DOI === 'string' && item.DOI.trim() ? item.DOI.trim().toLowerCase() : null;
+}
+
+/**
+ * Split `incoming` into items new to `existing` vs duplicates. An item is a
+ * duplicate if it shares a DOI (case-insensitive) or an `id` with an existing
+ * reference, or with an earlier-seen incoming item (so a batch dedups itself).
+ */
+export function dedupeReferences(existing: CSLItem[], incoming: CSLItem[]): DedupeResult {
+  const seenDois = new Set<string>();
+  const seenIds = new Set<string>();
+  for (const item of existing) {
+    const doi = doiKey(item);
+    if (doi) seenDois.add(doi);
+    seenIds.add(item.id);
+  }
+
+  const unique: CSLItem[] = [];
+  const duplicates: CSLItem[] = [];
+  for (const item of incoming) {
+    const doi = doiKey(item);
+    const isDup = (doi !== null && seenDois.has(doi)) || seenIds.has(item.id);
+    if (isDup) {
+      duplicates.push(item);
+      continue;
+    }
+    unique.push(item);
+    if (doi) seenDois.add(doi);
+    seenIds.add(item.id);
+  }
+  return { unique, duplicates };
+}
+
+/**
+ * Dedup `incoming` against the current document's library and upsert the new
+ * ones into `referenceStore`. Returns how many were added vs skipped.
+ */
+export function importReferences(incoming: CSLItem[]): ImportResult {
+  const store = useReferenceStore.getState();
+  const { unique, duplicates } = dedupeReferences(store.listReferences(), incoming);
+  for (const item of unique) {
+    store.upsertReference(item);
+  }
+  return { added: unique.length, duplicates: duplicates.length };
+}

--- a/src/types/citation-js.d.ts
+++ b/src/types/citation-js.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal ambient types for `@citation-js/core` (JP-89 slice 2).
+ *
+ * citation-js ships no TypeScript declarations. We only use a narrow surface —
+ * the `Cite` constructor with `forceType` and its `data` array (CSL-JSON items)
+ * — so we declare just that rather than depend on an out-of-tree `@types`
+ * package. The library is lazy-loaded (dynamic `import()`) so it stays out of
+ * the core PWA bundle; these declarations type both the static and dynamic import.
+ */
+
+declare module '@citation-js/core' {
+  export interface CiteOptions {
+    /** Force the input parser, e.g. `'@bibtex/text'`. */
+    forceType?: string;
+    generateGraph?: boolean;
+  }
+
+  export class Cite {
+    constructor(data?: unknown, options?: CiteOptions);
+    /** Parsed entries as CSL-JSON objects (ids auto-filled when absent). */
+    data: Array<Record<string, unknown>>;
+  }
+}
+
+/** Side-effect plugin: registers the `@bibtex/*` input formats with core. */
+declare module '@citation-js/plugin-bibtex';


### PR DESCRIPTION
Second slice of **JP-89 — Citations management**. Stacked on #162 (slice 1); **base is `jp-89`**, so this diff is slice-2-only. Service layer — no UI yet.

## What this slice does
Turns external bibliographic input into normalized CSL-JSON `CSLItem`s, ready for the formatting / UI / MCP slices.

- **`services/citations/ingest.ts`**
  - `parseReferences(text, format?)` — BibTeX (via **lazy-loaded** `@citation-js`) or CSL-JSON (native `JSON.parse`), format auto-detected or forced.
  - `resolveDoi(doi, { fetch })` — a single DOI resolved to CSL-JSON via **content negotiation against `doi.org`**, which transparently routes to the registration agency (**Crossref *or* DataCite**), so one path covers both. Fetch transport is **injectable** (defaults to global `fetch`) → tests run offline; desktop can swap transports later.
  - `detectFormat`, `normalizeDoi`, `normalizeItem` (guarantees `id`/`type`).
  - **Safe-parse throughout:** never throws — returns parsed items + an `IngestReport` of errors/warnings (mirrors the diagram import-adapter convention).
- **`services/citations/referenceImport.ts`** — pure `dedupeReferences` (by DOI case-insensitive, then `id`; self-dedups a batch) + `importReferences` store binding (upsert new, skip dupes, return counts).
- **`types/citation-js.d.ts`** — narrow ambient types for the `Cite` surface we use (`@citation-js` ships none).

## Bundle / dependency notes
- `@citation-js` is imported via dynamic `import()` **inside the BibTeX path only**, so it code-splits into a lazy chunk and stays out of the core PWA bundle. Today it's tree-shaken entirely (no app entry imports the service until the UI slice); the chunk materializes once slice 5 wires it.
- New deps: `@citation-js/core`, `@citation-js/plugin-bibtex`.

## Verification
- `bun run typecheck` — clean.
- 23 tests green: `ingest.test.ts` (17 — BibTeX, CSL-JSON, DOI via mock fetch, malformed-input / 404 / network-failure paths) + `referenceImport.test.ts` (6 — DOI/id dedup, batch self-dedup, store import).
- `bun run build` OK; OSS commercial-leak grep clean.

## Slice roadmap
1. Data model + store + wiring (#162)
2. **Ingest: BibTeX / CSL-JSON + DOI** ← this PR
3. CSL formatting engine (`@citation-js/plugin-csl`, lazy)
4. Tiptap inline-citation node + bibliography block node
5. UI: reference manager panel + citation picker + style selector
6. Relay MCP tools (`citations.add/resolve_doi/format/list`)

Assisted-by: Opus 4.8