### PR TITLE
JP-167 (Stage 3): canonical orthogonal route (Tier 1) for stable paths

### DIFF
--- a/src/engine/OrthogonalRouter.test.ts
+++ b/src/engine/OrthogonalRouter.test.ts
@@ -123,3 +123,39 @@ describe('calculateConnectorWaypoints — spatial-index obstacle query', () => {
     expect(indexed).toEqual(scanned);
   });
 });
+
+describe('calculateConnectorWaypoints — canonical orthogonal route (JP-167 Tier 1)', () => {
+  // Fixed anchors (right → left) so the route direction is deterministic, not
+  // inferred from relative position.
+  function rightToLeft(overrides: Partial<ConnectorShape>): ConnectorShape {
+    return orthoConnector({ startAnchor: 'right', endAnchor: 'left', ...overrides });
+  }
+
+  function fullPath(connector: ConnectorShape): Array<{ x: number; y: number }> {
+    const wp = calculateConnectorWaypoints(connector, {}) ?? [];
+    return [{ x: connector.x, y: connector.y }, ...wp, { x: connector.x2, y: connector.y2 }];
+  }
+
+  it('routes with axis-aligned segments only', () => {
+    const path = fullPath(rightToLeft({ x: 0, y: 0, x2: 200, y2: 120 }));
+    for (let i = 1; i < path.length; i++) {
+      const a = path[i - 1]!;
+      const b = path[i]!;
+      const axisAligned = Math.abs(a.x - b.x) < 1e-6 || Math.abs(a.y - b.y) < 1e-6;
+      expect(axisAligned).toBe(true);
+    }
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const a = calculateConnectorWaypoints(rightToLeft({ x: 0, y: 0, x2: 200, y2: 120 }), {});
+    const b = calculateConnectorWaypoints(rightToLeft({ x: 0, y: 0, x2: 200, y2: 120 }), {});
+    expect(a).toEqual(b);
+  });
+
+  it('keeps the same topology under a small endpoint move (no jitter)', () => {
+    const a = calculateConnectorWaypoints(rightToLeft({ x: 0, y: 0, x2: 200, y2: 120 }), {}) ?? [];
+    const b = calculateConnectorWaypoints(rightToLeft({ x: 0, y: 0, x2: 208, y2: 126 }), {}) ?? [];
+    // Same number of bends — the route doesn't flip to a different candidate.
+    expect(a.length).toBe(b.length);
+  });
+});

--- a/src/engine/OrthogonalRouter.ts
+++ b/src/engine/OrthogonalRouter.ts
@@ -146,50 +146,38 @@ export function calculateOrthogonalPath(
     endHorizontal
   );
 
