### PR TITLE
Deploy to staging: JP-328 prose/MCP defense (never-blank + write gate + get_skills)

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -93,6 +93,7 @@ All tools are namespaced `docushark.*`.
 | `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
 | `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |
 | `list_fields` | The document's fields (reusable `{{name}}` values) in display order, each `{ name, value }`. |
+| `get_skills` | Agent onboarding: with no args, the **content contract** (rules for valid prose + shapes) plus a recipe catalogue; with `{ skill }`, that recipe's full steps. Call it first if unsure how a tool expects its input — authoring valid content avoids the relay having to heal it. |
 
 ### Author
 

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -16,6 +16,7 @@ pub mod layout;
 pub mod local_mirror;
 pub mod outline;
 pub mod route;
+pub mod skills;
 pub mod token;
 pub mod tools;
 pub mod transport;

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -1,0 +1,155 @@
+//! Agent guidance for the MCP surface (JP-328, Pillar 3).
+//!
+//! Powers the `docushark.get_skills` tool. Agents that don't already know the
+//! DocuShark recipes tend to fire malformed tool calls — most damagingly
+//! malformed prose, the exact class the write gate (JP-328) has to heal. This
+//! module gives them the rules up front: a hand-authored **content contract**
+//! (what valid prose / shape input looks like) plus the repeatable **recipes**.
+//!
+//! **Traversal-safe by construction.** The recipe bodies are embedded at compile
+//! time via `include_str!` into a fixed, closed table (`SKILLS`). A `skill`
+//! argument is only ever *matched against* that table — it is never used to build
+//! a filesystem path, so there is no path-traversal surface at all (no `..`, no
+//! symlink, no disk read on the request path). The vendored copies under
+//! `skills/` are kept honest against the canonical top-level `skills/` by
+//! `vendored_skills_match_source` in the test module.
+
+use serde_json::{json, Value};
+
+/// The valid-content contract, surfaced so an agent authors schema-valid prose
+/// and shapes the first time instead of relying on the relay to heal it. Kept in
+/// lockstep with `sync::prose_validate` (the write gate) and the client prose
+/// schema (`proseSchemaContract.test.ts`).
+pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before writing)
+
+## Prose (set_prose / add_prose_page / insert_section)
+- Pass Markdown by default, or well-formed HTML with format:"html".
+- Allowed block types only: paragraph, heading (h1-h6), bulletList/orderedList
+  (with listItem), blockquote, codeBlock, table, horizontalRule, image, figure
+  (with figcaption), callout, gallery. Anything else is unwrapped to its text.
+- Atoms carry NO children: image, horizontalRule, hardBreak, an inline citation,
+  a field reference. Never nest content inside them.
+- Every <img> needs a real src (a blob:, https:, or data: URL). A src-less image
+  is dropped — it would crash the editor.
+- Tables must be rectangular: a <table> of <tr> rows, each row the same number of
+  <td>/<th> cells, every cell holding block content. Ragged tables are padded.
+- A page is never truly empty; an empty write leaves one empty paragraph.
+
+## Shapes (generate_diagram / add_shape / connect)
+- Prefer generate_diagram for anything with edges: pass nodes [{id,label,kind?}]
+  and edges [{from,to,label?}] and let the relay lay it out. Don't hand-place
+  coordinates — it fights the router.
+- Shape ids must be unique; every edge endpoint must name an existing node id.
+- Styling is inline per shape ({fill,stroke,strokeWidth,labelColor} or "AUTO").
+
+If a write still reports a `fixes` diff, it means the relay had to heal your
+input — read the diff, fix the source, and re-send so nothing is lost."#;
+
+/// `(slug, when-to-use, full SKILL.md body)`. Bodies embedded at compile time —
+/// a fixed set, so `skill_body` can only ever return one of these (no fs lookup).
+const SKILLS: &[(&str, &str, &str)] = &[
+    (
+        "architecture-rfc",
+        "Author an architecture/design RFC with a system diagram.",
+        include_str!("skills/architecture-rfc.SKILL.md"),
+    ),
+    (
+        "document-codebase-module",
+        "Document a code module: prose walkthrough plus a component diagram.",
+        include_str!("skills/document-codebase-module.SKILL.md"),
+    ),
+    (
+        "diagram-from-description",
+        "Turn a described system/sequence into a clean, auto-laid-out diagram.",
+        include_str!("skills/diagram-from-description.SKILL.md"),
+    ),
+    (
+        "meeting-notes-to-doc",
+        "Turn raw notes into a structured, outlined document.",
+        include_str!("skills/meeting-notes-to-doc.SKILL.md"),
+    ),
+];
+
+/// The catalogue (slug + when-to-use for every recipe) plus the content
+/// contract — what `get_skills` returns with no `skill` argument.
+pub fn catalogue_json() -> Value {
+    let skills: Vec<Value> = SKILLS
+        .iter()
+        .map(|(slug, when, _)| json!({ "skill": slug, "whenToUse": when }))
+        .collect();
+    json!({
+        "skills": skills,
+        "contentContract": CONTENT_CONTRACT,
+        "hint": "Call get_skills with { skill: \"<slug>\" } for a recipe's full steps.",
+    })
+}
+
+/// The full SKILL.md body for `slug`, or `None` if it isn't one of the fixed
+/// recipes. A plain table match — `slug` never touches the filesystem.
+pub fn skill_body(slug: &str) -> Option<&'static str> {
+    SKILLS
+        .iter()
+        .find(|(s, _, _)| *s == slug)
+        .map(|(_, _, body)| *body)
+}
+
+/// Comma-separated valid slugs, for an educational error on an unknown name.
+pub fn valid_slugs() -> String {
+    SKILLS
+        .iter()
+        .map(|(s, _, _)| *s)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogue_lists_every_recipe_and_the_contract() {
+        let cat = catalogue_json();
+        let skills = cat["skills"].as_array().unwrap();
+        assert_eq!(skills.len(), SKILLS.len());
+        assert!(cat["contentContract"].as_str().unwrap().contains("content contract"));
+    }
+
+    #[test]
+    fn known_slug_returns_its_body() {
+        let body = skill_body("diagram-from-description").unwrap();
+        assert!(body.contains("generate_diagram"), "expected the recipe body");
+    }
+
+    #[test]
+    fn unknown_and_traversal_slugs_return_none() {
+        // The whole point: a `skill` argument can never escape the fixed table.
+        assert!(skill_body("nope").is_none());
+        assert!(skill_body("../../../../etc/passwd").is_none());
+        assert!(skill_body("..%2f..%2fetc%2fpasswd").is_none());
+        assert!(skill_body("architecture-rfc/../meeting-notes-to-doc").is_none());
+        assert!(skill_body("").is_none());
+    }
+
+    #[test]
+    fn vendored_skills_match_source() {
+        // Keep the vendored copies honest: each must byte-match the canonical
+        // top-level skills/. Skips when the source tree isn't present (e.g. the
+        // relay-only Docker build context), so it never breaks a hermetic build —
+        // it only catches drift in dev / CI, where the full repo is checked out.
+        use std::path::Path;
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../skills");
+        if !root.exists() {
+            return;
+        }
+        for (slug, _, vendored) in SKILLS {
+            let src = root.join(slug).join("SKILL.md");
+            let source = std::fs::read_to_string(&src)
+                .unwrap_or_else(|e| panic!("reading canonical {src:?}: {e}"));
+            assert_eq!(
+                source, *vendored,
+                "vendored relay/src/mcp/skills/{slug}.SKILL.md has drifted from \
+                 skills/{slug}/SKILL.md — re-copy it",
+            );
+        }
+    }
+}

