### PR TITLE
Relay Y.Doc + MCP support for document fields (Phase 3c)

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -85,13 +85,14 @@ All tools are namespaced `docushark.*`.
 | Tool | Purpose |
 | -- | -- |
 | `list_documents` | List documents in the workspace (`id`, `name`, `pageCount`, `modifiedAt`, `source`). |
-| `get_document` | Document metadata + canvas `pages` summary + `prosePages` summary. The map of what exists. |
+| `get_document` | Document metadata + canvas `pages` summary + `prosePages` summary + `fields` (the document's `{{name}}` values). The map of what exists. |
 | `get_page` | The shapes on one canvas page, as DSL objects. |
 | `get_shape` | One shape on a page, by id, as a DSL object (the read-one companion to `get_page`). |
 | `get_prose` | All prose pages (or one, with `pageId`): `id`, `name`, `order`, HTML `content`. |
 | `get_outline` | A prose page's heading outline: ordered `{ index, level, title }`. `index` is used by the structural tools. |
 | `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
 | `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |
+| `list_fields` | The document's fields (reusable `{{name}}` values) in display order, each `{ name, value }`. |
 
 ### Author
 
@@ -145,6 +146,24 @@ the document's top-level `references` field and round-trips durably; a *connecte
 editor sees new references on reload, as references aren't live-synced yet.
 Formatting (CSL → APA/MLA/Chicago/Vancouver) is done in the editor, not the
 relay — the MCP surface only reads and writes CSL-JSON.
+
+### Fields (write)
+
+| Tool | Purpose |
+| -- | -- |
+| `set_fields` | Set/update document **fields** — reusable named values (e.g. `Company` → `Acme Inc.`, `Version` → `2.0`). Upsert by name: a new name is created, an existing name's value is replaced. Returns the names written + which were newly added. |
+
+A *field* is a `name → value` pair that propagates everywhere it's referenced. To
+**reference** a field in prose, write `{{name}}` in Markdown via
+`set_prose`/`add_prose_page` — it becomes a live field placeholder (`<span
+data-field data-name="name">`) that renders the current value and updates when the
+value changes. (`{{name}}` inside inline code or a code block stays literal.)
+
+Fields are stored as the document's top-level `fields` object —
+`{ fields: { "<name>": { name, value } }, order: [...] }` — and round-trip
+durably. On a *connected* (resident) document, `set_fields` writes the live CRDT
+library and broadcasts, so collaborators see new values immediately, per item (a
+concurrent editor's field isn't clobbered).
 
 (Renames: `rename_prose_page`.)
 

--- a/relay/src/mcp/fields.rs
+++ b/relay/src/mcp/fields.rs
@@ -1,0 +1,165 @@
+//! Document Fields — pure JSON helpers for the MCP `set_fields` / `list_fields`
+//! tools (Phase 3c). Mirrors `citations.rs`: the cold (non-resident) write/read
+//! paths operate directly on the document JSON, while the resident path goes
+//! through the live `Y.Doc` (`DocHandle::insert_fields` / `fields_json`).
+//!
+//! Storage shape (the v1 client + MCP wire contract):
+//! `doc["fields"] = { "fields": { "<name>": {"name": "<name>", "value": "<value>"} },
+//!                    "order": ["<name>", …] }`.
+//!
+//! Keep this free of network / serde-struct coupling — plain `serde_json::Value`
+//! mutation so it's safe to replay under `mutate_with_retry`.
+
+use serde_json::{json, Value};
+
+/// One field to set (upsert), as supplied by the `set_fields` tool.
+pub struct FieldSet {
+    pub name: String,
+    pub value: String,
+}
+
+/// The names written by a `set_fields` call + how many were newly created.
+pub struct SetOutcome {
+    /// Names written (added or updated), in input order.
+    pub set: Vec<String>,
+    /// Of those, the names that did not previously exist.
+    pub added: Vec<String>,
+}
+
+/// The doc's `fields` library as a mutable object, creating an empty one
+/// (`{fields:{}, order:[]}`) if absent or malformed. Mirrors `references_mut`.
+fn fields_mut(doc: &mut Value) -> Result<&mut serde_json::Map<String, Value>, String> {
+    let root = doc.as_object_mut().ok_or("Document is not an object")?;
+    let entry = root.entry("fields").or_insert_with(|| json!({"fields": {}, "order": []}));
+    // Repair a malformed value rather than fail the whole write.
+    if !entry.is_object() {
+        *entry = json!({"fields": {}, "order": []});
+    }
+    let lib = entry.as_object_mut().unwrap();
+    if !lib.get("fields").map(Value::is_object).unwrap_or(false) {
+        lib.insert("fields".into(), json!({}));
+    }
+    if !lib.get("order").map(Value::is_array).unwrap_or(false) {
+        lib.insert("order".into(), json!([]));
+    }
+    Ok(lib)
+}
+
+/// Upsert `incoming` fields into the doc's JSON `fields` library (the cold /
+/// non-resident path); new names are appended to `order`. Pure: safe to replay
+/// under `mutate_with_retry`. Re-setting an existing name updates its value in
+/// place with no duplicate `order` entry.
+pub fn set_fields_in_place(doc: &mut Value, incoming: &[FieldSet]) -> Result<SetOutcome, String> {
+    let lib = fields_mut(doc)?;
+
+    // Snapshot the existing names so we can report which were newly added and
+    // avoid duplicate order entries (borrow the map sections one at a time).
+    let existing: std::collections::HashSet<String> = lib
+        .get("fields")
+        .and_then(Value::as_object)
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default();
+
+    let items = lib.get_mut("fields").and_then(Value::as_object_mut).unwrap();
+    let mut set = Vec::with_capacity(incoming.len());
+    let mut added = Vec::new();
+    for f in incoming {
+        items.insert(f.name.clone(), json!({"name": f.name, "value": f.value}));
+        set.push(f.name.clone());
+        if !existing.contains(&f.name) {
+            added.push(f.name.clone());
+        }
+    }
+
+    let order = lib.get_mut("order").and_then(Value::as_array_mut).unwrap();
+    let in_order: std::collections::HashSet<String> =
+        order.iter().filter_map(Value::as_str).map(str::to_string).collect();
+    for name in &added {
+        if !in_order.contains(name) {
+            order.push(json!(name));
+        }
+    }
+
+    Ok(SetOutcome { set, added })
+}
+
+/// Build the `list_fields` result payload from raw library parts (the fields map
+/// + display order). Shared by the cold JSON and resident live read paths.
+pub fn list_payload(items: &serde_json::Map<String, Value>, order: &[String]) -> Value {
+    let ordered: Vec<Value> = if order.is_empty() {
+        items.values().cloned().collect()
+    } else {
+        order.iter().filter_map(|name| items.get(name).cloned()).collect()
+    };
+    json!({
+        "fields": ordered,
+        "count": ordered.len(),
+    })
+}
+
+/// Read the doc's JSON field library as a result payload (the cold /
+/// non-resident path): the fields in `order`, plus a count. Tolerant of a
+/// missing/empty library.
+pub fn list_fields_json(doc: &Value) -> Value {
+    let lib = doc.get("fields");
+    let empty = serde_json::Map::new();
+    let items = lib.and_then(|l| l.get("fields")).and_then(Value::as_object).unwrap_or(&empty);
+    let order: Vec<String> = lib
+        .and_then(|l| l.get("order"))
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).map(str::to_string).collect())
+        .unwrap_or_default();
+    list_payload(items, &order)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(name: &str, value: &str) -> FieldSet {
+        FieldSet { name: name.to_string(), value: value.to_string() }
+    }
+
+    #[test]
+    fn set_fields_creates_library_and_appends_order() {
+        let mut doc = json!({"id": "d"});
+        let out = set_fields_in_place(&mut doc, &[set("Company", "Acme"), set("Version", "2.0")]).unwrap();
+        assert_eq!(out.set, vec!["Company", "Version"]);
+        assert_eq!(out.added, vec!["Company", "Version"]);
+        assert_eq!(doc["fields"]["fields"]["Company"]["value"], "Acme");
+        assert_eq!(doc["fields"]["order"], json!(["Company", "Version"]));
+    }
+
+    #[test]
+    fn set_fields_updates_value_without_duplicating_order() {
+        let mut doc = json!({"id": "d", "fields": {"fields": {"Company": {"name": "Company", "value": "Acme"}}, "order": ["Company"]}});
+        let out = set_fields_in_place(&mut doc, &[set("Company", "Globex")]).unwrap();
+        assert_eq!(out.added, Vec::<String>::new());
+        assert_eq!(doc["fields"]["fields"]["Company"]["value"], "Globex");
+        assert_eq!(doc["fields"]["order"], json!(["Company"]));
+    }
+
+    #[test]
+    fn set_fields_repairs_a_malformed_library() {
+        let mut doc = json!({"id": "d", "fields": "garbage"});
+        set_fields_in_place(&mut doc, &[set("A", "1")]).unwrap();
+        assert_eq!(doc["fields"]["fields"]["A"]["value"], "1");
+        assert_eq!(doc["fields"]["order"], json!(["A"]));
+    }
+
+    #[test]
+    fn list_fields_returns_ordered_payload() {
+        let doc = json!({"id": "d", "fields": {"fields": {"B": {"name": "B", "value": "2"}, "A": {"name": "A", "value": "1"}}, "order": ["A", "B"]}});
+        let payload = list_fields_json(&doc);
+        assert_eq!(payload["count"], 2);
+        assert_eq!(payload["fields"][0]["name"], "A");
+        assert_eq!(payload["fields"][1]["name"], "B");
+    }
+
+    #[test]
+    fn list_fields_tolerates_missing_library() {
+        let payload = list_fields_json(&json!({"id": "d"}));
+        assert_eq!(payload["count"], 0);
+        assert_eq!(payload["fields"], json!([]));
+    }
+}

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -11,6 +11,7 @@
 pub mod adapter;
 pub mod citations;
 pub mod config;
