### PR TITLE
JP-315: floating, movable collab indicator

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -317,6 +317,31 @@ describe('uiPreferencesStore — migration', () => {
       proseBackground: 'default',
     });
   });
+
+  it('v7 → v8 defaults the floating collab-indicator position to null', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          // v7 payload has no collabIndicatorPos field.
+        },
+        version: 7,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().collabIndicatorPos).toBeNull();
+  });
+});
+
+describe('uiPreferencesStore — collab indicator position', () => {
+  it('defaults to null and pins on set', () => {
+    expect(useUIPreferencesStore.getState().collabIndicatorPos).toBeNull();
+    useUIPreferencesStore.getState().setCollabIndicatorPos({ x: 120, y: 64 });
+    expect(useUIPreferencesStore.getState().collabIndicatorPos).toEqual({ x: 120, y: 64 });
+  });
 });
 
 describe('uiPreferencesStore — appearance slice', () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -106,6 +106,12 @@ export interface UIPreferencesState {
   layout: LayoutState;
   /** Appearance slice — accent + motion (theme is in `themeStore`). */
   appearancePrefs: AppearancePrefs;
+  /**
+   * Persisted top-left (viewport px) of the floating collaboration indicator.
+   * `null` = use the default top-right anchor; the user's first drag pins it.
+   * App-level (not per-doc), clamped into the viewport at render time.
+   */
+  collabIndicatorPos: { x: number; y: number } | null;
 }
 
 /**
@@ -126,6 +132,8 @@ export interface UIPreferencesActions {
   setPropertyPanelWidth: (width: number) => void;
   /** Set the Relaxed split secondary-canvas width (px). */
   setRelaxedSplitCanvasWidth: (width: number) => void;
+  /** Pin the floating collaboration indicator's top-left (viewport px). */
+  setCollabIndicatorPos: (pos: { x: number; y: number }) => void;
   /** Set the document browser view (list/grid) */
   setDocumentBrowserView: (view: DocumentBrowserView) => void;
   /** Set the document browser sort key */
@@ -251,6 +259,7 @@ const initialState: UIPreferencesState = {
   storageInfoToastSeen: false,
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
+  collabIndicatorPos: null,
 };
 
 /**
@@ -370,6 +379,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setRelaxedSplitCanvasWidth: (width: number) => {
         set({ relaxedSplitCanvasWidth: width });
+      },
+
+      setCollabIndicatorPos: (pos: { x: number; y: number }) => {
+        set({ collabIndicatorPos: { x: pos.x, y: pos.y } });
       },
 
       setDocumentBrowserView: (view) => set({ documentBrowserView: view }),
@@ -505,7 +518,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 7,
+      version: 8,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -518,6 +531,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         storageInfoToastSeen: state.storageInfoToastSeen,
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
+        collabIndicatorPos: state.collabIndicatorPos,
       }),
       migrate: (persisted, fromVersion) => {
         // Cast away the loose persisted-state typing — older payloads carry
@@ -613,6 +627,12 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         if (fromVersion < 7) {
           const axis = next['documentBrowserGroupBy'];
           next['documentBrowserGroupBy'] = axis === 'group' ? 'collection' : axis === 'collection' ? 'collection' : 'none';
+        }
+        // v7 → v8: added the floating collaboration-indicator position. Default
+        // to `null` (the top-right anchor) so existing users see no change until
+        // they first drag it. (The `merge` below also backstops this.)
+        if (fromVersion < 8) {
+          next['collabIndicatorPos'] = next['collabIndicatorPos'] ?? null;
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -137,18 +137,6 @@
   }
 }
 
-/* Presence indicators - positioned in top-right of canvas area */
-.app-presence {
-  position: fixed;
-  top: 52px; /* Below toolbar */
-  right: 260px; /* Offset for property panel */
-  z-index: 100;
-  padding: 8px;
-  background: var(--color-bg-secondary);
-  border-radius: 0 0 0 8px;
-  box-shadow: var(--shadow-sm);
-}
-
 /* ==========================================================================
    Unified Form Element Styles
    ========================================================================== */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -22,7 +22,7 @@ import { DocumentsHome } from './home/DocumentsHome';
 import { UnifiedToolbar } from './UnifiedToolbar';
 import { CanvasToolbar } from './CanvasToolbar';
 import { StatusBar } from './StatusBar';
-import { PresenceIndicators } from './PresenceIndicators';
+import { FloatingCollabIndicator } from './FloatingCollabIndicator';
 import { NotificationToast } from './NotificationToast';
 import { UploadIndicator } from './UploadIndicator';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -549,10 +549,9 @@ function App() {
         </main>
         <StatusBar />
 
-        {/* Presence indicators for collaboration */}
-        <div className="app-presence">
-          <PresenceIndicators size="small" />
-        </div>
+        {/* Floating, draggable collaboration indicator (JP-315). Hides itself
+            when no remote collaborators are present. */}
+        <FloatingCollabIndicator />
 
         {/* Settings Modal (includes Documents, Storage, etc.) */}
         <SettingsModal

--- a/src/ui/FloatingCollabIndicator.css
+++ b/src/ui/FloatingCollabIndicator.css
@@ -1,0 +1,53 @@
+/**
+ * Floating collaboration indicator (JP-315) — a draggable presence pill.
+ */
+
+.floating-collab {
+  position: fixed;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 4px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-md);
+  user-select: none;
+  /* Only the shadow animates — never left/top, which must track the pointer. */
+  transition: box-shadow 0.15s ease;
+}
+
+.floating-collab--dragging {
+  box-shadow: var(--shadow-lg);
+}
+
+.floating-collab-grip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  cursor: grab;
+  border-radius: var(--radius-sm);
+  /* Block touch-scroll so a drag from the grip moves the pill, not the page. */
+  touch-action: none;
+}
+
+.floating-collab-grip:hover {
+  color: var(--text-primary);
+}
+
+.floating-collab-grip:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.floating-collab--dragging .floating-collab-grip {
+  cursor: grabbing;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-collab {
+    transition: none;
+  }
+}

