### PR TITLE
JP-130: warn when a shared relay pod has an unlimited limit fallback

### DIFF
--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -488,6 +488,21 @@ impl Default for TenancyConfig {
     }
 }
 
+impl TenancyConfig {
+    /// JP-130: true when this is a `shared` pod whose per-workspace limit
+    /// fallback is unlimited (`0`) on either axis. In that state a token that
+    /// omits the `wsp[]` limit claim resolves to *unlimited* storage/editors —
+    /// a fail-open the control plane should close by setting a non-zero
+    /// `RELAY_STORAGE_QUOTA_BYTES` / `RELAY_MAX_EDITORS_PER_WORKSPACE` fallback.
+    /// A `dedicated` pod keeps the unlimited fallback by design (the claim omits
+    /// and the pod's own config governs), so it is never flagged.
+    pub fn shared_fallback_unlimited(&self) -> bool {
+        matches!(self.mode, TenancyMode::Shared)
+            && (self.limits.storage_quota_bytes == 0
+                || self.limits.max_editors_per_workspace == 0)
+    }
+}
+
 /// Observability section. Controls the metering signals the relay
 /// exposes for the storage / concurrency / write-throttle axes. The
 /// pod-level Prometheus series at `/metrics` are always on; this section
@@ -1029,6 +1044,32 @@ mod tests {
         let cfg = LimitsConfig::default();
         assert_eq!(cfg.storage_quota_bytes, 0);
         assert_eq!(cfg.max_editors_per_workspace, 0);
+    }
+
+    #[test]
+    fn shared_fallback_unlimited_flags_fail_open() {
+        // JP-130: shared + unlimited fallback (either axis 0) is a fail-open.
+        let mut cfg = TenancyConfig {
+            mode: TenancyMode::Shared,
+            ..TenancyConfig::default()
+        };
+        assert!(cfg.shared_fallback_unlimited()); // both 0 by default
+
+        // A non-zero floor on both axes clears it.
+        cfg.limits.storage_quota_bytes = 26_214_400;
+        cfg.limits.max_editors_per_workspace = 2;
+        assert!(!cfg.shared_fallback_unlimited());
+
+        // Either axis unlimited still flags.
+        cfg.limits.max_editors_per_workspace = 0;
+        assert!(cfg.shared_fallback_unlimited());
+
+        // Dedicated keeps the unlimited fallback by design — never flagged.
+        let ded = TenancyConfig {
+            mode: TenancyMode::Dedicated,
+            ..TenancyConfig::default()
+        };
+        assert!(!ded.shared_fallback_unlimited());
     }
 
     #[test]

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -214,6 +214,24 @@ async fn run_serve(
         );
     }
 
+    // JP-130: on a shared pod an unlimited limit fallback means a token that
+    // omits the wsp[] limit claim (a minting regression) silently resolves to
+    // *unlimited* storage + editors — a fail-open cost/abuse exposure. Warn so
+    // the misconfig is visible; a non-zero RELAY_STORAGE_QUOTA_BYTES /
+    // RELAY_MAX_EDITORS_PER_WORKSPACE fallback makes an omitted claim fail safe.
+    // (A dedicated pod keeps the unlimited fallback by design and is not flagged.)
+    if config.tenancy.shared_fallback_unlimited() {
+        log::warn!(
+            "tenancy.mode = \"shared\" but the per-workspace limit fallback is unlimited \
+             (storage_quota_bytes={}, max_editors_per_workspace={}; 0 = unlimited): a token that \
+             omits the wsp[] limit claim would get unlimited storage/editors on this shared pod. \
+             Set a non-zero RELAY_STORAGE_QUOTA_BYTES / RELAY_MAX_EDITORS_PER_WORKSPACE fallback \
+             so an omitted claim fails safe (the JWT claim still overrides upward).",
+            config.tenancy.limits.storage_quota_bytes,
+            config.tenancy.limits.max_editors_per_workspace,
+        );
+    }
+
     std::fs::create_dir_all(&config.storage.path)?;
 
     // Build the OIDC validator + JWKS cache + revocation set. The


### PR DESCRIPTION
Closes JP-130.

Defense-in-depth for the fail-open found in the JP-124 staging round-trip. On a `shared` pod, a token that omits the `wsp[]` limit claim (a minting regression — a new mint path that forgets the limit spread, a tier added to the enum but not the map, an auth-exchange bug) resolves via `resolve_limits()` to the config fallback, which defaults to `0 = unlimited`. Those workspaces would silently get **unlimited storage + editors** on a multi-tenant pod — a cost/abuse exposure that wouldn't surface until a bill.

## Change (relay code)
- `TenancyConfig::shared_fallback_unlimited()` — a small, unit-tested helper: true when `mode = shared` and either `storage_quota_bytes` or `max_editors_per_workspace` fallback is `0`.
- A startup `warn` in `main.rs` (mirroring the AU-5a revocation check) when that holds, naming the env vars to set.
- The relay keeps its `0 = unlimited` compiled default (self-host safety); a **dedicated** pod is never flagged (claim omits → its own config governs, by design).

## Out of band (not in this PR)
- **The actual fail-safe is ops:** set the shared pod's fallback to the Free-tier floor — `RELAY_STORAGE_QUOTA_BYTES=26214400` (25 MiB, post-JP-88) + `RELAY_MAX_EDITORS_PER_WORKSPACE=2`. The issue's original `262144000` is stale after JP-88 cut Free to 25 MiB. The JWT claim still overrides upward for paid tiers.
- Internal docs (Free-Tier Enforcement Spec / Cloud Setup Recipe) record the floor.

## Verification
- `cargo check --all-targets` clean (bin compiles).
- `cargo test --lib shared_fallback_unlimited` — 1 passed.

Assisted-by: Opus 4.8