+pub mod fields;
 pub mod layout;
 pub mod local_mirror;
 pub mod outline;

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -489,6 +489,45 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "additionalProperties": false
             }),
         },
+        ToolDescriptor {
+            name: "docushark.list_fields",
+            description:
+                "Return a document's fields (reusable named values like \"Company\" or \"Version\") in display order, each as {name, value}. Read-only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.set_fields",
+            description:
+                "Set or update one or more document fields (reusable named values). Each field is upserted by name: a new name is created, an existing name has its value replaced. Returns the names written and which were newly added. To reference a field in prose, write {{name}} in Markdown via set_prose/add_prose_page (it becomes a live field placeholder). Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "fields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string", "description": "Field name — the {{name}} token. Required, non-empty."},
+                                "value": {"type": "string", "description": "Field value. Substituted wherever {{name}} appears. Defaults to empty."}
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                        },
+                        "description": "The fields to set (upsert by name)."
+                    }
+                },
+                "required": ["docId", "fields"],
+                "additionalProperties": false
+            }),
+        },
     ]
 }
 
@@ -600,6 +639,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.reorder_prose_pages" => reorder_prose_pages(ctx, args),
         "docushark.list_references" => list_references(ctx, args),
         "docushark.add_reference" => add_reference(ctx, args),
+        "docushark.list_fields" => list_fields(ctx, args),
+        "docushark.set_fields" => set_fields(ctx, args),
         // docushark.resolve_doi is resolved async in the transport layer before
         // dispatch (it needs a network call); it never reaches this match.
         _ => Err(format!("Unknown tool: {}", name)),
@@ -703,6 +744,13 @@ fn get_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
         })
         .unwrap_or_default();
 
