### PR TITLE
JP-341: guard — make off-relay canvas page view-only in collab

### DIFF
--- a/src/collaboration/canvasPageGuard.test.ts
+++ b/src/collaboration/canvasPageGuard.test.ts
@@ -1,0 +1,40 @@
+/**
+ * JP-341 — canvas page-guard predicate. The guard is ON only in an online relay
+ * session bound to a DIFFERENT page than the one currently active (editing it
+ * would flatten shapes onto the relay's hydrated page, JP-340). It must be OFF
+ * for local/offline docs (full multi-page editing) and on the bound page itself.
+ */
+import { describe, it, expect } from 'vitest';
+import { canvasPageGuarded } from './canvasPageGuard';
+
+describe('canvasPageGuarded (JP-341)', () => {
+  it('is OFF when no relay session is live (local / offline docs edit freely)', () => {
+    expect(
+      canvasPageGuarded({ relayLive: false, relayPageId: 'p1', activePageId: 'p2' }),
+    ).toBe(false);
+  });
+
+  it('is OFF when no relay page is bound yet', () => {
+    expect(
+      canvasPageGuarded({ relayLive: true, relayPageId: null, activePageId: 'p1' }),
+    ).toBe(false);
+  });
+
+  it('is OFF on the relay-bound page (the editable page)', () => {
+    expect(
+      canvasPageGuarded({ relayLive: true, relayPageId: 'p1', activePageId: 'p1' }),
+    ).toBe(false);
+  });
+
+  it('is ON after switching to a different page in a live relay session', () => {
+    expect(
+      canvasPageGuarded({ relayLive: true, relayPageId: 'p1', activePageId: 'p2' }),
+    ).toBe(true);
+  });
+
+  it('treats a null active page as not-guarded (nothing to protect)', () => {
+    expect(
+      canvasPageGuarded({ relayLive: true, relayPageId: 'p1', activePageId: null }),
+    ).toBe(true); // p1 !== null → guarded; the page-switch case is the real driver
+  });
+});

