### PR TITLE
feat(prose): add collapsible toggle sections

### DIFF
--- a/src/tiptap/DetailsExtension.css
+++ b/src/tiptap/DetailsExtension.css
@@ -1,0 +1,66 @@
+/* Collapsible toggle sections. The disclosure triangle is a pure-CSS border
+   shape (no glyph/emoji); the body is hidden when the section is closed.
+   The `.details-body` wrapper exists only in the live nodeView — the static
+   getHTML() output nests the summary/content directly, and both shapes are
+   matched by the descendant selectors below. */
+
+.details {
+  position: relative;
+  margin: 0.5rem 0;
+  padding-left: 1.4em;
+}
+
+.details-toggle {
+  position: absolute;
+  left: 0;
+  top: 0.15em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1em;
+  height: 1.1em;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.details-toggle:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+}
+
+/* Triangle drawn with borders, rotated 90deg when open. */
+.details-toggle::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 5px solid var(--text-secondary, #888);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.15s ease;
+}
+
+.details[data-open='true'] .details-toggle::before {
+  transform: rotate(90deg);
+}
+
+.details-summary {
+  font-weight: 600;
+}
+
+.details-content {
+  margin-top: 0.25rem;
+}
+
+.details-content > :first-child {
+  margin-top: 0;
+}
+
+.details-content > :last-child {
+  margin-bottom: 0;
+}
+
+.details[data-open='false'] .details-content {
+  display: none;
+}

--- a/src/tiptap/DetailsExtension.test.ts
+++ b/src/tiptap/DetailsExtension.test.ts
@@ -71,3 +71,29 @@ describe('details open/close', () => {
     element.remove();
   });
 });
