### PR TITLE
JP-320: MCP write/persist correctness

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -120,11 +120,13 @@ All tools are namespaced `docushark.*`.
 
 | Tool | Purpose |
 | -- | -- |
+| `add_canvas_page` | Append a blank canvas page; returns `{ id }`. Target it with the returned id in `add_shape(s)`/`generate_diagram` to build a second diagram in the same document. |
+| `rename_canvas_page` | Rename a canvas page. |
 | `add_shape` | Add one shape (rectangle, ellipse, text, connector). |
 | `add_shapes` | Add many shapes in one all-or-nothing call. |
 | `connect` | Connect two existing shapes with a connector. |
 | `update_shape` | Patch an existing shape (`x`, `y`, `w`, `h`, `text`, `style`). |
-| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` with crossing minimization, or `grid`) and wires connectors to typed anchors with orthogonal obstacle-avoiding routing (`routing: "straight"` opts out). |
+| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` with crossing minimization, or `grid`) and wires connectors to typed anchors with orthogonal obstacle-avoiding routing (`routing: "straight"` opts out). Writes the live Y.Doc on a resident doc (a connected editor sees the shapes immediately) — like the other shape tools. |
 
 ### Manage (write)
 
@@ -175,9 +177,11 @@ the relay, writes apply to the **authoritative Y.Doc** and broadcast a CRDT
 delta, so connected editors see the change immediately (they merge it — no
 reload):
 
-- **Shape** tools (`add_shape`/`add_shapes`/`connect`/`update_shape`) write the
-  live shape map when the doc is resident *and* the target page is the active
-  page.
+- **Shape** tools (`add_shape`/`add_shapes`/`connect`/`update_shape`/
+  `delete_shape`/`reorder_shapes`/`generate_diagram`) write the live shape map
+  when the doc is resident *and* the target page is the active page. (Canvas
+  page-list tools — `add_canvas_page`/`rename_canvas_page` — are JSON-only,
+  like the prose page list; a new page's *tab* may lag until reload.)
 - **Prose** tools (`set_prose`/`add_prose_page`/`insert_section`/
   `restructure_outline`) rebuild the page's live `prose:<pageId>` fragment
   (whole-page replace) when the doc is resident — so an agent's prose appears in

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -214,6 +214,35 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
             }),
         },
         ToolDescriptor {
+            name: "docushark.add_canvas_page",
+            description:
+                "Add a new (blank) canvas page to a document and return its id. Use this to start a second diagram in the same document; target it with the returned id in add_shape(s)/generate_diagram. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "name": {"type": "string", "description": "Page title. Defaults to \"Page N\"."}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.rename_canvas_page",
+            description:
+                "Rename a canvas page. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "name": {"type": "string"}
+                },
+                "required": ["docId", "pageId", "name"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
             name: "docushark.get_outline",
             description:
                 "Return the heading outline of a prose page as an ordered list of { index, level, title }. 'index' is the 0-based heading position used by insert_section and restructure_outline. Sections are flat: nesting is conveyed by 'level' (1–6), not containment.",
@@ -637,6 +666,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.add_prose_page" => add_prose_page(ctx, args),
         "docushark.set_prose" => set_prose(ctx, args),
         "docushark.rename_prose_page" => rename_prose_page(ctx, args),
+        "docushark.add_canvas_page" => add_canvas_page(ctx, args),
+        "docushark.rename_canvas_page" => rename_canvas_page(ctx, args),
         "docushark.get_outline" => get_outline(ctx, args),
         "docushark.insert_section" => insert_section(ctx, args),
         "docushark.restructure_outline" => restructure_outline(ctx, args),
@@ -1435,6 +1466,113 @@ fn rename_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Str
     })
 }
 
