### PR TITLE
Document Fields: reusable {{field}} placeholders (Phase 3)

### DIFF
--- a/src/store/fieldStore.test.ts
+++ b/src/store/fieldStore.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the field store (Phase 3 — Document Fields). Pure data store:
+ * upsert/update by name, remove, ordered listing, serialize, and defensive
+ * loadFields (mirrors referenceStore's coverage).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFieldStore } from './fieldStore';
+import type { FieldLibrary } from '../types/Field';
+
+beforeEach(() => {
+  useFieldStore.getState().clear();
+});
+
+describe('setField', () => {
+  it('adds a new field and appends it to the order', () => {
+    const s = useFieldStore.getState();
+    s.setField('Company', 'Acme');
+    expect(s.getField('Company')).toEqual({ name: 'Company', value: 'Acme' });
+    expect(useFieldStore.getState().order).toEqual(['Company']);
+  });
+
+  it('updates the value without duplicating the order entry', () => {
+    const s = useFieldStore.getState();
+    s.setField('Company', 'Acme');
+    s.setField('Company', 'Globex');
+    expect(useFieldStore.getState().getField('Company')?.value).toBe('Globex');
+    expect(useFieldStore.getState().order).toEqual(['Company']);
+  });
+
+  it('trims the name and ignores an empty name', () => {
+    const s = useFieldStore.getState();
+    s.setField('  Spaced  ', 'v');
+    s.setField('   ', 'ignored');
+    expect(useFieldStore.getState().order).toEqual(['Spaced']);
+    expect(useFieldStore.getState().getField('Spaced')?.value).toBe('v');
+  });
+});
+
+describe('removeField', () => {
+  it('removes a field and its order entry', () => {
+    const s = useFieldStore.getState();
+    s.setField('A', '1');
+    s.setField('B', '2');
+    s.removeField('A');
+    expect(useFieldStore.getState().getField('A')).toBeUndefined();
+    expect(useFieldStore.getState().order).toEqual(['B']);
+  });
+
+  it('is a no-op for an unknown name', () => {
+    const s = useFieldStore.getState();
+    s.setField('A', '1');
+    s.removeField('nope');
+    expect(useFieldStore.getState().order).toEqual(['A']);
+  });
+});
+
+describe('listFields', () => {
+  it('returns fields in insertion order', () => {
+    const s = useFieldStore.getState();
+    s.setField('Z', '1');
+    s.setField('A', '2');
+    expect(useFieldStore.getState().listFields().map((f) => f.name)).toEqual(['Z', 'A']);
+  });
+});
+
+describe('serialize / loadFields', () => {
+  it('round-trips through serialize → loadFields', () => {
+    const s = useFieldStore.getState();
+    s.setField('A', '1');
+    s.setField('B', '2');
+    const lib = useFieldStore.getState().serialize();
+
+    useFieldStore.getState().clear();
+    useFieldStore.getState().loadFields(lib);
+    expect(useFieldStore.getState().listFields()).toEqual([
+      { name: 'A', value: '1' },
+      { name: 'B', value: '2' },
+    ]);
+  });
+
+  it('reconciles order with fields (drops dangling, appends missing)', () => {
+    const lib: FieldLibrary = {
+      fields: { A: { name: 'A', value: '1' }, B: { name: 'B', value: '2' } },
+      order: ['A', 'ghost'], // ghost has no field; B missing from order
+    };
+    useFieldStore.getState().loadFields(lib);
+    expect(useFieldStore.getState().order).toEqual(['A', 'B']);
+  });
+
+  it('degrades malformed input to an empty library', () => {
+    useFieldStore.getState().setField('A', '1');
+    // @ts-expect-error — intentionally malformed
+    useFieldStore.getState().loadFields({ fields: null, order: 'nope' });
+    expect(useFieldStore.getState().order).toEqual([]);
+    expect(useFieldStore.getState().listFields()).toEqual([]);
+  });
+});

--- a/src/store/fieldStore.ts
+++ b/src/store/fieldStore.ts
@@ -1,0 +1,120 @@
+/**
+ * fieldStore - Per-document field library (Phase 3 — Document Fields).
+ *
+ * Holds the active document's named fields (the backing store for `{{field}}`
+ * placeholders in prose). Modelled almost 1:1 on `referenceStore`: a pure
+ * name-keyed map + order-array data store, serialized into
+ * `DiagramDocument.fields` on save and reloaded / cleared on document switch by
+ * `persistenceStore`.
+ *
+ * This is a **data store only** — no formatting, network, or Y.Doc imports
+ * (live-collab value sync is a deferred phase). Keep it light and synchronous.
+ * Fields are keyed by `name` (the `{{name}}` token); `setField` upserts.
+ */
+
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import type { Field, FieldLibrary } from '../types/Field';
+import { isFieldLibrary } from '../types/Field';
+
+interface FieldState {
+  /** Fields keyed by name. */
+  fields: Record<string, Field>;
+  /** Display order of field names. */
+  order: string[];
+}
+
+interface FieldActions {
+  /** Insert or update a field by name (added to the order if new). */
+  setField: (name: string, value: string) => void;
+  /** Remove a field by name. */
+  removeField: (name: string) => void;
+  /** Get a field by name. */
+  getField: (name: string) => Field | undefined;
+  /** All fields in display order. */
+  listFields: () => Field[];
+  /** Reset to an empty library (document switch / new document). */
+  clear: () => void;
+  /** Load a serialized library, defensively normalizing malformed input. */
+  loadFields: (data: FieldLibrary) => void;
+  /** Serialize for persistence into `DiagramDocument.fields`. */
+  serialize: () => FieldLibrary;
+}
+
+export const useFieldStore = create<FieldState & FieldActions>()(
+  immer((set, get) => ({
+    fields: {},
+    order: [],
+
+    setField: (name: string, value: string) => {
+      const key = name.trim();
+      if (!key) return; // a field must have a name (the `{{name}}` token)
+      set((draft) => {
+        if (!draft.fields[key]) {
+          draft.order.push(key);
+        }
+        draft.fields[key] = { name: key, value };
+      });
+    },
+
+    removeField: (name: string) => {
+      set((draft) => {
+        if (!draft.fields[name]) return;
+        delete draft.fields[name];
+        const index = draft.order.indexOf(name);
+        if (index !== -1) {
+          draft.order.splice(index, 1);
+        }
+      });
+    },
+
+    getField: (name: string) => {
+      return get().fields[name];
+    },
+
+    listFields: () => {
+      const state = get();
+      return state.order
+        .map((name) => state.fields[name])
+        .filter((field): field is Field => field !== undefined);
+    },
+
+    clear: () => {
+      set((draft) => {
+        draft.fields = {};
+        draft.order = [];
+      });
+    },
+
+    loadFields: (data: FieldLibrary) => {
+      set((draft) => {
+        if (!isFieldLibrary(data)) {
+          // Malformed input degrades to an empty library — never throw.
+          draft.fields = {};
+          draft.order = [];
+          return;
+        }
+        // Drop order entries with no backing field, and append any fields
+        // missing from the order, so the two collections stay consistent after
+        // an imperfect import.
+        const fields = data.fields;
+        const order = data.order.filter((name) => fields[name] !== undefined);
+        for (const name of Object.keys(fields)) {
+          if (!order.includes(name)) {
+            order.push(name);
+          }
+        }
+        draft.fields = fields;
+        draft.order = order;
+      });
+    },
+
+    serialize: () => {
+      const state = get();
+      return {
+        fields: state.fields,
+        order: state.order,
+      };
+    },
+  }))
+);

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -21,6 +21,7 @@ import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
 import { useReferenceStore } from './referenceStore';
+import { useFieldStore } from './fieldStore';
 import { useUserStore } from './userStore';
 import { isRelayAuthenticated, useConnectionStore } from './connectionStore';
 import { useRelayDocumentStore } from './relayDocumentStore';
@@ -503,6 +504,7 @@ function createDocumentFromPageStore(
   const richTextContent = useRichTextStore.getState().getContent();
   const richTextPages = useRichTextPagesStore.getState().serialize();
   const references = useReferenceStore.getState().serialize();
+  const fields = useFieldStore.getState().serialize();
   const whiteboardSnapshot = useWhiteboardStore.getState().getSnapshot();
 
   const doc: DiagramDocument = {
@@ -517,6 +519,7 @@ function createDocumentFromPageStore(
     richTextContent,
     richTextPages,
     references,
+    fields,
     whiteboard: whiteboardSnapshot,
   };
 
@@ -600,6 +603,15 @@ function loadDocumentToPageStore(doc: DiagramDocument): void {
       useReferenceStore.getState().loadReferences(doc.references);
     } else {
       useReferenceStore.getState().clear();
+    }
+
+    // Load field library (Phase 3) — clear when absent so a prior document's
+    // fields never bleed into one that has none (back-compat for pre-Phase-3
+    // documents). `loadFields` defensively normalizes malformed input.
+    if (doc.fields) {
+      useFieldStore.getState().loadFields(doc.fields);
+    } else {
+      useFieldStore.getState().clear();
     }
 
     // Load whiteboard state (or initialize with defaults if not present)

--- a/src/tiptap/FieldExtension.test.ts
+++ b/src/tiptap/FieldExtension.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the FieldRef node (Phase 3 — Document Fields). Headless `new Editor`
+ * in jsdom (same pattern as CitationExtension / Gallery tests). Covers
+ * serialization, the `setFieldRef` command, the live value projection, and the
+ * unset-field placeholder.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { FieldRef, resolveFieldValue } from './FieldExtension';
+import { useFieldStore } from '../store/fieldStore';
+
+const extensions = [StarterKit.configure({ history: false }), FieldRef];
+
+function makeEditor(content: string): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions, content });
+  return { editor, element };
+}
+
+beforeEach(() => {
+  useFieldStore.getState().clear();
+});
+
+describe('FieldRef serialization', () => {
+  it('round-trips a field reference (data-field + data-name) from HTML', () => {
+    const { editor, element } = makeEditor('<p><span data-field data-name="Company"></span></p>');
+    const html = editor.getHTML();
+    expect(html).toContain('data-field');
+    expect(html).toContain('data-name="Company"');
+    editor.destroy();
+    element.remove();
+  });
+
+  it('parses an MCP-style span with no cached label', () => {
+    // The future adapter emits `{{name}}` → <span data-field data-name> with no
+    // data-label; the node must still parse and carry the name.
+    const { editor, element } = makeEditor('<p><span data-field data-name="Term"></span></p>');
+    const json = editor.getJSON();
+    const node = json.content?.[0]?.content?.[0];
+    expect(node?.type).toBe('fieldRef');
+    expect(node?.attrs?.['name']).toBe('Term');
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('setFieldRef command', () => {
+  it('inserts a fieldRef node by name', () => {
+    const { editor, element } = makeEditor('<p></p>');
+    editor.commands.setFieldRef('Version');
+    expect(editor.getHTML()).toContain('data-name="Version"');
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('value projection', () => {
+  it('renders the field value when set', () => {
+    useFieldStore.getState().setField('Company', 'Acme');
+    const { editor, element } = makeEditor('<p></p>');
+    editor.commands.setFieldRef('Company');
+    const node = element.querySelector('.field-ref');
+    expect(node?.textContent).toBe('Acme');
+    editor.destroy();
+    element.remove();
+  });
+
+  it('shows a {name} placeholder when the field is unset', () => {
+    const { editor, element } = makeEditor('<p></p>');
+    editor.commands.setFieldRef('Unknown');
+    const node = element.querySelector('.field-ref');
+    expect(node?.textContent).toBe('{Unknown}');
+    expect(node?.classList.contains('field-ref-unset')).toBe(true);
+    editor.destroy();
+    element.remove();
+  });
+
+  it('repaints live when the field value changes', () => {
+    useFieldStore.getState().setField('Status', 'Draft');
+    const { editor, element } = makeEditor('<p></p>');
+    editor.commands.setFieldRef('Status');
+    expect(element.querySelector('.field-ref')?.textContent).toBe('Draft');
+
+    useFieldStore.getState().setField('Status', 'Final');
+    expect(element.querySelector('.field-ref')?.textContent).toBe('Final');
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('resolveFieldValue', () => {
+  it('resolves a user field value', () => {
+    useFieldStore.getState().setField('A', '1');
+    expect(resolveFieldValue('A')).toBe('1');
+  });
+
+  it('resolves a computed field live (today is non-empty)', () => {
+    expect(resolveFieldValue('today')).toBeTruthy();
+  });
+
+  it('returns undefined for an unknown name', () => {
+    expect(resolveFieldValue('nope')).toBeUndefined();
+  });
+});

--- a/src/tiptap/FieldExtension.ts
+++ b/src/tiptap/FieldExtension.ts
@@ -1,0 +1,187 @@
+/**
+ * FieldRef extension for Tiptap (Phase 3 — Document Fields).
+ *
+ * An inline atom holding a field `name`, rendered live as that field's current
+ * value from `fieldStore` (or a built-in computed value like `today` / `now`).
+ * Edit the value once in the Fields manager and every `{{name}}` reference
+ * repaints. Modelled almost 1:1 on `CitationInline`: an atom node + a
+ * store-reactive `nodeView` that caches the resolved value back into the node's
+ * `label` attribute (the "projection") so non-editor consumers (getHTML → PDF /
+ * MCP / offline) are self-contained.
+ *
+ * Serialization is the **MCP wire contract**: a `<span data-field
+ * data-name="NAME" data-label="VALUE">`. `parseHTML` keys off `data-field` and
+ * reads `data-name`; `data-label` is **optional** (the nodeView fills it live),
+ * so a future Markdown→HTML adapter can emit `{{name}}` → `<span data-field
+ * data-name="name">` with no label and the editor resolves it.
+ *
+ * v1 is client-side only — there is no relay/MCP write path for field values
+ * yet (the Fields manager surfaces this). The data model is kept forward-
+ * compatible so that work is purely additive.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+import { useFieldStore } from '../store/fieldStore';
+import { getComputedField } from '../types/Field';
+import { PROSE_PROJECTION_META } from './proseProjection';
+import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    fieldRef: {
+      /** Insert an inline field reference to `{{name}}`. */
+      setFieldRef: (name: string) => ReturnType;
+    };
+  }
+}
+
+export interface FieldOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+/**
+ * Resolve a field name to its display value: a computed field's live value, or
+ * the user field's stored value. `undefined` when the name is unknown / unset.
+ */
+export function resolveFieldValue(name: string): string | undefined {
+  const computed = getComputedField(name);
+  if (computed) return computed.resolve();
+  return useFieldStore.getState().getField(name)?.value;
+}
+
+/**
+ * Inline field node — `{{name}}` rendered as the field's current value.
+ */
+export const FieldRef = Node.create<FieldOptions>({
+  name: 'fieldRef',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  // Each attribute owns its `data-*` serialization (parse + render) so getHTML
+  // emits ONLY clean `data-*` attributes — the robust round-trip shape (same as
+  // CitationInline). `data-label` is the cached projection; it is optional on
+  // parse so an MCP-emitted `{{name}}`→span with no label still resolves live.
+  addAttributes() {
+    return {
+      name: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-name') ?? '',
+        renderHTML: (attrs) => (attrs['name'] ? { 'data-name': String(attrs['name']) } : {}),
+      },
+      // Cached resolved value (the "projection"): renderHTML is the source of
+      // truth for static HTML consumers, while the nodeView re-derives it live.
+      label: {
+        default: '',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-label') ?? '',
+        renderHTML: (attrs) => (attrs['label'] ? { 'data-label': String(attrs['label']) } : {}),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-field]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const label = (node.attrs['label'] as string) ?? '';
+    // Emit the cached label as the text child too, so static HTML consumers show
+    // it; the editor re-derives it live. `data-*` attrs come from addAttributes.
+    return [
+      'span',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-field': '',
+        class: 'field-ref',
+      }),
+      label,
+    ];
+  },
+
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const dom = document.createElement('span');
+      dom.setAttribute('data-field', '');
+      dom.className = 'field-ref';
+      dom.contentEditable = 'false';
+
+      let name = node.attrs['name'] as string;
+      // The last user value we resolved against, so the store subscription only
+      // re-renders when *this* field's value actually changes (loop-safe, cheap).
+      let lastUserValue = useFieldStore.getState().getField(name)?.value;
+
+      // Persist the resolved value into the node's `label` attr so the HTML
+      // projection (getHTML → PDF / MCP / offline) is self-contained. Same
+      // safety as CitationInline: idempotent, editable-only, out of undo, runs
+      // post-update, re-checks position + type + name before dispatch.
+      const writeBackLabel = (label: string) => {
+        if (!editor.isEditable) return; // view-only clients never dirty the doc
+        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
+        const pos = typeof getPos === 'function' ? getPos() : undefined;
+        if (pos == null) return;
+        const cur = editor.state.doc.nodeAt(pos);
+        if (!cur || cur.type.name !== this.name || cur.attrs['name'] !== name) return;
+        if (cur.attrs['label'] === label) return; // idempotent → loop-safe
+        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
+        tr.setMeta('addToHistory', false); // keep label-sync out of undo
+        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
+        editor.view.dispatch(tr);
+      };
+
+      const render = () => {
+        const value = resolveFieldValue(name);
+        if (value && value.length > 0) {
+          dom.textContent = value;
+          dom.classList.remove('field-ref-unset');
+          dom.title = getComputedField(name) ? `Computed field: ${name}` : name;
+          writeBackLabel(value);
+        } else {
+          // Unset / empty → a muted `{name}` placeholder so the field is visibly
+          // actionable. Never cache a placeholder as the label (not a real value).
+          dom.textContent = `{${name}}`;
+          dom.classList.add('field-ref-unset');
+          dom.title = getComputedField(name) ? `Computed field: ${name}` : `Field "${name}" has no value yet`;
+        }
+      };
+
+      render();
+
+      const unsubscribe = useFieldStore.subscribe((state) => {
+        const next = state.getField(name)?.value;
+        if (next !== lastUserValue) {
+          lastUserValue = next;
+          render();
+        }
+      });
+
+      return {
+        dom,
+        update: (updatedNode) => {
+          if (updatedNode.type.name !== this.name) return false;
+          const newName = updatedNode.attrs['name'] as string;
+          if (newName !== name) {
+            name = newName;
+            lastUserValue = useFieldStore.getState().getField(name)?.value;
+            render();
+          }
+          return true;
+        },
+        destroy: () => {
+          unsubscribe();
+        },
+      };
+    };
+  },
+
+  addCommands() {
+    return {
+      setFieldRef:
+        (name: string) =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name, attrs: { name } }),
+    };
+  },
+});

--- a/src/tiptap/FieldSuggestion.css
+++ b/src/tiptap/FieldSuggestion.css
@@ -1,0 +1,65 @@
+/* FieldSuggestion — `{{` field-picker popup. Mirrors the SlashMenu popup. */
+
+.field-suggest {
+  position: fixed;
+  z-index: 1100; /* above the editor; below modal dialogs */
+  min-width: 240px;
+  max-width: min(360px, 90vw);
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.18));
+  padding: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.field-suggest-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  padding: 0.4rem 0.55rem;
+  cursor: pointer;
+}
+
+.field-suggest-item:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+}
+
+.field-suggest-item.is-active {
+  background: var(--accent-soft, rgba(80, 120, 200, 0.18));
+}
+
+.field-suggest-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.field-suggest-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.field-suggest-hint {
+  flex: none;
+  max-width: 45%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.72rem;
+  color: var(--text-secondary, rgba(127, 127, 127, 0.9));
+}

