### PR TITLE
JP-89: round-trip custom prose nodes (citations) through the relay Y.Doc

### DIFF
--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -130,7 +130,13 @@ pub fn json_prose_to_ydoc(doc_json: &Value, doc: &Doc) {
 /// placeholder) has none, so it isn't seeded.
 fn block_has_substance(node: &super::prose_parse::PmNode) -> bool {
     use super::prose_parse::PmChild;
-    if matches!(node.node_type.as_str(), "image" | "horizontalRule") {
+    // Embeds + custom prose-helper atoms (JP-89) are substantial even with no
+    // text — a citation-only paragraph or a bibliography block must seed, not be
+    // mistaken for the empty-page placeholder.
+    if matches!(
+        node.node_type.as_str(),
+        "image" | "horizontalRule" | "citationInline" | "bibliography"
+    ) {
         return true;
     }
     node.children.iter().any(|child| match child {

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -833,6 +833,10 @@ mod tests {
             "<p>a<br>b</p>",
             "<p><strong><em>both</em></strong></p>",
             "<p>a &lt; b &amp; c</p>",
+            // JP-89 custom prose-helper nodes (byte-exact round-trip — the
+            // serializer's deterministic attr order matches these inputs).
+            r#"<p>see <span data-citation data-ref-id="knuth1997" data-label="(Knuth, 1997)">(Knuth, 1997)</span>.</p>"#,
+            r#"<div data-bibliography data-bib-html="&lt;div&gt;Knuth, D.&lt;/div&gt;"></div>"#,
         ];
         for html in cases {
             let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
@@ -840,6 +844,31 @@ mod tests {
             assert!(!framed.is_empty(), "a framed delta is returned to broadcast");
             assert_eq!(handle.prose_html("p1").as_deref(), Some(html), "round-trip: {html}");
         }
+    }
+
+    #[test]
+    fn custom_prose_nodes_survive_hydration() {
+        // The JP-89 collab-foundation regression, on the open-doc path: a doc
+        // hydrated from stored JSON whose prose carries a citation + bibliography
+        // must keep them in the live Y.Doc (seed → serialize), not degrade the
+        // <span> to plain text or drop the <div>. This is the exact flow that
+        // failed on staging once a doc went resident.
+        let content = concat!(
+            r#"<p>Sorting is deep <span data-citation data-ref-id="knuth1997" data-label="(Knuth, 1997)">(Knuth, 1997)</span>.</p>"#,
+            r#"<div data-bibliography data-bib-html="&lt;div&gt;Knuth, D.&lt;/div&gt;"></div>"#
+        );
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}},
+            "richTextPages": { "pageOrder": ["p1"], "pages": {
+                "p1": {"content": content}
+            }}
+        });
+        let handle = DocHandle::hydrate(&json, None, false);
+        let html = handle.prose_html("p1").expect("p1 prose seeded");
+        assert!(html.contains(r#"data-ref-id="knuth1997""#), "citation ref survives: {html}");
+        assert!(html.contains(r#"data-label="(Knuth, 1997)""#), "citation label survives: {html}");
+        assert!(html.contains(r#"<div data-bibliography data-bib-html="&lt;div&gt;Knuth, D.&lt;/div&gt;">"#), "bibliography survives: {html}");
     }
 
     #[test]

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -122,6 +122,10 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         "horizontalRule" => Block::Void("<hr>".to_string()),
         "hardBreak" => Block::Void("<br>".to_string()),
         "image" => Block::Void(image_html(el, txn)),
+        // Custom prose-helper leaves (JP-89), self-describing via `data-*` — the
+        // void-with-attrs round-trip, like `image`. See `prose_schema`.
+        "citationInline" => Block::Void(citation_html(el, txn)),
+        "bibliography" => Block::Void(bibliography_html(el, txn)),
         // Task list/item are read-only aliases of ul/li (not in the shared
         // round-trip table — a write never re-emits these PM types).
         "taskList" => wrap("ul"),
@@ -172,6 +176,47 @@ fn image_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
     }
     s.push('>');
     s
+}
+
+/// Read a single string attribute off an element (`None` for absent/non-string).
+fn str_attr<T: ReadTxn>(el: &XmlElementRef, txn: &T, key: &str) -> Option<String> {
+    el.get_attribute(txn, key).and_then(|o| match o {
+        Out::Any(Any::String(s)) => Some(s.to_string()),
+        _ => None,
+    })
+}
+
+/// Serialize a `citationInline` element to `<span data-citation …>label</span>`
+/// (JP-89). Attributes are written in a fixed order so output is deterministic;
+/// the `label` is also emitted as the text child so static consumers (PDF, MCP
+/// `get_prose`, a non-collab open) show the in-text citation. Mirrors the editor's
+/// `renderHTML` in `src/tiptap/CitationExtension.ts`.
+fn citation_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let mut s = String::from("<span data-citation");
+    if let Some(ref_id) = str_attr(el, txn, "refId") {
+        let _ = write!(s, " data-ref-id=\"{}\"", escape_attr(&ref_id));
+    }
+    if let Some(loc) = str_attr(el, txn, "locator").filter(|v| !v.is_empty()) {
+        let _ = write!(s, " data-locator=\"{}\"", escape_attr(&loc));
+    }
+    let label = str_attr(el, txn, "label").unwrap_or_default();
+    if !label.is_empty() {
+        let _ = write!(s, " data-label=\"{}\"", escape_attr(&label));
+    }
+    s.push('>');
+    push_escaped(&mut s, &label);
+    s.push_str("</span>");
+    s
+}
+
+/// Serialize a `bibliography` element to `<div data-bibliography data-bib-html=…>`
+/// (JP-89). Childless; the rendered entries live (escaped) in `bibHtml`. Emits
+/// `data-bib-html` only when non-empty, matching the editor's `renderHTML`.
+fn bibliography_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    match str_attr(el, txn, "bibHtml").filter(|v| !v.is_empty()) {
+        Some(bib) => format!("<div data-bibliography data-bib-html=\"{}\"></div>", escape_attr(&bib)),
+        None => "<div data-bibliography></div>".to_string(),
+    }
 }
 
 fn write_text<T: ReadTxn>(t: &XmlTextRef, txn: &T, out: &mut String) {
@@ -413,5 +458,56 @@ mod tests {
             parent.push_back(txn, XmlTextPrelim::new("deep"));
         });
         assert!(html.starts_with("<blockquote>"), "bounded output produced: {}", &html[..html.len().min(40)]);
+    }
+
+    // ---- JP-89: custom prose-helper nodes ----
+
+    #[test]
+    fn citation_inline_serializes_with_attrs_and_label() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("see "));
+            let c = p.push_back(txn, XmlElementPrelim::empty("citationInline"));
+            c.insert_attribute(txn, "refId", "knuth1997");
+            c.insert_attribute(txn, "locator", "p. 42");
+            c.insert_attribute(txn, "label", "(Knuth, 1997)");
+        });
+        assert_eq!(
+            html,
+            "<p>see <span data-citation data-ref-id=\"knuth1997\" data-locator=\"p. 42\" \
+             data-label=\"(Knuth, 1997)\">(Knuth, 1997)</span></p>"
+        );
+    }
+
+    #[test]
+    fn citation_inline_omits_empty_optional_attrs() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            let c = p.push_back(txn, XmlElementPrelim::empty("citationInline"));
+            c.insert_attribute(txn, "refId", "a");
+            // no locator, no label
+        });
+        assert_eq!(html, "<p><span data-citation data-ref-id=\"a\"></span></p>");
+    }
+
+    #[test]
+    fn bibliography_serializes_with_escaped_html() {
+        let html = render(|_doc, frag, txn| {
+            let b = frag.push_back(txn, XmlElementPrelim::empty("bibliography"));
+            b.insert_attribute(txn, "bibHtml", "<div class=\"csl-entry\">Knuth, D.</div>");
+        });
+        assert_eq!(
+            html,
+            "<div data-bibliography data-bib-html=\"&lt;div class=&quot;csl-entry&quot;&gt;\
+             Knuth, D.&lt;/div&gt;\"></div>"
+        );
+    }
+
+    #[test]
+    fn bibliography_without_html_is_bare() {
+        let html = render(|_doc, frag, txn| {
+            frag.push_back(txn, XmlElementPrelim::empty("bibliography"));
+        });
+        assert_eq!(html, "<div data-bibliography></div>");
     }
 }

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -317,8 +317,42 @@ fn map_blocks(nodes: &[HtmlNode]) -> Vec<PmNode> {
     out
 }
 