+    // Document fields (Phase 3c) — reusable {{name}} values, in display order.
+    // Read the live Y.Doc library when resident (fresher than the snapshot).
+    let fields = match resident.as_ref() {
+        Some(h) => super::fields::list_payload(&h.fields_json(), &h.field_order()),
+        None => super::fields::list_fields_json(&doc),
+    };
+
     Ok(ToolOutcome {
         result: json!({
             "id": doc.get("id").cloned().unwrap_or(Value::Null),
@@ -714,6 +762,8 @@ fn get_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
             // Prose pages (the written body) — id/name/order only; fetch
             // content with get_prose. Empty for diagram-only documents.
             "prosePages": prose_page_summaries(&doc),
+            // Reusable document fields ({{name}} values), each {name, value}.
+            "fields": fields.get("fields").cloned().unwrap_or_else(|| json!([])),
             "source": source,
         }),
         changed_doc_id: None,
@@ -946,17 +996,103 @@ fn create_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
 // ---------------------------------------------------------------------------
 
 /// Render Markdown to the HTML TipTap persists. GFM tables / strikethrough /
-/// task-lists are enabled to match the editor's extension set.
+/// task-lists are enabled to match the editor's extension set. `{{name}}` tokens
+/// in prose text become live field placeholders (Phase 3c) — see
+/// [`expand_field_tokens`].
 fn markdown_to_html(md: &str) -> String {
-    use pulldown_cmark::{html, Options, Parser};
+    use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
     let mut opts = Options::empty();
     opts.insert(Options::ENABLE_TABLES);
     opts.insert(Options::ENABLE_STRIKETHROUGH);
     opts.insert(Options::ENABLE_TASKLISTS);
-    let parser = Parser::new_ext(md, opts);
+
+    // Filter the event stream: transform `{{name}}` inside plain text into a
+    // `<span data-field …>` (a live field reference), but NEVER inside a code
+    // block (where `{{` must stay literal). Inline code is a separate
+    // `Event::Code`, so it's left untouched by only matching `Event::Text`.
+    let mut in_code_block = 0u32;
+    let mut events: Vec<Event> = Vec::new();
+    for ev in Parser::new_ext(md, opts) {
+        match ev {
+            Event::Start(Tag::CodeBlock(kind)) => {
+                in_code_block += 1;
+                events.push(Event::Start(Tag::CodeBlock(kind)));
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                in_code_block = in_code_block.saturating_sub(1);
+                events.push(Event::End(TagEnd::CodeBlock));
+            }
+            Event::Text(t) if in_code_block == 0 && t.contains("{{") => {
+                expand_field_tokens(&t, &mut events);
+            }
+            other => events.push(other),
+        }
+    }
+
     let mut out = String::new();
-    html::push_html(&mut out, parser);
+    html::push_html(&mut out, events.into_iter());
     out
+}
+
+/// Escape a string for an HTML double-quoted attribute value.
+fn escape_field_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Parse a field token at the start of `s` (the text right after an opening
+/// `{{`): the name runs to the closing `}}` and may not contain `{` or `}`.
+/// Returns the trimmed name + the byte count to skip past the closing `}}`, or
+/// `None` if it isn't a well-formed token. `{`/`}` are ASCII, so byte scanning
+/// is char-boundary safe.
+fn try_parse_field_token(s: &str) -> Option<(&str, usize)> {
+    let bytes = s.as_bytes();
+    let mut j = 0;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'{' => return None, // a name can't contain '{'
+            b'}' => {
+                if j + 1 < bytes.len() && bytes[j + 1] == b'}' {
+                    let name = s[..j].trim();
+                    return if name.is_empty() { None } else { Some((name, j + 2)) };
+                }
+                return None; // a lone '}' is not a close
+            }
+            _ => j += 1,
+        }
+    }
+    None
+}
+
+/// Split `text` on `{{name}}` tokens, pushing literal stretches as `Event::Text`
+/// and each token as an `Event::InlineHtml` `<span data-field data-name="name">`
+/// (no `data-label` — the editor's nodeView fills the live value). A malformed
+/// `{{…` with no valid close stays literal.
+fn expand_field_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>) {
+    use pulldown_cmark::{CowStr, Event};
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    let mut literal_start = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            if let Some((name, consumed)) = try_parse_field_token(&text[i + 2..]) {
+                if literal_start < i {
+                    out.push(Event::Text(CowStr::from(text[literal_start..i].to_string())));
+                }
+                let span = format!("<span data-field data-name=\"{}\"></span>", escape_field_attr(name));
+                out.push(Event::InlineHtml(CowStr::from(span)));
+                i += 2 + consumed;
+                literal_start = i;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    if literal_start < text.len() {
+        out.push(Event::Text(CowStr::from(text[literal_start..].to_string())));
+    }
 }
 
 /// Hard cap on a single prose write's content size, in bytes (JP-248). A safety
@@ -2064,6 +2200,120 @@ fn add_reference(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String>
 
     Ok(ToolOutcome {
         result,
+        changed_doc_id: Some(parsed.doc_id.clone()),
+        change_detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Fields tools (Phase 3c): read/write the document's reusable named values,
+// which live in `doc["fields"] = { fields: {name→{name,value}}, order: [...] }`.
+// Mirror the citations tools' resident-live / cold-JSON split.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct ListFieldsArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+}
+
+/// Read a document's field library in display order. Read-only. Reads the live
+/// Y.Doc library when the doc is resident (so an agent sees fields a peer/agent
+/// just set before the next flatten), else the JSON snapshot.
+fn list_fields(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: ListFieldsArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    let result = if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let items = handle.fields_json();
+        let order = handle.field_order();
+        let mut payload = super::fields::list_payload(&items, &order);
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("source".into(), json!(SOURCE_TEAM));
+        }
+        payload
+    } else {
+        let (doc, source) = fetch_doc(ctx, &parsed.doc_id)?;
+        let mut payload = super::fields::list_fields_json(&doc);
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("source".into(), json!(source));
+        }
+        payload
+    };
+    Ok(ToolOutcome { result, changed_doc_id: None, change_detail: None })
+}
+
+#[derive(Deserialize)]
+struct SetFieldsArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    fields: Vec<FieldInput>,
+}
+
+#[derive(Deserialize)]
+struct FieldInput {
+    name: String,
+    #[serde(default)]
+    value: String,
+}
+
+/// Set/update document fields by name. When the doc is **resident**, writes the
+/// live Y.Doc `fields` map per item + broadcasts the CRDT delta (so MCP and editor
+/// field edits converge — Phase 3b); else writes the JSON snapshot under optimistic
+/// concurrency. Mirrors `add_reference`.
+fn set_fields(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: SetFieldsArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    // Normalize + validate: every field needs a non-empty (trimmed) name.
+    let mut sets: Vec<super::fields::FieldSet> = Vec::with_capacity(parsed.fields.len());
+    for f in &parsed.fields {
+        let name = f.name.trim().to_string();
+        if name.is_empty() {
+            return Err("set_fields: every field requires a non-empty 'name'".into());
+        }
+        sets.push(super::fields::FieldSet { name, value: f.value.clone() });
+    }
+    if sets.is_empty() {
+        return Err("set_fields requires a non-empty 'fields' array".into());
+    }
+
+    // Resident → live Y.Doc per-item write (INVARIANT A) + broadcast; the client's
+    // fields observer merges it, so no reload nudge (changed_doc_id None).
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let items: Vec<(String, Value)> = sets
+            .iter()
+            .map(|s| (s.name.clone(), json!({"name": s.name, "value": s.value})))
+            .collect();
+        let added_before: std::collections::HashSet<String> =
+            handle.fields_json().keys().cloned().collect();
+        let framed = handle.insert_fields(&items);
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        let set: Vec<String> = sets.iter().map(|s| s.name.clone()).collect();
+        let added: Vec<String> =
+            set.iter().filter(|n| !added_before.contains(*n)).cloned().collect();
+        return Ok(ToolOutcome {
+            result: json!({"set": set, "setCount": set.len(), "added": added}),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    // Cold path: JSON snapshot under optimistic concurrency.
+    let outcome = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let out = super::fields::set_fields_in_place(doc, &sets)?;
+        stamp_doc_modified(doc, now_ms());
+        Ok(out)
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({
+            "set": outcome.set,
+            "setCount": outcome.set.len(),
+            "added": outcome.added,
+        }),
         changed_doc_id: Some(parsed.doc_id.clone()),
         change_detail: None,
     })
@@ -4286,5 +4536,140 @@ mod tests {
             .unwrap();
         assert_eq!(out.result["count"], json!(0));
         assert_eq!(out.result["references"], json!([]));
+    }
+
+    // ---- Phase 3c: fields tools ----
+
+    #[test]
+    fn set_fields_cold_persists_and_lists() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.set_fields",
+            &json!({"docId": "doc1", "fields": [
+                {"name": "Company", "value": "Acme"},
+                {"name": "Version", "value": "2.0"},
+            ]}),
+        )
+        .unwrap();
+        assert_eq!(out.result["setCount"], json!(2));
+        assert_eq!(out.result["added"], json!(["Company", "Version"]));
+        // Cold write nudges the app to reload.
+        assert_eq!(out.changed_doc_id.as_ref().unwrap().as_str(), "doc1");
+
+        // Durable in the JSON store (top-level `fields`).
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".to_string()).unwrap();
+        let json = f.team.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(json["fields"]["order"], json!(["Company", "Version"]));
+        assert_eq!(json["fields"]["fields"]["Company"]["value"], json!("Acme"));
+
+        // list_fields reflects them in order; get_document exposes them too.
+        let listed = dispatch(&f.ctx(true), "docushark.list_fields", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(listed.result["count"], json!(2));
+        assert_eq!(listed.result["fields"][0]["name"], json!("Company"));
+        assert!(listed.changed_doc_id.is_none(), "a read must not nudge a reload");
+
+        let got = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(got.result["fields"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn set_fields_upserts_value_in_place() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        dispatch(&f.ctx(true), "docushark.set_fields", &json!({"docId": "doc1", "fields": [{"name": "Company", "value": "Acme"}]})).unwrap();
+        let out = dispatch(&f.ctx(true), "docushark.set_fields", &json!({"docId": "doc1", "fields": [{"name": "Company", "value": "Globex"}]})).unwrap();
+        // An existing name → updated, not newly added.
+        assert_eq!(out.result["added"], json!([]));
+        let listed = dispatch(&f.ctx(true), "docushark.list_fields", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(listed.result["count"], json!(1));
+        assert_eq!(listed.result["fields"][0]["value"], json!("Globex"));
+    }
+
+    #[test]
+    fn set_fields_resident_writes_ydoc_and_broadcasts() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let handle = f.make_resident("doc1");
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.set_fields",
+            &json!({"docId": "doc1", "fields": [{"name": "Company", "value": "Acme"}]}),
+        )
+        .unwrap();
+
+        // Applied to the live Y.Doc.
+        assert_eq!(handle.fields_json().get("Company").unwrap()["value"], json!("Acme"));
+        assert_eq!(handle.field_order(), vec!["Company".to_string()]);
+        // One CRDT delta broadcast; no reload nudge (the client's observer merges).
+        let bc = f.broadcasts();
+        assert_eq!(bc.len(), 1, "exactly one broadcast");
+        assert_eq!(bc[0].1.as_str(), "doc1");
+        assert!(!bc[0].2.is_empty());
+        assert!(out.changed_doc_id.is_none());
+        assert_eq!(out.result["added"], json!(["Company"]));
+    }
+
+    #[test]
+    fn set_fields_requires_non_empty_name() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let err = dispatch(&f.ctx(true), "docushark.set_fields", &json!({"docId": "doc1", "fields": [{"name": "  ", "value": "x"}]}))
+            .unwrap_err();
+        assert!(err.contains("non-empty 'name'"), "got: {}", err);
+    }
+
+    #[test]
+    fn set_fields_rejects_local_document() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        f.local.mirror(&WorkspaceId::single_tenant(), make_doc("local1", "p1", "Local Doc")).unwrap();
+        let err = dispatch(&f.ctx(true), "docushark.set_fields", &json!({"docId": "local1", "fields": [{"name": "A", "value": "1"}]}))
+            .unwrap_err();
+        assert!(err.contains("read-only"), "got: {}", err);
+    }
+
+    #[test]
+    fn list_fields_empty_for_fresh_doc() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let out = dispatch(&f.ctx(true), "docushark.list_fields", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(out.result["count"], json!(0));
+        assert_eq!(out.result["fields"], json!([]));
+    }
+
+    // ---- Phase 3c: {{name}} markdown adapter ----
+
+    #[test]
+    fn markdown_field_token_becomes_span() {
+        let html = markdown_to_html("The {{Company}} agrees to pay {{Amount}}.");
+        assert!(html.contains(r#"<span data-field data-name="Company"></span>"#), "got: {html}");
+        assert!(html.contains(r#"<span data-field data-name="Amount"></span>"#), "got: {html}");
+        assert!(html.contains("The "), "literal text preserved");
+    }
+
+    #[test]
+    fn markdown_field_token_left_literal_in_code() {
+        // Inline code and fenced code blocks must keep `{{…}}` verbatim.
+        let inline = markdown_to_html("use `{{notAField}}` here");
+        assert!(inline.contains("{{notAField}}"), "inline code untouched: {inline}");
+        assert!(!inline.contains("data-field"));
+
+        let fenced = markdown_to_html("```\n{{alsoNotAField}}\n```");
+        assert!(fenced.contains("{{alsoNotAField}}"), "code block untouched: {fenced}");
+        assert!(!fenced.contains("data-field"));
+    }
+
+    #[test]
+    fn markdown_malformed_field_token_stays_literal() {
+        // No closing braces / an inner brace → not a token.
+        let html = markdown_to_html("a {{unclosed and {{x}} b");
+        assert!(html.contains("{{unclosed and "), "got: {html}");
+        // The well-formed `{{x}}` after the junk still converts.
+        assert!(html.contains(r#"<span data-field data-name="x"></span>"#), "got: {html}");
     }
 }

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -770,7 +770,9 @@ mod tests {
         assert!(names.contains(&"docushark.list_references"));
         assert!(names.contains(&"docushark.resolve_doi"));
         assert!(names.contains(&"docushark.add_reference"));
-        assert_eq!(tools.len(), 24);
+        assert!(names.contains(&"docushark.list_fields"));
+        assert!(names.contains(&"docushark.set_fields"));
+        assert_eq!(tools.len(), 26);
     }
 
     #[tokio::test]

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -192,6 +192,37 @@ pub fn project_references_into(doc: &Doc, json: &mut Value) {
     }
 }
 
+/// Project the live field library — `fields` `Y.Map` (name → Field) +
+/// `fieldOrder` `Y.Array` — into `json["fields"] = {fields, order}` (Phase 3c).
+/// The write projection paired with [`super::hydration::json_fields_to_ydoc`]:
+/// the relay owns the library in the authoritative `Y.Doc`, so every flatten
+/// re-asserts the merged set. An empty map writes an empty library (a real "all
+/// deleted"), **except** we never synthesize a `fields` field for a doc that
+/// never had one (back-compat for pre-Phase-3 documents).
+pub fn project_fields_into(doc: &Doc, json: &mut Value) {
+    let fields = doc.get_or_insert_map("fields");
+    let field_order = doc.get_or_insert_array("fieldOrder");
+
+    let (fields_any, order_any) = {
+        let txn = doc.transact();
+        (fields.to_json(&txn), field_order.to_json(&txn))
+    };
+
+    let items = any_to_json(&fields_any);
+    let is_empty = items.as_object().map(JsonMap::is_empty).unwrap_or(true);
+    // Back-compat: leave a doc that never had a library without one.
+    if is_empty && json.get("fields").is_none() {
+        return;
+    }
+
+    if let Some(obj) = json.as_object_mut() {
+        let mut lib = JsonMap::new();
+        lib.insert("fields".to_string(), items);
+        lib.insert("order".to_string(), any_to_json(&order_any));
+        obj.insert("fields".to_string(), Value::Object(lib));
+    }
+}
+
 /// Convert a yrs `Any` into a `serde_json::Value` — the inverse of
 /// `hydration::json_to_any`. Integral numbers are emitted as JSON integers so
 /// a shape's `x: 10` round-trips as `10` rather than `10.0`.
@@ -406,5 +437,45 @@ mod tests {
         project_references_into(&doc, &mut json);
         assert_eq!(json["references"]["items"], json!({}));
         assert_eq!(json["references"]["itemOrder"], json!([]));
+    }
+
+    // ---- Phase 3c: field library projection ----
+
+    fn doc_with_fields() -> Doc {
+        use yrs::{Array, Map};
+        let doc = Doc::new();
+        let fields = doc.get_or_insert_map("fields");
+        let order = doc.get_or_insert_array("fieldOrder");
+        let mut txn = doc.transact_mut();
+        fields.insert(&mut txn, "Company", super::super::hydration::json_to_any(&json!({"name": "Company", "value": "Acme"})));
+        order.push_back(&mut txn, Any::String("Company".into()));
+        drop(txn);
+        doc
+    }
+
+    #[test]
+    fn project_fields_round_trips_fields_and_order() {
+        let doc = doc_with_fields();
+        let mut json = json!({"id": "d"});
+        project_fields_into(&doc, &mut json);
+        assert_eq!(json["fields"]["order"], json!(["Company"]));
+        assert_eq!(json["fields"]["fields"]["Company"]["value"], json!("Acme"));
+    }
+
+    #[test]
+    fn project_fields_skips_synthesizing_for_pre_phase3_docs() {
+        let doc = Doc::new();
+        let mut json = json!({"id": "d"});
+        project_fields_into(&doc, &mut json);
+        assert!(json.get("fields").is_none());
+    }
+
+    #[test]
+    fn project_fields_writes_empty_on_full_deletion() {
+        let doc = Doc::new();
+        let mut json = json!({"id": "d", "fields": {"fields": {"X": {"name": "X", "value": "1"}}, "order": ["X"]}});
+        project_fields_into(&doc, &mut json);
+        assert_eq!(json["fields"]["fields"], json!({}));
+        assert_eq!(json["fields"]["order"], json!([]));
     }
 }

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -172,6 +172,42 @@ pub fn json_references_to_ydoc(doc_json: &Value, doc: &Doc) {
     }
 }
 
+/// Seed the `fields` `Y.Map` (name → Field JSON) + `fieldOrder` `Y.Array` from a
+/// persisted document's top-level `fields` library (Phase 3c). The relay owns the
+/// library in the authoritative `Y.Doc` so MCP and editor field edits converge
+/// **per item** (a `Y.Map` merge) instead of clobbering a whole field at a time.
+///
+/// JSON shape is `doc["fields"] = { fields: {name→{name,value}}, order: [...] }`
+/// (the v1 client shape). **Idempotent — only seeds an EMPTY map** (mirrors
+/// [`json_references_to_ydoc`] / the prose backstop): a populated map means the
+/// sidecar is authoritative, so leave it; an older sidecar with no `fields` map
+/// gets it backfilled from JSON.
+pub fn json_fields_to_ydoc(doc_json: &Value, doc: &Doc) {
+    let fields = doc.get_or_insert_map("fields");
+    let field_order = doc.get_or_insert_array("fieldOrder");
+
+    let mut txn = doc.transact_mut();
+
+    if fields.len(&txn) > 0 {
+        return;
+    }
+
+    let Some(lib) = doc_json.get("fields").and_then(Value::as_object) else {
+        return;
+    };
+
+    if let Some(items) = lib.get("fields").and_then(Value::as_object) {
+        for (name, field) in items {
+            fields.insert(&mut txn, name.clone(), json_to_any(field));
+        }
+    }
+    if let Some(order) = lib.get("order").and_then(Value::as_array) {
+        for name in order.iter().filter_map(Value::as_str) {
+            field_order.push_back(&mut txn, Any::String(name.into()));
+        }
+    }
+}
+
 /// Whether a parsed prose block carries real content — any non-whitespace text,
 /// or an embed (image / horizontal rule). A bare/empty paragraph (the empty-page
 /// placeholder) has none, so it isn't seeded.
@@ -182,7 +218,7 @@ fn block_has_substance(node: &super::prose_parse::PmNode) -> bool {
     // mistaken for the empty-page placeholder.
     if matches!(
         node.node_type.as_str(),
-        "image" | "horizontalRule" | "citationInline" | "bibliography"
+        "image" | "horizontalRule" | "citationInline" | "bibliography" | "fieldRef"
     ) {
         return true;
     }
@@ -460,5 +496,52 @@ mod tests {
         json_references_to_ydoc(&json!({"id": "d"}), &doc);
         let refs = doc.get_or_insert_map("references");
         assert_eq!(refs.len(&doc.transact()), 0);
+    }
+
+    fn fields_json() -> Value {
+        json!({
+            "id": "d",
+            "fields": {
+                "fields": {
+                    "Company": {"name": "Company", "value": "Acme"},
+                    "Version": {"name": "Version", "value": "2.0"}
+                },
+                "order": ["Company", "Version"]
+            }
+        })
+    }
+
+    #[test]
+    fn json_fields_to_ydoc_seeds_map_and_order() {
+        let doc = Doc::new();
+        super::json_fields_to_ydoc(&fields_json(), &doc);
+        let fields = doc.get_or_insert_map("fields");
+        let order = doc.get_or_insert_array("fieldOrder");
+        let txn = doc.transact();
+        assert_eq!(fields.len(&txn), 2);
+        assert!(fields.contains_key(&txn, "Company"));
+        assert_eq!(order.len(&txn), 2);
+    }
+
+    #[test]
+    fn json_fields_to_ydoc_is_idempotent_only_seeds_empty() {
+        let doc = Doc::new();
+        super::json_fields_to_ydoc(&fields_json(), &doc);
+        super::json_fields_to_ydoc(
+            &json!({"fields": {"fields": {"Other": {"name": "Other", "value": "x"}}, "order": ["Other"]}}),
+            &doc,
+        );
+        let fields = doc.get_or_insert_map("fields");
+        let txn = doc.transact();
+        assert_eq!(fields.len(&txn), 2, "second seed must be a no-op on a populated map");
+        assert!(!fields.contains_key(&txn, "Other"));
+    }
+
+    #[test]
+    fn json_fields_to_ydoc_noop_without_fields() {
+        let doc = Doc::new();
+        super::json_fields_to_ydoc(&json!({"id": "d"}), &doc);
+        let fields = doc.get_or_insert_map("fields");
+        assert_eq!(fields.len(&doc.transact()), 0);
     }
 }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -193,6 +193,8 @@ impl DocHandle {
                                 // backfilled from JSON (idempotent; never wipes a
                                 // populated map).
                                 hydration::json_references_to_ydoc(doc_json, &doc);
+                                // Phase 3c: same backstop for the field library.
+                                hydration::json_fields_to_ydoc(doc_json, &doc);
                                 return (doc, false);
                             }
                         }
@@ -213,6 +215,8 @@ impl DocHandle {
         // JP-89: seed the reference library into the authoritative Y.Doc so MCP +
         // editor ref edits converge per item instead of whole-field clobbering.
         hydration::json_references_to_ydoc(doc_json, &doc);
+        // Phase 3c: same for the field library.
+        hydration::json_fields_to_ydoc(doc_json, &doc);
         (doc, poison_healed)
     }
 
@@ -330,6 +334,8 @@ impl DocHandle {
         // JP-89: re-assert the reference library from the authoritative Y.Doc, so
         // a merged set (incl. live MCP/peer adds) is what persists.
         flatten::project_references_into(&self.doc, json);
+        // Phase 3c: same for the field library (live MCP/peer field edits).
+        flatten::project_fields_into(&self.doc, json);
         true
     }
 
@@ -511,6 +517,61 @@ impl DocHandle {
             references.insert(&mut txn, id.clone(), hydration::json_to_any(item));
             if !existing.contains(id) {
                 order.push_back(&mut txn, Any::String(id.clone().into()));
+            }
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
+    }
+
+    /// The `fields` `Y.Map` as a JSON object (name → Field). Used by the MCP
+    /// `set_fields` live path to read the merged library and by `list_fields` to
+    /// read the resident library. Empty object if unset. (Phase 3c.)
+    pub fn fields_json(&self) -> serde_json::Map<String, Value> {
+        let fields = self.doc.get_or_insert_map("fields");
+        let txn = self.doc.transact();
+        match flatten::any_to_json(&fields.to_json(&txn)) {
+            Value::Object(m) => m,
+            _ => serde_json::Map::new(),
+        }
+    }
+
+    /// The `fieldOrder` array as a list of field names (display order). (Phase 3c.)
+    pub fn field_order(&self) -> Vec<String> {
+        let order = self.doc.get_or_insert_array("fieldOrder");
+        let txn = self.doc.transact();
+        order
+            .iter(&txn)
+            .filter_map(|o| match o {
+                yrs::Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Insert/update field(s) into the live `fields` `Y.Map` and append any new
+    /// names to `fieldOrder`, in one transaction (INVARIANT A: strictly per-item
+    /// `set` — never a whole-map rewrite, so a concurrent writer's not-yet-observed
+    /// field can't be wiped). A name already present is overwritten (LWW — i.e.
+    /// "edit a value") without a duplicate `fieldOrder` entry. Returns the framed
+    /// CRDT delta to broadcast; marks dirty. (Phase 3c.)
+    pub fn insert_fields(&self, items: &[(String, Value)]) -> Vec<u8> {
+        let fields = self.doc.get_or_insert_map("fields");
+        let order = self.doc.get_or_insert_array("fieldOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        let existing: std::collections::HashSet<String> = order
+            .iter(&txn)
+            .filter_map(|o| match o {
+                yrs::Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect();
+        for (name, field) in items {
+            fields.insert(&mut txn, name.clone(), hydration::json_to_any(field));
+            if !existing.contains(name) {
+                order.push_back(&mut txn, Any::String(name.clone().into()));
             }
         }
         let update = txn.encode_state_as_update_v1(&before);

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -126,6 +126,7 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         // void-with-attrs round-trip, like `image`. See `prose_schema`.
         "citationInline" => Block::Void(citation_html(el, txn)),
         "bibliography" => Block::Void(bibliography_html(el, txn)),
+        "fieldRef" => Block::Void(field_html(el, txn)),
         // Task list/item are read-only aliases of ul/li (not in the shared
         // round-trip table — a write never re-emits these PM types).
         "taskList" => wrap("ul"),
@@ -198,6 +199,25 @@ fn citation_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
     }
     if let Some(loc) = str_attr(el, txn, "locator").filter(|v| !v.is_empty()) {
         let _ = write!(s, " data-locator=\"{}\"", escape_attr(&loc));
+    }
+    let label = str_attr(el, txn, "label").unwrap_or_default();
+    if !label.is_empty() {
+        let _ = write!(s, " data-label=\"{}\"", escape_attr(&label));
+    }
+    s.push('>');
+    push_escaped(&mut s, &label);
+    s.push_str("</span>");
+    s
+}
+
+/// Serialize a `fieldRef` element to `<span data-field data-name=… [data-label=…]>value</span>`
+/// (Phase 3c). The `label` (cached resolved value) is also emitted as the text
+/// child so static consumers (PDF, MCP `get_prose`, a non-collab open) show the
+/// value. Mirrors the editor's `renderHTML` in `src/tiptap/FieldExtension.ts`.
+fn field_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let mut s = String::from("<span data-field");
+    if let Some(name) = str_attr(el, txn, "name") {
+        let _ = write!(s, " data-name=\"{}\"", escape_attr(&name));
     }
     let label = str_attr(el, txn, "label").unwrap_or_default();
     if !label.is_empty() {
@@ -488,6 +508,32 @@ mod tests {
             // no locator, no label
         });
         assert_eq!(html, "<p><span data-citation data-ref-id=\"a\"></span></p>");
+    }
+
+    #[test]
+    fn field_ref_serializes_with_name_and_label() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("The "));
+            let f = p.push_back(txn, XmlElementPrelim::empty("fieldRef"));
+            f.insert_attribute(txn, "name", "Company");
+            f.insert_attribute(txn, "label", "Acme Inc.");
+        });
+        assert_eq!(
+            html,
+            "<p>The <span data-field data-name=\"Company\" data-label=\"Acme Inc.\">Acme Inc.</span></p>"
+        );
+    }
+
+    #[test]
+    fn field_ref_omits_empty_label() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            let f = p.push_back(txn, XmlElementPrelim::empty("fieldRef"));
+            f.insert_attribute(txn, "name", "Version");
+            // no label
+        });
+        assert_eq!(html, "<p><span data-field data-name=\"Version\"></span></p>");
     }
 
     #[test]

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -342,6 +342,18 @@ fn citation_node(attrs: &[(String, String)]) -> PmNode {
     PmNode { node_type: "citationInline".to_string(), attrs: a, children: vec![] }
 }
 
