### PR TITLE
JP-240: cross-provider MCP agent-recipes library (SKILL.md)

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -77,6 +77,7 @@ export default withMermaid(
               { text: 'Plugin Development', link: '/developer/plugin-development' },
               { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
               { text: 'Utility Modules', link: '/developer/utilities' },
+              { text: 'AI Agents (MCP) & Recipes', link: '/developer/mcp-agent-recipes' },
               { text: 'Contributing', link: '/developer/contributing' },
               { text: 'Roadmap', link: '/developer/roadmap' },
             ],

--- a/docs-site/developer/mcp-agent-recipes.md
+++ b/docs-site/developer/mcp-agent-recipes.md
@@ -1,0 +1,43 @@
+# AI Agents (MCP) & Recipes
+
+DocuShark ships an **MCP server** (in the relay) so an AI agent can author
+documents for you — write prose, build diagrams, manage references — through a
+standard tool interface. Because [MCP](https://modelcontextprotocol.io) is an open
+standard, this works from **Claude or ChatGPT** (and anything else that speaks MCP).
+
+## Use DocuShark from Claude or ChatGPT
+
+1. **Connect your agent** to a relay's MCP endpoint (`/mcp`). The setup differs per
+   client — see the connection matrix in the
+   [skills/CONNECTING.md](https://github.com/JPE-Net-Technologies/docushark/blob/master/skills/CONNECTING.md)
+   guide. In short:
+   - **Claude Code / Claude Desktop** and the **OpenAI API / ChatGPT Developer Mode**
+     accept a bearer token.
+   - **claude.ai (web)** currently uses OAuth-only connectors (no bearer field), so
+     use Claude Desktop/Code there for now.
+2. **Load a recipe.** The [skills library](https://github.com/JPE-Net-Technologies/docushark/tree/master/skills)
+   has ready-made workflows. On Claude they're auto-loading `SKILL.md` skills; on
+   OpenAI you paste a recipe's body into a Custom GPT / system prompt.
+
+## The recipes
+
+| Recipe | What it produces |
+|---|---|
+| **architecture-rfc** | A design RFC with a system diagram. |
+| **document-codebase-module** | A module reference: prose + a component diagram. |
+| **diagram-from-description** | A clean, auto-laid-out diagram from a description. |
+| **meeting-notes-to-doc** | A structured, outlined document from raw notes. |
+
+Browse them in the repo:
+[`skills/`](https://github.com/JPE-Net-Technologies/docushark/tree/master/skills).
+
+## The tool surface
+
+The authoritative reference for every MCP tool (params, returns, the
+`generate_diagram` node/edge DSL, the Markdown prose contract) lives in
+[`relay/docs/mcp/README.md`](https://github.com/JPE-Net-Technologies/docushark/blob/master/relay/docs/mcp/README.md).
+Recipes target that surface; write your own against it the same way.
+
+> **Note:** MCP writes target *team* documents (local documents are read-only over
+> MCP), and shape styling is set inline per shape — saved style profiles are a
+> client-side feature not exposed over MCP.

--- a/skills/CONNECTING.md
+++ b/skills/CONNECTING.md
@@ -1,0 +1,47 @@
+# Connecting an agent to DocuShark (MCP)
+
+Every recipe assumes your agent can reach a DocuShark relay's MCP endpoint. The
+relay exposes a Streamable-HTTP MCP server at **`/mcp`** (use `https://` for any
+remote relay). The credential is either:
+
+- a **static MCP token** — generated on the relay's first run, written to
+  `mcp_token` in its data dir and surfaced in the desktop app's Settings (this maps
+  to a single workspace); or
+- a **relay JWT** — for a public/multi-workspace relay, obtained via the relay's
+  OAuth flow (RFC 9728 discovery at `/.well-known/oauth-protected-resource`).
+
+## Per-client setup
+
+The MCP server is the same for everyone; clients differ in how you add it and which
+auth they accept.
+
+| Client | How to add the server | Auth it accepts |
+|---|---|---|
+| **Claude Code** | `claude mcp add --transport http docushark https://<host>/mcp --header "Authorization: Bearer <token>"` (or an `.mcp.json` entry) | Bearer token / custom header ✅ |
+| **Claude Desktop** | Add an HTTP server to `claude_desktop_config.json` with the `/mcp` URL + an `Authorization: Bearer <token>` header | Bearer token / custom header ✅ |
+| **claude.ai (web)** | Settings → Connectors → add a custom connector by URL | **OAuth only** — the web connector UI has no bearer/header field, so the static token won't work here. Needs the relay's OAuth flow live + a public relay. **Until then, use Claude Desktop or Claude Code.** |
+| **ChatGPT (web)** | Enable **Developer Mode** (Settings → Connectors → Advanced), then add the `/mcp` URL + token under Connectors | URL + auth token ✅ |
+| **OpenAI API** (Responses / Agents SDK) | Pass it as an MCP tool: `tools: [{ type: "mcp", server_label: "docushark", server_url: "https://<host>/mcp", headers: { Authorization: "Bearer <token>" } }]` | Bearer token / header ✅ |
+
+> **claude.ai caveat:** the web product's connector flow is OAuth-based and does not
+> expose a place to paste a bearer token. This is the one surface where the static
+> MCP token can't be used today — connect from Claude Desktop/Code instead, or wait
+> for the relay's hosted OAuth.
+
+## Smoke-test the connection
+
+```bash
+curl -s -H "Authorization: Bearer <token>" https://<host>/mcp -d '{}'
+```
+
+- A JSON-RPC error (e.g. `"Unknown method"`) means the connection + auth are good.
+- A **401** means the token is missing or invalid.
+
+## First call
+
+Once connected, confirm tools are visible by listing documents, then create one:
+
+1. `list_documents` → should return your workspace's documents.
+2. `create_document` → returns a new `{ id }` you then write prose + diagrams into.
+
+From here, follow any recipe in this directory.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,47 @@
+# DocuShark Agent Recipes
+
+A curated set of **recipes** that drive the DocuShark [MCP server](../relay/docs/mcp/README.md)
+to author real documents — prose + diagrams — from a plain-language ask. Each recipe
+is a repeatable workflow an AI agent follows using the DocuShark MCP tools.
+
+These work with **any MCP-capable agent** — the recipe content is provider-agnostic
+because [MCP](https://modelcontextprotocol.io) is the universal layer; only *how you
+load the recipe* and *how you connect* differ between Claude and OpenAI. See
+**[CONNECTING.md](./CONNECTING.md)** for the per-client setup.
+
+## The recipes
+
+| Recipe | Use it when you want to… |
+|---|---|
+| [architecture-rfc](./architecture-rfc/SKILL.md) | Author an architecture/design RFC with a system diagram. |
+| [document-codebase-module](./document-codebase-module/SKILL.md) | Document a code module: prose walkthrough + a component diagram. |
+| [diagram-from-description](./diagram-from-description/SKILL.md) | Turn a described system/sequence into a clean, auto-laid-out diagram. |
+| [meeting-notes-to-doc](./meeting-notes-to-doc/SKILL.md) | Turn raw notes into a structured, outlined document. |
+
+## Two ways to use a recipe
+
+Every recipe is a `SKILL.md` — YAML frontmatter (`name`, `description`) + a
+provider-agnostic instruction body.
+
+- **Claude (Code / Desktop):** drop the recipe folder into your skills directory
+  (e.g. `~/.claude/skills/`) and Claude auto-loads it when the `description` matches
+  the task.
+- **OpenAI (ChatGPT Custom GPT, a Project, or the Responses/Agents SDK):** copy the
+  body (everything below the frontmatter) into the GPT's *Instructions* / the
+  Project's custom instructions / a system (developer) message.
+
+Either way, your agent must first be **connected to a DocuShark relay's MCP
+endpoint** — see [CONNECTING.md](./CONNECTING.md).
+
+## How the recipes are built
+
+They target the live tool surface documented in
+[`relay/docs/mcp/README.md`](../relay/docs/mcp/README.md) (the authoritative
+reference) and exercised by [`relay/scripts/mcp-smoke.sh`](../relay/scripts/mcp-smoke.sh).
+Two things worth knowing up front:
+
+- **Writes target *team* documents.** Local (renderer-owned) documents are
+  read-only over MCP, so a recipe creates and owns its own document.
+- **Styling is inline.** DocuShark's saved *style profiles* are a client-side
+  feature and aren't exposed over MCP — recipes set colors inline per shape (or
+  use `"AUTO"` for contrast-aware colors) and otherwise lean on sensible defaults.

--- a/skills/architecture-rfc/SKILL.md
+++ b/skills/architecture-rfc/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: docushark-architecture-rfc
+description: Use when the user wants to write an architecture RFC, design doc, or system-design proposal in DocuShark — a prose document plus a system diagram of the components. Requires the DocuShark MCP server to be connected.
+---
+
+# Author an architecture RFC in DocuShark
+
+Produce a design document with a written RFC and an auto-laid-out system diagram,
+using the DocuShark MCP tools. Work in one **team** document (MCP can't write
+local documents).
+
+## Steps
+
+1. **Create the document.** Call `create_document` with a clear `name`
+   (e.g. `"RFC: <system> architecture"`). Keep the returned `id` — it's `docId`
+   for every later call.
+
+2. **Find the pages.** Call `get_document(docId)`. It returns `pages` (canvas pages,
+   each `{ id, name, shapeCount }`) and `prosePages` (each `{ id, name, order }`).
+   Use the first prose page's id for writing and the first canvas page's id for the
+   diagram.
+
+3. **Write the RFC skeleton.** Call `set_prose(docId, prosePageId, content)` with
+   Markdown. Use a standard RFC shape and `{{field}}` tokens for values that recur:
+
+   ```markdown
+   # Architecture RFC: {{System}}
+
+   **Status:** Draft · **Author:** {{Author}}
+
+   ## Context & Problem
+   ## Goals / Non-Goals
+   ## Proposed Architecture
+   ## Alternatives Considered
+   ## Risks & Open Questions
+   ```
+
+   Then set the field values once with `set_fields(docId, [{name:"System", value:"…"}, …])`.
+
+4. **Draft each section.** Fill sections from what the user told you. To edit just
+   one section later without touching the rest, call `set_prose` with an `anchor`
+   set to the exact current text of the block you're replacing (it's a
+   compare-and-swap; if it matches none/several you get an `ERR_ANCHOR_*` error —
+   read the page with `get_prose` and copy the block text). Use
+   `insert_section(docId, prosePageId, level, title, body)` to add a heading+body,
+   and `restructure_outline` (`promote`/`demote`/`move` by heading index from
+   `get_outline`) to reorganize.
+
+5. **Build the system diagram.** Call `generate_diagram(docId, canvasPageId, nodes, edges)`:
+   - `nodes`: `[{ id, label, kind }]` — `id` is your logical id, `label` is the text,
+     `kind` is `"rectangle"` (default) or `"ellipse"` (use ellipse for external
+     actors/agents).
+   - `edges`: `[{ from, to, label }]` referencing node `id`s.
+   - Keep `layout: "layered"` and `routing: "orthogonal"` (the defaults) — the relay
+     does Sugiyama layering + obstacle-avoiding routing, so don't pass coordinates.
+
+   It returns `{ nodes: { <yourId>: <shapeId> }, edges: [<connectorId>], layout, routing }`.
+   Keep the `nodes` map if you later need to tweak a specific shape with
+   `update_shape`.
+
+6. **Tie prose to the diagram.** In "Proposed Architecture", describe each node you
+   created so the reader can match the prose to the picture.
+
+7. **Confirm.** Call `get_document(docId)` and check the canvas page's `shapeCount`
+   grew (nodes + connectors) and the prose page exists. Give the user the document
+   `id`/name.
+
+## Tips
+
+- **Styling is inline.** To color a component, set it per shape (in `add_shape`/
+  `update_shape` via `style: { fill, stroke, strokeWidth, labelColor }`, or `"AUTO"`
+  for contrast-aware). There is no saved style-profile to reference over MCP.
+- Prefer `generate_diagram` over hand-placing shapes — you get clean layout +
+  routing for free. Use `add_shapes`/`connect` only for shapes the graph model can't
+  express.
+- Keep diagrams legible: ~5–12 nodes. Split a large system into multiple canvas
+  pages rather than one dense graph.

--- a/skills/diagram-from-description/SKILL.md
+++ b/skills/diagram-from-description/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: docushark-diagram-from-description
+description: Use when the user describes a system, flow, or sequence in words and wants it turned into a clean diagram in DocuShark (architecture, flowchart, dependency graph, or sequence-style flow). Requires the DocuShark MCP server to be connected.
+---
+
+# Generate a diagram from a description in DocuShark
+
+Convert a plain-language description into an auto-laid-out diagram. The relay does
+all positioning and routing — your job is to model the description as a graph of
+**nodes** and **edges**. Work in one **team** document.
+
+## Steps
+
+1. **Model the description as a graph.** Extract:
+   - **Nodes** — the things (services, steps, states, participants). Give each a
+     short stable `id` and a human `label`.
+     Mark anything external/an actor as `kind: "ellipse"`; everything else is a
+     `"rectangle"`.
+   - **Edges** — the relationships/messages/transitions, each `{ from, to, label }`
+     by node `id`. Direction matters: it drives the layout and the arrowhead.
+   - For a **sequence/flow**, order the edges as the steps happen (1→2→3…); the
+     layered layout reads top-to-bottom along edge direction.
+
+2. **Create or reuse a document.** `create_document` (keep the `id`), or use an
+   existing team `docId` the user names. Get a canvas page id from
+   `get_document(docId).pages[0].id`.
+
+3. **Generate the diagram.**
+   `generate_diagram(docId, canvasPageId, nodes, edges, layout, routing)`:
+   - `nodes`: `[{ id, label, kind? }]` (unique ids; min 1; up to 500).
+   - `edges`: `[{ from, to, label? }]` (up to 1000; every endpoint must name a node).
+   - `layout`: `"layered"` (default with edges — best for flow/architecture/sequence)
+     or `"grid"` (for an unconnected set of nodes).
+   - `routing`: `"orthogonal"` (default — right-angle paths around shapes, with
+     waypoints) or `"straight"` (plain lines).
+   - Returns `{ nodes: { id: shapeId }, edges: [connectorId], layout, routing }`.
+
+4. **Refine if asked.** To rename/recolor/resize a specific node, look up its shape
+   id in the returned `nodes` map and call `update_shape(docId, canvasPageId, id,
+   patch)` with a subset of `{ x, y, w, h, text, style }`. To add a stray connector
+   the graph missed, use `connect(docId, canvasPageId, fromId, toId, label)`.
+
+5. **Confirm.** `get_page(docId, canvasPageId)` to see the placed shapes, or
+   `get_document` to check `shapeCount`. Report what you drew.
+
+## Tips
+
+- **Don't pass coordinates.** Let `generate_diagram` lay things out; hand-placing
+  fights the router. Only `update_shape` x/y for deliberate nudges.
+- Parallel edges between the same two nodes are automatically staggered, and
+  self-loops get a clean path — model them naturally.
+- Styling is inline per shape (`style: { fill, stroke, strokeWidth, labelColor }`,
+  or `"AUTO"`). There's no saved style-profile over MCP.
+- If the description is really two diagrams (e.g. a high-level map + a detailed
+  sequence), make two and put each on its own canvas page for legibility.

--- a/skills/document-codebase-module/SKILL.md
+++ b/skills/document-codebase-module/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: docushark-document-codebase-module
+description: Use when the user wants to document a code module, service, or package in DocuShark — a prose walkthrough of its responsibilities and APIs plus a component diagram showing how the pieces relate. Requires the DocuShark MCP server to be connected.
+---
+
+# Document a codebase module in DocuShark
+
+Turn your understanding of a module (from reading its code) into a DocuShark
+document: a prose reference plus a component diagram. Work in one **team** document.
+
+## Steps
+
+1. **Gather the facts first.** From the code, identify: the module's purpose, its
+   main components (files/classes/functions), each component's responsibility, the
+   public API/entry points, and the dependencies *between* components (who calls
+   whom). You'll turn the "who calls whom" into diagram edges.
+
+2. **Create the document.** `create_document` with `name` like
+   `"<module> — module reference"`. Keep the `id` (`docId`).
+
+3. **Get the page ids.** `get_document(docId)` → take the first `prosePages[].id`
+   (prose) and the first `pages[].id` (canvas).
+
+4. **Write the reference.** `set_prose(docId, prosePageId, content)` in Markdown:
+
+   ```markdown
+   # {{Module}} — Module Reference
+
+   ## Overview
+   One paragraph: what it does and where it sits.
+
+   ## Components
+   | Component | Responsibility | Key API |
+   |---|---|---|
+   | … | … | … |
+
+   ## Data / Control Flow
+   How a request moves through the components (mirrors the diagram).
+
+   ## Gotchas
+   - …
+   ```
+
+   Use a GFM table for the component list (tables are supported). Set
+   `{{Module}}` with `set_fields`.
+
+5. **Draw the component diagram.** `generate_diagram(docId, canvasPageId, nodes, edges)`:
+   - One `node` per component: `{ id, label }` (use the component name as `label`).
+   - One `edge` per dependency: `{ from, to, label }` where `label` is the relationship
+     ("calls", "reads", "emits"). Edge direction = caller → callee.
+   - Leave `layout: "layered"` / `routing: "orthogonal"` (defaults) so the relay
+     lays it out by dependency direction.
+
+   It returns `{ nodes: { id: shapeId }, edges: [connectorId], … }`.
+
+6. **Cross-link.** In "Data / Control Flow", reference the same component names so
+   the prose and the diagram describe the same thing.
+
+7. **Verify.** `get_document(docId)` — the canvas page `shapeCount` should equal
+   components + dependencies. Return the document id/name.
+
+## Tips
+
+- If the module has distinct layers (e.g. API / core / storage), color them inline
+  per shape (`style.fill`) via `update_shape` after `generate_diagram`, using the
+  returned `nodes` map to find each shape id. There's no saved style-profile over
+  MCP, so set colors inline.
+- Keep one diagram per cohesive view. For a big module, make a high-level component
+  diagram on page 1 and a detailed sub-flow on another canvas page.
+- For an external dependency (a third-party service), use `kind: "ellipse"` to
+  visually distinguish it from in-module components.

--- a/skills/meeting-notes-to-doc/SKILL.md
+++ b/skills/meeting-notes-to-doc/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docushark-meeting-notes-to-doc
+description: Use when the user has raw meeting notes, a transcript, or a brain-dump and wants a clean, structured DocuShark document — summary, decisions, action items, and an organized outline. Requires the DocuShark MCP server to be connected.
+---
+
+# Turn meeting notes into a structured document in DocuShark
+
+Convert messy notes into a well-organized prose document with a clear outline. Work
+in one **team** document. This recipe is prose-only (no diagram) unless the notes
+clearly describe a flow worth drawing.
+
+## Steps
+
+1. **Read and classify the notes.** Separate the raw input into: a one-paragraph
+   **summary**, **decisions made**, **action items** (owner + what + when),
+   **discussion** by topic, and **open questions**.
+
+2. **Create the document.** `create_document` with a descriptive `name`
+   (e.g. `"<topic> — <date> notes"`). Keep the `id`. Get the first prose page id
+   from `get_document(docId).prosePages[0].id`.
+
+3. **Write the structured page.** `set_prose(docId, prosePageId, content)` in
+   Markdown. Put the high-value parts first:
+
+   ```markdown
+   # {{Title}}
+
+   **Date:** {{Date}} · **Attendees:** {{Attendees}}
+
+   ## Summary
+   …
+
+   ## Decisions
+   - …
+
+   ## Action Items
+   - [ ] **@owner** — task — _due …_
+
+   ## Discussion
+   ### <Topic 1>
+   …
+
+   ## Open Questions
+   - …
+   ```
+
+   Use task-list checkboxes (`- [ ]`) for action items (supported), and set
+   `{{Title}}`/`{{Date}}`/`{{Attendees}}` with `set_fields`.
+
+4. **Organize the discussion.** Add one `### <Topic>` per discussion thread. If you
+   write topics out of order, fix the structure with the outline tools rather than
+   rewriting the page:
+   - `get_outline(docId, prosePageId)` → the flat list of headings with their
+     `index` and `level`.
+   - `restructure_outline(docId, prosePageId, op, index, toIndex?)` to
+     `move` / `promote` / `demote` a section.
+   - `insert_section(docId, prosePageId, level, title, body, afterIndex?)` to slot a
+     new section in a specific spot.
+
+5. **Refine a single section** without touching the rest by calling `set_prose`
+   with `anchor` = the exact current text of the block to replace (read it first
+   with `get_prose`; it's a compare-and-swap that errors rather than clobbering if
+   ambiguous).
+
+6. **Confirm.** `get_prose(docId, prosePageId)` to review, then return the document
+   id/name and a one-line recap (e.g. "3 decisions, 5 action items").
+
+## Tips
+
+- Lead with **Decisions** and **Action Items** — they're what people reopen the doc
+  for. Keep "Discussion" as the supporting detail.
+- Prose is Markdown (GFM): use tables for attendee/owner grids, headings for the
+  outline, and `{{fields}}` for values you'll reuse across related docs.
+- Each write replaces the whole page unless you use `anchor`; for incremental
+  additions during a long meeting, prefer `insert_section` or anchored `set_prose`
+  so you don't overwrite earlier content.


### PR DESCRIPTION
Closes JP-240.

A curated, installable library of recipes that drive the DocuShark MCP server to author real documents (prose + auto-laid-out diagrams) from a plain-language ask — the "DocuShark has an MCP server" → "my agent reliably produces a good doc" bridge. Unblocked by JP-238 (live prose writes) + JP-235 (public-pod hardening).

## What's here
- **`skills/`** — `README.md` (index + the two consumption paths), `CONNECTING.md` (per-client auth matrix), and **4 Engineering recipes** as `SKILL.md`: `architecture-rfc`, `document-codebase-module`, `diagram-from-description`, `meeting-notes-to-doc`.
- **`docs-site/developer/mcp-agent-recipes.md`** + a Developer sidebar entry — a dev-facing "Use DocuShark from Claude or ChatGPT" page. Deliberately **not** in the user `/guide/` (thin/stale, slated for a founder-led rewrite).

## Cross-provider by design (Claude *and* OpenAI)
MCP is the universal layer, so each recipe's instruction body is **provider-agnostic** (verified: no Claude-isms). It ships as a `SKILL.md` Claude auto-loads, and the same body pastes into an OpenAI Custom GPT / system prompt / Agents-SDK developer message. `CONNECTING.md` is a per-client matrix and flags the real gotcha: **claude.ai web connectors are OAuth-only (no bearer field)** → that surface depends on the relay OAuth flow (JP-203); Claude Code/Desktop, ChatGPT Developer Mode, and the OpenAI API all take bearer tokens.

## Verification (dogfooded against staging MCP)
Ran the recipes' tool sequences end-to-end on staging: `create_document` → `get_document` → `set_prose` (Markdown + `{{fields}}`) → `set_fields` → `get_outline` → `insert_section` → `restructure_outline move` → `generate_diagram` (layered/orthogonal). All work; this also **corrected a doc drift** — `generate_diagram` returns `{ nodes, edges }`, not `{ nodeMap, connectorIds }` (recipes use the real shape). Also: provider-agnostic grep clean, every recipe tool-name exists in `relay/docs/mcp/README.md`, frontmatter valid on all four, and `vitepress build` passes (no dead links).

## Notes / follow-ups
- **Style profiles aren't exposed over MCP** (client-only `styleProfileStore`); recipes style inline. Worth a future MCP tool if agent docs should inherit a workspace profile.
- JP-241 (one-click connector / discovery manifest) is the companion distribution artifact.
- Researcher/Personal-persona recipes are a later cut.

Content-only; no code or relay/web changes.

Assisted-by: Opus 4.8