+/// Does `attrs` carry an attribute named `name` (any value, incl. bare/empty)?
+fn has_attr(attrs: &[(String, String)], name: &str) -> bool {
+    attrs.iter().any(|(k, _)| k == name)
+}
+
+/// The value of attribute `name`, if present.
+fn get_attr<'a>(attrs: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    attrs.iter().find(|(k, _)| k == name).map(|(_, v)| v.as_str())
+}
+
+/// Build a `citationInline` PM node from a `<span data-citation …>` element's
+/// attributes. Caller guarantees `data-ref-id` is present. `locator`/`label` are
+/// emitted only when non-empty, symmetric with the editor's `renderHTML`
+/// (`src/tiptap/CitationExtension.ts`). It's an atom — no children.
+fn citation_node(attrs: &[(String, String)]) -> PmNode {
+    let mut a = vec![("refId".to_string(), get_attr(attrs, "data-ref-id").unwrap_or("").to_string())];
+    if let Some(loc) = get_attr(attrs, "data-locator").filter(|s| !s.is_empty()) {
+        a.push(("locator".to_string(), loc.to_string()));
+    }
+    if let Some(label) = get_attr(attrs, "data-label").filter(|s| !s.is_empty()) {
+        a.push(("label".to_string(), label.to_string()));
+    }
+    PmNode { node_type: "citationInline".to_string(), attrs: a, children: vec![] }
+}
+
 /// Map a known block-level HTML element to a PM node, else `None`.
 fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode]) -> Option<PmNode> {
+    // Bibliography block atom (JP-89): `<div data-bibliography data-bib-html=…>`.
+    // Childless — the rendered entries live (escaped) in `bibHtml`.
+    if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)) == Some("bibliography") {
+        let mut a = vec![];
+        if let Some(b) = get_attr(attrs, "data-bib-html") {
+            a.push(("bibHtml".to_string(), b.to_string()));
+        }
+        return Some(PmNode { node_type: "bibliography".to_string(), attrs: a, children: vec![] });
+    }
     // Heading h1..h6.
     if tag.len() == 2 && tag.as_bytes()[0] == b'h' && tag.as_bytes()[1].is_ascii_digit() {
         let level = (tag.as_bytes()[1] - b'0').clamp(1, 6);
@@ -379,6 +413,15 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                     let mut m = marks.to_vec();
                     m.push(PmMark { name: "link".to_string(), href });
                     out.extend(collect_inline(children, &m));
+                } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
+                    == Some("citationInline")
+                    && get_attr(attrs, "data-ref-id").is_some()
+                {
+                    // Inline citation atom (JP-89). Self-describing via `data-*`;
+                    // the text content is the cached projection, kept in `label`.
+                    // Require `data-ref-id` — a refId-less citation is useless, so
+                    // fall through to the unwrap below and keep the text instead.
+                    out.push(PmChild::Node(citation_node(attrs)));
                 } else if let Some(mark) = prose_schema::mark_pm(tag) {
                     let mut m = marks.to_vec();
                     m.push(PmMark { name: mark.to_string(), href: None });
@@ -530,5 +573,88 @@ mod tests {
             text_of(b, &mut text);
         }
         assert!(text.contains("content"), "text survives the depth cap");
+    }
+
+    // ---- JP-89: custom prose-helper nodes ----
+
+    fn attr<'a>(node: &'a PmNode, k: &str) -> Option<&'a str> {
+        node.attrs.iter().find(|(key, _)| key == k).map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn citation_span_parses_to_inline_node() {
+        let b = html_to_blocks(
+            r#"<p>see <span data-citation data-ref-id="knuth1997" data-locator="p. 42" data-label="(Knuth, 1997)">(Knuth, 1997)</span></p>"#,
+        );
+        assert_eq!(b[0].node_type, "paragraph");
+        assert_eq!(b[0].children[0], text("see "));
+        let PmChild::Node(c) = &b[0].children[1] else { panic!("citation not a node") };
+        assert_eq!(c.node_type, "citationInline");
+        assert!(c.children.is_empty(), "citation is an atom");
+        assert_eq!(attr(c, "refId"), Some("knuth1997"));
+        assert_eq!(attr(c, "locator"), Some("p. 42"));
+        assert_eq!(attr(c, "label"), Some("(Knuth, 1997)"));
+    }
+
+    #[test]
+    fn citation_omits_absent_optional_attrs() {
+        let b = html_to_blocks(r#"<p><span data-citation data-ref-id="a">x</span></p>"#);
+        let PmChild::Node(c) = &b[0].children[0] else { panic!() };
+        assert_eq!(attr(c, "refId"), Some("a"));
+        assert_eq!(attr(c, "locator"), None);
+        assert_eq!(attr(c, "label"), None);
+    }
+
+    #[test]
+    fn citation_without_ref_id_degrades_to_text() {
+        // Defensive: a refId-less citation isn't minted — keep the text instead.
+        let b = html_to_blocks(r#"<p>before <span data-citation>kept</span> after</p>"#);
+        assert_eq!(b[0].node_type, "paragraph");
+        let all: String = b[0]
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                PmChild::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(all, "before kept after");
+        assert!(b[0].children.iter().all(|c| matches!(c, PmChild::Text { .. })));
+    }
+
+    #[test]
+    fn plain_span_still_unwraps() {
+        let b = html_to_blocks(r#"<p>a <span class="x">b</span> c</p>"#);
+        let joined: String = b[0]
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                PmChild::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(joined, "a b c");
+    }
+
+    #[test]
+    fn bibliography_div_parses_to_block_node() {
+        let b = html_to_blocks(
+            r#"<div data-bibliography data-bib-html="&lt;div class=&quot;csl-entry&quot;&gt;Knuth, D.&lt;/div&gt;"></div>"#,
+        );
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].node_type, "bibliography");
+        assert!(b[0].children.is_empty());
+        // Entities in the attribute value are decoded back to real markup.
+        assert_eq!(
+            attr(&b[0], "bibHtml"),
+            Some("<div class=\"csl-entry\">Knuth, D.</div>")
+        );
+    }
+
+    #[test]
+    fn plain_div_still_unwraps_children() {
+        let b = html_to_blocks("<div><p>kept</p></div>");
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].node_type, "paragraph");
     }
 }

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -58,3 +58,30 @@ pub fn simple_block_pm(html_tag: &str) -> Option<&'static str> {
 pub fn mark_pm(html_tag: &str) -> Option<&'static str> {
     MARKS.iter().find(|(_, h)| *h == html_tag).map(|(m, _)| *m)
 }
