### PR TITLE
feat(prose): add `/` slash command menu

### DIFF
--- a/src/tiptap/SlashMenu.css
+++ b/src/tiptap/SlashMenu.css
@@ -1,0 +1,61 @@
+/* SlashMenu — `/` command palette popup. Mirrors the CitationSuggestion popup. */
+
+.slash-menu {
+  position: fixed;
+  z-index: 1100; /* above the editor; below modal dialogs (1000 overlay + content) */
+  min-width: 240px;
+  max-width: min(360px, 90vw);
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.18));
+  padding: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.slash-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  padding: 0.4rem 0.55rem;
+  cursor: pointer;
+}
+
+.slash-menu-item:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+}
+
+.slash-menu-item.is-active {
+  background: var(--accent-soft, rgba(80, 120, 200, 0.18));
+}
+
+.slash-menu-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.slash-menu-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.slash-menu-group {
+  flex: none;
+  font-size: 0.72rem;
+  color: var(--text-secondary, rgba(127, 127, 127, 0.9));
+}

--- a/src/tiptap/SlashMenu.ts
+++ b/src/tiptap/SlashMenu.ts
@@ -1,0 +1,64 @@
+/**
+ * SlashMenu — the `/` command palette for prose.
+ *
+ * Typing `/` at a word boundary opens a dropdown of insert commands
+ * (`slashCommands.ts`), filtered live by what you type; picking one removes the
+ * `/query` token and runs the command. It's the fast path next to the toolbar's
+ * Insert tab, and the discovery surface every later prose feature plugs into
+ * (each new node registers a `SlashCommand`).
+ *
+ * Built on the shared `createTriggerPlugin` factory (the generalized
+ * `CitationSuggestion` mechanism), so it works identically in both prose editors
+ * when shared via `sharedProseExtensions`. It owns no nodes/marks, so the headless
+ * schema (`registerProseSchema`) and collab are unaffected.
+ */
+
+import { Extension } from '@tiptap/core';
+import { PluginKey } from '@tiptap/pm/state';
+import { createTriggerPlugin, type TriggerState } from './triggerPlugin';
+import { matchSlashTrigger, filterCommands, type SlashCommand } from './slashCommands';
+import './SlashMenu.css';
+
+const slashMenuKey = new PluginKey<TriggerState>('slashMenu');
+
+/** Build a row: command title with a muted group label on the right. */
+function renderSlashRow(command: SlashCommand): HTMLElement {
+  const row = document.createElement('span');
+  row.className = 'slash-menu-row';
+
+  const title = document.createElement('span');
+  title.className = 'slash-menu-title';
+  title.textContent = command.title;
+  row.appendChild(title);
+
+  const group = document.createElement('span');
+  group.className = 'slash-menu-group';
+  group.textContent = command.group;
+  row.appendChild(group);
+
+  return row;
+}
+
+export const SlashMenu = Extension.create({
+  name: 'slashMenu',
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    return [
+      createTriggerPlugin<SlashCommand>({
+        pluginKey: slashMenuKey,
+        popupClass: 'slash-menu',
+        match: matchSlashTrigger,
+        getItems: (query) => filterCommands(query),
+        rowKey: (command) => command.id,
+        renderRow: renderSlashRow,
+        commit: (view, command, range) => {
+          // Remove the `/query` token first, then run the command so the insert
+          // lands at a clean caret (and the trigger state resets on the delete).
+          view.dispatch(view.state.tr.delete(range.from, range.to));
+          command.run(editor);
+        },
+      }),
+    ];
+  },
+});

