### PR TITLE
JP-330: dedupe shapeOrder at every consumer (stop the doubling mess)

### DIFF
--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -899,12 +899,17 @@ fn get_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     // snapshot. Mirrors the prose resident-read (JP-201) + `get_shape`.
     if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
         let shapes_map = handle.shapes_json();
-        let shapes: Vec<Value> = handle
-            .shape_order()
-            .iter()
-            .filter_map(|id| shapes_map.get(id))
-            .map(shape_to_dsl_or_generic)
-            .collect();
+        // JP-330: dedupe the live shapeOrder so an agent never sees a shape
+        // twice if the Y.Array doubled (dual-origin merge); orphans drop here too.
+        let order = handle.shape_order();
+        let shapes: Vec<Value> = crate::sync::dedupe_order(
+            order.iter().map(String::as_str),
+            |id| shapes_map.contains_key(id),
+        )
+        .iter()
+        .filter_map(|id| shapes_map.get(id))
+        .map(shape_to_dsl_or_generic)
+        .collect();
         return Ok(ToolOutcome {
             result: json!({"shapes": shapes, "source": "team"}),
             changed_doc_id: None,

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -51,7 +51,27 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
             return false;
         };
         page.insert("shapes".to_string(), any_to_json(&shapes_any));
-        page.insert("shapeOrder".to_string(), any_to_json(&order_any));
+        // JP-330: dedupe-keep-first + drop orphans so a live array doubled by a
+        // dual-origin merge persists clean — the stored doc self-heals here.
+        let present = |id: &str| match &shapes_any {
+            Any::Map(m) => m.contains_key(id),
+            _ => false,
+        };
+        let order_ids = match &order_any {
+            Any::Array(arr) => arr
+                .iter()
+                .filter_map(|a| match a {
+                    Any::String(s) => Some(s.as_ref()),
+                    _ => None,
+                })
+                .collect::<Vec<&str>>(),
+            _ => Vec::new(),
+        };
+        let deduped = super::dedupe_order(order_ids, present);
+        page.insert(
+            "shapeOrder".to_string(),
+            Value::Array(deduped.into_iter().map(Value::String).collect()),
+        );
     }
 
     // CRDT-native rename: adopt `metadata.title` as the document `name`, but
