### PR TITLE
Fix four property-panel bugs (dark dropdowns, flyout collapse, resize, shape-switch)

### DIFF
--- a/src/ui/BorderStylePicker.tsx
+++ b/src/ui/BorderStylePicker.tsx
@@ -130,6 +130,9 @@ export function BorderStylePicker({ value, onChange }: BorderStylePickerProps) {
           <div
             ref={dropdownRef}
             className="border-style-dropdown"
+            // Portaled to body but logically part of the host panel — keeps an
+            // unpinned FlyoutPanel from collapsing while picking a border style.
+            data-flyout-keep-open
             style={{ top: dropdownPosition.top, left: dropdownPosition.left }}
           >
             {BORDER_STYLES.map(({ key, label }) => (

--- a/src/ui/CompactColorInput.tsx
+++ b/src/ui/CompactColorInput.tsx
@@ -199,6 +199,10 @@ export function CompactColorInput({
   const dropdownContent = isPaletteOpen && showPalette && dropdownPosition && (
     <div
       className="compact-color-palette-dropdown compact-color-palette-portal"
+      // Logically part of whatever panel opened us, even though we render in a
+      // portal on document.body — keeps an unpinned FlyoutPanel from collapsing
+      // when the user picks a color here.
+      data-flyout-keep-open
       style={{
         position: 'fixed',
         top: dropdownPosition.top,

--- a/src/ui/IconPicker.tsx
+++ b/src/ui/IconPicker.tsx
@@ -237,6 +237,9 @@ export function IconPicker({ value, onChange, label = 'Icon' }: IconPickerProps)
   const dropdownContent = isOpen && dropdownPosition && (
     <div
       className="icon-picker-dropdown icon-picker-dropdown-portal"
+      // Portaled to body but logically part of the host panel — keeps an
+      // unpinned FlyoutPanel from collapsing while picking an icon.
+      data-flyout-keep-open
       style={{
         position: 'fixed',
         top: dropdownPosition.top,

--- a/src/ui/PatternPicker.tsx
+++ b/src/ui/PatternPicker.tsx
@@ -249,6 +249,9 @@ export function PatternPicker({ value, onChange }: PatternPickerProps) {
           <div
             ref={dropdownRef}
             className="pattern-picker-dropdown"
+            // Portaled to body but logically part of the host panel — keeps an
+            // unpinned FlyoutPanel from collapsing while picking a pattern.
+            data-flyout-keep-open
             style={{ top: dropdownPosition.top, left: dropdownPosition.left }}
           >
             {PATTERN_TYPES.map((type) => (

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -418,14 +418,17 @@
 }
 
 .compact-select:hover {
-  background: var(--bg-tertiary);
+  /* Use background-color, not the `background` shorthand: the shorthand resets
+     background-repeat to `repeat`, which would tile the chevron SVG across the
+     control. Keeping only the color preserves the base no-repeat chevron. */
+  background-color: var(--bg-tertiary);
 }
 
 .compact-select:focus {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(31, 51, 84, 0.15);
-  background: var(--bg-primary);
+  background-color: var(--bg-primary);
 }
 
 /* Compact String Row */
@@ -668,7 +671,10 @@
 [data-theme="dark"] .property-text-input,
 [data-theme="dark"] .property-textarea,
 [data-theme="dark"] .compact-select {
-  background: var(--bg-secondary);
+  /* background-color (not the shorthand) so the chevron set just below keeps the
+     base `background-repeat: no-repeat`; the shorthand would reset it to `repeat`
+     and tile the chevron into a striped texture. */
+  background-color: var(--bg-secondary);
   border-color: var(--border-color-input);
 }
 
@@ -685,14 +691,14 @@
 [data-theme="dark"] .property-text-input:hover,
 [data-theme="dark"] .property-textarea:hover,
 [data-theme="dark"] .compact-select:hover {
-  background: var(--bg-tertiary);
+  background-color: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .compact-number-input:focus,
 [data-theme="dark"] .property-text-input:focus,
 [data-theme="dark"] .property-textarea:focus,
 [data-theme="dark"] .compact-select:focus {
-  background: var(--bg-primary);
+  background-color: var(--bg-primary);
 }
 
 [data-theme="dark"] .info-value {

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -1448,6 +1448,10 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   const [isResizing, setIsResizing] = useState(false);
   const startXRef = useRef(0);
   const startWidthRef = useRef(storedWidth);
+  // Live drag bookkeeping kept in refs so the resize effect can subscribe once
+  // per drag (not re-run every frame) while still committing the freshest width.
+  const latestWidthRef = useRef(storedWidth);
+  const resizeRafRef = useRef<number | null>(null);
 
   // Sync width with store
   useEffect(() => {
@@ -1461,11 +1465,13 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
       setIsResizing(true);
       startXRef.current = e.clientX;
       startWidthRef.current = width;
+      latestWidthRef.current = width;
     },
     [width]
   );
 
-  // Handle resize move and end
+  // Handle resize move and end. Deps deliberately exclude `width` so the
+  // listeners subscribe once per drag; the live width lives in refs instead.
   useEffect(() => {
     if (!isResizing) return;
 
@@ -1478,12 +1484,27 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
         ? e.clientX - startXRef.current
         : startXRef.current - e.clientX;
       const newWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidthRef.current + delta));
+      latestWidthRef.current = newWidth;
       setWidth(newWidth);
+      // Mirror the live width into the layout store (rAF-throttled to one write
+      // per frame) so an unpinned FlyoutPanel body — which sizes itself from the
+      // store — tracks the drag in real time instead of overflowing and only
+      // snapping back on release.
+      if (resizeRafRef.current === null) {
+        resizeRafRef.current = requestAnimationFrame(() => {
+          resizeRafRef.current = null;
+          setPanelWidth('properties', latestWidthRef.current);
+        });
+      }
     };
 
     const handleMouseUp = () => {
+      if (resizeRafRef.current !== null) {
+        cancelAnimationFrame(resizeRafRef.current);
+        resizeRafRef.current = null;
+      }
+      setPanelWidth('properties', latestWidthRef.current);
       setIsResizing(false);
-      setPanelWidth('properties', width);
     };
 
     document.addEventListener('mousemove', handleMouseMove);
@@ -1492,8 +1513,12 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
+      if (resizeRafRef.current !== null) {
+        cancelAnimationFrame(resizeRafRef.current);
+        resizeRafRef.current = null;
+      }
     };
-  }, [isResizing, width, setPanelWidth, className]);
+  }, [isResizing, setPanelWidth, className]);
 
   // Get selected shapes
   const selectedShapes = Array.from(selectedIds)

--- a/src/ui/layout/FlyoutPanel.tsx
+++ b/src/ui/layout/FlyoutPanel.tsx
@@ -140,9 +140,21 @@ export function FlyoutPanel({
 
     const handlePointerDown = (e: PointerEvent) => {
       const target = e.target as Node | null;
-      if (target && !panelRef.current?.contains(target) && !railRef.current?.contains(target)) {
-        collapseNow();
-      }
+      if (!target) return;
+      // Inside the panel or its rail — never collapse.
+      if (panelRef.current?.contains(target) || railRef.current?.contains(target)) return;
+      // A panel-owned popover (e.g. the color palette) renders outside our DOM
+      // subtree via a portal but is logically part of the panel. It opts in by
+      // tagging its root with `data-flyout-keep-open`, so interacting with it
+      // must not collapse us.
+      if (target instanceof Element && target.closest('[data-flyout-keep-open]')) return;
+      // Selection-driven panels (Properties) let the selection effect own
+      // visibility: clicking a different shape keeps a non-empty selection, so
+      // collapsing here would race the auto-expand effect (flicker, or a stale
+      // expandedRef leaving us stuck closed). Clicking truly away clears the
+      // selection, and the selection effect collapses us then.
+      if (expandOnSelection && useSessionStore.getState().selectedIds.size > 0) return;
+      collapseNow();
     };
 
     window.addEventListener('keydown', handleKey);
@@ -151,7 +163,7 @@ export function FlyoutPanel({
       window.removeEventListener('keydown', handleKey);
       window.removeEventListener('pointerdown', handlePointerDown);
     };
-  }, [isExpanded, collapseNow]);
+  }, [isExpanded, collapseNow, expandOnSelection]);
 
   // Auto-collapse 500ms after focus leaves the panel body.
   const handleFocusIn = useCallback(() => {
@@ -163,9 +175,11 @@ export function FlyoutPanel({
       // Only schedule collapse if focus left the panel entirely (relatedTarget
       // is null or outside our subtree).
       const next = e.relatedTarget as Node | null;
-      if (!next || !panelRef.current?.contains(next)) {
-        scheduleCollapse();
-      }
+      if (next && panelRef.current?.contains(next)) return;
+      // Focus moving into a panel-owned portaled popover (color palette, etc.)
+      // is still "inside" the panel — don't collapse.
+      if (next instanceof Element && next.closest('[data-flyout-keep-open]')) return;
+      scheduleCollapse();
     },
     [scheduleCollapse]
   );


### PR DESCRIPTION
Warmup pass over the property panel ahead of a larger overhaul. Four user-reported bugs, each fixed at the root cause.

## 1. Dark-mode dropdowns show a sawtooth/striped texture
The dark `.compact-select` rules set the color with the `background` **shorthand**, which silently resets `background-repeat` to `repeat`. A following rule re-added only `background-image`, so the 12×12 chevron SVG **tiled** across the control — the texture — clearing only on `:focus` (where the shorthand wiped the image entirely). Switched those color-only state rules to `background-color` so the base `background-repeat: no-repeat` chevron survives every state. CSS only; light mode was never affected.

## 2. Unpinned panel disappeared when using the color picker
`CompactColorInput`'s palette renders in a portal on `document.body`, so it sat **outside** `FlyoutPanel`'s DOM subtree and tripped the outside-click / focus-out collapse. Added a generic `data-flyout-keep-open` marker on panel-owned portaled popovers (color palette + icon / border-style / pattern pickers) and made FlyoutPanel's `handlePointerDown` and `handleFocusOut` treat a target within `[data-flyout-keep-open]` as inside.

## 3. Panel overflowed the viewport while resizing, realigned on release
The drag width lived in `PropertyPanel` local state and was written to the layout store (which the flyout body sizes itself from) only on `mouseup`. Now mirror the live width into the store, rAF-throttled to one write per frame, so the flyout body tracks the drag in real time. Listeners subscribe once per drag (live width + rAF id moved to refs; `width` dropped from the effect deps so the rAF isn't cancelled each frame).

## 4. Shape-switch flicker / stuck-closed when unpinned
Clicking a different shape is a pointerdown outside the panel, firing FlyoutPanel's `collapseNow()` — which raced the selection-driven auto-expand effect (and no-ops on a stale `expandedRef`, leaving it stuck closed). For selection-driven panels (`expandOnSelection`), don't collapse on outside pointerdown while a selection exists; the selection effect owns visibility. Escape / deselect / mouse-leave still close.

## Verification
- `bun run typecheck` clean; `bun run test --run` green (2224 tests).
- OSS leak grep on touched files: clean (only false positives — the `stripes` fill-pattern type and a "striped texture" code comment).
- Manual (pending, visual): dark-mode selects show a single non-tiled chevron when tabbed through; picking a color/border/pattern/icon in an unpinned panel keeps it open; resizing tracks live with no overflow snap; clicking A→B→C updates contents without flicker or stuck-closed.

Assisted-by: Opus 4.8