### PR TITLE
Sync document fields over the collaborative Y.Doc (Phase 3b)

### DIFF
--- a/src/collaboration/YjsDocument.fields.test.ts
+++ b/src/collaboration/YjsDocument.fields.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Phase 3b — document field library as a Y.Doc shared type. Asserts the per-item
+ * `fields` Y.Map + `fieldOrder` Y.Array round-trip, and — the headline guarantee
+ * — that a concurrent MCP-style set and author-style set merge instead of
+ * clobbering (mirrors the references concurrency test / the relay's).
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+import type { Field } from '../types/Field';
+
+function field(name: string, value = name): Field {
+  return { name, value };
+}
+
+describe('YjsDocument fields (Phase 3b)', () => {
+  it('setField stores per-item + appends order; getFieldLibrary merges', () => {
+    const doc = new YjsDocument();
+    doc.setField(field('Company', 'Acme'));
+    doc.setField(field('Version', '2.0'));
+
+    const lib = doc.getFieldLibrary();
+    expect(Object.keys(lib.fields).sort()).toEqual(['Company', 'Version']);
+    expect(lib.order).toEqual(['Company', 'Version']);
+    expect(lib.fields['Company']?.value).toBe('Acme');
+  });
+
+  it('re-setting an existing name is a value update, no duplicate order entry', () => {
+    const doc = new YjsDocument();
+    doc.setField(field('Company', 'Acme'));
+    doc.setField(field('Company', 'Globex'));
+    const lib = doc.getFieldLibrary();
+    expect(lib.order).toEqual(['Company']);
+    expect(lib.fields['Company']?.value).toBe('Globex');
+  });
+
+  it('deleteField removes from the map and the order', () => {
+    const doc = new YjsDocument();
+    doc.setField(field('A'));
+    doc.setField(field('B'));
+    doc.deleteField('A');
+    const lib = doc.getFieldLibrary();
+    expect(lib.fields['A']).toBeUndefined();
+    expect(lib.order).toEqual(['B']);
+  });
+
+  it('getFieldLibrary drops order names with no field and appends unordered fields', () => {
+    const doc = new YjsDocument();
+    doc.getDoc().transact(() => {
+      doc.getDoc().getMap('fields').set('present', field('present'));
+      const order = doc.getDoc().getArray<string>('fieldOrder');
+      order.push(['ghost', 'present', 'present']); // ghost has no field; dup name
+    });
+    const lib = doc.getFieldLibrary();
+    expect(lib.order).toEqual(['present']);
+  });
+
+  it('concurrent MCP-style set and author set BOTH survive (no clobber)', () => {
+    const relay = new YjsDocument();
+    const client = new YjsDocument();
+
+    // Share the (empty) base so the two have common history.
+    Y.applyUpdate(client.getDoc(), Y.encodeStateAsUpdate(relay.getDoc()));
+
+    // MCP-style set on the relay; author-style set on the client — concurrently.
+    relay.setField(field('Company', 'Acme'));
+    client.setField(field('Version', '2.0'));
+
+    // Exchange updates both ways (as the relay rebroadcast would).
+    const relayUpdate = Y.encodeStateAsUpdate(relay.getDoc());
+    const clientUpdate = Y.encodeStateAsUpdate(client.getDoc());
+    Y.applyUpdate(client.getDoc(), relayUpdate);
+    Y.applyUpdate(relay.getDoc(), clientUpdate);
+
+    for (const doc of [relay, client]) {
+      const lib = doc.getFieldLibrary();
+      expect(Object.keys(lib.fields).sort()).toEqual(['Company', 'Version']);
+      expect([...lib.order].sort()).toEqual(['Company', 'Version']);
+    }
+  });
+
+  it('onFieldChange fires for a remote update, not for a local write', () => {
+    const local = new YjsDocument();
+    const remote = new YjsDocument();
+    Y.applyUpdate(remote.getDoc(), Y.encodeStateAsUpdate(local.getDoc()));
+
+    let fired = 0;
+    local.onFieldChange(() => {
+      fired += 1;
+    });
+
+    // Local write must NOT fire the remote callback (origin === this).
+    local.setField(field('local'));
+    expect(fired).toBe(0);
+
+    // A remote peer's set, applied as an external update, fires it.
+    remote.setField(field('fromRemote', 'x'));
+    Y.applyUpdate(local.getDoc(), Y.encodeStateAsUpdate(remote.getDoc()));
+    expect(fired).toBeGreaterThan(0);
+    expect(local.getFieldLibrary().fields['fromRemote']?.value).toBe('x');
+  });
+});

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -21,6 +21,7 @@ import { yXmlFragmentToProseMirrorRootNode, updateYFragment } from 'y-prosemirro
 import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle, ReferenceLibrary } from '../types/Citation';
