### PR TITLE
JP-339 (Slice A): make the prose page-list collaborative

### DIFF
--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1372,14 +1372,14 @@ fn add_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String
         Ok(page_id)
     })?;
 
-    // JP-238: the page list (name/order) is JSON-only (not CRDT-synced), so the
-    // metadata write above always runs. Additionally seed the live `prose:<id>`
-    // fragment when the doc is resident, so the content is in the Y.Doc for when
-    // the tab surfaces (its live appearance awaits prose page-list sync, JP-171).
+    // Seed the live `prose:<id>` fragment when resident, so the content is in the
+    // Y.Doc for the new tab. JP-339: ALSO push the `prosePages` metadata delta so
+    // the tab itself surfaces live — no reload (the JP-338 dup trigger).
     if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
         let framed = handle.replace_prose(&id, &html)?;
         ctx.broadcast_update(&parsed.doc_id, framed);
     }
+    broadcast_prose_page_meta(ctx, &parsed.doc_id, &id);
 
     // JP-328: surface what the structural gate healed in the new page's content.
     let fixes = crate::sync::validate_prose_html(&html);
@@ -1493,6 +1493,9 @@ fn rename_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Str
         stamp_doc_modified(doc, now);
         Ok(())
     })?;
+
+    // JP-339: push the rename to connected clients live (no reload).
+    broadcast_prose_page_meta(ctx, &parsed.doc_id, &parsed.page_id);
 
     Ok(ToolOutcome {
         result: json!({"pageId": parsed.page_id, "name": name}),
@@ -2309,6 +2312,31 @@ fn resident_handle(ctx: &ToolContext, doc_id: &DocId) -> Option<Arc<DocHandle>> 
     ctx.registry.get(&ctx.workspace_id, doc_id)
 }
 
+/// The full stored metadata object for a prose page (incl. content), read from
+/// the just-persisted JSON — the source the live page-list write strips content
+/// from. `None` if the doc or page is absent. (JP-339)
+fn read_prose_page_json(ctx: &ToolContext, doc_id: &DocId, page_id: &str) -> Option<Value> {
+    let doc = ctx.team.get_document(&ctx.workspace_id, doc_id).ok()?;
+    doc.get("richTextPages")
+        .and_then(|r| r.get("pages"))
+        .and_then(|p| p.get(page_id))
+        .cloned()
+}
+
+/// Push a prose page-list metadata upsert to connected clients (JP-339): when the
+/// doc is resident, broadcast the `prosePages` delta for `page_id` (read from the
+/// just-persisted JSON) so the tab appears/renames LIVE — removing the reload that
+/// triggered the JP-338 prose dup. No-op when the doc isn't resident (a cold
+/// `changed_doc_id` nudge still reloads it).
+fn broadcast_prose_page_meta(ctx: &ToolContext, doc_id: &DocId, page_id: &str) {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
+        if let Some(page) = read_prose_page_json(ctx, doc_id, page_id) {
+            let framed = handle.set_prose_page_meta(page_id, &page);
+            ctx.broadcast_update(doc_id, framed);
+        }
+    }
+}
+
 /// Write a prose page's full HTML to the **live** Y.Doc fragment when the doc is
 /// resident — broadcasting the CRDT delta so connected editors update live
 /// (JP-238, whole-page replace) — else fall back to the JSON path. The live path
@@ -3071,11 +3099,13 @@ fn delete_prose_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Str
         Ok(())
     })?;
 
-    // If resident, blank the live fragment so a connected editor's view of the
-    // (now-delisted) page clears immediately. The tab itself may linger until
-    // reload — the prose page list isn't live-synced (JP-171).
+    // If resident, blank the live fragment AND remove the tab from the live
+    // `prosePages` list (JP-339), so a connected client's view of the page clears
+    // and the tab disappears immediately — no reload.
     if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
         let framed = handle.clear_prose(&parsed.page_id);
+        ctx.broadcast_update(&parsed.doc_id, framed);
+        let framed = handle.remove_prose_page(&parsed.page_id);
         ctx.broadcast_update(&parsed.doc_id, framed);
     }
 
@@ -3191,6 +3221,12 @@ fn reorder_prose_pages(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, S
         stamp_doc_modified(doc, now_ms());
         Ok(())
     })?;
+
+    // JP-339: push the new tab order to connected clients live (no reload).
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let framed = handle.set_prose_page_order(&parsed.order);
+        ctx.broadcast_update(&parsed.doc_id, framed);
+    }
 
     Ok(ToolOutcome {
         result: json!({"order": parsed.order, "ok": true}),
@@ -4307,6 +4343,36 @@ mod tests {
         assert!(html.contains("<strong>bold</strong>"));
         assert!(html.contains("<li>one</li>"));
         assert_eq!(got.result["page"]["name"], "Overview");
+    }
+
+    #[test]
+    fn add_prose_page_surfaces_in_live_prose_page_list_when_resident() {
+        // JP-339: on a resident doc, add_prose_page must write the new tab into
+        // the live `prosePages`/`prosePageOrder` shared types (so connected
+        // clients see it without reload). We prove it by flattening the live
+        // handle — flatten reads the page list FROM the Y.Doc.
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".into()).unwrap();
+        let handle = f.make_resident("doc1");
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.add_prose_page",
+            &json!({"docId": "doc1", "name": "Live Tab", "content": "body"}),
+        )
+        .unwrap();
+        let page_id = out.result["id"].as_str().unwrap().to_string();
+
+        let mut json = f.team.get_document(&ws, &doc_id).unwrap();
+        assert!(handle.flatten_into(&mut json));
+        let rtp = &json["richTextPages"];
+        assert_eq!(rtp["pages"][&page_id]["name"], "Live Tab", "tab in live page list");
+        assert!(
+            rtp["pageOrder"].as_array().unwrap().iter().any(|v| v.as_str() == Some(&page_id)),
+            "new tab id present in flattened pageOrder"
+        );
     }
 
     #[test]

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -255,6 +255,91 @@ pub fn project_fields_into(doc: &Doc, json: &mut Value) {
     }
 }
 