+// ---------------------------------------------------------------------------
+// Canvas-page tools (JP-320). The canvas page LIST (`pages` map + `pageOrder`)
+// is JSON-only — only the active page's shapes live in the authoritative Y.Doc
+// — so these mirror the prose page-list ops (`add_prose_page` /
+// `rename_prose_page`): write the JSON store under optimistic concurrency and
+// nudge a reload via `changed_doc_id`.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct AddCanvasPageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    name: Option<String>,
+}
+
+fn add_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: AddCanvasPageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    let id = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let order_len = doc
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        let page_id = format!("page-{}", nanoid::nanoid!(12));
+        let name = parsed
+            .name
+            .clone()
+            .map(|n| n.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| format!("Page {}", order_len + 1));
+
+        let obj = doc.as_object_mut().ok_or("Document is not an object")?;
+        obj.entry("pages")
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .ok_or("Document 'pages' is not an object")?
+            .insert(
+                page_id.clone(),
+                json!({
+                    "id": page_id,
+                    "name": name,
+                    "shapes": {},
+                    "shapeOrder": [],
+                    "createdAt": now,
+                    "modifiedAt": now,
+                }),
+            );
+        obj.entry("pageOrder")
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .ok_or("Document 'pageOrder' is not an array")?
+            .push(json!(page_id.clone()));
+
+        stamp_doc_modified(doc, now);
+        Ok(page_id)
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"id": id}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct RenameCanvasPageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    name: String,
+}
+
+fn rename_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: RenameCanvasPageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+    let name = parsed.name.trim().to_string();
+    if name.is_empty() {
+        return Err("Page name must not be empty".into());
+    }
+
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let page = doc
+            .get_mut("pages")
+            .and_then(|v| v.as_object_mut())
+            .and_then(|pages| pages.get_mut(&parsed.page_id))
+            .and_then(|p| p.as_object_mut())
+            .ok_or_else(|| format!("Canvas page '{}' not found", parsed.page_id))?;
+        page.insert("name".into(), json!(name.clone()));
+        page.insert("modifiedAt".into(), json!(now));
+        stamp_doc_modified(doc, now);
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "name": name}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
 /// Stamp the document's top-level `modifiedAt` (prose edits don't belong to
 /// a canvas page, so `stamp_modified`'s page arm doesn't apply).
 fn stamp_doc_modified(doc: &mut Value, now: u64) {
@@ -1795,87 +1933,113 @@ fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Stri
         layout_diagram(&node_specs, &edge_pairs, mode)
     };
 
-    let (node_map, edge_ids) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        // logical node id -> created shape id, for wiring connectors.
-        let mut node_map = serde_json::Map::new();
-        for (n, (_, pos)) in parsed.nodes.iter().zip(diagram.nodes.iter()) {
-            let kind = match n.kind.as_deref() {
-                Some("ellipse") => super::adapter::DslKind::Ellipse,
-                _ => super::adapter::DslKind::Rectangle,
-            };
-            let dsl = DslShape {
-                kind,
-                x: pos.x,
-                y: pos.y,
-                w: Some(NODE_W),
-                h: Some(NODE_H),
-                text: Some(n.label.clone().unwrap_or_else(|| n.id.clone())),
-                style: None,
-                id: None,
-                start_shape_id: None,
-                end_shape_id: None,
-                start_anchor: None,
-                end_anchor: None,
-                start_arrow_style: None,
-                end_arrow_style: None,
-                routing_mode: None,
-                waypoints: None,
-                label_position: None,
-                x2: None,
-                y2: None,
-            };
-            let shape_id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
-            node_map.insert(n.id.trim().to_string(), json!(shape_id));
-        }
+    // Build every shape up front with a pre-assigned id (nodes first, then
+    // edges) so the live and cold write paths persist the identical set and the
+    // returned id map is stable regardless of which path runs. Connectors carry
+    // the node shape ids, which are assigned in this same pass before either
+    // path runs. Mirrors `add_shapes` — `generate_diagram` previously wrote the
+    // JSON store directly, so on a resident doc its shapes never reached the
+    // authoritative Y.Doc and could be clobbered by the live doc on flatten.
+    let mut node_map = serde_json::Map::new();
+    let mut shapes: Vec<(String, DslShape)> =
+        Vec::with_capacity(parsed.nodes.len() + parsed.edges.len());
+    for (n, (_, pos)) in parsed.nodes.iter().zip(diagram.nodes.iter()) {
+        let kind = match n.kind.as_deref() {
+            Some("ellipse") => super::adapter::DslKind::Ellipse,
+            _ => super::adapter::DslKind::Rectangle,
+        };
+        let mut dsl = DslShape {
+            kind,
+            x: pos.x,
+            y: pos.y,
+            w: Some(NODE_W),
+            h: Some(NODE_H),
+            text: Some(n.label.clone().unwrap_or_else(|| n.id.clone())),
+            style: None,
+            id: None,
+            start_shape_id: None,
+            end_shape_id: None,
+            start_anchor: None,
+            end_anchor: None,
+            start_arrow_style: None,
+            end_arrow_style: None,
+            routing_mode: None,
+            waypoints: None,
+            label_position: None,
+            x2: None,
+            y2: None,
+        };
+        let id = shape_id_or_gen(&dsl);
+        dsl.id = Some(id.clone());
+        node_map.insert(n.id.trim().to_string(), json!(id));
+        shapes.push((id, dsl));
+    }
 