-  // Find the shortest path that doesn't intersect obstacles
+  // Tier 1: prefer the canonical anchor-directed route (the first candidate)
+  // whenever it is obstacle-free. It is a deterministic function of the anchors
+  // and endpoints, so it stays stable as endpoints move — no flip-flopping
+  // between similar-length candidates, which is what makes routes look jittery
+  // and kinked — and its bend sits at the alley midpoint.
+  const canonical = simplifyPath(candidates[0]!);
+  if (isRouteValid(startPoint, canonical, endPoint, obstacles, connectedShapeObstacles)) {
+    return canonical;
+  }
+
+  // Otherwise pick the shortest obstacle-free candidate, falling back to nudging
+  // around obstacles when none is clear. (This obstacle tier is slated to become
+  // a visibility-graph + A* router — see JP-167.)
   let bestPath = candidates[0]!; // Default to first candidate
   let bestLength = Infinity;
 
   for (const candidate of candidates) {
     const simplified = simplifyPath(candidate);
-
-    // Build full path: startPoint -> waypoints -> endPoint
-    const fullPath = [startPoint, ...simplified.map((wp) => new Vec2(wp.x, wp.y)), endPoint];
-
-    let valid = true;
-    for (let i = 0; i < fullPath.length - 1; i++) {
-      // First segment (start to first waypoint) and last segment (last waypoint to end)
-      // naturally exit/enter from connected shapes, so only check against regular obstacles
-      const isExitSegment = i === 0;
-      const isEntrySegment = i === fullPath.length - 2;
-
-      if (isExitSegment || isEntrySegment) {
-        // Only check against non-connected obstacles
-        if (segmentIntersectsObstacles(fullPath[i]!, fullPath[i + 1]!, obstacles)) {
-          valid = false;
-          break;
-        }
-      } else {
-        // Middle segments check against all obstacles including connected shapes
-        const allObstacles = [...obstacles, ...connectedShapeObstacles];
-        if (segmentIntersectsObstacles(fullPath[i]!, fullPath[i + 1]!, allObstacles)) {
-          valid = false;
-          break;
-        }
-      }
+    if (!isRouteValid(startPoint, simplified, endPoint, obstacles, connectedShapeObstacles)) {
+      continue;
     }
 
-    if (valid) {
-      // Calculate path length
-      let length = 0;
-      for (let i = 0; i < fullPath.length - 1; i++) {
-        length += Vec2.distance(fullPath[i]!, fullPath[i + 1]!);
-      }
+    // Calculate path length over the full start -> waypoints -> end path.
+    const fullPath = [startPoint, ...simplified.map((wp) => new Vec2(wp.x, wp.y)), endPoint];
+    let length = 0;
+    for (let i = 0; i < fullPath.length - 1; i++) {
+      length += Vec2.distance(fullPath[i]!, fullPath[i + 1]!);
+    }
 
-      if (length < bestLength) {
-        bestLength = length;
-        bestPath = simplified;
-      }
+    if (length < bestLength) {
+      bestLength = length;
+      bestPath = simplified;
     }
   }
 
@@ -199,6 +187,33 @@ export function calculateOrthogonalPath(
   }
 
   return bestPath;
+}
+
+/**
+ * Whether an orthogonal route (start → waypoints → end) is free of obstacle
+ * intersections. The first and last segments exit/enter the connected shapes,
+ * so they are only tested against regular obstacles; middle segments are tested
+ * against all obstacles, including the connected shapes.
+ */
+function isRouteValid(
+  startPoint: Vec2,
+  waypoints: Array<{ x: number; y: number }>,
+  endPoint: Vec2,
+  obstacles: Box[],
+  connectedShapeObstacles: Box[]
+): boolean {
+  const fullPath = [startPoint, ...waypoints.map((wp) => new Vec2(wp.x, wp.y)), endPoint];
+  for (let i = 0; i < fullPath.length - 1; i++) {
+    const isExitSegment = i === 0;
+    const isEntrySegment = i === fullPath.length - 2;
+    if (isExitSegment || isEntrySegment) {
+      if (segmentIntersectsObstacles(fullPath[i]!, fullPath[i + 1]!, obstacles)) return false;
+    } else {
+      const allObstacles = [...obstacles, ...connectedShapeObstacles];
+      if (segmentIntersectsObstacles(fullPath[i]!, fullPath[i + 1]!, allObstacles)) return false;
+    }
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
First slice of the orthogonal-router quality rework (the "routing is genuinely bad / kinky / unstable" complaint), now that straight is the default and orthogonal is opt-in.

## Problem
`calculateOrthogonalPath` generated ~6 L/Z/U candidate routes and returned the **shortest valid** one. As endpoints move, the shortest candidate flips between topologies, so the bend jumps around — the jittery, kinked paths.

## Fix — Tier 1: deterministic canonical route
Prefer the **canonical anchor-directed route** (the first candidate — the L/Z dictated by the start/end anchor directions) whenever it is obstacle-free. It's a deterministic function of the anchors and endpoints, so:
- it stays **stable** under small endpoint moves (no flip-flop between similar-length candidates), and
- its bend sits at the alley midpoint.

The shortest-valid search and the obstacle-nudge fallback are kept **only for the obstacle case** — that obstacle tier is slated to become a visibility-graph + A* router (JP-167 Tier 2). The per-candidate validity logic is factored into `isRouteValid`, shared by the canonical check and the fallback loop, so the obstacle-case behaviour is unchanged.

Net effect: obstacle-free orthogonal routes now follow the natural anchor-directed elbow instead of whichever candidate happened to be shortest.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2160 passed** (nothing asserted specific waypoints that the canonical change alters)
- New tests: route is axis-aligned, deterministic for identical inputs, and keeps the **same topology under a small endpoint move** (the anti-jitter property). Existing index==scan equivalence still holds.

## Needs your eyes
This changes orthogonal route *shapes* (visual). Switch a few connectors to orthogonal and confirm the routes look cleaner/stable as you drag endpoints. Obstacle avoidance is unchanged (same fallback).

Next: Tier 2 — replace the candidate-search/nudge fallback with the 1-bend visibility-graph + A* obstacle router from the research, for clean routes *through* dense diagrams.

Assisted-by: Opus 4.8