### PR TITLE
[staging] JP-89: reference library shared type (E2E)

### DIFF
--- a/relay/src/mcp/citations.rs
+++ b/relay/src/mcp/citations.rs
@@ -140,37 +140,37 @@ fn references_mut(doc: &mut Value) -> Result<&mut serde_json::Map<String, Value>
     Ok(refs)
 }
 
-/// Upsert `incoming` CSL items into the doc's `references` library, deduping by
-/// DOI (case-insensitive) then by id — against existing items *and* earlier
-/// items in the same batch. New ids are appended to `itemOrder`. Mirrors the TS
-/// `dedupeReferences` + `importReferences`. Returns which ids were added.
-///
-/// Pure: safe to replay under `mutate_with_retry`.
-pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<AddOutcome, String> {
-    let refs = references_mut(doc)?;
+/// The normalized items to add (after dedup) + how many were skipped.
+pub struct AdditionPlan {
+    /// `(id, normalized CSL item)` pairs to insert, in input order.
+    pub added: Vec<(String, Value)>,
+    /// Incoming items skipped as duplicates (by DOI then id).
+    pub duplicates: usize,
+}
 
-    // Seed the seen-sets from existing library contents.
+/// Decide which of `incoming` to add to a library whose current items are
+/// `existing` (id → CSLItem). Dedups by DOI (case-insensitive) then by id —
+/// against `existing` *and* earlier items in the same batch. Pure; shared by the
+/// JSON (cold) and live-Y.Doc (resident) write paths so they dedup identically.
+/// Mirrors the TS `dedupeReferences`.
+pub fn plan_additions(
+    existing: &serde_json::Map<String, Value>,
+    incoming: &[Value],
+) -> Result<AdditionPlan, String> {
     let mut seen_dois: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
-    if let Some(items) = refs.get("items").and_then(Value::as_object) {
-        for (id, item) in items {
-            seen_ids.insert(id.clone());
-            if let Some(doi) = doi_key(item) {
-                seen_dois.insert(doi);
-            }
+    for (id, item) in existing {
+        seen_ids.insert(id.clone());
+        if let Some(doi) = doi_key(item) {
+            seen_dois.insert(doi);
         }
     }
 
-    let mut added: Vec<String> = Vec::new();
+    let mut added: Vec<(String, Value)> = Vec::new();
     let mut duplicates = 0usize;
-
     for raw in incoming {
-        let item = match normalize_item(raw.clone(), "") {
-            Some(it) => it,
-            None => {
-                return Err("a reference was not a CSL-JSON object".into());
-            }
-        };
+        let item =
+            normalize_item(raw.clone(), "").ok_or("a reference was not a CSL-JSON object")?;
         let id = item
             .get("id")
             .and_then(|v| v.as_str())
@@ -184,52 +184,77 @@ pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<Ad
             duplicates += 1;
             continue;
         }
-
-        // Insert into items map + append to itemOrder. Re-borrow each iteration
-        // to satisfy the borrow checker (the seen-sets above are owned copies).
-        refs.get_mut("items")
-            .and_then(Value::as_object_mut)
-            .unwrap()
-            .insert(id.clone(), item);
-        refs.get_mut("itemOrder")
-            .and_then(Value::as_array_mut)
-            .unwrap()
-            .push(json!(id.clone()));
-
         seen_ids.insert(id.clone());
         if let Some(d) = doi {
             seen_dois.insert(d);
         }
-        added.push(id);
+        added.push((id, item));
     }
-
-    Ok(AddOutcome { added, duplicates })
+    Ok(AdditionPlan { added, duplicates })
 }
 
-/// Read the doc's reference library as a result payload: the CSL items in
-/// `itemOrder`, the active `style` (or null), and a count. Tolerant of a
-/// missing/empty library (returns an empty list).
-pub fn list_references_json(doc: &Value) -> Value {
-    let refs = doc.get("references");
-    let items = refs.and_then(|r| r.get("items")).and_then(Value::as_object);
-    let order = refs.and_then(|r| r.get("itemOrder")).and_then(Value::as_array);
+/// Upsert `incoming` CSL items into the doc's JSON `references` library (the
+/// cold / non-resident path), deduping via [`plan_additions`]; new ids are
+/// appended to `itemOrder`. Pure: safe to replay under `mutate_with_retry`.
+pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<AddOutcome, String> {
+    let existing = doc
+        .get("references")
+        .and_then(|r| r.get("items"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let plan = plan_additions(&existing, incoming)?;
 
-    let ordered: Vec<Value> = match (items, order) {
-        (Some(items), Some(order)) => order
-            .iter()
-            .filter_map(Value::as_str)
-            .filter_map(|id| items.get(id).cloned())
-            .collect(),
-        // No explicit order — fall back to whatever items exist (unordered).
-        (Some(items), None) => items.values().cloned().collect(),
-        _ => Vec::new(),
+    let refs = references_mut(doc)?;
+    let items = refs.get_mut("items").and_then(Value::as_object_mut).unwrap();
+    for (id, item) in &plan.added {
+        items.insert(id.clone(), item.clone());
+    }
+    let order = refs.get_mut("itemOrder").and_then(Value::as_array_mut).unwrap();
+    for (id, _) in &plan.added {
+        order.push(json!(id.clone()));
+    }
+
+    Ok(AddOutcome {
+        added: plan.added.into_iter().map(|(id, _)| id).collect(),
+        duplicates: plan.duplicates,
+    })
+}
+
+/// Build the `list_references` result payload from raw library parts (items map,
+/// display order, optional style). Shared by the cold JSON and resident live
+/// read paths.
+pub fn list_payload(
+    items: &serde_json::Map<String, Value>,
+    order: &[String],
+    style: Option<&str>,
+) -> Value {
+    let ordered: Vec<Value> = if order.is_empty() {
+        items.values().cloned().collect()
+    } else {
+        order.iter().filter_map(|id| items.get(id).cloned()).collect()
     };
-
     json!({
         "references": ordered,
-        "style": refs.and_then(|r| r.get("style")).cloned().unwrap_or(Value::Null),
+        "style": style.map(|s| Value::String(s.to_string())).unwrap_or(Value::Null),
         "count": ordered.len(),
     })
+}
+
+/// Read the doc's JSON reference library as a result payload (the cold /
+/// non-resident path): the CSL items in `itemOrder`, the active `style` (or
+/// null), and a count. Tolerant of a missing/empty library.
+pub fn list_references_json(doc: &Value) -> Value {
+    let refs = doc.get("references");
+    let empty = serde_json::Map::new();
+    let items = refs.and_then(|r| r.get("items")).and_then(Value::as_object).unwrap_or(&empty);
+    let order: Vec<String> = refs
+        .and_then(|r| r.get("itemOrder"))
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).map(str::to_string).collect())
+        .unwrap_or_default();
+    let style = refs.and_then(|r| r.get("style")).and_then(Value::as_str);
+    list_payload(items, &order, style)
 }
 
 /// Shared HTTP client for DOI lookups. Built once; reused across calls.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1933,14 +1933,29 @@ struct ListReferencesArgs {
 }
 
 /// Read a document's reference library as CSL-JSON in display order. Read-only.
+/// Reads the live Y.Doc library when the doc is resident (so an agent sees refs a
+/// peer/agent just added before the next flatten), else the JSON snapshot.
 fn list_references(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: ListReferencesArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
-    let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
-    let mut result = super::citations::list_references_json(&doc);
-    if let Some(obj) = result.as_object_mut() {
-        obj.insert("source".into(), json!(source));
-    }
+
+    let result = if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let items = handle.references_json();
+        let order = handle.reference_order();
+        let mut payload =
+            super::citations::list_payload(&items, &order, handle.citation_style().as_deref());
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("source".into(), json!(SOURCE_TEAM));
+        }
+        payload
+    } else {
+        let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
+        let mut payload = super::citations::list_references_json(&doc);
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("source".into(), json!(source));
+        }
+        payload
+    };
     Ok(ToolOutcome { result, changed_doc_id: None, change_detail: None })
 }
 