--- a/src/tiptap/slashCommands.test.ts
+++ b/src/tiptap/slashCommands.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the slash-menu matcher + filter (the pure, DOM-free parts).
+ * Mirrors CitationSuggestion.test.ts.
+ */
+
+import { matchSlashTrigger, filterCommands, SLASH_COMMANDS } from './slashCommands';
+
+describe('matchSlashTrigger', () => {
+  it('matches a bare slash at the start of a block', () => {
+    expect(matchSlashTrigger('/')).toEqual({ query: '', from: 0 });
+  });
+
+  it('captures the query typed after the slash', () => {
+    expect(matchSlashTrigger('/head')).toEqual({ query: 'head', from: 0 });
+  });
+
+  it('matches a slash after whitespace and reports the slash offset', () => {
+    // "foo /tab" → the `/` sits at index 4.
+    expect(matchSlashTrigger('foo /tab')).toEqual({ query: 'tab', from: 4 });
+  });
+
+  it('does not fire inside a URL (slash not at a word boundary)', () => {
+    expect(matchSlashTrigger('see http://')).toBeNull();
+  });
+
+  it('does not fire inside a path segment', () => {
+    expect(matchSlashTrigger('a/b')).toBeNull();
+  });
+
+  it('does not match when the query contains a space (token ended)', () => {
+    expect(matchSlashTrigger('/head ')).toBeNull();
+  });
+
+  it('returns null when there is no slash', () => {
+    expect(matchSlashTrigger('hello world')).toBeNull();
+  });
+});
+
+describe('filterCommands', () => {
+  it('returns the first `limit` commands for an empty query', () => {
+    const out = filterCommands('', 5);
+    expect(out).toHaveLength(5);
+    expect(out[0]).toBe(SLASH_COMMANDS[0]);
+  });
+
+  it('matches against the title', () => {
+    const ids = filterCommands('heading').map((c) => c.id);
+    expect(ids).toContain('h1');
+    expect(ids).toContain('h2');
+  });
+
+  it('matches against keywords', () => {
+    const ids = filterCommands('todo').map((c) => c.id);
+    expect(ids).toContain('task');
+  });
+
+  it('matches against the id', () => {
+    const ids = filterCommands('hr').map((c) => c.id);
+    expect(ids).toContain('divider');
+  });
+
+  it('is case-insensitive', () => {
+    expect(filterCommands('TABLE').map((c) => c.id)).toContain('table');
+  });
+
+  it('returns nothing for a non-matching query', () => {
+    expect(filterCommands('zzzznope')).toEqual([]);
+  });
+
+  it('respects the limit', () => {
+    expect(filterCommands('', 3)).toHaveLength(3);
+  });
+});

