### PR TITLE
JP-319: prose node integrity & MCP-page seeding (crash + duplication)

### DIFF
--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -107,21 +107,21 @@ pub fn json_prose_to_ydoc(doc_json: &Value, doc: &Doc) {
         if !blocks.iter().any(block_has_substance) {
             continue;
         }
-        // Grab the fragment handle before opening the txn (`get_or_insert_*`
-        // transacts; nesting deadlocks).
-        let frag = doc.get_or_insert_xml_fragment(format!("prose:{id}").as_str());
-        let mut txn = doc.transact_mut();
         // Idempotent backstop (JP-284): only seed an EMPTY fragment. The JSON
         // rebuild path passes a fresh Doc (every fragment empty → seeds all); the
         // binary-hydration backstop may already carry prose for this page, and
-        // re-seeding a populated fragment would duplicate it (the JP-282 failure
-        // mode). This makes the relay the single, safe prose seeder on both paths.
-        if frag.len(&txn) > 0 {
+        // re-seeding a populated fragment would clobber a live-edited / sidecar-
+        // restored lineage. (`get_or_insert_*` transacts, so check `len` under
+        // its own read txn — nesting a live txn deadlocks.)
+        let frag = doc.get_or_insert_xml_fragment(format!("prose:{id}").as_str());
+        if frag.len(&doc.transact()) > 0 {
             continue;
         }
-        for node in &blocks {
-            super::build_prose_node(&frag, &mut txn, node);
-        }
+        // Deterministic seed (JP-319): identical content yields byte-identical
+        // CRDT items, so a later rehydrate — or a client carrying the prior
+        // bootstrap in y-indexeddb — DEDUPES on merge instead of doubling the
+        // page (CRDT lineage churn). Replaces the previous random-clientID build.
+        super::seed_prose_deterministic(doc, id, &blocks);
     }
 }
 

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1110,6 +1110,37 @@ mod tests {
     }
 
     #[test]
+    fn jp319_2d_structural_blocks_round_trip() {
+        // Callout / figure / gallery now round-trip through the relay instead of
+        // being silently unwrapped (lossy). HTML↔PM attr translation: callout
+        // `data-variant`↔`variant`, gallery `data-layout`↔`layout`; gallery
+        // images are lifted out of the render-only `.gallery-items` wrapper.
+        let cases = [
+            r#"<div data-callout data-variant="warning"><p>heads up</p></div>"#,
+            r#"<figure><img src="blob:x" alt="diagram"><figcaption>Fig 1</figcaption></figure>"#,
+            r#"<div data-gallery data-layout="row"><div class="gallery-items"><img src="blob:a"><img src="blob:b"></div></div>"#,
+        ];
+        for html in cases {
+            let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+            handle.replace_prose("p1", html).unwrap();
+            assert_eq!(handle.prose_html("p1").as_deref(), Some(html), "round-trip: {html}");
+        }
+    }
+
+    #[test]
+    fn jp319_2d_figure_without_image_degrades_safely() {
+        // `figcaption` has no block group on the client — emitting one standalone
+        // would crash. A <figure> with no usable <img> must degrade to its text,
+        // never leave an orphan figcaption.
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        handle
+            .replace_prose("p1", "<figure><figcaption>orphan</figcaption></figure>")
+            .unwrap();
+        let html = handle.prose_html("p1").unwrap_or_default();
+        assert!(!html.contains("figcaption"), "no standalone figcaption, got: {html}");
+    }
+
+    #[test]
     fn jp319_json_seed_lineage_churn_does_not_duplicate_on_merge() {
         use yrs::updates::decoder::Decode;
         use yrs::{StateVector, Update};

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -736,6 +736,54 @@ fn build_prose_children<P: XmlFragment>(
     }
 }
 
