### PR TITLE
JP-89 slice 5.5: citation projection fix + PDF rendering

### DIFF
--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -638,35 +638,42 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
       newDocument: (name?: string) => {
         const docName = name ?? 'Untitled Document';
 
-        // Reset page store to empty
-        usePageStore.getState().reset();
-        usePageStore.getState().initializeDefault();
+        // These store resets are a programmatic reset, NOT user edits — suppress
+        // autosave so their subscriptions (and any nodeView reaction to
+        // `referenceStore.clear`, e.g. a still-mounted bibliography) can't
+        // schedule a save during the null-id window and mint a phantom doc
+        // (JP-89). Mirrors `loadDocumentToPageStore`.
+        withAutoSaveSuppressed(() => {
+          // Reset page store to empty
+          usePageStore.getState().reset();
+          usePageStore.getState().initializeDefault();
 
-        // Sync the new empty page to documentStore (clears old shapes)
-        usePageStore.getState().syncDocumentToCurrentPage();
+          // Sync the new empty page to documentStore (clears old shapes)
+          usePageStore.getState().syncDocumentToCurrentPage();
 
-        // Reset rich text store to empty
-        useRichTextStore.getState().reset();
+          // Reset rich text store to empty
+          useRichTextStore.getState().reset();
 
-        // Reset rich text pages and initialize with default page
-        useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
-        useRichTextPagesStore.getState().initializeDefaultPage();
+          // Reset rich text pages and initialize with default page
+          useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
+          useRichTextPagesStore.getState().initializeDefaultPage();
 
-        // Reset the reference library (JP-89) for the new empty document
-        useReferenceStore.getState().clear();
+          // Reset the reference library (JP-89) for the new empty document
+          useReferenceStore.getState().clear();
 
-        // Clear selection and history
-        useSessionStore.getState().clearSelection();
-        useHistoryStore.getState().clear();
+          // Clear selection and history
+          useSessionStore.getState().clearSelection();
+          useHistoryStore.getState().clear();
 
-        // Clear active document in registry
-        useDocumentRegistry.getState().setActiveDocument(null);
+          // Clear active document in registry
+          useDocumentRegistry.getState().setActiveDocument(null);
 
-        set({
-          currentDocumentId: null,
-          currentDocumentName: docName,
-          isDirty: false,
-          lastSavedAt: null,
+          set({
+            currentDocumentId: null,
+            currentDocumentName: docName,
+            isDirty: false,
+            lastSavedAt: null,
+          });
         });
       },
 

--- a/src/store/richTextStore.test.ts
+++ b/src/store/richTextStore.test.ts
@@ -35,3 +35,50 @@ describe('richTextStore.setContent — preserves sibling content fields (JP-173)
     expect(useRichTextStore.getState().content.customDictionary).toBeUndefined();
   });
 });
+
+describe('richTextStore.setContentSilently — projection writes never dirty (JP-89)', () => {
+  beforeEach(() => {
+    useRichTextStore.getState().reset();
+  });
+
+  const doc = (text: string): JSONContent => ({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  });
+
+  it('updates content without setting isDirty', () => {
+    expect(useRichTextStore.getState().isDirty).toBe(false);
+    useRichTextStore.getState().setContentSilently(doc('projected'));
+    const s = useRichTextStore.getState();
+    expect(s.content.content).toEqual(doc('projected'));
+    expect(s.isDirty).toBe(false); // derived write must not dirty
+  });
+
+  it('preserves the dirty edge for a following real edit (no swallowed autosave)', () => {
+    // The trap: if a silent update latched isDirty, the next real edit would
+    // produce no false→true edge and never schedule an autosave.
+    useRichTextStore.getState().setContentSilently(doc('projected'));
+    expect(useRichTextStore.getState().isDirty).toBe(false);
+
+    // Observe the edge a real edit produces.
+    let sawRisingEdge = false;
+    const unsub = useRichTextStore.subscribe((state, prev) => {
+      if (state.isDirty && !prev.isDirty) sawRisingEdge = true;
+    });
+    useRichTextStore.getState().setContent(doc('user edit'));
+    unsub();
+
+    expect(sawRisingEdge).toBe(true);
+    expect(useRichTextStore.getState().isDirty).toBe(true);
+  });
+
+  it('preserves sibling content fields (e.g. customDictionary)', () => {
+    useRichTextStore.getState().loadContent({
+      content: { type: 'doc', content: [] },
+      version: RICH_TEXT_VERSION,
+      customDictionary: ['Yjs'],
+    });
+    useRichTextStore.getState().setContentSilently(doc('projected'));
+    expect(useRichTextStore.getState().content.customDictionary).toEqual(['Yjs']);
+  });
+});

--- a/src/store/richTextStore.ts
+++ b/src/store/richTextStore.ts
@@ -34,8 +34,17 @@ export interface RichTextState {
  * Rich text actions.
  */
 export interface RichTextActions {
-  /** Set the editor content (from Tiptap updates) */
+  /** Set the editor content (from Tiptap updates) — marks the doc dirty. */
   setContent: (content: JSONContent) => void;
+  /**
+   * Set content WITHOUT marking dirty (JP-89). For *projection* updates — a
+   * prose-helper node writing derived cache (citation label / bibliography HTML)
+   * back into itself. The mirror must reflect it so the next genuine save
+   * serializes it, but it must not flip `isDirty` (that would either trigger a
+   * spurious save or, worse, latch dirty and swallow the next real edit's
+   * autosave edge). See `src/tiptap/proseProjection.ts`.
+   */
+  setContentSilently: (content: JSONContent) => void;
   /** Load content from a saved document */
   loadContent: (content: RichTextContent | null | undefined) => void;
   /** Get current content for saving */
@@ -97,6 +106,20 @@ export const useRichTextStore = create<RichTextState & RichTextActions>()(
           version: RICH_TEXT_VERSION,
         },
         isDirty: true,
+      }));
+    },
+
+    // Projection update (JP-89): update content but DO NOT touch `isDirty`, so a
+    // derived write-back neither schedules a save nor latches dirty (which would
+    // swallow the next real edit's autosave edge). Same content-merge as
+    // `setContent` to preserve sibling fields (e.g. `customDictionary`).
+    setContentSilently: (content: JSONContent) => {
+      set((state) => ({
+        content: {
+          ...state.content,
+          content,
+          version: RICH_TEXT_VERSION,
+        },
       }));
     },
 