--- a/src/ui/FloatingCollabIndicator.tsx
+++ b/src/ui/FloatingCollabIndicator.tsx
@@ -1,0 +1,174 @@
+/**
+ * Floating, draggable collaboration indicator (JP-315).
+ *
+ * Wraps {@link PresenceIndicators} in a movable pill that the user can drag
+ * anywhere on screen; its position persists app-wide via `uiPreferencesStore`.
+ * It mounts **only when at least one remote collaborator is present** — when
+ * you are alone it shows nothing (the old fixed overlay showed a bare dot).
+ *
+ * Dragging uses pointer events (not HTML5 DnD, which is dead in WebKitGTK — see
+ * ReorderableList.tsx / JP-30). The floating form is also the seam for future
+ * in-document communications.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { GripVertical } from 'lucide-react';
+import { useCollaborationStore } from '../collaboration';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+import { PresenceIndicators } from './PresenceIndicators';
+import {
+  clampToViewport,
+  resolveIndicatorPosition,
+  type Point,
+  type Size,
+} from './floatingPosition';
+import './FloatingCollabIndicator.css';
+
+/** Pixels nudged per arrow-key press on the focused grip (a11y). */
+const KEY_NUDGE = 12;
+
+function readViewport(): Size {
+  return { w: window.innerWidth, h: window.innerHeight };
+}
+
+export function FloatingCollabIndicator() {
+  const isActive = useCollaborationStore((s) => s.isActive);
+  const remoteUsers = useCollaborationStore((s) => s.remoteUsers);
+  const stored = useUIPreferencesStore((s) => s.collabIndicatorPos);
+  const setStored = useUIPreferencesStore((s) => s.setCollabIndicatorPos);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Viewport tracked in state so a resize re-clamps the rendered position. This
+  // only re-renders; it never writes to the store (which would thrash
+  // localStorage) — the store is committed solely on drag-end / key-nudge.
+  const [viewport, setViewport] = useState<Size>(() => readViewport());
+  // Measured pill size; seeded with an estimate, corrected after layout.
+  const [size, setSize] = useState<Size>({ w: 160, h: 40 });
+  // Transient top-left while dragging (null = not dragging, use resolved).
+  const [dragPos, setDragPos] = useState<Point | null>(null);
+
+  // Mirrors for window listeners, which would otherwise capture stale state.
+  const pointerOffsetRef = useRef<Point>({ x: 0, y: 0 });
+  const sizeRef = useRef<Size>(size);
+  sizeRef.current = size;
+  const dragPosRef = useRef<Point | null>(null);
+
+  // Keep the rendered size in sync (the pill widens as collaborators join).
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width && rect.height) {
+      setSize((prev) =>
+        prev.w === rect.width && prev.h === rect.height
+          ? prev
+          : { w: rect.width, h: rect.height }
+      );
+    }
+  }, [remoteUsers.length, isActive]);
+
+  // Re-clamp on viewport resize (render-only; no persistence).
+  useEffect(() => {
+    const onResize = () => setViewport(readViewport());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const resolved = resolveIndicatorPosition(stored, size, viewport);
+  const rendered = dragPos ?? resolved;
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const rect = containerRef.current?.getBoundingClientRect();
+      const topLeft = rect ? { x: rect.left, y: rect.top } : rendered;
+      pointerOffsetRef.current = { x: e.clientX - topLeft.x, y: e.clientY - topLeft.y };
+      dragPosRef.current = topLeft;
+      setDragPos(topLeft);
+    },
+    [rendered]
+  );
+
+  // Window-level drag listeners — survive the pointer leaving the small grip.
+  useEffect(() => {
+    if (dragPos === null) return;
+
+    const handleMove = (e: PointerEvent) => {
+      const next = clampToViewport(
+        {
+          x: e.clientX - pointerOffsetRef.current.x,
+          y: e.clientY - pointerOffsetRef.current.y,
+        },
+        sizeRef.current,
+        readViewport()
+      );
+      dragPosRef.current = next;
+      setDragPos(next);
+    };
+    const handleUp = () => {
+      const committed = dragPosRef.current;
+      if (committed) setStored(committed);
+      dragPosRef.current = null;
+      setDragPos(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+    };
+  }, [dragPos, setStored]);
+
+  const onGripKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const delta: Point = { x: 0, y: 0 };
+      if (e.key === 'ArrowLeft') delta.x = -KEY_NUDGE;
+      else if (e.key === 'ArrowRight') delta.x = KEY_NUDGE;
+      else if (e.key === 'ArrowUp') delta.y = -KEY_NUDGE;
+      else if (e.key === 'ArrowDown') delta.y = KEY_NUDGE;
+      else return;
+      e.preventDefault();
+      setStored(
+        clampToViewport(
+          { x: resolved.x + delta.x, y: resolved.y + delta.y },
+          sizeRef.current,
+          readViewport()
+        )
+      );
+    },
+    [resolved, setStored]
+  );
+
+  // Hide-when-alone gate — placed AFTER all hooks (rules of hooks). With no
+  // remote users present, render nothing.
+  if (!isActive || remoteUsers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`floating-collab${dragPos ? ' floating-collab--dragging' : ''}`}
+      style={{ left: rendered.x, top: rendered.y }}
+    >
+      <span
+        className="floating-collab-grip"
+        role="button"
+        tabIndex={0}
+        aria-label="Move collaboration indicator"
+        onPointerDown={startDrag}
+        onKeyDown={onGripKeyDown}
+      >
+        <GripVertical size={14} strokeWidth={1.5} aria-hidden />
+      </span>
+      <PresenceIndicators size="small" />
+    </div>
+  );
+}
+
+export default FloatingCollabIndicator;