--- a/src/tiptap/FieldSuggestion.test.ts
+++ b/src/tiptap/FieldSuggestion.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the `{{` field trigger (Phase 3 — Document Fields). The matcher and
+ * option builder are pure; the rest of the plugin is DOM/PM-coupled.
+ */
+import { describe, it, expect } from 'vitest';
+import { matchFieldTrigger, buildFieldOptions } from './FieldSuggestion';
+import type { Field } from '../types/Field';
+
+describe('matchFieldTrigger', () => {
+  it('matches `{{` at the start with an empty query', () => {
+    expect(matchFieldTrigger('{{')).toEqual({ query: '', from: 0 });
+  });
+
+  it('captures the query after `{{`', () => {
+    expect(matchFieldTrigger('{{Comp')).toEqual({ query: 'Comp', from: 0 });
+  });
+
+  it('reports the `{` offset mid-text', () => {
+    // "Hello {{na" → first brace at index 6
+    expect(matchFieldTrigger('Hello {{na')).toEqual({ query: 'na', from: 6 });
+  });
+
+  it('allows spaces in the query (multi-word field names)', () => {
+    expect(matchFieldTrigger('{{Effective Da')).toEqual({ query: 'Effective Da', from: 0 });
+  });
+
+  it('does not match without `{{`', () => {
+    expect(matchFieldTrigger('just text')).toBeNull();
+    expect(matchFieldTrigger('a { b')).toBeNull();
+  });
+
+  it('stops matching once the field is closed', () => {
+    expect(matchFieldTrigger('{{name}}')).toBeNull();
+    expect(matchFieldTrigger('{{name} ')).toBeNull();
+  });
+
+  it('does not re-trigger on a triple brace', () => {
+    // The leading `[^{]` guard means `{{{` is not a fresh `{{` token.
+    expect(matchFieldTrigger('{{{')).toBeNull();
+  });
+});
+
+describe('buildFieldOptions', () => {
+  const fields: Field[] = [
+    { name: 'Company', value: 'Acme' },
+    { name: 'Version', value: '2.0' },
+  ];
+
+  it('lists user fields then computed fields', () => {
+    const opts = buildFieldOptions('', fields);
+    const userNames = opts.filter((o) => o.kind === 'field').map((o) => o.name);
+    const computedNames = opts.filter((o) => o.kind === 'computed').map((o) => o.name);
+    expect(userNames).toEqual(['Company', 'Version']);
+    expect(computedNames).toContain('today');
+    expect(computedNames).toContain('now');
+  });
+
+  it('filters by query (case-insensitive)', () => {
+    const opts = buildFieldOptions('comp', fields);
+    expect(opts.filter((o) => o.kind === 'field').map((o) => o.name)).toEqual(['Company']);
+  });
+
+  it('offers a create row for a non-matching query', () => {
+    const opts = buildFieldOptions('Brand New', fields);
+    const create = opts.find((o) => o.kind === 'create');
+    expect(create).toEqual({ kind: 'create', name: 'Brand New' });
+  });
+
+  it('omits the create row when the query exactly names an existing field', () => {
+    const opts = buildFieldOptions('Company', fields);
+    expect(opts.some((o) => o.kind === 'create')).toBe(false);
+  });
+
+  it('omits the create row for an empty query', () => {
+    const opts = buildFieldOptions('', fields);
+    expect(opts.some((o) => o.kind === 'create')).toBe(false);
+  });
+});