@@ -1955,8 +1970,10 @@ struct AddReferenceArgs {
 }
 
 /// Add reference(s) to a document's CSL-JSON library. The DOI form is resolved
-/// to a CSL item upstream (transport) and arrives as `items`; this handler is
-/// the pure JSON-store write path under optimistic concurrency.
+/// to a CSL item upstream (transport) and arrives as `items`. When the doc is
+/// **resident**, writes the live Y.Doc `references` map per item + broadcasts the
+/// CRDT delta (so MCP and editor adds converge — JP-89), mirroring the shape
+/// live-write path; else writes the JSON snapshot under optimistic concurrency.
 fn add_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     let parsed: AddReferenceArgs =
         serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
@@ -1968,12 +1985,32 @@ fn add_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String>
         return Err("add_reference requires 'doi' or non-empty 'items'".into());
     }
 
-    // Capture any lock warning before the write (advisory only, like add_shape).
+    // Resident → live Y.Doc per-item write (INVARIANT A) + broadcast; the client's
+    // references observer merges it, so no reload nudge (changed_doc_id None).
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let existing = handle.references_json();
+        let plan = super::citations::plan_additions(&existing, &items)?;
+        if !plan.added.is_empty() {
+            let framed = handle.insert_references(&plan.added);
+            ctx.broadcast_update(&parsed.doc_id, framed);
+        }
+        let added: Vec<String> = plan.added.iter().map(|(id, _)| id.clone()).collect();
+        return Ok(ToolOutcome {
+            result: json!({
+                "added": added,
+                "addedCount": added.len(),
+                "duplicates": plan.duplicates,
+            }),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    // Cold path: JSON snapshot under optimistic concurrency.
     let lock = {
         let (doc, _) = fetch_doc(ctx, &parsed.doc_id)?;
         lock_warning(&doc)
     };
-
     let outcome = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
         let out = super::citations::add_references_in_place(doc, &items)?;
         stamp_doc_modified(doc, now_ms());

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -148,6 +148,50 @@ pub fn project_prose_into(pages: &[(String, String)], json: &mut Value) {
     }
 }
 
+/// Project the live reference library — `references` `Y.Map` (id → CSLItem) +
+/// `referenceOrder` `Y.Array` + `metadata.citationStyle` — into
+/// `json["references"] = {items, itemOrder, style}` (JP-89). The write
+/// projection paired with [`super::hydration::json_references_to_ydoc`]: the
+/// relay owns the library in the authoritative `Y.Doc`, so every flatten
+/// re-asserts the merged set. An empty map writes an empty library (a real
+/// "all deleted"), **except** we never synthesize a `references` field for a doc
+/// that never had one (pre-JP-89 back-compat).
+pub fn project_references_into(doc: &Doc, json: &mut Value) {
+    let references = doc.get_or_insert_map("references");
+    let reference_order = doc.get_or_insert_array("referenceOrder");
+    let metadata = doc.get_or_insert_map("metadata");
+
+    let (refs_any, order_any, meta_any) = {
+        let txn = doc.transact();
+        (references.to_json(&txn), reference_order.to_json(&txn), metadata.to_json(&txn))
+    };
+
+    let items = any_to_json(&refs_any);
+    let is_empty = items.as_object().map(JsonMap::is_empty).unwrap_or(true);
+    // Back-compat: leave a doc that never had a library without one.
+    if is_empty && json.get("references").is_none() {
+        return;
+    }
+
+    let style = match &meta_any {
+        Any::Map(m) => match m.get("citationStyle") {
+            Some(Any::String(s)) => Some(s.to_string()),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    if let Some(obj) = json.as_object_mut() {
+        let mut lib = JsonMap::new();
+        lib.insert("items".to_string(), items);
+        lib.insert("itemOrder".to_string(), any_to_json(&order_any));
+        if let Some(style) = style {
+            lib.insert("style".to_string(), Value::String(style));
+        }
+        obj.insert("references".to_string(), Value::Object(lib));
+    }
+}
+
 /// Convert a yrs `Any` into a `serde_json::Value` — the inverse of
 /// `hydration::json_to_any`. Integral numbers are emitted as JSON integers so
 /// a shape's `x: 10` round-trips as `10` rather than `10.0`.
@@ -315,5 +359,52 @@ mod tests {
         });
         project_prose_into(&[], &mut json);
         assert_eq!(json["richTextPages"]["pages"]["rt1"]["content"], "<p>keep</p>");
+    }
+
+    // ---- JP-89: reference library projection ----
+
+    fn doc_with_refs() -> Doc {
+        use yrs::{Array, Map};
+        let doc = Doc::new();
+        let refs = doc.get_or_insert_map("references");
+        let order = doc.get_or_insert_array("referenceOrder");
+        let meta = doc.get_or_insert_map("metadata");
+        let mut txn = doc.transact_mut();
+        refs.insert(&mut txn, "knuth1997", super::super::hydration::json_to_any(&json!({"id": "knuth1997", "type": "book"})));
+        order.push_back(&mut txn, Any::String("knuth1997".into()));
+        meta.insert(&mut txn, "citationStyle", Any::String("chicago".into()));
+        drop(txn);
+        doc
+    }
+
+    #[test]
+    fn project_references_round_trips_items_order_style() {
+        let doc = doc_with_refs();
+        let mut json = json!({"id": "d"});
+        project_references_into(&doc, &mut json);
+        assert_eq!(json["references"]["itemOrder"], json!(["knuth1997"]));
+        assert_eq!(json["references"]["items"]["knuth1997"]["type"], json!("book"));
+        assert_eq!(json["references"]["style"], json!("chicago"));
+    }
+
+    #[test]
+    fn project_references_skips_synthesizing_for_pre_jp89_docs() {
+        // Empty Y.Doc library + a doc that never had a `references` field → leave
+        // it absent (back-compat), never write an empty library.
+        let doc = Doc::new();
+        let mut json = json!({"id": "d"});
+        project_references_into(&doc, &mut json);
+        assert!(json.get("references").is_none());
+    }
+
+    #[test]
+    fn project_references_writes_empty_on_full_deletion() {
+        // A doc that HAD a library, now emptied in the Y.Doc → write the empty set
+        // (a real "all deleted"), not the stale JSON.
+        let doc = Doc::new();
+        let mut json = json!({"id": "d", "references": {"items": {"x": {"id": "x"}}, "itemOrder": ["x"]}});
+        project_references_into(&doc, &mut json);
+        assert_eq!(json["references"]["items"], json!({}));
+        assert_eq!(json["references"]["itemOrder"], json!([]));
     }
 }

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -125,6 +125,53 @@ pub fn json_prose_to_ydoc(doc_json: &Value, doc: &Doc) {
     }
 }
 