--- a/relay/src/mcp/skills/architecture-rfc.SKILL.md
+++ b/relay/src/mcp/skills/architecture-rfc.SKILL.md
@@ -1,0 +1,77 @@
+---
+name: docushark-architecture-rfc
+description: Use when the user wants to write an architecture RFC, design doc, or system-design proposal in DocuShark — a prose document plus a system diagram of the components. Requires the DocuShark MCP server to be connected.
+---
+
+# Author an architecture RFC in DocuShark
+
+Produce a design document with a written RFC and an auto-laid-out system diagram,
+using the DocuShark MCP tools. Work in one **team** document (MCP can't write
+local documents).
+
+## Steps
+
+1. **Create the document.** Call `create_document` with a clear `name`
+   (e.g. `"RFC: <system> architecture"`). Keep the returned `id` — it's `docId`
+   for every later call.
+
+2. **Find the pages.** Call `get_document(docId)`. It returns `pages` (canvas pages,
+   each `{ id, name, shapeCount }`) and `prosePages` (each `{ id, name, order }`).
+   Use the first prose page's id for writing and the first canvas page's id for the
+   diagram.
+
+3. **Write the RFC skeleton.** Call `set_prose(docId, prosePageId, content)` with
+   Markdown. Use a standard RFC shape and `{{field}}` tokens for values that recur:
+
+   ```markdown
+   # Architecture RFC: {{System}}
+
+   **Status:** Draft · **Author:** {{Author}}
+
+   ## Context & Problem
+   ## Goals / Non-Goals
+   ## Proposed Architecture
+   ## Alternatives Considered
+   ## Risks & Open Questions
+   ```
+
+   Then set the field values once with `set_fields(docId, [{name:"System", value:"…"}, …])`.
+
+4. **Draft each section.** Fill sections from what the user told you. To edit just
+   one section later without touching the rest, call `set_prose` with an `anchor`
+   set to the exact current text of the block you're replacing (it's a
+   compare-and-swap; if it matches none/several you get an `ERR_ANCHOR_*` error —
+   read the page with `get_prose` and copy the block text). Use
+   `insert_section(docId, prosePageId, level, title, body)` to add a heading+body,
+   and `restructure_outline` (`promote`/`demote`/`move` by heading index from
+   `get_outline`) to reorganize.
+
+5. **Build the system diagram.** Call `generate_diagram(docId, canvasPageId, nodes, edges)`:
+   - `nodes`: `[{ id, label, kind }]` — `id` is your logical id, `label` is the text,
+     `kind` is `"rectangle"` (default) or `"ellipse"` (use ellipse for external
+     actors/agents).
+   - `edges`: `[{ from, to, label }]` referencing node `id`s.
+   - Keep `layout: "layered"` and `routing: "orthogonal"` (the defaults) — the relay
+     does Sugiyama layering + obstacle-avoiding routing, so don't pass coordinates.
+
+   It returns `{ nodes: { <yourId>: <shapeId> }, edges: [<connectorId>], layout, routing }`.
+   Keep the `nodes` map if you later need to tweak a specific shape with
+   `update_shape`.
+
+6. **Tie prose to the diagram.** In "Proposed Architecture", describe each node you
+   created so the reader can match the prose to the picture.
+
+7. **Confirm.** Call `get_document(docId)` and check the canvas page's `shapeCount`
+   grew (nodes + connectors) and the prose page exists. Give the user the document
+   `id`/name.
+
+## Tips
+
+- **Styling is inline.** To color a component, set it per shape (in `add_shape`/
+  `update_shape` via `style: { fill, stroke, strokeWidth, labelColor }`, or `"AUTO"`
+  for contrast-aware). There is no saved style-profile to reference over MCP.
+- Prefer `generate_diagram` over hand-placing shapes — you get clean layout +
+  routing for free. Use `add_shapes`/`connect` only for shapes the graph model can't
+  express.
+- Keep diagrams legible: ~5–12 nodes. Split a large system into multiple canvas
+  pages rather than one dense graph.

--- a/relay/src/mcp/skills/diagram-from-description.SKILL.md
+++ b/relay/src/mcp/skills/diagram-from-description.SKILL.md
@@ -1,0 +1,55 @@
+---
+name: docushark-diagram-from-description
+description: Use when the user describes a system, flow, or sequence in words and wants it turned into a clean diagram in DocuShark (architecture, flowchart, dependency graph, or sequence-style flow). Requires the DocuShark MCP server to be connected.
+---
+
+# Generate a diagram from a description in DocuShark
+
+Convert a plain-language description into an auto-laid-out diagram. The relay does
+all positioning and routing — your job is to model the description as a graph of
+**nodes** and **edges**. Work in one **team** document.
+
+## Steps
+
+1. **Model the description as a graph.** Extract:
+   - **Nodes** — the things (services, steps, states, participants). Give each a
+     short stable `id` and a human `label`.
+     Mark anything external/an actor as `kind: "ellipse"`; everything else is a
+     `"rectangle"`.
+   - **Edges** — the relationships/messages/transitions, each `{ from, to, label }`
+     by node `id`. Direction matters: it drives the layout and the arrowhead.
+   - For a **sequence/flow**, order the edges as the steps happen (1→2→3…); the
+     layered layout reads top-to-bottom along edge direction.
+
+2. **Create or reuse a document.** `create_document` (keep the `id`), or use an
+   existing team `docId` the user names. Get a canvas page id from
+   `get_document(docId).pages[0].id`.
+
+3. **Generate the diagram.**
+   `generate_diagram(docId, canvasPageId, nodes, edges, layout, routing)`:
+   - `nodes`: `[{ id, label, kind? }]` (unique ids; min 1; up to 500).
+   - `edges`: `[{ from, to, label? }]` (up to 1000; every endpoint must name a node).
+   - `layout`: `"layered"` (default with edges — best for flow/architecture/sequence)
+     or `"grid"` (for an unconnected set of nodes).
+   - `routing`: `"orthogonal"` (default — right-angle paths around shapes, with
+     waypoints) or `"straight"` (plain lines).
+   - Returns `{ nodes: { id: shapeId }, edges: [connectorId], layout, routing }`.
+
+4. **Refine if asked.** To rename/recolor/resize a specific node, look up its shape
+   id in the returned `nodes` map and call `update_shape(docId, canvasPageId, id,
+   patch)` with a subset of `{ x, y, w, h, text, style }`. To add a stray connector
+   the graph missed, use `connect(docId, canvasPageId, fromId, toId, label)`.
+
+5. **Confirm.** `get_page(docId, canvasPageId)` to see the placed shapes, or
+   `get_document` to check `shapeCount`. Report what you drew.
+
+## Tips
+
+- **Don't pass coordinates.** Let `generate_diagram` lay things out; hand-placing
+  fights the router. Only `update_shape` x/y for deliberate nudges.
+- Parallel edges between the same two nodes are automatically staggered, and
+  self-loops get a clean path — model them naturally.
+- Styling is inline per shape (`style: { fill, stroke, strokeWidth, labelColor }`,
+  or `"AUTO"`). There's no saved style-profile over MCP.
+- If the description is really two diagrams (e.g. a high-level map + a detailed
+  sequence), make two and put each on its own canvas page for legibility.

--- a/relay/src/mcp/skills/document-codebase-module.SKILL.md
+++ b/relay/src/mcp/skills/document-codebase-module.SKILL.md
@@ -1,0 +1,71 @@
+---
+name: docushark-document-codebase-module
+description: Use when the user wants to document a code module, service, or package in DocuShark — a prose walkthrough of its responsibilities and APIs plus a component diagram showing how the pieces relate. Requires the DocuShark MCP server to be connected.
+---
+
+# Document a codebase module in DocuShark
+
+Turn your understanding of a module (from reading its code) into a DocuShark
+document: a prose reference plus a component diagram. Work in one **team** document.
+
+## Steps
+
+1. **Gather the facts first.** From the code, identify: the module's purpose, its
+   main components (files/classes/functions), each component's responsibility, the
+   public API/entry points, and the dependencies *between* components (who calls
+   whom). You'll turn the "who calls whom" into diagram edges.
+
+2. **Create the document.** `create_document` with `name` like
+   `"<module> — module reference"`. Keep the `id` (`docId`).
+
+3. **Get the page ids.** `get_document(docId)` → take the first `prosePages[].id`
+   (prose) and the first `pages[].id` (canvas).
+
+4. **Write the reference.** `set_prose(docId, prosePageId, content)` in Markdown:
+
+   ```markdown
+   # {{Module}} — Module Reference
+
+   ## Overview
+   One paragraph: what it does and where it sits.
+
+   ## Components
+   | Component | Responsibility | Key API |
+   |---|---|---|
+   | … | … | … |
+
+   ## Data / Control Flow
+   How a request moves through the components (mirrors the diagram).
+
+   ## Gotchas
+   - …
+   ```
+
+   Use a GFM table for the component list (tables are supported). Set
+   `{{Module}}` with `set_fields`.
+
+5. **Draw the component diagram.** `generate_diagram(docId, canvasPageId, nodes, edges)`:
+   - One `node` per component: `{ id, label }` (use the component name as `label`).
+   - One `edge` per dependency: `{ from, to, label }` where `label` is the relationship
+     ("calls", "reads", "emits"). Edge direction = caller → callee.
+   - Leave `layout: "layered"` / `routing: "orthogonal"` (defaults) so the relay
+     lays it out by dependency direction.
+
+   It returns `{ nodes: { id: shapeId }, edges: [connectorId], … }`.
+
+6. **Cross-link.** In "Data / Control Flow", reference the same component names so
+   the prose and the diagram describe the same thing.
+
+7. **Verify.** `get_document(docId)` — the canvas page `shapeCount` should equal
+   components + dependencies. Return the document id/name.
+
+## Tips
+
+- If the module has distinct layers (e.g. API / core / storage), color them inline
+  per shape (`style.fill`) via `update_shape` after `generate_diagram`, using the
+  returned `nodes` map to find each shape id. There's no saved style-profile over
+  MCP, so set colors inline.
+- Keep one diagram per cohesive view. For a big module, make a high-level component
+  diagram on page 1 and a detailed sub-flow on another canvas page.
+- For an external dependency (a third-party service), use `kind: "ellipse"` to
+  visually distinguish it from in-module components.

