### PR TITLE
Polish: color palette apply/width, checkbox styling, rotation unit toggle

### DIFF
--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -80,6 +80,8 @@ export interface AppearancePrefs {
 export interface UIPreferencesState {
   /** Expanded state of property panel sections */
   expandedSections: Record<string, boolean>;
+  /** Unit used to display/edit shape rotation in the property panel. */
+  rotationUnit: 'degrees' | 'radians';
   /** Property panel width */
   propertyPanelWidth: number;
   /**
@@ -116,6 +118,8 @@ export interface UIPreferencesActions {
   setSection: (sectionId: string, expanded: boolean) => void;
   /** Set many sections' expanded state at once (e.g. expand/collapse all). */
   setSections: (sectionIds: string[], expanded: boolean) => void;
+  /** Set the rotation display unit. */
+  setRotationUnit: (unit: 'degrees' | 'radians') => void;
   /** Check if a section is expanded */
   isSectionExpanded: (sectionId: string, defaultExpanded?: boolean) => boolean;
   /** Set property panel width */
@@ -237,6 +241,7 @@ function clampUiScale(value: number): number {
  */
 const initialState: UIPreferencesState = {
   expandedSections: { ...DEFAULT_EXPANDED },
+  rotationUnit: 'degrees',
   propertyPanelWidth: 240,
   relaxedSplitCanvasWidth: 480,
   documentBrowserView: 'list',
@@ -345,6 +350,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         for (const id of sectionIds) next[id] = expanded;
         set({ expandedSections: next });
       },
+
+      setRotationUnit: (unit) => set({ rotationUnit: unit }),
 
       isSectionExpanded: (sectionId: string, defaultExpanded?: boolean): boolean => {
         const { expandedSections } = get();
@@ -501,6 +508,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
       version: 7,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
+        rotationUnit: state.rotationUnit,
         propertyPanelWidth: state.propertyPanelWidth,
         relaxedSplitCanvasWidth: state.relaxedSplitCanvasWidth,
         documentBrowserView: state.documentBrowserView,

--- a/src/ui/ColorPalette.tsx
+++ b/src/ui/ColorPalette.tsx
@@ -107,8 +107,12 @@ export function ColorPalette({
       const color = e.target.value;
       setCustomInputValue(color);
       setCustomColor(color);
+      // Apply immediately — picking a colour in the native picker should take
+      // effect right away, not wait for the user to open the hex field and hit
+      // Apply.
+      handleColorSelect(color);
     },
-    [setCustomColor]
+    [setCustomColor, handleColorSelect]
   );
 
   const handleCustomInputChange = useCallback(

--- a/src/ui/CompactColorInput.tsx
+++ b/src/ui/CompactColorInput.tsx
@@ -64,11 +64,11 @@ export function CompactColorInput({
   const updateDropdownPosition = useCallback(() => {
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect();
-      setDropdownPosition({
-        top: rect.bottom + 4,
-        left: rect.left,
-        width: Math.max(rect.width, 200), // Minimum width for palette
-      });
+      // Bound the width so the palette never stretches across the screen, and
+      // clamp the left edge so it stays on-screen.
+      const width = Math.min(264, Math.max(rect.width, 232));
+      const left = Math.max(8, Math.min(rect.left, window.innerWidth - width - 8));
+      setDropdownPosition({ top: rect.bottom + 4, left, width });
     }
   }, []);
 
@@ -207,7 +207,9 @@ export function CompactColorInput({
         position: 'fixed',
         top: dropdownPosition.top,
         left: dropdownPosition.left,
-        minWidth: dropdownPosition.width,
+        width: dropdownPosition.width,
+        maxWidth: 'calc(100vw - 16px)',
+        boxSizing: 'border-box',
         zIndex: 10000,
       }}
     >

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -590,6 +590,107 @@
   box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
+/* --- Inline checkbox labels (checkbox + text inside one <label>) -----------
+ * Many rows use a raw `<label><input type="checkbox"><span>…</span></label>`
+ * with no classes, which rendered as a tiny native box next to oversized text
+ * with awkward baseline alignment. Normalize them here without disturbing the
+ * styled `.compact-checkbox` (which opts out via :not()). */
+.compact-checkbox-row label:not(.compact-checkbox-label) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.compact-checkbox-row label:not(.compact-checkbox-label) span {
+  font-size: var(--font-size-sm);
+}
+
+.compact-checkbox-row input[type="checkbox"]:not(.compact-checkbox) {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  flex-shrink: 0;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+/* --- Rotation row: editable value + degrees/radians unit toggle ----------- */
+.rotation-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.rotation-row .compact-number-label {
+  min-width: 70px;
+}
+
+.rotation-input {
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  padding: 0 var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.rotation-input::-webkit-outer-spin-button,
+.rotation-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.rotation-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
+}
+
+.rotation-unit-toggle {
+  display: inline-flex;
+  flex-shrink: 0;
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.rotation-unit-toggle button {
+  height: 28px;
+  min-width: 30px;
+  padding: 0 var(--space-2);
+  border: none;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.rotation-unit-toggle button + button {
+  border-left: 1px solid var(--border-color-input);
+}
+
+.rotation-unit-toggle button:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.rotation-unit-toggle button.active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
 /* Legacy styles for backwards compatibility */
 .property-section {
   font-size: var(--font-size-sm);

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -1383,6 +1383,8 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   // to keep in sync.
   const expandedSections = useUIPreferencesStore((s) => s.expandedSections);
   const setSections = useUIPreferencesStore((s) => s.setSections);
+  const rotationUnit = useUIPreferencesStore((s) => s.rotationUnit);
+  const setRotationUnit = useUIPreferencesStore((s) => s.setRotationUnit);
   const contentRef = useRef<HTMLDivElement>(null);
   const [allExpanded, setAllExpanded] = useState(true);
 
@@ -2366,7 +2368,43 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
               <InfoRow label="X" value={Math.round(shape.x)} />
               <InfoRow label="Y" value={Math.round(shape.y)} />
             </div>
-            <InfoRow label="Rotation" value={`${Math.round((shape.rotation * 180) / Math.PI)}°`} />
+            <div className="rotation-row">
+              <label className="compact-number-label">Rotation</label>
+              <input
+                type="number"
+                className="rotation-input"
+                value={
+                  rotationUnit === 'degrees'
+                    ? Math.round((shape.rotation * 180) / Math.PI)
+                    : Math.round(shape.rotation * 1000) / 1000
+                }
+                step={rotationUnit === 'degrees' ? 1 : 0.05}
+                onChange={(e) => {
+                  const v = Number(e.target.value);
+                  if (Number.isNaN(v)) return;
+                  const rad = rotationUnit === 'degrees' ? (v * Math.PI) / 180 : v;
+                  handleBulkUpdate({ rotation: rad });
+                }}
+              />
+              <div className="rotation-unit-toggle" role="group" aria-label="Rotation unit">
+                <button
+                  type="button"
+                  className={rotationUnit === 'degrees' ? 'active' : ''}
+                  onClick={() => setRotationUnit('degrees')}
+                  title="Degrees"
+                >
+                  °
+                </button>
+                <button
+                  type="button"
+                  className={rotationUnit === 'radians' ? 'active' : ''}
+                  onClick={() => setRotationUnit('radians')}
+                  title="Radians"
+                >
+                  rad
+                </button>
+              </div>
+            </div>
           </PropertySection>
         )}
 


### PR DESCRIPTION
Three follow-up fixes to the property panel.

## 1. Color palette
- **Native picker applies immediately.** Picking a colour in the palette's native picker only updated the custom *preview* — `handleNativePickerChange` never called `onChange`, so nothing applied until you opened the hex field and hit Apply. It now applies on pick.
- **Bounded width.** The palette popup stretched across the screen (it used `minWidth` with no upper bound). It now has a bounded width (clamped 232–264px) with its left edge clamped on-screen.

## 2. Checkbox styling
Inline `<label><input type="checkbox"><span>…</span></label>` rows (e.g. "Shrink text to fit") had no styling — a tiny native checkbox next to oversized, baseline-misaligned text. A scoped rule (`.compact-checkbox-row label:not(.compact-checkbox-label)` + the native checkbox) aligns them, sets a consistent 15px box with `accent-color`, and matches the panel's font size. The custom `.compact-checkbox` opts out via `:not()`, so it's untouched.

## 3. Rotation unit toggle (feat)
Position → Rotation was a read-only degrees label. It's now an **editable** field with a **°/rad toggle**. The unit is a persisted UI preference (`uiPreferencesStore`, default degrees); the input converts to/from the stored radians on edit.

## Verification
- `bun run typecheck` clean; `bun run test --run` → **2230 passed**. OSS leak grep clean.
- Manual: pick a colour in the native picker → applies at once; open a Fill/Stroke palette → it's a sensible width, not full-screen; the "Shrink text to fit"-style checkboxes look aligned; rotate a shape and toggle °/rad → value converts and edits both ways.

Assisted-by: Opus 4.8