### PR TITLE
Redesign property-panel sections as fluid, responsive cards (Slice 1)

### DIFF
--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -114,6 +114,8 @@ export interface UIPreferencesActions {
   toggleSection: (sectionId: string) => void;
   /** Set a section's expanded state */
   setSection: (sectionId: string, expanded: boolean) => void;
+  /** Set many sections' expanded state at once (e.g. expand/collapse all). */
+  setSections: (sectionIds: string[], expanded: boolean) => void;
   /** Check if a section is expanded */
   isSectionExpanded: (sectionId: string, defaultExpanded?: boolean) => boolean;
   /** Set property panel width */
@@ -334,6 +336,14 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             [sectionId]: expanded,
           },
         });
+      },
+
+      setSections: (sectionIds: string[], expanded: boolean) => {
+        if (sectionIds.length === 0) return;
+        const { expandedSections } = get();
+        const next = { ...expandedSections };
+        for (const id of sectionIds) next[id] = expanded;
+        set({ expandedSections: next });
       },
 
       isSectionExpanded: (sectionId: string, defaultExpanded?: boolean): boolean => {

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -42,22 +42,110 @@
 
 /* Header */
 .property-panel-header {
-  padding: var(--space-3) 14px;
-  font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2) var(--space-2) 14px;
   background-color: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   color: var(--text-primary);
   letter-spacing: 0.01em;
 }
 
+.property-panel-header-title {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-md);
+}
+
+.property-panel-collapse-all {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-muted, var(--text-secondary));
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.property-panel-collapse-all:hover {
+  background: var(--bg-tertiary);
+  color: var(--color-primary);
+}
+
+.property-panel-collapse-all:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
+  color: var(--color-primary);
+}
+
 /* Empty State */
 .property-panel-empty {
-  padding: var(--space-6) var(--space-4);
-  color: var(--text-muted, var(--text-secondary));
-  font-size: var(--font-size-md);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1-5);
+  margin: var(--space-3) 14px;
+  padding: var(--space-5) var(--space-4);
+  border: 1px dashed var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
   text-align: center;
+}
+
+.property-panel-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-1);
+  border-radius: var(--radius-lg);
+  background: var(--bg-tertiary);
+  color: var(--text-muted, var(--text-secondary));
+}
+
+.property-panel-empty-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.property-panel-empty-hint {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted, var(--text-secondary));
   line-height: var(--line-height-relaxed);