--- a/src/tiptap/slashCommands.ts
+++ b/src/tiptap/slashCommands.ts
@@ -1,0 +1,104 @@
+/**
+ * slashCommands — the `/` command registry + matcher for the prose slash menu.
+ *
+ * Each command is a small descriptor the `SlashMenu` extension renders and runs.
+ * Most commands delegate to the shared `editorCommands` helpers (the same ones the
+ * toolbar + context menu use) so a slash insert and a toolbar insert are identical.
+ *
+ * A couple of inserts (image upload, citation picker) are driven by React UI that
+ * lives outside the editor, so they go through a tiny handler seam
+ * (`registerSlashUiHandler`) — the React component registers the handler on mount,
+ * and the slash command invokes it. When no handler is registered (e.g. a headless
+ * editor), those commands are harmless no-ops. Later slices (Fields, file embed,
+ * callouts, …) append to `SLASH_COMMANDS`.
+ */
+
+import type { Editor } from '@tiptap/core';
+import * as cmd from '../ui/editorCommands';
+
+/** A single `/` command. `group` buckets related commands in the menu. */
+export interface SlashCommand {
+  id: string;
+  title: string;
+  /** Extra search terms (matched case-insensitively alongside the title/id). */
+  keywords: string[];
+  group: string;
+  run: (editor: Editor) => void;
+}
+
+// ─── UI-flow seam (inserts whose UI lives in React) ──────────────────────────
+
+/** Inserts that open React UI rather than running a pure editor command. */
+export type SlashUiAction = 'image' | 'citation';
+
+const uiHandlers = new Map<SlashUiAction, () => void>();
+
+/**
+ * Register the handler for a UI-flow slash command (image upload / citation
+ * picker). Call from a React effect; the returned function unregisters it.
+ * Identity-checked on cleanup so a remount doesn't clobber a newer handler.
+ */
+export function registerSlashUiHandler(action: SlashUiAction, fn: () => void): () => void {
+  uiHandlers.set(action, fn);
+  return () => {
+    if (uiHandlers.get(action) === fn) uiHandlers.delete(action);
+  };
+}
+
+function runUi(action: SlashUiAction): void {
+  uiHandlers.get(action)?.();
+}
+
+// ─── The registry ────────────────────────────────────────────────────────────
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { id: 'h1', title: 'Heading 1', keywords: ['h1', 'title', 'heading'], group: 'Headings', run: (e) => cmd.setHeading(e, 1) },
+  { id: 'h2', title: 'Heading 2', keywords: ['h2', 'subtitle', 'heading'], group: 'Headings', run: (e) => cmd.setHeading(e, 2) },
+  { id: 'h3', title: 'Heading 3', keywords: ['h3', 'heading'], group: 'Headings', run: (e) => cmd.setHeading(e, 3) },
+  { id: 'paragraph', title: 'Text', keywords: ['paragraph', 'body', 'plain'], group: 'Basic', run: (e) => cmd.setParagraph(e) },
+  { id: 'bullet', title: 'Bulleted list', keywords: ['ul', 'bullet', 'list', 'unordered'], group: 'Lists', run: (e) => cmd.toggleBulletList(e) },
+  { id: 'ordered', title: 'Numbered list', keywords: ['ol', 'ordered', 'list', 'number'], group: 'Lists', run: (e) => cmd.toggleOrderedList(e) },
+  { id: 'task', title: 'Task list', keywords: ['todo', 'task', 'checklist', 'checkbox'], group: 'Lists', run: (e) => cmd.toggleTaskList(e) },
+  { id: 'quote', title: 'Quote', keywords: ['blockquote', 'quote'], group: 'Basic', run: (e) => cmd.toggleBlockquote(e) },
+  { id: 'code', title: 'Code block', keywords: ['code', 'pre', 'snippet'], group: 'Basic', run: (e) => cmd.toggleCodeBlock(e) },
+  { id: 'divider', title: 'Divider', keywords: ['hr', 'divider', 'rule', 'separator'], group: 'Basic', run: (e) => cmd.insertHorizontalRule(e) },
+  { id: 'table', title: 'Table', keywords: ['table', 'grid'], group: 'Insert', run: (e) => cmd.insertTable(e) },
+  { id: 'math', title: 'Math block', keywords: ['math', 'latex', 'equation', 'formula'], group: 'Insert', run: (e) => cmd.setMathBlock(e, '') },
+  { id: 'image', title: 'Image', keywords: ['image', 'picture', 'photo', 'upload'], group: 'Insert', run: () => runUi('image') },
+  { id: 'citation', title: 'Citation', keywords: ['cite', 'citation', 'reference', 'source'], group: 'References', run: () => runUi('citation') },
+  { id: 'bibliography', title: 'Bibliography', keywords: ['bibliography', 'references', 'works cited'], group: 'References', run: (e) => cmd.insertBibliography(e) },
+];
+
+// ─── Matcher + filter (pure, unit-tested) ────────────────────────────────────
+
+/**
+ * Match a slash trigger at the end of the text before the caret: a `/` at a word
+ * boundary (block start, or after whitespace), followed by the query (letters /
+ * digits, no spaces). Returns the query and the `/` offset within `textBefore`,
+ * or `null`. The boundary keeps it from firing inside URLs / paths (`http://`,
+ * `a/b`), where the `/` is preceded by a non-space character.
+ */
+export function matchSlashTrigger(textBefore: string): { query: string; from: number } | null {
+  const m = /(?:^|\s)\/([a-zA-Z0-9]*)$/.exec(textBefore);
+  if (!m) return null;
+  const query = m[1] ?? '';
+  const from = m.index + m[0].length - query.length - 1;
+  return { query, from };
+}
+
+/**
+ * Filter the registry by `query` (matched against title, id, and keywords). An
+ * empty query returns the first `limit` commands so a bare `/` shows the menu.
+ */
+export function filterCommands(query: string, limit = 8): SlashCommand[] {
+  const q = query.trim().toLowerCase();
+  const matched = q
+    ? SLASH_COMMANDS.filter(
+        (c) =>
+          c.title.toLowerCase().includes(q) ||
+          c.id.includes(q) ||
+          c.keywords.some((k) => k.includes(q))
+      )
+    : SLASH_COMMANDS;
+  return matched.slice(0, limit);
+}

