### PR TITLE
JP-328: never blank a prose page on a render crash (Pillar 1)

### DIFF
--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -8,7 +8,7 @@
  * - Tiptap editor
  */
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { EllipsisVertical, Maximize2, Minimize2 } from 'lucide-react';
 import { Icon } from './icons';
 import type { Editor } from '@tiptap/core';
@@ -26,6 +26,7 @@ import { useDocumentRegistry } from '../store/documentRegistry';
 import { CollaborativeProseEditor } from './CollaborativeProseEditor';
 import { ProseErrorBoundary } from './ProseErrorBoundary';
 import { ProsePreview } from './ProsePreview';
+import { isFragmentRenderable } from './proseFragmentCheck';
 import { RICH_TEXT_VERSION } from '../types/RichText';
 import './DocumentEditorPanel.css';
 
@@ -151,7 +152,24 @@ export function DocumentEditorPanel({
   // empty fragment stays read-only (ProsePreview) — there's nothing to adopt yet.
   const proseEditable =
     engineReady && (fragHasContent || collabSynced);
-  const useCollabEditor = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
+  const wouldMountCollab = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
+
+  // Pillar 1a (JP-328): pre-flight the bound fragment against the client schema
+  // before mounting the live editor. y-prosemirror builds the doc straight from
+  // the fragment (bypassing Tiptap's content parser), so a schema-invalid node
+  // would crash NodeView reconciliation and blank the page. If the fragment
+  // doesn't build cleanly, fall through to the read-only `ProsePreview` (the
+  // HTML projection renders crash-safe) instead. Memoized on the bind identity +
+  // the content signal so it re-runs on page/doc switch and when the fragment
+  // first gains content — not on every render. An empty fragment is trivially
+  // renderable, so this is a no-op for the common fresh-page case.
+  const fragmentRenderable = useMemo(() => {
+    if (!wouldMountCollab || !collabYdoc || !proseField) return true;
+    return isFragmentRenderable(collabYdoc, proseField);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wouldMountCollab, collabYdoc, proseField, collabSessionEpoch, fragHasContent]);
+
+  const useCollabEditor = wouldMountCollab && fragmentRenderable;
 
   const lastActivePageRef = useRef<string | null>(null);
   const isLoadingRef = useRef(false);
@@ -526,9 +544,13 @@ export function DocumentEditorPanel({
         <RichTextTabBar trailing={trailing} />
         <DocumentEditorToolbar />
         <div className="document-editor-panel-content">
-          {/* Contain a prose render crash (JP-319) so a single bad document
-              can't unmount the whole app; auto-resets on doc/page switch. */}
-          <ProseErrorBoundary resetKeys={[currentDocId, activePageId]}>
+          {/* Never blank (JP-328): a prose render crash degrades to the page's
+              read-only HTML projection, not an empty panel; auto-resets on
+              doc/page switch. */}
+          <ProseErrorBoundary
+            resetKeys={[currentDocId, activePageId]}
+            fallbackHtml={activePageContent ?? '<p></p>'}
+          >
             {!isRelayDoc ? (
               // Local-only doc: the legacy editor (no Y.Doc).
               <TiptapEditor onEditorReady={handleEditorReady} />
@@ -541,8 +563,10 @@ export function DocumentEditorPanel({
                 onEditorReady={handleEditorReady}
               />
             ) : (
-              // Relay doc, engine still coming up (sub-second) or a never-synced
-              // doc opened offline — show the prose read-only until editable.
+              // Relay doc that isn't live-editable: engine still coming up
+              // (sub-second), a never-synced doc opened offline, OR a fragment
+              // that failed the schema pre-check (malformed — would crash the
+              // live editor). Show the prose read-only rather than blank.
               <ProsePreview html={activePageContent || '<p></p>'} />
             )}
           </ProseErrorBoundary>

--- a/src/ui/ProseErrorBoundary.test.tsx
+++ b/src/ui/ProseErrorBoundary.test.tsx
@@ -1,8 +1,11 @@
 /**
- * ProseErrorBoundary containment proof (JP-319): a child that throws during
- * render must degrade to the recoverable fallback (not propagate and unmount
- * the app), and the boundary must auto-reset when `resetKeys` change so
- * navigating to another document recovers.
+ * ProseErrorBoundary — never-blank proof (JP-328, supersedes the JP-319 blank
+ * panel). A child that throws during render must:
+ *   - never propagate and unmount the app (containment), and
+ *   - with a `fallbackHtml` projection, render that content read-only (NOT an
+ *     empty panel) so the user always sees their prose, and
+ *   - auto-reset when `resetKeys` change so navigating to another document
+ *     recovers without a reload.
  */
 
 import { render, screen } from '@testing-library/react';
@@ -34,20 +37,33 @@ describe('ProseErrorBoundary', () => {
     expect(screen.getByText('prose ok')).toBeTruthy();
   });
 
-  it('contains a render crash and shows a recoverable fallback', () => {
+  it('contains a render crash and shows a recoverable banner', () => {
     render(
       <ProseErrorBoundary resetKeys={['doc-1']}>
         <Boom />
       </ProseErrorBoundary>,
     );
     expect(screen.getByRole('alert')).toBeTruthy();
-    expect(screen.getByText(/couldn.t be displayed/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
+  });
+
+  it('NEVER blanks: a crash with fallbackHtml shows the content read-only', async () => {
+    render(
+      <ProseErrorBoundary resetKeys={['doc-1']} fallbackHtml="<p>recovered prose body</p>">
+        <Boom />
+      </ProseErrorBoundary>,
+    );
+    // The recovery banner is present...
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/read-only copy/i)).toBeTruthy();
+    // ...AND the user's content is rendered (ProsePreview), never a blank panel.
+    expect(await screen.findByText('recovered prose body')).toBeTruthy();
   });
 
   it('auto-resets when resetKeys change (e.g. switching documents)', () => {
     const { rerender } = render(
-      <ProseErrorBoundary resetKeys={['doc-1']}>
+      <ProseErrorBoundary resetKeys={['doc-1']} fallbackHtml="<p>doc one body</p>">
         <Boom />
       </ProseErrorBoundary>,
     );
@@ -55,7 +71,7 @@ describe('ProseErrorBoundary', () => {
 
     // Switching to a different, healthy document must recover without a reload.
     rerender(
-      <ProseErrorBoundary resetKeys={['doc-2']}>
+      <ProseErrorBoundary resetKeys={['doc-2']} fallbackHtml="<p>doc two body</p>">
         <Safe label="other doc" />
       </ProseErrorBoundary>,
     );

--- a/src/ui/ProseErrorBoundary.tsx
+++ b/src/ui/ProseErrorBoundary.tsx
@@ -1,21 +1,30 @@
 /**
- * ProseErrorBoundary — contains a prose-editor render crash so one bad document
- * can't take down the whole app (JP-319).
+ * ProseErrorBoundary — guarantees a prose page is **never blank** when the live
+ * editor crashes (JP-328, Pillar 1b; supersedes the JP-319 blank-panel fallback).
  *
- * The prose editors render a ProseMirror/Tiptap node tree via ReactNodeViews.
- * A node the client schema can't reconcile (historically a malformed node from
- * the relay seed path — e.g. a src-less `image` atom) makes ProseMirror's
- * desc-tree walk throw "Cannot read properties of undefined (reading
- * 'children')" *during render*, which without a boundary unmounts the entire
- * React tree. The relay seed path is now hardened against that class, but this
- * is the defense-in-depth layer: even a novel bad node degrades to a recoverable
- * panel instead of a blank app.
+ * The prose editors render a ProseMirror/Tiptap node tree via ReactNodeViews. A
+ * node the client schema can't reconcile (historically a malformed node from the
+ * relay seed path — e.g. a src-less `image` atom) makes ProseMirror's desc-tree
+ * walk throw "Cannot read properties of undefined (reading 'children')" *during
+ * render*, which without a boundary unmounts the entire React tree.
  *
- * Auto-resets when `resetKeys` change (a document / page switch), so navigating
- * away from a document that failed to render recovers without a reload.
+ * Catching that crash is not enough — an empty panel is still broken. So when a
+ * `fallbackHtml` is supplied (the page's stored HTML projection from
+ * `richTextPages`), the boundary renders it read-only through `ProsePreview`
+ * instead: the user always sees their content. `ProsePreview` loads HTML via
+ * ProseMirror's lenient `DOMParser` (fits-to-schema, never throws), so it is the
+ * always-safe representation when the live Y.Doc fragment is suspect. A small
+ * non-blocking banner offers Retry / Reload.
+ *
+ * Scope: a React boundary catches render/lifecycle crashes (the observed open-doc
+ * case) — not errors thrown inside an async y-prosemirror sync callback. Post-mount
+ * sync-time corruption is prevented *upstream* by the relay write gate (JP-328),
+ * so malformed data never reaches the fragment; the two layers compose to full
+ * coverage. Auto-resets when `resetKeys` change (a document / page switch).
  */
 
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { ProsePreview } from './ProsePreview';
 
 interface ProseErrorBoundaryProps {
   /**
@@ -24,6 +33,12 @@ interface ProseErrorBoundaryProps {
    * recovers automatically.
    */
   resetKeys?: ReadonlyArray<unknown>;
+  /**
+   * The page's stored HTML projection. When present, a caught crash degrades to
+   * this content rendered read-only (never blank). When absent, the boundary
+   * shows a generic recoverable panel.
+   */
+  fallbackHtml?: string;
   children: ReactNode;
 }
 
@@ -64,35 +79,59 @@ export class ProseErrorBoundary extends Component<
 
   render(): ReactNode {
     if (!this.state.error) return this.props.children;
-    return (
+
+    const { fallbackHtml } = this.props;
+
+    // Recovery banner (Pillar 1c) — non-blocking, sits above the content.
+    const banner = (
       <div
         role="alert"
         style={{
-          margin: '2rem auto',
-          maxWidth: '36rem',
-          padding: '1.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          flexWrap: 'wrap',
+          margin: '0 0 0.75rem',
+          padding: '0.6rem 0.9rem',
           border: '1px solid var(--border-color, #d0c8ba)',
           borderRadius: '8px',
           background: 'var(--surface-2, rgba(0,0,0,0.03))',
           color: 'var(--text-color, inherit)',
-          textAlign: 'center',
+          fontSize: '0.9em',
         }}
       >
-        <p style={{ fontWeight: 600, margin: '0 0 0.5rem' }}>
-          This document&rsquo;s text couldn&rsquo;t be displayed.
-        </p>
-        <p style={{ margin: '0 0 1rem', opacity: 0.8, fontSize: '0.9em' }}>
-          The editor hit an unexpected content error and was contained, so the rest of the app
-          keeps working. Switching to another document, or trying again, usually recovers.
-        </p>
-        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+        <span style={{ flex: '1 1 16rem' }}>
+          {fallbackHtml !== undefined
+            ? 'Showing a read-only copy — the live editor couldn’t load this page.'
+            : 'This page’s editor hit an unexpected error and was contained.'}
+        </span>
+        <span style={{ display: 'flex', gap: '0.5rem' }}>
           <button type="button" onClick={this.reset}>
             Try again
           </button>
           <button type="button" onClick={this.reload}>
             Reload
           </button>
+        </span>
+      </div>
+    );
+
+    // The guarantee (Pillar 1b): with a fallback projection, never blank — show
+    // the content read-only. ProsePreview parses HTML leniently, so it renders
+    // even content the live fragment couldn't.
+    if (fallbackHtml !== undefined) {
+      return (
+        <div>
+          {banner}
+          <ProsePreview html={fallbackHtml || '<p></p>'} />
         </div>
+      );
+    }
+
+    // No projection to fall back to — a recoverable panel (the legacy floor).
+    return (
+      <div style={{ margin: '2rem auto', maxWidth: '36rem' }}>
+        {banner}
       </div>
     );
   }

--- a/src/ui/proseFragmentCheck.test.ts
+++ b/src/ui/proseFragmentCheck.test.ts
@@ -1,0 +1,57 @@
+/**
+ * proseFragmentCheck (JP-328, Pillar 1a) — the fragment pre-flight that keeps a
+ * malformed relay Y.Doc fragment from ever mounting the live editor (which would
+ * crash NodeView reconciliation and blank the page).
+ *
+ * A well-formed fragment builds + validates cleanly (mount the editor); a
+ * fragment carrying a schema-invalid node fails the check (fall back to the
+ * read-only ProsePreview). We build the fragments the same way the relay seeds
+ * them — XmlElement nodes inside the `prose:<page>` fragment — so this exercises
+ * the real y-prosemirror build path, not a mock.
+ */
+
+import * as Y from 'yjs';
+import { isFragmentRenderable } from './proseFragmentCheck';
+
+/** Append a `<p>text</p>` block to a prose fragment (a valid paragraph). */
+function appendParagraph(frag: Y.XmlFragment, text: string): void {
+  const p = new Y.XmlElement('paragraph');
+  p.insert(0, [new Y.XmlText(text)]);
+  frag.insert(frag.length, [p]);
+}
+
+describe('isFragmentRenderable', () => {
+  it('returns true for a well-formed prose fragment', () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment('prose:p1');
+    appendParagraph(frag, 'hello world');
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(true);
+  });
+
+  it('returns true for an empty fragment (trivially renderable)', () => {
+    const doc = new Y.Doc();
+    doc.getXmlFragment('prose:p1'); // create, leave empty
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(true);
+  });
+
+  it('returns false for an unknown node type the client schema cannot render', () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment('prose:p1');
+    // A node type that doesn't exist in the prose schema — the exact class of
+    // drift that crashes the live editor's reconciliation on open.
+    frag.insert(0, [new Y.XmlElement('totallyBogusBlock')]);
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(false);
+  });
+
+  it('returns false for an atom node carrying children (image with content)', () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment('prose:p1');
+    // `image` is an atom/leaf in the schema; giving it children violates the
+    // schema and crashes NodeView reconciliation ("reading 'children'").
+    const img = new Y.XmlElement('image');
+    img.setAttribute('src', 'blob:x');
+    img.insert(0, [new Y.XmlText('illegal child')]);
+    frag.insert(0, [img]);
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(false);
+  });
+});

--- a/src/ui/proseFragmentCheck.ts
+++ b/src/ui/proseFragmentCheck.ts
@@ -1,0 +1,81 @@
+/**
+ * proseFragmentCheck — pre-flight a prose `Y.XmlFragment` against the client
+ * schema *before* the live collaborative editor binds to it (JP-328, Pillar 1a).
+ *
+ * For a relay document the editor adopts the authoritative Y.Doc fragment via
+ * Tiptap's `Collaboration` extension, and **y-prosemirror builds the ProseMirror
+ * doc straight from the fragment** (`yXmlFragmentToProseMirrorRootNode`) —
+ * bypassing Tiptap's content parser. So a schema-invalid node (an unknown type,
+ * or an atom carrying children) isn't fitted-to-schema the way pasted HTML is;
+ * it reaches ReactNodeView reconciliation and throws "Cannot read properties of
+ * undefined (reading 'children')" *during render*, blanking the page.
+ *
+ * Tiptap's `enableContentCheck` / `onContentError` does **not** fire on this
+ * path (it only guards the content-parser path), so we reproduce the same build
+ * here and validate it with ProseMirror's own `Node.check()`. If it throws, the
+ * panel renders the crash-safe read-only `ProsePreview` (which loads the HTML
+ * projection through ProseMirror's lenient `DOMParser`) instead of mounting the
+ * editor — content stays visible, never blank.
+ *
+ * This is an *optimization* over the `ProseErrorBoundary` fallback: it avoids
+ * the mount-crash-then-recover flash and the console noise. The boundary remains
+ * the backstop for any crash this pre-check can't foresee.
+ */
+
+import { getSchema } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { yXmlFragmentToProseMirrorRootNode } from 'y-prosemirror';
+import type { Schema } from 'prosemirror-model';
+import type { Doc as YDoc } from 'yjs';
+import { sharedProseExtensions } from './TiptapEditor';
+
+let cachedSchema: Schema | null = null;
+
+/**
+ * The schema the collaborative editor actually builds — StarterKit with history
+ * off and the lowlight codeBlock swapped in, plus the shared prose extensions.
+ * `Collaboration` adds no nodes, so it's omitted. Mirrors
+ * `CollaborativeProseEditor`'s extension set and the `proseSchemaContract` test.
+ * Built once and cached (the extension set is static for the app's lifetime).
+ */
+export function collabProseSchema(): Schema {
+  if (!cachedSchema) {
+    cachedSchema = getSchema([
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3, 4, 5, 6] },
+        codeBlock: false,
+        history: false,
+      }),
+      ...sharedProseExtensions,
+    ]);
+  }
+  return cachedSchema;
+}
+
+/**
+ * `true` if the fragment builds into a schema-valid ProseMirror doc the live
+ * editor can render; `false` if building or validation throws (the caller should
+ * fall back to read-only `ProsePreview`). Read-only: builds a throwaway PM node,
+ * never mutates the Y.Doc.
+ */
+export function isFragmentRenderable(ydoc: YDoc, field: string): boolean {
+  try {
+    const frag = ydoc.getXmlFragment(field);
+    // An empty fragment is trivially fine: the live editor seeds an empty
+    // paragraph itself, so don't reject it here (the bare `doc` would fail its
+    // `block+` content rule). The panel only mounts on an empty fragment once
+    // the relay has confirmed it (`isSynced`).
+    if (frag.length === 0) return true;
+    const root = yXmlFragmentToProseMirrorRootNode(frag, collabProseSchema());
+    // `check()` recurses the whole tree, asserting content expressions and atom
+    // constraints — the exact violations that crash NodeView reconciliation.
+    root.check();
+    return true;
+  } catch (err) {
+    console.warn(
+      `[prose] fragment "${field}" failed the schema pre-check; rendering read-only`,
+      err,
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Why

A single schema-invalid prose node could blank the **whole page**. For a relay
doc the editor adopts the authoritative Y.Doc fragment, and y-prosemirror builds
the ProseMirror doc straight from it — **bypassing Tiptap's content parser** — so
a node the client schema can't reconcile throws "Cannot read properties of
undefined (reading 'children')" *during render* and unmounts the editor. The
JP-319 `ProseErrorBoundary` only *caught* that crash and showed an empty panel —
contained, but still broken. Blank = broken.

## What

Two composing layers, both leaning on the **HTML projection** (`richTextPages`),
which renders crash-safe through `ProsePreview` (ProseMirror's `DOMParser` is
lenient and fits-to-schema, never throws):

- **1b — the guarantee.** `ProseErrorBoundary` takes a `fallbackHtml` and renders
  it read-only via `ProsePreview` on catch, with a non-blocking Retry/Reload
  banner. Even an unforeseen render crash shows the user's content — never blank.
- **1a — the optimization.** `proseFragmentCheck.isFragmentRenderable` pre-flights
  the bound fragment (`yXmlFragmentToProseMirrorRootNode(...).check()`) before
  mounting the live editor; on failure the panel renders `ProsePreview` instead,
  avoiding the crash-then-recover flash and console noise. Empty fragments are
  trivially renderable (the live editor seeds its own empty paragraph).

`onContentError` is not usable here — it doesn't fire for the y-prosemirror
fragment path (confirmed in `node_modules`). Post-mount sync-time corruption is
prevented *upstream* by the relay write gate (JP-328, PR #234), so the two
pillars compose to full coverage. The read-only fallback is the legacy-only floor.

## Tests

- `proseFragmentCheck.test.ts` — valid / empty / unknown-type / atom-with-children.
- `ProseErrorBoundary.test.tsx` — reworked to assert the **content** renders on
  crash (never blank) + auto-reset.
- 2349 client tests green, typecheck clean.

Assisted-by: Opus 4.8