### PR TITLE
JP-302: clip connector endpoints to the true outline (diamonds, ellipses)

### DIFF
--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -18,8 +18,9 @@ import {
   clipConnectorEndpoints,
 } from './Connector';
 import { ConnectorShape, RectangleShape, Shape, resolveArrowStyle } from './Shape';
-// Import Rectangle to register its handler
+// Import shape handlers to register them
 import './Rectangle';
+import './Ellipse';
 
 /**
  * Helper to create a test connector shape.
@@ -615,6 +616,32 @@ describe('endpoint boundary clipping', () => {
       const shape = box({ id: 'r' });
       const outside = new Vec2(300, 0);
       expect(clipPointToShapeBoundary(outside, new Vec2(0, 0), shape)).toBe(outside);
+    });
+
+    it('refines onto a non-rectangular outline (ellipse) instead of the box corner (JP-302)', () => {
+      // A radius-50 circle. A diagonal approach exits the bounding box at the
+      // corner (~70.7 from centre); the true circle edge is at radius 50.
+      const circle: Shape = {
+        id: 'circle',
+        type: 'ellipse',
+        x: 0,
+        y: 0,
+        radiusX: 50,
+        radiusY: 50,
+        rotation: 0,
+        opacity: 1,
+        locked: false,
+        visible: true,
+        fill: '#ffffff',
+        stroke: '#000000',
+        strokeWidth: 0, // no stroke band → exact fill edge
+      } as Shape;
+
+      const clipped = clipPointToShapeBoundary(new Vec2(0, 0), new Vec2(200, 200), circle);
+      const dist = Math.hypot(clipped.x, clipped.y);
+      expect(dist).toBeGreaterThan(45); // on the circle, not the centre
+      expect(dist).toBeLessThan(60); // NOT the box corner (~70.7)
+      expect(Math.abs(clipped.x - clipped.y)).toBeLessThan(1); // symmetric at 45°
     });
   });
 

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -659,16 +659,29 @@ function getPathPoints(shape: ConnectorShape): Vec2[] {
 }
 
 /**
+ * Bisection steps used to refine the box exit onto a non-rectangular shape's
+ * true outline. ~2^-12 of the box span — well under a pixel — and only run for
+ * shapes whose outline is inset from their bounding box.
+ */
+const OUTLINE_CLIP_ITERATIONS = 12;
+
+/**
  * Clip a connector endpoint that sits *inside* its bound shape — e.g. the
- * default `center` anchor — to the shape's bounding box, along the line toward
- * the next path point. This stops the drawn line and arrowhead at the shape's
- * edge instead of spearing through to its centre. Points that are already on or
- * outside the box (explicit edge anchors, floating endpoints) are returned
+ * default `center` anchor — to the shape's edge, along the line toward the next
+ * path point. This stops the drawn line and arrowhead at the shape's edge
+ * instead of spearing through to its centre. Points already on or outside the
+ * shape's bounding box (explicit edge anchors, floating endpoints) are returned
  * unchanged (same reference), so callers can cheaply detect a no-op.
+ *
+ * The box exit is exact for rectangles. For shapes whose outline is inset from
+ * their bounding box — decision diamonds, ellipses, other library shapes — the
+ * box exit lands outside the shape, so it is refined onto the true outline by
+ * bisecting the handler's hit test along the ray (JP-302).
  */
 export function clipPointToShapeBoundary(from: Vec2, toward: Vec2, shape: Shape): Vec2 {
   if (!shapeRegistry.hasHandler(shape.type)) return from;
-  const bounds = shapeRegistry.getHandler(shape.type).getBounds(shape);
+  const handler = shapeRegistry.getHandler(shape.type);
+  const bounds = handler.getBounds(shape);
 
   const inside =
     from.x > bounds.minX &&
@@ -689,7 +702,21 @@ export function clipPointToShapeBoundary(from: Vec2, toward: Vec2, shape: Shape)
   else if (dy < 0) t = Math.min(t, (bounds.minY - from.y) / dy);
 
   if (!Number.isFinite(t) || t <= 0) return from;
-  return new Vec2(from.x + t * dx, from.y + t * dy);
+  const boxExit = new Vec2(from.x + t * dx, from.y + t * dy);
+
+  // Rectangles fill their box, so the box exit is the answer. For inset outlines
+  // it falls outside the shape; refine onto the true edge. `from` is interior,
+  // `boxExit` is outside the outline — bisect for the crossing.
+  if (handler.hitTest(shape, boxExit)) return boxExit;
+
+  let insidePt: Vec2 = from;
+  let outsidePt: Vec2 = boxExit;
+  for (let i = 0; i < OUTLINE_CLIP_ITERATIONS; i++) {
+    const mid = new Vec2((insidePt.x + outsidePt.x) / 2, (insidePt.y + outsidePt.y) / 2);
+    if (handler.hitTest(shape, mid)) insidePt = mid;
+    else outsidePt = mid;
+  }
+  return outsidePt;
 }
 
 /**


### PR DESCRIPTION
Fixes JP-302 — the gap you spotted on decision diamonds. Follow-up to the #184 endpoint clip.

## Problem
The endpoint clip (#184) stops a bound connector at the shape's **axis-aligned bounding box**. Exact for rectangles, but a decision diamond's rhombus is inset from its box (and so are ellipses and other library shapes), so the arrowhead floats above/beside the shape with a visible gap — clearest at a diamond's apex and on diagonal approaches.

## Fix
Keep the cheap box-exit as the baseline (exact for rectangles / `hitTestMode: 'bounds'` shapes). When the box exit falls **outside** the shape's true outline, refine it onto the outline by **bisecting the handler's `hitTest`** along the connector ray. `handler.hitTest` is standalone — bounds math for rectangles, `isPointInPath` (via an offscreen context) for path shapes — so this needs no new geometry, no handler-interface changes, and stays render-path only. 12 bisection steps (sub-pixel) run **only** for the non-rectangular case; rectangles take a single extra `hitTest` and are otherwise unchanged.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2151 passed**
- New test: a radius-50 circle approached on the diagonal clips onto the circle (~50 from centre, symmetric at 45°) instead of the box corner (~70.7). The old AABB-only code returns the corner and fails it. Existing rectangle clip tests unchanged.

## Needs your eyes
Confirm on the deploy: connectors now meet a decision diamond's edge (apex and sides) with no gap; same for ellipses. Rectangles look as before. Note: `hitTest` includes a small stroke tolerance, so on a thick-bordered shape the tip lands at the border's outer edge — effectively touching.

Closes JP-302 after visual confirmation.

Assisted-by: Opus 4.8