-        let mut edge_ids = Vec::with_capacity(parsed.edges.len());
-        for (e, routed) in parsed.edges.iter().zip(diagram.edges.iter()) {
-            let from = node_map.get(e.from.trim()).and_then(|v| v.as_str()).unwrap();
-            let to = node_map.get(e.to.trim()).and_then(|v| v.as_str()).unwrap();
-            let dsl = DslShape {
-                kind: super::adapter::DslKind::Connector,
-                x: routed.start.x,
-                y: routed.start.y,
-                w: None,
-                h: None,
-                text: e.label.clone(),
-                style: None,
-                id: None,
-                start_shape_id: Some(from.to_string()),
-                end_shape_id: Some(to.to_string()),
-                start_anchor: Some(routed.start_anchor.as_str().to_string()),
-                end_anchor: Some(routed.end_anchor.as_str().to_string()),
-                start_arrow_style: None,
-                end_arrow_style: None,
-                routing_mode: orthogonal.then(|| "orthogonal".to_string()),
-                waypoints: orthogonal.then(|| {
-                    routed
-                        .waypoints
-                        .iter()
-                        .map(|p| super::adapter::DslPoint { x: p.x, y: p.y })
-                        .collect()
-                }),
-                label_position: routed.label_position,
-                x2: Some(routed.end.x),
-                y2: Some(routed.end.y),
-            };
-            edge_ids.push(json!(append_shape_in_place(doc, &parsed.page_id, &dsl)?));
-        }
+    let mut edge_ids = Vec::with_capacity(parsed.edges.len());
+    for (e, routed) in parsed.edges.iter().zip(diagram.edges.iter()) {
+        let from = node_map.get(e.from.trim()).and_then(|v| v.as_str()).unwrap().to_string();
+        let to = node_map.get(e.to.trim()).and_then(|v| v.as_str()).unwrap().to_string();
+        let mut dsl = DslShape {
+            kind: super::adapter::DslKind::Connector,
+            x: routed.start.x,
+            y: routed.start.y,
+            w: None,
+            h: None,
+            text: e.label.clone(),
+            style: None,
+            id: None,
+            start_shape_id: Some(from),
+            end_shape_id: Some(to),
+            start_anchor: Some(routed.start_anchor.as_str().to_string()),
+            end_anchor: Some(routed.end_anchor.as_str().to_string()),
+            start_arrow_style: None,
+            end_arrow_style: None,
+            routing_mode: orthogonal.then(|| "orthogonal".to_string()),
+            waypoints: orthogonal.then(|| {
+                routed
+                    .waypoints
+                    .iter()
+                    .map(|p| super::adapter::DslPoint { x: p.x, y: p.y })
+                    .collect()
+            }),
+            label_position: routed.label_position,
+            x2: Some(routed.end.x),
+            y2: Some(routed.end.y),
+        };
+        let id = shape_id_or_gen(&dsl);
+        dsl.id = Some(id.clone());
+        edge_ids.push(json!(id));
+        shapes.push((id, dsl));
+    }
 
-        stamp_modified(doc, &parsed.page_id);
-        Ok((node_map, edge_ids))
-    })?;
+    let result = json!({
+        "nodes": node_map,
+        "edges": edge_ids,
+        "layout": match mode { LayoutMode::Layered => "layered", LayoutMode::Grid => "grid" },
+        "routing": if orthogonal { "orthogonal" } else { "straight" },
+    });
 
