### PR TITLE
JP-321: re-anchor connectors on re-layout so it can recover

### DIFF
--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -13,6 +13,7 @@ import {
   checkConnectorHealth,
   findOrphanedConnectors,
   findClosestAnchor,
+  chooseConnectorAnchors,
   updateConnectorEndpoints,
   clipPointToShapeBoundary,
   clipConnectorEndpoints,
@@ -867,5 +868,41 @@ describe('straight mode ignores stale waypoints', () => {
     });
     const bounds = connectorHandler.getBounds(conn);
     expect(bounds.maxY).toBeGreaterThan(400);
+  });
+});
+
+describe('chooseConnectorAnchors (JP-321)', () => {
+  const shape = (id: string, x: number, y: number): Shape =>
+    ({ id, type: 'rectangle', x, y } as Shape);
+
+  it('picks vertical sides when the target is below/above', () => {
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 0, 300))).toEqual({
+      startAnchor: 'bottom',
+      endAnchor: 'top',
+    });
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 0, -300))).toEqual({
+      startAnchor: 'top',
+      endAnchor: 'bottom',
+    });
+  });
+
+  it('picks horizontal sides when the target is right/left (and on ties)', () => {
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 300, 0))).toEqual({
+      startAnchor: 'right',
+      endAnchor: 'left',
+    });
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', -300, 0))).toEqual({
+      startAnchor: 'left',
+      endAnchor: 'right',
+    });
+    // |dx| == |dy| → horizontal wins (matches the relay's grid branch).
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 100, 100))?.startAnchor).toBe(
+      'right'
+    );
+  });
+
+  it('returns null for degenerate cases (self / coincident centers)', () => {
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('a', 0, 0))).toBeNull();
+    expect(chooseConnectorAnchors(shape('a', 5, 5), shape('b', 5, 5))).toBeNull();
   });
 });

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -5,6 +5,7 @@ import {
   ConnectorShape,
   Handle,
   Anchor,
+  AnchorPosition,
   Shape,
   DEFAULT_CONNECTOR,
   ERDCardinality,
@@ -1400,6 +1401,39 @@ export function updateConnectorEndpoints(
   }
 
   return updates;
+}
+
+/**
+ * Choose the connector anchor *sides* that match the two shapes' current
+ * relative geometry — the dominant axis between their centers. Mirrors the
+ * relay's `edge_anchors` grid/defensive branch (relay/src/mcp/layout/mod.rs) so
+ * a re-layout or route rebuild re-seats a connector on the correct faces rather
+ * than honoring the sides baked at create/generate time. Without this, a node
+ * move (e.g. a collaborator's edit, or a TB→LR re-layout) leaves the stored
+ * `startAnchor`/`endAnchor` facing the wrong way, the endpoints attach to the
+ * wrong faces, and the orthogonal route tangles with no re-layout able to
+ * recover it (JP-321). Geometry-only ⇒ direction-agnostic and idempotent.
+ *
+ * Returns `null` for the degenerate case (same shape on both ends, or
+ * coincident centers) where there is no meaningful dominant axis — the caller
+ * leaves the existing anchors untouched.
+ */
+export function chooseConnectorAnchors(
+  startShape: Shape,
+  endShape: Shape
+): { startAnchor: AnchorPosition; endAnchor: AnchorPosition } | null {
+  if (startShape.id === endShape.id) return null;
+  const dx = endShape.x - startShape.x;
+  const dy = endShape.y - startShape.y;
+  if (dx === 0 && dy === 0) return null;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0
+      ? { startAnchor: 'right', endAnchor: 'left' }
+      : { startAnchor: 'left', endAnchor: 'right' };
+  }
+  return dy >= 0
+    ? { startAnchor: 'bottom', endAnchor: 'top' }
+    : { startAnchor: 'top', endAnchor: 'bottom' };
 }
 
 /**

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -5,7 +5,7 @@ import {
   shapeExists,
 } from './documentStore';
 import { getProvenance } from './writeProvenance';
-import { RectangleShape, type ConnectorShape, DEFAULT_CONNECTOR } from '../shapes/Shape';
+import { RectangleShape, type ConnectorShape, type AnchorPosition, DEFAULT_CONNECTOR } from '../shapes/Shape';
 import '../shapes/Rectangle'; // registers the handler computeAutoLayout reads for sizing
 
 /**
@@ -104,6 +104,87 @@ describe('Document Store', () => {
       const s = useDocumentStore.getState().shapes['lone']!;
       expect(s.x).toBe(42);
       expect(s.y).toBe(7);
+    });
+  });
+
+  describe('connector re-anchoring on re-layout (JP-321)', () => {
+    function orthConnector(
+      id: string,
+      from: string,
+      to: string,
+      startAnchor: AnchorPosition,
+      endAnchor: AnchorPosition
+    ): ConnectorShape {
+      return {
+        ...DEFAULT_CONNECTOR,
+        id,
+        type: 'connector',
+        x: 0,
+        y: 0,
+        x2: 0,
+        y2: 0,
+        rotation: 0,
+        opacity: 1,
+        locked: false,
+        visible: true,
+        startShapeId: from,
+        endShapeId: to,
+        startAnchor,
+        endAnchor,
+        routingMode: 'orthogonal',
+        waypoints: [{ x: 0, y: 0 }],
+      } as ConnectorShape;
+    }
+
+    it('rebuildAllConnectorRoutes re-seats stale anchors after a move, idempotently', () => {
+      const store = useDocumentStore.getState();
+      // b below a → (bottom, top) is correct initially (as generate_diagram bakes it).
+      store.addShapes([
+        createTestRect({ id: 'a', x: 0, y: 0 }),
+        createTestRect({ id: 'b', x: 0, y: 300 }),
+        orthConnector('c1', 'a', 'b', 'bottom', 'top'),
+      ]);
+      // Simulate a collab edit: b jumps ABOVE a, leaving the baked sides stale.
+      store.updateShape('b', { y: -300 });
+
+      store.rebuildAllConnectorRoutes();
+      const c = useDocumentStore.getState().shapes['c1'] as ConnectorShape;
+      // Sides flip to match the new geometry (b above a) — the old waypoint-only
+      // rebuild left these at (bottom, top) and could never recover the tangle.
+      expect(c.startAnchor).toBe('top');
+      expect(c.endAnchor).toBe('bottom');
+      // Start endpoint pulled to a's top face (above a's center at y=0).
+      expect(c.y).toBeLessThan(0);
+      expect(Array.isArray(c.waypoints)).toBe(true);
+
+      // Idempotent: a second rebuild reproduces the same result exactly.
+      store.rebuildAllConnectorRoutes();
+      const c2 = useDocumentStore.getState().shapes['c1'] as ConnectorShape;
+      expect(c2.startAnchor).toBe('top');
+      expect(c2.endAnchor).toBe('bottom');
+      expect([c2.x, c2.y, c2.x2, c2.y2]).toEqual([c.x, c.y, c.x2, c.y2]);
+      expect(c2.waypoints).toEqual(c.waypoints);
+    });
+
+    it('autoLayoutShapes re-seats anchors to match the laid-out geometry', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([
+        createTestRect({ id: 'a', x: 0, y: 0 }),
+        createTestRect({ id: 'b', x: 0, y: 300 }),
+        // Deliberately wrong (horizontal) sides — must be corrected by re-layout.
+        orthConnector('c1', 'a', 'b', 'left', 'right'),
+      ]);
+      store.autoLayoutShapes(['a', 'b']);
+
+      const after = useDocumentStore.getState().shapes;
+      const c = after['c1'] as ConnectorShape;
+      // TB layout stacks the two nodes vertically; anchors follow that geometry.
+      const expected =
+        after['a']!.y < after['b']!.y
+          ? { startAnchor: 'bottom', endAnchor: 'top' }
+          : { startAnchor: 'top', endAnchor: 'bottom' };
+      expect(c.startAnchor).toBe(expected.startAnchor);
+      expect(c.endAnchor).toBe(expected.endAnchor);
     });
   });
 

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -4,6 +4,7 @@ import { Shape, GroupShape, ConnectorShape, isGroup } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Box } from '../math/Box';
 import { calculateConnectorWaypoints } from '../engine/OrthogonalRouter';
+import { chooseConnectorAnchors, updateConnectorEndpoints } from '../shapes/Connector';
 import { SpatialIndex } from '../engine/SpatialIndex';
 import { wouldCreateCycle, wouldExceedMaxDepth, findParentGroup } from '../shapes/GroupHierarchy';
 import { computeAutoLayout, type AutoLayoutOptions } from '../shapes/autoLayout';
@@ -147,6 +148,40 @@ const initialState: DocumentState = {
   shapes: {},
   shapeOrder: [],
 };
+
+/**
+ * Re-seat a connector against the current geometry: re-pick its anchor sides
+ * (when both ends are bound), pull its endpoints to those anchor points, then
+ * recompute orthogonal waypoints. Used by the re-layout / route-rebuild paths
+ * so a single run is a true reset that recovers connectors whose baked anchor
+ * sides drifted out of date (JP-321) — not just a waypoint recompute against
+ * stale endpoints/sides. `connector` is mutated in place (an Immer draft).
+ */
+function recoverConnectorRouting(
+  connector: ConnectorShape,
+  shapes: Record<string, Shape>,
+  obstacleIndex: SpatialIndex
+): void {
+  const startShape = connector.startShapeId ? shapes[connector.startShapeId] : undefined;
+  const endShape = connector.endShapeId ? shapes[connector.endShapeId] : undefined;
+  if (startShape && endShape) {
+    const anchors = chooseConnectorAnchors(startShape, endShape);
+    if (anchors) {
+      connector.startAnchor = anchors.startAnchor;
+      connector.endAnchor = anchors.endAnchor;
+    }
+  }
+  // Endpoints first (they read the just-updated anchor sides), so routing runs
+  // against the current geometry rather than stale x/y/x2/y2.
+  const endpoints = updateConnectorEndpoints(connector, shapes);
+  if (endpoints.x !== undefined) connector.x = endpoints.x;
+  if (endpoints.y !== undefined) connector.y = endpoints.y;
+  if (endpoints.x2 !== undefined) connector.x2 = endpoints.x2;
+  if (endpoints.y2 !== undefined) connector.y2 = endpoints.y2;
+  if (connector.routingMode === 'orthogonal') {
+    connector.waypoints = calculateConnectorWaypoints(connector, shapes, obstacleIndex) ?? [];
+  }
+}
 
 /**
  * Document store for managing shape data.
@@ -643,10 +678,11 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
     rebuildAllConnectorRoutes: () => {
       set((state) => {
-        // Find all connectors with orthogonal routing
+        // Re-seat every connector (re-anchor + re-endpoint + re-route), not just
+        // orthogonal ones — straight connectors also carry stale anchor sides
+        // after a node move, so a "rebuild routes" must reset their faces too.
         const connectors = Object.values(state.shapes).filter(
-          (shape): shape is ConnectorShape =>
-            shape.type === 'connector' && (shape as ConnectorShape).routingMode === 'orthogonal'
+          (shape): shape is ConnectorShape => shape.type === 'connector'
         );
         if (connectors.length === 0) return;
 
@@ -657,12 +693,8 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
         const obstacleIndex = new SpatialIndex();
         obstacleIndex.rebuild(Object.values(state.shapes));
 
-        // Recalculate waypoints for each connector
         for (const connector of connectors) {
-          const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
-          if (waypoints) {
-            (state.shapes[connector.id] as ConnectorShape).waypoints = waypoints;
-          }
+          recoverConnectorRouting(connector, state.shapes, obstacleIndex);
         }
       });
     },
@@ -678,19 +710,18 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
             shape.y = pos.y;
           }
         }
-        // Reroute orthogonal connectors against the new positions.
+        // Re-seat connectors against the new node positions: re-pick anchor
+        // sides, re-pull endpoints, then re-route. A waypoint-only recompute
+        // (the old behavior) kept stale faces/endpoints, so a re-layout could
+        // not recover a connector whose sides had drifted (JP-321).
         const connectors = Object.values(state.shapes).filter(
-          (shape): shape is ConnectorShape =>
-            shape.type === 'connector' && (shape as ConnectorShape).routingMode === 'orthogonal'
+          (shape): shape is ConnectorShape => shape.type === 'connector'
         );
         if (connectors.length === 0) return;
         const obstacleIndex = new SpatialIndex();
         obstacleIndex.rebuild(Object.values(state.shapes));
         for (const connector of connectors) {
-          const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
-          if (waypoints) {
-            (state.shapes[connector.id] as ConnectorShape).waypoints = waypoints;
-          }
+          recoverConnectorRouting(connector, state.shapes, obstacleIndex);
         }
       });
     },


### PR DESCRIPTION
Closes JP-321. Client-only fix in the OSS editor.

## Symptom (JP-312 joy-ride Pre-test #8)
An MCP `generate_diagram` with auto-layout looks clean, then after collab edits becomes a tangled mess that **no auto-layout / re-route run can fix**. A real corrupted snapshot confirmed it: **14/14 connectors had stored anchor sides that disagreed with current geometry** (e.g. `browser→cms`, dx=762 dy=-104, still `(bottom,top)` instead of `(right,left)`).

## Root cause
A connector stores fixed `startAnchor`/`endAnchor` *sides* chosen at create/generate time. `getConnectorStartPoint`/`getConnectorEndPoint` resolve endpoints from those sides verbatim and never re-pick from current geometry. When a node moves (a collaborator's edit, or a TB→LR re-layout), the baked sides face the wrong way, endpoints attach to the wrong faces, and the orthogonal route tangles. Both recovery actions — `autoLayoutShapes` and `rebuildAllConnectorRoutes` — only recomputed *waypoints*, against stale endpoints and stale sides, so re-layout reroutes the path but keeps the wrong faces and **can't recover**.

## Fix (client-only)
- `chooseConnectorAnchors(start, end)` (`src/shapes/Connector.ts`): picks anchor sides from the dominant axis between the shapes' centers. Mirrors the relay's reference chooser `edge_anchors` grid branch (`relay/src/mcp/layout/mod.rs`) — geometry-only, so it's **direction-agnostic** (correct for TB *and* LR re-layout) and idempotent. Returns `null` for degenerate cases (self-loop / coincident centers), leaving anchors untouched.
- `recoverConnectorRouting` (`src/store/documentStore.ts`): for a bound connector, re-seat anchors → pull endpoints to the new anchor points (`updateConnectorEndpoints`) → recompute orthogonal waypoints. Used by both `autoLayoutShapes` and `rebuildAllConnectorRoutes` for **all** connectors (straight ones re-anchor too). One run is now a true reset.

## Out of scope (filed separately)
The same snapshot also showed `shapeOrder` doubled (50 entries = 25 ids ++ 25) from non-idempotent `Y.Array` hydration on the relay — a distinct CRDT-durability bug (relay dedup + a repair migration). Filed as its own issue; not addressed here.

## Verification
`bun run typecheck` + full `bun run test --run` (**2359 pass**). New tests: `chooseConnectorAnchors` dominant-axis unit tests; a regression test that moves a node to invert geometry and asserts `rebuildAllConnectorRoutes`/`autoLayoutShapes` flip the anchors to match and are idempotent. Real-app / collab E2E to follow via the local stack.

Assisted-by: Opus 4.8