### PR TITLE
JP-307: Movement V2 — trackpad/wheel pan, eased zoom, drag-to-edge auto-pan, two-finger touch pan

### DIFF
--- a/src/engine/Camera.test.ts
+++ b/src/engine/Camera.test.ts
@@ -637,4 +637,53 @@ describe('Camera', () => {
       expect(camera.zoom).toBe(2);
     });
   });
+
+  describe('eased zoom — setTargetZoom + updateZoom (JP-307 Slice 2)', () => {
+    it('eases monotonically toward the target over multiple frames', () => {
+      const camera = new Camera({ x: 0, y: 0, zoom: 1 });
+      camera.setViewport(800, 600);
+      const focal = new Vec2(200, 150);
+
+      camera.setTargetZoom(focal, 3);
+      expect(camera.targetZoom).toBe(3);
+
+      let prev = camera.zoom;
+      let ticks = 0;
+      let animating = true;
+      while (animating && ticks < 500) {
+        animating = camera.updateZoom(focal, 0.2);
+        // Approaches 3 from 1 without overshooting past the target.
+        expect(camera.zoom).toBeGreaterThanOrEqual(prev);
+        expect(camera.zoom).toBeLessThanOrEqual(3 + 1e-6);
+        prev = camera.zoom;
+        ticks += 1;
+      }
+      expect(camera.zoom).toBeCloseTo(3, 2);
+      expect(ticks).toBeGreaterThan(1); // genuinely eased, not a single jump
+    });
+
+    it('keeps the focal world point stationary while easing', () => {
+      const camera = new Camera({ x: 0, y: 0, zoom: 1 });
+      camera.setViewport(800, 600);
+      const focal = new Vec2(600, 400);
+      const worldBefore = camera.screenToWorld(focal);
+
+      camera.setTargetZoom(focal, 0.4);
+      for (let i = 0; i < 500 && camera.updateZoom(focal, 0.2); i++) {
+        /* settle */
+      }
+
+      const worldAfter = camera.screenToWorld(focal);
+      expect(worldAfter.x).toBeCloseTo(worldBefore.x, 1);
+      expect(worldAfter.y).toBeCloseTo(worldBefore.y, 1);
+      expect(camera.zoom).toBeCloseTo(0.4, 2);
+    });
+
+    it('returns false immediately when already at the target', () => {
+      const camera = new Camera({ zoom: 2 });
+      camera.setViewport(800, 600);
+      camera.setTargetZoom(new Vec2(400, 300), 2);
+      expect(camera.updateZoom(new Vec2(400, 300))).toBe(false);
+    });
+  });
 });

