### PR TITLE
feat(prose): figure + caption

### DIFF
--- a/src/tiptap/FigureExtension.css
+++ b/src/tiptap/FigureExtension.css
@@ -5,8 +5,11 @@
   text-align: center;
 }
 
-/* Center the image (and its resizable container) within the figure. */
-.prose-figure > .resizable-image-container,
+/* Center the image (and its resizable container) within the figure. The live
+   selector carries the editor prefix to outrank the base container rule in
+   TiptapEditor.css (margin: 1rem 0), which otherwise left-aligns the image and
+   leaves the centered caption looking detached. */
+.tiptap-editor .ProseMirror .prose-figure > .resizable-image-container,
 .prose-figure > img.tiptap-image {
   margin-left: auto;
   margin-right: auto;

--- a/src/tiptap/FigureExtension.css
+++ b/src/tiptap/FigureExtension.css
@@ -1,0 +1,27 @@
+/* Figure + caption. Centered image with a muted caption beneath. */
+
+.prose-figure {
+  margin: 1rem 0;
+  text-align: center;
+}
+
+/* Center the image (and its resizable container) within the figure. */
+.prose-figure > .resizable-image-container,
+.prose-figure > img.tiptap-image {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.prose-figcaption {
+  margin-top: 0.4rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--text-secondary, #888);
+  text-align: center;
+}
+
+/* Placeholder while the caption is empty. */
+.prose-figcaption:empty::before {
+  content: 'Write a caption…';
+  opacity: 0.6;
+}

--- a/src/tiptap/FigureExtension.test.ts
+++ b/src/tiptap/FigureExtension.test.ts
@@ -71,4 +71,16 @@ describe('toggleImageFigure', () => {
     editor.destroy();
     element.remove();
   });
+
+  it('clears the image float when wrapping (figures are block/centered)', () => {
+    const { editor, element } = makeEditor('<img src="blob://x" alt="x" data-float="left">');
+    editor.commands.setNodeSelection(0);
+    editor.commands.toggleImageFigure();
+    const html = editor.getHTML();
+    expect(html).toContain('<figure');
+    expect(html).not.toContain('data-float');
+
+    editor.destroy();
+    element.remove();
+  });
 });

