### PR TITLE
JP-89 slice 6: relay MCP citation tools

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -68,6 +68,10 @@ A DocuShark document carries **two surfaces in one object**:
 - **Canvas pages** (`pages`) — the diagram: shapes and connectors.
 - **Prose pages** (`richTextPages`) — the written body, stored as **HTML**.
 
+A document may also carry a **reference library** (`references`) — citations as
+**CSL-JSON** keyed by id, with an explicit display order — manipulated by the
+citation tools below.
+
 The MCP tools operate on both. Prose is authored in **Markdown** by default
 (agents produce it reliably) and rendered to the HTML the editor persists;
 pass `format: "html"` to supply HTML directly.
@@ -86,6 +90,8 @@ All tools are namespaced `docushark.*`.
 | `get_shape` | One shape on a page, by id, as a DSL object (the read-one companion to `get_page`). |
 | `get_prose` | All prose pages (or one, with `pageId`): `id`, `name`, `order`, HTML `content`. |
 | `get_outline` | A prose page's heading outline: ordered `{ index, level, title }`. `index` is used by the structural tools. |
+| `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
+| `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |
 
 ### Author
 
@@ -126,6 +132,19 @@ All tools are namespaced `docushark.*`.
 | `delete_prose_page` | Delete a prose page by id. Refuses to delete the **last** remaining prose page. In a connected editor the page's *tab* may persist until reload (the prose page list isn't yet live-synced); its content is cleared immediately. |
 | `reorder_shapes` | Set a page's z-order. `order` must be a permutation of the page's current shape ids (later ids render on top). |
 | `reorder_prose_pages` | Set the order of a document's prose pages. `order` must be a permutation of the current prose page ids. Tab order may update on reload (page list not yet live-synced). |
+
+### Citations (write)
+
+| Tool | Purpose |
+| -- | -- |
+| `add_reference` | Add reference(s) to the document's library. Supply **either** `doi` (resolved via doi.org to CSL-JSON) **or** `items` (raw CSL-JSON object(s)). Dedups by DOI then id; returns the ids added + how many were skipped. |
+
+This populates the **library** only — it doesn't yet insert an inline citation
+or bibliography into the prose (do that in the editor). The library is stored as
+the document's top-level `references` field and round-trips durably; a *connected*
+editor sees new references on reload, as references aren't live-synced yet.
+Formatting (CSL → APA/MLA/Chicago/Vancouver) is done in the editor, not the
+relay — the MCP surface only reads and writes CSL-JSON.
 
 (Renames: `rename_prose_page`.)
 

