### PR TITLE
JP-299: relay P0 hardening — bounded blob ingest + REST-save blob-ref correctness

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -121,6 +121,33 @@ fn collect_blob_refs_walk(
     }
 }
 
+/// Blob references to keep when a REST save updates a doc's refcount (RB-2 /
+/// JP-299): the **union** of the (possibly stale) top-level `blobReferences`
+/// array and the refs derived from the live content (`collect_blob_references`).
+///
+/// `save_doc_handler` used only the array, but the relay's collab-snapshot
+/// flatten never writes it (JP-278), so a REST save with an outdated array would
+/// release blobs the content still uses — irreversible at `blob_gc_grace_secs =
+/// 0` (the same data-loss class as JP-127). Taking the union never under-counts:
+/// a blob referenced by *either* source is retained.
+pub(crate) fn save_blob_refs(doc: &Value) -> HashSet<String> {
+    let mut refs = blob_refs_from_doc(doc);
+    refs.extend(collect_blob_references(doc));
+    refs
+}
+
+/// Append `chunk` to `buf` unless that would exceed `max` bytes; returns `false`
+/// when the cap would be exceeded so the caller can abort (RB-1 / JP-299). Keeps
+/// peak buffer memory at ~`max` even when a source omits or lies about its
+/// Content-Length.
+fn append_capped(buf: &mut Vec<u8>, chunk: &[u8], max: usize) -> bool {
+    if buf.len().saturating_add(chunk.len()) > max {
+        return false;
+    }
+    buf.extend_from_slice(chunk);
+    true
+}
+
 /// Whether `hash` is a well-formed SHA-256 hex digest (64 lowercase hex
 /// chars). Beyond rejecting junk, this is a **security gate** for the presign
 /// path: the hash becomes part of the R2 object key, so anything but `[0-9a-f]`
@@ -793,8 +820,9 @@ async fn save_doc_handler(
 
     // Capture the doc's referenced blob hashes before `document` is moved
     // into the store — used to update the blob refcount after a successful
-    // save (JP-120).
-    let blob_refs = blob_refs_from_doc(&document);
+    // save (JP-120). RB-2: union the (stale) `blobReferences` array with refs
+    // derived from live content so a save can't release in-use blobs.
+    let blob_refs = save_blob_refs(&document);
 
     let outcome = match state
         .doc_store()
@@ -1282,7 +1310,7 @@ async fn blob_ingest_from_url_handler(
         }
     };
 
-    let resp = match client
+    let mut resp = match client
         .get(url)
         .header(reqwest::header::AUTHORIZATION, &req.authorization)
         .send()