+/// Seed the `references` `Y.Map` (id → CSLItem JSON) + `referenceOrder`
+/// `Y.Array` + active citation `style` (in `metadata`) from a persisted
+/// document's top-level `references` library (JP-89).
+///
+/// Like [`json_prose_to_ydoc`], the relay owns the library in the authoritative
+/// `Y.Doc` so MCP and editor reference edits converge **per item** (a `Y.Map`
+/// merge) instead of clobbering each other a whole field at a time.
+///
+/// **Idempotent — only seeds an EMPTY map.** Both hydration paths call it: the
+/// JSON rebuild (a fresh `Doc` → seeds) and, as a backstop, the binary-sidecar
+/// path. A binary sidecar predating this feature carries no `references` map; the
+/// emptiness check backfills it from JSON there — guarding the binary-hydration
+/// **references wipe** — while never double-seeding a sidecar that already holds
+/// the library. Mirrors the JP-284 prose backstop exactly.
+pub fn json_references_to_ydoc(doc_json: &Value, doc: &Doc) {
+    let references = doc.get_or_insert_map("references");
+    let reference_order = doc.get_or_insert_array("referenceOrder");
+    let metadata = doc.get_or_insert_map("metadata");
+
+    let mut txn = doc.transact_mut();
+
+    // Idempotent backstop: only seed an empty map (mirrors json_prose_to_ydoc's
+    // per-fragment emptiness check). A populated map → the sidecar is
+    // authoritative; leave it.
+    if references.len(&txn) > 0 {
+        return;
+    }
+
+    let Some(lib) = doc_json.get("references").and_then(Value::as_object) else {
+        return;
+    };
+
+    if let Some(items) = lib.get("items").and_then(Value::as_object) {
+        for (id, item) in items {
+            references.insert(&mut txn, id.clone(), json_to_any(item));
+        }
+    }
+    if let Some(order) = lib.get("itemOrder").and_then(Value::as_array) {
+        for id in order.iter().filter_map(Value::as_str) {
+            reference_order.push_back(&mut txn, Any::String(id.into()));
+        }
+    }
+    if let Some(style) = lib.get("style").and_then(Value::as_str) {
+        metadata.insert(&mut txn, "citationStyle", Any::String(style.into()));
+    }
+}
+
 /// Whether a parsed prose block carries real content — any non-whitespace text,
 /// or an embed (image / horizontal rule). A bare/empty paragraph (the empty-page
 /// placeholder) has none, so it isn't seeded.