--- a/relay/src/mcp/skills/meeting-notes-to-doc.SKILL.md
+++ b/relay/src/mcp/skills/meeting-notes-to-doc.SKILL.md
@@ -1,0 +1,76 @@
+---
+name: docushark-meeting-notes-to-doc
+description: Use when the user has raw meeting notes, a transcript, or a brain-dump and wants a clean, structured DocuShark document — summary, decisions, action items, and an organized outline. Requires the DocuShark MCP server to be connected.
+---
+
+# Turn meeting notes into a structured document in DocuShark
+
+Convert messy notes into a well-organized prose document with a clear outline. Work
+in one **team** document. This recipe is prose-only (no diagram) unless the notes
+clearly describe a flow worth drawing.
+
+## Steps
+
+1. **Read and classify the notes.** Separate the raw input into: a one-paragraph
+   **summary**, **decisions made**, **action items** (owner + what + when),
+   **discussion** by topic, and **open questions**.
+
+2. **Create the document.** `create_document` with a descriptive `name`
+   (e.g. `"<topic> — <date> notes"`). Keep the `id`. Get the first prose page id
+   from `get_document(docId).prosePages[0].id`.
+
+3. **Write the structured page.** `set_prose(docId, prosePageId, content)` in
+   Markdown. Put the high-value parts first:
+
+   ```markdown
+   # {{Title}}
+
+   **Date:** {{Date}} · **Attendees:** {{Attendees}}
+
+   ## Summary
+   …
+
+   ## Decisions
+   - …
+
+   ## Action Items
+   - [ ] **@owner** — task — _due …_
+
+   ## Discussion
+   ### <Topic 1>
+   …
+
+   ## Open Questions
+   - …
+   ```
+
+   Use task-list checkboxes (`- [ ]`) for action items (supported), and set
+   `{{Title}}`/`{{Date}}`/`{{Attendees}}` with `set_fields`.
+
+4. **Organize the discussion.** Add one `### <Topic>` per discussion thread. If you
+   write topics out of order, fix the structure with the outline tools rather than
+   rewriting the page:
+   - `get_outline(docId, prosePageId)` → the flat list of headings with their
+     `index` and `level`.
+   - `restructure_outline(docId, prosePageId, op, index, toIndex?)` to
+     `move` / `promote` / `demote` a section.
+   - `insert_section(docId, prosePageId, level, title, body, afterIndex?)` to slot a
+     new section in a specific spot.
+
+5. **Refine a single section** without touching the rest by calling `set_prose`
+   with `anchor` = the exact current text of the block to replace (read it first
+   with `get_prose`; it's a compare-and-swap that errors rather than clobbering if
+   ambiguous).
+
+6. **Confirm.** `get_prose(docId, prosePageId)` to review, then return the document
+   id/name and a one-line recap (e.g. "3 decisions, 5 action items").
+
+## Tips
+
+- Lead with **Decisions** and **Action Items** — they're what people reopen the doc
+  for. Keep "Discussion" as the supporting detail.
+- Prose is Markdown (GFM): use tables for attendee/owner grids, headings for the
+  outline, and `{{fields}}` for values you'll reuse across related docs.
+- Each write replaces the whole page unless you use `anchor`; for incremental
+  additions during a long meeting, prefer `insert_section` or anchored `set_prose`
+  so you don't overwrite earlier content.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1264,8 +1264,14 @@ fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
         ctx.broadcast_update(&parsed.doc_id, framed);
     }
 
+    // JP-328: surface what the structural gate healed in the new page's content.
+    let fixes = crate::sync::validate_prose_html(&html);
+    let mut result = json!({"id": id});
+    if !fixes.is_empty() {
+        result["fixes"] = serde_json::to_value(&fixes).unwrap_or(Value::Null);
+    }
     Ok(ToolOutcome {
-        result: json!({"id": id}),
+        result,
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
     })
@@ -1296,6 +1302,8 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     reject_if_local(ctx, &parsed.doc_id)?;
     check_prose_size(&parsed.content)?;
     let html = content_to_html(&parsed.content, parsed.format.as_deref())?;
+    // JP-328: report what the structural gate healed, so the author sees it.
+    let fixes = crate::sync::validate_prose_html(&html);
 
     match &parsed.anchor {
         // JP-239: anchored, block-level replace — only the matched block(s) change.
@@ -1325,8 +1333,12 @@ fn set_prose(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         })?,
     }
 
+    let mut result = json!({"pageId": parsed.page_id, "ok": true});
+    if !fixes.is_empty() {
+        result["fixes"] = serde_json::to_value(&fixes).unwrap_or(Value::Null);
+    }
     Ok(ToolOutcome {
-        result: json!({"pageId": parsed.page_id, "ok": true}),
+        result,
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
     })

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -167,7 +167,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.add_prose_page",
             description:
-                "Add a new prose page to a document and return its id. Content is Markdown by default (set format:\"html\" to pass HTML through). Use this to start a new section/chapter of the written document.",
+                "Add a new prose page to a document and return its id. Content is Markdown by default (set format:\"html\" to pass HTML through). Use this to start a new section/chapter of the written document. Unsure what valid content looks like? Call get_skills first for the content contract.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -183,7 +183,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.set_prose",
             description:
-                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents.",
+                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents. Unsure what valid content looks like? Call get_skills first for the content contract.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -528,6 +528,18 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                 "additionalProperties": false
             }),
         },
+        ToolDescriptor {
+            name: "docushark.get_skills",
+            description:
+                "Learn how to drive DocuShark before writing. With no arguments, returns the content contract (the rules for valid prose + shapes, so your writes aren't malformed) and a catalogue of recipes. Pass {skill:\"<slug>\"} for a recipe's full steps. Call this first if you're unsure how a tool expects its input.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "skill": {"type": "string", "description": "A recipe slug from the catalogue. Omit to get the contract + catalogue."}
+                },
+                "additionalProperties": false
+            }),
+        },
     ]
 }
 
@@ -641,10 +653,49 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.add_reference" => add_reference(ctx, args),
         "docushark.list_fields" => list_fields(ctx, args),
         "docushark.set_fields" => set_fields(ctx, args),
+        "docushark.get_skills" => get_skills(args),
         // docushark.resolve_doi is resolved async in the transport layer before
         // dispatch (it needs a network call); it never reaches this match.
         _ => Err(format!("Unknown tool: {}", name)),
     }
+}
+
+#[derive(Deserialize, Default)]
+struct GetSkillsArgs {
+    skill: Option<String>,
+}
+
+/// `docushark.get_skills` — agent guidance (JP-328). No `skill`: the content
+/// contract + recipe catalogue. With `skill`: that recipe's full body. Pure
+/// static content (no document, no filesystem), so it takes no `ToolContext`
+/// and the `skill` argument is matched against a fixed table — there is no path
+/// to traverse.
+fn get_skills(args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: GetSkillsArgs = if args.is_null() {
+        GetSkillsArgs::default()
+    } else {
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?
+    };
+
+    let result = match parsed.skill.as_deref().filter(|s| !s.is_empty()) {
+        None => super::skills::catalogue_json(),
+        Some(slug) => match super::skills::skill_body(slug) {
+            Some(body) => json!({ "skill": slug, "content": body }),
+            None => {
+                return Err(format!(
+                    "ERR_SKILL_NOT_FOUND: no skill named {slug:?}. Valid skills: {}. \
+                     Call get_skills with no arguments for the catalogue + content contract.",
+                    super::skills::valid_slugs()
+                ))
+            }
+        },
+    };
+
+    Ok(ToolOutcome {
+        result,
+        changed_doc_id: None,
+        change_detail: None,
+    })
 }
 
 /// Look up a document across team + local sources. Returns the document

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -772,7 +772,8 @@ mod tests {
         assert!(names.contains(&"docushark.add_reference"));
         assert!(names.contains(&"docushark.list_fields"));
         assert!(names.contains(&"docushark.set_fields"));
-        assert_eq!(tools.len(), 26);
+        assert!(names.contains(&"docushark.get_skills"));
+        assert_eq!(tools.len(), 27);
     }
 
     #[tokio::test]

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -431,6 +431,33 @@ mod tests {
     }
 
     #[test]
