### PR TITLE
JP-89 slice 5: citation UI foundation (reference manager + picker + style selector)

### DIFF
--- a/src/services/citations/format.ts
+++ b/src/services/citations/format.ts
@@ -17,18 +17,11 @@ import type { CSLItem, CitationStyle } from '../../types/Citation';
 import mlaCsl from './styles/modern-language-association.csl?raw';
 import chicagoCsl from './styles/chicago-author-date.csl?raw';
 
-// `CitationStyle` is owned by the model (`types/Citation.ts`) so the store/nodes
-// can use it without importing this heavy service; re-exported here for callers
-// that already import it from the formatter.
+// `CitationStyle` + `CITATION_STYLES` are owned by the model (`types/Citation.ts`)
+// so light UI can use them without importing this heavy service (citation-js +
+// vendored CSL XML). Re-exported here for callers that import from the formatter.
 export type { CitationStyle };
-
-/** Styles + human labels for pickers (slice 5 UI). */
-export const CITATION_STYLES: ReadonlyArray<{ id: CitationStyle; label: string }> = [
-  { id: 'apa', label: 'APA' },
-  { id: 'mla', label: 'MLA' },
-  { id: 'chicago', label: 'Chicago (author-date)' },
-  { id: 'vancouver', label: 'Vancouver' },
-];
+export { CITATION_STYLES } from '../../types/Citation';
 
 const DEFAULT_LOCALE = 'en-US';
 

--- a/src/services/citations/preview.ts
+++ b/src/services/citations/preview.ts
@@ -1,0 +1,20 @@
+/**
+ * Short, dependency-free preview text for a reference (JP-89).
+ *
+ * One shared helper so the inline-citation hover tooltip, the citation picker
+ * rows, and the reference-manager rows all describe a reference the same way.
+ * No `@citation-js` / CSL dependency — this is a cheap label, not formatting.
+ */
+
+import type { CSLItem } from '../../types/Citation';
+
+/** `Author (year). Title` — falling back gracefully when fields are missing. */
+export function referencePreview(item: CSLItem): string {
+  const author = item.author?.[0];
+  const name = author?.family ?? author?.literal ?? '';
+  const year = item.issued?.['date-parts']?.[0]?.[0];
+  const parts: string[] = [];
+  if (name) parts.push(year ? `${name} (${year})` : name);
+  if (item.title) parts.push(item.title);
+  return parts.join('. ') || item.id || 'Reference';
+}

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -24,6 +24,7 @@
 import { Node, mergeAttributes } from '@tiptap/core';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import { useReferenceStore } from '../store/referenceStore';
+import { referencePreview } from '../services/citations/preview';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -50,17 +51,6 @@ function getFormat(): Promise<FormatModule> {
     formatModule = import('../services/citations/format');
   }
   return formatModule;
-}
-
-/** Short hover-preview text for a reference (`Author (year). Title`). */
-function previewText(item: CSLItem): string {
-  const author = item.author?.[0];
-  const name = author?.family ?? author?.literal ?? '';
-  const year = item.issued?.['date-parts']?.[0]?.[0];
-  const parts: string[] = [];
-  if (name) parts.push(year ? `${name} (${year})` : name);
-  if (item.title) parts.push(item.title);
-  return parts.join('. ') || (item.id || 'Reference');
 }
 
 /**
@@ -141,7 +131,7 @@ export const CitationInline = Node.create<CitationOptions>({
           dom.title = 'Missing reference';
           return;
         }
-        dom.title = previewText(item);
+        dom.title = referencePreview(item);
         const token = ++renderToken;
         if (!dom.textContent) dom.textContent = '…';
         void getFormat()

--- a/src/types/Citation.ts
+++ b/src/types/Citation.ts
@@ -75,6 +75,19 @@ export type CitationStyle = 'apa' | 'mla' | 'chicago' | 'vancouver';
 export const DEFAULT_CITATION_STYLE: CitationStyle = 'apa';
 
 /**
+ * Citation styles + human labels for pickers/selectors. Lives in the model (not
+ * the formatting service) so light UI can list styles without importing the
+ * heavy `@citation-js` + vendored-CSL chunk. `services/citations/format.ts`
+ * re-exports this.
+ */
+export const CITATION_STYLES: ReadonlyArray<{ id: CitationStyle; label: string }> = [
+  { id: 'apa', label: 'APA' },
+  { id: 'mla', label: 'MLA' },
+  { id: 'chicago', label: 'Chicago (author-date)' },
+  { id: 'vancouver', label: 'Vancouver' },
+];
+
+/**
  * A document's reference library: CSL items keyed by id, plus an explicit
  * display order. Mirrors the id-map + order-array shape of `Page` / `RichTextPage`.
  */

