### PR TITLE
JP-305 Slice D: select connected chain + auto-layout a selection

### DIFF
--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -13,6 +13,12 @@ import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
 import { alignHorizontal, alignVertical, distribute } from '../shapes/utils/alignment';
+import {
+  selectConnectedChain,
+  canSelectConnectedChain,
+  autoLayoutSelection,
+  canAutoLayoutSelection,
+} from './selectionLayout';
 import type { ShortcutCategory } from './KeyboardShortcuts';
 import { LAYOUT_LABELS } from '../ui/layout/modes';
 import { LAYOUT_MODES, type LayoutMode } from '../ui/layout/types';
@@ -141,6 +147,31 @@ export function getAllCommands(): Command[] {
 
     // --- Alignment ---
     ...alignmentCommands(),
+
+    // --- Diagram layout (JP-305) ---
+    {
+      id: 'arrange.selectConnected',
+      label: 'Select connected shapes',
+      category: 'Editing',
+      shortcut: 'Ctrl+Shift+A',
+      execute: () => selectConnectedChain(),
+      canExecute: canSelectConnectedChain,
+    },
+    {
+      id: 'arrange.autoLayoutTB',
+      label: 'Auto-layout selection (top to bottom)',
+      category: 'Editing',
+      shortcut: 'Ctrl+Shift+L',
+      execute: () => autoLayoutSelection('TB'),
+      canExecute: canAutoLayoutSelection,
+    },
+    {
+      id: 'arrange.autoLayoutLR',
+      label: 'Auto-layout selection (left to right)',
+      category: 'Editing',
+      execute: () => autoLayoutSelection('LR'),
+      canExecute: canAutoLayoutSelection,
+    },
 
     // --- View ---
     { id: 'view.zoomIn', label: 'Zoom in', category: 'Navigation', shortcut: 'E', execute: () => { /* dispatched via Engine key handler */ } },

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -22,6 +22,7 @@ import { collectChangedShapes, isConnectorAffected } from './connectorReroute';
 import { useDocumentStore } from '../store/documentStore';
 import { useSessionStore, ToolType, deleteSelected } from '../store/sessionStore';
 import { useHistoryStore, pushHistory } from '../store/historyStore';
+import { selectConnectedChain, autoLayoutSelection } from './selectionLayout';
 import { useShapeLibraryStore } from '../store/shapeLibraryStore';
 import { useCustomShapeLibraryStore } from '../store/customShapeLibraryStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
@@ -705,6 +706,22 @@ export class Engine {
           this.renderer.requestRender();
         }
       }
+      return;
+    }
+
+    // Ctrl+Shift+A: Select the connected chain(s) of the current selection
+    if (isCtrl && isShift && event.key.toLowerCase() === 'a') {
+      event.preventDefault();
+      selectConnectedChain();
+      this.renderer.requestRender();
+      return;
+    }
+
+    // Ctrl+Shift+L: Auto-layout the current selection (top-to-bottom)
+    if (isCtrl && isShift && event.key.toLowerCase() === 'l') {
+      event.preventDefault();
+      autoLayoutSelection('TB');
+      this.renderer.requestRender();
       return;
     }
 

