### PR TITLE
JP-167 (Stage 2): incremental connector reroute (dirty-set)

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -18,6 +18,7 @@ import { Vec2 } from '../math/Vec2';
 import { Shape, isConnector, isGroup, ConnectorShape } from '../shapes/Shape';
 import { updateConnectorEndpoints } from '../shapes/Connector';
 import { calculateConnectorWaypoints } from './OrthogonalRouter';
+import { collectChangedShapes, isConnectorAffected } from './connectorReroute';
 import { useDocumentStore } from '../store/documentStore';
 import { useSessionStore, ToolType, deleteSelected } from '../store/sessionStore';
 import { useHistoryStore, pushHistory } from '../store/historyStore';
@@ -574,8 +575,18 @@ export class Engine {
   private updateConnectors(shapes: Record<string, Shape>): void {
     const updates: Array<{ id: string; updates: Partial<ConnectorShape> }> = [];
 
+    // Only reroute connectors actually affected by this change (bound to a
+    // changed shape, or with an obstacle that moved into/out of their route),
+    // instead of every orthogonal connector on every edit. For a bulk change
+    // (initial load, page switch, import, select-all move) fall back to
+    // considering all connectors — cheaper than per-connector corridor diffing.
+    const changed = collectChangedShapes(this.previousShapes, shapes);
+    const rerouteAll = changed.count > Object.keys(shapes).length * 0.5;
+
     for (const shape of Object.values(shapes)) {
       if (isConnector(shape)) {
+        if (!rerouteAll && !isConnectorAffected(shape, changed)) continue;
+
         const connectorUpdates: Partial<ConnectorShape> = {};
         let hasChanges = false;
 

--- a/src/engine/connectorReroute.test.ts
+++ b/src/engine/connectorReroute.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectChangedShapes,
+  isConnectorAffected,
+  connectorRouteBox,
+} from './connectorReroute';
+import { ConnectorShape, RectangleShape, Shape } from '../shapes/Shape';
+
+// Register handlers so getBounds works for changed-shape obstacle boxes.
+import '../shapes/Rectangle';
+import '../shapes/Connector';
+
+function rect(overrides: Partial<RectangleShape> & { id: string }): RectangleShape {
+  return {
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 80,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#4a90d9',
+    stroke: '#2c5282',
+    strokeWidth: 2,
+    cornerRadius: 0,
+    ...overrides,
+  };
+}
+
+function connector(overrides: Partial<ConnectorShape> & { id: string }): ConnectorShape {
+  return {
+    type: 'connector',
+    x: 0,
+    y: 0,
+    x2: 400,
+    y2: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: null,
+    stroke: '#333',
+    strokeWidth: 2,
+    startShapeId: null,
+    endShapeId: null,
+    startAnchor: 'center',
+    endAnchor: 'center',
+    startArrow: false,
+    endArrow: true,
+    routingMode: 'orthogonal',
+    ...overrides,
+  };
+}
+
+function toRecord(shapes: Shape[]): Record<string, Shape> {
+  const out: Record<string, Shape> = {};
+  for (const s of shapes) out[s.id] = s;
+  return out;
+}
+
+describe('collectChangedShapes', () => {
+  it('detects a moved shape and records both old and new bounds', () => {
+    const prev = toRecord([rect({ id: 'r1', x: 0, y: 0 })]);
+    const next = toRecord([rect({ id: 'r1', x: 500, y: 0 })]);
+
+    const changed = collectChangedShapes(prev, next);
+
+    expect(changed.ids.has('r1')).toBe(true);
+    expect(changed.count).toBe(1);
+    // Old position (~0,0) and new position (~500,0) both recorded as obstacles.
+    expect(changed.obstacleBoxes.length).toBe(2);
+  });
+
+  it('detects added and removed shapes', () => {
+    const keep = rect({ id: 'keep' }); // same reference in both states = unchanged
+    const prev = toRecord([keep, rect({ id: 'gone' })]);
+    const next = toRecord([keep, rect({ id: 'added' })]);
+
+    const changed = collectChangedShapes(prev, next);
+
+    expect(changed.ids.has('added')).toBe(true);
+    expect(changed.ids.has('gone')).toBe(true);
+    expect(changed.ids.has('keep')).toBe(false);
+    expect(changed.count).toBe(2);
+  });
+
+  it('ignores unchanged shapes (reference equality)', () => {
+    const shared = rect({ id: 'r1' });
+    const changed = collectChangedShapes(toRecord([shared]), toRecord([shared]));
+
+    expect(changed.count).toBe(0);
+    expect(changed.obstacleBoxes).toHaveLength(0);
+  });
+
+  it('records changed connectors in ids but not as obstacles', () => {
+    const prev = toRecord([connector({ id: 'c1', x: 0 })]);
+    const next = toRecord([connector({ id: 'c1', x: 10 })]);
+
+    const changed = collectChangedShapes(prev, next);
+
+    expect(changed.ids.has('c1')).toBe(true);
+    expect(changed.obstacleBoxes).toHaveLength(0); // connectors aren't obstacles
+  });
+});
+
+describe('isConnectorAffected', () => {
+  it('is affected when the connector itself changed', () => {
+    const conn = connector({ id: 'c1' });
+    const changed = collectChangedShapes(
+      toRecord([connector({ id: 'c1', x: 0 })]),
+      toRecord([connector({ id: 'c1', x: 5 })])
+    );
+    expect(isConnectorAffected(conn, changed)).toBe(true);
+  });
+
+  it('is affected when a bound shape changed', () => {
+    const conn = connector({ id: 'c1', startShapeId: 'r1' });
+    const changed = collectChangedShapes(
+      toRecord([rect({ id: 'r1', x: 0 })]),
+      toRecord([rect({ id: 'r1', x: 40 })])
+    );
+    expect(isConnectorAffected(conn, changed)).toBe(true);
+  });
+
+  it('is affected when an obstacle moves onto its route', () => {
+    // Connector runs straight along y=0 from x=0..400 (no waypoints).
+    const conn = connector({ id: 'c1' });
+    // An unrelated rect moves to sit on the route at (200, 0).
+    const changed = collectChangedShapes(
+      toRecord([rect({ id: 'blocker', x: 200, y: 600 })]),
+      toRecord([rect({ id: 'blocker', x: 200, y: 0 })])
+    );
+    expect(isConnectorAffected(conn, changed)).toBe(true);
+  });
+
+  it('is NOT affected by an unrelated, far-away change', () => {
+    const conn = connector({ id: 'c1' });
+    const changed = collectChangedShapes(
+      toRecord([rect({ id: 'far', x: 200, y: 1000 })]),
+      toRecord([rect({ id: 'far', x: 260, y: 1000 })])
+    );
+    expect(isConnectorAffected(conn, changed)).toBe(false);
+  });
+});
+
+describe('connectorRouteBox', () => {
+  it('encloses endpoints and waypoints', () => {
+    const conn = connector({
+      id: 'c1',
+      x: 0,
+      y: 0,
+      x2: 400,
+      y2: 0,
+      waypoints: [
+        { x: 100, y: 200 },
+        { x: 300, y: 200 },
+      ],
+    });
+    const box = connectorRouteBox(conn);
+    expect(box.minX).toBe(0);
+    expect(box.minY).toBe(0);
+    expect(box.maxX).toBe(400);
+    expect(box.maxY).toBe(200);
+  });
+});

--- a/src/engine/connectorReroute.ts
+++ b/src/engine/connectorReroute.ts
@@ -1,0 +1,119 @@
+import { Box } from '../math/Box';
+import { Shape, ConnectorShape, isConnector } from '../shapes/Shape';
+import { shapeRegistry } from '../shapes/ShapeRegistry';
+
+/**
+ * Incremental connector-reroute affected-set computation.
+ *
+ * On every document change the engine used to reroute *every* orthogonal
+ * connector (O(connectors × shapes)). These helpers narrow that to the
+ * connectors a given change can actually affect, so dragging one node reroutes
+ * only the connectors touching it instead of the whole document.
+ */
+
+/**
+ * Margin (world units) added around changed-shape bounds when deciding whether
+ * a change can affect a connector's route. A conservative superset of the
+ * router's own obstacle padding so the affected-set never misses a connector
+ * that would genuinely reroute; an over-generous margin only costs a few
+ * redundant reroutes, never a stale route.
+ */
+export const REROUTE_AFFECT_MARGIN = 32;
+
+export interface ChangedShapes {
+  /** Ids of every shape added, removed, or mutated since the previous state. */
+  ids: Set<string>;
+  /** Padded bounds (old and new) of changed NON-connector shapes — potential obstacles. */
+  obstacleBoxes: Box[];
+  /** Total number of changed shapes (drives the bulk-change fallback). */
+  count: number;
+}
+
+function paddedBounds(shape: Shape): Box | null {
+  try {
+    const b = shapeRegistry.getHandler(shape.type).getBounds(shape);
+    return new Box(
+      b.minX - REROUTE_AFFECT_MARGIN,
+      b.minY - REROUTE_AFFECT_MARGIN,
+      b.maxX + REROUTE_AFFECT_MARGIN,
+      b.maxY + REROUTE_AFFECT_MARGIN
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Diff the previous and next shape maps to find what changed. Reference
+ * equality is the change signal — Immer yields a fresh reference only for a
+ * mutated slice. Both the old and the new bounds of a moved/resized shape are
+ * recorded so a connector the obstacle moved *away from* (and should straighten)
+ * is detected as well as one it moved *into*.
+ */
+export function collectChangedShapes(
+  prev: Record<string, Shape>,
+  next: Record<string, Shape>
+): ChangedShapes {
+  const ids = new Set<string>();
+  const obstacleBoxes: Box[] = [];
+  let count = 0;
+
+  const note = (id: string, nextShape: Shape | undefined, prevShape: Shape | undefined): void => {
+    ids.add(id);
+    count++;
+    for (const shape of [nextShape, prevShape]) {
+      if (!shape || isConnector(shape)) continue; // connectors aren't obstacles
+      const box = paddedBounds(shape);
+      if (box) obstacleBoxes.push(box);
+    }
+  };
+
+  for (const id in next) {
+    if (next[id] !== prev[id]) note(id, next[id], prev[id]);
+  }
+  for (const id in prev) {
+    if (!(id in next)) note(id, undefined, prev[id]);
+  }
+
+  return { ids, obstacleBoxes, count };
+}
+
+/**
+ * Bounding box of a connector's current routed polyline
+ * ([start, ...waypoints, end]).
+ */
+export function connectorRouteBox(connector: ConnectorShape): Box {
+  let minX = Math.min(connector.x, connector.x2);
+  let minY = Math.min(connector.y, connector.y2);
+  let maxX = Math.max(connector.x, connector.x2);
+  let maxY = Math.max(connector.y, connector.y2);
+  for (const wp of connector.waypoints ?? []) {
+    minX = Math.min(minX, wp.x);
+    minY = Math.min(minY, wp.y);
+    maxX = Math.max(maxX, wp.x);
+    maxY = Math.max(maxY, wp.y);
+  }
+  return new Box(minX, minY, maxX, maxY);
+}
+
+/**
+ * Whether a connector must be rerouted given a set of changed shapes. Affected when:
+ *  - the connector shape itself changed (endpoint dragged, routing-mode toggled,
+ *    freshly added), or
+ *  - it is bound to a changed shape (a connected shape moved/resized), or
+ *  - a changed shape's padded bounds intersect the connector's current route box
+ *    (an obstacle moved into or out of its path).
+ */
+export function isConnectorAffected(connector: ConnectorShape, changed: ChangedShapes): boolean {
+  if (changed.ids.has(connector.id)) return true;
+  if (connector.startShapeId && changed.ids.has(connector.startShapeId)) return true;
+  if (connector.endShapeId && changed.ids.has(connector.endShapeId)) return true;
+
+  if (changed.obstacleBoxes.length > 0) {
+    const routeBox = connectorRouteBox(connector);
+    for (const box of changed.obstacleBoxes) {
+      if (box.intersects(routeBox)) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Stage 2 of the connector-routing rework (JP-167), after Stage 0 (#181) and Stage 1 (#182). Per the research plan: **replace the global reroute with an incremental dirty-set so an edit reroutes only the affected connectors.**

## Problem
`Engine.updateConnectors` runs on every document-store change and recomputes endpoints + orthogonal waypoints for **every** connector — **O(connectors × shapes)** per edit. Dragging a single node re-routed the entire document (and, before #182, each route also scanned all shapes).

## Fix
The store subscription already tracks `previousShapes`, so we diff it against the new shapes and reroute only connectors a change can affect:
- the **connector itself** changed (endpoint dragged, routing-mode toggled, freshly added),
- it is **bound** to a changed shape (a connected shape moved/resized), or
- a changed shape's padded bounds — **old or new** position — intersect the connector's current **route box** (an obstacle moved into or out of its path; recording the old position is what lets a connector *straighten* once an obstacle leaves).

Dragging one node now reroutes only O(local) connectors. A **bulk change** (initial load, page switch, import, select-all move — >50% of shapes) falls back to considering all connectors, preserving today's behaviour where it's actually needed.

The affected-set logic lives in a pure, unit-tested module `connectorReroute.ts` (`collectChangedShapes`, `connectorRouteBox`, `isConnectorAffected`). The store subscription ordering and the existing endpoint/waypoint code are untouched — only *which* connectors enter the loop changed.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2145 passed** (existing Engine-exercising tests still pass through the behaviour change)
- 9 new `connectorReroute` tests: diff of moved/added/removed, reference-equality no-op, connectors excluded as obstacles; affected by self / bound / obstacle-on-route, **not** affected by far-away changes; route-box bounds.

## Needs your E2E (behaviour change)
This changes *which* connectors recompute, so please sanity-check on the deploy: drag a node and confirm its connectors follow + reroute; move an unrelated box onto a connector's straight path and confirm it bends to avoid; move it away and confirm the connector straightens. The unit tests cover the decision logic; the interactive feel is best confirmed live.

Next: Stage 3 — the two-tier router quality rework (deterministic elbow + 1-bend OVG/A*) plus straight-as-default and the toolbar/property-panel controls.

Assisted-by: Opus 4.8