--- a/relay/src/mcp/citations.rs
+++ b/relay/src/mcp/citations.rs
@@ -1,0 +1,386 @@
+//! Citation / reference-library support for the MCP surface (JP-89 slice 6).
+//!
+//! A document carries a top-level `references` library — CSL-JSON items keyed
+//! by id plus an explicit `itemOrder`, mirroring the TS `ReferenceLibrary`
+//! (`src/types/Citation.ts`). It is an ordinary unknown-to-the-Y.Doc top-level
+//! field, so it round-trips durably through the snapshot flatten with **zero**
+//! relay sync changes (same property the prose-page metadata relies on).
+//!
+//! This module is split in two halves:
+//!   - **pure JSON helpers** (`list_references_json`, `add_references_in_place`)
+//!     used by the synchronous `tools::dispatch` under `mutate_with_retry`;
+//!   - an **async** `resolve_doi_to_csl` network call (content-negotiation
+//!     against `doi.org`), invoked from the async transport layer *before*
+//!     dispatch so the sync tool path stays network-free.
+//!
+//! Formatting (CSL → APA/MLA/… strings) deliberately stays client-side in the
+//! editor's lazy citation-js chunk — the relay only ever stores and returns
+//! CSL-JSON, never a formatted bibliography. Keeping a CSL engine out of the
+//! Rust relay mirrors the SigV4-not-aws-sdk call (MSRV / build-cost).
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// CSL-JSON content type for DOI content negotiation against `doi.org`, which
+/// transparently routes to the registration agency (Crossref / DataCite / …).
+const CSL_JSON_DOI_ACCEPT: &str = "application/vnd.citationstyles.csl+json";
+
+/// Default CSL item `type` when an ingested item omits one (matches the TS
+/// `normalizeItem` fallback).
+const DEFAULT_CSL_TYPE: &str = "document";
+
+/// Outcome of an `add_references_in_place` call.
+#[derive(Debug)]
+pub struct AddOutcome {
+    /// Ids of the references actually inserted, in input order.
+    pub added: Vec<String>,
+    /// Count of incoming items skipped as duplicates (by DOI or id).
+    pub duplicates: usize,
+}
+
+/// Strip the common DOI prefixes to a bare `10.xxxx/...` form. Mirrors the TS
+/// `normalizeDoi` so the relay and editor accept the same shapes.
+pub fn normalize_doi(input: &str) -> String {
+    let mut s = input.trim();
+    // Order matters: URL form, then the `doi:` / `info:doi/` schemes.
+    for prefix in ["https://dx.doi.org/", "https://doi.org/", "http://dx.doi.org/", "http://doi.org/"]
+    {
+        if let Some(rest) = strip_prefix_ci(s, prefix) {
+            s = rest;
+            break;
+        }
+    }
+    if let Some(rest) = strip_prefix_ci(s, "doi:") {
+        s = rest.trim_start();
+    } else if let Some(rest) = strip_prefix_ci(s, "info:doi/") {
+        s = rest;
+    }
+    s.trim().to_string()
+}
+
+/// Case-insensitive prefix strip.
+fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        Some(&s[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+/// A bare DOI looks like `10.<4-9 digits>/<suffix>`. Mirrors the TS guard
+/// `^10\.\d{4,9}\//` without pulling in a regex dependency.
+pub fn is_valid_doi(bare: &str) -> bool {
+    let rest = match bare.strip_prefix("10.") {
+        Some(r) => r,
+        None => return false,
+    };
+    let slash = match rest.find('/') {
+        Some(i) => i,
+        None => return false,
+    };
+    let registrant = &rest[..slash];
+    let suffix = &rest[slash + 1..];
+    (4..=9).contains(&registrant.len())
+        && registrant.bytes().all(|b| b.is_ascii_digit())
+        && !suffix.is_empty()
+}
+
+/// Lower-cased DOI for an item, or `None` when absent — DOIs are
+/// case-insensitive, matching the TS `doiKey`.
+fn doi_key(item: &Value) -> Option<String> {
+    item.get("DOI")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase())
+}
+
+/// Coerce a raw value into a minimally-valid CSL item: must be a JSON object;
+/// `id` is set (using `fallback_id` when missing/blank) and `type` defaults to
+/// `"document"`. Returns `None` for non-objects. Mirrors the TS `normalizeItem`.
+pub fn normalize_item(value: Value, fallback_id: &str) -> Option<Value> {
+    let mut obj = match value {
+        Value::Object(o) => o,
+        _ => return None,
+    };
+    let has_id = obj
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+    if !has_id {
+        obj.insert("id".into(), json!(fallback_id));
+    }
+    if !obj.contains_key("type") {
+        obj.insert("type".into(), json!(DEFAULT_CSL_TYPE));
+    }
+    Some(Value::Object(obj))
+}
+
+/// The doc's `references` library as a mutable object, creating an empty one
+/// (`{items:{}, itemOrder:[]}`) if absent or malformed.
+fn references_mut(doc: &mut Value) -> Result<&mut serde_json::Map<String, Value>, String> {
+    let root = doc.as_object_mut().ok_or("Document is not an object")?;
+    let entry = root
+        .entry("references")
+        .or_insert_with(|| json!({"items": {}, "itemOrder": []}));
+    // Repair a malformed value rather than fail the whole write.
+    if !entry.is_object() {
+        *entry = json!({"items": {}, "itemOrder": []});
+    }
+    let refs = entry.as_object_mut().unwrap();
+    if !refs.get("items").map(Value::is_object).unwrap_or(false) {
+        refs.insert("items".into(), json!({}));
+    }
+    if !refs.get("itemOrder").map(Value::is_array).unwrap_or(false) {
+        refs.insert("itemOrder".into(), json!([]));
+    }
+    Ok(refs)
+}
+
+/// Upsert `incoming` CSL items into the doc's `references` library, deduping by
+/// DOI (case-insensitive) then by id — against existing items *and* earlier
+/// items in the same batch. New ids are appended to `itemOrder`. Mirrors the TS
+/// `dedupeReferences` + `importReferences`. Returns which ids were added.
+///
+/// Pure: safe to replay under `mutate_with_retry`.
+pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<AddOutcome, String> {
+    let refs = references_mut(doc)?;
+
+    // Seed the seen-sets from existing library contents.
+    let mut seen_dois: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if let Some(items) = refs.get("items").and_then(Value::as_object) {
+        for (id, item) in items {
+            seen_ids.insert(id.clone());
+            if let Some(doi) = doi_key(item) {
+                seen_dois.insert(doi);
+            }
+        }
+    }
+
+    let mut added: Vec<String> = Vec::new();
+    let mut duplicates = 0usize;
+
+    for raw in incoming {
+        let item = match normalize_item(raw.clone(), "") {
+            Some(it) => it,
+            None => {
+                return Err("a reference was not a CSL-JSON object".into());
+            }
+        };
+        let id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+            .ok_or("a reference is missing an 'id'")?;
+        let doi = doi_key(&item);
+
+        let is_dup = doi.as_ref().is_some_and(|d| seen_dois.contains(d)) || seen_ids.contains(&id);
+        if is_dup {
+            duplicates += 1;
+            continue;
+        }
+
+        // Insert into items map + append to itemOrder. Re-borrow each iteration
+        // to satisfy the borrow checker (the seen-sets above are owned copies).
+        refs.get_mut("items")
+            .and_then(Value::as_object_mut)
+            .unwrap()
+            .insert(id.clone(), item);
+        refs.get_mut("itemOrder")
+            .and_then(Value::as_array_mut)
+            .unwrap()
+            .push(json!(id.clone()));
+
+        seen_ids.insert(id.clone());
+        if let Some(d) = doi {
+            seen_dois.insert(d);
+        }
+        added.push(id);
+    }
+
+    Ok(AddOutcome { added, duplicates })
+}
+
+/// Read the doc's reference library as a result payload: the CSL items in
+/// `itemOrder`, the active `style` (or null), and a count. Tolerant of a
+/// missing/empty library (returns an empty list).
+pub fn list_references_json(doc: &Value) -> Value {
+    let refs = doc.get("references");
+    let items = refs.and_then(|r| r.get("items")).and_then(Value::as_object);
+    let order = refs.and_then(|r| r.get("itemOrder")).and_then(Value::as_array);
+
+    let ordered: Vec<Value> = match (items, order) {
+        (Some(items), Some(order)) => order
+            .iter()
+            .filter_map(Value::as_str)
+            .filter_map(|id| items.get(id).cloned())
+            .collect(),
+        // No explicit order — fall back to whatever items exist (unordered).
+        (Some(items), None) => items.values().cloned().collect(),
+        _ => Vec::new(),
+    };
+
+    json!({
+        "references": ordered,
+        "style": refs.and_then(|r| r.get("style")).cloned().unwrap_or(Value::Null),
+        "count": ordered.len(),
+    })
+}
+
+/// Shared HTTP client for DOI lookups. Built once; reused across calls.
+fn doi_http() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .user_agent("docushark-relay (+https://docushark.app)")
+            .build()
+            .expect("failed to build DOI HTTP client")
+    })
+}
+
+/// Resolve a single DOI to a CSL-JSON item via `doi.org` content negotiation.
+/// Async (network); call this from the transport layer before the sync
+/// dispatch. Mirrors the TS `resolveDoi`: never panics, returns a descriptive
+/// `Err` on any failure.
+pub async fn resolve_doi_to_csl(doi: &str) -> Result<Value, String> {
+    let bare = normalize_doi(doi);
+    if !is_valid_doi(&bare) {
+        return Err(format!("Not a valid DOI: \"{}\"", doi));
+    }
+
+    let res = doi_http()
+        .get(format!("https://doi.org/{}", bare))
+        .header(reqwest::header::ACCEPT, CSL_JSON_DOI_ACCEPT)
+        .send()
+        .await
+        .map_err(|e| format!("DOI lookup failed: {}", e))?;
+
+    if res.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(format!("DOI not found: {}", bare));
+    }
+    if !res.status().is_success() {
+        return Err(format!("DOI lookup failed (HTTP {})", res.status().as_u16()));
+    }
+
+    let body: Value = res
+        .json()
+        .await
+        .map_err(|e| format!("DOI response was not JSON: {}", e))?;
+
+    // doi.org CSL-JSON carries `DOI` but usually no `id`; key it off the DOI.
+    let fallback_id = body
+        .get("DOI")
+        .and_then(Value::as_str)
+        .unwrap_or(&bare)
+        .to_string();
+    normalize_item(body, &fallback_id).ok_or_else(|| "DOI response was not a CSL item".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_doi_strips_prefixes() {
+        assert_eq!(normalize_doi("  10.1000/xyz  "), "10.1000/xyz");
+        assert_eq!(normalize_doi("https://doi.org/10.1000/xyz"), "10.1000/xyz");
+        assert_eq!(normalize_doi("HTTPS://DX.DOI.ORG/10.1000/xyz"), "10.1000/xyz");
+        assert_eq!(normalize_doi("doi: 10.1000/xyz"), "10.1000/xyz");
+        assert_eq!(normalize_doi("info:doi/10.1000/xyz"), "10.1000/xyz");
+    }
+
+    #[test]
+    fn is_valid_doi_matches_shape() {
+        assert!(is_valid_doi("10.1000/xyz"));
+        assert!(is_valid_doi("10.12345678/abc.def"));
+        assert!(!is_valid_doi("10.1/xyz")); // registrant too short
+        assert!(!is_valid_doi("10.1000")); // no slash
+        assert!(!is_valid_doi("10.1000/")); // empty suffix
+        assert!(!is_valid_doi("notadoi"));
+    }
+
+    #[test]
+    fn normalize_item_sets_id_and_type() {
+        let it = normalize_item(json!({"title": "X"}), "fallback").unwrap();
+        assert_eq!(it["id"], json!("fallback"));
+        assert_eq!(it["type"], json!("document"));
+
+        let it2 = normalize_item(json!({"id": "keep", "type": "book"}), "fb").unwrap();
+        assert_eq!(it2["id"], json!("keep"));
+        assert_eq!(it2["type"], json!("book"));
+
+        assert!(normalize_item(json!("not-an-object"), "fb").is_none());
+    }
+
+    #[test]
+    fn add_references_dedups_by_doi_and_id() {
+        let mut doc = json!({"id": "d1"});
+        let incoming = vec![
+            json!({"id": "a", "DOI": "10.1/AAA", "type": "article-journal"}),
+            json!({"id": "b", "DOI": "10.1/bbb"}),
+            // duplicate DOI (different case) of "a" — should skip
+            json!({"id": "c", "DOI": "10.1/aaa"}),
+            // duplicate id of "a" — should skip
+            json!({"id": "a", "DOI": "10.1/ddd"}),
+        ];
+        let out = add_references_in_place(&mut doc, &incoming).unwrap();
+        assert_eq!(out.added, vec!["a", "b"]);
+        assert_eq!(out.duplicates, 2);
+
+        let refs = &doc["references"];
+        assert_eq!(refs["itemOrder"], json!(["a", "b"]));
+        assert!(refs["items"].get("a").is_some());
+        assert!(refs["items"].get("b").is_some());
+        assert_eq!(refs["items"].as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn add_references_appends_to_existing_library() {
+        let mut doc = json!({
+            "references": {"items": {"x": {"id": "x", "DOI": "10.1/xxx"}}, "itemOrder": ["x"]}
+        });
+        let out =
+            add_references_in_place(&mut doc, &[json!({"id": "y", "DOI": "10.1/yyy"})]).unwrap();
+        assert_eq!(out.added, vec!["y"]);
+        assert_eq!(doc["references"]["itemOrder"], json!(["x", "y"]));
+    }
+
+    #[test]
+    fn add_references_generates_no_id_errors() {
+        // An item with a blank id falls back to "" then errors — callers (the
+        // DOI path) always supply an id, so this guards the items[] path.
+        let mut doc = json!({});
+        let err = add_references_in_place(&mut doc, &[json!({"title": "no id"})]).unwrap_err();
+        assert!(err.contains("'id'"));
+    }
+
+    #[test]
+    fn list_references_returns_ordered_items() {
+        let doc = json!({
+            "references": {
+                "items": {"b": {"id": "b"}, "a": {"id": "a"}},
+                "itemOrder": ["a", "b"],
+                "style": "mla"
+            }
+        });
+        let out = list_references_json(&doc);
+        assert_eq!(out["count"], json!(2));
+        assert_eq!(out["style"], json!("mla"));
+        assert_eq!(out["references"][0]["id"], json!("a"));
+        assert_eq!(out["references"][1]["id"], json!("b"));
+    }
+
+    #[test]
+    fn list_references_empty_when_absent() {
+        let out = list_references_json(&json!({"id": "d"}));
+        assert_eq!(out["count"], json!(0));
+        assert_eq!(out["references"], json!([]));
+        assert_eq!(out["style"], Value::Null);
+    }
+}

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -9,6 +9,7 @@
 //! live CRDT writes).
 
 pub mod adapter;
+pub mod citations;
 pub mod config;
 pub mod layout;
 pub mod local_mirror;

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -443,6 +443,51 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "additionalProperties": false
             }),
         },
