### PR TITLE
JP-328: add the docushark.get_skills MCP tool (Pillar 3)

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -93,6 +93,7 @@ All tools are namespaced `docushark.*`.
 | `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
 | `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |
 | `list_fields` | The document's fields (reusable `{{name}}` values) in display order, each `{ name, value }`. |
+| `get_skills` | Agent onboarding: with no args, the **content contract** (rules for valid prose + shapes) plus a recipe catalogue; with `{ skill }`, that recipe's full steps. Call it first if unsure how a tool expects its input — authoring valid content avoids the relay having to heal it. |
 
 ### Author
 

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -16,6 +16,7 @@ pub mod layout;
 pub mod local_mirror;
 pub mod outline;
 pub mod route;
+pub mod skills;
 pub mod token;
 pub mod tools;
 pub mod transport;

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -1,0 +1,155 @@
+//! Agent guidance for the MCP surface (JP-328, Pillar 3).
+//!
+//! Powers the `docushark.get_skills` tool. Agents that don't already know the
+//! DocuShark recipes tend to fire malformed tool calls — most damagingly
+//! malformed prose, the exact class the write gate (JP-328) has to heal. This
+//! module gives them the rules up front: a hand-authored **content contract**
+//! (what valid prose / shape input looks like) plus the repeatable **recipes**.
+//!
+//! **Traversal-safe by construction.** The recipe bodies are embedded at compile
+//! time via `include_str!` into a fixed, closed table (`SKILLS`). A `skill`
+//! argument is only ever *matched against* that table — it is never used to build
+//! a filesystem path, so there is no path-traversal surface at all (no `..`, no
+//! symlink, no disk read on the request path). The vendored copies under
+//! `skills/` are kept honest against the canonical top-level `skills/` by
+//! `vendored_skills_match_source` in the test module.
+
+use serde_json::{json, Value};
+
+/// The valid-content contract, surfaced so an agent authors schema-valid prose
+/// and shapes the first time instead of relying on the relay to heal it. Kept in
+/// lockstep with `sync::prose_validate` (the write gate) and the client prose
+/// schema (`proseSchemaContract.test.ts`).
+pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before writing)
+
+## Prose (set_prose / add_prose_page / insert_section)
+- Pass Markdown by default, or well-formed HTML with format:"html".
+- Allowed block types only: paragraph, heading (h1-h6), bulletList/orderedList
+  (with listItem), blockquote, codeBlock, table, horizontalRule, image, figure
+  (with figcaption), callout, gallery. Anything else is unwrapped to its text.
+- Atoms carry NO children: image, horizontalRule, hardBreak, an inline citation,
+  a field reference. Never nest content inside them.
+- Every <img> needs a real src (a blob:, https:, or data: URL). A src-less image
+  is dropped — it would crash the editor.
+- Tables must be rectangular: a <table> of <tr> rows, each row the same number of
+  <td>/<th> cells, every cell holding block content. Ragged tables are padded.
+- A page is never truly empty; an empty write leaves one empty paragraph.
+
+## Shapes (generate_diagram / add_shape / connect)
+- Prefer generate_diagram for anything with edges: pass nodes [{id,label,kind?}]
+  and edges [{from,to,label?}] and let the relay lay it out. Don't hand-place
+  coordinates — it fights the router.
+- Shape ids must be unique; every edge endpoint must name an existing node id.
+- Styling is inline per shape ({fill,stroke,strokeWidth,labelColor} or "AUTO").
+
+If a write still reports a `fixes` diff, it means the relay had to heal your
+input — read the diff, fix the source, and re-send so nothing is lost."#;
+
+/// `(slug, when-to-use, full SKILL.md body)`. Bodies embedded at compile time —
+/// a fixed set, so `skill_body` can only ever return one of these (no fs lookup).
+const SKILLS: &[(&str, &str, &str)] = &[
+    (
+        "architecture-rfc",
+        "Author an architecture/design RFC with a system diagram.",
+        include_str!("skills/architecture-rfc.SKILL.md"),
+    ),
+    (
+        "document-codebase-module",
+        "Document a code module: prose walkthrough plus a component diagram.",
+        include_str!("skills/document-codebase-module.SKILL.md"),
+    ),
+    (
+        "diagram-from-description",
+        "Turn a described system/sequence into a clean, auto-laid-out diagram.",
+        include_str!("skills/diagram-from-description.SKILL.md"),
+    ),
+    (
+        "meeting-notes-to-doc",
+        "Turn raw notes into a structured, outlined document.",
+        include_str!("skills/meeting-notes-to-doc.SKILL.md"),
+    ),
+];
+
+/// The catalogue (slug + when-to-use for every recipe) plus the content
+/// contract — what `get_skills` returns with no `skill` argument.
+pub fn catalogue_json() -> Value {
+    let skills: Vec<Value> = SKILLS
+        .iter()
+        .map(|(slug, when, _)| json!({ "skill": slug, "whenToUse": when }))
+        .collect();
+    json!({
+        "skills": skills,
+        "contentContract": CONTENT_CONTRACT,
+        "hint": "Call get_skills with { skill: \"<slug>\" } for a recipe's full steps.",
+    })
+}
+
+/// The full SKILL.md body for `slug`, or `None` if it isn't one of the fixed
+/// recipes. A plain table match — `slug` never touches the filesystem.
+pub fn skill_body(slug: &str) -> Option<&'static str> {
+    SKILLS
+        .iter()
+        .find(|(s, _, _)| *s == slug)
+        .map(|(_, _, body)| *body)
+}
+
+/// Comma-separated valid slugs, for an educational error on an unknown name.
+pub fn valid_slugs() -> String {
+    SKILLS
+        .iter()
+        .map(|(s, _, _)| *s)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogue_lists_every_recipe_and_the_contract() {
+        let cat = catalogue_json();
+        let skills = cat["skills"].as_array().unwrap();
+        assert_eq!(skills.len(), SKILLS.len());
+        assert!(cat["contentContract"].as_str().unwrap().contains("content contract"));
+    }
+
+    #[test]
+    fn known_slug_returns_its_body() {
+        let body = skill_body("diagram-from-description").unwrap();
+        assert!(body.contains("generate_diagram"), "expected the recipe body");
+    }
+
+    #[test]
+    fn unknown_and_traversal_slugs_return_none() {
+        // The whole point: a `skill` argument can never escape the fixed table.
+        assert!(skill_body("nope").is_none());
+        assert!(skill_body("../../../../etc/passwd").is_none());
+        assert!(skill_body("..%2f..%2fetc%2fpasswd").is_none());
+        assert!(skill_body("architecture-rfc/../meeting-notes-to-doc").is_none());
+        assert!(skill_body("").is_none());
+    }
+
+    #[test]
+    fn vendored_skills_match_source() {
+        // Keep the vendored copies honest: each must byte-match the canonical
+        // top-level skills/. Skips when the source tree isn't present (e.g. the
+        // relay-only Docker build context), so it never breaks a hermetic build —
+        // it only catches drift in dev / CI, where the full repo is checked out.
+        use std::path::Path;
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../skills");
+        if !root.exists() {
+            return;
+        }
+        for (slug, _, vendored) in SKILLS {
+            let src = root.join(slug).join("SKILL.md");
+            let source = std::fs::read_to_string(&src)
+                .unwrap_or_else(|e| panic!("reading canonical {src:?}: {e}"));
+            assert_eq!(
+                source, *vendored,
+                "vendored relay/src/mcp/skills/{slug}.SKILL.md has drifted from \
+                 skills/{slug}/SKILL.md — re-copy it",
+            );
+        }
+    }
+}