--- a/src/collaboration/canvasPageGuard.ts
+++ b/src/collaboration/canvasPageGuard.ts
@@ -1,0 +1,36 @@
+import { usePageStore } from '../store/pageStore';
+import { isRelaySessionLive, useCollaborationStore } from './collaborationStore';
+
+/**
+ * JP-341: canvas page-guard. The relay's authoritative Y.Doc holds only the
+ * **active page's** shapes, bound to the page it hydrated on join (JP-34
+ * active-page-only). A client can switch canvas pages locally without the relay
+ * following, so a shape drawn on the switched-to page would flow into the relay's
+ * surface and flatten onto the WRONG page (silent misplacement). Until per-page
+ * shape surfaces land (JP-340), the off-relay page is made view-only.
+ *
+ * Scoped to ONLINE relay collab only (`relayLive`): purely-local and offline docs
+ * persist the whole document (all pages) via `pageStore`, so they have no
+ * relay-flatten contamination and must keep full multi-page editing.
+ */
+
+/** Pure decision: an online relay session bound to a DIFFERENT page than the one
+ *  currently active → the active page can't be safely edited this session. */
+export function canvasPageGuarded(args: {
+  relayLive: boolean;
+  relayPageId: string | null;
+  activePageId: string | null;
+}): boolean {
+  const { relayLive, relayPageId, activePageId } = args;
+  if (!relayLive || relayPageId === null) return false;
+  return activePageId !== relayPageId;
+}
+
+/** Store-wired imperative form — read at mutation/sync time (engine + write-gate). */
+export function isCanvasPageGuarded(): boolean {
+  return canvasPageGuarded({
+    relayLive: isRelaySessionLive(),
+    relayPageId: useCollaborationStore.getState().relayPageId,
+    activePageId: usePageStore.getState().activePageId,
+  });
+}

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -21,6 +21,7 @@ import { YjsDocument } from './YjsDocument';
 import type { ProsePageMeta, CanvasPageMeta } from './YjsDocument';
 import { UnifiedSyncProvider, AwarenessUserState } from './UnifiedSyncProvider';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { usePageStore } from '../store/pageStore';
 import { reattachAwaitingTeamDocument, syncCurrentDocToRelayOnConnect } from '../store/persistenceStore';
 import { getSyncStateManager } from './SyncStateManager';
 import {
@@ -115,6 +116,16 @@ interface CollaborationState {
    * on the old, destroyed Y.Doc and remote changes would never reach the view.
    */
   sessionEpoch: number;
+  /**
+   * JP-341: the canvas page the relay's authoritative Y.Doc is bound to for this
+   * session — captured at `startSession` from the just-loaded `activePageId` (the
+   * join page; collab docs never re-write it). The relay's `shapes` surface is
+   * active-page-only (JP-34), so editing any OTHER page would flatten onto this
+   * one. The canvas page-guard (`canvasPageGuard.ts`) compares the live
+   * `activePageId` against this to make off-page editing view-only until per-page
+   * shape surfaces land (JP-340). `null` when no session is bound.
+   */
+  relayPageId: string | null;
 }
 
 /**
@@ -353,6 +364,7 @@ function teardownSession(
     error: null,
     remoteUsers: [],
     config: null,
+    relayPageId: null,
   });
 }
 
@@ -369,6 +381,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     error: null,
     remoteUsers: [],
     config: null,
+    relayPageId: null,
     sessionEpoch: 0,
 
     startSession: (config: CollaborationConfig) => {
@@ -423,7 +436,16 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // Bump `sessionEpoch` so the view effects re-bind to this fresh
       // YjsDocument — a switchDocument restart nets isActive true→true and would
       // otherwise leave onShapeChange registered on the old, destroyed instance.
-      set({ isActive: true, config, error: null, sessionEpoch: get().sessionEpoch + 1 });
+      // JP-341: bind the guard to the page the relay hydrates — the doc's current
+      // (just-loaded) active page. Captured here, before any user page-switch, so
+      // a later switch is detectable as "off the relay's page" (→ view-only).
+      set({
+        isActive: true,
+        config,
+        error: null,
+        sessionEpoch: get().sessionEpoch + 1,
+        relayPageId: usePageStore.getState().activePageId,
+      });
 
       // Only attach the WS provider when we have a token. A token-less provider
       // would no-auth-join → get rejected → fire the "this document isn't syncing

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -94,21 +94,29 @@ vi.mock('../store/relayDocumentStore', () => ({
     }),
   },
 }));
-vi.mock('../store/connectionStore', () => ({
-  useConnectionStore: {
-    getState: () => ({
-      setHost: vi.fn(),
-      reset: vi.fn(),
-      setToken: vi.fn(),
-      token: null,
-      tokenExpiresAt: null,
-    }),
-    subscribe: () => () => {},
-  },
-  startTokenExpirationMonitor: vi.fn(),
-  stopTokenExpirationMonitor: vi.fn(),
-  muteConnectionToasts: vi.fn(),
-}));
+vi.mock('../store/connectionStore', () => {
+  const state = {
+    status: 'authenticated' as const,
+    setHost: vi.fn(),
+    reset: vi.fn(),
+    setToken: vi.fn(),
+    token: null,
+    tokenExpiresAt: null,
+  };
+  // Callable as a hook (`useConnectionStore(selector)`) AND exposes getState —
+  // useIsRelaySessionLive (JP-341) reads it via a selector.
+  const useConnectionStore = Object.assign(
+    (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state),
+    { getState: () => state, subscribe: () => () => {} },
+  );
+  return {
+    useConnectionStore,
+    isRelayAuthenticated: () => state.status === 'authenticated',
+    startTokenExpirationMonitor: vi.fn(),
+    stopTokenExpirationMonitor: vi.fn(),
+    muteConnectionToasts: vi.fn(),
+  };
+});
 vi.mock('../store/presenceStore', () => ({
   usePresenceStore: {
     getState: () => ({ setLocalUser: vi.fn(), clearRemoteUsers: vi.fn(), syncRemoteUsers: vi.fn() }),
@@ -116,11 +124,18 @@ vi.mock('../store/presenceStore', () => ({
 }));
 // Avoid the heavy persistenceStore import chain; the name-apply is irrelevant here.
 vi.mock('../store/persistenceStore', () => ({ applyRemoteDocumentName: vi.fn() }));
+// JP-341: control the canvas page-guard directly so we can assert the write-gate
+// without standing up a real relay-bound page.
+vi.mock('./canvasPageGuard', () => ({
+  isCanvasPageGuarded: vi.fn(() => false),
+  canvasPageGuarded: vi.fn(() => false),
+}));
 
 import { useCollaborationStore } from './collaborationStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useCollaborationSync } from './useCollaborationSync';
 import { withAutoSaveSuppressed } from '../store/autoSaveGuard';
+import { isCanvasPageGuarded } from './canvasPageGuard';
 
 function shape(id: string): Shape {
   return {
@@ -159,6 +174,8 @@ describe('useCollaborationSync', () => {
       isIdbSynced: false,
       config: null,
     });
+    // Default the page-guard OFF (clearAllMocks keeps mockReturnValue, so reset it).
+    vi.mocked(isCanvasPageGuarded).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -241,6 +258,28 @@ describe('useCollaborationSync', () => {
 
     act(() => useDocumentStore.getState().deleteShape('S1'));
     expect(currentYjs.deleteShape).toHaveBeenCalledWith('S1');
+  });
+
+  it('does NOT propagate shape edits while the canvas page-guard is active (JP-341)', () => {
+    startSyncedSession();
+    currentYjs.getAllShapes.mockReturnValue(new Map([['S1', shape('S1')]]));
+    renderHook(() => useCollaborationSync());
+    currentYjs.setShape.mockClear();
+    currentYjs.deleteShape.mockClear();
+
+    // Off-relay page → guard ON: a genuine user add/delete must not reach the CRDT
+    // (it would flatten onto the relay's hydrated page — JP-340).
+    vi.mocked(isCanvasPageGuarded).mockReturnValue(true);
+    act(() => useDocumentStore.getState().addShape(shape('S2')));
+    act(() => useDocumentStore.getState().deleteShape('S1'));
+
+    expect(currentYjs.setShape).not.toHaveBeenCalled();
+    expect(currentYjs.deleteShape).not.toHaveBeenCalled();
+
+    // Back on the bound page → guard OFF: edits flow again (control).
+    vi.mocked(isCanvasPageGuarded).mockReturnValue(false);
+    act(() => useDocumentStore.getState().addShape(shape('S3')));
+    expect(currentYjs.setShape).toHaveBeenCalled();
   });
 
   it('re-binds onShapeChange to the new Y.Doc after switchDocument (#60)', () => {

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -21,10 +21,12 @@ import { useReferenceStore } from '../store/referenceStore';
 import { useFieldStore } from '../store/fieldStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { usePageStore } from '../store/pageStore';
+import { useSessionStore } from '../store/sessionStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
-import { useCollaborationStore } from './collaborationStore';
+import { useCollaborationStore, useIsRelaySessionLive } from './collaborationStore';
+import { canvasPageGuarded, isCanvasPageGuarded } from './canvasPageGuard';
 import type { YjsDocument, ProsePageMeta, CanvasPageMeta } from './YjsDocument';
 
 /**
@@ -90,6 +92,20 @@ export function useCollaborationSync(): void {
 
   // Track if we've initialized for this session
   const initializedRef = useRef(false);
+
+  // JP-341: mirror the canvas page-guard into the single `canvasReadOnly` flag
+  // (sessionStore) that the engine + UI read. The guard is on when an online relay
+  // session is bound to a different page than the one currently active — editing
+  // it would flatten shapes onto the relay's hydrated page (JP-340). Recomputed
+  // reactively from relay-live + the bound page + the active page.
+  const relayLive = useIsRelaySessionLive();
+  const relayPageId = useCollaborationStore((state) => state.relayPageId);
+  const activePageId = usePageStore((state) => state.activePageId);
+  useEffect(() => {
+    useSessionStore
+      .getState()
+      .setCanvasReadOnly(canvasPageGuarded({ relayLive, relayPageId, activePageId }));
+  }, [relayLive, relayPageId, activePageId]);
 
   // Subscribe to remote CRDT changes and apply to local store
   useEffect(() => {
@@ -338,6 +354,16 @@ export function useCollaborationSync(): void {
         // constraint). Once `initializedRef` is set the Y.Doc owns the content
         // and live edits flow normally.
         if (!initializedRef.current) return;
+
+        // JP-341 canvas page-guard (the corruption guarantee): when the client's
+        // active canvas page differs from the page the relay's active-page-only
+        // surface is bound to, a shape edit here would flatten onto the WRONG page.
+        // Skip the sync entirely so no off-page edit reaches the relay — from ANY
+        // path (tool, property panel, paste, programmatic). The input gates
+        // (read-only canvas) stop the user making such edits in the first place;
+        // this is the structural backstop. Prose/field/reference are per-page-safe
+        // and intentionally NOT gated here.
+        if (isCanvasPageGuarded()) return;
 
         // Detect shape changes
         const currentIds = new Set(Object.keys(state.shapes));

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -378,11 +378,30 @@ export class Engine {
       addToSelection: (ids) => sessionStore.getState().addToSelection(ids),
       removeFromSelection: (ids) => sessionStore.getState().removeFromSelection(ids),
       clearSelection: () => sessionStore.getState().clearSelection(),
-      addShape: (shape) => documentStore.getState().addShape(shape),
-      updateShape: (id, updates) => documentStore.getState().updateShape(id, updates),
-      updateShapes: (updates) => documentStore.getState().updateShapes(updates),
-      deleteShape: (id) => documentStore.getState().deleteShape(id),
-      deleteShapes: (ids) => documentStore.getState().deleteShapes(ids),
+      // JP-341: shape mutations are no-ops when the canvas is view-only (the
+      // page-guard — editing an off-relay page would misplace shapes). Gates every
+      // tool-driven create/move/delete + Delete/Backspace + paste at one choke
+      // point; pan/zoom/selection (non-mutating, above) stay live.
+      addShape: (shape) => {
+        if (sessionStore.getState().canvasReadOnly) return;
+        documentStore.getState().addShape(shape);
+      },
+      updateShape: (id, updates) => {
+        if (sessionStore.getState().canvasReadOnly) return;
+        documentStore.getState().updateShape(id, updates);
+      },
+      updateShapes: (updates) => {
+        if (sessionStore.getState().canvasReadOnly) return;
+        documentStore.getState().updateShapes(updates);
+      },
+      deleteShape: (id) => {
+        if (sessionStore.getState().canvasReadOnly) return;
+        documentStore.getState().deleteShape(id);
+      },
+      deleteShapes: (ids) => {
+        if (sessionStore.getState().canvasReadOnly) return;
+        documentStore.getState().deleteShapes(ids);
+      },
 
       // UI state
       setCursor: (cursor) => {

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -153,6 +153,13 @@ export interface SessionState {
    * Relaxed layout. See `resolveRegions` in ui/layout/modes.ts.
    */
   relaxedFocus: RelaxedFocus;
+  /**
+   * Whether the canvas is currently view-only — shape mutations are blocked and a
+   * "view-only" indicator shows. Ephemeral (resets on reload). Today its sole
+   * producer is the JP-341 canvas page-guard (off-relay page in collab); future
+   * producers (doc lock / RBAC) should OR into it rather than overwrite.
+   */
+  canvasReadOnly: boolean;
 }
 
 /**
@@ -222,6 +229,10 @@ export interface SessionActions {
   /** Advance the Relaxed focus write → split → diagram → write. */
   cycleRelaxedFocus: () => void;
 
