### PR TITLE
JP-167 (Stage 0): persist contrast cache across frames

### DIFF
--- a/src/engine/Renderer.test.ts
+++ b/src/engine/Renderer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Renderer, RendererOptions } from './Renderer';
 import { Camera } from './Camera';
+import { Vec2 } from '../math/Vec2';
 
 /**
  * Create a mock canvas element with a mock 2D context.
@@ -317,6 +318,66 @@ describe('Renderer', () => {
 
       // Only save/restore for main loop, no grid-specific drawing
       expect(ctx.beginPath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('contrast cache lifecycle', () => {
+    function makeRenderer() {
+      const canvas = createMockCanvas();
+      const camera = new Camera();
+      camera.setViewport(800, 600);
+      const renderer = new Renderer(canvas, camera, { showGrid: false });
+      const cache = (
+        renderer as unknown as { contrastCache: { clear: () => void } }
+      ).contrastCache;
+      const clearSpy = vi.spyOn(cache, 'clear');
+      return { renderer, camera, clearSpy };
+    }
+
+    it('does not clear the contrast cache on camera-only frames', () => {
+      const { renderer, camera, clearSpy } = makeRenderer();
+      // Stable shape-data + z-order references across the frames below.
+      renderer.setShapes({}, []);
+
+      renderer.renderNow();
+      const afterFirstFrame = clearSpy.mock.calls.length;
+
+      // Pan only — shape data and z-order references are unchanged, so the
+      // resolved AUTO colours must survive (the per-frame-cost regression fix).
+      camera.pan(new Vec2(40, 25));
+      renderer.renderNow();
+      camera.pan(new Vec2(-10, 5));
+      renderer.renderNow();
+
+      expect(clearSpy.mock.calls.length).toBe(afterFirstFrame);
+    });
+
+    it('clears the contrast cache when shape data changes', () => {
+      const { renderer, clearSpy } = makeRenderer();
+      renderer.setShapes({}, []);
+      renderer.renderNow();
+      const afterFirstFrame = clearSpy.mock.calls.length;
+
+      // A new shapes reference (a document mutation) must invalidate the cache.
+      renderer.setShapes({}, []);
+      renderer.renderNow();
+
+      expect(clearSpy.mock.calls.length).toBe(afterFirstFrame + 1);
+    });
+
+    it('clears the contrast cache when only the z-order changes', () => {
+      const { renderer, clearSpy } = makeRenderer();
+      const shapes = {};
+      renderer.setShapes(shapes, ['a', 'b']);
+      renderer.renderNow();
+      const afterFirstFrame = clearSpy.mock.calls.length;
+
+      // Same shapes object, new shapeOrder array — a z-order edit changes which
+      // background is topmost, so AUTO colours must be re-resolved.
+      renderer.setShapes(shapes, ['b', 'a']);
+      renderer.renderNow();
+
+      expect(clearSpy.mock.calls.length).toBe(afterFirstFrame + 1);
     });
   });
 

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -144,8 +144,16 @@ export class Renderer {
   private emphasizedShapeId: string | null = null;
   private emphasisStartTime: number = 0;
 
-  // Per-frame contrast resolution cache (reused across frames, cleared at start)
+  // Contrast resolution cache for AUTO colours. Persisted across frames and
+  // cleared only when the inputs that affect resolution change (shape data,
+  // z-order, page background) — never on camera pan/zoom — so a static scene
+  // does not re-resolve AUTO colours O(connectors × shapes) every frame.
+  // The `lastContrast*` fields hold the inputs the live cache was populated
+  // against; a reference/value mismatch on a frame triggers a clear.
   private contrastCache: ContrastCache = new ContrastCache();
+  private lastContrastShapes: Record<string, Shape> | null = null;
+  private lastContrastShapeOrder: string[] | null = null;
+  private lastContrastPageBackground: string | null = null;
 
   // Performance metrics
   private lastFrameTime: number = 0;
@@ -382,11 +390,27 @@ export class Renderer {
 
     // 4. Draw shapes in z-order with viewport culling.
     // Publish per-frame render context so shape handlers can resolve AUTO colors.
-    this.contrastCache.clear();
+    // Invalidate the contrast cache only when an input that affects AUTO-colour
+    // resolution changed since the last populated frame — shape data, z-order,
+    // or the page background. These references are set via `setShapes` on
+    // document mutations; camera pan/zoom leaves them untouched, so panning a
+    // static scene keeps the resolved colours cached instead of re-resolving
+    // every frame.
+    const pageBackground = options.backgroundColor;
+    if (
+      this.shapes !== this.lastContrastShapes ||
+      this.shapeOrder !== this.lastContrastShapeOrder ||
+      pageBackground !== this.lastContrastPageBackground
+    ) {
+      this.contrastCache.clear();
+      this.lastContrastShapes = this.shapes;
+      this.lastContrastShapeOrder = this.shapeOrder;
+      this.lastContrastPageBackground = pageBackground;
+    }
     setRenderContext({
       shapes: this.shapes,
       shapeOrder: this.shapeOrder,
-      pageBackground: options.backgroundColor,
+      pageBackground,
       contrastCache: this.contrastCache,
     });
     try {


### PR DESCRIPTION
First slice of the connector-routing rework (JP-167), following the highest-ROI recommendation in the deep-research plan: **Stage 0 — stop the AUTO-colour contrast cache from being thrown away every frame.**

## Problem
`Renderer.render()` called `contrastCache.clear()` unconditionally at the start of every frame. AUTO-stroke connectors resolve their colour by finding the topmost opaque shape under a sampled point (`resolveAutoColor`, O(shapes)). With the cache wiped each frame, a static scene re-resolved **O(connectors × samples × shapes) every pan/zoom/idle frame** — the dominant cost behind the ~30-node Mermaid-import jank (per the research, this recurs 60×/s even when nothing changed).

## Fix
Persist the cache across frames; clear it only when an input that actually affects AUTO resolution changes:
- `shapes` (shape geometry/fill/opacity — new reference on any document mutation)
- `shapeOrder` (z-order — changes which background is topmost)
- page background (theme)

These are pushed via `setShapes` on document mutations; **camera pan/zoom never touches them**, so resolved colours now survive across camera-only frames. Per-frame contrast cost drops to O(0) on pan/zoom/idle and is paid only on real content / z-order changes. Reference-identity invalidation is conservative-correct: Immer yields fresh references precisely when the relevant slice changes.

## Scope
Deliberately minimal and decoupled from the router rework. The deeper Stage-0 refinements (resolve-once-per-connector at a representative point, RBush-accelerated point queries) and Stages 1–5 (spatial-indexed obstacles, incremental reroute, two-tier OVG/A* router, curves, relay convergence) land in follow-up slices.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2133 passed**
- 3 new `Renderer` tests: no clear on camera-only frames; clear on shape-data change; clear on z-order change

The 60fps-on-import threshold from the research is a manual/visual check on your deploy — flagging for E2E confirmation there.

Assisted-by: Opus 4.8