-    Ok(ToolOutcome {
-        result: json!({
-            "nodes": node_map,
-            "edges": edge_ids,
-            "layout": match mode { LayoutMode::Layered => "layered", LayoutMode::Grid => "grid" },
-            "routing": if orthogonal { "orthogonal" } else { "straight" },
-        }),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            // One transaction, single broadcast (atomic) — same as `add_shapes`.
+            let items: Vec<(String, Value)> =
+                shapes.iter().map(|(id, dsl)| (id.clone(), build_shape_json(dsl, id))).collect();
+            let framed = handle.insert_shapes(&items)?;
+            Ok((framed, result.clone()))
+        },
+        |doc| {
+            for (idx, (_, dsl)) in shapes.iter().enumerate() {
+                if let Err(e) = append_shape_in_place(doc, &parsed.page_id, dsl) {
+                    return Err(format!("shape[{}]: {}", idx, e));
+                }
+            }
+            stamp_modified(doc, &parsed.page_id);
+            Ok(result.clone())
+        },
+    )
 }
 
 #[derive(Deserialize)]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -758,6 +758,8 @@ mod tests {
         assert!(names.contains(&"docushark.add_prose_page"));
         assert!(names.contains(&"docushark.set_prose"));
         assert!(names.contains(&"docushark.rename_prose_page"));
+        assert!(names.contains(&"docushark.add_canvas_page"));
+        assert!(names.contains(&"docushark.rename_canvas_page"));
         assert!(names.contains(&"docushark.get_outline"));
         assert!(names.contains(&"docushark.insert_section"));
         assert!(names.contains(&"docushark.restructure_outline"));
@@ -773,7 +775,7 @@ mod tests {
         assert!(names.contains(&"docushark.list_fields"));
         assert!(names.contains(&"docushark.set_fields"));
         assert!(names.contains(&"docushark.get_skills"));
-        assert_eq!(tools.len(), 27);
+        assert_eq!(tools.len(), 29);
     }
 
     #[tokio::test]

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -332,13 +332,28 @@ fn map_blocks(nodes: &[HtmlNode]) -> Vec<PmNode> {
 /// Is `n` inline content that joins an inline run (wrapped into one paragraph by
 /// [`map_blocks`]), versus a block-level element that breaks the run? All text
 /// counts — interior whitespace keeps a run together, and an all-whitespace run
-/// is dropped by [`paragraph_from_inline`]. Among elements, only marks and `<a>`
-/// are inline; everything else (known block, or unknown→unwrapped) breaks the run,
-/// preserving the prior per-node handling for those.
+/// is dropped by [`paragraph_from_inline`]. Among elements, marks, `<a>`, `<br>`,
+/// and the inline atoms (`fieldRef`/`citationInline` spans) are inline;
+/// everything else (known block, or unknown→unwrapped) breaks the run.
+///
+/// This must mirror what [`collect_inline`] recognizes: an inline element that
+/// breaks the run is later treated as a block by [`map_blocks`], so `<span>`
+/// fails to map and its (empty atom) children are unwrapped to nothing —
+/// silently dropping a `{{field}}` or citation inside a table cell / list item
+/// (the leading token vanishes, leaving an orphan separator). Keeping the atom
+/// in the run lets `collect_inline` build its `fieldRef`/`citationInline` node.
 fn is_inline_member(n: &HtmlNode) -> bool {
     match n {
         HtmlNode::Text(_) => true,
-        HtmlNode::Element { tag, .. } => prose_schema::mark_pm(tag).is_some() || tag == "a",
+        HtmlNode::Element { tag, attrs, .. } => {
+            prose_schema::mark_pm(tag).is_some()
+                || tag == "a"
+                || tag == "br"
+                || matches!(
+                    prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)),
+                    Some("fieldRef") | Some("citationInline")
+                )
+        }
     }
 }
 
