### PR TITLE
JP-167 (Stage 1): spatial-index the connector obstacle query

### DIFF
--- a/src/engine/OrthogonalRouter.test.ts
+++ b/src/engine/OrthogonalRouter.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { calculateConnectorWaypoints } from './OrthogonalRouter';
+import { SpatialIndex } from './SpatialIndex';
+import { ConnectorShape, RectangleShape, Shape } from '../shapes/Shape';
+
+// Register shape handlers so getBounds works for indexed shapes. Mirrors
+// production, where the index is built from every shape (connectors included,
+// then skipped as obstacles).
+import '../shapes/Rectangle';
+import '../shapes/Connector';
+
+function rect(overrides: Partial<RectangleShape> & { id: string }): RectangleShape {
+  return {
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 80,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#4a90d9',
+    stroke: '#2c5282',
+    strokeWidth: 2,
+    cornerRadius: 0,
+    ...overrides,
+  };
+}
+
+function orthoConnector(overrides: Partial<ConnectorShape> = {}): ConnectorShape {
+  return {
+    id: 'conn',
+    type: 'connector',
+    x: 0,
+    y: 0,
+    x2: 400,
+    y2: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: null,
+    stroke: '#333333',
+    strokeWidth: 2,
+    startShapeId: null,
+    endShapeId: null,
+    startAnchor: 'center',
+    endAnchor: 'center',
+    startArrow: false,
+    endArrow: true,
+    routingMode: 'orthogonal',
+    ...overrides,
+  };
+}
+
+function toRecord(shapes: Shape[]): Record<string, Shape> {
+  const out: Record<string, Shape> = {};
+  for (const s of shapes) out[s.id] = s;
+  return out;
+}
+
+function indexOf(shapes: Shape[]): SpatialIndex {
+  const index = new SpatialIndex();
+  index.rebuild(shapes);
+  return index;
+}
+
+describe('calculateConnectorWaypoints — spatial-index obstacle query', () => {
+  it('produces identical waypoints with and without the index (obstacle in the path)', () => {
+    // A tall rectangle straddling y=0 blocks the straight route from (0,0)→(400,0),
+    // forcing the router to bend around it.
+    const shapes = [
+      rect({ id: 'blocker', x: 200, y: 0, width: 80, height: 220 }),
+      orthoConnector(),
+    ];
+    const record = toRecord(shapes);
+    const connector = record['conn'] as ConnectorShape;
+
+    const scanned = calculateConnectorWaypoints(connector, record);
+    const indexed = calculateConnectorWaypoints(connector, record, indexOf(shapes));
+
+    expect(indexed).toEqual(scanned);
+    // Sanity: the blocker actually forced a detour (more than a single elbow).
+    expect((scanned ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('ignores obstacles outside the corridor identically to a full scan', () => {
+    // The blocker is in the corridor; the rest sit far outside the bbox of the
+    // endpoints (grown by the stub/padding margin) and must not affect routing.
+    const shapes = [
+      rect({ id: 'blocker', x: 200, y: 0, width: 80, height: 220 }),
+      rect({ id: 'far-up', x: 200, y: 1000, width: 80, height: 80 }),
+      rect({ id: 'far-down', x: 200, y: -1000, width: 80, height: 80 }),
+      rect({ id: 'far-right', x: 3000, y: 0, width: 80, height: 80 }),
+      orthoConnector(),
+    ];
+    const record = toRecord(shapes);
+    const connector = record['conn'] as ConnectorShape;
+
+    // Route against only the in-corridor shapes (no far obstacles, no index)…
+    const nearOnly = calculateConnectorWaypoints(
+      connector,
+      toRecord([record['blocker'] as Shape, connector])
+    );
+    // …must equal routing against the full scene through the index.
+    const indexedFull = calculateConnectorWaypoints(connector, record, indexOf(shapes));
+
+    expect(indexedFull).toEqual(nearOnly);
+  });
+
+  it('produces identical waypoints with and without the index (clear path)', () => {
+    const shapes = [
+      rect({ id: 'far', x: 200, y: 2000, width: 80, height: 80 }),
+      orthoConnector(),
+    ];
+    const record = toRecord(shapes);
+    const connector = record['conn'] as ConnectorShape;
+
+    const scanned = calculateConnectorWaypoints(connector, record);
+    const indexed = calculateConnectorWaypoints(connector, record, indexOf(shapes));
+
+    expect(indexed).toEqual(scanned);
+  });
+});

--- a/src/engine/OrthogonalRouter.ts
+++ b/src/engine/OrthogonalRouter.ts
@@ -12,6 +12,7 @@ import { Vec2 } from '../math/Vec2';
 import { Box } from '../math/Box';
 import { Shape, ConnectorShape, AnchorPosition } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
+import type { SpatialIndex } from './SpatialIndex';
 
 /**
  * Direction vectors for standard anchor positions.
@@ -87,7 +88,8 @@ export function calculateOrthogonalPath(
   shapes?: Record<string, Shape>,
   excludeIds?: Set<string>,
   startShapeId?: string,
-  endShapeId?: string
+  endShapeId?: string,
+  obstacleIndex?: SpatialIndex
 ): Array<{ x: number; y: number }> {
   // Get exit and entry directions
   // For center anchor or no anchor, infer from relative position
@@ -113,11 +115,20 @@ export function calculateOrthogonalPath(
   const startHorizontal = Math.abs(startDir.x) > Math.abs(startDir.y);
   const endHorizontal = Math.abs(endDir.x) > Math.abs(endDir.y);
 
-  // Get obstacles for validation
+  // Get obstacles for validation. When a spatial index is available, restrict
+  // the obstacle lookup to the connector's corridor: the bounding box of the
+  // two endpoints, grown by the stub length (the farthest a candidate path
+  // bends out from an endpoint) plus the obstacle padding (so an obstacle whose
+  // padded box just reaches a corridor-edge segment is still included). Every
+  // candidate path produced by `generatePathCandidates` lies inside this box,
+  // so the corridor query yields the same obstacle set as a full scan.
   let obstacles: Box[] = [];
   let connectedShapeObstacles: Box[] = [];
   if (shapes && excludeIds) {
-    obstacles = getObstacles(shapes, excludeIds);
+    const corridor = obstacleIndex
+      ? Box.fromPoints(startPoint, endPoint).expand(MIN_STUB_LENGTH + OBSTACLE_PADDING)
+      : undefined;
+    obstacles = getObstacles(shapes, excludeIds, obstacleIndex, corridor);
     connectedShapeObstacles = getConnectedShapeObstacles(
       shapes,
       startShapeId,
@@ -372,11 +383,34 @@ function calculateZPathWithStubs(
 
 /**
  * Get obstacle bounding boxes from shapes.
+ *
+ * When `obstacleIndex` and `corridor` are supplied, only the shapes whose
+ * bounds intersect the connector's corridor are considered — an O(log n + k)
+ * spatial-index query instead of an O(n) scan over every shape. The corridor
+ * is sized (in `calculateOrthogonalPath`) to contain every candidate path, so
+ * the resulting obstacle set — and therefore the routed waypoints — is
+ * identical to the full scan; only the work done to find it is cheaper.
+ * Obstacle order does not affect routing (the consumers test boolean
+ * intersection and a commutative combined-bounds), so the index's traversal
+ * order is irrelevant.
  */
-function getObstacles(shapes: Record<string, Shape>, excludeIds: Set<string>): Box[] {
+function getObstacles(
+  shapes: Record<string, Shape>,
+  excludeIds: Set<string>,
+  obstacleIndex?: SpatialIndex,
+  corridor?: Box
+): Box[] {
   const obstacles: Box[] = [];
 
-  for (const shape of Object.values(shapes)) {
+  const candidateShapes: Shape[] =
+    obstacleIndex && corridor
+      ? obstacleIndex
+          .queryRect(corridor)
+          .map((id) => shapes[id])
+          .filter((shape): shape is Shape => shape !== undefined)
+      : Object.values(shapes);
+
+  for (const shape of candidateShapes) {
     if (excludeIds.has(shape.id)) continue;
     if (shape.type === 'connector') continue; // Don't avoid other connectors
 
@@ -618,7 +652,8 @@ function avoidObstacles(
  */
 export function calculateConnectorWaypoints(
   connector: ConnectorShape,
-  shapes: Record<string, Shape>
+  shapes: Record<string, Shape>,
+  obstacleIndex?: SpatialIndex
 ): Array<{ x: number; y: number }> | undefined {
   // Only calculate for orthogonal mode
   if (connector.routingMode !== 'orthogonal') {
@@ -642,6 +677,7 @@ export function calculateConnectorWaypoints(
     shapes,
     excludeIds,
     connector.startShapeId ?? undefined,
-    connector.endShapeId ?? undefined
+    connector.endShapeId ?? undefined,
+    obstacleIndex
   );
 }

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -4,6 +4,7 @@ import { Shape, GroupShape, ConnectorShape, isGroup } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Box } from '../math/Box';
 import { calculateConnectorWaypoints } from '../engine/OrthogonalRouter';
+import { SpatialIndex } from '../engine/SpatialIndex';
 import { wouldCreateCycle, wouldExceedMaxDepth, findParentGroup } from '../shapes/GroupHierarchy';
 import { runWithProvenance } from './writeProvenance';
 
@@ -637,10 +638,18 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
           (shape): shape is ConnectorShape =>
             shape.type === 'connector' && (shape as ConnectorShape).routingMode === 'orthogonal'
         );
+        if (connectors.length === 0) return;
+
+        // Build a spatial index of all shapes once so each connector's obstacle
+        // lookup is an O(log n + k) corridor query instead of an O(n) scan. This
+        // turns the whole rebuild from O(connectors × shapes) into
+        // O(shapes + connectors × (log shapes + k)).
+        const obstacleIndex = new SpatialIndex();
+        obstacleIndex.rebuild(Object.values(state.shapes));
 
         // Recalculate waypoints for each connector
         for (const connector of connectors) {
-          const waypoints = calculateConnectorWaypoints(connector, state.shapes);
+          const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
           if (waypoints) {
             (state.shapes[connector.id] as ConnectorShape).waypoints = waypoints;
           }


### PR DESCRIPTION
Stage 1 of the connector-routing rework (JP-167), following Stage 0 (#181). Per the research plan: **route the obstacle lookup through the existing RBush spatial index instead of scanning all shapes.**

## Problem
`getObstacles` iterated *every* shape (O(n)) for each routed connector. `rebuildAllConnectorRoutes` calls the router for every orthogonal connector and fires globally on every import / shape change — so it was **O(connectors × shapes)**, a dominant per-edit cost on imported diagrams (e.g. ~30 connectors over ~30 shapes).

## Fix
- `getObstacles` takes an optional `(SpatialIndex, corridor)`. When supplied, it queries `index.queryRect(corridor)` for the few shapes in the connector's corridor — **O(log n + k)** — instead of scanning all shapes.
- The corridor is `bbox(start, end).expand(MIN_STUB_LENGTH + OBSTACLE_PADDING)`. Every candidate path `generatePathCandidates` produces has all its points within the start/end **stub** bbox, and obstacles are padded by `OBSTACLE_PADDING`, so the corridor is a provable superset of all routing geometry. The obstacle set — and therefore the emitted waypoints — is **identical to the full scan**.
- Order-independence: the only consumers of the obstacle list are a boolean intersection test and a commutative combined-bounds in `avoidObstacles`, so RBush traversal order can't change output.
- `rebuildAllConnectorRoutes` builds **one** index from all shapes and reuses it across every connector → **O(shapes + connectors × (log shapes + k))**.
- The index arg is optional; single-connector callers (`ConnectorTool`, `Engine` drag) and the serialization path are unchanged (a one-off route isn't worth an index build).

## Verification
- `bun run typecheck` — clean
- Full suite green: **2136 passed**
- New `OrthogonalRouter.test.ts` (3 tests) asserts **indexed waypoints `toEqual` scanned waypoints**: with an obstacle in the path, with far obstacles outside the corridor, and on a clear path — i.e. it's a perf-only change with byte-identical routing output.

Next in the stack: Stage 2 — replace the global `rebuildAllConnectorRoutes` with an incremental dirty-set reroute (reverse index + corridor RBush), so a single node move reroutes only the affected connectors instead of all of them.

Assisted-by: Opus 4.8