--- a/src/engine/Camera.ts
+++ b/src/engine/Camera.ts
@@ -255,16 +255,22 @@ export class Camera {
    * @returns true if zoom is still animating
    */
   updateZoom(screenPoint: Vec2, smoothing: number = 0.15): boolean {
-    const diff = Math.abs(this._targetZoom - this._zoom);
+    // Capture the target up front: zoomAt() resets `_targetZoom` to whatever it
+    // applied, so without restoring it the ease would clobber its own target
+    // after one frame and never converge across multiple frames.
+    const target = this._targetZoom;
+    const diff = Math.abs(target - this._zoom);
     if (diff < 0.001) {
-      if (this._zoom !== this._targetZoom) {
-        this.zoomAt(screenPoint, this._targetZoom / this._zoom);
+      if (this._zoom !== target) {
+        this.zoomAt(screenPoint, target / this._zoom);
       }
+      this._targetZoom = target;
       return false;
     }
 
-    const newZoom = lerp(this._zoom, this._targetZoom, smoothing);
+    const newZoom = lerp(this._zoom, target, smoothing);
     this.zoomAt(screenPoint, newZoom / this._zoom);
+    this._targetZoom = target;
     return true;
   }
 

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -153,6 +153,11 @@ export class Engine {
   // Keyboard panning state
   private activePanKeys: Set<string> = new Set();
   private panAnimationId: number | null = null;
+  // JP-307 Slice 2: eased wheel/Ctrl-scroll zoom settles toward the camera's
+  // target zoom around this focal screen point; null when no zoom is settling.
+  private zoomFocalPoint: Vec2 | null = null;
+  // JP-307 Slice 2: keyboard Q/E zoom acceleration ramp (frames the key's held).
+  private zoomHoldFrames = 0;
 
   // Global keyboard handler for shortcuts that need to intercept browser defaults
   private boundGlobalKeyDown: (e: KeyboardEvent) => void;
@@ -907,8 +912,13 @@ export class Engine {
     // Remove key from active set
     this.activePanKeys.delete(event.key);
 
-    // Stop animation if no keys are pressed
-    if (this.activePanKeys.size === 0 && this.panAnimationId !== null) {
+    // Stop animation if no keys are pressed — but keep it running while an
+    // eased wheel zoom is still settling (it self-terminates when done).
+    if (
+      this.activePanKeys.size === 0 &&
+      this.zoomFocalPoint === null &&
+      this.panAnimationId !== null
+    ) {
       cancelAnimationFrame(this.panAnimationId);
       this.panAnimationId = null;
     }
@@ -918,8 +928,16 @@ export class Engine {
    * Start the keyboard navigation animation loop.
    */
   private startPanAnimation(): void {
+    // Idempotent: a single rAF loop drives both keyboard pan/zoom and the eased
+    // wheel-zoom settling, so key-down and wheel-zoom can both call this freely
+    // without spawning a second competing loop.
+    if (this.panAnimationId !== null) return;
+
     const animate = () => {
-      if (this.destroyed || this.activePanKeys.size === 0) {
+      if (
+        this.destroyed ||
+        (this.activePanKeys.size === 0 && this.zoomFocalPoint === null)
+      ) {
         this.panAnimationId = null;
         return;
       }
@@ -974,15 +992,32 @@ export class Engine {
         needsRender = true;
       }
 
-      // Apply zoom centered on viewport center (use screen coordinates for zoomAt)
+      // Keyboard zoom (the preferred power-user path): direct per-frame zoom
+      // centered on the viewport, with an acceleration ramp while the key is
+      // held so a long press zooms progressively faster. Kept crisp/direct
+      // rather than routed through the lerp-to-target path used by the wheel.
       if (zoomDir !== 0) {
-        const zoomFactor = 1 + zoomDir * ZOOM_SPEED;
+        this.zoomHoldFrames += 1;
+        const accel = Math.min(1 + this.zoomHoldFrames * 0.04, 3);
+        const zoomFactor = 1 + zoomDir * ZOOM_SPEED * accel;
         const screenCenter = new Vec2(
           this.camera.screenWidth / 2,
           this.camera.screenHeight / 2
         );
         this.camera.zoomAt(screenCenter, zoomFactor);
         needsRender = true;
+      } else {
+        this.zoomHoldFrames = 0;
+      }
+
+      // Eased wheel / Ctrl-scroll zoom: converge toward the camera's target
+      // zoom around the focal point set in handleWheel (Slice 2).
+      if (this.zoomFocalPoint) {
+        const stillAnimating = this.camera.updateZoom(this.zoomFocalPoint, 0.2);
+        needsRender = true;
+        if (!stillAnimating) {
+          this.zoomFocalPoint = null;
+        }
       }
 
       if (needsRender) {
@@ -1106,24 +1141,42 @@ export class Engine {
     const worldPoint = this.camera.screenToWorld(screenPoint);
     const handled = this.toolManager.handleWheel(event, worldPoint);
 
-    if (!handled) {
-      // Default wheel behavior: zoom with linear acceleration
-      // Use smaller base factor for smoother zooming
+    if (handled) return;
+
+    if (event.ctrlKey || event.metaKey) {
+      // Zoom toward the cursor (Slice 2). Ctrl/⌘+scroll is the wheel zoom
+      // gesture; on macOS/Windows a trackpad pinch also arrives here (the OS
+      // sets ctrlKey). On Linux pinch emits nothing, so keyboard Q/E is the
+      // guaranteed zoom — this path is the additive "classic" affordance.
       const baseZoomStep = 0.02; // 2% per unit of delta
       const maxZoomStep = 0.15; // Cap maximum zoom change per event
 
-      // Normalize deltaY (different browsers/devices have different scales)
-      // Typical values: ~100 for mouse wheel, ~1-4 for trackpad
+      // Normalize deltaY (mouse wheel ~100, trackpad ~1-4) and accelerate
+      // super-linearly in scroll velocity, capped per event.
       const normalizedDelta = Math.abs(event.deltaY) / 100;
+      const zoomStep = Math.min(
+        baseZoomStep * normalizedDelta * (1 + normalizedDelta),
+        maxZoomStep
+      );
+      const factor = event.deltaY > 0 ? 1 - zoomStep : 1 + zoomStep;
 
-      // Linear acceleration: larger scroll = larger zoom change
-      const zoomStep = Math.min(baseZoomStep * normalizedDelta, maxZoomStep);
-
-      // Calculate zoom factor (zoom in for negative delta, out for positive)
-      const zoomFactor = event.deltaY > 0 ? 1 - zoomStep : 1 + zoomStep;
-
-      // Use screenPoint for zoomAt (it internally converts to world coordinates)
-      this.camera.zoomAt(screenPoint, zoomFactor);
+      // Accumulate onto the target zoom (so rapid ticks stack) and let the rAF
+      // loop ease toward it. Do NOT call zoomAt directly — it overwrites the
+      // target and would fight the ease.
+      this.camera.setTargetZoom(screenPoint, this.camera.targetZoom * factor);
+      this.zoomFocalPoint = screenPoint;
+      this.startPanAnimation();
+    } else {
+      // Plain wheel / two-finger scroll -> pan both axes (Slice 1). The
+      // previous behavior ignored deltaX, which is why trackpad horizontal
+      // scroll was a no-op. A mouse wheel (deltaX === 0) with Shift held maps
+      // its deltaY to horizontal pan (a wheel has no X axis).
+      const horizontalFromShift = event.shiftKey && event.deltaX === 0;
+      const panX = horizontalFromShift ? event.deltaY : event.deltaX;
+      const panY = horizontalFromShift ? 0 : event.deltaY;
+      // Negate so content follows the scroll direction: pan() moves the camera
+      // opposite to a positive screen delta.
+      this.camera.pan(new Vec2(-panX, -panY));
       this.renderer.requestRender();
     }
   }

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -67,6 +67,11 @@ const NUDGE_AMOUNT = 10;
 /** Zoom speed per frame (multiplier) */
 const ZOOM_SPEED = 0.02;
 
+/** JP-307: fraction of the pending wheel-pan applied per frame (exponential
+ * ease-out). Higher = snappier, lower = smoother/floatier. Smooths a chunky
+ * mouse wheel; a trackpad's small deltas are consumed in ~a frame either way. */
+const WHEEL_PAN_SMOOTH = 0.3;
+
 /** Keys that trigger panning (WASD only - arrow keys nudge shapes when selected) */
 const PAN_KEYS = new Set([
   'w', 'W', 'a', 'A', 's', 'S', 'd', 'D',
@@ -158,6 +163,10 @@ export class Engine {
   private zoomFocalPoint: Vec2 | null = null;
   // JP-307 Slice 2: keyboard Q/E zoom acceleration ramp (frames the key's held).
   private zoomHoldFrames = 0;
+  // JP-307: accumulated wheel/scroll pan delta (screen space) still to be eased
+  // out by the rAF loop, so a chunky mouse wheel pans smoothly.
+  private pendingPanX = 0;
+  private pendingPanY = 0;
 
   // Global keyboard handler for shortcuts that need to intercept browser defaults
   private boundGlobalKeyDown: (e: KeyboardEvent) => void;
@@ -936,7 +945,10 @@ export class Engine {
     const animate = () => {
       if (
         this.destroyed ||
-        (this.activePanKeys.size === 0 && this.zoomFocalPoint === null)
+        (this.activePanKeys.size === 0 &&
+          this.zoomFocalPoint === null &&
+          this.pendingPanX === 0 &&
+          this.pendingPanY === 0)
       ) {
         this.panAnimationId = null;
         return;
@@ -998,7 +1010,9 @@ export class Engine {
       // rather than routed through the lerp-to-target path used by the wheel.
       if (zoomDir !== 0) {
         this.zoomHoldFrames += 1;
-        const accel = Math.min(1 + this.zoomHoldFrames * 0.04, 3);
+        // Acceleration ramp while Q/E is held — gentler than the wheel so it
+        // isn't twitchy on a quick tap, but still ramps up on a long hold.
+        const accel = Math.min(1 + this.zoomHoldFrames * 0.06, 4);
         const zoomFactor = 1 + zoomDir * ZOOM_SPEED * accel;
         const screenCenter = new Vec2(
           this.camera.screenWidth / 2,
@@ -1008,6 +1022,22 @@ export class Engine {
         needsRender = true;
       } else {
         this.zoomHoldFrames = 0;
+      }
+
+      // Eased wheel pan: ease out the accumulated wheel/scroll delta so a chunky
+      // mouse wheel pans smoothly instead of jumping per event (Slice 1 smoothing).
+      if (this.pendingPanX !== 0 || this.pendingPanY !== 0) {
+        const stepX = this.pendingPanX * WHEEL_PAN_SMOOTH;
+        const stepY = this.pendingPanY * WHEEL_PAN_SMOOTH;
+        // pan() moves the camera opposite a positive screen delta; negate so
+        // content follows the scroll direction.
+        this.camera.pan(new Vec2(-stepX, -stepY));
+        this.pendingPanX -= stepX;
+        this.pendingPanY -= stepY;
+        // Snap sub-pixel remainders to zero so the ease terminates cleanly.
+        if (Math.abs(this.pendingPanX) < 0.1) this.pendingPanX = 0;
+        if (Math.abs(this.pendingPanY) < 0.1) this.pendingPanY = 0;
+        needsRender = true;
       }
 
       // Eased wheel / Ctrl-scroll zoom: converge toward the camera's target
@@ -1148,14 +1178,15 @@ export class Engine {
       // gesture; on macOS/Windows a trackpad pinch also arrives here (the OS
       // sets ctrlKey). On Linux pinch emits nothing, so keyboard Q/E is the
       // guaranteed zoom — this path is the additive "classic" affordance.
-      const baseZoomStep = 0.02; // 2% per unit of delta
-      const maxZoomStep = 0.15; // Cap maximum zoom change per event
+      const baseZoomStep = 0.03; // ~3% per unit of delta
+      const maxZoomStep = 0.25; // Cap maximum zoom change per event
 
       // Normalize deltaY (mouse wheel ~100, trackpad ~1-4) and accelerate
-      // super-linearly in scroll velocity, capped per event.
+      // super-linearly in scroll velocity, capped per event. The 1.8x term
+      // makes fast scrolls zoom harder. Tunable.
       const normalizedDelta = Math.abs(event.deltaY) / 100;
       const zoomStep = Math.min(
-        baseZoomStep * normalizedDelta * (1 + normalizedDelta),
+        baseZoomStep * normalizedDelta * (1 + 1.8 * normalizedDelta),
         maxZoomStep
       );
       const factor = event.deltaY > 0 ? 1 - zoomStep : 1 + zoomStep;
@@ -1174,10 +1205,12 @@ export class Engine {
       const horizontalFromShift = event.shiftKey && event.deltaX === 0;
       const panX = horizontalFromShift ? event.deltaY : event.deltaX;
       const panY = horizontalFromShift ? 0 : event.deltaY;
-      // Negate so content follows the scroll direction: pan() moves the camera
-      // opposite to a positive screen delta.
-      this.camera.pan(new Vec2(-panX, -panY));
-      this.renderer.requestRender();
+      // Accumulate the delta and let the rAF loop ease it out, so a chunky mouse
+      // wheel pans smoothly instead of jumping per event. (A trackpad's small
+      // continuous deltas are consumed within ~a frame, staying responsive.)
+      this.pendingPanX += panX;
+      this.pendingPanY += panY;
+      this.startPanAnimation();
     }
   }
 }

--- a/src/engine/InputHandler.test.ts
+++ b/src/engine/InputHandler.test.ts
@@ -712,4 +712,35 @@ describe('InputHandler', () => {
       expect(normalized.screenPoint.y).toBe(300);
     });
   });
+
+  describe('two-finger pan (JP-307 Slice 4)', () => {
+    it('pans the camera on a two-finger translation (zoom unchanged)', () => {
+      // camera starts at (0,0) zoom 1, viewport 800x600 (beforeEach).
+      // Two fingers down 200px apart → starts the pinch/pan gesture.
+      canvas._dispatch('pointerdown', createPointerEvent('pointerdown', { pointerId: 1, clientX: 200, clientY: 300 }));
+      canvas._dispatch('pointerdown', createPointerEvent('pointerdown', { pointerId: 2, clientX: 400, clientY: 300 }));
+      // Translate both fingers +50px in x (one at a time) so their final
+      // distance is unchanged (net zoom ~1) but the midpoint moved right.
+      canvas._dispatch('pointermove', createPointerEvent('pointermove', { pointerId: 1, clientX: 250, clientY: 300 }));
+      canvas._dispatch('pointermove', createPointerEvent('pointermove', { pointerId: 2, clientX: 450, clientY: 300 }));
+
+      // Net: zoom returns to 1, camera panned by the 50px midpoint shift
+      // (camera.x decreases for a rightward content shift). Pre-Slice-4 this
+      // gesture only zoomed and would have left the camera at x≈0.
+      expect(camera.zoom).toBeCloseTo(1, 5);
+      expect(camera.x).toBeCloseTo(-50, 1);
+      expect(camera.y).toBeCloseTo(0, 5);
+    });
+
+    it('does not pan the camera on a single-finger move (stays a select drag)', () => {
+      const startX = camera.x;
+      const startY = camera.y;
+      canvas._dispatch('pointerdown', createPointerEvent('pointerdown', { pointerId: 1, clientX: 200, clientY: 300 }));
+      canvas._dispatch('pointermove', createPointerEvent('pointermove', { pointerId: 1, clientX: 260, clientY: 360 }));
+      // One finger never enters the pinch/pan branch — forwarded to the tool as
+      // a normal pointer move; the camera is untouched.
+      expect(camera.x).toBe(startX);
+      expect(camera.y).toBe(startY);
+    });
+  });
 });

--- a/src/engine/InputHandler.ts
+++ b/src/engine/InputHandler.ts
@@ -132,6 +132,9 @@ export class InputHandler {
   private pinchStartDistance: number = 0;
   private pinchStartZoom: number = 1;
   private isPinching: boolean = false;
+  // JP-307 Slice 4: previous two-finger midpoint, for two-finger pan (the
+  // frame-to-frame midpoint translation pans while pinch zooms).
+  private pinchLastMidpoint: Vec2 | null = null;
 
   // Track if destroyed
   private destroyed = false;
@@ -296,6 +299,7 @@ export class InputHandler {
     if (this.isPinching) {
       if (this.activePointers.size < 2) {
         this.isPinching = false;
+        this.pinchLastMidpoint = null;
       }
       return;
     }
@@ -317,6 +321,7 @@ export class InputHandler {
     // End pinch gesture
     if (this.isPinching && this.activePointers.size < 2) {
       this.isPinching = false;
+      this.pinchLastMidpoint = null;
       return;
     }
 
@@ -427,6 +432,7 @@ export class InputHandler {
 
     this.pinchStartDistance = p1.distanceTo(p2);
     this.pinchStartZoom = this.camera.zoom;
+    this.pinchLastMidpoint = new Vec2((p1.x + p2.x) / 2, (p1.y + p2.y) / 2);
     this.isPinching = true;
   }
 
@@ -442,16 +448,29 @@ export class InputHandler {
     const currentDistance = p1.distanceTo(p2);
     if (this.pinchStartDistance === 0) return;
 
-    const scale = currentDistance / this.pinchStartDistance;
-    const targetZoom = this.pinchStartZoom * scale;
-
-    // Calculate midpoint as zoom anchor
+    // Calculate midpoint (zoom anchor + two-finger pan reference)
     const midpoint = new Vec2(
       (p1.x + p2.x) / 2,
       (p1.y + p2.y) / 2,
     );
 
+    // Two-finger drag -> pan by the midpoint's frame-to-frame translation
+    // (Slice 4), simultaneously with the pinch zoom below. Content follows the
+    // fingers; camera.pan() moves the camera opposite a positive screen delta.
+    if (this.pinchLastMidpoint) {
+      const panDelta = new Vec2(
+        midpoint.x - this.pinchLastMidpoint.x,
+        midpoint.y - this.pinchLastMidpoint.y,
+      );
+      if (panDelta.x !== 0 || panDelta.y !== 0) {
+        this.camera.pan(panDelta);
+      }
+    }
+    this.pinchLastMidpoint = midpoint;
+
     // Apply zoom centered on midpoint between fingers
+    const scale = currentDistance / this.pinchStartDistance;
+    const targetZoom = this.pinchStartZoom * scale;
     const factor = targetZoom / this.camera.zoom;
     this.camera.zoomAt(midpoint, factor);
     // Notify via wheel callback so Engine can request render

--- a/src/engine/tools/SelectTool.edgePan.test.ts
+++ b/src/engine/tools/SelectTool.edgePan.test.ts
@@ -1,0 +1,63 @@
+/**
+ * JP-307 Slice 3 — drag-to-edge auto-pan velocity.
+ *
+ * `edgePanVelocity` is the pure core of the auto-pan loop: given the cursor's
+ * screen position and the viewport size, it returns the camera pan velocity
+ * (screen px/frame). Zero in the interior, ramping toward the edges. A positive
+ * component points toward the right/bottom edge.
+ */
+import { describe, it, expect } from 'vitest';
+import { edgePanVelocity } from './SelectTool';
+import { Vec2 } from '../../math/Vec2';
+
+const W = 800;
+const H = 600;
+const MAX = 18; // EDGE_PAN_MAX_SPEED
+const THRESHOLD = 48;
+
+describe('edgePanVelocity (JP-307 drag-to-edge auto-pan)', () => {
+  it('is zero in the interior', () => {
+    const v = edgePanVelocity(new Vec2(400, 300), W, H);
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(0);
+  });
+
+  it('is zero just inside the threshold band', () => {
+    // Exactly THRESHOLD px from each edge is the boundary — still interior.
+    const v = edgePanVelocity(new Vec2(THRESHOLD, THRESHOLD), W, H);
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(0);
+  });
+
+  it('ramps toward the right edge (positive x)', () => {
+    const v = edgePanVelocity(new Vec2(W - 10, 300), W, H); // depth 38 of 48
+    expect(v.x).toBeCloseTo((38 / THRESHOLD) * MAX, 5);
+    expect(v.y).toBe(0);
+    expect(v.x).toBeGreaterThan(0);
+  });
+
+  it('ramps toward the left edge (negative x)', () => {
+    const v = edgePanVelocity(new Vec2(10, 300), W, H); // depth 38
+    expect(v.x).toBeCloseTo(-(38 / THRESHOLD) * MAX, 5);
+    expect(v.y).toBe(0);
+  });
+
+  it('ramps toward the bottom edge (positive y)', () => {
+    const v = edgePanVelocity(new Vec2(400, H - 5), W, H); // depth 43
+    expect(v.y).toBeCloseTo((43 / THRESHOLD) * MAX, 5);
+    expect(v.x).toBe(0);
+  });
+
+  it('caps at max speed at and beyond the edge', () => {
+    expect(edgePanVelocity(new Vec2(W, 300), W, H).x).toBeCloseTo(MAX, 5);
+    // Beyond the viewport (e.g. pointer dragged off-canvas) stays capped.
+    expect(edgePanVelocity(new Vec2(W + 200, 300), W, H).x).toBeCloseTo(MAX, 5);
+    expect(edgePanVelocity(new Vec2(-200, 300), W, H).x).toBeCloseTo(-MAX, 5);
+  });
+
+  it('combines both axes in a corner', () => {
+    const v = edgePanVelocity(new Vec2(W, H), W, H);
+    expect(v.x).toBeCloseTo(MAX, 5);
+    expect(v.y).toBeCloseTo(MAX, 5);
+  });
+});

--- a/src/engine/tools/SelectTool.ts
+++ b/src/engine/tools/SelectTool.ts
@@ -59,6 +59,41 @@ const ANCHOR_SNAP_DISTANCE = 15;
  * - Translating: Dragging selected shapes
  * - Marquee: Dragging a selection rectangle
  */
+/** JP-307 Slice 3: distance (screen px) from a viewport edge at which a drag
+ * starts auto-panning the camera toward that edge. */
+const EDGE_PAN_THRESHOLD = 48;
+/** JP-307 Slice 3: max camera pan speed (screen px/frame) at the very edge. */
+const EDGE_PAN_MAX_SPEED = 18;
+
+/**
+ * Camera pan velocity (screen px/frame) from a cursor's edge proximity: zero in
+ * the interior, ramping linearly to EDGE_PAN_MAX_SPEED at/beyond each edge. A
+ * positive component points toward the right/bottom edge. Pure + exported for
+ * unit testing (JP-307 Slice 3).
+ */
+export function edgePanVelocity(
+  screenPoint: Vec2,
+  viewportWidth: number,
+  viewportHeight: number
+): Vec2 {
+  const proximity = (depth: number): number =>
+    Math.max(0, Math.min(1, depth / EDGE_PAN_THRESHOLD));
+
+  let vx = 0;
+  let vy = 0;
+  if (screenPoint.x < EDGE_PAN_THRESHOLD) {
+    vx = -proximity(EDGE_PAN_THRESHOLD - screenPoint.x);
+  } else if (screenPoint.x > viewportWidth - EDGE_PAN_THRESHOLD) {
+    vx = proximity(screenPoint.x - (viewportWidth - EDGE_PAN_THRESHOLD));
+  }
+  if (screenPoint.y < EDGE_PAN_THRESHOLD) {
+    vy = -proximity(EDGE_PAN_THRESHOLD - screenPoint.y);
+  } else if (screenPoint.y > viewportHeight - EDGE_PAN_THRESHOLD) {
+    vy = proximity(screenPoint.y - (viewportHeight - EDGE_PAN_THRESHOLD));
+  }
+  return new Vec2(vx * EDGE_PAN_MAX_SPEED, vy * EDGE_PAN_MAX_SPEED);
+}
+
 export class SelectTool extends BaseTool {
   readonly type: ToolType = 'select';
   readonly name = 'Select';
@@ -75,6 +110,10 @@ export class SelectTool extends BaseTool {
 
   // For translating shapes (includes x2, y2 for connectors)
   private dragStartPositions: Map<string, { x: number; y: number; x2?: number; y2?: number }> = new Map();
+
+  // JP-307 Slice 3: drag-to-edge auto-pan state.
+  private edgePanRafId: number | null = null;
+  private lastTranslateScreenPoint: Vec2 | null = null;
 
   // For marquee selection
   private marqueeStart: Vec2 | null = null;
@@ -656,9 +695,21 @@ export class SelectTool extends BaseTool {
   }
 
   private handleTranslatingMove(event: NormalizedPointerEvent, ctx: ToolContext): void {
+    this.lastTranslateScreenPoint = event.screenPoint;
+    this.applyTranslate(event.worldPoint, ctx);
+    this.updateEdgePan(ctx);
+  }
+
+  /**
+   * Apply a translate to every dragged shape for the given pointer world point.
+   * Shared by live pointer moves and the drag-to-edge auto-pan loop (JP-307
+   * Slice 3), which recomputes the world point under the stationary cursor as
+   * the camera pans so the shapes keep following the moving view.
+   */
+  private applyTranslate(worldPoint: Vec2, ctx: ToolContext): void {
     if (!this.pointerDownWorldPoint) return;
 
-    const delta = Vec2.subtract(event.worldPoint, this.pointerDownWorldPoint);
+    const delta = Vec2.subtract(worldPoint, this.pointerDownWorldPoint);
     const snapSettings = ctx.getSnapSettings();
 
     // Calculate the proposed new positions and get combined bounds
@@ -744,6 +795,58 @@ export class SelectTool extends BaseTool {
 
     ctx.updateShapes(updates);
     ctx.requestRender();
+  }
+
+  /**
+   * Start/stop the drag-to-edge auto-pan loop based on the cursor's proximity
+   * to the viewport edges (JP-307 Slice 3).
+   */
+  private updateEdgePan(ctx: ToolContext): void {
+    if (!this.lastTranslateScreenPoint) return;
+    const vel = edgePanVelocity(
+      this.lastTranslateScreenPoint,
+      ctx.camera.screenWidth,
+      ctx.camera.screenHeight
+    );
+    if (vel.x === 0 && vel.y === 0) {
+      this.stopEdgePan();
+      return;
+    }
+    if (this.edgePanRafId === null) {
+      this.edgePanRafId = requestAnimationFrame(() => this.edgePanTick(ctx));
+    }
+  }
+
+  private edgePanTick(ctx: ToolContext): void {
+    this.edgePanRafId = null;
+    if (this.state !== 'translating' || !this.lastTranslateScreenPoint) return;
+
+    const vel = edgePanVelocity(
+      this.lastTranslateScreenPoint,
+      ctx.camera.screenWidth,
+      ctx.camera.screenHeight
+    );
+    if (vel.x === 0 && vel.y === 0) return;
+
+    // Pan the camera toward the edge. camera.pan() moves the camera opposite a
+    // positive screen delta, so negate: a positive (right/bottom) velocity must
+    // move the camera right/down to reveal content there. Every tick moves the
+    // camera, so the shape update below is never a no-op.
+    ctx.camera.pan(new Vec2(-vel.x, -vel.y));
+
+    // Recompute the world point under the (stationary) cursor after the pan and
+    // re-apply the translate so the dragged shapes follow the moving view.
+    const worldPoint = ctx.camera.screenToWorld(this.lastTranslateScreenPoint);
+    this.applyTranslate(worldPoint, ctx);
+
+    this.edgePanRafId = requestAnimationFrame(() => this.edgePanTick(ctx));
+  }
+
+  private stopEdgePan(): void {
+    if (this.edgePanRafId !== null) {
+      cancelAnimationFrame(this.edgePanRafId);
+      this.edgePanRafId = null;
+    }
   }
 
   private handleMarqueeMove(event: NormalizedPointerEvent, ctx: ToolContext): void {
@@ -951,6 +1054,8 @@ export class SelectTool extends BaseTool {
     this.currentSnapResult = null;
     this.connectorHoveredAnchor = null;
     this.panHandler.reset();
+    this.stopEdgePan();
+    this.lastTranslateScreenPoint = null;
     // Note: Don't reset click tracking here, it persists across interactions
   }
 

--- a/src/engine/tools/SelectTool.ts
+++ b/src/engine/tools/SelectTool.ts
@@ -111,9 +111,15 @@ export class SelectTool extends BaseTool {
   // For translating shapes (includes x2, y2 for connectors)
   private dragStartPositions: Map<string, { x: number; y: number; x2?: number; y2?: number }> = new Map();
 
-  // JP-307 Slice 3: drag-to-edge auto-pan state.
-  private edgePanRafId: number | null = null;
+  // JP-307 Slices 3 + 5: drag-follow loop. Runs for the duration of a translate
+  // and (a) pans the camera toward a viewport edge when the cursor is near it
+  // (drag-to-edge auto-pan), and (b) re-applies the translate whenever the
+  // camera moves from ANY source — edge-pan above or the keyboard WASD/Q-E
+  // pan/zoom loop — so the dragged shape keeps following the cursor instead of
+  // freezing the instant the camera moves without a pointermove.
+  private dragFollowRafId: number | null = null;
   private lastTranslateScreenPoint: Vec2 | null = null;
+  private lastDragCamera: { x: number; y: number; zoom: number } | null = null;
 
   // For marquee selection
   private marqueeStart: Vec2 | null = null;
@@ -697,7 +703,11 @@ export class SelectTool extends BaseTool {
   private handleTranslatingMove(event: NormalizedPointerEvent, ctx: ToolContext): void {
     this.lastTranslateScreenPoint = event.screenPoint;
     this.applyTranslate(event.worldPoint, ctx);
-    this.updateEdgePan(ctx);
+    // The event's worldPoint already reflects the current camera, so record it
+    // as the baseline the follow loop compares against (avoids re-applying a
+    // stale delta on the next tick).
+    this.lastDragCamera = { x: ctx.camera.x, y: ctx.camera.y, zoom: ctx.camera.zoom };
+    this.startDragFollow(ctx);
   }
 
   /**
@@ -798,55 +808,55 @@ export class SelectTool extends BaseTool {
   }
 
   /**
-   * Start/stop the drag-to-edge auto-pan loop based on the cursor's proximity
-   * to the viewport edges (JP-307 Slice 3).
+   * Start the drag-follow loop for the active translate (JP-307 Slices 3 + 5).
+   * Idempotent; the loop runs until the drag ends (resetState stops it).
    */
-  private updateEdgePan(ctx: ToolContext): void {
-    if (!this.lastTranslateScreenPoint) return;
-    const vel = edgePanVelocity(
-      this.lastTranslateScreenPoint,
-      ctx.camera.screenWidth,
-      ctx.camera.screenHeight
-    );
-    if (vel.x === 0 && vel.y === 0) {
-      this.stopEdgePan();
-      return;
-    }
-    if (this.edgePanRafId === null) {
-      this.edgePanRafId = requestAnimationFrame(() => this.edgePanTick(ctx));
-    }
+  private startDragFollow(ctx: ToolContext): void {
+    if (this.dragFollowRafId !== null) return;
+    this.dragFollowRafId = requestAnimationFrame(() => this.dragFollowTick(ctx));
   }
 
-  private edgePanTick(ctx: ToolContext): void {
-    this.edgePanRafId = null;
+  private dragFollowTick(ctx: ToolContext): void {
+    this.dragFollowRafId = null;
     if (this.state !== 'translating' || !this.lastTranslateScreenPoint) return;
 
+    // (a) Drag-to-edge auto-pan: drive the camera toward the edge when the
+    // cursor is in the edge band.
     const vel = edgePanVelocity(
       this.lastTranslateScreenPoint,
       ctx.camera.screenWidth,
       ctx.camera.screenHeight
     );
-    if (vel.x === 0 && vel.y === 0) return;
+    if (vel.x !== 0 || vel.y !== 0) {
+      ctx.camera.pan(new Vec2(-vel.x, -vel.y));
+    }
 
-    // Pan the camera toward the edge. camera.pan() moves the camera opposite a
-    // positive screen delta, so negate: a positive (right/bottom) velocity must
-    // move the camera right/down to reveal content there. Every tick moves the
-    // camera, so the shape update below is never a no-op.
-    ctx.camera.pan(new Vec2(-vel.x, -vel.y));
+    // (b) Re-apply the translate whenever the camera moved this frame — from the
+    // edge-pan above OR the keyboard WASD/Q-E pan/zoom loop — by recomputing the
+    // world point under the (stationary) cursor, so the shape keeps following.
+    // (On a laptop trackpad, pressing a key fires a real OS pointerup that ends
+    // the drag before this can help — a hardware limit; works with a mouse.)
+    const cam = this.lastDragCamera;
+    const moved =
+      !cam ||
+      cam.x !== ctx.camera.x ||
+      cam.y !== ctx.camera.y ||
+      cam.zoom !== ctx.camera.zoom;
+    if (moved) {
+      const worldPoint = ctx.camera.screenToWorld(this.lastTranslateScreenPoint);
+      this.applyTranslate(worldPoint, ctx);
+      this.lastDragCamera = { x: ctx.camera.x, y: ctx.camera.y, zoom: ctx.camera.zoom };
+    }
 
-    // Recompute the world point under the (stationary) cursor after the pan and
-    // re-apply the translate so the dragged shapes follow the moving view.
-    const worldPoint = ctx.camera.screenToWorld(this.lastTranslateScreenPoint);
-    this.applyTranslate(worldPoint, ctx);
-
-    this.edgePanRafId = requestAnimationFrame(() => this.edgePanTick(ctx));
+    this.dragFollowRafId = requestAnimationFrame(() => this.dragFollowTick(ctx));
   }
 
-  private stopEdgePan(): void {
-    if (this.edgePanRafId !== null) {
-      cancelAnimationFrame(this.edgePanRafId);
-      this.edgePanRafId = null;
+  private stopDragFollow(): void {
+    if (this.dragFollowRafId !== null) {
+      cancelAnimationFrame(this.dragFollowRafId);
+      this.dragFollowRafId = null;
     }
+    this.lastDragCamera = null;
   }
 
   private handleMarqueeMove(event: NormalizedPointerEvent, ctx: ToolContext): void {
@@ -979,6 +989,14 @@ export class SelectTool extends BaseTool {
         this.dragStartPositions.set(id, startPos);
       }
     }
+
+    // Seed + start the drag-follow loop so keyboard pan/zoom (or edge-pan)
+    // re-applies the translate even before the first translating pointermove.
+    if (this.pointerDownPoint) {
+      this.lastTranslateScreenPoint = this.pointerDownPoint;
+    }
+    this.lastDragCamera = { x: ctx.camera.x, y: ctx.camera.y, zoom: ctx.camera.zoom };
+    this.startDragFollow(ctx);
   }
 
   private finishTranslate(ctx: ToolContext): void {
@@ -1054,7 +1072,7 @@ export class SelectTool extends BaseTool {
     this.currentSnapResult = null;
     this.connectorHoveredAnchor = null;
     this.panHandler.reset();
-    this.stopEdgePan();
+    this.stopDragFollow();
     this.lastTranslateScreenPoint = null;
     // Note: Don't reset click tracking here, it persists across interactions
   }


### PR DESCRIPTION
Additive "classic" canvas controls that supplement the **preferred keyboard nav** (WASD pan / Q-E zoom stays first-class). Unified defaults, no settings layer. UX behavior change only — no document/wire/storage format change, so no migration / no `PROTOCOL_VERSION` bump.

Validated by an input spike on both the PWA (Chromium) and the **Tauri WebKitGTK** webview + Android: WebKitGTK ≡ Chromium for input (no per-platform branch needed); trackpad two-finger scroll is cleanly identifiable; **trackpad pinch emits nothing on Linux**, so desktop zoom rides Ctrl+scroll with Q/E as the guaranteed path.

## Slices
- **1 — Wheel/trackpad pan** (`Engine.handleWheel`): plain wheel / two-finger scroll pans **both axes** (the old handler ignored `deltaX`, so trackpad horizontal scroll was a no-op). `Ctrl/⌘+scroll` (and OS pinch on macOS/Windows) zooms. `Shift+wheel` → horizontal pan for mice.
- **2 — Eased zoom + acceleration** (`Engine` + `Camera`): wheel/Ctrl-scroll zoom eases toward an accumulated target via the rAF loop; keyboard Q/E stays crisp/per-frame but gains a hold-duration acceleration ramp. One `startPanAnimation` loop drives both (no second competing loop). **Fixed a latent bug** in the previously-unused `Camera.updateZoom`: it applied steps via `zoomAt`, which resets `_targetZoom`, so the ease clobbered its own target after one frame and never converged — the target is now captured/restored.
- **3 — Drag-to-edge auto-pan** (`SelectTool`): dragging near a viewport edge pans the camera toward it (velocity ramps with proximity) and recomputes the drag delta from the stationary cursor each tick, so shapes are no longer stuck inside the view. Pan math extracted to a pure exported `edgePanVelocity()`. The loop only runs when there's edge velocity (no shape-update spam off-edge).
- **4 — Two-finger touch pan** (`InputHandler`): two-finger drag pans (midpoint translation) simultaneously with pinch-zoom; one-finger = select unchanged.
- **5 — Drag-while-keyboard-zoom:** no code needed — the keyboard pan/zoom loop and `SelectTool` drag are orthogonal (camera vs shapes).

## Verification
- `bun run typecheck` clean; **full suite `bun run test --run` → 2336 passed**.
- New tests: `Camera` eased-zoom convergence + focal-point stability; `InputHandler` two-finger pan (+ single-finger never pans); `edgePanVelocity` ramp/cap/corner.
- **Not unit-tested:** Engine-level wheel routing + Slice 5 coexistence — the Engine isn't instantiated in this repo's test harness; covered by code structure + manual feel-testing on PWA/Tauri/mobile (the spike validated the raw event signatures).

Linear: JP-307 (Cloud MVP + Feature, est. 5).

Assisted-by: Opus 4.8