@@ -897,6 +912,38 @@ mod tests {
         let PmChild::Node(cell) = &row.children[0] else { panic!("tableCell") };
         assert_eq!(cell.node_type, "tableCell");
         only_paragraph(cell);
+    }
+
+    #[test]
+    fn field_and_citation_spans_survive_in_a_table_cell() {
+        // JP-320 Report #3: a `{{field}}` (and a citation) leading a table cell
+        // was dropped, leaving an orphan separator — the field/citation span
+        // broke the inline run and was then unwrapped as a failed block. The
+        // markdown adapter emits `{{Framework}}` → `<span data-field …>`.
+        let b = html_to_blocks(concat!(
+            "<table><tr>",
+            r#"<td><span data-field data-name="Framework"></span>, fast</td>"#,
+            r#"<td>see <span data-citation data-ref-id="r1">[1]</span></td>"#,
+            "</tr></table>",
+        ));
+        let PmChild::Node(row) = &b[0].children[0] else { panic!("tableRow") };
+        let PmChild::Node(c0) = &row.children[0] else { panic!("tableCell 0") };
+        let p0 = only_paragraph(c0);
+        // The field atom survives AND the trailing literal is kept (no orphan).
+        assert!(
+            matches!(&p0.children[0], PmChild::Node(n) if n.node_type == "fieldRef"),
+            "leading fieldRef survives in cell: {p0:?}"
+        );
+        assert!(
+            p0.children.iter().any(|c| matches!(c, PmChild::Text { text, .. } if text.contains("fast"))),
+            "trailing text kept (no orphan comma): {p0:?}"
+        );
+        let PmChild::Node(c1) = &row.children[1] else { panic!("tableCell 1") };
+        let p1 = only_paragraph(c1);
+        assert!(
+            p1.children.iter().any(|c| matches!(c, PmChild::Node(n) if n.node_type == "citationInline")),
+            "citation survives in cell: {p1:?}"
+        );
     }
 
     #[test]

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -1174,3 +1174,277 @@ async fn jp35_mcp_live_write_reaches_connected_client() {
     mcp.stop().await.ok();
     relay.server.stop().await.expect("stop");
 }
