### PR TITLE
JP-328: prose validation gate + self-heal with scoped diff

### DIFF
--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1264,8 +1264,14 @@ fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
         ctx.broadcast_update(&parsed.doc_id, framed);
     }
 
+    // JP-328: surface what the structural gate healed in the new page's content.
+    let fixes = crate::sync::validate_prose_html(&html);
+    let mut result = json!({"id": id});
+    if !fixes.is_empty() {
+        result["fixes"] = serde_json::to_value(&fixes).unwrap_or(Value::Null);
+    }
     Ok(ToolOutcome {
-        result: json!({"id": id}),
+        result,
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
     })
@@ -1296,6 +1302,8 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     reject_if_local(ctx, &parsed.doc_id)?;
     check_prose_size(&parsed.content)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
+    // JP-328: report what the structural gate healed, so the author sees it.
+    let fixes = crate::sync::validate_prose_html(&html);
 
     match &parsed.anchor {
         // JP-239: anchored, block-level replace — only the matched block(s) change.
@@ -1325,8 +1333,12 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         })?,
     }
 
+    let mut result = json!({"pageId": parsed.page_id, "ok": true});
+    if !fixes.is_empty() {
+        result["fixes"] = serde_json::to_value(&fixes).unwrap_or(Value::Null);
+    }
     Ok(ToolOutcome {
-        result: json!({"pageId": parsed.page_id, "ok": true}),
+        result,
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
     })

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -431,6 +431,33 @@ mod tests {
     }
 
     #[test]
