### PR TITLE
JP-305 Slice C: chunked async imports + viewport-centered placement

### DIFF
--- a/src/services/importPipeline.test.ts
+++ b/src/services/importPipeline.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import '../shapes/Rectangle'; // registers the 'rectangle' handler (for bounds/framing)
-import { applyImportResult, importDiagramText, importDiagramFiles } from './importPipeline';
+import { applyImportResult, importDiagramText, importDiagramFiles, IMPORT_CHUNK_SIZE } from './importPipeline';
 import type { ImportContext } from './FileImportService';
 import { registerImportAdapter, unregisterImportAdapter, type ImportAdapter } from '../shapes/import/ImportAdapter';
 import { DEFAULT_RECTANGLE, type Shape } from '../shapes/Shape';
 import { useDocumentStore } from '../store/documentStore';
 import { useSessionStore } from '../store/sessionStore';
+import { useNotificationStore } from '../store/notificationStore';
 
 function rect(id: string, x: number): Shape {
   return { ...DEFAULT_RECTANGLE, id, type: 'rectangle', x, y: 0, width: 100, height: 60 } as Shape;
@@ -42,12 +43,13 @@ const graphAdapter: ImportAdapter = {
 describe('importPipeline', () => {
   beforeEach(() => {
     useDocumentStore.getState().loadSnapshot({ shapes: {}, shapeOrder: [], version: 1 });
+    useNotificationStore.getState().dismissAll();
   });
 
   describe('applyImportResult', () => {
-    it('adds shapes, selects, frames, and reports', () => {
+    it('adds shapes, selects, frames, and reports', async () => {
       const { ctx, zoomToFit, requestRender } = makeCtx();
-      const report = applyImportResult('test', { shapes: [rect('a', 0), rect('b', 300)] }, ctx);
+      const report = await applyImportResult('test', { shapes: [rect('a', 0), rect('b', 300)] }, ctx);
 
       const shapes = useDocumentStore.getState().shapes;
       expect(shapes['a']).toBeTruthy();
@@ -58,14 +60,51 @@ describe('importPipeline', () => {
       expect(report.shapeCount).toBe(2);
     });
 
-    it('surfaces adapter warnings in the report', () => {
+    it('surfaces adapter warnings in the report', async () => {
       const { ctx } = makeCtx();
-      const report = applyImportResult('test', {
+      const report = await applyImportResult('test', {
         shapes: [rect('a', 0)],
         warnings: [{ kind: 'freedraw', detail: '2 skipped', count: 2 }],
       }, ctx);
       expect(report.warnings).toHaveLength(1);
       expect(report.warnings[0]!.kind).toBe('freedraw');
+    });
+
+    it('centers the import on the viewport, not the world origin (JP-305)', async () => {
+      const { ctx } = makeCtx(); // mock viewport center is (0, 0)
+      // Adapter emits the diagram far from the origin (x spans 1000..1300).
+      await applyImportResult('test', { shapes: [rect('a', 1000), rect('b', 1300)] }, ctx);
+      const shapes = useDocumentStore.getState().shapes;
+      // Recentered so the import's midpoint sits at the viewport center.
+      const midX = (shapes['a']!.x + shapes['b']!.x) / 2;
+      expect(Math.round(midX)).toBe(0);
+    });
+
+    it('drops the import clear of existing content when it would overlap (JP-305)', async () => {
+      // Existing shape sitting at the viewport center (bounds y: -30..30).
+      useDocumentStore.getState().loadSnapshot({
+        shapes: { e: rect('e', 0) },
+        shapeOrder: ['e'],
+        version: 1,
+      });
+      const { ctx } = makeCtx();
+      await applyImportResult('test', { shapes: [rect('a', 0)] }, ctx);
+      const a = useDocumentStore.getState().shapes['a']!;
+      // Pushed below the existing content's bottom edge (30) by the gap, so
+      // its own top edge (a.y - 30) clears it — no overlap.
+      expect(a.y - 30).toBeGreaterThan(30);
+    });
+
+    it('inserts a large import in chunks and clears the progress toast (JP-305)', async () => {
+      const { ctx } = makeCtx();
+      const many = Array.from({ length: IMPORT_CHUNK_SIZE + 50 }, (_, i) => rect(`n${i}`, i * 5));
+      await applyImportResult('test', { shapes: many }, ctx);
+
+      expect(Object.keys(useDocumentStore.getState().shapes)).toHaveLength(IMPORT_CHUNK_SIZE + 50);
+      // The transient "Importing N/M…" toast is gone; only the final result
+      // notification remains.
+      const messages = useNotificationStore.getState().notifications.map((n) => n.message);
+      expect(messages.some((m) => m.startsWith('Importing'))).toBe(false);
     });
   });
 

--- a/src/services/importPipeline.ts
+++ b/src/services/importPipeline.ts
@@ -65,32 +65,147 @@ function reportImport(shapeCount: number, warnings: ImportWarning[]): void {
 }
 
 /**
- * Insert a parsed result onto the canvas as one undoable step: register any new
- * shape kinds, batch-add the shapes, select + frame them, and notify the user.
+ * Above this shape count an import is inserted in chunks across animation
+ * frames (with a progress toast) so the main thread stays responsive and the
+ * diagram materializes progressively instead of freezing the UI on one giant
+ * synchronous write. At or below it, the single-shot path keeps small imports
+ * instant. (JP-305 Slice C.)
  */
-export function applyImportResult(
+export const IMPORT_CHUNK_SIZE = 300;
+
+/** Gap left between an import and existing content when nudging clear of it. */
+const PLACEMENT_GAP = 80;
+
+/**
+ * Shift `shapes` in place so the import lands centered on the current viewport
+ * — where the user is looking — instead of at the world origin the adapters
+ * emit to. When that would overlap existing canvas content, drop the import
+ * into clear space just below that content so it doesn't bury anything
+ * (best-effort; an empty canvas / empty view is left exactly centered).
+ */
+function placeImport(shapes: Shape[], ctx: ImportContext): void {
+  const importBounds = combinedBounds(shapes);
+  if (!importBounds) return;
+
+  const target = ctx.engine.camera.getViewportCenter();
+  let dx = target.x - importBounds.centerX;
+  let dy = target.y - importBounds.centerY;
+
+  const existing = combinedBounds(Object.values(useDocumentStore.getState().shapes));
+  if (existing) {
+    const placed = new Box(
+      importBounds.minX + dx,
+      importBounds.minY + dy,
+      importBounds.maxX + dx,
+      importBounds.maxY + dy,
+    );
+    if (placed.intersects(existing)) {
+      // Push straight down past the existing content's bottom edge.
+      dy += existing.maxY + PLACEMENT_GAP - placed.minY;
+    }
+  }
+
+  if (dx === 0 && dy === 0) return;
+  for (const shape of shapes) translateShape(shape, dx, dy);
+}
+
+/** Shift a shape and any endpoint/waypoint geometry by (dx, dy), in place. */
+function translateShape(shape: Shape, dx: number, dy: number): void {
+  shape.x += dx;
+  shape.y += dy;
+  const geo = shape as Shape & {
+    x2?: number;
+    y2?: number;
+    waypoints?: Array<{ x: number; y: number }>;
+  };
+  if (typeof geo.x2 === 'number') geo.x2 += dx;
+  if (typeof geo.y2 === 'number') geo.y2 += dy;
+  if (geo.waypoints) geo.waypoints = geo.waypoints.map((p) => ({ x: p.x + dx, y: p.y + dy }));
+}
+
+/** Yield to the browser so it can paint a chunk before the next one lands. */
+function yieldToFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+/**
+ * Insert `shapes` as one undoable step. Small imports go in a single write;
+ * large ones are chunked across frames with a live progress toast. Either way
+ * connectors are routed once, after every node is present, so the router sees
+ * the full obstacle set.
+ *
+ * Each chunk is its own synchronous `mutateDocument('programmatic', …)` call:
+ * provenance is an ambient flag that does NOT survive the `await` between
+ * chunks (see the writeProvenance CONTRACT), so the write must be tagged inside
+ * each synchronous step, not around the whole async loop.
+ */
+async function insertShapes(shapes: Shape[]): Promise<void> {
+  if (shapes.length <= IMPORT_CHUNK_SIZE) {
+    mutateDocument('programmatic', () => {
+      useDocumentStore.getState().addShapes(shapes);
+      useDocumentStore.getState().rebuildAllConnectorRoutes();
+    });
+    return;
+  }
+
+  const notifications = useNotificationStore.getState();
+  const total = shapes.length;
+  const progressId = notifications.notify({
+    message: `Importing 0/${total}…`,
+    severity: 'info',
+    duration: 0,
+  });
+
+  try {
+    for (let offset = 0; offset < total; offset += IMPORT_CHUNK_SIZE) {
+      const chunk = shapes.slice(offset, offset + IMPORT_CHUNK_SIZE);
+      mutateDocument('programmatic', () => {
+        useDocumentStore.getState().addShapes(chunk);
+      });
+      const done = Math.min(offset + IMPORT_CHUNK_SIZE, total);
+      notifications.update(progressId, { message: `Importing ${done}/${total}…` });
+      await yieldToFrame();
+    }
+    mutateDocument('programmatic', () => {
+      useDocumentStore.getState().rebuildAllConnectorRoutes();
+    });
+  } finally {
+    notifications.dismiss(progressId);
+  }
+}
+
+/**
+ * Insert a parsed result onto the canvas as one undoable step: register any new
+ * shape kinds, place the import at the viewport (not the world origin), batch-
+ * add the shapes (chunked for large imports), select + frame them, and notify.
+ */
+export async function applyImportResult(
   adapterId: string,
   result: ImportResult,
   ctx: ImportContext,
-): ImportReport {
+): Promise<ImportReport> {
   const { shapes, libraryDefs, warnings = [] } = result;
 
+  // One snapshot before any insertion → one undo reverts the whole import,
+  // however many chunks it lands in.
   pushHistory(`Import ${adapterId}`);
 
   if (libraryDefs && libraryDefs.length > 0) {
     useShapeLibraryStore.getState().registerShapes(libraryDefs);
   }
 
-  // An import is app-generated content, not a keystroke — route through the
-  // provenance entrypoint (JP-192) so it propagates to collaborators as a
-  // distinct `programmatic` write rather than masquerading as a user edit.
-  mutateDocument('programmatic', () => {
-    useDocumentStore.getState().addShapes(shapes);
-    // Connectors hitch to the right anchors, but their routed waypoints aren't
-    // computed until a route rebuild — run one now so any imported diagram
-    // renders cleanly immediately instead of looking off until the first edit.
-    useDocumentStore.getState().rebuildAllConnectorRoutes();
-  });
+  placeImport(shapes, ctx);
+
+  // An import is app-generated content, not a keystroke — the writes inside
+  // insertShapes route through the provenance entrypoint (JP-192) so they
+  // propagate to collaborators as `programmatic`, not as user edits.
+  await insertShapes(shapes);
 
   const ids = shapes.map((s) => s.id);
   if (ids.length > 0) {
@@ -116,7 +231,9 @@ export async function importDiagramText(raw: string, ctx: ImportContext): Promis
   if (!adapter) return null;
   try {
     const result = await adapter.import(raw);
-    return applyImportResult(adapter.id, result, ctx);
+    // `await` (not bare return) so a rejection from the async insert is caught
+    // here and surfaced as an error toast, not leaked as an unhandled rejection.
+    return await applyImportResult(adapter.id, result, ctx);
   } catch (err) {
     useNotificationStore
       .getState()

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -70,6 +70,14 @@ interface NotificationState {
   warning: (message: string, options?: Partial<NotificationOptions>) => string;
   error: (message: string, options?: Partial<NotificationOptions>) => string;
 
+  /**
+   * Update an existing notification's message/severity in place (no-op if the
+   * id is gone). Used for live progress toasts — e.g. a long-running import
+   * ticking its count up — so we update one toast instead of spamming new
+   * ones. Does not change the auto-dismiss timer.
+   */
+  update: (id: string, changes: Partial<Pick<Notification, 'message' | 'severity'>>) => void;
+
   /** Dismiss a notification by ID */
   dismiss: (id: string) => void;
 
@@ -153,6 +161,12 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
       severity: 'error',
       category: options.category ?? 'permanent',
     });
+  },
+
+  update: (id, changes) => {
+    set((state) => ({
+      notifications: state.notifications.map((n) => (n.id === id ? { ...n, ...changes } : n)),
+    }));
   },
 
   dismiss: (id) => {


### PR DESCRIPTION
Slice C of JP-305, plus a placement fix you flagged. Builds on the merged layout v2 + routing work (#198).

## Two problems, both in the import path

**1. Large imports froze the UI.** Adapter parse + one giant `addShapes` + the spatial-index/connector work all ran in a single synchronous turn — a big Mermaid/drawio file would lock the main thread.

**2. Imports landed at the world origin** the adapters emit to, burying whatever was already on the canvas.

## Insertion — chunked + responsive

- Imports over **`IMPORT_CHUNK_SIZE` (300)** shapes insert in chunks across animation frames, so the main thread stays responsive and the diagram materializes progressively. A live **"Importing N/M…"** toast tracks progress and is dismissed when done. Small imports keep the instant single-shot path (no async, no toast).
- Each chunk is its own synchronous `mutateDocument('programmatic', …)` — provenance is ambient and **does not survive the `await`** between chunks (the `writeProvenance` CONTRACT), so it's tagged inside each step, not around the loop. Connectors route **once**, after every node is present (full obstacle set). One `pushHistory` before the loop keeps the whole import a **single undo**.
- Full Web Worker offload stays out of scope — the drawio adapter needs `DOMParser`, unavailable in workers — so the parse spike for huge drawio files remains; the insertion freeze (the dominant cost) is gone.

## Placement — centered on the viewport, clear of existing content

- `placeImport()` translates the import so it lands **centered on the current viewport** — where you're looking — instead of at the world origin. When that would overlap existing content, it drops the import into clear space just **below** it (best-effort collision avoidance via union bounds; collision-avoidance was the optional ask). It's a pure rigid translation, so drawio/Excalidraw **relative layout fidelity is preserved** — only the absolute origin changes. `zoomToFit` still frames the result.

## Supporting change

- `notificationStore` gains `update(id, { message, severity })` so a long-running toast ticks its progress in place instead of spawning new toasts.
- `applyImportResult` is now `async`; `importDiagramText` uses `return await` so an async insert failure is still caught and surfaced as an error toast.

## Remaining JP-305 work

Slice D (stretch): aspect-aware serpentine wrapping for very long chains + a "Re-layout diagram" command. Not in this PR.

## Tests

New: centers-on-viewport, collision-clears-existing-content, large-import-chunks-and-clears-progress-toast. Existing `applyImportResult` contract updated to `await`. `tsc` clean; full suite **2202 passed**.

Assisted-by: Opus 4.8