--- a/src/tiptap/triggerPlugin.ts
+++ b/src/tiptap/triggerPlugin.ts
@@ -1,0 +1,246 @@
+/**
+ * triggerPlugin — a reusable inline character-trigger autocomplete for prose.
+ *
+ * This is the generalized core of `CitationSuggestion.ts` (the `@`-cite popup):
+ * a hand-rolled ProseMirror suggestion plugin (no `@tiptap/suggestion` / tippy
+ * dependency — keeping the AGPL bundle lean) that watches the text before the
+ * caret, and when a configured trigger token is present, shows an imperative
+ * dropdown of items with keyboard nav, committing the highlighted item back into
+ * the document. The popup is a plain DOM element managed by the plugin's `view`,
+ * so it works identically in both prose editors (local `TiptapEditor` and the
+ * relay `CollaborativeProseEditor`) when shared via `sharedProseExtensions`.
+ *
+ * Everything trigger-specific (the match regex, the item source, how a row
+ * renders, and how a chosen item is inserted) is injected via `TriggerPluginConfig`
+ * so a single, tested mechanism backs the `/` slash menu and the Fields `{{`
+ * trigger without copy-paste. `CitationSuggestion` predates this and keeps its own
+ * copy for now; it can migrate onto this factory later.
+ */
+
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+/** A trigger match: the query typed after the trigger char + the char's offset. */
+export interface TriggerMatch {
+  query: string;
+  /** Offset of the trigger char within the matched `textBefore`. */
+  from: number;
+}
+
+/** Document range of the active trigger token (the char + its query). */
+export interface TriggerRange {
+  from: number;
+  to: number;
+}
+
+/** Plugin state. `from === null` means inactive. */
+export interface TriggerState {
+  /** Doc position of the trigger char, or `null` when inactive. */
+  from: number | null;
+  /** Doc position of the caret (end of the trigger token). */
+  to: number;
+  /** The query typed after the trigger char (may be empty). */
+  query: string;
+  /** Highlighted row index into the current results. */
+  index: number;
+  /** True once the user dismissed (Escape) this token — stays closed until it changes. */
+  closed: boolean;
+}
+
+type TriggerMeta = { type: 'move'; dir: 1 | -1 } | { type: 'close' };
+
+const INACTIVE: TriggerState = { from: null, to: 0, query: '', index: 0, closed: false };
+
+/** Default number of rows shown in the dropdown. */
+const DEFAULT_MAX_RESULTS = 8;
+
+export interface TriggerPluginConfig<T> {
+  /** Unique plugin key — one per trigger (so multiple triggers can coexist). */
+  pluginKey: PluginKey<TriggerState>;
+  /** CSS class applied to the popup container. */
+  popupClass: string;
+  /** Max rows shown (defaults to 8). */
+  maxResults?: number;
+  /**
+   * Match the trigger token at the END of the text preceding the caret. Return
+   * the query and the trigger char's offset within `textBefore`, or `null` when
+   * no trigger is active. Pure + exported per-trigger for unit testing.
+   */
+  match(textBefore: string): TriggerMatch | null;
+  /** The items offered for `query` (the factory also slices to `maxResults`). */
+  getItems(query: string): T[];
+  /** Stable key per item — used to cheaply gate popup re-renders. */
+  rowKey(item: T): string;
+  /** Build a row's inner content element (factory wraps it in the button + click). */
+  renderRow(item: T): HTMLElement;
+  /**
+   * Insert the chosen `item`, replacing `range` (the trigger token). The consumer
+   * dispatches its own transaction(s); removing the token text resets the trigger
+   * state on the next `apply`, so no explicit close is required.
+   */
+  commit(view: EditorView, item: T, range: TriggerRange): void;
+}
+
+/** The items currently offered for `state` (empty when inactive/dismissed). */
+function resultsFor<T>(state: TriggerState, config: TriggerPluginConfig<T>): T[] {
+  if (state.from === null || state.closed) return [];
+  return config.getItems(state.query).slice(0, config.maxResults ?? DEFAULT_MAX_RESULTS);
+}
+
+/**
+ * Commit the highlighted (or explicitly given) item. Returns true when something
+ * was inserted. Shared by the Enter/Tab keybinding and the popup's click handler.
+ */
+function commitActive<T>(view: EditorView, config: TriggerPluginConfig<T>, item?: T): boolean {
+  const state = config.pluginKey.getState(view.state);
+  if (!state || state.from === null) return false;
+  const results = resultsFor(state, config);
+  const chosen = item ?? results[state.index];
+  if (!chosen) return false;
+  config.commit(view, chosen, { from: state.from, to: state.to });
+  view.focus();
+  return true;
+}
+
+/**
+ * Build a ProseMirror plugin for the given trigger config. Add it to a Tiptap
+ * `Extension`'s `addProseMirrorPlugins()`.
+ */
+export function createTriggerPlugin<T>(config: TriggerPluginConfig<T>): Plugin<TriggerState> {
+  const { pluginKey } = config;
+
+  return new Plugin<TriggerState>({
+    key: pluginKey,
+
+    state: {
+      init: () => INACTIVE,
+      apply(tr, value, _old, newState): TriggerState {
+        const meta = tr.getMeta(pluginKey) as TriggerMeta | undefined;
+        if (meta?.type === 'move') {
+          if (value.from === null) return value;
+          const len = resultsFor(value, config).length;
+          if (len === 0) return value;
+          return { ...value, index: (value.index + meta.dir + len) % len };
+        }
+        if (meta?.type === 'close') {
+          return value.from === null ? value : { ...value, closed: true };
+        }
+
+        // Recompute the active token from the caret position.
+        const sel = newState.selection;
+        if (!sel.empty || !sel.$from.parent.isTextblock) return INACTIVE;
+        const $from = sel.$from;
+        // Inline atoms (e.g. an existing citation) count as one placeholder char
+        // so positions stay aligned with the text offsets we match against.
+        const textBefore = $from.parent.textBetween(0, $from.parentOffset, undefined, '￼');
+        const match = config.match(textBefore);
+        if (!match) return INACTIVE;
+
+        const from = $from.start() + match.from;
+        const to = sel.from;
+        // Same token as before → preserve the user's dismissal + highlight.
+        if (value.from === from && value.query === match.query) {
+          return { ...value, from, to };
+        }
+        return { from, to, query: match.query, index: 0, closed: false };
+      },
+    },
+
+    props: {
+      handleKeyDown(view, event) {
+        const state = pluginKey.getState(view.state);
+        if (!state || state.from === null || state.closed) return false;
+        if (event.key === 'Escape') {
+          view.dispatch(view.state.tr.setMeta(pluginKey, { type: 'close' } satisfies TriggerMeta));
+          return true;
+        }
+        // Only capture navigation/commit keys when there's something to pick.
+        if (resultsFor(state, config).length === 0) return false;
+        if (event.key === 'ArrowDown') {
+          view.dispatch(view.state.tr.setMeta(pluginKey, { type: 'move', dir: 1 } satisfies TriggerMeta));
+          return true;
+        }
+        if (event.key === 'ArrowUp') {
+          view.dispatch(view.state.tr.setMeta(pluginKey, { type: 'move', dir: -1 } satisfies TriggerMeta));
+          return true;
+        }
+        if (event.key === 'Enter' || event.key === 'Tab') {
+          return commitActive(view, config);
+        }
+        return false;
+      },
+    },
+
+    view: (editorView) => new TriggerPopup<T>(editorView, config),
+  });
+}
+
+/** Imperative dropdown rendered next to the caret while a trigger is active. */
+class TriggerPopup<T> {
+  private readonly dom: HTMLDivElement;
+  private rendered = '';
+
+  constructor(
+    private readonly view: EditorView,
+    private readonly config: TriggerPluginConfig<T>
+  ) {
+    this.dom = document.createElement('div');
+    this.dom.className = config.popupClass;
+    this.dom.style.display = 'none';
+    // Keep the editor selection on mousedown so a click doesn't blur/collapse.
+    this.dom.addEventListener('mousedown', (e) => e.preventDefault());
+    document.body.appendChild(this.dom);
+    this.update();
+  }
+
+  update(): void {
+    const state = this.config.pluginKey.getState(this.view.state);
+    const results = state ? resultsFor(state, this.config) : [];
+    if (!state || state.from === null || results.length === 0) {
+      this.hide();
+      return;
+    }
+    // Cheap render gate: rebuild only when the visible set/selection changes.
+    const signature = `${state.index}|${results.map((r) => this.config.rowKey(r)).join(',')}`;
+    if (signature !== this.rendered) {
+      this.renderList(results, state.index);
+      this.rendered = signature;
+    }
+    this.position(state.from);
+  }
+
+  private renderList(results: T[], index: number): void {
+    this.dom.replaceChildren();
+    results.forEach((item, i) => {
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = i === index ? `${this.config.popupClass}-item is-active` : `${this.config.popupClass}-item`;
+      row.appendChild(this.config.renderRow(item));
+      row.addEventListener('click', () => commitActive(this.view, this.config, item));
+      this.dom.appendChild(row);
+    });
+    this.dom.style.display = 'block';
+  }
+
+  private position(from: number): void {
+    try {
+      const coords = this.view.coordsAtPos(from);
+      this.dom.style.left = `${Math.round(coords.left)}px`;
+      this.dom.style.top = `${Math.round(coords.bottom + 4)}px`;
+    } catch {
+      // coordsAtPos can throw mid-transaction for a stale position; the next
+      // update repositions, so just keep the popup where it is.
+    }
+  }
+
+  private hide(): void {
+    if (this.dom.style.display !== 'none') {
+      this.dom.style.display = 'none';
+      this.rendered = '';
+    }
+  }
+
+  destroy(): void {
+    this.dom.remove();
+  }
+}

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { useTiptapEditor } from './TiptapEditorContext';
 import * as cmd from './editorCommands';
