### PR TITLE
JP-300 (part 1): relay-side OAuth hardening — AU-4, AU-5, AU-7

### DIFF
--- a/relay/src/auth/error.rs
+++ b/relay/src/auth/error.rs
@@ -46,6 +46,9 @@ pub enum AuthError {
 
     #[error("jwks unavailable (fail-open grace expired)")]
     JwksUnavailable,
+
+    #[error("token lifetime exceeds the maximum allowed")]
+    ExcessiveLifetime,
 }
 
 impl AuthError {
@@ -66,6 +69,7 @@ impl AuthError {
             AuthError::WorkspaceMismatch => "wsp",
             AuthError::RegionMismatch => "region",
             AuthError::JwksUnavailable => "jwks_unavailable",
+            AuthError::ExcessiveLifetime => "excessive_lifetime",
         }
     }
 }

--- a/relay/src/auth/jwt.rs
+++ b/relay/src/auth/jwt.rs
@@ -16,6 +16,19 @@ use super::{AuthError, JwksCache, RevocationSet};
 /// order".
 const CLOCK_SKEW_SECONDS: u64 = 60;
 
+/// AU-5b (JP-300): hard ceiling on accepted token lifetime (`exp - iat`), as
+/// insurance against an issuer misconfigured to mint absurdly long-lived
+/// bearers (a long-lived token in a plaintext MCP config is the system's most
+/// likely theft vector). 90 days.
+const MAX_TOKEN_LIFETIME_SECONDS: u64 = 90 * 24 * 60 * 60;
+
+/// Whether a token's declared lifetime is within [`MAX_TOKEN_LIFETIME_SECONDS`].
+/// Pure so it can be unit-tested without minting a signed token. A token whose
+/// `exp` precedes `iat` is left to the normal expiry check (lifetime 0 here).
+fn lifetime_within_ceiling(iat: u64, exp: u64) -> bool {
+    exp.saturating_sub(iat) <= MAX_TOKEN_LIFETIME_SECONDS
+}
+
 /// `wsp[].role` values the relay enforces on document operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -148,6 +161,12 @@ pub async fn validate_token(
         return Err(AuthError::NotYetValid);
     }
 
+    // AU-5b: reject tokens whose declared lifetime exceeds the ceiling, even if
+    // their `exp` is still in the future — insurance against issuer misconfig.
+    if !lifetime_within_ceiling(data.claims.iat, data.claims.exp) {
+        return Err(AuthError::ExcessiveLifetime);
+    }
+
     if revocations.is_revoked(&data.claims.jti) {
         return Err(AuthError::Revoked);
     }
@@ -196,6 +215,18 @@ mod tests {
         let serialized = serde_json::to_value(&without).unwrap();
         assert!(serialized.get("quota_bytes").is_none());
         assert!(serialized.get("editor_limit").is_none());
+    }
+
+    #[test]
+    fn lifetime_ceiling_accepts_within_and_rejects_over() {
+        let day = 24 * 60 * 60;
+        // Exactly at the ceiling and a typical 30-day token are accepted.
+        assert!(lifetime_within_ceiling(1000, 1000 + MAX_TOKEN_LIFETIME_SECONDS));
+        assert!(lifetime_within_ceiling(1000, 1000 + 30 * day));
+        // One day past the ceiling is rejected.
+        assert!(!lifetime_within_ceiling(1000, 1000 + MAX_TOKEN_LIFETIME_SECONDS + day));
+        // exp < iat → lifetime saturates to 0; the normal expiry check handles it.
+        assert!(lifetime_within_ceiling(2000, 1000));
     }
 
     #[tokio::test]

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -262,6 +262,24 @@ impl Default for AuthConfig {
     }
 }
 
