### PR TITLE
JP-167 (Stage 3): default new connectors to straight routing

### DIFF
--- a/src/shapes/Shape.ts
+++ b/src/shapes/Shape.ts
@@ -879,7 +879,7 @@ export const DEFAULT_CONNECTOR = {
   endArrow: true,
   startArrowStyle: 'none' as ArrowStyle,
   endArrowStyle: 'triangle' as ArrowStyle,
-  routingMode: 'orthogonal' as RoutingMode,
+  routingMode: 'straight' as RoutingMode,
   connectorType: 'default' as ConnectorType,
   lineStyle: 'solid' as LineStyle,
 } as const;

--- a/src/store/settingsStore.test.ts
+++ b/src/store/settingsStore.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { useSettingsStore, migrateSettings } from './settingsStore';
+
+describe('settingsStore default connector routing', () => {
+  it('defaults new connectors to straight routing', () => {
+    // jsdom localStorage is empty, so the store falls back to initial state.
+    expect(useSettingsStore.getState().defaultConnectorType).toBe('straight');
+  });
+});
+
+describe('migrateSettings (v0 → v1)', () => {
+  it('rewrites the stale v0 orthogonal default to straight', () => {
+    const result = migrateSettings({ defaultConnectorType: 'orthogonal' }, 0);
+    expect(result.defaultConnectorType).toBe('straight');
+  });
+
+  it('leaves a v0 straight value alone', () => {
+    const result = migrateSettings({ defaultConnectorType: 'straight' }, 0);
+    expect(result.defaultConnectorType).toBe('straight');
+  });
+
+  it('does not touch an orthogonal value already stored at v1 (a deliberate choice)', () => {
+    const result = migrateSettings({ defaultConnectorType: 'orthogonal' }, 1);
+    expect(result.defaultConnectorType).toBe('orthogonal');
+  });
+
+  it('preserves other persisted fields', () => {
+    const result = migrateSettings(
+      { defaultConnectorType: 'orthogonal', showMinimap: true, gridOpacity: 0.3 },
+      0
+    );
+    expect(result.defaultConnectorType).toBe('straight');
+    expect(result.showMinimap).toBe(true);
+    expect(result.gridOpacity).toBe(0.3);
+  });
+
+  it('tolerates empty/undefined persisted state', () => {
+    expect(migrateSettings(undefined, 0)).toEqual({});
+  });
+});

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -81,8 +81,26 @@ export interface SettingsActions {
 /**
  * Initial state with default values.
  */
+/**
+ * Persist migration. v0→v1 flipped the default new-connector routing from
+ * 'orthogonal' to 'straight'; move stored installs that still carry the old
+ * default forward so the change actually takes effect. A user who deliberately
+ * picks 'orthogonal' after v1 stores it at version 1, so this never clobbers a
+ * real choice — it only rewrites the stale v0 default.
+ */
+export function migrateSettings(
+  persisted: unknown,
+  version: number
+): Partial<SettingsState> {
+  const state = (persisted ?? {}) as Partial<SettingsState>;
+  if (version < 1 && state.defaultConnectorType === 'orthogonal') {
+    return { ...state, defaultConnectorType: 'straight' };
+  }
+  return state;
+}
+
 const initialState: SettingsState = {
-  defaultConnectorType: 'orthogonal',
+  defaultConnectorType: 'straight',
   defaultStyleProfileId: null,
   showStaticProperties: true,
   hideDefaultStyleProfiles: false,
@@ -187,6 +205,9 @@ export const useSettingsStore = create<SettingsState & SettingsActions>()(
     }),
     {
       name: 'docushark-settings',
+      // v1: the default new-connector routing flipped orthogonal → straight.
+      version: 1,
+      migrate: (persisted, version) => migrateSettings(persisted, version),
       partialize: (state) => ({
         defaultConnectorType: state.defaultConnectorType,
         defaultStyleProfileId: state.defaultStyleProfileId,


### PR DESCRIPTION
Stage 3 quick win, after #184 made straight connectors meet shape edges cleanly. Per the JP-167 user feedback ("routing is genuinely bad; straight should be the default"), new connectors now default to **straight**.

## Changes
- `DEFAULT_CONNECTOR.routingMode` → `'straight'` (the `connectorHandler.create` factory default).
- `settingsStore` initial `defaultConnectorType` → `'straight'` (what `ConnectorTool` stamps on drawn connectors).
- **Persist migration v0→v1**: the setting is persisted, so a stored `'orthogonal'` would otherwise win and the flip would silently not apply. The migration rewrites the stale v0 default forward. A user who *deliberately* picks orthogonal after this ships stores it at version 1, so the migration never clobbers a real choice — it only rewrites the old default.

## Not changed (by design)
- **Existing connectors** keep their stored `routingMode` — the field already exists, so no document migration. Switch any connector via the property-panel or context-menu **Routing** control (both already exist).
- **MCP-created connectors** don't set `routingMode` and already render as straight lines, so no relay/adapter change is needed.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2156 passed**
- New `settingsStore` tests: default resolves to `'straight'`; `migrateSettings` rewrites v0 orthogonal→straight, leaves v0 straight / v1 orthogonal untouched, preserves other fields, tolerates empty state.

## Needs your eyes
Draw a fresh connector and confirm it's straight by default; confirm you can still switch one to orthogonal via the property panel / right-click Routing. (If your local settings already had orthogonal stored, the migration flips it to straight on next load.)

Next in Stage 3: the heavier **two-tier orthogonal router** (deterministic elbow → 1-bend OVG/A*) for when users *do* pick orthogonal, then optional curved mode.

Assisted-by: Opus 4.8