### PR TITLE
JP-309: chunk oversized offline-reconnect updates (no more silent data loss)

### DIFF
--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -50,11 +50,13 @@ pub const DEFAULT_READS_PER_SEC: u32 = 100;
 pub const DEFAULT_READS_BURST: u32 = 200;
 /// Default cap on concurrent authenticated WS connections per workspace.
 pub const DEFAULT_MAX_WS_CONNECTIONS_PER_WORKSPACE: u32 = 25;
-/// Default cap on a single WS frame's payload size (bytes). Pathological
-/// updates are rejected with WS close 1009. Phase 21.3 reframed
-/// deliverable: there is no server-side Y.Doc history to bound, but a
-/// per-frame size cap closes the same blast-radius concern.
-pub const DEFAULT_MAX_WS_PAYLOAD_BYTES: usize = 262_144; // 256 KiB
+/// Default cap on a single WS *inbound* frame's payload size (bytes). An
+/// over-cap frame is gracefully rejected (MESSAGE_ERROR, connection kept) and
+/// large logical updates are delivered via MESSAGE_SYNC_CHUNK reassembly
+/// (JP-309) — so this bounds one frame's blast radius without dropping the
+/// session. Raised 256 KiB → 1 MiB (covers most offline-reconnect deltas in a
+/// single frame); chunk frames stay under it.
+pub const DEFAULT_MAX_WS_PAYLOAD_BYTES: usize = 1_048_576; // 1 MiB (JP-309)
 
 /// Max body size for a single blob upload (`POST /api/blobs/:hash`). The
 /// per-workspace `storage_quota_bytes` is the real cap; this just bounds one