+/// AU-4: accept an `https://` JWKS URL, or `http://` only for a loopback host
+/// (dev). Rejects plaintext to any real host, where a MITM could swap the keys.
+fn jwks_url_scheme_ok(url: &str) -> bool {
+    let lower = url.trim().to_ascii_lowercase();
+    if lower.starts_with("https://") {
+        return true;
+    }
+    if let Some(rest) = lower.strip_prefix("http://") {
+        // Host runs up to the first `/`, `:`, `?`, or `#`.
+        let host = rest
+            .split(['/', ':', '?', '#'])
+            .next()
+            .unwrap_or("");
+        return matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1");
+    }
+    false
+}
+
 impl AuthConfig {
     /// Returns an error if any required OIDC field is unset. Called by
     /// `relay serve` at startup before binding listeners.
@@ -272,10 +290,26 @@ impl AuthConfig {
         if self.jwks_url.trim().is_empty() {
             return Err("auth.jwks_url is required".to_string());
         }
+        // AU-4 (JP-300): an `http://` JWKS URL lets a network MITM inject signing
+        // keys — a full auth bypass for self-hosters. Require HTTPS, carving out
+        // loopback for local dev.
+        if !jwks_url_scheme_ok(self.jwks_url.trim()) {
+            return Err(
+                "auth.jwks_url must use https:// (http:// is allowed only for localhost)"
+                    .to_string(),
+            );
+        }
         if self.audience.trim().is_empty() {
             return Err("auth.audience is required".to_string());
         }
         Ok(())
+    }
+
+    /// Whether the relay has *any* revocation transport wired — a control-plane
+    /// push bearer or a polling URL. With neither, revoked tokens are accepted
+    /// until expiry (AU-5a).
+    pub fn has_revocation_transport(&self) -> bool {
+        self.revocation_push_bearer.is_some() || self.revocation_polling_url.is_some()
     }
 
     pub fn revocation_polling_interval(&self) -> std::time::Duration {
@@ -1023,5 +1057,49 @@ mod tests {
         std::fs::write(&path, RelayConfig::fresh().to_toml_string().unwrap()).unwrap();
         let loaded = RelayConfig::load(&path).unwrap().expect("Some");
         assert_eq!(loaded.server.port, DEFAULT_LISTEN_PORT);
+    }
+
+    // AU-4 (JP-300)
+    #[test]
+    fn jwks_url_requires_https_except_localhost() {
+        assert!(jwks_url_scheme_ok("https://issuer.example/.well-known/jwks.json"));
+        assert!(jwks_url_scheme_ok("http://localhost:9999/jwks.json"));
+        assert!(jwks_url_scheme_ok("http://127.0.0.1/jwks.json"));
+        // Plaintext to a real host is rejected…
+        assert!(!jwks_url_scheme_ok("http://issuer.example/jwks.json"));
+        // …and a look-alike host that merely contains "localhost" is not loopback.
+        assert!(!jwks_url_scheme_ok("http://evil.localhost.attacker.com/jwks.json"));
+        assert!(!jwks_url_scheme_ok("ftp://issuer.example/jwks.json"));
+    }
+
+    #[test]
+    fn auth_validate_rejects_plaintext_jwks_url() {
+        let mut cfg = AuthConfig {
+            issuer: "https://issuer.example".to_string(),
+            jwks_url: "http://issuer.example/jwks.json".to_string(),
+            ..AuthConfig::default()
+        };
+        assert!(cfg.validate().is_err(), "http jwks to a real host must fail");
+        cfg.jwks_url = "https://issuer.example/jwks.json".to_string();
+        assert!(cfg.validate().is_ok(), "https jwks validates");
+    }
+
+    // AU-5a (JP-300)
+    #[test]
+    fn has_revocation_transport_detects_either_channel() {
+        let none = AuthConfig::default();
+        assert!(!none.has_revocation_transport());
+
+        let polling = AuthConfig {
+            revocation_polling_url: Some("https://cp.example/revocations".to_string()),
+            ..AuthConfig::default()
+        };
+        assert!(polling.has_revocation_transport());
+
+        let push = AuthConfig {
+            revocation_push_bearer: Some("secret".to_string()),
+            ..AuthConfig::default()
+        };
+        assert!(push.has_revocation_transport());
     }
 }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -308,7 +308,7 @@ async fn run_serve(
         // pods reject the static token anyway and require a `wsp`-scoped JWT.
         log::info!(
             "MCP static token (diagnostics only — public pods require a JWT): {}",
-            redact_token(mount.token())
+            redact_token(&mount.token())
         );
         server.set_mcp_public_mount(mount).await;
     }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -195,6 +195,25 @@ async fn run_serve(
         .validate()
         .map_err(|e| anyhow::anyhow!("invalid [auth] in {}: {}", config_path.display(), e))?;
 
+    // AU-5a (JP-300): with no revocation transport, revoked tokens stay valid
+    // until expiry. Tolerable for a single-tenant self-host pod, unacceptable
+    // for a multi-tenant shared Cloud pod — refuse to start there; warn loudly
+    // otherwise (a silent fail-open is the dangerous case).
+    if !config.auth.has_revocation_transport() {
+        if config.tenancy.mode == docushark_relay::config::TenancyMode::Shared {
+            anyhow::bail!(
+                "refusing to start: tenancy.mode = \"shared\" but no revocation transport is \
+                 configured (set [auth] revocation_push_bearer and/or revocation_polling_url) — \
+                 revoked tokens would stay valid until expiry on a multi-tenant pod"
+            );
+        }
+        log::warn!(
+            "no revocation transport configured ([auth] revocation_push_bearer / \
+             revocation_polling_url both unset): revoked tokens are accepted until they expire. \
+             Acceptable only for single-tenant/self-host; configure one for production."
+        );
+    }
+
     std::fs::create_dir_all(&config.storage.path)?;
 
     // Build the OIDC validator + JWKS cache + revocation set. The
@@ -284,11 +303,12 @@ async fn run_serve(
             mcp_read_limiter.clone(),
         )
         .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
-        // Logged for local diagnostics only; public pods reject the static
-        // token and require a `wsp`-scoped JWT.
+        // AU-7 (JP-300): never write the bearer to logs that ship to
+        // aggregators. Redact unless the operator explicitly opts in. Public
+        // pods reject the static token anyway and require a `wsp`-scoped JWT.
         log::info!(
             "MCP static token (diagnostics only — public pods require a JWT): {}",
-            mount.token()
+            redact_token(mount.token())
         );
         server.set_mcp_public_mount(mount).await;
     }
@@ -354,7 +374,7 @@ async fn run_serve(
                     match mcp.start().await {
                         Ok(addr) => {
                             log::info!("MCP endpoint on {}", addr);
-                            log::info!("MCP bearer token: {}", mcp.get_token().await);
+                            log::info!("MCP bearer token: {}", redact_token(&mcp.get_token().await));
                             Some(mcp)
                         }
                         Err(e) => {
@@ -442,6 +462,22 @@ fn http_origin(bound: &str) -> String {
     } else {
         bound.to_string()
     }
+}
+
+/// AU-7 (JP-300): render an MCP bearer token for a log line without leaking it.
+/// Startup logs ship to aggregators, so by default emit only a short suffix
+/// fingerprint; the full token is shown only when the operator opts in with
+/// `RELAY_SHOW_MCP_TOKEN` set truthy (the `--show-token` equivalent).
+fn redact_token(token: &str) -> String {
+    let reveal = std::env::var("RELAY_SHOW_MCP_TOKEN")
+        .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false);
+    if reveal {
+        return token.to_string();
+    }
+    let n = token.chars().count();
+    let suffix: String = token.chars().skip(n.saturating_sub(4)).collect();
+    format!("***{suffix} ({n} chars; set RELAY_SHOW_MCP_TOKEN=1 to reveal)")
 }
 
 /// Block until the process is asked to shut down. We wait on **both** SIGINT


### PR DESCRIPTION
**Partial — the self-contained relay-side slice of JP-300. Does _not_ close the issue.** AU-1/AU-2/AU-6 are docushark-web-coordinated; AU-3 (live-session revocation/expiry recheck) touches the WS connection state machine and lands as its own slice. AU-8 is a decision tied to the deferred preview surface (JP-84).

From the Fable OAuth review ([project comment](https://linear.app/justins-awesome-apps/project/docushark-d30d015a4b86/activity#comment-176cd983)).

## AU-4 — JWKS scheme unvalidated
An `http://` `jwks_url` let a network MITM inject signing keys → **full auth bypass for self-hosters**. `AuthConfig::validate` now requires `https://`, carving out loopback (`localhost`/`127.0.0.1`/`::1`) for dev (`jwks_url_scheme_ok`). A look-alike host like `evil.localhost.attacker.com` is correctly *not* treated as loopback.

## AU-5 — silent fail-opens made loud
- **(a)** Startup **refuses to boot in `shared` tenancy** when no revocation transport is configured (neither `revocation_push_bearer` nor `revocation_polling_url`) — otherwise revoked tokens stay valid until expiry on a multi-tenant pod. Dedicated/self-host **warns loudly** instead (`has_revocation_transport`).
- **(b)** `validate_token` rejects tokens whose declared lifetime (`exp − iat`) exceeds a **90-day ceiling**, as insurance against an issuer misconfigured to mint long-lived bearers (new `AuthError::ExcessiveLifetime` + metric reason `excessive_lifetime`).

## AU-7 — bearer tokens in startup logs
`main.rs` logged the MCP static token + loopback bearer in full, and logs ship to aggregators. Now **redacted to a 4-char suffix fingerprint** by default; full reveal only via `RELAY_SHOW_MCP_TOKEN=1` (the `--show-token` equivalent).

## Verification
- New unit tests: JWKS scheme matrix, `validate` rejects plaintext JWKS, `has_revocation_transport`, lifetime ceiling (at/over/exp<iat).
- **Relay suite green (343)**; `cargo check` + `cargo clippy` clean on touched code.
- Not in-repo verifiable: the shared-mode boot refusal + redacted log output want a live relay (E2E).

## Remaining on JP-300
AU-3 (live-session recheck, relay), AU-1 / AU-2 / AU-6 (docushark-web), AU-8 (decision).

Assisted-by: Opus 4.8