--- a/relay/src/mcp/skills/architecture-rfc.SKILL.md
+++ b/relay/src/mcp/skills/architecture-rfc.SKILL.md
@@ -1,0 +1,77 @@
+---
+name: docushark-architecture-rfc
+description: Use when the user wants to write an architecture RFC, design doc, or system-design proposal in DocuShark — a prose document plus a system diagram of the components. Requires the DocuShark MCP server to be connected.
+---
+
+# Author an architecture RFC in DocuShark
+
+Produce a design document with a written RFC and an auto-laid-out system diagram,
+using the DocuShark MCP tools. Work in one **team** document (MCP can't write
+local documents).
+
+## Steps
+
+1. **Create the document.** Call `create_document` with a clear `name`
+   (e.g. `"RFC: <system> architecture"`). Keep the returned `id` — it's `docId`
+   for every later call.
+
+2. **Find the pages.** Call `get_document(docId)`. It returns `pages` (canvas pages,
+   each `{ id, name, shapeCount }`) and `prosePages` (each `{ id, name, order }`).
+   Use the first prose page's id for writing and the first canvas page's id for the
+   diagram.
+
+3. **Write the RFC skeleton.** Call `set_prose(docId, prosePageId, content)` with
+   Markdown. Use a standard RFC shape and `{{field}}` tokens for values that recur:
+
+   ```markdown
+   # Architecture RFC: {{System}}
+
+   **Status:** Draft · **Author:** {{Author}}
+
+   ## Context & Problem
+   ## Goals / Non-Goals
+   ## Proposed Architecture
+   ## Alternatives Considered
+   ## Risks & Open Questions
+   ```
+
+   Then set the field values once with `set_fields(docId, [{name:"System", value:"…"}, …])`.
+
+4. **Draft each section.** Fill sections from what the user told you. To edit just
+   one section later without touching the rest, call `set_prose` with an `anchor`
+   set to the exact current text of the block you're replacing (it's a
+   compare-and-swap; if it matches none/several you get an `ERR_ANCHOR_*` error —
+   read the page with `get_prose` and copy the block text). Use
+   `insert_section(docId, prosePageId, level, title, body)` to add a heading+body,
+   and `restructure_outline` (`promote`/`demote`/`move` by heading index from
+   `get_outline`) to reorganize.
+
+5. **Build the system diagram.** Call `generate_diagram(docId, canvasPageId, nodes, edges)`:
+   - `nodes`: `[{ id, label, kind }]` — `id` is your logical id, `label` is the text,
+     `kind` is `"rectangle"` (default) or `"ellipse"` (use ellipse for external
+     actors/agents).
+   - `edges`: `[{ from, to, label }]` referencing node `id`s.
+   - Keep `layout: "layered"` and `routing: "orthogonal"` (the defaults) — the relay
+     does Sugiyama layering + obstacle-avoiding routing, so don't pass coordinates.
+
+   It returns `{ nodes: { <yourId>: <shapeId> }, edges: [<connectorId>], layout, routing }`.
+   Keep the `nodes` map if you later need to tweak a specific shape with
+   `update_shape`.
+
+6. **Tie prose to the diagram.** In "Proposed Architecture", describe each node you
+   created so the reader can match the prose to the picture.
+
+7. **Confirm.** Call `get_document(docId)` and check the canvas page's `shapeCount`
+   grew (nodes + connectors) and the prose page exists. Give the user the document
+   `id`/name.
+
+## Tips
+
+- **Styling is inline.** To color a component, set it per shape (in `add_shape`/
+  `update_shape` via `style: { fill, stroke, strokeWidth, labelColor }`, or `"AUTO"`
+  for contrast-aware). There is no saved style-profile to reference over MCP.
+- Prefer `generate_diagram` over hand-placing shapes — you get clean layout +
+  routing for free. Use `add_shapes`/`connect` only for shapes the graph model can't
+  express.
+- Keep diagrams legible: ~5–12 nodes. Split a large system into multiple canvas
+  pages rather than one dense graph.