@@ -187,9 +234,9 @@ pub(crate) fn json_to_any(value: &Value) -> Any {
 
 #[cfg(test)]
 mod tests {
-    use super::{active_page_shape_count, json_to_ydoc};
+    use super::{active_page_shape_count, json_references_to_ydoc, json_to_ydoc};
     use serde_json::{json, Value};
-    use yrs::{Array, Doc, Map, Transact};
+    use yrs::{Any, Array, Doc, Map, Transact};
 
     #[test]
     fn active_page_shape_count_counts_active_page_only() {
@@ -360,5 +407,58 @@ mod tests {
         assert_eq!(shapes.len(&txn), 0);
         // metadata still hydrated from the top-level fields.
         assert!(meta.contains_key(&txn, "title"));
+    }
+
+    // ---- JP-89: reference library seeding ----
+
+    fn lib_json() -> Value {
+        json!({
+            "id": "d", "name": "x",
+            "references": {
+                "items": {
+                    "knuth1997": {"id": "knuth1997", "type": "book", "DOI": "10.5555/aocp"},
+                    "shannon": {"id": "shannon", "type": "article-journal"}
+                },
+                "itemOrder": ["knuth1997", "shannon"],
+                "style": "mla"
+            }
+        })
+    }
+
+    #[test]
+    fn json_references_to_ydoc_seeds_map_order_style() {
+        let doc = Doc::new();
+        json_references_to_ydoc(&lib_json(), &doc);
+        let refs = doc.get_or_insert_map("references");
+        let order = doc.get_or_insert_array("referenceOrder");
+        let meta = doc.get_or_insert_map("metadata");
+        let txn = doc.transact();
+        assert_eq!(refs.len(&txn), 2);
+        assert!(refs.contains_key(&txn, "knuth1997"));
+        assert_eq!(order.len(&txn), 2);
+        assert!(matches!(meta.get(&txn, "citationStyle"), Some(yrs::Out::Any(Any::String(s))) if s.as_ref() == "mla"));
+    }
+
+    #[test]
+    fn json_references_to_ydoc_is_idempotent_only_seeds_empty() {
+        let doc = Doc::new();
+        json_references_to_ydoc(&lib_json(), &doc);
+        // Re-run with a DIFFERENT library — a populated map must not be re-seeded.
+        json_references_to_ydoc(
+            &json!({"references": {"items": {"other": {"id": "other"}}, "itemOrder": ["other"]}}),
+            &doc,
+        );
+        let refs = doc.get_or_insert_map("references");
+        let txn = doc.transact();
+        assert_eq!(refs.len(&txn), 2, "second seed must be a no-op on a populated map");
+        assert!(!refs.contains_key(&txn, "other"));
+    }
+
+    #[test]
+    fn json_references_to_ydoc_noop_without_references() {
+        let doc = Doc::new();
+        json_references_to_ydoc(&json!({"id": "d"}), &doc);
+        let refs = doc.get_or_insert_map("references");
+        assert_eq!(refs.len(&doc.transact()), 0);
     }
 }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -188,6 +188,11 @@ impl DocHandle {
                                 // the client never has to. Idempotent: never
                                 // re-seeds a populated fragment.
                                 hydration::json_prose_to_ydoc(doc_json, &doc);
+                                // JP-89: same backstop for the reference library —
+                                // an older sidecar with no `references` map gets it
+                                // backfilled from JSON (idempotent; never wipes a
+                                // populated map).
+                                hydration::json_references_to_ydoc(doc_json, &doc);
                                 return (doc, false);
                             }
                         }
@@ -205,6 +210,9 @@ impl DocHandle {
         // from `richTextPages` here. Without this, cold-authored prose (MCP, never
         // opened in an editor) hydrates empty and a joining editor renders blank.
         hydration::json_prose_to_ydoc(doc_json, &doc);
+        // JP-89: seed the reference library into the authoritative Y.Doc so MCP +
+        // editor ref edits converge per item instead of whole-field clobbering.
+        hydration::json_references_to_ydoc(doc_json, &doc);
         (doc, poison_healed)
     }
 
@@ -319,6 +327,9 @@ impl DocHandle {
         // shape-only flatten above never wrote). Read projection only — restore
         // stays binary-sidecar based.
         flatten::project_prose_into(&self.prose_pages(), json);
+        // JP-89: re-assert the reference library from the authoritative Y.Doc, so
+        // a merged set (incl. live MCP/peer adds) is what persists.
+        flatten::project_references_into(&self.doc, json);
         true
     }
 
@@ -438,6 +449,74 @@ impl DocHandle {
         drop(txn);
         self.dirty.store(true, Ordering::Relaxed);
         Ok(protocol::frame_update(update))
+    }
+
+    // ---- Reference library (JP-89) — live Y.Doc surface ----
+
+    /// The `references` `Y.Map` as a JSON object (id → CSLItem). Used by the MCP
+    /// `add_reference` live path to dedup against the merged library and by
+    /// `list_references` to read the resident library. Empty object if unset.
+    pub fn references_json(&self) -> serde_json::Map<String, Value> {
+        let references = self.doc.get_or_insert_map("references");
+        let txn = self.doc.transact();
+        match flatten::any_to_json(&references.to_json(&txn)) {
+            Value::Object(m) => m,
+            _ => serde_json::Map::new(),
+        }
+    }
+
+    /// The `referenceOrder` array as a list of reference ids (display order).
+    pub fn reference_order(&self) -> Vec<String> {
+        let order = self.doc.get_or_insert_array("referenceOrder");
+        let txn = self.doc.transact();
+        order
+            .iter(&txn)
+            .filter_map(|o| match o {
+                yrs::Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The active citation style from `metadata.citationStyle`, if set.
+    pub fn citation_style(&self) -> Option<String> {
+        let metadata = self.doc.get_or_insert_map("metadata");
+        let txn = self.doc.transact();
+        match metadata.get(&txn, "citationStyle") {
+            Some(yrs::Out::Any(Any::String(s))) => Some(s.to_string()),
+            _ => None,
+        }
+    }
+
+    /// Insert reference(s) into the live `references` `Y.Map` and append any new
+    /// ids to `referenceOrder`, in one transaction (INVARIANT A: strictly
+    /// per-item `set` — never a whole-map rewrite, so a concurrent writer's
+    /// not-yet-observed ref can't be wiped). An id already present is overwritten
+    /// (LWW, same as a re-add) without a duplicate `referenceOrder` entry. Returns
+    /// the framed CRDT delta to broadcast; marks dirty. The caller dedups against
+    /// [`references_json`] before calling.
+    pub fn insert_references(&self, items: &[(String, Value)]) -> Vec<u8> {
+        let references = self.doc.get_or_insert_map("references");
+        let order = self.doc.get_or_insert_array("referenceOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        let existing: std::collections::HashSet<String> = order
+            .iter(&txn)
+            .filter_map(|o| match o {
+                yrs::Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect();
+        for (id, item) in items {
+            references.insert(&mut txn, id.clone(), hydration::json_to_any(item));
+            if !existing.contains(id) {
+                order.push_back(&mut txn, Any::String(id.clone().into()));
+            }
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
     }
 
     /// Clear the live `prose:<page_id>` fragment to empty (used by
@@ -690,10 +769,10 @@ impl DocRegistry {
 
 #[cfg(test)]
 mod tests {
-    use super::{binary, DocHandle, DocRegistry};
+    use super::{binary, hydration, DocHandle, DocRegistry};
     use serde_json::json;
     use std::sync::Arc;
-    use yrs::{Doc, GetString, Map, Text, Transact};
+    use yrs::{Any, Array, Doc, GetString, Map, ReadTxn, Text, Transact};
 
     use crate::server::protocol::{DocId, WorkspaceId};
 
@@ -1034,5 +1113,112 @@ mod tests {
         reg.evict(&ws, &doc);
         assert!(reg.is_empty());
         assert!(reg.get(&ws, &doc).is_none());
+    }
+
+    // ---- JP-89: reference library as a shared type ----
+
+    fn empty_lib_json(version: u64) -> serde_json::Value {
+        json!({
+            "id": "d", "serverVersion": version, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}}
+        })
+    }
+
+    #[test]
+    fn references_round_trip_through_hydrate_and_flatten() {
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}},
+            "references": {
+                "items": {"knuth1997": {"id": "knuth1997", "type": "book"}},
+                "itemOrder": ["knuth1997"], "style": "mla"
+            }
+        });
+        let handle = DocHandle::hydrate(&json, None, false);
+        assert!(handle.references_json().contains_key("knuth1997"));
+        assert_eq!(handle.reference_order(), vec!["knuth1997".to_string()]);
+        assert_eq!(handle.citation_style().as_deref(), Some("mla"));
+
+        let mut out = json.clone();
+        assert!(handle.flatten_into(&mut out));
+        assert_eq!(out["references"]["itemOrder"], json!(["knuth1997"]));
+        assert_eq!(out["references"]["style"], json!("mla"));
+    }
+
+    #[test]
+    fn concurrent_mcp_and_author_adds_both_survive() {
+        use yrs::updates::decoder::Decode;
+        use yrs::{StateVector, Update};
+
+        // Resident doc, empty library. Capture the shared base BEFORE either add.
+        let handle = DocHandle::hydrate(&empty_lib_json(1), None, false);
+        let base = handle
+            .doc
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+
+        // A "client" cloned from the same base — it has NOT seen the MCP add.
+        let client = binary::doc_from_update(&base).unwrap();
+
+        // MCP add (id A) lands on the authoritative Y.Doc (per-item set).
+        handle.insert_references(&[("refA".to_string(), json!({"id": "refA", "type": "book"}))]);
+
+        // Concurrently, the client adds a DIFFERENT ref (id B) to its own copy.
+        {
+            let refs = client.get_or_insert_map("references");
+            let order = client.get_or_insert_array("referenceOrder");
+            let mut txn = client.transact_mut();
+            refs.insert(&mut txn, "refB", hydration::json_to_any(&json!({"id": "refB", "type": "article-journal"})));
+            order.push_back(&mut txn, Any::String("refB".into()));
+        }
+
+        // The client's update flows to the relay and merges into the authoritative doc.
+        let client_update = client
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        {
+            let mut txn = handle.doc.transact_mut();
+            txn.apply_update(Update::decode_v1(&client_update).unwrap()).unwrap();
+        }
+
+        // BOTH survive — no clobber on simultaneous add (the user's headline concern).
+        let merged = handle.references_json();
+        assert!(merged.contains_key("refA"), "MCP-added ref survived: {merged:?}");
+        assert!(merged.contains_key("refB"), "author-added ref survived: {merged:?}");
+        let order = handle.reference_order();
+        assert!(order.contains(&"refA".to_string()) && order.contains(&"refB".to_string()));
+
+        // And flatten emits both.
+        let mut out = empty_lib_json(1);
+        assert!(handle.flatten_into(&mut out));
+        let items = out["references"]["items"].as_object().unwrap();
+        assert!(items.contains_key("refA") && items.contains_key("refB"));
+    }
+
+    #[test]
+    fn binary_backstop_backfills_references_without_wiping() {
+        use yrs::Map;
+        // A binary sidecar predating the feature: has shapes, NO references map.
+        let bin = {
+            let doc = Doc::new();
+            let shapes = doc.get_or_insert_map("shapes");
+            let mut txn = doc.transact_mut();
+            shapes.insert(&mut txn, "s1", Any::String("rect".into()));
+            drop(txn);
+            binary::encode_snapshot(9, &doc)
+        };
+        // JSON (lower version → binary wins) DOES carry a library.
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {"s1": {"id": "s1"}}, "shapeOrder": ["s1"]}},
+            "references": {"items": {"k": {"id": "k", "type": "book"}}, "itemOrder": ["k"]}
+        });
+        let handle = DocHandle::hydrate(&json, Some(&bin), true);
+        // Backstop seeded the library into the Y.Doc (would otherwise be empty →
+        // flatten would wipe the JSON's refs).
+        assert!(handle.references_json().contains_key("k"), "references backfilled from JSON");
+        let mut out = json.clone();
+        assert!(handle.flatten_into(&mut out));
+        assert_eq!(out["references"]["itemOrder"], json!(["k"]));
     }
 }

