### PR TITLE
JP-298: review-backlog P1 cheap wins (RB-3/4/5) → staging

### DIFF
--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -6,11 +6,12 @@ authors = ["DocuShark Team"]
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/JPE-Net-Technologies/docushark"
 edition = "2021"
-# Bumped from 1.77.2 for JP-34: the authoritative server-side CRDT (`yrs`
-# 0.26) and its modern transitive stack (thiserror 2.x, the icu4x 2.x crates
-# pulled via url/reqwest) require a newer compiler. We take the latest `yrs`
-# for its CRDT fixes rather than pinning an older release to hold the old MSRV.
-rust-version = "1.82"
+# MSRV floor is 1.85: locked deps using the `edition2024` Cargo feature (e.g.
+# `time-macros` 0.2.27) won't even parse their manifests on older toolchains,
+# which is why the Dockerfile builder is `rust:1.88`. (History: 1.77.2 → 1.82
+# came first with JP-34's `yrs` 0.26 + thiserror 2.x / icu4x 2.x stack; the
+# edition2024 dep then pushed the real floor to 1.85.)
+rust-version = "1.85"
 
 # Independent crate. Not a workspace member of `src-tauri/`. Built with
 # its own `cargo build` / `cargo test` from this directory.
@@ -114,7 +115,12 @@ hex = "0.4"
 tokio-tungstenite = "0.21"
 futures-util = "0.3"
 
+# RB-4 (JP-298): the relay is a long-lived server — optimize for runtime
+# throughput, not binary size. `opt-level = 3` + `codegen-units = 1` + `lto`
+# is the standard max-optimization pairing (trades slower release builds and a
+# larger binary for faster request handling).
 [profile.release]
 lto = true
-opt-level = "s"
+opt-level = 3
+codegen-units = 1
 strip = true