+
+describe('details summary Enter', () => {
+  it('exitSummaryToContent moves the caret from the summary into the body', () => {
+    const { editor, element } = makeEditor(DETAILS_HTML);
+    editor.commands.setTextSelection(3); // inside the summary ("Title")
+    expect(editor.state.selection.$from.parent.type.name).toBe('detailsSummary');
+
+    const moved = editor.commands.exitSummaryToContent();
+    expect(moved).toBe(true);
+
+    const { $from } = editor.state.selection;
+    expect($from.parent.type.name).toBe('paragraph');
+    expect($from.node($from.depth - 1).type.name).toBe('detailsContent');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('exitSummaryToContent is a no-op when the caret is already in the body', () => {
+    const { editor, element } = makeEditor(DETAILS_HTML);
+    editor.commands.setTextSelection(12); // inside the body paragraph
+    expect(editor.commands.exitSummaryToContent()).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/DetailsExtension.test.ts
+++ b/src/tiptap/DetailsExtension.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the Details (collapsible toggle) nodes. Headless via `new Editor`
+ * in jsdom (same pattern as CalloutExtension.test.ts). Covers the sync schema
+ * round-trip and the open/close attribute.
+ */
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Details, DetailsSummary, DetailsContent } from './DetailsExtension';
+
+const extensions = [StarterKit.configure({ history: false }), Details, DetailsSummary, DetailsContent];
+
+function makeEditor(content = '<p></p>'): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content });
+  return { editor, element };
+}
+
+const DETAILS_HTML =
+  '<div data-details data-open="true"><div data-details-summary>Title</div><div data-details-content><p>body text</p></div></div>';
+
+describe('details schema round-trip', () => {
+  it('insertDetails creates an open section with a summary + body', () => {
+    const { editor, element } = makeEditor();
+    editor.commands.insertDetails();
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-details');
+    expect(html).toContain('data-open="true"');
+    expect(html).toContain('data-details-summary');
+    expect(html).toContain('data-details-content');
+    expect(html).toContain('Toggle'); // seeded summary text
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('round-trips the summary + content from HTML', () => {
+    const { editor, element } = makeEditor(DETAILS_HTML);
+    const html = editor.getHTML();
+    expect(html).toContain('data-details-summary');
+    expect(html).toContain('Title');
+    expect(html).toContain('body text');
+    expect(html).toContain('data-open="true"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('preserves a closed (data-open="false") section', () => {
+    const { editor, element } = makeEditor(DETAILS_HTML.replace('data-open="true"', 'data-open="false"'));
+    expect(editor.getHTML()).toContain('data-open="false"');
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('details open/close', () => {
+  it('toggleDetailsOpen flips the open attribute when the selection is inside', () => {
+    const { editor, element } = makeEditor(DETAILS_HTML);
+    // Place the caret inside the summary text ("Title").
+    editor.commands.setTextSelection(3);
+    expect(editor.getHTML()).toContain('data-open="true"');
+
+    const toggled = editor.commands.toggleDetailsOpen();
+    expect(toggled).toBe(true);
+    expect(editor.getHTML()).toContain('data-open="false"');
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/DetailsExtension.ts
+++ b/src/tiptap/DetailsExtension.ts
@@ -18,6 +18,7 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import { TextSelection } from '@tiptap/pm/state';
 import './DetailsExtension.css';
 
 declare module '@tiptap/core' {
@@ -27,6 +28,8 @@ declare module '@tiptap/core' {
       insertDetails: () => ReturnType;
       /** Toggle the open/closed state of the details around the selection. */
       toggleDetailsOpen: () => ReturnType;
+      /** Move the caret from the summary into the body (the Enter behaviour). */
+      exitSummaryToContent: () => ReturnType;
     };
   }
 }
@@ -41,6 +44,9 @@ export const DetailsSummary = Node.create({
   content: 'inline*',
   defining: true,
   selectable: false,
+  // Above StarterKit (priority 100) so our Enter handler wins over its
+  // split-on-Enter (which can't split the single-summary schema → "stuck").
+  priority: 1000,
 
   parseHTML() {
     return [{ tag: 'div[data-details-summary]' }];
@@ -48,6 +54,15 @@ export const DetailsSummary = Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return ['div', mergeAttributes(HTMLAttributes, { 'data-details-summary': '', class: 'details-summary' }), 0];
+  },
+
+  // Enter in the title moves the caret into the body rather than trying (and
+  // failing) to split the summary. Down-arrow naturally does the same; this makes
+  // the common keystroke do the expected thing. (The command lives on `details`.)
+  addKeyboardShortcuts() {
+    return {
+      Enter: () => this.editor.commands.exitSummaryToContent(),
+    };
   },
 });
 
@@ -173,6 +188,21 @@ export const Details = Node.create<DetailsOptions>({
             }
           }
           return false;
+        },
+      exitSummaryToContent:
+        () =>
+        ({ state, dispatch }) => {
+          // Only when the caret is collapsed inside a detailsSummary: jump to the
+          // first text position of the sibling detailsContent (the body). The
+          // summary is a single-line title — it never splits, so Enter moves on.
+          const { $head, empty } = state.selection;
+          if (!empty || $head.parent.type.name !== 'detailsSummary') return false;
+          const afterSummary = $head.after($head.depth); // start of the detailsContent
+          if (dispatch) {
+            const sel = TextSelection.near(state.doc.resolve(afterSummary + 1), 1);
+            dispatch(state.tr.setSelection(sel).scrollIntoView());
+          }
+          return true;
         },
     };
   },

--- a/src/tiptap/DetailsExtension.ts
+++ b/src/tiptap/DetailsExtension.ts
@@ -1,0 +1,179 @@
+/**
+ * Details extension for Tiptap — collapsible toggle sections.
+ *
+ * Three nodes mirroring HTML <details>/<summary> but rendered as plain `<div>`s
+ * with `data-*` attributes (NOT native <details>/<summary>, whose built-in
+ * click-to-toggle fights cursor placement when editing the title):
+ *   - `details`        — block container, `content: 'detailsSummary detailsContent'`,
+ *                        an `open` attribute, and a nodeView with a disclosure
+ *                        triangle that toggles `open`.
+ *   - `detailsSummary` — the always-visible title (`inline*`).
+ *   - `detailsContent` — the collapsible body (`block+`), hidden by CSS when closed.
+ *
+ * Serialization is sync + div-based so `getHTML()` round-trips losslessly
+ * (PDF / MCP / offline) and re-parses cleanly. The disclosure triangle and the
+ * `.details-body` wrapper are nodeView-only chrome — never serialized. `open` is
+ * an ordinary attribute (a genuine user toggle), so it persists + syncs like any
+ * edit; no projection machinery needed.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+import './DetailsExtension.css';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    details: {
+      /** Insert a collapsible section (titled summary + a body paragraph). */
+      insertDetails: () => ReturnType;
+      /** Toggle the open/closed state of the details around the selection. */
+      toggleDetailsOpen: () => ReturnType;
+    };
+  }
+}
+
+export interface DetailsOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/** The collapsible title line. */
+export const DetailsSummary = Node.create({
+  name: 'detailsSummary',
+  content: 'inline*',
+  defining: true,
+  selectable: false,
+
+  parseHTML() {
+    return [{ tag: 'div[data-details-summary]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-details-summary': '', class: 'details-summary' }), 0];
+  },
+});
+
+/** The collapsible body. */
+export const DetailsContent = Node.create({
+  name: 'detailsContent',
+  content: 'block+',
+
+  parseHTML() {
+    return [{ tag: 'div[data-details-content]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-details-content': '', class: 'details-content' }), 0];
+  },
+});
+
+/** The container — summary + content, with an `open` flag and a toggle nodeView. */
+export const Details = Node.create<DetailsOptions>({
+  name: 'details',
+  group: 'block',
+  content: 'detailsSummary detailsContent',
+  defining: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      open: {
+        default: true,
+        parseHTML: (el: HTMLElement) =>
+          el.hasAttribute('data-open') ? el.getAttribute('data-open') !== 'false' : el.hasAttribute('open'),
+        renderHTML: (attrs) => ({ 'data-open': attrs['open'] ? 'true' : 'false' }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-details]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { 'data-details': '', class: 'details' }),
+      0,
+    ];
+  },
+
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement('div');
+      dom.className = 'details';
+      dom.setAttribute('data-details', '');
+      dom.setAttribute('data-open', node.attrs['open'] ? 'true' : 'false');
+
+      // Disclosure triangle — chrome (contentEditable=false), outside contentDOM
+      // so it isn't part of the document. Clicking toggles the `open` attr.
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'details-toggle';
+      toggle.contentEditable = 'false';
+      toggle.setAttribute('aria-label', 'Toggle section');
+      toggle.addEventListener('mousedown', (e) => e.preventDefault()); // keep selection
+      toggle.addEventListener('click', () => {
+        if (typeof getPos !== 'function') return;
+        const pos = getPos();
+        if (pos == null) return;
+        const cur = editor.state.doc.nodeAt(pos);
+        if (!cur || cur.type.name !== this.name) return;
+        editor.view.dispatch(
+          editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, open: !cur.attrs['open'] })
+        );
+      });
+
+      // contentDOM holds the summary + content children.
+      const body = document.createElement('div');
+      body.className = 'details-body';
+
+      dom.appendChild(toggle);
+      dom.appendChild(body);
+
+      return {
+        dom,
+        contentDOM: body,
+        update: (updated) => {
+          if (updated.type.name !== this.name) return false;
+          dom.setAttribute('data-open', updated.attrs['open'] ? 'true' : 'false');
+          return true;
+        },
+      };
+    };
+  },
+
+  addCommands() {
+    return {
+      insertDetails:
+        () =>
+        ({ commands }) =>
+          commands.insertContent({
+            type: this.name,
+            attrs: { open: true },
+            content: [
+              { type: 'detailsSummary', content: [{ type: 'text', text: 'Toggle' }] },
+              { type: 'detailsContent', content: [{ type: 'paragraph' }] },
+            ],
+          }),
+      toggleDetailsOpen:
+        () =>
+        ({ state, dispatch }) => {
+          // Walk up from the selection to the enclosing details node.
+          const { $from } = state.selection;
+          for (let depth = $from.depth; depth > 0; depth--) {
+            const node = $from.node(depth);
+            if (node.type.name === this.name) {
+              if (dispatch) {
+                const pos = $from.before(depth);
+                dispatch(state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, open: !node.attrs['open'] }));
+              }
+              return true;
+            }
+          }
+          return false;
+        },
+    };
+  },
+});