--- a/src/engine/KeyboardShortcuts.ts
+++ b/src/engine/KeyboardShortcuts.ts
@@ -50,6 +50,8 @@ export const KEYBOARD_SHORTCUTS: ShortcutEntry[] = [
   { keys: 'Ctrl+V', description: 'Paste', category: 'Editing' },
   { keys: 'Ctrl+G', description: 'Group selected shapes', category: 'Editing' },
   { keys: 'Ctrl+Shift+G', description: 'Ungroup', category: 'Editing' },
+  { keys: 'Ctrl+Shift+A', description: 'Select connected shapes (chain)', category: 'Editing' },
+  { keys: 'Ctrl+Shift+L', description: 'Auto-layout selection', category: 'Editing' },
   { keys: 'Delete / Backspace', description: 'Delete selected', category: 'Editing' },
   { keys: 'Escape', description: 'Clear selection', category: 'Editing' },
 

--- a/src/engine/selectionLayout.test.ts
+++ b/src/engine/selectionLayout.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../shapes/Rectangle'; // registers the handler computeAutoLayout reads for sizing
+import { useDocumentStore } from '../store/documentStore';
+import { useSessionStore } from '../store/sessionStore';
+import {
+  selectConnectedChain,
+  autoLayoutSelection,
+  canSelectConnectedChain,
+  canAutoLayoutSelection,
+} from './selectionLayout';
+import { DEFAULT_RECTANGLE, DEFAULT_CONNECTOR, type Shape } from '../shapes/Shape';
+
+function node(id: string, x: number, y: number): Shape {
+  return { ...DEFAULT_RECTANGLE, id, type: 'rectangle', x, y, width: 100, height: 60 } as Shape;
+}
+
+function conn(id: string, from: string, to: string): Shape {
+  return {
+    ...DEFAULT_CONNECTOR,
+    id,
+    type: 'connector',
+    x: 0,
+    y: 0,
+    x2: 0,
+    y2: 0,
+    startShapeId: from,
+    endShapeId: to,
+  } as Shape;
+}
+
+describe('selectionLayout actions (JP-305 Slice D)', () => {
+  beforeEach(() => {
+    useDocumentStore.getState().clear();
+    useSessionStore.getState().clearSelection();
+  });
+
+  it('selectConnectedChain expands the selection to the whole chain', () => {
+    useDocumentStore.getState().addShapes([
+      node('a', 0, 0), node('b', 0, 200), node('c', 0, 400),
+      conn('c1', 'a', 'b'), conn('c2', 'b', 'c'),
+    ]);
+    useSessionStore.getState().select(['a']);
+    selectConnectedChain();
+    expect(useSessionStore.getState().getSelectedIds().sort()).toEqual(['a', 'b', 'c', 'c1', 'c2']);
+  });
+
+  it('selectConnectedChain is a no-op with nothing selected', () => {
+    selectConnectedChain();
+    expect(useSessionStore.getState().getSelectedIds()).toEqual([]);
+  });
+
+  it('autoLayoutSelection ranks a connected selection top-to-bottom', () => {
+    useDocumentStore.getState().addShapes([node('a', 500, 0), node('b', 0, 300), conn('c1', 'a', 'b')]);
+    useSessionStore.getState().select(['a', 'b']);
+    autoLayoutSelection('TB');
+    const s = useDocumentStore.getState().shapes;
+    expect(s['a']!.y).toBeLessThan(s['b']!.y);
+  });
+
+  it('autoLayoutSelection LR flows along x on a shared row', () => {
+    useDocumentStore.getState().addShapes([node('a', 0, 0), node('b', 0, 500), conn('c1', 'a', 'b')]);
+    useSessionStore.getState().select(['a', 'b']);
+    autoLayoutSelection('LR');
+    const s = useDocumentStore.getState().shapes;
+    expect(s['a']!.x).toBeLessThan(s['b']!.x);
+    expect(Math.abs(s['a']!.y - s['b']!.y)).toBeLessThan(1);
+  });
+
+  it('guards reflect the selection size', () => {
+    expect(canSelectConnectedChain()).toBe(false);
+    expect(canAutoLayoutSelection()).toBe(false);
+
+    useDocumentStore.getState().addShapes([node('a', 0, 0), node('b', 0, 0)]);
+    useSessionStore.getState().select(['a']);
+    expect(canSelectConnectedChain()).toBe(true);
+    expect(canAutoLayoutSelection()).toBe(false);
+
+    useSessionStore.getState().select(['a', 'b']);
+    expect(canAutoLayoutSelection()).toBe(true);
+  });
+});

--- a/src/engine/selectionLayout.ts
+++ b/src/engine/selectionLayout.ts
@@ -1,0 +1,50 @@
+/**
+ * Selection-scoped layout actions (JP-305 Slice D) — the single implementation
+ * behind the context menu, command palette, and keyboard shortcuts so all three
+ * surfaces behave identically.
+ *
+ * - `selectConnectedChain` expands the selection to the whole connected
+ *   component(s) of what's selected (a pure selection change — not undoable,
+ *   so no history entry).
+ * - `autoLayoutSelection` tidies the selected shapes with the shared Sugiyama
+ *   auto-layout; one history entry, applied through the document store (which
+ *   reroutes connectors), matching the alignment commands' pattern.
+ */
+
+import { useSessionStore } from '../store/sessionStore';
+import { useDocumentStore } from '../store/documentStore';
+import { pushHistory } from '../store/historyStore';
+import { findConnectedShapes } from '../shapes/connectivity';
+import type { GraphDirection } from '../shapes/import/layoutGraph';
+
+/** True when the current selection touches at least one connector-linked shape. */
+export function canSelectConnectedChain(): boolean {
+  return useSessionStore.getState().getSelectedIds().length >= 1;
+}
+
+/** Expand the selection to the full connected chain(s) of the current selection. */
+export function selectConnectedChain(): void {
+  const session = useSessionStore.getState();
+  const seedIds = session.getSelectedIds();
+  if (seedIds.length === 0) return;
+  const connected = findConnectedShapes(seedIds, useDocumentStore.getState().shapes);
+  if (connected.length > seedIds.length) {
+    session.select(connected);
+  }
+}
+
+/** True when there are enough shapes selected for auto-layout to do anything. */
+export function canAutoLayoutSelection(): boolean {
+  return useSessionStore.getState().getSelectedIds().length >= 2;
+}
+
+/**
+ * Tidy the selected shapes with the shared auto-layout. `direction` controls
+ * the flow (top-to-bottom by default). No-op for fewer than two shapes.
+ */
+export function autoLayoutSelection(direction: GraphDirection = 'TB'): void {
+  const ids = useSessionStore.getState().getSelectedIds();
+  if (ids.length < 2) return;
+  pushHistory('Auto-layout');
+  useDocumentStore.getState().autoLayoutShapes(ids, { direction });
+}

--- a/src/shapes/autoLayout.test.ts
+++ b/src/shapes/autoLayout.test.ts
@@ -77,6 +77,17 @@ describe('computeAutoLayout', () => {
     expect(pos.has('c1')).toBe(false);
   });
 
+  it('packs a connector-less selection into a grid, not a single row', () => {
+    // Four loose boxes, no connectors → 2×2 grid (two distinct rows + cols).
+    const shapes = map([node('a', 0, 0), node('b', 0, 0), node('c', 0, 0), node('d', 0, 0)]);
+    const pos = computeAutoLayout(['a', 'b', 'c', 'd'], shapes);
+    expect(pos.size).toBe(4);
+    const ys = new Set([...pos.values()].map((p) => Math.round(p.y)));
+    const xs = new Set([...pos.values()].map((p) => Math.round(p.x)));
+    expect(ys.size).toBe(2); // two rows, not all on one line
+    expect(xs.size).toBe(2); // two columns
+  });
+
   it('is deterministic', () => {
     const shapes = map([
       node('a', 0, 0), node('b', 200, 0), node('c', 400, 0), node('d', 100, 200),

--- a/src/shapes/autoLayout.test.ts
+++ b/src/shapes/autoLayout.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import './Rectangle'; // registers the 'rectangle' handler for getBounds
+import { computeAutoLayout } from './autoLayout';
+import { DEFAULT_RECTANGLE, DEFAULT_CONNECTOR, type Shape } from './Shape';
+
+function node(id: string, x: number, y: number): Shape {
+  return { ...DEFAULT_RECTANGLE, id, type: 'rectangle', x, y, width: 100, height: 60 } as Shape;
+}
+
+function conn(id: string, from: string, to: string): Shape {
+  return {
+    ...DEFAULT_CONNECTOR,
+    id,
+    type: 'connector',
+    x: 0,
+    y: 0,
+    x2: 0,
+    y2: 0,
+    startShapeId: from,
+    endShapeId: to,
+  } as Shape;
+}
+
+function map(shapes: Shape[]): Record<string, Shape> {
+  return Object.fromEntries(shapes.map((s) => [s.id, s]));
+}
+
+describe('computeAutoLayout', () => {
+  it('is a no-op for fewer than two nodes', () => {
+    const shapes = map([node('a', 0, 0)]);
+    expect(computeAutoLayout(['a'], shapes).size).toBe(0);
+  });
+
+  it('stacks a connected chain into ranks (TB: increasing y)', () => {
+    // a → b → c, currently scrambled on the canvas.
+    const shapes = map([
+      node('a', 500, 0), node('b', 0, 300), node('c', 900, 100),
+      conn('c1', 'a', 'b'), conn('c2', 'b', 'c'),
+    ]);
+    const pos = computeAutoLayout(['a', 'b', 'c'], shapes);
+    expect(pos.size).toBe(3);
+    expect(pos.get('a')!.y).toBeLessThan(pos.get('b')!.y);
+    expect(pos.get('b')!.y).toBeLessThan(pos.get('c')!.y);
+  });
+
+  it('keeps the group anchored on its current centre', () => {
+    const shapes = map([
+      node('a', 1000, 1000), node('b', 1000, 1200),
+      conn('c1', 'a', 'b'),
+    ]);
+    const before = { x: (1000 + 1000) / 2, y: (1000 + 1200) / 2 };
+    const pos = computeAutoLayout(['a', 'b'], shapes);
+    const after = {
+      x: (pos.get('a')!.x + pos.get('b')!.x) / 2,
+      y: (pos.get('a')!.y + pos.get('b')!.y) / 2,
+    };
+    expect(Math.round(after.x)).toBe(before.x);
+    expect(Math.round(after.y)).toBe(before.y);
+  });
+
+  it('only uses connectors whose both endpoints are selected', () => {
+    // c2 leaves the selection (b → external); it must not pull layout.
+    const shapes = map([
+      node('a', 0, 0), node('b', 0, 0), node('external', 5000, 5000),
+      conn('c1', 'a', 'b'), conn('c2', 'b', 'external'),
+    ]);
+    const pos = computeAutoLayout(['a', 'b'], shapes);
+    // a and b are ranked (a above b) purely by c1.
+    expect(pos.get('a')!.y).toBeLessThan(pos.get('b')!.y);
+    expect(pos.has('external')).toBe(false);
+  });
+
+  it('ignores connectors in the id list (they are not nodes)', () => {
+    const shapes = map([node('a', 0, 0), node('b', 0, 0), conn('c1', 'a', 'b')]);
+    const pos = computeAutoLayout(['a', 'b', 'c1'], shapes);
+    expect(pos.size).toBe(2);
+    expect(pos.has('c1')).toBe(false);
+  });
+
+  it('is deterministic', () => {
+    const shapes = map([
+      node('a', 0, 0), node('b', 200, 0), node('c', 400, 0), node('d', 100, 200),
+      conn('c1', 'a', 'd'), conn('c2', 'b', 'd'), conn('c3', 'c', 'd'),
+    ]);
+    const ids = ['a', 'b', 'c', 'd'];
+    expect([...computeAutoLayout(ids, shapes)]).toEqual([...computeAutoLayout(ids, shapes)]);
+  });
+});

--- a/src/shapes/autoLayout.ts
+++ b/src/shapes/autoLayout.ts
@@ -20,6 +20,9 @@ export interface AutoLayoutOptions {
   direction?: GraphDirection;
 }
 
+/** Gap between cells when grid-packing a selection that has no connectors. */
+const GRID_GAP = 48;
+
 /**
  * Compute tidied **centre** positions for the layout-eligible shapes among
  * `ids`. Nodes are the selected, existing, non-connector shapes; edges are the
@@ -54,7 +57,10 @@ export function computeAutoLayout(
     return { id: n.id, width: b.width, height: b.height };
   });
 
-  const laid = layoutGraph(layoutNodes, edges, options);
+  // Connected selections flow through the Sugiyama pipeline; a selection with
+  // no connectors between its nodes has no structure to honour, so pack it
+  // into a tidy grid instead of the pipeline's single-row edgeless output.
+  const laid = edges.length === 0 ? gridLayout(layoutNodes) : layoutGraph(layoutNodes, edges, options);
 
   // Anchor: keep the group's current centre fixed (re-flow in place). Both
   // centres are the midpoint of the node-centre spread; node x/y is the centre
@@ -66,6 +72,33 @@ export function computeAutoLayout(
 
   const out = new Map<string, { x: number; y: number }>();
   for (const [id, p] of laid) out.set(id, { x: p.x + dx, y: p.y + dy });
+  return out;
+}
+
+/**
+ * Pack nodes into a near-square grid (row-major), uniform cells sized to the
+ * largest node so everything lines up. Centre positions, origin-relative; the
+ * caller re-anchors to the selection's current centre.
+ */
+function gridLayout(
+  nodes: Array<{ id: string; width: number; height: number }>,
+): Map<string, { x: number; y: number }> {
+  const cols = Math.max(1, Math.ceil(Math.sqrt(nodes.length)));
+  let cellW = 0;
+  let cellH = 0;
+  for (const n of nodes) {
+    if (n.width > cellW) cellW = n.width;
+    if (n.height > cellH) cellH = n.height;
+  }
+  cellW += GRID_GAP;
+  cellH += GRID_GAP;
+
+  const out = new Map<string, { x: number; y: number }>();
+  nodes.forEach((n, i) => {
+    const row = Math.floor(i / cols);
+    const col = i % cols;
+    out.set(n.id, { x: col * cellW, y: row * cellH });
+  });
   return out;
 }
 

--- a/src/shapes/autoLayout.ts
+++ b/src/shapes/autoLayout.ts
@@ -1,0 +1,85 @@
+/**
+ * Auto-layout for a selection of shapes (JP-305 Slice D foundation).
+ *
+ * Reuses the shared Sugiyama pipeline (`layoutGraph`, the same engine the MCP
+ * relay and diagram imports use) to tidy an arbitrary group of canvas shapes:
+ * the selected non-connector shapes are the nodes, the connectors among them
+ * are the edges. The result is anchored on the group's current centre, so the
+ * diagram re-flows *in place* instead of jumping to the world origin.
+ *
+ * Pure: computes positions only. Applying them to the document (and rerouting
+ * connectors) is the caller's job — see `documentStore.autoLayoutShapes`.
+ */
+
+import { type Shape, isConnector } from './Shape';
+import { shapeRegistry } from './ShapeRegistry';
+import { layoutGraph, type GraphDirection } from './import/layoutGraph';
+
+export interface AutoLayoutOptions {
+  /** Flow direction; defaults to top-to-bottom. */
+  direction?: GraphDirection;
+}
+
+/**
+ * Compute tidied **centre** positions for the layout-eligible shapes among
+ * `ids`. Nodes are the selected, existing, non-connector shapes; edges are the
+ * connectors whose both endpoints are in that node set (whether or not the
+ * connector itself is in `ids`). Returns a map of node id → new `{x, y}`.
+ *
+ * Returns an empty map (a no-op) when there are fewer than two nodes — there's
+ * nothing to arrange.
+ */
+export function computeAutoLayout(
+  ids: string[],
+  shapes: Record<string, Shape>,
+  options: AutoLayoutOptions = {},
+): Map<string, { x: number; y: number }> {
+  const nodes = ids
+    .map((id) => shapes[id])
+    .filter((s): s is Shape => s !== undefined && !isConnector(s));
+  if (nodes.length < 2) return new Map();
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+
+  const edges: Array<{ from: string; to: string }> = [];
+  for (const shape of Object.values(shapes)) {
+    if (!isConnector(shape)) continue;
+    const a = shape.startShapeId;
+    const b = shape.endShapeId;
+    if (a && b && nodeIds.has(a) && nodeIds.has(b)) edges.push({ from: a, to: b });
+  }
+
+  const layoutNodes = nodes.map((n) => {
+    const b = shapeRegistry.getHandler(n.type).getBounds(n);
+    return { id: n.id, width: b.width, height: b.height };
+  });
+
+  const laid = layoutGraph(layoutNodes, edges, options);
+
+  // Anchor: keep the group's current centre fixed (re-flow in place). Both
+  // centres are the midpoint of the node-centre spread; node x/y is the centre
+  // for box shapes, matching what layoutGraph emits.
+  const current = spreadCenter(nodes.map((n) => ({ x: n.x, y: n.y })));
+  const next = spreadCenter([...laid.values()]);
+  const dx = current.x - next.x;
+  const dy = current.y - next.y;
+
+  const out = new Map<string, { x: number; y: number }>();
+  for (const [id, p] of laid) out.set(id, { x: p.x + dx, y: p.y + dy });
+  return out;
+}
+
+/** Midpoint of the min/max spread of a set of points. */
+function spreadCenter(points: Array<{ x: number; y: number }>): { x: number; y: number } {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+}

--- a/src/shapes/connectivity.test.ts
+++ b/src/shapes/connectivity.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { findConnectedShapes } from './connectivity';
+import { DEFAULT_RECTANGLE, DEFAULT_CONNECTOR, type Shape } from './Shape';
+
+function node(id: string): Shape {
+  return { ...DEFAULT_RECTANGLE, id, type: 'rectangle', x: 0, y: 0, width: 100, height: 60 } as Shape;
+}
+
+function conn(id: string, from: string | null, to: string | null): Shape {
+  return {
+    ...DEFAULT_CONNECTOR,
+    id,
+    type: 'connector',
+    x: 0,
+    y: 0,
+    x2: 0,
+    y2: 0,
+    startShapeId: from,
+    endShapeId: to,
+  } as Shape;
+}
+
+function map(shapes: Shape[]): Record<string, Shape> {
+  return Object.fromEntries(shapes.map((s) => [s.id, s]));
+}
+
+describe('findConnectedShapes', () => {
+  it('returns the seed alone when nothing connects to it', () => {
+    const shapes = map([node('a'), node('b')]);
+    expect(findConnectedShapes(['a'], shapes).sort()).toEqual(['a']);
+  });
+
+  it('walks a chain through connectors, including the connectors', () => {
+    // a —c1→ b —c2→ c ;  d is separate.
+    const shapes = map([
+      node('a'), node('b'), node('c'), node('d'),
+      conn('c1', 'a', 'b'), conn('c2', 'b', 'c'),
+    ]);
+    expect(findConnectedShapes(['a'], shapes).sort()).toEqual(['a', 'b', 'c', 'c1', 'c2']);
+  });
+
+  it('traverses in both directions regardless of connector orientation', () => {
+    const shapes = map([node('a'), node('b'), node('c'), conn('c1', 'a', 'b'), conn('c2', 'c', 'b')]);
+    // Seeding the middle reaches both ends.
+    expect(findConnectedShapes(['b'], shapes).sort()).toEqual(['a', 'b', 'c', 'c1', 'c2']);
+  });
+
+  it('seeding a connector selects its component', () => {
+    const shapes = map([node('a'), node('b'), conn('c1', 'a', 'b')]);
+    expect(findConnectedShapes(['c1'], shapes).sort()).toEqual(['a', 'b', 'c1']);
+  });
+
+  it('ignores dangling connector endpoints', () => {
+    // c1 binds a to a missing shape; only a (and c1) come back.
+    const shapes = map([node('a'), conn('c1', 'a', 'ghost')]);
+    expect(findConnectedShapes(['a'], shapes).sort()).toEqual(['a', 'c1']);
+  });
+
+  it('unions the components of multiple seeds', () => {
+    const shapes = map([
+      node('a'), node('b'), conn('c1', 'a', 'b'),
+      node('x'), node('y'), conn('c2', 'x', 'y'),
+    ]);
+    expect(findConnectedShapes(['a', 'x'], shapes).sort()).toEqual(['a', 'b', 'c1', 'c2', 'x', 'y']);
+  });
+
+  it('does not span two components when only one is seeded', () => {
+    const shapes = map([
+      node('a'), node('b'), conn('c1', 'a', 'b'),
+      node('x'), node('y'), conn('c2', 'x', 'y'),
+    ]);
+    expect(findConnectedShapes(['a'], shapes).sort()).toEqual(['a', 'b', 'c1']);
+  });
+
+  it('skips seed ids that do not exist', () => {
+    const shapes = map([node('a')]);
+    expect(findConnectedShapes(['ghost'], shapes)).toEqual([]);
+  });
+});

--- a/src/shapes/connectivity.ts
+++ b/src/shapes/connectivity.ts
@@ -1,0 +1,83 @@
+/**
+ * Shape connectivity — treats the canvas as a graph where connectors are edges
+ * between the shapes they bind (`startShapeId`/`endShapeId`). The foundation
+ * for "select the whole chain" from any shape and for scoping auto-layout to a
+ * connected group (JP-305 Slice D).
+ *
+ * Pure: no store, engine, or registry access.
+ */
+
+import { type Shape, isConnector } from './Shape';
+
+/**
+ * Every shape id reachable from `seedIds` through connectors — the union of the
+ * connected components containing the seeds, including the seed shapes and the
+ * connectors that wire the component together.
+ *
+ * - A connector counts as connected to both endpoints it actually binds; a
+ *   dangling endpoint (null, or a shape that no longer exists) contributes
+ *   nothing.
+ * - Seeding on a connector starts traversal from its endpoints.
+ * - Ids in `seedIds` that don't exist in `shapes` are skipped.
+ *
+ * The result is unordered (a set, returned as an array). Callers that need a
+ * stable order should sort, but selection doesn't care.
+ */
+export function findConnectedShapes(
+  seedIds: Iterable<string>,
+  shapes: Record<string, Shape>,
+): string[] {
+  // node id -> linked node ids (via any binding connector)
+  const neighbors = new Map<string, Set<string>>();
+  // node id -> connector ids touching it
+  const incident = new Map<string, string[]>();
+
+  const link = (a: string, b: string): void => {
+    (neighbors.get(a) ?? neighbors.set(a, new Set()).get(a)!).add(b);
+  };
+  const touch = (nodeId: string, connId: string): void => {
+    (incident.get(nodeId) ?? incident.set(nodeId, []).get(nodeId)!).push(connId);
+  };
+
+  for (const shape of Object.values(shapes)) {
+    if (!isConnector(shape)) continue;
+    const a = shape.startShapeId && shapes[shape.startShapeId] ? shape.startShapeId : null;
+    const b = shape.endShapeId && shapes[shape.endShapeId] ? shape.endShapeId : null;
+    if (a) touch(a, shape.id);
+    if (b) touch(b, shape.id);
+    if (a && b && a !== b) {
+      link(a, b);
+      link(b, a);
+    }
+  }
+
+  const result = new Set<string>();
+  const queue: string[] = [];
+  const enqueueNode = (id: string): void => {
+    if (!result.has(id)) {
+      result.add(id);
+      queue.push(id);
+    }
+  };
+
+  for (const id of seedIds) {
+    const seed = shapes[id];
+    if (!seed) continue;
+    if (isConnector(seed)) {
+      // Include the seed connector and traverse from its bound endpoints.
+      result.add(id);
+      if (seed.startShapeId && shapes[seed.startShapeId]) enqueueNode(seed.startShapeId);
+      if (seed.endShapeId && shapes[seed.endShapeId]) enqueueNode(seed.endShapeId);
+    } else {
+      enqueueNode(id);
+    }
+  }
+
+  while (queue.length > 0) {
+    const cur = queue.pop()!;
+    for (const connId of incident.get(cur) ?? []) result.add(connId);
+    for (const nb of neighbors.get(cur) ?? []) enqueueNode(nb);
+  }
+
+  return [...result];
+}

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -5,7 +5,8 @@ import {
   shapeExists,
 } from './documentStore';
 import { getProvenance } from './writeProvenance';
-import { RectangleShape } from '../shapes/Shape';
+import { RectangleShape, type ConnectorShape, DEFAULT_CONNECTOR } from '../shapes/Shape';
+import '../shapes/Rectangle'; // registers the handler computeAutoLayout reads for sizing
 
 /**
  * Create a test rectangle with default properties.
@@ -57,6 +58,52 @@ describe('Document Store', () => {
 
     it('defaults to user-edit (no bulk op in flight)', () => {
       expect(getProvenance()).toBe('user-edit');
+    });
+  });
+
+  describe('autoLayoutShapes (JP-305 Slice D)', () => {
+    function connector(id: string, from: string, to: string): ConnectorShape {
+      return {
+        ...DEFAULT_CONNECTOR,
+        id,
+        type: 'connector',
+        x: 0,
+        y: 0,
+        x2: 0,
+        y2: 0,
+        rotation: 0,
+        opacity: 1,
+        locked: false,
+        visible: true,
+        startShapeId: from,
+        endShapeId: to,
+        routingMode: 'orthogonal',
+      } as ConnectorShape;
+    }
+
+    it('repositions a connected selection into ranks and reroutes', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([
+        createTestRect({ id: 'a', x: 500, y: 0 }),
+        createTestRect({ id: 'b', x: 0, y: 300 }),
+        connector('c1', 'a', 'b'),
+      ]);
+
+      store.autoLayoutShapes(['a', 'b']);
+
+      const after = useDocumentStore.getState().shapes;
+      // a now ranks above b (TB flow), and the connector got routed waypoints.
+      expect(after['a']!.y).toBeLessThan(after['b']!.y);
+      expect((after['c1'] as ConnectorShape).waypoints).toBeDefined();
+    });
+
+    it('is a no-op for a selection with fewer than two nodes', () => {
+      const store = useDocumentStore.getState();
+      store.addShape(createTestRect({ id: 'lone', x: 42, y: 7 }));
+      store.autoLayoutShapes(['lone']);
+      const s = useDocumentStore.getState().shapes['lone']!;
+      expect(s.x).toBe(42);
+      expect(s.y).toBe(7);
     });
   });
 

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -6,6 +6,7 @@ import { Box } from '../math/Box';
 import { calculateConnectorWaypoints } from '../engine/OrthogonalRouter';
 import { SpatialIndex } from '../engine/SpatialIndex';
 import { wouldCreateCycle, wouldExceedMaxDepth, findParentGroup } from '../shapes/GroupHierarchy';
+import { computeAutoLayout, type AutoLayoutOptions } from '../shapes/autoLayout';
 import { runWithProvenance } from './writeProvenance';
 
 /**
@@ -88,6 +89,15 @@ export interface DocumentActions {
    * Useful when shapes have been moved or modified.
    */
   rebuildAllConnectorRoutes: () => void;
+
+  /**
+   * Tidy a selection of shapes with the shared Sugiyama auto-layout: lay the
+   * selected non-connector shapes out by the connectors between them, anchored
+   * on their current centre (re-flows in place), then reroute connectors.
+   * No-op for fewer than two layout-eligible shapes. Caller wraps in history +
+   * provenance, as with `rebuildAllConnectorRoutes`.
+   */
+  autoLayoutShapes: (ids: string[], options?: AutoLayoutOptions) => void;
 }
 
 /**
@@ -648,6 +658,34 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
         obstacleIndex.rebuild(Object.values(state.shapes));
 
         // Recalculate waypoints for each connector
+        for (const connector of connectors) {
+          const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
+          if (waypoints) {
+            (state.shapes[connector.id] as ConnectorShape).waypoints = waypoints;
+          }
+        }
+      });
+    },
+
+    autoLayoutShapes: (ids: string[], options?: AutoLayoutOptions) => {
+      const positions = computeAutoLayout(ids, get().shapes, options);
+      if (positions.size === 0) return;
+      set((state) => {
+        for (const [id, pos] of positions) {
+          const shape = state.shapes[id];
+          if (shape) {
+            shape.x = pos.x;
+            shape.y = pos.y;
+          }
+        }
+        // Reroute orthogonal connectors against the new positions.
+        const connectors = Object.values(state.shapes).filter(
+          (shape): shape is ConnectorShape =>
+            shape.type === 'connector' && (shape as ConnectorShape).routingMode === 'orthogonal'
+        );
+        if (connectors.length === 0) return;
+        const obstacleIndex = new SpatialIndex();
+        obstacleIndex.rebuild(Object.values(state.shapes));
         for (const connector of connectors) {
           const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
           if (waypoints) {

--- a/src/ui/ContextMenu.tsx
+++ b/src/ui/ContextMenu.tsx
@@ -4,6 +4,7 @@ import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore } from '../store/historyStore';
 import { isGroup, isConnector, isFile, RoutingMode, GroupShape } from '../shapes/Shape';
 import { replaceFileContents } from '../services/FileReplaceService';
+import { selectConnectedChain, autoLayoutSelection } from '../engine/selectionLayout';
 import { nanoid } from 'nanoid';
 import './ContextMenu.css';
 
@@ -276,6 +277,22 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
     onClose();
   }, [hasSelection, selectedArray, push, deleteShapes, clearSelection, onClose]);
 
+  // JP-305 Slice D: expand to the connected chain, and auto-layout the
+  // selection. Both delegate to the shared selectionLayout actions so the
+  // menu, command palette, and keyboard shortcuts stay in lockstep.
+  const handleSelectConnected = useCallback(() => {
+    selectConnectedChain();
+    onClose();
+  }, [onClose]);
+
+  const autoLayoutItems: SubmenuItem[] = useMemo(
+    () => [
+      { label: 'Top to bottom', onClick: () => { autoLayoutSelection('TB'); onClose(); } },
+      { label: 'Left to right', onClick: () => { autoLayoutSelection('LR'); onClose(); } },
+    ],
+    [onClose],
+  );
+
   const handleBringToFront = useCallback(() => {
     if (hasSelection) {
       push('Bring to front');
@@ -471,6 +488,14 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
 
       {hasSelection && (
         <>
+          <button className="context-menu-item" onClick={handleSelectConnected}>
+            <span className="context-menu-label">Select connected</span>
+            <span className="context-menu-shortcut">Ctrl+Shift+A</span>
+          </button>
+          {canGroup && <Submenu label="Auto-layout" items={autoLayoutItems} onClose={onClose} />}
+
+          <div className="context-menu-separator" />
+
           <button className="context-menu-item" onClick={handleBringToFront}>
             <span className="context-menu-label">Bring to Front</span>
           </button>


### PR DESCRIPTION
The interactive half of JP-305: turn the shared layout engine into two editor actions. Independent of the Slice C PR (#199) — different files, either can merge first.

## Two features, one shared core

**Select connected chain** — expand the selection to the whole connected component(s) of whatever's selected (shapes + the connectors wiring them).

**Auto-layout a selection** — tidy the selected shapes with the same Sugiyama pipeline the MCP relay and imports use, in a user-chosen direction, re-flowed in place.

Both route through one module — `src/engine/selectionLayout.ts` — so the context menu, command palette, and keyboard shortcuts can't drift.

## Foundations (pure, fully tested)

- **`src/shapes/connectivity.ts`** — `findConnectedShapes(seeds, shapes)`: graph traversal treating connectors as edges. Handles dangling endpoints, connector seeds, multi-seed unions, component isolation.
- **`src/shapes/autoLayout.ts`** — `computeAutoLayout(ids, shapes, opts)`: nodes = selected non-connector shapes, edges = connectors with both endpoints selected. Anchored on the group's current centre (re-flows in place, doesn't jump to origin). A selection with **no connectors** packs into a tidy grid instead of the pipeline's single-row edgeless output. No-op for <2 nodes.
- **`documentStore.autoLayoutShapes(ids, opts)`** — applies the positions and reroutes orthogonal connectors in one `set()` (caller wraps history, matching `rebuildAllConnectorRoutes`).

## Surfaces (your choices)

| Action | Context menu | Shortcut | Command palette |
|---|---|---|---|
| Select connected | "Select connected" | **Ctrl+Shift+A** | ✓ |
| Auto-layout | "Auto-layout ▸ Top to bottom / Left to right" | **Ctrl+Shift+L** (TB) | ✓ (TB + LR) |

Auto-layout items gate on 2+ selected. Shortcut-conflict checks: Ctrl+Shift+A is distinct from Ctrl+A (select-all matches lowercase `'a'` only, so it ignores Shift); single-key tool shortcuts skip when Ctrl is held, so Ctrl+Shift+L is free. Both added to the keyboard-shortcut reference panel.

## Direction / edgeless decisions (from our back-and-forth)

- **Direction**: user picks TB or LR (menu + palette both offer both; the shortcut defaults to TB).
- **No connectors among the selection**: pack into a grid.

## Tests

8 connectivity + 7 autoLayout (incl. grid-pack) + 2 store-action + 5 selectionLayout action tests. `tsc` clean; full suite **2224 passed**.

Assisted-by: Opus 4.8