+    fn jp328_json_prose_to_ydoc_self_heals_malformed_content() {
+        // The hydration self-heal arm of the JP-328 gate: a doc whose stored
+        // `richTextPages` HTML carries a malformed node (a src-less <img> atom,
+        // which crashes the client's NodeView reconciliation) must hydrate to a
+        // SANE fragment — the cold/JSON path heals on load, not just new writes.
+        let doc = Doc::new();
+        super::json_prose_to_ydoc(
+            &json!({
+                "id": "d",
+                "richTextPages": {
+                    "pageOrder": ["rt1"],
+                    "pages": { "rt1": {"content": "<p>before<img>after</p>"} }
+                }
+            }),
+            &doc,
+        );
+        let f1 = doc.get_or_insert_xml_fragment("prose:rt1");
+        let txn = doc.transact();
+        let html = super::super::prose_html::fragment_to_html(&f1, &txn);
+        assert!(
+            !html.contains("<img"),
+            "hydration must drop the src-less image atom, got: {html}"
+        );
+        assert!(html.contains("beforeafter"), "surrounding text must survive: {html}");
+    }
+
+    #[test]
     fn json_prose_to_ydoc_noop_without_richtextpages() {
         use yrs::ReadTxn;
         let doc = Doc::new();

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -98,7 +98,18 @@ pub fn json_prose_to_ydoc(doc_json: &Value, doc: &Doc) {
         if content.trim().is_empty() {
             continue;
         }
-        let blocks = super::prose_parse::html_to_blocks(content);
+        // Self-heal on hydration (JP-328): validate + normalize the parsed tree
+        // before seeding, so a doc whose stored prose carries a malformed node
+        // (e.g. an older, pre-gate write) comes back renderable instead of
+        // crashing the editor — no manual snapshot surgery needed.
+        let (blocks, fixes) =
+            super::prose_validate::sanitize_blocks(super::prose_parse::html_to_blocks(content));
+        if !fixes.is_empty() {
+            log::info!(
+                "prose_validate self-healed {} defect(s) hydrating prose:{id}: {fixes:?}",
+                fixes.len()
+            );
+        }
         // An "empty" page serializes to the placeholder `<p></p>` (the editor's
         // never-truly-empty invariant). Seeding that would leave a spurious empty
         // paragraph that the editor's first real edit then appends after — an

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1149,6 +1149,24 @@ mod tests {
     }
 
     #[test]
+    fn jp328_validate_prose_html_reports_a_diff_for_malformed_input() {
+        // `validate_prose_html` is what the MCP set_prose/add_prose_page tools
+        // call to surface the `fixes` diff to the author. Clean HTML reports no
+        // fixes; malformed HTML (a ragged table the gate rebuilds rectangular)
+        // reports at least one.
+        assert!(
+            super::validate_prose_html("<p>clean</p>").is_empty(),
+            "well-formed prose must report no fixes"
+        );
+        let fixes =
+            super::validate_prose_html("<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>");
+        assert!(
+            !fixes.is_empty(),
+            "a ragged table must be reported as a fix so the author sees the heal"
+        );
+    }
+
+    #[test]
     fn jp319_2d_figure_without_image_degrades_safely() {
         // `figcaption` has no block group on the client — emitting one standalone
         // would crash. A <figure> with no usable <img> must degrade to its text,

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -24,11 +24,24 @@ mod prose_block;
 mod prose_html;
 mod prose_parse;
 mod prose_schema;
+mod prose_validate;
 mod protocol;
 
 /// Apply an anchored, block-level prose edit to a page's HTML off the live path
 /// (the MCP cold path for a non-resident document). See [`prose_block`].
 pub use prose_block::replace_block_in_html;
+
+pub use prose_validate::ProseFix;
+
+/// Validate + normalize prose HTML for the MCP write gate (JP-328): parse to
+/// blocks, run the structural sanitizer, and return the scoped diff of fixes
+/// (empty when clean). The build/seed paths sanitize independently, so this is
+/// purely to surface "here's what was malformed and how it was healed" back to
+/// the MCP author.
+pub fn validate_prose_html(html: &str) -> Vec<ProseFix> {
+    let (_blocks, fixes) = prose_validate::sanitize_blocks(prose_parse::html_to_blocks(html));
+    fixes
+}
 
 pub use hydration::active_page_shape_count;
 pub use protocol::{SyncError, SyncOutcome};
@@ -651,7 +664,15 @@ impl DocHandle {
         // transacts; nesting deadlocks).
         let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
 
-        let mut blocks = prose_parse::html_to_blocks(html);
+        // Gate: validate + normalize before the tree reaches the Y.Doc (JP-328),
+        // so a malformed node can't crash the client's NodeView reconciliation.
+        let (mut blocks, fixes) = prose_validate::sanitize_blocks(prose_parse::html_to_blocks(html));
+        if !fixes.is_empty() {
+            log::info!(
+                "prose_validate healed {} defect(s) seeding prose:{page_id}: {fixes:?}",
+                fixes.len()
+            );
+        }
         if blocks.is_empty() {
             blocks.push(prose_parse::PmNode {
                 node_type: "paragraph".to_string(),

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -71,7 +71,15 @@ pub fn replace_block_in_fragment<F: XmlFragment>(
     };
     let count = (end - start + 1) as u32;
 
-    let new_blocks = prose_parse::html_to_blocks(new_html);
+    // Gate (JP-328): validate + normalize the inserted blocks before they reach
+    // the fragment, so an anchored write can't smuggle a malformed node past the
+    // whole-page gate. Covers both the live path (replace_prose_block) and the
+    // cold path (replace_block_in_html delegates here).
+    let (new_blocks, fixes) =
+        super::prose_validate::sanitize_blocks(prose_parse::html_to_blocks(new_html));
+    if !fixes.is_empty() {
+        log::info!("prose_validate healed {} defect(s) in anchored prose write: {fixes:?}", fixes.len());
+    }
 
     frag.remove_range(txn, start as u32, count);
     for (i, node) in new_blocks.iter().enumerate() {
@@ -317,6 +325,38 @@ mod tests {
         // Replacing the only block with empty content leaves one empty paragraph.
         let out = apply("<p>only</p>", "only", None, "").unwrap();
         assert_eq!(out, "<p></p>");
+    }
+
+    #[test]
+    fn jp328_anchored_write_heals_a_srcless_image() {
+        // The anchored path must run the same JP-328 gate as the whole-page
+        // replace: a src-less <img> (a naked atom that crashes the client's
+        // NodeView reconciliation) is dropped before it reaches the fragment.
+        let out = apply(
+            "<p>keep</p><p>swap</p>",
+            "swap",
+            None,
+            "<p>before<img>after</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>keep</p><p>beforeafter</p>");
+        assert!(!out.contains("<img"), "src-less image must not survive the gate: {out}");
+    }
+
+    #[test]
+    fn jp328_anchored_write_rebuilds_a_ragged_table() {
+        // A ragged table (rows of differing cell counts) is padded to the
+        // rectangular table>tableRow+>cell+ the client schema requires, so the
+        // anchored write can't smuggle a malformed table past the gate.
+        let out = apply(
+            "<p>anchor</p>",
+            "anchor",
+            None,
+            "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>",
+        )
+        .unwrap();
+        // Both rows must now carry two cells (the second was padded).
+        assert_eq!(out.matches("<td").count(), 4, "ragged table must be padded rectangular: {out}");
     }
 
     #[test]

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -1,0 +1,536 @@
+//! Structural validation + normalization of the prose node tree before it
+//! reaches the Y.Doc (JP-328).
+//!
+//! The relay accepts machine-generated prose (the MCP markdown/HTML path, the
+//! editor's `getHTML()`). A structurally-invalid node — an atom carrying
+//! children, an unknown node type, a malformed table — serializes back to clean
+//! HTML yet crashes the **client** editor's NodeView reconciliation
+//! ("Cannot read properties of undefined (reading 'children')"). This pass
+//! demotes such nodes into a valid, content-preserving shape and reports a
+//! scoped [`ProseFix`] diff for each change, so an MCP author sees exactly what
+//! was malformed and how it was healed.
+//!
+//! **Demotion over elimination.** Unknown wrappers unwrap to their children;
+//! malformed tables are rebuilt; illegal children are stripped off atoms; stray
+//! inline is wrapped in a paragraph. The only outright drops are nodes with no
+//! recoverable content (a src-less image, a table with no rows).
+
+use serde::Serialize;
+
+use super::prose_parse::{PmChild, PmNode};
+use super::prose_schema;
+
+/// What was done to heal one node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FixAction {
+    /// Removed entirely (no recoverable content).
+    Dropped,
+    /// Replaced by its children (unknown wrapper type).
+    Unwrapped,
+    /// Table rebuilt into `table > tableRow+ > cell+`, rectangular.
+    RebuiltTable,
+    /// Illegal children stripped off an atom (leaf) node.
+    StrippedChildren,
+}
+
+/// One healed structural defect, surfaced to the writer + logged on self-heal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProseFix {
+    /// Index path to the node, e.g. `0/table` or `2/listItem`.
+    pub path: String,
+    pub node_type: String,
+    pub action: FixAction,
+    pub reason: &'static str,
+}
+
+/// Node types the client schema (`sharedProseExtensions` + StarterKit + tables)
+/// can render. Anything else is unwrapped to its children. Keep in sync with
+/// `prose_schema` + the client extension set.
+fn is_known_type(t: &str) -> bool {
+    matches!(
+        t,
+        "paragraph"
+            | "heading"
+            | "bulletList"
+            | "orderedList"
+            | "listItem"
+            | "blockquote"
+            | "table"
+            | "tableRow"
+            | "tableCell"
+            | "tableHeader"
+            | "codeBlock"
+            | "horizontalRule"
+            | "image"
+            | "bibliography"
+            | "callout"
+            | "figure"
+            | "figcaption"
+            | "gallery"
+            | "citationInline"
+            | "fieldRef"
+            | "hardBreak"
+    )
+}
+
+/// Leaf/atom node types: the client treats these as atoms, so they must carry
+/// **no** children. A child here is the exact shape that crashes NodeView
+/// reconciliation.
+fn is_atom(t: &str) -> bool {
+    matches!(
+        t,
+        "image" | "citationInline" | "fieldRef" | "horizontalRule" | "bibliography" | "hardBreak"
+    )
+}
+
+fn attr<'a>(node: &'a PmNode, k: &str) -> Option<&'a str> {
+    node.attrs.iter().find(|(key, _)| key == k).map(|(_, v)| v.as_str())
+}
+
+fn has_node_children(node: &PmNode) -> bool {
+    !node.children.is_empty()
+}
+
+fn paragraph(children: Vec<PmChild>) -> PmNode {
+    PmNode { node_type: "paragraph".to_string(), attrs: vec![], children }
+}
+
+fn empty_cell() -> PmNode {
+    PmNode {
+        node_type: "tableCell".to_string(),
+        attrs: vec![],
+        children: vec![PmChild::Node(paragraph(vec![]))],
+    }
+}
+
+/// Validate + normalize top-level prose blocks, returning the healed tree and a
+/// scoped diff of every fix. Idempotent: a healed tree re-sanitizes to itself
+/// with no fixes.
+pub fn sanitize_blocks(blocks: Vec<PmNode>) -> (Vec<PmNode>, Vec<ProseFix>) {
+    let mut fixes = Vec::new();
+    let out = sanitize_list(blocks, "", 0, &mut fixes);
+    (out, fixes)
+}
+
+fn sanitize_list(
+    blocks: Vec<PmNode>,
+    prefix: &str,
+    depth: usize,
+    fixes: &mut Vec<ProseFix>,
+) -> Vec<PmNode> {
+    let mut out = Vec::new();
+    for (i, node) in blocks.into_iter().enumerate() {
+        let path = format!("{prefix}{i}/{}", node.node_type);
+        out.extend(sanitize_node(node, &path, depth, fixes));
+    }
+    out
+}
+
+/// Sanitize one node. Returns 0+ nodes (drop → 0, unwrap → its children, normal → 1).
+fn sanitize_node(
+    node: PmNode,
+    path: &str,
+    depth: usize,
+    fixes: &mut Vec<ProseFix>,
+) -> Vec<PmNode> {
+    // Depth bound (defense in depth alongside the parser's): drop the deep tail.
+    if depth > prose_schema::MAX_PROSE_DEPTH {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: node.node_type.clone(),
+            action: FixAction::Dropped,
+            reason: "nesting exceeded MAX_PROSE_DEPTH",
+        });
+        return vec![];
+    }
+
+    // Unknown type → unwrap to children (keep text by wrapping it in a paragraph).
+    if !is_known_type(&node.node_type) {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: node.node_type.clone(),
+            action: FixAction::Unwrapped,
+            reason: "unknown node type the client schema can't render",
+        });
+        return unwrap_children(node, path, depth, fixes);
+    }
+
+    // Image atom: requires `src`, never carries children.
+    if node.node_type == "image" {
+        match attr(&node, "src").filter(|s| !s.is_empty()) {
+            None => {
+                fixes.push(ProseFix {
+                    path: path.to_string(),
+                    node_type: "image".to_string(),
+                    action: FixAction::Dropped,
+                    reason: "image has no src (client parses only img[src]; a naked image atom crashes)",
+                });
+                return vec![];
+            }
+            Some(_) => {
+                return vec![strip_children_if_any(node, path, fixes)];
+            }
+        }
+    }
+
+    // Other atoms: force childless.
+    if is_atom(&node.node_type) {
+        return vec![strip_children_if_any(node, path, fixes)];
+    }
+
+    // Tables: rebuild into a well-formed, rectangular shape.
+    if node.node_type == "table" {
+        return normalize_table(node, path, depth, fixes);
+    }
+
+    // Container: recurse into block/inline children.
+    vec![sanitize_container(node, path, depth, fixes)]
+}
+
+/// Strip children off an atom node, recording a fix if any were present.
+fn strip_children_if_any(mut node: PmNode, path: &str, fixes: &mut Vec<ProseFix>) -> PmNode {
+    if has_node_children(&node) {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: node.node_type.clone(),
+            action: FixAction::StrippedChildren,
+            reason: "atom node must be childless",
+        });
+        node.children.clear();
+    }
+    node
+}
+
+/// Recurse into a container's children: sanitize block-node children in place,
+/// keep text/inline runs as-is.
+fn sanitize_container(mut node: PmNode, path: &str, depth: usize, fixes: &mut Vec<ProseFix>) -> PmNode {
+    // codeBlock content is plain text — never recurse into it as structure.
+    if node.node_type == "codeBlock" {
+        return node;
+    }
+    let mut new_children = Vec::new();
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                let child_path = format!("{path}/{}", n.node_type);
+                for sn in sanitize_node(n, &child_path, depth + 1, fixes) {
+                    new_children.push(PmChild::Node(sn));
+                }
+            }
+            text @ PmChild::Text { .. } => new_children.push(text),
+        }
+    }
+    node.children = new_children;
+    node
+}
+
+/// Unwrap an unknown node to its content: sanitized block children, plus any
+/// stray inline text gathered into a paragraph (never dropped).
+fn unwrap_children(node: PmNode, path: &str, depth: usize, fixes: &mut Vec<ProseFix>) -> Vec<PmNode> {
+    let mut blocks = Vec::new();
+    let mut inline: Vec<PmChild> = Vec::new();
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                let child_path = format!("{path}/{}", n.node_type);
+                blocks.extend(sanitize_node(n, &child_path, depth, fixes));
+            }
+            t @ PmChild::Text { .. } => inline.push(t),
+        }
+    }
+    let has_text = inline.iter().any(|c| matches!(c, PmChild::Text { text, .. } if !text.trim().is_empty()));
+    if has_text {
+        blocks.insert(0, paragraph(inline));
+    }
+    blocks
+}
+
+/// Rebuild a `table` into `table > tableRow+ > (tableCell|tableHeader)+`, with
+/// every cell holding `block+` and all rows the same width. A non-row child is
+/// dropped; a table with no rows is dropped. Records `RebuiltTable` if anything
+/// changed.
+fn normalize_table(node: PmNode, path: &str, depth: usize, fixes: &mut Vec<ProseFix>) -> Vec<PmNode> {
+    let mut changed = false;
+    let mut rows: Vec<PmNode> = Vec::new();
+
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) if n.node_type == "tableRow" => {
+                rows.push(normalize_row(n, depth + 1, fixes));
+            }
+            _ => changed = true, // non-row child in a table → drop
+        }
+    }
+
+    if rows.is_empty() {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "table".to_string(),
+            action: FixAction::Dropped,
+            reason: "table has no rows",
+        });
+        return vec![];
+    }
+
+    // Rectangularize: pad short rows with empty cells.
+    let width = rows.iter().map(|r| r.children.len()).max().unwrap_or(0);
+    for row in rows.iter_mut() {
+        while row.children.len() < width {
+            row.children.push(PmChild::Node(empty_cell()));
+            changed = true;
+        }
+    }
+
+    if changed {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "table".to_string(),
+            action: FixAction::RebuiltTable,
+            reason: "table was not a rectangular table>row+>cell+ structure",
+        });
+    }
+
+    vec![PmNode {
+        node_type: "table".to_string(),
+        attrs: node.attrs,
+        children: rows.into_iter().map(PmChild::Node).collect(),
+    }]
+}
+
+/// Ensure a row holds only cells, each with `block+`. Non-cell content is
+/// wrapped into a cell; an empty row gets one empty cell.
+fn normalize_row(node: PmNode, depth: usize, fixes: &mut Vec<ProseFix>) -> PmNode {
+    let mut cells: Vec<PmChild> = Vec::new();
+    let mut stray_inline: Vec<PmChild> = Vec::new();
+
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) if n.node_type == "tableCell" || n.node_type == "tableHeader" => {
+                cells.push(PmChild::Node(normalize_cell(n, depth + 1, fixes)));
+            }
+            PmChild::Node(n) => {
+                // A stray block inside a row → wrap it in a cell (preserve it).
+                cells.push(PmChild::Node(PmNode {
+                    node_type: "tableCell".to_string(),
+                    attrs: vec![],
+                    children: vec![PmChild::Node(n)],
+                }));
+            }
+            t @ PmChild::Text { .. } => stray_inline.push(t),
+        }
+    }
+    if !stray_inline.is_empty() {
+        cells.push(PmChild::Node(PmNode {
+            node_type: "tableCell".to_string(),
+            attrs: vec![],
+            children: vec![PmChild::Node(paragraph(stray_inline))],
+        }));
+    }
+    if cells.is_empty() {
+        cells.push(PmChild::Node(empty_cell()));
+    }
+    PmNode { node_type: node.node_type, attrs: node.attrs, children: cells }
+}
+
+/// Ensure a cell holds `block+`: bare inline/text is wrapped in a paragraph; an
+/// empty cell gets an empty paragraph; block children are sanitized.
+fn normalize_cell(node: PmNode, depth: usize, fixes: &mut Vec<ProseFix>) -> PmNode {
+    let mut blocks: Vec<PmChild> = Vec::new();
+    let mut inline: Vec<PmChild> = Vec::new();
+    let path = "tableCell";
+
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                // flush any pending inline into a paragraph first (order-preserving)
+                if !inline.is_empty() {
+                    blocks.push(PmChild::Node(paragraph(std::mem::take(&mut inline))));
+                }
+                let child_path = format!("{path}/{}", n.node_type);
+                for sn in sanitize_node(n, &child_path, depth + 1, fixes) {
+                    blocks.push(PmChild::Node(sn));
+                }
+            }
+            t @ PmChild::Text { .. } => inline.push(t),
+        }
+    }
+    if !inline.is_empty() {
+        blocks.push(PmChild::Node(paragraph(inline)));
+    }
+    if blocks.is_empty() {
+        blocks.push(PmChild::Node(paragraph(vec![])));
+    }
+    PmNode { node_type: node.node_type, attrs: node.attrs, children: blocks }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::prose_parse::{PmChild, PmNode};
+
+    fn n(t: &str, children: Vec<PmChild>) -> PmNode {
+        PmNode { node_type: t.to_string(), attrs: vec![], children }
+    }
+    fn na(t: &str, attrs: &[(&str, &str)], children: Vec<PmChild>) -> PmNode {
+        PmNode {
+            node_type: t.to_string(),
+            attrs: attrs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect(),
+            children,
+        }
+    }
+    fn text(s: &str) -> PmChild {
+        PmChild::Text { text: s.to_string(), marks: vec![] }
+    }
+    fn node(p: PmNode) -> PmChild {
+        PmChild::Node(p)
+    }
+
+    #[test]
+    fn clean_prose_is_unchanged_and_reports_no_fixes() {
+        let input = vec![
+            n("heading", vec![text("Title")]),
+            n("paragraph", vec![text("hello")]),
+        ];
+        let (out, fixes) = sanitize_blocks(input.clone());
+        assert_eq!(out, input);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn src_less_image_is_dropped() {
+        let input = vec![na("image", &[("alt", "logo")], vec![])];
+        let (out, fixes) = sanitize_blocks(input);
+        assert!(out.is_empty(), "src-less image dropped");
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, FixAction::Dropped);
+        assert_eq!(fixes[0].node_type, "image");
+    }
+
+    #[test]
+    fn image_with_src_survives() {
+        let input = vec![na("image", &[("src", "blob://x")], vec![])];
+        let (out, fixes) = sanitize_blocks(input.clone());
+        assert_eq!(out, input);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn atom_with_children_is_stripped() {
+        // A fieldRef (inline atom) that wrongly carries children.
+        let input = vec![n("paragraph", vec![node(na(
+            "fieldRef",
+            &[("name", "X")],
+            vec![text("should not be here")],
+        ))])];
+        let (out, fixes) = sanitize_blocks(input);
+        let field = match &out[0].children[0] {
+            PmChild::Node(f) => f,
+            _ => panic!("expected fieldRef node"),
+        };
+        assert!(field.children.is_empty(), "atom forced childless");
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, FixAction::StrippedChildren);
+    }
+
+    #[test]
+    fn unknown_type_is_unwrapped_to_children() {
+        let input = vec![n("mysteryBlock", vec![node(n("paragraph", vec![text("kept")]))])];
+        let (out, fixes) = sanitize_blocks(input);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].node_type, "paragraph");
+        assert_eq!(fixes[0].action, FixAction::Unwrapped);
+    }
+
+    #[test]
+    fn well_formed_table_is_unchanged() {
+        let row = |cells: Vec<PmChild>| node(n("tableRow", cells));
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        let input = vec![n(
+            "table",
+            vec![row(vec![cell("a"), cell("b")]), row(vec![cell("1"), cell("2")])],
+        )];
+        let (out, fixes) = sanitize_blocks(input.clone());
+        assert_eq!(out, input, "rectangular table untouched");
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn ragged_table_is_rectangularized() {
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        // Row 1 has 2 cells, row 2 has 1 — should pad row 2 to width 2.
+        let input = vec![n(
+            "table",
+            vec![
+                node(n("tableRow", vec![cell("a"), cell("b")])),
+                node(n("tableRow", vec![cell("1")])),
+            ],
+        )];
+        let (out, fixes) = sanitize_blocks(input);
+        let table = &out[0];
+        let r2 = match &table.children[1] {
+            PmChild::Node(r) => r,
+            _ => panic!(),
+        };
+        assert_eq!(r2.children.len(), 2, "short row padded to table width");
+        assert!(fixes.iter().any(|f| f.action == FixAction::RebuiltTable));
+    }
+
+    #[test]
+    fn table_with_non_row_child_drops_the_stray_and_rebuilds() {
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        let input = vec![n(
+            "table",
+            vec![
+                node(n("paragraph", vec![text("stray")])), // illegal direct child
+                node(n("tableRow", vec![cell("a")])),
+            ],
+        )];
+        let (out, fixes) = sanitize_blocks(input);
+        let table = &out[0];
+        assert_eq!(table.children.len(), 1, "only the row remains");
+        assert!(fixes.iter().any(|f| f.action == FixAction::RebuiltTable));
+    }
+
+    #[test]
+    fn empty_table_is_dropped() {
+        let input = vec![n("table", vec![])];
+        let (out, fixes) = sanitize_blocks(input);
+        assert!(out.is_empty());
+        assert_eq!(fixes[0].action, FixAction::Dropped);
+    }
+
+    #[test]
+    fn cell_with_bare_text_gets_a_paragraph() {
+        // tableCell whose child is raw text (no paragraph) → wrap in a paragraph.
+        let input = vec![n(
+            "table",
+            vec![node(n("tableRow", vec![node(n("tableCell", vec![text("bare")]))]))],
+        )];
+        let (out, _fixes) = sanitize_blocks(input);
+        let cell = match &out[0].children[0] {
+            PmChild::Node(r) => match &r.children[0] {
+                PmChild::Node(c) => c,
+                _ => panic!(),
+            },
+            _ => panic!(),
+        };
+        assert_eq!(cell.children.len(), 1);
+        assert!(matches!(&cell.children[0], PmChild::Node(p) if p.node_type == "paragraph"));
+    }
+
+    #[test]
+    fn sanitize_is_idempotent() {
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        let messy = vec![
+            na("image", &[("alt", "x")], vec![]), // dropped
+            n("table", vec![node(n("tableRow", vec![cell("a")])), node(n("tableRow", vec![cell("1"), cell("2")]))]),
+            n("mystery", vec![node(n("paragraph", vec![text("k")]))]),
+        ];
+        let (once, _) = sanitize_blocks(messy);
+        let (twice, fixes2) = sanitize_blocks(once.clone());
+        assert_eq!(once, twice, "second pass is a no-op");
+        assert!(fixes2.is_empty(), "healed tree needs no further fixes");
+    }
+}


