### PR TITLE
Don't demote docs from another relay; badge them instead (JP-308)

### DIFF
--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -37,7 +37,7 @@ import { RestDocumentProvider } from '../api/restDocumentProvider';
 import { clearJwt, saveConnection } from '../api/relayConnection';
 import { useNotificationStore } from '../store/notificationStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
-import { isRemoteDocument } from '../types/DocumentRegistry';
+import { isRemoteDocument, isForeignRelayDoc } from '../types/DocumentRegistry';
 import { mutateDocument } from '../store/writeProvenance';
 import type { JSONContent } from '@tiptap/core';
 import type { Shape } from '../shapes/Shape';
@@ -491,13 +491,21 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
           // local-only, rather than letting them edit into the void.
           if (isUnknownDocError(error) && docId) {
             const record = useDocumentRegistry.getState().getRecord(docId);
-            if (record && (record.type === 'remote' || record.type === 'cached')) {
-              // The relay has no record of a doc we believed was relay-backed —
-              // it was deleted, possibly while we were offline. Converge on the
-              // same strand/demote path as a live Deleted event (JP-175) so the
-              // user keeps their copy instead of editing a ghost into the void.
-              // No deleter id (this is our own rejected JOIN), so it's treated
-              // as a foreign deletion (never self-skipped).
+            const connectedRelayAddress = useConnectionStore.getState().host?.address;
+            if (record && isForeignRelayDoc(record, connectedRelayAddress)) {
+              // JP-308: the doc belongs to a DIFFERENT relay than the one we're
+              // connected to. This relay rejecting the JOIN is expected — the doc
+              // lives on its home relay, it is NOT deleted. Do nothing destructive:
+              // keep the remote record intact (the card derives idle/offline from
+              // the relay mismatch, and edits queue under the doc's home relay for
+              // replay on return — JP-117). Demoting here was the bug.
+            } else if (record && (record.type === 'remote' || record.type === 'cached')) {
+              // The doc's OWN home relay has no record of it — it was deleted,
+              // possibly while we were offline. Converge on the same strand/demote
+              // path as a live Deleted event (JP-175) so the user keeps their copy
+              // instead of editing a ghost into the void. No deleter id (this is
+              // our own rejected JOIN), so it's treated as a foreign deletion
+              // (never self-skipped).
               useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
             } else {
               // Diverged / never-promoted local id — not a deletion. Keep the

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for `reconcileLocalDocuments` — the on-open / refresh reconcile that
+ * heals the browser's local entries from the authoritative index without
+ * clobbering relay-owned (remote/cached) entries or churning when nothing
+ * changed.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDocumentRegistry } from './documentRegistry';
+import type { DocumentMetadata } from '../types/Document';
+
+function meta(id: string, name = 'Doc', isRelayDocument = false): DocumentMetadata {
+  return {
+    id,
+    name,
+    pageCount: 1,
+    createdAt: 0,
+    modifiedAt: 0,
+    ...(isRelayDocument ? { isRelayDocument: true } : {}),
+  };
+}
+
+beforeEach(() => {
+  useDocumentRegistry.getState().reset();
+});
+
+describe('reconcileLocalDocuments', () => {
+  it('upserts a new local doc as a local record', () => {
+    useDocumentRegistry.getState().reconcileLocalDocuments([meta('a', 'Alpha')]);
+    const rec = useDocumentRegistry.getState().getRecord('a');
+    expect(rec?.type).toBe('local');
+    expect(rec?.name).toBe('Alpha');
+  });
+
+  it('refreshes a changed name on an existing local entry', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerLocal(meta('a', 'Old'));
+    r.reconcileLocalDocuments([meta('a', 'New')]);
+    expect(useDocumentRegistry.getState().getRecord('a')?.name).toBe('New');
+  });
+
+  it('does not clobber an existing remote entry with the same id (no demote)', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('a', 'Remote'), 'relay-a:9876', 'owner', 'synced');
+    // The local index still lists it (e.g. mirrored) as a non-relay meta.
+    r.reconcileLocalDocuments([meta('a', 'Stale Local')]);
+    const rec = useDocumentRegistry.getState().getRecord('a');
+    expect(rec?.type).toBe('remote'); // stayed remote, not demoted to local
+    expect(rec?.name).toBe('Remote');
+  });
+
+  it('ignores relay-flagged metas', () => {
+    useDocumentRegistry.getState().reconcileLocalDocuments([meta('a', 'Relay', true)]);
+    expect(useDocumentRegistry.getState().getRecord('a')).toBeUndefined();
+  });
+
+  it('no-ops (keeps entries identity) when nothing changed', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerLocal(meta('a', 'Same'));
+    const before = useDocumentRegistry.getState().entries;
+    r.reconcileLocalDocuments([meta('a', 'Same')]);
+    expect(useDocumentRegistry.getState().entries).toBe(before);
+  });
+});

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -73,6 +73,16 @@ interface DocumentRegistryActions {
   /** Register a local document */
   registerLocal: (metadata: DocumentMetadata) => void;
 
+  /**
+   * Reconcile the registry's LOCAL entries against the authoritative local
+   * index (`persistenceStore.getDocumentList()`), called when the browser opens
+   * / on manual refresh. Upsert-and-refresh only: it picks up renames /
+   * creations / metadata drift that an individual `registerLocal` path missed.
+   * Never demotes a `remote`/`cached` entry (relay docs are owned by the remote
+   * refetch); never removes (deletions go through `removeDocument`).
+   */
+  reconcileLocalDocuments: (localMetas: DocumentMetadata[]) => void;
+
   /** Register a remote document */
   registerRemote: (
     metadata: DocumentMetadata,
@@ -227,6 +237,35 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
             },
           },
         }));
