### PR TITLE
feat(prose): add callout/admonition blocks

### DIFF
--- a/src/tiptap/CalloutExtension.css
+++ b/src/tiptap/CalloutExtension.css
@@ -1,0 +1,56 @@
+/* Callout (admonition) blocks. Presentation only — the variant label is a
+   CSS ::before, never serialized into the document. Colours use rgba tints so
+   they read on both the light (warm-paper) and dark (navy) themes. */
+
+.callout {
+  position: relative;
+  margin: 0.75rem 0;
+  padding: 0.55rem 0.85rem 0.6rem 1rem;
+  border-left: 3px solid var(--callout-accent);
+  border-radius: 4px;
+  background: var(--callout-bg);
+}
+
+.callout > :first-child {
+  margin-top: 0;
+}
+
+.callout > :last-child {
+  margin-bottom: 0;
+}
+
+/* Variant label header (e.g. "WARNING") — purely presentational. */
+.callout::before {
+  content: var(--callout-label);
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--callout-accent);
+}
+
+.callout[data-variant='note'] {
+  --callout-accent: #4a86e8;
+  --callout-bg: rgba(74, 134, 232, 0.08);
+  --callout-label: 'Note';
+}
+
+.callout[data-variant='tip'] {
+  --callout-accent: #2e9e5b;
+  --callout-bg: rgba(46, 158, 91, 0.1);
+  --callout-label: 'Tip';
+}
+
+.callout[data-variant='warning'] {
+  --callout-accent: #d99a00;
+  --callout-bg: rgba(217, 154, 0, 0.12);
+  --callout-label: 'Warning';
+}
+
+.callout[data-variant='danger'] {
+  --callout-accent: #d64545;
+  --callout-bg: rgba(214, 69, 69, 0.1);
+  --callout-label: 'Danger';
+}

