### PR TITLE
JP-245: bring the routing slice to master (post-merge of #195)

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -122,7 +122,7 @@ All tools are namespaced `docushark.*`.
 | `add_shapes` | Add many shapes in one all-or-nothing call. |
 | `connect` | Connect two existing shapes with a connector. |
 | `update_shape` | Patch an existing shape (`x`, `y`, `w`, `h`, `text`, `style`). |
-| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` or `grid`) and wires connectors. |
+| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` with crossing minimization, or `grid`) and wires connectors to typed anchors with orthogonal obstacle-avoiding routing (`routing: "straight"` opts out). |
 
 ### Manage (write)
 
@@ -196,9 +196,15 @@ current.
 - **Outlines are flat.** A section is a heading plus the content up to the
   next heading; nesting is conveyed by `level`, not containment. `move` moves a
   single section, not its descendants.
-- **`generate_diagram` layout is relay-side and approximate** — a layered or
-  grid placement, not the editor's full auto-layout. The editor can re-layout
-  on open. Node caps: 500 nodes / 1000 edges per call.
+- **`generate_diagram` layout is relay-side and self-contained.** Layered mode
+  runs a full Sugiyama pipeline (cycle handling, crossing minimization,
+  deterministic coordinates); connectors attach to typed anchors and are
+  routed orthogonally around intervening shapes with explicit `waypoints`
+  (`routing: "straight"` opts out), so the document looks right before any
+  editor opens it. The same input always reproduces the same geometry. The
+  editor re-routes connectors with the same algorithm when shapes move.
+  Connectors route around nodes, not around each other — heavily parallel
+  edges can still overlap. Node caps: 500 nodes / 1000 edges per call.
 - **Rate limits (per workspace).** Writes draw from the shared write bucket
   (`[tenancy.limits] writes_per_sec`/`writes_burst`, shared with WS sync); reads
   draw from a **separate** bucket (`reads_per_sec`/`reads_burst`, `0` =

--- a/relay/scripts/mcp-smoke.sh
+++ b/relay/scripts/mcp-smoke.sh
@@ -74,7 +74,7 @@ DIAG=$(call docushark.generate_diagram "$(jq -nc --arg d "$DOCID" --arg p "$CANV
   '{docId:$d, pageId:$p,
     nodes:[{id:"client",label:"Client"},{id:"relay",label:"Relay"},{id:"r2",label:"R2",kind:"ellipse"}],
     edges:[{from:"client",to:"relay",label:"WS"},{from:"relay",to:"r2"}]}')")
-echo "7. generate_diagram           → $(jq -c '{nodes:(.nodes|length),edges:(.edges|length),layout}' <<<"$DIAG")"
+echo "7. generate_diagram           → $(jq -c '{nodes:(.nodes|length),edges:(.edges|length),layout,routing}' <<<"$DIAG")"
 
 PAGE=$(call docushark.get_page "$(jq -nc --arg d "$DOCID" --arg p "$CANVAS" '{docId:$d,pageId:$p}')")
 echo "8. get_page                   → $(jq -c '.shapes|map(.kind)' <<<"$PAGE")"

--- a/relay/src/mcp/adapter.rs
+++ b/relay/src/mcp/adapter.rs
@@ -68,6 +68,40 @@ pub struct DslShape {
     /// Connector-only: arrowhead style at the end endpoint.
     /// One of "none" | "triangle" | "open" | "diamond". Defaults to "triangle".
     pub end_arrow_style: Option<String>,
+    /// Connector-only: path routing mode. One of "straight" | "orthogonal" |
+    /// "curved". Omitted = the editor's default (straight). Invalid values
+    /// are dropped rather than guessed.
+    pub routing_mode: Option<String>,
+    /// Connector-only: interior waypoints of a routed path, start to end
+    /// (endpoints excluded — they come from the anchors). Only meaningful
+    /// with a non-straight `routing_mode`.
+    pub waypoints: Option<Vec<DslPoint>>,
+    /// Connector-only: label position along the path as an arc-length
+    /// fraction (clamped to 0..=1; the editor defaults to 0.5).
+    pub label_position: Option<f64>,
+    /// Connector-only: end-point seed. Defaults to `x`/`y`; the renderer
+    /// recalculates both endpoints from the connected shapes each frame, so
+    /// this only shapes the first paint of a cold document.
+    pub x2: Option<f64>,
+    pub y2: Option<f64>,
+}
+
+/// A waypoint on a routed connector path.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+pub struct DslPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// Validate a DSL routing-mode string. Keep the accepted set in lockstep
+/// with `RoutingMode` in `src/shapes/Shape.ts`.
+fn normalize_routing_mode(s: &str) -> Option<&'static str> {
+    match s {
+        "straight" => Some("straight"),
+        "orthogonal" => Some("orthogonal"),
+        "curved" => Some("curved"),
+        _ => None,
+    }
 }
 
 /// Validate a DSL arrow-style string against the four accepted values.
@@ -258,6 +292,15 @@ pub fn shape_json_to_dsl(shape: &Value) -> Option<Value> {
         if let Some(v) = shape.get("endAnchor").cloned() {
             out["endAnchor"] = v;
         }
+        if let Some(v) = shape.get("routingMode").cloned() {
+            out["routingMode"] = v;
+        }
+        if let Some(v) = shape.get("waypoints").cloned() {
+            out["waypoints"] = v;
+        }
+        if let Some(v) = shape.get("labelPosition").cloned() {
+            out["labelPosition"] = v;
+        }
     }
 
     Some(out)
@@ -364,10 +407,23 @@ fn connector(dsl: &DslShape, id: &str) -> Value {
         json!(dsl.end_anchor.clone().unwrap_or_else(|| "center".into())),
     );
     // The renderer recalculates `x2`/`y2` from the connected shapes each
-    // frame; seeding with the start coords keeps the first paint sensible
-    // before that recalculation happens.
-    o.insert("x2".into(), json!(dsl.x));
-    o.insert("y2".into(), json!(dsl.y));
+    // frame; seeding (with the explicit end point when given, else the start
+    // coords) keeps the first paint sensible before that recalculation.
+    o.insert("x2".into(), json!(dsl.x2.unwrap_or(dsl.x)));
+    o.insert("y2".into(), json!(dsl.y2.unwrap_or(dsl.y)));
+    // Routed-path fields (JP-245). Emitted only when set so connectors from
+    // `connect`/`add_shape` stay byte-identical to pre-routing output; the
+    // field names mirror `ConnectorShape` in `src/shapes/Shape.ts` exactly.
+    if let Some(mode) = dsl.routing_mode.as_deref().and_then(normalize_routing_mode) {
+        o.insert("routingMode".into(), json!(mode));
+    }
+    if let Some(wps) = &dsl.waypoints {
+        let points: Vec<Value> = wps.iter().map(|p| json!({"x": p.x, "y": p.y})).collect();
+        o.insert("waypoints".into(), Value::Array(points));
+    }
+    if let Some(lp) = dsl.label_position {
+        o.insert("labelPosition".into(), json!(lp.clamp(0.0, 1.0)));
+    }
     // Per-endpoint arrow style. Defaults match `DEFAULT_CONNECTOR`: no head
     // at the start, a filled triangle at the end. Mirror to the legacy
     // boolean fields so older renderers / consumers stay in sync.
@@ -475,6 +531,11 @@ mod tests {
             end_anchor: None,
             start_arrow_style: None,
             end_arrow_style: None,
+            routing_mode: None,
+            waypoints: None,
+            label_position: None,
+            x2: None,
+            y2: None,
         }
     }
 
@@ -697,5 +758,63 @@ mod tests {
         apply_dsl_patch(&mut s, &patch);
         assert_eq!(s["content"], "new");
         assert!(s.get("label").map(|v| v.is_null()).unwrap_or(true));
+    }
+
+    // ---- JP-245: routed-path connector fields ----
+
+    #[test]
+    fn connector_emits_routed_path_fields_when_set() {
+        let mut d = make(DslKind::Connector, 10.0, 20.0);
+        d.routing_mode = Some("orthogonal".into());
+        d.waypoints = Some(vec![DslPoint { x: 50.0, y: 20.0 }, DslPoint { x: 50.0, y: 90.0 }]);
+        d.label_position = Some(0.35);
+        d.x2 = Some(120.0);
+        d.y2 = Some(90.0);
+        let s = dsl_to_shape_json(&d, "c1");
+        // Field names mirror ConnectorShape in src/shapes/Shape.ts exactly.
+        assert_eq!(s["routingMode"], "orthogonal");
+        assert_eq!(s["waypoints"], json!([{"x": 50.0, "y": 20.0}, {"x": 50.0, "y": 90.0}]));
+        assert_eq!(s["labelPosition"], 0.35);
+        assert_eq!(s["x2"], 120.0);
+        assert_eq!(s["y2"], 90.0);
+    }
+
+    #[test]
+    fn connector_omits_routed_path_fields_when_unset() {
+        // `connect`/`add_shape` connectors must stay byte-identical to the
+        // pre-routing output: absent fields, not nulls or defaults.
+        let s = dsl_to_shape_json(&make(DslKind::Connector, 10.0, 20.0), "c1");
+        let o = s.as_object().unwrap();
+        assert!(!o.contains_key("routingMode"));
+        assert!(!o.contains_key("waypoints"));
+        assert!(!o.contains_key("labelPosition"));
+        // x2/y2 keep seeding from the start coords when no end point given.
+        assert_eq!(s["x2"], 10.0);
+        assert_eq!(s["y2"], 20.0);
+    }
+
+    #[test]
+    fn connector_drops_invalid_routing_mode_and_clamps_label_position() {
+        let mut d = make(DslKind::Connector, 0.0, 0.0);
+        d.routing_mode = Some("zigzag".into());
+        d.label_position = Some(1.5);
+        let s = dsl_to_shape_json(&d, "c1");
+        assert!(!s.as_object().unwrap().contains_key("routingMode"));
+        assert_eq!(s["labelPosition"], 1.0);
+    }
+
+    #[test]
+    fn reverse_mapping_surfaces_routed_path_fields() {
+        let mut d = make(DslKind::Connector, 0.0, 0.0);
+        d.start_shape_id = Some("a".into());
+        d.end_shape_id = Some("b".into());
+        d.routing_mode = Some("orthogonal".into());
+        d.waypoints = Some(vec![DslPoint { x: 5.0, y: 6.0 }]);
+        d.label_position = Some(0.65);
+        let s = dsl_to_shape_json(&d, "c1");
+        let back = shape_json_to_dsl(&s).unwrap();
+        assert_eq!(back["routingMode"], "orthogonal");
+        assert_eq!(back["waypoints"], json!([{"x": 5.0, "y": 6.0}]));
+        assert_eq!(back["labelPosition"], 0.65);
     }
 }