+    fn jp328_json_prose_to_ydoc_self_heals_malformed_content() {
+        // The hydration self-heal arm of the JP-328 gate: a doc whose stored
+        // `richTextPages` HTML carries a malformed node (a src-less <img> atom,
+        // which crashes the client's NodeView reconciliation) must hydrate to a
+        // SANE fragment — the cold/JSON path heals on load, not just new writes.
+        let doc = Doc::new();
+        super::json_prose_to_ydoc(
+            &json!({
+                "id": "d",
+                "richTextPages": {
+                    "pageOrder": ["rt1"],
+                    "pages": { "rt1": {"content": "<p>before<img>after</p>"} }
+                }
+            }),
+            &doc,
+        );
+        let f1 = doc.get_or_insert_xml_fragment("prose:rt1");
+        let txn = doc.transact();
+        let html = super::super::prose_html::fragment_to_html(&f1, &txn);
+        assert!(
+            !html.contains("<img"),
+            "hydration must drop the src-less image atom, got: {html}"
+        );
+        assert!(html.contains("beforeafter"), "surrounding text must survive: {html}");
+    }
+
+    #[test]
     fn json_prose_to_ydoc_noop_without_richtextpages() {
         use yrs::ReadTxn;
         let doc = Doc::new();

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -98,7 +98,18 @@ pub fn json_prose_to_ydoc(doc_json: &Value, doc: &Doc) {
         if content.trim().is_empty() {
             continue;
         }
-        let blocks = super::prose_parse::html_to_blocks(content);
+        // Self-heal on hydration (JP-328): validate + normalize the parsed tree
+        // before seeding, so a doc whose stored prose carries a malformed node
+        // (e.g. an older, pre-gate write) comes back renderable instead of
+        // crashing the editor — no manual snapshot surgery needed.
+        let (blocks, fixes) =
+            super::prose_validate::sanitize_blocks(super::prose_parse::html_to_blocks(content));
+        if !fixes.is_empty() {
+            log::info!(
+                "prose_validate self-healed {} defect(s) hydrating prose:{id}: {fixes:?}",
+                fixes.len()
+            );
+        }
         // An "empty" page serializes to the placeholder `<p></p>` (the editor's
         // never-truly-empty invariant). Seeding that would leave a spurious empty
         // paragraph that the editor's first real edit then appends after — an

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1149,6 +1149,24 @@ mod tests {
     }
 
     #[test]
+    fn jp328_validate_prose_html_reports_a_diff_for_malformed_input() {
+        // `validate_prose_html` is what the MCP set_prose/add_prose_page tools
+        // call to surface the `fixes` diff to the author. Clean HTML reports no
+        // fixes; malformed HTML (a ragged table the gate rebuilds rectangular)
+        // reports at least one.
+        assert!(
+            super::validate_prose_html("<p>clean</p>").is_empty(),
+            "well-formed prose must report no fixes"
+        );
+        let fixes =
+            super::validate_prose_html("<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>");
+        assert!(
+            !fixes.is_empty(),
+            "a ragged table must be reported as a fix so the author sees the heal"
+        );
+    }
+
+    #[test]
     fn jp319_2d_figure_without_image_degrades_safely() {
         // `figcaption` has no block group on the client — emitting one standalone
         // would crash. A <figure> with no usable <img> must degrade to its text,

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -24,11 +24,24 @@ mod prose_block;
 mod prose_html;
 mod prose_parse;
 mod prose_schema;
+mod prose_validate;
 mod protocol;
 
 /// Apply an anchored, block-level prose edit to a page's HTML off the live path
 /// (the MCP cold path for a non-resident document). See [`prose_block`].
 pub use prose_block::replace_block_in_html;
+
+pub use prose_validate::ProseFix;
+
+/// Validate + normalize prose HTML for the MCP write gate (JP-328): parse to
+/// blocks, run the structural sanitizer, and return the scoped diff of fixes
+/// (empty when clean). The build/seed paths sanitize independently, so this is
+/// purely to surface "here's what was malformed and how it was healed" back to
+/// the MCP author.
+pub fn validate_prose_html(html: &str) -> Vec<ProseFix> {
+    let (_blocks, fixes) = prose_validate::sanitize_blocks(prose_parse::html_to_blocks(html));
+    fixes
+}
 
 pub use hydration::active_page_shape_count;
 pub use protocol::{SyncError, SyncOutcome};
@@ -651,7 +664,15 @@ impl DocHandle {
         // transacts; nesting deadlocks).
         let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
 
-        let mut blocks = prose_parse::html_to_blocks(html);
+        // Gate: validate + normalize before the tree reaches the Y.Doc (JP-328),
+        // so a malformed node can't crash the client's NodeView reconciliation.
+        let (mut blocks, fixes) = prose_validate::sanitize_blocks(prose_parse::html_to_blocks(html));
+        if !fixes.is_empty() {
+            log::info!(
+                "prose_validate healed {} defect(s) seeding prose:{page_id}: {fixes:?}",
+                fixes.len()
+            );
+        }
         if blocks.is_empty() {
             blocks.push(prose_parse::PmNode {
                 node_type: "paragraph".to_string(),

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -71,7 +71,15 @@ pub fn replace_block_in_fragment<F: XmlFragment>(
     };
     let count = (end - start + 1) as u32;
 
-    let new_blocks = prose_parse::html_to_blocks(new_html);
+    // Gate (JP-328): validate + normalize the inserted blocks before they reach
+    // the fragment, so an anchored write can't smuggle a malformed node past the
+    // whole-page gate. Covers both the live path (replace_prose_block) and the
+    // cold path (replace_block_in_html delegates here).
+    let (new_blocks, fixes) =
+        super::prose_validate::sanitize_blocks(prose_parse::html_to_blocks(new_html));
+    if !fixes.is_empty() {
+        log::info!("prose_validate healed {} defect(s) in anchored prose write: {fixes:?}", fixes.len());
+    }
 
     frag.remove_range(txn, start as u32, count);
     for (i, node) in new_blocks.iter().enumerate() {
@@ -317,6 +325,38 @@ mod tests {
         // Replacing the only block with empty content leaves one empty paragraph.
         let out = apply("<p>only</p>", "only", None, "").unwrap();
         assert_eq!(out, "<p></p>");
+    }
+
+    #[test]
+    fn jp328_anchored_write_heals_a_srcless_image() {
+        // The anchored path must run the same JP-328 gate as the whole-page
+        // replace: a src-less <img> (a naked atom that crashes the client's
+        // NodeView reconciliation) is dropped before it reaches the fragment.
+        let out = apply(
+            "<p>keep</p><p>swap</p>",
+            "swap",
+            None,
+            "<p>before<img>after</p>",
+        )
+        .unwrap();
+        assert_eq!(out, "<p>keep</p><p>beforeafter</p>");
+        assert!(!out.contains("<img"), "src-less image must not survive the gate: {out}");
+    }
+
+    #[test]
+    fn jp328_anchored_write_rebuilds_a_ragged_table() {
+        // A ragged table (rows of differing cell counts) is padded to the
+        // rectangular table>tableRow+>cell+ the client schema requires, so the
+        // anchored write can't smuggle a malformed table past the gate.
+        let out = apply(
+            "<p>anchor</p>",
+            "anchor",
+            None,
+            "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>",
+        )
+        .unwrap();
+        // Both rows must now carry two cells (the second was padded).
+        assert_eq!(out.matches("<td").count(), 4, "ragged table must be padded rectangular: {out}");
     }
 
     #[test]

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -1,0 +1,536 @@
+//! Structural validation + normalization of the prose node tree before it
+//! reaches the Y.Doc (JP-328).
+//!
+//! The relay accepts machine-generated prose (the MCP markdown/HTML path, the
+//! editor's `getHTML()`). A structurally-invalid node — an atom carrying
+//! children, an unknown node type, a malformed table — serializes back to clean
+//! HTML yet crashes the **client** editor's NodeView reconciliation
+//! ("Cannot read properties of undefined (reading 'children')"). This pass
+//! demotes such nodes into a valid, content-preserving shape and reports a
+//! scoped [`ProseFix`] diff for each change, so an MCP author sees exactly what
+//! was malformed and how it was healed.
+//!
+//! **Demotion over elimination.** Unknown wrappers unwrap to their children;
+//! malformed tables are rebuilt; illegal children are stripped off atoms; stray
+//! inline is wrapped in a paragraph. The only outright drops are nodes with no
+//! recoverable content (a src-less image, a table with no rows).
+
+use serde::Serialize;
+
+use super::prose_parse::{PmChild, PmNode};
+use super::prose_schema;
+
+/// What was done to heal one node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FixAction {
+    /// Removed entirely (no recoverable content).
+    Dropped,
+    /// Replaced by its children (unknown wrapper type).
+    Unwrapped,
+    /// Table rebuilt into `table > tableRow+ > cell+`, rectangular.
+    RebuiltTable,
+    /// Illegal children stripped off an atom (leaf) node.
+    StrippedChildren,
+}
+
+/// One healed structural defect, surfaced to the writer + logged on self-heal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProseFix {
+    /// Index path to the node, e.g. `0/table` or `2/listItem`.
+    pub path: String,
+    pub node_type: String,
+    pub action: FixAction,
+    pub reason: &'static str,
+}
+
+/// Node types the client schema (`sharedProseExtensions` + StarterKit + tables)
+/// can render. Anything else is unwrapped to its children. Keep in sync with
+/// `prose_schema` + the client extension set.
+fn is_known_type(t: &str) -> bool {
+    matches!(
+        t,
+        "paragraph"
+            | "heading"
+            | "bulletList"
+            | "orderedList"
+            | "listItem"
+            | "blockquote"
+            | "table"
+            | "tableRow"
+            | "tableCell"
+            | "tableHeader"
+            | "codeBlock"
+            | "horizontalRule"
+            | "image"
+            | "bibliography"
+            | "callout"
+            | "figure"
+            | "figcaption"
+            | "gallery"
+            | "citationInline"
+            | "fieldRef"
+            | "hardBreak"
+    )
+}
+
+/// Leaf/atom node types: the client treats these as atoms, so they must carry
+/// **no** children. A child here is the exact shape that crashes NodeView
+/// reconciliation.
+fn is_atom(t: &str) -> bool {
+    matches!(
+        t,
+        "image" | "citationInline" | "fieldRef" | "horizontalRule" | "bibliography" | "hardBreak"
+    )
+}
+
+fn attr<'a>(node: &'a PmNode, k: &str) -> Option<&'a str> {
+    node.attrs.iter().find(|(key, _)| key == k).map(|(_, v)| v.as_str())
+}
+
+fn has_node_children(node: &PmNode) -> bool {
+    !node.children.is_empty()
+}
+
+fn paragraph(children: Vec<PmChild>) -> PmNode {
+    PmNode { node_type: "paragraph".to_string(), attrs: vec![], children }
+}
+
+fn empty_cell() -> PmNode {
+    PmNode {
+        node_type: "tableCell".to_string(),
+        attrs: vec![],
+        children: vec![PmChild::Node(paragraph(vec![]))],
+    }
+}
+
+/// Validate + normalize top-level prose blocks, returning the healed tree and a
+/// scoped diff of every fix. Idempotent: a healed tree re-sanitizes to itself
+/// with no fixes.
+pub fn sanitize_blocks(blocks: Vec<PmNode>) -> (Vec<PmNode>, Vec<ProseFix>) {
+    let mut fixes = Vec::new();
+    let out = sanitize_list(blocks, "", 0, &mut fixes);
+    (out, fixes)
+}
+
+fn sanitize_list(
+    blocks: Vec<PmNode>,
+    prefix: &str,
+    depth: usize,
+    fixes: &mut Vec<ProseFix>,
+) -> Vec<PmNode> {
+    let mut out = Vec::new();
+    for (i, node) in blocks.into_iter().enumerate() {
+        let path = format!("{prefix}{i}/{}", node.node_type);
+        out.extend(sanitize_node(node, &path, depth, fixes));
+    }
+    out
+}
+
+/// Sanitize one node. Returns 0+ nodes (drop → 0, unwrap → its children, normal → 1).
+fn sanitize_node(
+    node: PmNode,
+    path: &str,
+    depth: usize,
+    fixes: &mut Vec<ProseFix>,
+) -> Vec<PmNode> {
+    // Depth bound (defense in depth alongside the parser's): drop the deep tail.
+    if depth > prose_schema::MAX_PROSE_DEPTH {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: node.node_type.clone(),
+            action: FixAction::Dropped,
+            reason: "nesting exceeded MAX_PROSE_DEPTH",
+        });
+        return vec![];
+    }
+
+    // Unknown type → unwrap to children (keep text by wrapping it in a paragraph).
+    if !is_known_type(&node.node_type) {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: node.node_type.clone(),
+            action: FixAction::Unwrapped,
+            reason: "unknown node type the client schema can't render",
+        });
+        return unwrap_children(node, path, depth, fixes);
+    }
+
+    // Image atom: requires `src`, never carries children.
+    if node.node_type == "image" {
+        match attr(&node, "src").filter(|s| !s.is_empty()) {
+            None => {
+                fixes.push(ProseFix {
+                    path: path.to_string(),
+                    node_type: "image".to_string(),
+                    action: FixAction::Dropped,
+                    reason: "image has no src (client parses only img[src]; a naked image atom crashes)",
+                });
+                return vec![];
+            }
+            Some(_) => {
+                return vec![strip_children_if_any(node, path, fixes)];
+            }
+        }
+    }
+
+    // Other atoms: force childless.
+    if is_atom(&node.node_type) {
+        return vec![strip_children_if_any(node, path, fixes)];
+    }
+
+    // Tables: rebuild into a well-formed, rectangular shape.
+    if node.node_type == "table" {
+        return normalize_table(node, path, depth, fixes);
+    }
+
+    // Container: recurse into block/inline children.
+    vec![sanitize_container(node, path, depth, fixes)]
+}
+
+/// Strip children off an atom node, recording a fix if any were present.
+fn strip_children_if_any(mut node: PmNode, path: &str, fixes: &mut Vec<ProseFix>) -> PmNode {
+    if has_node_children(&node) {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: node.node_type.clone(),
+            action: FixAction::StrippedChildren,
+            reason: "atom node must be childless",
+        });
+        node.children.clear();
+    }
+    node
+}
+
+/// Recurse into a container's children: sanitize block-node children in place,
+/// keep text/inline runs as-is.
+fn sanitize_container(mut node: PmNode, path: &str, depth: usize, fixes: &mut Vec<ProseFix>) -> PmNode {
+    // codeBlock content is plain text — never recurse into it as structure.
+    if node.node_type == "codeBlock" {
+        return node;
+    }
+    let mut new_children = Vec::new();
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                let child_path = format!("{path}/{}", n.node_type);
+                for sn in sanitize_node(n, &child_path, depth + 1, fixes) {
+                    new_children.push(PmChild::Node(sn));
+                }
+            }
+            text @ PmChild::Text { .. } => new_children.push(text),
+        }
+    }
+    node.children = new_children;
+    node
+}
+
+/// Unwrap an unknown node to its content: sanitized block children, plus any
+/// stray inline text gathered into a paragraph (never dropped).
+fn unwrap_children(node: PmNode, path: &str, depth: usize, fixes: &mut Vec<ProseFix>) -> Vec<PmNode> {
+    let mut blocks = Vec::new();
+    let mut inline: Vec<PmChild> = Vec::new();
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                let child_path = format!("{path}/{}", n.node_type);
+                blocks.extend(sanitize_node(n, &child_path, depth, fixes));
+            }
+            t @ PmChild::Text { .. } => inline.push(t),
+        }
+    }
+    let has_text = inline.iter().any(|c| matches!(c, PmChild::Text { text, .. } if !text.trim().is_empty()));
+    if has_text {
+        blocks.insert(0, paragraph(inline));
+    }
+    blocks
+}
+
+/// Rebuild a `table` into `table > tableRow+ > (tableCell|tableHeader)+`, with
+/// every cell holding `block+` and all rows the same width. A non-row child is
+/// dropped; a table with no rows is dropped. Records `RebuiltTable` if anything
+/// changed.
+fn normalize_table(node: PmNode, path: &str, depth: usize, fixes: &mut Vec<ProseFix>) -> Vec<PmNode> {
+    let mut changed = false;
+    let mut rows: Vec<PmNode> = Vec::new();
+
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) if n.node_type == "tableRow" => {
+                rows.push(normalize_row(n, depth + 1, fixes));
+            }
+            _ => changed = true, // non-row child in a table → drop
+        }
+    }
+
+    if rows.is_empty() {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "table".to_string(),
+            action: FixAction::Dropped,
+            reason: "table has no rows",
+        });
+        return vec![];
+    }
+
+    // Rectangularize: pad short rows with empty cells.
+    let width = rows.iter().map(|r| r.children.len()).max().unwrap_or(0);
+    for row in rows.iter_mut() {
+        while row.children.len() < width {
+            row.children.push(PmChild::Node(empty_cell()));
+            changed = true;
+        }
+    }
+
+    if changed {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "table".to_string(),
+            action: FixAction::RebuiltTable,
+            reason: "table was not a rectangular table>row+>cell+ structure",
+        });
+    }
+
+    vec![PmNode {
+        node_type: "table".to_string(),
+        attrs: node.attrs,
+        children: rows.into_iter().map(PmChild::Node).collect(),
+    }]
+}
+
+/// Ensure a row holds only cells, each with `block+`. Non-cell content is
+/// wrapped into a cell; an empty row gets one empty cell.
+fn normalize_row(node: PmNode, depth: usize, fixes: &mut Vec<ProseFix>) -> PmNode {
+    let mut cells: Vec<PmChild> = Vec::new();
+    let mut stray_inline: Vec<PmChild> = Vec::new();
+
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) if n.node_type == "tableCell" || n.node_type == "tableHeader" => {
+                cells.push(PmChild::Node(normalize_cell(n, depth + 1, fixes)));
+            }
+            PmChild::Node(n) => {
+                // A stray block inside a row → wrap it in a cell (preserve it).
+                cells.push(PmChild::Node(PmNode {
+                    node_type: "tableCell".to_string(),
+                    attrs: vec![],
+                    children: vec![PmChild::Node(n)],
+                }));
+            }
+            t @ PmChild::Text { .. } => stray_inline.push(t),
+        }
+    }
+    if !stray_inline.is_empty() {
+        cells.push(PmChild::Node(PmNode {
+            node_type: "tableCell".to_string(),
+            attrs: vec![],
+            children: vec![PmChild::Node(paragraph(stray_inline))],
+        }));
+    }
+    if cells.is_empty() {
+        cells.push(PmChild::Node(empty_cell()));
+    }
+    PmNode { node_type: node.node_type, attrs: node.attrs, children: cells }
+}
+
+/// Ensure a cell holds `block+`: bare inline/text is wrapped in a paragraph; an
+/// empty cell gets an empty paragraph; block children are sanitized.
+fn normalize_cell(node: PmNode, depth: usize, fixes: &mut Vec<ProseFix>) -> PmNode {
+    let mut blocks: Vec<PmChild> = Vec::new();
+    let mut inline: Vec<PmChild> = Vec::new();
+    let path = "tableCell";
+
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                // flush any pending inline into a paragraph first (order-preserving)
+                if !inline.is_empty() {
+                    blocks.push(PmChild::Node(paragraph(std::mem::take(&mut inline))));
+                }
+                let child_path = format!("{path}/{}", n.node_type);
+                for sn in sanitize_node(n, &child_path, depth + 1, fixes) {
+                    blocks.push(PmChild::Node(sn));
+                }
+            }
+            t @ PmChild::Text { .. } => inline.push(t),
+        }
+    }
+    if !inline.is_empty() {
+        blocks.push(PmChild::Node(paragraph(inline)));
+    }
+    if blocks.is_empty() {
+        blocks.push(PmChild::Node(paragraph(vec![])));
+    }
+    PmNode { node_type: node.node_type, attrs: node.attrs, children: blocks }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::prose_parse::{PmChild, PmNode};
+
+    fn n(t: &str, children: Vec<PmChild>) -> PmNode {
+        PmNode { node_type: t.to_string(), attrs: vec![], children }
+    }
+    fn na(t: &str, attrs: &[(&str, &str)], children: Vec<PmChild>) -> PmNode {
+        PmNode {
+            node_type: t.to_string(),
+            attrs: attrs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect(),
+            children,
+        }
+    }
+    fn text(s: &str) -> PmChild {
+        PmChild::Text { text: s.to_string(), marks: vec![] }
+    }
+    fn node(p: PmNode) -> PmChild {
+        PmChild::Node(p)
+    }
+
+    #[test]
+    fn clean_prose_is_unchanged_and_reports_no_fixes() {
+        let input = vec![
+            n("heading", vec![text("Title")]),
+            n("paragraph", vec![text("hello")]),
+        ];
+        let (out, fixes) = sanitize_blocks(input.clone());
+        assert_eq!(out, input);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn src_less_image_is_dropped() {
+        let input = vec![na("image", &[("alt", "logo")], vec![])];
+        let (out, fixes) = sanitize_blocks(input);
+        assert!(out.is_empty(), "src-less image dropped");
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, FixAction::Dropped);
+        assert_eq!(fixes[0].node_type, "image");
+    }
+
+    #[test]
+    fn image_with_src_survives() {
+        let input = vec![na("image", &[("src", "blob://x")], vec![])];
+        let (out, fixes) = sanitize_blocks(input.clone());
+        assert_eq!(out, input);
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn atom_with_children_is_stripped() {
+        // A fieldRef (inline atom) that wrongly carries children.
+        let input = vec![n("paragraph", vec![node(na(
+            "fieldRef",
+            &[("name", "X")],
+            vec![text("should not be here")],
+        ))])];
+        let (out, fixes) = sanitize_blocks(input);
+        let field = match &out[0].children[0] {
+            PmChild::Node(f) => f,
+            _ => panic!("expected fieldRef node"),
+        };
+        assert!(field.children.is_empty(), "atom forced childless");
+        assert_eq!(fixes.len(), 1);
+        assert_eq!(fixes[0].action, FixAction::StrippedChildren);
+    }
+
+    #[test]
+    fn unknown_type_is_unwrapped_to_children() {
+        let input = vec![n("mysteryBlock", vec![node(n("paragraph", vec![text("kept")]))])];
+        let (out, fixes) = sanitize_blocks(input);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].node_type, "paragraph");
+        assert_eq!(fixes[0].action, FixAction::Unwrapped);
+    }
+
+    #[test]
+    fn well_formed_table_is_unchanged() {
+        let row = |cells: Vec<PmChild>| node(n("tableRow", cells));
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        let input = vec![n(
+            "table",
+            vec![row(vec![cell("a"), cell("b")]), row(vec![cell("1"), cell("2")])],
+        )];
+        let (out, fixes) = sanitize_blocks(input.clone());
+        assert_eq!(out, input, "rectangular table untouched");
+        assert!(fixes.is_empty());
+    }
+
+    #[test]
+    fn ragged_table_is_rectangularized() {
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        // Row 1 has 2 cells, row 2 has 1 — should pad row 2 to width 2.
+        let input = vec![n(
+            "table",
+            vec![
+                node(n("tableRow", vec![cell("a"), cell("b")])),
+                node(n("tableRow", vec![cell("1")])),
+            ],
+        )];
+        let (out, fixes) = sanitize_blocks(input);
+        let table = &out[0];
+        let r2 = match &table.children[1] {
+            PmChild::Node(r) => r,
+            _ => panic!(),
+        };
+        assert_eq!(r2.children.len(), 2, "short row padded to table width");
+        assert!(fixes.iter().any(|f| f.action == FixAction::RebuiltTable));
+    }
+
+    #[test]
+    fn table_with_non_row_child_drops_the_stray_and_rebuilds() {
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        let input = vec![n(
+            "table",
+            vec![
+                node(n("paragraph", vec![text("stray")])), // illegal direct child
+                node(n("tableRow", vec![cell("a")])),
+            ],
+        )];
+        let (out, fixes) = sanitize_blocks(input);
+        let table = &out[0];
+        assert_eq!(table.children.len(), 1, "only the row remains");
+        assert!(fixes.iter().any(|f| f.action == FixAction::RebuiltTable));
+    }
+
+    #[test]
+    fn empty_table_is_dropped() {
+        let input = vec![n("table", vec![])];
+        let (out, fixes) = sanitize_blocks(input);
+        assert!(out.is_empty());
+        assert_eq!(fixes[0].action, FixAction::Dropped);
+    }
+
+    #[test]
+    fn cell_with_bare_text_gets_a_paragraph() {
+        // tableCell whose child is raw text (no paragraph) → wrap in a paragraph.
+        let input = vec![n(
+            "table",
+            vec![node(n("tableRow", vec![node(n("tableCell", vec![text("bare")]))]))],
+        )];
+        let (out, _fixes) = sanitize_blocks(input);
+        let cell = match &out[0].children[0] {
+            PmChild::Node(r) => match &r.children[0] {
+                PmChild::Node(c) => c,
+                _ => panic!(),
+            },
+            _ => panic!(),
+        };
+        assert_eq!(cell.children.len(), 1);
+        assert!(matches!(&cell.children[0], PmChild::Node(p) if p.node_type == "paragraph"));
+    }
+
+    #[test]
+    fn sanitize_is_idempotent() {
+        let cell = |s: &str| node(n("tableCell", vec![node(n("paragraph", vec![text(s)]))]));
+        let messy = vec![
+            na("image", &[("alt", "x")], vec![]), // dropped
+            n("table", vec![node(n("tableRow", vec![cell("a")])), node(n("tableRow", vec![cell("1"), cell("2")]))]),
+            n("mystery", vec![node(n("paragraph", vec![text("k")]))]),
+        ];
+        let (once, _) = sanitize_blocks(messy);
+        let (twice, fixes2) = sanitize_blocks(once.clone());
+        assert_eq!(once, twice, "second pass is a no-op");
+        assert!(fixes2.is_empty(), "healed tree needs no further fixes");
+    }
+}

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -116,6 +116,42 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         .filter_map(|t| t["name"].as_str())
         .collect();
     assert!(names.contains(&"docushark.create_document"), "{names:?}");