--- a/src/collaboration/YjsDocument.references.test.ts
+++ b/src/collaboration/YjsDocument.references.test.ts
@@ -1,0 +1,105 @@
+/**
+ * JP-89 — reference library as a Y.Doc shared type. Asserts the per-item
+ * `references` Y.Map + `referenceOrder` Y.Array round-trip, and — the headline
+ * guarantee — that a concurrent MCP-style add and author-style add merge instead
+ * of clobbering (the client-side mirror of the relay's concurrency test).
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+import type { CSLItem } from '../types/Citation';
+
+function ref(id: string, doi?: string): CSLItem {
+  return { id, type: 'book', title: id, ...(doi ? { DOI: doi } : {}) } as CSLItem;
+}
+
+describe('YjsDocument references (JP-89)', () => {
+  it('setReference stores per-item + appends order; getReferenceLibrary merges', () => {
+    const doc = new YjsDocument();
+    doc.setReference(ref('knuth1997'));
+    doc.setReference(ref('shannon'));
+    doc.setReferenceStyle('mla');
+
+    const lib = doc.getReferenceLibrary();
+    expect(Object.keys(lib.items).sort()).toEqual(['knuth1997', 'shannon']);
+    expect(lib.itemOrder).toEqual(['knuth1997', 'shannon']);
+    expect(lib.style).toBe('mla');
+  });
+
+  it('re-setting an existing id does not duplicate the order entry', () => {
+    const doc = new YjsDocument();
+    doc.setReference(ref('a'));
+    doc.setReference({ ...ref('a'), title: 'updated' } as CSLItem);
+    const lib = doc.getReferenceLibrary();
+    expect(lib.itemOrder).toEqual(['a']);
+    expect(lib.items['a']?.title).toBe('updated');
+  });
+
+  it('deleteReference removes from the map and the order', () => {
+    const doc = new YjsDocument();
+    doc.setReference(ref('a'));
+    doc.setReference(ref('b'));
+    doc.deleteReference('a');
+    const lib = doc.getReferenceLibrary();
+    expect(lib.items['a']).toBeUndefined();
+    expect(lib.itemOrder).toEqual(['b']);
+  });
+
+  it('getReferenceLibrary drops order ids with no item and appends unordered items', () => {
+    const doc = new YjsDocument();
+    // Simulate a stale/duplicated order entry + an item missing from order.
+    doc.getDoc().transact(() => {
+      doc.getDoc().getMap('references').set('present', ref('present'));
+      const order = doc.getDoc().getArray<string>('referenceOrder');
+      order.push(['ghost', 'present', 'present']); // ghost has no item; dup id
+    });
+    const lib = doc.getReferenceLibrary();
+    expect(lib.itemOrder).toEqual(['present']);
+  });
+
+  it('concurrent MCP-style add and author add BOTH survive (no clobber)', () => {
+    // Two docs sharing a base, each adds a DIFFERENT ref without seeing the other.
+    const relay = new YjsDocument();
+    const client = new YjsDocument();
+
+    // Sync the (empty) base both ways so they share history.
+    Y.applyUpdate(client.getDoc(), Y.encodeStateAsUpdate(relay.getDoc()));
+
+    // MCP-style add on the relay; author-style add on the client — concurrently.
+    relay.setReference(ref('refA', '10.1/a'));
+    client.setReference(ref('refB', '10.1/b'));
+
+    // Exchange updates (merge both directions, as the relay rebroadcast would).
+    const relayUpdate = Y.encodeStateAsUpdate(relay.getDoc());
+    const clientUpdate = Y.encodeStateAsUpdate(client.getDoc());
+    Y.applyUpdate(client.getDoc(), relayUpdate);
+    Y.applyUpdate(relay.getDoc(), clientUpdate);
+
+    for (const doc of [relay, client]) {
+      const lib = doc.getReferenceLibrary();
+      expect(Object.keys(lib.items).sort()).toEqual(['refA', 'refB']);
+      expect([...lib.itemOrder].sort()).toEqual(['refA', 'refB']);
+    }
+  });
+
+  it('onReferenceChange fires for a remote update, not for a local write', () => {
+    const local = new YjsDocument();
+    const remote = new YjsDocument();
+    Y.applyUpdate(remote.getDoc(), Y.encodeStateAsUpdate(local.getDoc()));
+
+    let fired = 0;
+    local.onReferenceChange(() => {
+      fired += 1;
+    });
+
+    // Local write must NOT fire the remote callback (origin === this).
+    local.setReference(ref('local'));
+    expect(fired).toBe(0);
+
+    // A remote peer's add, applied as an external update, fires it.
+    remote.setReference(ref('fromRemote'));
+    Y.applyUpdate(local.getDoc(), Y.encodeStateAsUpdate(remote.getDoc()));
+    expect(fired).toBeGreaterThan(0);
+    expect(local.getReferenceLibrary().items['fromRemote']).toBeDefined();
+  });
+});

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -20,6 +20,7 @@ import * as Y from 'yjs';
 import { yXmlFragmentToProseMirrorRootNode, updateYFragment } from 'y-prosemirror';
 import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
+import type { CSLItem, CitationStyle, ReferenceLibrary } from '../types/Citation';
 import { getProseSchema } from './proseSchema';
 
 /**
@@ -51,6 +52,14 @@ export type OrderChangeCallback = (order: string[]) => void;
 export type MetadataChangeCallback = (metadata: YjsDocumentMetadata) => void;
 
 /**
+ * Callback for when the reference library changes from remote updates (JP-89).
+ * Coarse by design (no per-item args): the binding bulk-reloads `referenceStore`
+ * from {@link YjsDocument.getReferenceLibrary} — the merged map snapshot — which
+ * is what keeps a simultaneous MCP+author add from clobbering (INVARIANT B).
+ */
+export type ReferenceChangeCallback = () => void;
+
+/**
  * YjsDocument wraps a Y.Doc for collaborative shape editing.
  *
  * Usage:
@@ -75,10 +84,16 @@ export class YjsDocument {
   private shapes: Y.Map<Shape>;
   private shapeOrder: Y.Array<string>;
   private metadata: Y.Map<unknown>;
+  // JP-89: the reference library as shared types — `references` keyed by id
+  // (per-item merge, like `shapes`) + `referenceOrder` (display order). The
+  // active citation style lives in `metadata` under `citationStyle`.
+  private references: Y.Map<CSLItem>;
+  private referenceOrder: Y.Array<string>;
 
   private shapeChangeCallbacks: Set<ShapeChangeCallback> = new Set();
   private orderChangeCallbacks: Set<OrderChangeCallback> = new Set();
   private metadataChangeCallbacks: Set<MetadataChangeCallback> = new Set();
+  private referenceChangeCallbacks: Set<ReferenceChangeCallback> = new Set();
 
   private isLocalUpdate = false;
 
@@ -99,6 +114,8 @@ export class YjsDocument {
     this.shapes = this.doc.getMap('shapes');
     this.shapeOrder = this.doc.getArray('shapeOrder');
     this.metadata = this.doc.getMap('metadata');
+    this.references = this.doc.getMap('references');
+    this.referenceOrder = this.doc.getArray('referenceOrder');
 
     // Set up observers
     this.setupObservers();
@@ -237,6 +254,74 @@ export class YjsDocument {
     });
   }
 
+  // ============ References (JP-89) — local to remote ============
+
+  /**
+   * Set or update one reference (local change → broadcast to peers). INVARIANT A:
+   * a strictly per-item `set` (+ append the id to `referenceOrder` if new) — never
+   * a whole-map rewrite, so a concurrent writer's not-yet-observed ref can't be
+   * wiped.
+   */
+  setReference(item: CSLItem): void {
+    this.withLocalUpdate(() => {
+      this.references.set(item.id, JSON.parse(JSON.stringify(item)));
+      if (!this.referenceOrder.toArray().includes(item.id)) {
+        this.referenceOrder.push([item.id]);
+      }
+    });
+  }
+
+  /**
+   * Delete a reference by id (per-item `delete` + drop it from `referenceOrder`).
+   */
+  deleteReference(id: string): void {
+    this.withLocalUpdate(() => {
+      this.references.delete(id);
+      const idx = this.referenceOrder.toArray().indexOf(id);
+      if (idx >= 0) this.referenceOrder.delete(idx, 1);
+    });
+  }
+
+  /**
+   * Set the active citation style (stored in `metadata.citationStyle`).
+   */
+  setReferenceStyle(style: CitationStyle): void {
+    this.withLocalUpdate(() => {
+      this.metadata.set('citationStyle', style);
+    });
+  }
+
+  /**
+   * The merged reference library as a {@link ReferenceLibrary} snapshot —
+   * `items` (id → CSLItem), a de-duplicated `itemOrder` (filtered to existing
+   * items, with any unordered items appended), and the active `style`. The
+   * binding bulk-reloads `referenceStore` from this on any remote change.
+   */
+  getReferenceLibrary(): ReferenceLibrary {
+    const items: Record<string, CSLItem> = {};
+    this.references.forEach((item, id) => {
+      items[id] = item;
+    });
+    const itemOrder: string[] = [];
+    const seen = new Set<string>();
+    for (const id of this.referenceOrder.toArray()) {
+      if (items[id] && !seen.has(id)) {
+        itemOrder.push(id);
+        seen.add(id);
+      }
+    }
+    for (const id of Object.keys(items)) {
+      if (!seen.has(id)) {
+        itemOrder.push(id);
+        seen.add(id);
+      }
+    }
+    const rawStyle = this.metadata.get('citationStyle');
+    const lib: ReferenceLibrary = { items, itemOrder };
+    if (typeof rawStyle === 'string') lib.style = rawStyle as CitationStyle;
+    return lib;
+  }
+
   // ============ Remote to Local Sync ============
 
   /**
@@ -261,6 +346,15 @@ export class YjsDocument {
   onMetadataChange(callback: MetadataChangeCallback): () => void {
     this.metadataChangeCallbacks.add(callback);
     return () => this.metadataChangeCallbacks.delete(callback);
+  }
+
+  /**
+   * Subscribe to reference-library changes from remote peers (JP-89). Fires on
+   * any `references` / `referenceOrder` / `metadata.citationStyle` change.
+   */
+  onReferenceChange(callback: ReferenceChangeCallback): () => void {
+    this.referenceChangeCallbacks.add(callback);
+    return () => this.referenceChangeCallbacks.delete(callback);
   }
 
   // ============ State Access ============