+  // Canvas read-only (JP-341)
+  /** Set whether the canvas is view-only (blocks shape mutations + shows indicator). */
+  setCanvasReadOnly: (readOnly: boolean) => void;
+
   // Page Camera
   /** Save current camera state for a page */
   savePageCamera: (pageId: string) => void;
@@ -281,6 +292,7 @@ const initialState: SessionState = {
   blobSyncProgress: null,
   editingGroupId: null,
   relaxedFocus: 'write',
+  canvasReadOnly: false,
 };
 
 /**
@@ -495,6 +507,11 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
     const idx = order.indexOf(get().relaxedFocus);
     const next = order[(idx + 1) % order.length] ?? 'write';
     set({ relaxedFocus: next });
+  },
+
+  // Canvas read-only (JP-341)
+  setCanvasReadOnly: (readOnly: boolean) => {
+    if (get().canvasReadOnly !== readOnly) set({ canvasReadOnly: readOnly });
   },
 
   // Page Camera

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { Engine } from '../engine/Engine';
 import { Camera } from '../engine/Camera';
 import { TextEditor } from './TextEditor';
+import { CanvasPageGuardIndicator } from './CanvasPageGuardIndicator';
 import { ContextMenu } from './ContextMenu';
 import { ExportDialog } from './ExportDialog';
 import { SaveToLibraryDialog } from './SaveToLibraryDialog';
@@ -309,6 +310,8 @@ export function CanvasContainer({
     const handlePaste = (e: ClipboardEvent) => {
       // Only handle when canvas is focused
       if (document.activeElement !== canvasRef.current) return;
+      // JP-341: no paste-into-canvas while view-only (off-relay page guard).
+      if (useSessionStore.getState().canvasReadOnly) return;
 
       const ctx = getImportContext();
       if (!ctx) return;
@@ -529,6 +532,8 @@ export function CanvasContainer({
           }}
         />
       )}
+      {/* JP-341: view-only indicator when the canvas page-guard is active. */}
+      <CanvasPageGuardIndicator />
       {/* Collaborative presence overlays */}
       <SelectionHighlight width={dimensions.width} height={dimensions.height} />
       <CollaborativeCursors width={dimensions.width} height={dimensions.height} />