+
+/// Call `docushark.generate_diagram` over MCP. Returns the `structuredContent`
+/// ({nodes: {logicalId: shapeId}, edges: [...], layout, routing}).
+async fn mcp_generate_diagram(
+    mcp_base: &str,
+    token: &str,
+    doc_id: &str,
+    page_id: &str,
+    nodes: Value,
+    edges: Value,
+) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.generate_diagram", "arguments": {
+            "docId": doc_id, "pageId": page_id, "nodes": nodes, "edges": edges
+        }}
+    });
+    let res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    res["result"]["structuredContent"].clone()
+}
+
+/// JP-320 Report #2: `generate_diagram` on a **resident** doc writes the live
+/// Y.Doc (a connected editor sees the shapes via the CRDT broadcast) and leaves
+/// the JSON store to the snapshot sweeper — the same live path every other
+/// shape tool uses. Previously it wrote JSON directly, so the shapes never
+/// reached the authoritative Y.Doc and were invisible / clobberable.
+#[tokio::test]
+async fn jp320_generate_diagram_reaches_connected_client() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-gen", "name": "Gen", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-gen").await;
+
+    let gen = mcp_generate_diagram(
+        &mcp_base,
+        &token,
+        "doc-gen",
+        "p1",
+        json!([{"id": "a", "label": "A"}, {"id": "b", "label": "B"}]),
+        json!([{"from": "a", "to": "b"}]),
+    )
+    .await;
+    let node_a = gen["nodes"]["a"].as_str().unwrap_or_else(|| panic!("no node id: {gen}")).to_string();
+    let node_b = gen["nodes"]["b"].as_str().expect("node b").to_string();
+
+    // The editor receives the generated shapes live (poll until both nodes land).
+    let mut delivered = false;
+    for _ in 0..30 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape(&node_a) && local.has_shape(&node_b) {
+            delivered = true;
+            break;
+        }
+    }
+    assert!(delivered, "editor never received the generated shapes live");
+
+    // Live path leaves the JSON snapshot to the sweeper, like a human's edits.
+    let doc = get_doc(&relay.http, &token, "doc-gen").await;
+    let json_shapes = doc["pages"]["p1"]["shapes"].as_object().unwrap().len();
+    assert_eq!(json_shapes, 0, "live generate must not touch the JSON store");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-320 Report #2 (cold path): `generate_diagram` on a **non-resident** doc
+/// (no editor joined) persists to the JSON store — the shapes are durably saved
+/// and readable, not a silent no-op.
+#[tokio::test]
+async fn jp320_generate_diagram_persists_on_cold_doc() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-cold", "name": "Cold", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    let gen = mcp_generate_diagram(
+        &mcp_base,
+        &token,
+        "doc-cold",
+        "p1",
+        json!([{"id": "a", "label": "A"}, {"id": "b", "label": "B"}]),
+        json!([{"from": "a", "to": "b"}]),
+    )
+    .await;
+    assert!(gen["nodes"]["a"].is_string(), "result reports node ids: {gen}");
+
+    // No editor was ever connected → cold path → the JSON store holds the shapes
+    // (2 nodes + 1 connector).
+    let doc = get_doc(&relay.http, &token, "doc-cold").await;
+    let shapes = doc["pages"]["p1"]["shapes"].as_object().expect("shapes map");
+    assert_eq!(shapes.len(), 3, "cold generate must persist all shapes: {doc}");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-320 Report #4: concurrent same-page writes must not silently drop one.
+/// The reported repro — a parallel `delete_shape` + `generate_diagram` leaving
+/// the page empty — was a symptom of Report #2: delete hit the live Y.Doc while
+/// generate wrote JSON, and the live doc clobbered the generated shapes on
+/// flatten. With both on the live path the writes serialize on the Y.Doc txn:
+/// the deleted shape is gone AND the generated shapes survive.
+#[tokio::test]
+async fn jp320_concurrent_delete_and_generate_no_loss() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-race", "name": "Race", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Editor joins → resident; seed shape s1 into the live Y.Doc.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-race").await;
+    editor.send_sync(&local.insert_shape_update("s1")).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(local.has_shape("s1"));
+
+    // Fire delete(s1) and generate(g) concurrently on the same page.
+    let del = mcp_delete_shape(&mcp_base, &token, "doc-race", "p1", "s1");
+    let gen = mcp_generate_diagram(
+        &mcp_base,
+        &token,
+        "doc-race",
+        "p1",
+        json!([{"id": "g", "label": "G"}]),
+        json!([]),
+    );
+    let (_del_res, gen_res) = tokio::join!(del, gen);
+    let gen_node = gen_res["nodes"]["g"].as_str().expect("generated node id").to_string();
+
+    // The editor converges: s1 dropped, the generated shape present (not lost).
+    let mut ok = false;
+    for _ in 0..30 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape(&gen_node) && !local.has_shape("s1") {
+            ok = true;
+            break;
+        }
+    }
+    assert!(ok, "generated shape lost or delete didn't apply under concurrency");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-320 papercut: `add_canvas_page` creates a real, targetable canvas page,
+/// and `rename_canvas_page` renames it — mirroring the prose page tools. The
+/// page list is JSON-only, so a cold (no editor joined) round-trip is enough.
+#[tokio::test]
+async fn jp320_add_and_rename_canvas_page_round_trip() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-canvas", "name": "Canvas", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "name": "Page 1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Add a second canvas page.
+    let add = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.add_canvas_page", "arguments": {"docId": "doc-canvas"}}
+    });
+    let add_res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(&token)
+        .json(&add)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    let new_page = add_res["result"]["structuredContent"]["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no canvas page id: {add_res}"))
+        .to_string();
+
+    // The new page is real + targetable: add a shape to it.
+    let shape_id = mcp_add_shape(&mcp_base, &token, "doc-canvas", &new_page).await;
+    let doc = get_doc(&relay.http, &token, "doc-canvas").await;
+    assert!(
+        doc["pageOrder"].as_array().unwrap().iter().any(|v| v == &json!(new_page)),
+        "new page in pageOrder: {doc}"
+    );
+    assert!(
+        doc["pages"][&new_page]["shapes"][&shape_id].is_object(),
+        "shape landed on the new canvas page: {doc}"
+    );
+    assert_eq!(doc["pages"][&new_page]["name"], json!("Page 2"), "default name");
+
+    // Rename it; the change is reflected in the document.
+    let ren = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.rename_canvas_page", "arguments": {
+            "docId": "doc-canvas", "pageId": new_page, "name": "Architecture"
+        }}
+    });
+    reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(&token)
+        .json(&ren)
+        .send()
+        .await
+        .expect("mcp post")
+        .json::<Value>()
+        .await
+        .expect("mcp json");
+    let doc = get_doc(&relay.http, &token, "doc-canvas").await;
+    assert_eq!(doc["pages"][&new_page]["name"], json!("Architecture"), "renamed");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -1258,6 +1258,15 @@ async fn jp320_generate_diagram_reaches_connected_client() {
     }
     assert!(delivered, "editor never received the generated shapes live");
 
