### PR TITLE
Fix list reordering (JP-30) + entity text color; restyle member rows (Slice 2)

### DIFF
--- a/src/shapes/library/erdShapes.ts
+++ b/src/shapes/library/erdShapes.ts
@@ -362,10 +362,14 @@ const renderERDWeakEntity: CustomRenderFunction = (ctx, shape) => {
 const erdEntityProperties: PropertyDefinition[] = [
   ...createStandardProperties({ includeLabel: false }),
   {
+    // `labelColor` is a top-level BaseShape field (the renderer reads
+    // `shape.labelColor`), so it must live in a section whose editor binds to
+    // the top-level field. 'custom' routes through `customProperties`, which the
+    // renderer never reads — that made the Text Color control a no-op.
     key: 'labelColor',
     label: 'Text Color',
     type: 'color',
-    section: 'custom',
+    section: 'appearance',
   },
 ];
 

--- a/src/shapes/library/umlClassShapes.ts
+++ b/src/shapes/library/umlClassShapes.ts
@@ -295,10 +295,13 @@ const renderUMLEnum: CustomRenderFunction = (ctx, shape) => {
 const umlClassProperties: PropertyDefinition[] = [
   ...createStandardProperties({ includeLabel: false }),
   {
+    // Top-level BaseShape field — see the matching note in erdShapes.ts. Must be
+    // 'appearance' (top-level binding), not 'custom' (customProperties), or the
+    // Text Color control silently does nothing.
     key: 'labelColor',
     label: 'Text Color',
     type: 'color',
-    section: 'custom',
+    section: 'appearance',
   },
 ];
 

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -1417,6 +1417,43 @@
   border-color: var(--color-primary);
 }
 
+/* --- Roomier member / lane editors --------------------------------------
+ * The attribute / method / lane rows were cramped (4px padding, tiny inputs).
+ * Give the text inputs and the UML visibility select a comfortable 28px target
+ * matching the rest of the panel's controls, with a touch more breathing room
+ * per row. */
+.erd-member-name,
+.erd-member-type,
+.uml-member-name,
+.uml-member-type,
+.swimlane-lane-name {
+  height: 28px;
+  padding: 0 var(--space-2);
+  min-width: 64px;
+}
+
+.erd-member-type,
+.uml-member-type {
+  min-width: 56px;
+}
+
+.uml-member-visibility {
+  height: 28px;
+}
+
+.erd-members-list,
+.uml-members-list,
+.swimlane-lanes-list {
+  gap: var(--space-2);
+}
+
+.erd-member-row,
+.uml-member-row,
+.swimlane-lane-row {
+  padding: var(--space-0-5);
+  border-radius: var(--radius-sm);
+}
+
 .swimlane-width-control {
   display: flex;
   align-items: center;

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -47,6 +47,7 @@ import { BorderStylePicker } from './BorderStylePicker';
 import { LabelPositionPicker } from './LabelPositionPicker';
 import { IconListEditor } from './IconListEditor';
 import { DisplayAsIconToggle } from './DisplayAsIconToggle';
+import { ReorderableList } from './properties/ReorderableList';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 // GroupStyles types are used via the PatternPicker, ShadowEditor, LabelPositionPicker components
 import type { ShapeMetadata, PropertyDefinition, PropertySection as PropertySectionType } from '../shapes/ShapeMetadata';
@@ -750,10 +751,6 @@ function ERDEntityProperties({
     }
   }, [members, updateCustomProps]);
 
-  // Drag state for reordering
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-
   return (
     <>
       <PropertySection id="erd-entity" title="Entity" defaultExpanded>
@@ -770,33 +767,14 @@ function ERDEntityProperties({
       </PropertySection>
 
       <PropertySection id="erd-members" title="Attributes" defaultExpanded>
-        <div className="erd-members-list">
-          {members.map((member, index) => (
-            <div
-              key={index}
-              className={`erd-member-row${dragIndex === index ? ' dragging' : ''}${dragOverIndex === index ? ' drag-over' : ''}`}
-              draggable
-              onDragStart={(e) => {
-                setDragIndex(index);
-                e.dataTransfer.effectAllowed = 'move';
-              }}
-              onDragEnd={() => {
-                if (dragIndex !== null && dragOverIndex !== null) {
-                  handleMoveMember(dragIndex, dragOverIndex);
-                }
-                setDragIndex(null);
-                setDragOverIndex(null);
-              }}
-              onDragOver={(e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                setDragOverIndex(index);
-              }}
-              onDragLeave={() => {
-                setDragOverIndex(null);
-              }}
-            >
-              <span className="member-drag-handle" title="Drag to reorder">⋮⋮</span>
+        <ReorderableList
+          items={members}
+          listClassName="erd-members-list"
+          rowClassName="erd-member-row"
+          onReorder={handleMoveMember}
+          renderItem={(member, index, handleProps) => (
+            <>
+              <span className="member-drag-handle" title="Drag to reorder" {...handleProps}>⋮⋮</span>
               <button
                 type="button"
                 className={`toggle-icon-btn erd-member-pk ${member.isPrimaryKey ? 'active' : ''}`}
@@ -828,9 +806,9 @@ function ERDEntityProperties({
               >
                 ×
               </button>
-            </div>
-          ))}
-        </div>
+            </>
+          )}
+        />
         <button className="erd-add-member" onClick={handleAddMember}>
           + Add Attribute
         </button>
@@ -986,14 +964,6 @@ function UMLClassProperties({
     }
   }, [methods, updateCustomProps]);
 
-  // Drag state for attributes
-  const [attrDragIndex, setAttrDragIndex] = useState<number | null>(null);
-  const [attrDragOverIndex, setAttrDragOverIndex] = useState<number | null>(null);
-
-  // Drag state for methods
-  const [methodDragIndex, setMethodDragIndex] = useState<number | null>(null);
-  const [methodDragOverIndex, setMethodDragOverIndex] = useState<number | null>(null);
-
   return (
     <>
       <PropertySection id="uml-class" title="Class" defaultExpanded>
@@ -1010,33 +980,14 @@ function UMLClassProperties({
       </PropertySection>
 
       <PropertySection id="uml-attributes" title="Attributes" defaultExpanded>
-        <div className="uml-members-list">
-          {attributes.map((attr, index) => (
-            <div
-              key={index}
-              className={`uml-member-row${attrDragIndex === index ? ' dragging' : ''}${attrDragOverIndex === index ? ' drag-over' : ''}`}
-              draggable
-              onDragStart={(e) => {
-                setAttrDragIndex(index);
-                e.dataTransfer.effectAllowed = 'move';
-              }}
-              onDragEnd={() => {
-                if (attrDragIndex !== null && attrDragOverIndex !== null) {
-                  handleMoveAttribute(attrDragIndex, attrDragOverIndex);
-                }
-                setAttrDragIndex(null);
-                setAttrDragOverIndex(null);
-              }}
-              onDragOver={(e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                setAttrDragOverIndex(index);
-              }}
-              onDragLeave={() => {
-                setAttrDragOverIndex(null);
-              }}
-            >
-              <span className="member-drag-handle" title="Drag to reorder">⋮⋮</span>
+        <ReorderableList
+          items={attributes}
+          listClassName="uml-members-list"
+          rowClassName="uml-member-row"
+          onReorder={handleMoveAttribute}
+          renderItem={(attr, index, handleProps) => (
+            <>
+              <span className="member-drag-handle" title="Drag to reorder" {...handleProps}>⋮⋮</span>
               <select
                 value={attr.visibility}
                 onChange={(e) => handleUpdateAttribute(index, { visibility: e.target.value as UMLClassMember['visibility'] })}
@@ -1080,42 +1031,23 @@ function UMLClassProperties({
               >
                 ×
               </button>
-            </div>
-          ))}
-        </div>
+            </>
+          )}
+        />
         <button className="uml-add-member" onClick={handleAddAttribute}>
           + Add Attribute
         </button>
       </PropertySection>
 
       <PropertySection id="uml-methods" title="Methods" defaultExpanded>
-        <div className="uml-members-list">
-          {methods.map((method, index) => (
-            <div
-              key={index}
-              className={`uml-member-row${methodDragIndex === index ? ' dragging' : ''}${methodDragOverIndex === index ? ' drag-over' : ''}`}
-              draggable
-              onDragStart={(e) => {
-                setMethodDragIndex(index);
-                e.dataTransfer.effectAllowed = 'move';
-              }}
-              onDragEnd={() => {
-                if (methodDragIndex !== null && methodDragOverIndex !== null) {
-                  handleMoveMethod(methodDragIndex, methodDragOverIndex);
-                }
-                setMethodDragIndex(null);
-                setMethodDragOverIndex(null);
-              }}
-              onDragOver={(e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                setMethodDragOverIndex(index);
-              }}
-              onDragLeave={() => {
-                setMethodDragOverIndex(null);
-              }}
-            >
-              <span className="member-drag-handle" title="Drag to reorder">⋮⋮</span>
+        <ReorderableList
+          items={methods}
+          listClassName="uml-members-list"
+          rowClassName="uml-member-row"
+          onReorder={handleMoveMethod}
+          renderItem={(method, index, handleProps) => (
+            <>
+              <span className="member-drag-handle" title="Drag to reorder" {...handleProps}>⋮⋮</span>
               <select
                 value={method.visibility}
                 onChange={(e) => handleUpdateMethod(index, { visibility: e.target.value as UMLClassMember['visibility'] })}
@@ -1159,9 +1091,9 @@ function UMLClassProperties({
               >
                 ×
               </button>
-            </div>
-          ))}
-        </div>
+            </>
+          )}
+        />
         <button className="uml-add-member" onClick={handleAddMethod}>
           + Add Method
         </button>
@@ -1272,39 +1204,16 @@ function SwimlaneProperties({
     });
   }, [laneHeaders, laneWidths, updateCustomProps]);
 
-  // Drag state for reordering
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-
   return (
     <PropertySection id="swimlane-lanes" title="Lanes" defaultExpanded>
-      <div className="swimlane-lanes-list">
-        {laneHeaders.map((header, index) => (
-          <div
-            key={index}
-            className={`swimlane-lane-row${dragIndex === index ? ' dragging' : ''}${dragOverIndex === index ? ' drag-over' : ''}`}
-            draggable
-            onDragStart={(e) => {
-              setDragIndex(index);
-              e.dataTransfer.effectAllowed = 'move';
-            }}
-            onDragEnd={() => {
-              if (dragIndex !== null && dragOverIndex !== null) {
-                handleMoveLane(dragIndex, dragOverIndex);
-              }
-              setDragIndex(null);
-              setDragOverIndex(null);
-            }}
-            onDragOver={(e) => {
-              e.preventDefault();
-              e.dataTransfer.dropEffect = 'move';
-              setDragOverIndex(index);
-            }}
-            onDragLeave={() => {
-              setDragOverIndex(null);
-            }}
-          >
-            <span className="member-drag-handle" title="Drag to reorder">⋮⋮</span>
+      <ReorderableList
+        items={laneHeaders}
+        listClassName="swimlane-lanes-list"
+        rowClassName="swimlane-lane-row"
+        onReorder={handleMoveLane}
+        renderItem={(header, index, handleProps) => (
+          <>
+            <span className="member-drag-handle" title="Drag to reorder" {...handleProps}>⋮⋮</span>
             <input
               type="text"
               value={header}
@@ -1320,9 +1229,9 @@ function SwimlaneProperties({
             >
               ×
             </button>
-          </div>
-        ))}
-      </div>
+          </>
+        )}
+      />
       <div className="swimlane-actions">
         <button className="swimlane-add-lane" onClick={handleAddLane}>
           + Add Lane

--- a/src/ui/properties/ReorderableList.css
+++ b/src/ui/properties/ReorderableList.css
@@ -1,0 +1,27 @@
+/* Pointer-based reorderable list. The container keeps whatever layout class the
+ * consumer passes (gap, etc.); these rules only add the drag affordances and
+ * compose with the per-list row classes (e.g. .erd-member-row). */
+.reorderable-list {
+  position: relative;
+}
+
+.reorderable-row {
+  transition: box-shadow 0.12s ease;
+}
+
+/* The row being dragged follows the pointer (inline transform) and lifts.
+ * Opacity is left to the per-list `.dragging` rule so the two don't fight. */
+.reorderable-row.dragging {
+  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-sm);
+  cursor: grabbing;
+}
+
+/* Drop target: a primary-coloured line at the top edge of the row the pointer
+ * is over, so the insertion point reads clearly (not just a row tint). */
+.reorderable-row.drag-over {
+  box-shadow: inset 0 2px 0 var(--color-primary);
+}
+
+/* While reduced motion is on, the transform jump is fine; adaptive-motion.css
+ * zeroes the transition globally. */

--- a/src/ui/properties/ReorderableList.test.tsx
+++ b/src/ui/properties/ReorderableList.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReorderableList } from './ReorderableList';
+
+function renderList(onReorder = vi.fn(), items = ['a', 'b', 'c']) {
+  render(
+    <ReorderableList
+      items={items}
+      onReorder={onReorder}
+      rowClassName="test-row"
+      renderItem={(item, _index, handleProps) => (
+        <>
+          <span {...handleProps}>handle</span>
+          <span>{item}</span>
+        </>
+      )}
+    />
+  );
+  return onReorder;
+}
+
+describe('ReorderableList', () => {
+  it('renders every item', () => {
+    renderList();
+    expect(screen.getByText('a')).toBeTruthy();
+    expect(screen.getByText('b')).toBeTruthy();
+    expect(screen.getByText('c')).toBeTruthy();
+  });
+
+  it('exposes an accessible drag handle per row', () => {
+    renderList();
+    const handles = screen.getAllByRole('button', { name: 'Drag to reorder' });
+    expect(handles).toHaveLength(3);
+  });
+
+  it('reorders down with ArrowDown', () => {
+    const onReorder = renderList();
+    const handles = screen.getAllByRole('button', { name: 'Drag to reorder' });
+    fireEvent.keyDown(handles[0]!, { key: 'ArrowDown' });
+    expect(onReorder).toHaveBeenCalledWith(0, 1);
+  });
+
+  it('reorders up with ArrowUp', () => {
+    const onReorder = renderList();
+    const handles = screen.getAllByRole('button', { name: 'Drag to reorder' });
+    fireEvent.keyDown(handles[2]!, { key: 'ArrowUp' });
+    expect(onReorder).toHaveBeenCalledWith(2, 1);
+  });
+
+  it('does not reorder past the top', () => {
+    const onReorder = renderList();
+    const handles = screen.getAllByRole('button', { name: 'Drag to reorder' });
+    fireEvent.keyDown(handles[0]!, { key: 'ArrowUp' });
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it('commits a pointer drag via onReorder', () => {
+    // In jsdom every row rect is zero, so the drop target resolves to index 0;
+    // dragging row 2 therefore commits a move from 2 → 0. This exercises the
+    // full pointerdown → pointermove → pointerup path.
+    const onReorder = renderList();
+    const handles = screen.getAllByRole('button', { name: 'Drag to reorder' });
+    fireEvent.pointerDown(handles[2]!, { button: 0, clientY: 30 });
+    fireEvent.pointerMove(window, { clientY: 0 });
+    fireEvent.pointerUp(window, { clientY: 0 });
+    expect(onReorder).toHaveBeenCalledWith(2, 0);
+  });
+});

--- a/src/ui/properties/ReorderableList.tsx
+++ b/src/ui/properties/ReorderableList.tsx
@@ -1,0 +1,172 @@
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import './ReorderableList.css';
+
+/**
+ * Props spread onto a row's drag handle element. The handle starts a pointer
+ * drag and also supports keyboard reordering (Arrow Up/Down).
+ */
+export interface ReorderHandleProps {
+  onPointerDown: (e: React.PointerEvent) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  role: 'button';
+  tabIndex: 0;
+  'aria-label': string;
+  style: React.CSSProperties;
+}
+
+interface ReorderableListProps<T> {
+  items: T[];
+  /** Stable-ish key per item. Defaults to the index. */
+  getKey?: (item: T, index: number) => string | number;
+  /** Commit a reorder: move the item at `fromIndex` to `toIndex`. */
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  /** Render a row's inner content; spread `handleProps` onto the drag handle. */
+  renderItem: (item: T, index: number, handleProps: ReorderHandleProps) => ReactNode;
+  /** Class on the list container (keeps existing layout CSS, e.g. gap). */
+  listClassName?: string;
+  /** Class on each row wrapper (e.g. 'erd-member-row'); 'dragging'/'drag-over' are appended. */
+  rowClassName?: string;
+}
+
+/**
+ * A small, dependency-free reorderable list driven by **pointer events**.
+ *
+ * Replaces the native HTML5 drag-and-drop API, which is unreliable across the
+ * web/Tauri matrix and frequently doesn't fire at all in WebKitGTK (the Linux
+ * webview Tauri uses) — the root cause of JP-30, where panel list items
+ * "don't move at all". Pointer events work everywhere.
+ *
+ * The dragged row follows the pointer (transform), the target gap shows a drop
+ * line, and the handle supports keyboard reordering for accessibility.
+ */
+export function ReorderableList<T>({
+  items,
+  getKey,
+  onReorder,
+  renderItem,
+  listClassName,
+  rowClassName,
+}: ReorderableListProps<T>) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+  const [dragY, setDragY] = useState(0);
+
+  // Mirrors for use inside window listeners (which capture stale state).
+  const rectsRef = useRef<DOMRect[]>([]);
+  const startYRef = useRef(0);
+  const dragIndexRef = useRef<number | null>(null);
+  const overIndexRef = useRef<number | null>(null);
+  const onReorderRef = useRef(onReorder);
+  onReorderRef.current = onReorder;
+
+  const setDrag = (v: number | null) => {
+    dragIndexRef.current = v;
+    setDragIndex(v);
+  };
+  const setOver = (v: number | null) => {
+    overIndexRef.current = v;
+    setOverIndex(v);
+  };
+
+  const startDrag = useCallback((e: React.PointerEvent, index: number) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+    // Cache row rects once, at drag start, so pointermove doesn't thrash layout.
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[data-reorder-index]'));
+    rectsRef.current = rows.map((r) => r.getBoundingClientRect());
+    startYRef.current = e.clientY;
+    setDragY(0);
+    setDrag(index);
+    setOver(index);
+  }, []);
+
+  useEffect(() => {
+    if (dragIndex === null) return;
+
+    // The row whose vertical span contains the pointer (clamped to the ends).
+    const computeOver = (y: number): number => {
+      const rects = rectsRef.current;
+      if (rects.length === 0) return dragIndexRef.current ?? 0;
+      if (y < rects[0]!.top) return 0;
+      for (let i = 0; i < rects.length; i++) {
+        if (y <= rects[i]!.bottom) return i;
+      }
+      return rects.length - 1;
+    };
+
+    const handleMove = (e: PointerEvent) => {
+      setDragY(e.clientY - startYRef.current);
+      setOver(computeOver(e.clientY));
+    };
+    const handleUp = () => {
+      const from = dragIndexRef.current;
+      const to = overIndexRef.current;
+      if (from !== null && to !== null && from !== to) onReorderRef.current(from, to);
+      setDrag(null);
+      setOver(null);
+      setDragY(0);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+    };
+  }, [dragIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      if (e.key === 'ArrowUp' && index > 0) {
+        e.preventDefault();
+        onReorderRef.current(index, index - 1);
+      } else if (e.key === 'ArrowDown' && index < items.length - 1) {
+        e.preventDefault();
+        onReorderRef.current(index, index + 1);
+      }
+    },
+    [items.length]
+  );
+
+  const makeHandleProps = (index: number): ReorderHandleProps => ({
+    onPointerDown: (e) => startDrag(e, index),
+    onKeyDown: (e) => handleKeyDown(e, index),
+    role: 'button',
+    tabIndex: 0,
+    'aria-label': 'Drag to reorder',
+    style: { cursor: dragIndex === null ? 'grab' : 'grabbing', touchAction: 'none' },
+  });
+
+  return (
+    <div className={`reorderable-list ${listClassName ?? ''}`} ref={containerRef}>
+      {items.map((item, index) => {
+        const isDragging = dragIndex === index;
+        const isTarget = dragIndex !== null && overIndex === index && !isDragging;
+        const rowStyle: React.CSSProperties = isDragging
+          ? { transform: `translateY(${dragY}px)`, zIndex: 2, position: 'relative' }
+          : {};
+        return (
+          <div
+            key={getKey ? getKey(item, index) : index}
+            data-reorder-index={index}
+            style={rowStyle}
+            className={
+              `${rowClassName ?? ''} reorderable-row` +
+              (isDragging ? ' dragging' : '') +
+              (isTarget ? ' drag-over' : '')
+            }
+          >
+            {renderItem(item, index, makeHandleProps(index))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default ReorderableList;


### PR DESCRIPTION
Second slice of the property-panel redesign (Slice 1 = #202). Fixes two bugs and lands the first reusable property control. Builds on the card redesign.

## JP-30 — draggable list items don't move
The ERD attribute, UML attribute/method, and swimlane lane rows used the **native HTML5 drag-and-drop API** (`draggable` + `dataTransfer`), which is unreliable across the web/Tauri matrix and frequently **doesn't fire at all in WebKitGTK** (Tauri's Linux webview) — so the rows didn't drag.

New `src/ui/properties/ReorderableList.tsx` — a generic, dependency-free list driven by **pointer events** (works everywhere):
- Dragged row follows the pointer; a primary-coloured **drop line** marks the target.
- **Keyboard reordering** (Arrow Up/Down on the handle) for accessibility.
- Row rects cached at drag start (no per-move layout thrash).
- All four lists migrated to it; the existing move handlers are unchanged.

## "Text Color" on entities did nothing
`labelColor` is a **top-level BaseShape field** (the renderer reads `shape.labelColor`), but `erdShapes.ts` and `umlClassShapes.ts` declared it `section: 'custom'`, so the generic editor wrote `shape.customProperties.labelColor` — which the renderer never reads. The control was inert. Moved both to `section: 'appearance'` (the top-level get/set path). Only ERD + UML class were affected (confirmed by an audit of every `section:'custom'` property). No migration needed — the custom value was never consumed.

## Cramped member rows
The attribute/method/lane text inputs and the UML visibility select now have a comfortable 28px height with more padding and a little per-row breathing room.

## Tests
- New `ReorderableList.test.tsx` (keyboard + pointer reorder paths).
- `bun run typecheck` clean; `bun run test --run` → **2230 passed**. OSS leak grep clean.

## Verification (manual)
- **JP-30 (the important one):** in the **desktop / WebKitGTK build** — where native DnD failed — drag the `⋮⋮` handle on ERD attributes, UML attributes/methods, and swimlane lanes → rows reorder; Arrow keys also reorder.
- ERD/UML **Text Color** now actually recolours the entity/class text.
- Member inputs look roomier.

Closes JP-30.

Assisted-by: Opus 4.8