--- a/src/ui/CanvasPageGuardIndicator.tsx
+++ b/src/ui/CanvasPageGuardIndicator.tsx
@@ -1,0 +1,46 @@
+import { Eye } from 'lucide-react';
+import { useSessionStore } from '../store/sessionStore';
+
+/**
+ * JP-341: a small, non-intrusive "view-only" pill shown when the canvas is
+ * read-only because of the page-guard — i.e. an online relay collab session is
+ * bound to a different canvas page than the one being viewed, so editing here is
+ * disabled to stop shapes landing on the wrong page (see JP-340 for the real
+ * fix). Reads the single `canvasReadOnly` flag; renders nothing otherwise.
+ */
+export function CanvasPageGuardIndicator() {
+  const readOnly = useSessionStore((state) => state.canvasReadOnly);
+  if (!readOnly) return null;
+
+  return (
+    <div
+      role="status"
+      title="Live editing is active on another page of this shared document. Editing here is disabled so changes don't land on the wrong page. Editing any page live is coming soon."
+      style={{
+        position: 'absolute',
+        top: 8,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 20,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 10px',
+        fontSize: 12,
+        fontWeight: 500,
+        color: 'var(--text-secondary, #4b5563)',
+        background: 'var(--bg-primary, #fff)',
+        border: '1px solid var(--border-color, #e5e7eb)',
+        borderRadius: 999,
+        boxShadow: '0 1px 4px rgba(0, 0, 0, 0.12)',
+        pointerEvents: 'none',
+        userSelect: 'none',
+      }}
+    >
+      <Eye size={14} strokeWidth={1.5} aria-hidden="true" />
+      View-only — live editing is on another page of this shared doc
+    </div>
+  );
+}
+
+export default CanvasPageGuardIndicator;

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -10,6 +10,14 @@
   overflow: hidden;
 }
 