+      },
+
+      reconcileLocalDocuments: (localMetas) => {
+        set((state) => {
+          const next = { ...state.entries };
+          let changed = false;
+          for (const meta of localMetas) {
+            // The index includes mirrored relay docs; those are owned by the
+            // remote refetch (registerRemote) — skip them here so we never
+            // demote a relay-backed doc to local in the UI (the JP-308 class).
+            if (meta.isRelayDocument) continue;
+            const existing = next[meta.id]?.record;
+            if (existing && existing.type !== 'local') continue;
+            const record = toLocalDocument(meta);
+            // Cheap dirty-check: skip identical entries so we don't churn the
+            // `entries` identity (which re-renders every card) when nothing drifted.
+            if (
+              existing &&
+              existing.name === record.name &&
+              existing.modifiedAt === record.modifiedAt &&
+              existing.pageCount === record.pageCount
+            ) {
+              continue;
+            }
+            next[meta.id] = { record, isLoading: false };
+            changed = true;
+          }
+          return changed ? { entries: next } : state;
+        });
       },
 
       registerRemote: (metadata, relayId, permission, syncState = 'synced') => {

--- a/src/types/DocumentRegistry.test.ts
+++ b/src/types/DocumentRegistry.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for `isForeignRelayDoc` (JP-308) — the discriminant that flags a doc
+ * belonging to a relay other than the one we're connected to. It gates both the
+ * "Other relay" browser badge and the strand/demote guard, so getting it wrong
+ * either wipes a doc's relay identity (false negative) or hides it (false
+ * positive). Pure function → tested directly.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isForeignRelayDoc,
+  type LocalDocument,
+  type RemoteDocument,
+  type CachedDocument,
+} from './DocumentRegistry';
+
+const base = { id: 'd1', name: 'Doc', pageCount: 1, createdAt: 0, modifiedAt: 0 };
+
+function remote(relayId: string): RemoteDocument {
+  return {
+    ...base,
+    type: 'remote',
+    relayId,
+    ownerId: 'u1',
+    ownerName: 'User',
+    permission: 'owner',
+    syncState: 'synced',
+    lastSyncedAt: 0,
+  };
+}
+
+function cached(relayId: string): CachedDocument {
+  return {
+    ...base,
+    type: 'cached',
+    relayId,
+    originalDocId: 'd1',
+    cachedAt: 0,
+    pendingChanges: 0,
+    permission: 'editor',
+  };
+}
+
+const local: LocalDocument = { ...base, type: 'local' };
+
+describe('isForeignRelayDoc', () => {
+  it('is true for a remote doc whose relay differs from the connected one', () => {
+    expect(isForeignRelayDoc(remote('relay-a:9876'), 'relay-b:9876')).toBe(true);
+  });
+
+  it('is true for a cached doc from another relay', () => {
+    expect(isForeignRelayDoc(cached('relay-a:9876'), 'relay-b:9876')).toBe(true);
+  });
+
+  it('is false when the doc is on the connected relay', () => {
+    expect(isForeignRelayDoc(remote('relay-a:9876'), 'relay-a:9876')).toBe(false);
+  });
+
+  it('is false when not connected to any relay (offline ≠ foreign)', () => {
+    expect(isForeignRelayDoc(remote('relay-a:9876'), undefined)).toBe(false);
+  });
+
+  it("is false for an unknown-origin relay doc (can't prove it's foreign)", () => {
+    expect(isForeignRelayDoc(remote('unknown'), 'relay-b:9876')).toBe(false);
+  });
+
+  it('is false for a local document', () => {
+    expect(isForeignRelayDoc(local, 'relay-b:9876')).toBe(false);
+  });
+});

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -156,6 +156,29 @@ export function isSyncedDocument(record: DocumentRecord): record is RemoteDocume
   return record.type === 'remote' || record.type === 'cached';
 }
 