--- a/src/tiptap/CalloutExtension.test.ts
+++ b/src/tiptap/CalloutExtension.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the Callout node. Headless via `new Editor` in jsdom (same pattern
+ * as CitationExtension.test.ts). Covers the sync schema round-trip
+ * (renderHTML/parseHTML) and the wrap/re-style/lift commands.
+ */
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Callout } from './CalloutExtension';
+
+const extensions = [StarterKit.configure({ history: false }), Callout];
+
+function makeEditor(content = '<p>Hello world</p>'): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content });
+  return { editor, element };
+}
+
+/** Count occurrences of `data-callout` in the serialized HTML. */
+function calloutCount(html: string): number {
+  return html.split('data-callout').length - 1;
+}
+
+describe('callout schema round-trip', () => {
+  it('setCallout wraps the block in a callout with the default variant', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.setCallout();
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-callout');
+    expect(html).toContain('data-variant="note"');
+    expect(html).toContain('Hello world');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('emits the chosen variant', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.setCallout('warning');
+    expect(editor.getHTML()).toContain('data-variant="warning"');
+    editor.destroy();
+    element.remove();
+  });
+
+  it('parses callout HTML back into a node, preserving variant + content', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.setContent('<div data-callout data-variant="danger"><p>Careful</p></div>');
+
+    expect(editor.isActive('callout')).toBe(true);
+    const html = editor.getHTML();
+    expect(html).toContain('data-variant="danger"');
+    expect(html).toContain('Careful');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('coerces an unknown variant to note on parse', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.setContent('<div data-callout data-variant="bogus"><p>x</p></div>');
+    expect(editor.getHTML()).toContain('data-variant="note"');
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('callout commands', () => {
+  it('setCallout while inside a callout re-styles it rather than nesting', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.setCallout('note');
+    editor.commands.setCallout('danger');
+
+    const html = editor.getHTML();
+    expect(calloutCount(html)).toBe(1); // not nested
+    expect(html).toContain('data-variant="danger"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('unsetCallout lifts the content back out', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.setCallout('tip');
+    expect(editor.isActive('callout')).toBe(true);
+
+    editor.commands.unsetCallout();
+    expect(editor.isActive('callout')).toBe(false);
+    expect(editor.getHTML()).not.toContain('data-callout');
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/CalloutExtension.ts
+++ b/src/tiptap/CalloutExtension.ts
@@ -1,0 +1,100 @@
+/**
+ * Callout extension for Tiptap — admonition blocks (note / tip / warning /
+ * danger).
+ *
+ * A `callout` is a `block+` container (like blockquote) carrying a single
+ * `variant` attribute that selects the colour + label. It's a plain
+ * structural node: sync `parseHTML`/`renderHTML` round-trip a clean
+ * `<div data-callout data-variant="…">`, and all presentation (the coloured
+ * left border, tint, and the uppercase variant label) is CSS-only — the label
+ * is a `::before` from the stylesheet, never serialized into the document, so
+ * `getHTML()` → PDF / MCP / offline stay self-contained without it.
+ *
+ * No nodeView (no async, no store) — the simplest of the new prose nodes, so it
+ * validates the slash/insert + serialization path before the heavier slices.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+import './CalloutExtension.css';
+
+export type CalloutVariant = 'note' | 'tip' | 'warning' | 'danger';
+
+const VARIANTS: readonly CalloutVariant[] = ['note', 'tip', 'warning', 'danger'];
+
+/** Coerce an arbitrary attribute value to a known variant (default `note`). */
+function asVariant(value: unknown): CalloutVariant {
+  return VARIANTS.includes(value as CalloutVariant) ? (value as CalloutVariant) : 'note';
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    callout: {
+      /** Wrap the selection in a callout, or re-style the current one. */
+      setCallout: (variant?: CalloutVariant) => ReturnType;
+      /** Toggle a callout wrap around the selection. */
+      toggleCallout: (variant?: CalloutVariant) => ReturnType;
+      /** Lift the selection out of its callout. */
+      unsetCallout: () => ReturnType;
+    };
+  }
+}
+
+export interface CalloutOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const Callout = Node.create<CalloutOptions>({
+  name: 'callout',
+  group: 'block',
+  content: 'block+',
+  defining: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      variant: {
+        default: 'note' as CalloutVariant,
+        parseHTML: (el: HTMLElement) => asVariant(el.getAttribute('data-variant')),
+        renderHTML: (attrs) => ({ 'data-variant': asVariant(attrs['variant']) }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-callout]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-callout': '',
+        class: 'callout',
+      }),
+      0,
+    ];
+  },
+
+  addCommands() {
+    return {
+      setCallout:
+        (variant = 'note') =>
+        ({ commands, editor }) =>
+          // Already in a callout → just change its variant; otherwise wrap.
+          editor.isActive(this.name)
+            ? commands.updateAttributes(this.name, { variant: asVariant(variant) })
+            : commands.wrapIn(this.name, { variant: asVariant(variant) }),
+      toggleCallout:
+        (variant = 'note') =>
+        ({ commands }) =>
+          commands.toggleWrap(this.name, { variant: asVariant(variant) }),
+      unsetCallout:
+        () =>
+        ({ commands }) =>
+          commands.lift(this.name),
+    };
+  },
+});

--- a/src/tiptap/slashCommands.ts
+++ b/src/tiptap/slashCommands.ts
@@ -62,6 +62,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { id: 'quote', title: 'Quote', keywords: ['blockquote', 'quote'], group: 'Basic', run: (e) => cmd.toggleBlockquote(e) },
   { id: 'code', title: 'Code block', keywords: ['code', 'pre', 'snippet'], group: 'Basic', run: (e) => cmd.toggleCodeBlock(e) },
   { id: 'divider', title: 'Divider', keywords: ['hr', 'divider', 'rule', 'separator'], group: 'Basic', run: (e) => cmd.insertHorizontalRule(e) },
+  { id: 'callout', title: 'Callout', keywords: ['callout', 'note', 'admonition', 'aside', 'info', 'warning'], group: 'Basic', run: (e) => cmd.setCallout(e, 'note') },
   { id: 'table', title: 'Table', keywords: ['table', 'grid'], group: 'Insert', run: (e) => cmd.insertTable(e) },
   { id: 'math', title: 'Math block', keywords: ['math', 'latex', 'equation', 'formula'], group: 'Insert', run: (e) => cmd.setMathBlock(e, '') },
   { id: 'image', title: 'Image', keywords: ['image', 'picture', 'photo', 'upload'], group: 'Insert', run: () => runUi('image') },

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -14,8 +14,9 @@ import {
   Highlighter, RemoveFormatting, List, ListOrdered, ListTodo, Quote, SquareCode,
   Link, AlignLeft, AlignCenter, AlignRight, AlignJustify,
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
-  BookMarked, Library,
+  BookMarked, Library, Info,
 } from 'lucide-react';
+import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
 import * as cmd from './editorCommands';
 import { registerSlashUiHandler } from '../tiptap/slashCommands';
@@ -60,6 +61,14 @@ export function DocumentEditorToolbar() {
   const [showLinkDialog, setShowLinkDialog] = useState(false);
   const [showCitationPicker, setShowCitationPicker] = useState(false);
   const [showRefManager, setShowRefManager] = useState(false);
+  const [showCalloutMenu, setShowCalloutMenu] = useState(false);
+
+  const CALLOUT_VARIANTS: { value: CalloutVariant; label: string }[] = [
+    { value: 'note', label: 'Note' },
+    { value: 'tip', label: 'Tip' },
+    { value: 'warning', label: 'Warning' },
+    { value: 'danger', label: 'Danger' },
+  ];
 
   // Let the `/citation` slash command open the citation picker (the picker is
   // React UI outside the editor). No-op headless: nothing registered.
@@ -353,6 +362,28 @@ export function DocumentEditorToolbar() {
               <button className="document-editor-toolbar-btn" onClick={() => editor && cmd.insertHorizontalRule(editor)} title="Horizontal Rule" aria-label="Horizontal rule">
                 <Minus {...ICON} />
               </button>
+            </div>
+
+
+            {/* Blocks */}
+            <div className="document-editor-toolbar-group">
+              <ToolbarDropdown
+                trigger={<Info {...ICON} />}
+                isOpen={showCalloutMenu}
+                onToggle={() => setShowCalloutMenu(!showCalloutMenu)}
+                onClose={() => setShowCalloutMenu(false)}
+                triggerClassName="document-editor-toolbar-btn"
+                title="Insert Callout"
+                isActive={isActive('callout')}
+              >
+                <div className="callout-variant-menu">
+                  {CALLOUT_VARIANTS.map(({ value, label }) => (
+                    <button key={value} onClick={() => { if (editor) cmd.setCallout(editor, value); setShowCalloutMenu(false); }}>
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </ToolbarDropdown>
             </div>
 
 

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -42,6 +42,7 @@ import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
 import { CitationSuggestion } from '../tiptap/CitationSuggestion';
 import { SlashMenu } from '../tiptap/SlashMenu';
+import { Callout } from '../tiptap/CalloutExtension';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
@@ -168,6 +169,10 @@ export const sharedProseExtensions = [
   // `/`-trigger command palette. Inserts existing nodes (no nodes/marks of its
   // own), so the shared schema + collab are unaffected — like CitationSuggestion.
   SlashMenu,
+  // Callout/admonition blocks (note/tip/warning/danger). Plain structural node
+  // (sync parse/render, no nodeView), so the headless schema + collab are
+  // unaffected — it serializes as a clean <div data-callout data-variant>.
+  Callout,
   EmbeddedGroup,
 ];
 

--- a/src/ui/ToolbarDropdown.css
+++ b/src/ui/ToolbarDropdown.css
@@ -52,15 +52,17 @@
   background: var(--bg-hover);
 }
 
-/* Table styles menu */
-.toolbar-dropdown-portal .table-styles-menu {
+/* Simple vertical button menu (table options, callout variants, …) */
+.toolbar-dropdown-portal .table-styles-menu,
+.toolbar-dropdown-portal .callout-variant-menu {
   display: flex;
   flex-direction: column;
   gap: var(--space-0-5);
   min-width: 160px;
 }
 
-.toolbar-dropdown-portal .table-styles-menu button {
+.toolbar-dropdown-portal .table-styles-menu button,
+.toolbar-dropdown-portal .callout-variant-menu button {
   display: block;
   width: 100%;
   padding: var(--space-2) var(--space-3);
@@ -74,6 +76,7 @@
   transition: background-color 0.15s ease;
 }
 
-.toolbar-dropdown-portal .table-styles-menu button:hover {
+.toolbar-dropdown-portal .table-styles-menu button:hover,
+.toolbar-dropdown-portal .callout-variant-menu button:hover {
   background: var(--bg-hover);
 }

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Editor } from '@tiptap/core';
+import type { CalloutVariant } from '../tiptap/CalloutExtension';
 
 // Text formatting
 export const toggleBold = (editor: Editor) => editor.chain().focus().toggleBold().run();
@@ -21,6 +22,10 @@ export const clearFormatting = (editor: Editor) => editor.chain().focus().unsetA
 export const toggleBlockquote = (editor: Editor) => editor.chain().focus().toggleBlockquote().run();
 export const toggleCodeBlock = (editor: Editor) => editor.chain().focus().toggleCodeBlock().run();
 export const insertHorizontalRule = (editor: Editor) => editor.chain().focus().setHorizontalRule().run();
+
+// Callouts — wrap the selection in an admonition (or re-style the current one).
+export const setCallout = (editor: Editor, variant: CalloutVariant) =>
+  editor.chain().focus().setCallout(variant).run();
 
 // Headings
 export const setHeading = (editor: Editor, level: 1 | 2 | 3 | 4 | 5 | 6) =>


### PR DESCRIPTION
## What

Phase 1a of the prose feature epic ([Notion: Prose Editor Features](https://app.notion.com/p/37e1694609d3816aab1bfdc59061799f)). Adds **callout / admonition blocks** — note, tip, warning, danger — the kind of block specs and contracts lean on constantly. It's intentionally the simplest of the new prose nodes, validating the insert + serialization path before the heavier slices (fields, layouts).

## How

- **`CalloutExtension.ts`** — a `block+` container (modelled on blockquote) with a single `variant` attribute. Sync `parseHTML`/`renderHTML` round-trip a clean `<div data-callout data-variant="…">`. Commands: `setCallout` (wrap the selection, or re-style the current callout instead of nesting), `toggleCallout`, `unsetCallout`. No nodeView and no store, so the headless schema (`registerProseSchema`) and collab are unaffected.
- **`CalloutExtension.css`** — coloured left border + tint per variant, and an uppercase variant label rendered **purely in CSS** (`::before`), so it is never serialized into the document — `getHTML()` → PDF / MCP / offline stay self-contained without it. `rgba` tints read on both the light (warm-paper) and dark (navy) themes.
- **Discovery** — added to `sharedProseExtensions`; an Insert-tab dropdown offers the four variants; a **`/callout` slash command** (Basic group); `editorCommands.setCallout`. Generalized the existing vertical-menu CSS to cover both the table-options and callout menus (no duplication).

## Notes

- Rebased onto master after the slash-menu PR (#206) merged, so the `/callout` slash entry ships **in this PR** rather than as a follow-up.
- Lucide icons in the callout (vs the CSS text label) can come with the later icon pass noted on #206.

## Verification

- `bun run typecheck` ✅
- `bun run test --run` — **2250 passed** (incl. 6 new `CalloutExtension.test.ts`: wrap, variant emit, parse round-trip, unknown-variant coercion, re-style-not-nest, lift) ✅
- `bun run build` ✅

Manual: Insert tab → callout dropdown, or type `/callout`, wraps the block; picking another variant while inside re-styles it.

Assisted-by: Opus 4.8