### PR TITLE
JP-167 (Stage 3): clip connector endpoints to the shape boundary + JP-137 uniform arrow tips

### DIFF
--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -14,6 +14,8 @@ import {
   findOrphanedConnectors,
   findClosestAnchor,
   updateConnectorEndpoints,
+  clipPointToShapeBoundary,
+  clipConnectorEndpoints,
 } from './Connector';
 import { ConnectorShape, RectangleShape, Shape, resolveArrowStyle } from './Shape';
 // Import Rectangle to register its handler
@@ -566,5 +568,72 @@ describe('resolveArrowStyle', () => {
       endArrowStyle: 'none' as const,
     };
     expect(resolveArrowStyle(shape, 'end')).toBe('none');
+  });
+});
+
+describe('endpoint boundary clipping', () => {
+  // Rectangle x,y is the centre; a 100×100 box at (0,0) spans [-50,50]².
+  function box(overrides: Partial<RectangleShape> & { id: string }): RectangleShape {
+    return {
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      rotation: 0,
+      opacity: 1,
+      locked: false,
+      visible: true,
+      fill: '#fff',
+      stroke: '#000',
+      // strokeWidth 0 so getBounds has no stroke padding — the box is exactly
+      // [-50,50]², keeping the clip assertions on round numbers.
+      strokeWidth: 0,
+      cornerRadius: 0,
+      ...overrides,
+    };
+  }
+
+  describe('clipPointToShapeBoundary', () => {
+    it('clips a centre point to the edge facing the target', () => {
+      const shape = box({ id: 'r' });
+      expect(clipPointToShapeBoundary(new Vec2(0, 0), new Vec2(200, 0), shape)).toEqual(
+        new Vec2(50, 0)
+      );
+      expect(clipPointToShapeBoundary(new Vec2(0, 0), new Vec2(0, -200), shape)).toEqual(
+        new Vec2(0, -50)
+      );
+    });
+
+    it('leaves a point already on the boundary unchanged (same reference)', () => {
+      const shape = box({ id: 'r' });
+      const edge = new Vec2(50, 0); // right-edge anchor, not strictly inside
+      expect(clipPointToShapeBoundary(edge, new Vec2(200, 0), shape)).toBe(edge);
+    });
+
+    it('leaves a point outside the shape unchanged', () => {
+      const shape = box({ id: 'r' });
+      const outside = new Vec2(300, 0);
+      expect(clipPointToShapeBoundary(outside, new Vec2(0, 0), shape)).toBe(outside);
+    });
+  });
+
+  describe('clipConnectorEndpoints', () => {
+    it('clips a bound start endpoint to the shape edge', () => {
+      const shapes: Record<string, Shape> = { r: box({ id: 'r' }) };
+      const connector = createTestConnector({ startShapeId: 'r', x: 0, y: 0, x2: 200, y2: 0 });
+      const points = [new Vec2(0, 0), new Vec2(200, 0)];
+
+      const result = clipConnectorEndpoints(points, connector, shapes);
+
+      expect(result[0]).toEqual(new Vec2(50, 0)); // clipped to right edge
+      expect(result[1]).toEqual(new Vec2(200, 0)); // unbound end untouched
+    });
+
+    it('returns the same array reference when nothing is bound', () => {
+      const connector = createTestConnector({ startShapeId: null, endShapeId: null });
+      const points = [new Vec2(0, 0), new Vec2(200, 0)];
+      expect(clipConnectorEndpoints(points, connector, {})).toBe(points);
+    });
   });
 });

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -659,6 +659,79 @@ function getPathPoints(shape: ConnectorShape): Vec2[] {
 }
 
 /**
+ * Clip a connector endpoint that sits *inside* its bound shape — e.g. the
+ * default `center` anchor — to the shape's bounding box, along the line toward
+ * the next path point. This stops the drawn line and arrowhead at the shape's
+ * edge instead of spearing through to its centre. Points that are already on or
+ * outside the box (explicit edge anchors, floating endpoints) are returned
+ * unchanged (same reference), so callers can cheaply detect a no-op.
+ */
+export function clipPointToShapeBoundary(from: Vec2, toward: Vec2, shape: Shape): Vec2 {
+  if (!shapeRegistry.hasHandler(shape.type)) return from;
+  const bounds = shapeRegistry.getHandler(shape.type).getBounds(shape);
+
+  const inside =
+    from.x > bounds.minX &&
+    from.x < bounds.maxX &&
+    from.y > bounds.minY &&
+    from.y < bounds.maxY;
+  if (!inside) return from;
+
+  const dx = toward.x - from.x;
+  const dy = toward.y - from.y;
+  if (dx === 0 && dy === 0) return from;
+
+  // Smallest positive parameter where the ray from `from` exits the box.
+  let t = Infinity;
+  if (dx > 0) t = Math.min(t, (bounds.maxX - from.x) / dx);
+  else if (dx < 0) t = Math.min(t, (bounds.minX - from.x) / dx);
+  if (dy > 0) t = Math.min(t, (bounds.maxY - from.y) / dy);
+  else if (dy < 0) t = Math.min(t, (bounds.minY - from.y) / dy);
+
+  if (!Number.isFinite(t) || t <= 0) return from;
+  return new Vec2(from.x + t * dx, from.y + t * dy);
+}
+
+/**
+ * Clip a connector's first and last path points to their bound shapes'
+ * boundaries (see {@link clipPointToShapeBoundary}). Returns the input array
+ * unchanged when neither endpoint needs clipping.
+ */
+export function clipConnectorEndpoints(
+  points: Vec2[],
+  shape: ConnectorShape,
+  shapes: Record<string, Shape>
+): Vec2[] {
+  if (points.length < 2) return points;
+  let result = points;
+
+  if (shape.startShapeId) {
+    const startShape = shapes[shape.startShapeId];
+    if (startShape && startShape.type !== 'connector') {
+      const clipped = clipPointToShapeBoundary(points[0]!, points[1]!, startShape);
+      if (clipped !== points[0]) {
+        if (result === points) result = [...points];
+        result[0] = clipped;
+      }
+    }
+  }
+
+  const last = points.length - 1;
+  if (shape.endShapeId) {
+    const endShape = shapes[shape.endShapeId];
+    if (endShape && endShape.type !== 'connector') {
+      const clipped = clipPointToShapeBoundary(points[last]!, points[last - 1]!, endShape);
+      if (clipped !== points[last]) {
+        if (result === points) result = [...points];
+        result[last] = clipped;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Calculate the total length of a path.
  */
 function calculatePathLength(points: Vec2[]): number {
@@ -803,6 +876,15 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
 
     // Get all path points (handle self-message routing)
     let points = getPathPoints(shape);
+
+    // Clip endpoints bound to a shape with an interior anchor (the default
+    // 'center') to that shape's edge, so the line/arrowhead touch the boundary
+    // instead of running to the centre. Needs the live shapes from the render
+    // context; outside a frame the raw points are used.
+    const renderCtx = getRenderContext();
+    if (renderCtx) {
+      points = clipConnectorEndpoints(points, shape, renderCtx.shapes);
+    }
 
     // Self-message routing: when both endpoints connect to the same shape
     // Route the connector as a loop to the right


### PR DESCRIPTION
First quality slice of Stage 3 (after the Stage 0–2 perf trilogy, #181/#182/#183). Two related connector-endpoint render fixes.

## 1 — Clip endpoints to the shape boundary (JP-167)
A bound endpoint with an interior anchor — the default `center` — resolves to the shape's **centre**, so straight connectors drew dead-centre-to-centre, spearing through both shapes (orthogonal hid it behind its stubs):

```
NOW:   +-------+         +-------+        FIXED: +-------+         +-------+
       |   *===|=========|==>*   |               |       *=========>       |
       +-------+         +-------+               +-------+         +-------+
```

Fix: in the render path, clip the first/last path points to their bound shape's bounding box, along the line toward the next point (`clipPointToShapeBoundary` / `clipConnectorEndpoints`), using the live shapes from the render context. Edge anchors / floating endpoints are untouched (same-reference no-op). `points` feeds the line, arrowheads, labels and the self-message loop, so all meet the edge cleanly; orthogonal stubs now start at the edge too. Render-only — `hitTest`/`getBounds` keep the unclipped points, so no handler signatures change.

## 2 — Uniform arrowhead colour (JP-137 — dark-mode black tips)
Root cause: the body resolves AUTO contrast **per-segment at the segment midpoint** (vs the background → white on a dark page), but the **arrowheads resolved AUTO at the endpoint**, which sits **on the hitched shape** — a light shape forced a black tip against the white body. (The clip in #1 moves the endpoint onto the shape edge, same code region, so it's folded in here.)

Fix: colour the start/end heads from their **adjacent body segment** (`resolveSegmentStroke` over `p0→p1` / `secondLast→last`), so the head is identical to the leg it attaches to and never samples the hitched shape. Explicit (non-AUTO) strokes pass through unchanged, so users can colour heads by colouring the connector. Along-path text labels are unaffected.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2151 passed**
- New tests: `clipPointToShapeBoundary` / `clipConnectorEndpoints` geometry (5), and a JP-137 regression that renders an AUTO connector hitched to a light shape over a dark page and asserts **no black tip** (records ctx colour assignments).

## Needs your eyes (visual)
Both are render-path/visual: confirm straight connectors meet the shape edges, and that dark-mode PWA arrowheads are no longer black. JP-137 is filed/updated with the root cause; close it after the dark-mode check.

This also unblocks making **straight the default** for new connectors (next small slice).

Assisted-by: Opus 4.8