### PR TITLE
JP-167 (Stage 3): curved routing mode + label outline (+ re-land JP-137)

### DIFF
--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -18,6 +18,8 @@ import {
   clipConnectorEndpoints,
 } from './Connector';
 import { ConnectorShape, RectangleShape, Shape, resolveArrowStyle } from './Shape';
+import { setRenderContext } from '../engine/RenderContext';
+import { ContrastCache } from '../engine/ContrastResolver';
 // Import shape handlers to register them
 import './Rectangle';
 import './Ellipse';
@@ -68,6 +70,7 @@ function createMockContext(): CanvasRenderingContext2D {
     fillRect: vi.fn(),
     strokeRect: vi.fn(),
     fillText: vi.fn(),
+    strokeText: vi.fn(),
     measureText: vi.fn().mockReturnValue({ width: 50 }),
     translate: vi.fn(),
     rotate: vi.fn(),
@@ -662,5 +665,131 @@ describe('endpoint boundary clipping', () => {
       const points = [new Vec2(0, 0), new Vec2(200, 0)];
       expect(clipConnectorEndpoints(points, connector, {})).toBe(points);
     });
+  });
+});
+
+describe('curved routing mode', () => {
+  it('renders a dense smooth path through the waypoints', () => {
+    const ctx = createMockContext();
+    connectorHandler.render(
+      ctx,
+      createTestConnector({
+        routingMode: 'curved',
+        stroke: '#000000',
+        x: 0,
+        y: 0,
+        x2: 200,
+        y2: 0,
+        waypoints: [{ x: 100, y: 80 }],
+      })
+    );
+    const lineToCalls = (ctx.lineTo as ReturnType<typeof vi.fn>).mock.calls;
+    // Many short segments (vs a single segment for a straight 2-point line).
+    expect(lineToCalls.length).toBeGreaterThan(10);
+    // Catmull-Rom interpolates its control points → the curve passes exactly
+    // through the waypoint.
+    expect(lineToCalls).toContainEqual([100, 80]);
+  });
+
+  it('stays straight when there are no waypoints (nothing to smooth)', () => {
+    const ctx = createMockContext();
+    connectorHandler.render(
+      ctx,
+      createTestConnector({
+        routingMode: 'curved',
+        stroke: '#000000',
+        x: 0,
+        y: 0,
+        x2: 200,
+        y2: 0,
+        startArrowStyle: 'none',
+        endArrowStyle: 'none', // isolate the body line from arrowhead lineTo calls
+      })
+    );
+    expect((ctx.lineTo as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+});
+
+describe('label outline (labelStrokeColor)', () => {
+  it('strokes the label text only when an outline colour is set', () => {
+    const withOutline = createMockContext();
+    connectorHandler.render(withOutline, createTestConnector({ label: 'Hi', labelStrokeColor: '#ffffff' }));
+    expect(withOutline.strokeText).toHaveBeenCalled();
+
+    const without = createMockContext();
+    connectorHandler.render(without, createTestConnector({ label: 'Hi' }));
+    expect(without.strokeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('arrowhead contrast colour (JP-137)', () => {
+  function recordingContext(): { ctx: CanvasRenderingContext2D; colors: string[] } {
+    const ctx = createMockContext();
+    const colors: string[] = [];
+    let fill = '';
+    let strokeColor = '';
+    Object.defineProperty(ctx, 'fillStyle', {
+      get: () => fill,
+      set: (v: string) => {
+        fill = v;
+        colors.push(v);
+      },
+      configurable: true,
+    });
+    Object.defineProperty(ctx, 'strokeStyle', {
+      get: () => strokeColor,
+      set: (v: string) => {
+        strokeColor = v;
+        colors.push(v);
+      },
+      configurable: true,
+    });
+    return { ctx, colors };
+  }
+
+  it('keeps the arrowhead uniform with the line instead of resolving on the hitched shape', () => {
+    const lightShape: RectangleShape = {
+      id: 'light',
+      type: 'rectangle',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      rotation: 0,
+      opacity: 1,
+      locked: false,
+      visible: true,
+      fill: '#ffffff',
+      stroke: '#ffffff',
+      strokeWidth: 0,
+      cornerRadius: 0,
+    };
+
+    setRenderContext({
+      shapes: { light: lightShape },
+      shapeOrder: ['light'],
+      pageBackground: '#101020', // dark
+      contrastCache: new ContrastCache(),
+    });
+    try {
+      const connector = createTestConnector({
+        stroke: 'auto',
+        startShapeId: 'light',
+        x: 0,
+        y: 0,
+        x2: 500,
+        y2: 0,
+        startArrowStyle: 'triangle',
+        endArrowStyle: 'triangle',
+      });
+
+      const { ctx, colors } = recordingContext();
+      connectorHandler.render(ctx, connector);
+
+      expect(colors).toContain('#ffffff'); // body + heads resolve to the dark-bg contrast
+      expect(colors).not.toContain('#000000'); // no black tip from the light hitched shape
+    } finally {
+      setRenderContext(null);
+    }
   });
 });

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -771,6 +771,53 @@ function calculatePathLength(points: Vec2[]): number {
   return length;
 }
 
+/** Samples taken along each segment when smoothing a curved connector. */
+const CURVE_SAMPLES_PER_SEGMENT = 12;
+
+/**
+ * A point on the Catmull-Rom spline (tau = 1/2) through p1→p2, using p0/p3 as
+ * the neighbouring tangents. The spline interpolates its control points, so the
+ * curve passes through every waypoint.
+ */
+function catmullRom(p0: Vec2, p1: Vec2, p2: Vec2, p3: Vec2, t: number): Vec2 {
+  const t2 = t * t;
+  const t3 = t2 * t;
+  const x =
+    0.5 *
+    (2 * p1.x +
+      (-p0.x + p2.x) * t +
+      (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 +
+      (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3);
+  const y =
+    0.5 *
+    (2 * p1.y +
+      (-p0.y + p2.y) * t +
+      (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 +
+      (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3);
+  return new Vec2(x, y);
+}
+
+/**
+ * Smooth a polyline into a dense point list following a Catmull-Rom spline
+ * through its points. Endpoints are duplicated as phantom neighbours so the
+ * curve starts/ends exactly at the first/last point. Returns the input
+ * unchanged for fewer than 3 points (nothing to smooth).
+ */
+function sampleSmoothCurve(points: Vec2[]): Vec2[] {
+  if (points.length < 3) return points;
+  const out: Vec2[] = [points[0]!];
+  for (let i = 0; i < points.length - 1; i++) {
+    const p0 = points[i - 1] ?? points[i]!;
+    const p1 = points[i]!;
+    const p2 = points[i + 1]!;
+    const p3 = points[i + 2] ?? p2;
+    for (let s = 1; s <= CURVE_SAMPLES_PER_SEGMENT; s++) {
+      out.push(catmullRom(p0, p1, p2, p3, s / CURVE_SAMPLES_PER_SEGMENT));
+    }
+  }
+  return out;
+}
+
 /**
  * Get a point along the path at position t (0-1).
  */
@@ -824,7 +871,8 @@ function renderConnectorLabel(
   backgroundColor?: string,
   offsetX: number = 0,
   offsetY: number = 0,
-  overflow?: LabelOverflow
+  overflow?: LabelOverflow,
+  strokeColor?: string
 ): void {
   // Background tri-state, resolved here so the label engine stays generic:
   //   undefined            → legacy default white pill (with subtle border)
@@ -833,6 +881,10 @@ function renderConnectorLabel(
   const noBackground = backgroundColor === '' || backgroundColor === 'transparent';
   const usingDefault = backgroundColor === undefined;
   const pillColor = noBackground ? undefined : backgroundColor || 'rgba(255, 255, 255, 0.9)';
+  const textStroke =
+    strokeColor && strokeColor !== '' && strokeColor !== 'transparent'
+      ? { color: strokeColor, width: Math.max(2, fontSize * 0.16) }
+      : undefined;
 
   ctx.save();
   ctx.translate(position.x, position.y);
@@ -846,6 +898,7 @@ function renderConnectorLabel(
     boxHeight: fontSize * 6,
     fontSize,
     color,
+    textStroke,
     background: pillColor,
     backgroundBorder: usingDefault,
     backgroundPadX: 8,
@@ -930,6 +983,14 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
       ];
     }
 
+    // Curved mode: smooth the polyline into a dense Catmull-Rom curve through
+    // its waypoints. Everything downstream (stroke, arrowhead tangent, label
+    // arc-length placement) then operates on the smoothed points with no
+    // special-casing. A 2-point path has nothing to smooth and stays straight.
+    if (shape.routingMode === 'curved' && points.length >= 3) {
+      points = sampleSmoothCurve(points);
+    }
+
     // Draw the line(s)
     if (stroke && strokeWidth > 0 && points.length >= 2) {
       ctx.lineWidth = strokeWidth;
@@ -990,7 +1051,12 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
         const p0 = points[0]!;
         const p1 = points[1]!;
         const startAngle = Math.atan2(p1.y - p0.y, p1.x - p0.x);
-        const startStroke = resolveStrokeAtPoint(stroke, p0, shape.id) ?? stroke;
+        // Colour the arrowhead/marker to match its adjacent body segment rather
+        // than resolving AUTO contrast at the endpoint itself: the endpoint sits
+        // on the hitched shape, so a light shape would force a dark tip that
+        // disjoints from the (background-resolved) line. Using the segment's
+        // colour keeps the head uniform with the leg it attaches to (JP-137).
+        const startStroke = resolveSegmentStroke(stroke, p0, p1, shape.id);
 
         if (connectorType === 'uml-sequence' && shape.startSequenceMarker && shape.startSequenceMarker !== 'none') {
           // Draw UML sequence marker
@@ -1017,7 +1083,10 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
         const lastPt = points[lastIdx]!;
         const secondLastPt = points[lastIdx - 1]!;
         const endAngle = Math.atan2(lastPt.y - secondLastPt.y, lastPt.x - secondLastPt.x);
-        const endStroke = resolveStrokeAtPoint(stroke, lastPt, shape.id) ?? stroke;
+        // Match the adjacent body segment (see start endpoint note above) so the
+        // arrowhead stays uniform with the line instead of resolving contrast on
+        // the hitched shape under the endpoint (JP-137).
+        const endStroke = resolveSegmentStroke(stroke, secondLastPt, lastPt, shape.id);
 
         if (connectorType === 'uml-sequence' && shape.endSequenceMarker && shape.endSequenceMarker !== 'none') {
           // Draw UML sequence marker
@@ -1073,7 +1142,7 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
       const offsetX = shape.labelOffsetX ?? 0;
       const offsetY = shape.labelOffsetY ?? 0;
 
-      renderConnectorLabel(ctx, shape.label, point, fontSize, color, backgroundColor, offsetX, offsetY, shape.labelOverflow);
+      renderConnectorLabel(ctx, shape.label, point, fontSize, color, backgroundColor, offsetX, offsetY, shape.labelOverflow, shape.labelStrokeColor);
     }
 
     // Draw guard condition if present (for activity diagrams)

--- a/src/shapes/Shape.ts
+++ b/src/shapes/Shape.ts
@@ -378,7 +378,7 @@ export interface LineShape extends BaseShape {
 /**
  * Routing mode for connectors.
  */
-export type RoutingMode = 'straight' | 'orthogonal';
+export type RoutingMode = 'straight' | 'orthogonal' | 'curved';
 
 /**
  * ERD (Entity-Relationship Diagram) cardinality notation.
@@ -495,9 +495,9 @@ export interface ConnectorShape extends BaseShape {
   startArrowStyle?: ArrowStyle;
   /** Arrowhead style at the end endpoint (overrides {@link endArrow}). */
   endArrowStyle?: ArrowStyle;
-  /** Routing mode: straight line or orthogonal (right-angle) path */
+  /** Routing mode: straight line, orthogonal (right-angle), or curved (smoothed) path */
   routingMode?: RoutingMode;
-  /** Waypoints for orthogonal routing (intermediate points between start and end) */
+  /** Waypoints for orthogonal/curved routing (intermediate points between start and end) */
   waypoints?: Array<{ x: number; y: number }>;
   /** Text label displayed on the connector */
   label?: string;
@@ -505,6 +505,8 @@ export interface ConnectorShape extends BaseShape {
   labelFontSize?: number;
   /** Color for the label (default: stroke color or black) */
   labelColor?: string;
+  /** Outline (stroke) color drawn around the label text for legibility. Unset = no outline. */
+  labelStrokeColor?: string;
   /** Label background color (default: transparent) */
   labelBackground?: string;
   /** Position of label along the path, 0-1 (default: 0.5 = midpoint) */

--- a/src/shapes/label/renderLabel.ts
+++ b/src/shapes/label/renderLabel.ts
@@ -36,6 +36,8 @@ export interface LabelRenderInput {
   fontSize: number;
   /** Resolved text color (AUTO already resolved by the caller). */
   color: string;
+  /** Optional outline drawn around the glyphs (legibility on busy backgrounds). */
+  textStroke?: { color: string; width: number } | undefined;
   /** Optional background pill color. */
   background?: string | undefined;
   /** Draw a subtle 1px border around the pill (the connector default pill). */
@@ -172,6 +174,19 @@ export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInp
   ctx.font = `${layout.fontSize}px ${fontFamily}`;
   const { lineHeight } = layout;
 
+  // Optional glyph outline, drawn under the fill so it reads as a clean halo.
+  const stroke = input.textStroke;
+  if (stroke && stroke.width > 0) {
+    ctx.strokeStyle = stroke.color;
+    ctx.lineWidth = stroke.width;
+    ctx.lineJoin = 'round';
+    ctx.miterLimit = 2;
+  }
+  const drawLine = (line: string, x: number, y: number): void => {
+    if (stroke && stroke.width > 0) ctx.strokeText(line, x, y);
+    ctx.fillText(line, x, y);
+  };
+
   if (anchor) {
     // Point-anchored: draw with the given canvas alignment. Multi-line stacks
     // are centered for a 'middle' baseline (connectors) and bottom-anchored for
@@ -191,7 +206,7 @@ export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInp
       startY = -(lineCount - 1) * lineHeight;
     }
     layout.lines.forEach((line, i) => {
-      ctx.fillText(line, 0, startY + i * lineHeight);
+      drawLine(line, 0, startY + i * lineHeight);
     });
     ctx.restore();
     return;
@@ -224,7 +239,7 @@ export function renderLabel(ctx: CanvasRenderingContext2D, input: LabelRenderInp
   }
 
   layout.lines.forEach((line, i) => {
-    ctx.fillText(line, anchorX, startY + i * lineHeight);
+    drawLine(line, anchorX, startY + i * lineHeight);
   });
 
   ctx.restore();

--- a/src/ui/ContextMenu.tsx
+++ b/src/ui/ContextMenu.tsx
@@ -332,6 +332,18 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
         });
       },
     },
+    {
+      label: 'Curved',
+      checked: connectorRoutingMode === 'curved',
+      onClick: () => {
+        push('Change routing mode');
+        selectedShapes.forEach(s => {
+          if (s && isConnector(s)) {
+            updateShape(s.id, { routingMode: 'curved' as RoutingMode });
+          }
+        });
+      },
+    },
   ];
 
   // Lock submenu items

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -383,6 +383,14 @@ function LibraryShapeProperties({
             onChange={(color) => handleUpdate('labelBackground', color)}
             showNoFill
           />
+          {isConnector(shape) && (
+            <CompactColorInput
+              label="Outline"
+              value={shape.labelStrokeColor || ''}
+              onChange={(color) => handleUpdate('labelStrokeColor', color)}
+              showNoFill
+            />
+          )}
           <div className="compact-checkbox-row">
             <label>
               <input
@@ -2394,6 +2402,7 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
               >
                 <option value="straight">Straight</option>
                 <option value="orthogonal">Orthogonal</option>
+                <option value="curved">Curved</option>
               </select>
             </div>
           </PropertySection>


### PR DESCRIPTION
Closes out JP-167's last feature goal, plus a label-customization add and a recovered fix.

## 1 — Curved routing mode
`RoutingMode` gains `'curved'`. Render smooths the path `[start, ...waypoints, end]` into a dense **Catmull-Rom** curve through its waypoints; everything downstream (stroke, arrowhead tangent, label arc-length placement) then runs on the smoothed points with no special-casing. A 2-point path has nothing to smooth and stays straight. Selectable in the **property-panel Routing dropdown** and the **right-click Routing submenu**; switching keeps waypoints, so **orthogonal → curved** smooths the existing bends.

## 2 — Label outline (`labelStrokeColor`)
New optional `ConnectorShape` field draws a glyph outline under the label fill, for legibility on busy backgrounds. The shared label engine (`renderLabel`) gains an optional `textStroke`; a connector-only **"Outline"** colour control in the property-panel label section sets it. (Width auto-scales with font size.)

## 3 — ⚠️ Re-land JP-137
While here I found the JP-137 arrowhead-uniformity fix **is not in master**. It was committed to the #184 branch (`3ffdac7`) but #184's merge didn't include it — master's heads still call `resolveStrokeAtPoint` (the dark-mode black-tip bug). The Linear issue and PR both claimed it shipped in #184; it didn't. Re-applied here (`resolveSegmentStroke` for both heads) with its regression test. JP-137 updated to reflect this.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2169 passed**
- New tests: curved renders a dense path **through the waypoint** and stays straight with no waypoints; label outline strokes text only when a colour is set; re-landed JP-137 regression (no black tip over a light hitched shape).

## Needs your eyes
Switch a connector (ideally one with bends, e.g. converted from orthogonal) to **Curved** and confirm the smooth curve + correctly-oriented arrowhead; set a label **Outline** colour and confirm the halo; and re-confirm dark-mode arrowheads are not black (JP-137).

Heads-up: this is the file-overlap reason JP-137 is bundled here rather than a separate PR. Next: JP-167 is feature-complete after this — the **connector-bug-squash** is queued (I've noted the transparent-label-background bug for it).

Assisted-by: Opus 4.8