### PR TITLE
Fix: two-finger touch pan froze until release (JP-307 regression)

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1205,12 +1205,22 @@ export class Engine {
       const horizontalFromShift = event.shiftKey && event.deltaX === 0;
       const panX = horizontalFromShift ? event.deltaY : event.deltaX;
       const panY = horizontalFromShift ? 0 : event.deltaY;
-      // Accumulate the delta and let the rAF loop ease it out, so a chunky mouse
-      // wheel pans smoothly instead of jumping per event. (A trackpad's small
-      // continuous deltas are consumed within ~a frame, staying responsive.)
-      this.pendingPanX += panX;
-      this.pendingPanY += panY;
-      this.startPanAnimation();
+      if (panX === 0 && panY === 0) {
+        // Zero-delta wheel: the two-finger touch gesture dispatches a synthetic
+        // wheel purely to request a redraw after it has panned the camera
+        // directly. Render immediately — routing a 0 delta through the smoothing
+        // accumulator applies nothing and renders nothing, which froze touch
+        // panning until release.
+        this.renderer.requestRender();
+      } else {
+        // Accumulate the delta and let the rAF loop ease it out, so a chunky
+        // mouse wheel pans smoothly instead of jumping per event. (A trackpad's
+        // small continuous deltas are consumed within ~a frame, staying
+        // responsive.)
+        this.pendingPanX += panX;
+        this.pendingPanY += panY;
+        this.startPanAnimation();
+      }
     }
   }
 }

--- a/src/engine/InputHandler.ts
+++ b/src/engine/InputHandler.ts
@@ -473,7 +473,8 @@ export class InputHandler {
     const targetZoom = this.pinchStartZoom * scale;
     const factor = targetZoom / this.camera.zoom;
     this.camera.zoomAt(midpoint, factor);
-    // Notify via wheel callback so Engine can request render
+    // Notify via wheel callback so Engine can request render. handleWheel treats
+    // a zero-delta wheel as a redraw request (see Engine.handleWheel).
     this.onWheelEvent(
       new WheelEvent('wheel', { deltaY: 0 }),
       midpoint,


### PR DESCRIPTION
## Problem
On touchscreens, two-finger panning was choppy and appeared to "freeze," only snapping to the final position when the fingers lifted — while mouse/desktop panning stayed smooth and shape-dragging held ~80fps.

## Root cause
The two-finger gesture (`InputHandler.updatePinchGesture`) pans the camera **directly**, then dispatches a synthetic `wheel{deltaY:0}` **purely to request a redraw**. Before JP-307, `Engine.handleWheel`'s pan branch called `requestRender()` synchronously. JP-307's wheel-pan smoothing rewired that branch to push deltas into the `pendingPan` accumulator + rAF ease-out — and a **zero** delta accumulates to nothing and renders nothing. So touch pans updated the camera every frame (~140fps, confirmed via a spike overlay) but never repainted until release.

A spike (zoom disabled, on-screen metrics overlay) confirmed it: `pinch update fps ≈ 140`, `scale wobble ≈ 0.0036` (zoom coupling negligible), camera moving but no paint until release.

## Fix
A zero-delta wheel now requests a render immediately; the smoothing accumulator only handles real (non-zero) wheel deltas. Untouched: mouse-wheel pan smoothing, wheel/keyboard zoom, and the two-finger pinch-zoom.

## Verification
- Confirmed smooth two-finger pan + pinch-zoom on a real touchscreen.
- `bun run typecheck` clean; full suite **2339 passed**. OSS-leak grep clean.

Tiny, contained change (one branch in `handleWheel` + a clarifying comment). Fixes a regression already on `master` from JP-307 (#221).

Assisted-by: Opus 4.8