+/// A per-page, content-independent **bootstrap** client-id for deterministic
+/// prose seeding (JP-319). FNV-1a over the page id — stable across builds and
+/// hosts (unlike `DefaultHasher`), so any relay or client that seeds the same
+/// page produces byte-identical CRDT items.
+///
+/// This is **not** a live-edit client-id and does **not** reintroduce the JP-172
+/// collision class: it authors only deterministic, never-yet-live bootstrap
+/// content, scoped to a single page within a single doc (page ids are unique per
+/// doc); live editors keep their random ids. Its sole job is to make a re-seed —
+/// a later rehydrate, or a client that cached the prior bootstrap in y-indexeddb
+/// — DEDUPE on merge instead of concatenating (the lineage-churn fix).
+fn deterministic_seed_client_id(page_id: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a 64-bit offset basis
+    for b in page_id.as_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3); // FNV prime
+    }
+    // yrs `ClientID` is a 53-bit (JS-safe-integer) value — the top 11 bits must
+    // be zero. Fold the hash into the low 53 bits.
+    h & ((1u64 << 53) - 1)
+}
+
+/// Seed one prose page's `prose:<page_id>` fragment into `live`
+/// **deterministically** (JP-319): build the blocks in a throwaway Doc whose
+/// client-id is fixed by [`deterministic_seed_client_id`], encode it as an
+/// update, and apply that to `live`. Because the seed's client-id + clocks +
+/// content are fully determined by `(page_id, blocks)`, seeding identical
+/// content always yields identical CRDT items — so when two independently-seeded
+/// copies meet (a relay rehydrate vs a client's cached bootstrap) they dedupe
+/// rather than doubling. Re-applying the same seed is a no-op.
+fn seed_prose_deterministic(live: &Doc, page_id: &str, blocks: &[prose_parse::PmNode]) {
+    use yrs::updates::decoder::Decode;
+    let seed = Doc::with_client_id(deterministic_seed_client_id(page_id));
+    let frag = seed.get_or_insert_xml_fragment(format!("prose:{page_id}").as_str());
+    {
+        let mut txn = seed.transact_mut();
+        for node in blocks {
+            build_prose_node(&frag, &mut txn, node);
+        }
+    }
+    let update = seed
+        .transact()
+        .encode_state_as_update_v1(&yrs::StateVector::default());
+    if let Ok(update) = yrs::Update::decode_v1(&update) {
+        let _ = live.transact_mut().apply_update(update);
+    }
+}
+
 /// All of a run's marks as one Yjs formatting attribute set: boolean marks →
 /// `true`, `link` → `{ href }` (matching the read side's `link_href`).
 fn marks_to_attrs(marks: &[prose_parse::PmMark]) -> Attrs {
@@ -1024,6 +1072,76 @@ mod tests {
         handle.replace_prose("p1", "<p>first</p><p>second</p>").unwrap();
         handle.replace_prose("p1", "<p>only</p>").unwrap();
         assert_eq!(handle.prose_html("p1").as_deref(), Some("<p>only</p>"));
+    }
+
+    // --- JP-319 prose-integrity repro (RED until the fix lands) ---
+    //
+    // These two tests pin the two faces of the MCP-page seeding bug. They are
+    // expected to FAIL on `master` — they are the acceptance gate (2a): the fix
+    // (relay node-validation gate + seed stabilization) turns them green.
+
+    #[test]
+    fn jp319_src_less_image_is_not_seeded_as_a_naked_atom() {
+        // The client's image node parses only `img[src]` and is an atom (no
+        // children). An `<img>` with no src seeds an `image` element with no
+        // `src` attribute, which the client can't reconcile — ReactNodeView's
+        // desc-tree walk throws "Cannot read properties of undefined (reading
+        // 'children')" on open. The relay must not seed a src-less image atom
+        // (drop it, or keep it as literal text — never a naked `image` node).
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        handle.replace_prose("p1", r#"<img alt="logo">"#).unwrap();
+        let html = handle.prose_html("p1").unwrap_or_default();
+        assert!(
+            !html.contains("<img") || html.contains("src=\""),
+            "a src-less <img> must not survive as a naked image atom, got: {html}"
+        );
+    }
+
+    #[test]
+    fn jp319_image_attrs_survive_the_mcp_round_trip() {
+        // pre-test #6: an image must keep src + sizing + float across an MCP
+        // HTML→Y.Doc→HTML round-trip. Dropping width/height/data-float reset the
+        // image to inline on every MCP edit; `data-float` ↔ `float` is the
+        // HTML↔PM name translation that makes the float survive.
+        let handle = DocHandle::hydrate(&empty_json_body(1), None, false);
+        let html = r#"<img src="blob:abc" alt="logo" width="300" height="120" data-float="left">"#;
+        handle.replace_prose("p1", html).unwrap();
+        assert_eq!(handle.prose_html("p1").as_deref(), Some(html));
+    }
+
+    #[test]
+    fn jp319_json_seed_lineage_churn_does_not_duplicate_on_merge() {
+        use yrs::updates::decoder::Decode;
+        use yrs::{StateVector, Update};
+        // The duplication root (report #1 / pre-test #7): a page seeded from the
+        // SAME JSON into two independent Docs gets two random client-ids → two
+        // CRDT lineages for identical content (JP-172 made client-id random). When
+        // a client carrying the prior lineage syncs with a freshly-rehydrated
+        // relay Doc, the fragments concatenate and the page doubles.
+        let snapshot = json!({
+            "id": "d",
+            "richTextPages": { "pageOrder": ["rt1"], "pages": { "rt1": {"content": "<p>hello</p>"} } }
+        });
+        let doc_a = Doc::new();
+        hydration::json_prose_to_ydoc(&snapshot, &doc_a);
+        let doc_b = Doc::new();
+        hydration::json_prose_to_ydoc(&snapshot, &doc_b);
+
+        let update_a = doc_a
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        doc_b
+            .transact_mut()
+            .apply_update(Update::decode_v1(&update_a).unwrap())
+            .unwrap();
+
+        let f = doc_b.get_or_insert_xml_fragment("prose:rt1");
+        let txn = doc_b.transact();
+        let html = super::prose_html::fragment_to_html(&f, &txn);
+        assert_eq!(
+            html, "<p>hello</p>",
+            "JSON-seed lineage churn must not duplicate identical content on merge, got: {html}"
+        );
     }
 
     #[test]

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -127,6 +127,38 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         "citationInline" => Block::Void(citation_html(el, txn)),
         "bibliography" => Block::Void(bibliography_html(el, txn)),
         "fieldRef" => Block::Void(field_html(el, txn)),
+        // Structural custom blocks (round-trip with the relay parser). `variant`/
+        // `layout` are PM attr names → emitted as `data-variant`/`data-layout`.
+        "callout" => {
+            let variant = match str_attr(el, txn, "variant").as_deref() {
+                Some("tip") => "tip",
+                Some("warning") => "warning",
+                Some("danger") => "danger",
+                _ => "note",
+            };
+            Block::Wrap {
+                open: format!("<div data-callout data-variant=\"{variant}\">"),
+                close: "</div>",
+            }
+        }
+        "figure" => Block::Wrap {
+            open: "<figure>".to_string(),
+            close: "</figure>",
+        },
+        "figcaption" => Block::Wrap {
+            open: "<figcaption>".to_string(),
+            close: "</figcaption>",
+        },
+        "gallery" => {
+            let layout = match str_attr(el, txn, "layout").as_deref() {
+                Some("row") => "row",
+                _ => "grid",
+            };
+            Block::Wrap {
+                open: format!("<div data-gallery data-layout=\"{layout}\"><div class=\"gallery-items\">"),
+                close: "</div></div>",
+            }
+        }
         // Task list/item are read-only aliases of ul/li (not in the shared
         // round-trip table — a write never re-emits these PM types).
         "taskList" => wrap("ul"),

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -175,6 +175,19 @@ fn image_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
     if let Some(title) = attr("title") {
         let _ = write!(s, " title=\"{}\"", escape_attr(&title));
     }
+    // Symmetric with the parser (`prose_parse` img): preserve sizing + float so
+    // the image survives an MCP HTML round-trip instead of resetting to inline.
+    if let Some(width) = attr("width") {
+        let _ = write!(s, " width=\"{}\"", escape_attr(&width));
+    }
+    if let Some(height) = attr("height") {
+        let _ = write!(s, " height=\"{}\"", escape_attr(&height));
+    }
+    // `float` (PM attr) → `data-float` (HTML), the reverse of the parser's
+    // translation; mirrors the editor's `renderHTML`.
+    if let Some(float) = attr("float") {
+        let _ = write!(s, " data-float=\"{}\"", escape_attr(&float));
+    }
     s.push('>');
     s
 }

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -365,6 +365,103 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
         }
         return Some(PmNode { node_type: "bibliography".to_string(), attrs: a, children: vec![] });
     }