--- a/src/ui/floatingPosition.test.ts
+++ b/src/ui/floatingPosition.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampToViewport,
+  resolveIndicatorPosition,
+  VIEWPORT_MARGIN,
+  DEFAULT_TOP,
+} from './floatingPosition';
+
+const SIZE = { w: 120, h: 40 };
+const VP = { w: 1000, h: 800 };
+
+describe('clampToViewport', () => {
+  it('leaves an in-bounds point untouched', () => {
+    expect(clampToViewport({ x: 300, y: 200 }, SIZE, VP)).toEqual({ x: 300, y: 200 });
+  });
+
+  it('pins to the margin when past the left/top edges', () => {
+    expect(clampToViewport({ x: -50, y: -50 }, SIZE, VP)).toEqual({
+      x: VIEWPORT_MARGIN,
+      y: VIEWPORT_MARGIN,
+    });
+  });
+
+  it('pulls back from the right edge by element width + margin', () => {
+    const { x } = clampToViewport({ x: 5000, y: 100 }, SIZE, VP);
+    expect(x).toBe(VP.w - SIZE.w - VIEWPORT_MARGIN); // 1000 - 120 - 16 = 864
+  });
+
+  it('pulls back from the bottom edge by element height + margin', () => {
+    const { y } = clampToViewport({ x: 100, y: 5000 }, SIZE, VP);
+    expect(y).toBe(VP.h - SIZE.h - VIEWPORT_MARGIN); // 800 - 40 - 16 = 744
+  });
+
+  it('pins to the top-left margin when the element is larger than the room', () => {
+    const tiny = { w: 50, h: 50 };
+    expect(clampToViewport({ x: 10, y: 10 }, { w: 200, h: 200 }, tiny)).toEqual({
+      x: VIEWPORT_MARGIN,
+      y: VIEWPORT_MARGIN,
+    });
+  });
+});
+
+describe('resolveIndicatorPosition', () => {
+  it('defaults a null position to the top-right anchor', () => {
+    expect(resolveIndicatorPosition(null, SIZE, VP)).toEqual({
+      x: VP.w - SIZE.w - VIEWPORT_MARGIN, // 864
+      y: DEFAULT_TOP, // 64
+    });
+  });
+
+  it('clamps a stored position that is now off-screen after a resize', () => {
+    const stored = { x: 980, y: 790 }; // valid on a big screen, off a small one
+    const small = { w: 600, h: 400 };
+    expect(resolveIndicatorPosition(stored, SIZE, small)).toEqual({
+      x: small.w - SIZE.w - VIEWPORT_MARGIN, // 464
+      y: small.h - SIZE.h - VIEWPORT_MARGIN, // 344
+    });
+  });
+
+  it('keeps an in-bounds stored position', () => {
+    expect(resolveIndicatorPosition({ x: 200, y: 150 }, SIZE, VP)).toEqual({
+      x: 200,
+      y: 150,
+    });
+  });
+});