+    // The AGENT's read-back is now consistent: `get_page` on a resident doc
+    // reads the live Y.Doc (the write path), so the agent sees the diagram it
+    // just generated. This is the exact field symptom — the human (rendering
+    // the doc) saw the shapes while the agent's read returned empty, because the
+    // old generate_diagram wrote only the JSON the agent's resident read skips.
+    let page = mcp_get_page(&mcp_base, &token, "doc-gen", "p1").await;
+    let read_shapes = page["shapes"].as_array().map(|a| a.len()).unwrap_or(0);
+    assert_eq!(read_shapes, 3, "agent get_page must read back the generated shapes: {page}");
+
     // Live path leaves the JSON snapshot to the sweeper, like a human's edits.
     let doc = get_doc(&relay.http, &token, "doc-gen").await;
     let json_shapes = doc["pages"]["p1"]["shapes"].as_object().unwrap().len();
@@ -1265,6 +1274,26 @@ async fn jp320_generate_diagram_reaches_connected_client() {
 
     mcp.stop().await.ok();
     relay.server.stop().await.expect("stop");
+}
+
+/// Call `docushark.get_page` over MCP and return the `structuredContent`
+/// ({shapes: [...], source}).
+async fn mcp_get_page(mcp_base: &str, token: &str, doc_id: &str, page_id: &str) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.get_page", "arguments": {"docId": doc_id, "pageId": page_id}}
+    });
+    let res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    res["result"]["structuredContent"].clone()
 }
 
 /// JP-320 Report #2 (cold path): `generate_diagram` on a **non-resident** doc


### PR DESCRIPTION
Fixes the headline MCP write paths from the JP-312 joy-ride that **reported success but lost data**. Closes JP-320. All changes are relay-side (AGPL); comments are purely technical.

## Fixes

### Report #2 — `generate_diagram` persisted to the wrong path
It wrote the JSON cold store directly via `mutate_with_retry` and never the live Y.Doc, so on a **resident** doc the generated shapes never broadcast, weren't in the authoritative Y.Doc, and could be clobbered by the live doc on flatten — the "shapeCount 0" no-op. It now routes through the existing `write_shape_live_or_json` gate, exactly like `add_shapes`. Shapes are built **once** with pre-assigned ids so the live and cold paths persist an identical set and the returned id map is stable.

### Report #4 — silent loss on concurrent same-page writes
The reported repro (parallel `delete_shape` + `generate_diagram` → empty page) was a **symptom of #2**: delete hit the live Y.Doc while generate wrote JSON, and the live doc won on flatten. With both on the live path the writes serialize on the Y.Doc transaction — the deleted shape is gone *and* the generated shapes survive. (The JSON cold path's `mutate_with_retry` already surfaces an optimistic-version error on exhaustion, so no new lock was needed.)

### Report #3 — `{{field}}` dropped inside Markdown table cells
Root cause was **not** in `markdown_to_html` (which correctly expands `{{Framework}}` → `<span data-field>`) but downstream in `prose_parse.rs::is_inline_member`: it didn't recognize the `fieldRef`/`citationInline` span atoms (or `<br>`) as inline, so inside a table cell (or list item) `map_blocks` treated the span as a failed block and unwrapped its empty children — leaving the orphan `, …`. It now mirrors what `collect_inline` already handles. This also fixes citations in cells.

### Papercut — no canvas-page MCP tool
Added `add_canvas_page` / `rename_canvas_page`, mirroring the prose page-list tools on the canvas tree (`doc.pages` / `doc.pageOrder`). JSON-only, like the prose page list. (`reorder`/`delete` parity is a deferred fast-follow.)

## Tests
- **Unit** (`prose_parse.rs`): field + citation span survive in a `<td>` (no orphan).
- **Black-box E2E** (`yjs_authority.rs`): live `generate_diagram` reaches a joined client and skips the JSON store; cold-doc persist (3 shapes); concurrent `delete_shape` + `generate_diagram` loses neither; `add_canvas_page` → targetable by `add_shape` → `rename_canvas_page` round-trip.
- Updated the `tools/list` count (27 → 29) + MCP `README.md`.

## Verification
`cargo test --lib` (456 pass) · `cargo test --test yjs_authority --test public_mcp` (16 pass) · `cargo build --bin relay`. Full local-stack + staging mock-prod smoke pending your E2E confirmation before Done.

Assisted-by: Opus 4.8