### PR TITLE
Deploy to staging: JP-338 prose dup fix + JP-337 field/ref dedupe (+ JP-315/334/336)

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -134,8 +134,10 @@ All tools are namespaced `docushark.*`.
 | -- | -- |
 | `delete_shape` | Delete a shape by id. **Cascade-removes** any connectors attached to it (start or end), so no dangling connectors are left; returns the ids actually deleted. |
 | `delete_prose_page` | Delete a prose page by id. Refuses to delete the **last** remaining prose page. In a connected editor the page's *tab* may persist until reload (the prose page list isn't yet live-synced); its content is cleared immediately. |
+| `delete_canvas_page` | Delete a canvas page by id. Refuses to delete the **last** remaining canvas page. Repoints the active page if the deleted one was active; a connected app reloads. |
 | `reorder_shapes` | Set a page's z-order. `order` must be a permutation of the page's current shape ids (later ids render on top). |
 | `reorder_prose_pages` | Set the order of a document's prose pages. `order` must be a permutation of the current prose page ids. Tab order may update on reload (page list not yet live-synced). |
+| `reorder_canvas_page` | Set the order of a document's canvas pages. `order` must be a permutation of the current canvas page ids. Tab order updates on reload (page list not live-synced). |
 
 ### Citations (write)
 

--- a/relay/src/mcp/citations.rs
+++ b/relay/src/mcp/citations.rs
@@ -211,8 +211,15 @@ pub fn add_references_in_place(doc: &mut Value, incoming: &[Value]) -> Result<Ad
         items.insert(id.clone(), item.clone());
     }
     let order = refs.get_mut("itemOrder").and_then(Value::as_array_mut).unwrap();
+    // JP-337: never append an id already present in `itemOrder` (mirrors
+    // `set_fields_in_place`). `plan_additions` only yields genuinely-new ids, but
+    // guard anyway so a re-run can't grow a duplicate order entry.
+    let in_order: std::collections::HashSet<String> =
+        order.iter().filter_map(Value::as_str).map(str::to_string).collect();
     for (id, _) in &plan.added {
-        order.push(json!(id.clone()));
+        if !in_order.contains(id) {
+            order.push(json!(id.clone()));
+        }
     }
 
     Ok(AddOutcome {
@@ -232,7 +239,12 @@ pub fn list_payload(
     let ordered: Vec<Value> = if order.is_empty() {
         items.values().cloned().collect()
     } else {
-        order.iter().filter_map(|id| items.get(id).cloned()).collect()
+        // JP-337: dedupe-keep-first so a resident doc whose live `referenceOrder`
+        // is already doubled still reports each reference once (mirrors fields).
+        crate::sync::dedupe_order(order.iter().map(String::as_str), |id| items.contains_key(id))
+            .iter()
+            .filter_map(|id| items.get(id).cloned())
+            .collect()
     };
     json!({
         "references": ordered,
@@ -407,5 +419,31 @@ mod tests {
         assert_eq!(out["count"], json!(0));
         assert_eq!(out["references"], json!([]));
         assert_eq!(out["style"], Value::Null);
+    }
+
+    #[test]
+    fn list_references_dedupes_a_doubled_order() {
+        // JP-337: a resident doc whose live referenceOrder is already doubled
+        // (`[a,b,a,b]`) must still report each reference once.
+        let doc = json!({
+            "references": {
+                "items": {"a": {"id": "a"}, "b": {"id": "b"}},
+                "itemOrder": ["a", "b", "a", "b"]
+            }
+        });
+        let out = list_references_json(&doc);
+        assert_eq!(out["count"], json!(2), "doubled order reports each reference once");
+        assert_eq!(out["references"][0]["id"], json!("a"));
+        assert_eq!(out["references"][1]["id"], json!("b"));
+    }
+
+    #[test]
+    fn add_references_does_not_grow_a_duplicate_order_entry() {
+        // JP-337: re-adding an existing id must not append a second order entry.
+        let mut doc = json!({
+            "references": {"items": {"a": {"id": "a"}}, "itemOrder": ["a"]}
+        });
+        add_references_in_place(&mut doc, &[json!({"id": "a", "type": "book"})]).unwrap();
+        assert_eq!(doc["references"]["itemOrder"], json!(["a"]), "no duplicate order entry");
     }
 }

--- a/relay/src/mcp/fields.rs
+++ b/relay/src/mcp/fields.rs
@@ -89,7 +89,14 @@ pub fn list_payload(items: &serde_json::Map<String, Value>, order: &[String]) ->
     let ordered: Vec<Value> = if order.is_empty() {
         items.values().cloned().collect()
     } else {
-        order.iter().filter_map(|name| items.get(name).cloned()).collect()
+        // JP-337: dedupe-keep-first so a resident doc whose live `fieldOrder` is
+        // already doubled (a dual-origin merge that hasn't re-flattened yet) still
+        // reports each field once. `dedupe_order`'s `present` predicate also drops
+        // orphans, matching the `items.get` filter below.
+        crate::sync::dedupe_order(order.iter().map(String::as_str), |name| items.contains_key(name))
+            .iter()
+            .filter_map(|name| items.get(name).cloned())
+            .collect()
     };
     json!({
         "fields": ordered,
@@ -152,6 +159,20 @@ mod tests {
         let doc = json!({"id": "d", "fields": {"fields": {"B": {"name": "B", "value": "2"}, "A": {"name": "A", "value": "1"}}, "order": ["A", "B"]}});
         let payload = list_fields_json(&doc);
         assert_eq!(payload["count"], 2);
+        assert_eq!(payload["fields"][0]["name"], "A");
+        assert_eq!(payload["fields"][1]["name"], "B");
+    }
+
+    #[test]
+    fn list_fields_dedupes_a_doubled_order() {
+        // JP-337: a resident doc whose live fieldOrder is already doubled
+        // (`[A,B,A,B]`) must still report each field once.
+        let doc = json!({"id": "d", "fields": {
+            "fields": {"A": {"name": "A", "value": "1"}, "B": {"name": "B", "value": "2"}},
+            "order": ["A", "B", "A", "B"]
+        }});
+        let payload = list_fields_json(&doc);
+        assert_eq!(payload["count"], 2, "doubled order reports each field once");
         assert_eq!(payload["fields"][0]["name"], "A");
         assert_eq!(payload["fields"][1]["name"], "B");
     }

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -243,6 +243,34 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
             }),
         },
         ToolDescriptor {
+            name: "docushark.reorder_canvas_page",
+            description:
+                "Set the order of a document's canvas pages. 'order' must be a permutation of the current canvas page ids. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "order": {"type": "array", "items": {"type": "string"}}
+                },
+                "required": ["docId", "order"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.delete_canvas_page",
+            description:
+                "Delete a canvas page by id. Refuses to delete the last remaining canvas page. Repoints the active page if the deleted one was active. Refuses local documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"}
+                },
+                "required": ["docId", "pageId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
             name: "docushark.get_outline",
             description:
                 "Return the heading outline of a prose page as an ordered list of { index, level, title }. 'index' is the 0-based heading position used by insert_section and restructure_outline. Sections are flat: nesting is conveyed by 'level' (1–6), not containment.",
@@ -668,6 +696,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.rename_prose_page" => rename_prose_page(ctx, args),
         "docushark.add_canvas_page" => add_canvas_page(ctx, args),
         "docushark.rename_canvas_page" => rename_canvas_page(ctx, args),
+        "docushark.reorder_canvas_page" => reorder_canvas_page(ctx, args),
+        "docushark.delete_canvas_page" => delete_canvas_page(ctx, args),
         "docushark.get_outline" => get_outline(ctx, args),
         "docushark.insert_section" => insert_section(ctx, args),
         "docushark.restructure_outline" => restructure_outline(ctx, args),
@@ -1573,6 +1603,109 @@ fn rename_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, St
 
     Ok(ToolOutcome {
         result: json!({"pageId": parsed.page_id, "name": name}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct ReorderCanvasPagesArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    order: Vec<String>,
+}
+
+fn reorder_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: ReorderCanvasPagesArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    // The canvas page list is JSON-only (the live Y.Doc holds only the active
+    // page's shapes), so this is always a JSON write; a connected app reloads.
+    // Unlike prose pages, canvas pages carry no numeric `order` field — the
+    // `pageOrder` array IS the order, so there's nothing to renumber.
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let current: Vec<String> = doc
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+        validate_order(&current, &parsed.order, "canvas page")?;
+        doc.as_object_mut()
+            .ok_or("Document is not an object")?
+            .insert("pageOrder".into(), json!(parsed.order));
+        stamp_doc_modified(doc, now_ms());
+        Ok(())
+    })?;
+
+    Ok(ToolOutcome {
+        result: json!({"order": parsed.order, "ok": true}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct DeleteCanvasPageArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+}
+
+fn delete_canvas_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: DeleteCanvasPageArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let obj = doc.as_object_mut().ok_or("Document is not an object")?;
+        let exists = obj
+            .get("pages")
+            .and_then(|v| v.as_object())
+            .is_some_and(|p| p.contains_key(&parsed.page_id));
+        if !exists {
+            return Err(format!("Canvas page '{}' not found", parsed.page_id));
+        }
+        let order_len = obj.get("pageOrder").and_then(|v| v.as_array()).map_or(0, Vec::len);
+        if order_len <= 1 {
+            return Err("Cannot delete the last canvas page; a document keeps at least one".into());
+        }
+        if let Some(pages) = obj.get_mut("pages").and_then(|v| v.as_object_mut()) {
+            pages.remove(&parsed.page_id);
+        }
+        if let Some(order) = obj.get_mut("pageOrder").and_then(|v| v.as_array_mut()) {
+            order.retain(|v| v.as_str() != Some(parsed.page_id.as_str()));
+        }
+        // Repoint the top-level activePageId if it was the deleted page.
+        if obj.get("activePageId").and_then(|v| v.as_str()) == Some(parsed.page_id.as_str()) {
+            let next = obj
+                .get("pageOrder")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            if let Some(next) = next {
+                obj.insert("activePageId".into(), json!(next));
+            }
+        }
+        stamp_doc_modified(doc, now_ms());
+        Ok(())
+    })?;
+
+    // Active-page-only limitation (JP-34): if the doc is resident on the page we
+    // just deleted, its shapes are still in the live Y.Doc. Evict so a rejoining
+    // client re-hydrates from the new `activePageId` instead of being served the
+    // delisted page's shapes. The JSON delete above is already persisted, and the
+    // evict's flatten bails on the now-gone page, so nothing resurrects.
+    if resident_handle(ctx, &parsed.doc_id)
+        .is_some_and(|h| h.page_id() == Some(parsed.page_id.as_str()))
+    {
+        ctx.registry.evict(&ctx.workspace_id, &parsed.doc_id);
+    }
+
+    Ok(ToolOutcome {
+        result: json!({"deleted": parsed.page_id}),
         changed_doc_id: Some(parsed.doc_id),
         change_detail: None,
     })
@@ -3514,6 +3647,107 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("permutation"), "{err}");
+    }
+
+    // ---- JP-336: canvas-page reorder / delete ----
+
+    fn save_canvas_pages_doc(f: &Fixture, ids: &[&str]) {
+        let pages: serde_json::Map<String, Value> = ids
+            .iter()
+            .map(|id| {
+                ((*id).to_string(), json!({"id": id, "name": id, "shapes": {}, "shapeOrder": []}))
+            })
+            .collect();
+        f.team
+            .save_document(
+                &WorkspaceId::single_tenant(),
+                json!({
+                    "id": "docc", "name": "C", "version": 1, "createdAt": 1u64, "modifiedAt": 1u64,
+                    "activePageId": ids[0], "pageOrder": ids, "pages": pages
+                }),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn reorder_canvas_page_reorders_and_validates() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        save_canvas_pages_doc(&f, &["c1", "c2", "c3"]);
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.reorder_canvas_page",
+            &json!({"docId": "docc", "order": ["c3", "c1", "c2"]}),
+        )
+        .unwrap();
+        assert_eq!(out.result["ok"], true);
+        let doc = f.team.get_document(&ws, &DocId::from_http_path("docc".into()).unwrap()).unwrap();
+        assert_eq!(doc["pageOrder"], json!(["c3", "c1", "c2"]));
+
+        // Non-permutation refused.
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.reorder_canvas_page",
+            &json!({"docId": "docc", "order": ["c1", "c2"]}),
+        )
+        .unwrap_err();
+        assert!(err.contains("permutation"), "{err}");
+    }
+
+    #[test]
+    fn delete_canvas_page_deletes_then_refuses_the_last() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        save_canvas_pages_doc(&f, &["c1", "c2"]);
+
+        // Delete the (active) first page → repoints activePageId to the survivor.
+        dispatch(
+            &f.ctx(true),
+            "docushark.delete_canvas_page",
+            &json!({"docId": "docc", "pageId": "c1"}),
+        )
+        .unwrap();
+        let doc = f.team.get_document(&ws, &DocId::from_http_path("docc".into()).unwrap()).unwrap();
+        assert!(doc["pages"].get("c1").is_none(), "c1 removed");
+        assert_eq!(doc["pageOrder"], json!(["c2"]));
+        assert_eq!(doc["activePageId"], "c2", "active repointed");
+
+        // The now-last page can't be deleted.
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.delete_canvas_page",
+            &json!({"docId": "docc", "pageId": "c2"}),
+        )
+        .unwrap_err();
+        assert!(err.contains("last canvas page"), "{err}");
+    }
+
+    #[test]
+    fn delete_canvas_page_evicts_resident_active_page() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("docc".into()).unwrap();
+        save_canvas_pages_doc(&f, &["c1", "c2"]);
+        let handle = f.make_resident("docc");
+        assert_eq!(handle.page_id(), Some("c1"), "resident on the active page");
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.delete_canvas_page",
+            &json!({"docId": "docc", "pageId": "c1"}),
+        )
+        .unwrap();
+
+        // The resident handle was on the deleted active page → evicted, so a
+        // rejoin re-hydrates from the repointed activePageId (c2).
+        assert!(f.registry.get(&ws, &doc_id).is_none(), "resident handle evicted");
+        let doc = f.team.get_document(&ws, &doc_id).unwrap();
+        assert_eq!(doc["activePageId"], "c2");
+        assert!(doc["pages"].get("c1").is_none());
     }
 
     #[test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -760,6 +760,8 @@ mod tests {
         assert!(names.contains(&"docushark.rename_prose_page"));
         assert!(names.contains(&"docushark.add_canvas_page"));
         assert!(names.contains(&"docushark.rename_canvas_page"));
