### PR TITLE
prose: defer node-view projection write-backs (fix "reading children" crash)

### DIFF
--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -26,8 +26,7 @@ import type { Node as PMNode } from '@tiptap/pm/model';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import { useReferenceStore } from '../store/referenceStore';
 import { referencePreview } from '../services/citations/preview';
-import { PROSE_PROJECTION_META } from './proseProjection';
-import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { scheduleProjectionWriteBack } from './proseProjection';
 import { showCitationCard, hideCitationCard } from './citationHoverCard';
 
 declare module '@tiptap/core' {
@@ -139,22 +138,18 @@ export const CitationInline = Node.create<CitationOptions>({
       };
 
       // Persist the formatted text into the node's `label` attr so the HTML
-      // projection (getHTML → PDF / MCP / offline) is self-contained. Runs in an
-      // async microtask after the PM update (never "dispatch during dispatch").
+      // projection (getHTML → PDF / MCP / offline) is self-contained. Deferred +
+      // re-validated by `scheduleProjectionWriteBack` (never "dispatch during
+      // dispatch") — the refId identity guard stops a stale pos writing a label
+      // onto a different citation. See the invariant in proseProjection.ts.
       const writeBackLabel = (label: string) => {
-        if (!editor.isEditable) return; // view-only clients never dirty the doc
-        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
-        const pos = typeof getPos === 'function' ? getPos() : undefined;
-        if (pos == null) return;
-        const cur = editor.state.doc.nodeAt(pos);
-        // type AND refId match → never write a label onto a different citation
-        // if `pos` went stale between format start and this resolve.
-        if (!cur || cur.type.name !== this.name || cur.attrs['refId'] !== refId) return;
-        if (cur.attrs['label'] === label) return; // idempotent → loop-safe
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
-        tr.setMeta('addToHistory', false); // keep label-sync out of undo
-        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
-        editor.view.dispatch(tr);
+        scheduleProjectionWriteBack({
+          editor,
+          getPos,
+          nodeName: this.name,
+          identity: (n) => n.attrs['refId'] === refId,
+          attrs: { label },
+        });
       };
 
       const render = () => {
@@ -425,23 +420,18 @@ export const Bibliography = Node.create<CitationOptions>({
       let lastCitedKey = '';
 
       // Persist the rendered bibliography HTML into the node's `bibHtml` attr so
-      // non-editor consumers are self-contained. Same safety as CitationInline:
-      // idempotent, editable-only, out of undo, runs post-update.
+      // non-editor consumers are self-contained. Deferred + re-validated by
+      // `scheduleProjectionWriteBack` (see the invariant in proseProjection.ts).
       const writeBackContent = (rawHtml: string) => {
-        if (!editor.isEditable) return;
-        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
         // Newlines → spaces: keep the persisted attribute value single-line and
         // robust across serializers (citeproc emits newlines between entries).
         const bibHtml = rawHtml.replace(/[\r\n]+/g, ' ');
-        const pos = typeof getPos === 'function' ? getPos() : undefined;
-        if (pos == null) return;
-        const cur = editor.state.doc.nodeAt(pos);
-        if (!cur || cur.type.name !== this.name) return;
-        if (cur.attrs['bibHtml'] === bibHtml) return;
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, bibHtml });
-        tr.setMeta('addToHistory', false);
-        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
-        editor.view.dispatch(tr);
+        scheduleProjectionWriteBack({
+          editor,
+          getPos,
+          nodeName: this.name,
+          attrs: { bibHtml },
+        });
       };
 
       const render = () => {

--- a/src/tiptap/FieldExtension.ts
+++ b/src/tiptap/FieldExtension.ts
@@ -23,8 +23,7 @@
 import { Node, mergeAttributes } from '@tiptap/core';
 import { useFieldStore } from '../store/fieldStore';
 import { getComputedField } from '../types/Field';
-import { PROSE_PROJECTION_META } from './proseProjection';
-import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { scheduleProjectionWriteBack } from './proseProjection';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -117,18 +116,20 @@ export const FieldRef = Node.create<FieldOptions>({
       // projection (getHTML → PDF / MCP / offline) is self-contained. Same
       // safety as CitationInline: idempotent, editable-only, out of undo, runs
       // post-update, re-checks position + type + name before dispatch.
+      // Persist the resolved value into the node's `label` attr so the HTML
+      // projection (getHTML → PDF / MCP / offline) is self-contained. Deferred +
+      // re-validated by `scheduleProjectionWriteBack` — fieldRef resolves its
+      // value synchronously in render(), so a direct dispatch would crash the
+      // view mid-reconciliation (MCP fieldRefs arrive label-less, so every one on
+      // the page would fire at once). See the invariant in proseProjection.ts.
       const writeBackLabel = (label: string) => {
-        if (!editor.isEditable) return; // view-only clients never dirty the doc
-        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
-        const pos = typeof getPos === 'function' ? getPos() : undefined;
-        if (pos == null) return;
-        const cur = editor.state.doc.nodeAt(pos);
-        if (!cur || cur.type.name !== this.name || cur.attrs['name'] !== name) return;
-        if (cur.attrs['label'] === label) return; // idempotent → loop-safe
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
-        tr.setMeta('addToHistory', false); // keep label-sync out of undo
-        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
-        editor.view.dispatch(tr);
+        scheduleProjectionWriteBack({
+          editor,
+          getPos,
+          nodeName: this.name,
+          identity: (n) => n.attrs['name'] === name,
+          attrs: { label },
+        });
       };
 
       const render = () => {

--- a/src/tiptap/proseProjection.test.ts
+++ b/src/tiptap/proseProjection.test.ts
@@ -1,10 +1,35 @@
 /**
- * Tests for the prose-projection transaction marker (JP-89).
+ * Tests for the prose-projection machinery (JP-89): the transaction marker AND
+ * `scheduleProjectionWriteBack`, the deferred write-back helper.
+ *
+ * The helper's contract (see the invariant in proseProjection.ts): a node view's
+ * derived-attr write-back must NEVER dispatch synchronously during view
+ * reconciliation — that re-enters the view tree and crashes with "Cannot read
+ * properties of undefined (reading 'children')". It defers to a microtask,
+ * re-validates the target, and tags the write as a silent projection.
+ *
+ * NOTE on the regression suite: the actual "reading 'children'" crash is a
+ * real-browser ProseMirror view-desc failure that jsdom (no layout) does NOT
+ * reproduce, even via the Collaboration fragment-adoption path. So the **guard**
+ * against the regression is the `defers ... never during reconciliation` contract
+ * test above — it fails the moment the helper dispatches synchronously (the exact
+ * cause of the crash). The mount tests below are jsdom **smoke tests**: they prove
+ * the deferred write-back path renders a page full of label-less fieldRefs and
+ * bakes the labels back in without throwing.
  */
-import { describe, it, expect } from 'vitest';
-import { Editor } from '@tiptap/core';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Editor, type Extensions } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
-import { PROSE_PROJECTION_META, isProjectionTransaction } from './proseProjection';
+import {
+  PROSE_PROJECTION_META,
+  isProjectionTransaction,
+  scheduleProjectionWriteBack,
+} from './proseProjection';
+import Collaboration from '@tiptap/extension-collaboration';
+import { prosemirrorToYDoc } from 'y-prosemirror';
+import { FieldRef } from './FieldExtension';
+import { extensions as fullProseExtensions, sharedProseExtensions } from '../ui/TiptapEditor';
+import { useFieldStore } from '../store/fieldStore';
 
 function makeEditor(): Editor {
   const element = document.createElement('div');
@@ -24,5 +49,241 @@ describe('isProjectionTransaction', () => {
     const tr = editor.state.tr.setMeta(PROSE_PROJECTION_META, true);
     expect(isProjectionTransaction(tr)).toBe(true);
     editor.destroy();
+  });
+});
+
+// ---- scheduleProjectionWriteBack ------------------------------------------
+
+const isolated: Extensions = [StarterKit.configure({ history: false }), FieldRef];
+
+function mount(content: string, exts: Extensions = isolated): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions: exts, content });
+  return { editor, element };
+}
+
+/** Position of the first fieldRef node in the doc, or -1. */
+function firstFieldPos(editor: Editor): number {
+  let pos = -1;
+  editor.state.doc.descendants((node, p) => {
+    if (pos === -1 && node.type.name === 'fieldRef') pos = p;
+    return pos === -1;
+  });
+  return pos;
+}
+
+const flush = () => Promise.resolve();
+
+describe('scheduleProjectionWriteBack', () => {
+  beforeEach(() => useFieldStore.getState().clear());
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A fieldRef whose cached label already equals the store value, so the node
+  // view's OWN write-back no-ops — letting us observe the helper in isolation.
+  function mountStableField(): { editor: Editor; element: HTMLElement; pos: number } {
+    useFieldStore.getState().setField('Company', 'Acme');
+    const { editor, element } = mount(
+      '<p><span data-field data-name="Company" data-label="Acme"></span></p>',
+    );
+    return { editor, element, pos: firstFieldPos(editor) };
+  }
+
+  it('defers the dispatch to a microtask (never during reconciliation)', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush(); // let any mount-time write-back settle (it no-ops here)
+    const spy = vi.spyOn(editor.view, 'dispatch');
+
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'Changed' } });
+    expect(spy).not.toHaveBeenCalled(); // synchronous: nothing yet
+
+    await flush();
+    expect(spy).toHaveBeenCalledTimes(1); // dispatched only after the microtask
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('tags the write-back as a silent projection, out of undo', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    let tagged = false;
+    let outOfUndo = false;
+    editor.on('transaction', ({ transaction }) => {
+      if (isProjectionTransaction(transaction)) {
+        tagged = true;
+        outOfUndo = transaction.getMeta('addToHistory') === false;
+      }
+    });
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'New' } });
+    await flush();
+    expect(tagged).toBe(true);
+    expect(outOfUndo).toBe(true);
+    editor.destroy();
+    element.remove();
+  });
+
+  it('is idempotent — no dispatch when attrs already match', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'Acme' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('skips when the identity guard fails (stale pos → different node)', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({
+      editor,
+      getPos: () => pos,
+      nodeName: 'fieldRef',
+      identity: (n) => n.attrs['name'] === 'SomeoneElse',
+      attrs: { label: 'New' },
+    });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('skips when the node type at pos does not match', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'citationInline', attrs: { label: 'New' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('never dirties a view-only (non-editable) editor', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    editor.setEditable(false);
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'Changed' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('skips when getPos is unavailable (boolean false)', async () => {
+    const { editor, element } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: false, nodeName: 'fieldRef', attrs: { label: 'New' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('multi-fieldRef live mount (regression: the "reading children" crash)', () => {
+  beforeEach(() => useFieldStore.getState().clear());
+
+  it('mounts an editable editor full of label-less fieldRefs without crashing', async () => {
+    // Smoke test (jsdom can't reproduce the real-browser crash): many label-less
+    // fieldRefs across paragraphs, a table cell, and list items render and write
+    // their labels back via the deferred helper without throwing.
+    const store = useFieldStore.getState();
+    for (const [n, v] of [
+      ['Project', 'My Lobby'],
+      ['Framework', 'Next.js 15'],
+      ['CMS', 'Payload CMS v3'],
+      ['Database', 'MongoDB'],
+      ['PackageManager', 'bun'],
+      ['DocStatus', 'Living document'],
+      ['LastReviewed', '2026-06-17'],
+    ] as const) {
+      store.setField(n, v);
+    }
+    const content =
+      '<p><span data-field data-name="Project"></span> is built on <span data-field data-name="Framework"></span> and <span data-field data-name="CMS"></span>, with <span data-field data-name="Database"></span> for data; the package manager is <span data-field data-name="PackageManager"></span>.</p>' +
+      '<table><tbody><tr><th><p>Layer</p></th><th><p>Choice</p></th></tr><tr><td><p>Framework</p></td><td><p><span data-field data-name="Framework"></span></p></td></tr></tbody></table>' +
+      '<ul><li><p>Status: <span data-field data-name="DocStatus"></span></p></li><li><p>Reviewed <span data-field data-name="LastReviewed"></span></p></li></ul>';
+
+    let editor!: Editor;
+    let element!: HTMLElement;
+    expect(() => {
+      ({ editor, element } = mount(content, fullProseExtensions));
+    }).not.toThrow();
+
+    await flush();
+    await flush(); // let the deferred label write-backs apply
+
+    // The page rendered AND the deferred write-backs baked the labels in, so the
+    // HTML projection is self-contained (values resolvable offline / in PDF).
+    const html = editor.getHTML();
+    expect(html).toContain('data-label="My Lobby"');
+    expect(html).toContain('data-label="bun"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('adopts a Collaboration fragment of label-less fieldRefs without crashing', async () => {
+    // Smoke test of the TRUE crash path: a relay doc binds the page's
+    // Y.XmlFragment via the Collaboration extension, and y-prosemirror builds the
+    // editor doc straight from the fragment. With label-less fieldRefs + fields
+    // set, every fieldRef's render() write-back fired synchronously during that
+    // adoption → the real-browser "reading 'children'" crash. jsdom doesn't
+    // reproduce the crash itself, but this exercises the adoption path end-to-end
+    // and proves the deferred write-back renders + labels it without throwing.
+    const store = useFieldStore.getState();
+    for (const [n, v] of [
+      ['Project', 'My Lobby'],
+      ['Framework', 'Next.js 15'],
+      ['CMS', 'Payload CMS v3'],
+      ['Database', 'MongoDB'],
+      ['PackageManager', 'bun'],
+      ['DocStatus', 'Living document'],
+      ['LastReviewed', '2026-06-17'],
+    ] as const) {
+      store.setField(n, v);
+    }
+    const content =
+      '<p><span data-field data-name="Project"></span> on <span data-field data-name="Framework"></span> + <span data-field data-name="CMS"></span>, data <span data-field data-name="Database"></span>, pkg <span data-field data-name="PackageManager"></span>.</p>' +
+      '<ul><li><p>Status: <span data-field data-name="DocStatus"></span></p></li><li><p>Reviewed <span data-field data-name="LastReviewed"></span></p></li></ul>';
+
+    // Seed the Y.Doc fragment from a NON-editable parse so the fieldRefs stay
+    // label-less (no write-back fires) — matching an MCP-authored relay doc.
+    const seedEl = document.createElement('div');
+    document.body.appendChild(seedEl);
+    const seed = new Editor({ element: seedEl, editable: false, extensions: fullProseExtensions, content });
+    const ydoc = prosemirrorToYDoc(seed.state.doc, 'prose:p1');
+    seed.destroy();
+    seedEl.remove();
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    let editor!: Editor;
+    expect(() => {
+      editor = new Editor({
+        element,
+        extensions: [
+          StarterKit.configure({ heading: { levels: [1, 2, 3, 4, 5, 6] }, codeBlock: false, history: false }),
+          ...sharedProseExtensions,
+          Collaboration.configure({ document: ydoc, field: 'prose:p1' }),
+        ],
+      });
+    }).not.toThrow();
+
+    await flush();
+    await flush();
+
+    expect(editor.getHTML()).toContain('data-label="My Lobby"');
+
+    editor.destroy();
+    element.remove();
   });
 });

--- a/src/tiptap/proseProjection.ts
+++ b/src/tiptap/proseProjection.ts
@@ -14,9 +14,21 @@
  * such transactions through a **non-dirtying** content update
  * (`richTextStore.setContentSilently`) instead of the normal dirtying one. This
  * is generic — any future prose helper reuses it, no per-node special-casing.
+ *
+ * ## The invariant — never dispatch a projection synchronously from a node view
+ *
+ * Node views render **during** ProseMirror's view reconciliation. A *synchronous*
+ * `editor.view.dispatch` from inside a node view's `render`/`update` re-enters the
+ * view tree while it is still being built and crashes with
+ * `Cannot read properties of undefined (reading 'children')`. So projection
+ * write-backs MUST be deferred to a microtask. Do not hand-roll that — always go
+ * through {@link scheduleProjectionWriteBack}, which is deferred by construction.
  */
 
+import type { Editor } from '@tiptap/core';
+import type { Node as PMNode } from '@tiptap/pm/model';
 import type { Transaction } from '@tiptap/pm/state';
+import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 
 /** Transaction meta key marking a derived/projection write (not a user edit). */
 export const PROSE_PROJECTION_META = 'proseProjection';
@@ -24,4 +36,54 @@ export const PROSE_PROJECTION_META = 'proseProjection';
 /** True if `tr` is a projection write-back (derived cache, not a user edit). */
 export function isProjectionTransaction(tr: Transaction): boolean {
   return tr.getMeta(PROSE_PROJECTION_META) === true;
+}
+
+export interface ProjectionWriteBackOptions {
+  /** The editor the node view belongs to. */
+  editor: Editor;
+  /** Tiptap's node-view `getPos` (a function, or `boolean` when unavailable). */
+  getPos: (() => number | undefined) | boolean;
+  /** The node's type name (`this.name` inside the extension). */
+  nodeName: string;
+  /**
+   * Extra identity guard so a stale `pos` can never write onto a *different*
+   * node of the same type (e.g. match on `name`/`refId`). Defaults to "match".
+   */
+  identity?: (node: PMNode) => boolean;
+  /** The derived attrs to merge into the node. Skipped if already equal. */
+  attrs: Record<string, unknown>;
+}
+
+/**
+ * Persist derived attrs back onto a node from inside its node view — **safely**.
+ *
+ * The dispatch is always deferred to a microtask (so it runs *after* the current
+ * view reconciliation, never re-entrantly — see the invariant above), tagged as a
+ * projection (`addToHistory:false` + {@link PROSE_PROJECTION_META}, so it never
+ * dirties the doc or enters undo), and re-validated at execution time (position,
+ * type, and `identity` may have changed since it was queued). Idempotent: if every
+ * target attr already equals the node's, nothing is dispatched — so a page of
+ * many such nodes converges instead of looping.
+ *
+ * Only for **derived/projection** writes. A genuine *user edit* (a layout toggle,
+ * a float choice) must keep history and dirty the doc, so it dispatches directly
+ * from its event handler — not through here.
+ */
+export function scheduleProjectionWriteBack(opts: ProjectionWriteBackOptions): void {
+  const { editor, getPos, nodeName, identity, attrs } = opts;
+  queueMicrotask(() => {
+    if (!editor.isEditable) return; // view-only clients never dirty the doc
+    if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
+    const pos = typeof getPos === 'function' ? getPos() : undefined;
+    if (pos == null) return;
+    const cur = editor.state.doc.nodeAt(pos);
+    if (!cur || cur.type.name !== nodeName) return;
+    if (identity && !identity(cur)) return; // pos went stale → wrong node, skip
+    // Idempotent → loop-safe: skip when the node already carries these values.
+    if (Object.entries(attrs).every(([k, v]) => cur.attrs[k] === v)) return;
+    const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, ...attrs });
+    tr.setMeta('addToHistory', false); // derived cache → out of undo
+    tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
+    editor.view.dispatch(tr);
+  });
 }


### PR DESCRIPTION
## Why

A clean, schema-valid MCP-authored doc crashed the **live** prose editor on open
with `TypeError: Cannot read properties of undefined (reading 'children')` (caught
by `ProseErrorBoundary` → read-only; the fields menu then can't open). Read-only
renders perfectly, so the content is fine.

**Root cause:** the `fieldRef` node view resolves its value synchronously in
`render()` and **dispatches a `label` write-back transaction during ProseMirror
reconciliation**. Node views render mid-reconciliation, so a synchronous
`editor.view.dispatch` there re-enters the view tree → the crash. MCP fieldRefs
arrive **label-less**, so the idempotent guard never skipped them — every fieldRef
on the page dispatched at once. (`editor.isEditable === false` in the read-only
preview short-circuits the write, which is why only the live editor died.)

`CitationInline` / `Bibliography` did the same write-back but dodged the crash only
*implicitly* — riding an async citation-formatter `.then()`. Fragile.

## What (fix it so it can never recur)

A single shared, **deferred-by-construction** helper `scheduleProjectionWriteBack`
in `proseProjection.ts` (the projection module that owns `PROSE_PROJECTION_META`).
It always `queueMicrotask`s the dispatch (after reconciliation), re-validates
pos/type/identity at execution time, is idempotent (a page of N nodes converges,
no loop), and tags the tr as a silent, out-of-undo projection. All three
projection write-backs migrated to it:
- `FieldRef` `label` — the crash; replaces the stop-gap.
- `CitationInline` `label` — now explicitly deferred (no longer relying on the
  async formatter for safety).
- `Bibliography` `bibHtml` — same.

The invariant ("never dispatch a projection synchronously from a node view") is
documented in `proseProjection.ts`.

**Out of scope** (different, safe patterns — untouched): event-handler dispatches
(Gallery/ResizableImage/Citation `scope` — user edits that fire after
reconciliation) and `LatexExtension` input-rule dispatches.

## Tests

`proseProjection.test.ts`:
- The **`defers … never during reconciliation`** contract test is the regression
  guard — **verified it FAILS on a synchronous dispatch and passes deferred**.
- idempotent / stale-pos / wrong-type / view-only / no-getPos / projection-tagging.
- A Collaboration fragment-adoption smoke test (the true crash path).

The real-browser crash isn't reproducible in jsdom (no layout), so the contract
test guards the exact invariant whose violation causes it. 2354 client tests
green, typecheck clean.

Assisted-by: Opus 4.8