@@ -368,6 +462,9 @@ export class YjsDocument {
     this.shapes.unobserve(this.handleShapeChange);
     this.shapeOrder.unobserve(this.handleOrderChange);
     this.metadata.unobserve(this.handleMetadataChange);
+    this.references.unobserve(this.handleReferenceChange);
+    this.referenceOrder.unobserve(this.handleReferenceChange);
+    this.metadata.unobserve(this.handleReferenceMetaChange);
     this.doc.destroy();
   }
 
@@ -382,6 +479,12 @@ export class YjsDocument {
 
     // Observe metadata changes
     this.metadata.observe(this.handleMetadataChange);
+
+    // JP-89: observe reference-library changes (map + order), and citation-style
+    // changes on the metadata map (a second observer — both fire independently).
+    this.references.observe(this.handleReferenceChange);
+    this.referenceOrder.observe(this.handleReferenceChange);
+    this.metadata.observe(this.handleReferenceMetaChange);
   }
 
   private handleShapeChange = (event: Y.YMapEvent<Shape>): void => {
@@ -430,6 +533,25 @@ export class YjsDocument {
 
     const metadata = this.getMetadata();
     this.metadataChangeCallbacks.forEach((cb) => cb(metadata));
+  };
+
+  // JP-89: a remote change to `references` or `referenceOrder` → fire the coarse
+  // reference callback (the binding bulk-reloads from the merged snapshot).
+  private handleReferenceChange = (
+    event: Y.YMapEvent<CSLItem> | Y.YArrayEvent<string>
+  ): void => {
+    if (this.isLocalUpdate || event.transaction.origin === this) return;
+    this.referenceChangeCallbacks.forEach((cb) => cb());
+  };
+
+  // JP-89: a remote `metadata.citationStyle` change also drives a reference
+  // reload (the library snapshot includes the active style). Gated to that key so
+  // an unrelated metadata edit (e.g. a rename) doesn't churn the library.
+  private handleReferenceMetaChange = (event: Y.YMapEvent<unknown>): void => {
+    if (this.isLocalUpdate || event.transaction.origin === this) return;
+    if (event.changes.keys.has('citationStyle')) {
+      this.referenceChangeCallbacks.forEach((cb) => cb());
+    }
   };
 
   /**

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -41,6 +41,7 @@ import { isRemoteDocument } from '../types/DocumentRegistry';
 import { mutateDocument } from '../store/writeProvenance';
 import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
+import type { CSLItem, CitationStyle } from '../types/Citation';
 import type { DocEvent } from './protocol';
 import { isUnknownDocError } from './protocol';
 import { throttle } from '../utils/requestUtils';
@@ -141,6 +142,12 @@ interface CollaborationActions {
   syncDeleteShape: (shapeId: string) => void;
   /** Sync shape order to remote peers */
   syncShapeOrder: (order: string[]) => void;
+  /** Sync a reference add/update to peers via the `references` Y.Map (JP-89). */
+  syncReference: (item: CSLItem) => void;
+  /** Sync a reference deletion to peers. */
+  syncDeleteReference: (id: string) => void;
+  /** Sync the active citation style to peers (`metadata.citationStyle`). */
+  syncReferenceStyle: (style: CitationStyle) => void;
   /**
    * Sync the document name (a rename) to peers via the Y.Doc `metadata` map
    * (CRDT-native rename, so it propagates + persists like shapes rather than
@@ -627,6 +634,24 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     syncShapeOrder: (order: string[]) => {
       if (yjsDoc) {
         yjsDoc.setShapeOrder(order);
+      }
+    },
+
+    syncReference: (item: CSLItem) => {
+      if (yjsDoc) {
+        yjsDoc.setReference(item);
+      }
+    },
+
+    syncDeleteReference: (id: string) => {
+      if (yjsDoc) {
+        yjsDoc.deleteReference(id);
+      }
+    },
+
+    syncReferenceStyle: (style: CitationStyle) => {
+      if (yjsDoc) {
+        yjsDoc.setReferenceStyle(style);
       }
     },
 

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -34,6 +34,12 @@ function makeMockYjs() {
     }),
     onOrderChange: vi.fn(() => () => {}),
     onMetadataChange: vi.fn(() => () => {}),
+    // JP-89 reference-library binding surface.
+    onReferenceChange: vi.fn(() => () => {}),
+    getReferenceLibrary: vi.fn(() => ({ items: {}, itemOrder: [] })),
+    setReference: vi.fn(),
+    deleteReference: vi.fn(),
+    setReferenceStyle: vi.fn(),
   };
 }
 

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -17,6 +17,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useDocumentStore } from '../store/documentStore';
+import { useReferenceStore } from '../store/referenceStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
@@ -44,6 +45,9 @@ export function useCollaborationSync(): void {
   const syncShape = useCollaborationStore((state) => state.syncShape);
   const syncDeleteShape = useCollaborationStore((state) => state.syncDeleteShape);
   const syncShapeOrder = useCollaborationStore((state) => state.syncShapeOrder);
+  const syncReference = useCollaborationStore((state) => state.syncReference);
+  const syncDeleteReference = useCollaborationStore((state) => state.syncDeleteReference);
+  const syncReferenceStyle = useCollaborationStore((state) => state.syncReferenceStyle);
 
   // Track if we've initialized for this session
   const initializedRef = useRef(false);
@@ -102,10 +106,20 @@ export function useCollaborationSync(): void {
       if (docId && name) applyRemoteDocumentName(docId, name);
     });
 
+    // Handle remote reference-library changes (JP-89). Coarse bulk reload from
+    // the merged Y.Doc snapshot — `runWithProvenance('remote-apply')` so the
+    // local referenceStore→Y.Doc subscription below skips it (no echo loop).
+    const unsubRefs = yjsDoc.onReferenceChange(() => {
+      runWithProvenance('remote-apply', () => {
+        useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
+      });
+    });
+
     return () => {
       unsubShapes();
       unsubOrder();
       unsubMeta();
+      unsubRefs();
     };
   }, [isActive, getYjsDocument, sessionEpoch]);
 
@@ -141,6 +155,8 @@ export function useCollaborationSync(): void {
         if (crdtOrder.length > 0) {
           store.reorderShapes(crdtOrder);
         }
+        // JP-89: adopt the authoritative reference library too.
+        useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
       });
       // Adopt the relay's authoritative document name too (CRDT-native rename),
       // so a joining client picks up a rename made before it connected.
@@ -165,6 +181,9 @@ export function useCollaborationSync(): void {
       // (`!hasProvider`) never reaches here either (isSynced is false).
       runWithProvenance('remote-apply', () => {
         useDocumentStore.getState().clear();
+        // JP-89: a doc can be empty of shapes but carry a reference library
+        // (prose + citations, no diagram) — adopt it here too.
+        useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
       });
       initializedRef.current = true;
     }
@@ -274,6 +293,40 @@ export function useCollaborationSync(): void {
 
     return unsubscribe;
   }, [isActive, syncShape, syncDeleteShape, syncShapeOrder]);
+
+  // Subscribe to local reference-library changes and sync to the CRDT (JP-89).
+  // Mirrors the shape subscription: same provenance + autosave-suppression +
+  // initialized gates, and a per-item diff (INVARIANT A — `set`/`delete` by id,
+  // never a whole-map rewrite) so a concurrent MCP/peer add is never clobbered.
+  useEffect(() => {
+    if (!isActive) return undefined;
+
+    const unsubscribe = useReferenceStore.subscribe((state, prevState) => {
+      const provenance = getProvenance();
+      if (provenance === 'remote-apply' || provenance === 'load') return;
+      if (isAutoSaveSuppressed()) return;
+      if (!useCollaborationStore.getState().isActive) return;
+      if (!initializedRef.current) return;
+
+      const curIds = new Set(Object.keys(state.items));
+      const prevIds = new Set(Object.keys(prevState.items));
+
+      // Added or updated items → per-item set.
+      for (const id of curIds) {
+        const cur = state.items[id];
+        if (!cur) continue;
+        if (!prevIds.has(id) || cur !== prevState.items[id]) syncReference(cur);
+      }
+      // Deleted items → per-item delete.
+      for (const id of prevIds) {
+        if (!curIds.has(id)) syncDeleteReference(id);
+      }
+      // Active style change.
+      if (state.activeStyle !== prevState.activeStyle) syncReferenceStyle(state.activeStyle);
+    });
+
+    return unsubscribe;
+  }, [isActive, syncReference, syncDeleteReference, syncReferenceStyle]);
 }
 
 /**


### PR DESCRIPTION
**Staging deploy for E2E** of the reference-library-as-shared-type fix (code review: #173 → master).

Fixes both things you hit: MCP/peer ref adds now sync live, and a simultaneous MCP+author add can't clobber.

## E2E checklist
1. Open a doc in the PWA so it's **resident**.
2. **Live add:** MCP `add_reference` by DOI → the ref appears in the manager + its citation/bibliography resolves **without a reload**.
3. **Survives autosave/reload:** keep editing prose, reload → the MCP-added refs are still there (the earlier clobber is gone).
4. **The concurrency case (your major concern):** at (nearly) the same moment, add one ref in the editor's reference manager **and** fire an MCP `add_reference` for a *different* DOI → **both** end up in the library + bibliography, on both the editor and via `list_references`.
5. **Delete:** remove a ref in the editor → it disappears (and via `list_references`); MCP `list_references` reflects it.
6. **Two browsers:** add a ref in one → it appears in the other live.

Assisted-by: Opus 4.8