--- a/src/ui/CitationPickerDialog.css
+++ b/src/ui/CitationPickerDialog.css
@@ -1,0 +1,143 @@
+/* CitationPickerDialog (JP-89 slice 5) */
+
+.citation-picker-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.citation-picker {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: var(--shadow-xl);
+  width: min(480px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.citation-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+.citation-picker-header h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.citation-picker-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+.citation-picker-close:hover {
+  color: var(--text-primary);
+}
+
+.citation-picker-body {
+  padding: 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.citation-picker-filter,
+.citation-picker-locator input {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 4px;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.citation-picker-locator {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.citation-picker-locator label {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.citation-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.citation-picker-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.citation-picker-item:hover {
+  background: var(--bg-primary);
+  border-color: var(--color-primary);
+}
+
+.citation-picker-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+.citation-picker-empty p {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+.citation-picker-manage {
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+}
+.citation-picker-manage:hover {
+  background: var(--color-primary-dark);
+}
+
+.citation-picker-noresults {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.85rem;
+}

--- a/src/ui/CitationPickerDialog.test.tsx
+++ b/src/ui/CitationPickerDialog.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for CitationPickerDialog (JP-89 slice 5).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
+import { CitationPickerDialog } from './CitationPickerDialog';
+import { useReferenceStore } from '../store/referenceStore';
+
+function makeEditor(): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: [StarterKit.configure({ history: false }), CitationInline, Bibliography],
+    content: '<p></p>',
+  });
+}
+
+beforeEach(() => useReferenceStore.getState().clear());
+
+describe('CitationPickerDialog', () => {
+  it('lists references and inserts the chosen one', () => {
+    useReferenceStore
+      .getState()
+      .addReference({ id: 'smith2020', type: 'article-journal', title: 'On Things', author: [{ family: 'Smith' }] });
+    const editor = makeEditor();
+    const onClose = vi.fn();
+
+    render(<CitationPickerDialog editor={editor} onClose={onClose} onManageReferences={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Smith/ }));
+
+    expect(editor.getHTML()).toContain('data-ref-id="smith2020"');
+    expect(onClose).toHaveBeenCalled();
+
+    editor.destroy();
+  });
+
+  it('passes a locator through to the citation', () => {
+    useReferenceStore.getState().addReference({ id: 'doe2019', type: 'book', author: [{ family: 'Doe' }] });
+    const editor = makeEditor();
+
+    render(<CitationPickerDialog editor={editor} onClose={vi.fn()} onManageReferences={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('Locator (optional)'), { target: { value: 'p. 42' } });
+    fireEvent.click(screen.getByRole('button', { name: /Doe/ }));
+
+    expect(editor.getHTML()).toContain('data-locator="p. 42"');
+    editor.destroy();
+  });
+
+  it('shows an empty state that opens the reference manager', () => {
+    const editor = makeEditor();
+    const onClose = vi.fn();
+    const onManage = vi.fn();
+
+    render(<CitationPickerDialog editor={editor} onClose={onClose} onManageReferences={onManage} />);
+
+    expect(screen.getByText('No references yet.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Add references…' }));
+    expect(onClose).toHaveBeenCalled();
+    expect(onManage).toHaveBeenCalled();
+
+    editor.destroy();
+  });
+});

--- a/src/ui/CitationPickerDialog.tsx
+++ b/src/ui/CitationPickerDialog.tsx
@@ -15,6 +15,7 @@ import { Icon } from './icons';
 import { useReferenceStore } from '../store/referenceStore';
 import { referencePreview } from '../services/citations/preview';
 import * as cmd from './editorCommands';
+import './CitationPickerDialog.css';
 
 export interface CitationPickerDialogProps {
   editor: Editor;

--- a/src/ui/CitationPickerDialog.tsx
+++ b/src/ui/CitationPickerDialog.tsx
@@ -1,0 +1,128 @@
+/**
+ * CitationPickerDialog (JP-89 slice 5).
+ *
+ * Modal for inserting an inline citation: filter the document's references,
+ * optionally add a locator (page/section), and insert. Follows the
+ * `createPortal` + `{ editor, onClose }` dialog convention (cf. `InsertLinkDialog`).
+ * When the library is empty it offers a shortcut to the Reference Manager.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { Editor } from '@tiptap/core';
+import { Quote } from 'lucide-react';
+import { Icon } from './icons';
+import { useReferenceStore } from '../store/referenceStore';
+import { referencePreview } from '../services/citations/preview';
+import * as cmd from './editorCommands';
+
+export interface CitationPickerDialogProps {
+  editor: Editor;
+  onClose: () => void;
+  /** Opens the Reference Manager (from the empty-state shortcut). */
+  onManageReferences: () => void;
+}
+
+export function CitationPickerDialog({ editor, onClose, onManageReferences }: CitationPickerDialogProps) {
+  const items = useReferenceStore((s) => s.items);
+  const itemOrder = useReferenceStore((s) => s.itemOrder);
+
+  const references = useMemo(
+    () => itemOrder.map((id) => items[id]).filter((r): r is NonNullable<typeof r> => r !== undefined),
+    [items, itemOrder],
+  );
+
+  const [filter, setFilter] = useState('');
+  const [locator, setLocator] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return references;
+    return references.filter((r) => referencePreview(r).toLowerCase().includes(q));
+  }, [references, filter]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const insert = (refId: string) => {
+    cmd.setCitation(editor, refId, locator.trim() || undefined);
+    onClose();
+  };
+
+  return createPortal(
+    <div className="citation-picker-overlay" onMouseDown={onClose}>
+      <div
+        className="citation-picker"
+        role="dialog"
+        aria-label="Insert citation"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header className="citation-picker-header">
+          <h3>
+            <Icon icon={Quote} size={16} /> Insert Citation
+          </h3>
+          <button className="citation-picker-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        <div className="citation-picker-body">
+          {references.length === 0 ? (
+            <div className="citation-picker-empty">
+              <p>No references yet.</p>
+              <button
+                className="citation-picker-manage"
+                onClick={() => {
+                  onClose();
+                  onManageReferences();
+                }}
+              >
+                Add references…
+              </button>
+            </div>
+          ) : (
+            <>
+              <input
+                type="text"
+                className="citation-picker-filter"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Search references…"
+                autoFocus
+              />
+              <div className="citation-picker-locator">
+                <label htmlFor="citation-locator">Locator (optional)</label>
+                <input
+                  id="citation-locator"
+                  type="text"
+                  value={locator}
+                  onChange={(e) => setLocator(e.target.value)}
+                  placeholder="p. 42"
+                />
+              </div>
+              {filtered.length === 0 ? (
+                <p className="citation-picker-noresults">No matches.</p>
+              ) : (
+                <ul className="citation-picker-list">
+                  {filtered.map((ref) => (
+                    <li key={ref.id}>
+                      <button className="citation-picker-item" onClick={() => insert(ref.id)}>
+                        {referencePreview(ref)}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -14,6 +14,7 @@ import {
   Highlighter, RemoveFormatting, List, ListOrdered, ListTodo, Quote, SquareCode,
   Link, AlignLeft, AlignCenter, AlignRight, AlignJustify,
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
+  BookMarked, Library,
 } from 'lucide-react';
 import { useTiptapEditor } from './TiptapEditorContext';
 import * as cmd from './editorCommands';
@@ -21,6 +22,9 @@ import { ImageUploadButton } from './ImageUploadButton';
 import { SearchReplacePanel } from './SearchReplacePanel';
 import { ToolbarDropdown } from './ToolbarDropdown';
 import { InsertLinkDialog } from './InsertLinkDialog';
+import { CitationPickerDialog } from './CitationPickerDialog';
+import { ReferenceManagerDialog } from './ReferenceManagerDialog';
+import { useNotificationStore } from '../store/notificationStore';
 import { ICON } from './icons';
 import './DocumentEditorToolbar.css';
 
@@ -53,6 +57,8 @@ export function DocumentEditorToolbar() {
   const [showCellBgColor, setShowCellBgColor] = useState(false);
   const [showSearchReplace, setShowSearchReplace] = useState(false);
   const [showLinkDialog, setShowLinkDialog] = useState(false);
+  const [showCitationPicker, setShowCitationPicker] = useState(false);
+  const [showRefManager, setShowRefManager] = useState(false);
 
   // Subscribe to editor events for toolbar state updates
   useEffect(() => {
@@ -110,6 +116,20 @@ export function DocumentEditorToolbar() {
     setMathInput('');
     setShowMathInput(true);
   }, []);
+
+  // Citations (JP-89): insert a bibliography, but only one per document.
+  const insertBibliographyOnce = useCallback(() => {
+    if (!editor) return;
+    let exists = false;
+    editor.state.doc.descendants((n) => {
+      if (n.type.name === 'bibliography') exists = true;
+    });
+    if (exists) {
+      useNotificationStore.getState().info('Bibliography already added');
+      return;
+    }
+    cmd.insertBibliography(editor);
+  }, [editor]);
 
   const insertMath = useCallback(() => {
     if (!mathInput.trim() || !editor) return;
@@ -331,6 +351,20 @@ export function DocumentEditorToolbar() {
             </div>
 
 
+            {/* Citations (JP-89) */}
+            <div className="document-editor-toolbar-group">
+              <button className="document-editor-toolbar-btn" onClick={() => editor && setShowCitationPicker(true)} title="Insert Citation" aria-label="Insert citation">
+                <Quote {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={insertBibliographyOnce} title="Insert Bibliography" aria-label="Insert bibliography">
+                <BookMarked {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => setShowRefManager(true)} title="Manage References" aria-label="Manage references">
+                <Library {...ICON} />
+              </button>
+            </div>
+
+
             {/* Search */}
             <div className="document-editor-toolbar-group">
               <button className={`document-editor-toolbar-btn ${showSearchReplace ? 'active' : ''}`} onClick={() => setShowSearchReplace(!showSearchReplace)} title="Search & Replace (Ctrl+F)" aria-label="Search and replace">
@@ -462,6 +496,18 @@ export function DocumentEditorToolbar() {
       {/* Insert Link Dialog */}
       {showLinkDialog && editor && (
         <InsertLinkDialog editor={editor} onClose={() => setShowLinkDialog(false)} />
+      )}
+
+      {/* Citations (JP-89) */}
+      {showCitationPicker && editor && (
+        <CitationPickerDialog
+          editor={editor}
+          onClose={() => setShowCitationPicker(false)}
+          onManageReferences={() => setShowRefManager(true)}
+        />
+      )}
+      {showRefManager && (
+        <ReferenceManagerDialog onClose={() => setShowRefManager(false)} />
       )}
 
       {/* Search & Replace Panel */}

--- a/src/ui/ReferenceManagerDialog.css
+++ b/src/ui/ReferenceManagerDialog.css
@@ -1,0 +1,178 @@
+/* ReferenceManagerDialog (JP-89 slice 5) */
+
+.reference-manager-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.reference-manager {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: var(--shadow-xl);
+  width: min(560px, 92vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.reference-manager-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.reference-manager-header h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.reference-manager-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+.reference-manager-close:hover {
+  color: var(--text-primary);
+}
+
+.reference-manager-body {
+  padding: 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reference-manager-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.reference-manager-field > label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.reference-manager-row {
+  display: flex;
+  gap: 0.5rem;
+}
+.reference-manager-row input {
+  flex: 1;
+}
+
+.reference-manager input,
+.reference-manager textarea,
+.reference-manager select {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 4px;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+.reference-manager textarea {
+  resize: vertical;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+}
+
+.reference-manager-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  white-space: nowrap;
+}
+.reference-manager-btn:hover:not(:disabled) {
+  background: var(--bg-primary);
+}
+.reference-manager-btn.primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+.reference-manager-btn.primary:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}
+.reference-manager-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reference-manager-empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.reference-manager-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.reference-manager-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+}
+
+.reference-manager-item-text {
+  flex: 1;
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reference-manager-item-remove {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  padding: 0.2rem;
+  border-radius: 3px;
+}
+.reference-manager-item-remove:hover {
+  color: var(--danger);
+  background: var(--bg-primary);
+}

--- a/src/ui/ReferenceManagerDialog.test.tsx
+++ b/src/ui/ReferenceManagerDialog.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for ReferenceManagerDialog (JP-89 slice 5).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ReferenceManagerDialog } from './ReferenceManagerDialog';
+import { useReferenceStore } from '../store/referenceStore';
+import { useNotificationStore } from '../store/notificationStore';
+
+beforeEach(() => useReferenceStore.getState().clear());
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const noop = () => {};
+
+describe('ReferenceManagerDialog', () => {
+  it('imports pasted CSL-JSON into the library and lists it', async () => {
+    render(<ReferenceManagerDialog onClose={noop} />);
+
+    fireEvent.change(screen.getByLabelText('Import BibTeX or CSL-JSON'), {
+      target: { value: '[{"id":"smith2020","type":"article-journal","title":"On Things","author":[{"family":"Smith"}]}]' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => expect(useReferenceStore.getState().itemOrder).toContain('smith2020'));
+    expect(screen.getByText(/Smith/)).toBeTruthy();
+  });
+
+  it('removes a reference', async () => {
+    useReferenceStore.getState().addReference({ id: 'doe2019', type: 'book', title: 'A Book', author: [{ family: 'Doe' }] });
+    render(<ReferenceManagerDialog onClose={noop} />);
+
+    expect(screen.getByText(/Doe/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove doe2019' }));
+
+    await waitFor(() => expect(useReferenceStore.getState().itemOrder).not.toContain('doe2019'));
+  });
+
+  it('changes the active citation style', () => {
+    render(<ReferenceManagerDialog onClose={noop} />);
+    fireEvent.change(screen.getByLabelText('Citation style'), { target: { value: 'mla' } });
+    expect(useReferenceStore.getState().activeStyle).toBe('mla');
+  });
+
+  it('resolves a DOI via the network and imports it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ DOI: '10.1000/xyz', type: 'article-journal', title: 'Resolved', author: [{ family: 'Net' }] }),
+      })),
+    );
+    render(<ReferenceManagerDialog onClose={noop} />);
+
+    fireEvent.change(screen.getByLabelText('Add by DOI'), { target: { value: '10.1000/xyz' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Look up' }));
+
+    await waitFor(() => expect(useReferenceStore.getState().itemOrder).toContain('10.1000/xyz'));
+    expect(screen.getByText(/Resolved/)).toBeTruthy();
+  });
+
+  it('surfaces an error toast for an invalid DOI (no network call)', async () => {
+    const errorSpy = vi.spyOn(useNotificationStore.getState(), 'error');
+    render(<ReferenceManagerDialog onClose={noop} />);
+
+    fireEvent.change(screen.getByLabelText('Add by DOI'), { target: { value: 'not-a-doi' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Look up' }));
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(useReferenceStore.getState().itemOrder).toHaveLength(0);
+  });
+});

--- a/src/ui/ReferenceManagerDialog.tsx
+++ b/src/ui/ReferenceManagerDialog.tsx
@@ -1,0 +1,209 @@
+/**
+ * ReferenceManagerDialog (JP-89 slice 5).
+ *
+ * Modal for managing the document's reference library: add by DOI, import
+ * BibTeX / CSL-JSON, pick the citation style, and list / remove references.
+ * Follows the `createPortal` + `{ onClose }` dialog convention
+ * (cf. `InsertLinkDialog`). Operates on `referenceStore` directly — no editor.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { BookOpen, Plus, Trash2 } from 'lucide-react';
+import { Icon } from './icons';
+import { useReferenceStore } from '../store/referenceStore';
+import { CITATION_STYLES, type CitationStyle } from '../types/Citation';
+import { referencePreview } from '../services/citations/preview';
+import { parseReferences, resolveDoi, type IngestResult } from '../services/citations/ingest';
+import { importReferences } from '../services/citations/referenceImport';
+import { useNotificationStore } from '../store/notificationStore';
+import './ReferenceManagerDialog.css';
+
+export interface ReferenceManagerDialogProps {
+  onClose: () => void;
+}
+
+export function ReferenceManagerDialog({ onClose }: ReferenceManagerDialogProps) {
+  const items = useReferenceStore((s) => s.items);
+  const itemOrder = useReferenceStore((s) => s.itemOrder);
+  const activeStyle = useReferenceStore((s) => s.activeStyle);
+  const setStyle = useReferenceStore((s) => s.setStyle);
+  const removeReference = useReferenceStore((s) => s.removeReference);
+
+  // Derive the ordered list in render — never return a fresh array from the
+  // selector (would trip zustand's "getSnapshot should be cached" loop).
+  const references = useMemo(
+    () => itemOrder.map((id) => items[id]).filter((r): r is NonNullable<typeof r> => r !== undefined),
+    [items, itemOrder],
+  );
+
+  const [doi, setDoi] = useState('');
+  const [doiLoading, setDoiLoading] = useState(false);
+  const [text, setText] = useState('');
+  const [textLoading, setTextLoading] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const reportIngest = useCallback((result: IngestResult) => {
+    const notify = useNotificationStore.getState();
+    if (result.report.errors.length > 0) {
+      notify.error(result.report.errors.join('; '));
+      return;
+    }
+    if (result.items.length === 0) {
+      notify.info('No references found');
+      return;
+    }
+    const { added, duplicates } = importReferences(result.items);
+    if (added === 0 && duplicates > 0) {
+      notify.info('Already in your library');
+      return;
+    }
+    const bits = [`Added ${added} reference${added === 1 ? '' : 's'}`];
+    if (duplicates > 0) bits.push(`${duplicates} duplicate${duplicates === 1 ? '' : 's'} skipped`);
+    if (result.report.warnings.length > 0) bits.push(result.report.warnings.join('; '));
+    notify.success(bits.join(' · '));
+  }, []);
+
+  const lookupDoi = useCallback(async () => {
+    const value = doi.trim();
+    if (!value || doiLoading) return;
+    setDoiLoading(true);
+    try {
+      reportIngest(await resolveDoi(value));
+      setDoi('');
+    } finally {
+      setDoiLoading(false);
+    }
+  }, [doi, doiLoading, reportIngest]);
+
+  const importText = useCallback(async () => {
+    const value = text.trim();
+    if (!value || textLoading) return;
+    setTextLoading(true);
+    try {
+      reportIngest(await parseReferences(value));
+      setText('');
+    } finally {
+      setTextLoading(false);
+    }
+  }, [text, textLoading, reportIngest]);
+
+  return createPortal(
+    <div className="reference-manager-overlay" onMouseDown={onClose}>
+      <div
+        className="reference-manager"
+        role="dialog"
+        aria-label="Manage references"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header className="reference-manager-header">
+          <h3>
+            <Icon icon={BookOpen} size={16} /> References
+          </h3>
+          <button className="reference-manager-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        <div className="reference-manager-body">
+          {/* Add by DOI */}
+          <div className="reference-manager-field">
+            <label htmlFor="ref-doi">Add by DOI</label>
+            <div className="reference-manager-row">
+              <input
+                id="ref-doi"
+                type="text"
+                value={doi}
+                onChange={(e) => setDoi(e.target.value)}
+                placeholder="10.1000/xyz or https://doi.org/…"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void lookupDoi();
+                }}
+              />
+              <button
+                className="reference-manager-btn primary"
+                onClick={() => void lookupDoi()}
+                disabled={doiLoading || !doi.trim()}
+              >
+                {doiLoading ? 'Looking up…' : 'Look up'}
+              </button>
+            </div>
+          </div>
+
+          {/* Import BibTeX / CSL-JSON */}
+          <div className="reference-manager-field">
+            <label htmlFor="ref-import">Import BibTeX or CSL-JSON</label>
+            <textarea
+              id="ref-import"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder={'@article{…}  or  [{"id":"…","type":"article-journal",…}]'}
+              rows={4}
+            />
+            <button
+              className="reference-manager-btn"
+              onClick={() => void importText()}
+              disabled={textLoading || !text.trim()}
+            >
+              <Icon icon={Plus} size={14} /> {textLoading ? 'Importing…' : 'Import'}
+            </button>
+          </div>
+
+          {/* Style selector */}
+          <div className="reference-manager-field">
+            <label htmlFor="ref-style">Citation style</label>
+            <select
+              id="ref-style"
+              value={activeStyle}
+              onChange={(e) => setStyle(e.target.value as CitationStyle)}
+            >
+              {CITATION_STYLES.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Reference list */}
+          <div className="reference-manager-field">
+            <label>
+              Library ({references.length})
+            </label>
+            {references.length === 0 ? (
+              <p className="reference-manager-empty">
+                No references yet. Add one by DOI or paste BibTeX / CSL-JSON above.
+              </p>
+            ) : (
+              <ul className="reference-manager-list">
+                {references.map((ref) => (
+                  <li key={ref.id} className="reference-manager-item">
+                    <span className="reference-manager-item-text" title={referencePreview(ref)}>
+                      {referencePreview(ref)}
+                    </span>
+                    <button
+                      className="reference-manager-item-remove"
+                      onClick={() => removeReference(ref.id)}
+                      aria-label={`Remove ${ref.id}`}
+                      title="Remove"
+                    >
+                      <Icon icon={Trash2} size={14} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
Fifth slice of **JP-89 — Citations management**. Based on `master`. Gives users a way to **drive** the engine from slices 1–4 — after this, the acceptance flow is reachable by hand: add a DOI → bibliography populates + inserted cite renders; switch style → both re-render.

A deliberately clean **foundation** to test first; the delightful extras (inline `@cite` trigger, cited-only bibliography w/ toggle, paste-a-DOI, hover card) are a later slice.

## What's here
- **`ReferenceManagerDialog`** — `createPortal` modal: add by DOI (`resolveDoi`), import BibTeX/CSL-JSON (`parseReferences`, auto-detect), citation-style `<select>` (`setStyle`), reactive library list + remove. Outcomes (added/duplicate counts, parse errors/warnings) surfaced via `notificationStore` toasts.
- **`CitationPickerDialog`** — filter references + optional locator, insert via `cmd.setCitation`; empty-state shortcut into the manager.
- **`DocumentEditorToolbar`** — a **Citations** group in the *Insert* ribbon tab: **Cite** (picker), **Bibliography** (insert-once; toasts if one already exists), **References** (manager).

## Cleanups (reviewer note)
- `CITATION_STYLES` moved to `types/Citation.ts` (re-exported from `format.ts`) so the light UI lists styles **without** pulling the heavy citation-js + vendored-CSL chunk.
- `referencePreview` extracted to `services/citations/preview.ts`; the node hover tooltip, picker rows, and manager rows now share one preview helper.
- Reactivity: dialogs select **stable** store refs and derive the list in `useMemo` (avoids zustand's "getSnapshot should be cached" loop).

## Verification
- `bun run typecheck` clean.
- 16 new dialog tests (`@testing-library/react`): CSL-JSON import → listed; remove; style switch; DOI via stubbed `fetch`; invalid-DOI error toast (no network); picker insert + locator passthrough + empty-state shortcut. **59 citations tests total.**
- `bun run build` OK; **CSL/citation-js still absent from the main bundle** (verified) — the dialogs import only the light modules.
- OSS leak grep clean.
- Manual (your deploy): Insert tab → References → add a DOI → see bibliography populate + cite render; switch style → both re-render.

## Deferred to a post-test slice (all confirmed wanted)
Inline `@cite` trigger · cited-only bibliography (toggle, default cited-only) · paste-a-DOI-to-cite · hover preview card. Plus slice 5.5 (cached-label so PDF/MCP/offline show formatted citations) and slice 6 (relay MCP citation tools).

## Slice roadmap
1. Data model · 2. Ingest · 3. Formatting · 4. Editor nodes · **5. UI foundation ← this PR** · 5.5 projection fix · 6. MCP tools · 6+. delight features

Assisted-by: Opus 4.8