@@ -1325,20 +1353,41 @@ async fn blob_ingest_from_url_handler(
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
-    let body = match resp.bytes().await {
-        Ok(b) => b,
-        Err(e) => {
-            log::info!("ingest body read failed for ws {}: {e}", ws.as_str());
-            return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
+    // RB-1b: bound concurrent in-memory uploads (shared gate with the proxy
+    // path) before buffering the body.
+    let _permit = match state.blob_upload_gate().clone().acquire_owned().await {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiError::body("upload gate unavailable"),
+            )
+                .into_response()
         }
     };
-    // Authoritative size check (the host may ignore/omit Content-Length).
-    if body.len() > max {
-        return (
-            StatusCode::PAYLOAD_TOO_LARGE,
-            ApiError::body("blob exceeds max size"),
-        )
-            .into_response();
+
+    // RB-1: stream the body in chunks, aborting the moment the running total
+    // exceeds `max` — a host that omits or lies about Content-Length can't make
+    // us buffer an unbounded response into RAM (the post-hoc `.bytes()` check
+    // read the whole body first).
+    let mut body: Vec<u8> = Vec::new();
+    loop {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                if !append_capped(&mut body, &chunk, max) {
+                    return (
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        ApiError::body("blob exceeds max size"),
+                    )
+                        .into_response();
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                log::info!("ingest body read failed for ws {}: {e}", ws.as_str());
+                return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
+            }
+        }
     }
 
     let hash = BlobStore::compute_hash(&body);
@@ -1526,5 +1575,45 @@ mod tests {
             collect_blob_references(&doc),
             vec![h_shape1.clone(), h_shape2.clone(), h_rich.clone()]
         );
+    }
+
+    #[test]
+    fn save_blob_refs_unions_array_and_content() {
+        let content = "a".repeat(64); // referenced by a FileShape only
+        let stale = "c".repeat(64); // present only in the top-level array
+
+        let doc = serde_json::json!({
+            "blobReferences": [stale],
+            "pages": { "p1": { "shapes": {
+                "s1": { "type": "file", "blobRef": content }
+            }}}
+        });
+
+        // Union (RB-2): keeps the content-derived ref the stale array omits AND
+        // the array entry the content omits — never under-counts, so a save can
+        // never release an in-use blob.
+        let refs = save_blob_refs(&doc);
+        assert!(refs.contains(&content), "content-derived ref must be kept");
+        assert!(refs.contains(&stale), "stale-array ref must be kept (union)");
+        assert_eq!(refs.len(), 2);
+    }
+
+    #[test]
+    fn append_capped_accepts_up_to_max_then_rejects() {
+        let max = 4;
+        let mut buf = Vec::new();
+        assert!(append_capped(&mut buf, &[1, 2], max)); // 2 <= 4
+        assert!(append_capped(&mut buf, &[3, 4], max)); // 4 <= 4 (exactly at cap)
+        assert_eq!(buf, vec![1, 2, 3, 4]);
+        // One more byte → 5 > 4: rejected, buffer left unchanged.
+        assert!(!append_capped(&mut buf, &[5], max));
+        assert_eq!(buf, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn append_capped_rejects_single_oversized_chunk() {
+        let mut buf = Vec::new();
+        assert!(!append_capped(&mut buf, &[0u8; 10], 4));
+        assert!(buf.is_empty());
     }
 }

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -62,6 +62,12 @@ pub const DEFAULT_MAX_WS_PAYLOAD_BYTES: usize = 262_144; // 256 KiB
 /// Axum's 2 MiB default silently 413s larger blobs (JP-125).
 pub const DEFAULT_MAX_BLOB_BYTES: usize = 157_286_400; // 150 MiB
 
+/// Default cap on concurrent in-memory blob uploads across the proxy and
+/// URL-ingest paths. Both buffer up to `max_blob_bytes`, so worst-case upload
+/// RAM ≈ this × `max_blob_bytes`. Bounds the cross-tenant OOM risk on small
+/// shared pods (RB-1b / JP-299). 4 × 150 MiB ≈ 600 MiB peak at the defaults.
+pub const DEFAULT_MAX_CONCURRENT_BLOB_UPLOADS: usize = 4;
+
 /// Default presigned PUT URL lifetime when `backend = "s3"`. Generous so a
 /// slow large upload can finish inside the window; the content-length pinned
 /// into the signature keeps a long TTL safe.
@@ -367,6 +373,13 @@ pub struct LimitsConfig {
     /// cap. Without this the Axum default (2 MiB) silently 413s larger blobs
     /// (JP-125).
     pub max_blob_bytes: usize,
+    /// Cap on concurrent in-memory blob uploads across the proxy
+    /// (`POST /api/blobs/:hash`) and URL-ingest paths. Both buffer up to
+    /// `max_blob_bytes`, so worst-case upload RAM ≈ `max_concurrent_blob_uploads
+    /// × max_blob_bytes`. Bounds the cross-tenant OOM risk on small shared pods
+    /// (RB-1b / JP-299); raise for throughput on larger pods. Effective minimum
+    /// is 1 (a `0` is treated as 1).
+    pub max_concurrent_blob_uploads: usize,
     /// Fallback per-workspace storage byte quota (JP-81), used when the
     /// JWT claim omits `quota_bytes`. `0` = unlimited.
     pub storage_quota_bytes: u64,
@@ -401,6 +414,7 @@ impl Default for LimitsConfig {
             max_ws_connections_per_workspace: DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE,
             max_ws_payload_bytes: DEFAULT_MAX_WS_PAYLOAD_BYTES,
             max_blob_bytes: DEFAULT_MAX_BLOB_BYTES,
+            max_concurrent_blob_uploads: DEFAULT_MAX_CONCURRENT_BLOB_UPLOADS,
             storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
             max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
             blob_gc_grace_secs: DEFAULT_BLOB_GC_GRACE_SECS,
@@ -632,6 +646,11 @@ impl RelayConfig {
             self.tenancy.limits.max_blob_bytes = v
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_MAX_BLOB_BYTES must be a usize (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_MAX_CONCURRENT_BLOB_UPLOADS") {
+            self.tenancy.limits.max_concurrent_blob_uploads = v.parse().map_err(|_| {
+                anyhow::anyhow!("RELAY_MAX_CONCURRENT_BLOB_UPLOADS must be a usize (got {v:?})")
+            })?;
         }
         if let Some(v) = get("RELAY_BLOB_GC_GRACE_SECS") {
             self.tenancy.limits.blob_gc_grace_secs = v

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -23,7 +23,7 @@ use axum::{
     body::Body,
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        DefaultBodyLimit, Path, Query, State,
+        Path, Query, State,
     },
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
@@ -497,6 +497,12 @@ pub struct ServerState {
     /// short critical sections only — never held across an `.await`.
     blob_recovery_done: std::sync::Mutex<HashSet<WorkspaceId>>,
     blob_recovery_locks: std::sync::Mutex<HashMap<WorkspaceId, Arc<tokio::sync::Mutex<()>>>>,
+    /// RB-1b (JP-299): bounds concurrent in-memory blob uploads across the proxy
+    /// (`POST /api/blobs/:hash`) and URL-ingest paths. Both buffer up to
+    /// `max_blob_bytes`, so the permit count (`max_concurrent_blob_uploads`)
+    /// caps worst-case upload RAM — a burst of large uploads can't OOM a shared
+    /// pod (cross-tenant availability).
+    blob_upload_gate: Arc<tokio::sync::Semaphore>,
 }
 
 impl ServerState {
@@ -569,6 +575,8 @@ impl ServerState {
                 None => (Arc::new(ds), None),
             }
         };
+        // RB-1b: at least one permit so uploads never deadlock on a 0 config.
+        let blob_upload_permits = tenancy.limits.max_concurrent_blob_uploads.max(1);
         Self {
             broadcast_tx,
             client_count: AtomicU16::new(0),
@@ -594,6 +602,7 @@ impl ServerState {
             panic_tenant_trigger,
             blob_recovery_done: std::sync::Mutex::new(HashSet::new()),
             blob_recovery_locks: std::sync::Mutex::new(HashMap::new()),
+            blob_upload_gate: Arc::new(tokio::sync::Semaphore::new(blob_upload_permits)),
         }
     }
 
@@ -1007,10 +1016,17 @@ impl ServerState {
     }
 
     /// Configured per-request blob size ceiling (`[tenancy.limits]
-    /// max_blob_bytes`). The proxy path enforces this via `DefaultBodyLimit`;
-    /// the presign path checks the client-asserted size against it at mint.
+    /// max_blob_bytes`). The proxy + ingest paths enforce this inline while
+    /// buffering (RB-1); the presign path checks the client-asserted size
+    /// against it at mint.
     pub(crate) fn max_blob_bytes(&self) -> usize {
         self.tenancy.limits.max_blob_bytes
+    }
+
+    /// RB-1b: permit gate bounding concurrent in-memory blob uploads (proxy +
+    /// URL-ingest). Handlers acquire one owned permit before buffering.
+    pub(crate) fn blob_upload_gate(&self) -> &Arc<tokio::sync::Semaphore> {
+        &self.blob_upload_gate
     }
 
     /// Host allowlist for the generic blob ingest-from-URL endpoint
@@ -1741,8 +1757,6 @@ impl WebSocketServer {
         let poison_guard = self.sync_config.read().await.poison_guard;
         let tenancy = self.tenancy.read().await.clone();
         let storage = self.storage.read().await.clone();
-        // JP-125: bound the blob upload body (Axum's default is a silent 2 MiB).
-        let max_blob_bytes = tenancy.limits.max_blob_bytes;
         // Reuse the cached limiter so MCP and WS share one bucket.
         let write_limiter = self.build_write_limiter().await;
         #[cfg(debug_assertions)]
@@ -1871,10 +1885,10 @@ impl WebSocketServer {
             .route("/ws", get(ws_handler))
             .route("/health", get(health_handler))
             .route("/metrics", get(metrics_handler))
-            .route(
-                "/api/blobs/:hash",
-                post(blob_upload_handler).layer(DefaultBodyLimit::max(max_blob_bytes)),
-            )
+            // RB-1: the proxy upload buffers the body inline with an explicit
+            // `max_blob_bytes` cap + the RB-1b concurrency gate (see
+            // `blob_upload_handler`), so no `DefaultBodyLimit` layer is needed.
+            .route("/api/blobs/:hash", post(blob_upload_handler))
             .route("/api/blobs/:hash", get(blob_download_handler))
             .route("/api/blobs/:hash", head(blob_exists_handler))
             .merge(crate::api::routes())
@@ -2186,7 +2200,7 @@ async fn blob_upload_handler(
     Path(hash): Path<String>,
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
-    body: axum::body::Bytes,
+    body: Body,
 ) -> impl IntoResponse {
     // Validate JWT
     let claims = match extract_jwt_from_headers(&headers, &state).await {
@@ -2196,6 +2210,30 @@ async fn blob_upload_handler(
     let (ws, claim_limits) = match resolve_blob_workspace(&state, &claims, None) {
         Ok(w) => w,
         Err(resp) => return resp,
+    };
+
+    // RB-1b (JP-299): acquire a permit *before* buffering the body so a burst of
+    // concurrent uploads can't OOM the pod — worst-case upload RAM is bounded to
+    // `max_concurrent_blob_uploads × max_blob_bytes`. The permit is held until
+    // this handler returns (covers the buffer + the store write).
+    let _permit = match state.blob_upload_gate().clone().acquire_owned().await {
+        Ok(p) => p,
+        Err(_) => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "upload gate unavailable".to_string())
+                .into_response()
+        }
+    };
+
+    // RB-1: buffer the request body with an explicit `max_blob_bytes` cap.
+    // `to_bytes` stops reading once the cap is exceeded, so memory is bounded to
+    // ~max even if the client lies about Content-Length (replaces the former
+    // `DefaultBodyLimit` layer on this route).
+    let body = match axum::body::to_bytes(body, state.max_blob_bytes()).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (StatusCode::PAYLOAD_TOO_LARGE, "blob exceeds max size".to_string())
+                .into_response()
+        }
     };
 
     // Extract MIME type from Content-Type header (default to application/octet-stream)


### PR DESCRIPTION
Closes the P0 relay items from the Fable pre-launch review (RB-1, RB-2). Parent: JP-298.

## RB-1 — bound blob-upload memory (cross-tenant OOM)

- **Ingest-from-URL** did `resp.bytes().await` with only a *post-hoc* size check, so a host omitting/lying about `Content-Length` could stream an unbounded body into RAM before rejection. Now reads via `resp.chunk()` and **aborts with 413 the moment the running total exceeds `max_blob_bytes`** (helper `append_capped`) — peak buffer ≈ max. No reqwest feature change (`chunk()` isn't gated).
- **Proxy upload** (`POST /api/blobs/:hash`) used an eager `Bytes` extractor (buffered before the handler ran, so an in-handler guard would be too late). Switched to a `Body` extractor + `axum::body::to_bytes(_, max_blob_bytes)` — the cap is enforced *while* buffering; the now-inert `DefaultBodyLimit` route layer is removed.
- **RB-1b (concurrency):** both buffered paths acquire one owned permit from a shared `Semaphore` on `ServerState` **before** buffering, so worst-case upload RAM is bounded to `max_concurrent_blob_uploads × max_blob_bytes` rather than scaling with client count. New config `max_concurrent_blob_uploads` (env `RELAY_MAX_CONCURRENT_BLOB_UPLOADS`, **default 4** ≈ 600 MiB peak at the 150 MiB default); document/tune down on small shared pods.

> Deep streaming into the storage backends (S3 multipart) is intentionally **out of scope** — both backends take a full buffer, so the per-request cap + concurrency gate bound memory without that larger/riskier refactor. Noted for a possible follow-up.

## RB-2 — REST save could release in-use blobs

`save_doc_handler` refcounted against the top-level `blobReferences` array, which the collab-snapshot flatten never writes (JP-278) — so a REST save with a **stale array released blobs the content still used**, irreversible at `blob_gc_grace_secs = 0` (same data-loss class as JP-127). Now unions the array with refs derived from live content:

```
save_blob_refs = blob_refs_from_doc ∪ collect_blob_references
```

Never under-counts → a save can't release an in-use blob.

## Verification

- New unit tests: `append_capped` (under/at/over cap), `save_blob_refs` union (keeps both a content-only ref and an array-only ref).
- **Relay suite green (342 tests)**; `cargo check` + `cargo clippy` clean on touched code (the 18 clippy warnings are all pre-existing).
- Not in-repo verifiable: the concurrency/abort behavior under real load + a live large-file upload need a running relay (E2E).

Assisted-by: Opus 4.8