+import type { Field, FieldLibrary } from '../types/Field';
 import { getProseSchema } from './proseSchema';
 
 /**
@@ -60,6 +61,15 @@ export type MetadataChangeCallback = (metadata: YjsDocumentMetadata) => void;
 export type ReferenceChangeCallback = () => void;
 
 /**
+ * Callback for when the document field library changes from remote updates
+ * (Phase 3b). Coarse by design (no per-item args), mirroring
+ * {@link ReferenceChangeCallback}: the binding bulk-reloads `fieldStore` from
+ * {@link YjsDocument.getFieldLibrary} — the merged map snapshot — so a
+ * simultaneous MCP+author field set can't clobber (INVARIANT A).
+ */
+export type FieldChangeCallback = () => void;
+
+/**
  * YjsDocument wraps a Y.Doc for collaborative shape editing.
  *
  * Usage:
@@ -89,11 +99,16 @@ export class YjsDocument {
   // active citation style lives in `metadata` under `citationStyle`.
   private references: Y.Map<CSLItem>;
   private referenceOrder: Y.Array<string>;
+  // Phase 3b: the document field library as shared types — `fields` keyed by
+  // name (per-item merge, like `references`) + `fieldOrder` (display order).
+  private fields: Y.Map<Field>;
+  private fieldOrder: Y.Array<string>;
 
   private shapeChangeCallbacks: Set<ShapeChangeCallback> = new Set();
   private orderChangeCallbacks: Set<OrderChangeCallback> = new Set();
   private metadataChangeCallbacks: Set<MetadataChangeCallback> = new Set();
   private referenceChangeCallbacks: Set<ReferenceChangeCallback> = new Set();
+  private fieldChangeCallbacks: Set<FieldChangeCallback> = new Set();
 
   private isLocalUpdate = false;
 
@@ -116,6 +131,8 @@ export class YjsDocument {
     this.metadata = this.doc.getMap('metadata');
     this.references = this.doc.getMap('references');
     this.referenceOrder = this.doc.getArray('referenceOrder');
+    this.fields = this.doc.getMap('fields');
+    this.fieldOrder = this.doc.getArray('fieldOrder');
 
     // Set up observers
     this.setupObservers();
@@ -322,6 +339,63 @@ export class YjsDocument {
     return lib;
   }
 
+  // ============ Fields (Phase 3b) — local to remote ============
+
+  /**
+   * Set or update one field (local change → broadcast to peers). INVARIANT A:
+   * a strictly per-item `set` (keyed by name) + append the name to `fieldOrder`
+   * if new — never a whole-map rewrite, so a concurrent writer's not-yet-observed
+   * field can't be wiped. Re-setting an existing name is an in-place value update
+   * (LWW), with no duplicate `fieldOrder` entry — i.e. "edit a value."
+   */
+  setField(field: Field): void {
+    this.withLocalUpdate(() => {
+      this.fields.set(field.name, JSON.parse(JSON.stringify(field)));
+      if (!this.fieldOrder.toArray().includes(field.name)) {
+        this.fieldOrder.push([field.name]);
+      }
+    });
+  }
+
+  /**
+   * Delete a field by name (per-item `delete` + drop it from `fieldOrder`).
+   */
+  deleteField(name: string): void {
+    this.withLocalUpdate(() => {
+      this.fields.delete(name);
+      const idx = this.fieldOrder.toArray().indexOf(name);
+      if (idx >= 0) this.fieldOrder.delete(idx, 1);
+    });
+  }
+
+  /**
+   * The merged field library as a {@link FieldLibrary} snapshot — `fields`
+   * (name → Field) + a de-duplicated `order` (filtered to existing fields, with
+   * any unordered fields appended). The binding bulk-reloads `fieldStore` from
+   * this on any remote change. Mirrors {@link getReferenceLibrary}.
+   */
+  getFieldLibrary(): FieldLibrary {
+    const fields: Record<string, Field> = {};
+    this.fields.forEach((field, name) => {
+      fields[name] = field;
+    });
+    const order: string[] = [];
+    const seen = new Set<string>();
+    for (const name of this.fieldOrder.toArray()) {
+      if (fields[name] && !seen.has(name)) {
+        order.push(name);
+        seen.add(name);
+      }
+    }
+    for (const name of Object.keys(fields)) {
+      if (!seen.has(name)) {
+        order.push(name);
+        seen.add(name);
+      }
+    }
+    return { fields, order };
+  }
+
   // ============ Remote to Local Sync ============
 
   /**
@@ -355,6 +429,15 @@ export class YjsDocument {
   onReferenceChange(callback: ReferenceChangeCallback): () => void {
     this.referenceChangeCallbacks.add(callback);
     return () => this.referenceChangeCallbacks.delete(callback);
+  }
+
+  /**
+   * Subscribe to field-library changes from remote peers (Phase 3b). Fires on
+   * any `fields` / `fieldOrder` change.
+   */
+  onFieldChange(callback: FieldChangeCallback): () => void {
+    this.fieldChangeCallbacks.add(callback);
+    return () => this.fieldChangeCallbacks.delete(callback);
   }
 
   // ============ State Access ============