--- a/src/tiptap/FieldSuggestion.ts
+++ b/src/tiptap/FieldSuggestion.ts
@@ -1,0 +1,126 @@
+/**
+ * FieldSuggestion — inline `{{`-trigger autocomplete for document fields
+ * (Phase 3 — Document Fields).
+ *
+ * Typing `{{` in prose opens a dropdown of the document's fields + the built-in
+ * computed fields, filtered live by what you type; picking one replaces the
+ * `{{query` token with a `fieldRef` node. A non-matching query offers a
+ * "Create field" row that defines an empty field on the spot. `{{name}}` is the
+ * same token humans type here and (in a future slice) MCP agents emit in
+ * Markdown — one mental model.
+ *
+ * Built on the shared `createTriggerPlugin` factory (the same mechanism behind
+ * the `/` slash menu), so it works identically in both prose editors when shared
+ * via `sharedProseExtensions`. It owns no nodes/marks, so the headless schema
+ * (`registerProseSchema`) and collab are unaffected. Requires the `fieldRef`
+ * node (also shared) to be present in the schema.
+ */
+
+import { Extension } from '@tiptap/core';
+import { PluginKey } from '@tiptap/pm/state';
+import { createTriggerPlugin, type TriggerState, type TriggerMatch } from './triggerPlugin';
+import { useFieldStore } from '../store/fieldStore';
+import { COMPUTED_FIELDS, type Field } from '../types/Field';
+import './FieldSuggestion.css';
+
+const fieldSuggestionKey = new PluginKey<TriggerState>('fieldSuggestion');
+
+/** A row in the `{{` dropdown. */
+export type FieldOption =
+  | { kind: 'field'; name: string; value: string }
+  | { kind: 'computed'; name: string; label: string }
+  | { kind: 'create'; name: string };
+
+/**
+ * Match a `{{`-trigger at the end of the text before the caret: `{{` followed
+ * by the query (any char but `{` or `}` — so spaces are allowed in field names,
+ * a closing `}` ends the token, and a third `{` opens a fresh trigger rather
+ * than extending the query). The leading `(?:^|[^{])` plus the brace-free query
+ * keep a stray triple-brace from matching. Returns the query and the offset of
+ * the first `{` within `textBefore`, or `null`. Exported pure for unit testing.
+ */
+export function matchFieldTrigger(textBefore: string): TriggerMatch | null {
+  const m = /(?:^|[^{])\{\{([^}{]*)$/.exec(textBefore);
+  if (!m) return null;
+  const query = m[1] ?? '';
+  // Offset of the first `{`, independent of whether the `(?:^|[^{])` matched a
+  // leading char: (match end) - query.length - 2 (the two braces).
+  const from = m.index + m[0].length - query.length - 2;
+  return { query, from };
+}
+
+/**
+ * Build the dropdown options for `query` from the given user fields: matching
+ * user fields + matching computed fields, plus a synthetic "create" row when the
+ * (non-empty) query doesn't exactly name an existing field. Pure — unit-tested.
+ */
+export function buildFieldOptions(query: string, userFields: Field[]): FieldOption[] {
+  const q = query.trim().toLowerCase();
+  const fields: FieldOption[] = userFields
+    .filter((f) => !q || f.name.toLowerCase().includes(q))
+    .map((f) => ({ kind: 'field', name: f.name, value: f.value }));
+  const computed: FieldOption[] = COMPUTED_FIELDS.filter(
+    (c) => !q || c.name.toLowerCase().includes(q)
+  ).map((c) => ({ kind: 'computed', name: c.name, label: c.label }));
+
+  const options = [...fields, ...computed];
+
+  const trimmed = query.trim();
+  const exact = options.some((o) => o.name.toLowerCase() === trimmed.toLowerCase());
+  if (trimmed && !exact) {
+    options.push({ kind: 'create', name: trimmed });
+  }
+  return options;
+}
+
+function getItems(query: string): FieldOption[] {
+  return buildFieldOptions(query, useFieldStore.getState().listFields());
+}
+
+/** Build a dropdown row: name + a muted hint (value / "Computed" / "Create"). */
+function renderFieldRow(option: FieldOption): HTMLElement {
+  const row = document.createElement('span');
+  row.className = 'field-suggest-row';
+
+  const name = document.createElement('span');
+  name.className = 'field-suggest-name';
+  name.textContent = option.kind === 'create' ? `Create field "${option.name}"` : option.name;
+  row.appendChild(name);
+
+  const hint = document.createElement('span');
+  hint.className = 'field-suggest-hint';
+  if (option.kind === 'field') hint.textContent = option.value || '(empty)';
+  else if (option.kind === 'computed') hint.textContent = 'Computed';
+  else hint.textContent = 'New field';
+  row.appendChild(hint);
+
+  return row;
+}
+
+export const FieldSuggestion = Extension.create({
+  name: 'fieldSuggestion',
+
+  addProseMirrorPlugins() {
+    return [
+      createTriggerPlugin<FieldOption>({
+        pluginKey: fieldSuggestionKey,
+        popupClass: 'field-suggest',
+        match: matchFieldTrigger,
+        getItems,
+        rowKey: (option) => `${option.kind}:${option.name}`,
+        renderRow: renderFieldRow,
+        commit: (view, option, range) => {
+          const fieldNode = view.state.schema.nodes['fieldRef'];
+          if (!fieldNode) return;
+          // A "create" row defines an empty field first; then every kind inserts
+          // a fieldRef by name (the nodeView resolves the value live).
+          if (option.kind === 'create') {
+            useFieldStore.getState().setField(option.name, '');
+          }
+          const node = fieldNode.create({ name: option.name });
+          view.dispatch(view.state.tr.replaceWith(range.from, range.to, node));
+        },
+      }),
+    ];
+  },
+});

--- a/src/tiptap/slashCommands.ts
+++ b/src/tiptap/slashCommands.ts
@@ -29,7 +29,7 @@ export interface SlashCommand {
 // ─── UI-flow seam (inserts whose UI lives in React) ──────────────────────────
 
 /** Inserts that open React UI rather than running a pure editor command. */
-export type SlashUiAction = 'image' | 'citation' | 'gallery';
+export type SlashUiAction = 'image' | 'citation' | 'gallery' | 'field';
 
 const uiHandlers = new Map<SlashUiAction, () => void>();
 
@@ -67,6 +67,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { id: 'math', title: 'Math block', keywords: ['math', 'latex', 'equation', 'formula'], group: 'Insert', run: (e) => cmd.setMathBlock(e, '') },
   { id: 'image', title: 'Image', keywords: ['image', 'picture', 'photo', 'upload'], group: 'Insert', run: () => runUi('image') },
   { id: 'gallery', title: 'Image gallery', keywords: ['gallery', 'images', 'grid', 'photos', 'album'], group: 'Insert', run: () => runUi('gallery') },
+  { id: 'field', title: 'Field', keywords: ['field', 'variable', 'merge', 'term', 'placeholder', 'value'], group: 'Insert', run: () => runUi('field') },
   { id: 'citation', title: 'Citation', keywords: ['cite', 'citation', 'reference', 'source'], group: 'References', run: () => runUi('citation') },
   { id: 'bibliography', title: 'Bibliography', keywords: ['bibliography', 'references', 'works cited'], group: 'References', run: (e) => cmd.insertBibliography(e) },
 ];

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -8,6 +8,7 @@ import type { RichTextPage } from '../store/richTextPagesStore';
 import type { WhiteboardState } from './Whiteboard';
 import type { PDFSettings } from './PDFExport';
 import type { ReferenceLibrary } from './Citation';
+import type { FieldLibrary } from './Field';
 
 /**
  * A single page within a document.
@@ -69,6 +70,17 @@ export interface DiagramDocument {
    * relay-flatten paths with no special handling.
    */
   references?: ReferenceLibrary;
+
+  // Document Fields (Phase 3)
+  /**
+   * Per-document field library — reusable `{{name}}` values (defined terms,
+   * versions, etc.). Optional for backwards compatibility: an older document
+   * has no `fields` key and loads as an empty library (additive, like
+   * `references` — no `version` bump). Plain JSON, so it rides the normal
+   * save/load and relay-flatten paths unchanged, and is the exact shape a
+   * future MCP `set_fields` tool will write.
+   */
+  fields?: FieldLibrary;
 
   // Team document fields (Phase 14.1)
   /** Whether this is a relay document (stored on host, synced via CRDT) */

--- a/src/types/Field.ts
+++ b/src/types/Field.ts
@@ -1,0 +1,89 @@
+/**
+ * Document Fields (Phase 3) — reusable named values that propagate through the
+ * prose via `{{field}}` placeholders.
+ *
+ * A *field* is a plain `name → value` pair (a defined term for lawyers — "the
+ * Company", "Effective Date" — a version/config string for engineers, etc.).
+ * Edit a value once and every `{{field}}` reference repaints. The data model is
+ * deliberately thin (string values only); it is also kept **MCP-forward-compatible**
+ * — the storage shape below is the exact JSON a future relay `set_fields` tool
+ * will write into `DiagramDocument.fields`, and the editor node serializes as a
+ * `<span data-field data-name data-label>` so a future Markdown→HTML adapter can
+ * turn `{{name}}` into the same node. v1 ships **client-side only** (no relay/MCP
+ * wiring yet) — see the Fields manager's info banner.
+ *
+ * This file is the data model only — no store, formatting, or network logic.
+ */
+
+/**
+ * A single document field. `value` is plain text in v1; the interface is kept
+ * open (extra keys tolerated) so a future `type` (date / number / select) can be
+ * added additively without a migration.
+ */
+export interface Field {
+  /** Unique key within the document — the `{{name}}` token. */
+  name: string;
+  /** The current value substituted for `{{name}}`. Plain text in v1. */
+  value: string;
+}
+
+/**
+ * A document's field library: fields keyed by name, plus an explicit display
+ * order. Mirrors the id-map + order-array shape of {@link ReferenceLibrary}.
+ * **This is the MCP wire contract** for `DiagramDocument.fields` — a future
+ * relay `set_fields` tool writes exactly this JSON.
+ */
+export interface FieldLibrary {
+  fields: Record<string, Field>;
+  order: string[];
+}
+
+/** Create an empty field library. */
+export function createEmptyFieldLibrary(): FieldLibrary {
+  return { fields: {}, order: [] };
+}
+
+/**
+ * Runtime guard: is `x` a structurally-valid {@link FieldLibrary}? Used to
+ * defensively normalize untrusted input (an imported document / partial
+ * snapshot) before loading — a malformed value degrades to an empty library,
+ * never throws. Mirrors `isReferenceLibrary`.
+ */
+export function isFieldLibrary(x: unknown): x is FieldLibrary {
+  if (!x || typeof x !== 'object') return false;
+  const lib = x as Record<string, unknown>;
+  return (
+    typeof lib['fields'] === 'object' &&
+    lib['fields'] !== null &&
+    !Array.isArray(lib['fields']) &&
+    Array.isArray(lib['order'])
+  );
+}
+
+/**
+ * A built-in computed field. Its value is derived live (never stored) — so
+ * `{{today}}` always resolves to the current date when rendered. The `name`
+ * shadows any same-named user field (computed wins; documented in the manager).
+ */
+export interface ComputedField {
+  name: string;
+  /** Human label for the manager / suggestion dropdown. */
+  label: string;
+  /** Resolve the live value (self-contained — date math only in v1). */
+  resolve: () => string;
+}
+
+/**
+ * The built-in computed fields. Self-contained date values only in v1
+ * (`docTitle` / `author` need a document-metadata accessor — deferred).
+ */
+export const COMPUTED_FIELDS: ReadonlyArray<ComputedField> = [
+  { name: 'today', label: "Today's date", resolve: () => new Date().toLocaleDateString() },
+  { name: 'now', label: 'Current date & time', resolve: () => new Date().toLocaleString() },
+];
+
+/** Look up a computed field by name (case-insensitive), or `undefined`. */
+export function getComputedField(name: string): ComputedField | undefined {
+  const n = name.trim().toLowerCase();
+  return COMPUTED_FIELDS.find((c) => c.name.toLowerCase() === n);
+}

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -14,7 +14,7 @@ import {
   Highlighter, RemoveFormatting, List, ListOrdered, ListTodo, Quote, SquareCode,
   Link, AlignLeft, AlignCenter, AlignRight, AlignJustify,
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
-  BookMarked, Library, Info,
+  BookMarked, Library, Info, Braces,
 } from 'lucide-react';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
@@ -27,6 +27,7 @@ import { ToolbarDropdown } from './ToolbarDropdown';
 import { InsertLinkDialog } from './InsertLinkDialog';
 import { CitationPickerDialog } from './CitationPickerDialog';
 import { ReferenceManagerDialog } from './ReferenceManagerDialog';
+import { FieldsManagerDialog } from './FieldsManagerDialog';
 import { useNotificationStore } from '../store/notificationStore';
 import { ICON } from './icons';
 import './DocumentEditorToolbar.css';
@@ -62,6 +63,7 @@ export function DocumentEditorToolbar() {
   const [showLinkDialog, setShowLinkDialog] = useState(false);
   const [showCitationPicker, setShowCitationPicker] = useState(false);
   const [showRefManager, setShowRefManager] = useState(false);
+  const [showFieldsManager, setShowFieldsManager] = useState(false);
   const [showCalloutMenu, setShowCalloutMenu] = useState(false);
 
   const CALLOUT_VARIANTS: { value: CalloutVariant; label: string }[] = [
@@ -74,6 +76,7 @@ export function DocumentEditorToolbar() {
   // Let the `/citation` slash command open the citation picker (the picker is
   // React UI outside the editor). No-op headless: nothing registered.
   useEffect(() => registerSlashUiHandler('citation', () => setShowCitationPicker(true)), []);
+  useEffect(() => registerSlashUiHandler('field', () => setShowFieldsManager(true)), []);
 
   // Subscribe to editor events for toolbar state updates
   useEffect(() => {
@@ -402,6 +405,13 @@ export function DocumentEditorToolbar() {
               </button>
             </div>
 
+            {/* Document Fields (Phase 3) */}
+            <div className="document-editor-toolbar-group">
+              <button className="document-editor-toolbar-btn" onClick={() => editor && setShowFieldsManager(true)} title="Fields (insert {{value}})" aria-label="Fields">
+                <Braces {...ICON} />
+              </button>
+            </div>
+
 
             {/* Search */}
             <div className="document-editor-toolbar-group">
@@ -546,6 +556,11 @@ export function DocumentEditorToolbar() {
       )}
       {showRefManager && (
         <ReferenceManagerDialog onClose={() => setShowRefManager(false)} />
+      )}
+
+      {/* Document Fields (Phase 3) */}
+      {showFieldsManager && editor && (
+        <FieldsManagerDialog editor={editor} onClose={() => setShowFieldsManager(false)} />
       )}
 
       {/* Search & Replace Panel */}

--- a/src/ui/FieldsManagerDialog.css
+++ b/src/ui/FieldsManagerDialog.css
@@ -1,0 +1,211 @@
+/* FieldsManagerDialog (Phase 3 — Document Fields). Mirrors ReferenceManagerDialog. */
+
+.fields-manager-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.fields-manager {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: var(--shadow-xl);
+  width: min(560px, 92vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.fields-manager-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.fields-manager-header h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.fields-manager-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+.fields-manager-close:hover {
+  color: var(--text-primary);
+}
+
+.fields-manager-body {
+  padding: 1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.fields-manager-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+.fields-manager-banner svg {
+  flex: none;
+  margin-top: 1px;
+}
+
+.fields-manager-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.fields-manager-field > label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.fields-manager-row {
+  display: flex;
+  gap: 0.5rem;
+}
+.fields-manager-row input {
+  flex: 1;
+}
+
+.fields-manager input {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 4px;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.fields-manager-btn {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  white-space: nowrap;
+}
+.fields-manager-btn:hover:not(:disabled) {
+  background: var(--bg-primary);
+}
+.fields-manager-btn.primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+.fields-manager-btn.primary:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}
+.fields-manager-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fields-manager-empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.85rem;
+}
+
+.fields-manager-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.fields-manager-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.fields-manager-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+}
+
+.fields-manager-item-name {
+  flex: none;
+  min-width: 7rem;
+  max-width: 11rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fields-manager-item-value {
+  flex: 1;
+}
+
+.fields-manager-item-computed {
+  flex: 1;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fields-manager-item-remove {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  padding: 0.2rem;
+  border-radius: 3px;
+}
+.fields-manager-item-remove:hover {
+  color: var(--danger);
+  background: var(--bg-primary);
+}

--- a/src/ui/FieldsManagerDialog.tsx
+++ b/src/ui/FieldsManagerDialog.tsx
@@ -1,0 +1,207 @@
+/**
+ * FieldsManagerDialog (Phase 3 — Document Fields).
+ *
+ * Modal for managing the document's field library: define named values, edit
+ * them in place (every `{{name}}` reference repaints live), insert a reference
+ * at the caret, and insert the built-in computed fields (`today` / `now`).
+ * Follows the `createPortal` + `{ onClose }` dialog convention
+ * (cf. `ReferenceManagerDialog`). Operates on `fieldStore` directly; takes the
+ * editor only to insert a reference.
+ *
+ * v1 is client-side only — a banner notes that fields aren't yet settable or
+ * insertable via MCP/agents (planned). The data model is kept forward-compatible
+ * so that work is purely additive.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { Editor } from '@tiptap/core';
+import { Braces, Info, Plus, Trash2 } from 'lucide-react';
+import { Icon } from './icons';
+import { useFieldStore } from '../store/fieldStore';
+import { COMPUTED_FIELDS } from '../types/Field';
+import './FieldsManagerDialog.css';
+
+export interface FieldsManagerDialogProps {
+  editor: Editor;
+  onClose: () => void;
+}
+
+export function FieldsManagerDialog({ editor, onClose }: FieldsManagerDialogProps) {
+  const fields = useFieldStore((s) => s.fields);
+  const order = useFieldStore((s) => s.order);
+  const setField = useFieldStore((s) => s.setField);
+  const removeField = useFieldStore((s) => s.removeField);
+
+  // Derive the ordered list in render — never return a fresh array from the
+  // selector (would trip zustand's "getSnapshot should be cached" loop).
+  const list = useMemo(
+    () => order.map((name) => fields[name]).filter((f): f is NonNullable<typeof f> => f !== undefined),
+    [fields, order],
+  );
+
+  const [newName, setNewName] = useState('');
+  const [newValue, setNewValue] = useState('');
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const insertField = useCallback(
+    (name: string) => {
+      editor.chain().focus().setFieldRef(name).run();
+      onClose();
+    },
+    [editor, onClose],
+  );
+
+  const addField = useCallback(() => {
+    const name = newName.trim();
+    if (!name) return;
+    setField(name, newValue);
+    setNewName('');
+    setNewValue('');
+  }, [newName, newValue, setField]);
+
+  const nameExists = useMemo(
+    () => list.some((f) => f.name.toLowerCase() === newName.trim().toLowerCase()),
+    [list, newName],
+  );
+
+  return createPortal(
+    <div className="fields-manager-overlay" onMouseDown={onClose}>
+      <div
+        className="fields-manager"
+        role="dialog"
+        aria-label="Manage fields"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header className="fields-manager-header">
+          <h3>
+            <Icon icon={Braces} size={16} /> Fields
+          </h3>
+          <button className="fields-manager-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        <div className="fields-manager-body">
+          {/* MCP scope note — v1 is client-side only. */}
+          <p className="fields-manager-banner">
+            <Icon icon={Info} size={14} />
+            <span>
+              Fields are stored with this document and update everywhere they’re used.
+              Setting or inserting fields through MCP / agents isn’t supported yet.
+            </span>
+          </p>
+
+          {/* Field list */}
+          <div className="fields-manager-field">
+            <label>Document fields ({list.length})</label>
+            {list.length === 0 ? (
+              <p className="fields-manager-empty">
+                No fields yet. Add one below, or type <code>{'{{'}</code> in the editor.
+              </p>
+            ) : (
+              <ul className="fields-manager-list">
+                {list.map((field) => (
+                  <li key={field.name} className="fields-manager-item">
+                    <span className="fields-manager-item-name" title={field.name}>
+                      {field.name}
+                    </span>
+                    <input
+                      className="fields-manager-item-value"
+                      type="text"
+                      value={field.value}
+                      placeholder="value"
+                      onChange={(e) => setField(field.name, e.target.value)}
+                      aria-label={`Value for ${field.name}`}
+                    />
+                    <button
+                      className="fields-manager-btn"
+                      onClick={() => insertField(field.name)}
+                      title="Insert at cursor"
+                    >
+                      Insert
+                    </button>
+                    <button
+                      className="fields-manager-item-remove"
+                      onClick={() => removeField(field.name)}
+                      aria-label={`Remove ${field.name}`}
+                      title="Remove"
+                    >
+                      <Icon icon={Trash2} size={14} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Add a field */}
+          <div className="fields-manager-field">
+            <label htmlFor="field-new-name">Add a field</label>
+            <div className="fields-manager-row">
+              <input
+                id="field-new-name"
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="name (e.g. Company)"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addField();
+                }}
+              />
+              <input
+                type="text"
+                value={newValue}
+                onChange={(e) => setNewValue(e.target.value)}
+                placeholder="value (e.g. Acme Inc.)"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addField();
+                }}
+              />
+              <button
+                className="fields-manager-btn primary"
+                onClick={addField}
+                disabled={!newName.trim()}
+              >
+                <Icon icon={Plus} size={14} /> {nameExists ? 'Update' : 'Add'}
+              </button>
+            </div>
+          </div>
+
+          {/* Computed fields */}
+          <div className="fields-manager-field">
+            <label>Computed fields</label>
+            <ul className="fields-manager-list">
+              {COMPUTED_FIELDS.map((c) => (
+                <li key={c.name} className="fields-manager-item">
+                  <span className="fields-manager-item-name" title={c.name}>
+                    {c.name}
+                  </span>
+                  <span className="fields-manager-item-computed">{c.label} · {c.resolve()}</span>
+                  <button
+                    className="fields-manager-btn"
+                    onClick={() => insertField(c.name)}
+                    title="Insert at cursor"
+                  >
+                    Insert
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <p className="fields-manager-hint">
+              Computed fields resolve live and take precedence over a field of the same name.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -439,6 +439,27 @@
   background-color: var(--bg-tertiary);
 }
 
+/* Document Fields (Phase 3): inline `{{name}}` value, painted from fieldStore. */
+.tiptap-editor .ProseMirror .field-ref {
+  cursor: pointer;
+  border-radius: 3px;
+  padding: 0 2px;
+  background-color: var(--accent-soft, rgba(80, 120, 200, 0.12));
+  white-space: nowrap;
+}
+
+.tiptap-editor .ProseMirror .field-ref:hover {
+  background-color: var(--bg-tertiary);
+}
+
+/* Unset / empty field → muted `{name}` placeholder (visibly actionable). */
+.tiptap-editor .ProseMirror .field-ref.field-ref-unset {
+  color: var(--text-secondary, rgba(127, 127, 127, 0.9));
+  font-style: italic;
+  background-color: transparent;
+  border: 1px dashed var(--border-color);
+}
+
 .tiptap-editor .ProseMirror .bibliography-block {
   margin: 1.5rem 0;
   padding: 1rem;

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -41,6 +41,8 @@ import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
 import { CitationInline, Bibliography } from '../tiptap/CitationExtension';
 import { CitationSuggestion } from '../tiptap/CitationSuggestion';
+import { FieldRef } from '../tiptap/FieldExtension';
+import { FieldSuggestion } from '../tiptap/FieldSuggestion';
 import { SlashMenu } from '../tiptap/SlashMenu';
 import { Callout } from '../tiptap/CalloutExtension';
 import { CodeBlock } from '../tiptap/CodeBlockExtension';
@@ -169,6 +171,13 @@ export const sharedProseExtensions = [
   // inserts that node). No nodes/marks of its own, so the shared schema is
   // unaffected (safe for the headless `registerProseSchema` below + collab).
   CitationSuggestion,
+  // Document Fields (Phase 3): inline `{{name}}` value, painted from fieldStore.
+  // Atom node (clean <span data-field data-name data-label> serialization) +
+  // its `{{`-trigger picker — same rails as CitationInline + CitationSuggestion,
+  // so the headless schema + collab are unaffected. FieldSuggestion must follow
+  // FieldRef (it inserts that node).
+  FieldRef,
+  FieldSuggestion,
   // `/`-trigger command palette. Inserts existing nodes (no nodes/marks of its
   // own), so the shared schema + collab are unaffected — like CitationSuggestion.
   SlashMenu,

--- a/src/utils/pdfExportUtils.test.ts
+++ b/src/utils/pdfExportUtils.test.ts
@@ -71,6 +71,8 @@ describe('warnUnhandledNodes', () => {
       'tableCell', 'tableHeader', 'mathInline', 'mathBlock', 'hardBreak',
       // New prose nodes (Phase 1-2)
       'callout', 'figure', 'figcaption', 'gallery',
+      // Document Fields (Phase 3)
+      'fieldRef',
     ]);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();

--- a/src/utils/pdfExportUtils.ts
+++ b/src/utils/pdfExportUtils.ts
@@ -1465,6 +1465,17 @@ export function extractSegments(node: JSONContent): TextSegment[] {
           color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
         });
       }
+    } else if (child.type === 'fieldRef') {
+      // Inline field: render the cached resolved value (Phase 3). Empty when a
+      // doc was never opened in the editor (no label cached) — skip then.
+      const label = (child.attrs?.['label'] as string | undefined) || '';
+      if (label) {
+        segments.push({
+          text: label,
+          bold: false, italic: false, underline: false, strike: false, code: false,
+          color: null, highlight: null, fontSizeScale: 1, yOffset: 0,
+        });
+      }
     }
     // Skip other non-text inline nodes (mathInline handled separately at block level)
   }
@@ -2129,8 +2140,11 @@ function extractSegmentsDeep(node: JSONContent): TextSegment[] {
     return extractSegments({ type: 'paragraph', content: [node] });
   }
 
-  // If this node has inline text (or inline citation) children directly, extract them
-  if (node.content && node.content.some((c) => c.type === 'text' || c.type === 'citationInline')) {
+  // If this node has inline text (or inline citation / field) children directly, extract them
+  if (
+    node.content &&
+    node.content.some((c) => c.type === 'text' || c.type === 'citationInline' || c.type === 'fieldRef')
+  ) {
     return extractSegments(node);
   }
 
@@ -2766,6 +2780,8 @@ pdfNodeRenderers.register('mathBlock', (ctx, node) =>
 pdfNodeRenderers.register('hardBreak', () => {});
 // citationInline is handled inline by extractSegments (renders its cached label)
 pdfNodeRenderers.register('citationInline', () => {});
+// fieldRef is likewise handled inline by extractSegments (renders cached value)
+pdfNodeRenderers.register('fieldRef', () => {});
 // New prose nodes (Phase 1-2)
 pdfNodeRenderers.register('callout', (ctx, node) => renderCallout(ctx, node));
 pdfNodeRenderers.register('figure', (ctx, node) => renderFigure(ctx, node));


### PR DESCRIPTION
## What

Phase 3 of the prose-editor epic — the headline differentiator: **Document Fields**, reusable named values that propagate through prose via `{{field}}`.

- Defined terms for lawyers ("the Company", "Effective Date"), versions/config for engineers, plus built-in **computed** fields (`today` / `now`).
- Edit a value once in the Fields manager → every `{{field}}` reference repaints live.

## How

Rides the citation rails almost 1:1:

- **`fieldRef`** inline atom (`src/tiptap/FieldExtension.ts`) — a store-reactive nodeView resolves the value from `fieldStore` (or a computed field) and caches it back into a `data-label` **projection** (silent, out-of-undo, autosave-guarded — same recipe as `CitationInline`), so `getHTML` → PDF / MCP / offline are self-contained.
- **`fieldStore`** (`src/store/fieldStore.ts`) — a name-keyed map + order array, serialized into `DiagramDocument.fields` and loaded/cleared on doc switch (mirrors `references`; additive, no version bump).
- **`{{` trigger** (`src/tiptap/FieldSuggestion.ts`) on the shared `createTriggerPlugin` factory — lists fields + computed fields, with a "Create field" row for new names.
- **Fields manager dialog** + a toolbar button + `/field` slash command.
- **PDF**: `fieldRef` renders its cached value via `extractSegments` + a no-op renderer registration, enforced by the `warnUnhandledNodes` coverage test.

## MCP scope (v1 is client-side only)

There is no relay/MCP write path for field values yet — the manager carries an info banner saying so. The data model is kept **forward-compatible** so a future slice is purely additive:

- `DiagramDocument.fields` is the exact JSON a future `set_fields` relay tool will write.
- `fieldRef` serializes as `<span data-field data-name="NAME" data-label="VALUE">`, with `data-label` **optional** on parse — so a future Markdown→HTML adapter can emit `{{name}}` → `<span data-field data-name>` and the editor resolves it live.
- `{{name}}` is the same token humans type and agents will emit.

## Tests

`fieldStore` (upsert/remove/order/serialize/loadFields), `FieldRef` (round-trip, MCP-style no-label parse, live value projection, unset placeholder, `resolveFieldValue`), `matchFieldTrigger` + `buildFieldOptions`, and the extended PDF coverage list. Full suite green (2307), typecheck + build clean.

## Verification

Code-verified in-repo (typecheck / 163 test files / build). Manual live check (define a field, `{{`-insert in several spots, edit value → all update, reload persistence, `{{today}}`, PDF export shows values) is for the deploy.

Assisted-by: Opus 4.8