--- a/relay/src/mcp/skills/diagram-from-description.SKILL.md
+++ b/relay/src/mcp/skills/diagram-from-description.SKILL.md
@@ -1,0 +1,55 @@
+---
+name: docushark-diagram-from-description
+description: Use when the user describes a system, flow, or sequence in words and wants it turned into a clean diagram in DocuShark (architecture, flowchart, dependency graph, or sequence-style flow). Requires the DocuShark MCP server to be connected.
+---
+
+# Generate a diagram from a description in DocuShark
+
+Convert a plain-language description into an auto-laid-out diagram. The relay does
+all positioning and routing — your job is to model the description as a graph of
+**nodes** and **edges**. Work in one **team** document.
+
+## Steps
+
+1. **Model the description as a graph.** Extract:
+   - **Nodes** — the things (services, steps, states, participants). Give each a
+     short stable `id` and a human `label`.
+     Mark anything external/an actor as `kind: "ellipse"`; everything else is a
+     `"rectangle"`.
+   - **Edges** — the relationships/messages/transitions, each `{ from, to, label }`
+     by node `id`. Direction matters: it drives the layout and the arrowhead.
+   - For a **sequence/flow**, order the edges as the steps happen (1→2→3…); the
+     layered layout reads top-to-bottom along edge direction.
+
+2. **Create or reuse a document.** `create_document` (keep the `id`), or use an
+   existing team `docId` the user names. Get a canvas page id from
+   `get_document(docId).pages[0].id`.
+
+3. **Generate the diagram.**
+   `generate_diagram(docId, canvasPageId, nodes, edges, layout, routing)`:
+   - `nodes`: `[{ id, label, kind? }]` (unique ids; min 1; up to 500).
+   - `edges`: `[{ from, to, label? }]` (up to 1000; every endpoint must name a node).
+   - `layout`: `"layered"` (default with edges — best for flow/architecture/sequence)
+     or `"grid"` (for an unconnected set of nodes).
+   - `routing`: `"orthogonal"` (default — right-angle paths around shapes, with
+     waypoints) or `"straight"` (plain lines).
+   - Returns `{ nodes: { id: shapeId }, edges: [connectorId], layout, routing }`.
+
+4. **Refine if asked.** To rename/recolor/resize a specific node, look up its shape
+   id in the returned `nodes` map and call `update_shape(docId, canvasPageId, id,
+   patch)` with a subset of `{ x, y, w, h, text, style }`. To add a stray connector
+   the graph missed, use `connect(docId, canvasPageId, fromId, toId, label)`.
+
+5. **Confirm.** `get_page(docId, canvasPageId)` to see the placed shapes, or
+   `get_document` to check `shapeCount`. Report what you drew.
+
+## Tips
+
+- **Don't pass coordinates.** Let `generate_diagram` lay things out; hand-placing
+  fights the router. Only `update_shape` x/y for deliberate nudges.
+- Parallel edges between the same two nodes are automatically staggered, and
+  self-loops get a clean path — model them naturally.
+- Styling is inline per shape (`style: { fill, stroke, strokeWidth, labelColor }`,
+  or `"AUTO"`). There's no saved style-profile over MCP.
+- If the description is really two diagrams (e.g. a high-level map + a detailed
+  sequence), make two and put each on its own canvas page for legibility.