+    // Callout block: `<div data-callout data-variant="…">` with block children.
+    // `data-variant` (HTML) ↔ `variant` (PM attr). Content is `block+` on the
+    // client, so guarantee at least one block. Mirrors `CalloutExtension`.
+    if tag == "div" && has_attr(attrs, "data-callout") {
+        let variant = match get_attr(attrs, "data-variant") {
+            Some("tip") => "tip",
+            Some("warning") => "warning",
+            Some("danger") => "danger",
+            _ => "note",
+        };
+        let mut kids: Vec<PmChild> = map_blocks(children).into_iter().map(PmChild::Node).collect();
+        if kids.is_empty() {
+            kids.push(PmChild::Node(PmNode {
+                node_type: "paragraph".to_string(),
+                attrs: vec![],
+                children: vec![],
+            }));
+        }
+        return Some(PmNode {
+            node_type: "callout".to_string(),
+            attrs: vec![("variant".to_string(), variant.to_string())],
+            children: kids,
+        });
+    }
+    // Gallery block: `<div data-gallery data-layout="…"><div class="gallery-items">
+    // <img>…</div></div>` — the images live in the inner wrapper (a render-only
+    // div, not a PM node), so we lift them directly under `gallery` (content
+    // `image+`). Degrade to unwrap if it carries no usable image. Mirrors
+    // `GalleryExtension`.
+    if tag == "div" && has_attr(attrs, "data-gallery") {
+        let layout = match get_attr(attrs, "data-layout") {
+            Some("row") => "row",
+            _ => "grid",
+        };
+        let inner = children
+            .iter()
+            .find_map(|c| match c {
+                HtmlNode::Element { tag: t, attrs: a, children: cc }
+                    if t == "div"
+                        && get_attr(a, "class")
+                            .map_or(false, |c| c.split_whitespace().any(|w| w == "gallery-items")) =>
+                {
+                    Some(cc.as_slice())
+                }
+                _ => None,
+            })
+            .unwrap_or(children);
+        let images: Vec<PmChild> = inner
+            .iter()
+            .filter_map(|c| match c {
+                HtmlNode::Element { tag: t, attrs: a, children: cc } if t == "img" => {
+                    map_block_element("img", a, cc).map(PmChild::Node)
+                }
+                _ => None,
+            })
+            .collect();
+        if images.is_empty() {
+            return None; // no images → not a valid gallery; fall through to unwrap
+        }
+        return Some(PmNode {
+            node_type: "gallery".to_string(),
+            attrs: vec![("layout".to_string(), layout.to_string())],
+            children: images,
+        });
+    }
+    // Figure: `<figure><img …><figcaption>…</figcaption></figure>`. The client
+    // content model is the strict `image figcaption`, so only emit a `figure`
+    // when a usable `<img>` is present, and always pair it with a `figcaption`
+    // (synthesized empty if absent) so the node is schema-valid. `figcaption`
+    // is emitted *only* here — never as a standalone block — since it has no
+    // block group on the client. Mirrors `FigureExtension`.
+    if tag == "figure" {
+        let mut image: Option<PmNode> = None;
+        let mut caption: Option<Vec<PmChild>> = None;
+        for c in children {
+            if let HtmlNode::Element { tag: t, attrs: a, children: cc } = c {
+                if t == "img" && image.is_none() {
+                    image = map_block_element("img", a, cc);
+                } else if t == "figcaption" && caption.is_none() {
+                    caption = Some(collect_inline(cc, &[]));
+                }
+            }
+        }
+        let Some(image) = image else {
+            return None; // no usable image → degrade to unwrap
+        };
+        let figcaption = PmNode {
+            node_type: "figcaption".to_string(),
+            attrs: vec![],
+            children: caption.unwrap_or_default(),
+        };
+        return Some(PmNode {
+            node_type: "figure".to_string(),
+            attrs: vec![],
+            children: vec![PmChild::Node(image), PmChild::Node(figcaption)],
+        });
+    }
     // Heading h1..h6.
     if tag.len() == 2 && tag.as_bytes()[0] == b'h' && tag.as_bytes()[1].is_ascii_digit() {
         let level = (tag.as_bytes()[1] - b'0').clamp(1, 6);

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -387,15 +387,31 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
             children: vec![PmChild::Text { text: text_content(children), marks: vec![] }],
         }),
         "hr" => Some(PmNode { node_type: "horizontalRule".to_string(), attrs: vec![], children: vec![] }),