+/**
+ * Whether `record` belongs to a relay *other than the one we're currently
+ * connected to* (JP-308). True only for a relay-backed doc with a known origin
+ * relay (`relayId` ≠ `'unknown'`) while we ARE connected to some relay
+ * (`connectedRelayAddress` set) whose address differs from the doc's.
+ *
+ * This is the single discriminant for "from another workspace": it gates both
+ * the UI badge (`DocumentCard`) and the strand/demote guard
+ * (`collaborationStore.onError`), so a doc that's merely on a different relay is
+ * never mistaken for a deleted one. A doc on our connected relay, a local doc,
+ * an unknown-origin doc, or being offline entirely all return false (each is a
+ * different state the existing sync/offline badges already cover).
+ */
+export function isForeignRelayDoc(
+  record: DocumentRecord,
+  connectedRelayAddress: string | undefined,
+): boolean {
+  if (record.type !== 'remote' && record.type !== 'cached') return false;
+  if (!connectedRelayAddress) return false;
+  if (record.relayId === 'unknown') return false;
+  return record.relayId !== connectedRelayAddress;
+}
+
 // ============ Conversion Helpers ============
 
 /**

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -116,6 +116,33 @@
   color: var(--text-muted);
 }
 
+/* JP-308: "Other relay" badge — the doc belongs to a relay other than the one
+   we're connected to (so it can't sync from here). Matches the type-badge
+   pattern; muted/neutral so it reads as informational, not an error. */
+.document-card__foreign-relay {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: #64748b;
+  background: rgba(100, 116, 139, 0.12);
+  white-space: nowrap;
+}
+
+.document-card__foreign-relay svg {
+  flex-shrink: 0;
+}
+
+:root[data-theme='dark'] .document-card__foreign-relay {
+  color: #94a3b8;
+  background: rgba(148, 163, 184, 0.15);
+}
+
 /* Offline-cache status badge (JP-281) — distinct from the sync badge: it tracks
    whether the doc's body + referenced blobs are saved locally for offline use. */
 .document-card__offline {

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -16,13 +16,14 @@ import {
   Download,
   HardDrive,
   Loader2,
+  Network,
   Pencil,
   Trash2,
   Upload,
   Users,
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
-import type { DocumentRecord, Permission } from '../types/DocumentRegistry';
+import { isForeignRelayDoc, type DocumentRecord, type Permission } from '../types/DocumentRegistry';
 import type { OfflineProgress, OfflineStatus } from '../store/offlineAvailability';
 import { useConnectionStore } from '../store/connectionStore';
 import './DocumentCard.css';
@@ -372,6 +373,10 @@ function DocumentCardImpl({
   );
 
   const relay = formatRelayLabel(record, connectedRelayAddress);
+  // JP-308: the doc belongs to a relay other than the one we're connected to —
+  // mark it explicitly ("Other relay") so it reads as intentionally-elsewhere
+  // rather than offline/online-ambiguous. Same discriminant the demote guard uses.
+  const isForeign = isForeignRelayDoc(record, connectedRelayAddress);
   // The sync badge must reflect the live connection, not the stale registry
   // default — drive it off the same connected/disconnected signal as the relay
   // badge above it. `relaySignedIn` (a valid cached token) splits a disconnected
@@ -450,6 +455,19 @@ function DocumentCardImpl({
           {/* Sync status. The connection/offline state lives here only — a
               separate relay badge would duplicate it and leak the relay host. */}
           <SyncStatusBadge state={syncState} size="small" showLabel />
+
+          {/* JP-308: document from another relay than the one we're on. Labelled
+              generically (no host:port leak — the full host lives in the details
+              panel); disambiguates "belongs elsewhere" from idle/offline. */}
+          {isForeign && relay && (
+            <span
+              className="document-card__foreign-relay"
+              title={`Stored on another relay (${relay.host}) — open it there to sync`}
+            >
+              <Network size={12} aria-hidden="true" />
+              Other relay
+            </span>
+          )}
 
           {/* Offline-cache status + action (JP-281): always-visible (not in the
               hover-only actions row), so it reads as passive status for every

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -429,6 +429,31 @@
   background: var(--color-primary-light);
   color: var(--text-primary);
 }
+.dh-refresh {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.dh-refresh:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.dh-refresh-spin {
+  animation: dh-refresh-spin 0.8s linear infinite;
+}
+@keyframes dh-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .dh-import {
   display: flex;
   align-items: center;

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -28,6 +28,7 @@ import {
   LayoutGrid,
   List,
   Moon,
+  RefreshCw,
   Search,
   Settings as SettingsIcon,
   Shapes,
@@ -42,6 +43,7 @@ import { RelaySettings } from '../settings/RelaySettings';
 import { TrashView } from './TrashView';
 import { ShapeLibraryManager } from '../ShapeLibraryManager';
 import { useTrashStore } from '../../store/trashStore';
+import { useDocumentRegistry } from '../../store/documentRegistry';
 import { useThemeStore } from '../../store/themeStore';
 import { getDocProvider } from '../../store/relayDocumentStore';
 import type { RelayUsage } from '../../api/relayClient';
@@ -94,7 +96,9 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
     hasSelection,
     handleNewDocument,
     handleImport,
+    handleRefresh,
   } = model;
+  const isFetchingRemote = useDocumentRegistry((s) => s.isFetchingRemote);
 
   const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
   const toggleTheme = useThemeStore((s) => s.toggle);
@@ -209,6 +213,13 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
   useEffect(() => {
     refreshTrash();
   }, [refreshTrash]);
+
+  // Self-heal the document list on open: reconcile local docs from the
+  // authoritative index + refetch remote, so renames / transfers / out-of-band
+  // changes show up without an extra edit (the list otherwise lags behind).
+  useEffect(() => {
+    handleRefresh();
+  }, [handleRefresh]);
 
   // "Continue working" strip: the most recent docs, shown on All without a query.
   const recents = useMemo(() => documentList.slice(0, 3), [documentList]);
@@ -478,6 +489,18 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
                 <LayoutGrid size={16} aria-hidden="true" />
               </button>
             </div>
+            <button
+              className="dh-refresh"
+              onClick={handleRefresh}
+              title="Refresh document list"
+              aria-label="Refresh document list"
+            >
+              <RefreshCw
+                size={16}
+                aria-hidden="true"
+                className={isFetchingRemote ? 'dh-refresh-spin' : undefined}
+              />
+            </button>
             <button
               className="dh-import"
               onClick={handleImport}

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -400,7 +400,14 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const handleNewDocument = useCallback(() => newDocument(), [newDocument]);
   const handleSave = useCallback(() => saveDocument(), [saveDocument]);
 
+  // Single shared refresh path — used by the on-open mount effect AND the manual
+  // Refresh button. Reconcile LOCAL docs from the authoritative index every time
+  // (unconditional; local docs drift even offline — renames/creates that an
+  // individual registerLocal path missed), then refetch REMOTE when connected.
   const handleRefresh = useCallback(() => {
+    useDocumentRegistry
+      .getState()
+      .reconcileLocalDocuments(usePersistenceStore.getState().getDocumentList());
     if (isConnectedToHost || isHost) fetchDocumentList();
   }, [fetchDocumentList, isConnectedToHost, isHost]);
 


### PR DESCRIPTION
Fixes **JP-308** (Cloud MVP).

## The bug

Switching to a different relay with a relay document open made the new relay *correctly* reject the rejoin (`JOIN_DOC` → `isUnknownDocError`, because the doc lives on its **home** relay). The client misread that as "deleted" and **demoted the doc to a local document** (`collaborationStore.onError` → `strandOrDemoteDeletedDoc` → `demoteCurrentDocumentToLocal`), wiping its relay identity. Foreign-relay docs also read as "online" since nothing distinguished them from same-relay docs.

## Why it's client-side fixable

The client already records each doc's **immutable home `relayId`** (JP-117) and knows the connected relay, so it can tell "deleted on its home relay" from "unreachable because I'm on a different relay." The strand/demote trigger just wasn't applying that check — the same home-relay gate already exists in `syncCurrentDocToRelayOnConnect` and the cached-staleness reconcile.

## Changes

- **`isForeignRelayDoc(record, connectedRelayAddress)`** — a new pure predicate in `DocumentRegistry` (true only for a relay-backed doc with a *known* origin relay that differs from the connected one). Single source of truth for both the gate and the badge; unit-tested directly (6 cases: foreign remote/cached, same-relay, offline, unknown-origin, local).
- **`collaborationStore.onError`** — when a rejected JOIN is for a foreign-relay doc, do nothing destructive: keep the remote record intact. The card derives `idle`/`offline` from the relay mismatch, and edits queue under the doc's **home** relay for replay on return (so it's not "editing into the void"). Only the doc's **own** home relay rejecting it is treated as a deletion. Guarded at this call site only — `strandOrDemoteDeletedDoc`'s other callers (a live `Deleted` DocEvent; the host-scoped cache reconcile) are legitimately home-relay-authoritative, so gating the shared function would risk suppressing a real deletion.
- **`DocumentCard`** — an "Other relay" badge (lucide `Network`) for foreign-relay docs, gated on the same predicate. Generic label; the host stays in the `title` + details panel (no host:port leak, per the existing design note).

## Tests / verification

`DocumentRegistry.test.ts` for the predicate; full suite green (2319), typecheck + build clean.

**Live (needs two relays):** sign into relay A, open a relay doc; switch to relay B. *Before:* doc demotes to local (toast). *After:* doc stays a relay doc, shows the "Other relay" badge + idle/offline sync, no demote; switching back to A reconnects and syncs cleanly. (The exact `onError` firing was confirmed by code path, not yet reproduced live — flagging for the manual pass.)

Assisted-by: Opus 4.8