--- a/relay/src/mcp/skills/document-codebase-module.SKILL.md
+++ b/relay/src/mcp/skills/document-codebase-module.SKILL.md
@@ -1,0 +1,71 @@
+---
+name: docushark-document-codebase-module
+description: Use when the user wants to document a code module, service, or package in DocuShark — a prose walkthrough of its responsibilities and APIs plus a component diagram showing how the pieces relate. Requires the DocuShark MCP server to be connected.
+---
+
+# Document a codebase module in DocuShark
+
+Turn your understanding of a module (from reading its code) into a DocuShark
+document: a prose reference plus a component diagram. Work in one **team** document.
+
+## Steps
+
+1. **Gather the facts first.** From the code, identify: the module's purpose, its
+   main components (files/classes/functions), each component's responsibility, the
+   public API/entry points, and the dependencies *between* components (who calls
+   whom). You'll turn the "who calls whom" into diagram edges.
+
+2. **Create the document.** `create_document` with `name` like
+   `"<module> — module reference"`. Keep the `id` (`docId`).
+
+3. **Get the page ids.** `get_document(docId)` → take the first `prosePages[].id`
+   (prose) and the first `pages[].id` (canvas).
+
+4. **Write the reference.** `set_prose(docId, prosePageId, content)` in Markdown:
+
+   ```markdown
+   # {{Module}} — Module Reference
+
+   ## Overview
+   One paragraph: what it does and where it sits.
+
+   ## Components
+   | Component | Responsibility | Key API |
+   |---|---|---|
+   | … | … | … |
+
+   ## Data / Control Flow
+   How a request moves through the components (mirrors the diagram).
+
+   ## Gotchas
+   - …
+   ```
+
+   Use a GFM table for the component list (tables are supported). Set
+   `{{Module}}` with `set_fields`.
+
+5. **Draw the component diagram.** `generate_diagram(docId, canvasPageId, nodes, edges)`:
+   - One `node` per component: `{ id, label }` (use the component name as `label`).
+   - One `edge` per dependency: `{ from, to, label }` where `label` is the relationship
+     ("calls", "reads", "emits"). Edge direction = caller → callee.
+   - Leave `layout: "layered"` / `routing: "orthogonal"` (defaults) so the relay
+     lays it out by dependency direction.
+
+   It returns `{ nodes: { id: shapeId }, edges: [connectorId], … }`.
+
+6. **Cross-link.** In "Data / Control Flow", reference the same component names so
+   the prose and the diagram describe the same thing.
+
+7. **Verify.** `get_document(docId)` — the canvas page `shapeCount` should equal
+   components + dependencies. Return the document id/name.
+
+## Tips
+
+- If the module has distinct layers (e.g. API / core / storage), color them inline
+  per shape (`style.fill`) via `update_shape` after `generate_diagram`, using the
+  returned `nodes` map to find each shape id. There's no saved style-profile over
+  MCP, so set colors inline.
+- Keep one diagram per cohesive view. For a big module, make a high-level component
+  diagram on page 1 and a detailed sub-flow on another canvas page.
+- For an external dependency (a third-party service), use `kind: "ellipse"` to
+  visually distinguish it from in-module components.