+  max-width: 220px;
+}
+
+/* Collapsed-section summary swatches */
+.summary-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 1px solid var(--border-color);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.summary-swatch-none {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--bg-tertiary),
+    var(--bg-tertiary) 3px,
+    transparent 3px,
+    transparent 6px
+  );
+}
+
+.summary-swatch-auto {
+  background: linear-gradient(135deg, #ffffff 0%, #ffffff 50%, #1f3354 50%, #1f3354 100%);
 }
 
 /* Content */

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { ChevronsDownUp, ChevronsUpDown, MousePointerClick } from 'lucide-react';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { useActivePanelState, useLayoutActions } from './layout/useLayout';
 import {
   Shape,
@@ -73,6 +75,20 @@ function getSharedValue<T>(shapes: Shape[], getter: (s: Shape) => T): T | typeof
 /** Constraints for panel width */
 const MIN_WIDTH = 180;
 const MAX_WIDTH = 400;
+
+/**
+ * A small colour chip used in a collapsed section's header summary so the user
+ * can see the current fill/stroke without expanding the section.
+ */
+function SummarySwatch({ color }: { color?: string | null }) {
+  if (!color || color === 'transparent') {
+    return <span className="summary-swatch summary-swatch-none" title="None" aria-hidden="true" />;
+  }
+  if (color === 'auto') {
+    return <span className="summary-swatch summary-swatch-auto" title="Auto" aria-hidden="true" />;
+  }
+  return <span className="summary-swatch" style={{ background: color }} aria-hidden="true" />;
+}
 
 /**
  * Compact number input component - wrapper around NumberInput for consistency.
@@ -1453,6 +1469,14 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   const latestWidthRef = useRef(storedWidth);
   const resizeRafRef = useRef<number | null>(null);
 
+  // Expand / collapse-all: operate on whatever sections are currently rendered
+  // (varies by shape type), read from the DOM so there's no section-id registry
+  // to keep in sync.
+  const expandedSections = useUIPreferencesStore((s) => s.expandedSections);
+  const setSections = useUIPreferencesStore((s) => s.setSections);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [allExpanded, setAllExpanded] = useState(true);
+
   // Sync width with store
   useEffect(() => {
     setWidth(storedWidth);
@@ -1559,6 +1583,28 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
     [selectedShapes, updateShape]
   );
 
+  // Collect the section ids currently in the DOM (sections vary by shape type).
+  const getRenderedSections = useCallback((): { ids: string[]; everyExpanded: boolean } => {
+    const root = contentRef.current;
+    if (!root) return { ids: [], everyExpanded: true };
+    const nodes = Array.from(root.querySelectorAll<HTMLElement>('[id^="section-content-"]'));
+    const ids = nodes.map((n) => n.id.replace('section-content-', ''));
+    const everyExpanded = nodes.length > 0 && nodes.every((n) => n.getAttribute('aria-hidden') === 'false');
+    return { ids, everyExpanded };
+  }, []);
+
+  // Keep the toggle-all icon in sync with the rendered sections.
+  useEffect(() => {
+    const { ids, everyExpanded } = getRenderedSections();
+    setAllExpanded(ids.length === 0 ? true : everyExpanded);
+  }, [expandedSections, selectedIds, shape, getRenderedSections]);
+
+  const handleToggleAll = useCallback(() => {
+    const { ids, everyExpanded } = getRenderedSections();
+    if (ids.length === 0) return;
+    setSections(ids, !everyExpanded);
+  }, [getRenderedSections, setSections]);
+
   // No selection state
   if (!shape) {
     return (
@@ -1567,8 +1613,18 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
           className={`property-panel-resize-handle ${isResizing ? 'resizing' : ''}`}
           onMouseDown={handleResizeStart}
         />
-        <div className="property-panel-header">Properties</div>
-        <div className="property-panel-empty">No shape selected</div>
+        <div className="property-panel-header">
+          <span className="property-panel-header-title">Properties</span>
+        </div>
+        <div className="property-panel-empty">
+          <span className="property-panel-empty-icon" aria-hidden="true">
+            <MousePointerClick size={26} strokeWidth={1.5} />
+          </span>
+          <span className="property-panel-empty-title">Nothing selected</span>
+          <span className="property-panel-empty-hint">
+            Select a shape on the canvas to edit its properties.
+          </span>
+        </div>
         <StyleProfilePanel />
       </div>
     );
@@ -1581,13 +1637,24 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
         onMouseDown={handleResizeStart}
       />
       <div className="property-panel-header">
-        Properties{isMultiple && ` (${selectedShapes.length})`}
+        <span className="property-panel-header-title">
+          Properties{isMultiple && ` (${selectedShapes.length})`}
+        </span>
+        <button
+          type="button"
+          className="property-panel-collapse-all"
+          onClick={handleToggleAll}
+          title={allExpanded ? 'Collapse all sections' : 'Expand all sections'}
+          aria-label={allExpanded ? 'Collapse all sections' : 'Expand all sections'}
+        >
+          {allExpanded ? <ChevronsDownUp size={15} strokeWidth={2} /> : <ChevronsUpDown size={15} strokeWidth={2} />}
+        </button>
       </div>
 
       {/* Alignment Panel for multi-selection */}
       <AlignmentPanel />
 
-      <div className="property-panel-content">
+      <div className="property-panel-content" ref={contentRef}>
         {/* Shape Type Badge */}
         <div className="property-type-badge">
           {isGroupSelected ? 'Group' : (shapeMetadata?.name || shape.type)}
@@ -1829,7 +1896,17 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
 
         {/* Appearance Section - only for non-group, non-library shapes */}
         {!isGroupSelected && !isLibraryShapeSelected && (
-          <PropertySection id="appearance" title="Appearance" defaultExpanded>
+          <PropertySection
+            id="appearance"
+            title="Appearance"
+            defaultExpanded
+            summary={
+              <>
+                {(shape.fill !== null || isText(shape)) && <SummarySwatch color={shape.fill} />}
+                {shape.stroke !== null && <SummarySwatch color={shape.stroke} />}
+              </>
+            }
+          >
             {/* Fill Color (Text shapes always show — `fill` is the text colour) */}
             {(shape.fill !== null || isText(shape)) && (
               <CompactColorInput
@@ -2370,27 +2447,45 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
 
         {/* Position Section - collapsed by default, for core shapes only */}
         {!isGroupSelected && !isLibraryShapeSelected && (
-          <PropertySection id="position" title="Position" defaultExpanded={false}>
-            <InfoRow label="X" value={Math.round(shape.x)} />
-            <InfoRow label="Y" value={Math.round(shape.y)} />
+          <PropertySection
+            id="position"
+            title="Position"
+            defaultExpanded={false}
+            summary={`${Math.round(shape.x)}, ${Math.round(shape.y)}`}
+          >
+            <div className="property-grid-2">
+              <InfoRow label="X" value={Math.round(shape.x)} />
+              <InfoRow label="Y" value={Math.round(shape.y)} />
+            </div>
             <InfoRow label="Rotation" value={`${Math.round((shape.rotation * 180) / Math.PI)}°`} />
           </PropertySection>
         )}
 
         {/* Size Section - collapsed by default */}
         {(isRectangle(shape) || isEllipse(shape)) && (
-          <PropertySection id="size" title="Size" defaultExpanded={false}>
+          <PropertySection
+            id="size"
+            title="Size"
+            defaultExpanded={false}
+            summary={
+              isRectangle(shape)
+                ? `${Math.round(shape.width)} × ${Math.round(shape.height)}`
+                : isEllipse(shape)
+                  ? `${Math.round(shape.radiusX)} × ${Math.round(shape.radiusY)}`
+                  : undefined
+            }
+          >
             {isRectangle(shape) && (
-              <>
+              <div className="property-grid-2">
                 <InfoRow label="Width" value={Math.round(shape.width)} />
                 <InfoRow label="Height" value={Math.round(shape.height)} />
-              </>
+              </div>
             )}
             {isEllipse(shape) && (
-              <>
+              <div className="property-grid-2">
                 <InfoRow label="Radius X" value={Math.round(shape.radiusX)} />
                 <InfoRow label="Radius Y" value={Math.round(shape.radiusY)} />
-              </>
+              </div>
             )}
           </PropertySection>
         )}

--- a/src/ui/PropertySection.css
+++ b/src/ui/PropertySection.css
@@ -1,65 +1,141 @@
-/* Property Section Container */
+/* Property Section — a collapsible property group rendered as a polished card.
+ *
+ * Note: the container deliberately does NOT set `overflow: hidden`. An
+ * overflow-clipping ancestor between a `position: sticky` header and its scroll
+ * container disables sticky, so corners are rounded on the header / content
+ * instead and the card itself never clips. */
 .property-section-container {
-  margin-bottom: var(--space-1);
+  margin-bottom: var(--space-1-5);
   border-radius: var(--radius-lg);
-  overflow: hidden;
   background: var(--bg-secondary);
   border: 1px solid transparent;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .property-section-container:hover {
   border-color: var(--border-color-light);
 }
 
+.property-section-container.expanded {
+  box-shadow: var(--shadow-sm);
+}
+
 .property-section-container:last-child {
   margin-bottom: 0;
 }
 
-/* Section Header */
+/* Section Header — sticky within the scrolling panel so the active group stays
+ * labelled while you scroll a long panel. */
 .property-section-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 10px var(--space-3);
+  padding: var(--space-2) var(--space-3);
   cursor: pointer;
   user-select: none;
-  transition: background-color 0.15s ease;
+  background: var(--bg-secondary);
   border-radius: var(--radius-lg);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+/* Expanded: only the top corners stay rounded so the header reads as the lid of
+ * the card, with the content forming the body below it. */
+.property-section-container.expanded .property-section-header {
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 
 .property-section-header:hover {
   background-color: var(--bg-tertiary);
 }
 
-.property-section-header:focus {
+.property-section-header:focus-visible {
   outline: none;
   background-color: var(--bg-tertiary);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
 }
 
-/* Chevron */
+/* Animated left accent rail — grows in on hover / focus / when expanded. */
+.property-section-header::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 7px;
+  bottom: 7px;
+  width: 2px;
+  border-radius: 0 2px 2px 0;
+  background: var(--color-primary);
+  opacity: 0;
+  transform: scaleY(0.4);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.property-section-container.expanded .property-section-header::before,
+.property-section-header:hover::before,
+.property-section-header:focus-visible::before {
+  opacity: 1;
+  transform: scaleY(1);
+}
+
+/* Chevron — a single glyph that rotates between states. */
 .property-section-chevron {
-  font-size: 0.5625rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
   color: var(--text-muted, var(--text-secondary));
+  opacity: 0.8;
   transition: transform 0.2s ease, color 0.15s ease;
-  width: 12px;
-  text-align: center;
-  opacity: 0.7;
+}
+
+.property-section-container.expanded .property-section-chevron {
+  transform: rotate(90deg);
 }
 
 .property-section-header:hover .property-section-chevron {
-  color: var(--color-primary, var(--color-primary));
+  color: var(--color-primary);
   opacity: 1;
+}
+
+/* Leading section icon. */
+.property-section-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted, var(--text-secondary));
+  transition: color 0.15s ease;
+}
+
+.property-section-header:hover .property-section-icon {
+  color: var(--color-primary);
 }
 
 /* Title */
 .property-section-title {
   flex: 1;
+  min-width: 0;
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+/* Collapsed-state value summary (e.g. swatches, coordinates). */
+.property-section-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  max-width: 55%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-muted, var(--text-secondary));
 }
 
 /* Badge */
@@ -72,47 +148,69 @@
   border-radius: 10px;
 }
 
-/* Content */
+/* Content — fluid height via grid-template-rows (0fr → 1fr). No max-height clip,
+ * so tall sections expand fully; reduced-motion zeroes the transition globally
+ * via adaptive-motion.css. */
 .property-section-content {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.25s ease;
+}
+
+.property-section-content-inner {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: 0 var(--space-3) var(--space-3) var(--space-3);
+  padding: var(--space-1) var(--space-3) var(--space-3) var(--space-3);
+  min-height: 0;
   overflow: hidden;
-  transition: max-height 0.25s ease, opacity 0.2s ease, padding 0.25s ease;
+  opacity: 1;
+  transition: opacity 0.2s ease;
+  /* Become a size container so controls inside (e.g. `.property-grid-2`) can
+   * respond to the panel's own resizable width via @container queries —
+   * independent of the viewport. Inline-axis only, so the grid-rows height
+   * animation on the parent is unaffected. */
+  container-type: inline-size;
+}
+
+/* Responsive control pairing: two columns when the section is wide enough,
+ * collapsing to one when the panel is dragged narrow. */
+.property-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+  align-items: start;
+}
+
+@container (max-width: 280px) {
+  .property-grid-2 {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Collapsed State */
 .property-section-container.collapsed .property-section-content {
-  max-height: 0;
+  grid-template-rows: 0fr;
+}
+
+.property-section-container.collapsed .property-section-content-inner {
   opacity: 0;
-  padding-top: 0;
-  padding-bottom: 0;
   pointer-events: none;
 }
 
-/* Expanded State */
-.property-section-container.expanded .property-section-content {
-  max-height: 600px;
-  opacity: 1;
-}
-
 /* Dark mode adjustments */
-[data-theme="dark"] .property-section-container {
-  background: var(--bg-secondary);
-}
-
 [data-theme="dark"] .property-section-container:hover {
   border-color: var(--border-color);
 }
 
-[data-theme="dark"] .property-section-header:hover,
-[data-theme="dark"] .property-section-header:focus {
-  background-color: var(--bg-tertiary);
+[data-theme="dark"] .property-section-header,
+[data-theme="dark"] .property-section-container {
+  background: var(--bg-secondary);
 }
 
-[data-theme="dark"] .property-section-title {
-  color: var(--text-primary);
+[data-theme="dark"] .property-section-header:hover,
+[data-theme="dark"] .property-section-header:focus-visible {
+  background-color: var(--bg-tertiary);
 }
 
 [data-theme="dark"] .property-section-badge {

--- a/src/ui/PropertySection.tsx
+++ b/src/ui/PropertySection.tsx
@@ -1,5 +1,7 @@
 import { useCallback, ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+import { sectionIconFor } from './propertySectionIcons';
 import './PropertySection.css';
 
 /**
@@ -14,23 +16,34 @@ interface PropertySectionProps {
   children: ReactNode;
   /** Default expanded state (used if no persisted state exists) */
   defaultExpanded?: boolean;
-  /** Optional badge content (e.g., count) */
+  /** Optional badge content (e.g., multi-selection count) */
   badge?: string | number;
+  /** Optional leading icon (a lucide glyph) shown before the title. */
+  icon?: ReactNode;
+  /**
+   * Optional compact summary of the section's current values, rendered in the
+   * header only while the section is COLLAPSED — so collapsing stays informative
+   * (e.g. fill/stroke swatches, or "110, 46") instead of just hiding the controls.
+   */
+  summary?: ReactNode;
 }
 
 /**
- * Collapsible property section component.
+ * Collapsible property section, rendered as a polished card.
  *
  * Features:
- * - Click header to expand/collapse
- * - Chevron indicator for expand state
- * - Persists expanded state across sessions
- * - Smooth animation for expand/collapse
+ * - Click / Enter / Space on the header to expand or collapse.
+ * - A single chevron that rotates between states (no glyph swap).
+ * - Fluid height animation via `grid-template-rows` (no `max-height` clip, so
+ *   tall sections like UML members never truncate). Reduced-motion is honored
+ *   globally by `adaptive-motion.css`.
+ * - Sticky header within the scrolling panel.
+ * - Persists expanded state across sessions (keyed by `id`).
  *
  * Usage:
  * ```tsx
- * <PropertySection id="appearance" title="Appearance" defaultExpanded>
- *   <PropertyRow label="Fill">...</PropertyRow>
+ * <PropertySection id="appearance" title="Appearance" icon={<Palette />}>
+ *   ...
  * </PropertySection>
  * ```
  */
@@ -40,10 +53,13 @@ export function PropertySection({
   children,
   defaultExpanded = true,
   badge,
+  icon,
+  summary,
 }: PropertySectionProps) {
   const { isSectionExpanded, toggleSection } = useUIPreferencesStore();
 
   const isExpanded = isSectionExpanded(id, defaultExpanded);
+  const resolvedIcon = icon ?? sectionIconFor(id);
 
   const handleToggle = useCallback(() => {
     toggleSection(id);
@@ -70,16 +86,28 @@ export function PropertySection({
         aria-expanded={isExpanded}
         aria-controls={`section-content-${id}`}
       >
-        <span className="property-section-chevron">{isExpanded ? '\u25BC' : '\u25B6'}</span>
+        <span className="property-section-chevron" aria-hidden="true">
+          <ChevronRight size={14} strokeWidth={2.25} />
+        </span>
+        {resolvedIcon !== null && resolvedIcon !== undefined && (
+          <span className="property-section-icon" aria-hidden="true">
+            {resolvedIcon}
+          </span>
+        )}
         <span className="property-section-title">{title}</span>
+        {!isExpanded && summary !== undefined && (
+          <span className="property-section-summary">{summary}</span>
+        )}
         {badge !== undefined && <span className="property-section-badge">{badge}</span>}
       </div>
       <div
         id={`section-content-${id}`}
         className="property-section-content"
+        role="region"
+        aria-label={title}
         aria-hidden={!isExpanded}
       >
-        {children}
+        <div className="property-section-content-inner">{children}</div>
       </div>
     </div>
   );

--- a/src/ui/propertySectionIcons.tsx
+++ b/src/ui/propertySectionIcons.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import {
+  Anchor,
+  Box,
+  Braces,
+  Diamond,
+  File,
+  Group,
+  List,
+  Layers,
+  Move,
+  Network,
+  PaintBucket,
+  Palette,
+  Rows3,
+  Ruler,
+  SlidersHorizontal,
+  Spline,
+  Sparkles,
+  Square,
+  Tag,
+  Type,
+  Workflow,
+} from 'lucide-react';
+
+/**
+ * Maps a {@link PropertySection} `id` to a small lucide glyph, so the panel's
+ * groups are scannable at a glance. Kept out of `PropertySection.tsx` so the
+ * section component stays presentation-only; the section resolves its icon from
+ * here by id, and any call site can still override via the `icon` prop.
+ *
+ * Unmapped ids fall back to `null` (no icon) rather than a misleading generic.
+ */
+const SECTION_ICONS: Record<string, ReactNode> = {
+  appearance: <Palette size={14} strokeWidth={2} />,
+  label: <Tag size={14} strokeWidth={2} />,
+  text: <Type size={14} strokeWidth={2} />,
+  position: <Move size={14} strokeWidth={2} />,
+  size: <Ruler size={14} strokeWidth={2} />,
+  dimensions: <Ruler size={14} strokeWidth={2} />,
+  icon: <Sparkles size={14} strokeWidth={2} />,
+  custom: <SlidersHorizontal size={14} strokeWidth={2} />,
+
+  // Connectors
+  'connector-routing': <Spline size={14} strokeWidth={2} />,
+  'connector-type': <Workflow size={14} strokeWidth={2} />,
+  'connector-label': <Tag size={14} strokeWidth={2} />,
+  'connector-cardinality': <Network size={14} strokeWidth={2} />,
+  'connector-endpoints': <Anchor size={14} strokeWidth={2} />,
+  'uml-markers': <Diamond size={14} strokeWidth={2} />,
+  endpoints: <Anchor size={14} strokeWidth={2} />,
+
+  // ERD
+  'erd-entity': <Box size={14} strokeWidth={2} />,
+  'erd-members': <List size={14} strokeWidth={2} />,
+  'erd-table-style': <PaintBucket size={14} strokeWidth={2} />,
+
+  // UML
+  'uml-class': <Box size={14} strokeWidth={2} />,
+  'uml-attributes': <List size={14} strokeWidth={2} />,
+  'uml-methods': <Braces size={14} strokeWidth={2} />,
+
+  // Swimlane
+  'swimlane-lanes': <Rows3 size={14} strokeWidth={2} />,
+
+  // File
+  'file-info': <File size={14} strokeWidth={2} />,
+  'file-label': <Tag size={14} strokeWidth={2} />,
+
+  // Group
+  group: <Group size={14} strokeWidth={2} />,
+  'group-background': <PaintBucket size={14} strokeWidth={2} />,
+  'group-border': <Square size={14} strokeWidth={2} />,
+  'group-label': <Tag size={14} strokeWidth={2} />,
+  'group-shadow': <Layers size={14} strokeWidth={2} />,
+};
+
+/** Resolve the icon for a section id, or `null` if none is mapped. */
+export function sectionIconFor(id: string): ReactNode {
+  return SECTION_ICONS[id] ?? null;
+}


### PR DESCRIPTION
First of two slices in the property-panel UX redesign (warmup bug-fixes shipped in #201). This slice upgrades the collapsible `PropertySection` groups **in place** — same public API, so the 34 call sites are untouched — and kills a latent clipping bug. Slice 2 (control componentization + JP-30 reorderable lists) follows.

## What's in this slice
- **Polished cards:** refined surface/elevation, hover + `:focus-visible`, an animated left accent rail, and a single chevron that **rotates** between states (replaces the ▼/▶ glyph swap).
- **Fluid height via `grid-template-rows: 0fr↔1fr`** on an inner wrapper — removes the `max-height: 600px` clip that silently truncated tall sections (UML attributes/methods, ERD members). Pure CSS; reduced-motion zeroes it globally via `adaptive-motion.css`.
- **Per-section icons** (lucide) via a small id→icon map (`propertySectionIcons.tsx`), resolved inside `PropertySection` with a prop override (no call-site churn).
- **Sticky section headers** within the scrolling panel. The container's `overflow: hidden` is dropped (an overflow-clipping ancestor disables `position: sticky`); corners are rounded on the header instead.
- **Responsive interior:** `container-type: inline-size` on the section content + a `.property-grid-2` helper that pairs X/Y and W/H at wide panel widths and collapses to one column under ~280px. Responds to the panel's own **resizable width**, not the viewport (matches the `ShapeLibraryManager.css` container-query precedent).
- **Expand / Collapse-all** in the panel header — new `setSections` bulk store action; the visible section ids are read from the DOM, so there's no id registry to keep in sync.
- **Collapsed summary chips:** a collapsed section surfaces its values in the header (Appearance → fill/stroke swatches, Position → "x, y", Size → "w × h"), so collapsing stays informative instead of just hiding.
- **Redesigned empty state** as a friendly hint card.
- **Defaults:** primary groups already opened and advanced ones collapsed, matching the agreed "primary open, advanced collapsed" — no default changes were needed.

## Notes
- The whole section system is **pure CSS** (grid-rows, sticky, container queries) — no JS layout work, no ResizeObserver/rAF. Grid-rows degrades to an instant toggle on older WebKitGTK.
- Density/reduced-motion ride existing tokens; light + dark both handled.

## Verification
- `bun run typecheck` clean; `bun run test --run` → **2224 passed**. OSS leak grep clean.
- Manual (pending, visual): select shapes across types (rect/connector/UML/ERD/group) → cards look polished, chevron rotates, **tall sections expand with no clipping**; resize 180↔400px → X/Y and W/H reflow 2-col↔1-col; headers stick while scrolling; Expand/Collapse-all works; collapsed sections show summaries; light + dark clean; reduced-motion disables the animation.

Assisted-by: Opus 4.8