+        ToolDescriptor {
+            name: "docushark.list_references",
+            description:
+                "Return a document's reference library (citations) as CSL-JSON items in display order, plus the active citation style. Read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.resolve_doi",
+            description:
+                "Resolve a DOI to a CSL-JSON reference via doi.org content negotiation, WITHOUT modifying any document. Use it to preview a reference before add_reference. Returns the CSL item.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "doi": {"type": "string", "description": "A DOI, bare (10.xxxx/…) or as a doi.org URL / doi: scheme."}
+                },
+                "required": ["doi"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.add_reference",
+            description:
+                "Add one or more references (citations) to a document's reference library. Supply EITHER 'doi' (resolved via doi.org to CSL-JSON) OR 'items' (raw CSL-JSON object(s)). Deduplicates by DOI then id; returns the ids added and how many were skipped as duplicates. This populates the library only — it does not insert an inline citation or bibliography into the prose (do that in the editor). A connected editor sees new references on reload (references aren't live-synced yet). Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "doi": {"type": "string", "description": "A DOI to resolve and add. Mutually complementary with 'items'; supply at least one."},
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": "CSL-JSON reference object(s) to add directly. Each should carry an 'id' (and ideally 'DOI'). Supply 'doi' instead to resolve one from a DOI."
+                    }
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
     ]
 }
 