+/// Project the live prose page LIST — `prosePages` `Y.Map` (id → metadata) +
+/// `prosePageOrder` `Y.Array` — into `json["richTextPages"].{pages,pageOrder}`
+/// (JP-339). The write projection paired with
+/// [`super::hydration::json_prose_pages_to_ydoc`]: the relay owns the page list
+/// in the authoritative `Y.Doc`, so every flatten re-asserts the merged set
+/// (live MCP/peer add/rename/reorder/delete).
+///
+/// Runs AFTER [`project_prose_into`] (the content overlay) so each page's
+/// `content` is already in place; this merges only the tab METADATA
+/// (name/color/order/timestamps) and **never touches `content`**. Pages present
+/// in JSON but absent from the map are pruned (a propagated delete);
+/// `activePageId` is repointed if it was the pruned page.
+///
+/// **Empty map ⇒ no-op.** Unlike references/fields, a prose doc always keeps ≥1
+/// page (the "never delete the last page" invariant), so an empty `prosePages`
+/// is never a legitimate "all deleted" — it means the relay carries no
+/// authoritative list (e.g. a pre-feature sidecar that somehow skipped
+/// hydration). Leaving the JSON (incl. the content overlay) intact is the safe
+/// choice; we never wipe the page list off an empty map.
+pub fn project_prose_pages_into(doc: &Doc, json: &mut Value) {
+    let prose_pages = doc.get_or_insert_map("prosePages");
+    let prose_page_order = doc.get_or_insert_array("prosePageOrder");
+
+    let (pages_any, order_any) = {
+        let txn = doc.transact();
+        (prose_pages.to_json(&txn), prose_page_order.to_json(&txn))
+    };
+
+    let Any::Map(meta_map) = &pages_any else {
+        return;
+    };
+    if meta_map.is_empty() {
+        return;
+    }
+
+    let Some(obj) = json.as_object_mut() else {
+        return;
+    };
+    let rtp = obj
+        .entry("richTextPages")
+        .or_insert_with(|| json!({"pages": {}, "pageOrder": []}));
+    let Some(rtp) = rtp.as_object_mut() else {
+        return;
+    };
+
+    // Merge each page's metadata, preserving its `content` (set by
+    // `project_prose_into`); create the entry if it's live-only.
+    let pages_map = rtp.entry("pages").or_insert_with(|| json!({}));
+    if let Some(pages_map) = pages_map.as_object_mut() {
+        for (id, meta) in meta_map.iter() {
+            let Any::Map(fields) = meta else { continue };
+            let page = pages_map
+                .entry(id.clone())
+                .or_insert_with(|| json!({"id": id, "content": ""}));
+            if let Some(page) = page.as_object_mut() {
+                for (k, v) in fields.iter() {
+                    if k == "content" {
+                        continue; // never overwrite content with metadata
+                    }
+                    page.insert(k.clone(), any_to_json(v));
+                }
+            }
+        }
+        // Prune pages the authoritative map no longer contains (a delete).
+        pages_map.retain(|id, _| meta_map.contains_key(id.as_str()));
+    }
+
+    // Rewrite `pageOrder` from the deduped order array, dropping orphans.
+    let order_ids = order_string_ids(&order_any);
+    let present = |id: &str| meta_map.contains_key(id);
+    let deduped = super::dedupe_order(order_ids, present);
+    // Repoint a now-orphaned activePageId to the first surviving page.
+    if let Some(active) = rtp.get("activePageId").and_then(Value::as_str) {
+        if !deduped.iter().any(|id| id == active) {
+            if let Some(first) = deduped.first() {
+                rtp.insert("activePageId".to_string(), Value::String(first.clone()));
+            }
+        }
+    }
+    rtp.insert(
+        "pageOrder".to_string(),
+        Value::Array(deduped.into_iter().map(Value::String).collect()),
+    );
+}
+
 /// Borrow the string ids out of an order `Any::Array` (e.g. `shapeOrder` /
 /// `fieldOrder` / `referenceOrder`), skipping any non-string entries. Pairs with
 /// [`super::dedupe_order`] for the flatten-side dedupe.
@@ -615,5 +700,92 @@ mod tests {
         project_fields_into(&doc, &mut json);
         assert_eq!(json["fields"]["fields"], json!({}));
         assert_eq!(json["fields"]["order"], json!([]));
+    }
+
+    // ---- JP-339: prose page-list projection ----
+
+    /// A Y.Doc carrying a `prosePages` map (`id` → meta, no content) +
+    /// `prosePageOrder`, mirroring what the relay holds for a live doc.
+    fn doc_with_prose_pages(entries: &[(&str, &str, u32)]) -> Doc {
+        use yrs::{Array, Map};
+        let doc = Doc::new();
+        let pages = doc.get_or_insert_map("prosePages");
+        let order = doc.get_or_insert_array("prosePageOrder");
+        let mut txn = doc.transact_mut();
+        for (id, name, ord) in entries {
+            pages.insert(
+                &mut txn,
+                (*id).to_string(),
+                super::super::hydration::json_to_any(&json!({"id": id, "name": name, "order": ord})),
+            );
+            order.push_back(&mut txn, Any::String((*id).into()));
+        }
+        drop(txn);
+        doc
+    }
+
+    #[test]
+    fn project_prose_pages_merges_metadata_preserving_content() {
+        let doc = doc_with_prose_pages(&[("rt-page-1", "Renamed", 0), ("rt-2", "Notes", 1)]);
+        // Content already overlaid by project_prose_into; the page-list projection
+        // must merge name/order WITHOUT touching content.
+        let mut json = json!({
+            "id": "d",
+            "richTextPages": {
+                "pageOrder": ["rt-page-1"],
+                "pages": {
+                    "rt-page-1": {"id": "rt-page-1", "name": "Page 1", "order": 0, "content": "<p>body</p>"}
+                }
+            }
+        });
+        project_prose_pages_into(&doc, &mut json);
+        let rtp = &json["richTextPages"];
+        assert_eq!(rtp["pages"]["rt-page-1"]["name"], json!("Renamed"), "rename merged");
+        assert_eq!(rtp["pages"]["rt-page-1"]["content"], json!("<p>body</p>"), "content preserved");
+        assert_eq!(rtp["pages"]["rt-2"]["name"], json!("Notes"), "live-only page created");
+        assert_eq!(rtp["pageOrder"], json!(["rt-page-1", "rt-2"]));
+    }
+
+    #[test]
+    fn project_prose_pages_prunes_a_deleted_page_and_repoints_active() {
+        let doc = doc_with_prose_pages(&[("rt-2", "Notes", 0)]); // rt-page-1 deleted
+        let mut json = json!({
+            "id": "d",
+            "richTextPages": {
+                "activePageId": "rt-page-1",
+                "pageOrder": ["rt-page-1", "rt-2"],
+                "pages": {
+                    "rt-page-1": {"id": "rt-page-1", "name": "Page 1", "content": "<p>a</p>"},
+                    "rt-2": {"id": "rt-2", "name": "Notes", "content": "<p>b</p>"}
+                }
+            }
+        });
+        project_prose_pages_into(&doc, &mut json);
+        let rtp = &json["richTextPages"];
+        assert!(rtp["pages"].get("rt-page-1").is_none(), "deleted page pruned");
+        assert_eq!(rtp["pageOrder"], json!(["rt-2"]));
+        assert_eq!(rtp["activePageId"], json!("rt-2"), "orphaned active repointed");
+    }
+
+    #[test]
+    fn project_prose_pages_empty_map_is_noop_never_wipes() {
+        // An empty prosePages map must NOT wipe the JSON page list (a prose doc
+        // always keeps ≥1 page; empty means "no authoritative list").
+        let doc = Doc::new();
+        let mut json = json!({
+            "id": "d",
+            "richTextPages": {"pageOrder": ["rt-page-1"], "pages": {"rt-page-1": {"id": "rt-page-1", "name": "Page 1", "content": "<p>keep</p>"}}}
+        });
+        project_prose_pages_into(&doc, &mut json);
+        assert_eq!(json["richTextPages"]["pages"]["rt-page-1"]["content"], json!("<p>keep</p>"));
+        assert_eq!(json["richTextPages"]["pageOrder"], json!(["rt-page-1"]));
+    }
+
+    #[test]
+    fn project_prose_pages_empty_map_does_not_synthesize_richtextpages() {
+        let doc = Doc::new();
+        let mut json = json!({"id": "d"});
+        project_prose_pages_into(&doc, &mut json);
+        assert!(json.get("richTextPages").is_none(), "no synth for a doc that never had prose");
     }
 }

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -240,6 +240,65 @@ pub fn json_fields_to_ydoc(doc_json: &Value, doc: &Doc) {
     }
 }
 