--- a/src/tiptap/slashCommands.ts
+++ b/src/tiptap/slashCommands.ts
@@ -63,6 +63,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { id: 'code', title: 'Code block', keywords: ['code', 'pre', 'snippet'], group: 'Basic', run: (e) => cmd.toggleCodeBlock(e) },
   { id: 'divider', title: 'Divider', keywords: ['hr', 'divider', 'rule', 'separator'], group: 'Basic', run: (e) => cmd.insertHorizontalRule(e) },
   { id: 'callout', title: 'Callout', keywords: ['callout', 'note', 'admonition', 'aside', 'info', 'warning'], group: 'Basic', run: (e) => cmd.setCallout(e, 'note') },
+  { id: 'toggle', title: 'Toggle section', keywords: ['toggle', 'collapse', 'details', 'expand', 'accordion', 'fold'], group: 'Basic', run: (e) => cmd.insertToggle(e) },
   { id: 'table', title: 'Table', keywords: ['table', 'grid'], group: 'Insert', run: (e) => cmd.insertTable(e) },
   { id: 'math', title: 'Math block', keywords: ['math', 'latex', 'equation', 'formula'], group: 'Insert', run: (e) => cmd.setMathBlock(e, '') },
   { id: 'image', title: 'Image', keywords: ['image', 'picture', 'photo', 'upload'], group: 'Insert', run: () => runUi('image') },

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -14,7 +14,7 @@ import {
   Highlighter, RemoveFormatting, List, ListOrdered, ListTodo, Quote, SquareCode,
   Link, AlignLeft, AlignCenter, AlignRight, AlignJustify,
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
-  BookMarked, Library, Info,
+  BookMarked, Library, Info, ChevronRight,
 } from 'lucide-react';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
