### PR TITLE
JP-305: layoutGraph v2 (Sugiyama port) + orthogonal routing for imports

### DIFF
--- a/src/shapes/import/adapters/drawioAdapter.test.ts
+++ b/src/shapes/import/adapters/drawioAdapter.test.ts
@@ -66,6 +66,13 @@ describe('drawioAdapter', () => {
     }
   });
 
+  it('marks connectors orthogonal so the import pipeline routes them (JP-305)', async () => {
+    const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
+    const connectors = byType(shapes, 'connector') as Array<{ routingMode?: string }>;
+    expect(connectors.length).toBeGreaterThan(0);
+    for (const c of connectors) expect(c.routingMode).toBe('orthogonal');
+  });
+
   it('honours drawio arrow style (start arrow + no end arrow)', async () => {
     const { shapes } = await drawioAdapter.import(SMALL_FLOWCHART);
     // Edge -17 has startArrow=classic;endArrow=none → exactly one such connector.

--- a/src/shapes/import/adapters/drawioAdapter.ts
+++ b/src/shapes/import/adapters/drawioAdapter.ts
@@ -337,6 +337,11 @@ async function importDrawio(raw: string): Promise<ImportResult> {
       strokeWidth: num(props['strokeWidth'] ?? null, DEFAULT_CONNECTOR.strokeWidth),
       startArrow: hasStartArrow,
       endArrow: hasEndArrow,
+      // We don't parse drawio's explicit edge waypoints, so today these render
+      // as straight lines through any shapes between the endpoints. Route them
+      // orthogonally instead (JP-305) — the import pipeline's
+      // rebuildAllConnectorRoutes() computes obstacle-avoiding paths.
+      routingMode: 'orthogonal',
       ...(stripHtmlLabel(cell.value) ? { label: stripHtmlLabel(cell.value) } : {}),
       ...(startId ? { startShapeId: startId } : {}),
       ...(startAnchor ? { startAnchor } : {}),

--- a/src/shapes/import/adapters/mermaidAdapter.test.ts
+++ b/src/shapes/import/adapters/mermaidAdapter.test.ts
@@ -56,6 +56,13 @@ describe('mermaidAdapter', () => {
     expect(conns.find((c) => c.label === 'retry')!.lineStyle).toBe('dashed');
   });
 
+  it('marks connectors orthogonal so the import pipeline routes them (JP-305)', async () => {
+    const { shapes } = await mermaidAdapter.import('flowchart TD\n  A --> B\n  B --> C');
+    const conns = byType(shapes, 'connector') as Array<{ routingMode?: string }>;
+    expect(conns.length).toBeGreaterThan(0);
+    for (const c of conns) expect(c.routingMode).toBe('orthogonal');
+  });
+
   it('applies classDef styling to assigned nodes', async () => {
     const src = `flowchart TD
       A[A] --> B[B]

--- a/src/shapes/import/adapters/mermaidAdapter.ts
+++ b/src/shapes/import/adapters/mermaidAdapter.ts
@@ -355,6 +355,11 @@ function importMermaid(raw: string): ImportResult {
       startAnchor: nearestEdgeAnchor(startBox, endPos),
       endShapeId: endId,
       endAnchor: nearestEdgeAnchor(endBox, startPos),
+      // Mermaid has no edge geometry of its own; route orthogonally around the
+      // laid-out nodes so the import pipeline's rebuildAllConnectorRoutes()
+      // produces clean right-angle paths (JP-305) instead of straight lines
+      // slicing through intervening shapes.
+      routingMode: 'orthogonal',
       ...(edge.label ? { label: edge.label } : {}),
     } as Shape);
   }

--- a/src/shapes/import/layout/acyclic.test.ts
+++ b/src/shapes/import/layout/acyclic.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { greedyFas } from './acyclic';
+
+/** Kahn's algorithm consumes every node iff the orientation is acyclic. */
+function isAcyclic(n: number, edges: ReadonlyArray<readonly [number, number]>): boolean {
+  const indeg = new Array(n).fill(0);
+  for (const [, v] of edges) indeg[v] += 1;
+  const queue: number[] = [];
+  for (let v = 0; v < n; v++) if (indeg[v] === 0) queue.push(v);
+  let seen = 0;
+  while (queue.length > 0) {
+    const v = queue.pop()!;
+    seen += 1;
+    for (const [u, w] of edges) {
+      if (u === v) {
+        indeg[w] -= 1;
+        if (indeg[w] === 0) queue.push(w);
+      }
+    }
+  }
+  return seen === n;
+}
+
+describe('greedyFas (cycle removal)', () => {
+  it('reverses nothing in an acyclic graph', () => {
+    const edges: Array<readonly [number, number]> = [[0, 1], [1, 2], [0, 2]];
+    expect(greedyFas(3, edges)).toEqual([false, false, false]);
+  });
+
+  it('reverses exactly one edge in a 3-cycle, deterministically', () => {
+    const edges: Array<readonly [number, number]> = [[0, 1], [1, 2], [2, 0]];
+    const flags = greedyFas(3, edges);
+    expect(flags.filter(Boolean).length).toBe(1);
+    // Node 0 wins the outdeg-indeg tie by lowest index, so it heads the
+    // sequence and the edge back into it (2 -> 0) is the feedback arc.
+    expect(flags).toEqual([false, false, true]);
+  });
+
+  it('reverses one edge in a 2-cycle', () => {
+    const flags = greedyFas(2, [[0, 1], [1, 0]]);
+    expect(flags.filter(Boolean).length).toBe(1);
+  });
+
+  it('produces an acyclic orientation after reversal', () => {
+    const edges: Array<readonly [number, number]> = [[0, 1], [1, 2], [2, 0], [2, 3], [3, 1]];
+    const flags = greedyFas(4, edges);
+    const oriented = edges.map(([u, v], i) => (flags[i] ? ([v, u] as const) : ([u, v] as const)));
+    expect(isAcyclic(4, oriented)).toBe(true);
+  });
+});

--- a/src/shapes/import/layout/acyclic.ts
+++ b/src/shapes/import/layout/acyclic.ts
@@ -1,0 +1,100 @@
+/**
+ * Cycle removal: greedy feedback arc set (Eades–Lin–Smyth 1993).
+ *
+ * Builds a vertex sequence by repeatedly peeling sinks to the right and
+ * sources to the left, otherwise taking the vertex with the largest
+ * `outdeg - indeg`. Edges that point right-to-left in the final sequence are
+ * the feedback set: the caller treats them as reversed for layering/ordering
+ * and keeps the original direction in the emitted shapes.
+ *
+ * Deterministic: every pick breaks ties by lowest node index (input order).
+ * TS twin of `relay/src/mcp/layout/acyclic.rs` — keep the two in step.
+ */
+
+/**
+ * Per-edge flags marking which of `edges` to treat as reversed so the
+ * remaining orientation is acyclic. `edges` must not contain self-loops.
+ */
+export function greedyFas(n: number, edges: ReadonlyArray<readonly [number, number]>): boolean[] {
+  if (n === 0 || edges.length === 0) {
+    return edges.map(() => false);
+  }
+
+  // Adjacency with multiplicity (parallel edges count toward degrees).
+  const outAdj: number[][] = Array.from({ length: n }, () => []);
+  const inAdj: number[][] = Array.from({ length: n }, () => []);
+  for (const [u, v] of edges) {
+    outAdj[u]!.push(v);
+    inAdj[v]!.push(u);
+  }
+  const outdeg = outAdj.map((a) => a.length);
+  const indeg = inAdj.map((a) => a.length);
+
+  const removed: boolean[] = new Array(n).fill(false);
+  const left: number[] = []; // s1, built front-to-back
+  const right: number[] = []; // s2, built back-to-front
+  let remaining = n;
+
+  const remove = (v: number): void => {
+    removed[v] = true;
+    for (const w of outAdj[v]!) {
+      if (!removed[w]) indeg[w]! -= 1;
+    }
+    for (const w of inAdj[v]!) {
+      if (!removed[w]) outdeg[w]! -= 1;
+    }
+  };
+
+  while (remaining > 0) {
+    // Peel sinks (lowest index first) to the right sequence.
+    let progressed = true;
+    while (progressed) {
+      progressed = false;
+      for (let v = 0; v < n; v++) {
+        if (!removed[v] && outdeg[v] === 0) {
+          right.push(v);
+          remove(v);
+          remaining -= 1;
+          progressed = true;
+        }
+      }
+    }
+    // Peel sources (lowest index first) to the left sequence.
+    progressed = true;
+    while (progressed) {
+      progressed = false;
+      for (let v = 0; v < n; v++) {
+        if (!removed[v] && indeg[v] === 0) {
+          left.push(v);
+          remove(v);
+          remaining -= 1;
+          progressed = true;
+        }
+      }
+    }
+    if (remaining === 0) break;
+    // Cycle core: take max(outdeg - indeg), lowest index on tie.
+    let best = -1;
+    for (let v = 0; v < n; v++) {
+      if (removed[v]) continue;
+      if (best < 0 || outdeg[v]! - indeg[v]! > outdeg[best]! - indeg[best]!) {
+        best = v;
+      }
+    }
+    left.push(best);
+    remove(best);
+    remaining -= 1;
+  }
+
+  // Sequence position: left order, then right reversed.
+  const position: number[] = new Array(n).fill(0);
+  let idx = 0;
+  for (const v of left) {
+    position[v] = idx++;
+  }
+  for (let i = right.length - 1; i >= 0; i--) {
+    position[right[i]!] = idx++;
+  }
+
+  return edges.map(([u, v]) => position[u]! > position[v]!);
+}

--- a/src/shapes/import/layout/coords.test.ts
+++ b/src/shapes/import/layout/coords.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { assignLayers, normalize, type LGraph } from './rank';
+import { minimizeCrossings } from './order';
+import { assignCoords } from './coords';
+import type { Point } from '../layoutGraph';
+
+const NODE_W = 160;
+const NODE_H = 72;
+const NODE_GAP = 48;
+const RANK_GAP = 72;
+
+function coords(n: number, edges: Array<readonly [number, number]>): { g: LGraph; pos: Point[] } {
+  const layer = assignLayers(n, edges);
+  const g = normalize(n, new Array(n).fill(NODE_W), new Array(n).fill(NODE_H), layer, edges);
+  const order = minimizeCrossings(g);
+  const pos = assignCoords(g, order, { nodeGap: NODE_GAP, rankGap: RANK_GAP });
+  return { g, pos };
+}
+
+describe('assignCoords (priority method)', () => {
+  it('produces no overlapping real nodes', () => {
+    const { g, pos } = coords(5, [[0, 1], [0, 2], [0, 3], [1, 4], [2, 4], [3, 4], [0, 4]]);
+    for (let a = 0; a < g.nReal; a++) {
+      for (let b = a + 1; b < g.nReal; b++) {
+        const dx = Math.abs(pos[a]!.x - pos[b]!.x);
+        const dy = Math.abs(pos[a]!.y - pos[b]!.y);
+        const overlapX = dx < (g.w[a]! + g.w[b]!) / 2;
+        const overlapY = dy < (g.h[a]! + g.h[b]!) / 2;
+        expect(overlapX && overlapY).toBe(false);
+      }
+    }
+  });
+
+  it('places the minimum real-node center at the origin', () => {
+    const { g, pos } = coords(4, [[0, 1], [0, 2], [1, 3], [2, 3]]);
+    let minX = Infinity;
+    let minY = Infinity;
+    for (let v = 0; v < g.nReal; v++) {
+      minX = Math.min(minX, pos[v]!.x);
+      minY = Math.min(minY, pos[v]!.y);
+    }
+    expect(minX).toBe(0);
+    expect(minY).toBe(0);
+  });
+
+  it('centers a single parent over its two children', () => {
+    const { pos } = coords(3, [[0, 1], [0, 2]]);
+    const mid = (pos[1]!.x + pos[2]!.x) / 2;
+    expect(Math.abs(pos[0]!.x - mid)).toBeLessThan(1);
+  });
+
+  it('separates layers by node height + rank gap', () => {
+    const { pos } = coords(2, [[0, 1]]);
+    expect(pos[1]!.y - pos[0]!.y).toBe(NODE_H + RANK_GAP);
+  });
+});

--- a/src/shapes/import/layout/coords.ts
+++ b/src/shapes/import/layout/coords.ts
@@ -1,0 +1,188 @@
+/**
+ * Coordinate assignment: the priority method (Sugiyama et al. 1981, as
+ * refined by Gansner et al. 1993).
+ *
+ * Alternating down/up sweeps move each node toward the median x of its
+ * neighbors in the fixed adjacent layer, processed in descending priority
+ * (degree toward the fixed layer). A move may push lower-priority neighbors
+ * aside but never equal-or-higher ones, so well-connected nodes and virtual
+ * chains end up aligned — chains straighten instead of zigzagging through
+ * ranks of different widths.
+ *
+ * TS twin of `relay/src/mcp/layout/coords.rs` — keep the two in step.
+ */
+
+import type { LGraph } from './rank';
+import type { Point } from '../layoutGraph';
+
+/** Cross-axis gap when at least one of the two neighbors is a virtual node. */
+const VIRTUAL_GAP = 20;
+
+/** Coordinate sweeps (alternating down/up). */
+const SWEEPS = 8;
+
+export interface CoordOptions {
+  /** Cross-axis gap between real sibling nodes within a rank. */
+  nodeGap: number;
+  /** Flow-axis gap between ranks. */
+  rankGap: number;
+}
+
+/**
+ * Assign center coordinates (pipeline space: x = cross axis, y = flow axis)
+ * to every node, real + virtual. Real nodes are translated so their minimum
+ * center sits at (0, 0).
+ */
+export function assignCoords(
+  g: LGraph,
+  order: ReadonlyArray<ReadonlyArray<number>>,
+  options: CoordOptions
+): Point[] {
+  const up: number[][] = Array.from({ length: g.nTotal }, () => []);
+  const down: number[][] = Array.from({ length: g.nTotal }, () => []);
+  for (const [u, v] of g.segments) {
+    down[u]!.push(v);
+    up[v]!.push(u);
+  }
+
+  const separation = (a: number, b: number): number => {
+    const gap = a < g.nReal && b < g.nReal ? options.nodeGap : VIRTUAL_GAP;
+    return g.w[a]! / 2 + g.w[b]! / 2 + gap;
+  };
+
+  // Initial x: pack each layer left-to-right from 0.
+  const x: number[] = new Array(g.nTotal).fill(0);
+  for (const layer of order) {
+    for (let i = 1; i < layer.length; i++) {
+      x[layer[i]!] = x[layer[i - 1]!]! + separation(layer[i - 1]!, layer[i]!);
+    }
+  }
+
+  for (let sweep = 0; sweep < SWEEPS; sweep++) {
+    if (sweep % 2 === 0) {
+      for (let l = 1; l < order.length; l++) {
+        priorityPass(g, order[l]!, up, x, separation);
+      }
+    } else {
+      for (let l = order.length - 2; l >= 0; l--) {
+        priorityPass(g, order[l]!, down, x, separation);
+      }
+    }
+  }
+
+  // Flow axis: stack layers by max node height + rankGap.
+  const layerH: number[] = new Array(g.nLayers).fill(0);
+  for (let v = 0; v < g.nTotal; v++) {
+    const l = g.layer[v]!;
+    if (g.h[v]! > layerH[l]!) layerH[l] = g.h[v]!;
+  }
+  const layerCy: number[] = new Array(g.nLayers).fill(0);
+  let top = 0;
+  for (let l = 0; l < g.nLayers; l++) {
+    layerCy[l] = top + layerH[l]! / 2;
+    top += layerH[l]! + options.rankGap;
+  }
+
+  // Translate so the minimum real-node center is (0, 0).
+  let minX = Infinity;
+  let minCy = Infinity;
+  for (let v = 0; v < g.nReal; v++) {
+    if (x[v]! < minX) minX = x[v]!;
+    const cy = layerCy[g.layer[v]!]!;
+    if (cy < minCy) minCy = cy;
+  }
+  const dx = g.nReal > 0 ? -minX : 0;
+  const dy = g.nReal > 0 ? -minCy : 0;
+
+  const out: Point[] = [];
+  for (let v = 0; v < g.nTotal; v++) {
+    out.push({ x: x[v]! + dx, y: layerCy[g.layer[v]!]! + dy });
+  }
+  return out;
+}
+
+/**
+ * One priority pass over `layer`: nodes in descending priority move toward
+ * the median x of their neighbors in the fixed layer, pushing only
+ * lower-priority nodes aside.
+ */
+function priorityPass(
+  g: LGraph,
+  layer: ReadonlyArray<number>,
+  adj: ReadonlyArray<ReadonlyArray<number>>,
+  x: number[],
+  separation: (a: number, b: number) => number
+): void {
+  const priority = (v: number): number => (v >= g.nReal ? Infinity : adj[v]!.length);
+
+  // Visit order: descending priority, position (left-to-right) on ties.
+  const visit = layer.map((_, i) => i);
+  visit.sort((i, j) => {
+    const pi = priority(layer[i]!);
+    const pj = priority(layer[j]!);
+    if (pi !== pj) return pj - pi;
+    return i - j;
+  });
+
+  for (const i of visit) {
+    const v = layer[i]!;
+    const neigh = adj[v]!;
+    if (neigh.length === 0) continue;
+    const desired = median(neigh.map((u) => x[u]!));
+    const p = priority(v);
+
+    if (desired > x[v]!) {
+      // Wall: nearest right neighbor with priority >= p.
+      let limit = Infinity;
+      let acc = 0;
+      for (let j = i + 1; j < layer.length; j++) {
+        acc += separation(layer[j - 1]!, layer[j]!);
+        if (priority(layer[j]!) >= p) {
+          limit = x[layer[j]!]! - acc;
+          break;
+        }
+      }
+      const newX = Math.min(desired, limit);
+      if (newX > x[v]!) {
+        x[v] = newX;
+        for (let j = i + 1; j < layer.length; j++) {
+          const minX = x[layer[j - 1]!]! + separation(layer[j - 1]!, layer[j]!);
+          if (x[layer[j]!]! < minX) {
+            x[layer[j]!] = minX;
+          } else {
+            break;
+          }
+        }
+      }
+    } else if (desired < x[v]!) {
+      let limit = -Infinity;
+      let acc = 0;
+      for (let j = i - 1; j >= 0; j--) {
+        acc += separation(layer[j]!, layer[j + 1]!);
+        if (priority(layer[j]!) >= p) {
+          limit = x[layer[j]!]! + acc;
+          break;
+        }
+      }
+      const newX = Math.max(desired, limit);
+      if (newX < x[v]!) {
+        x[v] = newX;
+        for (let j = i - 1; j >= 0; j--) {
+          const maxX = x[layer[j + 1]!]! - separation(layer[j]!, layer[j + 1]!);
+          if (x[layer[j]!]! > maxX) {
+            x[layer[j]!] = maxX;
+          } else {
+            break;
+          }
+        }
+      }
+    }
+  }
+}
+
+/** Median of the values; mean of the two middles on even counts. */
+function median(values: number[]): number {
+  const v = [...values].sort((a, b) => a - b);
+  const n = v.length;
+  return n % 2 === 1 ? v[(n - 1) / 2]! : (v[n / 2 - 1]! + v[n / 2]!) / 2;
+}

--- a/src/shapes/import/layout/order.test.ts
+++ b/src/shapes/import/layout/order.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { assignLayers, normalize, type LGraph } from './rank';
+import { minimizeCrossings, totalCrossings } from './order';
+
+function graph(n: number, edges: Array<readonly [number, number]>): LGraph {
+  const layer = assignLayers(n, edges);
+  return normalize(n, new Array(n).fill(160), new Array(n).fill(72), layer, edges);
+}
+
+/** Position index of every node within its layer, given an ordering. */
+function positions(g: LGraph, order: ReadonlyArray<ReadonlyArray<number>>): number[] {
+  const pos = new Array(g.nTotal).fill(0);
+  for (const layer of order) layer.forEach((v, i) => (pos[v] = i));
+  return pos;
+}
+
+describe('crossing counting + minimization', () => {
+  it('counts zero crossings for parallel edges', () => {
+    // 0->2, 1->3 with order [0,1] / [2,3]: parallel, no crossing.
+    const g = graph(4, [[0, 2], [1, 3]]);
+    const order = [[0, 1], [2, 3]];
+    expect(totalCrossings(g, order, positions(g, order))).toBe(0);
+  });
+
+  it('counts one crossing for an X pattern', () => {
+    // 0->3, 1->2 with order [0,1] / [2,3]: the segments cross once.
+    const g = graph(4, [[0, 3], [1, 2]]);
+    const order = [[0, 1], [2, 3]];
+    expect(totalCrossings(g, order, positions(g, order))).toBe(1);
+  });
+
+  it('orders away the X crossing', () => {
+    const g = graph(4, [[0, 3], [1, 2]]);
+    const order = minimizeCrossings(g);
+    expect(totalCrossings(g, order, positions(g, order))).toBe(0);
+  });
+
+  it('keeps exactly one crossing for K2,2', () => {
+    // K2,2 (0,1 -> 2,3 fully connected) cannot do better than 1 crossing.
+    const g = graph(4, [[0, 2], [0, 3], [1, 2], [1, 3]]);
+    const order = minimizeCrossings(g);
+    expect(totalCrossings(g, order, positions(g, order))).toBe(1);
+  });
+
+  it('is deterministic', () => {
+    const edges: Array<readonly [number, number]> = [[0, 4], [1, 3], [2, 5], [0, 5], [1, 4], [2, 3]];
+    const g1 = graph(6, edges);
+    const g2 = graph(6, edges);
+    expect(minimizeCrossings(g1)).toEqual(minimizeCrossings(g2));
+  });
+});

--- a/src/shapes/import/layout/order.ts
+++ b/src/shapes/import/layout/order.ts
@@ -1,0 +1,205 @@
+/**
+ * Vertex ordering / crossing minimization.
+ *
+ * Layer-by-layer barycenter sweeps (Sugiyama et al. 1981) with a bounded
+ * adjacent-transpose polish after each sweep, scored by exact bilayer
+ * crossing counts (Fenwick-tree inversion counting). The best ordering seen
+ * across all sweeps wins; ties keep the earlier one.
+ *
+ * Determinism: the initial order is ascending node index (= input order for
+ * real nodes, edge order for virtuals), barycenter sorts are stable
+ * (Array.prototype.sort is stable per ES2019), and sweep/transpose counts
+ * are fixed.
+ *
+ * TS twin of `relay/src/mcp/layout/order.rs` — keep the two in step.
+ */
+
+import type { LGraph } from './rank';
+
+/** Number of barycenter sweeps (alternating down/up). */
+const SWEEPS = 8;
+/** Max transpose passes after each sweep. */
+const TRANSPOSE_PASSES = 4;
+
+/** Compute a per-layer node ordering minimizing edge crossings (heuristic). */
+export function minimizeCrossings(g: LGraph): number[][] {
+  const order: number[][] = Array.from({ length: g.nLayers }, () => []);
+  for (let v = 0; v < g.nTotal; v++) {
+    order[g.layer[v]!]!.push(v); // ascending index per layer
+  }
+  if (g.segments.length === 0 || g.nLayers <= 1) {
+    return order;
+  }
+
+  // Adjacency over unit segments: up = neighbors one layer above, down =
+  // neighbors one layer below. Built in segment order (deterministic).
+  const up: number[][] = Array.from({ length: g.nTotal }, () => []);
+  const down: number[][] = Array.from({ length: g.nTotal }, () => []);
+  for (const [u, v] of g.segments) {
+    down[u]!.push(v);
+    up[v]!.push(u);
+  }
+
+  const pos = positions(g.nTotal, order);
+  let best = order.map((layer) => [...layer]);
+  let bestCrossings = totalCrossings(g, order, pos);
+
+  for (let sweep = 0; sweep < SWEEPS; sweep++) {
+    if (sweep % 2 === 0) {
+      for (let l = 1; l < g.nLayers; l++) {
+        barycenterSort(order[l]!, up, pos);
+      }
+    } else {
+      for (let l = g.nLayers - 2; l >= 0; l--) {
+        barycenterSort(order[l]!, down, pos);
+      }
+    }
+    transpose(order, pos, up, down);
+
+    const crossings = totalCrossings(g, order, pos);
+    if (crossings < bestCrossings) {
+      bestCrossings = crossings;
+      best = order.map((layer) => [...layer]);
+      if (crossings === 0) break;
+    }
+  }
+
+  return best;
+}
+
+function positions(nTotal: number, order: ReadonlyArray<ReadonlyArray<number>>): number[] {
+  const pos: number[] = new Array(nTotal).fill(0);
+  for (const layer of order) {
+    layer.forEach((v, i) => {
+      pos[v] = i;
+    });
+  }
+  return pos;
+}
+
+/**
+ * Stable-sort one layer by the mean position of its neighbors in the fixed
+ * adjacent layer; nodes without neighbors there keep their current position
+ * as the key (so they hold station instead of jumping to one end).
+ */
+function barycenterSort(layer: number[], adj: ReadonlyArray<ReadonlyArray<number>>, pos: number[]): void {
+  const keyed = layer.map((v) => {
+    const neigh = adj[v]!;
+    const key =
+      neigh.length === 0 ? pos[v]! : neigh.reduce((s, u) => s + pos[u]!, 0) / neigh.length;
+    return { v, key };
+  });
+  keyed.sort((a, b) => a.key - b.key);
+  keyed.forEach(({ v }, i) => {
+    layer[i] = v;
+    pos[v] = i;
+  });
+}
+
+/**
+ * Greedy adjacent-exchange polish: swap neighbors whenever it strictly
+ * reduces the crossings local to the pair, bounded passes.
+ */
+function transpose(
+  order: number[][],
+  pos: number[],
+  up: ReadonlyArray<ReadonlyArray<number>>,
+  down: ReadonlyArray<ReadonlyArray<number>>
+): void {
+  for (let pass = 0; pass < TRANSPOSE_PASSES; pass++) {
+    let improved = false;
+    for (const layer of order) {
+      for (let i = 0; i < layer.length - 1; i++) {
+        const a = layer[i]!;
+        const b = layer[i + 1]!;
+        const before = pairCrossings(a, b, up, pos) + pairCrossings(a, b, down, pos);
+        const after = pairCrossings(b, a, up, pos) + pairCrossings(b, a, down, pos);
+        if (after < before) {
+          layer[i] = b;
+          layer[i + 1] = a;
+          pos[b] = i;
+          pos[a] = i + 1;
+          improved = true;
+        }
+      }
+    }
+    if (!improved) break;
+  }
+}
+
+/**
+ * Crossings between the edge bundles of two nodes when `a` sits immediately
+ * left of `b`: pairs (p, q) with p in N(a), q in N(b), and p right of q.
+ */
+function pairCrossings(
+  a: number,
+  b: number,
+  adj: ReadonlyArray<ReadonlyArray<number>>,
+  pos: ReadonlyArray<number>
+): number {
+  let count = 0;
+  for (const p of adj[a]!) {
+    for (const q of adj[b]!) {
+      if (pos[p]! > pos[q]!) count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Exact crossing count between all adjacent layer pairs: sort each bilayer's
+ * segments by upper position and count inversions of the lower positions
+ * with a Fenwick tree — O(E log V) per bilayer.
+ */
+export function totalCrossings(
+  g: LGraph,
+  order: ReadonlyArray<ReadonlyArray<number>>,
+  pos: ReadonlyArray<number>
+): number {
+  const byUpperLayer: Array<Array<[number, number]>> = Array.from({ length: g.nLayers }, () => []);
+  for (const [u, v] of g.segments) {
+    byUpperLayer[g.layer[u]!]!.push([pos[u]!, pos[v]!]);
+  }
+
+  let total = 0;
+  byUpperLayer.forEach((pairs, l) => {
+    if (pairs.length < 2) return;
+    pairs.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+    const lowerLen = order[l + 1]?.length ?? 0;
+    const tree = new Fenwick(lowerLen);
+    // Walk in sorted order; each segment crosses every already-seen segment
+    // whose lower endpoint is strictly to its right.
+    pairs.forEach(([, lo], i) => {
+      total += i - tree.prefixSum(lo);
+      tree.add(lo);
+    });
+  });
+  return total;
+}
+
+class Fenwick {
+  private readonly tree: number[];
+
+  constructor(n: number) {
+    this.tree = new Array(n + 1).fill(0);
+  }
+
+  /** Count of added values <= i. */
+  prefixSum(i: number): number {
+    let idx = i + 1;
+    let sum = 0;
+    while (idx > 0) {
+      sum += this.tree[idx]!;
+      idx -= idx & -idx;
+    }
+    return sum;
+  }
+
+  add(i: number): void {
+    let idx = i + 1;
+    while (idx < this.tree.length) {
+      this.tree[idx]! += 1;
+      idx += idx & -idx;
+    }
+  }
+}

--- a/src/shapes/import/layout/rank.test.ts
+++ b/src/shapes/import/layout/rank.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { assignLayers, normalize } from './rank';
+
+describe('assignLayers (longest-path + tightening)', () => {
+  it('layers a chain by longest path', () => {
+    expect(assignLayers(3, [[0, 1], [1, 2]])).toEqual([0, 1, 2]);
+  });
+
+  it('tightens pure sources next to their nearest successor', () => {
+    // 0 -> 1 -> 2 -> 3, plus source 4 -> 3. Longest-path leaves 4 at layer 0;
+    // tightening pulls it to layer 2, one above its successor.
+    const layers = assignLayers(5, [[0, 1], [1, 2], [2, 3], [4, 3]]);
+    expect(layers[3]).toBe(3);
+    expect(layers[4]).toBe(2);
+  });
+
+  it('keeps isolated nodes at layer 0', () => {
+    expect(assignLayers(3, [[0, 1]])).toEqual([0, 1, 0]);
+  });
+});
+
+describe('normalize (long-edge dummy insertion)', () => {
+  it('inserts span-1 dummies for a long edge', () => {
+    // 0 -> 1 -> 2 -> 3 plus a long edge 0 -> 3 (span 3 -> 2 virtuals).
+    const edges: Array<readonly [number, number]> = [[0, 1], [1, 2], [2, 3], [0, 3]];
+    const layer = assignLayers(4, edges);
+    const g = normalize(4, [160, 160, 160, 160], [72, 72, 72, 72], layer, edges);
+    expect(g.nTotal).toBe(6);
+    // Every segment spans exactly one layer.
+    for (const [a, b] of g.segments) {
+      expect(g.layer[b]).toBe(g.layer[a]! + 1);
+    }
+    // The two virtuals sit on layers 1 and 2.
+    expect(g.layer[4]).toBe(1);
+    expect(g.layer[5]).toBe(2);
+  });
+});

--- a/src/shapes/import/layout/rank.ts
+++ b/src/shapes/import/layout/rank.ts
@@ -1,0 +1,143 @@
+/**
+ * Layer assignment + long-edge normalization.
+ *
+ * Layering is exact longest-path over the FAS-oriented DAG (`layer[v] =
+ * max(layer[u] + 1)` in topological order), followed by one tightening pass
+ * that pulls pure sources down next to their nearest successor — the classic
+ * longest-path artifact is sources stranded at layer 0 trailing long edges
+ * across the whole drawing (one of the import "elongation" causes).
+ *
+ * Normalization then breaks every edge spanning more than one layer into
+ * unit segments through narrow virtual nodes, which is what lets crossing
+ * minimization see long edges at every layer they pass through and reserves
+ * a channel between real nodes.
+ *
+ * TS twin of `relay/src/mcp/layout/rank.rs` — keep the two in step.
+ */
+
+/** Width reserved by a virtual (dummy) node: the long-edge channel. */
+export const DUMMY_SIZE = 8;
+
+/**
+ * Longest-path layering of a DAG. `edges` must be acyclic (FAS-oriented) and
+ * self-loop free. Returns one layer index per node, compacted so used layers
+ * are exactly `0..max`.
+ */
+export function assignLayers(n: number, edges: ReadonlyArray<readonly [number, number]>): number[] {
+  const indeg: number[] = new Array(n).fill(0);
+  const outAdj: number[][] = Array.from({ length: n }, () => []);
+  const inAdj: number[][] = Array.from({ length: n }, () => []);
+  for (const [u, v] of edges) {
+    indeg[v]! += 1;
+    outAdj[u]!.push(v);
+    inAdj[v]!.push(u);
+  }
+
+  // Kahn topological order (lowest index first — determinism, though the
+  // resulting layers are order-independent).
+  const layer: number[] = new Array(n).fill(0);
+  const ready: number[] = [];
+  for (let v = 0; v < n; v++) {
+    if (indeg[v] === 0) ready.push(v);
+  }
+  while (ready.length > 0) {
+    let pick = 0;
+    for (let i = 1; i < ready.length; i++) {
+      if (ready[i]! < ready[pick]!) pick = i;
+    }
+    const u = ready[pick]!;
+    ready[pick] = ready[ready.length - 1]!;
+    ready.pop();
+    for (const v of outAdj[u]!) {
+      if (layer[v]! < layer[u]! + 1) layer[v] = layer[u]! + 1;
+      indeg[v]! -= 1;
+      if (indeg[v] === 0) ready.push(v);
+    }
+  }
+
+  // Tightening: a source with successors sits just above its nearest one.
+  for (let v = 0; v < n; v++) {
+    if (inAdj[v]!.length === 0 && outAdj[v]!.length > 0) {
+      let minSucc = Infinity;
+      for (const w of outAdj[v]!) {
+        if (layer[w]! < minSucc) minSucc = layer[w]!;
+      }
+      layer[v] = Math.max(0, minSucc - 1);
+    }
+  }
+
+  compactLayers(layer);
+  return layer;
+}
+
+/** Remap layer values so the used set is contiguous from 0. */
+function compactLayers(layer: number[]): void {
+  if (layer.length === 0) return;
+  const used = [...new Set(layer)].sort((a, b) => a - b);
+  const remap = new Map(used.map((l, i) => [l, i]));
+  for (let i = 0; i < layer.length; i++) {
+    layer[i] = remap.get(layer[i]!)!;
+  }
+}
+
+/**
+ * The layered graph after normalization: real nodes first (their input
+ * indices), then virtual nodes appended in edge-input order.
+ */
+export interface LGraph {
+  nReal: number;
+  nTotal: number;
+  /** Node width/height in pipeline space, indexed by node. */
+  w: number[];
+  h: number[];
+  layer: number[];
+  nLayers: number;
+  /** Unit-span segments, oriented from lower to higher layer. */
+  segments: Array<readonly [number, number]>;
+}
+
+/**
+ * Break long edges into unit segments. `edges` are FAS-oriented (every edge
+ * spans at least one layer downward).
+ */
+export function normalize(
+  nReal: number,
+  widths: ReadonlyArray<number>,
+  heights: ReadonlyArray<number>,
+  layer: number[],
+  edges: ReadonlyArray<readonly [number, number]>
+): LGraph {
+  let nLayers = 0;
+  for (const l of layer) nLayers = Math.max(nLayers, l + 1);
+
+  const g: LGraph = {
+    nReal,
+    nTotal: nReal,
+    w: [...widths],
+    h: [...heights],
+    layer,
+    nLayers,
+    segments: [],
+  };
+
+  for (const [u, v] of edges) {
+    const lu = g.layer[u]!;
+    const lv = g.layer[v]!;
+    if (lv - lu === 1) {
+      g.segments.push([u, v]);
+      continue;
+    }
+    let prev = u;
+    for (let l = lu + 1; l < lv; l++) {
+      const d = g.nTotal++;
+      g.w.push(DUMMY_SIZE);
+      g.h.push(0);
+      g.layer.push(l);
+      g.segments.push([prev, d]);
+      prev = d;
+    }
+    g.segments.push([prev, v]);
+  }
+
+  return g;
+}

--- a/src/shapes/import/layoutGraph.test.ts
+++ b/src/shapes/import/layoutGraph.test.ts
@@ -44,4 +44,40 @@ describe('layoutGraph', () => {
       JSON.stringify([...layoutGraph(nodes, edges)])
     );
   });
+
+  it('orders siblings under their parents to avoid the crossing (v2 ordering)', () => {
+    // Two parents each with a dedicated child, listed in crossing order:
+    // a -> y, b -> x. v1 (input-order packing) drew an X; v2 uncrosses it.
+    const pos = layoutGraph(
+      [N('a'), N('b'), N('x'), N('y')],
+      [{ from: 'a', to: 'y' }, { from: 'b', to: 'x' }]
+    );
+    // a left of b implies y left of x (the edges no longer cross).
+    expect(pos.get('a')!.x < pos.get('b')!.x).toBe(pos.get('y')!.x < pos.get('x')!.x);
+  });
+
+  it('stays deterministic on a graph with a cycle and a long edge', () => {
+    const nodes = ['a', 'b', 'c', 'd', 'e', 'f'].map((id) => N(id));
+    const edges = [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+      { from: 'c', to: 'a' }, // cycle back
+      { from: 'a', to: 'd' },
+      { from: 'd', to: 'e' },
+      { from: 'a', to: 'f' }, // long edge (span > 1)
+      { from: 'e', to: 'f' },
+    ];
+    expect(JSON.stringify([...layoutGraph(nodes, edges)])).toBe(
+      JSON.stringify([...layoutGraph(nodes, edges)])
+    );
+  });
+
+  it('ignores self-loops and unknown endpoints without crashing', () => {
+    const pos = layoutGraph(
+      [N('a'), N('b')],
+      [{ from: 'a', to: 'a' }, { from: 'a', to: 'b' }, { from: 'a', to: 'ghost' }]
+    );
+    expect(pos.size).toBe(2);
+    expect(pos.get('a')!.y).toBeLessThan(pos.get('b')!.y);
+  });
 });

--- a/src/shapes/import/layoutGraph.ts
+++ b/src/shapes/import/layoutGraph.ts
@@ -1,17 +1,27 @@
 /**
  * Shared layered-graph layout for coordinate-less import adapters (JP-164 /
- * JP-85). Mermaid, PlantUML and friends describe a node/edge graph with no
- * geometry, so we assign positions here.
+ * JP-85 / JP-305). Mermaid, PlantUML and friends describe a node/edge graph
+ * with no geometry, so we assign positions here.
  *
- * This is the **light, editor-side** layout: longest-path layering (Sugiyama
- * without crossing minimisation) + per-rank packing using each node's real
- * size. It is deterministic (stable on re-run, tie-broken by input order) and
- * dependency-free — the heavyweight, crossing-minimised, obstacle-routed
- * version is the relay-side JP-245 work; this one just needs to produce a
- * readable diagram a human is happy to open and then tidy.
+ * v2 (JP-305): the full Sugiyama pipeline ported from the relay's JP-245
+ * layout (`relay/src/mcp/layout/`) — greedy feedback-arc-set cycle removal,
+ * longest-path layering with source tightening, long-edge normalization
+ * through virtual nodes, barycenter/transpose crossing minimization, and
+ * priority-method coordinates. This replaces the v1 "rank + pack" layout,
+ * whose missing ordering/tightening/alignment were the main cause of
+ * crossing spaghetti and awkwardly elongated Mermaid imports.
  *
- * Returns **centre** positions (DocuShark box shapes are centre-anchored).
+ * Deterministic (fixed sweep counts, all ties broken by input order) and
+ * dependency-free. The pipeline runs in TB space; other flow directions
+ * transpose/mirror the result. Returns **centre** positions (DocuShark box
+ * shapes are centre-anchored), with the minimum real-node centre at (0, 0)
+ * in pipeline space (callers frame via zoomToFit, so origin is arbitrary).
  */
+
+import { greedyFas } from './layout/acyclic';
+import { assignLayers, normalize } from './layout/rank';
+import { minimizeCrossings } from './layout/order';
+import { assignCoords } from './layout/coords';
 
 export interface GraphLayoutNode {
   id: string;
@@ -41,32 +51,6 @@ export interface Point {
   y: number;
 }
 
-/**
- * Assign ranks by longest path from the roots. Cycles are bounded: the relax
- * loop runs at most `n` passes, so a back-edge can't spin forever — it just
- * settles at a finite rank.
- */
-function assignRanks(
-  ids: string[],
-  edges: GraphLayoutEdge[],
-  has: (id: string) => boolean
-): Map<string, number> {
-  const rank = new Map<string, number>(ids.map((id) => [id, 0]));
-  for (let pass = 0; pass < ids.length; pass++) {
-    let changed = false;
-    for (const e of edges) {
-      if (e.from === e.to || !has(e.from) || !has(e.to)) continue;
-      const next = rank.get(e.from)! + 1;
-      if (next > rank.get(e.to)!) {
-        rank.set(e.to, next);
-        changed = true;
-      }
-    }
-    if (!changed) break;
-  }
-  return rank;
-}
-
 export function layoutGraph(
   nodes: GraphLayoutNode[],
   edges: GraphLayoutEdge[],
@@ -75,54 +59,37 @@ export function layoutGraph(
   const direction = options.direction ?? 'TB';
   const nodeGap = options.nodeGap ?? 48;
   const rankGap = options.rankGap ?? 72;
+  const horizontal = direction === 'LR' || direction === 'RL';
+  const mirrored = direction === 'BT' || direction === 'RL';
 
-  const byId = new Map(nodes.map((n) => [n.id, n]));
-  const ids = nodes.map((n) => n.id);
-  const rank = assignRanks(ids, edges, (id) => byId.has(id));
+  const index = new Map(nodes.map((n, i) => [n.id, i]));
 
-  // Group nodes by rank, preserving input order within each rank.
-  const ranks = new Map<number, GraphLayoutNode[]>();
-  let maxRank = 0;
-  for (const node of nodes) {
-    const r = rank.get(node.id)!;
-    maxRank = Math.max(maxRank, r);
-    (ranks.get(r) ?? ranks.set(r, []).get(r)!).push(node);
+  // Self-loops and edges with unknown endpoints don't influence layout.
+  const pipelineEdges: Array<readonly [number, number]> = [];
+  for (const e of edges) {
+    const u = index.get(e.from);
+    const v = index.get(e.to);
+    if (u === undefined || v === undefined || u === v) continue;
+    pipelineEdges.push([u, v]);
   }
 
-  const horizontal = direction === 'LR' || direction === 'RL';
-  // Flow-axis size = the dimension ranks advance along; cross-axis = the other.
-  const flowSize = (n: GraphLayoutNode) => (horizontal ? n.width : n.height);
-  const crossSize = (n: GraphLayoutNode) => (horizontal ? n.height : n.width);
+  // The pipeline works in TB space: x = cross axis, y = flow axis. For
+  // horizontal flow the node footprint transposes with the axes.
+  const widths = nodes.map((n) => (horizontal ? n.height : n.width));
+  const heights = nodes.map((n) => (horizontal ? n.width : n.height));
+
+  const reversed = greedyFas(nodes.length, pipelineEdges);
+  const oriented = pipelineEdges.map(([u, v], i) => (reversed[i] ? ([v, u] as const) : ([u, v] as const)));
+  const layer = assignLayers(nodes.length, oriented);
+  const g = normalize(nodes.length, widths, heights, layer, oriented);
+  const order = minimizeCrossings(g);
+  const coords = assignCoords(g, order, { nodeGap, rankGap });
 
   const positions = new Map<string, Point>();
-
-  // Walk ranks in flow order, accumulating the flow-axis offset by the tallest
-  // node in each rank. BT/RL just reverse the rank order.
-  const order: number[] = [];
-  for (let r = 0; r <= maxRank; r++) order.push(r);
-  if (direction === 'BT' || direction === 'RL') order.reverse();
-
-  let flowCursor = 0;
-  for (const r of order) {
-    const rankNodes = ranks.get(r) ?? [];
-    const rankExtent = rankNodes.reduce((m, n) => Math.max(m, flowSize(n)), 0);
-    const flowCenter = flowCursor + rankExtent / 2;
-
-    // Pack the rank along the cross axis, centred on 0.
-    const totalCross =
-      rankNodes.reduce((s, n) => s + crossSize(n), 0) + Math.max(0, rankNodes.length - 1) * nodeGap;
-    let crossCursor = -totalCross / 2;
-    for (const n of rankNodes) {
-      const crossCenter = crossCursor + crossSize(n) / 2;
-      positions.set(
-        n.id,
-        horizontal ? { x: flowCenter, y: crossCenter } : { x: crossCenter, y: flowCenter }
-      );
-      crossCursor += crossSize(n) + nodeGap;
-    }
-
-    flowCursor += rankExtent + rankGap;
-  }
-
+  nodes.forEach((n, i) => {
+    const p = coords[i]!;
+    const flow = mirrored ? -p.y : p.y;
+    positions.set(n.id, horizontal ? { x: flow, y: p.x } : { x: p.x, y: flow });
+  });
   return positions;
 }


### PR DESCRIPTION
Slices A + B of JP-305. Imports were the weak surface after JP-245 shipped: MCP-generated diagrams get the relay's Sugiyama layout + orthogonal routed connectors, while coordinate-less imports (Mermaid, eventually PlantUML) still ran the naive v1 `layoutGraph` — longest-path only, no crossing minimization, no source tightening — so Mermaid diagrams elongated awkwardly and crossed into spaghetti. And no import adapter set `routingMode`, so the `rebuildAllConnectorRoutes()` call in `importPipeline.ts` was a **no-op for every import** (its comment claimed it routed connectors; nothing qualified).

## Slice A — `layoutGraph` v2

Ports the JP-245 relay pipeline (`relay/src/mcp/layout/`) to TS behind the existing `layoutGraph()` signature. New `src/shapes/import/layout/`:

- **`acyclic.ts`** — greedy feedback-arc-set cycle removal (Eades–Lin–Smyth); feedback edges reversed for layering only, original direction kept in the emitted shapes.
- **`rank.ts`** — longest-path layering + source tightening (fixes sources stranded at rank 0 trailing long edges — a direct elongation cause) + dummy-node normalization of long edges.
- **`order.ts`** — barycenter sweeps + bounded transpose polish, scored by exact Fenwick-tree bilayer crossing counts; best ordering across sweeps wins.
- **`coords.ts`** — priority-method coordinate assignment; virtual chains get max priority so long edges straighten.

Direction support runs the pipeline in TB space and transposes/mirrors for LR/BT/RL. Deterministic (fixed sweep counts, all ties by input order). These are **TS twins of the Rust modules** — comments cross-reference, keep the two in step.

## Slice B — routed import connectors

Set `routingMode: 'orthogonal'` on Mermaid + drawio connectors so the pipeline's existing `rebuildAllConnectorRoutes()` computes obstacle-avoiding paths instead of skipping them. Excalidraw stays straight (its arrows carry real source geometry we shouldn't override).

## Scope notes

- Only **Mermaid** consumes `layoutGraph` (drawio/Excalidraw carry source coordinates), so the layout-quality jump lands on Mermaid + future PlantUML; drawio gets the routing improvement only.
- Deferred to later JP-305 slices: async/chunked large-import insertion (Slice C) and aspect-aware chain wrapping + a "Re-layout" command (Slice D).

## Tests

20 new layout unit tests mirroring the Rust coverage (FAS determinism + acyclicity, layering/tightening, dummy insertion, crossing counts on known patterns, X-uncrossing, K2,2 floor, overlap-free coords, origin, parent-centering) + 4 facade quality/determinism tests + 2 adapter routing assertions. Existing `layoutGraph` behavior contract preserved. `tsc` clean; full suite **2199 passed**.

Assisted-by: Opus 4.8