### PR TITLE
JP-300 (AU-2, relay half): accept a per-pod resource URI as a second audience

### DIFF
--- a/relay/docs/api/token-format.md
+++ b/relay/docs/api/token-format.md
@@ -15,11 +15,19 @@ default signing secret; the relay never mints tokens.
 issuer = "https://auth.example.com"
 jwks_url = "https://auth.example.com/.well-known/jwks.json"
 audience = "docushark-relay"
+# Optional, RFC 8707. This pod's resource URI — the value advertised by
+# /.well-known/oauth-protected-resource (typically "{origin}/mcp").
+resource = "https://relay.example.com/mcp"
 ```
 
 - `issuer` is checked against the JWT `iss` claim.
 - `jwks_url` is fetched on startup, cached in memory, refreshed in the background. See *JWKS caching + failure mode* below.
 - `audience` is checked against the JWT `aud` claim.
+- `resource` *(optional, RFC 8707)* — when set, a token is accepted if its
+  `aud` matches **either** `audience` **or** `resource`. This lets an issuer
+  resource-bind a token to a specific pod (minting `aud = [resource, audience]`)
+  while remaining accepted by relays that only know the shared `audience`.
+  Unset means only `audience` is accepted. Env override: `RELAY_JWT_RESOURCE`.
 
 ## Signing algorithm
 
@@ -53,7 +61,7 @@ Other algorithms are not accepted. In particular:
 | -- | -- |
 | `iss` | Must equal the configured issuer. |
 | `sub` | Opaque user identifier from the issuer. The relay stores this on documents the user creates. |
-| `aud` | Must equal the configured audience (default `docushark-relay`). |
+| `aud` | Must match the configured `audience` (default `docushark-relay`) or, if set, the configured `resource` (RFC 8707). May be a single string or an array; an array is accepted if any element matches. |
 | `iat`, `exp` | Standard issued-at + expiry. Tokens past `exp` are rejected. |
 | `jti` | Unique token identifier. Used for revocation lookups (see `revocation.md`). |
 

--- a/relay/src/auth/jwt.rs
+++ b/relay/src/auth/jwt.rs
@@ -91,6 +91,24 @@ impl OidcClaims {
 pub struct OidcValidationConfig {
     pub issuer: String,
     pub audience: String,
+    /// AU-2 (JP-300): an additional accepted audience — this pod's RFC 8707
+    /// resource URI (`{origin}/mcp`). When set, a token is valid if its `aud`
+    /// matches EITHER `audience` or `resource`, so the control plane can
+    /// resource-bind tokens per pod (it mints `aud = [resource, audience]`)
+    /// without breaking legacy `audience`-only tokens during rollout. `None`
+    /// accepts only `audience`.
+    pub resource: Option<String>,
+}
+
+/// The set of `aud` values this relay accepts: always `audience`, plus the
+/// per-pod `resource` URI when configured. A token is accepted if its `aud`
+/// intersects this set (jsonwebtoken's multi-audience semantics).
+fn accepted_audiences(config: &OidcValidationConfig) -> Vec<&str> {
+    let mut accepted = vec![config.audience.as_str()];
+    if let Some(resource) = config.resource.as_deref() {
+        accepted.push(resource);
+    }
+    accepted
 }
 
 /// Validate `token` end-to-end:
@@ -128,7 +146,7 @@ pub async fn validate_token(
 
     let mut validation = Validation::new(Algorithm::RS256);
     validation.set_issuer(&[config.issuer.as_str()]);
-    validation.set_audience(&[config.audience.as_str()]);
+    validation.set_audience(&accepted_audiences(config));
     validation.leeway = CLOCK_SKEW_SECONDS;
     validation.validate_exp = true;
     validation.validate_nbf = false;
@@ -185,7 +203,23 @@ mod tests {
         OidcValidationConfig {
             issuer: "https://issuer.test".to_string(),
             audience: "docushark-relay".to_string(),
+            resource: None,
         }
+    }
+
+    #[test]
+    fn accepted_audiences_adds_resource_when_configured() {
+        // No resource → only the legacy audience is accepted.
+        let mut c = cfg();
+        assert_eq!(accepted_audiences(&c), vec!["docushark-relay"]);
+
+        // With a resource → both the legacy audience and the per-pod resource
+        // are accepted (AU-2 non-breaking rollout).
+        c.resource = Some("https://pod-a.example/mcp".to_string());
+        assert_eq!(
+            accepted_audiences(&c),
+            vec!["docushark-relay", "https://pod-a.example/mcp"],
+        );
     }
 
     fn empty_jwks() -> JwksCache {

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -231,6 +231,14 @@ pub struct AuthConfig {
     pub jwks_url: String,
     /// Token `aud` claim value. Defaults to `"docushark-relay"`.
     pub audience: String,
+    /// AU-2 (JP-300): this pod's RFC 8707 resource URI (`{origin}/mcp`, the
+    /// value RFC 9728 discovery already advertises). When set, a token is
+    /// accepted if its `aud` matches EITHER `audience` or this `resource`,
+    /// letting the control plane resource-bind tokens per pod without breaking
+    /// legacy `audience`-only tokens during rollout. Empty/unset = accept only
+    /// `audience` (self-host / legacy default).
+    #[serde(default)]
+    pub resource: Option<String>,
     /// Shared secret authenticating the push transport
     /// (`POST /api/v1/internal/revoke`). Constant-time compared.
     /// Optional — leave blank to disable push.
@@ -254,6 +262,7 @@ impl Default for AuthConfig {
             issuer: String::new(),
             jwks_url: String::new(),
             audience: DEFAULT_AUDIENCE.to_string(),
+            resource: None,
             revocation_push_bearer: None,
             revocation_polling_url: None,
             revocation_polling_bearer: None,
@@ -642,6 +651,9 @@ impl RelayConfig {
         }
         if let Some(v) = get("RELAY_JWT_AUDIENCE") {
             self.auth.audience = v;
+        }
+        if let Some(v) = get("RELAY_JWT_RESOURCE") {
+            self.auth.resource = Some(v);
         }
         if let Some(v) = get("RELAY_REVOCATION_BEARER") {
             self.auth.revocation_push_bearer = Some(v);

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -224,6 +224,7 @@ async fn run_serve(
         OidcValidationConfig {
             issuer: config.auth.issuer.clone(),
             audience: config.auth.audience.clone(),
+            resource: config.auth.resource.clone(),
         },
         jwks_cache.clone(),
         revocations.clone(),

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -592,6 +592,7 @@ mod tests {
             OidcValidationConfig {
                 issuer: "https://test.example.com".to_string(),
                 audience: "docushark-relay".to_string(),
+                resource: None,
             },
             JwksCache::new("https://test.example.com/.well-known/jwks.json".to_string()),
             RevocationSet::new(),

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -3342,6 +3342,7 @@ mod tests {
             OidcValidationConfig {
                 issuer: "https://test.example.com".to_string(),
                 audience: "docushark-relay".to_string(),
+                resource: None,
             },
             JwksCache::new("https://test.example.com/.well-known/jwks.json".to_string()),
             RevocationSet::new(),

--- a/relay/src/test_support.rs
+++ b/relay/src/test_support.rs
@@ -23,8 +23,8 @@ use rsa::RsaPrivateKey;
 use sha2::{Digest, Sha256};
 
 use crate::auth::{
-    JwksCache, OidcAuthState, OidcClaims, OidcValidationConfig, Revocation, RevocationSet,
-    WorkspaceClaim, WorkspaceRole,
+    validate_token, AuthError, JwksCache, OidcAuthState, OidcClaims, OidcValidationConfig,
+    Revocation, RevocationSet, WorkspaceClaim, WorkspaceRole,
 };
 
 const TEST_ISSUER: &str = "https://test.docushark.local";
@@ -81,10 +81,52 @@ impl OidcTestIssuer {
             OidcValidationConfig {
                 issuer: TEST_ISSUER.to_string(),
                 audience: TEST_AUDIENCE.to_string(),
+                resource: None,
             },
             self.jwks_cache.clone(),
             self.revocations.clone(),
         )
+    }
+
+    /// AU-2 (JP-300): mint a token with an arbitrary `aud` value — a string or
+    /// an array (e.g. `json!([resource, audience])`, the production shape) — to
+    /// exercise resource-bound audience validation. Other claims are a minimal
+    /// single-workspace owner token.
+    pub fn mint_with_aud(&self, aud: serde_json::Value) -> String {
+        let now = Utc::now().timestamp() as u64;
+        let claims = OidcClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: "u_aud_test".to_string(),
+            aud,
+            iat: now,
+            exp: now + 3600,
+            jti: format!("tok_test_{}", nanoid::nanoid!(12)),
+            wsp: vec![WorkspaceClaim {
+                id: "ws_aud".to_string(),
+                role: WorkspaceRole::Owner,
+                region: "default".to_string(),
+                quota_bytes: None,
+                editor_limit: None,
+            }],
+        };
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(self.kid.clone());
+        jsonwebtoken::encode(&header, &claims, &self.encoding_key).expect("encode test token")
+    }
+
+    /// AU-2: validate `token` against this issuer with an optional per-pod
+    /// `resource` accepted alongside the standard audience.
+    pub async fn validate(
+        &self,
+        token: &str,
+        resource: Option<&str>,
+    ) -> Result<OidcClaims, AuthError> {
+        let config = OidcValidationConfig {
+            issuer: TEST_ISSUER.to_string(),
+            audience: TEST_AUDIENCE.to_string(),
+            resource: resource.map(|s| s.to_string()),
+        };
+        validate_token(token, &config, &self.jwks_cache, &self.revocations).await
     }
 
     pub fn jwks_cache(&self) -> JwksCache {

--- a/relay/tests/resource_aud.rs
+++ b/relay/tests/resource_aud.rs
@@ -1,0 +1,47 @@
+//! AU-2 (JP-300): resource-bound audience validation (RFC 8707).
+//!
+//! The control plane mints `aud = [resource, "docushark-relay"]` where the
+//! resource is the pod's `{origin}/mcp` (the value RFC 9728 discovery already
+//! advertises). A relay configured with that resource accepts the token; a
+//! legacy `audience`-only relay still accepts it via the shared legacy value
+//! (non-breaking rollout); and a relay for a *different* pod rejects a token
+//! that doesn't carry its resource — the per-pod isolation the design provides
+//! once the legacy audience is eventually dropped.
+
+use docushark_relay::auth::AuthError;
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::json;
+
+const POD_A: &str = "https://pod-a.example/mcp";
+const POD_B: &str = "https://pod-b.example/mcp";
+const LEGACY_AUD: &str = "docushark-relay";
+
+#[tokio::test]
+async fn array_aud_is_accepted_by_resource_pod_and_legacy_pod() {
+    let issuer = OidcTestIssuer::new().await;
+    // Production shape: aud carries the pod resource AND the legacy audience.
+    let token = issuer.mint_with_aud(json!([POD_A, LEGACY_AUD]));
+
+    // Pod A (configured with its resource) accepts via the resource match.
+    assert!(issuer.validate(&token, Some(POD_A)).await.is_ok());
+
+    // A relay with no resource configured still accepts via the legacy audience
+    // — this is what makes the rollout non-breaking regardless of deploy order.
+    assert!(issuer.validate(&token, None).await.is_ok());
+}
+
+#[tokio::test]
+async fn resource_only_token_is_isolated_to_its_pod() {
+    let issuer = OidcTestIssuer::new().await;
+    // A token bound to ONLY pod B's resource (no legacy aud) — the post-rollout
+    // shape once the legacy audience is dropped.
+    let token = issuer.mint_with_aud(json!(POD_B));
+
+    // Pod B accepts it.
+    assert!(issuer.validate(&token, Some(POD_B)).await.is_ok());
+
+    // Pod A rejects it: its accepted set is {legacy, POD_A}, and the token's aud
+    // (POD_B) intersects neither.
+    let err = issuer.validate(&token, Some(POD_A)).await.unwrap_err();
+    assert!(matches!(err, AuthError::AudienceMismatch), "got {err:?}");
+}


### PR DESCRIPTION
Relay half of **AU-2** (resource-bound tokens, RFC 8707) for JP-300. The docushark-web half (minting `aud = [resource, audience]`) is a separate PR.

## Problem

Tokens aren't resource-bound. Every relay validates the single global `aud = "docushark-relay"`, so a token stolen from one pod is replayable at every pod trusting the issuer — even though the relay's RFC 9728 discovery (`/.well-known/oauth-protected-resource`) already advertises `resource = {origin}/mcp`.

## Change

Optional `[auth].resource` (env `RELAY_JWT_RESOURCE`). When set, a token is accepted if its `aud` matches **either** `audience` **or** `resource` (jsonwebtoken's multi-audience intersection, via the new `accepted_audiences()` helper).

This is the **non-breaking, deploy-order-independent** half of the design: the control plane mints `aud = [resource, audience]`, so

- a relay configured with its `resource` accepts via the resource, and
- a relay that only knows the shared `audience` still accepts via that legacy value.

Unset = legacy single-audience behaviour (self-host default; no migration for existing deployments).

Full per-pod replay protection switches on only once the legacy `audience` is dropped (every relay carries a `resource` + all live tokens carry it) — tracked as a follow-up, not this PR.

## Verification

- `cargo build --bin relay` (main.rs wiring) + `cargo test` → **345 lib + all integration suites pass**.
- `accepted_audiences` unit test (resource added to the set only when configured).
- `tests/resource_aud.rs`: the `[resource, audience]` array shape is accepted by both a resource-configured **and** a legacy relay; a resource-only token is **rejected** (`AudienceMismatch`) by a different pod — proving the isolation the follow-up activates. `test_support` gains `mint_with_aud` + `validate`.
- Confirmed `audience_str()` has no callers, so the array `aud` shape breaks no logic.
- `token-format.md` documents the optional `resource` + array-`aud` acceptance (RFC 8707-framed).

Assisted-by: Opus 4.8