--- a/relay/src/mcp/skills/meeting-notes-to-doc.SKILL.md
+++ b/relay/src/mcp/skills/meeting-notes-to-doc.SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docushark-meeting-notes-to-doc
+description: Use when the user has raw meeting notes, a transcript, or a brain-dump and wants a clean, structured DocuShark document — summary, decisions, action items, and an organized outline. Requires the DocuShark MCP server to be connected.
+---
+
+# Turn meeting notes into a structured document in DocuShark
+
+Convert messy notes into a well-organized prose document with a clear outline. Work
+in one **team** document. This recipe is prose-only (no diagram) unless the notes
+clearly describe a flow worth drawing.
+
+## Steps
+
+1. **Read and classify the notes.** Separate the raw input into: a one-paragraph
+   **summary**, **decisions made**, **action items** (owner + what + when),
+   **discussion** by topic, and **open questions**.
+
+2. **Create the document.** `create_document` with a descriptive `name`
+   (e.g. `"<topic> — <date> notes"`). Keep the `id`. Get the first prose page id
+   from `get_document(docId).prosePages[0].id`.
+
+3. **Write the structured page.** `set_prose(docId, prosePageId, content)` in
+   Markdown. Put the high-value parts first:
+
+   ```markdown
+   # {{Title}}
+
+   **Date:** {{Date}} · **Attendees:** {{Attendees}}
+
+   ## Summary
+   …
+
+   ## Decisions
+   - …
+
+   ## Action Items
+   - [ ] **@owner** — task — _due …_
+
+   ## Discussion
+   ### <Topic 1>
+   …
+
+   ## Open Questions
+   - …
+   ```
+
+   Use task-list checkboxes (`- [ ]`) for action items (supported), and set
+   `{{Title}}`/`{{Date}}`/`{{Attendees}}` with `set_fields`.
+
+4. **Organize the discussion.** Add one `### <Topic>` per discussion thread. If you
+   write topics out of order, fix the structure with the outline tools rather than
+   rewriting the page:
+   - `get_outline(docId, prosePageId)` → the flat list of headings with their
+     `index` and `level`.
+   - `restructure_outline(docId, prosePageId, op, index, toIndex?)` to
+     `move` / `promote` / `demote` a section.
+   - `insert_section(docId, prosePageId, level, title, body, afterIndex?)` to slot a
+     new section in a specific spot.
+
+5. **Refine a single section** without touching the rest by calling `set_prose`
+   with `anchor` = the exact current text of the block to replace (read it first
+   with `get_prose`; it's a compare-and-swap that errors rather than clobbering if
+   ambiguous).
+
+6. **Confirm.** `get_prose(docId, prosePageId)` to review, then return the document
+   id/name and a one-line recap (e.g. "3 decisions, 5 action items").
+
+## Tips
+
+- Lead with **Decisions** and **Action Items** — they're what people reopen the doc
+  for. Keep "Discussion" as the supporting detail.
+- Prose is Markdown (GFM): use tables for attendee/owner grids, headings for the
+  outline, and `{{fields}}` for values you'll reuse across related docs.
+- Each write replaces the whole page unless you use `anchor`; for incremental
+  additions during a long meeting, prefer `insert_section` or anchored `set_prose`
+  so you don't overwrite earlier content.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -167,7 +167,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.add_prose_page",
             description:
