### PR TITLE
Deploy to staging: joy-ride fixes (JP-320/321/330) + prose write-back

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -120,11 +120,13 @@ All tools are namespaced `docushark.*`.
 
 | Tool | Purpose |
 | -- | -- |
+| `add_canvas_page` | Append a blank canvas page; returns `{ id }`. Target it with the returned id in `add_shape(s)`/`generate_diagram` to build a second diagram in the same document. |
+| `rename_canvas_page` | Rename a canvas page. |
 | `add_shape` | Add one shape (rectangle, ellipse, text, connector). |
 | `add_shapes` | Add many shapes in one all-or-nothing call. |
 | `connect` | Connect two existing shapes with a connector. |
 | `update_shape` | Patch an existing shape (`x`, `y`, `w`, `h`, `text`, `style`). |
-| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` with crossing minimization, or `grid`) and wires connectors to typed anchors with orthogonal obstacle-avoiding routing (`routing: "straight"` opts out). |
+| `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` with crossing minimization, or `grid`) and wires connectors to typed anchors with orthogonal obstacle-avoiding routing (`routing: "straight"` opts out). Writes the live Y.Doc on a resident doc (a connected editor sees the shapes immediately) — like the other shape tools. |
 
 ### Manage (write)
 
@@ -175,9 +177,11 @@ the relay, writes apply to the **authoritative Y.Doc** and broadcast a CRDT
 delta, so connected editors see the change immediately (they merge it — no
 reload):
 
-- **Shape** tools (`add_shape`/`add_shapes`/`connect`/`update_shape`) write the
-  live shape map when the doc is resident *and* the target page is the active
-  page.
+- **Shape** tools (`add_shape`/`add_shapes`/`connect`/`update_shape`/
+  `delete_shape`/`reorder_shapes`/`generate_diagram`) write the live shape map
+  when the doc is resident *and* the target page is the active page. (Canvas
+  page-list tools — `add_canvas_page`/`rename_canvas_page` — are JSON-only,
+  like the prose page list; a new page's *tab* may lag until reload.)
 - **Prose** tools (`set_prose`/`add_prose_page`/`insert_section`/
   `restructure_outline`) rebuild the page's live `prose:<pageId>` fragment
   (whole-page replace) when the doc is resident — so an agent's prose appears in

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -899,12 +899,17 @@ fn get_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     // snapshot. Mirrors the prose resident-read (JP-201) + `get_shape`.
     if let Some(handle) = live_handle(ctx, &parsed.doc_id, &parsed.page_id) {
         let shapes_map = handle.shapes_json();
-        let shapes: Vec<Value> = handle
-            .shape_order()
-            .iter()
-            .filter_map(|id| shapes_map.get(id))
-            .map(shape_to_dsl_or_generic)
-            .collect();
+        // JP-330: dedupe the live shapeOrder so an agent never sees a shape
+        // twice if the Y.Array doubled (dual-origin merge); orphans drop here too.
+        let order = handle.shape_order();
+        let shapes: Vec<Value> = crate::sync::dedupe_order(
+            order.iter().map(String::as_str),
+            |id| shapes_map.contains_key(id),
+        )
+        .iter()
+        .filter_map(|id| shapes_map.get(id))
+        .map(shape_to_dsl_or_generic)
+        .collect();
         return Ok(ToolOutcome {
             result: json!({"shapes": shapes, "source": "team"}),
             changed_doc_id: None,

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -214,6 +214,35 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
             }),
         },
         ToolDescriptor {
+            name: "docushark.add_canvas_page",
+            description:
+                "Add a new (blank) canvas page to a document and return its id. Use this to start a second diagram in the same document; target it with the returned id in add_shape(s)/generate_diagram. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "name": {"type": "string", "description": "Page title. Defaults to \"Page N\"."}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.rename_canvas_page",
+            description:
+                "Rename a canvas page. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "name": {"type": "string"}
+                },
+                "required": ["docId", "pageId", "name"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
             name: "docushark.get_outline",
             description:
                 "Return the heading outline of a prose page as an ordered list of { index, level, title }. 'index' is the 0-based heading position used by insert_section and restructure_outline. Sections are flat: nesting is conveyed by 'level' (1–6), not containment.",
@@ -637,6 +666,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.add_prose_page" => add_prose_page(ctx, args),
         "docushark.set_prose" => set_prose(ctx, args),
         "docushark.rename_prose_page" => rename_prose_page(ctx, args),
+        "docushark.add_canvas_page" => add_canvas_page(ctx, args),
+        "docushark.rename_canvas_page" => rename_canvas_page(ctx, args),
         "docushark.get_outline" => get_outline(ctx, args),
         "docushark.insert_section" => insert_section(ctx, args),
         "docushark.restructure_outline" => restructure_outline(ctx, args),
@@ -1435,6 +1466,113 @@ fn rename_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Str
     })
 }
 
+// ---------------------------------------------------------------------------
+// Canvas-page tools (JP-320). The canvas page LIST (`pages` map + `pageOrder`)
+// is JSON-only — only the active page's shapes live in the authoritative Y.Doc
+// — so these mirror the prose page-list ops (`add_prose_page` /
+// `rename_prose_page`): write the JSON store under optimistic concurrency and
+// nudge a reload via `changed_doc_id`.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct AddCanvasPageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    name: Option<String>,
+}
+
+fn add_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: AddCanvasPageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    let id = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let order_len = doc
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        let page_id = format!("page-{}", nanoid::nanoid!(12));
+        let name = parsed
+            .name
+            .clone()
+            .map(|n| n.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| format!("Page {}", order_len + 1));
+
+        let obj = doc.as_object_mut().ok_or("Document is not an object")?;
+        obj.entry("pages")
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .ok_or("Document 'pages' is not an object")?
+            .insert(
+                page_id.clone(),
+                json!({
+                    "id": page_id,
+                    "name": name,
+                    "shapes": {},
+                    "shapeOrder": [],
+                    "createdAt": now,
+                    "modifiedAt": now,
+                }),
+            );
+        obj.entry("pageOrder")
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+            .ok_or("Document 'pageOrder' is not an array")?
+            .push(json!(page_id.clone()));
+
+        stamp_doc_modified(doc, now);
+        Ok(page_id)
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"id": id}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct RenameCanvasPageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    name: String,
+}
+
+fn rename_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: RenameCanvasPageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+    let name = parsed.name.trim().to_string();
+    if name.is_empty() {
+        return Err("Page name must not be empty".into());
+    }
+
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let now = now_ms();
+        let page = doc
+            .get_mut("pages")
+            .and_then(|v| v.as_object_mut())
+            .and_then(|pages| pages.get_mut(&parsed.page_id))
+            .and_then(|p| p.as_object_mut())
+            .ok_or_else(|| format!("Canvas page '{}' not found", parsed.page_id))?;
+        page.insert("name".into(), json!(name.clone()));
+        page.insert("modifiedAt".into(), json!(now));
+        stamp_doc_modified(doc, now);
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "name": name}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
 /// Stamp the document's top-level `modifiedAt` (prose edits don't belong to
 /// a canvas page, so `stamp_modified`'s page arm doesn't apply).
 fn stamp_doc_modified(doc: &mut Value, now: u64) {
@@ -1795,87 +1933,113 @@ fn generate_diagram(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Stri
         layout_diagram(&node_specs, &edge_pairs, mode)
     };
 
-    let (node_map, edge_ids) = mutate_with_retry(ctx, &parsed.doc_id, |doc| {
-        // logical node id -> created shape id, for wiring connectors.
-        let mut node_map = serde_json::Map::new();
-        for (n, (_, pos)) in parsed.nodes.iter().zip(diagram.nodes.iter()) {
-            let kind = match n.kind.as_deref() {
-                Some("ellipse") => super::adapter::DslKind::Ellipse,
-                _ => super::adapter::DslKind::Rectangle,
-            };
-            let dsl = DslShape {
-                kind,
-                x: pos.x,
-                y: pos.y,
-                w: Some(NODE_W),
-                h: Some(NODE_H),
-                text: Some(n.label.clone().unwrap_or_else(|| n.id.clone())),
-                style: None,
-                id: None,
-                start_shape_id: None,
-                end_shape_id: None,
-                start_anchor: None,
-                end_anchor: None,
-                start_arrow_style: None,
-                end_arrow_style: None,
-                routing_mode: None,
-                waypoints: None,
-                label_position: None,
-                x2: None,
-                y2: None,
-            };
-            let shape_id = append_shape_in_place(doc, &parsed.page_id, &dsl)?;
-            node_map.insert(n.id.trim().to_string(), json!(shape_id));
-        }
+    // Build every shape up front with a pre-assigned id (nodes first, then
+    // edges) so the live and cold write paths persist the identical set and the
+    // returned id map is stable regardless of which path runs. Connectors carry
+    // the node shape ids, which are assigned in this same pass before either
+    // path runs. Mirrors `add_shapes` — `generate_diagram` previously wrote the
+    // JSON store directly, so on a resident doc its shapes never reached the
+    // authoritative Y.Doc and could be clobbered by the live doc on flatten.
+    let mut node_map = serde_json::Map::new();
+    let mut shapes: Vec<(String, DslShape)> =
+        Vec::with_capacity(parsed.nodes.len() + parsed.edges.len());
+    for (n, (_, pos)) in parsed.nodes.iter().zip(diagram.nodes.iter()) {
+        let kind = match n.kind.as_deref() {
+            Some("ellipse") => super::adapter::DslKind::Ellipse,
+            _ => super::adapter::DslKind::Rectangle,
+        };
+        let mut dsl = DslShape {
+            kind,
+            x: pos.x,
+            y: pos.y,
+            w: Some(NODE_W),
+            h: Some(NODE_H),
+            text: Some(n.label.clone().unwrap_or_else(|| n.id.clone())),
+            style: None,
+            id: None,
+            start_shape_id: None,
+            end_shape_id: None,
+            start_anchor: None,
+            end_anchor: None,
+            start_arrow_style: None,
+            end_arrow_style: None,
+            routing_mode: None,
+            waypoints: None,
+            label_position: None,
+            x2: None,
+            y2: None,
+        };
+        let id = shape_id_or_gen(&dsl);
+        dsl.id = Some(id.clone());
+        node_map.insert(n.id.trim().to_string(), json!(id));
+        shapes.push((id, dsl));
+    }
 
-        let mut edge_ids = Vec::with_capacity(parsed.edges.len());
-        for (e, routed) in parsed.edges.iter().zip(diagram.edges.iter()) {
-            let from = node_map.get(e.from.trim()).and_then(|v| v.as_str()).unwrap();
-            let to = node_map.get(e.to.trim()).and_then(|v| v.as_str()).unwrap();
-            let dsl = DslShape {
-                kind: super::adapter::DslKind::Connector,
-                x: routed.start.x,
-                y: routed.start.y,
-                w: None,
-                h: None,
-                text: e.label.clone(),
-                style: None,
-                id: None,
-                start_shape_id: Some(from.to_string()),
-                end_shape_id: Some(to.to_string()),
-                start_anchor: Some(routed.start_anchor.as_str().to_string()),
-                end_anchor: Some(routed.end_anchor.as_str().to_string()),
-                start_arrow_style: None,
-                end_arrow_style: None,
-                routing_mode: orthogonal.then(|| "orthogonal".to_string()),
-                waypoints: orthogonal.then(|| {
-                    routed
-                        .waypoints
-                        .iter()
-                        .map(|p| super::adapter::DslPoint { x: p.x, y: p.y })
-                        .collect()
-                }),
-                label_position: routed.label_position,
-                x2: Some(routed.end.x),
-                y2: Some(routed.end.y),
-            };
-            edge_ids.push(json!(append_shape_in_place(doc, &parsed.page_id, &dsl)?));
-        }
+    let mut edge_ids = Vec::with_capacity(parsed.edges.len());
+    for (e, routed) in parsed.edges.iter().zip(diagram.edges.iter()) {
+        let from = node_map.get(e.from.trim()).and_then(|v| v.as_str()).unwrap().to_string();
+        let to = node_map.get(e.to.trim()).and_then(|v| v.as_str()).unwrap().to_string();
+        let mut dsl = DslShape {
+            kind: super::adapter::DslKind::Connector,
+            x: routed.start.x,
+            y: routed.start.y,
+            w: None,
+            h: None,
+            text: e.label.clone(),
+            style: None,
+            id: None,
+            start_shape_id: Some(from),
+            end_shape_id: Some(to),
+            start_anchor: Some(routed.start_anchor.as_str().to_string()),
+            end_anchor: Some(routed.end_anchor.as_str().to_string()),
+            start_arrow_style: None,
+            end_arrow_style: None,
+            routing_mode: orthogonal.then(|| "orthogonal".to_string()),
+            waypoints: orthogonal.then(|| {
+                routed
+                    .waypoints
+                    .iter()
+                    .map(|p| super::adapter::DslPoint { x: p.x, y: p.y })
+                    .collect()
+            }),
+            label_position: routed.label_position,
+            x2: Some(routed.end.x),
+            y2: Some(routed.end.y),
+        };
+        let id = shape_id_or_gen(&dsl);
+        dsl.id = Some(id.clone());
+        edge_ids.push(json!(id));
+        shapes.push((id, dsl));
+    }
 
-        stamp_modified(doc, &parsed.page_id);
-        Ok((node_map, edge_ids))
-    })?;
+    let result = json!({
+        "nodes": node_map,
+        "edges": edge_ids,
+        "layout": match mode { LayoutMode::Layered => "layered", LayoutMode::Grid => "grid" },
+        "routing": if orthogonal { "orthogonal" } else { "straight" },
+    });
 
-    Ok(ToolOutcome {
-        result: json!({
-            "nodes": node_map,
-            "edges": edge_ids,
-            "layout": match mode { LayoutMode::Layered => "layered", LayoutMode::Grid => "grid" },
-            "routing": if orthogonal { "orthogonal" } else { "straight" },
-        }),
-        changed_doc_id: Some(parsed.doc_id),
-        change_detail: None,
-    })
+    write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle| {
+            // One transaction, single broadcast (atomic) — same as `add_shapes`.
+            let items: Vec<(String, Value)> =
+                shapes.iter().map(|(id, dsl)| (id.clone(), build_shape_json(dsl, id))).collect();
+            let framed = handle.insert_shapes(&items)?;
+            Ok((framed, result.clone()))
+        },
+        |doc| {
+            for (idx, (_, dsl)) in shapes.iter().enumerate() {
+                if let Err(e) = append_shape_in_place(doc, &parsed.page_id, dsl) {
+                    return Err(format!("shape[{}]: {}", idx, e));
+                }
+            }
+            stamp_modified(doc, &parsed.page_id);
+            Ok(result.clone())
+        },
+    )
 }
 
 #[derive(Deserialize)]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -758,6 +758,8 @@ mod tests {
         assert!(names.contains(&"docushark.add_prose_page"));
         assert!(names.contains(&"docushark.set_prose"));
         assert!(names.contains(&"docushark.rename_prose_page"));
+        assert!(names.contains(&"docushark.add_canvas_page"));
+        assert!(names.contains(&"docushark.rename_canvas_page"));
         assert!(names.contains(&"docushark.get_outline"));
         assert!(names.contains(&"docushark.insert_section"));
         assert!(names.contains(&"docushark.restructure_outline"));
@@ -773,7 +775,7 @@ mod tests {
         assert!(names.contains(&"docushark.list_fields"));
         assert!(names.contains(&"docushark.set_fields"));
         assert!(names.contains(&"docushark.get_skills"));
-        assert_eq!(tools.len(), 27);
+        assert_eq!(tools.len(), 29);
     }
 
     #[tokio::test]

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -51,7 +51,27 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
             return false;
         };
         page.insert("shapes".to_string(), any_to_json(&shapes_any));
-        page.insert("shapeOrder".to_string(), any_to_json(&order_any));
+        // JP-330: dedupe-keep-first + drop orphans so a live array doubled by a
+        // dual-origin merge persists clean — the stored doc self-heals here.
+        let present = |id: &str| match &shapes_any {
+            Any::Map(m) => m.contains_key(id),
+            _ => false,
+        };
+        let order_ids = match &order_any {
+            Any::Array(arr) => arr
+                .iter()
+                .filter_map(|a| match a {
+                    Any::String(s) => Some(s.as_ref()),
+                    _ => None,
+                })
+                .collect::<Vec<&str>>(),
+            _ => Vec::new(),
+        };
+        let deduped = super::dedupe_order(order_ids, present);
+        page.insert(
+            "shapeOrder".to_string(),
+            Value::Array(deduped.into_iter().map(Value::String).collect()),
+        );
     }
 
     // CRDT-native rename: adopt `metadata.title` as the document `name`, but
@@ -314,6 +334,41 @@ mod tests {
         // Other page untouched; modifiedAt bumped past the original.
         assert_eq!(json["pages"]["p2"]["shapes"]["s9"]["id"], json!("s9"));
         assert!(json["modifiedAt"].as_u64().unwrap() > 2);
+    }
+
+    /// JP-330 self-heal: a live `shapeOrder` doubled by a dual-origin merge
+    /// flattens to a deduped (keep-first) order with orphans dropped, so the
+    /// persisted JSON — the canonical stored copy — is always clean.
+    #[test]
+    fn jp330_flatten_dedupes_doubled_order() {
+        let doc = Doc::new();
+        let shapes = doc.get_or_insert_map("shapes");
+        let order = doc.get_or_insert_array("shapeOrder");
+        {
+            let mut txn = doc.transact_mut();
+            for id in ["s1", "s2"] {
+                shapes.insert(
+                    &mut txn,
+                    id,
+                    Any::Map(std::sync::Arc::new(std::collections::HashMap::from([(
+                        "id".to_string(),
+                        Any::String(id.into()),
+                    )]))),
+                );
+            }
+            // Doubled order + an orphan id with no backing shape.
+            for id in ["s1", "s2", "s1", "s2", "ghost"] {
+                order.push_back(&mut txn, Any::String(id.into()));
+            }
+        }
+
+        let mut json = json!({"pages": {"p1": {"id": "p1", "name": "One"}}, "modifiedAt": 0});
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(
+            json["pages"]["p1"]["shapeOrder"],
+            json!(["s1", "s2"]),
+            "deduped keep-first; 'ghost' orphan dropped"
+        );
     }
 
     #[test]

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -39,14 +39,25 @@ pub fn json_to_ydoc(doc_json: &Value, doc: &Doc) {
         .and_then(|(active, pages)| pages.get(active));
 
     if let Some(page) = active_page {
-        if let Some(page_shapes) = page.get("shapes").and_then(Value::as_object) {
-            for (id, shape) in page_shapes {
-                shapes.insert(&mut txn, id.clone(), json_to_any(shape));
+        // JP-330 once-gate (mirrors `json_references_to_ydoc`/`json_fields_to_ydoc`):
+        // only seed shapes + order into an EMPTY surface. Re-hydrating a populated
+        // Y.Doc would otherwise `push_back` the whole `shapeOrder` again — the
+        // shapes map dedupes by key, but the `shapeOrder` Y.Array (a sequence)
+        // does not, so it doubles.
+        if shapes.len(&txn) == 0 {
+            let page_shapes = page.get("shapes").and_then(Value::as_object);
+            if let Some(ps) = page_shapes {
+                for (id, shape) in ps {
+                    shapes.insert(&mut txn, id.clone(), json_to_any(shape));
+                }
             }
-        }
-        if let Some(order) = page.get("shapeOrder").and_then(Value::as_array) {
-            for id in order.iter().filter_map(Value::as_str) {
-                shape_order.push_back(&mut txn, Any::String(id.into()));
+            if let Some(order) = page.get("shapeOrder").and_then(Value::as_array) {
+                // Dedupe + orphan-drop the source too, so an already-doubled
+                // source JSON / binary sidecar hydrates clean.
+                let present = |id: &str| page_shapes.is_some_and(|m| m.contains_key(id));
+                for id in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+                    shape_order.push_back(&mut txn, Any::String(id.as_str().into()));
+                }
             }
         }
     }
@@ -581,5 +592,91 @@ mod tests {
         super::json_fields_to_ydoc(&json!({"id": "d"}), &doc);
         let fields = doc.get_or_insert_map("fields");
         assert_eq!(fields.len(&doc.transact()), 0);
+    }
+
+    // ---- JP-330 forensic repro: shapeOrder doubling ------------------------
+
+    fn ordered_doc() -> Value {
+        json!({
+            "id": "d", "activePageId": "p1", "pageOrder": ["p1"],
+            "pages": {"p1": {"id": "p1",
+                "shapes": {
+                    "s1": {"id": "s1"}, "s2": {"id": "s2"}, "s3": {"id": "s3"},
+                    "s4": {"id": "s4"}, "s5": {"id": "s5"}
+                },
+                "shapeOrder": ["s1", "s2", "s3", "s4", "s5"]
+            }}
+        })
+    }
+
+    fn read_order(doc: &Doc) -> Vec<String> {
+        use yrs::types::ToJson;
+        let order = doc.get_or_insert_array("shapeOrder");
+        let txn = doc.transact();
+        match order.to_json(&txn) {
+            Any::Array(arr) => arr
+                .iter()
+                .map(|a| match a {
+                    Any::String(s) => s.to_string(),
+                    _ => String::new(),
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Trigger A is now fixed by the once-gate: re-hydrating a populated Y.Doc
+    /// is a no-op for shapes + order (mirrors `json_references_to_ydoc`), so the
+    /// order stays unique instead of doubling.
+    #[test]
+    fn jp330_rehydration_no_longer_doubles() {
+        let doc = Doc::new();
+        json_to_ydoc(&ordered_doc(), &doc);
+        json_to_ydoc(&ordered_doc(), &doc); // second seed: must no-op
+
+        let shapes = doc.get_or_insert_map("shapes");
+        assert_eq!(shapes.len(&doc.transact()), 5);
+        assert_eq!(read_order(&doc), ["s1", "s2", "s3", "s4", "s5"], "no doubling");
+    }
+
+    /// An already-corrupted source (its persisted `shapeOrder` is doubled, like
+    /// the captured snapshot) hydrates clean — the seed dedupes the source.
+    #[test]
+    fn jp330_doubled_source_json_hydrates_clean() {
+        let mut src = ordered_doc();
+        src["pages"]["p1"]["shapeOrder"] =
+            json!(["s1", "s2", "s3", "s4", "s5", "s1", "s2", "s3", "s4", "s5", "ghost"]);
+        let doc = Doc::new();
+        json_to_ydoc(&src, &doc);
+        assert_eq!(
+            read_order(&doc),
+            ["s1", "s2", "s3", "s4", "s5"],
+            "deduped + orphan ('ghost') dropped on seed"
+        );
+    }
+
+    /// Trigger B (dual-origin merge) still doubles the LIVE in-memory array — we
+    /// deliberately don't prevent the merge (deferred). What matters is that no
+    /// consumer surfaces the dupes: `flatten` (persist) self-heals
+    /// (see `flatten::tests::jp330_flatten_dedupes_doubled_order`) and the agent
+    /// read / client render dedupe. This test pins the deferred behavior so a
+    /// future "prevent at source" change has a clear before/after.
+    #[test]
+    fn jp330_dual_origin_merge_still_doubles_live_array() {
+        use yrs::updates::decoder::Decode;
+        use yrs::{ReadTxn, StateVector, Update};
+
+        let a = Doc::new();
+        json_to_ydoc(&ordered_doc(), &a);
+        let b = Doc::new();
+        json_to_ydoc(&ordered_doc(), &b);
+
+        let update = b.transact().encode_state_as_update_v1(&StateVector::default());
+        a.transact_mut()
+            .apply_update(Update::decode_v1(&update).expect("decode"))
+            .expect("apply");
+
+        assert_eq!(a.get_or_insert_map("shapes").len(&a.transact()), 5, "map LWW");
+        assert_eq!(read_order(&a).len(), 10, "live array doubles (deferred: tolerated on read)");
     }
 }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -768,6 +768,24 @@ fn build_prose_children<P: XmlFragment>(
 /// doc); live editors keep their random ids. Its sole job is to make a re-seed —
 /// a later rehydrate, or a client that cached the prior bootstrap in y-indexeddb
 /// — DEDUPE on merge instead of concatenating (the lineage-churn fix).
+/// Keep-first dedupe of a `shapeOrder`-style id sequence, dropping ids for which
+/// `present` is false (orphans). JP-330: `shapeOrder` is a CRDT `Y.Array` (a
+/// sequence, not a set), so non-idempotent seeding (re-hydration) or a
+/// dual-origin merge can leave it with the same id twice while the `shapes`
+/// `Y.Map` stays unique. Every consumer that surfaces order — flatten (persist),
+/// `get_page` (agent read), hydration (re-seed) — routes through this so the
+/// rendered/served/stored order is canonical regardless of the live array.
+pub(crate) fn dedupe_order<'a>(
+    ids: impl IntoIterator<Item = &'a str>,
+    present: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    ids.into_iter()
+        .filter(|id| present(id) && seen.insert(id.to_string()))
+        .map(|id| id.to_string())
+        .collect()
+}
+
 fn deterministic_seed_client_id(page_id: &str) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a 64-bit offset basis
     for b in page_id.as_bytes() {

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -332,13 +332,28 @@ fn map_blocks(nodes: &[HtmlNode]) -> Vec<PmNode> {
 /// Is `n` inline content that joins an inline run (wrapped into one paragraph by
 /// [`map_blocks`]), versus a block-level element that breaks the run? All text
 /// counts — interior whitespace keeps a run together, and an all-whitespace run
-/// is dropped by [`paragraph_from_inline`]. Among elements, only marks and `<a>`
-/// are inline; everything else (known block, or unknown→unwrapped) breaks the run,
-/// preserving the prior per-node handling for those.
+/// is dropped by [`paragraph_from_inline`]. Among elements, marks, `<a>`, `<br>`,
+/// and the inline atoms (`fieldRef`/`citationInline` spans) are inline;
+/// everything else (known block, or unknown→unwrapped) breaks the run.
+///
+/// This must mirror what [`collect_inline`] recognizes: an inline element that
+/// breaks the run is later treated as a block by [`map_blocks`], so `<span>`
+/// fails to map and its (empty atom) children are unwrapped to nothing —
+/// silently dropping a `{{field}}` or citation inside a table cell / list item
+/// (the leading token vanishes, leaving an orphan separator). Keeping the atom
+/// in the run lets `collect_inline` build its `fieldRef`/`citationInline` node.
 fn is_inline_member(n: &HtmlNode) -> bool {
     match n {
         HtmlNode::Text(_) => true,
-        HtmlNode::Element { tag, .. } => prose_schema::mark_pm(tag).is_some() || tag == "a",
+        HtmlNode::Element { tag, attrs, .. } => {
+            prose_schema::mark_pm(tag).is_some()
+                || tag == "a"
+                || tag == "br"
+                || matches!(
+                    prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)),
+                    Some("fieldRef") | Some("citationInline")
+                )
+        }
     }
 }
 
@@ -897,6 +912,38 @@ mod tests {
         let PmChild::Node(cell) = &row.children[0] else { panic!("tableCell") };
         assert_eq!(cell.node_type, "tableCell");
         only_paragraph(cell);
+    }
+
+    #[test]
+    fn field_and_citation_spans_survive_in_a_table_cell() {
+        // JP-320 Report #3: a `{{field}}` (and a citation) leading a table cell
+        // was dropped, leaving an orphan separator — the field/citation span
+        // broke the inline run and was then unwrapped as a failed block. The
+        // markdown adapter emits `{{Framework}}` → `<span data-field …>`.
+        let b = html_to_blocks(concat!(
+            "<table><tr>",
+            r#"<td><span data-field data-name="Framework"></span>, fast</td>"#,
+            r#"<td>see <span data-citation data-ref-id="r1">[1]</span></td>"#,
+            "</tr></table>",
+        ));
+        let PmChild::Node(row) = &b[0].children[0] else { panic!("tableRow") };
+        let PmChild::Node(c0) = &row.children[0] else { panic!("tableCell 0") };
+        let p0 = only_paragraph(c0);
+        // The field atom survives AND the trailing literal is kept (no orphan).
+        assert!(
+            matches!(&p0.children[0], PmChild::Node(n) if n.node_type == "fieldRef"),
+            "leading fieldRef survives in cell: {p0:?}"
+        );
+        assert!(
+            p0.children.iter().any(|c| matches!(c, PmChild::Text { text, .. } if text.contains("fast"))),
+            "trailing text kept (no orphan comma): {p0:?}"
+        );
+        let PmChild::Node(c1) = &row.children[1] else { panic!("tableCell 1") };
+        let p1 = only_paragraph(c1);
+        assert!(
+            p1.children.iter().any(|c| matches!(c, PmChild::Node(n) if n.node_type == "citationInline")),
+            "citation survives in cell: {p1:?}"
+        );
     }
 
     #[test]

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -1174,3 +1174,277 @@ async fn jp35_mcp_live_write_reaches_connected_client() {
     mcp.stop().await.ok();
     relay.server.stop().await.expect("stop");
 }
+
+/// Call `docushark.generate_diagram` over MCP. Returns the `structuredContent`
+/// ({nodes: {logicalId: shapeId}, edges: [...], layout, routing}).
+async fn mcp_generate_diagram(
+    mcp_base: &str,
+    token: &str,
+    doc_id: &str,
+    page_id: &str,
+    nodes: Value,
+    edges: Value,
+) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.generate_diagram", "arguments": {
+            "docId": doc_id, "pageId": page_id, "nodes": nodes, "edges": edges
+        }}
+    });
+    let res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    res["result"]["structuredContent"].clone()
+}
+
+/// JP-320 Report #2: `generate_diagram` on a **resident** doc writes the live
+/// Y.Doc (a connected editor sees the shapes via the CRDT broadcast) and leaves
+/// the JSON store to the snapshot sweeper — the same live path every other
+/// shape tool uses. Previously it wrote JSON directly, so the shapes never
+/// reached the authoritative Y.Doc and were invisible / clobberable.
+#[tokio::test]
+async fn jp320_generate_diagram_reaches_connected_client() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-gen", "name": "Gen", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-gen").await;
+
+    let gen = mcp_generate_diagram(
+        &mcp_base,
+        &token,
+        "doc-gen",
+        "p1",
+        json!([{"id": "a", "label": "A"}, {"id": "b", "label": "B"}]),
+        json!([{"from": "a", "to": "b"}]),
+    )
+    .await;
+    let node_a = gen["nodes"]["a"].as_str().unwrap_or_else(|| panic!("no node id: {gen}")).to_string();
+    let node_b = gen["nodes"]["b"].as_str().expect("node b").to_string();
+
+    // The editor receives the generated shapes live (poll until both nodes land).
+    let mut delivered = false;
+    for _ in 0..30 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape(&node_a) && local.has_shape(&node_b) {
+            delivered = true;
+            break;
+        }
+    }
+    assert!(delivered, "editor never received the generated shapes live");
+
+    // Live path leaves the JSON snapshot to the sweeper, like a human's edits.
+    let doc = get_doc(&relay.http, &token, "doc-gen").await;
+    let json_shapes = doc["pages"]["p1"]["shapes"].as_object().unwrap().len();
+    assert_eq!(json_shapes, 0, "live generate must not touch the JSON store");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-320 Report #2 (cold path): `generate_diagram` on a **non-resident** doc
+/// (no editor joined) persists to the JSON store — the shapes are durably saved
+/// and readable, not a silent no-op.
+#[tokio::test]
+async fn jp320_generate_diagram_persists_on_cold_doc() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-cold", "name": "Cold", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    let gen = mcp_generate_diagram(
+        &mcp_base,
+        &token,
+        "doc-cold",
+        "p1",
+        json!([{"id": "a", "label": "A"}, {"id": "b", "label": "B"}]),
+        json!([{"from": "a", "to": "b"}]),
+    )
+    .await;
+    assert!(gen["nodes"]["a"].is_string(), "result reports node ids: {gen}");
+
+    // No editor was ever connected → cold path → the JSON store holds the shapes
+    // (2 nodes + 1 connector).
+    let doc = get_doc(&relay.http, &token, "doc-cold").await;
+    let shapes = doc["pages"]["p1"]["shapes"].as_object().expect("shapes map");
+    assert_eq!(shapes.len(), 3, "cold generate must persist all shapes: {doc}");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-320 Report #4: concurrent same-page writes must not silently drop one.
+/// The reported repro — a parallel `delete_shape` + `generate_diagram` leaving
+/// the page empty — was a symptom of Report #2: delete hit the live Y.Doc while
+/// generate wrote JSON, and the live doc clobbered the generated shapes on
+/// flatten. With both on the live path the writes serialize on the Y.Doc txn:
+/// the deleted shape is gone AND the generated shapes survive.
+#[tokio::test]
+async fn jp320_concurrent_delete_and_generate_no_loss() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-race", "name": "Race", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Editor joins → resident; seed shape s1 into the live Y.Doc.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-race").await;
+    editor.send_sync(&local.insert_shape_update("s1")).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(local.has_shape("s1"));
+
+    // Fire delete(s1) and generate(g) concurrently on the same page.
+    let del = mcp_delete_shape(&mcp_base, &token, "doc-race", "p1", "s1");
+    let gen = mcp_generate_diagram(
+        &mcp_base,
+        &token,
+        "doc-race",
+        "p1",
+        json!([{"id": "g", "label": "G"}]),
+        json!([]),
+    );
+    let (_del_res, gen_res) = tokio::join!(del, gen);
+    let gen_node = gen_res["nodes"]["g"].as_str().expect("generated node id").to_string();
+
+    // The editor converges: s1 dropped, the generated shape present (not lost).
+    let mut ok = false;
+    for _ in 0..30 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape(&gen_node) && !local.has_shape("s1") {
+            ok = true;
+            break;
+        }
+    }
+    assert!(ok, "generated shape lost or delete didn't apply under concurrency");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-320 papercut: `add_canvas_page` creates a real, targetable canvas page,
+/// and `rename_canvas_page` renames it — mirroring the prose page tools. The
+/// page list is JSON-only, so a cold (no editor joined) round-trip is enough.
+#[tokio::test]
+async fn jp320_add_and_rename_canvas_page_round_trip() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-canvas", "name": "Canvas", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "name": "Page 1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Add a second canvas page.
+    let add = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.add_canvas_page", "arguments": {"docId": "doc-canvas"}}
+    });
+    let add_res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(&token)
+        .json(&add)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    let new_page = add_res["result"]["structuredContent"]["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no canvas page id: {add_res}"))
+        .to_string();
+
+    // The new page is real + targetable: add a shape to it.
+    let shape_id = mcp_add_shape(&mcp_base, &token, "doc-canvas", &new_page).await;
+    let doc = get_doc(&relay.http, &token, "doc-canvas").await;
+    assert!(
+        doc["pageOrder"].as_array().unwrap().iter().any(|v| v == &json!(new_page)),
+        "new page in pageOrder: {doc}"
+    );
+    assert!(
+        doc["pages"][&new_page]["shapes"][&shape_id].is_object(),
+        "shape landed on the new canvas page: {doc}"
+    );
+    assert_eq!(doc["pages"][&new_page]["name"], json!("Page 2"), "default name");
+
+    // Rename it; the change is reflected in the document.
+    let ren = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.rename_canvas_page", "arguments": {
+            "docId": "doc-canvas", "pageId": new_page, "name": "Architecture"
+        }}
+    });
+    reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(&token)
+        .json(&ren)
+        .send()
+        .await
+        .expect("mcp post")
+        .json::<Value>()
+        .await
+        .expect("mcp json");
+    let doc = get_doc(&relay.http, &token, "doc-canvas").await;
+    assert_eq!(doc["pages"][&new_page]["name"], json!("Architecture"), "renamed");
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -1258,6 +1258,15 @@ async fn jp320_generate_diagram_reaches_connected_client() {
     }
     assert!(delivered, "editor never received the generated shapes live");
 
+    // The AGENT's read-back is now consistent: `get_page` on a resident doc
+    // reads the live Y.Doc (the write path), so the agent sees the diagram it
+    // just generated. This is the exact field symptom — the human (rendering
+    // the doc) saw the shapes while the agent's read returned empty, because the
+    // old generate_diagram wrote only the JSON the agent's resident read skips.
+    let page = mcp_get_page(&mcp_base, &token, "doc-gen", "p1").await;
+    let read_shapes = page["shapes"].as_array().map(|a| a.len()).unwrap_or(0);
+    assert_eq!(read_shapes, 3, "agent get_page must read back the generated shapes: {page}");
+
     // Live path leaves the JSON snapshot to the sweeper, like a human's edits.
     let doc = get_doc(&relay.http, &token, "doc-gen").await;
     let json_shapes = doc["pages"]["p1"]["shapes"].as_object().unwrap().len();
@@ -1265,6 +1274,26 @@ async fn jp320_generate_diagram_reaches_connected_client() {
 
     mcp.stop().await.ok();
     relay.server.stop().await.expect("stop");
+}
+
+/// Call `docushark.get_page` over MCP and return the `structuredContent`
+/// ({shapes: [...], source}).
+async fn mcp_get_page(mcp_base: &str, token: &str, doc_id: &str, page_id: &str) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "docushark.get_page", "arguments": {"docId": doc_id, "pageId": page_id}}
+    });
+    let res: Value = reqwest::Client::new()
+        .post(format!("{mcp_base}/mcp"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("mcp post")
+        .json()
+        .await
+        .expect("mcp json");
+    res["result"]["structuredContent"].clone()
 }
 
 /// JP-320 Report #2 (cold path): `generate_diagram` on a **non-resident** doc

--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -13,6 +13,7 @@ import {
   checkConnectorHealth,
   findOrphanedConnectors,
   findClosestAnchor,
+  chooseConnectorAnchors,
   updateConnectorEndpoints,
   clipPointToShapeBoundary,
   clipConnectorEndpoints,
@@ -867,5 +868,41 @@ describe('straight mode ignores stale waypoints', () => {
     });
     const bounds = connectorHandler.getBounds(conn);
     expect(bounds.maxY).toBeGreaterThan(400);
+  });
+});
+
+describe('chooseConnectorAnchors (JP-321)', () => {
+  const shape = (id: string, x: number, y: number): Shape =>
+    ({ id, type: 'rectangle', x, y } as Shape);
+
+  it('picks vertical sides when the target is below/above', () => {
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 0, 300))).toEqual({
+      startAnchor: 'bottom',
+      endAnchor: 'top',
+    });
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 0, -300))).toEqual({
+      startAnchor: 'top',
+      endAnchor: 'bottom',
+    });
+  });
+
+  it('picks horizontal sides when the target is right/left (and on ties)', () => {
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 300, 0))).toEqual({
+      startAnchor: 'right',
+      endAnchor: 'left',
+    });
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', -300, 0))).toEqual({
+      startAnchor: 'left',
+      endAnchor: 'right',
+    });
+    // |dx| == |dy| → horizontal wins (matches the relay's grid branch).
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('b', 100, 100))?.startAnchor).toBe(
+      'right'
+    );
+  });
+
+  it('returns null for degenerate cases (self / coincident centers)', () => {
+    expect(chooseConnectorAnchors(shape('a', 0, 0), shape('a', 0, 0))).toBeNull();
+    expect(chooseConnectorAnchors(shape('a', 5, 5), shape('b', 5, 5))).toBeNull();
   });
 });

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -5,6 +5,7 @@ import {
   ConnectorShape,
   Handle,
   Anchor,
+  AnchorPosition,
   Shape,
   DEFAULT_CONNECTOR,
   ERDCardinality,
@@ -1400,6 +1401,39 @@ export function updateConnectorEndpoints(
   }
 
   return updates;
+}
+
+/**
+ * Choose the connector anchor *sides* that match the two shapes' current
+ * relative geometry — the dominant axis between their centers. Mirrors the
+ * relay's `edge_anchors` grid/defensive branch (relay/src/mcp/layout/mod.rs) so
+ * a re-layout or route rebuild re-seats a connector on the correct faces rather
+ * than honoring the sides baked at create/generate time. Without this, a node
+ * move (e.g. a collaborator's edit, or a TB→LR re-layout) leaves the stored
+ * `startAnchor`/`endAnchor` facing the wrong way, the endpoints attach to the
+ * wrong faces, and the orthogonal route tangles with no re-layout able to
+ * recover it (JP-321). Geometry-only ⇒ direction-agnostic and idempotent.
+ *
+ * Returns `null` for the degenerate case (same shape on both ends, or
+ * coincident centers) where there is no meaningful dominant axis — the caller
+ * leaves the existing anchors untouched.
+ */
+export function chooseConnectorAnchors(
+  startShape: Shape,
+  endShape: Shape
+): { startAnchor: AnchorPosition; endAnchor: AnchorPosition } | null {
+  if (startShape.id === endShape.id) return null;
+  const dx = endShape.x - startShape.x;
+  const dy = endShape.y - startShape.y;
+  if (dx === 0 && dy === 0) return null;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0
+      ? { startAnchor: 'right', endAnchor: 'left' }
+      : { startAnchor: 'left', endAnchor: 'right' };
+  }
+  return dy >= 0
+    ? { startAnchor: 'bottom', endAnchor: 'top' }
+    : { startAnchor: 'top', endAnchor: 'bottom' };
 }
 
 /**

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -5,7 +5,7 @@ import {
   shapeExists,
 } from './documentStore';
 import { getProvenance } from './writeProvenance';
-import { RectangleShape, type ConnectorShape, DEFAULT_CONNECTOR } from '../shapes/Shape';
+import { RectangleShape, type ConnectorShape, type AnchorPosition, DEFAULT_CONNECTOR } from '../shapes/Shape';
 import '../shapes/Rectangle'; // registers the handler computeAutoLayout reads for sizing
 
 /**
@@ -104,6 +104,87 @@ describe('Document Store', () => {
       const s = useDocumentStore.getState().shapes['lone']!;
       expect(s.x).toBe(42);
       expect(s.y).toBe(7);
+    });
+  });
+
+  describe('connector re-anchoring on re-layout (JP-321)', () => {
+    function orthConnector(
+      id: string,
+      from: string,
+      to: string,
+      startAnchor: AnchorPosition,
+      endAnchor: AnchorPosition
+    ): ConnectorShape {
+      return {
+        ...DEFAULT_CONNECTOR,
+        id,
+        type: 'connector',
+        x: 0,
+        y: 0,
+        x2: 0,
+        y2: 0,
+        rotation: 0,
+        opacity: 1,
+        locked: false,
+        visible: true,
+        startShapeId: from,
+        endShapeId: to,
+        startAnchor,
+        endAnchor,
+        routingMode: 'orthogonal',
+        waypoints: [{ x: 0, y: 0 }],
+      } as ConnectorShape;
+    }
+
+    it('rebuildAllConnectorRoutes re-seats stale anchors after a move, idempotently', () => {
+      const store = useDocumentStore.getState();
+      // b below a → (bottom, top) is correct initially (as generate_diagram bakes it).
+      store.addShapes([
+        createTestRect({ id: 'a', x: 0, y: 0 }),
+        createTestRect({ id: 'b', x: 0, y: 300 }),
+        orthConnector('c1', 'a', 'b', 'bottom', 'top'),
+      ]);
+      // Simulate a collab edit: b jumps ABOVE a, leaving the baked sides stale.
+      store.updateShape('b', { y: -300 });
+
+      store.rebuildAllConnectorRoutes();
+      const c = useDocumentStore.getState().shapes['c1'] as ConnectorShape;
+      // Sides flip to match the new geometry (b above a) — the old waypoint-only
+      // rebuild left these at (bottom, top) and could never recover the tangle.
+      expect(c.startAnchor).toBe('top');
+      expect(c.endAnchor).toBe('bottom');
+      // Start endpoint pulled to a's top face (above a's center at y=0).
+      expect(c.y).toBeLessThan(0);
+      expect(Array.isArray(c.waypoints)).toBe(true);
+
+      // Idempotent: a second rebuild reproduces the same result exactly.
+      store.rebuildAllConnectorRoutes();
+      const c2 = useDocumentStore.getState().shapes['c1'] as ConnectorShape;
+      expect(c2.startAnchor).toBe('top');
+      expect(c2.endAnchor).toBe('bottom');
+      expect([c2.x, c2.y, c2.x2, c2.y2]).toEqual([c.x, c.y, c.x2, c.y2]);
+      expect(c2.waypoints).toEqual(c.waypoints);
+    });
+
+    it('autoLayoutShapes re-seats anchors to match the laid-out geometry', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([
+        createTestRect({ id: 'a', x: 0, y: 0 }),
+        createTestRect({ id: 'b', x: 0, y: 300 }),
+        // Deliberately wrong (horizontal) sides — must be corrected by re-layout.
+        orthConnector('c1', 'a', 'b', 'left', 'right'),
+      ]);
+      store.autoLayoutShapes(['a', 'b']);
+
+      const after = useDocumentStore.getState().shapes;
+      const c = after['c1'] as ConnectorShape;
+      // TB layout stacks the two nodes vertically; anchors follow that geometry.
+      const expected =
+        after['a']!.y < after['b']!.y
+          ? { startAnchor: 'bottom', endAnchor: 'top' }
+          : { startAnchor: 'top', endAnchor: 'bottom' };
+      expect(c.startAnchor).toBe(expected.startAnchor);
+      expect(c.endAnchor).toBe(expected.endAnchor);
     });
   });
 

--- a/src/store/documentStore.test.ts
+++ b/src/store/documentStore.test.ts
@@ -488,6 +488,42 @@ describe('Document Store', () => {
 
       expect(useDocumentStore.getState().shapeOrder).toEqual(['rect1']);
     });
+
+    it('collapses a doubled shapeOrder keep-first on load (JP-330)', () => {
+      // The dual-origin-merge corruption: each valid id appears twice (+ an
+      // orphan). loadSnapshot must dedupe keep-first and drop the orphan.
+      const snapshot = {
+        shapes: { a: createTestRect({ id: 'a' }), b: createTestRect({ id: 'b' }) },
+        shapeOrder: ['a', 'b', 'a', 'b', 'ghost'],
+        version: 1,
+      };
+
+      useDocumentStore.getState().loadSnapshot(snapshot);
+
+      expect(useDocumentStore.getState().shapeOrder).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('reorderShapes dedupe (JP-330)', () => {
+    it('collapses a doubled incoming order (the CRDT onOrderChange funnel)', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([createTestRect({ id: 'a' }), createTestRect({ id: 'b' })]);
+
+      // A doubled order arrives (dual-origin merge) — must not double z-order.
+      store.reorderShapes(['b', 'a', 'b', 'a']);
+
+      expect(useDocumentStore.getState().shapeOrder).toEqual(['b', 'a']);
+    });
+
+    it('still rejects a genuinely partial order', () => {
+      const store = useDocumentStore.getState();
+      store.addShapes([createTestRect({ id: 'a' }), createTestRect({ id: 'b' })]);
+
+      // Only one of two distinct shapes — not a permutation, so ignored.
+      store.reorderShapes(['a', 'a']);
+
+      expect(useDocumentStore.getState().shapeOrder).toEqual(['a', 'b']);
+    });
   });
 
   describe('utilities', () => {

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -4,6 +4,7 @@ import { Shape, GroupShape, ConnectorShape, isGroup } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Box } from '../math/Box';
 import { calculateConnectorWaypoints } from '../engine/OrthogonalRouter';
+import { chooseConnectorAnchors, updateConnectorEndpoints } from '../shapes/Connector';
 import { SpatialIndex } from '../engine/SpatialIndex';
 import { wouldCreateCycle, wouldExceedMaxDepth, findParentGroup } from '../shapes/GroupHierarchy';
 import { computeAutoLayout, type AutoLayoutOptions } from '../shapes/autoLayout';
@@ -147,6 +148,40 @@ const initialState: DocumentState = {
   shapes: {},
   shapeOrder: [],
 };
+
+/**
+ * Re-seat a connector against the current geometry: re-pick its anchor sides
+ * (when both ends are bound), pull its endpoints to those anchor points, then
+ * recompute orthogonal waypoints. Used by the re-layout / route-rebuild paths
+ * so a single run is a true reset that recovers connectors whose baked anchor
+ * sides drifted out of date (JP-321) — not just a waypoint recompute against
+ * stale endpoints/sides. `connector` is mutated in place (an Immer draft).
+ */
+function recoverConnectorRouting(
+  connector: ConnectorShape,
+  shapes: Record<string, Shape>,
+  obstacleIndex: SpatialIndex
+): void {
+  const startShape = connector.startShapeId ? shapes[connector.startShapeId] : undefined;
+  const endShape = connector.endShapeId ? shapes[connector.endShapeId] : undefined;
+  if (startShape && endShape) {
+    const anchors = chooseConnectorAnchors(startShape, endShape);
+    if (anchors) {
+      connector.startAnchor = anchors.startAnchor;
+      connector.endAnchor = anchors.endAnchor;
+    }
+  }
+  // Endpoints first (they read the just-updated anchor sides), so routing runs
+  // against the current geometry rather than stale x/y/x2/y2.
+  const endpoints = updateConnectorEndpoints(connector, shapes);
+  if (endpoints.x !== undefined) connector.x = endpoints.x;
+  if (endpoints.y !== undefined) connector.y = endpoints.y;
+  if (endpoints.x2 !== undefined) connector.x2 = endpoints.x2;
+  if (endpoints.y2 !== undefined) connector.y2 = endpoints.y2;
+  if (connector.routingMode === 'orthogonal') {
+    connector.waypoints = calculateConnectorWaypoints(connector, shapes, obstacleIndex) ?? [];
+  }
+}
 
 /**
  * Document store for managing shape data.
@@ -643,10 +678,11 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
     rebuildAllConnectorRoutes: () => {
       set((state) => {
-        // Find all connectors with orthogonal routing
+        // Re-seat every connector (re-anchor + re-endpoint + re-route), not just
+        // orthogonal ones — straight connectors also carry stale anchor sides
+        // after a node move, so a "rebuild routes" must reset their faces too.
         const connectors = Object.values(state.shapes).filter(
-          (shape): shape is ConnectorShape =>
-            shape.type === 'connector' && (shape as ConnectorShape).routingMode === 'orthogonal'
+          (shape): shape is ConnectorShape => shape.type === 'connector'
         );
         if (connectors.length === 0) return;
 
@@ -657,12 +693,8 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
         const obstacleIndex = new SpatialIndex();
         obstacleIndex.rebuild(Object.values(state.shapes));
 
-        // Recalculate waypoints for each connector
         for (const connector of connectors) {
-          const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
-          if (waypoints) {
-            (state.shapes[connector.id] as ConnectorShape).waypoints = waypoints;
-          }
+          recoverConnectorRouting(connector, state.shapes, obstacleIndex);
         }
       });
     },
@@ -678,19 +710,18 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
             shape.y = pos.y;
           }
         }
-        // Reroute orthogonal connectors against the new positions.
+        // Re-seat connectors against the new node positions: re-pick anchor
+        // sides, re-pull endpoints, then re-route. A waypoint-only recompute
+        // (the old behavior) kept stale faces/endpoints, so a re-layout could
+        // not recover a connector whose sides had drifted (JP-321).
         const connectors = Object.values(state.shapes).filter(
-          (shape): shape is ConnectorShape =>
-            shape.type === 'connector' && (shape as ConnectorShape).routingMode === 'orthogonal'
+          (shape): shape is ConnectorShape => shape.type === 'connector'
         );
         if (connectors.length === 0) return;
         const obstacleIndex = new SpatialIndex();
         obstacleIndex.rebuild(Object.values(state.shapes));
         for (const connector of connectors) {
-          const waypoints = calculateConnectorWaypoints(connector, state.shapes, obstacleIndex);
-          if (waypoints) {
-            (state.shapes[connector.id] as ConnectorShape).waypoints = waypoints;
-          }
+          recoverConnectorRouting(connector, state.shapes, obstacleIndex);
         }
       });
     },

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -359,11 +359,20 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
     reorderShapes: (newOrder: string[]) => {
       set((state) => {
-        // Validate that all IDs exist and no duplicates
-        const existingIds = new Set(Object.keys(state.shapes));
-        const validOrder = newOrder.filter((id) => existingIds.has(id));
-        // Only update if all shapes accounted for
-        if (validOrder.length === state.shapeOrder.length) {
+        // Keep-first dedupe + drop ids with no shape. This is the incremental
+        // CRDT order funnel (onOrderChange → reorderShapes); a `shapeOrder`
+        // doubled by a dual-origin merge (JP-330) must not double the rendered
+        // z-order. Comparing against the DISTINCT current ordered ids (not the
+        // raw length) also self-heals an already-doubled current order.
+        const seen = new Set<string>();
+        const validOrder = newOrder.filter((id) => {
+          if (!state.shapes[id] || seen.has(id)) return false;
+          seen.add(id);
+          return true;
+        });
+        // Only update when it accounts for every distinct shape currently
+        // ordered (a true permutation), so a partial order is still rejected.
+        if (validOrder.length === new Set(state.shapeOrder).size) {
           state.shapeOrder = validOrder;
         }
       });
@@ -389,14 +398,34 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
       const incomingOrder = snapshot.shapeOrder ?? [];
       const droppedFromOrder = incomingOrder.filter((id) => !incomingShapes[id]);
       const unorderedShapes: string[] = [];
+      // JP-330: collapse a doubled shapeOrder (a valid id appearing more than
+      // once — the dual-origin-merge corruption) keep-first, dropping orphans.
+      // `cleanOrder` is what we load so the rendered z-order is canonical and a
+      // persisted doubled doc self-heals on its next save.
+      const seenIds = new Set<string>();
+      const cleanOrder: string[] = [];
+      let duplicatesDropped = 0;
+      for (const id of incomingOrder) {
+        if (!incomingShapes[id]) continue; // orphan — counted in droppedFromOrder
+        if (seenIds.has(id)) {
+          duplicatesDropped++;
+          continue;
+        }
+        seenIds.add(id);
+        cleanOrder.push(id);
+      }
+      // `ok` (which gates the persistence layer's save-refusal) keys off orphans
+      // only; duplicates are repaired in place here, so a save of the cleaned
+      // state should still be allowed.
       const ok = droppedFromOrder.length === 0;
 
-      if (!ok) {
+      if (!ok || duplicatesDropped > 0) {
         // eslint-disable-next-line no-console
         console.error(
           '[documentStore] loadSnapshot integrity issue — possible page corruption.',
           {
             droppedFromOrder,
+            duplicatesDropped,
             unorderedShapes,
             shapeCount: Object.keys(incomingShapes).length,
             orderCount: incomingOrder.length,
@@ -423,9 +452,8 @@ export const useDocumentStore = create<DocumentState & DocumentActions>()(
 
           // Load snapshot data
           state.shapes = JSON.parse(JSON.stringify(incomingShapes));
-          // Filter out any orphaned IDs to keep rendering stable; the integrity
-          // flag above lets the persistence layer refuse a save if needed.
-          state.shapeOrder = incomingOrder.filter((id) => state.shapes[id]);
+          // Orphan-dropped + dedupe-keep-first (JP-330) order computed above.
+          state.shapeOrder = cleanOrder;
         });
       });
     },

--- a/src/tiptap/CitationExtension.ts
+++ b/src/tiptap/CitationExtension.ts
@@ -26,8 +26,7 @@ import type { Node as PMNode } from '@tiptap/pm/model';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import { useReferenceStore } from '../store/referenceStore';
 import { referencePreview } from '../services/citations/preview';
-import { PROSE_PROJECTION_META } from './proseProjection';
-import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { scheduleProjectionWriteBack } from './proseProjection';
 import { showCitationCard, hideCitationCard } from './citationHoverCard';
 
 declare module '@tiptap/core' {
@@ -139,22 +138,18 @@ export const CitationInline = Node.create<CitationOptions>({
       };
 
       // Persist the formatted text into the node's `label` attr so the HTML
-      // projection (getHTML → PDF / MCP / offline) is self-contained. Runs in an
-      // async microtask after the PM update (never "dispatch during dispatch").
+      // projection (getHTML → PDF / MCP / offline) is self-contained. Deferred +
+      // re-validated by `scheduleProjectionWriteBack` (never "dispatch during
+      // dispatch") — the refId identity guard stops a stale pos writing a label
+      // onto a different citation. See the invariant in proseProjection.ts.
       const writeBackLabel = (label: string) => {
-        if (!editor.isEditable) return; // view-only clients never dirty the doc
-        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
-        const pos = typeof getPos === 'function' ? getPos() : undefined;
-        if (pos == null) return;
-        const cur = editor.state.doc.nodeAt(pos);
-        // type AND refId match → never write a label onto a different citation
-        // if `pos` went stale between format start and this resolve.
-        if (!cur || cur.type.name !== this.name || cur.attrs['refId'] !== refId) return;
-        if (cur.attrs['label'] === label) return; // idempotent → loop-safe
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
-        tr.setMeta('addToHistory', false); // keep label-sync out of undo
-        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
-        editor.view.dispatch(tr);
+        scheduleProjectionWriteBack({
+          editor,
+          getPos,
+          nodeName: this.name,
+          identity: (n) => n.attrs['refId'] === refId,
+          attrs: { label },
+        });
       };
 
       const render = () => {
@@ -425,23 +420,18 @@ export const Bibliography = Node.create<CitationOptions>({
       let lastCitedKey = '';
 
       // Persist the rendered bibliography HTML into the node's `bibHtml` attr so
-      // non-editor consumers are self-contained. Same safety as CitationInline:
-      // idempotent, editable-only, out of undo, runs post-update.
+      // non-editor consumers are self-contained. Deferred + re-validated by
+      // `scheduleProjectionWriteBack` (see the invariant in proseProjection.ts).
       const writeBackContent = (rawHtml: string) => {
-        if (!editor.isEditable) return;
-        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
         // Newlines → spaces: keep the persisted attribute value single-line and
         // robust across serializers (citeproc emits newlines between entries).
         const bibHtml = rawHtml.replace(/[\r\n]+/g, ' ');
-        const pos = typeof getPos === 'function' ? getPos() : undefined;
-        if (pos == null) return;
-        const cur = editor.state.doc.nodeAt(pos);
-        if (!cur || cur.type.name !== this.name) return;
-        if (cur.attrs['bibHtml'] === bibHtml) return;
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, bibHtml });
-        tr.setMeta('addToHistory', false);
-        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
-        editor.view.dispatch(tr);
+        scheduleProjectionWriteBack({
+          editor,
+          getPos,
+          nodeName: this.name,
+          attrs: { bibHtml },
+        });
       };
 
       const render = () => {

--- a/src/tiptap/FieldExtension.ts
+++ b/src/tiptap/FieldExtension.ts
@@ -23,8 +23,7 @@
 import { Node, mergeAttributes } from '@tiptap/core';
 import { useFieldStore } from '../store/fieldStore';
 import { getComputedField } from '../types/Field';
-import { PROSE_PROJECTION_META } from './proseProjection';
-import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { scheduleProjectionWriteBack } from './proseProjection';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -117,18 +116,20 @@ export const FieldRef = Node.create<FieldOptions>({
       // projection (getHTML → PDF / MCP / offline) is self-contained. Same
       // safety as CitationInline: idempotent, editable-only, out of undo, runs
       // post-update, re-checks position + type + name before dispatch.
+      // Persist the resolved value into the node's `label` attr so the HTML
+      // projection (getHTML → PDF / MCP / offline) is self-contained. Deferred +
+      // re-validated by `scheduleProjectionWriteBack` — fieldRef resolves its
+      // value synchronously in render(), so a direct dispatch would crash the
+      // view mid-reconciliation (MCP fieldRefs arrive label-less, so every one on
+      // the page would fire at once). See the invariant in proseProjection.ts.
       const writeBackLabel = (label: string) => {
-        if (!editor.isEditable) return; // view-only clients never dirty the doc
-        if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
-        const pos = typeof getPos === 'function' ? getPos() : undefined;
-        if (pos == null) return;
-        const cur = editor.state.doc.nodeAt(pos);
-        if (!cur || cur.type.name !== this.name || cur.attrs['name'] !== name) return;
-        if (cur.attrs['label'] === label) return; // idempotent → loop-safe
-        const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, label });
-        tr.setMeta('addToHistory', false); // keep label-sync out of undo
-        tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
-        editor.view.dispatch(tr);
+        scheduleProjectionWriteBack({
+          editor,
+          getPos,
+          nodeName: this.name,
+          identity: (n) => n.attrs['name'] === name,
+          attrs: { label },
+        });
       };
 
       const render = () => {

--- a/src/tiptap/proseProjection.test.ts
+++ b/src/tiptap/proseProjection.test.ts
@@ -1,10 +1,35 @@
 /**
- * Tests for the prose-projection transaction marker (JP-89).
+ * Tests for the prose-projection machinery (JP-89): the transaction marker AND
+ * `scheduleProjectionWriteBack`, the deferred write-back helper.
+ *
+ * The helper's contract (see the invariant in proseProjection.ts): a node view's
+ * derived-attr write-back must NEVER dispatch synchronously during view
+ * reconciliation — that re-enters the view tree and crashes with "Cannot read
+ * properties of undefined (reading 'children')". It defers to a microtask,
+ * re-validates the target, and tags the write as a silent projection.
+ *
+ * NOTE on the regression suite: the actual "reading 'children'" crash is a
+ * real-browser ProseMirror view-desc failure that jsdom (no layout) does NOT
+ * reproduce, even via the Collaboration fragment-adoption path. So the **guard**
+ * against the regression is the `defers ... never during reconciliation` contract
+ * test above — it fails the moment the helper dispatches synchronously (the exact
+ * cause of the crash). The mount tests below are jsdom **smoke tests**: they prove
+ * the deferred write-back path renders a page full of label-less fieldRefs and
+ * bakes the labels back in without throwing.
  */
-import { describe, it, expect } from 'vitest';
-import { Editor } from '@tiptap/core';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Editor, type Extensions } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
-import { PROSE_PROJECTION_META, isProjectionTransaction } from './proseProjection';
+import {
+  PROSE_PROJECTION_META,
+  isProjectionTransaction,
+  scheduleProjectionWriteBack,
+} from './proseProjection';
+import Collaboration from '@tiptap/extension-collaboration';
+import { prosemirrorToYDoc } from 'y-prosemirror';
+import { FieldRef } from './FieldExtension';
+import { extensions as fullProseExtensions, sharedProseExtensions } from '../ui/TiptapEditor';
+import { useFieldStore } from '../store/fieldStore';
 
 function makeEditor(): Editor {
   const element = document.createElement('div');
@@ -24,5 +49,241 @@ describe('isProjectionTransaction', () => {
     const tr = editor.state.tr.setMeta(PROSE_PROJECTION_META, true);
     expect(isProjectionTransaction(tr)).toBe(true);
     editor.destroy();
+  });
+});
+
+// ---- scheduleProjectionWriteBack ------------------------------------------
+
+const isolated: Extensions = [StarterKit.configure({ history: false }), FieldRef];
+
+function mount(content: string, exts: Extensions = isolated): { editor: Editor; element: HTMLElement } {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = new Editor({ element, extensions: exts, content });
+  return { editor, element };
+}
+
+/** Position of the first fieldRef node in the doc, or -1. */
+function firstFieldPos(editor: Editor): number {
+  let pos = -1;
+  editor.state.doc.descendants((node, p) => {
+    if (pos === -1 && node.type.name === 'fieldRef') pos = p;
+    return pos === -1;
+  });
+  return pos;
+}
+
+const flush = () => Promise.resolve();
+
+describe('scheduleProjectionWriteBack', () => {
+  beforeEach(() => useFieldStore.getState().clear());
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A fieldRef whose cached label already equals the store value, so the node
+  // view's OWN write-back no-ops — letting us observe the helper in isolation.
+  function mountStableField(): { editor: Editor; element: HTMLElement; pos: number } {
+    useFieldStore.getState().setField('Company', 'Acme');
+    const { editor, element } = mount(
+      '<p><span data-field data-name="Company" data-label="Acme"></span></p>',
+    );
+    return { editor, element, pos: firstFieldPos(editor) };
+  }
+
+  it('defers the dispatch to a microtask (never during reconciliation)', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush(); // let any mount-time write-back settle (it no-ops here)
+    const spy = vi.spyOn(editor.view, 'dispatch');
+
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'Changed' } });
+    expect(spy).not.toHaveBeenCalled(); // synchronous: nothing yet
+
+    await flush();
+    expect(spy).toHaveBeenCalledTimes(1); // dispatched only after the microtask
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('tags the write-back as a silent projection, out of undo', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    let tagged = false;
+    let outOfUndo = false;
+    editor.on('transaction', ({ transaction }) => {
+      if (isProjectionTransaction(transaction)) {
+        tagged = true;
+        outOfUndo = transaction.getMeta('addToHistory') === false;
+      }
+    });
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'New' } });
+    await flush();
+    expect(tagged).toBe(true);
+    expect(outOfUndo).toBe(true);
+    editor.destroy();
+    element.remove();
+  });
+
+  it('is idempotent — no dispatch when attrs already match', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'Acme' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('skips when the identity guard fails (stale pos → different node)', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({
+      editor,
+      getPos: () => pos,
+      nodeName: 'fieldRef',
+      identity: (n) => n.attrs['name'] === 'SomeoneElse',
+      attrs: { label: 'New' },
+    });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('skips when the node type at pos does not match', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'citationInline', attrs: { label: 'New' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('never dirties a view-only (non-editable) editor', async () => {
+    const { editor, element, pos } = mountStableField();
+    await flush();
+    editor.setEditable(false);
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: () => pos, nodeName: 'fieldRef', attrs: { label: 'Changed' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+
+  it('skips when getPos is unavailable (boolean false)', async () => {
+    const { editor, element } = mountStableField();
+    await flush();
+    const spy = vi.spyOn(editor.view, 'dispatch');
+    scheduleProjectionWriteBack({ editor, getPos: false, nodeName: 'fieldRef', attrs: { label: 'New' } });
+    await flush();
+    expect(spy).not.toHaveBeenCalled();
+    editor.destroy();
+    element.remove();
+  });
+});
+
+describe('multi-fieldRef live mount (regression: the "reading children" crash)', () => {
+  beforeEach(() => useFieldStore.getState().clear());
+
+  it('mounts an editable editor full of label-less fieldRefs without crashing', async () => {
+    // Smoke test (jsdom can't reproduce the real-browser crash): many label-less
+    // fieldRefs across paragraphs, a table cell, and list items render and write
+    // their labels back via the deferred helper without throwing.
+    const store = useFieldStore.getState();
+    for (const [n, v] of [
+      ['Project', 'My Lobby'],
+      ['Framework', 'Next.js 15'],
+      ['CMS', 'Payload CMS v3'],
+      ['Database', 'MongoDB'],
+      ['PackageManager', 'bun'],
+      ['DocStatus', 'Living document'],
+      ['LastReviewed', '2026-06-17'],
+    ] as const) {
+      store.setField(n, v);
+    }
+    const content =
+      '<p><span data-field data-name="Project"></span> is built on <span data-field data-name="Framework"></span> and <span data-field data-name="CMS"></span>, with <span data-field data-name="Database"></span> for data; the package manager is <span data-field data-name="PackageManager"></span>.</p>' +
+      '<table><tbody><tr><th><p>Layer</p></th><th><p>Choice</p></th></tr><tr><td><p>Framework</p></td><td><p><span data-field data-name="Framework"></span></p></td></tr></tbody></table>' +
+      '<ul><li><p>Status: <span data-field data-name="DocStatus"></span></p></li><li><p>Reviewed <span data-field data-name="LastReviewed"></span></p></li></ul>';
+
+    let editor!: Editor;
+    let element!: HTMLElement;
+    expect(() => {
+      ({ editor, element } = mount(content, fullProseExtensions));
+    }).not.toThrow();
+
+    await flush();
+    await flush(); // let the deferred label write-backs apply
+
+    // The page rendered AND the deferred write-backs baked the labels in, so the
+    // HTML projection is self-contained (values resolvable offline / in PDF).
+    const html = editor.getHTML();
+    expect(html).toContain('data-label="My Lobby"');
+    expect(html).toContain('data-label="bun"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('adopts a Collaboration fragment of label-less fieldRefs without crashing', async () => {
+    // Smoke test of the TRUE crash path: a relay doc binds the page's
+    // Y.XmlFragment via the Collaboration extension, and y-prosemirror builds the
+    // editor doc straight from the fragment. With label-less fieldRefs + fields
+    // set, every fieldRef's render() write-back fired synchronously during that
+    // adoption → the real-browser "reading 'children'" crash. jsdom doesn't
+    // reproduce the crash itself, but this exercises the adoption path end-to-end
+    // and proves the deferred write-back renders + labels it without throwing.
+    const store = useFieldStore.getState();
+    for (const [n, v] of [
+      ['Project', 'My Lobby'],
+      ['Framework', 'Next.js 15'],
+      ['CMS', 'Payload CMS v3'],
+      ['Database', 'MongoDB'],
+      ['PackageManager', 'bun'],
+      ['DocStatus', 'Living document'],
+      ['LastReviewed', '2026-06-17'],
+    ] as const) {
+      store.setField(n, v);
+    }
+    const content =
+      '<p><span data-field data-name="Project"></span> on <span data-field data-name="Framework"></span> + <span data-field data-name="CMS"></span>, data <span data-field data-name="Database"></span>, pkg <span data-field data-name="PackageManager"></span>.</p>' +
+      '<ul><li><p>Status: <span data-field data-name="DocStatus"></span></p></li><li><p>Reviewed <span data-field data-name="LastReviewed"></span></p></li></ul>';
+
+    // Seed the Y.Doc fragment from a NON-editable parse so the fieldRefs stay
+    // label-less (no write-back fires) — matching an MCP-authored relay doc.
+    const seedEl = document.createElement('div');
+    document.body.appendChild(seedEl);
+    const seed = new Editor({ element: seedEl, editable: false, extensions: fullProseExtensions, content });
+    const ydoc = prosemirrorToYDoc(seed.state.doc, 'prose:p1');
+    seed.destroy();
+    seedEl.remove();
+
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    let editor!: Editor;
+    expect(() => {
+      editor = new Editor({
+        element,
+        extensions: [
+          StarterKit.configure({ heading: { levels: [1, 2, 3, 4, 5, 6] }, codeBlock: false, history: false }),
+          ...sharedProseExtensions,
+          Collaboration.configure({ document: ydoc, field: 'prose:p1' }),
+        ],
+      });
+    }).not.toThrow();
+
+    await flush();
+    await flush();
+
+    expect(editor.getHTML()).toContain('data-label="My Lobby"');
+
+    editor.destroy();
+    element.remove();
   });
 });

--- a/src/tiptap/proseProjection.ts
+++ b/src/tiptap/proseProjection.ts
@@ -14,9 +14,21 @@
  * such transactions through a **non-dirtying** content update
  * (`richTextStore.setContentSilently`) instead of the normal dirtying one. This
  * is generic — any future prose helper reuses it, no per-node special-casing.
+ *
+ * ## The invariant — never dispatch a projection synchronously from a node view
+ *
+ * Node views render **during** ProseMirror's view reconciliation. A *synchronous*
+ * `editor.view.dispatch` from inside a node view's `render`/`update` re-enters the
+ * view tree while it is still being built and crashes with
+ * `Cannot read properties of undefined (reading 'children')`. So projection
+ * write-backs MUST be deferred to a microtask. Do not hand-roll that — always go
+ * through {@link scheduleProjectionWriteBack}, which is deferred by construction.
  */
 
+import type { Editor } from '@tiptap/core';
+import type { Node as PMNode } from '@tiptap/pm/model';
 import type { Transaction } from '@tiptap/pm/state';
+import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 
 /** Transaction meta key marking a derived/projection write (not a user edit). */
 export const PROSE_PROJECTION_META = 'proseProjection';
@@ -24,4 +36,54 @@ export const PROSE_PROJECTION_META = 'proseProjection';
 /** True if `tr` is a projection write-back (derived cache, not a user edit). */
 export function isProjectionTransaction(tr: Transaction): boolean {
   return tr.getMeta(PROSE_PROJECTION_META) === true;
+}
+
+export interface ProjectionWriteBackOptions {
+  /** The editor the node view belongs to. */
+  editor: Editor;
+  /** Tiptap's node-view `getPos` (a function, or `boolean` when unavailable). */
+  getPos: (() => number | undefined) | boolean;
+  /** The node's type name (`this.name` inside the extension). */
+  nodeName: string;
+  /**
+   * Extra identity guard so a stale `pos` can never write onto a *different*
+   * node of the same type (e.g. match on `name`/`refId`). Defaults to "match".
+   */
+  identity?: (node: PMNode) => boolean;
+  /** The derived attrs to merge into the node. Skipped if already equal. */
+  attrs: Record<string, unknown>;
+}
+
+/**
+ * Persist derived attrs back onto a node from inside its node view — **safely**.
+ *
+ * The dispatch is always deferred to a microtask (so it runs *after* the current
+ * view reconciliation, never re-entrantly — see the invariant above), tagged as a
+ * projection (`addToHistory:false` + {@link PROSE_PROJECTION_META}, so it never
+ * dirties the doc or enters undo), and re-validated at execution time (position,
+ * type, and `identity` may have changed since it was queued). Idempotent: if every
+ * target attr already equals the node's, nothing is dispatched — so a page of
+ * many such nodes converges instead of looping.
+ *
+ * Only for **derived/projection** writes. A genuine *user edit* (a layout toggle,
+ * a float choice) must keep history and dirty the doc, so it dispatches directly
+ * from its event handler — not through here.
+ */
+export function scheduleProjectionWriteBack(opts: ProjectionWriteBackOptions): void {
+  const { editor, getPos, nodeName, identity, attrs } = opts;
+  queueMicrotask(() => {
+    if (!editor.isEditable) return; // view-only clients never dirty the doc
+    if (isAutoSaveSuppressed()) return; // never dispatch during load/new/switch
+    const pos = typeof getPos === 'function' ? getPos() : undefined;
+    if (pos == null) return;
+    const cur = editor.state.doc.nodeAt(pos);
+    if (!cur || cur.type.name !== nodeName) return;
+    if (identity && !identity(cur)) return; // pos went stale → wrong node, skip
+    // Idempotent → loop-safe: skip when the node already carries these values.
+    if (Object.entries(attrs).every(([k, v]) => cur.attrs[k] === v)) return;
+    const tr = editor.state.tr.setNodeMarkup(pos, undefined, { ...cur.attrs, ...attrs });
+    tr.setMeta('addToHistory', false); // derived cache → out of undo
+    tr.setMeta(PROSE_PROJECTION_META, true); // derived write → mirror silently, no autosave
+    editor.view.dispatch(tr);
+  });
 }


### PR DESCRIPTION
Promote `master` → `staging` to deploy (relay `:edge` image + editor PWA) for real-time repro of the JP-312 joy-ride fixes.

## What's promoting
- **JP-320** (#242) — MCP write/persist correctness: `generate_diagram` writes the live Y.Doc (no-op + concurrent-loss fixed), `{{field}}`/citation survive in table cells, `add_canvas_page`/`rename_canvas_page`.
- **JP-321** (#243) — connectors re-anchor on re-layout, so one re-layout recovers a collab-tangled diagram.
- **JP-330** (#244) — `shapeOrder` doubling fixed by dedupe-keep-first at every consumer; corrupted docs self-heal on next save.
- **#241** — prose node-view projection write-back deferral ("reading children" crash fix).

## Real-time repro checklist (post-deploy)
1. **JP-320**: with a doc open (resident), have the agent `generate_diagram` → shapes appear live AND a follow-up `get_page` reads them back (the "agent couldn't see it" case). `{{field}}` in a markdown table cell survives.
2. **JP-321**: auto-layout a diagram, move nodes around (or via collab), re-run auto-layout → connectors recover (no permanent tangle).
3. **JP-330**: open the previously-corrupted "My Lobby" doc → renders clean (no doubled shapes); re-save → stored `shapeOrder` is deduped.

Merging this triggers the staging deploy. No Supabase migrations in this set (relay + editor only).

Assisted-by: Opus 4.8