### PR TITLE
JP-334: contain offline-collab page contamination + prohibit offline page creation

### DIFF
--- a/src/collaboration/offlinePageGuard.test.ts
+++ b/src/collaboration/offlinePageGuard.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computeSharedDocOffline } from './offlinePageGuard';
+
+// A relay doc identified by an active collab session, currently online.
+const onlineRelay = {
+  currentDocId: 'doc-1',
+  collabDocId: 'doc-1',
+  collabActive: true,
+  recordType: undefined,
+  status: 'authenticated' as const,
+};
+
+describe('computeSharedDocOffline (JP-334)', () => {
+  it('is false when there is no open document', () => {
+    expect(computeSharedDocOffline({ ...onlineRelay, currentDocId: null })).toBe(false);
+  });
+
+  it('is false for a local-only doc, even disconnected', () => {
+    expect(
+      computeSharedDocOffline({
+        currentDocId: 'doc-1',
+        collabDocId: null,
+        collabActive: false,
+        recordType: 'local',
+        status: 'disconnected',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a relay doc that is fully connected (authenticated)', () => {
+    expect(computeSharedDocOffline(onlineRelay)).toBe(false);
+  });
+
+  it('is true for a relay doc (active session) that is not yet authenticated', () => {
+    for (const status of ['disconnected', 'connecting', 'connected', 'authenticating', 'error'] as const) {
+      expect(computeSharedDocOffline({ ...onlineRelay, status })).toBe(true);
+    }
+  });
+
+  it('is true for a relay doc identified by registry record type when offline', () => {
+    expect(
+      computeSharedDocOffline({
+        currentDocId: 'doc-1',
+        collabDocId: null,
+        collabActive: false,
+        recordType: 'remote',
+        status: 'connecting',
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/collaboration/offlinePageGuard.ts
+++ b/src/collaboration/offlinePageGuard.ts
@@ -1,0 +1,63 @@
+import type { ConnectionStatus } from '../store/connectionStore';
+import { useConnectionStore } from '../store/connectionStore';
+import { usePersistenceStore } from '../store/persistenceStore';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import { useCollaborationStore } from './collaborationStore';
+
+/**
+ * JP-334: while a relay-backed (shared) doc is offline, creating a new page —
+ * prose OR canvas — is blocked. Prose: a never-synced empty fragment is
+ * read-only by design (relay is the sole seeder, JP-284) and editing it would
+ * risk dual-lineage duplication. Canvas: a new page's shapes never reach the
+ * relay's active-page-only flatten → lost on reconnect. Either way the page
+ * can't be created safely until reconnect. Enabling it is JP-335.
+ *
+ * Local-only docs are never blocked (no relay involved).
+ */
+
+/** Pure decision: relay-backed AND the live connection isn't fully up. */
+export function computeSharedDocOffline(args: {
+  currentDocId: string | null;
+  collabDocId: string | null;
+  collabActive: boolean;
+  recordType: string | undefined;
+  status: ConnectionStatus;
+}): boolean {
+  const { currentDocId, collabDocId, collabActive, recordType, status } = args;
+  if (!currentDocId) return false;
+  // Mirror DocumentEditorPanel's `isRelayDoc`: an active session on this doc, or
+  // a registry record that isn't local-only.
+  const isRelayDoc =
+    (currentDocId === collabDocId && collabActive) ||
+    (recordType !== undefined && recordType !== 'local');
+  if (!isRelayDoc) return false;
+  // `authenticated` is the only fully-live state; anything else can't seed/persist.
+  return status !== 'authenticated';
+}
+
+/** Store-wired form used by the add-page handlers (imperative, at click time). */
+export function sharedDocOffline(): boolean {
+  const currentDocId = usePersistenceStore.getState().currentDocumentId;
+  const collab = useCollaborationStore.getState();
+  return computeSharedDocOffline({
+    currentDocId,
+    collabDocId: collab.config?.documentId ?? null,
+    collabActive: collab.isActive,
+    recordType: currentDocId
+      ? useDocumentRegistry.getState().getRecord(currentDocId)?.type
+      : undefined,
+    status: useConnectionStore.getState().status,
+  });
+}
+
+/** Reactive form for dimming the add-page controls (re-renders on status change). */
+export function useSharedDocOffline(): boolean {
+  const currentDocId = usePersistenceStore((s) => s.currentDocumentId);
+  const collabDocId = useCollaborationStore((s) => s.config?.documentId ?? null);
+  const collabActive = useCollaborationStore((s) => s.isActive);
+  const status = useConnectionStore((s) => s.status);
+  const recordType = useDocumentRegistry((s) =>
+    currentDocId ? s.getRecord(currentDocId)?.type : undefined,
+  );
+  return computeSharedDocOffline({ currentDocId, collabDocId, collabActive, recordType, status });
+}

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -44,8 +44,9 @@ export interface CollaborativeProseEditorProps {
   pageId: string;
   /** Optional class name. */
   className?: string;
-  /** Editor instance callback (the panel keeps it for autosave/toolbar). */
-  onEditorReady?: (editor: Editor | null) => void;
+  /** Editor instance callback (the panel keeps it for autosave/toolbar). The
+   *  `pageId` lets the panel pair the editor with its page (JP-334). */
+  onEditorReady?: (editor: Editor | null, pageId: string | null) => void;
 }
 
 export function CollaborativeProseEditor({
@@ -102,9 +103,9 @@ export function CollaborativeProseEditor({
 
   // Expose the editor instance to the panel (autosave + toolbar).
   useEffect(() => {
-    onEditorReady?.(editor);
-    return () => onEditorReady?.(null);
-  }, [editor, onEditorReady]);
+    onEditorReady?.(editor, pageId);
+    return () => onEditorReady?.(null, pageId);
+  }, [editor, onEditorReady, pageId]);
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={onContextMenu}>

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -23,6 +23,7 @@ import { useSessionStore } from '../store/sessionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
+import { shouldPersistLeavingPage } from './proseLeavingPageGuard';
 import { CollaborativeProseEditor } from './CollaborativeProseEditor';
 import { ProseErrorBoundary } from './ProseErrorBoundary';
 import { ProsePreview } from './ProsePreview';
@@ -162,6 +163,11 @@ export function DocumentEditorPanel({
   const useCollabEditor = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
 
   const lastActivePageRef = useRef<string | null>(null);
+  // The prose page id the currently-mounted `editor` is bound to (null when the
+  // active page is read-only `ProsePreview`, which mounts no editor). Lets the
+  // page-switch save below verify the editor actually belongs to the page being
+  // left, instead of cross-writing a read-only page's slot (JP-334).
+  const editorPageIdRef = useRef<string | null>(null);
   const isLoadingRef = useRef(false);
   /** Set while we're programmatically setting scrollTop (so the scroll listener
    *  doesn't persist transient values to the wrong page key). */
@@ -226,8 +232,11 @@ export function DocumentEditorPanel({
   }, []);
 
   // Handle editor ready callback from TiptapEditor
-  const handleEditorReady = useCallback((ed: Editor | null) => {
+  const handleEditorReady = useCallback((ed: Editor | null, pageId: string | null) => {
     setEditor(ed);
+    // Track which page this editor edits, so the page-switch save can't pair the
+    // incoming editor with the (read-only) page being left (JP-334).
+    editorPageIdRef.current = ed ? pageId : null;
     // Also keep window global for PDFExportDialog (non-component context)
     if (ed) {
       (window as unknown as { __tiptapEditor?: Editor }).__tiptapEditor = ed;
@@ -249,8 +258,17 @@ export function DocumentEditorPanel({
       pendingLoadRef.current = null;
     }
 
-    // Save the page we are leaving (skip if we were already mid-load)
-    if (lastActivePageRef.current && !isLoadingRef.current) {
+    // Save the page we are leaving — but ONLY when the mounted editor is the one
+    // bound to that page. Leaving a read-only page (offline-created → ProsePreview,
+    // no editor) desyncs editor/lastActivePageRef, and an unguarded save would
+    // write the incoming editable page's content into the read-only page's slot
+    // (JP-334). Relay docs mirror each fragment per page via the collab editor's
+    // own onUpdate, so skipping here loses nothing. (Skip too if mid-load.)
+    if (
+      lastActivePageRef.current &&
+      !isLoadingRef.current &&
+      shouldPersistLeavingPage(editorPageIdRef.current, lastActivePageRef.current)
+    ) {
       const currentContent = editor.getHTML();
       updatePageContent(lastActivePageRef.current, currentContent);
       const el = getScrollEl(editor);
@@ -542,8 +560,9 @@ export function DocumentEditorPanel({
             fallbackHtml={activePageContent ?? '<p></p>'}
           >
             {!isRelayDoc ? (
-              // Local-only doc: the legacy editor (no Y.Doc).
-              <TiptapEditor onEditorReady={handleEditorReady} />
+              // Local-only doc: the legacy editor (no Y.Doc). It edits the active
+              // page; pass that id so the leaving-page save guard pairs correctly.
+              <TiptapEditor onEditorReady={(ed) => handleEditorReady(ed, activePageId)} />
             ) : useCollabEditor ? (
               <CollaborativeProseEditor
                 key={`${currentDocId}:${activePageId}:${collabSessionEpoch}`}

--- a/src/ui/InlinePageTabs.tsx
+++ b/src/ui/InlinePageTabs.tsx
@@ -11,6 +11,8 @@ import { Icon } from './icons';
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
+import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useNotificationStore } from '../store/notificationStore';
 
 /**
  * Context menu state for page tabs.
@@ -58,7 +60,18 @@ export function InlinePageTabs() {
     [setActivePage, editingPageId]
   );
 
+  const sharedOffline = useSharedDocOffline();
+
+  // Blocked while a shared doc is offline (JP-334): the relay is active-page-only,
+  // so a new offline page's shapes never reach its flatten and are lost on
+  // reconnect. Enabling offline creation is JP-335.
   const handleAddPage = useCallback(() => {
+    if (sharedDocOffline()) {
+      useNotificationStore
+        .getState()
+        .warning('This shared document is offline — reconnect to add pages.');
+      return;
+    }
     const newPageId = createPage();
     setActivePage(newPageId);
     useHistoryStore.getState().setActivePage(newPageId);
@@ -187,7 +200,14 @@ export function InlinePageTabs() {
           );
         })}
       </div>
-      <button className="inline-tab-add" onClick={handleAddPage} title="Add page" aria-label="Add page">
+      <button
+        className="inline-tab-add"
+        onClick={handleAddPage}
+        aria-disabled={sharedOffline}
+        style={sharedOffline ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+        title={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add page'}
+        aria-label="Add page"
+      >
         <Icon icon={Plus} size={14} />
       </button>
 

--- a/src/ui/PageTabs.tsx
+++ b/src/ui/PageTabs.tsx
@@ -13,6 +13,8 @@ import { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
+import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useNotificationStore } from '../store/notificationStore';
 import './PageTabs.css';
 
 /**
@@ -219,8 +221,18 @@ export function PageTabs() {
     setDragOverId(null);
   }, []);
 
-  // Handle add page
+  const sharedOffline = useSharedDocOffline();
+
+  // Handle add page. Blocked while a shared doc is offline (JP-334): the relay is
+  // active-page-only, so a new offline page's shapes never reach its flatten and
+  // are lost on reconnect. Enabling offline creation is JP-335.
   const handleAddPage = useCallback(() => {
+    if (sharedDocOffline()) {
+      useNotificationStore
+        .getState()
+        .warning('This shared document is offline — reconnect to add pages.');
+      return;
+    }
     const newPageId = createPage();
     setActivePage(newPageId);
     useHistoryStore.getState().setActivePage(newPageId);
@@ -299,7 +311,13 @@ export function PageTabs() {
         })}
       </div>
 
-      <button className="page-tab-add" onClick={handleAddPage} title="Add new page">
+      <button
+        className="page-tab-add"
+        onClick={handleAddPage}
+        aria-disabled={sharedOffline}
+        style={sharedOffline ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+        title={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add new page'}
+      >
         +
       </button>
 

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -15,6 +15,8 @@ import { Plus } from 'lucide-react';
 import { Icon } from './icons';
 import { createPortal } from 'react-dom';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useNotificationStore } from '../store/notificationStore';
 import './RichTextTabBar.css';
 
 interface RichTextTabBarProps {
@@ -144,8 +146,18 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
     });
   }, []);
 
-  // Handle add new page
+  const sharedOffline = useSharedDocOffline();
+
+  // Handle add new page. Blocked while a shared doc is offline (JP-334): a new
+  // prose page can't be seeded offline without risking dual-lineage duplication
+  // (the relay is the sole seeder, JP-284). Enabling offline creation is JP-335.
   const handleAddPage = useCallback(() => {
+    if (sharedDocOffline()) {
+      useNotificationStore
+        .getState()
+        .warning('This shared document is offline — reconnect to add pages.');
+      return;
+    }
     const newId = createPage();
     setActivePage(newId);
   }, [createPage, setActivePage]);
@@ -256,7 +268,9 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
       <button
         className="rich-text-add-tab"
         onClick={handleAddPage}
-        title="Add new page"
+        aria-disabled={sharedOffline}
+        style={sharedOffline ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+        title={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add new page'}
         aria-label="Add new page"
       >
         <Icon icon={Plus} />

--- a/src/ui/proseLeavingPageGuard.test.ts
+++ b/src/ui/proseLeavingPageGuard.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { shouldPersistLeavingPage } from './proseLeavingPageGuard';
+
+describe('shouldPersistLeavingPage (JP-334)', () => {
+  it('persists when the editor is bound to the page being left', () => {
+    expect(shouldPersistLeavingPage('page-a', 'page-a')).toBe(true);
+  });
+
+  it('skips when the editor belongs to a different page (the read-only-page desync)', () => {
+    // Leaving read-only page B, but the mounted editor is the incoming page A —
+    // an unguarded save would write A's content into B's slot.
+    expect(shouldPersistLeavingPage('page-a', 'page-b')).toBe(false);
+  });
+
+  it('skips when no editor is mounted (read-only ProsePreview page)', () => {
+    expect(shouldPersistLeavingPage(null, 'page-b')).toBe(false);
+  });
+
+  it('skips when there is no leaving page', () => {
+    expect(shouldPersistLeavingPage('page-a', null)).toBe(false);
+    expect(shouldPersistLeavingPage(null, null)).toBe(false);
+  });
+});

--- a/src/ui/proseLeavingPageGuard.ts
+++ b/src/ui/proseLeavingPageGuard.ts
@@ -1,0 +1,18 @@
+/**
+ * JP-334: the page-switch effect saves "the page we are leaving" from the
+ * currently-mounted editor. That's only correct when the editor is actually
+ * bound to that page. When a read-only page is involved (an offline-created
+ * page renders `ProsePreview`, no editor), the mounted `editor`,
+ * `lastActivePageRef`, and `activePageId` fall out of lockstep, and the save
+ * would write the *incoming* editable page's content into the *leaving*
+ * (read-only) page's `richTextPages` slot — cross-page contamination.
+ *
+ * Guard the save on this: only persist when the editor's bound page id matches
+ * the page being left.
+ */
+export function shouldPersistLeavingPage(
+  editorPageId: string | null,
+  leavingPageId: string | null,
+): boolean {
+  return editorPageId != null && editorPageId === leavingPageId;
+}


### PR DESCRIPTION
Closes JP-334. Offline in a collab doc, a new prose page was read-only and switching to an online-authored page then back **bled that page's content onto the new page**. Online is fine. Scope (launch): **contain** the corruption + **prohibit** offline page creation (clean UX). Enabling offline creation safely is deferred to JP-335 (referenced from the code).

## A. Fix prose contamination
The page-switch effect saved "the page we are leaving" via the currently-mounted `editor.getHTML()` keyed to `lastActivePageRef`, **without checking the editor is bound to that page** (`DocumentEditorPanel.tsx`). A read-only page (offline new page → `ProsePreview`, no editor) desyncs `editor`/`lastActivePageRef`/`activePageId`, so the *incoming* editable page's content got written into the *leaving* read-only page's `richTextPages` slot — which `ProsePreview` (`activePageContent`) then renders. Online-safe because the new page is editable (`collabSynced`) and has its own editor.

Fix: track the editor's bound page (`editorPageIdRef`, via `onEditorReady(editor, pageId)`) and guard the save with `shouldPersistLeavingPage(editorPageId, leavingPageId)`. Relay docs mirror each fragment per page via the collab editor's own `onUpdate`, so skipping the redundant save loses nothing. Also closes a latent scroll-position cross-write.

## B. Prohibit new-page creation while a shared doc is offline (prose AND canvas)
Shared `sharedDocOffline()` guard (relay-backed doc + `connectionStore.status !== 'authenticated'`) gates the add-page handlers — `RichTextTabBar` (prose), `PageTabs` + `InlinePageTabs` (canvas). Blocked click → `notificationStore.warning(...)`; the `+` buttons dim (`aria-disabled` + dimmed). Local-only docs are never blocked.

Canvas is included for a *different* reason than prose: no dup risk (id-keyed Y.Map), but the relay is **active-page-only**, so a new offline page's shapes never reach its flatten → lost on reconnect. Same "new pages need a connection" rule.

## Deferred (JP-335, referenced in code comments)
Actually enabling offline page creation: prose needs a no-competing-lineage seeding handoff (relay stays sole seeder, JP-284); canvas needs non-active-page persistence. Not a launch-rush.

## Verification
`bun run typecheck` + full vitest **2371**. New pure-guard unit tests (`shouldPersistLeavingPage`, `computeSharedDocOffline`); `proseWriteBoundary` still green. Manual offline repro on staging: `+` dims + toast, no page created; existing-page switching never cross-writes; reconnect re-enables.

Assisted-by: Opus 4.8