@@ -552,6 +597,10 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.delete_prose_page" => delete_prose_page(ctx, args),
         "docushark.reorder_shapes" => reorder_shapes(ctx, args),
         "docushark.reorder_prose_pages" => reorder_prose_pages(ctx, args),
+        "docushark.list_references" => list_references(ctx, args),
+        "docushark.add_reference" => add_reference(ctx, args),
+        // docushark.resolve_doi is resolved async in the transport layer before
+        // dispatch (it needs a network call); it never reaches this match.
         _ => Err(format!("Unknown tool: {}", name)),
     }
 }
@@ -1873,6 +1922,78 @@ fn mutate_with_retry<R>(
         last_seen,
         MAX_WRITE_ATTEMPTS
     ))
+}
+
+// ============ Citations / references (JP-89 slice 6) ============
+
+#[derive(Deserialize)]
+struct ListReferencesArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+}
+
+/// Read a document's reference library as CSL-JSON in display order. Read-only.
+fn list_references(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: ListReferencesArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
+    let mut result = super::citations::list_references_json(&doc);
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("source".into(), json!(source));
+    }
+    Ok(ToolOutcome { result, changed_doc_id: None, change_detail: None })
+}
+
+#[derive(Deserialize)]
+struct AddReferenceArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    // `doi` is resolved upstream in the transport layer and injected as
+    // `items`, so it isn't read here — serde ignores it (no deny_unknown_fields).
+    #[serde(default)]
+    items: Option<Vec<Value>>,
+}
+
+/// Add reference(s) to a document's CSL-JSON library. The DOI form is resolved
+/// to a CSL item upstream (transport) and arrives as `items`; this handler is
+/// the pure JSON-store write path under optimistic concurrency.
+fn add_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: AddReferenceArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    let items = parsed.items.unwrap_or_default();
+    if items.is_empty() {
+        return Err("add_reference requires 'doi' or non-empty 'items'".into());
+    }
+
+    // Capture any lock warning before the write (advisory only, like add_shape).
+    let lock = {
+        let (doc, _) = fetch_doc(ctx, &parsed.doc_id)?;
+        lock_warning(&doc)
+    };
+
+    let outcome = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let out = super::citations::add_references_in_place(doc, &items)?;
+        stamp_doc_modified(doc, now_ms());
+        Ok(out)
+    })?;
+
+    let mut result = json!({
+        "added": outcome.added,
+        "addedCount": outcome.added.len(),
+        "duplicates": outcome.duplicates,
+    });
+    if let Some(w) = lock {
+        result.as_object_mut().unwrap().insert("warning".into(), json!(w));
+    }
+
+    Ok(ToolOutcome {
+        result,
+        changed_doc_id: Some(parsed.doc_id.clone()),
+        change_detail: None,
+    })
 }
 
 fn add_shape(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
@@ -3823,5 +3944,85 @@ mod tests {
             "expected a concurrency error, got: {}",
             err
         );
+    }
+
+    // ---- JP-89: citation / reference tools ----
+
+    #[test]
+    fn add_reference_items_persist_and_list() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_reference",
+            &json!({"docId": "doc1", "items": [
+                {"id": "smith2020", "type": "article-journal", "DOI": "10.1000/AAA"},
+                {"id": "jones2021", "DOI": "10.1000/bbb"},
+            ]}),
+        )
+        .unwrap();
+        assert_eq!(out.result["addedCount"], json!(2));
+        assert_eq!(out.result["duplicates"], json!(0));
+        // A write must nudge the app to reload (references aren't live-synced).
+        assert_eq!(out.changed_doc_id.as_ref().unwrap().as_str(), "doc1");
+
+        // Durable in the JSON store (top-level `references`).
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".to_string()).unwrap();
+        let json = f.team.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(json["references"]["itemOrder"], json!(["smith2020", "jones2021"]));
+
+        // list_references reflects them, in order, with the count.
+        let listed = dispatch(&f.ctx(true), "docushark.list_references", &json!({"docId": "doc1"}))
+            .unwrap();
+        assert_eq!(listed.result["count"], json!(2));
+        assert_eq!(listed.result["references"][0]["id"], json!("smith2020"));
+        assert_eq!(listed.result["source"], json!("team"));
+        assert!(listed.changed_doc_id.is_none(), "a read must not nudge a reload");
+    }
+
+    #[test]
+    fn add_reference_dedups_against_existing_library() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.add_reference",
+            &json!({"docId": "doc1", "items": [{"id": "a", "DOI": "10.1000/aaa"}]}),
+        )
+        .unwrap();
+        // Same DOI (different case) + a genuinely new one.
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_reference",
+            &json!({"docId": "doc1", "items": [
+                {"id": "a-again", "DOI": "10.1000/AAA"},
+                {"id": "b", "DOI": "10.1000/bbb"},
+            ]}),
+        )
+        .unwrap();
+        assert_eq!(out.result["added"], json!(["b"]));
+        assert_eq!(out.result["duplicates"], json!(1));
+    }
+
+    #[test]
+    fn add_reference_requires_items_or_doi() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let err = dispatch(&f.ctx(true), "docushark.add_reference", &json!({"docId": "doc1"}))
+            .unwrap_err();
+        assert!(err.contains("'doi' or non-empty 'items'"), "got: {}", err);
+    }
+
+    #[test]
+    fn list_references_empty_for_fresh_doc() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let out = dispatch(&f.ctx(true), "docushark.list_references", &json!({"docId": "doc1"}))
+            .unwrap();
+        assert_eq!(out.result["count"], json!(0));
+        assert_eq!(out.result["references"], json!([]));
     }
 }

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -37,7 +37,7 @@ use crate::server::WorkspaceWriteLimiter;
 use super::config::McpFeatureConfigStore;
 use super::local_mirror::LocalDocumentMirror;
 use super::token::TokenStore;