--- a/relay/src/server/chunk.rs
+++ b/relay/src/server/chunk.rs
@@ -1,0 +1,208 @@
+//! JP-309: reassembly of `MESSAGE_SYNC_CHUNK` fragments.
+//!
+//! A client whose outbound SYNC frame would exceed the inbound per-message cap
+//! (e.g. one big offline-reconnect update) splits it into sub-cap fragments,
+//! each `[msgId: 16 bytes][seq: u32 BE][total: u32 BE][payload]`. The relay
+//! buffers fragments per connection keyed by `msgId` and, once all `total`
+//! arrive, returns the reassembled original `[MESSAGE_SYNC | update]` frame,
+//! which is then applied via the normal sync path — so the CRDT merge is
+//! byte-identical to having received the update in one frame.
+//!
+//! The reassembler is intentionally pure (no async, no `ServerState`) so the
+//! bounds + timeout logic is unit-tested directly. The bounds are load-bearing:
+//! without them chunking would reintroduce the memory-exhaustion the cap guards.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Max distinct in-flight chunked messages per connection.
+const MAX_INFLIGHT: usize = 4;
+/// Max fragments in one logical message (256 KiB chunks ⇒ a 16 MiB ceiling).
+const MAX_TOTAL: u32 = 64;
+/// Max bytes buffered across all in-flight messages on one connection.
+const MAX_BUFFERED_BYTES: usize = 16 * 1024 * 1024;
+/// Drop a partial buffer with no fragment activity for this long.
+const STALE_AFTER: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+struct ChunkBuffer {
+    total: u32,
+    chunks: Vec<Option<Vec<u8>>>,
+    received: u32,
+    bytes: usize,
+    last_activity: Instant,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ChunkError {
+    /// `total` is zero or exceeds `MAX_TOTAL`.
+    BadTotal,
+    /// `seq` is out of range for the announced `total`.
+    BadSeq,
+    /// Already at `MAX_INFLIGHT` distinct messages on this connection.
+    TooManyInflight,
+    /// Would exceed the per-connection reassembly byte budget.
+    BudgetExceeded,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ChunkReassembler {
+    buffers: HashMap<[u8; 16], ChunkBuffer>,
+}
+
+impl ChunkReassembler {
+    /// Feed one fragment. Returns `Ok(Some(bytes))` once `msg_id` is complete
+    /// (the reassembled original frame), `Ok(None)` while still accumulating,
+    /// or `Err` on a malformed/abusive fragment (the caller logs + ignores).
+    pub(crate) fn push(
+        &mut self,
+        msg_id: [u8; 16],
+        seq: u32,
+        total: u32,
+        payload: &[u8],
+        now: Instant,
+    ) -> Result<Option<Vec<u8>>, ChunkError> {
+        if total == 0 || total > MAX_TOTAL {
+            return Err(ChunkError::BadTotal);
+        }
+        if seq >= total {
+            return Err(ChunkError::BadSeq);
+        }
+
+        // Reap abandoned partials before admitting a new fragment.
+        self.prune_stale(now);
+
+        // A buffer whose announced `total` disagrees means the client restarted
+        // the message — discard the stale partial and start fresh.
+        if self.buffers.get(&msg_id).is_some_and(|b| b.total != total) {
+            self.buffers.remove(&msg_id);
+        }
+
+        let is_new = !self.buffers.contains_key(&msg_id);
+        if is_new && self.buffers.len() >= MAX_INFLIGHT {
+            return Err(ChunkError::TooManyInflight);
+        }
+        let buffered: usize = self.buffers.values().map(|b| b.bytes).sum();
+        if buffered + payload.len() > MAX_BUFFERED_BYTES {
+            return Err(ChunkError::BudgetExceeded);
+        }
+
+        let complete = {
+            let buf = self.buffers.entry(msg_id).or_insert_with(|| ChunkBuffer {
+                total,
+                chunks: vec![None; total as usize],
+                received: 0,
+                bytes: 0,
+                last_activity: now,
+            });
+            buf.last_activity = now;
+            // A duplicate `seq` is ignored (idempotent retransmit).
+            let slot = &mut buf.chunks[seq as usize];
+            if slot.is_none() {
+                *slot = Some(payload.to_vec());
+                buf.received += 1;
+                buf.bytes += payload.len();
+            }
+            buf.received == buf.total
+        };
+
+        if complete {
+            let buf = self.buffers.remove(&msg_id).expect("just inserted");
+            let mut out = Vec::with_capacity(buf.bytes);
+            for chunk in buf.chunks {
+                out.extend_from_slice(&chunk.expect("all chunks present when complete"));
+            }
+            Ok(Some(out))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Drop partial buffers idle longer than `STALE_AFTER`. Called on each
+    /// fragment (prod) and directly from tests.
+    pub(crate) fn prune_stale(&mut self, now: Instant) {
+        self.buffers
+            .retain(|_, b| now.duration_since(b.last_activity) < STALE_AFTER);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inflight(&self) -> usize {
+        self.buffers.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u8) -> [u8; 16] {
+        let mut m = [0u8; 16];
+        m[0] = n;
+        m
+    }
+
+    #[test]
+    fn reassembles_in_order_and_byte_identical() {
+        let mut r = ChunkReassembler::default();
+        let t = Instant::now();
+        assert_eq!(r.push(id(1), 0, 3, b"aaa", t).unwrap(), None);
+        assert_eq!(r.push(id(1), 1, 3, b"bbb", t).unwrap(), None);
+        let out = r.push(id(1), 2, 3, b"ccc", t).unwrap().unwrap();
+        assert_eq!(out, b"aaabbbccc");
+        assert_eq!(r.inflight(), 0, "completed buffer is freed");
+    }
+
+    #[test]
+    fn reassembles_out_of_order() {
+        let mut r = ChunkReassembler::default();
+        let t = Instant::now();
+        assert_eq!(r.push(id(1), 2, 3, b"ccc", t).unwrap(), None);
+        assert_eq!(r.push(id(1), 0, 3, b"aaa", t).unwrap(), None);
+        let out = r.push(id(1), 1, 3, b"bbb", t).unwrap().unwrap();
+        assert_eq!(out, b"aaabbbccc");
+    }
+
+    #[test]
+    fn duplicate_seq_is_ignored() {
+        let mut r = ChunkReassembler::default();
+        let t = Instant::now();
+        assert_eq!(r.push(id(1), 0, 2, b"aa", t).unwrap(), None);
+        assert_eq!(r.push(id(1), 0, 2, b"aa", t).unwrap(), None); // dup
+        let out = r.push(id(1), 1, 2, b"bb", t).unwrap().unwrap();
+        assert_eq!(out, b"aabb");
+    }
+
+    #[test]
+    fn rejects_bad_total_and_seq() {
+        let mut r = ChunkReassembler::default();
+        let t = Instant::now();
+        assert_eq!(r.push(id(1), 0, 0, b"x", t), Err(ChunkError::BadTotal));
+        assert_eq!(r.push(id(1), 0, 9999, b"x", t), Err(ChunkError::BadTotal));
+        assert_eq!(r.push(id(1), 5, 3, b"x", t), Err(ChunkError::BadSeq));
+    }
+
+    #[test]
+    fn rejects_too_many_inflight() {
+        let mut r = ChunkReassembler::default();
+        let t = Instant::now();
+        for n in 0..MAX_INFLIGHT as u8 {
+            assert_eq!(r.push(id(n), 0, 2, b"a", t).unwrap(), None);
+        }
+        assert_eq!(
+            r.push(id(200), 0, 2, b"a", t),
+            Err(ChunkError::TooManyInflight)
+        );
+    }
+
+    #[test]
+    fn prunes_stale_partials() {
+        let mut r = ChunkReassembler::default();
+        let t0 = Instant::now();
+        assert_eq!(r.push(id(1), 0, 2, b"aa", t0).unwrap(), None);
+        assert_eq!(r.inflight(), 1);
+        // A fragment for a different message 11s later prunes the stale partial.
+        let later = t0 + Duration::from_secs(11);
+        assert_eq!(r.push(id(2), 0, 2, b"bb", later).unwrap(), None);
+        assert_eq!(r.inflight(), 1, "stale id(1) pruned, only id(2) remains");
+    }
+}

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -15,6 +15,7 @@
 
 mod blob_backend;
 pub mod blobs;
+pub(crate) mod chunk;
 pub mod documents;
 pub mod permissions;
 pub mod protocol;
@@ -341,6 +342,8 @@ struct ClientState {
     jti: Option<String>,
     token_exp: Option<u64>,
     tx: mpsc::Sender<Vec<u8>>,
+    /// JP-309: per-connection reassembly buffer for chunked SYNC frames.
+    reassembly: chunk::ChunkReassembler,
 }
 
 /// Where a broadcast should land. Replaces the pre-21.4-B
@@ -2514,7 +2517,11 @@ async fn ws_handler(
             return (StatusCode::UPGRADE_REQUIRED, body).into_response();
         }
     }
-    ws.on_upgrade(move |socket| handle_socket(socket, state))
+    // Bound a single frame at the WS layer. Must stay >= MAX_DOCUMENT_SIZE so the
+    // relay's *outbound* initial-sync of a large doc to a joining client is never
+    // truncated; the inbound per-message cap (gracefully rejected) is much lower.
+    ws.max_message_size(16 * 1024 * 1024)
+        .on_upgrade(move |socket| handle_socket(socket, state))
 }
 
 /// Handle an individual WebSocket connection
@@ -2522,6 +2529,11 @@ async fn ws_handler(
 /// revocation polling cadence so a revoked token is torn off an open socket
 /// within roughly the same window the relay learns of the revocation.
 const SESSION_RECHECK_INTERVAL_SECS: u64 = 60;
+
+/// JP-309: how many over-cap inbound frames a single connection may send before
+/// it's dropped as abuse. The first few are gracefully rejected (the client is
+/// told to chunk) so a transitional/legacy client isn't punished for one frame.
+const MAX_OVER_CAP_FRAMES: u32 = 3;
 
 /// AU-3: whether `client_id`'s authenticating token is now revoked or past its
 /// expiry. Unauthenticated connections have nothing to recheck yet (`false`).
@@ -2569,6 +2581,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<ServerState>) {
             jti: None,
             token_exp: None,
             tx: tx.clone(),
+            reassembly: chunk::ChunkReassembler::default(),
         });
     }
 
@@ -2631,6 +2644,9 @@ async fn handle_socket(socket: WebSocket, state: Arc<ServerState>) {
     recheck.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     recheck.tick().await;
 
+    // JP-309: per-connection count of over-cap frames; sustained abuse drops.
+    let mut over_cap_count: u32 = 0;
+
     // Handle incoming messages from this client
     loop {
         tokio::select! {
@@ -2638,6 +2654,35 @@ async fn handle_socket(socket: WebSocket, state: Arc<ServerState>) {
                 let Some(Ok(msg)) = incoming else { break };
                 match msg {
                     Message::Binary(data) => {
+                        // JP-309: enforce the inbound per-message cap here so an
+                        // over-cap frame is gracefully rejected (tell the client,
+                        // keep the connection) instead of dropping the session into
+                        // a reconnect-loop that silently loses offline edits. Large
+                        // logical updates arrive chunked (MESSAGE_SYNC_CHUNK), each
+                        // under the cap. Sustained abuse still drops.
+                        let cap = state.tenancy().limits.max_ws_payload_bytes;
+                        if data.len() > cap {
+                            log::warn!(
+                                "ws frame too large client_id={} bytes={} cap={}",
+                                client_id, data.len(), cap
+                            );
+                            let err = ErrorResponse {
+                                request_id: None,
+                                error: ERR_MESSAGE_TOO_LARGE.to_string(),
+                            };
+                            if let Ok(frame) = encode_message(MESSAGE_ERROR, &err) {
+                                send_to_client(client_id, frame, &state).await;
+                            }
+                            over_cap_count += 1;
+                            if over_cap_count > MAX_OVER_CAP_FRAMES {
+                                log::warn!(
+                                    "client {} dropped after {} over-cap frames",
+                                    client_id, over_cap_count
+                                );
+                                break;
+                            }
+                            continue;
+                        }
                         if let Some(msg_type) = decode_message_type(&data) {
                             if !handle_message(client_id, msg_type, &data, &state).await {
                                 // A handler panicked. Drop just this connection;
@@ -2730,28 +2775,10 @@ async fn handle_message(
     use futures_util::FutureExt;
     use std::panic::AssertUnwindSafe;
 
-    // Phase 21.3: per-message payload-size cap. Pathologically large
-    // frames are rejected before dispatch — see `max_ws_payload_bytes`
-    // in [tenancy.limits]. Returning `false` makes the receive loop
-    // drop this connection via the existing isolation path.
-    let cap = state.tenancy().limits.max_ws_payload_bytes;
-    if data.len() > cap {
-        let ws_id = {
-            let clients = state.clients.read().await;
-            clients
-                .get(&client_id)
-                .map(|c| c.current_workspace_id.as_str().to_string())
-                .unwrap_or_default()
-        };
-        log::warn!(
-            "ws frame too large client_id={} workspace_id={} bytes={} cap={}",
-            client_id,
-            ws_id,
-            data.len(),
-            cap,
-        );
-        return false;
-    }
+    // Phase 21.3 per-message payload-size cap is enforced in the receive loop
+    // (`handle_socket`) so an over-cap frame can be gracefully rejected
+    // (MESSAGE_ERROR, connection kept) rather than dropping the session — see
+    // JP-309. By the time a frame reaches here it is already within the cap.
 
     let correlation_id = nanoid::nanoid!(10);
     let fut = async {
@@ -2778,6 +2805,7 @@ async fn handle_message(
         match msg_type {
             MESSAGE_AUTH => handle_auth(client_id, data, state).await,
             MESSAGE_SYNC => handle_sync(client_id, data, state).await,
+            MESSAGE_SYNC_CHUNK => handle_sync_chunk(client_id, data, state).await,
             MESSAGE_AWARENESS => handle_awareness(client_id, data, state).await,
             MESSAGE_JOIN_DOC => handle_join_doc(client_id, data, state).await,
             _ => {
@@ -2962,10 +2990,66 @@ async fn send_auth_response(
         token,
         token_expires_at,
         error: error.map(String::from),
+        // JP-309: advertise the inbound cap (only meaningful on success) so the
+        // client knows the threshold above which it must chunk SYNC frames.
+        max_message_size: success.then(|| state.tenancy().limits.max_ws_payload_bytes as u64),
     };
 
     if let Ok(data) = encode_message(MESSAGE_AUTH_RESPONSE, &response) {
         send_to_client(client_id, data, state).await;
+    }
+}
+
+/// JP-309: buffer a chunked SYNC fragment. Once the logical message is complete,
+/// apply the reassembled `[MESSAGE_SYNC | update]` via the normal sync path (one
+/// rate-limit check, full CRDT merge + broadcast — byte-identical to having
+/// received it in one frame) and ack the msgId so the client can mark itself
+/// synced. Malformed/abusive fragments are logged + ignored (connection kept).
+async fn handle_sync_chunk(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
+    // [type][msgId: 16][seq: u32 BE][total: u32 BE][payload]
+    let body = &data[1..];
+    if body.len() < 24 {
+        log::warn!(
+            "malformed sync-chunk from client {} (body len {})",
+            client_id,
+            body.len()
+        );
+        return;
+    }
+    let mut msg_id = [0u8; 16];
+    msg_id.copy_from_slice(&body[0..16]);
+    let seq = u32::from_be_bytes([body[16], body[17], body[18], body[19]]);
+    let total = u32::from_be_bytes([body[20], body[21], body[22], body[23]]);
+    let payload = &body[24..];
+
+    let reassembled = {
+        let mut clients = state.clients.write().await;
+        let Some(client) = clients.get_mut(&client_id) else { return };
+        // Only an authenticated client may buffer — bounds pre-auth memory use.
+        if !client.authenticated {
+            log::warn!("sync-chunk from unauthenticated client {}", client_id);
+            return;
+        }
+        match client
+            .reassembly
+            .push(msg_id, seq, total, payload, std::time::Instant::now())
+        {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("sync-chunk rejected from client {}: {:?}", client_id, e);
+                return;
+            }
+        }
+    };
+
+    if let Some(frame) = reassembled {
+        // `frame` is the original [MESSAGE_SYNC | update]; apply as if it had
+        // arrived whole, then ack the completed msgId.
+        handle_sync(client_id, &frame, state).await;
+        let mut ack = Vec::with_capacity(1 + 16);
+        ack.push(MESSAGE_SYNC_CHUNK_ACK);
+        ack.extend_from_slice(&msg_id);
+        send_to_client(client_id, ack, state).await;
     }
 }
 
@@ -3327,6 +3411,7 @@ mod tests {
                     jti: None,
                     token_exp: None,
                     tx,
+                    reassembly: chunk::ChunkReassembler::default(),
                 },
             );
         }
@@ -3431,6 +3516,7 @@ mod tests {
                 jti: jti.map(|s| s.to_string()),
                 token_exp: exp,
                 tx,
+                reassembly: chunk::ChunkReassembler::default(),
             }
         };
         {
@@ -3531,6 +3617,7 @@ mod tests {
                     jti: None,
                     token_exp: None,
                     tx,
+                    reassembly: chunk::ChunkReassembler::default(),
                 },
             );
         }
@@ -3597,6 +3684,7 @@ mod tests {
                     jti: None,
                     token_exp: None,
                     tx,
+                    reassembly: chunk::ChunkReassembler::default(),
                 },
             );
         }

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -242,13 +242,18 @@ fn validate_doc_id(s: &str) -> Result<(), IdError> {
 /// `src/collaboration/protocol.ts`. Sent by clients as
 /// `?protocolVersion=<N>` on the WebSocket upgrade URL; the server
 /// refuses mismatched versions.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Query-parameter name carrying the client's protocol version.
 pub const PROTOCOL_VERSION_PARAM: &str = "protocolVersion";
 
 /// Error code returned when client/server protocol versions disagree.
 pub const ERR_PROTOCOL_VERSION_MISMATCH: &str = "ERR_PROTOCOL_VERSION_MISMATCH";
+
+/// Error code sent (MESSAGE_ERROR) when an inbound frame exceeds the
+/// per-message cap. The connection is kept open (JP-309) — the client should
+/// deliver large updates via MESSAGE_SYNC_CHUNK instead.
+pub const ERR_MESSAGE_TOO_LARGE: &str = "ERR_MESSAGE_TOO_LARGE";
 
 /// Message types for the sync protocol. Must match the TypeScript
 /// MESSAGE_* constants in `protocol.ts`.
@@ -263,6 +268,14 @@ pub const MESSAGE_ERROR: u8 = 8;
 pub const MESSAGE_AUTH_RESPONSE: u8 = 9;
 pub const MESSAGE_JOIN_DOC: u8 = 10;
 // 11..=13 reserved (formerly AUTH_LOGIN, DOC_SHARE, DOC_TRANSFER — now REST)
+/// A fragment of a large SYNC frame, split client→relay so a big offline-
+/// reconnect update can be delivered under the per-message cap (JP-309).
+/// Body (binary): `[msgId: 16 bytes][seq: u32 BE][total: u32 BE][payload]`.
+/// Reassembled bytes are the original `[MESSAGE_SYNC|update]` frame.
+pub const MESSAGE_SYNC_CHUNK: u8 = 14;
+/// Relay→client ack once a chunked update's msgId is fully reassembled and
+/// applied. Body (binary): `[msgId: 16 bytes]`.
+pub const MESSAGE_SYNC_CHUNK_ACK: u8 = 15;
 
 /// Authentication request with JWT token (sent by client)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -288,6 +301,10 @@ pub struct AuthResponse {
     pub token_expires_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Relay's inbound per-message cap in bytes (JP-309). The client splits any
+    /// outbound SYNC frame larger than this into MESSAGE_SYNC_CHUNK frames.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_message_size: Option<u64>,
 }
 
 /// Document event types

--- a/relay/src/sync/protocol.rs
+++ b/relay/src/sync/protocol.rs
@@ -133,6 +133,48 @@ mod tests {
         assert!(cshapes.contains_key(&client.transact(), "s1"));
     }
 
+    /// JP-309 end-to-end (headless): a real Yjs update is framed like the
+    /// client does, split into many tiny fragments, reassembled by the relay's
+    /// `ChunkReassembler`, then applied via this same sync path — proving
+    /// chunked delivery merges identically to a single frame and rebroadcasts.
+    #[test]
+    fn chunked_update_reassembles_and_applies_like_a_single_frame() {
+        use crate::server::chunk::ChunkReassembler;
+        use std::time::Instant;
+
+        let update = doc_with_shape("s1")
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        let frame = frame_update(update); // [MESSAGE_SYNC | lib0 Update]
+
+        // Split into deliberately tiny fragments to force reassembly.
+        let chunk_size = 7usize;
+        let total = frame.len().div_ceil(chunk_size) as u32;
+        assert!(total > 1, "test needs multiple fragments");
+
+        let mut r = ChunkReassembler::default();
+        let now = Instant::now();
+        let msg_id = [9u8; 16];
+        let mut reassembled = None;
+        for seq in 0..total {
+            let start = seq as usize * chunk_size;
+            let end = (start + chunk_size).min(frame.len());
+            reassembled = r.push(msg_id, seq, total, &frame[start..end], now).unwrap();
+        }
+        let reassembled = reassembled.expect("complete on the final fragment");
+        assert_eq!(reassembled, frame, "reassembled bytes are byte-identical");
+
+        // Apply via the same path handle_sync uses.
+        let server = Doc::new();
+        let sshapes = server.get_or_insert_map("shapes");
+        let outcome = process_sync_message(&server, &reassembled[1..]).unwrap();
+        assert!(outcome.broadcast.is_some(), "applied update rebroadcasts to peers");
+        assert!(
+            sshapes.contains_key(&server.transact(), "s1"),
+            "the chunked update merged into the authoritative doc"
+        );
+    }
+
     #[test]
     fn update_is_applied_and_rebroadcast() {
         let server = Doc::new();

--- a/src/collaboration/UnifiedSyncProvider.test.ts
+++ b/src/collaboration/UnifiedSyncProvider.test.ts
@@ -7,6 +7,8 @@ import {
   MESSAGE_DOC_EVENT,
   MESSAGE_JOIN_DOC,
   MESSAGE_ERROR,
+  MESSAGE_SYNC,
+  MESSAGE_SYNC_CHUNK,
   encodeMessage,
   decodeMessageType,
   decodePayload,
@@ -598,6 +600,83 @@ describe('UnifiedSyncProvider', () => {
       );
 
       expect(provider.getStatus()).toBe('connected');
+    });
+  });
+
+  describe('JP-309 large-update chunking', () => {
+    function parseChunk(frame: Uint8Array) {
+      const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
+      return {
+        type: frame[0]!,
+        msgId: frame.slice(1, 17),
+        seq: view.getUint32(17, false),
+        total: view.getUint32(21, false),
+        payload: frame.slice(25),
+      };
+    }
+
+    it('adopts the relay-advertised maxMessageSize from AUTH_RESPONSE', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket!.simulateOpen();
+      mockWebSocket!.simulateMessage(
+        encodeMessage(MESSAGE_AUTH_RESPONSE, {
+          success: true,
+          userId: 'u',
+          maxMessageSize: 4242,
+        } satisfies AuthResponse),
+      );
+      expect((provider as unknown as { maxMessageSize: number }).maxMessageSize).toBe(4242);
+    });
+
+    it('sends a sub-cap SYNC frame unchanged (single frame)', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket!.simulateOpen();
+      (provider as unknown as { maxMessageSize: number }).maxMessageSize = 1024 * 1024;
+      mockWebSocket!.clearSentMessages();
+
+      const frame = new Uint8Array(500);
+      frame[0] = MESSAGE_SYNC;
+      (provider as unknown as { sendSyncFrame(f: Uint8Array): void }).sendSyncFrame(frame);
+
+      expect(mockWebSocket!.sentMessages).toHaveLength(1);
+      expect(decodeMessageType(mockWebSocket!.sentMessages[0]!)).toBe(MESSAGE_SYNC);
+      expect(mockWebSocket!.sentMessages[0]).toEqual(frame);
+    });
+
+    it('splits an over-cap SYNC frame into chunks that reassemble byte-identically', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket!.simulateOpen();
+      (provider as unknown as { maxMessageSize: number }).maxMessageSize = 1000;
+      mockWebSocket!.clearSentMessages();
+
+      // 600 KiB > the 256 KiB chunk size ⇒ multiple fragments.
+      const frame = new Uint8Array(600 * 1024);
+      for (let i = 0; i < frame.length; i++) frame[i] = i & 0xff;
+      (provider as unknown as { sendSyncFrame(f: Uint8Array): void }).sendSyncFrame(frame);
+
+      const chunks = mockWebSocket!.sentMessages.map(parseChunk);
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.every((c) => c.type === MESSAGE_SYNC_CHUNK)).toBe(true);
+
+      const total = chunks[0]!.total;
+      expect(chunks).toHaveLength(total);
+      // Same msgId across all fragments.
+      const id0 = chunks[0]!.msgId;
+      expect(chunks.every((c) => c.msgId.every((b, i) => b === id0[i]))).toBe(true);
+
+      // Reassemble by seq and assert byte-identical to the original frame.
+      const ordered = [...chunks].sort((a, b) => a.seq - b.seq);
+      ordered.forEach((c, i) => expect(c.seq).toBe(i));
+      const reassembled = new Uint8Array(frame.length);
+      let off = 0;
+      for (const c of ordered) {
+        reassembled.set(c.payload, off);
+        off += c.payload.length;
+      }
+      expect(reassembled).toEqual(frame);
     });
   });
 });