### PR DESCRIPTION
Validation at the gate for malformed prose, with self-heal for existing docs and a scoped diff back to the author. Follows from JP-319 / the JP-312 joy-ride.

## Why
AI authors rich prose constantly, and a structurally-invalid node (an atom carrying children, an unknown node type, a malformed table) **serializes to clean HTML yet crashes the client editor's NodeView reconciliation** — `Cannot read properties of undefined (reading 'children')`. That error is *generic* to NodeView reconciliation (tables/images/fields/gallery all use NodeViews), so the fix is a **general structural validator**, not a node-specific patch.

## What
- **`relay/src/sync/prose_validate.rs`** — pure `sanitize_blocks(Vec<PmNode>) -> (Vec<PmNode>, Vec<ProseFix>)`. Rules, **demotion over elimination** (content preserved):
  - known node types only — unknown → unwrap to children;
  - atoms (image/citation/field/hr/bibliography/hardBreak) forced **childless**;
  - `<img>` without `src` → dropped (never a naked image atom);
  - **tables rebuilt** to rectangular `table > tableRow+ > (cell|header)+`, cells hold `block+`, short rows padded, stray children dropped;
  - depth-bounded; stray inline wrapped.
  - 11 unit tests incl. idempotency (a healed tree re-sanitizes to itself).
- **Gate + self-heal wiring** — `sanitize_blocks` runs at the build chokepoint (`replace_prose`) and in **hydration** (`json_prose_to_ydoc`). New writes can't persist malformed prose, and **existing corrupt docs self-heal on next load** — no R2/volume surgery.
- **Scoped diff** — `set_prose` / `add_prose_page` return a `fixes` array (`{path, nodeType, action, reason}`) so the agent sees exactly what was malformed and how it was healed.

## Tests
Relay **443** lib tests (+11) + integration (`yjs_authority` 12, `public_mcp`, `smoke`) green; bin builds; OSS-leak clean.

## Follow-ons (JP-328, separate)
- Client ErrorBoundary recovers a crashed page from the HTML projection (not just a dead panel).
- Repair/reset endpoint for *resident* (in-memory-pinned) docs — evict + rebuild + tell clients to purge their local room.
- Binary-sidecar structural check → rebuild-from-JSON for sidecar-corrupt docs.

Assisted-by: Opus 4.8