### PR TITLE
JP-337: dedupe field/reference order arrays (JP-330 deferred tail)

### DIFF
--- a/relay/src/mcp/citations.rs
+++ b/relay/src/mcp/citations.rs
@@ -211,8 +211,15 @@ pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<Ad
         items.insert(id.clone(), item.clone());
     }
     let order = refs.get_mut("itemOrder").and_then(Value::as_array_mut).unwrap();
+    // JP-337: never append an id already present in `itemOrder` (mirrors
+    // `set_fields_in_place`). `plan_additions` only yields genuinely-new ids, but
+    // guard anyway so a re-run can't grow a duplicate order entry.
+    let in_order: std::collections::HashSet<String> =
+        order.iter().filter_map(Value::as_str).map(str::to_string).collect();
     for (id, _) in &plan.added {
-        order.push(json!(id.clone()));
+        if !in_order.contains(id) {
+            order.push(json!(id.clone()));
+        }
     }
 
     Ok(AddOutcome {
@@ -232,7 +239,12 @@ pub fn list_payload(
     let ordered: Vec<Value> = if order.is_empty() {
         items.values().cloned().collect()
     } else {
-        order.iter().filter_map(|id| items.get(id).cloned()).collect()
+        // JP-337: dedupe-keep-first so a resident doc whose live `referenceOrder`
+        // is already doubled still reports each reference once (mirrors fields).
+        crate::sync::dedupe_order(order.iter().map(String::as_str), |id| items.contains_key(id))
+            .iter()
+            .filter_map(|id| items.get(id).cloned())
+            .collect()
     };
     json!({
         "references": ordered,
@@ -407,5 +419,31 @@ mod tests {
         assert_eq!(out["count"], json!(0));
         assert_eq!(out["references"], json!([]));
         assert_eq!(out["style"], Value::Null);
+    }
+
+    #[test]
+    fn list_references_dedupes_a_doubled_order() {
+        // JP-337: a resident doc whose live referenceOrder is already doubled
+        // (`[a,b,a,b]`) must still report each reference once.
+        let doc = json!({
+            "references": {
+                "items": {"a": {"id": "a"}, "b": {"id": "b"}},
+                "itemOrder": ["a", "b", "a", "b"]
+            }
+        });
+        let out = list_references_json(&doc);
+        assert_eq!(out["count"], json!(2), "doubled order reports each reference once");
+        assert_eq!(out["references"][0]["id"], json!("a"));
+        assert_eq!(out["references"][1]["id"], json!("b"));
+    }
+
+    #[test]
+    fn add_references_does_not_grow_a_duplicate_order_entry() {
+        // JP-337: re-adding an existing id must not append a second order entry.
+        let mut doc = json!({
+            "references": {"items": {"a": {"id": "a"}}, "itemOrder": ["a"]}
+        });
+        add_references_in_place(&mut doc, &[json!({"id": "a", "type": "book"})]).unwrap();
+        assert_eq!(doc["references"]["itemOrder"], json!(["a"]), "no duplicate order entry");
     }
 }

--- a/relay/src/mcp/fields.rs
+++ b/relay/src/mcp/fields.rs
@@ -89,7 +89,14 @@ pub fn list_payload(items: &serde_json::Map<String, Value>, order: &[String]) ->
     let ordered: Vec<Value> = if order.is_empty() {
         items.values().cloned().collect()
     } else {
-        order.iter().filter_map(|name| items.get(name).cloned()).collect()
+        // JP-337: dedupe-keep-first so a resident doc whose live `fieldOrder` is
+        // already doubled (a dual-origin merge that hasn't re-flattened yet) still
+        // reports each field once. `dedupe_order`'s `present` predicate also drops
+        // orphans, matching the `items.get` filter below.
+        crate::sync::dedupe_order(order.iter().map(String::as_str), |name| items.contains_key(name))
+            .iter()
+            .filter_map(|name| items.get(name).cloned())
+            .collect()
     };
     json!({
         "fields": ordered,
@@ -152,6 +159,20 @@ mod tests {
         let doc = json!({"id": "d", "fields": {"fields": {"B": {"name": "B", "value": "2"}, "A": {"name": "A", "value": "1"}}, "order": ["A", "B"]}});
         let payload = list_fields_json(&doc);
         assert_eq!(payload["count"], 2);
+        assert_eq!(payload["fields"][0]["name"], "A");
+        assert_eq!(payload["fields"][1]["name"], "B");
+    }
+
+    #[test]
+    fn list_fields_dedupes_a_doubled_order() {
+        // JP-337: a resident doc whose live fieldOrder is already doubled
+        // (`[A,B,A,B]`) must still report each field once.
+        let doc = json!({"id": "d", "fields": {
+            "fields": {"A": {"name": "A", "value": "1"}, "B": {"name": "B", "value": "2"}},
+            "order": ["A", "B", "A", "B"]
+        }});
+        let payload = list_fields_json(&doc);
+        assert_eq!(payload["count"], 2, "doubled order reports each field once");
         assert_eq!(payload["fields"][0]["name"], "A");
         assert_eq!(payload["fields"][1]["name"], "B");
     }

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -57,17 +57,7 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
             Any::Map(m) => m.contains_key(id),
             _ => false,
         };
-        let order_ids = match &order_any {
-            Any::Array(arr) => arr
-                .iter()
-                .filter_map(|a| match a {
-                    Any::String(s) => Some(s.as_ref()),
-                    _ => None,
-                })
-                .collect::<Vec<&str>>(),
-            _ => Vec::new(),
-        };
-        let deduped = super::dedupe_order(order_ids, present);
+        let deduped = super::dedupe_order(order_string_ids(&order_any), present);
         page.insert(
             "shapeOrder".to_string(),
             Value::Array(deduped.into_iter().map(Value::String).collect()),
@@ -203,8 +193,19 @@ pub fn project_references_into(doc: &Doc, json: &mut Value) {
 
     if let Some(obj) = json.as_object_mut() {
         let mut lib = JsonMap::new();
+        // JP-337: dedupe-keep-first + drop orphans so a live `referenceOrder`
+        // doubled by a dual-origin merge persists clean (mirrors shapeOrder).
+        let order_ids = order_string_ids(&order_any);
+        let present = |id: &str| match &refs_any {
+            Any::Map(m) => m.contains_key(id),
+            _ => false,
+        };
+        let deduped = super::dedupe_order(order_ids, present);
         lib.insert("items".to_string(), items);
-        lib.insert("itemOrder".to_string(), any_to_json(&order_any));
+        lib.insert(
+            "itemOrder".to_string(),
+            Value::Array(deduped.into_iter().map(Value::String).collect()),
+        );
         if let Some(style) = style {
             lib.insert("style".to_string(), Value::String(style));
         }
@@ -237,9 +238,36 @@ pub fn project_fields_into(doc: &Doc, json: &mut Value) {
 
     if let Some(obj) = json.as_object_mut() {
         let mut lib = JsonMap::new();
+        // JP-337: dedupe-keep-first + drop orphans so a live `fieldOrder` doubled
+        // by a dual-origin merge persists clean (mirrors shapeOrder).
+        let order_ids = order_string_ids(&order_any);
+        let present = |name: &str| match &fields_any {
+            Any::Map(m) => m.contains_key(name),
+            _ => false,
+        };
+        let deduped = super::dedupe_order(order_ids, present);
         lib.insert("fields".to_string(), items);
-        lib.insert("order".to_string(), any_to_json(&order_any));
+        lib.insert(
+            "order".to_string(),
+            Value::Array(deduped.into_iter().map(Value::String).collect()),
+        );
         obj.insert("fields".to_string(), Value::Object(lib));
+    }
+}
+
+/// Borrow the string ids out of an order `Any::Array` (e.g. `shapeOrder` /
+/// `fieldOrder` / `referenceOrder`), skipping any non-string entries. Pairs with
+/// [`super::dedupe_order`] for the flatten-side dedupe.
+fn order_string_ids(order_any: &Any) -> Vec<&str> {
+    match order_any {
+        Any::Array(arr) => arr
+            .iter()
+            .filter_map(|a| match a {
+                Any::String(s) => Some(s.as_ref()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -473,6 +501,32 @@ mod tests {
         assert_eq!(json["references"]["style"], json!("chicago"));
     }
 
+    /// JP-337: a live `referenceOrder` doubled by a dual-origin merge (plus an
+    /// orphan id) flattens to a deduped keep-first order, so the stored snapshot
+    /// self-heals — mirrors `jp330_flatten_dedupes_doubled_order` for shapes.
+    #[test]
+    fn jp337_flatten_dedupes_doubled_reference_order() {
+        let doc = Doc::new();
+        let refs = doc.get_or_insert_map("references");
+        let order = doc.get_or_insert_array("referenceOrder");
+        {
+            let mut txn = doc.transact_mut();
+            for id in ["a", "b"] {
+                refs.insert(&mut txn, id, super::super::hydration::json_to_any(&json!({"id": id})));
+            }
+            for id in ["a", "b", "a", "b", "ghost"] {
+                order.push_back(&mut txn, Any::String(id.into()));
+            }
+        }
+        let mut json = json!({"id": "d"});
+        project_references_into(&doc, &mut json);
+        assert_eq!(
+            json["references"]["itemOrder"],
+            json!(["a", "b"]),
+            "deduped keep-first; 'ghost' orphan dropped"
+        );
+    }
+
     #[test]
     fn project_references_skips_synthesizing_for_pre_jp89_docs() {
         // Empty Y.Doc library + a doc that never had a `references` field → leave
@@ -515,6 +569,35 @@ mod tests {
         project_fields_into(&doc, &mut json);
         assert_eq!(json["fields"]["order"], json!(["Company"]));
         assert_eq!(json["fields"]["fields"]["Company"]["value"], json!("Acme"));
+    }
+
+    /// JP-337: a live `fieldOrder` doubled by a dual-origin merge (the set_fields
+    /// 9 → 18 bug) flattens to a deduped keep-first order with orphans dropped.
+    #[test]
+    fn jp337_flatten_dedupes_doubled_field_order() {
+        let doc = Doc::new();
+        let fields = doc.get_or_insert_map("fields");
+        let order = doc.get_or_insert_array("fieldOrder");
+        {
+            let mut txn = doc.transact_mut();
+            for name in ["Project", "Owner"] {
+                fields.insert(
+                    &mut txn,
+                    name,
+                    super::super::hydration::json_to_any(&json!({"name": name, "value": "x"})),
+                );
+            }
+            for name in ["Project", "Owner", "Project", "Owner", "ghost"] {
+                order.push_back(&mut txn, Any::String(name.into()));
+            }
+        }
+        let mut json = json!({"id": "d"});
+        project_fields_into(&doc, &mut json);
+        assert_eq!(
+            json["fields"]["order"],
+            json!(["Project", "Owner"]),
+            "deduped keep-first; 'ghost' orphan dropped"
+        );
     }
 
     #[test]

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -179,14 +179,19 @@ pub fn json_references_to_ydoc(doc_json: &Value, doc: &Doc) {
         return;
     };
 
-    if let Some(items) = lib.get("items").and_then(Value::as_object) {
+    let items = lib.get("items").and_then(Value::as_object);
+    if let Some(items) = items {
         for (id, item) in items {
             references.insert(&mut txn, id.clone(), json_to_any(item));
         }
     }
     if let Some(order) = lib.get("itemOrder").and_then(Value::as_array) {
-        for id in order.iter().filter_map(Value::as_str) {
-            reference_order.push_back(&mut txn, Any::String(id.into()));
+        // JP-337: dedupe-keep-first + drop orphans (mirrors `json_to_ydoc` shapes).
+        // `referenceOrder` is a Y.Array with no LWW semantics, so an already-doubled
+        // source `itemOrder` would otherwise hydrate doubled.
+        let present = |id: &str| items.is_some_and(|m| m.contains_key(id));
+        for id in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+            reference_order.push_back(&mut txn, Any::String(id.as_str().into()));
         }
     }
     if let Some(style) = lib.get("style").and_then(Value::as_str) {
@@ -218,14 +223,19 @@ pub fn json_fields_to_ydoc(doc_json: &Value, doc: &Doc) {
         return;
     };
 
-    if let Some(items) = lib.get("fields").and_then(Value::as_object) {
+    let items = lib.get("fields").and_then(Value::as_object);
+    if let Some(items) = items {
         for (name, field) in items {
             fields.insert(&mut txn, name.clone(), json_to_any(field));
         }
     }
     if let Some(order) = lib.get("order").and_then(Value::as_array) {
-        for name in order.iter().filter_map(Value::as_str) {
-            field_order.push_back(&mut txn, Any::String(name.into()));
+        // JP-337: dedupe-keep-first + drop orphans (mirrors `json_to_ydoc` shapes).
+        // `fieldOrder` is a Y.Array with no LWW semantics, so an already-doubled
+        // source `order` would otherwise hydrate doubled (set_fields 9 → 18).
+        let present = |name: &str| items.is_some_and(|m| m.contains_key(name));
+        for name in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+            field_order.push_back(&mut txn, Any::String(name.as_str().into()));
         }
     }
 }
@@ -547,6 +557,25 @@ mod tests {
         assert_eq!(refs.len(&doc.transact()), 0);
     }
 
+    /// JP-337: an already-doubled `itemOrder` (`[a,b,a,b]`) plus an orphan must
+    /// hydrate to a deduped keep-first `referenceOrder` — not double the array.
+    #[test]
+    fn json_references_to_ydoc_dedupes_doubled_order() {
+        let doc = Doc::new();
+        json_references_to_ydoc(
+            &json!({
+                "references": {
+                    "items": {"knuth1997": {"id": "knuth1997"}, "shannon": {"id": "shannon"}},
+                    "itemOrder": ["knuth1997", "shannon", "knuth1997", "shannon", "ghost"]
+                }
+            }),
+            &doc,
+        );
+        let order = doc.get_or_insert_array("referenceOrder");
+        let txn = doc.transact();
+        assert_eq!(order.len(&txn), 2, "doubled order + orphan hydrates to 2");
+    }
+
     fn fields_json() -> Value {
         json!({
             "id": "d",
@@ -570,6 +599,25 @@ mod tests {
         assert_eq!(fields.len(&txn), 2);
         assert!(fields.contains_key(&txn, "Company"));
         assert_eq!(order.len(&txn), 2);
+    }
+
+    /// JP-337: an already-doubled `order` (the persisted set_fields 9 → 18 shape)
+    /// plus an orphan hydrates to a deduped keep-first `fieldOrder`.
+    #[test]
+    fn json_fields_to_ydoc_dedupes_doubled_order() {
+        let doc = Doc::new();
+        super::json_fields_to_ydoc(
+            &json!({
+                "fields": {
+                    "fields": {"Company": {"name": "Company", "value": "Acme"}, "Version": {"name": "Version", "value": "2.0"}},
+                    "order": ["Company", "Version", "Company", "Version", "ghost"]
+                }
+            }),
+            &doc,
+        );
+        let order = doc.get_or_insert_array("fieldOrder");
+        let txn = doc.transact();
+        assert_eq!(order.len(&txn), 2, "doubled order + orphan hydrates to 2");
     }
 
     #[test]


### PR DESCRIPTION
Closes JP-337.

## Problem (found in the JP-312 joyride)

On the MCP-authored relay doc "Lobby Docs", `set_fields` called **once** with 9 fields made `list_fields` report **18** — every field twice. The snapshot confirms the `fields.fields` map is correct (9 keys, LWW-deduped) but `fields.order = [1..9, 1..9]` — the order **array** doubled and persisted. References have the identical latent bug.

## Root cause

The deferred **"ref/field hardening" from JP-330**. Shapes got deterministic seeding + dedupe-keep-first at hydrate/flatten/read (`crate::sync::dedupe_order`), but `fieldOrder` / `referenceOrder` did not. A `Y.Array` has no LWW semantics, so a dual-origin merge or re-hydrate **concatenates** the order; the map stays correct because it dedupes by key.

## Fix

Mirror the shapes treatment for both order arrays, reusing `dedupe_order` (keep-first + orphan-drop):

- **hydration.rs** — `json_fields_to_ydoc` / `json_references_to_ydoc` dedupe the order against the items map before `push_back`.
- **flatten.rs** — `project_fields_into` / `project_references_into` dedupe before persisting. Extracted a shared `order_string_ids` helper (also adopted by `flatten_into`).
- **mcp/fields.rs + mcp/citations.rs** `list_payload` — dedupe-keep-first so a **resident** doc whose live order is already doubled reports each item once *immediately*, before any re-flatten.
- **citations** `add_references_in_place` — guard the order append against ids already in `itemOrder` (mirrors `set_fields_in_place`).

**Self-heal:** read-dedupe corrects the live count at once; the next flatten persists a clean `order`; the next hydrate yields a clean array — so the already-doubled "Lobby Docs" heals on its next save/rehydrate (same model as JP-330).

## Tests

New Rust tests cover the doubled-order case (`[1..n,1..n]` + an orphan) at **hydrate**, **flatten**, and **read** for both fields and references, plus the refs cold-append guard. Full suite green: `cargo test` 470 lib + all integration tests pass; `cargo build --bin relay` clean.

## Verification (after deploy)

1. `list_fields(doc-0s_cyeEQOYAM)` → count **9** (read-dedupe).
2. A save/flatten → snapshot `fields.order` length **9**.
3. `set_fields` again with the 9 → still **9**.

## Scope note

The prose `body×2` duplication found in the same joyride is a **separate** bug (a second CRDT lineage merging + the prose page-list not being CRDT-synced) and is tracked under its own issue — not in this PR.

Assisted-by: Opus 4.8