@@ -314,6 +334,41 @@ mod tests {
         // Other page untouched; modifiedAt bumped past the original.
         assert_eq!(json["pages"]["p2"]["shapes"]["s9"]["id"], json!("s9"));
         assert!(json["modifiedAt"].as_u64().unwrap() > 2);
+    }
+
+    /// JP-330 self-heal: a live `shapeOrder` doubled by a dual-origin merge
+    /// flattens to a deduped (keep-first) order with orphans dropped, so the
+    /// persisted JSON — the canonical stored copy — is always clean.
+    #[test]
+    fn jp330_flatten_dedupes_doubled_order() {
+        let doc = Doc::new();
+        let shapes = doc.get_or_insert_map("shapes");
+        let order = doc.get_or_insert_array("shapeOrder");
+        {
+            let mut txn = doc.transact_mut();
+            for id in ["s1", "s2"] {
+                shapes.insert(
+                    &mut txn,
+                    id,
+                    Any::Map(std::sync::Arc::new(std::collections::HashMap::from([(
+                        "id".to_string(),
+                        Any::String(id.into()),
+                    )]))),
+                );
+            }
+            // Doubled order + an orphan id with no backing shape.
+            for id in ["s1", "s2", "s1", "s2", "ghost"] {
+                order.push_back(&mut txn, Any::String(id.into()));
+            }
+        }
+
+        let mut json = json!({"pages": {"p1": {"id": "p1", "name": "One"}}, "modifiedAt": 0});
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(
+            json["pages"]["p1"]["shapeOrder"],
+            json!(["s1", "s2"]),
+            "deduped keep-first; 'ghost' orphan dropped"
+        );
     }
 
     #[test]

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -39,14 +39,25 @@ pub fn json_to_ydoc(doc_json: &Value, doc: &Doc) {
         .and_then(|(active, pages)| pages.get(active));
 
     if let Some(page) = active_page {
-        if let Some(page_shapes) = page.get("shapes").and_then(Value::as_object) {
-            for (id, shape) in page_shapes {
-                shapes.insert(&mut txn, id.clone(), json_to_any(shape));
+        // JP-330 once-gate (mirrors `json_references_to_ydoc`/`json_fields_to_ydoc`):
+        // only seed shapes + order into an EMPTY surface. Re-hydrating a populated
+        // Y.Doc would otherwise `push_back` the whole `shapeOrder` again — the
+        // shapes map dedupes by key, but the `shapeOrder` Y.Array (a sequence)
+        // does not, so it doubles.
+        if shapes.len(&txn) == 0 {
+            let page_shapes = page.get("shapes").and_then(Value::as_object);
+            if let Some(ps) = page_shapes {
+                for (id, shape) in ps {
+                    shapes.insert(&mut txn, id.clone(), json_to_any(shape));
+                }
             }
-        }
-        if let Some(order) = page.get("shapeOrder").and_then(Value::as_array) {
-            for id in order.iter().filter_map(Value::as_str) {
-                shape_order.push_back(&mut txn, Any::String(id.into()));
+            if let Some(order) = page.get("shapeOrder").and_then(Value::as_array) {
+                // Dedupe + orphan-drop the source too, so an already-doubled
+                // source JSON / binary sidecar hydrates clean.
+                let present = |id: &str| page_shapes.is_some_and(|m| m.contains_key(id));
+                for id in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+                    shape_order.push_back(&mut txn, Any::String(id.as_str().into()));
+                }
             }
         }
     }
@@ -581,5 +592,91 @@ mod tests {
         super::json_fields_to_ydoc(&json!({"id": "d"}), &doc);
         let fields = doc.get_or_insert_map("fields");
         assert_eq!(fields.len(&doc.transact()), 0);
+    }
+
+    // ---- JP-330 forensic repro: shapeOrder doubling ------------------------
+
+    fn ordered_doc() -> Value {
+        json!({
+            "id": "d", "activePageId": "p1", "pageOrder": ["p1"],
+            "pages": {"p1": {"id": "p1",
+                "shapes": {
+                    "s1": {"id": "s1"}, "s2": {"id": "s2"}, "s3": {"id": "s3"},
+                    "s4": {"id": "s4"}, "s5": {"id": "s5"}
+                },
+                "shapeOrder": ["s1", "s2", "s3", "s4", "s5"]
+            }}
+        })
+    }
+
+    fn read_order(doc: &Doc) -> Vec<String> {
+        use yrs::types::ToJson;
+        let order = doc.get_or_insert_array("shapeOrder");
+        let txn = doc.transact();
+        match order.to_json(&txn) {
+            Any::Array(arr) => arr
+                .iter()
+                .map(|a| match a {
+                    Any::String(s) => s.to_string(),
+                    _ => String::new(),
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Trigger A is now fixed by the once-gate: re-hydrating a populated Y.Doc
+    /// is a no-op for shapes + order (mirrors `json_references_to_ydoc`), so the
+    /// order stays unique instead of doubling.
+    #[test]
+    fn jp330_rehydration_no_longer_doubles() {
+        let doc = Doc::new();
+        json_to_ydoc(&ordered_doc(), &doc);
+        json_to_ydoc(&ordered_doc(), &doc); // second seed: must no-op
+
+        let shapes = doc.get_or_insert_map("shapes");
+        assert_eq!(shapes.len(&doc.transact()), 5);
+        assert_eq!(read_order(&doc), ["s1", "s2", "s3", "s4", "s5"], "no doubling");
+    }
+
+    /// An already-corrupted source (its persisted `shapeOrder` is doubled, like
+    /// the captured snapshot) hydrates clean — the seed dedupes the source.
+    #[test]
+    fn jp330_doubled_source_json_hydrates_clean() {
+        let mut src = ordered_doc();
+        src["pages"]["p1"]["shapeOrder"] =
+            json!(["s1", "s2", "s3", "s4", "s5", "s1", "s2", "s3", "s4", "s5", "ghost"]);
+        let doc = Doc::new();
+        json_to_ydoc(&src, &doc);
+        assert_eq!(
+            read_order(&doc),
+            ["s1", "s2", "s3", "s4", "s5"],
+            "deduped + orphan ('ghost') dropped on seed"
+        );
+    }
+
+    /// Trigger B (dual-origin merge) still doubles the LIVE in-memory array — we
+    /// deliberately don't prevent the merge (deferred). What matters is that no
+    /// consumer surfaces the dupes: `flatten` (persist) self-heals
+    /// (see `flatten::tests::jp330_flatten_dedupes_doubled_order`) and the agent
+    /// read / client render dedupe. This test pins the deferred behavior so a
+    /// future "prevent at source" change has a clear before/after.
+    #[test]
+    fn jp330_dual_origin_merge_still_doubles_live_array() {
+        use yrs::updates::decoder::Decode;
+        use yrs::{ReadTxn, StateVector, Update};
+
+        let a = Doc::new();
+        json_to_ydoc(&ordered_doc(), &a);
+        let b = Doc::new();
+        json_to_ydoc(&ordered_doc(), &b);
+
+        let update = b.transact().encode_state_as_update_v1(&StateVector::default());
+        a.transact_mut()
+            .apply_update(Update::decode_v1(&update).expect("decode"))
+            .expect("apply");
+
+        assert_eq!(a.get_or_insert_map("shapes").len(&a.transact()), 5, "map LWW");
+        assert_eq!(read_order(&a).len(), 10, "live array doubles (deferred: tolerated on read)");
     }
 }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -768,6 +768,24 @@ fn build_prose_children<P: XmlFragment>(
 /// doc); live editors keep their random ids. Its sole job is to make a re-seed —
 /// a later rehydrate, or a client that cached the prior bootstrap in y-indexeddb
 /// — DEDUPE on merge instead of concatenating (the lineage-churn fix).
+/// Keep-first dedupe of a `shapeOrder`-style id sequence, dropping ids for which
+/// `present` is false (orphans). JP-330: `shapeOrder` is a CRDT `Y.Array` (a
+/// sequence, not a set), so non-idempotent seeding (re-hydration) or a
+/// dual-origin merge can leave it with the same id twice while the `shapes`
+/// `Y.Map` stays unique. Every consumer that surfaces order — flatten (persist),
+/// `get_page` (agent read), hydration (re-seed) — routes through this so the
+/// rendered/served/stored order is canonical regardless of the live array.
+pub(crate) fn dedupe_order<'a>(
+    ids: impl IntoIterator<Item = &'a str>,
+    present: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    ids.into_iter()
+        .filter(|id| present(id) && seen.insert(id.to_string()))
+        .map(|id| id.to_string())
+        .collect()
+}
+
 fn deterministic_seed_client_id(page_id: &str) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a 64-bit offset basis
     for b in page_id.as_bytes() {

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -488,6 +488,42 @@ describe('Document Store', () => {
 
       expect(useDocumentStore.getState().shapeOrder).toEqual(['rect1']);
     });
+
+    it('collapses a doubled shapeOrder keep-first on load (JP-330)', () => {
+      // The dual-origin-merge corruption: each valid id appears twice (+ an
+      // orphan). loadSnapshot must dedupe keep-first and drop the orphan.
+      const snapshot = {
+        shapes: { a: createTestRect({ id: 'a' }), b: createTestRect({ id: 'b' }) },
+        shapeOrder: ['a', 'b', 'a', 'b', 'ghost'],
+        version: 1,
+      };
+
+      useDocumentStore.getState().loadSnapshot(snapshot);
+
+      expect(useDocumentStore.getState().shapeOrder).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('reorderShapes dedupe (JP-330)', () => {
+    it('collapses a doubled incoming order (the CRDT onOrderChange funnel)', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([createTestRect({ id: 'a' }), createTestRect({ id: 'b' })]);
+
+      // A doubled order arrives (dual-origin merge) — must not double z-order.
+      store.reorderShapes(['b', 'a', 'b', 'a']);
+
+      expect(useDocumentStore.getState().shapeOrder).toEqual(['b', 'a']);
+    });
+
+    it('still rejects a genuinely partial order', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([createTestRect({ id: 'a' }), createTestRect({ id: 'b' })]);
+
+      // Only one of two distinct shapes — not a permutation, so ignored.
+      store.reorderShapes(['a', 'a']);
+
+      expect(useDocumentStore.getState().shapeOrder).toEqual(['a', 'b']);
+    });
   });
 
   describe('utilities', () => {

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -359,11 +359,20 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
     reorderShapes: (newOrder: string[]) => {
       set((state) => {
-        // Validate that all IDs exist and no duplicates
-        const existingIds = new Set(Object.keys(state.shapes));
-        const validOrder = newOrder.filter((id) => existingIds.has(id));
-        // Only update if all shapes accounted for
-        if (validOrder.length === state.shapeOrder.length) {
+        // Keep-first dedupe + drop ids with no shape. This is the incremental
+        // CRDT order funnel (onOrderChange → reorderShapes); a `shapeOrder`
+        // doubled by a dual-origin merge (JP-330) must not double the rendered
+        // z-order. Comparing against the DISTINCT current ordered ids (not the
+        // raw length) also self-heals an already-doubled current order.
+        const seen = new Set<string>();
+        const validOrder = newOrder.filter((id) => {
+          if (!state.shapes[id] || seen.has(id)) return false;
+          seen.add(id);
+          return true;
+        });
+        // Only update when it accounts for every distinct shape currently
+        // ordered (a true permutation), so a partial order is still rejected.
+        if (validOrder.length === new Set(state.shapeOrder).size) {
           state.shapeOrder = validOrder;
         }
       });
@@ -389,14 +398,34 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
       const incomingOrder = snapshot.shapeOrder ?? [];
       const droppedFromOrder = incomingOrder.filter((id) => !incomingShapes[id]);
       const unorderedShapes: string[] = [];
+      // JP-330: collapse a doubled shapeOrder (a valid id appearing more than
+      // once — the dual-origin-merge corruption) keep-first, dropping orphans.
+      // `cleanOrder` is what we load so the rendered z-order is canonical and a
+      // persisted doubled doc self-heals on its next save.
+      const seenIds = new Set<string>();
+      const cleanOrder: string[] = [];
+      let duplicatesDropped = 0;
+      for (const id of incomingOrder) {
+        if (!incomingShapes[id]) continue; // orphan — counted in droppedFromOrder
+        if (seenIds.has(id)) {
+          duplicatesDropped++;
+          continue;
+        }
+        seenIds.add(id);
+        cleanOrder.push(id);
+      }
+      // `ok` (which gates the persistence layer's save-refusal) keys off orphans
+      // only; duplicates are repaired in place here, so a save of the cleaned
+      // state should still be allowed.
       const ok = droppedFromOrder.length === 0;
 
-      if (!ok) {
+      if (!ok || duplicatesDropped > 0) {
         // eslint-disable-next-line no-console
         console.error(
           '[documentStore] loadSnapshot integrity issue — possible page corruption.',
           {
             droppedFromOrder,
+            duplicatesDropped,
             unorderedShapes,
             shapeCount: Object.keys(incomingShapes).length,
             orderCount: incomingOrder.length,
@@ -423,9 +452,8 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
           // Load snapshot data
           state.shapes = JSON.parse(JSON.stringify(incomingShapes));
-          // Filter out any orphaned IDs to keep rendering stable; the integrity
-          // flag above lets the persistence layer refuse a save if needed.
-          state.shapeOrder = incomingOrder.filter((id) => state.shapes[id]);
+          // Orphan-dropped + dedupe-keep-first (JP-330) order computed above.
+          state.shapeOrder = cleanOrder;
         });
       });
     },


### PR DESCRIPTION
Closes JP-330. From the JP-312 joy-ride: a real corrupted snapshot had **25 shapes but a `shapeOrder` of 50** (the id list concatenated with itself), rendered as a doubled mess that no re-layout could fix.

## Root cause (reproduced)
`shapeOrder` is a CRDT **`Y.Array`** (a sequence — no key dedup), so non-idempotent seeding doubles it while the `shapes` **`Y.Map`** dedupes by key and stays unique. Two triggers, both reproduced exactly (`relay/src/sync/hydration.rs` `jp330_*` tests, clean `s1..s5 ++ s1..s5`):
- **A — re-hydration:** `json_to_ydoc` did `get_or_insert_array` + `push_back` with no once-gate (`json_references_to_ydoc`/`json_fields_to_ydoc` already had the guard; shapes never got it).
- **B — dual-origin merge:** an offline client's persisted y-indexeddb Y.Doc merges its independent `shapeOrder` lineage with the relay's on rejoin (the JP-282 prose-dup mechanism, for shapes).

## Fix — tolerate + self-heal + once-gate (launch-scoped)
Every consumer of `shapeOrder` dedupes keep-first (drop orphans) via one shared `crate::sync::dedupe_order` helper, so the view, MCP reads, and stored JSON are always clean and corrupted docs self-heal on the next save:

**Relay**
- `json_to_ydoc` — once-gate + dedupe source order (Trigger A; already-doubled source hydrates clean).
- `flatten_into` — dedupe + orphan-drop on write → persisted doc self-heals (repairs the captured snapshot on next flush).
- `get_page` live read — dedupe so an MCP agent never sees a shape twice mid-session (consistent with JP-320's agent-read guarantees).

**Client**
- `reorderShapes` (the `onOrderChange → reorderShapes` CRDT funnel) — keep-first dedupe + compare against *distinct* ordered ids, so a doubled order never doubles z-order and an already-doubled current order self-heals.
- `loadSnapshot` — collapse a doubled `shapeOrder` keep-first; log `duplicatesDropped`.

## Deliberately deferred (not launch-blocking)
Preventing the **live in-memory** Y.Array from doubling at all (purge-stale-room-on-rejoin / deterministic seeding, JP-282/JP-319 parity) and hardening `referenceOrder`/`fieldOrder` (same latent vuln, today shielded by their map once-gate). After this fix the in-memory dupes are harmless — never rendered, served, or persisted — and the canonical stored copy stays clean via flatten. No doc-format change, no migration (`DOCUMENT_VERSION` stays 1).

## Verification
Relay lib **460** + `cargo build --bin relay`; client `typecheck` + full vitest **2362**. New tests cover: re-hydration no longer doubles, doubled-source hydrates clean, dual-origin merge still doubles the live array (pins the deferred behavior), `flatten` self-heals, and client `loadSnapshot`/`reorderShapes` dedupe. Real-app/collab confirmation via the local stack later.

Assisted-by: Opus 4.8