-                "Add a new prose page to a document and return its id. Content is Markdown by default (set format:\"html\" to pass HTML through). Use this to start a new section/chapter of the written document.",
+                "Add a new prose page to a document and return its id. Content is Markdown by default (set format:\"html\" to pass HTML through). Use this to start a new section/chapter of the written document. Unsure what valid content looks like? Call get_skills first for the content contract.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -183,7 +183,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.set_prose",
             description:
-                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents.",
+                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents. Unsure what valid content looks like? Call get_skills first for the content contract.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -528,6 +528,18 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "additionalProperties": false
             }),
         },
+        ToolDescriptor {
+            name: "docushark.get_skills",
+            description:
+                "Learn how to drive DocuShark before writing. With no arguments, returns the content contract (the rules for valid prose + shapes, so your writes aren't malformed) and a catalogue of recipes. Pass {skill:\"<slug>\"} for a recipe's full steps. Call this first if you're unsure how a tool expects its input.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "skill": {"type": "string", "description": "A recipe slug from the catalogue. Omit to get the contract + catalogue."}
+                },
+                "additionalProperties": false
+            }),
+        },
     ]
 }
 
@@ -641,10 +653,49 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.add_reference" => add_reference(ctx, args),
         "docushark.list_fields" => list_fields(ctx, args),
         "docushark.set_fields" => set_fields(ctx, args),
+        "docushark.get_skills" => get_skills(args),
         // docushark.resolve_doi is resolved async in the transport layer before
         // dispatch (it needs a network call); it never reaches this match.
         _ => Err(format!("Unknown tool: {}", name)),
     }
+}
+
+#[derive(Deserialize, Default)]
+struct GetSkillsArgs {
+    skill: Option<String>,
+}
+
+/// `docushark.get_skills` — agent guidance (JP-328). No `skill`: the content
+/// contract + recipe catalogue. With `skill`: that recipe's full body. Pure
+/// static content (no document, no filesystem), so it takes no `ToolContext`
+/// and the `skill` argument is matched against a fixed table — there is no path
+/// to traverse.
+fn get_skills(args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: GetSkillsArgs = if args.is_null() {
+        GetSkillsArgs::default()
+    } else {
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?
+    };
+
+    let result = match parsed.skill.as_deref().filter(|s| !s.is_empty()) {
+        None => super::skills::catalogue_json(),
+        Some(slug) => match super::skills::skill_body(slug) {
+            Some(body) => json!({ "skill": slug, "content": body }),
+            None => {
+                return Err(format!(
+                    "ERR_SKILL_NOT_FOUND: no skill named {slug:?}. Valid skills: {}. \
+                     Call get_skills with no arguments for the catalogue + content contract.",
+                    super::skills::valid_slugs()
+                ))
+            }
+        },
+    };
+
+    Ok(ToolOutcome {
+        result,
+        changed_doc_id: None,
+        change_detail: None,
+    })
 }
 
 /// Look up a document across team + local sources. Returns the document

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -772,7 +772,8 @@ mod tests {
         assert!(names.contains(&"docushark.add_reference"));
         assert!(names.contains(&"docushark.list_fields"));
         assert!(names.contains(&"docushark.set_fields"));
-        assert_eq!(tools.len(), 26);
+        assert!(names.contains(&"docushark.get_skills"));
+        assert_eq!(tools.len(), 27);
     }
 
     #[tokio::test]

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -116,6 +116,42 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         .filter_map(|t| t["name"].as_str())
         .collect();
     assert!(names.contains(&"docushark.create_document"), "{names:?}");