+        assert!(names.contains(&"docushark.reorder_canvas_page"));
+        assert!(names.contains(&"docushark.delete_canvas_page"));
         assert!(names.contains(&"docushark.get_outline"));
         assert!(names.contains(&"docushark.insert_section"));
         assert!(names.contains(&"docushark.restructure_outline"));
@@ -775,7 +777,7 @@ mod tests {
         assert!(names.contains(&"docushark.list_fields"));
         assert!(names.contains(&"docushark.set_fields"));
         assert!(names.contains(&"docushark.get_skills"));
-        assert_eq!(tools.len(), 29);
+        assert_eq!(tools.len(), 31);
     }
 
     #[tokio::test]

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -57,17 +57,7 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
             Any::Map(m) => m.contains_key(id),
             _ => false,
         };
-        let order_ids = match &order_any {
-            Any::Array(arr) => arr
-                .iter()
-                .filter_map(|a| match a {
-                    Any::String(s) => Some(s.as_ref()),
-                    _ => None,
-                })
-                .collect::<Vec<&str>>(),
-            _ => Vec::new(),
-        };
-        let deduped = super::dedupe_order(order_ids, present);
+        let deduped = super::dedupe_order(order_string_ids(&order_any), present);
         page.insert(
             "shapeOrder".to_string(),
             Value::Array(deduped.into_iter().map(Value::String).collect()),
@@ -203,8 +193,19 @@ pub fn project_references_into(doc: &Doc, json: &mut Value) {
 
     if let Some(obj) = json.as_object_mut() {
         let mut lib = JsonMap::new();
+        // JP-337: dedupe-keep-first + drop orphans so a live `referenceOrder`
+        // doubled by a dual-origin merge persists clean (mirrors shapeOrder).
+        let order_ids = order_string_ids(&order_any);
+        let present = |id: &str| match &refs_any {
+            Any::Map(m) => m.contains_key(id),
+            _ => false,
+        };
+        let deduped = super::dedupe_order(order_ids, present);
         lib.insert("items".to_string(), items);
-        lib.insert("itemOrder".to_string(), any_to_json(&order_any));
+        lib.insert(
+            "itemOrder".to_string(),
+            Value::Array(deduped.into_iter().map(Value::String).collect()),
+        );
         if let Some(style) = style {
             lib.insert("style".to_string(), Value::String(style));
         }
@@ -237,9 +238,36 @@ pub fn project_fields_into(doc: &Doc, json: &mut Value) {
 
     if let Some(obj) = json.as_object_mut() {
         let mut lib = JsonMap::new();
+        // JP-337: dedupe-keep-first + drop orphans so a live `fieldOrder` doubled
+        // by a dual-origin merge persists clean (mirrors shapeOrder).
+        let order_ids = order_string_ids(&order_any);
+        let present = |name: &str| match &fields_any {
+            Any::Map(m) => m.contains_key(name),
+            _ => false,
+        };
+        let deduped = super::dedupe_order(order_ids, present);
         lib.insert("fields".to_string(), items);
-        lib.insert("order".to_string(), any_to_json(&order_any));
+        lib.insert(
+            "order".to_string(),
+            Value::Array(deduped.into_iter().map(Value::String).collect()),
+        );
         obj.insert("fields".to_string(), Value::Object(lib));
+    }
+}
+
+/// Borrow the string ids out of an order `Any::Array` (e.g. `shapeOrder` /
+/// `fieldOrder` / `referenceOrder`), skipping any non-string entries. Pairs with
+/// [`super::dedupe_order`] for the flatten-side dedupe.
+fn order_string_ids(order_any: &Any) -> Vec<&str> {
+    match order_any {
+        Any::Array(arr) => arr
+            .iter()
+            .filter_map(|a| match a {
+                Any::String(s) => Some(s.as_ref()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -473,6 +501,32 @@ mod tests {
         assert_eq!(json["references"]["style"], json!("chicago"));
     }
 
+    /// JP-337: a live `referenceOrder` doubled by a dual-origin merge (plus an
+    /// orphan id) flattens to a deduped keep-first order, so the stored snapshot
+    /// self-heals — mirrors `jp330_flatten_dedupes_doubled_order` for shapes.
+    #[test]
+    fn jp337_flatten_dedupes_doubled_reference_order() {
+        let doc = Doc::new();
+        let refs = doc.get_or_insert_map("references");
+        let order = doc.get_or_insert_array("referenceOrder");
+        {
+            let mut txn = doc.transact_mut();
+            for id in ["a", "b"] {
+                refs.insert(&mut txn, id, super::super::hydration::json_to_any(&json!({"id": id})));
+            }
+            for id in ["a", "b", "a", "b", "ghost"] {
+                order.push_back(&mut txn, Any::String(id.into()));
+            }
+        }
+        let mut json = json!({"id": "d"});
+        project_references_into(&doc, &mut json);
+        assert_eq!(
+            json["references"]["itemOrder"],
+            json!(["a", "b"]),
+            "deduped keep-first; 'ghost' orphan dropped"
+        );
+    }
+
     #[test]
     fn project_references_skips_synthesizing_for_pre_jp89_docs() {
         // Empty Y.Doc library + a doc that never had a `references` field → leave
@@ -515,6 +569,35 @@ mod tests {
         project_fields_into(&doc, &mut json);
         assert_eq!(json["fields"]["order"], json!(["Company"]));
         assert_eq!(json["fields"]["fields"]["Company"]["value"], json!("Acme"));
+    }
+
+    /// JP-337: a live `fieldOrder` doubled by a dual-origin merge (the set_fields
+    /// 9 → 18 bug) flattens to a deduped keep-first order with orphans dropped.
+    #[test]
+    fn jp337_flatten_dedupes_doubled_field_order() {
+        let doc = Doc::new();
+        let fields = doc.get_or_insert_map("fields");
+        let order = doc.get_or_insert_array("fieldOrder");
+        {
+            let mut txn = doc.transact_mut();
+            for name in ["Project", "Owner"] {
+                fields.insert(
+                    &mut txn,
+                    name,
+                    super::super::hydration::json_to_any(&json!({"name": name, "value": "x"})),
+                );
+            }
+            for name in ["Project", "Owner", "Project", "Owner", "ghost"] {
+                order.push_back(&mut txn, Any::String(name.into()));
+            }
+        }
+        let mut json = json!({"id": "d"});
+        project_fields_into(&doc, &mut json);
+        assert_eq!(
+            json["fields"]["order"],
+            json!(["Project", "Owner"]),
+            "deduped keep-first; 'ghost' orphan dropped"
+        );
     }
 
     #[test]

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -179,14 +179,19 @@ pub fn json_references_to_ydoc(doc_json: &Value, doc: &Doc) {
         return;
     };
 
-    if let Some(items) = lib.get("items").and_then(Value::as_object) {
+    let items = lib.get("items").and_then(Value::as_object);
+    if let Some(items) = items {
         for (id, item) in items {
             references.insert(&mut txn, id.clone(), json_to_any(item));
         }
     }
     if let Some(order) = lib.get("itemOrder").and_then(Value::as_array) {
-        for id in order.iter().filter_map(Value::as_str) {
-            reference_order.push_back(&mut txn, Any::String(id.into()));
+        // JP-337: dedupe-keep-first + drop orphans (mirrors `json_to_ydoc` shapes).
+        // `referenceOrder` is a Y.Array with no LWW semantics, so an already-doubled
+        // source `itemOrder` would otherwise hydrate doubled.
+        let present = |id: &str| items.is_some_and(|m| m.contains_key(id));
+        for id in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+            reference_order.push_back(&mut txn, Any::String(id.as_str().into()));
         }
     }
     if let Some(style) = lib.get("style").and_then(Value::as_str) {
@@ -218,14 +223,19 @@ pub fn json_fields_to_ydoc(doc_json: &Value, doc: &Doc) {
         return;
     };
 
-    if let Some(items) = lib.get("fields").and_then(Value::as_object) {
+    let items = lib.get("fields").and_then(Value::as_object);
+    if let Some(items) = items {
         for (name, field) in items {
             fields.insert(&mut txn, name.clone(), json_to_any(field));
         }
     }
     if let Some(order) = lib.get("order").and_then(Value::as_array) {
-        for name in order.iter().filter_map(Value::as_str) {
-            field_order.push_back(&mut txn, Any::String(name.into()));
+        // JP-337: dedupe-keep-first + drop orphans (mirrors `json_to_ydoc` shapes).
+        // `fieldOrder` is a Y.Array with no LWW semantics, so an already-doubled
+        // source `order` would otherwise hydrate doubled (set_fields 9 → 18).
+        let present = |name: &str| items.is_some_and(|m| m.contains_key(name));
+        for name in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+            field_order.push_back(&mut txn, Any::String(name.as_str().into()));
         }
     }
 }
@@ -547,6 +557,25 @@ mod tests {
         assert_eq!(refs.len(&doc.transact()), 0);
     }
 
+    /// JP-337: an already-doubled `itemOrder` (`[a,b,a,b]`) plus an orphan must
+    /// hydrate to a deduped keep-first `referenceOrder` — not double the array.
+    #[test]
+    fn json_references_to_ydoc_dedupes_doubled_order() {
+        let doc = Doc::new();
+        json_references_to_ydoc(
+            &json!({
+                "references": {
+                    "items": {"knuth1997": {"id": "knuth1997"}, "shannon": {"id": "shannon"}},
+                    "itemOrder": ["knuth1997", "shannon", "knuth1997", "shannon", "ghost"]
+                }
+            }),
+            &doc,
+        );
+        let order = doc.get_or_insert_array("referenceOrder");
+        let txn = doc.transact();
+        assert_eq!(order.len(&txn), 2, "doubled order + orphan hydrates to 2");
+    }
+
     fn fields_json() -> Value {
         json!({
             "id": "d",
@@ -570,6 +599,25 @@ mod tests {
         assert_eq!(fields.len(&txn), 2);
         assert!(fields.contains_key(&txn, "Company"));
         assert_eq!(order.len(&txn), 2);
+    }
+
+    /// JP-337: an already-doubled `order` (the persisted set_fields 9 → 18 shape)
+    /// plus an orphan hydrates to a deduped keep-first `fieldOrder`.
+    #[test]
+    fn json_fields_to_ydoc_dedupes_doubled_order() {
+        let doc = Doc::new();
+        super::json_fields_to_ydoc(
+            &json!({
+                "fields": {
+                    "fields": {"Company": {"name": "Company", "value": "Acme"}, "Version": {"name": "Version", "value": "2.0"}},
+                    "order": ["Company", "Version", "Company", "Version", "ghost"]
+                }
+            }),
+            &doc,
+        );
+        let order = doc.get_or_insert_array("fieldOrder");
+        let txn = doc.transact();
+        assert_eq!(order.len(&txn), 2, "doubled order + orphan hydrates to 2");
     }
 
     #[test]

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -55,7 +55,7 @@ use yrs::types::Attrs;
 use yrs::types::ToJson;
 use yrs::{
     Any, Array, Doc, Map, ReadTxn, Text, Transact, TransactionMut, Xml, XmlElementPrelim,
-    XmlFragment, XmlTextPrelim,
+    XmlFragment, XmlFragmentRef, XmlTextPrelim,
 };
 
 use crate::server::protocol::{DocId, WorkspaceId};
@@ -208,7 +208,12 @@ impl DocHandle {
                                 hydration::json_references_to_ydoc(doc_json, &doc);
                                 // Phase 3c: same backstop for the field library.
                                 hydration::json_fields_to_ydoc(doc_json, &doc);
-                                return (doc, false);
+                                // JP-338 self-heal: collapse any prose fragment
+                                // that hydrated as an exact `body+body` double
+                                // (write-vs-hydrate lineage merge); dirty so the
+                                // next snapshot rewrites the repaired state.
+                                let healed = heal_doubled_prose_in(&doc);
+                                return (doc, healed);
                             }
                         }
                         Err(e) => log::warn!(
@@ -230,7 +235,12 @@ impl DocHandle {
         hydration::json_references_to_ydoc(doc_json, &doc);
         // Phase 3c: same for the field library.
         hydration::json_fields_to_ydoc(doc_json, &doc);
-        (doc, poison_healed)
+        // JP-338 self-heal: a doc whose persisted `richTextPages` content was
+        // already doubled hydrates doubled (the deterministic seed faithfully
+        // re-creates `body+body`); collapse it here so the live doc — and the
+        // next snapshot — are single.
+        let healed = heal_doubled_prose_in(&doc);
+        (doc, poison_healed || healed)
     }
 
     /// Number of shapes currently in the live `Y.Doc` (active-page surface).
@@ -684,11 +694,24 @@ impl DocHandle {
         let mut txn = self.doc.transact_mut();
         let before = txn.before_state().clone();
         let len = frag.len(&txn);
-        if len > 0 {
+        if len == 0 {
+            // JP-338: FIRST seed of an empty fragment (a new `add_prose_page`, or
+            // the first `set_prose` into the empty default page) — build the
+            // **deterministic** lineage, identical to what a future re-hydration
+            // (`json_prose_to_ydoc`) produces, so a client that caches this write
+            // dedupes on merge instead of doubling. Safe only because the fragment
+            // is empty (no prior FNV structs → no clock/tombstone collision); a
+            // rewrite (`len > 0`) keeps the live build below.
+            if let Some(update) = deterministic_seed_update(page_id, &blocks) {
+                let _ = txn.apply_update(update);
+            }
+        } else {
+            // Rewrite/edit of existing content — clear + live build (the live
+            // client-id is correct here; the content already had a lineage).
             frag.remove_range(&mut txn, 0, len);
-        }
-        for node in &blocks {
-            build_prose_node(&frag, &mut txn, node);
+            for node in &blocks {
+                build_prose_node(&frag, &mut txn, node);
+            }
         }
         let update = txn.encode_state_as_update_v1(&before);
         drop(txn);
@@ -806,6 +829,21 @@ fn deterministic_seed_client_id(page_id: &str) -> u64 {
 /// copies meet (a relay rehydrate vs a client's cached bootstrap) they dedupe
 /// rather than doubling. Re-applying the same seed is a no-op.
 fn seed_prose_deterministic(live: &Doc, page_id: &str, blocks: &[prose_parse::PmNode]) {
+    if let Some(update) = deterministic_seed_update(page_id, blocks) {
+        let _ = live.transact_mut().apply_update(update);
+    }
+}
+
+/// Build the deterministic seed **update** for a page's prose (the shared core of
+/// [`seed_prose_deterministic`]): author `blocks` in a throwaway `Doc` whose
+/// client-id is fixed by [`deterministic_seed_client_id`], then encode the full
+/// state as a v1 update. Applying it to an **empty** `prose:<page_id>` fragment —
+/// on any relay or client — yields byte-identical CRDT items, so independent
+/// seeders dedupe on merge instead of doubling. Returned (rather than applied) so
+/// a caller (JP-338: `replace_prose`'s first-seed) can apply it inside its own
+/// transaction and capture the delta to broadcast. `None` only on a malformed
+/// (undecodable) update, which never happens for content we just built.
+fn deterministic_seed_update(page_id: &str, blocks: &[prose_parse::PmNode]) -> Option<yrs::Update> {
     use yrs::updates::decoder::Decode;
     let seed = Doc::with_client_id(deterministic_seed_client_id(page_id));
     let frag = seed.get_or_insert_xml_fragment(format!("prose:{page_id}").as_str());
@@ -818,9 +856,61 @@ fn seed_prose_deterministic(live: &Doc, page_id: &str, blocks: &[prose_parse::Pm
     let update = seed
         .transact()
         .encode_state_as_update_v1(&yrs::StateVector::default());
-    if let Ok(update) = yrs::Update::decode_v1(&update) {
-        let _ = live.transact_mut().apply_update(update);
+    yrs::Update::decode_v1(&update).ok()
+}
+
+/// JP-338 self-heal: if a `prose:<id>` fragment is the body concatenated **exactly
+/// twice** — the write-vs-hydrate lineage-merge signature — drop the duplicate
+/// half. Returns whether it collapsed.
+///
+/// **Strict**: fires only on an exact full-fragment 2× repetition — an even
+/// top-level child count where the first half serializes byte-identically to the
+/// second. Never a per-block dedup, so prose that legitimately repeats a paragraph
+/// is left untouched. The delete is a normal CRDT op, so whoever runs it (relay on
+/// hydrate, or a client after sync) propagates the repair to every peer.
+pub(crate) fn collapse_doubled_prose(frag: &XmlFragmentRef, txn: &mut TransactionMut) -> bool {
+    let n = frag.len(txn);
+    // Require ≥2 blocks per half (n ≥ 4): the real bug doubles a whole multi-block
+    // page body, while two identical *single* paragraphs (n == 2) are plausibly
+    // intentional — never collapse those.
+    if n < 4 || n % 2 != 0 {
+        return false;
     }
+    let half = n / 2;
+    let first = prose_html::fragment_children_range_to_html(frag, txn, 0, half);
+    if first.is_empty() {
+        return false;
+    }
+    let second = prose_html::fragment_children_range_to_html(frag, txn, half, n);
+    if first != second {
+        return false;
+    }
+    frag.remove_range(txn, half, half);
+    true
+}
+
+/// Collapse any doubled `prose:*` fragments in `doc` in place (JP-338 self-heal on
+/// hydrate). Returns whether anything changed — the caller marks the handle dirty
+/// so the next snapshot rewrites the repaired state. Repairs a doc whose persisted
+/// `richTextPages` content was already doubled (it hydrates doubled, then heals).
+fn heal_doubled_prose_in(doc: &Doc) -> bool {
+    let names: Vec<String> = {
+        let txn = doc.transact();
+        txn.root_refs()
+            .map(|(name, _)| name)
+            .filter(|name| name.starts_with("prose:"))
+            .map(String::from)
+            .collect()
+    };
+    let mut healed = false;
+    for name in names {
+        let frag = doc.get_or_insert_xml_fragment(name.as_str());
+        let mut txn = doc.transact_mut();
+        if collapse_doubled_prose(&frag, &mut txn) {
+            healed = true;
+        }
+    }
+    healed
 }
 
 /// All of a run's marks as one Yjs formatting attribute set: boolean marks →
@@ -917,7 +1007,10 @@ impl DocRegistry {
 
 #[cfg(test)]
 mod tests {
-    use super::{binary, hydration, DocHandle, DocRegistry};
+    use super::{
+        binary, collapse_doubled_prose, hydration, prose_html, DocHandle, DocRegistry,
+        TransactionMut, XmlFragmentRef,
+    };
     use serde_json::json;
     use std::sync::Arc;
     use yrs::{Any, Array, Doc, GetString, Map, ReadTxn, Text, Transact};
@@ -1071,6 +1164,129 @@ mod tests {
             assert!(!framed.is_empty(), "a framed delta is returned to broadcast");
             assert_eq!(handle.prose_html("p1").as_deref(), Some(html), "round-trip: {html}");
         }
+    }
+
+    #[test]
+    fn jp338_first_seed_dedupes_with_rehydration() {
+        // Root-cause regression (Stage 1a): a page's FIRST content-write (into an
+        // empty fragment) must use the deterministic lineage, so a client that
+        // cached the write and the relay's later re-hydration DEDUPE on merge
+        // instead of doubling. Before the fix the write used the live client-id
+        // (lineage L) and this merge doubled.
+        use yrs::updates::decoder::Decode;
+        use yrs::{StateVector, Update};
+        let html = "<h1>Architecture</h1><p>body text</p>";
+
+        // First write via replace_prose (empty fragment → deterministic seed).
+        let writer = DocHandle::hydrate(&empty_json_body(1), None, false);
+        writer.replace_prose("p1", html).unwrap();
+        let cached = writer
+            .doc
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+
+        // Independent fresh hydration of the same content from richTextPages (D).
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}},
+            "richTextPages": {"pageOrder": ["p1"], "pages": {"p1": {"content": html}}}
+        });
+        let relay = DocHandle::hydrate(&json, None, false);
+
+        // The cached write meets the re-hydrated relay (the reload merge).
+        {
+            let mut txn = relay.doc.transact_mut();
+            txn.apply_update(Update::decode_v1(&cached).unwrap()).unwrap();
+        }
+        assert_eq!(
+            relay.prose_html("p1").as_deref(),
+            Some(html),
+            "deterministic first-seed dedupes on rehydrate — single copy, not doubled"
+        );
+    }
+
+    #[test]
+    fn jp338_collapse_doubled_prose_heals_exact_double() {
+        use yrs::{Xml, XmlElementPrelim, XmlFragment, XmlTextPrelim};
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("prose:p1");
+        {
+            let mut txn = doc.transact_mut();
+            // body = [h1, p]; doubled = [h1, p, h1, p] (the observed signature).
+            for _ in 0..2 {
+                let h = frag.push_back(&mut txn, XmlElementPrelim::empty("heading"));
+                h.insert_attribute(&mut txn, "level", "1");
+                h.push_back(&mut txn, XmlTextPrelim::new("Title"));
+                let p = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+                p.push_back(&mut txn, XmlTextPrelim::new("body"));
+            }
+        }
+        {
+            let mut txn = doc.transact_mut();
+            assert!(collapse_doubled_prose(&frag, &mut txn), "exact double collapses");
+        }
+        let txn = doc.transact();
+        assert_eq!(
+            prose_html::fragment_to_html(&frag, &txn),
+            "<h1>Title</h1><p>body</p>",
+            "duplicate half removed"
+        );
+    }
+
+    #[test]
+    fn jp338_collapse_is_strict_no_false_positives() {
+        use yrs::{XmlElementPrelim, XmlFragment, XmlTextPrelim};
+        let para = |frag: &XmlFragmentRef, txn: &mut TransactionMut, label: &str| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new(label));
+        };
+
+        // Two identical SINGLE paragraphs (n == 2) — plausibly intentional; never
+        // collapse (the ≥2-blocks-per-half guard).
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("prose:p1");
+        {
+            let mut txn = doc.transact_mut();
+            para(&frag, &mut txn, "same");
+            para(&frag, &mut txn, "same");
+        }
+        {
+            let mut txn = doc.transact_mut();
+            assert!(!collapse_doubled_prose(&frag, &mut txn), "n==2 is never collapsed");
+        }
+
+        // Halves differ ([A,B,A,C]) — not a clean double → untouched.
+        let doc2 = Doc::new();
+        let frag2 = doc2.get_or_insert_xml_fragment("prose:p2");
+        {
+            let mut txn = doc2.transact_mut();
+            for label in ["A", "B", "A", "C"] {
+                para(&frag2, &mut txn, label);
+            }
+        }
+        {
+            let mut txn = doc2.transact_mut();
+            assert!(!collapse_doubled_prose(&frag2, &mut txn), "unequal halves untouched");
+        }
+    }
+
+    #[test]
+    fn jp338_hydration_heals_already_doubled_richtextpages() {
+        // Repair path: a doc whose persisted prose is already `body+body` hydrates
+        // doubled, then self-heals to a single copy (so the next snapshot is clean).
+        let html = "<h1>Overview</h1><p>the body</p>";
+        let doubled = format!("{html}{html}");
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}},
+            "richTextPages": {"pageOrder": ["p1"], "pages": {"p1": {"content": doubled}}}
+        });
+        let handle = DocHandle::hydrate(&json, None, false);
+        assert_eq!(
+            handle.prose_html("p1").as_deref(),
+            Some(html),
+            "doubled richTextPages hydrates, then heals to single"
+        );
     }
 
     #[test]

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -38,6 +38,27 @@ pub fn fragment_to_html<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> String {
     out
 }
 
+/// Serialize the top-level children of `frag` in the index range `[start, end)`
+/// to HTML. Used by the JP-338 prose self-heal to compare a fragment's halves.
+pub fn fragment_children_range_to_html<T: ReadTxn>(
+    frag: &XmlFragmentRef,
+    txn: &T,
+    start: u32,
+    end: u32,
+) -> String {
+    let mut out = String::new();
+    for (i, node) in frag.children(txn).enumerate() {
+        let i = i as u32;
+        if i >= end {
+            break;
+        }
+        if i >= start {
+            write_node(&node, txn, &mut out, 0);
+        }
+    }
+    out
+}
+
 fn write_children<F, T>(frag: &F, txn: &T, out: &mut String, depth: usize)
 where
     F: XmlFragment,

--- a/src/collaboration/YjsDocument.prose.test.ts
+++ b/src/collaboration/YjsDocument.prose.test.ts
@@ -9,6 +9,7 @@ import { getSchema, Editor, type JSONContent } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import Collaboration from '@tiptap/extension-collaboration';
 import { yXmlFragmentToProseMirrorRootNode } from 'y-prosemirror';
+import * as Y from 'yjs';
 import { YjsDocument } from './YjsDocument';
 import { registerProseSchema, __resetProseSchemaForTests } from './proseSchema';
 
@@ -93,5 +94,51 @@ describe('YjsDocument prose (JP-193)', () => {
     __resetProseSchemaForTests();
     const doc = new YjsDocument();
     expect(() => doc.setProse('p1', paras('x'))).toThrow(/no schema registered/);
+  });
+});
+
+describe('YjsDocument.healDoubledProse (JP-338)', () => {
+  beforeEach(() => registerProseSchema(schema));
+  afterEach(() => __resetProseSchemaForTests());
+
+  // Append a [heading, paragraph] body to the fragment as independent items —
+  // the raw shape a merged duplicate lineage produces (cf. proseReseedDuplication).
+  function appendBody(doc: YjsDocument, pageId: string, title: string, body: string): void {
+    const frag = doc.getDoc().getXmlFragment(`prose:${pageId}`);
+    const h = new Y.XmlElement('heading');
+    h.setAttribute('level', '1');
+    const ht = new Y.XmlText();
+    ht.insert(0, title);
+    h.insert(0, [ht]);
+    const p = new Y.XmlElement('paragraph');
+    const pt = new Y.XmlText();
+    pt.insert(0, body);
+    p.insert(0, [pt]);
+    frag.insert(frag.length, [h, p]);
+  }
+
+  it('collapses an exact body×2 double and propagates the delete', () => {
+    const doc = new YjsDocument();
+    appendBody(doc, 'p1', 'Title', 'the body'); // [h, p]
+    appendBody(doc, 'p1', 'Title', 'the body'); // doubled → [h, p, h, p]
+    expect(doc.getDoc().getXmlFragment('prose:p1').length).toBe(4);
+
+    expect(doc.healDoubledProse('p1')).toBe(true);
+    expect(doc.getDoc().getXmlFragment('prose:p1').length).toBe(2);
+    expect(readText(doc, 'p1')).toBe('Title\nthe body');
+  });
+
+  it('is a no-op for two identical single paragraphs (n === 2)', () => {
+    const doc = new YjsDocument();
+    doc.setProse('p1', paras('same', 'same'));
+    expect(doc.healDoubledProse('p1')).toBe(false);
+    expect(readText(doc, 'p1')).toBe('same\nsame');
+  });
+
+  it('is a no-op on a clean single body', () => {
+    const doc = new YjsDocument();
+    appendBody(doc, 'p1', 'Title', 'body');
+    expect(doc.healDoubledProse('p1')).toBe(false);
+    expect(doc.getDoc().getXmlFragment('prose:p1').length).toBe(2);
   });
 });

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -206,6 +206,33 @@ export class YjsDocument {
     });
   }
 
+  /**
+   * JP-338 self-heal: if a prose page's fragment is the body concatenated
+   * **exactly twice** — the write-vs-hydrate CRDT-lineage-merge signature (a
+   * client cached a live write `L` while the relay later re-seeded the
+   * deterministic `D`) — delete the duplicate half. The delete is a normal CRDT
+   * op, so it propagates to the relay + peers and heals everyone. Returns whether
+   * it collapsed.
+   *
+   * **Strict** (mirrors the relay's `collapse_doubled_prose`): only an exact
+   * full-fragment 2× repetition with **≥2 blocks per half** (so two identical
+   * single paragraphs — plausibly intentional — are never touched). Runs once
+   * after the initial sync settles, when a poisoned `y-indexeddb` lineage has
+   * merged with the relay's.
+   */
+  healDoubledProse(pageId: string): boolean {
+    const fragment = this.proseFragment(pageId);
+    const n = fragment.length;
+    if (n < 4 || n % 2 !== 0) return false;
+    const half = n / 2;
+    const kids = fragment.toArray();
+    const firstHalf = kids.slice(0, half).map((k) => k.toString()).join('');
+    const secondHalf = kids.slice(half).map((k) => k.toString()).join('');
+    if (!firstHalf || firstHalf !== secondHalf) return false;
+    this.doc.transact(() => fragment.delete(half, half));
+    return true;
+  }
+
   // ============ Local to Remote Sync ============
 
   /**

--- a/src/collaboration/offlinePageGuard.test.ts
+++ b/src/collaboration/offlinePageGuard.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computeSharedDocOffline } from './offlinePageGuard';
+
+// A relay doc identified by an active collab session, currently online.
+const onlineRelay = {
+  currentDocId: 'doc-1',
+  collabDocId: 'doc-1',
+  collabActive: true,
+  recordType: undefined,
+  status: 'authenticated' as const,
+};
+
+describe('computeSharedDocOffline (JP-334)', () => {
+  it('is false when there is no open document', () => {
+    expect(computeSharedDocOffline({ ...onlineRelay, currentDocId: null })).toBe(false);
+  });
+
+  it('is false for a local-only doc, even disconnected', () => {
+    expect(
+      computeSharedDocOffline({
+        currentDocId: 'doc-1',
+        collabDocId: null,
+        collabActive: false,
+        recordType: 'local',
+        status: 'disconnected',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a relay doc that is fully connected (authenticated)', () => {
+    expect(computeSharedDocOffline(onlineRelay)).toBe(false);
+  });
+
+  it('is true for a relay doc (active session) that is not yet authenticated', () => {
+    for (const status of ['disconnected', 'connecting', 'connected', 'authenticating', 'error'] as const) {
+      expect(computeSharedDocOffline({ ...onlineRelay, status })).toBe(true);
+    }
+  });
+
+  it('is true for a relay doc identified by registry record type when offline', () => {
+    expect(
+      computeSharedDocOffline({
+        currentDocId: 'doc-1',
+        collabDocId: null,
+        collabActive: false,
+        recordType: 'remote',
+        status: 'connecting',
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/collaboration/offlinePageGuard.ts
+++ b/src/collaboration/offlinePageGuard.ts
@@ -1,0 +1,63 @@
+import type { ConnectionStatus } from '../store/connectionStore';
+import { useConnectionStore } from '../store/connectionStore';
+import { usePersistenceStore } from '../store/persistenceStore';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import { useCollaborationStore } from './collaborationStore';
+
+/**
+ * JP-334: while a relay-backed (shared) doc is offline, creating a new page —
+ * prose OR canvas — is blocked. Prose: a never-synced empty fragment is
+ * read-only by design (relay is the sole seeder, JP-284) and editing it would
+ * risk dual-lineage duplication. Canvas: a new page's shapes never reach the
+ * relay's active-page-only flatten → lost on reconnect. Either way the page
+ * can't be created safely until reconnect. Enabling it is JP-335.
+ *
+ * Local-only docs are never blocked (no relay involved).
+ */
+
+/** Pure decision: relay-backed AND the live connection isn't fully up. */
+export function computeSharedDocOffline(args: {
+  currentDocId: string | null;
+  collabDocId: string | null;
+  collabActive: boolean;
+  recordType: string | undefined;
+  status: ConnectionStatus;
+}): boolean {
+  const { currentDocId, collabDocId, collabActive, recordType, status } = args;
+  if (!currentDocId) return false;
+  // Mirror DocumentEditorPanel's `isRelayDoc`: an active session on this doc, or
+  // a registry record that isn't local-only.
+  const isRelayDoc =
+    (currentDocId === collabDocId && collabActive) ||
+    (recordType !== undefined && recordType !== 'local');
+  if (!isRelayDoc) return false;
+  // `authenticated` is the only fully-live state; anything else can't seed/persist.
+  return status !== 'authenticated';
+}
+
+/** Store-wired form used by the add-page handlers (imperative, at click time). */
+export function sharedDocOffline(): boolean {
+  const currentDocId = usePersistenceStore.getState().currentDocumentId;
+  const collab = useCollaborationStore.getState();
+  return computeSharedDocOffline({
+    currentDocId,
+    collabDocId: collab.config?.documentId ?? null,
+    collabActive: collab.isActive,
+    recordType: currentDocId
+      ? useDocumentRegistry.getState().getRecord(currentDocId)?.type
+      : undefined,
+    status: useConnectionStore.getState().status,
+  });
+}
+
+/** Reactive form for dimming the add-page controls (re-renders on status change). */
+export function useSharedDocOffline(): boolean {
+  const currentDocId = usePersistenceStore((s) => s.currentDocumentId);
+  const collabDocId = useCollaborationStore((s) => s.config?.documentId ?? null);
+  const collabActive = useCollaborationStore((s) => s.isActive);
+  const status = useConnectionStore((s) => s.status);
+  const recordType = useDocumentRegistry((s) =>
+    currentDocId ? s.getRecord(currentDocId)?.type : undefined,
+  );
+  return computeSharedDocOffline({ currentDocId, collabDocId, collabActive, recordType, status });
+}

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -19,6 +19,7 @@ import { useEffect, useRef } from 'react';
 import { useDocumentStore } from '../store/documentStore';
 import { useReferenceStore } from '../store/referenceStore';
 import { useFieldStore } from '../store/fieldStore';
+import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
@@ -207,6 +208,17 @@ export function useCollaborationSync(): void {
     // else: offline + empty Y.Doc — defer (leave `initializedRef` false). The
     // doc-store→CRDT subscription below stays gated off so an edit can't fork a
     // new identity; the engine will adopt once it goes online and syncs.
+
+    // JP-338 prose self-heal: once the Y.Doc holds the complete (idb+relay)
+    // truth, collapse any prose page that came back doubled — a stale
+    // y-indexeddb lineage (a cached live write) meeting the relay's deterministic
+    // seed concatenates `body+body`. The collapse is a CRDT delete, so it
+    // propagates to the relay + peers and heals everyone. No-op on clean docs.
+    if (initializedRef.current) {
+      for (const pageId of useRichTextPagesStore.getState().pageOrder) {
+        yjsDoc.healDoubledProse(pageId);
+      }
+    }
   }, [isActive, isSynced, isIdbSynced, hasProvider, getYjsDocument, sessionEpoch]);
 
   // Subscribe to local document store changes and sync to CRDT

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -317,6 +317,31 @@ describe('uiPreferencesStore — migration', () => {
       proseBackground: 'default',
     });
   });
+
+  it('v7 → v8 defaults the floating collab-indicator position to null', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          // v7 payload has no collabIndicatorPos field.
+        },
+        version: 7,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().collabIndicatorPos).toBeNull();
+  });
+});
+
+describe('uiPreferencesStore — collab indicator position', () => {
+  it('defaults to null and pins on set', () => {
+    expect(useUIPreferencesStore.getState().collabIndicatorPos).toBeNull();
+    useUIPreferencesStore.getState().setCollabIndicatorPos({ x: 120, y: 64 });
+    expect(useUIPreferencesStore.getState().collabIndicatorPos).toEqual({ x: 120, y: 64 });
+  });
 });
 
 describe('uiPreferencesStore — appearance slice', () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -106,6 +106,12 @@ export interface UIPreferencesState {
   layout: LayoutState;
   /** Appearance slice — accent + motion (theme is in `themeStore`). */
   appearancePrefs: AppearancePrefs;
+  /**
+   * Persisted top-left (viewport px) of the floating collaboration indicator.
+   * `null` = use the default top-right anchor; the user's first drag pins it.
+   * App-level (not per-doc), clamped into the viewport at render time.
+   */
+  collabIndicatorPos: { x: number; y: number } | null;
 }
 
 /**
@@ -126,6 +132,8 @@ export interface UIPreferencesActions {
   setPropertyPanelWidth: (width: number) => void;
   /** Set the Relaxed split secondary-canvas width (px). */
   setRelaxedSplitCanvasWidth: (width: number) => void;
+  /** Pin the floating collaboration indicator's top-left (viewport px). */
+  setCollabIndicatorPos: (pos: { x: number; y: number }) => void;
   /** Set the document browser view (list/grid) */
   setDocumentBrowserView: (view: DocumentBrowserView) => void;
   /** Set the document browser sort key */
@@ -251,6 +259,7 @@ const initialState: UIPreferencesState = {
   storageInfoToastSeen: false,
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
+  collabIndicatorPos: null,
 };
 
 /**
@@ -370,6 +379,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setRelaxedSplitCanvasWidth: (width: number) => {
         set({ relaxedSplitCanvasWidth: width });
+      },
+
+      setCollabIndicatorPos: (pos: { x: number; y: number }) => {
+        set({ collabIndicatorPos: { x: pos.x, y: pos.y } });
       },
 
       setDocumentBrowserView: (view) => set({ documentBrowserView: view }),
@@ -505,7 +518,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 7,
+      version: 8,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -518,6 +531,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         storageInfoToastSeen: state.storageInfoToastSeen,
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
+        collabIndicatorPos: state.collabIndicatorPos,
       }),
       migrate: (persisted, fromVersion) => {
         // Cast away the loose persisted-state typing — older payloads carry
@@ -613,6 +627,12 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         if (fromVersion < 7) {
           const axis = next['documentBrowserGroupBy'];
           next['documentBrowserGroupBy'] = axis === 'group' ? 'collection' : axis === 'collection' ? 'collection' : 'none';
+        }
+        // v7 → v8: added the floating collaboration-indicator position. Default
+        // to `null` (the top-right anchor) so existing users see no change until
+        // they first drag it. (The `merge` below also backstops this.)
+        if (fromVersion < 8) {
+          next['collabIndicatorPos'] = next['collabIndicatorPos'] ?? null;
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -137,18 +137,6 @@
   }
 }
 
-/* Presence indicators - positioned in top-right of canvas area */
-.app-presence {
-  position: fixed;
-  top: 52px; /* Below toolbar */
-  right: 260px; /* Offset for property panel */
-  z-index: 100;
-  padding: 8px;
-  background: var(--color-bg-secondary);
-  border-radius: 0 0 0 8px;
-  box-shadow: var(--shadow-sm);
-}
-
 /* ==========================================================================
    Unified Form Element Styles
    ========================================================================== */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -22,7 +22,7 @@ import { DocumentsHome } from './home/DocumentsHome';
 import { UnifiedToolbar } from './UnifiedToolbar';
 import { CanvasToolbar } from './CanvasToolbar';
 import { StatusBar } from './StatusBar';
-import { PresenceIndicators } from './PresenceIndicators';
+import { FloatingCollabIndicator } from './FloatingCollabIndicator';
 import { NotificationToast } from './NotificationToast';
 import { UploadIndicator } from './UploadIndicator';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -549,10 +549,9 @@ function App() {
         </main>
         <StatusBar />
 
-        {/* Presence indicators for collaboration */}
-        <div className="app-presence">
-          <PresenceIndicators size="small" />
-        </div>
+        {/* Floating, draggable collaboration indicator (JP-315). Hides itself
+            when no remote collaborators are present. */}
+        <FloatingCollabIndicator />
 
         {/* Settings Modal (includes Documents, Storage, etc.) */}
         <SettingsModal

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -44,8 +44,9 @@ export interface CollaborativeProseEditorProps {
   pageId: string;
   /** Optional class name. */
   className?: string;
-  /** Editor instance callback (the panel keeps it for autosave/toolbar). */
-  onEditorReady?: (editor: Editor | null) => void;
+  /** Editor instance callback (the panel keeps it for autosave/toolbar). The
+   *  `pageId` lets the panel pair the editor with its page (JP-334). */
+  onEditorReady?: (editor: Editor | null, pageId: string | null) => void;
 }
 
 export function CollaborativeProseEditor({
@@ -102,9 +103,9 @@ export function CollaborativeProseEditor({
 
   // Expose the editor instance to the panel (autosave + toolbar).
   useEffect(() => {
-    onEditorReady?.(editor);
-    return () => onEditorReady?.(null);
-  }, [editor, onEditorReady]);
+    onEditorReady?.(editor, pageId);
+    return () => onEditorReady?.(null, pageId);
+  }, [editor, onEditorReady, pageId]);
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={onContextMenu}>

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -23,6 +23,7 @@ import { useSessionStore } from '../store/sessionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
+import { shouldPersistLeavingPage } from './proseLeavingPageGuard';
 import { CollaborativeProseEditor } from './CollaborativeProseEditor';
 import { ProseErrorBoundary } from './ProseErrorBoundary';
 import { ProsePreview } from './ProsePreview';
@@ -162,6 +163,11 @@ export function DocumentEditorPanel({
   const useCollabEditor = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
 
   const lastActivePageRef = useRef<string | null>(null);
+  // The prose page id the currently-mounted `editor` is bound to (null when the
+  // active page is read-only `ProsePreview`, which mounts no editor). Lets the
+  // page-switch save below verify the editor actually belongs to the page being
+  // left, instead of cross-writing a read-only page's slot (JP-334).
+  const editorPageIdRef = useRef<string | null>(null);
   const isLoadingRef = useRef(false);
   /** Set while we're programmatically setting scrollTop (so the scroll listener
    *  doesn't persist transient values to the wrong page key). */
@@ -226,8 +232,11 @@ export function DocumentEditorPanel({
   }, []);
 
   // Handle editor ready callback from TiptapEditor
-  const handleEditorReady = useCallback((ed: Editor | null) => {
+  const handleEditorReady = useCallback((ed: Editor | null, pageId: string | null) => {
     setEditor(ed);
+    // Track which page this editor edits, so the page-switch save can't pair the
+    // incoming editor with the (read-only) page being left (JP-334).
+    editorPageIdRef.current = ed ? pageId : null;
     // Also keep window global for PDFExportDialog (non-component context)
     if (ed) {
       (window as unknown as { __tiptapEditor?: Editor }).__tiptapEditor = ed;
@@ -249,8 +258,17 @@ export function DocumentEditorPanel({
       pendingLoadRef.current = null;
     }
 
-    // Save the page we are leaving (skip if we were already mid-load)
-    if (lastActivePageRef.current && !isLoadingRef.current) {
+    // Save the page we are leaving — but ONLY when the mounted editor is the one
+    // bound to that page. Leaving a read-only page (offline-created → ProsePreview,
+    // no editor) desyncs editor/lastActivePageRef, and an unguarded save would
+    // write the incoming editable page's content into the read-only page's slot
+    // (JP-334). Relay docs mirror each fragment per page via the collab editor's
+    // own onUpdate, so skipping here loses nothing. (Skip too if mid-load.)
+    if (
+      lastActivePageRef.current &&
+      !isLoadingRef.current &&
+      shouldPersistLeavingPage(editorPageIdRef.current, lastActivePageRef.current)
+    ) {
       const currentContent = editor.getHTML();
       updatePageContent(lastActivePageRef.current, currentContent);
       const el = getScrollEl(editor);
@@ -542,8 +560,9 @@ export function DocumentEditorPanel({
             fallbackHtml={activePageContent ?? '<p></p>'}
           >
             {!isRelayDoc ? (
-              // Local-only doc: the legacy editor (no Y.Doc).
-              <TiptapEditor onEditorReady={handleEditorReady} />
+              // Local-only doc: the legacy editor (no Y.Doc). It edits the active
+              // page; pass that id so the leaving-page save guard pairs correctly.
+              <TiptapEditor onEditorReady={(ed) => handleEditorReady(ed, activePageId)} />
             ) : useCollabEditor ? (
               <CollaborativeProseEditor
                 key={`${currentDocId}:${activePageId}:${collabSessionEpoch}`}

--- a/src/ui/FloatingCollabIndicator.css
+++ b/src/ui/FloatingCollabIndicator.css
@@ -1,0 +1,53 @@
+/**
+ * Floating collaboration indicator (JP-315) — a draggable presence pill.
+ */
+
+.floating-collab {
+  position: fixed;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 4px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-md);
+  user-select: none;
+  /* Only the shadow animates — never left/top, which must track the pointer. */
+  transition: box-shadow 0.15s ease;
+}
+
+.floating-collab--dragging {
+  box-shadow: var(--shadow-lg);
+}
+
+.floating-collab-grip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  cursor: grab;
+  border-radius: var(--radius-sm);
+  /* Block touch-scroll so a drag from the grip moves the pill, not the page. */
+  touch-action: none;
+}
+
+.floating-collab-grip:hover {
+  color: var(--text-primary);
+}
+
+.floating-collab-grip:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
+.floating-collab--dragging .floating-collab-grip {
+  cursor: grabbing;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-collab {
+    transition: none;
+  }
+}

--- a/src/ui/FloatingCollabIndicator.tsx
+++ b/src/ui/FloatingCollabIndicator.tsx
@@ -1,0 +1,174 @@
+/**
+ * Floating, draggable collaboration indicator (JP-315).
+ *
+ * Wraps {@link PresenceIndicators} in a movable pill that the user can drag
+ * anywhere on screen; its position persists app-wide via `uiPreferencesStore`.
+ * It mounts **only when at least one remote collaborator is present** — when
+ * you are alone it shows nothing (the old fixed overlay showed a bare dot).
+ *
+ * Dragging uses pointer events (not HTML5 DnD, which is dead in WebKitGTK — see
+ * ReorderableList.tsx / JP-30). The floating form is also the seam for future
+ * in-document communications.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { GripVertical } from 'lucide-react';
+import { useCollaborationStore } from '../collaboration';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+import { PresenceIndicators } from './PresenceIndicators';
+import {
+  clampToViewport,
+  resolveIndicatorPosition,
+  type Point,
+  type Size,
+} from './floatingPosition';
+import './FloatingCollabIndicator.css';
+
+/** Pixels nudged per arrow-key press on the focused grip (a11y). */
+const KEY_NUDGE = 12;
+
+function readViewport(): Size {
+  return { w: window.innerWidth, h: window.innerHeight };
+}
+
+export function FloatingCollabIndicator() {
+  const isActive = useCollaborationStore((s) => s.isActive);
+  const remoteUsers = useCollaborationStore((s) => s.remoteUsers);
+  const stored = useUIPreferencesStore((s) => s.collabIndicatorPos);
+  const setStored = useUIPreferencesStore((s) => s.setCollabIndicatorPos);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Viewport tracked in state so a resize re-clamps the rendered position. This
+  // only re-renders; it never writes to the store (which would thrash
+  // localStorage) — the store is committed solely on drag-end / key-nudge.
+  const [viewport, setViewport] = useState<Size>(() => readViewport());
+  // Measured pill size; seeded with an estimate, corrected after layout.
+  const [size, setSize] = useState<Size>({ w: 160, h: 40 });
+  // Transient top-left while dragging (null = not dragging, use resolved).
+  const [dragPos, setDragPos] = useState<Point | null>(null);
+
+  // Mirrors for window listeners, which would otherwise capture stale state.
+  const pointerOffsetRef = useRef<Point>({ x: 0, y: 0 });
+  const sizeRef = useRef<Size>(size);
+  sizeRef.current = size;
+  const dragPosRef = useRef<Point | null>(null);
+
+  // Keep the rendered size in sync (the pill widens as collaborators join).
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width && rect.height) {
+      setSize((prev) =>
+        prev.w === rect.width && prev.h === rect.height
+          ? prev
+          : { w: rect.width, h: rect.height }
+      );
+    }
+  }, [remoteUsers.length, isActive]);
+
+  // Re-clamp on viewport resize (render-only; no persistence).
+  useEffect(() => {
+    const onResize = () => setViewport(readViewport());
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const resolved = resolveIndicatorPosition(stored, size, viewport);
+  const rendered = dragPos ?? resolved;
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const rect = containerRef.current?.getBoundingClientRect();
+      const topLeft = rect ? { x: rect.left, y: rect.top } : rendered;
+      pointerOffsetRef.current = { x: e.clientX - topLeft.x, y: e.clientY - topLeft.y };
+      dragPosRef.current = topLeft;
+      setDragPos(topLeft);
+    },
+    [rendered]
+  );
+
+  // Window-level drag listeners — survive the pointer leaving the small grip.
+  useEffect(() => {
+    if (dragPos === null) return;
+
+    const handleMove = (e: PointerEvent) => {
+      const next = clampToViewport(
+        {
+          x: e.clientX - pointerOffsetRef.current.x,
+          y: e.clientY - pointerOffsetRef.current.y,
+        },
+        sizeRef.current,
+        readViewport()
+      );
+      dragPosRef.current = next;
+      setDragPos(next);
+    };
+    const handleUp = () => {
+      const committed = dragPosRef.current;
+      if (committed) setStored(committed);
+      dragPosRef.current = null;
+      setDragPos(null);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+    };
+  }, [dragPos, setStored]);
+
+  const onGripKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const delta: Point = { x: 0, y: 0 };
+      if (e.key === 'ArrowLeft') delta.x = -KEY_NUDGE;
+      else if (e.key === 'ArrowRight') delta.x = KEY_NUDGE;
+      else if (e.key === 'ArrowUp') delta.y = -KEY_NUDGE;
+      else if (e.key === 'ArrowDown') delta.y = KEY_NUDGE;
+      else return;
+      e.preventDefault();
+      setStored(
+        clampToViewport(
+          { x: resolved.x + delta.x, y: resolved.y + delta.y },
+          sizeRef.current,
+          readViewport()
+        )
+      );
+    },
+    [resolved, setStored]
+  );
+
+  // Hide-when-alone gate — placed AFTER all hooks (rules of hooks). With no
+  // remote users present, render nothing.
+  if (!isActive || remoteUsers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`floating-collab${dragPos ? ' floating-collab--dragging' : ''}`}
+      style={{ left: rendered.x, top: rendered.y }}
+    >
+      <span
+        className="floating-collab-grip"
+        role="button"
+        tabIndex={0}
+        aria-label="Move collaboration indicator"
+        onPointerDown={startDrag}
+        onKeyDown={onGripKeyDown}
+      >
+        <GripVertical size={14} strokeWidth={1.5} aria-hidden />
+      </span>
+      <PresenceIndicators size="small" />
+    </div>
+  );
+}
+
+export default FloatingCollabIndicator;

--- a/src/ui/InlinePageTabs.tsx
+++ b/src/ui/InlinePageTabs.tsx
@@ -11,6 +11,8 @@ import { Icon } from './icons';
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
+import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useNotificationStore } from '../store/notificationStore';
 
 /**
  * Context menu state for page tabs.
@@ -58,7 +60,18 @@ export function InlinePageTabs() {
     [setActivePage, editingPageId]
   );
 
+  const sharedOffline = useSharedDocOffline();
+
+  // Blocked while a shared doc is offline (JP-334): the relay is active-page-only,
+  // so a new offline page's shapes never reach its flatten and are lost on
+  // reconnect. Enabling offline creation is JP-335.
   const handleAddPage = useCallback(() => {
+    if (sharedDocOffline()) {
+      useNotificationStore
+        .getState()
+        .warning('This shared document is offline — reconnect to add pages.');
+      return;
+    }
     const newPageId = createPage();
     setActivePage(newPageId);
     useHistoryStore.getState().setActivePage(newPageId);
@@ -187,7 +200,14 @@ export function InlinePageTabs() {
           );
         })}
       </div>
-      <button className="inline-tab-add" onClick={handleAddPage} title="Add page" aria-label="Add page">
+      <button
+        className="inline-tab-add"
+        onClick={handleAddPage}
+        aria-disabled={sharedOffline}
+        style={sharedOffline ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+        title={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add page'}
+        aria-label="Add page"
+      >
         <Icon icon={Plus} size={14} />
       </button>
 

--- a/src/ui/PageTabs.tsx
+++ b/src/ui/PageTabs.tsx
@@ -13,6 +13,8 @@ import { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
+import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useNotificationStore } from '../store/notificationStore';
 import './PageTabs.css';
 
 /**
@@ -219,8 +221,18 @@ export function PageTabs() {
     setDragOverId(null);
   }, []);
 
-  // Handle add page
+  const sharedOffline = useSharedDocOffline();
+
+  // Handle add page. Blocked while a shared doc is offline (JP-334): the relay is
+  // active-page-only, so a new offline page's shapes never reach its flatten and
+  // are lost on reconnect. Enabling offline creation is JP-335.
   const handleAddPage = useCallback(() => {
+    if (sharedDocOffline()) {
+      useNotificationStore
+        .getState()
+        .warning('This shared document is offline — reconnect to add pages.');
+      return;
+    }
     const newPageId = createPage();
     setActivePage(newPageId);
     useHistoryStore.getState().setActivePage(newPageId);
@@ -299,7 +311,13 @@ export function PageTabs() {
         })}
       </div>
 
-      <button className="page-tab-add" onClick={handleAddPage} title="Add new page">
+      <button
+        className="page-tab-add"
+        onClick={handleAddPage}
+        aria-disabled={sharedOffline}
+        style={sharedOffline ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+        title={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add new page'}
+      >
         +
       </button>
 

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -15,6 +15,8 @@ import { Plus } from 'lucide-react';
 import { Icon } from './icons';
 import { createPortal } from 'react-dom';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useNotificationStore } from '../store/notificationStore';
 import './RichTextTabBar.css';
 
 interface RichTextTabBarProps {
@@ -144,8 +146,18 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
     });
   }, []);
 
-  // Handle add new page
+  const sharedOffline = useSharedDocOffline();
+
+  // Handle add new page. Blocked while a shared doc is offline (JP-334): a new
+  // prose page can't be seeded offline without risking dual-lineage duplication
+  // (the relay is the sole seeder, JP-284). Enabling offline creation is JP-335.
   const handleAddPage = useCallback(() => {
+    if (sharedDocOffline()) {
+      useNotificationStore
+        .getState()
+        .warning('This shared document is offline — reconnect to add pages.');
+      return;
+    }
     const newId = createPage();
     setActivePage(newId);
   }, [createPage, setActivePage]);
@@ -256,7 +268,9 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
       <button
         className="rich-text-add-tab"
         onClick={handleAddPage}
-        title="Add new page"
+        aria-disabled={sharedOffline}
+        style={sharedOffline ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+        title={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add new page'}
         aria-label="Add new page"
       >
         <Icon icon={Plus} />

--- a/src/ui/floatingPosition.test.ts
+++ b/src/ui/floatingPosition.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampToViewport,
+  resolveIndicatorPosition,
+  VIEWPORT_MARGIN,
+  DEFAULT_TOP,
+} from './floatingPosition';
+
+const SIZE = { w: 120, h: 40 };
+const VP = { w: 1000, h: 800 };
+
+describe('clampToViewport', () => {
+  it('leaves an in-bounds point untouched', () => {
+    expect(clampToViewport({ x: 300, y: 200 }, SIZE, VP)).toEqual({ x: 300, y: 200 });
+  });
+
+  it('pins to the margin when past the left/top edges', () => {
+    expect(clampToViewport({ x: -50, y: -50 }, SIZE, VP)).toEqual({
+      x: VIEWPORT_MARGIN,
+      y: VIEWPORT_MARGIN,
+    });
+  });
+
+  it('pulls back from the right edge by element width + margin', () => {
+    const { x } = clampToViewport({ x: 5000, y: 100 }, SIZE, VP);
+    expect(x).toBe(VP.w - SIZE.w - VIEWPORT_MARGIN); // 1000 - 120 - 16 = 864
+  });
+
+  it('pulls back from the bottom edge by element height + margin', () => {
+    const { y } = clampToViewport({ x: 100, y: 5000 }, SIZE, VP);
+    expect(y).toBe(VP.h - SIZE.h - VIEWPORT_MARGIN); // 800 - 40 - 16 = 744
+  });
+
+  it('pins to the top-left margin when the element is larger than the room', () => {
+    const tiny = { w: 50, h: 50 };
+    expect(clampToViewport({ x: 10, y: 10 }, { w: 200, h: 200 }, tiny)).toEqual({
+      x: VIEWPORT_MARGIN,
+      y: VIEWPORT_MARGIN,
+    });
+  });
+});
+
+describe('resolveIndicatorPosition', () => {
+  it('defaults a null position to the top-right anchor', () => {
+    expect(resolveIndicatorPosition(null, SIZE, VP)).toEqual({
+      x: VP.w - SIZE.w - VIEWPORT_MARGIN, // 864
+      y: DEFAULT_TOP, // 64
+    });
+  });
+
+  it('clamps a stored position that is now off-screen after a resize', () => {
+    const stored = { x: 980, y: 790 }; // valid on a big screen, off a small one
+    const small = { w: 600, h: 400 };
+    expect(resolveIndicatorPosition(stored, SIZE, small)).toEqual({
+      x: small.w - SIZE.w - VIEWPORT_MARGIN, // 464
+      y: small.h - SIZE.h - VIEWPORT_MARGIN, // 344
+    });
+  });
+
+  it('keeps an in-bounds stored position', () => {
+    expect(resolveIndicatorPosition({ x: 200, y: 150 }, SIZE, VP)).toEqual({
+      x: 200,
+      y: 150,
+    });
+  });
+});

--- a/src/ui/floatingPosition.ts
+++ b/src/ui/floatingPosition.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure positioning helpers for the floating collaboration indicator (JP-315).
+ *
+ * Kept dependency-free and side-effect-free so the placement logic — default
+ * anchor + viewport clamping — is unit-testable without a DOM.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  w: number;
+  h: number;
+}
+
+export interface Viewport {
+  w: number;
+  h: number;
+}
+
+/** Gap (px) kept between the indicator and the viewport edges. */
+export const VIEWPORT_MARGIN = 16;
+
+/** Default vertical offset (px) of the top-right anchor — clears the toolbar. */
+export const DEFAULT_TOP = 64;
+
+/**
+ * Clamp a top-left point so the element stays fully on screen, never closer
+ * than `margin` to any edge. When the element is wider/taller than the room
+ * available, it pins to the top-left margin rather than going off the left/top.
+ */
+export function clampToViewport(
+  pos: Point,
+  size: Size,
+  viewport: Viewport,
+  margin: number = VIEWPORT_MARGIN
+): Point {
+  const maxX = Math.max(margin, viewport.w - size.w - margin);
+  const maxY = Math.max(margin, viewport.h - size.h - margin);
+  return {
+    x: Math.min(Math.max(pos.x, margin), maxX),
+    y: Math.min(Math.max(pos.y, margin), maxY),
+  };
+}
+
+/**
+ * Resolve the effective top-left for the indicator. A `null` stored position
+ * falls back to the top-right anchor; a stored position is clamped into the
+ * current viewport (so a window resize can never strand it off-screen).
+ */
+export function resolveIndicatorPosition(
+  stored: Point | null,
+  size: Size,
+  viewport: Viewport
+): Point {
+  if (stored == null) {
+    return clampToViewport(
+      { x: viewport.w - size.w - VIEWPORT_MARGIN, y: DEFAULT_TOP },
+      size,
+      viewport
+    );
+  }
+  return clampToViewport(stored, size, viewport);
+}

--- a/src/ui/proseLeavingPageGuard.test.ts
+++ b/src/ui/proseLeavingPageGuard.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { shouldPersistLeavingPage } from './proseLeavingPageGuard';
+
+describe('shouldPersistLeavingPage (JP-334)', () => {
+  it('persists when the editor is bound to the page being left', () => {
+    expect(shouldPersistLeavingPage('page-a', 'page-a')).toBe(true);
+  });
+
+  it('skips when the editor belongs to a different page (the read-only-page desync)', () => {
+    // Leaving read-only page B, but the mounted editor is the incoming page A —
+    // an unguarded save would write A's content into B's slot.
+    expect(shouldPersistLeavingPage('page-a', 'page-b')).toBe(false);
+  });
+
+  it('skips when no editor is mounted (read-only ProsePreview page)', () => {
+    expect(shouldPersistLeavingPage(null, 'page-b')).toBe(false);
+  });
+
+  it('skips when there is no leaving page', () => {
+    expect(shouldPersistLeavingPage('page-a', null)).toBe(false);
+    expect(shouldPersistLeavingPage(null, null)).toBe(false);
+  });
+});

--- a/src/ui/proseLeavingPageGuard.ts
+++ b/src/ui/proseLeavingPageGuard.ts
@@ -1,0 +1,18 @@
+/**
+ * JP-334: the page-switch effect saves "the page we are leaving" from the
+ * currently-mounted editor. That's only correct when the editor is actually
+ * bound to that page. When a read-only page is involved (an offline-created
+ * page renders `ProsePreview`, no editor), the mounted `editor`,
+ * `lastActivePageRef`, and `activePageId` fall out of lockstep, and the save
+ * would write the *incoming* editable page's content into the *leaving*
+ * (read-only) page's `richTextPages` slot — cross-page contamination.
+ *
+ * Guard the save on this: only persist when the editor's bound page id matches
+ * the page being left.
+ */
+export function shouldPersistLeavingPage(
+  editorPageId: string | null,
+  leavingPageId: string | null,
+): boolean {
+  return editorPageId != null && editorPageId === leavingPageId;
+}


### PR DESCRIPTION
Promotes current `master` to `staging` for E2E verification.

## What's being deployed (master ahead of staging)

- **JP-338 (#250) — prose body-doubling fix** *(primary; launch-blocking)*. Write/hydrate CRDT-lineage asymmetry: deterministic first-seed prevention + `body×2` self-heal (relay hydration repair + client adopt heal).
- **JP-337 (#249) — field/reference order-array dedupe** (the deferred JP-330 tail; fixes `set_fields` 9→18).
- **JP-315 (#248)** — floating, movable collab indicator (hides when alone).
- **JP-336 (#247)** — MCP canvas-page parity (`reorder_canvas_page` / `delete_canvas_page`).
- **JP-334 (#246)** — contain offline-collab page contamination.

## E2E focus on staging

- **JP-338:** `get_prose(doc-0s_cyeEQOYAM)` per page → single `<h1>`/body; a save persists single content; newly MCP-authored pages do **not** dup on reload; an already-poisoned client heals on next sync via the propagated delete (hard reload if stuck).
- **JP-337:** `list_fields(doc-0s_cyeEQOYAM)` → count 9; a save persists `fields.order` length 9.

CI `migrate` job (`supabase db push`) gates the web deploy as usual; relay image publishes to GHCR from this branch.

Assisted-by: Opus 4.8