+/// Build a `fieldRef` PM node from a `<span data-field …>` element's attributes
+/// (Phase 3c). Caller guarantees `data-name` is present. `label` (the cached
+/// resolved value) is emitted only when non-empty, symmetric with the editor's
+/// `renderHTML` (`src/tiptap/FieldExtension.ts`). It's an atom — no children.
+fn field_node(attrs: &[(String, String)]) -> PmNode {
+    let mut a = vec![("name".to_string(), get_attr(attrs, "data-name").unwrap_or("").to_string())];
+    if let Some(label) = get_attr(attrs, "data-label").filter(|s| !s.is_empty()) {
+        a.push(("label".to_string(), label.to_string()));
+    }
+    PmNode { node_type: "fieldRef".to_string(), attrs: a, children: vec![] }
+}
+
 /// Map a known block-level HTML element to a PM node, else `None`.
 fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode]) -> Option<PmNode> {
     // Bibliography block atom (JP-89): `<div data-bibliography data-bib-html=…>`.
@@ -422,6 +434,14 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                     // Require `data-ref-id` — a refId-less citation is useless, so
                     // fall through to the unwrap below and keep the text instead.
                     out.push(PmChild::Node(citation_node(attrs)));
+                } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
+                    == Some("fieldRef")
+                    && get_attr(attrs, "data-name").filter(|s| !s.is_empty()).is_some()
+                {
+                    // Inline field atom (Phase 3c). Require a non-empty `data-name`
+                    // — a nameless field reference is useless, so fall through to
+                    // the unwrap below and keep the text instead.
+                    out.push(PmChild::Node(field_node(attrs)));
                 } else if let Some(mark) = prose_schema::mark_pm(tag) {
                     let mut m = marks.to_vec();
                     m.push(PmMark { name: mark.to_string(), href: None });
@@ -594,6 +614,46 @@ mod tests {
         assert_eq!(attr(c, "refId"), Some("knuth1997"));
         assert_eq!(attr(c, "locator"), Some("p. 42"));
         assert_eq!(attr(c, "label"), Some("(Knuth, 1997)"));
+    }
+
+    #[test]
+    fn field_span_parses_to_inline_node() {
+        let b = html_to_blocks(
+            r#"<p>The <span data-field data-name="Company" data-label="Acme Inc.">Acme Inc.</span> agrees</p>"#,
+        );
+        assert_eq!(b[0].node_type, "paragraph");
+        assert_eq!(b[0].children[0], text("The "));
+        let PmChild::Node(f) = &b[0].children[1] else { panic!("field not a node") };
+        assert_eq!(f.node_type, "fieldRef");
+        assert!(f.children.is_empty(), "field is an atom");
+        assert_eq!(attr(f, "name"), Some("Company"));
+        assert_eq!(attr(f, "label"), Some("Acme Inc."));
+    }
+
+    #[test]
+    fn field_span_omits_absent_label() {
+        // The MCP markdown adapter emits `{{name}}` → <span data-field data-name>
+        // with no label; it must still parse and carry the name.
+        let b = html_to_blocks(r#"<p><span data-field data-name="Version"></span></p>"#);
+        let PmChild::Node(f) = &b[0].children[0] else { panic!() };
+        assert_eq!(f.node_type, "fieldRef");
+        assert_eq!(attr(f, "name"), Some("Version"));
+        assert_eq!(attr(f, "label"), None);
+    }
+
+    #[test]
+    fn field_span_without_name_degrades_to_text() {
+        let b = html_to_blocks(r#"<p>a <span data-field>kept</span> b</p>"#);
+        let all: String = b[0]
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                PmChild::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(all, "a kept b");
+        assert!(b[0].children.iter().all(|c| matches!(c, PmChild::Text { .. })));
     }
 
     #[test]

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -73,6 +73,11 @@ pub fn mark_pm(html_tag: &str) -> Option<&'static str> {
 pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
     ("citationInline", "span", "data-citation"),
     ("bibliography", "div", "data-bibliography"),
+    // Document Fields (Phase 3c): an inline `{{name}}` reference. Without this
+    // entry the relay's prose serializer would unwrap the span to its text on
+    // any reserialize/flatten, dropping the field node. Mirrors
+    // `src/tiptap/FieldExtension.ts`.
+    ("fieldRef", "span", "data-field"),
 ];
 
 /// PM node type for an HTML element that matches a custom prose-helper node:

--- a/src/ui/FieldsManagerDialog.css
+++ b/src/ui/FieldsManagerDialog.css
@@ -59,24 +59,6 @@
   gap: 1rem;
 }
 
-.fields-manager-banner {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.45rem;
-  margin: 0;
-  padding: 0.55rem 0.65rem;
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  line-height: 1.4;
-}
-.fields-manager-banner svg {
-  flex: none;
-  margin-top: 1px;
-}
-
 .fields-manager-field {
   display: flex;
   flex-direction: column;

--- a/src/ui/FieldsManagerDialog.tsx
+++ b/src/ui/FieldsManagerDialog.tsx
@@ -16,7 +16,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { Editor } from '@tiptap/core';
-import { Braces, Info, Plus, Trash2 } from 'lucide-react';
+import { Braces, Plus, Trash2 } from 'lucide-react';
 import { Icon } from './icons';
 import { useFieldStore } from '../store/fieldStore';
 import { COMPUTED_FIELDS } from '../types/Field';
@@ -90,15 +90,6 @@ export function FieldsManagerDialog({ editor, onClose }: FieldsManagerDialogProp
         </header>
 
         <div className="fields-manager-body">
-          {/* MCP scope note — v1 is client-side only. */}
-          <p className="fields-manager-banner">
-            <Icon icon={Info} size={14} />
-            <span>
-              Fields are stored with this document and update everywhere they’re used.
-              Setting or inserting fields through MCP / agents isn’t supported yet.
-            </span>
-          </p>
-
           {/* Field list */}
           <div className="fields-manager-field">
             <label>Document fields ({list.length})</label>


### PR DESCRIPTION
## What

Phase 3c — completes Document Fields end to end. The relay now owns the field library in its authoritative Y.Doc, MCP agents can set/read fields, and `{{name}}` authored in prose Markdown becomes a live field placeholder. A 1:1 mirror of the JP-89 references integration across every layer.

Stacks conceptually on **#215** (the client collab binding, Phase 3b) — they touch disjoint files and can merge in either order; together they finish the feature.

## How

**Relay Y.Doc (persistence symmetry)**
- `hydration::json_fields_to_ydoc` + `flatten::project_fields_into`, wired beside the references calls in `sync/mod.rs` (idempotent seed; never synthesize `fields` for a doc that never had one).
- `DocHandle::fields_json` / `field_order` / `insert_fields` (per-item set + append, **INVARIANT A**) for the resident live-write path.

**MCP tools** (`src/mcp/fields.rs` + `tools.rs`)
- `set_fields` (upsert; resident → live Y.Doc + broadcast, cold → JSON under `mutate_with_retry`; `reject_if_local`) and `list_fields`; `fields` exposed in `get_document`.

**Prose serializer knows `fieldRef`** (correctness foundation, found in review) — registered in `prose_schema` `CUSTOM_PROSE_NODES` + `prose_html` (write) + `prose_parse` (read). Without this the relay unwraps the span to its text on any reserialize/flatten, **dropping the field node** — latent since v1, independent of MCP.

**`{{name}}` → `<span data-field data-name>` Markdown adapter** as a pulldown-cmark event filter that **skips code spans/blocks** (so `{{` stays literal in code).

**Client**: drop the now-obsolete "MCP unsupported" banner from the Fields manager (fields are fully agent-capable now). **Docs**: `relay/docs/mcp/README.md` gains a Fields section + the `{{name}}` author syntax.

## Wire contract

`fields` Y.Map + `fieldOrder` Y.Array (matches #215's client types byte-for-byte); JSON `doc.fields = { fields, order }`. Additive shared type — **no `PROTOCOL_VERSION` bump** (same as references).

## Tests

`fields.rs` helpers, `set_fields`/`list_fields`/`get_document` tool tests (cold + resident-broadcast + reject-local), the `{{name}}` adapter (paragraph / inline-code / fenced / malformed), prose round-trip (parse + serialize), and hydration/flatten round-trip + back-compat. Full relay suite green (419 lib + integration); app typecheck + build clean; clippy clean.

## Verification

Code-verified in-repo. Live E2E (set fields via MCP, `{{name}}` in prose, collab propagation, resident broadcast) is covered by the staging E2E PR.

Assisted-by: Opus 4.8