### PR TITLE
Connector squash: AUTO contrast outline test (JP-304) + straight ignores stale waypoints

### DIFF
--- a/src/engine/ContrastResolver.test.ts
+++ b/src/engine/ContrastResolver.test.ts
@@ -125,6 +125,31 @@ describe('resolveAutoColor', () => {
     expect(resolveAutoColor({ x: 0, y: 0 }, shapes, order, '#ffffff')).toBe('#000000');
   });
 
+  it('ignores a point in a non-rectangular shape\'s bounding-box corner (JP-304)', () => {
+    // A radius-50 circle with a light fill. (40,40) is inside its bounding box
+    // but outside the circle (~56.6 from centre), i.e. actually over the page.
+    shapes['circle'] = {
+      id: 'circle',
+      type: 'ellipse',
+      x: 0,
+      y: 0,
+      radiusX: 50,
+      radiusY: 50,
+      rotation: 0,
+      opacity: 1,
+      locked: false,
+      visible: true,
+      fill: '#ffffff',
+      stroke: '#ffffff',
+      strokeWidth: 0,
+    } as EllipseShape;
+    order = ['circle'];
+    // Corner point falls through to the dark page → white (was black via AABB).
+    expect(resolveAutoColor({ x: 40, y: 40 }, shapes, order, '#101020')).toBe('#ffffff');
+    // A point genuinely over the circle still contrasts its light fill → black.
+    expect(resolveAutoColor({ x: 0, y: 0 }, shapes, order, '#101020')).toBe('#000000');
+  });
+
   it('skips the excluded shape itself', () => {
     shapes['self'] = baseRect({ id: 'self', fill: '#000000' });
     order = ['self'];

--- a/src/engine/ContrastResolver.ts
+++ b/src/engine/ContrastResolver.ts
@@ -1,6 +1,7 @@
 import { Shape, isGroup } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { getContrastColor } from '../utils/color';
+import { Vec2 } from '../math/Vec2';
 
 /**
  * Sentinel value used in shape `fill` / `stroke` / group `backgroundColor`
@@ -74,23 +75,27 @@ export function resolveAutoColor(
     const bg = effectiveBackground(shape);
     if (!bg) continue;
 
-    // Bounds check
-    let inside = false;
+    // Containment: a cheap AABB pre-filter, then a precise outline hit-test so a
+    // point in a non-rectangular shape's empty bounding-box corner (e.g. a
+    // diamond's corner, actually over the canvas) is not falsely attributed to
+    // that shape and coloured against its fill. The hit-test runs only for the
+    // few shapes whose box contains the point, and the whole resolution is
+    // memoised by the contrast cache, so the cost is negligible.
     try {
       const handler = shapeRegistry.getHandler(shape.type);
       const bounds = handler.getBounds(shape);
-      inside =
+      const inAABB =
         point.x >= bounds.minX &&
         point.x <= bounds.maxX &&
         point.y >= bounds.minY &&
         point.y <= bounds.maxY;
+      if (!inAABB) continue;
+      if (!handler.hitTest(shape, new Vec2(point.x, point.y))) continue;
     } catch {
       continue;
     }
 
-    if (inside) {
-      return getContrastColor(bg);
-    }
+    return getContrastColor(bg);
   }
 
   return getContrastColor(pageBackground);

--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -793,3 +793,31 @@ describe('arrowhead contrast colour (JP-137)', () => {
     }
   });
 });
+
+describe('straight mode ignores stale waypoints', () => {
+  it('does not route through waypoints when routingMode is straight', () => {
+    const conn = createTestConnector({
+      routingMode: 'straight',
+      x: 0,
+      y: 0,
+      x2: 200,
+      y2: 0,
+      waypoints: [{ x: 100, y: 500 }], // a leftover bend far off the straight line
+    });
+    const bounds = connectorHandler.getBounds(conn);
+    expect(bounds.maxY).toBeLessThan(100); // the y=500 waypoint is not part of the path
+  });
+
+  it('still routes through waypoints in orthogonal mode', () => {
+    const conn = createTestConnector({
+      routingMode: 'orthogonal',
+      x: 0,
+      y: 0,
+      x2: 200,
+      y2: 0,
+      waypoints: [{ x: 100, y: 500 }],
+    });
+    const bounds = connectorHandler.getBounds(conn);
+    expect(bounds.maxY).toBeGreaterThan(400);
+  });
+});

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -648,7 +648,10 @@ function drawUMLSequenceMarker(
 function getPathPoints(shape: ConnectorShape): Vec2[] {
   const points: Vec2[] = [new Vec2(shape.x, shape.y)];
 
-  if (shape.waypoints && shape.waypoints.length > 0) {
+  // Straight mode ignores any waypoints, so a connector switched to Straight
+  // with bends left over (e.g. via the right-click menu, which doesn't clear
+  // them) draws as an actual straight line rather than a stale bent path.
+  if (shape.routingMode !== 'straight' && shape.waypoints && shape.waypoints.length > 0) {
     for (const wp of shape.waypoints) {
       points.push(new Vec2(wp.x, wp.y));
     }

--- a/src/ui/ContextMenu.tsx
+++ b/src/ui/ContextMenu.tsx
@@ -315,7 +315,8 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
         push('Change routing mode');
         selectedShapes.forEach(s => {
           if (s && isConnector(s)) {
-            updateShape(s.id, { routingMode: 'straight' as RoutingMode });
+            // Clear bends when going straight (mirrors the property panel).
+            updateShape(s.id, { routingMode: 'straight' as RoutingMode, waypoints: [] });
           }
         });
       },


### PR DESCRIPTION
Connector-bug-squash batch (two fixes, per the batching call).

## JP-304 — black connector segment near a diamond (your reported bug)
`resolveAutoColor` decided which shape a point sits over using the shape's **bounding box**, not its outline. A connector segment in a diamond's empty AABB corner — actually over the canvas — was attributed to the diamond and coloured against its fill. The default fill `#4a90d9` has luminance **0.515** (just over the `isLightColor` 0.5 line) → `getContrastColor` returns **black**, so the segment went black.

This shows up **only in dark mode**, which is the tell: a corner point wrongly attributed to the diamond resolves black; the *correct* answer over the dark canvas is white → mismatch (visible). In light mode the correct answer is also black → no mismatch → invisible. (You confirmed: "doesn't happen in light mode.")

**Fix:** keep the AABB as a cheap pre-filter, then require a precise `handler.hitTest` before attributing the point — same AABB-vs-outline class as JP-302, now in the contrast resolver. The hit-test runs only for shapes whose box contains the point and sits behind the per-content contrast cache, so **no perf cost** worth measuring.

## Straight mode kept stale waypoints
`getPathPoints` always included `waypoints`, so a connector switched to **Straight** that still had bends (the right-click Routing menu, unlike the property panel, didn't clear them) drew as a *bent* line. Fix: `getPathPoints` ignores waypoints when `routingMode === 'straight'`, and the context-menu action clears them.

## Verification
- `bun run typecheck` — clean
- Full suite green: **2172 passed**
- New tests: a point in an ellipse's AABB corner resolves to the page, not the shape (JP-304); straight mode excludes a stray waypoint from `getBounds`, orthogonal keeps it.

## Needs your eyes
The headline check: in **dark mode**, the connector segment near the diamond should now be **white** (not the black bit). And right-click → Straight on a bent connector should snap it straight.

Closes JP-304. Note: a segment routed *genuinely over* the diamond's blue fill will still go black (the blue is a hair over the light threshold) — that's correct AUTO contrast, separate from this corner bug; flag it if it bugs you and we can revisit the threshold.

Assisted-by: Opus 4.8