+/// Seed the `prosePages` `Y.Map` (id → page metadata) + `prosePageOrder`
+/// `Y.Array` from a persisted document's `richTextPages.{pages,pageOrder}`
+/// (JP-339). The relay owns the prose page LIST in the authoritative `Y.Doc` so
+/// MCP and editor tab edits (add/rename/reorder/delete) converge **per item** and
+/// surface live — no reload (which was the JP-338 dup trigger).
+///
+/// Metadata ONLY — the per-page `content` is **stripped** here; it lives in the
+/// `prose:<id>` fragment ([`json_prose_to_ydoc`]) and must not be double-owned.
+///
+/// **Idempotent — only seeds an EMPTY map** (mirrors [`json_fields_to_ydoc`] /
+/// [`json_references_to_ydoc`]): a populated map means the sidecar is
+/// authoritative, so leave it; an older sidecar with no `prosePages` map gets it
+/// backfilled from JSON. The order is deduped (JP-337) so an already-doubled
+/// source `pageOrder` hydrates clean.
+pub fn json_prose_pages_to_ydoc(doc_json: &Value, doc: &Doc) {
+    let prose_pages = doc.get_or_insert_map("prosePages");
+    let prose_page_order = doc.get_or_insert_array("prosePageOrder");
+
+    let mut txn = doc.transact_mut();
+
+    if prose_pages.len(&txn) > 0 {
+        return;
+    }
+
+    let Some(rtp) = doc_json.get("richTextPages") else {
+        return;
+    };
+    let pages = rtp.get("pages").and_then(Value::as_object);
+    if let Some(pages) = pages {
+        for (id, page) in pages {
+            prose_pages.insert(&mut txn, id.clone(), prose_page_meta_any(id, page));
+        }
+    }
+    if let Some(order) = rtp.get("pageOrder").and_then(Value::as_array) {
+        let present = |id: &str| pages.is_some_and(|m| m.contains_key(id));
+        for id in super::dedupe_order(order.iter().filter_map(Value::as_str), present) {
+            prose_page_order.push_back(&mut txn, Any::String(id.as_str().into()));
+        }
+    }
+}
+
+/// Build the CRDT `Any::Map` for one prose page's metadata — every field of the
+/// stored page object EXCEPT `content` (which is owned by the `prose:<id>`
+/// fragment). Guarantees an `id`. Mirrors the client's `ProsePageMeta`.
+pub(super) fn prose_page_meta_any(id: &str, page: &Value) -> Any {
+    let mut map: HashMap<String, Any> = HashMap::new();
+    if let Some(obj) = page.as_object() {
+        for (k, v) in obj {
+            if k == "content" {
+                continue;
+            }
+            map.insert(k.clone(), json_to_any(v));
+        }
+    }
+    map.entry("id".to_string())
+        .or_insert_with(|| Any::String(id.into()));
+    Any::Map(Arc::new(map))
+}
+
 /// Whether a parsed prose block carries real content — any non-whitespace text,
 /// or an embed (image / horizontal rule). A bare/empty paragraph (the empty-page
 /// placeholder) has none, so it isn't seeded.