-        "img" => Some(PmNode {
-            node_type: "image".to_string(),
-            attrs: attrs
-                .iter()
-                .filter(|(k, _)| matches!(k.as_str(), "src" | "alt" | "title"))
-                .cloned()
-                .collect(),
-            children: vec![],
-        }),
+        "img" => {
+            // The client image node is an atom that parses only `img[src]`
+            // (`src/tiptap/ResizableImageExtension.ts`). A src-less <img> seeds a
+            // naked `image` atom the client can't reconcile — its desc-tree walk
+            // throws "Cannot read properties of undefined (reading 'children')".
+            // Drop it (no src ⇒ nothing to render) rather than seed the crash.
+            let src = get_attr(attrs, "src").filter(|s| !s.is_empty())?;
+            let mut a = vec![("src".to_string(), src.to_string())];
+            // Preserve the full image attribute set, not just src/alt/title —
+            // dropping width/height/float was the "image resets to inline on MCP
+            // edit" half of the bug (the editor re-defaults float to inline).
+            for k in ["alt", "title", "width", "height"] {
+                if let Some(v) = get_attr(attrs, k).filter(|s| !s.is_empty()) {
+                    a.push((k.to_string(), v.to_string()));
+                }
+            }
+            // `data-float` (HTML) ↔ `float` (the PM attr name the editor + the
+            // y-prosemirror binding store in the Y.Doc) — the same HTML↔PM name
+            // translation citations do (`data-ref-id` ↔ `refId`). Without it the
+            // float wouldn't survive the MCP HTML→Y.Doc round-trip.
+            if let Some(f) = get_attr(attrs, "data-float").filter(|v| *v == "left" || *v == "right") {
+                a.push(("float".to_string(), f.to_string()));
+            }
+            Some(PmNode { node_type: "image".to_string(), attrs: a, children: vec![] })
+        }
         // Block containers — children are blocks (map_blocks wraps stray inline
         // into paragraphs, so a loose `<li>text` still works).
         _ => prose_schema::simple_block_pm(tag).map(|pm| PmNode {

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -24,6 +24,7 @@ import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { CollaborativeProseEditor } from './CollaborativeProseEditor';
+import { ProseErrorBoundary } from './ProseErrorBoundary';
 import { ProsePreview } from './ProsePreview';
 import { RICH_TEXT_VERSION } from '../types/RichText';
 import './DocumentEditorPanel.css';
@@ -525,22 +526,26 @@ export function DocumentEditorPanel({
         <RichTextTabBar trailing={trailing} />
         <DocumentEditorToolbar />
         <div className="document-editor-panel-content">
-          {!isRelayDoc ? (
-            // Local-only doc: the legacy editor (no Y.Doc).
-            <TiptapEditor onEditorReady={handleEditorReady} />
-          ) : useCollabEditor ? (
-            <CollaborativeProseEditor
-              key={`${currentDocId}:${activePageId}:${collabSessionEpoch}`}
-              ydoc={collabYdoc!}
-              field={proseField!}
-              pageId={activePageId!}
-              onEditorReady={handleEditorReady}
-            />
-          ) : (
-            // Relay doc, engine still coming up (sub-second) or a never-synced
-            // doc opened offline — show the prose read-only until editable.
-            <ProsePreview html={activePageContent || '<p></p>'} />
-          )}
+          {/* Contain a prose render crash (JP-319) so a single bad document
+              can't unmount the whole app; auto-resets on doc/page switch. */}
+          <ProseErrorBoundary resetKeys={[currentDocId, activePageId]}>
+            {!isRelayDoc ? (
+              // Local-only doc: the legacy editor (no Y.Doc).
+              <TiptapEditor onEditorReady={handleEditorReady} />
+            ) : useCollabEditor ? (
+              <CollaborativeProseEditor
+                key={`${currentDocId}:${activePageId}:${collabSessionEpoch}`}
+                ydoc={collabYdoc!}
+                field={proseField!}
+                pageId={activePageId!}
+                onEditorReady={handleEditorReady}
+              />
+            ) : (
+              // Relay doc, engine still coming up (sub-second) or a never-synced
+              // doc opened offline — show the prose read-only until editable.
+              <ProsePreview html={activePageContent || '<p></p>'} />
+            )}
+          </ProseErrorBoundary>
         </div>
       </div>
     </TiptapEditorProvider>

--- a/src/ui/ProseErrorBoundary.test.tsx
+++ b/src/ui/ProseErrorBoundary.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * ProseErrorBoundary containment proof (JP-319): a child that throws during
+ * render must degrade to the recoverable fallback (not propagate and unmount
+ * the app), and the boundary must auto-reset when `resetKeys` change so
+ * navigating to another document recovers.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { ProseErrorBoundary } from './ProseErrorBoundary';
+
+function Boom(): JSX.Element {
+  throw new Error('simulated prose node crash: reading "children"');
+}
+
+function Safe({ label }: { label: string }): JSX.Element {
+  return <div>{label}</div>;
+}
+
+describe('ProseErrorBoundary', () => {
+  // React logs caught errors to console.error; silence it for these cases.
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when they do not throw', () => {
+    render(
+      <ProseErrorBoundary resetKeys={['doc-1']}>
+        <Safe label="prose ok" />
+      </ProseErrorBoundary>,
+    );
+    expect(screen.getByText('prose ok')).toBeTruthy();
+  });
+
+  it('contains a render crash and shows a recoverable fallback', () => {
+    render(
+      <ProseErrorBoundary resetKeys={['doc-1']}>
+        <Boom />
+      </ProseErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/couldn.t be displayed/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+  });
+
+  it('auto-resets when resetKeys change (e.g. switching documents)', () => {
+    const { rerender } = render(
+      <ProseErrorBoundary resetKeys={['doc-1']}>
+        <Boom />
+      </ProseErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeTruthy();
+
+    // Switching to a different, healthy document must recover without a reload.
+    rerender(
+      <ProseErrorBoundary resetKeys={['doc-2']}>
+        <Safe label="other doc" />
+      </ProseErrorBoundary>,
+    );
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByText('other doc')).toBeTruthy();
+  });
+});

--- a/src/ui/ProseErrorBoundary.tsx
+++ b/src/ui/ProseErrorBoundary.tsx
@@ -1,0 +1,101 @@
+/**
+ * ProseErrorBoundary — contains a prose-editor render crash so one bad document
+ * can't take down the whole app (JP-319).
+ *
+ * The prose editors render a ProseMirror/Tiptap node tree via ReactNodeViews.
+ * A node the client schema can't reconcile (historically a malformed node from
+ * the relay seed path — e.g. a src-less `image` atom) makes ProseMirror's
+ * desc-tree walk throw "Cannot read properties of undefined (reading
+ * 'children')" *during render*, which without a boundary unmounts the entire
+ * React tree. The relay seed path is now hardened against that class, but this
+ * is the defense-in-depth layer: even a novel bad node degrades to a recoverable
+ * panel instead of a blank app.
+ *
+ * Auto-resets when `resetKeys` change (a document / page switch), so navigating
+ * away from a document that failed to render recovers without a reload.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ProseErrorBoundaryProps {
+  /**
+   * When any entry changes between renders, the boundary clears its error and
+   * retries its children — pass `[docId, pageId]` so switching documents/pages
+   * recovers automatically.
+   */
+  resetKeys?: ReadonlyArray<unknown>;
+  children: ReactNode;
+}
+
+interface ProseErrorBoundaryState {
+  error: Error | null;
+}
+
+function keysChanged(a?: ReadonlyArray<unknown>, b?: ReadonlyArray<unknown>): boolean {
+  if (a === b) return false;
+  if (!a || !b || a.length !== b.length) return true;
+  return a.some((v, i) => !Object.is(v, b[i]));
+}
+
+export class ProseErrorBoundary extends Component<
+  ProseErrorBoundaryProps,
+  ProseErrorBoundaryState
+> {
+  state: ProseErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ProseErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Log for diagnostics — the component stack points at the failing node view.
+    console.error('[ProseErrorBoundary] prose editor crashed (contained):', error, info.componentStack);
+  }
+
+  componentDidUpdate(prev: ProseErrorBoundaryProps): void {
+    if (this.state.error && keysChanged(prev.resetKeys, this.props.resetKeys)) {
+      this.setState({ error: null });
+    }
+  }
+
+  private readonly reset = (): void => this.setState({ error: null });
+
+  private readonly reload = (): void => window.location.reload();
+
+  render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div
+        role="alert"
+        style={{
+          margin: '2rem auto',
+          maxWidth: '36rem',
+          padding: '1.5rem',
+          border: '1px solid var(--border-color, #d0c8ba)',
+          borderRadius: '8px',
+          background: 'var(--surface-2, rgba(0,0,0,0.03))',
+          color: 'var(--text-color, inherit)',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{ fontWeight: 600, margin: '0 0 0.5rem' }}>
+          This document&rsquo;s text couldn&rsquo;t be displayed.
+        </p>
+        <p style={{ margin: '0 0 1rem', opacity: 0.8, fontSize: '0.9em' }}>
+          The editor hit an unexpected content error and was contained, so the rest of the app
+          keeps working. Switching to another document, or trying again, usually recovers.
+        </p>
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+          <button type="button" onClick={this.reset}>
+            Try again
+          </button>
+          <button type="button" onClick={this.reload}>
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ProseErrorBoundary;

--- a/src/ui/proseSchemaContract.test.ts
+++ b/src/ui/proseSchemaContract.test.ts
@@ -38,6 +38,11 @@ const RELAY_EMITTABLE_NODES = [
   'citationInline',
   'fieldRef',
   'hardBreak',
+  // Structural custom blocks (JP-319 2d) — round-tripped by the relay parser.
+  'callout',
+  'figure',
+  'figcaption',
+  'gallery',
 ] as const;
 
 // Relay-emitted nodes that are atoms/leaves on the relay side (built childless).

--- a/src/ui/proseSchemaContract.test.ts
+++ b/src/ui/proseSchemaContract.test.ts
@@ -1,0 +1,83 @@
+/**
+ * T3 — relay ↔ client prose schema contract (JP-319).
+ *
+ * The relay's prose parser (`relay/src/sync/prose_parse.rs` + `prose_schema.rs`)
+ * seeds a `prose:<page>` Y.XmlFragment with a fixed set of ProseMirror node
+ * types. The client adopts that fragment and renders it via ReactNodeViews — so
+ * if the relay can emit a node type the client schema doesn't define, or emits
+ * an atom the client doesn't treat as a leaf, the desc-tree walk throws
+ * "Cannot read properties of undefined (reading 'children')" on open.
+ *
+ * This pins the contract from the client side: every type the relay can emit
+ * must exist in the schema the collab editor builds, and the relay's atoms must
+ * be atoms here. Keep `RELAY_EMITTABLE_*` in sync with `prose_schema.rs`
+ * (SIMPLE_BLOCKS + CUSTOM_PROSE_NODES) and the explicit cases in
+ * `prose_parse.rs::map_block_element` (heading / codeBlock / hr / img).
+ */
+
+import { getSchema } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { sharedProseExtensions } from './TiptapEditor';
+
+// Every ProseMirror node type the relay parser can produce.
+const RELAY_EMITTABLE_NODES = [
+  'paragraph',
+  'heading',
+  'bulletList',
+  'orderedList',
+  'listItem',
+  'blockquote',
+  'table',
+  'tableRow',
+  'tableCell',
+  'tableHeader',
+  'codeBlock',
+  'horizontalRule',
+  'image',
+  'bibliography',
+  'citationInline',
+  'fieldRef',
+  'hardBreak',
+] as const;
+
+// Relay-emitted nodes that are atoms/leaves on the relay side (built childless).
+// The client MUST treat these as atoms — otherwise an unexpected child crashes
+// the node-view reconciliation.
+const RELAY_EMITTABLE_ATOMS = [
+  'image',
+  'citationInline',
+  'fieldRef',
+  'horizontalRule',
+  'hardBreak',
+] as const;
+
+describe('relay↔client prose schema contract (JP-319)', () => {
+  // Mirror the collaborative editor's extension set (CollaborativeProseEditor:
+  // history-disabled StarterKit with the lowlight codeBlock, plus the shared
+  // extensions). Collaboration adds no schema nodes, so it's omitted here.
+  const schema = getSchema([
+    StarterKit.configure({
+      heading: { levels: [1, 2, 3, 4, 5, 6] },
+      codeBlock: false,
+      history: false,
+    }),
+    ...sharedProseExtensions,
+  ]);
+
+  it('defines every node type the relay can emit', () => {
+    for (const name of RELAY_EMITTABLE_NODES) {
+      expect(schema.nodes[name], `client schema must define relay node '${name}'`).toBeDefined();
+    }
+  });
+
+  it('treats every relay-emitted atom as a leaf/atom node', () => {
+    for (const name of RELAY_EMITTABLE_ATOMS) {
+      const nodeType = schema.nodes[name];
+      expect(nodeType, `relay atom '${name}' missing from client schema`).toBeDefined();
+      expect(
+        nodeType!.isLeaf || nodeType!.isAtom,
+        `relay atom '${name}' must be an atom/leaf in the client schema`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -159,12 +159,26 @@ export function useProseEditorChrome(
 
   // Resolve blob:// images to object URLs (initial + on every update) —
   // collaborators on other devices embed images we must load.
+  //
+  // JP-319: a collab/MCP update re-renders the image node view, which resets the
+  // DOM <img> back to the unresolved `blob://` src from the node attrs. Running
+  // the resolver only synchronously can lose that race (the node view re-renders
+  // after we resolve), leaving a broken-image icon until the next interaction
+  // (the "toggle float to make it reappear" symptom). So also re-resolve on the
+  // next frame, after the node view has settled. The resolver is idempotent —
+  // it only touches remaining `blob://` srcs, never object/http/data URLs.
   useEffect(() => {
     if (!editor) return;
-    const convert = () => void resolveBlobImagesIn(editor.view.dom);
+    let raf = 0;
+    const convert = () => {
+      void resolveBlobImagesIn(editor.view.dom);
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => void resolveBlobImagesIn(editor.view.dom));
+    };
     convert();
     editor.on('update', convert);
     return () => {
+      cancelAnimationFrame(raf);
       editor.off('update', convert);
     };
   }, [editor]);


### PR DESCRIPTION
Fixes the two worst findings from the JP-312 pre-launch joy ride (P0, Cloud MVP) — both rooted in the MCP-created prose-page seeding path. Master reference: JP-312.

## What was broken
- **Crash on opening a document** (`Cannot read properties of undefined (reading 'children')`): the relay prose parser seeded an `image` atom with **no `src`**; the client parses only `img[src]` and treats image as an atom, so ProseMirror's ReactNodeView desc-tree walk threw *during render* — with no error boundary anywhere, that unmounted the whole app.
- **Prose blocks duplicated under live collab** (+ MCP pages "not picked up until wiping storage"): JSON-seeded prose fragments got a **random per-instance Y.Doc client-id**, so every evict→rehydrate minted a fresh CRDT lineage; a client holding the prior lineage in y-indexeddb merged old+new and the page doubled.
- **Images reset to inline + went broken-icon after an MCP edit**: the relay round-trip dropped `width`/`height`/`float`, and on a collab/MCP update the image node view reset the DOM `<img>` to the unresolved `blob://` src faster than the resolver re-ran.

## Fix
**Relay (`f5ed863`)**
- Drop a src-less `<img>` instead of seeding a naked `image` atom; preserve the full image attribute set with `data-float`↔`float` HTML↔PM name translation (so images survive the MCP round-trip).
- **Deterministic prose seeding**: `seed_prose_deterministic` builds each page in a throwaway Doc with a stable per-page (FNV, 53-bit-masked) client-id, so identical content yields identical CRDT items and a re-seed dedupes on merge. A bootstrap origin for never-yet-live content, scoped per page — not a JP-172 regression.

**Client (`18bbdb2`)**
- `ProseErrorBoundary` around the prose mount: a render crash degrades to a recoverable panel instead of unmounting the app; auto-resets on doc/page switch.
- Re-resolve blob images on the next frame after a collab/MCP update settles, closing the "broken image until I toggle float" race.

## Tests
- Repro/acceptance tests (`relay/src/sync/mod.rs` `jp319_*`): RED on master → green here (src-less image, image-attr round-trip, lineage-churn dedup).
- T3 cross-runtime schema-contract test: every relay-emittable node type must exist in the client schema and relay atoms must be atoms — the durable drift guard.
- `ProseErrorBoundary` containment test.
- **Verified local-first**: relay `cargo build --bin relay` + 430 lib tests; client typecheck + full suite (2344). Staging (mock-prod) untouched.

## Follow-ups (not in this PR)
- 2d data-fidelity: callout/figure/gallery currently round-trip lossy through the relay (text survives, structure unwrapped); stop `{{field}}` expansion inside inline code.
- Full local-stack real-auth E2E (T4).

Assisted-by: Opus 4.8