@@ -465,6 +548,8 @@ export class YjsDocument {
     this.references.unobserve(this.handleReferenceChange);
     this.referenceOrder.unobserve(this.handleReferenceChange);
     this.metadata.unobserve(this.handleReferenceMetaChange);
+    this.fields.unobserve(this.handleFieldChange);
+    this.fieldOrder.unobserve(this.handleFieldChange);
     this.doc.destroy();
   }
 
@@ -485,6 +570,11 @@ export class YjsDocument {
     this.references.observe(this.handleReferenceChange);
     this.referenceOrder.observe(this.handleReferenceChange);
     this.metadata.observe(this.handleReferenceMetaChange);
+
+    // Phase 3b: observe field-library changes (map + order). No metadata
+    // analogue — fields carry no style/active-key.
+    this.fields.observe(this.handleFieldChange);
+    this.fieldOrder.observe(this.handleFieldChange);
   }
 
   private handleShapeChange = (event: Y.YMapEvent<Shape>): void => {
@@ -552,6 +642,15 @@ export class YjsDocument {
     if (event.changes.keys.has('citationStyle')) {
       this.referenceChangeCallbacks.forEach((cb) => cb());
     }
+  };
+
+  // Phase 3b: a remote change to `fields` or `fieldOrder` → fire the coarse
+  // field callback (the binding bulk-reloads from the merged snapshot).
+  private handleFieldChange = (
+    event: Y.YMapEvent<Field> | Y.YArrayEvent<string>
+  ): void => {
+    if (this.isLocalUpdate || event.transaction.origin === this) return;
+    this.fieldChangeCallbacks.forEach((cb) => cb());
   };
 
   /**

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -42,6 +42,7 @@ import { mutateDocument } from '../store/writeProvenance';
 import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle } from '../types/Citation';
+import type { Field } from '../types/Field';
 import type { DocEvent } from './protocol';
 import { isUnknownDocError } from './protocol';
 import { throttle } from '../utils/requestUtils';
@@ -148,6 +149,10 @@ interface CollaborationActions {
   syncDeleteReference: (id: string) => void;
   /** Sync the active citation style to peers (`metadata.citationStyle`). */
   syncReferenceStyle: (style: CitationStyle) => void;
+  /** Sync a field add/update to peers via the `fields` Y.Map (Phase 3b). */
+  syncField: (field: Field) => void;
+  /** Sync a field deletion to peers. */
+  syncDeleteField: (name: string) => void;
   /**
    * Sync the document name (a rename) to peers via the Y.Doc `metadata` map
    * (CRDT-native rename, so it propagates + persists like shapes rather than
@@ -652,6 +657,18 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     syncReferenceStyle: (style: CitationStyle) => {
       if (yjsDoc) {
         yjsDoc.setReferenceStyle(style);
+      }
+    },
+
+    syncField: (field: Field) => {
+      if (yjsDoc) {
+        yjsDoc.setField(field);
+      }
+    },
+
+    syncDeleteField: (name: string) => {
+      if (yjsDoc) {
+        yjsDoc.deleteField(name);
       }
     },
 

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -40,6 +40,11 @@ function makeMockYjs() {
     setReference: vi.fn(),
     deleteReference: vi.fn(),
     setReferenceStyle: vi.fn(),
+    // Phase 3b field-library binding surface.
+    onFieldChange: vi.fn(() => () => {}),
+    getFieldLibrary: vi.fn(() => ({ fields: {}, order: [] })),
+    setField: vi.fn(),
+    deleteField: vi.fn(),
   };
 }
 

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -18,6 +18,7 @@
 import { useEffect, useRef } from 'react';
 import { useDocumentStore } from '../store/documentStore';
 import { useReferenceStore } from '../store/referenceStore';
+import { useFieldStore } from '../store/fieldStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
@@ -48,6 +49,8 @@ export function useCollaborationSync(): void {
   const syncReference = useCollaborationStore((state) => state.syncReference);
   const syncDeleteReference = useCollaborationStore((state) => state.syncDeleteReference);
   const syncReferenceStyle = useCollaborationStore((state) => state.syncReferenceStyle);
+  const syncField = useCollaborationStore((state) => state.syncField);
+  const syncDeleteField = useCollaborationStore((state) => state.syncDeleteField);
 
   // Track if we've initialized for this session
   const initializedRef = useRef(false);
@@ -115,11 +118,21 @@ export function useCollaborationSync(): void {
       });
     });
 
+    // Handle remote field-library changes (Phase 3b). Same coarse bulk-reload
+    // pattern as references — `remote-apply` so the local fieldStore→Y.Doc
+    // subscription below skips it (no echo loop).
+    const unsubFields = yjsDoc.onFieldChange(() => {
+      runWithProvenance('remote-apply', () => {
+        useFieldStore.getState().loadFields(yjsDoc.getFieldLibrary());
+      });
+    });
+
     return () => {
       unsubShapes();
       unsubOrder();
       unsubMeta();
       unsubRefs();
+      unsubFields();
     };
   }, [isActive, getYjsDocument, sessionEpoch]);
 
@@ -157,6 +170,8 @@ export function useCollaborationSync(): void {
         }
         // JP-89: adopt the authoritative reference library too.
         useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
+        // Phase 3b: adopt the authoritative field library too.
+        useFieldStore.getState().loadFields(yjsDoc.getFieldLibrary());
       });
       // Adopt the relay's authoritative document name too (CRDT-native rename),
       // so a joining client picks up a rename made before it connected.
@@ -184,6 +199,8 @@ export function useCollaborationSync(): void {
         // JP-89: a doc can be empty of shapes but carry a reference library
         // (prose + citations, no diagram) — adopt it here too.
         useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
+        // Phase 3b: a prose-only doc can carry fields with no shapes — adopt too.
+        useFieldStore.getState().loadFields(yjsDoc.getFieldLibrary());
       });
       initializedRef.current = true;
     }
@@ -327,6 +344,40 @@ export function useCollaborationSync(): void {
 
     return unsubscribe;
   }, [isActive, syncReference, syncDeleteReference, syncReferenceStyle]);
+
+  // Subscribe to local field-library changes and sync to the CRDT (Phase 3b).
+  // Mirrors the reference subscription: same provenance + autosave-suppression +
+  // initialized gates, and a per-item diff by NAME (INVARIANT A — `set`/`delete`,
+  // never a whole-map rewrite) so a concurrent MCP/peer set is never clobbered.
+  // Computed fields (today/now) never enter `fieldStore.fields`, so they're never
+  // synced — by design (each client resolves them live).
+  useEffect(() => {
+    if (!isActive) return undefined;
+
+    const unsubscribe = useFieldStore.subscribe((state, prevState) => {
+      const provenance = getProvenance();
+      if (provenance === 'remote-apply' || provenance === 'load') return;
+      if (isAutoSaveSuppressed()) return;
+      if (!useCollaborationStore.getState().isActive) return;
+      if (!initializedRef.current) return;
+
+      const curNames = new Set(Object.keys(state.fields));
+      const prevNames = new Set(Object.keys(prevState.fields));
+
+      // Added or value-changed fields → per-item set.
+      for (const name of curNames) {
+        const cur = state.fields[name];
+        if (!cur) continue;
+        if (!prevNames.has(name) || cur !== prevState.fields[name]) syncField(cur);
+      }
+      // Deleted fields → per-item delete.
+      for (const name of prevNames) {
+        if (!curNames.has(name)) syncDeleteField(name);
+      }
+    });
+
+    return unsubscribe;
+  }, [isActive, syncField, syncDeleteField]);
 }
 
 /**


### PR DESCRIPTION
## What

Phase 3b of Document Fields. v1 (PR #214) shipped fields as a client-/single-user-only feature — a field value edited in one collab session did **not** propagate to peers. This makes field values live-collaborative, mirroring the JP-89 reference-library binding end to end.

## How

The reference library already solved this exact problem; fields ride the same rails on all three layers:

- **`YjsDocument.ts`** — `fields` Y.Map (keyed by name) + `fieldOrder` Y.Array as shared types. Per-item `setField`/`deleteField` (**INVARIANT A**: never a whole-map rewrite, so a concurrent peer's field can't be clobbered), a merged `getFieldLibrary()` snapshot, an `onFieldChange` observer guarded by `isLocalUpdate` / transaction origin, and `destroy()` cleanup.
- **`collaborationStore.ts`** — `syncField` / `syncDeleteField`.
- **`useCollaborationSync.ts`** — remote→local coarse reload (`runWithProvenance('remote-apply')` so the local subscription skips the echo), adoption of the authoritative library on session start (both adopt branches), and a local→remote per-item diff **by name** under the same provenance / autosave-suppressed / initialized gates as references.

## Notes

- **Computed fields** (`today`/`now`) never enter `fieldStore.fields`, so they're never synced — each client resolves them live (by design).
- **No `PROTOCOL_VERSION` bump** — `fields`/`fieldOrder` are additive Y.Doc shared types, behavior-only, exactly like the JP-89 references types. The relay's authoritative-Y.Doc + MCP support for these types is the follow-up (Phase 3c).
- Wire-type names (`fields`, `fieldOrder`) are pinned to match the upcoming relay hydration/flatten.

## Tests

`YjsDocument.fields.test.ts` mirrors the references suite — per-item store + order round-trip, value-update without dup order, delete, ghost-order reconciliation, the **concurrent set-survival** guarantee, and `onFieldChange` firing on remote (not local) writes. The `useCollaborationSync` mock gains the field surface. Full suite green (2313), typecheck + build clean.

## Verification

Code-verified in-repo (typecheck / 164 test files / build). Manual (deploy): two browsers in one collab doc, edit a field value in one → its `{{field}}` references repaint live in the other.

Assisted-by: Opus 4.8