### PR TITLE
JP-317 P1: document fully-local relay dev config

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -100,6 +100,26 @@ Settings can also come from `RELAY_*` environment variables (see
 [Configuration → Environment variables](#environment-variables)) — handy
 for containerized deploys that ship no `relay.toml`.
 
+For **fully-local development** against a control plane running on
+loopback, point `[auth]` at it and use the on-disk store — no S3/R2 needed:
+
+```toml
+[auth]
+issuer = "http://localhost:3000"
+jwks_url = "http://localhost:3000/.well-known/jwks.json"
+audience = "docushark-relay"
+
+[storage]
+backend = "filesystem"   # blobs + docs under ./data
+
+[server]
+network_mode = "localhost"
+```
+
+`http` JWKS is accepted only for **loopback** issuers; any remote issuer
+must be `https`. Keep `relay.toml` out of version control — it is
+git-ignored and created per-machine by `relay init`.
+
 ## Authentication
 
 The relay is a pure **OIDC resource server**. It validates RS256 JWTs


### PR DESCRIPTION
Part of the pre-prod pipeline work (tracked in the private control-plane repo). Adds a loopback dev recipe to `relay/README.md` so the relay runs against a local control plane with no S3/R2:

- `[auth] issuer = http://localhost:3000` + local JWKS, `backend = "filesystem"`, `network_mode = "localhost"`.
- Notes that `http` JWKS is accepted only for loopback issuers, and that `relay.toml` is git-ignored / per-machine.

Docs-only; keeps the OSS README generic (no Cloud topology). The relay's `init` template is already neutral (blank `[auth]`), so no code change.

Assisted-by: Opus 4.8