+
+/// Custom "prose-helper" leaf nodes — neither plain wrappers nor marks. Each
+/// carries its state in `data-*` attributes and is round-tripped **explicitly**
+/// by [`super::prose_parse`] (HTML→PM) and [`super::prose_html`] (PM→HTML), the
+/// same way the `<img>` void node is. They differ in shape (an inline atom that
+/// also carries a rendered-text child, vs. a childless block atom), so the
+/// handlers stay hand-written; this table is the single source of truth for the
+/// `(pm type, html tag, marker attribute)` triple so the two sides can't drift.
+/// Mirrors the editor extensions in `src/tiptap/CitationExtension.ts`.
+///
+/// `mathInline`/`mathBlock` are the next entries (same mechanism) when math
+/// round-trips through the relay.
+pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
+    ("citationInline", "span", "data-citation"),
+    ("bibliography", "div", "data-bibliography"),
+];
+
+/// PM node type for an HTML element that matches a custom prose-helper node:
+/// its tag must match and `has_attr` must report the marker attribute present.
+/// Used by the parser to detect these nodes before its generic
+/// unwrap-the-unknown fallback.
+pub fn custom_node_pm(html_tag: &str, has_attr: impl Fn(&str) -> bool) -> Option<&'static str> {
+    CUSTOM_PROSE_NODES
+        .iter()
+        .find(|(_, tag, marker)| *tag == html_tag && has_attr(marker))
+        .map(|(pm, _, _)| *pm)
+}