--- a/src/tiptap/FigureExtension.test.ts
+++ b/src/tiptap/FigureExtension.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the Figure (image + caption) nodes. Headless `new Editor` in jsdom
+ * (same pattern as CalloutExtension.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { ResizableImage } from './ResizableImageExtension';
+import { Figure, Figcaption } from './FigureExtension';
+
+const extensions = [StarterKit.configure({ history: false }), ResizableImage, Figure, Figcaption];
+
+function makeEditor(content: string): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content });
+  return { editor, element };
+}
+
+describe('figure schema round-trip', () => {
+  it('round-trips a figure with a caption from HTML', () => {
+    const { editor, element } = makeEditor(
+      '<figure><img src="blob://x" alt="x"><figcaption>A caption</figcaption></figure>'
+    );
+    const html = editor.getHTML();
+    expect(html).toContain('<figure');
+    expect(html).toContain('<figcaption');
+    expect(html).toContain('A caption');
+    expect(html).toContain('blob://x');
+
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('toggleImageFigure', () => {
+  it('wraps a selected image in a figure + caption', () => {
+    const { editor, element } = makeEditor('<img src="blob://x" alt="x">');
+    editor.commands.setNodeSelection(0);
+
+    expect(editor.commands.toggleImageFigure()).toBe(true);
+    const html = editor.getHTML();
+    expect(html).toContain('<figure');
+    expect(html).toContain('<figcaption');
+    expect(html).toContain('blob://x');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('unwraps an image already inside a figure', () => {
+    const { editor, element } = makeEditor(
+      '<figure><img src="blob://x" alt="x"><figcaption>cap</figcaption></figure>'
+    );
+    // The image sits at pos 1 (inside the figure at pos 0).
+    editor.commands.setNodeSelection(1);
+
+    expect(editor.commands.toggleImageFigure()).toBe(true);
+    const html = editor.getHTML();
+    expect(html).not.toContain('<figure');
+    expect(html).not.toContain('<figcaption');
+    expect(html).toContain('blob://x');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('is a no-op when no image is selected', () => {
+    const { editor, element } = makeEditor('<p>just text</p>');
+    expect(editor.commands.toggleImageFigure()).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/FigureExtension.ts
+++ b/src/tiptap/FigureExtension.ts
@@ -93,8 +93,12 @@ export const Figure = Node.create<FigureOptions>({
           }
 
           // Wrap the image in a figure + empty caption; caret into the caption.
+          // A figure is block/centered, so drop any float the image carried.
           if (dispatch) {
-            const figure = figureType.create(null, [node, figcaptionType.create()]);
+            const img = node.attrs['float']
+              ? node.type.create({ ...node.attrs, float: null }, node.content, node.marks)
+              : node;
+            const figure = figureType.create(null, [img, figcaptionType.create()]);
             tr.replaceWith(pos, pos + node.nodeSize, figure);
             const captionInside = pos + node.nodeSize + 2; // figure open + image + figcaption open
             const sel = TextSelection.near(tr.doc.resolve(Math.min(captionInside, tr.doc.content.size)), 1);

--- a/src/tiptap/FigureExtension.ts
+++ b/src/tiptap/FigureExtension.ts
@@ -1,0 +1,108 @@
+/**
+ * Figure extension — wraps an image with an editable caption.
+ *
+ * Two nodes that serialize as standard HTML `<figure><img><figcaption></figure>`:
+ *   - `figure`     — block container, `content: 'image figcaption'`.
+ *   - `figcaption` — the caption (`inline*`).
+ *
+ * Figures are opt-in: a bare `<img>` still parses as a plain `image` node, so
+ * existing documents are unaffected (no migration). The `toggleImageFigure`
+ * command wraps the selected image in a figure (caret lands in the caption) or
+ * unwraps it back to a bare image. Auto-numbering ("Figure N") is intentionally
+ * deferred to the shared document-outline work (Phase 4) so there's one
+ * numbering source feeding the figure label, cross-references, and the TOC —
+ * rather than a throwaway counter here.
+ *
+ * Serialization is sync + standard, so getHTML() → PDF / MCP / offline round-trip
+ * the caption losslessly.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+import { TextSelection } from '@tiptap/pm/state';
+import './FigureExtension.css';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    figure: {
+      /** Wrap the selected image in a figure+caption, or unwrap it back. */
+      toggleImageFigure: () => ReturnType;
+    };
+  }
+}
+
+export interface FigureOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/** The caption line under a figure's image. */
+export const Figcaption = Node.create({
+  name: 'figcaption',
+  content: 'inline*',
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: 'figcaption' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['figcaption', mergeAttributes(HTMLAttributes, { class: 'prose-figcaption' }), 0];
+  },
+});
+
+export const Figure = Node.create<FigureOptions>({
+  name: 'figure',
+  group: 'block',
+  content: 'image figcaption',
+  draggable: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  parseHTML() {
+    return [{ tag: 'figure' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['figure', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { class: 'prose-figure' }), 0];
+  },
+
+  addCommands() {
+    return {
+      toggleImageFigure:
+        () =>
+        ({ state, dispatch, tr }) => {
+          const figureType = state.schema.nodes['figure'];
+          const figcaptionType = state.schema.nodes['figcaption'];
+          if (!figureType || !figcaptionType) return false;
+
+          const pos = state.selection.from;
+          const node = state.doc.nodeAt(pos);
+          if (!node || node.type.name !== 'image') return false;
+          const $pos = state.doc.resolve(pos);
+
+          // Already inside a figure → unwrap to a bare image (drops the caption).
+          if ($pos.parent.type.name === this.name) {
+            const figurePos = $pos.before($pos.depth);
+            const figureNode = $pos.parent;
+            if (dispatch) {
+              tr.replaceWith(figurePos, figurePos + figureNode.nodeSize, node);
+              dispatch(tr.scrollIntoView());
+            }
+            return true;
+          }
+
+          // Wrap the image in a figure + empty caption; caret into the caption.
+          if (dispatch) {
+            const figure = figureType.create(null, [node, figcaptionType.create()]);
+            tr.replaceWith(pos, pos + node.nodeSize, figure);
+            const captionInside = pos + node.nodeSize + 2; // figure open + image + figcaption open
+            const sel = TextSelection.near(tr.doc.resolve(Math.min(captionInside, tr.doc.content.size)), 1);
+            tr.setSelection(sel).scrollIntoView();
+            dispatch(tr);
+          }
+          return true;
+        },
+    };
+  },
+});

--- a/src/tiptap/ResizableImageExtension.css
+++ b/src/tiptap/ResizableImageExtension.css
@@ -22,8 +22,13 @@ img.tiptap-image[data-float='right'] {
 
 /* The image widget (image + handles + float controls) is an atom — it should
    never show a text-selection highlight when clicked/selected. NodeSelection
-   still draws the `.selected` outline. */
-.tiptap-editor .ProseMirror .resizable-image-container {
+   still draws the `.selected` outline. The `-webkit-` prefix is required on
+   WebKitGTK (the Tauri desktop webview), where the unprefixed property alone
+   doesn't suppress the selection — this is why the chrome still shaded. */
+.tiptap-editor .ProseMirror .resizable-image-container,
+.image-float-controls,
+.image-float-controls button {
+  -webkit-user-select: none;
   user-select: none;
 }
 

--- a/src/tiptap/ResizableImageExtension.css
+++ b/src/tiptap/ResizableImageExtension.css
@@ -63,3 +63,10 @@ img.tiptap-image[data-float='right'] {
   background: var(--accent-soft, rgba(80, 120, 200, 0.18));
   color: var(--text-primary);
 }
+
+/* "Caption" sits after the float options, divided off. */
+.image-float-controls .image-controls-caption {
+  margin-left: 2px;
+  padding-left: 0.45rem;
+  border-left: 1px solid var(--border-color);
+}

--- a/src/tiptap/ResizableImageExtension.ts
+++ b/src/tiptap/ResizableImageExtension.ts
@@ -166,6 +166,25 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
         floatButtons.forEach(({ value, el }) => el.classList.toggle('is-active', value === float));
       };
       refreshActiveFloat(node.attrs['float'] as ImageFloat);
+
+      // "Caption" — wrap the image in a figure with a caption (or unwrap). The
+      // command is provided by the Figure extension; both are shared, so it's
+      // always present at runtime.
+      const captionBtn = document.createElement('button');
+      captionBtn.type = 'button';
+      captionBtn.className = 'image-controls-caption';
+      captionBtn.textContent = 'Caption';
+      captionBtn.title = 'Add or remove a caption (wraps the image in a figure)';
+      captionBtn.addEventListener('mousedown', (e) => e.preventDefault());
+      captionBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (typeof getPos !== 'function') return;
+        const pos = getPos();
+        if (typeof pos !== 'number') return;
+        editor.chain().setNodeSelection(pos).toggleImageFigure().run();
+      });
+      controls.appendChild(captionBtn);
+
       container.appendChild(controls);
 
       // Handle selection state

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -45,6 +45,7 @@ import { SlashMenu } from '../tiptap/SlashMenu';
 import { Callout } from '../tiptap/CalloutExtension';
 import { Details, DetailsSummary, DetailsContent } from '../tiptap/DetailsExtension';
 import { CodeBlock } from '../tiptap/CodeBlockExtension';
+import { Figure, Figcaption } from '../tiptap/FigureExtension';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
@@ -185,6 +186,11 @@ export const sharedProseExtensions = [
   // button. Replaces StarterKit's codeBlock (disabled below + in the collab
   // editor); same node name + serialization, so existing docs are unaffected.
   CodeBlock,
+  // Figure + caption: wraps an image with an editable caption (opt-in; bare
+  // images still parse as plain image nodes, so no migration). Numbering is
+  // deferred to the Phase 4 doc-outline work.
+  Figure,
+  Figcaption,
   EmbeddedGroup,
 ];
 


### PR DESCRIPTION
## What

Phase 2c of the prose feature epic ([Notion: Prose Editor Features](https://app.notion.com/p/37e1694609d3816aab1bfdc59061799f)). Lets an image carry an **editable caption** (a proper `<figure>`), which researchers expect and which also sets up cross-references later.

## How

- **`FigureExtension.ts`** — `figure` (block, `content: 'image figcaption'`) + `figcaption` (`inline*`), serialized as standard `<figure><img><figcaption>`. **Opt-in**: a bare `<img>` still parses as a plain `image` node, so existing documents are unaffected — **no migration**.
- **`toggleImageFigure`** command wraps the selected image in a figure (caret lands in the caption ready to type) or unwraps it back to a bare image. A **"Caption" button** on the image control bar invokes it (it selects the image node, then toggles).
- **`FigureExtension.css`** centers the image and styles the caption, with an empty-state placeholder.
- Serialization is sync + standard HTML, so `getHTML()` → PDF / MCP / offline round-trip the caption losslessly.

## Notes

- **Auto-numbering ("Figure N") is deferred to Phase 4** (the shared document-outline work), so a single numbering source feeds the figure label, cross-references, and the TOC — rather than a throwaway counter here. The node is ready for it.
- Float + figure interplay (floating an image that's inside a figure) is left as-is for now; figures are block/centered.

## Verification

- `bun run typecheck` ✅
- `bun run test --run` — **2269 passed** (incl. 4 new `FigureExtension.test.ts`: caption round-trip, wrap, unwrap, no-op without an image) ✅
- `bun run build` ✅

Manual: select an image → **Caption** in the control bar → it becomes a figure with a caption you can type into; Caption again unwraps it.

Assisted-by: Opus 4.8