--- a/src/collaboration/UnifiedSyncProvider.ts
+++ b/src/collaboration/UnifiedSyncProvider.ts
@@ -22,6 +22,8 @@ import {
   PROTOCOL_VERSION,
   PROTOCOL_VERSION_PARAM,
   MESSAGE_SYNC,
+  MESSAGE_SYNC_CHUNK,
+  MESSAGE_SYNC_CHUNK_ACK,
   MESSAGE_AWARENESS,
   MESSAGE_AUTH,
   MESSAGE_AUTH_RESPONSE,
@@ -37,6 +39,13 @@ import {
 } from './protocol';
 
 import { useConnectionStore, type ConnectionStatus, type AuthenticatedUser } from '../store/connectionStore';
+
+// ============ JP-309: large-update chunking ============
+
+/** Conservative default until the relay advertises its cap on AUTH_RESPONSE. */
+const DEFAULT_MAX_MESSAGE_SIZE = 1024 * 1024; // 1 MiB (matches relay default)
+/** Payload bytes per MESSAGE_SYNC_CHUNK fragment — well under the 1 MiB cap. */
+const CHUNK_PAYLOAD_BYTES = 256 * 1024;
 
 // ============ Types ============
 
@@ -127,6 +136,12 @@ export class UnifiedSyncProvider {
   private status: ConnectionStatus = 'disconnected';
   private synced = false;
   private authenticated = false;
+  /**
+   * Relay's inbound per-message cap (JP-309), advertised on AUTH_RESPONSE. Any
+   * outbound SYNC frame larger than this is split into MESSAGE_SYNC_CHUNK
+   * fragments. Defaults to the pre-advertisement value until auth completes.
+   */
+  private maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private reconnectAttempts = 0;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -384,6 +399,11 @@ export class UnifiedSyncProvider {
       case MESSAGE_ERROR:
         this.handleErrorMessage(data);
         break;
+      case MESSAGE_SYNC_CHUNK_ACK:
+        // JP-309: the relay reassembled + applied a chunked update we sent. The
+        // local delta lives durably in the Y.Doc/y-indexeddb and the broadcast
+        // path already informs peers, so this is just a delivery confirmation.
+        break;
       default:
         // Unknown message type, ignore
         break;
@@ -408,6 +428,37 @@ export class UnifiedSyncProvider {
 
   // ============ Private: CRDT Sync ============
 
+  /**
+   * Send a SYNC frame, transparently splitting it into MESSAGE_SYNC_CHUNK
+   * fragments when it exceeds the relay's inbound cap (JP-309) — so a large
+   * offline-reconnect update is delivered + merged rather than dropped into a
+   * reconnect loop. The reassembled bytes are byte-identical, so the relay's
+   * CRDT merge is unchanged.
+   */
+  private sendSyncFrame(frame: Uint8Array): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    if (frame.length <= this.maxMessageSize) {
+      this.ws.send(frame);
+      return;
+    }
+    const msgId = new Uint8Array(16);
+    crypto.getRandomValues(msgId);
+    const total = Math.ceil(frame.length / CHUNK_PAYLOAD_BYTES);
+    for (let seq = 0; seq < total; seq++) {
+      const start = seq * CHUNK_PAYLOAD_BYTES;
+      const slice = frame.subarray(start, Math.min(start + CHUNK_PAYLOAD_BYTES, frame.length));
+      const out = new Uint8Array(25 + slice.length);
+      out[0] = MESSAGE_SYNC_CHUNK;
+      out.set(msgId, 1);
+      // Big-endian seq/total to match the relay's u32::from_be_bytes.
+      const view = new DataView(out.buffer);
+      view.setUint32(17, seq, false);
+      view.setUint32(21, total, false);
+      out.set(slice, 25);
+      this.ws.send(out);
+    }
+  }
+
   private handleDocumentUpdate = (update: Uint8Array, origin: unknown): void => {
     // Don't send updates that originated from the server
     if (origin === this) return;
@@ -416,7 +467,7 @@ export class UnifiedSyncProvider {
       const encoder = encoding.createEncoder();
       encoding.writeVarUint(encoder, MESSAGE_SYNC);
       syncProtocol.writeUpdate(encoder, update);
-      this.ws.send(encoding.toUint8Array(encoder));
+      this.sendSyncFrame(encoding.toUint8Array(encoder));
     }
   };
 
@@ -446,11 +497,11 @@ export class UnifiedSyncProvider {
       this
     );
 
-    // Send response if needed
+    // Send response if needed. This is the offline-reconnect reply (the local
+    // delta the server is missing) — the frame most likely to exceed the cap,
+    // so it goes through the chunk-aware path (JP-309).
     if (encoding.length(encoder) > 1) {
-      if (this.ws?.readyState === WebSocket.OPEN) {
-        this.ws.send(encoding.toUint8Array(encoder));
-      }
+      this.sendSyncFrame(encoding.toUint8Array(encoder));
     }
 
     // Mark as synced after sync step 2
@@ -477,7 +528,7 @@ export class UnifiedSyncProvider {
     const encoder = encoding.createEncoder();
     encoding.writeVarUint(encoder, MESSAGE_SYNC);
     syncProtocol.writeSyncStep1(encoder, this.doc);
-    this.ws.send(encoding.toUint8Array(encoder));
+    this.sendSyncFrame(encoding.toUint8Array(encoder));
   }
 
   private sendAwarenessUpdate(): void {
@@ -507,6 +558,12 @@ export class UnifiedSyncProvider {
 
       if (response.success) {
         this.authenticated = true;
+
+        // JP-309: adopt the relay's advertised inbound cap so the chunk
+        // threshold tracks its config rather than a drifting client constant.
+        if (typeof response.maxMessageSize === 'number' && response.maxMessageSize > 0) {
+          this.maxMessageSize = response.maxMessageSize;
+        }
 
         const user: AuthenticatedUser | undefined = response.userId
           ? { id: response.userId, username: response.username ?? '', role: response.role ?? undefined }

--- a/src/collaboration/protocol.ts
+++ b/src/collaboration/protocol.ts
@@ -23,7 +23,7 @@ import type { DocumentMetadata } from '../types/Document';
  * server refuses connections with a different version. Bump on any
  * breaking change to message types, payload shapes, or framing.
  */
-export const PROTOCOL_VERSION = 2;
+export const PROTOCOL_VERSION = 3;
 
 /** Query-parameter name carrying the client's protocol version. */
 export const PROTOCOL_VERSION_PARAM = 'protocolVersion';
@@ -60,6 +60,17 @@ export const MESSAGE_JOIN_DOC = 10;
 
 // 11..=13 reserved (formerly AUTH_LOGIN, DOC_SHARE, DOC_TRANSFER — now REST)
 
+/**
+ * A fragment of a large SYNC frame, split client→relay so a big offline-
+ * reconnect update can be delivered under the per-message cap (JP-309).
+ * Body (binary): `[msgId: 16 bytes][seq: u32 BE][total: u32 BE][payload]`.
+ */
+export const MESSAGE_SYNC_CHUNK = 14;
+
+/** Relay→client ack once a chunked update's msgId is reassembled + applied.
+ * Body (binary): `[msgId: 16 bytes]`. */
+export const MESSAGE_SYNC_CHUNK_ACK = 15;
+
 // ============ Request/Response Types ============
 
 /** Authentication response from server */
@@ -73,6 +84,12 @@ export interface AuthResponse {
   /** Token expiration timestamp in milliseconds */
   tokenExpiresAt?: number;
   error?: string;
+  /**
+   * Relay's inbound per-message cap in bytes (JP-309). The client splits any
+   * outbound SYNC frame larger than this into MESSAGE_SYNC_CHUNK frames. Absent
+   * on older relays → the client falls back to its built-in default.
+   */
+  maxMessageSize?: number;
 }
 
 /** Document event types */


### PR DESCRIPTION
Closes JP-309.

After a substantial **offline** session, `y-indexeddb` produces one large merged Yjs update. If it exceeded the relay's 256 KiB per-message cap, the relay **dropped the connection** (close 1009) → client reconnected, resent the same frame, dropped again → reconnect loop, **offline edits silently lost**. MVP-blocking data loss.

Per the research (`Offline-Reconnect-Update-Strats`), **transport-level chunking is the merge-preserving fix** — `Y.applyUpdate` is transport-independent, so splitting one binary update into sub-cap fragments and reassembling server-side yields the *identical* CRDT merge (no LWW, no clobber of a concurrent collaborator). The earlier flatten/snapshot+LWW idea was dropped (unsafe for shared docs).

## Phase 0 — stop the bleeding
- **Graceful reject, not connection-drop:** an over-cap inbound frame now gets a `MESSAGE_ERROR` (`ERR_MESSAGE_TOO_LARGE`) and the connection stays open; only sustained abuse (>3 over-cap frames) drops. Kills the reconnect loop.
- **Cap 256 KiB → 1 MiB** (covers most offline-reconnect deltas in one frame), still tunable via `[tenancy.limits]`.
- **WS layer bounded at 16 MiB** — must stay ≥ `MAX_DOCUMENT_SIZE` (8 MiB) so the relay's *outbound* initial-sync of a large doc to a joining client is never truncated (the cap is inbound-only).

## Phase 1 — chunking (robust fix)
- `PROTOCOL_VERSION` 2→3; new binary frames `MESSAGE_SYNC_CHUNK` (14) + `MESSAGE_SYNC_CHUNK_ACK` (15); `AuthResponse` advertises `maxMessageSize` so the client's threshold tracks relay config.
- **Relay `ChunkReassembler`** (`server/chunk.rs`): per-connection, keyed by msgId, **bounded** — max in-flight (4), per-connection byte budget (16 MiB), 10 s stale-prune, idempotent duplicate-seq. Reassembled bytes feed the existing `handle_sync` path → one rate-limit check, full CRDT merge + broadcast.
- **Client** splits any over-cap SYNC frame into ~256 KiB fragments (`UnifiedSyncProvider.sendSyncFrame`). The offline delta stays durable in y-indexeddb, so an interrupted stream is re-derived by the next reconnect handshake — no complex pending-queue.

## Tests (fully automated; no manual testing)
- Reassembler unit tests: in/out-of-order, duplicate-seq, bad total/seq, too-many-inflight, stale-prune.
- **Headless end-to-end:** a real Yjs update framed → split into tiny fragments → reassembled → applied via the sync path, asserting **byte-identical reassembly + merge + rebroadcast** (the issue's verification target).
- Client: over-cap frame splits into reassemblable chunks (byte-identical), sub-cap sends unchanged, `maxMessageSize` adopted from `AuthResponse`.
- Relay **426 lib + all integration** green; client **collaboration suite (252)** green; typecheck clean.

No external/web changes; single repo. `PROTOCOL_VERSION` bump is safe pre-GA (no in-the-wild clients; client+relay co-deploy).

Assisted-by: Opus 4.8