+    assert!(names.contains(&"docushark.get_skills"), "get_skills must be advertised: {names:?}");
+
+    // JP-328: get_skills (no args) returns the content contract + catalogue.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 10, "method": "tools/call",
+            "params": {"name": "docushark.get_skills", "arguments": {}}
+        }))
+        .send()
+        .await
+        .expect("get_skills post");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.expect("skills json");
+    let sc = &body["result"]["structuredContent"];
+    assert!(
+        sc["contentContract"].as_str().unwrap_or("").contains("content contract"),
+        "get_skills must surface the content contract: {body}"
+    );
+    assert!(sc["skills"].as_array().is_some_and(|a| !a.is_empty()), "catalogue: {body}");
+
+    // JP-328: a traversal-style skill name is just an unknown slug — there is no
+    // filesystem lookup, so it can only ever be a clean ERR_SKILL_NOT_FOUND.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 11, "method": "tools/call",
+            "params": {"name": "docushark.get_skills", "arguments": {"skill": "../../../../etc/passwd"}}
+        }))
+        .send()
+        .await
+        .expect("get_skills traversal post");
+    let body: serde_json::Value = resp.json().await.expect("skills err json");
+    assert_eq!(body["result"]["isError"], json!(true), "traversal name must error cleanly: {body}");
 
     // JP-235 (1): a write authenticated as `ws-public` routes the coarse reload
     // nudge to *that* workspace, not the catch-all `single_tenant()`.


### PR DESCRIPTION
## Why

Agents that don't already know the DocuShark recipes fire **malformed tool
calls** — most damagingly malformed prose, the exact class the write gate
(JP-328, PR #234) has to heal. `get_skills` gives them the rules up front so
they author valid content the first time instead of relying on the relay to fix it.

## What

- **No args** → the **content contract** (valid prose + shape rules, kept in
  lockstep with the write gate `sync::prose_validate` and the client prose
  schema) plus a recipe catalogue.
- **`{ skill: "<slug>" }`** → that recipe's full `SKILL.md` body.

### Traversal-safe by construction

Recipe bodies are embedded at compile time (`include_str!`) into a **fixed,
closed table**, and the `skill` argument is only ever *matched against* that
table — never used to build a filesystem path. There is **no disk read on the
request path**, so there is no path-traversal surface at all. An unknown slug
(including a `"../.."` string) is a clean `ERR_SKILL_NOT_FOUND`. Lean: no new
deps, no `build.rs`, no runtime fs.

### Why vendored copies

The skills live at the repo-root `skills/`, which is **outside the relay's
Docker build context** (`docker build -f relay/Dockerfile relay/`). So they're
vendored under `relay/src/mcp/skills/` (inside the context) and kept honest by a
**drift test** that byte-compares against the canonical `skills/` copies (skipped
when the source tree is absent, e.g. a relay-only build). **No Dockerfile / CI /
deploy change.**

Also points the prose-write tool descriptions at `get_skills` and documents it in
`relay/docs/mcp/README.md`.

## Tests

- `mcp::skills` — catalogue / known-slug / **traversal-rejection** / drift guard.
- `public_mcp` E2E — advertised over `/mcp`, catalogue returned, traversal name
  errors cleanly.
- transport tool-count bumped (26 → 27).
- 436 relay tests green.

Assisted-by: Opus 4.8