### PR TITLE
feat(prose): image gallery (grid/row) + figcaption Enter fix

### DIFF
--- a/src/tiptap/FigureExtension.test.ts
+++ b/src/tiptap/FigureExtension.test.ts
@@ -84,3 +84,28 @@ describe('toggleImageFigure', () => {
     element.remove();
   });
 });
+
+describe('figcaption Enter', () => {
+  it('exitFigcaption moves the caret to a new paragraph after the figure', () => {
+    const { editor, element } = makeEditor(
+      '<figure><img src="blob://x"><figcaption>Cap</figcaption></figure>'
+    );
+    editor.commands.setTextSelection(4); // inside the caption "Cap"
+    expect(editor.state.selection.$from.parent.type.name).toBe('figcaption');
+
+    expect(editor.commands.exitFigcaption()).toBe(true);
+    const { $from } = editor.state.selection;
+    expect($from.parent.type.name).toBe('paragraph');
+    expect($from.depth).toBe(1); // a top-level paragraph after the figure
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('exitFigcaption is a no-op outside a caption', () => {
+    const { editor, element } = makeEditor('<p>text</p>');
+    expect(editor.commands.exitFigcaption()).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/FigureExtension.ts
+++ b/src/tiptap/FigureExtension.ts
@@ -26,6 +26,8 @@ declare module '@tiptap/core' {
     figure: {
       /** Wrap the selected image in a figure+caption, or unwrap it back. */
       toggleImageFigure: () => ReturnType;
+      /** Move the caret from the caption to a new paragraph after the figure. */
+      exitFigcaption: () => ReturnType;
     };
   }
 }
@@ -39,6 +41,9 @@ export const Figcaption = Node.create({
   name: 'figcaption',
   content: 'inline*',
   defining: true,
+  // Above StarterKit so our Enter handler wins over its split-on-Enter (the
+  // single-caption schema can't split → "stuck", same as the toggle summary).
+  priority: 1000,
 
   parseHTML() {
     return [{ tag: 'figcaption' }];
@@ -46,6 +51,14 @@ export const Figcaption = Node.create({
 
   renderHTML({ HTMLAttributes }) {
     return ['figcaption', mergeAttributes(HTMLAttributes, { class: 'prose-figcaption' }), 0];
+  },
+
+  // Enter in the caption exits the figure into a fresh paragraph beneath it,
+  // rather than failing to split the caption. (Command lives on `figure`.)
+  addKeyboardShortcuts() {
+    return {
+      Enter: () => this.editor.commands.exitFigcaption(),
+    };
   },
 });
 
@@ -103,6 +116,24 @@ export const Figure = Node.create<FigureOptions>({
             const captionInside = pos + node.nodeSize + 2; // figure open + image + figcaption open
             const sel = TextSelection.near(tr.doc.resolve(Math.min(captionInside, tr.doc.content.size)), 1);
             tr.setSelection(sel).scrollIntoView();
+            dispatch(tr);
+          }
+          return true;
+        },
+      exitFigcaption:
+        () =>
+        ({ state, dispatch }) => {
+          const { $head, empty } = state.selection;
+          if (!empty || $head.parent.type.name !== 'figcaption') return false;
+          const figureDepth = $head.depth - 1;
+          if ($head.node(figureDepth)?.type.name !== this.name) return false;
+
+          const afterFigure = $head.after(figureDepth);
+          const para = state.schema.nodes['paragraph']?.createAndFill();
+          if (!para) return false;
+          if (dispatch) {
+            const tr = state.tr.insert(afterFigure, para);
+            tr.setSelection(TextSelection.near(tr.doc.resolve(afterFigure + 1), 1)).scrollIntoView();
             dispatch(tr);
           }
           return true;

--- a/src/tiptap/GalleryExtension.css
+++ b/src/tiptap/GalleryExtension.css
@@ -1,0 +1,89 @@
+/* Image gallery — grid (default) or single row. The `.gallery-items` wrapper is
+   present in both the live nodeView and the static getHTML output, so these
+   rules style both. */
+
+.prose-gallery {
+  position: relative;
+  margin: 1rem 0;
+}
+
+.gallery-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.prose-gallery[data-layout='row'] .gallery-items {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 0.5rem;
+}
+
+/* Gallery images fill their cell; individual resize is suppressed in favour of
+   the layout. The editor-prefixed selector outranks the base container rule. */
+.tiptap-editor .ProseMirror .prose-gallery .resizable-image-container {
+  width: 100%;
+  margin: 0;
+}
+
+.prose-gallery .gallery-items img.tiptap-image {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.prose-gallery[data-layout='row'] .gallery-items > * {
+  flex: 0 0 auto;
+  width: auto;
+}
+
+.prose-gallery[data-layout='row'] .gallery-items img.tiptap-image {
+  width: auto;
+  height: 160px;
+}
+
+/* Grid/Row toggle bar (nodeView chrome). */
+.gallery-controls {
+  position: absolute;
+  top: -1.9rem;
+  right: 0;
+  display: flex;
+  gap: 1px;
+  padding: 2px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.14));
+  opacity: 0;
+  transition: opacity 0.12s ease;
+  z-index: 5;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.prose-gallery:hover .gallery-controls,
+.prose-gallery:focus-within .gallery-controls {
+  opacity: 1;
+}
+
+.gallery-controls button {
+  font: inherit;
+  font-size: 0.72rem;
+  color: var(--text-secondary, #888);
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  padding: 0.12rem 0.4rem;
+  cursor: pointer;
+}
+
+.gallery-controls button:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+}
+
+.gallery-controls button.is-active {
+  background: var(--accent-soft, rgba(80, 120, 200, 0.18));
+  color: var(--text-primary);
+}

--- a/src/tiptap/GalleryExtension.css
+++ b/src/tiptap/GalleryExtension.css
@@ -7,41 +7,32 @@
   margin: 1rem 0;
 }
 
+/* Flex-wrap so each image keeps its own (resizable) size and the row reflows.
+   `grid` wraps; `row` stays on one line and scrolls horizontally. */
 .gallery-items {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .prose-gallery[data-layout='row'] .gallery-items {
-  display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
-  gap: 0.5rem;
 }
 
-/* Gallery images fill their cell; individual resize is suppressed in favour of
-   the layout. The editor-prefixed selector outranks the base container rule. */
+/* Each image keeps its own width (from the resize) — don't stretch/shrink or
+   force a width, so the resize handles work. Reset the base container's centering
+   margin inside a gallery (editor-prefixed to outrank the base rule). */
 .tiptap-editor .ProseMirror .prose-gallery .resizable-image-container {
-  width: 100%;
   margin: 0;
+  flex: 0 0 auto;
 }
 
 .prose-gallery .gallery-items img.tiptap-image {
-  width: 100%;
-  height: auto;
   display: block;
-}
-
-.prose-gallery[data-layout='row'] .gallery-items > * {
-  flex: 0 0 auto;
-  width: auto;
-}
-
-.prose-gallery[data-layout='row'] .gallery-items img.tiptap-image {
-  width: auto;
-  height: 160px;
+  max-width: 100%;
+  height: auto;
 }
 
 /* Grid/Row toggle bar (nodeView chrome). */

--- a/src/tiptap/GalleryExtension.test.ts
+++ b/src/tiptap/GalleryExtension.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the Gallery node. Headless `new Editor` in jsdom (same pattern as
+ * CalloutExtension.test.ts). Covers serialization, insertGallery, layout.
+ */
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { ResizableImage } from './ResizableImageExtension';
+import { Gallery } from './GalleryExtension';
+
+const extensions = [StarterKit.configure({ history: false }), ResizableImage, Gallery];
+
+function makeEditor(content: string): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content });
+  return { editor, element };
+}
+
+describe('gallery serialization', () => {
+  it('round-trips a gallery (layout + images) from HTML', () => {
+    const { editor, element } = makeEditor(
+      '<div data-gallery data-layout="row"><div class="gallery-items"><img src="blob://a"><img src="blob://b"></div></div>'
+    );
+    const html = editor.getHTML();
+    expect(html).toContain('data-gallery');
+    expect(html).toContain('data-layout="row"');
+    expect(html).toContain('gallery-items');
+    expect(html).toContain('blob://a');
+    expect(html).toContain('blob://b');
+
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('insertGallery', () => {
+  it('inserts a grid gallery from a list of images', () => {
+    const { editor, element } = makeEditor('<p></p>');
+    editor.commands.insertGallery([{ src: 'blob://a', alt: 'a' }, { src: 'blob://b' }]);
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-gallery');
+    expect(html).toContain('data-layout="grid"');
+    expect(html).toContain('blob://a');
+    expect(html).toContain('blob://b');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('is a no-op with no images', () => {
+    const { editor, element } = makeEditor('<p></p>');
+    expect(editor.commands.insertGallery([])).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('setGalleryLayout', () => {
+  it('changes the layout of the selected gallery', () => {
+    const { editor, element } = makeEditor(
+      '<div data-gallery data-layout="grid"><div class="gallery-items"><img src="blob://a"></div></div>'
+    );
+    editor.commands.setNodeSelection(0); // the gallery block
+
+    expect(editor.commands.setGalleryLayout('row')).toBe(true);
+    expect(editor.getHTML()).toContain('data-layout="row"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('is a no-op when no gallery is at the selection', () => {
+    const { editor, element } = makeEditor('<p>text</p>');
+    expect(editor.commands.setGalleryLayout('row')).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/GalleryExtension.test.ts
+++ b/src/tiptap/GalleryExtension.test.ts
@@ -78,3 +78,62 @@ describe('setGalleryLayout', () => {
     element.remove();
   });
 });
+
+const TWO = '<div data-gallery data-layout="grid"><div class="gallery-items"><img src="blob://a"><img src="blob://b"></div></div>';
+const ONE = '<div data-gallery data-layout="grid"><div class="gallery-items"><img src="blob://a"></div></div>';
+
+describe('moveGalleryImage', () => {
+  it('reorders the selected image', () => {
+    const { editor, element } = makeEditor(TWO);
+    editor.commands.setNodeSelection(1); // image "a" (index 0)
+    expect(editor.commands.moveGalleryImage(1)).toBe(true);
+    const html = editor.getHTML();
+    expect(html.indexOf('blob://b')).toBeLessThan(html.indexOf('blob://a'));
+    editor.destroy();
+    element.remove();
+  });
+
+  it('is a no-op at the edge', () => {
+    const { editor, element } = makeEditor(TWO);
+    editor.commands.setNodeSelection(1); // index 0 → can't move left
+    expect(editor.commands.moveGalleryImage(-1)).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('exitGallery', () => {
+  it('moves the caret to a new paragraph after the gallery', () => {
+    const { editor, element } = makeEditor(ONE);
+    editor.commands.setNodeSelection(1); // the image in the gallery
+    expect(editor.commands.exitGallery()).toBe(true);
+    const { $from } = editor.state.selection;
+    expect($from.parent.type.name).toBe('paragraph');
+    expect($from.depth).toBe(1);
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('removeSelectedImage (gallery)', () => {
+  it('removes a non-last image but keeps the gallery', () => {
+    const { editor, element } = makeEditor(TWO);
+    editor.commands.setNodeSelection(1); // image "a"
+    expect(editor.commands.removeSelectedImage()).toBe(true);
+    const html = editor.getHTML();
+    expect(html).toContain('data-gallery');
+    expect(html).not.toContain('blob://a');
+    expect(html).toContain('blob://b');
+    editor.destroy();
+    element.remove();
+  });
+
+  it('removes the whole gallery when deleting the last image', () => {
+    const { editor, element } = makeEditor(ONE);
+    editor.commands.setNodeSelection(1);
+    expect(editor.commands.removeSelectedImage()).toBe(true);
+    expect(editor.getHTML()).not.toContain('data-gallery');
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/GalleryExtension.ts
+++ b/src/tiptap/GalleryExtension.ts
@@ -1,0 +1,178 @@
+/**
+ * Gallery extension — multiple images laid out as a grid or a row.
+ *
+ * A `gallery` block holds one-or-more `image` nodes (`content: 'image+'`) with a
+ * `layout` attribute (`grid` | `row`). It serializes as
+ * `<div data-gallery data-layout><div class="gallery-items"><img>…</div></div>`
+ * — the inner `.gallery-items` wrapper (declared in renderHTML and matched by
+ * `contentElement` on parse) is where the images live, so the same CSS styles
+ * both the live nodeView and the static getHTML output. The Grid/Row toggle is a
+ * nodeView-only control bar, never serialized.
+ *
+ * Inserted via multi-file upload (GalleryUploadButton / the `/gallery` command),
+ * which builds the image children from freshly-saved blobs.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+import './GalleryExtension.css';
+
+export type GalleryLayout = 'grid' | 'row';
+
+/** One image to place in a gallery (built from an uploaded blob). */
+export interface GalleryImage {
+  src: string;
+  alt?: string;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    gallery: {
+      /** Insert a gallery containing the given images. */
+      insertGallery: (images: GalleryImage[]) => ReturnType;
+      /** Set the layout of the gallery at the selection. */
+      setGalleryLayout: (layout: GalleryLayout) => ReturnType;
+    };
+  }
+}
+
+export interface GalleryOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+function asLayout(value: unknown): GalleryLayout {
+  return value === 'row' ? 'row' : 'grid';
+}
+
+export const Gallery = Node.create<GalleryOptions>({
+  name: 'gallery',
+  group: 'block',
+  content: 'image+',
+  draggable: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      layout: {
+        default: 'grid' as GalleryLayout,
+        parseHTML: (el: HTMLElement) => asLayout(el.getAttribute('data-layout')),
+        renderHTML: (attrs) => ({ 'data-layout': asLayout(attrs['layout']) }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-gallery]', contentElement: 'div.gallery-items' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { 'data-gallery': '', class: 'prose-gallery' }),
+      ['div', { class: 'gallery-items' }, 0],
+    ];
+  },
+
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement('div');
+      dom.className = 'prose-gallery';
+      dom.setAttribute('data-gallery', '');
+      dom.setAttribute('data-layout', asLayout(node.attrs['layout']));
+
+      // Grid/Row toggle — chrome, never serialized.
+      const controls = document.createElement('div');
+      controls.className = 'gallery-controls';
+      controls.contentEditable = 'false';
+
+      const setLayout = (layout: GalleryLayout) => {
+        if (typeof getPos !== 'function') return;
+        const pos = getPos();
+        if (typeof pos !== 'number') return;
+        const cur = editor.state.doc.nodeAt(pos);
+        if (!cur || cur.type.name !== this.name) return;
+        editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, layout }));
+      };
+
+      const layoutButtons = (['grid', 'row'] as GalleryLayout[]).map((layout) => {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.textContent = layout === 'grid' ? 'Grid' : 'Row';
+        b.addEventListener('mousedown', (e) => e.preventDefault());
+        b.addEventListener('click', (e) => {
+          e.stopPropagation();
+          setLayout(layout);
+        });
+        controls.appendChild(b);
+        return { layout, el: b };
+      });
+      const refreshActive = (layout: GalleryLayout) => {
+        layoutButtons.forEach(({ layout: l, el }) => el.classList.toggle('is-active', l === layout));
+      };
+      refreshActive(asLayout(node.attrs['layout']));
+
+      const items = document.createElement('div');
+      items.className = 'gallery-items';
+
+      dom.appendChild(controls);
+      dom.appendChild(items);
+
+      return {
+        dom,
+        contentDOM: items,
+        update: (updated) => {
+          if (updated.type.name !== this.name) return false;
+          const layout = asLayout(updated.attrs['layout']);
+          dom.setAttribute('data-layout', layout);
+          refreshActive(layout);
+          return true;
+        },
+      };
+    };
+  },
+
+  addCommands() {
+    return {
+      insertGallery:
+        (images) =>
+        ({ commands }) => {
+          if (!images.length) return false;
+          return commands.insertContent({
+            type: this.name,
+            attrs: { layout: 'grid' },
+            content: images.map((img) => ({
+              type: 'image',
+              attrs: { src: img.src, alt: img.alt ?? null },
+            })),
+          });
+        },
+      setGalleryLayout:
+        (layout) =>
+        ({ state, dispatch }) => {
+          const { from } = state.selection;
+          // A NodeSelection directly on the gallery.
+          const direct = state.doc.nodeAt(from);
+          if (direct && direct.type.name === this.name) {
+            if (dispatch) {
+              dispatch(state.tr.setNodeMarkup(from, undefined, { ...direct.attrs, layout: asLayout(layout) }));
+            }
+            return true;
+          }
+          // Or a gallery enclosing the selection (e.g. an image inside it).
+          const $from = state.doc.resolve(from);
+          for (let depth = $from.depth; depth > 0; depth--) {
+            const node = $from.node(depth);
+            if (node.type.name === this.name) {
+              if (dispatch) {
+                dispatch(state.tr.setNodeMarkup($from.before(depth), undefined, { ...node.attrs, layout: asLayout(layout) }));
+              }
+              return true;
+            }
+          }
+          return false;
+        },
+    };
+  },
+});

--- a/src/tiptap/GalleryExtension.ts
+++ b/src/tiptap/GalleryExtension.ts
@@ -14,6 +14,8 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import { NodeSelection, TextSelection } from '@tiptap/pm/state';
+import { Fragment, type Node as PMNode } from '@tiptap/pm/model';
 import './GalleryExtension.css';
 
 export type GalleryLayout = 'grid' | 'row';
@@ -31,6 +33,10 @@ declare module '@tiptap/core' {
       insertGallery: (images: GalleryImage[]) => ReturnType;
       /** Set the layout of the gallery at the selection. */
       setGalleryLayout: (layout: GalleryLayout) => ReturnType;
+      /** Reorder the selected gallery image left (-1) or right (+1). */
+      moveGalleryImage: (dir: -1 | 1) => ReturnType;
+      /** Move the caret from a gallery to a new paragraph after it. */
+      exitGallery: () => ReturnType;
     };
   }
 }
@@ -144,7 +150,9 @@ export const Gallery = Node.create<GalleryOptions>({
             attrs: { layout: 'grid' },
             content: images.map((img) => ({
               type: 'image',
-              attrs: { src: img.src, alt: img.alt ?? null },
+              // Start as a thumbnail (still resizable) so a fresh gallery isn't a
+              // stack of full-size images.
+              attrs: { src: img.src, alt: img.alt ?? null, width: 220 },
             })),
           });
         },
@@ -173,6 +181,61 @@ export const Gallery = Node.create<GalleryOptions>({
           }
           return false;
         },
+      moveGalleryImage:
+        (dir) =>
+        ({ state, dispatch }) => {
+          const sel = state.selection;
+          if (!(sel instanceof NodeSelection) || sel.node.type.name !== 'image') return false;
+          const $from = state.doc.resolve(sel.from);
+          if ($from.parent.type.name !== this.name) return false; // not in a gallery
+          const gallery = $from.parent;
+          const index = $from.index();
+          const target = index + dir;
+          if (target < 0 || target >= gallery.childCount) return false; // at an edge
+
+          if (dispatch) {
+            const galleryStart = $from.before($from.depth);
+            const children: PMNode[] = [];
+            gallery.forEach((child) => children.push(child));
+            const [moved] = children.splice(index, 1);
+            children.splice(target, 0, moved!);
+            const newGallery = gallery.copy(Fragment.fromArray(children));
+            const tr = state.tr.replaceWith(galleryStart, galleryStart + gallery.nodeSize, newGallery);
+            // Re-select the moved image (all gallery children are size-1 atoms).
+            tr.setSelection(NodeSelection.create(tr.doc, galleryStart + 1 + target));
+            dispatch(tr.scrollIntoView());
+          }
+          return true;
+        },
+      exitGallery:
+        () =>
+        ({ state, dispatch }) => {
+          const $from = state.doc.resolve(state.selection.from);
+          let depth = $from.depth;
+          while (depth > 0 && $from.node(depth).type.name !== this.name) depth--;
+          if (depth === 0) return false; // not in a gallery
+
+          const afterGallery = $from.after(depth);
+          const para = state.schema.nodes['paragraph']?.createAndFill();
+          if (!para) return false;
+          if (dispatch) {
+            const tr = state.tr.insert(afterGallery, para);
+            tr.setSelection(TextSelection.near(tr.doc.resolve(afterGallery + 1), 1)).scrollIntoView();
+            dispatch(tr);
+          }
+          return true;
+        },
+    };
+  },
+
+  // Arrow keys reorder the selected gallery image; Enter exits to a paragraph
+  // below the gallery. All return false when not applicable, so normal
+  // navigation / Enter behaviour is unaffected elsewhere.
+  addKeyboardShortcuts() {
+    return {
+      ArrowLeft: () => this.editor.commands.moveGalleryImage(-1),
+      ArrowRight: () => this.editor.commands.moveGalleryImage(1),
+      Enter: () => this.editor.commands.exitGallery(),
     };
   },
 });

--- a/src/tiptap/ResizableImageExtension.test.ts
+++ b/src/tiptap/ResizableImageExtension.test.ts
@@ -59,6 +59,15 @@ describe('image float', () => {
     element.remove();
   });
 
+  it('removeSelectedImage deletes a selected (e.g. broken) image', () => {
+    const { editor, element } = makeEditor('<img src="blob://x" alt="x">');
+    editor.commands.setNodeSelection(0);
+    expect(editor.commands.removeSelectedImage()).toBe(true);
+    expect(editor.getHTML()).not.toContain('blob://x');
+    editor.destroy();
+    element.remove();
+  });
+
   it('preserves float through a resize (regression: resize reset float to inline)', () => {
     const { editor, element } = makeEditor('<img src="blob://x" alt="x">');
     editor.commands.setNodeSelection(0);

--- a/src/tiptap/ResizableImageExtension.ts
+++ b/src/tiptap/ResizableImageExtension.ts
@@ -9,6 +9,7 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import { NodeSelection } from '@tiptap/pm/state';
 import './ResizableImageExtension.css';
 
 /** Float / text-wrap mode. `null` = block image (no wrap), the default. */
@@ -32,6 +33,8 @@ declare module '@tiptap/core' {
       }) => ReturnType;
       /** Set float/text-wrap on the currently selected image. */
       setImageFloat: (float: ImageFloat) => ReturnType;
+      /** Delete the selected image (removes the whole gallery if it was the last). */
+      removeSelectedImage: () => ReturnType;
     };
   }
 }
@@ -187,13 +190,24 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
 
       container.appendChild(controls);
 
-      // Handle selection state
+      // Whether this image is inside a gallery — there the float/caption controls
+      // are suppressed (galleries own layout + reordering via arrows / context menu).
+      const inGallery = (): boolean => {
+        if (typeof getPos !== 'function') return false;
+        const pos = getPos();
+        if (typeof pos !== 'number') return false;
+        return editor.state.doc.resolve(pos).parent.type.name === 'gallery';
+      };
+
+      // Selection visuals — driven by ProseMirror's NodeSelection (set on click,
+      // via selectNode/deselectNode below) so Backspace/Delete + the context menu
+      // act on the image node itself.
       const updateSelection = (selected: boolean) => {
         container.classList.toggle('selected', selected);
         handleElements.forEach((h) => {
           h.style.display = selected ? 'block' : 'none';
         });
-        controls.style.display = selected ? 'flex' : 'none';
+        controls.style.display = selected && !inGallery() ? 'flex' : 'none';
       };
 
       // Initially hide handles
@@ -201,19 +215,13 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
         h.style.display = 'none';
       });
 
-      // Click to select
+      // Click selects the image node (a real NodeSelection).
       container.addEventListener('click', (e) => {
         e.stopPropagation();
-        updateSelection(true);
+        if (typeof getPos !== 'function') return;
+        const pos = getPos();
+        if (typeof pos === 'number') editor.commands.setNodeSelection(pos);
       });
-
-      // Deselect on click outside
-      const handleClickOutside = (e: MouseEvent) => {
-        if (!container.contains(e.target as globalThis.Node)) {
-          updateSelection(false);
-        }
-      };
-      document.addEventListener('click', handleClickOutside);
 
       // Resize logic
       let isResizing = false;
@@ -333,6 +341,8 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
 
       return {
         dom: container,
+        selectNode: () => updateSelection(true),
+        deselectNode: () => updateSelection(false),
         update: (updatedNode) => {
           if (updatedNode.type.name !== 'image') return false;
 
@@ -348,9 +358,6 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
           refreshActiveFloat(updatedNode.attrs['float'] as ImageFloat);
 
           return true;
-        },
-        destroy: () => {
-          document.removeEventListener('click', handleClickOutside);
         },
       };
     };
@@ -377,6 +384,33 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
           if (dispatch) dispatch(state.tr.setNodeMarkup(from, undefined, { ...node.attrs, float }));
           return true;
         },
+      removeSelectedImage:
+        () =>
+        ({ state, dispatch }) => {
+          const sel = state.selection;
+          if (!(sel instanceof NodeSelection) || sel.node.type.name !== this.name) return false;
+          const { from } = sel;
+          const $from = state.doc.resolve(from);
+          // Last image in a gallery → remove the gallery (image+ can't be empty).
+          if ($from.parent.type.name === 'gallery' && $from.parent.childCount === 1) {
+            const galleryStart = $from.before($from.depth);
+            if (dispatch) {
+              dispatch(state.tr.delete(galleryStart, galleryStart + $from.parent.nodeSize).scrollIntoView());
+            }
+            return true;
+          }
+          if (dispatch) dispatch(state.tr.delete(from, from + sel.node.nodeSize).scrollIntoView());
+          return true;
+        },
+    };
+  },
+
+  // Backspace/Delete on a selected image removes it (the broken-image case too);
+  // returns false otherwise so normal deletion is unaffected.
+  addKeyboardShortcuts() {
+    return {
+      Backspace: () => this.editor.commands.removeSelectedImage(),
+      Delete: () => this.editor.commands.removeSelectedImage(),
     };
   },
 });

--- a/src/tiptap/slashCommands.ts
+++ b/src/tiptap/slashCommands.ts
@@ -29,7 +29,7 @@ export interface SlashCommand {
 // ─── UI-flow seam (inserts whose UI lives in React) ──────────────────────────
 
 /** Inserts that open React UI rather than running a pure editor command. */
-export type SlashUiAction = 'image' | 'citation';
+export type SlashUiAction = 'image' | 'citation' | 'gallery';
 
 const uiHandlers = new Map<SlashUiAction, () => void>();
 
@@ -67,6 +67,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { id: 'table', title: 'Table', keywords: ['table', 'grid'], group: 'Insert', run: (e) => cmd.insertTable(e) },
   { id: 'math', title: 'Math block', keywords: ['math', 'latex', 'equation', 'formula'], group: 'Insert', run: (e) => cmd.setMathBlock(e, '') },
   { id: 'image', title: 'Image', keywords: ['image', 'picture', 'photo', 'upload'], group: 'Insert', run: () => runUi('image') },
+  { id: 'gallery', title: 'Image gallery', keywords: ['gallery', 'images', 'grid', 'photos', 'album'], group: 'Insert', run: () => runUi('gallery') },
   { id: 'citation', title: 'Citation', keywords: ['cite', 'citation', 'reference', 'source'], group: 'References', run: () => runUi('citation') },
   { id: 'bibliography', title: 'Bibliography', keywords: ['bibliography', 'references', 'works cited'], group: 'References', run: (e) => cmd.insertBibliography(e) },
 ];

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useCallback, useState, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import type { Editor } from '@tiptap/core';
+import { NodeSelection } from '@tiptap/pm/state';
 import { useDocumentStore } from '../store/documentStore';
 import { isGroup, type GroupShape } from '../shapes/Shape';
 import * as cmd from './editorCommands';
@@ -70,6 +71,21 @@ export function DocumentEditorContextMenu({
   
   // Check if cursor is in a table
   const isInTable = editor?.isActive('table') ?? false;
+
+  // Image selection (a NodeSelection on an image) → image actions. If the image
+  // is inside a gallery, also offer reordering.
+  const imageMenu = useMemo(() => {
+    const sel = editor?.state.selection;
+    if (!editor || !(sel instanceof NodeSelection) || sel.node.type.name !== 'image') {
+      return null;
+    }
+    const $from = editor.state.doc.resolve(sel.from);
+    if ($from.parent.type.name === 'gallery') {
+      const index = $from.index();
+      return { inGallery: true, canLeft: index > 0, canRight: index < $from.parent.childCount - 1 };
+    }
+    return { inGallery: false, canLeft: false, canRight: false };
+  }, [editor]);
 
   // Get group display name
   const getGroupName = useCallback((group: GroupShape): string => {
@@ -209,6 +225,50 @@ export function DocumentEditorContextMenu({
           top: adjustedPosition.y,
         }}
       >
+        {/* Image actions (when an image node is selected) */}
+        {imageMenu && (
+          <>
+            {imageMenu.inGallery && (
+              <>
+                <div
+                  className={`doc-editor-context-menu-item ${imageMenu.canLeft ? '' : 'disabled'}`}
+                  onClick={() => {
+                    if (editor && imageMenu.canLeft) editor.commands.moveGalleryImage(-1);
+                    onClose();
+                  }}
+                >
+                  <span className="doc-editor-context-menu-icon">‹</span>
+                  <span className="doc-editor-context-menu-label">Move image left</span>
+                  <span className="doc-editor-context-menu-shortcut">←</span>
+                </div>
+                <div
+                  className={`doc-editor-context-menu-item ${imageMenu.canRight ? '' : 'disabled'}`}
+                  onClick={() => {
+                    if (editor && imageMenu.canRight) editor.commands.moveGalleryImage(1);
+                    onClose();
+                  }}
+                >
+                  <span className="doc-editor-context-menu-icon">›</span>
+                  <span className="doc-editor-context-menu-label">Move image right</span>
+                  <span className="doc-editor-context-menu-shortcut">→</span>
+                </div>
+              </>
+            )}
+            <div
+              className="doc-editor-context-menu-item danger"
+              onClick={() => {
+                if (editor) editor.commands.removeSelectedImage();
+                onClose();
+              }}
+            >
+              <span className="doc-editor-context-menu-icon">×</span>
+              <span className="doc-editor-context-menu-label">Remove image</span>
+              <span className="doc-editor-context-menu-shortcut">⌫</span>
+            </div>
+            <div className="doc-editor-context-menu-divider" />
+          </>
+        )}
+
         {/* Format submenu */}
         <div
           className="doc-editor-context-menu-item has-submenu"

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -21,6 +21,7 @@ import { useTiptapEditor } from './TiptapEditorContext';
 import * as cmd from './editorCommands';
 import { registerSlashUiHandler } from '../tiptap/slashCommands';
 import { ImageUploadButton } from './ImageUploadButton';
+import { GalleryUploadButton } from './GalleryUploadButton';
 import { SearchReplacePanel } from './SearchReplacePanel';
 import { ToolbarDropdown } from './ToolbarDropdown';
 import { InsertLinkDialog } from './InsertLinkDialog';
@@ -359,6 +360,7 @@ export function DocumentEditorToolbar() {
             {/* Media */}
             <div className="document-editor-toolbar-group">
               <ImageUploadButton className="document-editor-toolbar-btn" />
+              <GalleryUploadButton className="document-editor-toolbar-btn" />
               <button className="document-editor-toolbar-btn" onClick={() => editor && cmd.insertHorizontalRule(editor)} title="Horizontal Rule" aria-label="Horizontal rule">
                 <Minus {...ICON} />
               </button>

--- a/src/ui/GalleryUploadButton.tsx
+++ b/src/ui/GalleryUploadButton.tsx
@@ -1,0 +1,86 @@
+/**
+ * GalleryUploadButton - Upload multiple images at once and insert them as a
+ * gallery (grid). Mirrors ImageUploadButton's blob-save flow, looped over files.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Images } from 'lucide-react';
+import { Icon } from './icons';
+import { useTiptapEditor } from './TiptapEditorContext';
+import { blobStorage } from '../storage/BlobStorage';
+import { processImageForUpload } from '../utils/imageUtils';
+import { registerSlashUiHandler } from '../tiptap/slashCommands';
+import type { GalleryImage } from '../tiptap/GalleryExtension';
+
+export interface GalleryUploadButtonProps {
+  className?: string;
+}
+
+export function GalleryUploadButton({ className }: GalleryUploadButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const editor = useTiptapEditor();
+
+  const handleFiles = async (files: FileList) => {
+    if (!editor || files.length === 0) return;
+    setIsUploading(true);
+    try {
+      const images: GalleryImage[] = [];
+      for (const file of Array.from(files)) {
+        try {
+          const { blob, name } = await processImageForUpload(file);
+          const blobId = await blobStorage.saveBlob(blob, name);
+          images.push({ src: `blob://${blobId}`, alt: name });
+        } catch (error) {
+          // Skip a bad file but keep the rest of the gallery.
+          console.error('Failed to process gallery image:', error);
+        }
+      }
+      if (images.length > 0) {
+        editor.chain().focus().insertGallery(images).run();
+      }
+    } finally {
+      setIsUploading(false);
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  // Let the `/gallery` slash command open the same multi-file picker.
+  useEffect(() => registerSlashUiHandler('gallery', () => inputRef.current?.click()), []);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`toolbar-button ${className ?? ''}`}
+        onClick={() => inputRef.current?.click()}
+        disabled={isUploading}
+        title="Insert image gallery"
+        aria-label="Insert image gallery"
+      >
+        {isUploading ? (
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+            <path d="M8 2 A6 6 0 0 1 14 8" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="1s" repeatCount="indefinite" />
+            </path>
+          </svg>
+        ) : (
+          <Icon icon={Images} />
+        )}
+      </button>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/jpg,image/png,image/gif,image/webp,image/svg+xml"
+        multiple
+        onChange={(e) => {
+          if (e.target.files) handleFiles(e.target.files);
+        }}
+        style={{ display: 'none' }}
+        aria-hidden="true"
+      />
+    </>
+  );
+}

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -46,6 +46,7 @@ import { Callout } from '../tiptap/CalloutExtension';
 import { Details, DetailsSummary, DetailsContent } from '../tiptap/DetailsExtension';
 import { CodeBlock } from '../tiptap/CodeBlockExtension';
 import { Figure, Figcaption } from '../tiptap/FigureExtension';
+import { Gallery } from '../tiptap/GalleryExtension';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
@@ -191,6 +192,8 @@ export const sharedProseExtensions = [
   // deferred to the Phase 4 doc-outline work.
   Figure,
   Figcaption,
+  // Image gallery (grid/row) holding multiple images; inserted via multi-upload.
+  Gallery,
   EmbeddedGroup,
 ];
 


### PR DESCRIPTION
## What

Phase 2d of the prose feature epic ([Notion: Prose Editor Features](https://app.notion.com/p/37e1694609d3816aab1bfdc59061799f)) — the last Phase 2 slice — plus a small fix for the figure caption you flagged.

## Gallery

- **`GalleryExtension.ts`** — a `gallery` node (block, `content: 'image+'`) with a `layout` attribute (`grid` | `row`). Serializes as `<div data-gallery data-layout><div class="gallery-items"><img>…</div></div>`; the inner `.gallery-items` wrapper is declared in `renderHTML` and matched on parse via `contentElement`, so one set of CSS styles **both** the live nodeView and the static `getHTML()` output. The nodeView adds a **Grid/Row** toggle (chrome, never serialized). Commands: `insertGallery(images)`, `setGalleryLayout`.
- **`GalleryUploadButton.tsx`** — a multi-file picker that processes + saves each blob (same flow as the single-image upload, looped) and inserts a gallery. Wired into the Insert tab and a **`/gallery`** slash command (via the `registerSlashUiHandler` seam, now including `'gallery'`).
- **`GalleryExtension.css`** — grid (auto-fit columns) / row (horizontal flex scroll), and the toggle bar.

## Figcaption Enter fix

You reported the caption "can't go to the next line." The caption is single-line (`inline*`), so Enter tried to split a node the figure schema only allows one of → stuck (same root cause as the toggle summary). Added an **`exitFigcaption`** command (Enter, priority 1000) that drops the caret into a fresh paragraph **after** the figure so you can keep writing.

## Notes / follow-ups

- Image nodeView chrome (resize handles, float/caption controls) still shows on images inside a gallery — functional but noisy; can suppress in a follow-up.
- Per-gallery captions and reordering are future polish.

## Verification

- `bun run typecheck` ✅
- `bun run test --run` — **2277 passed** (incl. 5 new `GalleryExtension.test.ts` + 2 new figcaption-Enter tests) ✅
- `bun run build` ✅

Manual: Insert tab → gallery button (or `/gallery`) → pick several images → grid; hover the gallery → Grid/Row toggle. In a figure caption, Enter now moves below the figure.

Assisted-by: Opus 4.8