### PR DESCRIPTION
## The collab foundation for prose-helper nodes

The relay's HTML↔Y.Doc prose pipeline only knew `p / lists / blockquote / table`, a fixed mark set, and the void nodes `br/hr/img`. Custom prose-helper nodes — `citationInline` and `bibliography` — were unknown, so **once a doc went resident** (opened in a collaborative editor) every prose round-trip degraded the inline citation `<span>` to plain text (losing the ref binding) and dropped the childless bibliography `<div>` entirely.

**Reproduced live on staging** (PR #170): adding a citation via MCP `set_prose` persisted fine while the doc was cold, but after opening it in the PWA, `get_prose` came back as `<p>Sorting is a deep topic (Knuth, 1997) with a long history.</p>` — span degraded, bibliography gone.

It bit three relay paths (live write `replace_prose`, hydration seeding, read/flatten serializer) — plus a citation synced **client↔client over raw WS**, which serialized transparently and was dropped on the JSON flatten.

## Fix — explicit void-with-attrs handling, mirroring `<img>`

| File | Change |
|---|---|
| `prose_parse.rs` | `span[data-citation]` → `citationInline` (`refId`/`locator`/`label`; requires `data-ref-id`, else falls through to the text-preserving unwrap); `div[data-bibliography]` → `bibliography` (`bibHtml`). Attribute entities already decode, so the escaped HTML in `data-bib-html` parses to real markup. |
| `prose_html.rs` | Serialize `citationInline` → `<span data-citation …>label</span>` (label also as text child for PDF/MCP/non-collab consumers); `bibliography` → `<div data-bibliography data-bib-html=…>`. Fixed attr order + re-escaping → deterministic, lossless round-trip. |
| `hydration.rs` | `block_has_substance` treats `citationInline`/`bibliography` as substance, so a citation-only paragraph or a bibliography block seeds. |
| `prose_schema.rs` | `CUSTOM_PROSE_NODES` const + `custom_node_pm()` — single source of truth for the `(pm type, html tag, marker attr)` triple so parse/serialize can't drift. `mathInline`/`mathBlock` join here next. |

`build_prose_node` is already generic, so no Y.Doc-builder change. **No protocol bump, no document migration, no TS change** — the editor already ships these extensions; names/attrs verified against `src/tiptap/CitationExtension.ts`.

### Notable
- **One genuinely novel shape:** `citationInline` is the first inline-leaf-*with-attributes* in the relay Y.Doc (`hardBreak` = inline/no-attrs, `image` = block/attrs). Individually proven; the combination is new — gated by the full round-trip test + staging E2E.
- **Pre-existing (out of scope):** `data-bib-html` round-trips arbitrary HTML; the sink is the client bibliography nodeView (slice 5.5), already reachable via `set_prose`. No new sink here (relay output is attribute-escaped); a client-side sanitization pass is a separate follow-up.

## Verification
- `cargo test --lib` — **327 passing** (+11): `prose_parse` units (parse, defensive no-refId unwrap, plain `span`/`div` unwrap, `data-bib-html` entity decode), `prose_html` units (serialize/escape/omitted optionals), byte-exact `replace_prose` round-trip cases, and a `DocHandle::hydrate` round-trip mirroring the staging repro.
- `cargo clippy --lib` clean (no new warnings); OSS-leak grep clean.
- **Staging E2E** (separate PR): in a resident doc, `set_prose` the citation+bibliography HTML → `get_prose` returns them intact; reload → inline cite + bibliography still render. The exact flow that failed.

Assisted-by: Opus 4.8