@@ -640,6 +699,83 @@ mod tests {
         super::json_fields_to_ydoc(&json!({"id": "d"}), &doc);
         let fields = doc.get_or_insert_map("fields");
         assert_eq!(fields.len(&doc.transact()), 0);
+    }
+
+    // ---- JP-339: prose page-list seeding ----
+
+    fn prose_pages_json() -> Value {
+        json!({
+            "id": "d",
+            "richTextPages": {
+                "pageOrder": ["rt-page-1", "rt-2"],
+                "pages": {
+                    "rt-page-1": {"id": "rt-page-1", "name": "Page 1", "order": 0,
+                                  "content": "<p>hello</p>", "createdAt": 1, "modifiedAt": 2},
+                    "rt-2": {"id": "rt-2", "name": "Notes", "color": "#abc", "order": 1,
+                             "content": "<p>notes</p>", "createdAt": 3, "modifiedAt": 4}
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn json_prose_pages_to_ydoc_seeds_metadata_and_order_without_content() {
+        let doc = Doc::new();
+        super::json_prose_pages_to_ydoc(&prose_pages_json(), &doc);
+        let pages = doc.get_or_insert_map("prosePages");
+        let order = doc.get_or_insert_array("prosePageOrder");
+        let txn = doc.transact();
+        assert_eq!(pages.len(&txn), 2);
+        assert_eq!(order.len(&txn), 2);
+        // Metadata is present; content is stripped (it lives in the fragment).
+        let Some(yrs::Out::Any(Any::Map(meta))) = pages.get(&txn, "rt-2") else {
+            panic!("rt-2 meta missing");
+        };
+        assert!(matches!(meta.get("name"), Some(Any::String(s)) if s.as_ref() == "Notes"));
+        assert!(matches!(meta.get("color"), Some(Any::String(s)) if s.as_ref() == "#abc"));
+        assert!(meta.get("content").is_none(), "content must NOT be in the page-list meta");
+    }
+
+    #[test]
+    fn json_prose_pages_to_ydoc_is_idempotent_only_seeds_empty() {
+        let doc = Doc::new();
+        super::json_prose_pages_to_ydoc(&prose_pages_json(), &doc);
+        // Re-run with a different list — a populated map must not be re-seeded.
+        super::json_prose_pages_to_ydoc(
+            &json!({"richTextPages": {"pageOrder": ["x"], "pages": {"x": {"id": "x", "name": "X"}}}}),
+            &doc,
+        );
+        let pages = doc.get_or_insert_map("prosePages");
+        let txn = doc.transact();
+        assert_eq!(pages.len(&txn), 2, "second seed must no-op on a populated map");
+        assert!(!pages.contains_key(&txn, "x"));
+    }
+
+    #[test]
+    fn json_prose_pages_to_ydoc_dedupes_doubled_order() {
+        let doc = Doc::new();
+        super::json_prose_pages_to_ydoc(
+            &json!({
+                "richTextPages": {
+                    "pageOrder": ["rt-page-1", "rt-2", "rt-page-1", "rt-2", "ghost"],
+                    "pages": {
+                        "rt-page-1": {"id": "rt-page-1", "name": "Page 1"},
+                        "rt-2": {"id": "rt-2", "name": "Notes"}
+                    }
+                }
+            }),
+            &doc,
+        );
+        let order = doc.get_or_insert_array("prosePageOrder");
+        assert_eq!(order.len(&doc.transact()), 2, "doubled order + orphan hydrates to 2");
+    }
+
+    #[test]
+    fn json_prose_pages_to_ydoc_noop_without_richtextpages() {
+        let doc = Doc::new();
+        super::json_prose_pages_to_ydoc(&json!({"id": "d", "name": "x"}), &doc);
+        let pages = doc.get_or_insert_map("prosePages");
+        assert_eq!(pages.len(&doc.transact()), 0);
     }
 
     // ---- JP-330 forensic repro: shapeOrder doubling ------------------------

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -208,6 +208,10 @@ impl DocHandle {
                                 hydration::json_references_to_ydoc(doc_json, &doc);
                                 // Phase 3c: same backstop for the field library.
                                 hydration::json_fields_to_ydoc(doc_json, &doc);
+                                // JP-339: same backstop for the prose page list
+                                // (an older sidecar with no `prosePages` map gets
+                                // it backfilled from `richTextPages`; idempotent).
+                                hydration::json_prose_pages_to_ydoc(doc_json, &doc);
                                 // JP-338 self-heal: collapse any prose fragment
                                 // that hydrated as an exact `body+body` double
                                 // (write-vs-hydrate lineage merge); dirty so the
@@ -235,6 +239,10 @@ impl DocHandle {
         hydration::json_references_to_ydoc(doc_json, &doc);
         // Phase 3c: same for the field library.
         hydration::json_fields_to_ydoc(doc_json, &doc);
+        // JP-339: seed the prose page LIST (tab metadata) so MCP/editor tab edits
+        // converge per item and surface live — removing the reload that triggered
+        // the JP-338 dup. Metadata only; content stays in the `prose:<id>` seed.
+        hydration::json_prose_pages_to_ydoc(doc_json, &doc);
         // JP-338 self-heal: a doc whose persisted `richTextPages` content was
         // already doubled hydrates doubled (the deterministic seed faithfully
         // re-creates `body+body`); collapse it here so the live doc — and the
@@ -359,6 +367,10 @@ impl DocHandle {
         flatten::project_references_into(&self.doc, json);
         // Phase 3c: same for the field library (live MCP/peer field edits).
         flatten::project_fields_into(&self.doc, json);
+        // JP-339: re-assert the prose page LIST from the authoritative Y.Doc.
+        // After `project_prose_into` (content overlay) so content is preserved and
+        // only tab metadata/order is merged; prunes pages deleted in the Y.Doc.
+        flatten::project_prose_pages_into(&self.doc, json);
         true
     }
 
@@ -643,6 +655,92 @@ impl DocHandle {
     /// framed delta to broadcast; marks dirty.
     pub fn set_shape_order(&self, order: &[String]) -> Vec<u8> {
         let arr = self.doc.get_or_insert_array("shapeOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        let len = arr.len(&txn);
+        if len > 0 {
+            arr.remove_range(&mut txn, 0, len);
+        }
+        for id in order {
+            arr.push_back(&mut txn, Any::String(id.as_str().into()));
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
+    }
+
+    // ---- MCP prose page-LIST write surface (JP-339) ----
+    //
+    // The prose page list (tabs) lives in the authoritative Y.Doc as
+    // `prosePages` (id → metadata Y.Map) + `prosePageOrder` (Y.Array), mirroring
+    // the client's `YjsDocument`. These let the MCP page tools mutate the live
+    // list when a doc is resident — broadcasting the delta so connected clients
+    // see the tab add/rename/reorder/delete WITHOUT a reload (the JP-338 dup
+    // trigger). Durability is snapshot-driven (the JP-36 flatten projects the
+    // list back), identical to the prose-content write path.
+
+    /// Set/replace one prose page's metadata in `prosePages` (+ append its id to
+    /// `prosePageOrder` if new). `page_json` is the page's full stored object;
+    /// `content` is stripped (it's owned by the `prose:<id>` fragment). Per-item
+    /// (never a whole-map rewrite) so a concurrent writer's page isn't wiped.
+    /// Returns the framed delta to broadcast; marks dirty.
+    pub fn set_prose_page_meta(&self, page_id: &str, page_json: &Value) -> Vec<u8> {
+        let pages = self.doc.get_or_insert_map("prosePages");
+        let order = self.doc.get_or_insert_array("prosePageOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        pages.insert(
+            &mut txn,
+            page_id.to_string(),
+            hydration::prose_page_meta_any(page_id, page_json),
+        );
+        let already = order.iter(&txn).any(
+            |o| matches!(o, yrs::Out::Any(Any::String(s)) if s.as_ref() == page_id),
+        );
+        if !already {
+            order.push_back(&mut txn, Any::String(page_id.into()));
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
+    }
+
+    /// Remove one prose page from `prosePages` + `prosePageOrder` (a tab delete).
+    /// The page's `prose:<id>` fragment is cleared separately via
+    /// [`clear_prose`]. Returns the framed delta to broadcast; marks dirty.
+    pub fn remove_prose_page(&self, page_id: &str) -> Vec<u8> {
+        let pages = self.doc.get_or_insert_map("prosePages");
+        let order = self.doc.get_or_insert_array("prosePageOrder");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        pages.remove(&mut txn, page_id);
+        // Drop every occurrence from the order array (defensive against a
+        // pre-doubled array), scanning back-to-front so indices stay valid.
+        let ids: Vec<String> = order
+            .iter(&txn)
+            .filter_map(|o| match o {
+                yrs::Out::Any(Any::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect();
+        for (i, id) in ids.iter().enumerate().rev() {
+            if id == page_id {
+                order.remove(&mut txn, i as u32);
+            }
+        }
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
+    }
+
+    /// Replace `prosePageOrder` with `order` (clear + repush, one txn) — the tab
+    /// reorder. Mirrors [`set_shape_order`]; the caller validates `order` is a
+    /// permutation. Returns the framed delta to broadcast; marks dirty.
+    pub fn set_prose_page_order(&self, order: &[String]) -> Vec<u8> {
+        let arr = self.doc.get_or_insert_array("prosePageOrder");
         let mut txn = self.doc.transact_mut();
         let before = txn.before_state().clone();
         let len = arr.len(&txn);
@@ -1596,6 +1694,45 @@ mod tests {
         reg.evict(&ws, &doc);
         assert!(reg.is_empty());
         assert!(reg.get(&ws, &doc).is_none());
+    }
+
+    // ---- JP-339: prose page-LIST as a shared type ----
+
+    #[test]
+    fn prose_page_list_round_trips_through_hydrate_handle_and_flatten() {
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "activePageId": "rt-page-1",
+                "pageOrder": ["rt-page-1"],
+                "pages": {"rt-page-1": {"id": "rt-page-1", "name": "Page 1", "order": 0,
+                                        "content": "<p>hi</p>"}}
+            }
+        });
+        let handle = DocHandle::hydrate(&json, None, false);
+
+        // Add a tab live, reorder it ahead of the default, then flatten.
+        handle.set_prose_page_meta(
+            "rt-3",
+            &json!({"id": "rt-3", "name": "New", "order": 1, "content": "<p>ignored</p>"}),
+        );
+        handle.set_prose_page_order(&["rt-3".to_string(), "rt-page-1".to_string()]);
+
+        let mut out = json.clone();
+        assert!(handle.flatten_into(&mut out));
+        let rtp = &out["richTextPages"];
+        assert_eq!(rtp["pages"]["rt-3"]["name"], json!("New"), "added tab flattened");
+        assert_eq!(rtp["pages"]["rt-3"]["content"], json!(""), "meta carries no content");
+        assert_eq!(rtp["pages"]["rt-page-1"]["content"], json!("<p>hi</p>"), "content preserved");
+        assert_eq!(rtp["pageOrder"], json!(["rt-3", "rt-page-1"]), "reorder flattened");
+
+        // Now delete the added tab → it disappears from the flattened list.
+        handle.remove_prose_page("rt-3");
+        let mut out2 = json.clone();
+        assert!(handle.flatten_into(&mut out2));
+        assert!(out2["richTextPages"]["pages"].get("rt-3").is_none(), "deleted tab pruned");
+        assert_eq!(out2["richTextPages"]["pageOrder"], json!(["rt-page-1"]));
     }
 
     // ---- JP-89: reference library as a shared type ----

--- a/src/collaboration/YjsDocument.prosePages.test.ts
+++ b/src/collaboration/YjsDocument.prosePages.test.ts
@@ -1,0 +1,128 @@
+/**
+ * JP-339 — prose page LIST (tabs) as a Y.Doc shared type. Asserts the per-item
+ * `prosePages` Y.Map + `prosePageOrder` Y.Array round-trip, the order-array
+ * reorder, and — the headline guarantee — that a concurrent MCP-style add and an
+ * author-style add merge instead of clobbering (mirrors the fields/references
+ * concurrency tests / the relay's). Metadata only — page content lives in the
+ * `prose:<id>` fragment and is never carried here.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+import type { ProsePageMeta } from './YjsDocument';
+
+function page(id: string, name = id, order = 0): ProsePageMeta {
+  return { id, name, order };
+}
+
+describe('YjsDocument prose page-list (JP-339)', () => {
+  it('setProsePage stores per-item + appends order; getProsePageList merges', () => {
+    const doc = new YjsDocument();
+    doc.setProsePage(page('rt-page-1', 'Page 1', 0));
+    doc.setProsePage(page('rt-2', 'Notes', 1));
+
+    const list = doc.getProsePageList();
+    expect(Object.keys(list.pages).sort()).toEqual(['rt-2', 'rt-page-1']);
+    expect(list.pageOrder).toEqual(['rt-page-1', 'rt-2']);
+    expect(list.pages['rt-2']?.name).toBe('Notes');
+  });
+
+  it('re-setting an existing id is a metadata update, no duplicate order entry', () => {
+    const doc = new YjsDocument();
+    doc.setProsePage(page('rt-page-1', 'Page 1'));
+    doc.setProsePage(page('rt-page-1', 'Renamed'));
+    const list = doc.getProsePageList();
+    expect(list.pageOrder).toEqual(['rt-page-1']);
+    expect(list.pages['rt-page-1']?.name).toBe('Renamed');
+  });
+
+  it('deleteProsePage removes from the map and the order', () => {
+    const doc = new YjsDocument();
+    doc.setProsePage(page('a'));
+    doc.setProsePage(page('b'));
+    doc.deleteProsePage('a');
+    const list = doc.getProsePageList();
+    expect(list.pages['a']).toBeUndefined();
+    expect(list.pageOrder).toEqual(['b']);
+  });
+
+  it('setProsePageOrder reorders the tabs (array-driven order)', () => {
+    const doc = new YjsDocument();
+    doc.setProsePage(page('a'));
+    doc.setProsePage(page('b'));
+    doc.setProsePage(page('c'));
+    doc.setProsePageOrder(['c', 'a', 'b']);
+    expect(doc.getProsePageList().pageOrder).toEqual(['c', 'a', 'b']);
+  });
+
+  it('getProsePageList drops order ids with no page and appends unordered pages', () => {
+    const doc = new YjsDocument();
+    doc.getDoc().transact(() => {
+      doc.getDoc().getMap('prosePages').set('present', page('present'));
+      const order = doc.getDoc().getArray<string>('prosePageOrder');
+      order.push(['ghost', 'present', 'present']); // ghost has no page; dup id
+    });
+    const list = doc.getProsePageList();
+    expect(list.pageOrder).toEqual(['present']);
+  });
+
+  it('concurrent MCP-style add and author add BOTH survive (no clobber)', () => {
+    const relay = new YjsDocument();
+    const client = new YjsDocument();
+    Y.applyUpdate(client.getDoc(), Y.encodeStateAsUpdate(relay.getDoc()));
+
+    relay.setProsePage(page('rt-mcp', 'From MCP', 1));
+    client.setProsePage(page('rt-author', 'From Author', 1));
+
+    const relayUpdate = Y.encodeStateAsUpdate(relay.getDoc());
+    const clientUpdate = Y.encodeStateAsUpdate(client.getDoc());
+    Y.applyUpdate(client.getDoc(), relayUpdate);
+    Y.applyUpdate(relay.getDoc(), clientUpdate);
+
+    for (const doc of [relay, client]) {
+      const list = doc.getProsePageList();
+      expect(Object.keys(list.pages).sort()).toEqual(['rt-author', 'rt-mcp']);
+      expect([...list.pageOrder].sort()).toEqual(['rt-author', 'rt-mcp']);
+    }
+  });
+
+  it('onProsePagesChange fires for a remote update, not for a local write', () => {
+    const local = new YjsDocument();
+    const remote = new YjsDocument();
+    Y.applyUpdate(remote.getDoc(), Y.encodeStateAsUpdate(local.getDoc()));
+
+    let fired = 0;
+    local.onProsePagesChange(() => {
+      fired += 1;
+    });
+
+    local.setProsePage(page('local'));
+    expect(fired).toBe(0);
+
+    remote.setProsePage(page('fromRemote', 'Remote'));
+    Y.applyUpdate(local.getDoc(), Y.encodeStateAsUpdate(remote.getDoc()));
+    expect(fired).toBeGreaterThan(0);
+    expect(local.getProsePageList().pages['fromRemote']?.name).toBe('Remote');
+  });
+
+  it('two clients seeding the default rt-page-1 converge to a single page', () => {
+    // First-page identity reconciliation: a never-had-prose doc has both clients
+    // create the SAME deterministic id, so the map merge is LWW on one key and
+    // the order-array dup collapses in the merged snapshot.
+    const a = new YjsDocument();
+    const b = new YjsDocument();
+    Y.applyUpdate(b.getDoc(), Y.encodeStateAsUpdate(a.getDoc()));
+
+    a.setProsePage(page('rt-page-1', 'Page 1'));
+    b.setProsePage(page('rt-page-1', 'Page 1'));
+
+    Y.applyUpdate(a.getDoc(), Y.encodeStateAsUpdate(b.getDoc()));
+    Y.applyUpdate(b.getDoc(), Y.encodeStateAsUpdate(a.getDoc()));
+
+    for (const doc of [a, b]) {
+      const list = doc.getProsePageList();
+      expect(Object.keys(list.pages)).toEqual(['rt-page-1']);
+      expect(list.pageOrder).toEqual(['rt-page-1']);
+    }
+  });
+});

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -34,6 +34,33 @@ export interface YjsDocumentMetadata {
 }
 
 /**
+ * One prose page's metadata as a CRDT shared item (JP-339). Mirrors
+ * `RichTextPage` **without `content`** — page content lives in its own
+ * `prose:<id>` `Y.XmlFragment` (already CRDT-synced), so the page LIST syncs
+ * only the tab metadata (name/color/order/timestamps). Storing content here too
+ * would double-own it and fight the fragment.
+ */
+export interface ProsePageMeta {
+  id: string;
+  name: string;
+  color?: string;
+  order: number;
+  createdAt?: number;
+  modifiedAt?: number;
+}
+
+/**
+ * The merged prose page-list snapshot — `pages` (id → meta) + a de-duplicated
+ * `pageOrder` (filtered to existing pages, unordered pages appended). The
+ * binding bulk-reloads `richTextPagesStore` from this on any remote change.
+ * Mirrors {@link ReferenceLibrary} / {@link FieldLibrary}.
+ */
+export interface ProsePageList {
+  pages: Record<string, ProsePageMeta>;
+  pageOrder: string[];
+}
+
+/**
  * Callback for when shapes change from remote updates
  */
 export type ShapeChangeCallback = (
@@ -70,6 +97,16 @@ export type ReferenceChangeCallback = () => void;
 export type FieldChangeCallback = () => void;
 
 /**
+ * Callback for when the prose page-list changes from remote updates (JP-339).
+ * Coarse by design (no per-item args), mirroring {@link ReferenceChangeCallback}:
+ * the binding bulk-reloads `richTextPagesStore` from
+ * {@link YjsDocument.getProsePageList} — the merged snapshot — so a simultaneous
+ * MCP+author page add/rename/reorder can't clobber, and the merge preserves each
+ * page's already-synced `content`.
+ */
+export type ProsePagesChangeCallback = () => void;
+
+/**
  * YjsDocument wraps a Y.Doc for collaborative shape editing.
  *
  * Usage:
@@ -103,12 +140,18 @@ export class YjsDocument {
   // name (per-item merge, like `references`) + `fieldOrder` (display order).
   private fields: Y.Map<Field>;
   private fieldOrder: Y.Array<string>;
+  // JP-339: the prose page LIST as shared types — `prosePages` keyed by id
+  // (per-item merge, like `fields`) + `prosePageOrder` (tab order). Page content
+  // is NOT here — it stays in the per-page `prose:<id>` fragments.
+  private prosePages: Y.Map<ProsePageMeta>;
+  private prosePageOrder: Y.Array<string>;
 
   private shapeChangeCallbacks: Set<ShapeChangeCallback> = new Set();
   private orderChangeCallbacks: Set<OrderChangeCallback> = new Set();
   private metadataChangeCallbacks: Set<MetadataChangeCallback> = new Set();
   private referenceChangeCallbacks: Set<ReferenceChangeCallback> = new Set();
   private fieldChangeCallbacks: Set<FieldChangeCallback> = new Set();
+  private prosePagesChangeCallbacks: Set<ProsePagesChangeCallback> = new Set();
 
   private isLocalUpdate = false;
 
@@ -133,6 +176,8 @@ export class YjsDocument {
     this.referenceOrder = this.doc.getArray('referenceOrder');
     this.fields = this.doc.getMap('fields');
     this.fieldOrder = this.doc.getArray('fieldOrder');
+    this.prosePages = this.doc.getMap('prosePages');
+    this.prosePageOrder = this.doc.getArray('prosePageOrder');
 
     // Set up observers
     this.setupObservers();
@@ -423,6 +468,80 @@ export class YjsDocument {
     return { fields, order };
   }
 
+  // ============ Prose page-list (JP-339) — local to remote ============
+
+  /**
+   * Set or update one prose page's metadata (local change → broadcast to peers).
+   * INVARIANT A: a strictly per-item `set` (keyed by id) + append the id to
+   * `prosePageOrder` if new — never a whole-map rewrite, so a concurrent
+   * writer's not-yet-observed page can't be wiped. Re-setting an existing id is
+   * an in-place value update (LWW: rename/recolor/reorder) with no duplicate
+   * order entry. Content is untouched — it lives in the `prose:<id>` fragment.
+   */
+  setProsePage(meta: ProsePageMeta): void {
+    this.withLocalUpdate(() => {
+      this.prosePages.set(meta.id, JSON.parse(JSON.stringify(meta)));
+      if (!this.prosePageOrder.toArray().includes(meta.id)) {
+        this.prosePageOrder.push([meta.id]);
+      }
+    });
+  }
+
+  /**
+   * Replace `prosePageOrder` with `order` (clear + repush, one txn) — the tab
+   * reorder op. Mirrors {@link setShapeOrder}: ordering is driven by this
+   * Y.Array (not the meta `order` field), so a reorder rewrites it wholesale.
+   * The merged {@link getProsePageList} filters to existing pages and appends
+   * any unordered ones, so a concurrent add racing this rewrite is never lost,
+   * only ordered last.
+   */
+  setProsePageOrder(order: string[]): void {
+    this.withLocalUpdate(() => {
+      this.prosePageOrder.delete(0, this.prosePageOrder.length);
+      this.prosePageOrder.push(order);
+    });
+  }
+
+  /**
+   * Delete a prose page by id (per-item `delete` + drop it from
+   * `prosePageOrder`). The page's `prose:<id>` fragment is cleared separately.
+   */
+  deleteProsePage(id: string): void {
+    this.withLocalUpdate(() => {
+      this.prosePages.delete(id);
+      const idx = this.prosePageOrder.toArray().indexOf(id);
+      if (idx >= 0) this.prosePageOrder.delete(idx, 1);
+    });
+  }
+
+  /**
+   * The merged prose page-list snapshot — `pages` (id → meta) + a de-duplicated
+   * `pageOrder` (filtered to existing pages, with any unordered pages appended).
+   * The binding bulk-reloads `richTextPagesStore` from this on any remote
+   * change. Mirrors {@link getReferenceLibrary} / {@link getFieldLibrary}.
+   */
+  getProsePageList(): ProsePageList {
+    const pages: Record<string, ProsePageMeta> = {};
+    this.prosePages.forEach((meta, id) => {
+      pages[id] = meta;
+    });
+    const pageOrder: string[] = [];
+    const seen = new Set<string>();
+    for (const id of this.prosePageOrder.toArray()) {
+      if (pages[id] && !seen.has(id)) {
+        pageOrder.push(id);
+        seen.add(id);
+      }
+    }
+    for (const id of Object.keys(pages)) {
+      if (!seen.has(id)) {
+        pageOrder.push(id);
+        seen.add(id);
+      }
+    }
+    return { pages, pageOrder };
+  }
+
   // ============ Remote to Local Sync ============
 
   /**
@@ -465,6 +584,15 @@ export class YjsDocument {
   onFieldChange(callback: FieldChangeCallback): () => void {
     this.fieldChangeCallbacks.add(callback);
     return () => this.fieldChangeCallbacks.delete(callback);
+  }
+
+  /**
+   * Subscribe to prose page-list changes from remote peers (JP-339). Fires on
+   * any `prosePages` / `prosePageOrder` change.
+   */
+  onProsePagesChange(callback: ProsePagesChangeCallback): () => void {
+    this.prosePagesChangeCallbacks.add(callback);
+    return () => this.prosePagesChangeCallbacks.delete(callback);
   }
 
   // ============ State Access ============
@@ -577,6 +705,8 @@ export class YjsDocument {
     this.metadata.unobserve(this.handleReferenceMetaChange);
     this.fields.unobserve(this.handleFieldChange);
     this.fieldOrder.unobserve(this.handleFieldChange);
+    this.prosePages.unobserve(this.handleProsePagesChange);
+    this.prosePageOrder.unobserve(this.handleProsePagesChange);
     this.doc.destroy();
   }
 
@@ -602,6 +732,11 @@ export class YjsDocument {
     // analogue — fields carry no style/active-key.
     this.fields.observe(this.handleFieldChange);
     this.fieldOrder.observe(this.handleFieldChange);
+
+    // JP-339: observe prose page-list changes (map + order). No metadata
+    // analogue.
+    this.prosePages.observe(this.handleProsePagesChange);
+    this.prosePageOrder.observe(this.handleProsePagesChange);
   }
 
   private handleShapeChange = (event: Y.YMapEvent<Shape>): void => {
@@ -678,6 +813,16 @@ export class YjsDocument {
   ): void => {
     if (this.isLocalUpdate || event.transaction.origin === this) return;
     this.fieldChangeCallbacks.forEach((cb) => cb());
+  };
+
+  // JP-339: a remote change to `prosePages` or `prosePageOrder` → fire the
+  // coarse page-list callback (the binding bulk-reloads from the merged
+  // snapshot, preserving each page's already-synced content).
+  private handleProsePagesChange = (
+    event: Y.YMapEvent<ProsePageMeta> | Y.YArrayEvent<string>
+  ): void => {
+    if (this.isLocalUpdate || event.transaction.origin === this) return;
+    this.prosePagesChangeCallbacks.forEach((cb) => cb());
   };
 
   /**

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -18,6 +18,7 @@
 import { create } from 'zustand';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import { YjsDocument } from './YjsDocument';
+import type { ProsePageMeta } from './YjsDocument';
 import { UnifiedSyncProvider, AwarenessUserState } from './UnifiedSyncProvider';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { reattachAwaitingTeamDocument, syncCurrentDocToRelayOnConnect } from '../store/persistenceStore';
@@ -153,6 +154,13 @@ interface CollaborationActions {
   syncField: (field: Field) => void;
   /** Sync a field deletion to peers. */
   syncDeleteField: (name: string) => void;
+  /** Sync a prose page add/update (tab metadata) to peers via the `prosePages`
+   *  Y.Map (JP-339). */
+  syncProsePage: (meta: ProsePageMeta) => void;
+  /** Sync a prose page deletion (tab removal) to peers. */
+  syncDeleteProsePage: (id: string) => void;
+  /** Sync the prose tab order to peers (`prosePageOrder` Y.Array). */
+  syncProsePageOrder: (order: string[]) => void;
   /**
    * Sync the document name (a rename) to peers via the Y.Doc `metadata` map
    * (CRDT-native rename, so it propagates + persists like shapes rather than
@@ -677,6 +685,24 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     syncDeleteField: (name: string) => {
       if (yjsDoc) {
         yjsDoc.deleteField(name);
+      }
+    },
+
+    syncProsePage: (meta: ProsePageMeta) => {
+      if (yjsDoc) {
+        yjsDoc.setProsePage(meta);
+      }
+    },
+
+    syncDeleteProsePage: (id: string) => {
+      if (yjsDoc) {
+        yjsDoc.deleteProsePage(id);
+      }
+    },
+
+    syncProsePageOrder: (order: string[]) => {
+      if (yjsDoc) {
+        yjsDoc.setProsePageOrder(order);
       }
     },
 

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -45,6 +45,12 @@ function makeMockYjs() {
     getFieldLibrary: vi.fn(() => ({ fields: {}, order: [] })),
     setField: vi.fn(),
     deleteField: vi.fn(),
+    // JP-339 prose page-list binding surface.
+    onProsePagesChange: vi.fn(() => () => {}),
+    getProsePageList: vi.fn(() => ({ pages: {}, pageOrder: [] })),
+    setProsePage: vi.fn(),
+    deleteProsePage: vi.fn(),
+    setProsePageOrder: vi.fn(),
   };
 }
 

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -24,6 +24,21 @@ import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
 import { useCollaborationStore } from './collaborationStore';
+import type { YjsDocument, ProsePageMeta } from './YjsDocument';
+
+/**
+ * Adopt the relay's authoritative prose page LIST into `richTextPagesStore`
+ * (JP-339), but only when non-empty — an empty list means the relay carries no
+ * prose page list (a never-had-prose doc), where the local default-page
+ * bootstrap (`rt-page-1`) must stand rather than be wiped. Caller runs this
+ * inside a `remote-apply` provenance window so the local→CRDT subscription
+ * skips the echo.
+ */
+function adoptProsePageList(yjsDoc: YjsDocument): void {
+  const list = yjsDoc.getProsePageList();
+  if (list.pageOrder.length === 0) return;
+  useRichTextPagesStore.getState().applyRemoteProsePageList(list);
+}
 
 /**
  * Hook that manages bidirectional sync between CRDT and document store.
@@ -52,6 +67,9 @@ export function useCollaborationSync(): void {
   const syncReferenceStyle = useCollaborationStore((state) => state.syncReferenceStyle);
   const syncField = useCollaborationStore((state) => state.syncField);
   const syncDeleteField = useCollaborationStore((state) => state.syncDeleteField);
+  const syncProsePage = useCollaborationStore((state) => state.syncProsePage);
+  const syncDeleteProsePage = useCollaborationStore((state) => state.syncDeleteProsePage);
+  const syncProsePageOrder = useCollaborationStore((state) => state.syncProsePageOrder);
 
   // Track if we've initialized for this session
   const initializedRef = useRef(false);
@@ -128,12 +146,28 @@ export function useCollaborationSync(): void {
       });
     });
 
+    // Handle remote prose page-LIST changes (JP-339). Coarse bulk-merge from the
+    // merged Y.Doc snapshot — `remote-apply` so the local richTextPagesStore→Y.Doc
+    // subscription below skips it (no echo loop). The merge preserves each page's
+    // already-synced `content`, so an MCP-added tab appears live without reload
+    // and without clobbering prose. Skipped when the list is empty: an empty map
+    // is "the relay has no prose page list" (a never-had-prose doc), where the
+    // local default-page bootstrap (`rt-page-1`) must stand, not be wiped.
+    const unsubProsePages = yjsDoc.onProsePagesChange(() => {
+      const list = yjsDoc.getProsePageList();
+      if (list.pageOrder.length === 0) return;
+      runWithProvenance('remote-apply', () => {
+        useRichTextPagesStore.getState().applyRemoteProsePageList(list);
+      });
+    });
+
     return () => {
       unsubShapes();
       unsubOrder();
       unsubMeta();
       unsubRefs();
       unsubFields();
+      unsubProsePages();
     };
   }, [isActive, getYjsDocument, sessionEpoch]);
 
@@ -173,6 +207,11 @@ export function useCollaborationSync(): void {
         useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
         // Phase 3b: adopt the authoritative field library too.
         useFieldStore.getState().loadFields(yjsDoc.getFieldLibrary());
+        // JP-339: adopt the authoritative prose page LIST (tab metadata), so a
+        // joining client picks up pages/renames/reorders made before it
+        // connected. Only when non-empty — an empty list means the relay has no
+        // prose page list yet, where the local default-page bootstrap stands.
+        adoptProsePageList(yjsDoc);
       });
       // Adopt the relay's authoritative document name too (CRDT-native rename),
       // so a joining client picks up a rename made before it connected.
@@ -202,6 +241,8 @@ export function useCollaborationSync(): void {
         useReferenceStore.getState().loadReferences(yjsDoc.getReferenceLibrary());
         // Phase 3b: a prose-only doc can carry fields with no shapes — adopt too.
         useFieldStore.getState().loadFields(yjsDoc.getFieldLibrary());
+        // JP-339: a prose-only doc carries its page list with no shapes — adopt.
+        adoptProsePageList(yjsDoc);
       });
       initializedRef.current = true;
     }
@@ -390,6 +431,60 @@ export function useCollaborationSync(): void {
 
     return unsubscribe;
   }, [isActive, syncField, syncDeleteField]);
+
+  // Subscribe to local prose page-LIST changes and sync to the CRDT (JP-339).
+  // Mirrors the reference/field subscriptions: same provenance +
+  // autosave-suppression + initialized gates. The diff is META-ONLY — page
+  // `content` has its own `prose:<id>` channel, so we compare name/color and set
+  // membership (NOT object identity, which `updatePageContent` would churn) and
+  // sync the tab order separately. A page-switch (`setActivePage`) only moves
+  // `activePageId` — which is deliberately client-local — so it produces no sync.
+  useEffect(() => {
+    if (!isActive) return undefined;
+
+    const unsubscribe = useRichTextPagesStore.subscribe((state, prevState) => {
+      const provenance = getProvenance();
+      if (provenance === 'remote-apply' || provenance === 'load') return;
+      if (isAutoSaveSuppressed()) return;
+      if (!useCollaborationStore.getState().isActive) return;
+      if (!initializedRef.current) return;
+
+      const curIds = new Set(Object.keys(state.pages));
+      const prevIds = new Set(Object.keys(prevState.pages));
+
+      // Added or metadata-changed pages → per-item set (ignore `content`).
+      state.pageOrder.forEach((id, index) => {
+        const cur = state.pages[id];
+        if (!cur) return;
+        const prev = prevState.pages[id];
+        const metaChanged =
+          !prev || prev.name !== cur.name || prev.color !== cur.color || prev.order !== cur.order;
+        if (metaChanged) {
+          const meta: ProsePageMeta = {
+            id,
+            name: cur.name,
+            order: index,
+            createdAt: cur.createdAt,
+            modifiedAt: cur.modifiedAt,
+          };
+          if (cur.color !== undefined) meta.color = cur.color;
+          syncProsePage(meta);
+        }
+      });
+
+      // Deleted pages → per-item delete.
+      for (const id of prevIds) {
+        if (!curIds.has(id)) syncDeleteProsePage(id);
+      }
+
+      // Tab reorder → rewrite the order array (mirrors shapeOrder).
+      if (state.pageOrder !== prevState.pageOrder) {
+        syncProsePageOrder(state.pageOrder);
+      }
+    });
+
+    return unsubscribe;
+  }, [isActive, syncProsePage, syncDeleteProsePage, syncProsePageOrder]);
 }
 
 /**

--- a/src/store/richTextPagesStore.test.ts
+++ b/src/store/richTextPagesStore.test.ts
@@ -32,3 +32,66 @@ describe('richTextPagesStore — deterministic default page id (JP-171)', () => 
     expect(generated).toMatch(/^page-/);
   });
 });
+
+describe('richTextPagesStore — applyRemoteProsePageList (JP-339)', () => {
+  beforeEach(() => {
+    useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
+  });
+
+  it('adds a remote tab while PRESERVING existing pages content', () => {
+    // Local page has live prose content (synced over its own fragment).
+    useRichTextPagesStore.getState().createPage('Page 1', undefined, 'rt-page-1');
+    useRichTextPagesStore.getState().updatePageContent('rt-page-1', '<p>my prose</p>');
+
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: {
+        'rt-page-1': { id: 'rt-page-1', name: 'Page 1', order: 0 },
+        'rt-new': { id: 'rt-new', name: 'From MCP', order: 1 },
+      },
+      pageOrder: ['rt-page-1', 'rt-new'],
+    });
+
+    const { pages, pageOrder } = useRichTextPagesStore.getState();
+    expect(pageOrder).toEqual(['rt-page-1', 'rt-new']);
+    // Content of the existing page must NOT be clobbered by the meta merge.
+    expect(pages['rt-page-1']?.content).toBe('<p>my prose</p>');
+    // The new tab arrives with empty content (its fragment syncs separately).
+    expect(pages['rt-new']?.name).toBe('From MCP');
+    expect(pages['rt-new']?.content).toBe('');
+  });
+
+  it('applies a remote rename + reorder without touching content', () => {
+    useRichTextPagesStore.getState().createPage('Page 1', undefined, 'a');
+    useRichTextPagesStore.getState().createPage('Page 2', undefined, 'b');
+    useRichTextPagesStore.getState().updatePageContent('b', '<p>b body</p>');
+
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: {
+        a: { id: 'a', name: 'A', order: 1 },
+        b: { id: 'b', name: 'B renamed', order: 0 },
+      },
+      pageOrder: ['b', 'a'],
+    });
+
+    const { pages, pageOrder } = useRichTextPagesStore.getState();
+    expect(pageOrder).toEqual(['b', 'a']);
+    expect(pages['b']?.name).toBe('B renamed');
+    expect(pages['b']?.content).toBe('<p>b body</p>');
+  });
+
+  it('prunes a deleted page and repoints the active page', () => {
+    useRichTextPagesStore.getState().createPage('Page 1', undefined, 'a');
+    useRichTextPagesStore.getState().createPage('Page 2', undefined, 'b');
+    useRichTextPagesStore.getState().setActivePage('a');
+
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: { b: { id: 'b', name: 'Page 2', order: 0 } },
+      pageOrder: ['b'],
+    });
+
+    const { pages, pageOrder, activePageId } = useRichTextPagesStore.getState();
+    expect(pages['a']).toBeUndefined();
+    expect(pageOrder).toEqual(['b']);
+    expect(activePageId).toBe('b'); // the pruned active page was repointed
+  });
+});

--- a/src/store/richTextPagesStore.ts
+++ b/src/store/richTextPagesStore.ts
@@ -14,6 +14,7 @@
 
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
+import type { ProsePageList } from '../collaboration/YjsDocument';
 
 /**
  * Represents a single page in the rich text editor.
@@ -72,6 +73,10 @@ interface RichTextPagesActions {
   initializeDefaultPage: () => void;
   /** Load pages from serialized data */
   loadPages: (data: { pages: Record<string, RichTextPage>; pageOrder: string[]; activePageId: string | null }) => void;
+  /** Adopt a remote prose page-LIST (JP-339): merge tab metadata
+   *  (name/color/order) from the CRDT, preserving each page's already-synced
+   *  `content`, and prune pages absent from the merged set. */
+  applyRemoteProsePageList: (list: ProsePageList) => void;
   /** Get serialized data for persistence */
   serialize: () => { pages: Record<string, RichTextPage>; pageOrder: string[]; activePageId: string | null };
 }
@@ -264,6 +269,55 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
         pageOrder: state.pageOrder,
         activePageId: state.activePageId,
       };
+    },
+
+    applyRemoteProsePageList: (list) => {
+      set((draft) => {
+        const incoming = new Set(list.pageOrder);
+
+        // Upsert each remote page's METADATA, preserving local content (which
+        // syncs over its own `prose:<id>` fragment) so a page-list delta can
+        // never wipe live prose. A page new to this client is created with
+        // empty content — its fragment populates via the prose sync.
+        list.pageOrder.forEach((id, index) => {
+          const meta = list.pages[id];
+          if (!meta) return;
+          const existing = draft.pages[id];
+          const now = Date.now();
+          const page: RichTextPage = {
+            id,
+            name: meta.name,
+            content: existing?.content ?? '',
+            // Order is driven by `pageOrder` (the array), so the index in the
+            // merged order is authoritative — not the (possibly stale) numeric
+            // `meta.order`.
+            order: index,
+            createdAt: meta.createdAt ?? existing?.createdAt ?? now,
+            modifiedAt: meta.modifiedAt ?? existing?.modifiedAt ?? now,
+          };
+          if (meta.color !== undefined) {
+            page.color = meta.color;
+          } else if (existing?.color !== undefined) {
+            // Remote cleared the color — drop it (don't resurrect the old one).
+            // (page.color already unset.)
+          }
+          draft.pages[id] = page;
+        });
+
+        // Drop pages the merged set no longer contains (a remote delete).
+        for (const id of Object.keys(draft.pages)) {
+          if (!incoming.has(id)) {
+            delete draft.pages[id];
+          }
+        }
+
+        draft.pageOrder = [...list.pageOrder];
+
+        // Repoint the (client-local) active page if it was pruned.
+        if (!draft.activePageId || !draft.pages[draft.activePageId]) {
+          draft.activePageId = draft.pageOrder[0] ?? null;
+        }
+      });
     },
   }))
 );


### PR DESCRIPTION
## What

Makes the **prose page-list** (tabs) a CRDT shared type so add/rename/reorder/delete propagate **live** — closes the first half of JP-339 (Slice A; canvas page-list follows in Slice B).

Today `richTextPagesStore` (`pages` + `pageOrder`) is loaded once from the JSON snapshot and treated as client-owned. An MCP `add_prose_page` (rename/reorder/delete) only surfaced in a connected client **after a full reload** — and that reload was the **JP-338 prose body-doubling trigger** (a cached live-write lineage meeting the relay's deterministic re-seed). Syncing the list removes the trigger: defence in depth on top of JP-338's dup fix.

This is a direct third application of the **references (JP-89)** / **fields (Phase 3b)** pattern — per-item `Y.Map` + order `Y.Array`, coarse change-callback, bulk-reload-on-remote / per-item-diff-on-local, `dedupe_order` on flatten+hydrate, idempotent once-gate seed.

## Changes

**Client**
- `YjsDocument`: `prosePages` `Y.Map` (id → metadata, **no content**) + `prosePageOrder` `Y.Array`; `setProsePage`/`deleteProsePage` (INVARIANT A per-item) + `setProsePageOrder` (reorder), coarse `onProsePagesChange`, merged `getProsePageList`.
- `richTextPagesStore.applyRemoteProsePageList`: bulk-merges tab metadata from the CRDT **preserving each page's already-synced `content`**, creates new tabs empty, prunes deletes, repoints a pruned active page.
- `useCollaborationSync`: remote bulk-reload + adoption in both adopt branches (skipped when the list is empty, so the deterministic `rt-page-1` bootstrap stands — the first-page identity reconciliation JP-339 asks for); local **meta-only** per-item diff (ignores `content`, which has its own channel) under the existing provenance / autosave-suppression / initialized gates.

**Relay**
- `json_prose_pages_to_ydoc` — seed map+order from `richTextPages` (idempotent once-gate + `dedupe_order`, strips `content`); wired into both hydrate paths.
- `project_prose_pages_into` — re-assert the list on flatten (after the content overlay so `content` is preserved; prunes deletes; **empty map = no-op**, never wipes the page list).
- `DocHandle::set_prose_page_meta` / `remove_prose_page` / `set_prose_page_order` delta methods.
- `add`/`rename`/`reorder`/`delete_prose_page` push the live `prosePages` delta + broadcast when resident → tabs appear without reload.

## Scope / safety
- Page **content** stays in the `prose:<id>` fragments (already synced); **active page is client-local** (not synced — per-client navigation).
- Doc JSON format **unchanged** → no `/src/migrations/` migration. `PROTOCOL_VERSION` **unchanged** → additive shared types, wire frames are the same lib0-v1 bodies.
- Shared-type names (`prosePages`/`prosePageOrder`) are pinned by tests on both the TS and Rust sides (the AGENTS.md "relay Y.Doc must mirror YjsDocument" rule).

## Tests
- `YjsDocument.prosePages.test.ts` — per-item set/delete, reorder, merged-snapshot dedupe, concurrent MCP+author add converge, **two clients seeding `rt-page-1` converge to one page**.
- `richTextPagesStore.test.ts` — `applyRemoteProsePageList` preserves content / applies rename+reorder / prunes + repoints active.
- Relay `hydration.rs` / `flatten.rs` / `mod.rs` — seed/idempotent/dedupe, flatten round-trip (content preserved, delete pruned, active repointed, empty-map no-op), DocHandle round-trip, MCP add surfaces in the live list.
- Client typecheck + **2395** tests green; relay builds (`--bin relay`) + **484** lib tests + all integration targets green.

## Verify (E2E, deploy-gated)
With a client open on a doc, run MCP `docushark_add_prose_page` → the new tab appears **without reload**; two clients → add/rename/reorder/delete propagates live with no JP-338 doubling and no mass-deletion (dev tripwire stays silent).

Assisted-by: Opus 4.8