### PR TITLE
JP-303: transparent default label bg + break the line behind the label

### DIFF
--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -16,7 +16,9 @@ import {
   updateConnectorEndpoints,
   clipPointToShapeBoundary,
   clipConnectorEndpoints,
+  segmentBoxOverlap,
 } from './Connector';
+import { Box } from '../math/Box';
 import { ConnectorShape, RectangleShape, Shape, resolveArrowStyle } from './Shape';
 import { setRenderContext } from '../engine/RenderContext';
 import { ContrastCache } from '../engine/ContrastResolver';
@@ -665,6 +667,52 @@ describe('endpoint boundary clipping', () => {
       const points = [new Vec2(0, 0), new Vec2(200, 0)];
       expect(clipConnectorEndpoints(points, connector, {})).toBe(points);
     });
+  });
+});
+
+describe('segmentBoxOverlap', () => {
+  it('returns the inside parameter range for a crossing segment', () => {
+    const overlap = segmentBoxOverlap(new Vec2(0, 0), new Vec2(100, 0), new Box(40, -10, 60, 10));
+    expect(overlap).toEqual([0.4, 0.6]);
+  });
+
+  it('returns null for a segment that misses the box', () => {
+    expect(segmentBoxOverlap(new Vec2(0, 0), new Vec2(100, 0), new Box(40, 20, 60, 40))).toBeNull();
+  });
+
+  it('returns [0,1] for a segment fully inside the box', () => {
+    expect(segmentBoxOverlap(new Vec2(0, 0), new Vec2(100, 0), new Box(-10, -10, 110, 10))).toEqual([0, 1]);
+  });
+});
+
+describe('label line-break (JP-303)', () => {
+  // measureText is mocked to width 50 → label box at the midpoint (100,0) is
+  // x∈[100-31, 100+31] = [69, 131]; the line gap therefore resumes at x=131.
+  it('breaks the connector line behind a label with no background pill', () => {
+    const ctx = createMockContext();
+    connectorHandler.render(
+      ctx,
+      createTestConnector({ label: 'Hi', stroke: '#000000', x: 0, y: 0, x2: 200, y2: 0 })
+    );
+    // The body line resumes after the label box — a moveTo at the gap exit.
+    expect((ctx.moveTo as ReturnType<typeof vi.fn>).mock.calls).toContainEqual([131, 0]);
+  });
+
+  it('does not break the line when the label has an explicit background pill', () => {
+    const ctx = createMockContext();
+    connectorHandler.render(
+      ctx,
+      createTestConnector({
+        label: 'Hi',
+        labelBackground: '#ffffff',
+        stroke: '#000000',
+        x: 0,
+        y: 0,
+        x2: 200,
+        y2: 0,
+      })
+    );
+    expect((ctx.moveTo as ReturnType<typeof vi.fn>).mock.calls).not.toContainEqual([131, 0]);
   });
 });
 

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -819,6 +819,65 @@ function sampleSmoothCurve(points: Vec2[]): Vec2[] {
 }
 
 /**
+ * Clip a segment a→b against an axis-aligned box (Liang–Barsky). Returns the
+ * parameter range `[tEnter, tExit]` (within [0,1]) over which the segment lies
+ * inside the box, or null if it never enters. Used to break a connector line
+ * behind its label.
+ */
+export function segmentBoxOverlap(a: Vec2, b: Vec2, box: Box): [number, number] | null {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  let t0 = 0;
+  let t1 = 1;
+  const edges: Array<[number, number]> = [
+    [-dx, a.x - box.minX],
+    [dx, box.maxX - a.x],
+    [-dy, a.y - box.minY],
+    [dy, box.maxY - a.y],
+  ];
+  for (const [p, q] of edges) {
+    if (p === 0) {
+      if (q < 0) return null; // parallel to this edge and fully outside it
+    } else {
+      const r = q / p;
+      if (p < 0) {
+        if (r > t1) return null;
+        if (r > t0) t0 = r;
+      } else {
+        if (r < t0) return null;
+        if (r < t1) t1 = r;
+      }
+    }
+  }
+  return t0 <= t1 ? [t0, t1] : null;
+}
+
+/** Stroke a→b but skip the portion inside `box` (the gap behind a label). */
+function strokeSegmentWithGap(ctx: CanvasRenderingContext2D, a: Vec2, b: Vec2, box: Box | null): void {
+  const overlap = box ? segmentBoxOverlap(a, b, box) : null;
+  if (!overlap) {
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+    return;
+  }
+  const [t0, t1] = overlap;
+  if (t0 > 0) {
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(a.x + t0 * (b.x - a.x), a.y + t0 * (b.y - a.y));
+    ctx.stroke();
+  }
+  if (t1 < 1) {
+    ctx.beginPath();
+    ctx.moveTo(a.x + t1 * (b.x - a.x), a.y + t1 * (b.y - a.y));
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+  }
+}
+
+/**
  * Get a point along the path at position t (0-1).
  */
 function getPointAlongPath(points: Vec2[], t: number): { point: Vec2; angle: number } {
@@ -878,9 +937,13 @@ function renderConnectorLabel(
   //   undefined            → legacy default white pill (with subtle border)
   //   '' (or 'transparent') → user chose No Fill; no pill
   //   <colour>             → that colour, no border
-  const noBackground = backgroundColor === '' || backgroundColor === 'transparent';
-  const usingDefault = backgroundColor === undefined;
-  const pillColor = noBackground ? undefined : backgroundColor || 'rgba(255, 255, 255, 0.9)';
+  // Background tri-state. Unset (undefined) now reads as transparent — no pill —
+  // the same as an explicit "No Fill". The connector line is instead broken
+  // behind the label (see the line-break in render) so text stays readable
+  // without an opaque box. Only an explicit colour draws a pill.
+  const noBackground =
+    backgroundColor === undefined || backgroundColor === '' || backgroundColor === 'transparent';
+  const pillColor = noBackground ? undefined : backgroundColor;
   const textStroke =
     strokeColor && strokeColor !== '' && strokeColor !== 'transparent'
       ? { color: strokeColor, width: Math.max(2, fontSize * 0.16) }
@@ -900,7 +963,7 @@ function renderConnectorLabel(
     color,
     textStroke,
     background: pillColor,
-    backgroundBorder: usingDefault,
+    backgroundBorder: false,
     backgroundPadX: 8,
     backgroundPadY: 8,
     anchor: { textAlign: 'center', textBaseline: 'middle' },
@@ -1005,6 +1068,24 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
         ctx.setLineDash([]);
       }
 
+      // When the label has no opaque pill, break the line behind its text so
+      // it reads cleanly without a box (the line is otherwise transparent
+      // through the label). Compute the label's box once, in world space.
+      let labelGapBox: Box | null = null;
+      const labelBg = shape.labelBackground;
+      const labelHasPill = labelBg !== undefined && labelBg !== '' && labelBg !== 'transparent';
+      if (shape.label && shape.label.trim() && !labelHasPill) {
+        const { point } = getPointAlongPath(points, shape.labelPosition ?? 0.5);
+        const labelFontSize = shape.labelFontSize ?? 12;
+        ctx.font = `${labelFontSize}px sans-serif`;
+        const textWidth = ctx.measureText(shape.label).width;
+        const cx = point.x + (shape.labelOffsetX ?? 0);
+        const cy = point.y + (shape.labelOffsetY ?? 0);
+        const halfW = textWidth / 2 + 6;
+        const halfH = labelFontSize / 2 + 4;
+        labelGapBox = new Box(cx - halfW, cy - halfH, cx + halfW, cy + halfH);
+      }
+
       if (isAutoColor(stroke)) {
         // Per-segment colour resolution so a connector crossing dark→light
         // backgrounds gets the right contrast on each leg.
@@ -1012,21 +1093,13 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
           const a = points[i - 1]!;
           const b = points[i]!;
           ctx.strokeStyle = resolveSegmentStroke(stroke, a, b, shape.id);
-          ctx.beginPath();
-          ctx.moveTo(a.x, a.y);
-          ctx.lineTo(b.x, b.y);
-          ctx.stroke();
+          strokeSegmentWithGap(ctx, a, b, labelGapBox);
         }
       } else {
         ctx.strokeStyle = stroke;
-        const firstPoint = points[0]!;
-        ctx.beginPath();
-        ctx.moveTo(firstPoint.x, firstPoint.y);
         for (let i = 1; i < points.length; i++) {
-          const pt = points[i]!;
-          ctx.lineTo(pt.x, pt.y);
+          strokeSegmentWithGap(ctx, points[i - 1]!, points[i]!, labelGapBox);
         }
-        ctx.stroke();
       }
 
       // Reset dash for markers (they should always be solid)


### PR DESCRIPTION
First connector-bug-squash fix. The white box behind connector labels.

## Problem
A connector label that's never had a background set (`labelBackground === undefined`) rendered a **~90%-opaque white pill + border** — the legacy default. It reads as an ugly box and degrades visual quality, especially on dark/coloured canvases. (Explicit "No Fill" was already transparent; only the *unset* default was the box.)

## Fix (per your call: break the line, no box)
1. **Unset background → transparent** (no pill, no border), same as "No Fill". Only an explicit colour draws a pill.
2. **Break the connector line behind the label** so the now-transparent label stays readable instead of the line cutting through the text — the classic diagramming look. The path is stroked per-segment, skipping the label's box (`segmentBoxOverlap` = Liang–Barsky clip → `strokeSegmentWithGap`). Applied only when the label has no pill (an explicit background already occludes the line). For stronger separation, the label outline (`labelStrokeColor`, #189) stacks on top.

## Perf
Pure geometry, no cost worth measuring: one text measure (already done to draw the label) + O(path points) segment/box clips per connector per frame — 1 segment straight, ~3–5 orthogonal, ~24 curved. No per-pixel work, no extra layers.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2174 passed**
- New tests: `segmentBoxOverlap` (crossing range / miss / fully-inside); the line breaks behind a no-pill label (gap resumes past the box) and stays continuous when an explicit pill is set.

## Needs your eyes
Confirm: a connector label with no background shows no box and the line has a clean gap behind the text; setting an explicit label background still draws a pill; adding a label outline reads well over the gap.

Closes JP-303. Next squash items: continuing the code sweep (e.g. JP-30 — ERD attribute rows won't drag in the property panel — is the nearest filed one).

Assisted-by: Opus 4.8