+    assert!(names.contains(&"docushark.get_skills"), "get_skills must be advertised: {names:?}");
+
+    // JP-328: get_skills (no args) returns the content contract + catalogue.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 10, "method": "tools/call",
+            "params": {"name": "docushark.get_skills", "arguments": {}}
+        }))
+        .send()
+        .await
+        .expect("get_skills post");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = resp.json().await.expect("skills json");
+    let sc = &body["result"]["structuredContent"];
+    assert!(
+        sc["contentContract"].as_str().unwrap_or("").contains("content contract"),
+        "get_skills must surface the content contract: {body}"
+    );
+    assert!(sc["skills"].as_array().is_some_and(|a| !a.is_empty()), "catalogue: {body}");
+
+    // JP-328: a traversal-style skill name is just an unknown slug — there is no
+    // filesystem lookup, so it can only ever be a clean ERR_SKILL_NOT_FOUND.
+    let resp = client
+        .post(format!("{http}/mcp"))
+        .bearer_auth(&jwt)
+        .json(&json!({
+            "jsonrpc": "2.0", "id": 11, "method": "tools/call",
+            "params": {"name": "docushark.get_skills", "arguments": {"skill": "../../../../etc/passwd"}}
+        }))
+        .send()
+        .await
+        .expect("get_skills traversal post");
+    let body: serde_json::Value = resp.json().await.expect("skills err json");
+    assert_eq!(body["result"]["isError"], json!(true), "traversal name must error cleanly: {body}");
 
     // JP-235 (1): a write authenticated as `ws-public` routes the coarse reload
     // nudge to *that* workspace, not the catch-all `single_tenant()`.

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -8,7 +8,7 @@
  * - Tiptap editor
  */
 
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
 import { EllipsisVertical, Maximize2, Minimize2 } from 'lucide-react';
 import { Icon } from './icons';
 import type { Editor } from '@tiptap/core';