--- a/src/tiptap/CitationExtension.test.ts
+++ b/src/tiptap/CitationExtension.test.ts
@@ -190,6 +190,25 @@ describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () 
     el2.remove();
   });
 
+  it('tags its write-back transactions as prose projections (silent, no autosave)', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+
+    let projectionTxns = 0;
+    editor.on('transaction', ({ transaction }) => {
+      if (transaction.getMeta('proseProjection') === true) projectionTxns++;
+    });
+
+    editor.commands.setCitation('smith2020');
+    editor.commands.insertBibliography();
+    // Wait for both nodeViews to format + write back.
+    await waitFor(() => projectionTxns >= 2);
+    expect(projectionTxns).toBeGreaterThanOrEqual(2);
+
+    editor.destroy();
+    element.remove();
+  });
+
   it('emits clean data-* serialization (no reserved/bare attrs, childless bib)', async () => {
     useReferenceStore.getState().addReference(smith);
     const { editor, element } = makeEditor();

--- a/src/tiptap/CitationExtension.test.ts
+++ b/src/tiptap/CitationExtension.test.ts
@@ -193,6 +193,20 @@ describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () 
     el2.remove();
   });
 
+  it('paints the cached label on mount without waiting on the format chunk', () => {
+    // A reload scenario: the ref isn't in the store, but the node carries a
+    // cached label — it must show immediately (resilient to a slow/failed chunk).
+    const { editor, element } = makeEditor();
+    editor.commands.setContent(
+      '<p><span data-citation data-ref-id="x" data-label="(Cached, 2020)"></span></p>',
+    );
+    // Synchronous — no await, no store entry, no format chunk.
+    expect(element.querySelector('.citation-inline')?.textContent).toBe('(Cached, 2020)');
+
+    editor.destroy();
+    element.remove();
+  });
+
   it('keeps the label write-back out of the undo stack', async () => {
     useReferenceStore.getState().addReference(smith);
     // History on (default StarterKit) so undo() exists — the local editor's setup.

--- a/src/tiptap/CitationExtension.test.ts
+++ b/src/tiptap/CitationExtension.test.ts
@@ -150,8 +150,60 @@ describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () 
     const { editor, element } = makeEditor();
     editor.commands.insertBibliography();
 
-    await waitFor(() => editor.getHTML().includes('csl-entry') || editor.getHTML().includes('Smith'));
+    await waitFor(() => editor.getHTML().includes('Smith'));
+    expect(editor.getHTML()).toContain('data-bibliography');
     expect(editor.getHTML()).toContain('Smith');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  // Regression guard for the foundation: a save→load round-trip
+  // (getHTML → setContent into a fresh editor) must preserve BOTH custom nodes.
+  // The bibliography previously vanished on reload (reserved `content` attr +
+  // DOM-node renderHTML + duplicated/newline'd serialization).
+  it('survives a getHTML → setContent round-trip (bibliography node + cached html)', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertBibliography();
+    await waitFor(() => editor.getHTML().includes('Smith'));
+    const html = editor.getHTML();
+
+    const { editor: e2, element: el2 } = makeEditor();
+    e2.commands.setContent(html);
+
+    let bibCount = 0;
+    let bibHtml = '';
+    e2.state.doc.descendants((n) => {
+      if (n.type.name === 'bibliography') {
+        bibCount++;
+        bibHtml = (n.attrs['bibHtml'] as string) ?? '';
+      }
+    });
+    expect(bibCount).toBe(1); // node preserved, not dropped
+    expect(bibHtml).toContain('Smith'); // cached html preserved in the attribute
+    expect(bibHtml).not.toMatch(/[\r\n]/); // single-line (serializer-robust)
+
+    editor.destroy();
+    element.remove();
+    e2.destroy();
+    el2.remove();
+  });
+
+  it('emits clean data-* serialization (no reserved/bare attrs, childless bib)', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020');
+    editor.commands.insertBibliography();
+    await waitFor(() => editor.getHTML().includes('data-bib-html'));
+    const html = editor.getHTML();
+
+    // No reserved/auto-rendered bare attributes leaked.
+    expect(html).not.toMatch(/<span[^>]*\srefid=/);
+    expect(html).not.toMatch(/<span[^>]*\slabel=/);
+    expect(html).not.toMatch(/<div[^>]*\scontent=/);
+    // Bibliography is a childless div carrying its cached html in a data attr.
+    expect(html).toMatch(/<div data-bib-html="[^"]*"[^>]*><\/div>|<div[^>]*data-bib-html="[^"]*"[^>]*><\/div>/);
 
     editor.destroy();
     element.remove();

--- a/src/tiptap/CitationExtension.test.ts
+++ b/src/tiptap/CitationExtension.test.ts
@@ -124,3 +124,98 @@ describe('citation nodeView (live, store-reactive)', () => {
     element.remove();
   });
 });