@@ -384,6 +384,9 @@ export function DocumentEditorToolbar() {
                   ))}
                 </div>
               </ToolbarDropdown>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && cmd.insertToggle(editor)} title="Insert Toggle Section" aria-label="Insert toggle section">
+                <ChevronRight {...ICON} />
+              </button>
             </div>
 
 

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -43,6 +43,7 @@ import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
 import { CitationSuggestion } from '../tiptap/CitationSuggestion';
 import { SlashMenu } from '../tiptap/SlashMenu';
 import { Callout } from '../tiptap/CalloutExtension';
+import { Details, DetailsSummary, DetailsContent } from '../tiptap/DetailsExtension';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
@@ -173,6 +174,12 @@ export const sharedProseExtensions = [
   // (sync parse/render, no nodeView), so the headless schema + collab are
   // unaffected — it serializes as a clean <div data-callout data-variant>.
   Callout,
+  // Collapsible toggle sections (details/summary/content). Div-based sync
+  // serialization (no native <details>), so the headless schema + collab are
+  // unaffected; the disclosure triangle is nodeView-only chrome.
+  Details,
+  DetailsSummary,
+  DetailsContent,
   EmbeddedGroup,
 ];
 

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -27,6 +27,9 @@ export const insertHorizontalRule = (editor: Editor) => editor.chain().focus().s
 export const setCallout = (editor: Editor, variant: CalloutVariant) =>
   editor.chain().focus().setCallout(variant).run();
 
+// Toggle — insert a collapsible section (summary + body).
+export const insertToggle = (editor: Editor) => editor.chain().focus().insertDetails().run();
+
 // Headings
 export const setHeading = (editor: Editor, level: 1 | 2 | 3 | 4 | 5 | 6) =>
   editor.chain().focus().toggleHeading({ level }).run();


### PR DESCRIPTION
## What

Phase 1b of the prose feature epic ([Notion: Prose Editor Features](https://app.notion.com/p/37e1694609d3816aab1bfdc59061799f)). Adds **collapsible toggle sections** — a titled disclosure that folds away its body. Good for long specs, FAQs, and optional detail. Completes the Phase 1 "easy validator nodes" before the heavier slices.

## How

Three nodes modelled on HTML `details`/`summary`, but rendered as plain `<div>`s with `data-*` attributes:

- **`details`** — block container, `content: 'detailsSummary detailsContent'`, an `open` attribute, and a nodeView with a disclosure triangle.
- **`detailsSummary`** — the always-visible title (`inline*`).
- **`detailsContent`** — the collapsible body (`block+`), hidden by CSS when closed.

Key choices:
- **Not native `<details>`/`<summary>`** — their built-in click-to-toggle fights cursor placement when you try to edit the title. Instead a dedicated disclosure triangle (a pure-CSS border shape, no glyph/emoji) toggles the `open` attr, and clicking the title text just edits it.
- **Sync, div-based serialization** round-trips losslessly so `getHTML()` → PDF / MCP / offline re-parse cleanly. The triangle and the `.details-body` nodeView wrapper are chrome only — never serialized. `open` is an ordinary attribute, so collapse state persists and syncs like any edit (no projection machinery).
- **Discovery**: added to `sharedProseExtensions`; an Insert-tab button; a `/toggle` slash command; `editorCommands.insertToggle`.

## Notes / follow-ups

- Native `<details>`/`<summary>` **paste** import isn't wired (our own div format round-trips fully); can add a parse rule later if external-paste interop is wanted.
- Lucide icon for the toolbar button is in place; the in-content triangle stays CSS (it rotates on open).

## Verification

- `bun run typecheck` ✅
- `bun run test --run` — **2254 passed** (incl. 4 new `DetailsExtension.test.ts`: insert structure/defaults, HTML round-trip, closed-state preserved, `toggleDetailsOpen` flips `open`) ✅
- `bun run build` ✅

Manual: Insert tab → toggle button, or type `/toggle`; click the triangle to fold/unfold; edit the title without it collapsing.

Assisted-by: Opus 4.8