--- a/relay/src/mcp/layout/mod.rs
+++ b/relay/src/mcp/layout/mod.rs
@@ -17,6 +17,8 @@ mod coords;
 mod order;
 mod rank;
 
+use super::route;
+
 /// Node footprint + spacing used when placing generated shapes.
 pub const NODE_W: f64 = 160.0;
 pub const NODE_H: f64 = 72.0;
@@ -128,15 +130,72 @@ pub fn layout(node_ids: &[String], edges: &[(String, String)], mode: LayoutMode)
 /// `edges` are (from, to) pairs of node ids; edges whose endpoints aren't in
 /// `nodes` get center anchors and no geometry (callers validate upstream).
 pub fn layout_diagram(nodes: &[NodeSpec], edges: &[(String, String)], mode: LayoutMode) -> DiagramLayout {
+    build(nodes, edges, mode, false)
+}
+
+/// [`layout_diagram`] plus orthogonal connector routing: every edge gets
+/// obstacle-avoiding waypoints (the JP-245 router, mirroring the editor's),
+/// self-loops get a fixed loop path, and labels on parallel edges are
+/// staggered along their paths so they don't pile up.
+pub fn layout_and_route(nodes: &[NodeSpec], edges: &[(String, String)], mode: LayoutMode) -> DiagramLayout {
+    build(nodes, edges, mode, true)
+}
+
+/// How far a self-loop extends beyond its node's box.
+const SELF_LOOP_MARGIN: f64 = 20.0;
+
+/// Arc-length label positions handed out to parallel edges between the same
+/// node pair, in input order. The first keeps the editor's 0.5 default.
+const LABEL_STAGGER: [f64; 5] = [0.5, 0.35, 0.65, 0.25, 0.75];
+
+enum EdgeClass {
+    Unknown,
+    SelfLoop(usize),
+    Normal { from: usize, to: usize, pipeline_idx: usize },
+}
+
+impl EdgeClass {
+    /// Grouping key for label staggering: the unordered endpoint pair.
+    fn pair_key(&self) -> Option<(usize, usize)> {
+        match *self {
+            EdgeClass::Unknown => None,
+            EdgeClass::SelfLoop(v) => Some((v, v)),
+            EdgeClass::Normal { from, to, .. } => Some((from.min(to), from.max(to))),
+        }
+    }
+}
+
+/// Stagger `label_position` for edges sharing an endpoint pair so their
+/// labels spread along the (near-identical) paths instead of piling up at
+/// the midpoint. Deterministic: assignment follows edge input order.
+fn stagger_labels(classes: &[EdgeClass], routed: &mut [RoutedEdge]) {
+    let mut group_size: std::collections::BTreeMap<(usize, usize), usize> =
+        std::collections::BTreeMap::new();
+    for class in classes {
+        if let Some(key) = class.pair_key() {
+            *group_size.entry(key).or_insert(0) += 1;
+        }
+    }
+    let mut seen: std::collections::BTreeMap<(usize, usize), usize> = std::collections::BTreeMap::new();
+    for (class, edge) in classes.iter().zip(routed.iter_mut()) {
+        let Some(key) = class.pair_key() else { continue };
+        if group_size[&key] < 2 {
+            continue;
+        }
+        let k = seen.entry(key).or_insert(0);
+        let position = LABEL_STAGGER[*k % LABEL_STAGGER.len()];
+        *k += 1;
+        if position != 0.5 {
+            edge.label_position = Some(position);
+        }
+    }
+}
+
+fn build(nodes: &[NodeSpec], edges: &[(String, String)], mode: LayoutMode, route_edges: bool) -> DiagramLayout {
     let index: std::collections::BTreeMap<&str, usize> =
         nodes.iter().enumerate().map(|(i, n)| (n.id.as_str(), i)).collect();
 
     // Classify edges once; the pipeline only sees normal (known, non-loop) ones.
-    enum EdgeClass {
-        Unknown,
-        SelfLoop(usize),
-        Normal { from: usize, to: usize, pipeline_idx: usize },
-    }
     let mut classes: Vec<EdgeClass> = Vec::with_capacity(edges.len());
     let mut pipeline_edges: Vec<(usize, usize)> = Vec::new();
     for (from_id, to_id) in edges {
@@ -172,8 +231,16 @@ pub fn layout_diagram(nodes: &[NodeSpec], edges: &[(String, String)], mode: Layo
     let anchor_point = |v: usize, a: Anchor| -> Pos {
         a.point(positions[v].x, positions[v].y, nodes[v].w, nodes[v].h)
     };
+    let node_rect = |v: usize| -> route::Rect {
+        route::Rect {
+            min_x: positions[v].x - nodes[v].w / 2.0,
+            min_y: positions[v].y - nodes[v].h / 2.0,
+            max_x: positions[v].x + nodes[v].w / 2.0,
+            max_y: positions[v].y + nodes[v].h / 2.0,
+        }
+    };
 
-    let routed: Vec<RoutedEdge> = classes
+    let mut routed: Vec<RoutedEdge> = classes
         .iter()
         .map(|class| match *class {
             EdgeClass::Unknown => RoutedEdge {
@@ -184,14 +251,29 @@ pub fn layout_diagram(nodes: &[NodeSpec], edges: &[(String, String)], mode: Layo
                 end: Pos { x: ORIGIN, y: ORIGIN },
                 label_position: None,
             },
-            EdgeClass::SelfLoop(v) => RoutedEdge {
-                start_anchor: Anchor::Right,
-                end_anchor: Anchor::Bottom,
-                waypoints: Vec::new(),
-                start: anchor_point(v, Anchor::Right),
-                end: anchor_point(v, Anchor::Bottom),
-                label_position: None,
-            },
+            EdgeClass::SelfLoop(v) => {
+                let start = anchor_point(v, Anchor::Right);
+                let end = anchor_point(v, Anchor::Bottom);
+                // Fixed loop out the right flank and under the bottom edge;
+                // no router call (a self-loop never crosses other nodes).
+                let waypoints = if route_edges {
+                    vec![
+                        Pos { x: start.x + SELF_LOOP_MARGIN, y: start.y },
+                        Pos { x: start.x + SELF_LOOP_MARGIN, y: end.y + SELF_LOOP_MARGIN },
+                        Pos { x: end.x, y: end.y + SELF_LOOP_MARGIN },
+                    ]
+                } else {
+                    Vec::new()
+                };
+                RoutedEdge {
+                    start_anchor: Anchor::Right,
+                    end_anchor: Anchor::Bottom,
+                    waypoints,
+                    start,
+                    end,
+                    label_position: None,
+                }
+            }
             EdgeClass::Normal { from, to, pipeline_idx } => {
                 let (sa, ea) = edge_anchors(
                     mode,
@@ -201,17 +283,41 @@ pub fn layout_diagram(nodes: &[NodeSpec], edges: &[(String, String)], mode: Layo
                     from,
                     to,
                 );
+                let start = anchor_point(from, sa);
+                let end = anchor_point(to, ea);
+                let waypoints = if route_edges {
+                    // Obstacles: every other node whose box intersects the
+                    // route corridor, padded — in node input order.
+                    let corridor = route::bbox(start, end).expand(route::CORRIDOR_PADDING);
+                    let obstacles: Vec<route::Rect> = (0..nodes.len())
+                        .filter(|&v| v != from && v != to)
+                        .map(node_rect)
+                        .filter(|r| r.intersects(&corridor))
+                        .map(|r| r.expand(route::OBSTACLE_PADDING))
+                        .collect();
+                    let connected = [
+                        node_rect(from).expand(route::CONNECTED_SHAPE_PADDING),
+                        node_rect(to).expand(route::CONNECTED_SHAPE_PADDING),
+                    ];
+                    route::route_orthogonal(start, end, sa.dir(), ea.dir(), &obstacles, &connected)
+                } else {
+                    Vec::new()
+                };
                 RoutedEdge {
                     start_anchor: sa,
                     end_anchor: ea,
-                    waypoints: Vec::new(),
-                    start: anchor_point(from, sa),
-                    end: anchor_point(to, ea),
+                    waypoints,
+                    start,
+                    end,
                     label_position: None,
                 }
             }
         })
         .collect();
+
+    if route_edges {
+        stagger_labels(&classes, &mut routed);
+    }
 
     DiagramLayout {
         nodes: nodes.iter().zip(&positions).map(|(n, &p)| (n.id.clone(), p)).collect(),
@@ -399,6 +505,112 @@ mod tests {
         // a left of b implies y left of x (no crossing).
         let (a, b, x, y) = (x_of("a"), x_of("b"), x_of("x"), x_of("y"));
         assert_eq!(a < b, y < x, "edges still cross: a={} b={} x={} y={}", a, b, x, y);
+    }
+
+    // ---- JP-245: routing ----
+
+    /// Full path of an edge: start anchor point, interior waypoints, end
+    /// anchor point.
+    fn full_path(edge: &RoutedEdge) -> Vec<Pos> {
+        let mut path = vec![edge.start];
+        path.extend(edge.waypoints.iter().copied());
+        path.push(edge.end);
+        path
+    }
+
+    #[test]
+    fn routed_paths_stay_clear_of_other_nodes() {
+        // A 3-cycle stacks a/b/c vertically; the back edge c -> a must route
+        // around b on the right flank, not through it.
+        let nodes = specs(&["a", "b", "c"]);
+        let edges = e(&[("a", "b"), ("b", "c"), ("c", "a")]);
+        let d = layout_and_route(&nodes, &edges, LayoutMode::Layered);
+
+        let back = &d.edges[2];
+        assert!(!back.waypoints.is_empty(), "back edge should detour, got none");
+
+        let endpoint_ids = [
+            [("a"), ("b")],
+            [("b"), ("c")],
+            [("c"), ("a")],
+        ];
+        for (edge, endpoints) in d.edges.iter().zip(endpoint_ids.iter()) {
+            let path = full_path(edge);
+            for (id, pos) in &d.nodes {
+                if endpoints.contains(&id.as_str()) {
+                    continue;
+                }
+                let rect = route::Rect {
+                    min_x: pos.x - NODE_W / 2.0,
+                    min_y: pos.y - NODE_H / 2.0,
+                    max_x: pos.x + NODE_W / 2.0,
+                    max_y: pos.y + NODE_H / 2.0,
+                };
+                for i in 1..path.len() {
+                    assert!(
+                        !route::segment_crosses_box(
+                            path[i - 1].x,
+                            path[i - 1].y,
+                            path[i].x,
+                            path[i].y,
+                            &rect
+                        ),
+                        "edge segment {:?} -> {:?} crosses node '{}'",
+                        path[i - 1],
+                        path[i],
+                        id
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn self_loop_gets_a_fixed_loop_path() {
+        let d = layout_and_route(&specs(&["a"]), &e(&[("a", "a")]), LayoutMode::Layered);
+        let edge = &d.edges[0];
+        let center = d.nodes[0].1;
+        // Out the right flank, under the bottom edge, back up into the
+        // bottom anchor.
+        assert_eq!(
+            edge.waypoints,
+            vec![
+                Pos { x: center.x + NODE_W / 2.0 + 20.0, y: center.y },
+                Pos { x: center.x + NODE_W / 2.0 + 20.0, y: center.y + NODE_H / 2.0 + 20.0 },
+                Pos { x: center.x, y: center.y + NODE_H / 2.0 + 20.0 },
+            ]
+        );
+    }
+
+    #[test]
+    fn parallel_edges_stagger_their_labels() {
+        // Three edges on the same node pair (two parallel + one reversed):
+        // the first keeps the 0.5 default (None), the rest spread out.
+        let nodes = specs(&["a", "b"]);
+        let edges = e(&[("a", "b"), ("a", "b"), ("b", "a")]);
+        let d = layout_and_route(&nodes, &edges, LayoutMode::Layered);
+        assert_eq!(d.edges[0].label_position, None);
+        assert_eq!(d.edges[1].label_position, Some(0.35));
+        assert_eq!(d.edges[2].label_position, Some(0.65));
+    }
+
+    #[test]
+    fn single_edges_keep_the_default_label_position() {
+        let d = layout_and_route(&specs(&["a", "b"]), &e(&[("a", "b")]), LayoutMode::Layered);
+        assert_eq!(d.edges[0].label_position, None);
+    }
+
+    #[test]
+    fn layout_and_route_is_deterministic() {
+        let nodes = specs(&["a", "b", "c", "d", "e"]);
+        let edges = e(&[("a", "b"), ("b", "c"), ("c", "a"), ("a", "d"), ("d", "e"), ("a", "e")]);
+        let d1 = layout_and_route(&nodes, &edges, LayoutMode::Layered);
+        let d2 = layout_and_route(&nodes, &edges, LayoutMode::Layered);
+        assert_eq!(d1.nodes, d2.nodes);
+        for (e1, e2) in d1.edges.iter().zip(&d2.edges) {
+            assert_eq!(e1.waypoints, e2.waypoints);
+            assert_eq!(e1.label_position, e2.label_position);
+        }
     }
 
     #[test]

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod layout;
 pub mod local_mirror;
 pub mod outline;
+pub mod route;
 pub mod token;
 pub mod tools;
 pub mod transport;

--- a/relay/src/mcp/route.rs
+++ b/relay/src/mcp/route.rs
@@ -1,0 +1,894 @@
+//! Deterministic orthogonal connector routing (JP-245).
+//!
+//! A faithful Rust port of the editor's router so relay-emitted waypoints
+//! agree with what the editor computes when it re-routes after a node move:
+//!
+//! - Tier 1/fallbacks: `calculateOrthogonalPath` in
+//!   `src/engine/OrthogonalRouter.ts` (anchor-directed candidates, shortest
+//!   clear candidate, combined-bounds nudge).
+//! - Tier 2: `routeOrthogonalAvoiding` in
+//!   `src/engine/orthogonalRouterCore.ts` (orthogonal visibility graph + A*).
+//!
+//! Constants, tie-break orders, and arithmetic mirror the TypeScript
+//! line-for-line; both sides are IEEE doubles, so identical inputs produce
+//! identical waypoints (pinned by cross-language parity tests below).
+//! **Changes here must be mirrored in the TS router and vice versa.**
+
+use super::layout::Pos;
+
+/// Minimum distance to extend from an anchor before turning.
+const MIN_STUB_LENGTH: f64 = 20.0;
+/// Padding around shapes for obstacle avoidance.
+pub const OBSTACLE_PADDING: f64 = 15.0;
+/// Padding around the two connected endpoint shapes (just enough to detect
+/// a route cutting back through them).
+pub const CONNECTED_SHAPE_PADDING: f64 = 2.0;
+/// Clearance placed just outside each obstacle so a route can hug it without
+/// the segment-clear test rejecting an edge-grazing path.
+const CLEARANCE: f64 = 1.0;
+/// Cost added whenever the route changes direction. Biases toward few bends.
+const BEND_COST: f64 = 20.0;
+/// Above this obstacle count the visibility graph is too large to build;
+/// the caller falls back to the nudge heuristic.
+pub const MAX_OVG_OBSTACLES: usize = 40;
+/// Corridor expansion when collecting per-edge obstacles: the farthest a
+/// candidate path bends out from an endpoint (the stub) plus the obstacle
+/// padding, so an obstacle whose padded box just reaches a corridor-edge
+/// segment is still included. Matches the editor's spatial-index corridor.
+pub const CORRIDOR_PADDING: f64 = MIN_STUB_LENGTH + OBSTACLE_PADDING;
+
+/// Axis-aligned obstacle box in world space.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rect {
+    pub min_x: f64,
+    pub min_y: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+}
+
+impl Rect {
+    pub fn expand(&self, by: f64) -> Rect {
+        Rect {
+            min_x: self.min_x - by,
+            min_y: self.min_y - by,
+            max_x: self.max_x + by,
+            max_y: self.max_y + by,
+        }
+    }
+
+    pub fn intersects(&self, other: &Rect) -> bool {
+        self.min_x <= other.max_x
+            && self.max_x >= other.min_x
+            && self.min_y <= other.max_y
+            && self.max_y >= other.min_y
+    }
+}
+
+/// Bounding box of two points.
+pub fn bbox(a: Pos, b: Pos) -> Rect {
+    Rect {
+        min_x: a.x.min(b.x),
+        min_y: a.y.min(b.y),
+        max_x: a.x.max(b.x),
+        max_y: a.y.max(b.y),
+    }
+}
+
+/// Route an orthogonal connector from `start` to `end`, preferring to leave
+/// in `start_dir` and enter against `end_dir` (anchor exit directions; a zero
+/// vector means "infer from the relative position", the center-anchor case).
+/// Returns interior waypoints (endpoints excluded). Mirrors the editor's
+/// `calculateOrthogonalPath` tiering:
+///
+/// 1. the canonical anchor-directed candidate when obstacle-free (stable as
+///    endpoints move — no flip-flopping between similar-length routes),
+/// 2. else the shortest obstacle-free of the simple candidates,
+/// 3. else visibility-graph + A* ([`route_avoiding`]),
+/// 4. else the combined-bounds nudge heuristic.
+///
+/// `obstacles` are pre-padded boxes excluding the connected endpoint shapes;
+/// `connected` holds those two shapes (lightly padded) — exit/entry segments
+/// may touch them, middle segments may not.
+pub fn route_orthogonal(
+    start: Pos,
+    end: Pos,
+    start_dir: (f64, f64),
+    end_dir: (f64, f64),
+    obstacles: &[Rect],
+    connected: &[Rect],
+) -> Vec<Pos> {
+    let start_dir = resolve_dir(start_dir, start, end);
+    let end_dir = resolve_dir(end_dir, end, start);
+
+    let start_stub = Pos {
+        x: start.x + start_dir.0 * MIN_STUB_LENGTH,
+        y: start.y + start_dir.1 * MIN_STUB_LENGTH,
+    };
+    let end_stub = Pos {
+        x: end.x + end_dir.0 * MIN_STUB_LENGTH,
+        y: end.y + end_dir.1 * MIN_STUB_LENGTH,
+    };
+    let start_horizontal = start_dir.0.abs() > start_dir.1.abs();
+    let end_horizontal = end_dir.0.abs() > end_dir.1.abs();
+
+    let candidates = generate_candidates(start_stub, end_stub, start_horizontal, end_horizontal);
+
+    // Tier 1: the canonical anchor-directed route whenever it is clear.
+    let canonical = simplify_path(&candidates[0]);
+    if is_route_valid(start, &canonical, end, obstacles, connected) {
+        return canonical;
+    }
+
+    // Shortest clear simple candidate.
+    let mut best_path = candidates[0].clone();
+    let mut best_length = f64::INFINITY;
+    for candidate in &candidates {
+        let simplified = simplify_path(candidate);
+        if !is_route_valid(start, &simplified, end, obstacles, connected) {
+            continue;
+        }
+        let length = path_length(start, &simplified, end);
+        if length < best_length {
+            best_length = length;
+            best_path = simplified;
+        }
+    }
+
+    // Tier 2: visibility graph + A*; nudge heuristic as the last resort.
+    if best_length.is_infinite() && !obstacles.is_empty() {
+        best_path = route_avoiding(start, end, start_dir, obstacles)
+            .unwrap_or_else(|| avoid_obstacles(start, end, simplify_path(&candidates[0]), obstacles));
+    }
+
+    best_path
+}
+
+fn resolve_dir(dir: (f64, f64), from: Pos, to: Pos) -> (f64, f64) {
+    if dir.0 == 0.0 && dir.1 == 0.0 {
+        infer_direction(from, to)
+    } else {
+        dir
+    }
+}
+
+/// Prefer horizontal when |dx| is larger, vertical otherwise.
+fn infer_direction(from: Pos, to: Pos) -> (f64, f64) {
+    let dx = to.x - from.x;
+    let dy = to.y - from.y;
+    if dx.abs() > dy.abs() {
+        if dx > 0.0 {
+            (1.0, 0.0)
+        } else {
+            (-1.0, 0.0)
+        }
+    } else if dy > 0.0 {
+        (0.0, 1.0)
+    } else {
+        (0.0, -1.0)
+    }
+}
+
+/// Candidate waypoint lists between the stub points (start/end excluded).
+/// Order matters: index 0 is the canonical anchor-directed route.
+fn generate_candidates(
+    start_stub: Pos,
+    end_stub: Pos,
+    start_horizontal: bool,
+    end_horizontal: bool,
+) -> Vec<Vec<Pos>> {
+    let mut candidates: Vec<Vec<Pos>> = Vec::new();
+
+    // Strategy 1: anchor-directed stubs joined by an L (mixed orientation)
+    // or Z (same orientation) path.
+    if start_horizontal == end_horizontal {
+        let middle = if start_horizontal {
+            let mid_x = (start_stub.x + end_stub.x) / 2.0;
+            vec![Pos { x: mid_x, y: start_stub.y }, Pos { x: mid_x, y: end_stub.y }]
+        } else {
+            let mid_y = (start_stub.y + end_stub.y) / 2.0;
+            vec![Pos { x: start_stub.x, y: mid_y }, Pos { x: end_stub.x, y: mid_y }]
+        };
+        let mut path = vec![start_stub];
+        path.extend(middle);
+        path.push(end_stub);
+        candidates.push(path);
+    } else {
+        let corner = if start_horizontal {
+            Pos { x: end_stub.x, y: start_stub.y }
+        } else {
+            Pos { x: start_stub.x, y: end_stub.y }
+        };
+        candidates.push(vec![start_stub, corner, end_stub]);
+    }
+
+    // Strategy 2: Z-path with a vertical middle segment at the midpoint x.
+    let mid_x = (start_stub.x + end_stub.x) / 2.0;
+    candidates.push(vec![
+        start_stub,
+        Pos { x: mid_x, y: start_stub.y },
+        Pos { x: mid_x, y: end_stub.y },
+        end_stub,
+    ]);
+
+    // Strategy 3: Z-path with a horizontal middle segment at the midpoint y.
+    let mid_y = (start_stub.y + end_stub.y) / 2.0;
+    candidates.push(vec![
+        start_stub,
+        Pos { x: start_stub.x, y: mid_y },
+        Pos { x: end_stub.x, y: mid_y },
+        end_stub,
+    ]);
+
+    // Strategies 4 + 5: the two L-path corners.
+    candidates.push(vec![start_stub, Pos { x: end_stub.x, y: start_stub.y }, end_stub]);
+    candidates.push(vec![start_stub, Pos { x: start_stub.x, y: end_stub.y }, end_stub]);
+
+    // Strategy 6: direct connection when the stubs are already in line.
+    if (end_stub.x - start_stub.x).abs() < 1.0 {
+        candidates.push(vec![start_stub, Pos { x: start_stub.x, y: end_stub.y }]);
+    }
+    if (end_stub.y - start_stub.y).abs() < 1.0 {
+        candidates.push(vec![start_stub, Pos { x: end_stub.x, y: start_stub.y }]);
+    }
+
+    candidates
+}
+
+/// Drop collinear interior points (corners only survive).
+fn simplify_path(waypoints: &[Pos]) -> Vec<Pos> {
+    if waypoints.len() <= 2 {
+        return waypoints.to_vec();
+    }
+    let mut result = vec![waypoints[0]];
+    for i in 1..waypoints.len() - 1 {
+        let prev = result[result.len() - 1];
+        let curr = waypoints[i];
+        let next = waypoints[i + 1];
+        let same_x = prev.x == curr.x && curr.x == next.x;
+        let same_y = prev.y == curr.y && curr.y == next.y;
+        if !same_x && !same_y {
+            result.push(curr);
+        }
+    }
+    result.push(waypoints[waypoints.len() - 1]);
+    result
+}
+
+/// Whether a route is free of obstacle intersections. Exit/entry segments
+/// leave/enter the connected shapes, so they are only tested against regular
+/// obstacles; middle segments also avoid the connected shapes themselves.
+fn is_route_valid(
+    start: Pos,
+    waypoints: &[Pos],
+    end: Pos,
+    obstacles: &[Rect],
+    connected: &[Rect],
+) -> bool {
+    let full = full_path(start, waypoints, end);
+    for i in 0..full.len() - 1 {
+        let is_exit = i == 0;
+        let is_entry = i == full.len() - 2;
+        if segment_intersects_obstacles(full[i], full[i + 1], obstacles) {
+            return false;
+        }
+        if !is_exit && !is_entry && segment_intersects_obstacles(full[i], full[i + 1], connected) {
+            return false;
+        }
+    }
+    true
+}
+
+fn full_path(start: Pos, waypoints: &[Pos], end: Pos) -> Vec<Pos> {
+    let mut full = Vec::with_capacity(waypoints.len() + 2);
+    full.push(start);
+    full.extend_from_slice(waypoints);
+    full.push(end);
+    full
+}
+
+fn path_length(start: Pos, waypoints: &[Pos], end: Pos) -> f64 {
+    let full = full_path(start, waypoints, end);
+    let mut length = 0.0;
+    for i in 0..full.len() - 1 {
+        let dx = full[i + 1].x - full[i].x;
+        let dy = full[i + 1].y - full[i].y;
+        length += (dx * dx + dy * dy).sqrt();
+    }
+    length
+}
+
+fn segment_intersects_obstacles(p1: Pos, p2: Pos, obstacles: &[Rect]) -> bool {
+    obstacles.iter().any(|o| line_intersects_box(p1, p2, o))
+}
+
+/// Liang–Barsky segment/box test (boundary contact counts as intersecting —
+/// these boxes are pre-padded, so touching the pad is already too close).
+fn line_intersects_box(p1: Pos, p2: Pos, b: &Rect) -> bool {
+    let dx = p2.x - p1.x;
+    let dy = p2.y - p1.y;
+    let mut t_min = 0.0f64;
+    let mut t_max = 1.0f64;
+
+    if dx != 0.0 {
+        let t1 = (b.min_x - p1.x) / dx;
+        let t2 = (b.max_x - p1.x) / dx;
+        if dx > 0.0 {
+            t_min = t_min.max(t1);
+            t_max = t_max.min(t2);
+        } else {
+            t_min = t_min.max(t2);
+            t_max = t_max.min(t1);
+        }
+    } else if p1.x < b.min_x || p1.x > b.max_x {
+        return false;
+    }
+
+    if dy != 0.0 {
+        let t1 = (b.min_y - p1.y) / dy;
+        let t2 = (b.max_y - p1.y) / dy;
+        if dy > 0.0 {
+            t_min = t_min.max(t1);
+            t_max = t_max.min(t2);
+        } else {
+            t_min = t_min.max(t2);
+            t_max = t_max.min(t1);
+        }
+    } else if p1.y < b.min_y || p1.y > b.max_y {
+        return false;
+    }
+
+    t_min <= t_max
+}
+
+/// Last-resort nudge: route the whole path around the combined bounds of the
+/// intersecting obstacles, picking the shortest clear detour of the four
+/// sides (above/below/left/right, first wins ties).
+fn avoid_obstacles(start: Pos, end: Pos, waypoints: Vec<Pos>, obstacles: &[Rect]) -> Vec<Pos> {
+    if obstacles.is_empty() {
+        return waypoints;
+    }
+    let full = full_path(start, &waypoints, end);
+    let mut has_intersection = false;
+    for i in 0..full.len() - 1 {
+        if segment_intersects_obstacles(full[i], full[i + 1], obstacles) {
+            has_intersection = true;
+            break;
+        }
+    }
+    if !has_intersection {
+        return waypoints;
+    }
+
+    let mut combined: Option<Rect> = None;
+    for o in obstacles {
+        for i in 0..full.len() - 1 {
+            if line_intersects_box(full[i], full[i + 1], o) {
+                combined = Some(match combined {
+                    None => *o,
+                    Some(c) => Rect {
+                        min_x: c.min_x.min(o.min_x),
+                        min_y: c.min_y.min(o.min_y),
+                        max_x: c.max_x.max(o.max_x),
+                        max_y: c.max_y.max(o.max_y),
+                    },
+                });
+            }
+        }
+    }
+    let Some(bounds) = combined else {
+        return waypoints;
+    };
+
+    let routes = [
+        vec![
+            Pos { x: start.x, y: bounds.min_y - OBSTACLE_PADDING },
+            Pos { x: end.x, y: bounds.min_y - OBSTACLE_PADDING },
+        ],
+        vec![
+            Pos { x: start.x, y: bounds.max_y + OBSTACLE_PADDING },
+            Pos { x: end.x, y: bounds.max_y + OBSTACLE_PADDING },
+        ],
+        vec![
+            Pos { x: bounds.min_x - OBSTACLE_PADDING, y: start.y },
+            Pos { x: bounds.min_x - OBSTACLE_PADDING, y: end.y },
+        ],
+        vec![
+            Pos { x: bounds.max_x + OBSTACLE_PADDING, y: start.y },
+            Pos { x: bounds.max_x + OBSTACLE_PADDING, y: end.y },
+        ],
+    ];
+
+    let mut best_route = waypoints;
+    let mut best_length = f64::INFINITY;
+    for route in routes {
+        let test = full_path(start, &route, end);
+        let mut valid = true;
+        for i in 0..test.len() - 1 {
+            if segment_intersects_obstacles(test[i], test[i + 1], obstacles) {
+                valid = false;
+                break;
+            }
+        }
+        if valid {
+            let length = path_length(start, &route, end);
+            if length < best_length {
+                best_length = length;
+                best_route = route;
+            }
+        }
+    }
+    best_route
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: orthogonal visibility graph + A*
+// (port of src/engine/orthogonalRouterCore.ts)
+// ---------------------------------------------------------------------------
+
+// Absolute directions, indexed: 0=+x, 1=-x, 2=+y, 3=-y (screen space, y down).
+const DIRS: [(f64, f64); 4] = [(1.0, 0.0), (-1.0, 0.0), (0.0, 1.0), (0.0, -1.0)];
+
+fn dir_index_of(v: (f64, f64)) -> usize {
+    if v.0.abs() >= v.1.abs() {
+        if v.0 >= 0.0 {
+            0
+        } else {
+            1
+        }
+    } else if v.1 >= 0.0 {
+        2
+    } else {
+        3
+    }
+}
+
+/// Candidate move directions given the arrival direction, ordered
+/// straight -> right -> left -> reverse. The fixed order makes equal-cost
+/// routes resolve identically.
+fn ordered_moves(arrival_dir: usize) -> [usize; 4] {
+    match arrival_dir {
+        0 => [0, 2, 3, 1], // +x: straight +x, right +y, left -y, reverse -x
+        1 => [1, 3, 2, 0], // -x
+        2 => [2, 1, 0, 3], // +y
+        3 => [3, 0, 1, 2], // -y
+        _ => [0, 1, 2, 3],
+    }
+}
+
+/// Whether an axis-aligned segment crosses a box's interior (edge-grazing is
+/// clear — this is the OVG's hug-the-clearance test, deliberately different
+/// from [`line_intersects_box`]). `pub(crate)` so integration tests can
+/// assert routed paths stay clear of node interiors.
+pub(crate) fn segment_crosses_box(x1: f64, y1: f64, x2: f64, y2: f64, o: &Rect) -> bool {
+    if y1 == y2 {
+        let y = y1;
+        if y <= o.min_y || y >= o.max_y {
+            return false;
+        }
+        let lo = x1.min(x2);
+        let hi = x1.max(x2);
+        return hi > o.min_x && lo < o.max_x;
+    }
+    let x = x1;
+    if x <= o.min_x || x >= o.max_x {
+        return false;
+    }
+    let lo = y1.min(y2);
+    let hi = y1.max(y2);
+    hi > o.min_y && lo < o.max_y
+}
+
+#[derive(Clone, Copy)]
+struct HeapNode {
+    xi: usize,
+    yi: usize,
+    dir: usize,
+    g: f64,
+    f: f64,
+    seq: u64,
+}
+
+/// Minimal binary min-heap ordered by (f, seq) — seq gives a stable tie-break.
+struct NodeHeap {
+    items: Vec<HeapNode>,
+}
+
+impl NodeHeap {
+    fn new() -> Self {
+        NodeHeap { items: Vec::new() }
+    }
+
+    fn less(a: &HeapNode, b: &HeapNode) -> bool {
+        a.f < b.f || (a.f == b.f && a.seq < b.seq)
+    }
+
+    fn push(&mut self, node: HeapNode) {
+        let items = &mut self.items;
+        items.push(node);
+        let mut i = items.len() - 1;
+        while i > 0 {
+            let parent = (i - 1) >> 1;
+            if Self::less(&items[i], &items[parent]) {
+                items.swap(i, parent);
+                i = parent;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn pop(&mut self) -> Option<HeapNode> {
+        let items = &mut self.items;
+        if items.is_empty() {
+            return None;
+        }
+        let top = items[0];
+        let last = items.pop().expect("non-empty");
+        if !items.is_empty() {
+            items[0] = last;
+            let mut i = 0;
+            loop {
+                let l = 2 * i + 1;
+                let r = 2 * i + 2;
+                let mut smallest = i;
+                if l < items.len() && Self::less(&items[l], &items[smallest]) {
+                    smallest = l;
+                }
+                if r < items.len() && Self::less(&items[r], &items[smallest]) {
+                    smallest = r;
+                }
+                if smallest == i {
+                    break;
+                }
+                items.swap(i, smallest);
+                i = smallest;
+            }
+        }
+        Some(top)
+    }
+}
+
+/// Route from `start` to `end` around `obstacles` through a sparse orthogonal
+/// visibility graph with an A* search minimizing path length plus a per-bend
+/// penalty, preferring to leave `start` in `start_dir`. Returns the interior
+/// waypoints, or `None` when there are no obstacles, the graph is too large,
+/// or no route exists — the caller falls back. Obstacles are expected
+/// pre-padded and must NOT include the connected endpoint shapes.
+pub fn route_avoiding(
+    start: Pos,
+    end: Pos,
+    start_dir: (f64, f64),
+    obstacles: &[Rect],
+) -> Option<Vec<Pos>> {
+    if obstacles.is_empty() || obstacles.len() > MAX_OVG_OBSTACLES {
+        return None;
+    }
+
+    // Gridlines: the endpoints plus each obstacle edge nudged out by the
+    // clearance (deduplicated, sorted).
+    let mut xs: Vec<f64> = vec![start.x, end.x];
+    let mut ys: Vec<f64> = vec![start.y, end.y];
+    for o in obstacles {
+        xs.push(o.min_x - CLEARANCE);
+        xs.push(o.max_x + CLEARANCE);
+        ys.push(o.min_y - CLEARANCE);
+        ys.push(o.max_y + CLEARANCE);
+    }
+    xs.sort_by(|a, b| a.partial_cmp(b).expect("finite coordinate"));
+    xs.dedup();
+    ys.sort_by(|a, b| a.partial_cmp(b).expect("finite coordinate"));
+    ys.dedup();
+    let nx = xs.len();
+    let ny = ys.len();
+
+    let index_of = |v: f64, axis: &[f64]| -> Option<usize> {
+        axis.binary_search_by(|p| p.partial_cmp(&v).expect("finite coordinate")).ok()
+    };
+    let start_xi = index_of(start.x, &xs)?;
+    let start_yi = index_of(start.y, &ys)?;
+    let end_xi = index_of(end.x, &xs)?;
+    let end_yi = index_of(end.y, &ys)?;
+
+    let blocked = |xi: usize, yi: usize| -> bool {
+        let px = xs[xi];
+        let py = ys[yi];
+        obstacles
+            .iter()
+            .any(|o| px > o.min_x && px < o.max_x && py > o.min_y && py < o.max_y)
+    };
+    if blocked(start_xi, start_yi) || blocked(end_xi, end_yi) {
+        return None;
+    }
+
+    let clear = |x1: f64, y1: f64, x2: f64, y2: f64| -> bool {
+        !obstacles.iter().any(|o| segment_crosses_box(x1, y1, x2, y2, o))
+    };
+
+    let key_of = |xi: usize, yi: usize, dir: usize| -> usize { (yi * nx + xi) * 4 + dir };
+    let heuristic =
+        |xi: usize, yi: usize| -> f64 { (xs[xi] - xs[end_xi]).abs() + (ys[yi] - ys[end_yi]).abs() };
+
+    let n_states = nx * ny * 4;
+    let mut g_score = vec![f64::INFINITY; n_states];
+    let mut came_from = vec![usize::MAX; n_states];
+    let mut heap = NodeHeap::new();
+    let mut seq: u64 = 0;
+
+    let start_dir_idx = dir_index_of(start_dir);
+    let start_key = key_of(start_xi, start_yi, start_dir_idx);
+    g_score[start_key] = 0.0;
+    heap.push(HeapNode {
+        xi: start_xi,
+        yi: start_yi,
+        dir: start_dir_idx,
+        g: 0.0,
+        f: heuristic(start_xi, start_yi),
+        seq,
+    });
+    seq += 1;
+
+    let mut goal_key = usize::MAX;
+    while let Some(cur) = heap.pop() {
+        let cur_key = key_of(cur.xi, cur.yi, cur.dir);
+        if cur.g > g_score[cur_key] {
+            continue; // stale heap entry
+        }
+        if cur.xi == end_xi && cur.yi == end_yi {
+            goal_key = cur_key;
+            break;
+        }
+
+        for move_dir in ordered_moves(cur.dir) {
+            let d = DIRS[move_dir];
+            let nxi = if d.0 > 0.0 {
+                cur.xi + 1
+            } else if d.0 < 0.0 {
+                match cur.xi.checked_sub(1) {
+                    Some(v) => v,
+                    None => continue,
+                }
+            } else {
+                cur.xi
+            };
+            let nyi = if d.1 > 0.0 {
+                cur.yi + 1
+            } else if d.1 < 0.0 {
+                match cur.yi.checked_sub(1) {
+                    Some(v) => v,
+                    None => continue,
+                }
+            } else {
+                cur.yi
+            };
+            if nxi >= nx || nyi >= ny {
+                continue;
+            }
+            if blocked(nxi, nyi) {
+                continue;
+            }
+            if !clear(xs[cur.xi], ys[cur.yi], xs[nxi], ys[nyi]) {
+                continue;
+            }
+
+            let seg_len = (xs[nxi] - xs[cur.xi]).abs() + (ys[nyi] - ys[cur.yi]).abs();
+            let bend = if move_dir == cur.dir { 0.0 } else { BEND_COST };
+            let ng = cur.g + seg_len + bend;
+            let n_key = key_of(nxi, nyi, move_dir);
+            if ng < g_score[n_key] {
+                g_score[n_key] = ng;
+                came_from[n_key] = cur_key;
+                heap.push(HeapNode {
+                    xi: nxi,
+                    yi: nyi,
+                    dir: move_dir,
+                    g: ng,
+                    f: ng + heuristic(nxi, nyi),
+                    seq,
+                });
+                seq += 1;
+            }
+        }
+    }
+
+    if goal_key == usize::MAX {
+        return None;
+    }
+
+    // Reconstruct start -> end, then drop collinear points and the endpoints.
+    let mut pts: Vec<Pos> = Vec::new();
+    let mut k = goal_key;
+    loop {
+        let rest = k / 4;
+        let xi = rest % nx;
+        let yi = rest / nx;
+        pts.push(Pos { x: xs[xi], y: ys[yi] });
+        if came_from[k] == usize::MAX {
+            break;
+        }
+        k = came_from[k];
+    }
+    pts.reverse();
+
+    let simplified = simplify_path(&pts);
+    let take = simplified.len().saturating_sub(1).max(1);
+    Some(simplified[1..take].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_axis_aligned(path: &[Pos]) {
+        for i in 1..path.len() {
+            assert!(
+                path[i - 1].x == path[i].x || path[i - 1].y == path[i].y,
+                "segment {} not axis-aligned: {:?} -> {:?}",
+                i,
+                path[i - 1],
+                path[i]
+            );
+        }
+    }
+
+    fn assert_clear_of(path: &[Pos], obstacles: &[Rect]) {
+        for i in 1..path.len() {
+            for o in obstacles {
+                assert!(
+                    !segment_crosses_box(path[i - 1].x, path[i - 1].y, path[i].x, path[i].y, o),
+                    "segment {:?} -> {:?} crosses {:?}",
+                    path[i - 1],
+                    path[i],
+                    o
+                );
+            }
+        }
+    }
+
+    fn p(x: f64, y: f64) -> Pos {
+        Pos { x, y }
+    }
+
+    fn r(min_x: f64, min_y: f64, max_x: f64, max_y: f64) -> Rect {
+        Rect { min_x, min_y, max_x, max_y }
+    }
+
+    // -- route_avoiding: mirrors src/engine/orthogonalRouterCore.test.ts --
+
+    #[test]
+    fn avoiding_returns_none_without_obstacles() {
+        assert!(route_avoiding(p(0.0, 0.0), p(200.0, 0.0), (1.0, 0.0), &[]).is_none());
+    }
+
+    #[test]
+    fn avoiding_returns_none_when_graph_too_large() {
+        let obstacles: Vec<Rect> = (0..=MAX_OVG_OBSTACLES)
+            .map(|i| r(i as f64 * 10.0, -5.0, i as f64 * 10.0 + 5.0, 5.0))
+            .collect();
+        assert!(route_avoiding(p(0.0, 0.0), p(500.0, 0.0), (1.0, 0.0), &obstacles).is_none());
+    }
+
+    #[test]
+    fn avoiding_routes_around_a_wall() {
+        let wall = r(80.0, -20.0, 120.0, 20.0);
+        let wps = route_avoiding(p(0.0, 0.0), p(200.0, 0.0), (1.0, 0.0), &[wall]).unwrap();
+        assert!(!wps.is_empty());
+        let path = full_path(p(0.0, 0.0), &wps, p(200.0, 0.0));
+        assert_axis_aligned(&path);
+        assert_clear_of(&path, &[wall]);
+    }
+
+    #[test]
+    fn avoiding_is_deterministic() {
+        let route = || {
+            route_avoiding(p(0.0, 0.0), p(200.0, 0.0), (1.0, 0.0), &[r(80.0, -20.0, 120.0, 20.0)])
+        };
+        assert_eq!(route(), route());
+    }
+
+    // -- Cross-language parity: expected waypoints captured from the TS
+    // implementation (bun run over orthogonalRouterCore.ts). Both sides do
+    // the same IEEE-double arithmetic, so equality is exact. --
+
+    #[test]
+    fn parity_wall_detour_matches_ts_router() {
+        let wps =
+            route_avoiding(p(0.0, 0.0), p(200.0, 0.0), (1.0, 0.0), &[r(80.0, -20.0, 120.0, 20.0)])
+                .unwrap();
+        assert_eq!(wps, vec![p(79.0, 0.0), p(79.0, 21.0), p(200.0, 21.0)]);
+    }
+
+    #[test]
+    fn parity_stacked_seam_matches_ts_router() {
+        // Two boxes meeting at y=0: the seam is edge-grazing on both, so the
+        // straight route threads it with zero interior waypoints.
+        let obstacles = [r(80.0, -60.0, 120.0, 0.0), r(80.0, 0.0, 120.0, 60.0)];
+        let wps = route_avoiding(p(0.0, 0.0), p(300.0, 0.0), (1.0, 0.0), &obstacles).unwrap();
+        assert_eq!(wps, Vec::<Pos>::new());
+    }
+
+    #[test]
+    fn parity_vertical_corridor_matches_ts_router() {
+        let obstacles = [r(10.0, 100.0, 90.0, 150.0), r(110.0, 100.0, 190.0, 150.0)];
+        let wps = route_avoiding(p(50.0, 0.0), p(50.0, 250.0), (0.0, 1.0), &obstacles).unwrap();
+        assert_eq!(wps, vec![p(50.0, 99.0), p(9.0, 99.0), p(9.0, 250.0)]);
+    }
+
+    // -- route_orthogonal tiering --
+
+    #[test]
+    fn clear_field_uses_the_canonical_route() {
+        // Right-exit to left-entry across open space: canonical Z with the
+        // bend at the alley midpoint.
+        let wps = route_orthogonal(p(0.0, 0.0), p(200.0, 100.0), (1.0, 0.0), (-1.0, 0.0), &[], &[]);
+        assert_eq!(wps, vec![p(20.0, 0.0), p(100.0, 0.0), p(100.0, 100.0), p(180.0, 100.0)]);
+    }
+
+    #[test]
+    fn vertical_anchor_pair_makes_a_z_path() {
+        // Bottom-exit to top-entry (the layered flow case): Z-path with the
+        // horizontal run at the alley midpoint.
+        let wps = route_orthogonal(p(0.0, 0.0), p(200.0, 200.0), (0.0, 1.0), (0.0, -1.0), &[], &[]);
+        assert_eq!(wps, vec![p(0.0, 20.0), p(0.0, 100.0), p(200.0, 100.0), p(200.0, 180.0)]);
+    }
+
+    #[test]
+    fn perpendicular_anchors_make_an_l_path() {
+        // Right-exit to top-entry: single corner at (end_stub.x, start_stub.y).
+        let wps = route_orthogonal(p(0.0, 0.0), p(200.0, 200.0), (1.0, 0.0), (0.0, -1.0), &[], &[]);
+        assert_eq!(wps, vec![p(20.0, 0.0), p(200.0, 0.0), p(200.0, 180.0)]);
+    }
+
+    #[test]
+    fn blocked_canonical_falls_through_to_a_clear_candidate() {
+        // An obstacle sits on the canonical mid-alley bend; some other simple
+        // candidate (or the OVG) must produce a clear route.
+        let obstacle = r(85.0, -30.0, 115.0, 30.0);
+        let wps = route_orthogonal(
+            p(0.0, 0.0),
+            p(200.0, 0.0),
+            (1.0, 0.0),
+            (-1.0, 0.0),
+            &[obstacle],
+            &[],
+        );
+        let path = full_path(p(0.0, 0.0), &wps, p(200.0, 0.0));
+        assert_axis_aligned(&path);
+        assert_clear_of(&path, &[obstacle]);
+    }
+
+    #[test]
+    fn connected_shapes_invalidate_middle_segments() {
+        // Exit right, target to the left: every simple candidate's middle
+        // run cuts back through the start shape, so none validates. With no
+        // regular obstacles the editor falls back to the raw canonical
+        // candidate (endpoint clipping handles the visual) — parity demands
+        // we do the same rather than "improve" on it.
+        let connected = [r(-20.0, -40.0, 20.0, 40.0)];
+        let wps = route_orthogonal(
+            p(20.0, 0.0),
+            p(-60.0, 0.0),
+            (1.0, 0.0), // forced to exit right, away from the target
+            (-1.0, 0.0),
+            &[],
+            &connected,
+        );
+        // Canonical Z, unsimplified: stubs at x=40 / x=-80, mid x=-20.
+        assert_eq!(wps, vec![p(40.0, 0.0), p(-20.0, 0.0), p(-20.0, 0.0), p(-80.0, 0.0)]);
+    }
+
+    #[test]
+    fn route_orthogonal_is_deterministic() {
+        let obstacles = [r(60.0, -30.0, 140.0, 30.0), r(60.0, 50.0, 140.0, 110.0)];
+        let route = || {
+            route_orthogonal(
+                p(0.0, 0.0),
+                p(200.0, 80.0),
+                (1.0, 0.0),
+                (-1.0, 0.0),
+                &obstacles,
+                &[],
+            )
+        };
+        assert_eq!(route(), route());
+    }
+}

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -29,7 +29,7 @@ use crate::sync::{DocHandle, DocRegistry};
 use super::adapter::{apply_dsl_patch, dsl_to_shape_json, shape_json_to_dsl, DslPatch, DslShape};
 use super::local_mirror::LocalDocumentMirror;
 use super::outline::{clamp_level, escape_html, Outline, Section};
-use super::layout::{layout_diagram, LayoutMode, NodeSpec, NODE_H, NODE_W};
+use super::layout::{layout_and_route, layout_diagram, LayoutMode, NodeSpec, NODE_H, NODE_W};
 
 /// Where a document came from, surfaced in MCP tool results so clients
 /// know whether they're looking at a team-shared or a (read-only) local
@@ -267,7 +267,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.generate_diagram",
             description:
-                "Generate a whole diagram in one call from a graph of nodes and edges. Each node becomes a labelled shape (rectangle by default, or ellipse); each edge becomes a connector between two nodes. The relay auto-positions everything: \"layered\" (top-down by edge direction, good for flow/architecture diagrams; the default when edges exist) or \"grid\". Reference nodes in edges by their caller-supplied 'id'. Returns the map of node id → created shape id, plus the connector ids. Refuses local documents.",
+                "Generate a whole diagram in one call from a graph of nodes and edges. Each node becomes a labelled shape (rectangle by default, or ellipse); each edge becomes a connector between two nodes. The relay auto-positions everything: \"layered\" (top-down by edge direction with crossing minimization, good for flow/architecture diagrams; the default when edges exist) or \"grid\". Connectors attach to typed anchors and by default are routed orthogonally around intervening shapes with explicit waypoints; pass routing \"straight\" for plain anchor-to-anchor lines. Reference nodes in edges by their caller-supplied 'id'. Returns the map of node id → created shape id, plus the connector ids. Refuses local documents.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -300,7 +300,8 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                             "additionalProperties": false
                         }
                     },
-                    "layout": {"type": "string", "enum": ["layered", "grid"], "description": "Placement strategy. Default: \"layered\" when edges are present, else \"grid\"."}
+                    "layout": {"type": "string", "enum": ["layered", "grid"], "description": "Placement strategy. Default: \"layered\" when edges are present, else \"grid\"."},
+                    "routing": {"type": "string", "enum": ["orthogonal", "straight"], "description": "Connector routing. \"orthogonal\" (default) routes right-angle paths around intervening shapes and emits waypoints; \"straight\" draws plain anchor-to-anchor lines."}
                 },
                 "required": ["docId", "pageId", "nodes"],
                 "additionalProperties": false
@@ -1522,6 +1523,7 @@ struct GenerateDiagramArgs {
     #[serde(default)]
     edges: Vec<GenEdge>,
     layout: Option<String>,
+    routing: Option<String>,
 }
 
 fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
@@ -1579,7 +1581,20 @@ fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Stri
         .iter()
         .map(|id| NodeSpec { id: id.clone(), w: NODE_W, h: NODE_H })
         .collect();
-    let diagram = layout_diagram(&node_specs, &edge_pairs, mode);
+    // Routing: orthogonal obstacle-avoiding waypoints by default; "straight"
+    // keeps plain anchor-to-anchor connectors (no routed-path fields).
+    let orthogonal = match parsed.routing.as_deref() {
+        Some("orthogonal") | None => true,
+        Some("straight") => false,
+        Some(other) => {
+            return Err(format!("Unknown routing '{}'; expected 'orthogonal' or 'straight'", other))
+        }
+    };
+    let diagram = if orthogonal {
+        layout_and_route(&node_specs, &edge_pairs, mode)
+    } else {
+        layout_diagram(&node_specs, &edge_pairs, mode)
+    };
 
     let (node_map, edge_ids) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
         // logical node id -> created shape id, for wiring connectors.
@@ -1604,6 +1619,11 @@ fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Stri
                 end_anchor: None,
                 start_arrow_style: None,
                 end_arrow_style: None,
+                routing_mode: None,
+                waypoints: None,
+                label_position: None,
+                x2: None,
+                y2: None,
             };
             let shape_id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
             node_map.insert(n.id.trim().to_string(), json!(shape_id));
@@ -1628,6 +1648,17 @@ fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Stri
                 end_anchor: Some(routed.end_anchor.as_str().to_string()),
                 start_arrow_style: None,
                 end_arrow_style: None,
+                routing_mode: orthogonal.then(|| "orthogonal".to_string()),
+                waypoints: orthogonal.then(|| {
+                    routed
+                        .waypoints
+                        .iter()
+                        .map(|p| super::adapter::DslPoint { x: p.x, y: p.y })
+                        .collect()
+                }),
+                label_position: routed.label_position,
+                x2: Some(routed.end.x),
+                y2: Some(routed.end.y),
             };
             edge_ids.push(json!(append_shape_in_place(doc, &parsed.page_id, &dsl)?));
         }
@@ -1641,6 +1672,7 @@ fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Stri
             "nodes": node_map,
             "edges": edge_ids,
             "layout": match mode { LayoutMode::Layered => "layered", LayoutMode::Grid => "grid" },
+            "routing": if orthogonal { "orthogonal" } else { "straight" },
         }),
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
@@ -2164,6 +2196,11 @@ fn connect(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         end_anchor: parsed.to_anchor.clone(),
         start_arrow_style: None,
         end_arrow_style: None,
+        routing_mode: None,
+        waypoints: None,
+        label_position: None,
+        x2: None,
+        y2: None,
     };
 
     write_shape_live_or_json(
@@ -3847,11 +3884,177 @@ mod tests {
 
         // Layered layout assigns flow anchors (JP-245): forward edges leave
         // the bottom of their source and enter the top of their target —
-        // not the old center-to-center attachment.
+        // not the old center-to-center attachment. Routing defaults to
+        // orthogonal with explicit waypoints.
         for s in page.result["shapes"].as_array().unwrap() {
             if s["kind"] == "connector" {
                 assert_eq!(s["startAnchor"], "bottom");
                 assert_eq!(s["endAnchor"], "top");
+                assert_eq!(s["routingMode"], "orthogonal");
+                assert!(s["waypoints"].is_array());
+            }
+        }
+        assert_eq!(out.result["routing"], "orthogonal");
+    }
+
+    /// The headline JP-245 acceptance: a connector forced past an
+    /// intervening node detours around it — no path segment crosses any
+    /// non-endpoint node's interior.
+    #[test]
+    fn generate_diagram_routes_around_intervening_nodes() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        // 3x3 grid; an edge across the top row must clear the middle node.
+        let nodes: Vec<Value> = (0..9).map(|i| json!({"id": format!("n{}", i)})).collect();
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.generate_diagram",
+            &json!({
+                "docId": "doc1",
+                "pageId": "p1",
+                "nodes": nodes,
+                "edges": [{"from": "n0", "to": "n2"}],
+                "layout": "grid"
+            }),
+        )
+        .unwrap();
+
+        let ws = WorkspaceId::single_tenant();
+        let raw = f.team.get_document(&ws, &DocId::from_body_id("doc1".into()).unwrap()).unwrap();
+        let shapes = raw["pages"]["p1"]["shapes"].as_object().unwrap();
+
+        let connector_id = out.result["edges"][0].as_str().unwrap();
+        let conn = &shapes[connector_id];
+        let waypoints = conn["waypoints"].as_array().unwrap();
+        assert!(!waypoints.is_empty(), "expected a detour, got a straight shot");
+
+        // Full path: start, waypoints, end.
+        let mut path: Vec<(f64, f64)> =
+            vec![(conn["x"].as_f64().unwrap(), conn["y"].as_f64().unwrap())];
+        for p in waypoints {
+            path.push((p["x"].as_f64().unwrap(), p["y"].as_f64().unwrap()));
+        }
+        path.push((conn["x2"].as_f64().unwrap(), conn["y2"].as_f64().unwrap()));
+
+        let endpoint_ids = [
+            out.result["nodes"]["n0"].as_str().unwrap(),
+            out.result["nodes"]["n2"].as_str().unwrap(),
+        ];
+        for (logical, shape_id) in out.result["nodes"].as_object().unwrap() {
+            if endpoint_ids.contains(&shape_id.as_str().unwrap()) {
+                continue;
+            }
+            let s = &shapes[shape_id.as_str().unwrap()];
+            let (cx, cy) = (s["x"].as_f64().unwrap(), s["y"].as_f64().unwrap());
+            let (w, h) = (s["width"].as_f64().unwrap(), s["height"].as_f64().unwrap());
+            let rect = crate::mcp::route::Rect {
+                min_x: cx - w / 2.0,
+                min_y: cy - h / 2.0,
+                max_x: cx + w / 2.0,
+                max_y: cy + h / 2.0,
+            };
+            for i in 1..path.len() {
+                assert!(
+                    !crate::mcp::route::segment_crosses_box(
+                        path[i - 1].0,
+                        path[i - 1].1,
+                        path[i].0,
+                        path[i].1,
+                        &rect
+                    ),
+                    "segment {:?} -> {:?} crosses node '{}'",
+                    path[i - 1],
+                    path[i],
+                    logical
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn generate_diagram_straight_routing_omits_routed_fields() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.generate_diagram",
+            &json!({
+                "docId": "doc1",
+                "pageId": "p1",
+                "nodes": [{"id": "a"}, {"id": "b"}],
+                "edges": [{"from": "a", "to": "b"}],
+                "routing": "straight"
+            }),
+        )
+        .unwrap();
+        assert_eq!(out.result["routing"], "straight");
+
+        let ws = WorkspaceId::single_tenant();
+        let raw = f.team.get_document(&ws, &DocId::from_body_id("doc1".into()).unwrap()).unwrap();
+        let conn = &raw["pages"]["p1"]["shapes"][out.result["edges"][0].as_str().unwrap()];
+        let obj = conn.as_object().unwrap();
+        // Plain anchor-to-anchor connector: typed anchors but no routed-path
+        // fields at all.
+        assert_eq!(conn["startAnchor"], "bottom");
+        assert_eq!(conn["endAnchor"], "top");
+        assert!(!obj.contains_key("routingMode"));
+        assert!(!obj.contains_key("waypoints"));
+        assert!(!obj.contains_key("labelPosition"));
+    }
+
+    #[test]
+    fn generate_diagram_is_deterministic_across_documents() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let created = dispatch(&f.ctx(true), "docushark.create_document", &json!({"name": "Two"}))
+            .unwrap();
+        let doc2 = created.result["id"].as_str().unwrap().to_string();
+        let got = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": doc2})).unwrap();
+        let page2 = got.result["pages"][0]["id"].as_str().unwrap().to_string();
+
+        let graph = |doc: &str, page: &str| {
+            json!({
+                "docId": doc,
+                "pageId": page,
+                "nodes": [{"id": "a"}, {"id": "b"}, {"id": "c"}, {"id": "d"}],
+                "edges": [
+                    {"from": "a", "to": "b"}, {"from": "a", "to": "c"},
+                    {"from": "b", "to": "d"}, {"from": "c", "to": "d"},
+                    {"from": "d", "to": "a"}
+                ]
+            })
+        };
+        let out1 =
+            dispatch(&f.ctx(true), "docushark.generate_diagram", &graph("doc1", "p1")).unwrap();
+        let out2 =
+            dispatch(&f.ctx(true), "docushark.generate_diagram", &graph(&doc2, &page2)).unwrap();
+
+        let ws = WorkspaceId::single_tenant();
+        let raw1 = f.team.get_document(&ws, &DocId::from_body_id("doc1".into()).unwrap()).unwrap();
+        let raw2 = f.team.get_document(&ws, &DocId::from_body_id(doc2).unwrap()).unwrap();
+        let shapes1 = &raw1["pages"]["p1"]["shapes"];
+        let shapes2 = &raw2["pages"][&page2]["shapes"];
+
+        // Same geometry in both documents (ids differ, fields don't).
+        for key in ["a", "b", "c", "d"] {
+            let s1 = &shapes1[out1.result["nodes"][key].as_str().unwrap()];
+            let s2 = &shapes2[out2.result["nodes"][key].as_str().unwrap()];
+            assert_eq!(s1["x"], s2["x"], "node '{}' x diverged", key);
+            assert_eq!(s1["y"], s2["y"], "node '{}' y diverged", key);
+        }
+        for (e1, e2) in out1.result["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .zip(out2.result["edges"].as_array().unwrap())
+        {
+            let c1 = &shapes1[e1.as_str().unwrap()];
+            let c2 = &shapes2[e2.as_str().unwrap()];
+            for field in ["x", "y", "x2", "y2", "startAnchor", "endAnchor", "waypoints"] {
+                assert_eq!(c1[field], c2[field], "connector field '{}' diverged", field);
             }
         }
     }
@@ -3876,6 +4079,14 @@ mod tests {
         )
         .unwrap_err();
         assert!(dangling.contains("unknown node 'ghost'"));
+
+        let bad_routing = dispatch(
+            &f.ctx(true),
+            "docushark.generate_diagram",
+            &json!({"docId":"doc1","pageId":"p1","nodes":[{"id":"a"}],"routing":"diagonal"}),
+        )
+        .unwrap_err();
+        assert!(bad_routing.contains("Unknown routing"));
 
         let local_refused = {
             f.local.mirror(&WorkspaceId::single_tenant(), make_doc("local1", "p1", "Local")).unwrap();

--- a/src/engine/orthogonalRouterCore.ts
+++ b/src/engine/orthogonalRouterCore.ts
@@ -11,6 +11,10 @@ import { Box } from '../math/Box';
  * a given input always yields the same route — stable under small endpoint
  * moves, and portable enough that the relay-side router (JP-245) can mirror it.
  *
+ * The relay mirrors this algorithm in `relay/src/mcp/route.rs` so server-
+ * routed connectors agree with editor re-routes; changes here must be made
+ * there too (parity is pinned by tests on the Rust side).
+ *
  * Pure module: no canvas, store, or shape-registry access.
  */
 


### PR DESCRIPTION
#195 (orthogonal connector routing) merged into `jp-245-layout` a few minutes *after* #194 had already merged that branch to master — so master currently has only the layout slice. This PR carries the #195 merge commit (the routing work: `route.rs` port, adapter `routingMode`/`waypoints` fields, `routing` arg) to master. No new changes; this is exactly the reviewed #195 diff.

Merge this before the staging deploy PR so staging gets both JP-245 slices.

Assisted-by: Fable 5