-use super::tools::{descriptors, dispatch, ToolContext};
+use super::tools::{descriptors, dispatch, ToolContext, ToolOutcome};
 
 /// MCP protocol version this server implements. Update in lockstep with
 /// the spec the user's Claude Code client supports.
@@ -276,7 +276,7 @@ async fn handle_rpc(
     match method.as_str() {
         "initialize" => Json(rpc_result(id, initialize_result())).into_response(),
         "tools/list" => Json(rpc_result(id, tools_list_result())).into_response(),
-        "tools/call" => handle_tools_call(&state, &auth.workspace, id, &params),
+        "tools/call" => handle_tools_call(&state, &auth.workspace, id, &params).await,
         // Spec-defined no-op notifications we may receive from the client.
         "notifications/initialized" | "ping" => {
             (StatusCode::OK, Json(json!({"jsonrpc": "2.0", "id": id, "result": {}}))).into_response()
@@ -373,10 +373,65 @@ fn is_mcp_write_tool(name: &str) -> bool {
             | "docushark.delete_prose_page"
             | "docushark.reorder_shapes"
             | "docushark.reorder_prose_pages"
+            | "docushark.add_reference"
     )
 }
 
-fn handle_tools_call(
+/// Result of the JP-89 async DOI preflight for citation tools.
+enum DoiPreflight {
+    /// Not a DOI-resolving tool (or no DOI supplied) — proceed to sync dispatch
+    /// with `args` (possibly mutated to carry the resolved item).
+    Continue,
+    /// A finished tool result to return directly (`resolve_doi`).
+    Reply(Value),
+    /// A tool error message (DOI invalid / lookup failed).
+    Error(String),
+}
+
+/// Resolve the DOI that `resolve_doi` / `add_reference` may carry, before the
+/// synchronous `dispatch`. For `add_reference` the resolved CSL item is injected
+/// at the front of `args.items` so the pure JSON write path adds it like any
+/// other item. A non-DOI tool (or `add_reference` with no `doi`) returns
+/// `Continue` unchanged.
+async fn resolve_citation_doi(name: &str, args: &mut Value) -> DoiPreflight {
+    match name {
+        "docushark.resolve_doi" => {
+            let doi = args.get("doi").and_then(|v| v.as_str()).unwrap_or("");
+            match super::citations::resolve_doi_to_csl(doi).await {
+                Ok(item) => DoiPreflight::Reply(json!({"reference": item})),
+                Err(e) => DoiPreflight::Error(e),
+            }
+        }
+        "docushark.add_reference" => {
+            let doi = args
+                .get("doi")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .filter(|d| !d.trim().is_empty());
+            let Some(doi) = doi else {
+                return DoiPreflight::Continue;
+            };
+            let item = match super::citations::resolve_doi_to_csl(&doi).await {
+                Ok(item) => item,
+                Err(e) => return DoiPreflight::Error(e),
+            };
+            let Some(obj) = args.as_object_mut() else {
+                return DoiPreflight::Error("invalid arguments".into());
+            };
+            let items = obj.entry("items").or_insert_with(|| json!([]));
+            match items.as_array_mut() {
+                Some(arr) => {
+                    arr.insert(0, item);
+                    DoiPreflight::Continue
+                }
+                None => DoiPreflight::Error("'items' must be an array".into()),
+            }
+        }
+        _ => DoiPreflight::Continue,
+    }
+}
+
+async fn handle_tools_call(
     state: &McpAppState,
     workspace: &WorkspaceId,
     id: Value,
@@ -386,7 +441,7 @@ fn handle_tools_call(
         Some(n) => n,
         None => return rpc_error(id, -32602, "Invalid params: missing tool name"),
     };
-    let args = params.get("arguments").cloned().unwrap_or(json!({}));
+    let mut args = params.get("arguments").cloned().unwrap_or(json!({}));
 
     let ctx = ToolContext {
         team: &state.doc_store,
@@ -434,29 +489,43 @@ fn handle_tools_call(
             .into_response();
     }
 
-    // Phase 21.2: catch tool panics so one bad tool call can't take
-    // down the MCP HTTP server. `dispatch` is sync, so we use the
-    // stdlib catch_unwind directly (no future combinator needed).
-    let outcome = match std::panic::catch_unwind(AssertUnwindSafe(|| dispatch(&ctx, name, &args))) {
-        Ok(result) => result,
-        Err(panic) => {
-            state.panic_counter.fetch_add(1, Ordering::Relaxed);
-            let correlation_id = nanoid::nanoid!(10);
-            log::error!(
-                "mcp tool panic tool={} workspace_id={} correlation_id={} panic={}",
-                name,
-                ctx.workspace_id.as_str(),
-                correlation_id,
-                crate::server::panic_message(&panic),
-            );
-            return Json(rpc_result(
-                id,
-                json!({
-                    "content": [{"type": "text", "text": "internal error"}],
-                    "isError": true,
-                }),
-            ))
-            .into_response();
+    // JP-89: `resolve_doi` and the DOI form of `add_reference` need an outbound
+    // network call (doi.org content negotiation), which the synchronous
+    // `dispatch` can't make. Resolve it here (async) — `resolve_doi` returns the
+    // CSL item directly; `add_reference` gets the resolved item injected into
+    // `args.items` and then falls through to the normal sync write dispatch. The
+    // rate-limit gate above already ran, so a DOI-lookup storm is throttled.
+    let outcome = match resolve_citation_doi(name, &mut args).await {
+        DoiPreflight::Reply(result) => {
+            Ok(ToolOutcome { result, changed_doc_id: None, change_detail: None })
+        }
+        DoiPreflight::Error(msg) => Err(msg),
+        DoiPreflight::Continue => {
+            // Phase 21.2: catch tool panics so one bad tool call can't take
+            // down the MCP HTTP server. `dispatch` is sync, so we use the
+            // stdlib catch_unwind directly (no future combinator needed).
+            match std::panic::catch_unwind(AssertUnwindSafe(|| dispatch(&ctx, name, &args))) {
+                Ok(result) => result,
+                Err(panic) => {
+                    state.panic_counter.fetch_add(1, Ordering::Relaxed);
+                    let correlation_id = nanoid::nanoid!(10);
+                    log::error!(
+                        "mcp tool panic tool={} workspace_id={} correlation_id={} panic={}",
+                        name,
+                        ctx.workspace_id.as_str(),
+                        correlation_id,
+                        crate::server::panic_message(&panic),
+                    );
+                    return Json(rpc_result(
+                        id,
+                        json!({
+                            "content": [{"type": "text", "text": "internal error"}],
+                            "isError": true,
+                        }),
+                    ))
+                    .into_response();
+                }
+            }
         }
     };
 
@@ -697,7 +766,10 @@ mod tests {
         assert!(names.contains(&"docushark.delete_prose_page"));
         assert!(names.contains(&"docushark.reorder_shapes"));
         assert!(names.contains(&"docushark.reorder_prose_pages"));
-        assert_eq!(tools.len(), 21);
+        assert!(names.contains(&"docushark.list_references"));
+        assert!(names.contains(&"docushark.resolve_doi"));
+        assert!(names.contains(&"docushark.add_reference"));
+        assert_eq!(tools.len(), 24);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Slice 6 of JP-89 — relay MCP citation tools

Gives an MCP agent the ability to manage a document's **reference library** without the editor, satisfying the JP-89 acceptance clause *"MCP agent can add a citation by DOI without UI."*

### Tools
| Tool | Kind | Purpose |
|---|---|---|
| `docushark.list_references` | read | The doc's CSL-JSON library in display order + active `style`. |
| `docushark.resolve_doi` | read + network | Resolve a DOI → CSL-JSON via doi.org content negotiation; no write. Preview before adding. |
| `docushark.add_reference` | write | Add by `doi` **or** `items` (raw CSL-JSON). Dedups by DOI then id, appends to `itemOrder`, persists under optimistic concurrency. |

### Design notes
- **Storage:** the library is the document's top-level `references` field (CSL-JSON, mirroring `src/types/Citation.ts`). It round-trips durably through the snapshot flatten with **zero relay sync changes** (unknown-to-the-Y.Doc top-level field).
- **Formatting stays client-side.** The relay only reads/writes CSL-JSON; CSL→APA/MLA/Chicago/Vancouver rendering remains in the editor's lazy citation-js chunk. No citeproc engine in the Rust build (same call as SigV4-not-aws-sdk).
- **Async DOI resolution.** `dispatch` is synchronous and can't make the doi.org call, so resolution runs async in the transport layer *after* the rate-limit gate, *before* dispatch: `resolve_doi` returns the item directly; `add_reference` gets the resolved item injected into `args.items` and falls through to the pure JSON write path. Shared `reqwest::Client` via `OnceLock`, 15s timeout.

### Scope boundary
- **Library-level only.** `add_reference` does **not** insert an inline `citationInline`/bibliography node into prose — that waits on the next slice (relay custom-node round-trip), since a custom node would be dropped on flatten today.
- references aren't Y.Doc-synced, so a *connected* editor sees new entries on reload (same caveat as `reorder_prose_pages`).

### Verification
- `cargo build` / `cargo clippy --lib` clean (no new warnings).
- `cargo test --lib` — **316 passing**, including new `citations` units (DOI normalize/validate, item normalize, dedup, list) and tools-dispatch round-trips (add → persist → list, dedup, error paths). `tools/list` count updated 21 → 24.
- OSS-leak grep on touched relay files: clean.

Docs updated in `relay/docs/mcp/README.md`.

Assisted-by: Opus 4.8