### PR TITLE
JP-89: citation delight — @cite, cited-only bibliography, paste-DOI, hover card

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -72,6 +72,7 @@ export default withMermaid(
               { text: 'State Management', link: '/developer/state-management' },
               { text: 'Creating Custom Shapes', link: '/developer/creating-shapes' },
               { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
+              { text: 'Creating Prose Helpers', link: '/developer/creating-prose-helpers' },
               { text: 'Shape Properties', link: '/developer/shape-properties' },
               { text: 'Plugin Development', link: '/developer/plugin-development' },
               { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },

--- a/docs-site/developer/creating-prose-helpers.md
+++ b/docs-site/developer/creating-prose-helpers.md
@@ -1,0 +1,177 @@
+# Creating Prose Helpers
+
+A **prose helper** is a custom Tiptap/ProseMirror node that lives in the written
+body (not the canvas) and renders something richer than text — a **citation**, a
+**bibliography**, **math**, a **callout**, a **footnote**, an embed. Citations
+were the first; this guide is the paved path for the next one.
+
+The hard part isn't the Tiptap node — it's making it survive everywhere a
+document goes:
+
+```mermaid
+flowchart LR
+  A["Editor node\n(Tiptap)"] -->|getHTML| B["Local persistence\n(richText JSON)"]
+  A -->|y-prosemirror| C["Collab Y.Doc\n(relay round-trip)"]
+  A --> D["PDF / MCP get_prose"]
+```
+
+Each arrow broke at least once while citations were built. The kit below is what
+makes them not break for the next helper.
+
+## The prose-helper kit
+
+| Layer | What it gives you | Where |
+|---|---|---|
+| **Serialization discipline** | A self-describing node that survives reload in WebKitGTK/Tauri (jsdom tests alone miss this) | the rules below + `src/tiptap/CitationExtension.ts` as the worked example |
+| **Projection foundation** | Derived/async-rendered content that doesn't corrupt local persistence | `src/tiptap/proseProjection.ts` |
+| **Relay round-trip** | The node survives the collaborative Y.Doc (HTML → Y.Doc → HTML) | `relay/src/sync/prose_schema.rs` (`CUSTOM_PROSE_NODES`), `prose_parse.rs`, `prose_html.rs`, `hydration.rs` |
+| **Export** | Renders in PDF + MCP `get_prose` | `src/utils/pdfExportUtils.ts` |
+
+## Pick your category first
+
+This decides the effort:
+
+- **Self-contained** (math, callouts, footnotes, embeds) — *all* the helper's
+  data lives in its own node attributes/content. → You need only the four layers
+  above. This is the common case and is cheap.
+- **Data-backed** (citations point at a shared reference *library*) — the node
+  references out-of-band document data. → You **also** need a **Y.Doc shared
+  type** for that data, or it won't sync in collab and concurrent edits will
+  clobber. See [Data-backed helpers](#data-backed-helpers). Most helpers are
+  *not* this.
+
+---
+
+## Building a self-contained helper
+
+### 1. Define the node (serialization rules)
+
+Custom prose nodes must serialize **robustly** or they vanish on reload in
+WebKit/Tauri (they survive jsdom, so unit tests alone won't catch it). The rules,
+learned the hard way:
+
+1. **Store state in `data-*` attributes**, each with its own `parseHTML` /
+   `renderHTML` in `addAttributes` — no bare auto-rendered attrs.
+2. **Never name an attribute `content`** — it's a reserved ProseMirror schema
+   keyword.
+3. **Array-form `renderHTML`** (`['span', {...}]`), never a
+   `document.createElement` DOM node (fragile across serializers).
+4. **Childless atoms** (`atom: true`) — don't nest block children in a leaf's
+   DOM; cache any rendered HTML in a `data-*` attr instead.
+5. **Normalize newlines out of attribute values.**
+
+Register the node in `sharedProseExtensions` (`src/ui/TiptapEditor.tsx`) so both
+the standalone and collaborative editors load it.
+
+A permanent `getHTML → setContent` round-trip test guards all of the above —
+copy the citation node's test.
+
+### 2. Projection (only if the rendered content is derived)
+
+If your node renders something computed asynchronously (a formatted citation, a
+KaTeX render), it caches that output back into a `data-*` attr so static
+consumers (PDF/MCP/offline) show it. **That write-back is NOT a user edit** —
+treat it as a projection or it drives autosave and corrupts local persistence
+(the slice-5.5 bug).
+
+Use `src/tiptap/proseProjection.ts`:
+
+- Tag the write-back transaction: `tr.setMeta(PROSE_PROJECTION_META, true)` (plus
+  `tr.setMeta('addToHistory', false)`).
+- In the editor's `onUpdate`, route projection transactions through
+  `richTextStore.setContentSilently` (a non-dirtying mirror) instead of
+  `setContent`. **Do not** wrap the write-back in `withAutoSaveSuppressed` — that
+  latches `isDirty` and swallows the *next* real edit's autosave.
+- Bail the write-back if `isAutoSaveSuppressed()` (no dispatch during
+  load/new/switch).
+
+### 3. Relay round-trip (so it survives collab)
+
+The relay's HTML↔Y.Doc prose pipeline only knows a fixed node set; an unknown
+node is **dropped** (inline → unwrapped to text; block → unwrapped to children).
+`<img>` is the precedent for a void-with-attrs node that survives. Mirror it:
+
+1. **`relay/src/sync/prose_schema.rs`** — add a row to `CUSTOM_PROSE_NODES`:
+   `(pm_type, html_tag, marker_data_attr)`. This is the single source of truth
+   for the three coordinates; the parser uses `custom_node_pm()` to detect it.
+2. **`prose_parse.rs`** (HTML → PM) — recognize your `tag[data-marker]` before
+   the unknown-node fallback and emit a `PmNode` with the PM attr names (camelCase
+   — they must match the editor node's `addAttributes` keys, *not* the `data-*`
+   names). Inline nodes go in `collect_inline`; block nodes in `map_block_element`.
+3. **`prose_html.rs`** (PM → HTML) — add a `block_for` arm returning
+   `Block::Void(your_html(el, txn))`; write attrs in a **fixed order**, escaped
+   with `escape_attr`. Model it on `citation_html` / `image_html`.
+4. **`hydration.rs`** — add your node type to `block_has_substance` so a block
+   that's childless-but-meaningful (or a paragraph containing only your inline
+   atom) seeds instead of being mistaken for the empty-page placeholder.
+
+No `PROTOCOL_VERSION` bump and no document migration — this is purely additive
+(the frames stay lib0-v1 sync; an older client just doesn't round-trip the new
+node). Add a full **HTML → `html_to_blocks` → `build_prose_node` →
+`fragment_to_html`** round-trip test — that's the regression that proves it
+survives the collaborative pipeline, not just jsdom.
+
+::: tip
+The parse/serialize handlers are explicit per node today (the two citation nodes
+differ in shape: inline-atom-with-text-child vs childless block). When a third or
+fourth node makes them feel repetitive, data-drive them off `CUSTOM_PROSE_NODES`
+— it's a clean, low-risk refactor. `mathInline`/`mathBlock` is the named next
+entry.
+:::
+
+### 4. Export
+
+Register a renderer in `src/utils/pdfExportUtils.ts` (`pdfNodeRenderers.register`
++ handle the node in `extractSegments`) so the node appears in PDF export and is
+carried through MCP `get_prose`.
+
+---
+
+## Data-backed helpers
+
+If your node references **document-level data outside the node** (as a citation
+references the shared reference *library*), that data must become a **Y.Doc
+shared type** too — otherwise it won't sync in collaboration and concurrent edits
+will clobber it a whole field at a time. The reference library is the worked
+example (`references` `Y.Map` + `referenceOrder` `Y.Array`):
+
+- **Relay** owns it: seed on hydrate (`hydration.rs`, idempotent + run on the
+  binary-sidecar backstop path too), re-assert on flatten (`flatten.rs`), and let
+  MCP writes hit the live Y.Doc when resident.
+- **Client** binds it: `src/collaboration/YjsDocument.ts` (shared-type accessors
+  + a coarse change observer) ↔ the feature store, wired in
+  `useCollaborationSync.ts` (remote → bulk-reload under
+  `runWithProvenance('remote-apply')`; local → per-item writes, provenance-gated).
+
+Two invariants make concurrent edits safe:
+
+- **Writes are strictly per-item** (`map.set`/`delete` by id) — never a whole-map
+  rewrite from a store snapshot (that wipes a concurrent writer's not-yet-seen
+  entry).
+- **Reads bulk-reload the *merged* map** — so the store (and any autosave) always
+  reflects every writer.
+
+## The hard rules (don't relearn these)
+
+- **A projection write-back is not a user edit.** Tag it; mirror it silently.
+  (Local-persistence corruption otherwise.)
+- **Serialize robustly** — `data-*` atoms, array `renderHTML`, childless, no
+  reserved attr names. (WebKit reload-vanish otherwise.)
+- **Round-trip through the relay** — unknown nodes are dropped on the collab
+  Y.Doc path. (Citations/bibliography degraded to plain text until this landed.)
+- **Out-of-band data needs a shared type.** (No live sync + concurrent-add
+  clobber otherwise.)
+
+## Checklist
+
+- [ ] Tiptap node, registered in `sharedProseExtensions`, follows the 5
+      serialization rules
+- [ ] `getHTML → setContent` round-trip test
+- [ ] (if derived) projection write-back via `PROSE_PROJECTION_META` +
+      `setContentSilently`
+- [ ] `CUSTOM_PROSE_NODES` row + `prose_parse` arm + `prose_html` arm +
+      `block_has_substance` entry
+- [ ] Relay HTML → Y.Doc → HTML round-trip test
+- [ ] PDF/`get_prose` renderer
+- [ ] (data-backed only) Y.Doc shared type + binding + the two invariants +
+      a concurrency test

--- a/docs-site/developer/creating-prose-helpers.md
+++ b/docs-site/developer/creating-prose-helpers.md
@@ -85,6 +85,16 @@ Use `src/tiptap/proseProjection.ts`:
 - Bail the write-back if `isAutoSaveSuppressed()` (no dispatch during
   load/new/switch).
 
+::: tip Deriving from *other* prose
+If the node's render depends on the rest of the document — the cited-only
+bibliography lists only the references whose `citationInline` nodes are present
+— subscribe to the editor's `update` event in the nodeView and **gate the
+re-render on a cheap derived key** (e.g. the sorted set of cited ids). The gate
+matters: your own projection write-back fires `update` too, so re-rendering
+unconditionally loops. Recompute the key, compare, and only re-render on a real
+change.
+:::
+
 ### 3. Relay round-trip (so it survives collab)
 
 The relay's HTML↔Y.Doc prose pipeline only knows a fixed node set; an unknown
@@ -104,6 +114,18 @@ node is **dropped** (inline → unwrapped to text; block → unwrapped to childr
 4. **`hydration.rs`** — add your node type to `block_has_substance` so a block
    that's childless-but-meaningful (or a paragraph containing only your inline
    atom) seeds instead of being mistaken for the empty-page placeholder.
+
+::: warning A new node attribute needs the relay round-trip to be durable in collab
+A custom attribute (beyond the ones already wired) survives local docs via
+`getHTML`/JSON and live collab via peer Y.Xml attribute sync — but the relay's
+HTML↔Y.Doc pipeline **drops attrs it doesn't serialize**, so a relay
+cold-rehydrate (eviction + rejoin, or a restart) resets the attr to its node
+default. Add it to `prose_html` + `prose_parse` (the steps above) to make it
+fully durable. A *view preference* whose default is the safe direction — the
+bibliography's `scope` resets to cited-only, which never hides a cited reference
+and loses no library data — can ship best-effort without the relay change; real
+content must round-trip.
+:::
 
 No `PROTOCOL_VERSION` bump and no document migration — this is purely additive
 (the frames stay lib0-v1 sync; an older client just doesn't round-trip the new

--- a/src/tiptap/CitationBibliographyFallback.test.ts
+++ b/src/tiptap/CitationBibliographyFallback.test.ts
@@ -58,4 +58,28 @@ describe('bibliography fallback when the formatter yields nothing', () => {
     editor.destroy();
     element.remove();
   });
+
+  it('inline citation degrades to a readable author-year, not the bare DOI', async () => {
+    // A DOI-resolved ref whose id IS the DOI — the exact "displays DOI URIs" case.
+    useReferenceStore.getState().addReference({
+      id: '10.1038/nphys1170',
+      type: 'article-journal',
+      title: 'Measured measurement',
+      author: [{ family: 'Aspelmeyer', given: 'Markus' }],
+      issued: { 'date-parts': [[2009]] },
+      DOI: '10.1038/nphys1170',
+    });
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({ element, extensions, content: '<p></p>' });
+    editor.commands.setCitation('10.1038/nphys1170');
+
+    const cite = () => element.querySelector('.citation-inline');
+    await waitFor(() => (cite()?.textContent ?? '').includes('Aspelmeyer'));
+    expect(cite()?.textContent).toBe('(Aspelmeyer, 2009)');
+    expect(cite()?.textContent).not.toContain('10.1038'); // never the bare DOI
+
+    editor.destroy();
+    element.remove();
+  });
 });

--- a/src/tiptap/CitationBibliographyFallback.test.ts
+++ b/src/tiptap/CitationBibliographyFallback.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Bibliography fallback (JP-89 delight follow-up).
+ *
+ * When the lazy CSL formatter is unavailable (failed dynamic import) or citeproc
+ * returns nothing, the bibliography must degrade to a dependency-free list built
+ * from `referencePreview` instead of showing an error box. Here the format
+ * module is mocked to return empty strings (the citeproc-produced-nothing case),
+ * scoped to this file so it doesn't affect the real-formatting tests.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+
+vi.mock('../services/citations/format', () => ({
+  formatBibliography: async () => '',
+  formatCitation: async () => '',
+  __resetCiteCacheForTests: () => {},
+}));
+
+import { CitationInline, Bibliography } from './CitationExtension';
+import { useReferenceStore } from '../store/referenceStore';
+import type { CSLItem } from '../types/Citation';
+
+const extensions = [StarterKit.configure({ history: false }), CitationInline, Bibliography];
+
+const smith: CSLItem = {
+  id: 'smith2020',
+  type: 'article-journal',
+  title: 'On the Behaviour of Things',
+  author: [{ family: 'Smith', given: 'Jane' }],
+  issued: { 'date-parts': [[2020]] },
+};
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+beforeEach(() => useReferenceStore.getState().clear());
+
+describe('bibliography fallback when the formatter yields nothing', () => {
+  it('renders a plain preview list instead of an error box', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({ element, extensions, content: '<p></p>' });
+    editor.commands.setCitation('smith2020'); // cited-only default → cite it first
+    editor.commands.insertBibliography();
+
+    const content = () => element.querySelector('.bibliography-content');
+    await waitFor(() => (content()?.textContent ?? '').includes('Smith'));
+    expect(content()?.textContent).toContain('Behaviour of Things'); // referencePreview
+    expect(content()?.textContent).not.toContain('Could not render');
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/CitationExtension.test.ts
+++ b/src/tiptap/CitationExtension.test.ts
@@ -125,6 +125,32 @@ describe('citation nodeView (live, store-reactive)', () => {
   });
 });
 
+describe('citation hover card (JP-89 delight slice)', () => {
+  it('shows a card with the reference on hover and hides it on leave', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020');
+
+    const cite = element.querySelector('.citation-inline') as HTMLElement;
+    expect(cite).not.toBeNull();
+
+    cite.dispatchEvent(new MouseEvent('mouseenter'));
+    // Card appears after the dwell delay, painted synchronously with the cheap
+    // preview text (no need to await the async CSL format).
+    await waitFor(() => {
+      const card = document.querySelector('.citation-card') as HTMLElement | null;
+      return !!card && card.style.display === 'block' && (card.textContent ?? '').includes('Smith');
+    });
+
+    cite.dispatchEvent(new MouseEvent('mouseleave'));
+    const card = document.querySelector('.citation-card') as HTMLElement | null;
+    expect(card?.style.display).toBe('none');
+
+    editor.destroy();
+    element.remove();
+  });
+});
+
 describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () => {
   it('caches the formatted citation into getHTML (refId + label)', async () => {
     useReferenceStore.getState().addReference(smith);

--- a/src/tiptap/CitationExtension.test.ts
+++ b/src/tiptap/CitationExtension.test.ts
@@ -111,8 +111,12 @@ describe('citation nodeView (live, store-reactive)', () => {
 
   it('bibliography renders entries and reacts to added references', async () => {
     const { editor, element } = makeEditor();
+    // Default scope is cited-only, so cite smith up front (ref not in the store
+    // yet → renders [?]); the bibliography lists it once the ref is added.
+    editor.commands.insertContent('Body text. ');
+    editor.commands.setCitation('smith2020');
     editor.commands.insertBibliography();
-    const bib = () => element.querySelector('.bibliography-block');
+    const bib = () => element.querySelector('.bibliography-content');
 
     await waitFor(() => (bib()?.textContent ?? '').includes('No references'));
 
@@ -151,6 +155,90 @@ describe('citation hover card (JP-89 delight slice)', () => {
   });
 });
 
+describe('cited-only bibliography (JP-89 delight slice)', () => {
+  const doe: CSLItem = {
+    id: 'doe2019',
+    type: 'book',
+    title: 'A Treatise',
+    author: [{ family: 'Doe', given: 'John' }],
+    issued: { 'date-parts': [[2019]] },
+  };
+
+  it('defaults to cited-only: lists a ref only once it is cited', async () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertContent('Body text. '); // non-empty para so the bib appends after it
+    editor.commands.insertBibliography();
+    const content = () => element.querySelector('.bibliography-content');
+
+    // Ref exists but is not cited → cited-only shows the empty-cited message.
+    await waitFor(() => (content()?.textContent ?? '').includes('No citations in this document'));
+
+    editor.commands.focus('start'); // caret into the paragraph (not on the bib node)
+    editor.commands.setCitation('smith2020');
+    await waitFor(() => (content()?.textContent ?? '').includes('Smith'));
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('the All toggle shows uncited references and persists data-scope', async () => {
+    useReferenceStore.getState().addReference(smith); // uncited
+    useReferenceStore.getState().addReference(doe); // uncited
+    const { editor, element } = makeEditor();
+    editor.commands.insertBibliography();
+    const content = () => element.querySelector('.bibliography-content');
+    await waitFor(() => (content()?.textContent ?? '').includes('No citations in this document'));
+
+    // Default scope emits no data-scope attr (clean serialization).
+    expect(editor.getHTML()).not.toContain('data-scope');
+
+    const allBtn = [...element.querySelectorAll('.bibliography-scope-btn')].find(
+      (b) => b.textContent === 'All references',
+    ) as HTMLButtonElement;
+    expect(allBtn).toBeTruthy();
+    allBtn.click();
+
+    await waitFor(() => (content()?.textContent ?? '').includes('Smith') && (content()?.textContent ?? '').includes('Doe'));
+    expect(editor.getHTML()).toContain('data-scope="all"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('round-trips the scope attr through getHTML → setContent', () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertBibliography();
+    // Force scope=all via a node-attr update (the toggle's effect).
+    let pos = -1;
+    editor.state.doc.descendants((n, p) => {
+      if (n.type.name === 'bibliography') pos = p;
+    });
+    editor.view.dispatch(
+      editor.state.tr.setNodeMarkup(pos, undefined, {
+        ...editor.state.doc.nodeAt(pos)!.attrs,
+        scope: 'all',
+      }),
+    );
+    const html = editor.getHTML();
+    expect(html).toContain('data-scope="all"');
+
+    const { editor: e2, element: el2 } = makeEditor();
+    e2.commands.setContent(html);
+    let scope: unknown = null;
+    e2.state.doc.descendants((n) => {
+      if (n.type.name === 'bibliography') scope = n.attrs['scope'];
+    });
+    expect(scope).toBe('all');
+
+    editor.destroy();
+    element.remove();
+    e2.destroy();
+    el2.remove();
+  });
+});
+
 describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () => {
   it('caches the formatted citation into getHTML (refId + label)', async () => {
     useReferenceStore.getState().addReference(smith);
@@ -174,6 +262,7 @@ describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () 
   it('caches the bibliography HTML into getHTML', async () => {
     useReferenceStore.getState().addReference(smith);
     const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020'); // cited-only default → cite it first
     editor.commands.insertBibliography();
 
     await waitFor(() => editor.getHTML().includes('Smith'));
@@ -191,6 +280,7 @@ describe('citation projection — getHTML self-contained (JP-89 slice 5.5)', () 
   it('survives a getHTML → setContent round-trip (bibliography node + cached html)', async () => {
     useReferenceStore.getState().addReference(smith);
     const { editor, element } = makeEditor();
+    editor.commands.setCitation('smith2020'); // cited-only default → cite it first
     editor.commands.insertBibliography();
     await waitFor(() => editor.getHTML().includes('Smith'));
     const html = editor.getHTML();

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -27,6 +27,7 @@ import { useReferenceStore } from '../store/referenceStore';
 import { referencePreview } from '../services/citations/preview';
 import { PROSE_PROJECTION_META } from './proseProjection';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { showCitationCard, hideCitationCard } from './citationHoverCard';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -191,6 +192,25 @@ export const CitationInline = Node.create<CitationOptions>({
       applyAttrs();
       render();
 
+      // Hover preview: after a short dwell, show a card with the full formatted
+      // reference (the bibliography-style entry). A small delay avoids flashing
+      // it while the pointer just passes over the citation.
+      let hoverTimer: number | undefined;
+      const onEnter = () => {
+        window.clearTimeout(hoverTimer);
+        hoverTimer = window.setTimeout(() => {
+          const state = useReferenceStore.getState();
+          const item = state.getReference(refId);
+          if (item) showCitationCard(dom, item, state.activeStyle);
+        }, 220);
+      };
+      const onLeave = () => {
+        window.clearTimeout(hoverTimer);
+        hideCitationCard();
+      };
+      dom.addEventListener('mouseenter', onEnter);
+      dom.addEventListener('mouseleave', onLeave);
+
       const unsubscribe = useReferenceStore.subscribe((state) => {
         if (state.getReference(refId) !== lastItem || state.activeStyle !== lastStyle) {
           render();
@@ -211,7 +231,13 @@ export const CitationInline = Node.create<CitationOptions>({
           }
           return true;
         },
-        destroy: () => unsubscribe(),
+        destroy: () => {
+          window.clearTimeout(hoverTimer);
+          hideCitationCard();
+          dom.removeEventListener('mouseenter', onEnter);
+          dom.removeEventListener('mouseleave', onLeave);
+          unsubscribe();
+        },
       };
     };
   },

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -22,6 +22,7 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import type { Node as PMNode } from '@tiptap/pm/model';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import { useReferenceStore } from '../store/referenceStore';
 import { referencePreview } from '../services/citations/preview';
@@ -255,9 +256,24 @@ export const CitationInline = Node.create<CitationOptions>({
   },
 });
 
+/** Collect the set of refIds actually cited (via inline citations) in `doc`. */
+function collectCitedRefIds(doc: PMNode): Set<string> {
+  const cited = new Set<string>();
+  doc.descendants((node) => {
+    if (node.type.name === 'citationInline') {
+      const id = node.attrs['refId'] as string;
+      if (id) cited.add(id);
+    }
+  });
+  return cited;
+}
+
 /**
- * Bibliography block — renders the document's full reference list in the active
- * style. Reads everything from the store (no node attributes).
+ * Bibliography block — renders the document's reference list in the active
+ * style. By default it lists only the references **actually cited** in the
+ * document (`scope: 'cited'`); a per-node toggle switches it to the full
+ * library (`scope: 'all'`). The reference data comes from the store; which
+ * subset to show is the node's only persisted attribute besides the cached HTML.
  */
 export const Bibliography = Node.create<CitationOptions>({
   name: 'bibliography',
@@ -272,13 +288,20 @@ export const Bibliography = Node.create<CitationOptions>({
   // attribute (NOT a node named `content` — that's a reserved ProseMirror schema
   // keyword — and NOT child markup, which forced a fragile DOM-node renderHTML).
   // The node serializes as a clean, childless `<div data-bibliography
-  // data-bib-html="…">` that round-trips losslessly everywhere (JP-89 5.5).
+  // data-bib-html="…" [data-scope]>` that round-trips losslessly everywhere
+  // (JP-89 5.5). `scope` defaults to 'cited', so the attr is only emitted for
+  // the 'all' opt-out — keeping the common serialization clean.
   addAttributes() {
     return {
       bibHtml: {
         default: '',
         parseHTML: (el: HTMLElement) => el.getAttribute('data-bib-html') ?? '',
         renderHTML: (attrs) => (attrs['bibHtml'] ? { 'data-bib-html': String(attrs['bibHtml']) } : {}),
+      },
+      scope: {
+        default: 'cited',
+        parseHTML: (el: HTMLElement) => (el.getAttribute('data-scope') === 'all' ? 'all' : 'cited'),
+        renderHTML: (attrs) => (attrs['scope'] === 'all' ? { 'data-scope': 'all' } : {}),
       },
     };
   },
@@ -306,14 +329,62 @@ export const Bibliography = Node.create<CitationOptions>({
       dom.setAttribute('data-bibliography', '');
       dom.className = 'bibliography-block';
       dom.contentEditable = 'false';
+
+      // The visible bibliography lives in `content`; an editable-only `header`
+      // hosts the cited-only / all toggle (chrome, never serialized). The static
+      // renderHTML stays a childless div — the header is nodeView-only.
+      const content = document.createElement('div');
+      content.className = 'bibliography-content';
       // Paint the cached bibliography HTML immediately (JP-89 5.5) so it shows on
       // reload without waiting on the async format chunk (offline-safe).
-      if (node.attrs['bibHtml']) dom.innerHTML = node.attrs['bibHtml'] as string;
+      if (node.attrs['bibHtml']) content.innerHTML = node.attrs['bibHtml'] as string;
+
+      let scope = (node.attrs['scope'] as 'cited' | 'all') ?? 'cited';
+
+      const setScope = (next: 'cited' | 'all') => {
+        const pos = typeof getPos === 'function' ? getPos() : undefined;
+        if (pos == null) return;
+        const cur = editor.state.doc.nodeAt(pos);
+        if (!cur || cur.type.name !== this.name || cur.attrs['scope'] === next) return;
+        // A genuine user choice (NOT a projection) — it should persist + sync.
+        editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, scope: next }));
+        editor.view.focus();
+      };
+
+      // Editable header with the scope toggle. View-only clients get no header.
+      const header = document.createElement('div');
+      header.className = 'bibliography-header';
+      const renderHeader = () => {
+        if (!editor.isEditable) {
+          header.style.display = 'none';
+          return;
+        }
+        header.replaceChildren();
+        const mkBtn = (label: string, value: 'cited' | 'all', title: string) => {
+          const b = document.createElement('button');
+          b.type = 'button';
+          b.textContent = label;
+          b.title = title;
+          b.className = scope === value ? 'bibliography-scope-btn is-active' : 'bibliography-scope-btn';
+          b.addEventListener('mousedown', (e) => e.preventDefault()); // keep selection
+          b.addEventListener('click', () => setScope(value));
+          return b;
+        };
+        const group = document.createElement('div');
+        group.className = 'bibliography-scope-toggle';
+        group.appendChild(mkBtn('Cited only', 'cited', 'Show only references cited in this document'));
+        group.appendChild(mkBtn('All references', 'all', 'Show the whole reference library'));
+        header.appendChild(group);
+      };
+
+      dom.appendChild(header);
+      dom.appendChild(content);
 
       let renderToken = 0;
       let lastItems: Record<string, CSLItem> | undefined;
       let lastOrderKey = '';
       let lastStyle: CitationStyle | undefined;
+      let lastCitedKey = '';
 
       // Persist the rendered bibliography HTML into the node's `bibHtml` attr so
       // non-editor consumers are self-contained. Same safety as CitationInline:
@@ -336,16 +407,26 @@ export const Bibliography = Node.create<CitationOptions>({
       };
 
       const render = () => {
+        renderHeader();
         const state = useReferenceStore.getState();
-        const items = state.listReferences();
+        const all = state.listReferences();
         const style = state.activeStyle;
         lastItems = state.items;
         lastOrderKey = state.itemOrder.join(',');
         lastStyle = style;
 
+        // In 'cited' scope, restrict to references actually cited in the prose.
+        const cited = collectCitedRefIds(editor.state.doc);
+        lastCitedKey = [...cited].sort().join(',');
+        const items = scope === 'all' ? all : all.filter((r) => cited.has(r.id));
+
         if (items.length === 0) {
-          const empty = '<p class="bibliography-empty">No references yet.</p>';
-          dom.innerHTML = empty;
+          const msg =
+            scope === 'cited' && all.length > 0
+              ? 'No citations in this document yet.'
+              : 'No references yet.';
+          const empty = `<p class="bibliography-empty">${msg}</p>`;
+          content.innerHTML = empty;
           writeBackContent(empty);
           return;
         }
@@ -354,15 +435,15 @@ export const Bibliography = Node.create<CitationOptions>({
           .then(({ formatBibliography }) => formatBibliography(items, style))
           .then((html) => {
             if (token !== renderToken) return;
-            dom.innerHTML = html || '';
-            writeBackContent(dom.innerHTML);
+            content.innerHTML = html || '';
+            writeBackContent(content.innerHTML);
           })
           .catch((err) => {
             if (token !== renderToken) return;
             console.error('[citations] bibliography render failed:', err);
             // Keep any cached content already painted; only show a notice if blank.
-            if (!dom.innerHTML) {
-              dom.innerHTML = '<p class="bibliography-empty">Could not render bibliography.</p>';
+            if (!content.innerHTML) {
+              content.innerHTML = '<p class="bibliography-empty">Could not render bibliography.</p>';
             }
           });
       };
@@ -379,10 +460,35 @@ export const Bibliography = Node.create<CitationOptions>({
         }
       });
 
+      // In 'cited' scope the list depends on which citations exist in the prose,
+      // so re-render when the cited set changes. Gated on the set (not every
+      // keystroke) — and our own projection write-back never changes it, so this
+      // can't loop.
+      const onDocUpdate = () => {
+        if (scope !== 'cited') return;
+        const citedKey = [...collectCitedRefIds(editor.state.doc)].sort().join(',');
+        if (citedKey !== lastCitedKey) render();
+      };
+      editor.on('update', onDocUpdate);
+
       return {
         dom,
-        update: (updatedNode) => updatedNode.type.name === this.name,
-        destroy: () => unsubscribe(),
+        // Ignore our own header/content mutations; re-render when the persisted
+        // scope attr changes (the toggle).
+        ignoreMutation: () => true,
+        update: (updatedNode) => {
+          if (updatedNode.type.name !== this.name) return false;
+          const nextScope = (updatedNode.attrs['scope'] as 'cited' | 'all') ?? 'cited';
+          if (nextScope !== scope) {
+            scope = nextScope;
+            render();
+          }
+          return true;
+        },
+        destroy: () => {
+          editor.off('update', onDocUpdate);
+          unsubscribe();
+        },
       };
     };
   },

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -165,13 +165,17 @@ export const CitationInline = Node.create<CitationOptions>({
         lastStyle = style;
 
         if (!item) {
+          // Missing refs show no hover card, so the native title is the only
+          // hint — keep it.
           dom.title = 'Missing reference';
           // Keep an already-painted cached label as a fallback (ref not loaded
           // yet, or offline); only show [?] when we have nothing to show.
           if (!dom.textContent || dom.textContent === '…') dom.textContent = '[?]';
           return;
         }
-        dom.title = referencePreview(item);
+        // The rich hover card replaces the native tooltip for resolved refs —
+        // leaving `title` set would fire BOTH (a native tooltip over our card).
+        dom.removeAttribute('title');
         const token = ++renderToken;
         if (!dom.textContent || dom.textContent === '[?]') dom.textContent = '…';
         void getFormat()
@@ -266,6 +270,21 @@ function collectCitedRefIds(doc: PMNode): Set<string> {
     }
   });
   return cited;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Dependency-free fallback bibliography: a plain list built from the cheap
+ * `referencePreview` label (no `@citation-js`/CSL). Used when the lazy format
+ * chunk is unavailable (offline / a failed dynamic import) or citeproc returns
+ * nothing — so the bibliography degrades to a readable list instead of an error
+ * box, mirroring how an inline citation falls back to `[refId]`.
+ */
+function plainBibliography(items: CSLItem[]): string {
+  return items.map((it) => `<div class="csl-entry">${escapeHtml(referencePreview(it))}</div>`).join('');
 }
 
 /**
@@ -435,16 +454,19 @@ export const Bibliography = Node.create<CitationOptions>({
           .then(({ formatBibliography }) => formatBibliography(items, style))
           .then((html) => {
             if (token !== renderToken) return;
-            content.innerHTML = html || '';
+            // citeproc returned nothing (logged in format.ts) → degrade to the
+            // plain preview list rather than a blank box.
+            content.innerHTML = html || plainBibliography(items);
             writeBackContent(content.innerHTML);
           })
           .catch((err) => {
             if (token !== renderToken) return;
+            // The lazy format chunk failed to load (offline / stale SW / broken
+            // dynamic import). Degrade to the dependency-free list so the refs
+            // still show; the real error is in the console for diagnosis.
             console.error('[citations] bibliography render failed:', err);
-            // Keep any cached content already painted; only show a notice if blank.
-            if (!content.innerHTML) {
-              content.innerHTML = '<p class="bibliography-empty">Could not render bibliography.</p>';
-            }
+            content.innerHTML = plainBibliography(items);
+            writeBackContent(content.innerHTML);
           });
       };
 

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -182,15 +182,17 @@ export const CitationInline = Node.create<CitationOptions>({
           .then(({ formatCitation }) => formatCitation([item], style, 'html'))
           .then((html) => {
             if (token !== renderToken) return; // a newer render superseded this
-            dom.innerHTML = html || '[?]';
+            dom.innerHTML = html || escapeHtml(inlineFallback(item));
             writeBackLabel(dom.textContent ?? '');
           })
           .catch((err) => {
             if (token !== renderToken) return;
-            // Don't hang on the loading placeholder — surface the failure and
-            // degrade to a readable fallback (the cite key in brackets).
+            // The lazy format chunk failed to load (offline / stale SW / a chunk
+            // served with the wrong MIME type). Degrade to a readable author-year
+            // rather than the bare refId (a DOI for DOI-resolved refs). Don't
+            // cache this fallback as the label — it's not the real formatted cite.
             console.error('[citations] inline citation render failed:', err);
-            dom.textContent = `[${refId}]`;
+            dom.textContent = inlineFallback(item);
           });
       };
 
@@ -274,6 +276,23 @@ function collectCitedRefIds(doc: PMNode): Set<string> {
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Dependency-free in-text fallback (no `@citation-js`/CSL): a compact
+ * `(Family, year)`. Used when the lazy format chunk is unavailable so an inline
+ * citation degrades to something readable instead of the bare refId — which, for
+ * DOI-resolved refs, is a DOI string (the "displays DOI URIs" symptom when the
+ * format chunk is served with the wrong MIME type / fails to import).
+ */
+function inlineFallback(item: CSLItem): string {
+  const author = item.author?.[0];
+  const name = author?.family ?? author?.literal;
+  const year = item.issued?.['date-parts']?.[0]?.[0];
+  if (name && year) return `(${name}, ${year})`;
+  if (name) return `(${name})`;
+  if (year) return `(${year})`;
+  return `[${item.id}]`;
 }
 
 /**

--- a/src/tiptap/CitationSuggestion.css
+++ b/src/tiptap/CitationSuggestion.css
@@ -1,0 +1,45 @@
+/* CitationSuggestion — inline `@` citation autocomplete popup (JP-89). */
+
+.citation-suggest {
+  position: fixed;
+  z-index: 1100; /* above the editor; below modal dialogs (1000 overlay + content) */
+  min-width: 220px;
+  max-width: min(360px, 90vw);
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.18));
+  padding: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.citation-suggest-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  padding: 0.4rem 0.55rem;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.citation-suggest-item:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+}
+
+.citation-suggest-item.is-active {
+  background: var(--accent-soft, rgba(80, 120, 200, 0.18));
+}

--- a/src/tiptap/CitationSuggestion.test.ts
+++ b/src/tiptap/CitationSuggestion.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the `@`-trigger citation autocomplete (JP-89 delight slice).
+ *
+ * The pure trigger/filter helpers are unit-tested directly; activation +
+ * commit are exercised through a headless `Editor` (jsdom), reading the plugin
+ * state via `citationSuggestionKey` and inserting via `commitActiveSuggestion`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { TextSelection } from '@tiptap/pm/state';
+import { CitationInline, Bibliography } from './CitationExtension';
+import {
+  CitationSuggestion,
+  citationSuggestionKey,
+  commitActiveSuggestion,
+  matchCitationTrigger,
+  filterReferences,
+} from './CitationSuggestion';
+import { useReferenceStore } from '../store/referenceStore';
+import type { CSLItem } from '../types/Citation';
+
+const extensions = [
+  StarterKit.configure({ history: false }),
+  CitationInline,
+  Bibliography,
+  CitationSuggestion,
+];
+
+const smith: CSLItem = {
+  id: 'smith2020',
+  type: 'article-journal',
+  title: 'On the Behaviour of Things',
+  author: [{ family: 'Smith', given: 'Jane' }],
+  issued: { 'date-parts': [[2020]] },
+};
+const doe: CSLItem = {
+  id: 'doe2019',
+  type: 'book',
+  title: 'A Treatise',
+  author: [{ family: 'Doe', given: 'John' }],
+  issued: { 'date-parts': [[2019]] },
+};
+
+function makeEditor() {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content: '<p></p>' });
+  return { editor, element };
+}
+
+beforeEach(() => useReferenceStore.getState().clear());
+
+describe('matchCitationTrigger', () => {
+  it('matches `@` at the start of a block', () => {
+    expect(matchCitationTrigger('@smi')).toEqual({ query: 'smi', from: 0 });
+  });
+  it('matches `@` after whitespace and reports the @ offset', () => {
+    expect(matchCitationTrigger('see @smith')).toEqual({ query: 'smith', from: 4 });
+  });
+  it('matches a bare `@` with an empty query', () => {
+    expect(matchCitationTrigger('hello @')).toEqual({ query: '', from: 6 });
+  });
+  it('matches after an opening bracket', () => {
+    expect(matchCitationTrigger('(@doe')).toEqual({ query: 'doe', from: 1 });
+  });
+  it('does NOT match `@` glued to a preceding word (emails)', () => {
+    expect(matchCitationTrigger('user@host')).toBeNull();
+  });
+  it('does NOT match once whitespace breaks the token', () => {
+    expect(matchCitationTrigger('@smith now')).toBeNull();
+  });
+});
+
+describe('filterReferences', () => {
+  it('returns all (capped) for an empty query', () => {
+    expect(filterReferences([smith, doe], '')).toHaveLength(2);
+    expect(filterReferences([smith, doe], '', 1)).toHaveLength(1);
+  });
+  it('filters by author/title preview and by id', () => {
+    expect(filterReferences([smith, doe], 'smith').map((r) => r.id)).toEqual(['smith2020']);
+    expect(filterReferences([smith, doe], 'treatise').map((r) => r.id)).toEqual(['doe2019']);
+    expect(filterReferences([smith, doe], 'doe2019').map((r) => r.id)).toEqual(['doe2019']);
+  });
+});
+
+describe('suggestion activation + commit (headless editor)', () => {
+  it('activates on a `@` token and tracks the query', () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertContent('@smi');
+
+    const state = citationSuggestionKey.getState(editor.state)!;
+    expect(state.from).not.toBeNull();
+    expect(state.query).toBe('smi');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('inserts a citationInline for the highlighted ref and removes the @token', () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertContent('see @smi');
+
+    expect(commitActiveSuggestion(editor.view)).toBe(true);
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-ref-id="smith2020"');
+    expect(html).not.toContain('@smi'); // the trigger token was consumed
+    // suggestion is closed after commit
+    expect(citationSuggestionKey.getState(editor.state)!.from).toBeNull();
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('commits an explicitly-named ref (the popup click path)', () => {
+    useReferenceStore.getState().addReference(smith);
+    useReferenceStore.getState().addReference(doe);
+    const { editor, element } = makeEditor();
+    editor.commands.insertContent('@');
+
+    expect(commitActiveSuggestion(editor.view, 'doe2019')).toBe(true);
+    expect(editor.getHTML()).toContain('data-ref-id="doe2019"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('does not activate inside an email-like token', () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertContent('mail user@host');
+
+    expect(citationSuggestionKey.getState(editor.state)!.from).toBeNull();
+    expect(commitActiveSuggestion(editor.view)).toBe(false);
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('deactivates when the caret leaves the token', () => {
+    useReferenceStore.getState().addReference(smith);
+    const { editor, element } = makeEditor();
+    editor.commands.insertContent('@smi');
+    expect(citationSuggestionKey.getState(editor.state)!.from).not.toBeNull();
+
+    // Move the caret to the very start of the doc, away from the token.
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.atStart(editor.state.doc)),
+    );
+    expect(citationSuggestionKey.getState(editor.state)!.from).toBeNull();
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/CitationSuggestion.ts
+++ b/src/tiptap/CitationSuggestion.ts
@@ -1,0 +1,257 @@
+/**
+ * CitationSuggestion — inline `@`-trigger autocomplete for citations (JP-89
+ * delight slice).
+ *
+ * Typing `@` (at a word boundary) in prose opens a small dropdown of the
+ * document's references, filtered live by what you type after the `@`; picking
+ * one replaces the `@query` token with a `citationInline` node. It is the
+ * pandoc-style `@citekey` affordance, the fast path next to the toolbar's
+ * "Insert Citation" dialog.
+ *
+ * Implemented as a hand-rolled ProseMirror suggestion plugin (no
+ * `@tiptap/suggestion` / tippy dependency — keeping the AGPL bundle lean, the
+ * same reasoning as the relay hand-rolling SigV4 over the AWS SDK). The popup is
+ * an imperative DOM element managed by the plugin's `view`, so it works
+ * identically in both prose editors (local `TiptapEditor` and the relay
+ * `CollaborativeProseEditor`) — they share this extension via
+ * `sharedProseExtensions`. References are read live from `referenceStore`, the
+ * same source the citation nodeViews render from.
+ */
+
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+import type { CSLItem } from '../types/Citation';
+import { useReferenceStore } from '../store/referenceStore';
+import { referencePreview } from '../services/citations/preview';
+import './CitationSuggestion.css';
+
+/** Max rows shown in the dropdown (the filtered library can be large). */
+const MAX_RESULTS = 8;
+
+/** Plugin state. `from === null` means inactive. */
+interface SuggestionState {
+  /** Doc position of the trigger `@`, or `null` when inactive. */
+  from: number | null;
+  /** Doc position of the caret (end of the `@query` token). */
+  to: number;
+  /** The query typed after `@` (may be empty). */
+  query: string;
+  /** Highlighted row index into the filtered results. */
+  index: number;
+  /** True once the user dismissed (Escape) this token — stays closed until it changes. */
+  closed: boolean;
+}
+
+type SuggestionMeta = { type: 'move'; dir: 1 | -1 } | { type: 'close' };
+
+const INACTIVE: SuggestionState = { from: null, to: 0, query: '', index: 0, closed: false };
+
+export const citationSuggestionKey = new PluginKey<SuggestionState>('citationSuggestion');
+
+/**
+ * Match a citation trigger at the end of the text preceding the caret. The
+ * trigger is an `@` at a word boundary (start of block, or after whitespace /
+ * an opening bracket), followed by the query (no whitespace, no second `@`).
+ * Returns the query and the offset of the `@` within `textBefore`, or `null`.
+ *
+ * Exported for unit testing — the rest of the plugin is DOM/PM-coupled.
+ */
+export function matchCitationTrigger(textBefore: string): { query: string; from: number } | null {
+  // `(?:^|[\s(\[])` — `@` must open a token, so it won't fire inside an email.
+  const m = /(?:^|[\s([])@([^\s@]*)$/.exec(textBefore);
+  if (!m) return null;
+  const query = m[1] ?? '';
+  // `m.index` points at the boundary char (or -1-ish at string start); the `@`
+  // sits at the end of the matched prefix, i.e. matchEnd - query.length - 1.
+  const from = m.index + m[0].length - query.length - 1;
+  return { query, from };
+}
+
+/** Filter the library by `query` (matched against the shared preview label). */
+export function filterReferences(items: CSLItem[], query: string, limit = MAX_RESULTS): CSLItem[] {
+  const q = query.trim().toLowerCase();
+  const matched = q
+    ? items.filter((r) => referencePreview(r).toLowerCase().includes(q) || r.id.toLowerCase().includes(q))
+    : items;
+  return matched.slice(0, limit);
+}
+
+function listReferences(): CSLItem[] {
+  return useReferenceStore.getState().listReferences();
+}
+
+/** The references currently offered for `state` (empty when inactive). */
+function resultsFor(state: SuggestionState): CSLItem[] {
+  if (state.from === null || state.closed) return [];
+  return filterReferences(listReferences(), state.query);
+}
+
+/**
+ * Commit the highlighted (or explicitly given) reference: replace the `@query`
+ * token with a `citationInline` node. Returns true when a citation was
+ * inserted. Shared by the Enter/Tab keybinding and the popup's click handler.
+ */
+export function commitActiveSuggestion(view: EditorView, refId?: string): boolean {
+  const state = citationSuggestionKey.getState(view.state);
+  if (!state || state.from === null) return false;
+  const citation = view.state.schema.nodes['citationInline'];
+  if (!citation) return false;
+
+  const results = resultsFor(state);
+  const chosen = refId ?? results[state.index]?.id;
+  if (!chosen) return false;
+
+  const node = citation.create({ refId: chosen, locator: null });
+  const tr = view.state.tr.replaceWith(state.from, state.to, node);
+  tr.setMeta(citationSuggestionKey, { type: 'close' } satisfies SuggestionMeta);
+  view.dispatch(tr);
+  view.focus();
+  return true;
+}
+
+function citationSuggestionPlugin(): Plugin<SuggestionState> {
+  return new Plugin<SuggestionState>({
+    key: citationSuggestionKey,
+
+    state: {
+      init: () => INACTIVE,
+      apply(tr, value, _old, newState): SuggestionState {
+        const meta = tr.getMeta(citationSuggestionKey) as SuggestionMeta | undefined;
+        if (meta?.type === 'move') {
+          if (value.from === null) return value;
+          const len = resultsFor(value).length;
+          if (len === 0) return value;
+          return { ...value, index: (value.index + meta.dir + len) % len };
+        }
+        if (meta?.type === 'close') {
+          return value.from === null ? value : { ...value, closed: true };
+        }
+
+        // Recompute the active token from the caret position.
+        const sel = newState.selection;
+        if (!sel.empty || !sel.$from.parent.isTextblock) return INACTIVE;
+        const $from = sel.$from;
+        // Inline atoms (e.g. an existing citation) count as one placeholder char
+        // so positions stay aligned with the text offsets we match against.
+        const textBefore = $from.parent.textBetween(0, $from.parentOffset, undefined, '\uFFFC');
+        const match = matchCitationTrigger(textBefore);
+        if (!match) return INACTIVE;
+
+        const from = $from.start() + match.from;
+        const to = sel.from;
+        // Same token as before → preserve the user's dismissal + highlight.
+        if (value.from === from && value.query === match.query) {
+          return { ...value, from, to };
+        }
+        return { from, to, query: match.query, index: 0, closed: false };
+      },
+    },
+
+    props: {
+      handleKeyDown(view, event) {
+        const state = citationSuggestionKey.getState(view.state);
+        if (!state || state.from === null || state.closed) return false;
+        if (event.key === 'Escape') {
+          view.dispatch(view.state.tr.setMeta(citationSuggestionKey, { type: 'close' } satisfies SuggestionMeta));
+          return true;
+        }
+        // Only capture navigation/commit keys when there's something to pick.
+        if (resultsFor(state).length === 0) return false;
+        if (event.key === 'ArrowDown') {
+          view.dispatch(view.state.tr.setMeta(citationSuggestionKey, { type: 'move', dir: 1 } satisfies SuggestionMeta));
+          return true;
+        }
+        if (event.key === 'ArrowUp') {
+          view.dispatch(view.state.tr.setMeta(citationSuggestionKey, { type: 'move', dir: -1 } satisfies SuggestionMeta));
+          return true;
+        }
+        if (event.key === 'Enter' || event.key === 'Tab') {
+          return commitActiveSuggestion(view);
+        }
+        return false;
+      },
+    },
+
+    view: (editorView) => new SuggestionPopup(editorView),
+  });
+}
+
+/** Imperative dropdown rendered next to the caret while a trigger is active. */
+class SuggestionPopup {
+  private readonly dom: HTMLDivElement;
+  private rendered = '';
+
+  constructor(private readonly view: EditorView) {
+    this.dom = document.createElement('div');
+    this.dom.className = 'citation-suggest';
+    this.dom.style.display = 'none';
+    // Keep the editor selection on mousedown so a click doesn't blur/collapse.
+    this.dom.addEventListener('mousedown', (e) => e.preventDefault());
+    document.body.appendChild(this.dom);
+    this.update();
+  }
+
+  update(): void {
+    const state = citationSuggestionKey.getState(this.view.state);
+    const results = state ? resultsFor(state) : [];
+    if (!state || state.from === null || results.length === 0) {
+      this.hide();
+      return;
+    }
+    // Cheap render gate: rebuild only when the visible set/selection changes.
+    const signature = `${state.index}|${results.map((r) => r.id).join(',')}`;
+    if (signature !== this.rendered) {
+      this.renderList(results, state.index);
+      this.rendered = signature;
+    }
+    this.position(state.from);
+  }
+
+  private renderList(results: CSLItem[], index: number): void {
+    this.dom.replaceChildren();
+    results.forEach((ref, i) => {
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = i === index ? 'citation-suggest-item is-active' : 'citation-suggest-item';
+      row.textContent = referencePreview(ref);
+      row.addEventListener('click', () => commitActiveSuggestion(this.view, ref.id));
+      this.dom.appendChild(row);
+    });
+    this.dom.style.display = 'block';
+  }
+
+  private position(from: number): void {
+    try {
+      const coords = this.view.coordsAtPos(from);
+      this.dom.style.left = `${Math.round(coords.left)}px`;
+      this.dom.style.top = `${Math.round(coords.bottom + 4)}px`;
+    } catch {
+      // coordsAtPos can throw mid-transaction for a stale position; the next
+      // update repositions, so just keep the popup where it is.
+    }
+  }
+
+  private hide(): void {
+    if (this.dom.style.display !== 'none') {
+      this.dom.style.display = 'none';
+      this.rendered = '';
+    }
+  }
+
+  destroy(): void {
+    this.dom.remove();
+  }
+}
+
+/**
+ * Tiptap extension wrapper. Added to `sharedProseExtensions` so both prose
+ * editors get the `@` trigger; requires the `citationInline` node (also shared)
+ * to be present in the schema.
+ */
+export const CitationSuggestion = Extension.create({
+  name: 'citationSuggestion',
+  addProseMirrorPlugins() {
+    return [citationSuggestionPlugin()];
+  },
+});

--- a/src/tiptap/citationHoverCard.css
+++ b/src/tiptap/citationHoverCard.css
@@ -1,0 +1,19 @@
+/* Citation hover card — full formatted reference on inline-citation hover (JP-89). */
+
+.citation-card {
+  position: fixed;
+  z-index: 1100;
+  max-width: min(380px, 90vw);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.18));
+  padding: 0.6rem 0.75rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.citation-card-entry .csl-entry {
+  margin: 0;
+}

--- a/src/tiptap/citationHoverCard.ts
+++ b/src/tiptap/citationHoverCard.ts
@@ -1,0 +1,92 @@
+/**
+ * Citation hover card (JP-89 delight slice).
+ *
+ * Hovering an inline citation shows a small popover with the *full* formatted
+ * reference (the bibliography-style entry) in the document's active style — a
+ * quick "what is this?" without scrolling to the bibliography.
+ *
+ * A single shared card element (one per app, reused across every citation)
+ * managed imperatively, the same approach as the `@`-trigger suggestion popup.
+ * The CSL formatter is lazy-loaded (citation-js + vendored CSL), so the heavy
+ * chunk only loads when someone actually hovers a citation; until it resolves
+ * (or if it fails / we're offline) the card shows the cheap, dependency-free
+ * `referencePreview` label.
+ */
+
+import type { CSLItem, CitationStyle } from '../types/Citation';
+import { referencePreview } from '../services/citations/preview';
+import './citationHoverCard.css';
+
+type FormatModule = typeof import('../services/citations/format');
+let formatModule: Promise<FormatModule> | null = null;
+function getFormat(): Promise<FormatModule> {
+  if (!formatModule) formatModule = import('../services/citations/format');
+  return formatModule;
+}
+
+let card: HTMLDivElement | null = null;
+/** Bumped on every show/hide so a slow async format can't paint a stale card. */
+let token = 0;
+
+function ensureCard(): HTMLDivElement {
+  if (!card) {
+    card = document.createElement('div');
+    card.className = 'citation-card';
+    card.setAttribute('role', 'tooltip');
+    // The card is non-interactive; pointer events would steal hover from the
+    // citation and flicker it away.
+    card.style.pointerEvents = 'none';
+    card.style.display = 'none';
+    document.body.appendChild(card);
+  }
+  return card;
+}
+
+function position(el: HTMLDivElement, anchor: HTMLElement): void {
+  const rect = anchor.getBoundingClientRect();
+  // Measure after content is set; clamp into the viewport.
+  el.style.left = '0px';
+  el.style.top = '0px';
+  const cardRect = el.getBoundingClientRect();
+  const margin = 8;
+  let left = rect.left;
+  if (left + cardRect.width > window.innerWidth - margin) {
+    left = Math.max(margin, window.innerWidth - margin - cardRect.width);
+  }
+  // Prefer below; flip above when it would overflow the bottom.
+  let top = rect.bottom + 6;
+  if (top + cardRect.height > window.innerHeight - margin) {
+    top = Math.max(margin, rect.top - cardRect.height - 6);
+  }
+  el.style.left = `${Math.round(left)}px`;
+  el.style.top = `${Math.round(top)}px`;
+}
+
+/** Show the hover card for `item` anchored to `anchor`, formatted in `style`. */
+export function showCitationCard(anchor: HTMLElement, item: CSLItem, style: CitationStyle): void {
+  const el = ensureCard();
+  const my = ++token;
+  // Cheap, synchronous content first so the card never appears empty.
+  el.textContent = referencePreview(item);
+  el.style.display = 'block';
+  position(el, anchor);
+
+  void getFormat()
+    .then(({ formatBibliography }) => formatBibliography([item], style))
+    .then((html) => {
+      if (my !== token) return; // superseded by another hover / a hide
+      if (html) {
+        el.innerHTML = `<div class="citation-card-entry">${html}</div>`;
+        position(el, anchor); // re-measure: formatted entry may be taller
+      }
+    })
+    .catch(() => {
+      /* keep the preview-text fallback */
+    });
+}
+
+/** Hide the hover card (and cancel any in-flight async render). */
+export function hideCitationCard(): void {
+  token++;
+  if (card) card.style.display = 'none';
+}

--- a/src/tiptap/citationPaste.test.ts
+++ b/src/tiptap/citationPaste.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for paste-a-DOI-to-cite (JP-89 delight slice).
+ *
+ * `isBareDoi` is unit-tested directly; the paste handler is exercised through a
+ * headless editor with `resolveDoi` mocked (no network), asserting the pasted
+ * DOI text becomes a citation and the reference lands in the store.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { CitationInline, Bibliography } from './CitationExtension';
+
+vi.mock('../services/citations/ingest', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveDoi: vi.fn(async (doi: string) => ({
+      items: [
+        {
+          id: 'resolved-1',
+          type: 'article-journal',
+          title: 'Resolved Work',
+          author: [{ family: 'Curie', given: 'Marie' }],
+          issued: { 'date-parts': [[1903]] },
+          DOI: doi.replace(/^https?:\/\/doi\.org\//, ''),
+        },
+      ],
+      report: { source: 'doi', count: 1, errors: [], warnings: [] },
+    })),
+  };
+});
+
+import { handleCitationDoiPaste, isBareDoi } from './citationPaste';
+import { useReferenceStore } from '../store/referenceStore';
+
+const extensions = [StarterKit.configure({ history: false }), CitationInline, Bibliography];
+
+function makeEditor() {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content: '<p></p>' });
+  return { editor, element };
+}
+
+function pasteEvent(text: string): ClipboardEvent {
+  return { clipboardData: { getData: () => text } } as unknown as ClipboardEvent;
+}
+
+async function tick(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('tick timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+beforeEach(() => useReferenceStore.getState().clear());
+
+describe('isBareDoi', () => {
+  it('accepts a bare DOI and a doi.org URL', () => {
+    expect(isBareDoi('10.1000/xyz123')).toBe(true);
+    expect(isBareDoi('https://doi.org/10.1000/xyz123')).toBe(true);
+    expect(isBareDoi('  10.1000/xyz123  ')).toBe(true);
+  });
+  it('rejects non-DOIs and multi-token pastes', () => {
+    expect(isBareDoi('hello world')).toBe(false);
+    expect(isBareDoi('10.1000/xyz here is text')).toBe(false);
+    expect(isBareDoi('not a doi')).toBe(false);
+    expect(isBareDoi('')).toBe(false);
+  });
+});
+
+describe('handleCitationDoiPaste', () => {
+  it('ignores a non-DOI paste (returns false)', () => {
+    const { editor, element } = makeEditor();
+    expect(handleCitationDoiPaste(editor.view, pasteEvent('just some text'))).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+
+  it('resolves a pasted DOI into a citation and adds the reference', async () => {
+    const { editor, element } = makeEditor();
+    editor.commands.focus();
+
+    expect(handleCitationDoiPaste(editor.view, pasteEvent('10.1000/xyz123'))).toBe(true);
+    // The DOI text is inserted synchronously first (nothing lost).
+    expect(editor.getText()).toContain('10.1000/xyz123');
+
+    // After async resolution the text is replaced with a citation node.
+    await tick(() => editor.getHTML().includes('data-ref-id'));
+    expect(editor.getHTML()).toContain('data-citation');
+    expect(editor.getHTML()).not.toContain('10.1000/xyz123'); // text consumed
+
+    // The resolved reference is in the library.
+    expect(useReferenceStore.getState().listReferences().some((r) => r.DOI === '10.1000/xyz123')).toBe(true);
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/citationPaste.ts
+++ b/src/tiptap/citationPaste.ts
@@ -1,0 +1,91 @@
+/**
+ * Paste-a-DOI-to-cite (JP-89 delight slice).
+ *
+ * When the clipboard holds a single bare DOI (or a `doi.org` URL), pasting it
+ * into prose resolves the DOI to a reference, adds it to the document's library
+ * (dedup-safe), and turns the pasted text into an inline citation — the fast
+ * "I have a DOI, cite it" path.
+ *
+ * The handler is synchronous (ProseMirror `handlePaste` must return immediately)
+ * so it inserts the DOI text at the caret right away — nothing is ever lost —
+ * then resolves asynchronously and *replaces that exact text* with a citation
+ * once the lookup returns. If the user edited the pasted text meanwhile, the
+ * replace is skipped (the reference is still added to the library), so the async
+ * write can never clobber unrelated edits.
+ *
+ * Wired into both prose editors via `editorProps.handlePaste`.
+ */
+
+import type { EditorView } from '@tiptap/pm/view';
+import { normalizeDoi, resolveDoi } from '../services/citations/ingest';
+import { importReferences } from '../services/citations/referenceImport';
+import { referencePreview } from '../services/citations/preview';
+import { useReferenceStore } from '../store/referenceStore';
+import { useNotificationStore } from '../store/notificationStore';
+
+/** True when `text` is a single token that resolves to a bare DOI (`10.x/y`). */
+export function isBareDoi(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || /\s/.test(trimmed)) return false; // single token only
+  return /^10\.\d{4,9}\/\S+$/.test(normalizeDoi(trimmed));
+}
+
+/** Find an existing library entry's id by DOI (case-insensitive). */
+function refIdForDoi(doi: string): string | undefined {
+  const norm = doi.trim().toLowerCase();
+  return useReferenceStore
+    .getState()
+    .listReferences()
+    .find((r) => typeof r.DOI === 'string' && r.DOI.trim().toLowerCase() === norm)?.id;
+}
+
+async function resolveAndCite(view: EditorView, bareDoi: string, from: number, to: number): Promise<void> {
+  const notify = useNotificationStore.getState();
+  const result = await resolveDoi(bareDoi);
+  if (result.report.errors.length > 0 || result.items.length === 0) {
+    notify.error(result.report.errors[0] ?? `Couldn't resolve DOI ${bareDoi}`);
+    return; // leave the pasted DOI text untouched
+  }
+
+  const resolved = result.items[0]!;
+  importReferences([resolved]); // dedup-safe upsert into the library
+  const refId = refIdForDoi(resolved.DOI ?? bareDoi) ?? resolved.id;
+  const label = referencePreview(resolved);
+
+  const citation = view.state.schema.nodes['citationInline'];
+  // Replace the inserted DOI text with a citation only if it's still exactly
+  // there — otherwise a subsequent edit would be clobbered; just keep the ref.
+  const untouched =
+    !!citation &&
+    to <= view.state.doc.content.size &&
+    view.state.doc.textBetween(from, to) === bareDoi;
+
+  if (untouched) {
+    const node = citation.create({ refId, locator: null });
+    view.dispatch(view.state.tr.replaceWith(from, to, node));
+    notify.success(`Cited ${label}`);
+  } else {
+    notify.success(`Added ${label} to your references`);
+  }
+}
+
+/**
+ * ProseMirror `handlePaste` hook: consume a bare-DOI paste and resolve→cite it.
+ * Returns false for any other paste so normal paste handling proceeds.
+ */
+export function handleCitationDoiPaste(view: EditorView, event: ClipboardEvent): boolean {
+  const text = event.clipboardData?.getData('text/plain') ?? '';
+  if (!isBareDoi(text)) return false;
+
+  const bareDoi = normalizeDoi(text.trim());
+  // Insert the bare DOI text now (replacing any selection) so the position is
+  // exact and the content is never lost if resolution fails.
+  const { from: selFrom, to: selTo } = view.state.selection;
+  view.dispatch(view.state.tr.insertText(bareDoi, selFrom, selTo));
+  const from = selFrom;
+  const to = selFrom + bareDoi.length;
+
+  useNotificationStore.getState().info(`Resolving DOI ${bareDoi}…`, { duration: 2000 });
+  void resolveAndCite(view, bareDoi, from, to);
+  return true;
+}

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -29,6 +29,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Collaboration from '@tiptap/extension-collaboration';
 import type { Doc as YDoc } from 'yjs';
 import { sharedProseExtensions } from './TiptapEditor';
+import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { useRichTextStore } from '../store/richTextStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { useProseEditorChrome } from './useProseEditorChrome';
@@ -69,7 +70,11 @@ export function CollaborativeProseEditor({
       // No initial `content`: the relay is the sole prose seeder (JP-284), so the
       // editor adopts the bound fragment. Passing content would inject a second
       // prose lineage that merges into the fragment and duplicates content.
-      editorProps: { attributes: { class: 'tiptap-prose' } },
+      editorProps: {
+        attributes: { class: 'tiptap-prose' },
+        // Paste a bare DOI → resolve + add to the library + insert a citation.
+        handlePaste: (view, event) => handleCitationDoiPaste(view, event),
+      },
       onUpdate: ({ editor }) => {
         const json = editor.getJSON();
         const html = editor.getHTML();

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -457,6 +457,38 @@
   margin: 0;
 }
 
+.tiptap-editor .ProseMirror .bibliography-block .bibliography-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.tiptap-editor .ProseMirror .bibliography-scope-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.tiptap-editor .ProseMirror .bibliography-scope-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.72rem;
+  padding: 0.2rem 0.55rem;
+  cursor: pointer;
+}
+
+.tiptap-editor .ProseMirror .bibliography-scope-btn + .bibliography-scope-btn {
+  border-left: 1px solid var(--border-color);
+}
+
+.tiptap-editor .ProseMirror .bibliography-scope-btn.is-active {
+  background: var(--accent-soft, rgba(80, 120, 200, 0.18));
+  color: var(--text-primary);
+}
+
 /* ============================================
    Resizable Image Container
    ============================================ */

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -40,6 +40,7 @@ import { EmbeddedGroup } from '../tiptap/EmbeddedGroupExtension';
 import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
+import { CitationSuggestion } from '../tiptap/CitationSuggestion';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
@@ -158,6 +159,10 @@ export const sharedProseExtensions = [
   // Citations (JP-89): inline cite + bibliography block, rendered from referenceStore
   CitationInline,
   Bibliography,
+  // `@`-trigger inline citation autocomplete (must follow CitationInline — it
+  // inserts that node). No nodes/marks of its own, so the shared schema is
+  // unaffected (safe for the headless `registerProseSchema` below + collab).
+  CitationSuggestion,
   EmbeddedGroup,
 ];
 

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -41,6 +41,7 @@ import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
 import { CitationSuggestion } from '../tiptap/CitationSuggestion';
+import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
@@ -223,6 +224,8 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
       attributes: {
         class: 'tiptap-prose',
       },
+      // Paste a bare DOI → resolve + add to the library + insert a citation.
+      handlePaste: (view, event) => handleCitationDoiPaste(view, event),
     },
   });
 


### PR DESCRIPTION
The final JP-89 slice: four client-side citation affordances built on the
existing citation nodes, `referenceStore`, and the lazy CSL formatter. Each is
its own commit. Builds on the merged foundation (MCP tools #169, prose-node
relay round-trip #171, references as a Y.Doc shared type #173).

## Features

1. **Inline `@cite` trigger** (`CitationSuggestion.ts`) — typing `@` at a word
   boundary opens a dropdown of the library, filtered live by the query after
   `@`; picking one inserts a `citationInline` node. Hand-rolled ProseMirror
   suggestion plugin with an imperative popup — no `@tiptap/suggestion`/tippy
   dependency (keeps the AGPL bundle lean). Shared by both prose editors via
   `sharedProseExtensions`.
2. **Cited-only bibliography** (`CitationExtension.ts`) — the bibliography now
   lists only references actually cited in the prose by **default** (new `scope`
   attr, default `cited`); an editable header toggle switches to the full
   library. The cited set is derived from the doc's `citationInline` nodes and
   re-rendered on change (gated so the projection write-back can't loop).
3. **Paste-a-DOI-to-cite** (`citationPaste.ts`) — a bare-DOI (or doi.org URL)
   paste resolves the DOI, adds it to the library (dedup-safe), and replaces the
   pasted text with a citation. The DOI text is inserted synchronously first so
   nothing is lost; the async replace only fires if that text is untouched, so
   it can't clobber later edits. Wired into both editors' `handlePaste`.
4. **Hover preview card** (`citationHoverCard.ts`) — hovering an inline citation
   shows a popover with the full formatted reference in the active style. Single
   shared, non-interactive card; lazy formatter with a `referencePreview`
   fallback until it resolves (offline-safe).

## Notes / decisions

- **No relay changes.** The `scope` attr persists via getHTML/JSON and syncs
  live between collab peers as a node attribute, but a relay cold-rehydrate
  resets it to the safe cited-only default — no reference data is ever lost (the
  library is the durable shared type). Making `scope` fully durable through the
  relay HTML round-trip is a documented follow-up in the prose-helper guide.
- The prose-helper dev guide gains two reusable lessons from this slice
  (deriving a nodeView from other prose; the durable-attr/relay tradeoff).

## Verification

- `bun run typecheck` clean
- `bun run test --run` — 2105 passed (+21 new: suggestion, paste, hover, cited-only)
- `bun run build` clean
- OSS-leak grep on the diff: clean
- Staging E2E optional (editor-UX); the foundation it builds on was E2E-proven
  live in #173.

Assisted-by: Opus 4.8