--- a/src/ui/floatingPosition.ts
+++ b/src/ui/floatingPosition.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure positioning helpers for the floating collaboration indicator (JP-315).
+ *
+ * Kept dependency-free and side-effect-free so the placement logic — default
+ * anchor + viewport clamping — is unit-testable without a DOM.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  w: number;
+  h: number;
+}
+
+export interface Viewport {
+  w: number;
+  h: number;
+}
+
+/** Gap (px) kept between the indicator and the viewport edges. */
+export const VIEWPORT_MARGIN = 16;
+
+/** Default vertical offset (px) of the top-right anchor — clears the toolbar. */
+export const DEFAULT_TOP = 64;
+
+/**
+ * Clamp a top-left point so the element stays fully on screen, never closer
+ * than `margin` to any edge. When the element is wider/taller than the room
+ * available, it pins to the top-left margin rather than going off the left/top.
+ */
+export function clampToViewport(
+  pos: Point,
+  size: Size,
+  viewport: Viewport,
+  margin: number = VIEWPORT_MARGIN
+): Point {
+  const maxX = Math.max(margin, viewport.w - size.w - margin);
+  const maxY = Math.max(margin, viewport.h - size.h - margin);
+  return {
+    x: Math.min(Math.max(pos.x, margin), maxX),
+    y: Math.min(Math.max(pos.y, margin), maxY),
+  };
+}
+
+/**
+ * Resolve the effective top-left for the indicator. A `null` stored position
+ * falls back to the top-right anchor; a stored position is clamped into the
+ * current viewport (so a window resize can never strand it off-screen).
+ */
+export function resolveIndicatorPosition(
+  stored: Point | null,
+  size: Size,
+  viewport: Viewport
+): Point {
+  if (stored == null) {
+    return clampToViewport(
+      { x: viewport.w - size.w - VIEWPORT_MARGIN, y: DEFAULT_TOP },
+      size,
+      viewport
+    );
+  }
+  return clampToViewport(stored, size, viewport);
+}


### PR DESCRIPTION
## What

Reworks the collaboration presence indicator (JP-315). It was a fixed canvas overlay pinned with a hard-coded `right: 260px` (assuming the properties panel was always visible) and it showed a bare connection dot even when no remote peers were on the doc.

It's now a **draggable floating pill** that **hides itself when you're alone**.

## Changes

- **`FloatingCollabIndicator`** wraps the existing `PresenceIndicators` in a movable pill.
  - Dragging uses pointer events with window-level `pointermove`/`pointerup`/`pointercancel` — the WebKitGTK-safe approach already used by `ReorderableList` (no HTML5 DnD, no new drag library).
  - **Hide-when-alone:** mounts only when `isActive && remoteUsers.length > 0`.
  - Grip handle is keyboard-movable (arrow keys) for a11y.
- **Persistence:** position stored app-wide on `uiPreferencesStore` as `collabIndicatorPos` (`null` = default top-right anchor). Bumped persisted version **7 → 8** with a migration.
- **Pure `floatingPosition` helpers** resolve the anchor + clamp into the viewport at render time. A window resize re-clamps the rendered position only; the store is written **solely on drag-end / key-nudge**, so resizes don't thrash localStorage.
- Removes the brittle `.app-presence` CSS rule.

## Verification

- `bun run typecheck`, `bun run build`, full `bun run test --run` — all green.
- New unit tests: `floatingPosition.test.ts` (clamp + default-anchor + off-screen-after-resize) and a `v7 → v8` migration case in `uiPreferencesStore.test.ts`.
- **Pending live (needs 2 clients on staging):** solo → nothing shown; second client joins → pill appears; drag + reload → position persists; window resize → pill stays on-screen; last peer leaves → pill disappears.

Assisted-by: Opus 4.8