@@ -26,6 +26,7 @@ import { useDocumentRegistry } from '../store/documentRegistry';
 import { CollaborativeProseEditor } from './CollaborativeProseEditor';
 import { ProseErrorBoundary } from './ProseErrorBoundary';
 import { ProsePreview } from './ProsePreview';
+import { isFragmentRenderable } from './proseFragmentCheck';
 import { RICH_TEXT_VERSION } from '../types/RichText';
 import './DocumentEditorPanel.css';
 
@@ -151,7 +152,24 @@ export function DocumentEditorPanel({
   // empty fragment stays read-only (ProsePreview) — there's nothing to adopt yet.
   const proseEditable =
     engineReady && (fragHasContent || collabSynced);
-  const useCollabEditor = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
+  const wouldMountCollab = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
+
+  // Pillar 1a (JP-328): pre-flight the bound fragment against the client schema
+  // before mounting the live editor. y-prosemirror builds the doc straight from
+  // the fragment (bypassing Tiptap's content parser), so a schema-invalid node
+  // would crash NodeView reconciliation and blank the page. If the fragment
+  // doesn't build cleanly, fall through to the read-only `ProsePreview` (the
+  // HTML projection renders crash-safe) instead. Memoized on the bind identity +
+  // the content signal so it re-runs on page/doc switch and when the fragment
+  // first gains content — not on every render. An empty fragment is trivially
+  // renderable, so this is a no-op for the common fresh-page case.
+  const fragmentRenderable = useMemo(() => {
+    if (!wouldMountCollab || !collabYdoc || !proseField) return true;
+    return isFragmentRenderable(collabYdoc, proseField);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wouldMountCollab, collabYdoc, proseField, collabSessionEpoch, fragHasContent]);
+
+  const useCollabEditor = wouldMountCollab && fragmentRenderable;
 
   const lastActivePageRef = useRef<string | null>(null);
   const isLoadingRef = useRef(false);
@@ -526,9 +544,13 @@ export function DocumentEditorPanel({
         <RichTextTabBar trailing={trailing} />
         <DocumentEditorToolbar />
         <div className="document-editor-panel-content">
-          {/* Contain a prose render crash (JP-319) so a single bad document
-              can't unmount the whole app; auto-resets on doc/page switch. */}
-          <ProseErrorBoundary resetKeys={[currentDocId, activePageId]}>
+          {/* Never blank (JP-328): a prose render crash degrades to the page's
+              read-only HTML projection, not an empty panel; auto-resets on
+              doc/page switch. */}
+          <ProseErrorBoundary
+            resetKeys={[currentDocId, activePageId]}
+            fallbackHtml={activePageContent ?? '<p></p>'}
+          >
             {!isRelayDoc ? (
               // Local-only doc: the legacy editor (no Y.Doc).
               <TiptapEditor onEditorReady={handleEditorReady} />
@@ -541,8 +563,10 @@ export function DocumentEditorPanel({
                 onEditorReady={handleEditorReady}
               />
             ) : (
-              // Relay doc, engine still coming up (sub-second) or a never-synced
-              // doc opened offline — show the prose read-only until editable.
+              // Relay doc that isn't live-editable: engine still coming up
+              // (sub-second), a never-synced doc opened offline, OR a fragment
+              // that failed the schema pre-check (malformed — would crash the
+              // live editor). Show the prose read-only rather than blank.
               <ProsePreview html={activePageContent || '<p></p>'} />
             )}
           </ProseErrorBoundary>

--- a/src/ui/ProseErrorBoundary.test.tsx
+++ b/src/ui/ProseErrorBoundary.test.tsx
@@ -1,8 +1,11 @@
 /**
- * ProseErrorBoundary containment proof (JP-319): a child that throws during
- * render must degrade to the recoverable fallback (not propagate and unmount
- * the app), and the boundary must auto-reset when `resetKeys` change so
- * navigating to another document recovers.
+ * ProseErrorBoundary — never-blank proof (JP-328, supersedes the JP-319 blank
+ * panel). A child that throws during render must:
+ *   - never propagate and unmount the app (containment), and
+ *   - with a `fallbackHtml` projection, render that content read-only (NOT an
+ *     empty panel) so the user always sees their prose, and
+ *   - auto-reset when `resetKeys` change so navigating to another document
+ *     recovers without a reload.
  */
 
 import { render, screen } from '@testing-library/react';
@@ -34,20 +37,33 @@ describe('ProseErrorBoundary', () => {
     expect(screen.getByText('prose ok')).toBeTruthy();
   });
 
-  it('contains a render crash and shows a recoverable fallback', () => {
+  it('contains a render crash and shows a recoverable banner', () => {
     render(
       <ProseErrorBoundary resetKeys={['doc-1']}>
         <Boom />
       </ProseErrorBoundary>,
     );
     expect(screen.getByRole('alert')).toBeTruthy();
-    expect(screen.getByText(/couldn.t be displayed/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
+  });
+
+  it('NEVER blanks: a crash with fallbackHtml shows the content read-only', async () => {
+    render(
+      <ProseErrorBoundary resetKeys={['doc-1']} fallbackHtml="<p>recovered prose body</p>">
+        <Boom />
+      </ProseErrorBoundary>,
+    );
+    // The recovery banner is present...
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/read-only copy/i)).toBeTruthy();
+    // ...AND the user's content is rendered (ProsePreview), never a blank panel.
+    expect(await screen.findByText('recovered prose body')).toBeTruthy();
   });
 
   it('auto-resets when resetKeys change (e.g. switching documents)', () => {
     const { rerender } = render(
-      <ProseErrorBoundary resetKeys={['doc-1']}>
+      <ProseErrorBoundary resetKeys={['doc-1']} fallbackHtml="<p>doc one body</p>">
         <Boom />
       </ProseErrorBoundary>,
     );
@@ -55,7 +71,7 @@ describe('ProseErrorBoundary', () => {
 
     // Switching to a different, healthy document must recover without a reload.
     rerender(
-      <ProseErrorBoundary resetKeys={['doc-2']}>
+      <ProseErrorBoundary resetKeys={['doc-2']} fallbackHtml="<p>doc two body</p>">
         <Safe label="other doc" />
       </ProseErrorBoundary>,
     );

--- a/src/ui/ProseErrorBoundary.tsx
+++ b/src/ui/ProseErrorBoundary.tsx
@@ -1,21 +1,30 @@
 /**
- * ProseErrorBoundary — contains a prose-editor render crash so one bad document
- * can't take down the whole app (JP-319).
+ * ProseErrorBoundary — guarantees a prose page is **never blank** when the live
+ * editor crashes (JP-328, Pillar 1b; supersedes the JP-319 blank-panel fallback).
  *
- * The prose editors render a ProseMirror/Tiptap node tree via ReactNodeViews.
- * A node the client schema can't reconcile (historically a malformed node from
- * the relay seed path — e.g. a src-less `image` atom) makes ProseMirror's
- * desc-tree walk throw "Cannot read properties of undefined (reading
- * 'children')" *during render*, which without a boundary unmounts the entire
- * React tree. The relay seed path is now hardened against that class, but this
- * is the defense-in-depth layer: even a novel bad node degrades to a recoverable
- * panel instead of a blank app.
+ * The prose editors render a ProseMirror/Tiptap node tree via ReactNodeViews. A
+ * node the client schema can't reconcile (historically a malformed node from the
+ * relay seed path — e.g. a src-less `image` atom) makes ProseMirror's desc-tree
+ * walk throw "Cannot read properties of undefined (reading 'children')" *during
+ * render*, which without a boundary unmounts the entire React tree.
  *
- * Auto-resets when `resetKeys` change (a document / page switch), so navigating
- * away from a document that failed to render recovers without a reload.
+ * Catching that crash is not enough — an empty panel is still broken. So when a
+ * `fallbackHtml` is supplied (the page's stored HTML projection from
+ * `richTextPages`), the boundary renders it read-only through `ProsePreview`
+ * instead: the user always sees their content. `ProsePreview` loads HTML via
+ * ProseMirror's lenient `DOMParser` (fits-to-schema, never throws), so it is the
+ * always-safe representation when the live Y.Doc fragment is suspect. A small
+ * non-blocking banner offers Retry / Reload.
+ *
+ * Scope: a React boundary catches render/lifecycle crashes (the observed open-doc
+ * case) — not errors thrown inside an async y-prosemirror sync callback. Post-mount
+ * sync-time corruption is prevented *upstream* by the relay write gate (JP-328),
+ * so malformed data never reaches the fragment; the two layers compose to full
+ * coverage. Auto-resets when `resetKeys` change (a document / page switch).
  */
 
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { ProsePreview } from './ProsePreview';
 
 interface ProseErrorBoundaryProps {
   /**
@@ -24,6 +33,12 @@ interface ProseErrorBoundaryProps {
    * recovers automatically.
    */
   resetKeys?: ReadonlyArray<unknown>;
+  /**
+   * The page's stored HTML projection. When present, a caught crash degrades to
+   * this content rendered read-only (never blank). When absent, the boundary
+   * shows a generic recoverable panel.
+   */
+  fallbackHtml?: string;
   children: ReactNode;
 }
 
@@ -64,35 +79,59 @@ export class ProseErrorBoundary extends Component<
 
   render(): ReactNode {
     if (!this.state.error) return this.props.children;
-    return (
+
+    const { fallbackHtml } = this.props;
+
+    // Recovery banner (Pillar 1c) — non-blocking, sits above the content.
+    const banner = (
       <div
         role="alert"
         style={{
-          margin: '2rem auto',
-          maxWidth: '36rem',
-          padding: '1.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          flexWrap: 'wrap',
+          margin: '0 0 0.75rem',
+          padding: '0.6rem 0.9rem',
           border: '1px solid var(--border-color, #d0c8ba)',
           borderRadius: '8px',
           background: 'var(--surface-2, rgba(0,0,0,0.03))',
           color: 'var(--text-color, inherit)',
-          textAlign: 'center',
+          fontSize: '0.9em',
         }}
       >
-        <p style={{ fontWeight: 600, margin: '0 0 0.5rem' }}>
-          This document&rsquo;s text couldn&rsquo;t be displayed.
-        </p>
-        <p style={{ margin: '0 0 1rem', opacity: 0.8, fontSize: '0.9em' }}>
-          The editor hit an unexpected content error and was contained, so the rest of the app
-          keeps working. Switching to another document, or trying again, usually recovers.
-        </p>
-        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
+        <span style={{ flex: '1 1 16rem' }}>
+          {fallbackHtml !== undefined
+            ? 'Showing a read-only copy — the live editor couldn’t load this page.'
+            : 'This page’s editor hit an unexpected error and was contained.'}
+        </span>
+        <span style={{ display: 'flex', gap: '0.5rem' }}>
           <button type="button" onClick={this.reset}>
             Try again
           </button>
           <button type="button" onClick={this.reload}>
             Reload
           </button>
+        </span>
+      </div>
+    );
+
+    // The guarantee (Pillar 1b): with a fallback projection, never blank — show
+    // the content read-only. ProsePreview parses HTML leniently, so it renders
+    // even content the live fragment couldn't.
+    if (fallbackHtml !== undefined) {
+      return (
+        <div>
+          {banner}
+          <ProsePreview html={fallbackHtml || '<p></p>'} />
         </div>
+      );
+    }
+
+    // No projection to fall back to — a recoverable panel (the legacy floor).
+    return (
+      <div style={{ margin: '2rem auto', maxWidth: '36rem' }}>
+        {banner}
       </div>
     );
   }

--- a/src/ui/proseFragmentCheck.test.ts
+++ b/src/ui/proseFragmentCheck.test.ts
@@ -1,0 +1,57 @@
+/**
+ * proseFragmentCheck (JP-328, Pillar 1a) — the fragment pre-flight that keeps a
+ * malformed relay Y.Doc fragment from ever mounting the live editor (which would
+ * crash NodeView reconciliation and blank the page).
+ *
+ * A well-formed fragment builds + validates cleanly (mount the editor); a
+ * fragment carrying a schema-invalid node fails the check (fall back to the
+ * read-only ProsePreview). We build the fragments the same way the relay seeds
+ * them — XmlElement nodes inside the `prose:<page>` fragment — so this exercises
+ * the real y-prosemirror build path, not a mock.
+ */
+
+import * as Y from 'yjs';
+import { isFragmentRenderable } from './proseFragmentCheck';
+
+/** Append a `<p>text</p>` block to a prose fragment (a valid paragraph). */
+function appendParagraph(frag: Y.XmlFragment, text: string): void {
+  const p = new Y.XmlElement('paragraph');
+  p.insert(0, [new Y.XmlText(text)]);
+  frag.insert(frag.length, [p]);
+}
+
+describe('isFragmentRenderable', () => {
+  it('returns true for a well-formed prose fragment', () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment('prose:p1');
+    appendParagraph(frag, 'hello world');
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(true);
+  });
+
+  it('returns true for an empty fragment (trivially renderable)', () => {
+    const doc = new Y.Doc();
+    doc.getXmlFragment('prose:p1'); // create, leave empty
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(true);
+  });
+
+  it('returns false for an unknown node type the client schema cannot render', () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment('prose:p1');
+    // A node type that doesn't exist in the prose schema — the exact class of
+    // drift that crashes the live editor's reconciliation on open.
+    frag.insert(0, [new Y.XmlElement('totallyBogusBlock')]);
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(false);
+  });
+
+  it('returns false for an atom node carrying children (image with content)', () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment('prose:p1');
+    // `image` is an atom/leaf in the schema; giving it children violates the
+    // schema and crashes NodeView reconciliation ("reading 'children'").
+    const img = new Y.XmlElement('image');
+    img.setAttribute('src', 'blob:x');
+    img.insert(0, [new Y.XmlText('illegal child')]);
+    frag.insert(0, [img]);
+    expect(isFragmentRenderable(doc, 'prose:p1')).toBe(false);
+  });
+});

--- a/src/ui/proseFragmentCheck.ts
+++ b/src/ui/proseFragmentCheck.ts
@@ -1,0 +1,81 @@
+/**
+ * proseFragmentCheck — pre-flight a prose `Y.XmlFragment` against the client
+ * schema *before* the live collaborative editor binds to it (JP-328, Pillar 1a).
+ *
+ * For a relay document the editor adopts the authoritative Y.Doc fragment via
+ * Tiptap's `Collaboration` extension, and **y-prosemirror builds the ProseMirror
+ * doc straight from the fragment** (`yXmlFragmentToProseMirrorRootNode`) —
+ * bypassing Tiptap's content parser. So a schema-invalid node (an unknown type,
+ * or an atom carrying children) isn't fitted-to-schema the way pasted HTML is;
+ * it reaches ReactNodeView reconciliation and throws "Cannot read properties of
+ * undefined (reading 'children')" *during render*, blanking the page.
+ *
+ * Tiptap's `enableContentCheck` / `onContentError` does **not** fire on this
+ * path (it only guards the content-parser path), so we reproduce the same build
+ * here and validate it with ProseMirror's own `Node.check()`. If it throws, the
+ * panel renders the crash-safe read-only `ProsePreview` (which loads the HTML
+ * projection through ProseMirror's lenient `DOMParser`) instead of mounting the
+ * editor — content stays visible, never blank.
+ *
+ * This is an *optimization* over the `ProseErrorBoundary` fallback: it avoids
+ * the mount-crash-then-recover flash and the console noise. The boundary remains
+ * the backstop for any crash this pre-check can't foresee.
+ */
+
+import { getSchema } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { yXmlFragmentToProseMirrorRootNode } from 'y-prosemirror';
+import type { Schema } from 'prosemirror-model';
+import type { Doc as YDoc } from 'yjs';
+import { sharedProseExtensions } from './TiptapEditor';
+
+let cachedSchema: Schema | null = null;
+
+/**
+ * The schema the collaborative editor actually builds — StarterKit with history
+ * off and the lowlight codeBlock swapped in, plus the shared prose extensions.
+ * `Collaboration` adds no nodes, so it's omitted. Mirrors
+ * `CollaborativeProseEditor`'s extension set and the `proseSchemaContract` test.
+ * Built once and cached (the extension set is static for the app's lifetime).
+ */
+export function collabProseSchema(): Schema {
+  if (!cachedSchema) {
+    cachedSchema = getSchema([
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3, 4, 5, 6] },
+        codeBlock: false,
+        history: false,
+      }),
+      ...sharedProseExtensions,
+    ]);
+  }
+  return cachedSchema;
+}
+
+/**
+ * `true` if the fragment builds into a schema-valid ProseMirror doc the live
+ * editor can render; `false` if building or validation throws (the caller should
+ * fall back to read-only `ProsePreview`). Read-only: builds a throwaway PM node,
+ * never mutates the Y.Doc.
+ */
+export function isFragmentRenderable(ydoc: YDoc, field: string): boolean {
+  try {
+    const frag = ydoc.getXmlFragment(field);
+    // An empty fragment is trivially fine: the live editor seeds an empty
+    // paragraph itself, so don't reject it here (the bare `doc` would fail its
+    // `block+` content rule). The panel only mounts on an empty fragment once
+    // the relay has confirmed it (`isSynced`).
+    if (frag.length === 0) return true;
+    const root = yXmlFragmentToProseMirrorRootNode(frag, collabProseSchema());
+    // `check()` recurses the whole tree, asserting content expressions and atom
+    // constraints — the exact violations that crash NodeView reconciliation.
+    root.check();
+    return true;
+  } catch (err) {
+    console.warn(
+      `[prose] fragment "${field}" failed the schema pre-check; rendering read-only`,
+      err,
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
Promote master → staging to deploy the JP-328 prose/MCP hardening for live E2E.

## What's deploying

- **PR #234 — write gate finished.** Anchored `set_prose` now gated; full gate
  test matrix (anchored heal, hydration self-heal, `validate_prose_html` diff).
- **PR #235 — never blank (client).** A single malformed prose node can no longer
  blank a page: `ProseErrorBoundary` falls back to read-only `ProsePreview`, and a
  fragment pre-check degrades gracefully before mounting the live editor.
- **PR #236 — `docushark.get_skills` (relay).** Content contract + recipe catalogue
  for agents; traversal-safe by construction; skills vendored into the relay build
  context. No Dockerfile/CI change.

## Verified locally

Relay 436 tests + client 2349 tests green; typecheck clean. Staging E2E to confirm:
the never-blank fallback on a real malformed doc, the anchored-write heal over MCP,
and `get_skills` answering on the staging relay's `/mcp`.

Assisted-by: Opus 4.8