--- a/relay/README.md
+++ b/relay/README.md
@@ -25,10 +25,13 @@ docker run --rm \
   docushark/relay
 ```
 
-On first boot `relay init` runs automatically inside the container —
-if `/data/relay.toml` doesn't exist, the entrypoint creates one with
-a freshly-rolled JWT secret. **Do not commit `/data/relay.toml` to
-any repo: it holds the per-deploy signing key.**
+The container runs `relay serve` (see the `CMD` in the Dockerfile). If
+`/data/relay.toml` doesn't exist the relay starts on built-in defaults and
+logs a warning; create one with `relay init` (below) and fill in the `[auth]`
+OIDC fields. The relay validates external OIDC tokens against the issuer's
+JWKS — it never mints or signs tokens, so there is no signing key.
+**Do not commit `/data/relay.toml` to any repo: it may hold operational
+secrets (`revocation_push_bearer` / `revocation_polling_bearer`).**
 
 > Note: the bundled CMD assumes `/data/relay.toml` already exists.
 > Run `relay init` once on a fresh volume:

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -689,9 +689,9 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        App token verified per `token-format.md`. Either an OIDC-issued
-        access token validated via JWKS (preferred), or a legacy
-        HS256-signed token from the deprecated auth surface.
+        App token verified per `token-format.md`: an OIDC-issued, RS256-signed
+        access token validated against the issuer's JWKS. The relay does not
+        mint or sign tokens.
     revocationBearer:
       type: http
       scheme: bearer

--- a/relay/docs/api/revocation.md
+++ b/relay/docs/api/revocation.md
@@ -27,7 +27,7 @@ Operators with stricter requirements should shorten the polling interval.
 
 ### Authentication
 
-`Authorization: Bearer <revocation_push_bearer>` — the shared secret configured in `relay.toml` `[webhooks]`. Constant-time comparison.
+`Authorization: Bearer <revocation_push_bearer>` — the shared secret configured in `relay.toml` `[auth]`. Constant-time comparison.
 
 ### Request body
 
@@ -92,8 +92,8 @@ The control plane is expected to serve revocations in stable timestamp order and
 - **No expiry.** Revocations stay in the set forever (memory-bounded by the token TTL — once `exp` passes, the JTI is naturally moot). Operators with very long-lived tokens may want to GC the set externally and re-push.
 - **Bounded memory.** The relay caps the in-memory revocation set at 1M entries. Beyond this it starts evicting the oldest entries — choose token TTLs and revocation patterns accordingly.
 
-## Fail-open vs fail-closed
+## Revocation failure modes
 
-By default the relay **fails closed** on revocation lookup — if both push and polling transports are unconfigured, every token-bearing request is accepted (no revocations to check against). To require revocation infrastructure, configure at least one transport.
+By default the relay **does not enforce revocation** — if both push and polling transports are unconfigured, the revocation set is empty, so every otherwise-valid token is accepted (there is nothing to check against). This is fail-open on revocation. To make revocation enforceable, configure at least one transport.
 
 If you configure both transports and both fail simultaneously, the relay continues serving with the last-known revocation set. This is intentional — a control-plane outage should not knock all relays offline. If your threat model requires fail-closed-on-staleness, monitor the `revocation_set_age_seconds` metric and decommission stale relays externally.

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1236,7 +1236,7 @@ fn ingest_ip_blocked(host: &str) -> bool {
 
 /// SSRF gate: https only, host on the allowlist, not a blocked IP literal.
 /// Enforced on the initial URL and (via the redirect policy) every hop.
-fn ingest_url_ok(url: &reqwest::Url, allow: &[String]) -> bool {
+pub(crate) fn ingest_url_ok(url: &reqwest::Url, allow: &[String]) -> bool {
     if url.scheme() != "https" {
         return false;
     }
@@ -1285,30 +1285,12 @@ async fn blob_ingest_from_url_handler(
 
     let max = state.max_blob_bytes();
 
-    // Validate every redirect hop against the same allowlist (an open redirect
-    // to an internal host is the classic SSRF escape).
-    let policy_allow = allow.clone();
-    let client = match reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
-            if attempt.previous().len() > 5 {
-                return attempt.error("too many redirects");
-            }
-            if ingest_url_ok(attempt.url(), &policy_allow) {
-                attempt.follow()
-            } else {
-                attempt.stop()
-            }
-        }))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            log::warn!("ingest client build failed: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body("client_error"))
-                .into_response();
-        }
-    };
+    // RB-3: reuse the process-wide ingest client (built once at startup). Its
+    // redirect policy already re-validates every hop against the same allowlist
+    // (an open redirect to an internal host is the classic SSRF escape); the
+    // allowlist is process-global config, so the startup-built policy matches
+    // what a per-request build would have produced.
+    let client = state.ingest_http_client();
 
     let mut resp = match client
         .get(url)

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -509,6 +509,13 @@ pub struct ServerState {
     /// caps worst-case upload RAM — a burst of large uploads can't OOM a shared
     /// pod (cross-tenant availability).
     blob_upload_gate: Arc<tokio::sync::Semaphore>,
+    /// RB-3 (JP-298): shared HTTP client for the URL blob-ingest endpoint, built
+    /// once at startup instead of per request so the connection pool / keep-alive
+    /// is reused. Carries the same SSRF redirect policy as before — the host
+    /// allowlist (`tenancy.limits.blob_ingest_allowed_hosts`) is process-global
+    /// config, so a startup-built policy is equivalent to the old per-request one.
+    /// A `reqwest::Client` clone is a cheap `Arc` bump sharing the pool.
+    ingest_http_client: reqwest::Client,
 }
 
 impl ServerState {
@@ -583,6 +590,27 @@ impl ServerState {
         };
         // RB-1b: at least one permit so uploads never deadlock on a 0 config.
         let blob_upload_permits = tenancy.limits.max_concurrent_blob_uploads.max(1);
+        // RB-3: build the URL-ingest HTTP client once. The redirect policy
+        // re-validates every hop against the ingest allowlist (the classic
+        // open-redirect SSRF escape); the allowlist is process-global config, so
+        // snapshotting it here is equivalent to the old per-request build. A
+        // build failure is a catastrophic startup condition (TLS backend init) —
+        // fail loudly rather than degrade to a per-request 500.
+        let ingest_allow = tenancy.limits.blob_ingest_allowed_hosts.clone();
+        let ingest_http_client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+                if attempt.previous().len() > 5 {
+                    return attempt.error("too many redirects");
+                }
+                if crate::api::ingest_url_ok(attempt.url(), &ingest_allow) {
+                    attempt.follow()
+                } else {
+                    attempt.stop()
+                }
+            }))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build blob-ingest HTTP client");
         Self {
             broadcast_tx,
             client_count: AtomicU16::new(0),
@@ -609,6 +637,7 @@ impl ServerState {
             blob_recovery_done: std::sync::Mutex::new(HashSet::new()),
             blob_recovery_locks: std::sync::Mutex::new(HashMap::new()),
             blob_upload_gate: Arc::new(tokio::sync::Semaphore::new(blob_upload_permits)),
+            ingest_http_client,
         }
     }
 
@@ -1039,6 +1068,12 @@ impl ServerState {
     /// (`[tenancy.limits] blob_ingest_allowed_hosts`). Empty = endpoint disabled.
     pub(crate) fn blob_ingest_allowed_hosts(&self) -> &[String] {
         &self.tenancy.limits.blob_ingest_allowed_hosts
+    }
+
+    /// RB-3: the shared URL-ingest HTTP client (built once at startup with the
+    /// SSRF redirect policy). Clone is a cheap `Arc` bump sharing the pool.
+    pub(crate) fn ingest_http_client(&self) -> &reqwest::Client {
+        &self.ingest_http_client
     }
 
     /// Snapshot of per-workspace live connection counts (editor/viewer


### PR DESCRIPTION
Cherry-pick of the JP-298 P1 fixes onto `staging` for the `:edge` relay image, so they're live on staging ASAP. Scoped to **only** RB-3/4/5 (cherry-picked, not a master merge) to avoid dragging unrelated master commits into staging.

Master-targeted PR: #219.

- **RB-3** — URL blob-ingest `reqwest::Client` built once on `ServerState` instead of per request (pool reuse); SSRF redirect policy preserved (allowlist is process-global config).
- **RB-4** — relay release profile → `opt-level = 3` + `codegen-units = 1` (lto already on).
- **RB-5** — doc drift: revocation.md `[webhooks]`→`[auth]` + fail-open wording; openapi.yaml HS256 remnant; README `relay init`/JWT-secret claims; Cargo.toml MSRV `1.82`→`1.85`.

## Verification (on the staging base)
- `cargo check --all-targets` clean; `cargo test --lib` → 419 passed. Cherry-pick applied cleanly onto staging's relay code (no conflicts).

Assisted-by: Opus 4.8