+import { registerSlashUiHandler } from '../tiptap/slashCommands';
 import { ImageUploadButton } from './ImageUploadButton';
 import { SearchReplacePanel } from './SearchReplacePanel';
 import { ToolbarDropdown } from './ToolbarDropdown';
@@ -59,6 +60,10 @@ export function DocumentEditorToolbar() {
   const [showLinkDialog, setShowLinkDialog] = useState(false);
   const [showCitationPicker, setShowCitationPicker] = useState(false);
   const [showRefManager, setShowRefManager] = useState(false);
+
+  // Let the `/citation` slash command open the citation picker (the picker is
+  // React UI outside the editor). No-op headless: nothing registered.
+  useEffect(() => registerSlashUiHandler('citation', () => setShowCitationPicker(true)), []);
 
   // Subscribe to editor events for toolbar state updates
   useEffect(() => {

--- a/src/ui/ImageUploadButton.tsx
+++ b/src/ui/ImageUploadButton.tsx
@@ -8,12 +8,13 @@
  * - Inserts blob:// URLs into editor
  */
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
 import { Icon } from './icons';
 import { useTiptapEditor } from './TiptapEditorContext';
 import { blobStorage } from '../storage/BlobStorage';
 import { processImageForUpload, formatFileSize } from '../utils/imageUtils';
+import { registerSlashUiHandler } from '../tiptap/slashCommands';
 
 export interface ImageUploadButtonProps {
   /** Optional class name */
@@ -72,6 +73,10 @@ export function ImageUploadButton({ className }: ImageUploadButtonProps) {
   const handleClick = () => {
     inputRef.current?.click();
   };
+
+  // Let the `/image` slash command open this same file picker (the upload flow
+  // lives here, not in the editor). No-op headless: nothing registered.
+  useEffect(() => registerSlashUiHandler('image', () => inputRef.current?.click()), []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -41,6 +41,7 @@ import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
 import { CitationSuggestion } from '../tiptap/CitationSuggestion';
+import { SlashMenu } from '../tiptap/SlashMenu';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
@@ -164,6 +165,9 @@ export const sharedProseExtensions = [
   // inserts that node). No nodes/marks of its own, so the shared schema is
   // unaffected (safe for the headless `registerProseSchema` below + collab).
   CitationSuggestion,
+  // `/`-trigger command palette. Inserts existing nodes (no nodes/marks of its
+  // own), so the shared schema + collab are unaffected — like CitationSuggestion.
+  SlashMenu,
   EmbeddedGroup,
 ];
 


### PR DESCRIPTION
## What

Adds a `/` slash command palette to the prose editor — the first slice of the pre-launch prose feature epic. It's the discovery surface every later prose feature plugs into (each new node registers a `SlashCommand`) and a fast path next to the Insert tab.

Type `/` at a word boundary → a filtered dropdown of insert commands → Enter/click removes the `/query` token and runs the command.

## How

- **`triggerPlugin.ts`** — generalizes `CitationSuggestion`'s hand-rolled `@`-trigger plugin into a reusable `createTriggerPlugin({ match, getItems, rowKey, renderRow, commit })` factory (imperative popup, keyboard nav, no `@tiptap/suggestion`/tippy dependency). Shared infra so the slash `/` and the upcoming Fields `{{` trigger aren't copy-paste of each other. `CitationSuggestion` keeps its own copy for now and can migrate onto this later.
- **`slashCommands.ts`** — the `/` registry. Most commands delegate to the shared `editorCommands` helpers (the same ones the toolbar + context menu use), so a slash insert and a toolbar insert are identical. Image upload + citation picker live in React, so they go through a tiny `registerSlashUiHandler` seam — no-op when headless. Pure `matchSlashTrigger` + `filterCommands` for testing.
- **`SlashMenu.ts` / `.css`** — the Tiptap extension, shared via `sharedProseExtensions` so both the local `TiptapEditor` and the relay `CollaborativeProseEditor` get it. Owns **no nodes/marks**, so the headless schema (`registerProseSchema`) and collab are unaffected (same property as `CitationSuggestion`).
- Wire the **image** (`ImageUploadButton`) and **citation-picker** (`DocumentEditorToolbar`) handlers into the seam.

## Notes / follow-ups

- Rows are text (title + group label); lucide icons in rows were deferred to avoid rendering React components into the imperative popup — easy follow-up.
- Seeded commands: headings, text, lists (bullet/numbered/task), quote, code block, divider, table, math block, image, citation, bibliography. Later slices (callouts, fields, file embed, …) append to the registry.

## Verification

- `bun run typecheck` ✅
- `bun run test --run` — **2244 passed** (incl. 14 new `slashCommands.test.ts`) ✅
- `bun run build` ✅ (only the pre-existing chunk-size warning)

Manual: type `/`, filter, Enter/click inserts; `/image` opens the upload picker; `/citation` opens the picker dialog.

Assisted-by: Opus 4.8