+/* JP-341: view-only (canvas page-guard) — dim the panel + make its controls
+ * inert. Editing is already no-oped in JS; this signals disabled. The resize
+ * handle and header stay interactive (viewing/resizing is fine). */
+.property-panel--readonly .property-panel-header ~ * {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 /* When the panel is docked on the left of the canvas, swap the border side
  * and put the resize handle on the right edge instead of the left. */
 .property-panel.property-panel-left-dock {

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -1361,7 +1361,13 @@ export interface PropertyPanelProps {
 export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   const selectedIds = useSessionStore((state) => state.selectedIds);
   const shapes = useDocumentStore((state) => state.shapes);
-  const updateShape = useDocumentStore((state) => state.updateShape);
+  const rawUpdateShape = useDocumentStore((state) => state.updateShape);
+  // JP-341: when the canvas is view-only (off-relay page in collab), property
+  // edits must be inert — they'd be local-only and lost, or land on the wrong
+  // page. No-op the mutator centrally so every control is blocked at once, and
+  // dim the panel so it reads as disabled.
+  const canvasReadOnly = useSessionStore((state) => state.canvasReadOnly);
+  const updateShape = canvasReadOnly ? () => {} : rawUpdateShape;
 
   // Width is sourced from the layout store now — single source of truth so
   // both PropertyPanel and FlyoutPanel (when wrapping it) stay in sync.
@@ -1542,7 +1548,10 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   }
 
   return (
-    <div className={`property-panel ${className ?? ''}`} style={{ width }}>
+    <div
+      className={`property-panel ${canvasReadOnly ? 'property-panel--readonly' : ''} ${className ?? ''}`}
+      style={{ width }}
+    >
       <div
         className={`property-panel-resize-handle ${isResizing ? 'resizing' : ''}`}
         onMouseDown={handleResizeStart}


### PR DESCRIPTION
## What

Stopgap for the cross-page shape contamination in **JP-340** (found testing JP-339 on staging): the relay's authoritative Y.Doc is **active-page-only** (JP-34), bound to the page it hydrated on join. A client can switch canvas pages locally without the relay following — the `'load'`-provenance guard (JP-178) stops the *switch* from syncing, but the **next shape drawn** flows into the relay's surface and flattens onto the **wrong page** (silent misplacement). The bug predates JP-339; live tab-switching just made it trivially reachable.

Until per-page shape surfaces land (**JP-340**, the real fix), make the off-relay page **view-only** so no edit can misplace. **Client-only — no relay/protocol change.**

## How

The relay's bound page == the doc's `activePageId` at session start (collab docs never re-write it). Capture it; guard = online-relay-live AND `activePageId` ≠ that. Two layers: the **write-gate is the corruption guarantee**; the **input gates** stop the user making edits that would be silently lost + show why.

- **`collaborationStore`** — capture `relayPageId` in `startSession` (race-free: before any user switch), reset on teardown.
- **`canvasPageGuard.ts`** (NEW, mirrors `offlinePageGuard.ts`) — pure `canvasPageGuarded` + `isCanvasPageGuarded`. Gated on `isRelaySessionLive()` (**online relay only**) so local/offline docs (whole-document persistence, no relay-flatten) keep full multi-page editing.
- **`sessionStore.canvasReadOnly`** — generic flag (one source of truth; doc-lock/RBAC can OR in later); a `useCollaborationSync` effect mirrors the guard into it, so the engine reads only sessionStore (no engine→collaboration import).
- **Mutation surfaces honor the flag** — `ToolContext` mutators no-op (tool draws, Delete/Backspace, paste); `PropertyPanel` inputs no-op + dim; `CanvasContainer` paste-import early-returns.
- **Write-gate** — the documentStore→CRDT **shape** subscription returns early when guarded (prose/field/reference untouched — per-page-safe). Guarantees no off-page edit reaches the relay from *any* path.
- **`CanvasPageGuardIndicator`** (NEW) — a small "View-only — live editing is on another page of this shared doc" pill.

Switching back to the bound page restores full editing; a collaborator on the synced page is unaffected.

## Scope / safety
- **Online relay collab only.** Local + offline docs are never made read-only.
- Client-only; no relay, protocol, or doc-format change.

## Tests
- `canvasPageGuard.test.ts` — predicate truth table (off for local/offline; off on the bound page; on after a switch).
- `useCollaborationSync.test.ts` — guarded → `syncShape`/`deleteShape` NOT called; off → edits flow (control); JP-178 tripwire unaffected.
- The `ToolContext` input gate is covered by the E2E (a full-Engine unit harness isn't warranted for a store-flag read).
- Client typecheck + **2411** tests green. Client-only (no relay).

## Verify (E2E on staging — the original repro)
Collab doc, switch to a non-join canvas page → view-only pill, drawing/delete/property-edit do nothing, **no shape lands on the other page**; switch back → fully editable; a second collaborator on the synced page is unaffected.

## Follow-up
**JP-340** — per-page canvas shape surfaces (`shapes:<pageId>`, mirroring prose `prose:<id>`) lifts the active-page-only limitation so any page is live-editable and this guard can relax.

Assisted-by: Opus 4.8