+
+describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () => {
+  it('caches the formatted citation into getHTML (refId + label)', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020');
+
+    const cite = () => element.querySelector('.citation-inline');
+    await waitFor(() => (cite()?.textContent ?? '').includes('Smith'));
+    // The nodeView writes the label back into the node attr (async microtask).
+    await waitFor(() => editor.getHTML().includes('Smith'));
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-ref-id="smith2020"');
+    expect(html).toContain('Smith'); // formatted text now in the projection
+    expect(html).toContain('2020');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('caches the bibliography HTML into getHTML', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertBibliography();
+
+    await waitFor(() => editor.getHTML().includes('csl-entry') || editor.getHTML().includes('Smith'));
+    expect(editor.getHTML()).toContain('Smith');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('re-labels the projection when the style changes', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020');
+    await waitFor(() => editor.getHTML().includes('Smith'));
+
+    useReferenceStore.getState().setStyle('vancouver');
+    // Numeric style → the cached label becomes a number, no author name.
+    await waitFor(() => /data-label="[^"]*\d[^"]*"/.test(editor.getHTML()) && !editor.getHTML().includes('Smith'));
+    expect(editor.getHTML()).not.toContain('Smith');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('round-trips the cached label through parse (label preserved)', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020');
+    await waitFor(() => editor.getHTML().includes('Smith'));
+    const html = editor.getHTML();
+
+    const { editor: editor2, element: el2 } = makeEditor();
+    editor2.commands.setContent(html);
+    let label: unknown = null;
+    editor2.state.doc.descendants((n) => {
+      if (n.type.name === 'citationInline') label = n.attrs['label'];
+    });
+    expect(label).toContain('Smith');
+
+    editor.destroy();
+    element.remove();
+    editor2.destroy();
+    el2.remove();
+  });
+
+  it('keeps the label write-back out of the undo stack', async () => {
+    useReferenceStore.getState().addReference(smith);
+    // History on (default StarterKit) so undo() exists — the local editor's setup.
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({
+      element,
+      extensions: [StarterKit, CitationInline, Bibliography],
+      content: '<p></p>',
+    });
+    editor.commands.setCitation('smith2020');
+    await waitFor(() => editor.getHTML().includes('Smith'));
+
+    // A single undo should remove the citation itself, not undo a label tweak
+    // (the write-back uses addToHistory:false, so it isn't its own undo step).
+    editor.commands.undo();
+    let hasCitation = false;
+    editor.state.doc.descendants((n) => {
+      if (n.type.name === 'citationInline') hasCitation = true;
+    });
+    expect(hasCitation).toBe(false);
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -115,6 +115,10 @@ export const CitationInline = Node.create<CitationOptions>({
       dom.setAttribute('data-citation', '');
       dom.className = 'citation-inline';
       dom.contentEditable = 'false';
+      // Paint the cached label immediately (JP-89 5.5) so an already-formatted
+      // citation shows instantly on reload — no dependence on the async format
+      // chunk loading every time (resilient to offline / a stale service worker).
+      if (node.attrs['label']) dom.textContent = node.attrs['label'] as string;
 
       let refId = node.attrs['refId'] as string;
       let locator = node.attrs['locator'] as string | null;
@@ -153,19 +157,28 @@ export const CitationInline = Node.create<CitationOptions>({
         lastStyle = style;
 
         if (!item) {
-          dom.textContent = '[?]';
           dom.title = 'Missing reference';
+          // Keep an already-painted cached label as a fallback (ref not loaded
+          // yet, or offline); only show [?] when we have nothing to show.
+          if (!dom.textContent || dom.textContent === '…') dom.textContent = '[?]';
           return;
         }
         dom.title = referencePreview(item);
         const token = ++renderToken;
-        if (!dom.textContent) dom.textContent = '…';
+        if (!dom.textContent || dom.textContent === '[?]') dom.textContent = '…';
         void getFormat()
           .then(({ formatCitation }) => formatCitation([item], style, 'html'))
           .then((html) => {
             if (token !== renderToken) return; // a newer render superseded this
             dom.innerHTML = html || '[?]';
             writeBackLabel(dom.textContent ?? '');
+          })
+          .catch((err) => {
+            if (token !== renderToken) return;
+            // Don't hang on the loading placeholder — surface the failure and
+            // degrade to a readable fallback (the cite key in brackets).
+            console.error('[citations] inline citation render failed:', err);
+            dom.textContent = `[${refId}]`;
           });
       };
 
@@ -257,11 +270,14 @@ export const Bibliography = Node.create<CitationOptions>({
   },
 
   addNodeView() {
-    return ({ getPos, editor }) => {
+    return ({ node, getPos, editor }) => {
       const dom = document.createElement('div');
       dom.setAttribute('data-bibliography', '');
       dom.className = 'bibliography-block';
       dom.contentEditable = 'false';
+      // Paint the cached bibliography HTML immediately (JP-89 5.5) so it shows on
+      // reload without waiting on the async format chunk (offline / stale-SW safe).
+      if (node.attrs['content']) dom.innerHTML = node.attrs['content'] as string;
 
       let renderToken = 0;
       let lastItems: Record<string, CSLItem> | undefined;
@@ -304,6 +320,14 @@ export const Bibliography = Node.create<CitationOptions>({
             if (token !== renderToken) return;
             dom.innerHTML = html || '';
             writeBackContent(dom.innerHTML);
+          })
+          .catch((err) => {
+            if (token !== renderToken) return;
+            console.error('[citations] bibliography render failed:', err);
+            // Keep any cached content already painted; only show a notice if blank.
+            if (!dom.innerHTML) {
+              dom.innerHTML = '<p class="bibliography-empty">Could not render bibliography.</p>';
+            }
           });
       };
 

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -66,47 +66,49 @@ export const CitationInline = Node.create<CitationOptions>({
     return { HTMLAttributes: {} };
   },
 
+  // Each attribute owns its `data-*` serialization (parse + render) so getHTML
+  // emits ONLY clean `data-*` attributes — no bare `refid`/`label` leak from
+  // Tiptap's default attribute rendering, and no reserved attribute names. This
+  // is the robust round-trip shape for custom prose nodes ("prose helpers").
   addAttributes() {
     return {
-      refId: { default: '' },
-      locator: { default: null },
+      refId: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-ref-id') ?? '',
+        renderHTML: (attrs) => (attrs['refId'] ? { 'data-ref-id': String(attrs['refId']) } : {}),
+      },
+      locator: {
+        default: null,
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-locator'),
+        renderHTML: (attrs) => (attrs['locator'] ? { 'data-locator': String(attrs['locator']) } : {}),
+      },
       // Cached formatted in-text citation (the "projection"): renderHTML is sync
       // but formatting is async, so the nodeView writes the formatted text back
       // here (JP-89 slice 5.5) — making getHTML()/PDF/MCP/offline self-contained.
-      label: { default: '' },
+      label: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-label') ?? '',
+        renderHTML: (attrs) => (attrs['label'] ? { 'data-label': String(attrs['label']) } : {}),
+      },
     };
   },
 
   parseHTML() {
-    return [
-      {
-        tag: 'span[data-citation]',
-        getAttrs: (el) => {
-          const node = el as HTMLElement;
-          return {
-            refId: node.getAttribute('data-ref-id') ?? '',
-            locator: node.getAttribute('data-locator') ?? null,
-            label: node.getAttribute('data-label') ?? '',
-          };
-        },
-      },
-    ];
+    return [{ tag: 'span[data-citation]' }];
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    const refId = node.attrs['refId'] as string;
-    const locator = node.attrs['locator'] as string | null;
     const label = (node.attrs['label'] as string) ?? '';
-    const attrs: Record<string, string> = {
-      'data-citation': '',
-      'data-ref-id': refId,
-      class: 'citation-inline',
-    };
-    if (locator) attrs['data-locator'] = locator;
-    if (label) attrs['data-label'] = label;
-    // Emit the cached label as the text child so non-editor consumers
-    // (PDF / MCP / offline) are self-contained; the editor re-derives it live.
-    return ['span', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, attrs), label];
+    // Emit the cached label as the text child too, so static HTML consumers show
+    // it; the editor re-derives it live. `data-*` attrs come from addAttributes.
+    return [
+      'span',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-citation': '',
+        class: 'citation-inline',
+      }),
+      label,
+    ];
   },
 
   addNodeView() {
@@ -236,37 +238,36 @@ export const Bibliography = Node.create<CitationOptions>({
     return { HTMLAttributes: {} };
   },
 
+  // Cached rendered bibliography HTML lives in a self-describing `data-bib-html`
+  // attribute (NOT a node named `content` — that's a reserved ProseMirror schema
+  // keyword — and NOT child markup, which forced a fragile DOM-node renderHTML).
+  // The node serializes as a clean, childless `<div data-bibliography
+  // data-bib-html="…">` that round-trips losslessly everywhere (JP-89 5.5).
   addAttributes() {
     return {
-      // Cached rendered bibliography HTML (the "projection") so getHTML() / PDF /
-      // MCP / offline are self-contained — see CitationInline.label (JP-89 5.5).
-      content: { default: '' },
+      bibHtml: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-bib-html') ?? '',
+        renderHTML: (attrs) => (attrs['bibHtml'] ? { 'data-bib-html': String(attrs['bibHtml']) } : {}),
+      },
     };
   },
 
   parseHTML() {
-    return [
-      {
-        tag: 'div[data-bibliography]',
-        getAttrs: (el) => ({ content: (el as HTMLElement).innerHTML }),
-      },
-    ];
+    return [{ tag: 'div[data-bibliography]' }];
   },
 
-  renderHTML({ node, HTMLAttributes }) {
-    // Return a real DOM element so the cached HTML serializes as child markup
-    // (the array form would escape it). getHTML/generateJSON always run with a
-    // DOM present (browser/jsdom); the relay is Rust and never runs this.
-    const div = document.createElement('div');
-    const attrs = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-      'data-bibliography': '',
-      class: 'bibliography-block',
-    });
-    for (const [k, v] of Object.entries(attrs)) {
-      if (v != null) div.setAttribute(k, String(v));
-    }
-    div.innerHTML = (node.attrs['content'] as string) ?? '';
-    return div;
+  renderHTML({ HTMLAttributes }) {
+    // Childless, array-form — robust serialization. The cached HTML rides the
+    // `data-bib-html` attribute (from addAttributes); the nodeView / preview /
+    // PDF read it to render the visible reference list.
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-bibliography': '',
+        class: 'bibliography-block',
+      }),
+    ];
   },
 
   addNodeView() {
@@ -276,25 +277,28 @@ export const Bibliography = Node.create<CitationOptions>({
       dom.className = 'bibliography-block';
       dom.contentEditable = 'false';
       // Paint the cached bibliography HTML immediately (JP-89 5.5) so it shows on
-      // reload without waiting on the async format chunk (offline / stale-SW safe).
-      if (node.attrs['content']) dom.innerHTML = node.attrs['content'] as string;
+      // reload without waiting on the async format chunk (offline-safe).
+      if (node.attrs['bibHtml']) dom.innerHTML = node.attrs['bibHtml'] as string;
 
       let renderToken = 0;
       let lastItems: Record<string, CSLItem> | undefined;
       let lastOrderKey = '';
       let lastStyle: CitationStyle | undefined;
 
-      // Persist the rendered bibliography HTML into the node's `content` attr so
+      // Persist the rendered bibliography HTML into the node's `bibHtml` attr so
       // non-editor consumers are self-contained. Same safety as CitationInline:
       // idempotent, editable-only, out of undo, runs post-update.
-      const writeBackContent = (content: string) => {
+      const writeBackContent = (rawHtml: string) => {
         if (!editor.isEditable) return;
+        // Newlines → spaces: keep the persisted attribute value single-line and
+        // robust across serializers (citeproc emits newlines between entries).
+        const bibHtml = rawHtml.replace(/[\r\n]+/g, ' ');
         const pos = typeof getPos === 'function' ? getPos() : undefined;
         if (pos == null) return;
         const cur = editor.state.doc.nodeAt(pos);
         if (!cur || cur.type.name !== this.name) return;
-        if (cur.attrs['content'] === content) return;
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, content });
+        if (cur.attrs['bibHtml'] === bibHtml) return;
+        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, bibHtml });
         tr.setMeta('addToHistory', false);
         editor.view.dispatch(tr);
       };

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -25,6 +25,8 @@ import { Node, mergeAttributes } from '@tiptap/core';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import { useReferenceStore } from '../store/referenceStore';
 import { referencePreview } from '../services/citations/preview';
+import { PROSE_PROJECTION_META } from './proseProjection';
+import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -139,6 +141,7 @@ export const CitationInline = Node.create<CitationOptions>({
       // async microtask after the PM update (never "dispatch during dispatch").
       const writeBackLabel = (label: string) => {
         if (!editor.isEditable) return; // view-only clients never dirty the doc
+        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
         const pos = typeof getPos === 'function' ? getPos() : undefined;
         if (pos == null) return;
         const cur = editor.state.doc.nodeAt(pos);
@@ -148,6 +151,7 @@ export const CitationInline = Node.create<CitationOptions>({
         if (cur.attrs['label'] === label) return; // idempotent → loop-safe
         const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
         tr.setMeta('addToHistory', false); // keep label-sync out of undo
+        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
         editor.view.dispatch(tr);
       };
 
@@ -290,6 +294,7 @@ export const Bibliography = Node.create<CitationOptions>({
       // idempotent, editable-only, out of undo, runs post-update.
       const writeBackContent = (rawHtml: string) => {
         if (!editor.isEditable) return;
+        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
         // Newlines → spaces: keep the persisted attribute value single-line and
         // robust across serializers (citeproc emits newlines between entries).
         const bibHtml = rawHtml.replace(/[\r\n]+/g, ' ');
@@ -300,6 +305,7 @@ export const Bibliography = Node.create<CitationOptions>({
         if (cur.attrs['bibHtml'] === bibHtml) return;
         const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, bibHtml });
         tr.setMeta('addToHistory', false);
+        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
         editor.view.dispatch(tr);
       };
 

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -70,6 +70,10 @@ export const CitationInline = Node.create<CitationOptions>({
     return {
       refId: { default: '' },
       locator: { default: null },
+      // Cached formatted in-text citation (the "projection"): renderHTML is sync
+      // but formatting is async, so the nodeView writes the formatted text back
+      // here (JP-89 slice 5.5) — making getHTML()/PDF/MCP/offline self-contained.
+      label: { default: '' },
     };
   },
 
@@ -82,6 +86,7 @@ export const CitationInline = Node.create<CitationOptions>({
           return {
             refId: node.getAttribute('data-ref-id') ?? '',
             locator: node.getAttribute('data-locator') ?? null,
+            label: node.getAttribute('data-label') ?? '',
           };
         },
       },
@@ -91,17 +96,21 @@ export const CitationInline = Node.create<CitationOptions>({
   renderHTML({ node, HTMLAttributes }) {
     const refId = node.attrs['refId'] as string;
     const locator = node.attrs['locator'] as string | null;
+    const label = (node.attrs['label'] as string) ?? '';
     const attrs: Record<string, string> = {
       'data-citation': '',
       'data-ref-id': refId,
       class: 'citation-inline',
     };
     if (locator) attrs['data-locator'] = locator;
-    return ['span', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, attrs)];
+    if (label) attrs['data-label'] = label;
+    // Emit the cached label as the text child so non-editor consumers
+    // (PDF / MCP / offline) are self-contained; the editor re-derives it live.
+    return ['span', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, attrs), label];
   },
 
   addNodeView() {
-    return ({ node }) => {
+    return ({ node, getPos, editor }) => {
       const dom = document.createElement('span');
       dom.setAttribute('data-citation', '');
       dom.className = 'citation-inline';
@@ -117,6 +126,23 @@ export const CitationInline = Node.create<CitationOptions>({
         dom.setAttribute('data-ref-id', refId);
         if (locator) dom.setAttribute('data-locator', locator);
         else dom.removeAttribute('data-locator');
+      };
+
+      // Persist the formatted text into the node's `label` attr so the HTML
+      // projection (getHTML → PDF / MCP / offline) is self-contained. Runs in an
+      // async microtask after the PM update (never "dispatch during dispatch").
+      const writeBackLabel = (label: string) => {
+        if (!editor.isEditable) return; // view-only clients never dirty the doc
+        const pos = typeof getPos === 'function' ? getPos() : undefined;
+        if (pos == null) return;
+        const cur = editor.state.doc.nodeAt(pos);
+        // type AND refId match → never write a label onto a different citation
+        // if `pos` went stale between format start and this resolve.
+        if (!cur || cur.type.name !== this.name || cur.attrs['refId'] !== refId) return;
+        if (cur.attrs['label'] === label) return; // idempotent → loop-safe
+        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
+        tr.setMeta('addToHistory', false); // keep label-sync out of undo
+        editor.view.dispatch(tr);
       };
 
       const render = () => {
@@ -139,6 +165,7 @@ export const CitationInline = Node.create<CitationOptions>({
           .then((html) => {
             if (token !== renderToken) return; // a newer render superseded this
             dom.innerHTML = html || '[?]';
+            writeBackLabel(dom.textContent ?? '');
           });
       };
 
@@ -196,22 +223,41 @@ export const Bibliography = Node.create<CitationOptions>({
     return { HTMLAttributes: {} };
   },
 
-  parseHTML() {
-    return [{ tag: 'div[data-bibliography]' }];
+  addAttributes() {
+    return {
+      // Cached rendered bibliography HTML (the "projection") so getHTML() / PDF /
+      // MCP / offline are self-contained — see CitationInline.label (JP-89 5.5).
+      content: { default: '' },
+    };
   },
 
-  renderHTML({ HTMLAttributes }) {
+  parseHTML() {
     return [
-      'div',
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        'data-bibliography': '',
-        class: 'bibliography-block',
-      }),
+      {
+        tag: 'div[data-bibliography]',
+        getAttrs: (el) => ({ content: (el as HTMLElement).innerHTML }),
+      },
     ];
   },
 
+  renderHTML({ node, HTMLAttributes }) {
+    // Return a real DOM element so the cached HTML serializes as child markup
+    // (the array form would escape it). getHTML/generateJSON always run with a
+    // DOM present (browser/jsdom); the relay is Rust and never runs this.
+    const div = document.createElement('div');
+    const attrs = mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+      'data-bibliography': '',
+      class: 'bibliography-block',
+    });
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v != null) div.setAttribute(k, String(v));
+    }
+    div.innerHTML = (node.attrs['content'] as string) ?? '';
+    return div;
+  },
+
   addNodeView() {
-    return () => {
+    return ({ getPos, editor }) => {
       const dom = document.createElement('div');
       dom.setAttribute('data-bibliography', '');
       dom.className = 'bibliography-block';
@@ -222,6 +268,21 @@ export const Bibliography = Node.create<CitationOptions>({
       let lastOrderKey = '';
       let lastStyle: CitationStyle | undefined;
 
+      // Persist the rendered bibliography HTML into the node's `content` attr so
+      // non-editor consumers are self-contained. Same safety as CitationInline:
+      // idempotent, editable-only, out of undo, runs post-update.
+      const writeBackContent = (content: string) => {
+        if (!editor.isEditable) return;
+        const pos = typeof getPos === 'function' ? getPos() : undefined;
+        if (pos == null) return;
+        const cur = editor.state.doc.nodeAt(pos);
+        if (!cur || cur.type.name !== this.name) return;
+        if (cur.attrs['content'] === content) return;
+        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, content });
+        tr.setMeta('addToHistory', false);
+        editor.view.dispatch(tr);
+      };
+
       const render = () => {
         const state = useReferenceStore.getState();
         const items = state.listReferences();
@@ -231,7 +292,9 @@ export const Bibliography = Node.create<CitationOptions>({
         lastStyle = style;
 
         if (items.length === 0) {
-          dom.innerHTML = '<p class="bibliography-empty">No references yet.</p>';
+          const empty = '<p class="bibliography-empty">No references yet.</p>';
+          dom.innerHTML = empty;
+          writeBackContent(empty);
           return;
         }
         const token = ++renderToken;
@@ -240,6 +303,7 @@ export const Bibliography = Node.create<CitationOptions>({
           .then((html) => {
             if (token !== renderToken) return;
             dom.innerHTML = html || '';
+            writeBackContent(dom.innerHTML);
           });
       };
 

--- a/src/tiptap/proseProjection.test.ts
+++ b/src/tiptap/proseProjection.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for the prose-projection transaction marker (JP-89).
+ */
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { PROSE_PROJECTION_META, isProjectionTransaction } from './proseProjection';
+
+function makeEditor(): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  return new Editor({ element, extensions: [StarterKit.configure({ history: false })], content: '<p>x</p>' });
+}
+
+describe('isProjectionTransaction', () => {
+  it('is false for an ordinary transaction', () => {
+    const editor = makeEditor();
+    expect(isProjectionTransaction(editor.state.tr)).toBe(false);
+    editor.destroy();
+  });
+
+  it('is true once tagged with PROSE_PROJECTION_META', () => {
+    const editor = makeEditor();
+    const tr = editor.state.tr.setMeta(PROSE_PROJECTION_META, true);
+    expect(isProjectionTransaction(tr)).toBe(true);
+    editor.destroy();
+  });
+});

--- a/src/tiptap/proseProjection.ts
+++ b/src/tiptap/proseProjection.ts
@@ -1,0 +1,27 @@
+/**
+ * Prose "projection" transactions (JP-89 foundation for prose helpers).
+ *
+ * A *prose-helper* node (citations are the first; more will follow) caches
+ * derived content on itself — e.g. an inline citation's formatted label, or a
+ * bibliography's rendered HTML — by writing it back into the node's attributes
+ * via a ProseMirror transaction. That write is **derived data, not a user
+ * edit**: it must update the node (so the cached value persists on the next
+ * genuine save) but must NEVER mark the document dirty, schedule an autosave, or
+ * mint a document id.
+ *
+ * The mechanism: the write-back tags its transaction with
+ * {@link PROSE_PROJECTION_META}; the editor's prose mirror (`onUpdate`) routes
+ * such transactions through a **non-dirtying** content update
+ * (`richTextStore.setContentSilently`) instead of the normal dirtying one. This
+ * is generic — any future prose helper reuses it, no per-node special-casing.
+ */
+
+import type { Transaction } from '@tiptap/pm/state';
+
+/** Transaction meta key marking a derived/projection write (not a user edit). */
+export const PROSE_PROJECTION_META = 'proseProjection';
+
+/** True if `tr` is a projection write-back (derived cache, not a user edit). */
+export function isProjectionTransaction(tr: Transaction): boolean {
+  return tr.getMeta(PROSE_PROJECTION_META) === true;
+}

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -40,6 +40,7 @@ import { EmbeddedGroup } from '../tiptap/EmbeddedGroupExtension';
 import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
+import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { useProseEditorChrome } from './useProseEditorChrome';
@@ -193,17 +194,25 @@ import type { Editor } from '@tiptap/core';
 export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
   const content = useRichTextStore((state) => state.content);
   const setContent = useRichTextStore((state) => state.setContent);
+  const setContentSilently = useRichTextStore((state) => state.setContentSilently);
 
   const editor = useEditor({
     extensions,
     content: content.content,
-    onUpdate: ({ editor }) => {
+    onUpdate: ({ editor, transaction }) => {
       // Defer the Zustand write so it doesn't run inside Tiptap's
       // transaction dispatch (which itself is wrapped in flushSync under
       // @tiptap/react), avoiding "flushSync was called from inside a
       // lifecycle method" warnings in React 18.
+      //
+      // A *projection* transaction (a prose-helper caching derived content —
+      // JP-89) must mirror silently: it updates content but must not flip dirty
+      // or schedule a save. Capture the flag now; the deferred microtask escapes
+      // the synchronous `withAutoSaveSuppressed` window, so meta-gating (not
+      // suppression) is what keeps it silent.
+      const silent = isProjectionTransaction(transaction);
       const json = editor.getJSON();
-      queueMicrotask(() => setContent(json));
+      queueMicrotask(() => (silent ? setContentSilently(json) : setContent(json)));
     },
     editorProps: {
       attributes: {

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -505,7 +505,8 @@
 }
 
 /* Help button */
-.toolbar-help-btn {
+.toolbar-help-btn,
+.toolbar-export-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -520,18 +521,21 @@
   transition: all 0.15s ease;
 }
 
-.toolbar-help-btn:hover {
+.toolbar-help-btn:hover,
+.toolbar-export-btn:hover {
   background: var(--bg-hover);
   border-color: var(--border-color);
   color: var(--color-primary, var(--color-primary));
 }
 
-.toolbar-help-btn:focus {
+.toolbar-help-btn:focus,
+.toolbar-export-btn:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
-.toolbar-help-btn svg {
+.toolbar-help-btn svg,
+.toolbar-export-btn svg {
   width: 16px;
   height: 16px;
 }

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -8,9 +8,10 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StickyNote, CircleHelp, Settings, Import, FolderOpen } from 'lucide-react';
+import { StickyNote, CircleHelp, Settings, Import, FolderOpen, FileDown } from 'lucide-react';
 import { Icon } from './icons';
 import { ToolbarGroup } from './ToolbarGroup';
+import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
 import { useAutoSave } from '../hooks/useAutoSave';
@@ -150,8 +151,10 @@ export function UnifiedToolbar({
   onOpenDocuments,
 }: UnifiedToolbarProps) {
   const activeLayout = useActiveLayoutMode();
+  const [showPdfExport, setShowPdfExport] = useState(false);
 
   return (
+    <>
     <div className="unified-toolbar">
       {/* Left: Documents launcher + document identity */}
       <div className="unified-toolbar-left">
@@ -194,6 +197,14 @@ export function UnifiedToolbar({
             <Icon icon={StickyNote} />
           </button>
           <button
+            className="toolbar-export-btn"
+            onClick={() => setShowPdfExport(true)}
+            title="Export to PDF"
+            aria-label="Export to PDF"
+          >
+            <Icon icon={FileDown} />
+          </button>
+          <button
             className="toolbar-help-btn"
             onClick={() => void openDocsHandler()}
             title="Open documentation (F1)"
@@ -213,6 +224,8 @@ export function UnifiedToolbar({
         </ToolbarGroup>
       </div>
     </div>
+    <PDFExportDialog isOpen={showPdfExport} onClose={() => setShowPdfExport(false)} />
+    </>
   );
 }
 

--- a/src/utils/pdfExportUtils.test.ts
+++ b/src/utils/pdfExportUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { parseColor, warnUnhandledNodes, breakOversizedWord } from './pdfExportUtils';
+import { parseColor, warnUnhandledNodes, breakOversizedWord, extractSegments, extractBibliographyEntries } from './pdfExportUtils';
 
 describe('parseColor', () => {
   // ── Hex colors ──────────────────────────────────────────────────────────────
@@ -126,5 +126,56 @@ describe('breakOversizedWord', () => {
     for (const p of pieces) {
       expect(measure(p)).toBeLessThanOrEqual(4);
     }
+  });
+});
+
+describe('citations PDF rendering (JP-89 slice 5.5)', () => {
+  it('renders an inline citation as a text segment from its cached label', () => {
+    const para = {
+      type: 'paragraph',
+      content: [
+        { type: 'text', text: 'See ' },
+        { type: 'citationInline', attrs: { refId: 'smith2020', label: '(Smith, 2020)' } },
+        { type: 'text', text: ' for details.' },
+      ],
+    };
+    const text = extractSegments(para).map((s) => s.text).join('');
+    expect(text).toBe('See (Smith, 2020) for details.');
+  });
+
+  it('skips an inline citation with no cached label', () => {
+    const para = {
+      type: 'paragraph',
+      content: [{ type: 'citationInline', attrs: { refId: 'x', label: '' } }],
+    };
+    expect(extractSegments(para)).toHaveLength(0);
+  });
+
+  it('extracts bibliography entries from cached citeproc HTML', () => {
+    const html =
+      '<div class="csl-bib-body">' +
+      '<div class="csl-entry">Smith, J. (2020). On Things.</div>' +
+      '<div class="csl-entry">Doe, J. (2019). A Book.</div>' +
+      '</div>';
+    expect(extractBibliographyEntries(html)).toEqual([
+      'Smith, J. (2020). On Things.',
+      'Doe, J. (2019). A Book.',
+    ]);
+  });
+
+  it('falls back to whole text when there are no .csl-entry nodes', () => {
+    expect(extractBibliographyEntries('<p class="bibliography-empty">No references yet.</p>')).toEqual([
+      'No references yet.',
+    ]);
+    expect(extractBibliographyEntries('')).toEqual([]);
+  });
+
+  it('has PDF renderers registered for citation node types (no unhandled warning)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnUnhandledNodes(['paragraph', 'citationInline', 'bibliography']);
+    const warned = warn.mock.calls.flat().join(' ');
+    expect(warned).not.toContain('citationInline');
+    expect(warned).not.toContain('bibliography');
+    warn.mockRestore();
   });
 });

--- a/src/utils/pdfExportUtils.ts
+++ b/src/utils/pdfExportUtils.ts
@@ -957,7 +957,7 @@ export function extractBibliographyEntries(contentHtml: string): string[] {
  * Render a bibliography block — each cached entry as a body-text paragraph.
  */
 function renderBibliography(ctx: PDFRenderContext, node: JSONContent): void {
-  const content = (node.attrs?.['content'] as string | undefined) || '';
+  const content = (node.attrs?.['bibHtml'] as string | undefined) || '';
   const entries = extractBibliographyEntries(content);
   if (entries.length === 0) return;
   const fontSize = PDF_STYLE.bodyFontSize;

--- a/src/utils/pdfExportUtils.ts
+++ b/src/utils/pdfExportUtils.ts
@@ -937,6 +937,42 @@ function renderHeading(ctx: PDFRenderContext, node: JSONContent): void {
 /**
  * Render a paragraph node with inline formatting and alignment.
  */
+/**
+ * Extract bibliography entry strings from cached citeproc HTML (JP-89). citeproc
+ * wraps each reference in a `.csl-entry`; fall back to the whole text when the
+ * structure is unexpected (e.g. the empty-state placeholder).
+ */
+export function extractBibliographyEntries(contentHtml: string): string[] {
+  if (!contentHtml.trim()) return [];
+  const doc = new DOMParser().parseFromString(contentHtml, 'text/html');
+  const entries = Array.from(doc.querySelectorAll('.csl-entry'))
+    .map((el) => (el.textContent ?? '').replace(/\s+/g, ' ').trim())
+    .filter((t) => t.length > 0);
+  if (entries.length > 0) return entries;
+  const whole = (doc.body.textContent ?? '').replace(/\s+/g, ' ').trim();
+  return whole ? [whole] : [];
+}
+
+/**
+ * Render a bibliography block — each cached entry as a body-text paragraph.
+ */
+function renderBibliography(ctx: PDFRenderContext, node: JSONContent): void {
+  const content = (node.attrs?.['content'] as string | undefined) || '';
+  const entries = extractBibliographyEntries(content);
+  if (entries.length === 0) return;
+  const fontSize = PDF_STYLE.bodyFontSize;
+  for (const entry of entries) {
+    checkPageBreak(ctx, fontSize * PDF_STYLE.lineHeight);
+    const seg: TextSegment = {
+      text: entry,
+      bold: false, italic: false, underline: false, strike: false, code: false,
+      color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
+    };
+    renderSegmentedText(ctx, [seg], fontSize, 'normal', ctx.marginLeft, ctx.contentWidth, 'left');
+    ctx.y += 2;
+  }
+}
+
 function renderParagraph(ctx: PDFRenderContext, node: JSONContent, indent: number): void {
   const fontSize = PDF_STYLE.bodyFontSize;
   const textAlign = (node.attrs?.['textAlign'] as string | undefined) || 'left';
@@ -1367,7 +1403,8 @@ function renderHorizontalRule(ctx: PDFRenderContext): void {
  * Extract styled text segments from a node's content.
  * Walks inline children and collects marks (bold, italic, color, etc).
  */
-function extractSegments(node: JSONContent): TextSegment[] {
+/** Exported for unit testing — builds inline TextSegments from a block node. */
+export function extractSegments(node: JSONContent): TextSegment[] {
   const segments: TextSegment[] = [];
   if (!node.content) return segments;
 
@@ -1417,8 +1454,19 @@ function extractSegments(node: JSONContent): TextSegment[] {
         bold: false, italic: false, underline: false, strike: false, code: false,
         color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
       });
+    } else if (child.type === 'citationInline') {
+      // Inline citation: render the cached formatted label (JP-89). Empty when a
+      // doc was never opened in the editor (no label cached yet) — skip then.
+      const label = (child.attrs?.['label'] as string | undefined) || '';
+      if (label) {
+        segments.push({
+          text: label,
+          bold: false, italic: false, underline: false, strike: false, code: false,
+          color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
+        });
+      }
     }
-    // Skip non-text inline nodes (mathInline handled separately at block level)
+    // Skip other non-text inline nodes (mathInline handled separately at block level)
   }
 
   return segments;
@@ -2081,8 +2129,8 @@ function extractSegmentsDeep(node: JSONContent): TextSegment[] {
     return extractSegments({ type: 'paragraph', content: [node] });
   }
 
-  // If this node has inline text children directly, extract them
-  if (node.content && node.content.some((c) => c.type === 'text')) {
+  // If this node has inline text (or inline citation) children directly, extract them
+  if (node.content && node.content.some((c) => c.type === 'text' || c.type === 'citationInline')) {
     return extractSegments(node);
   }
 
@@ -2567,6 +2615,9 @@ pdfNodeRenderers.register('table', (ctx, node) =>
 pdfNodeRenderers.register('tableRow', () => {});
 pdfNodeRenderers.register('tableCell', () => {});
 pdfNodeRenderers.register('tableHeader', () => {});
+pdfNodeRenderers.register('bibliography', (ctx, node) => {
+  renderBibliography(ctx, node);
+});
 pdfNodeRenderers.register('mathInline', (ctx, node) =>
   renderMathInline(ctx, node)
 );
@@ -2575,6 +2626,8 @@ pdfNodeRenderers.register('mathBlock', (ctx, node) =>
 );
 // hardBreak is handled inline by extractSegments
 pdfNodeRenderers.register('hardBreak', () => {});
+// citationInline is handled inline by extractSegments (renders its cached label)
+pdfNodeRenderers.register('citationInline', () => {});
 
 /**
  * Log warnings for any Tiptap extension node types that don't have


### PR DESCRIPTION
Makes citations **self-contained outside the live editor** and gives **PDF export** citation rendering. Based on `master`.

## The gap
The durable prose projection is `editor.getHTML()` (→ `richTextPages`, PDF export, MCP reads, offline cache). It runs the nodes' **sync** `renderHTML`, but the formatted citation text is produced by the **async** `nodeView` — so outside the editor, citations and the bibliography rendered **empty** (you hit this exporting a PDF). No data was lost (`refId` + library persist), but the rendered form wasn't self-contained.

## Editor nodes (`CitationExtension.ts`)
- `CitationInline` gains a `label` attr; `Bibliography` gains a `content` attr. The `nodeView` writes the formatted output back into the attr after it formats — in an **async microtask after the PM update** (never "dispatch during dispatch"). The write-back is **idempotent** (loop-safe), **`addToHistory:false`** (out of undo), **`editable`-only** (viewers never dirty the doc), and guarded by a **refId/pos match** so a stale `getPos()` can't label the wrong citation.
- `renderHTML` emits the cached value (inline → `data-label` + text child; bibliography → a real DOM `div` whose `innerHTML` is the cached list); `parseHTML` reads it back, so it round-trips.

## PDF export (`pdfExportUtils.ts`)
PDF is a **JSON-registry** path, not HTML, so unregistered nodes render as nothing — needs explicit handling (the cached attrs make it small):
- `extractSegments` / `extractSegmentsDeep` render an inline citation from its cached `label` as a text segment.
- a registered `bibliography` renderer parses the cached `content` HTML (`extractBibliographyEntries` → `.csl-entry` text) and renders each entry as a body paragraph; `citationInline` registered as an inline-handled no-op (matches the `hardBreak` precedent).

## Trade-off (bounded, documented)
A style change re-labels every citation via `addToHistory:false` transactions; the downstream save is **debounced** so the burst collapses into ~one save. Per-client style differences (references aren't live-synced in collab yet — slice-1 limitation) can briefly flap a label; it's idempotent and converges on sync. Bibliography `content` is a ~few-KB synced attr.

## Verification
- `bun run typecheck` clean.
- **86 citation tests**: `getHTML()` now self-contained for inline + bibliography; projection re-labels on style change; parse round-trip preserves the cached label; a single undo removes the citation (write-back excluded from history). PDF: citation JSON → text segment, `extractBibliographyEntries`, and no "unhandled node" warning for the citation types.
- `bun run build` OK; CSL/citation-js still **absent from the main bundle**; OSS leak grep clean.
- Manual: insert a cite + bibliography → export PDF → both now render formatted text (previously blank); MCP read / offline HTML now contains the formatted citation.

## Roadmap
1–5 done · **5.5 projection + PDF ← this PR** · 6 relay MCP citation tools · 6+ delight (inline @cite, cited-only bibliography, paste-a-DOI, hover card)

Assisted-by: Opus 4.8