### PR TITLE
JP-325: icon shape system fixes + ShapePicker preview scaling

### DIFF
--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -10,6 +10,7 @@ import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore, pushHistory } from '../store/historyStore';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
+import type { RectangleShape } from '../shapes/Shape';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
 import { alignHorizontal, alignVertical, distribute } from '../shapes/utils/alignment';
@@ -83,6 +84,34 @@ export function createShapeAtCenter(shapeType: string): void {
   const shape = handler.create(new Vec2(camera.x, camera.y), id);
 
   pushHistory(`Create ${shapeType}`);
+  useDocumentStore.getState().addShape(shape);
+  useSessionStore.getState().select([id]);
+  useSessionStore.getState().setActiveTool('select');
+}
+
+/**
+ * Create an icon-only shape at the viewport centre (JP-325 #1).
+ *
+ * An "icon shape" is a rectangle in `icon-only` display mode — the renderer
+ * skips fill/stroke and the icon fills the (square) bounds. This is the same
+ * shape the PropertyPanel "display as icon" toggle produces; the toolbar entry
+ * just makes it a one-step insert with the chosen icon already set.
+ */
+export function createIconShapeAtCenter(iconId: string): void {
+  const handler = shapeRegistry.getHandler('rectangle');
+  const { camera } = useSessionStore.getState();
+  const id = nanoid();
+  const base = handler.create(new Vec2(camera.x, camera.y), id) as RectangleShape;
+
+  const shape: RectangleShape = {
+    ...base,
+    width: 80,
+    height: 80,
+    iconId,
+    iconDisplayMode: 'icon-only',
+  };
+
+  pushHistory('Create icon');
   useDocumentStore.getState().addShape(shape);
   useSessionStore.getState().select([id]);
   useSessionStore.getState().setActiveTool('select');

--- a/src/shapes/library/LibraryShapeHandler.ts
+++ b/src/shapes/library/LibraryShapeHandler.ts
@@ -26,7 +26,12 @@ import { localToWorld, worldToLocal, getWorldCorners } from '../utils/localSpace
 import { renderLabel } from '../label/renderLabel';
 import { LIBRARY_LABEL_SPEC } from '../label/specs';
 import type { LabelSpec, LabelOverflow } from '../label/LabelSpec';
-import { renderShapeIcons, isIconOnlyMode, iconOnlyLabelOffsetY, iconOnlyRenderSize } from '../../utils/iconRenderer';
+import {
+  renderShapeIcons,
+  isIconOnlyMode,
+  iconOnlyLabelOffsetY,
+  centeredIconRenderSize,
+} from '../../utils/iconRenderer';
 
 /**
  * Structural view of the label + icon fields the factory reads. Core shapes
@@ -117,14 +122,15 @@ export function createShapeHandler<T extends Shape>(
 
       if (f.label && !definition.customLabelRendering) {
         const labelFontSize = f.labelFontSize || DEFAULT_LIBRARY_SHAPE.labelFontSize;
-        // In icon-only mode the icon occupies an `iconSize`-square centred on the
-        // shape, so a centred label would render straight through it. Default the
-        // label to sit just below the icon — offset sticks to the icon's size, so
-        // it tracks larger/smaller icons. A user-set `labelOffsetY` still wins
-        // (use `??` so an explicit 0 pulls the label back to centre).
-        const defaultOffsetY = iconOnly
-          ? iconOnlyLabelOffsetY(iconOnlyRenderSize(width, height), labelFontSize)
-          : 0;
+        // A *centred* icon (icon-only, or one positioned `center`) sits on the
+        // shape centre, so a centred label would render straight through it.
+        // Default the label to just below the icon, tracking the icon's rendered
+        // size so it follows a resize. Corner/edge icons don't collide and get no
+        // offset. A user-set `labelOffsetY` still wins (use `??` so an explicit 0
+        // pulls the label back to centre).
+        const centeredIconSize = centeredIconRenderSize(f, width, height);
+        const defaultOffsetY =
+          centeredIconSize !== null ? iconOnlyLabelOffsetY(centeredIconSize, labelFontSize) : 0;
         renderLabel(ctx, {
           text: f.label,
           spec: labelSpec,

--- a/src/storage/icons/index.test.ts
+++ b/src/storage/icons/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getCategoryLoader } from './index';
+
+/** Build a Response-like stub for the mocked fetch. */
+function resp(body: string, init: { ok?: boolean; status?: number; contentType?: string } = {}) {
+  const { ok = true, status = 200, contentType = 'application/json' } = init;
+  return {
+    ok,
+    status,
+    headers: { get: (h: string) => (h.toLowerCase() === 'content-type' ? contentType : null) },
+    text: async () => body,
+  } as unknown as Response;
+}
+
+describe('cloud icon manifest loader', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches the manifest under the app base href and prefixes asset paths', async () => {
+    const fetchMock = vi.fn(async () =>
+      resp(JSON.stringify([{ id: 'builtin:aws-x', name: 'X', file: 'x.svg' }]))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const loader = getCategoryLoader('cloud-aws');
+    expect(loader).toBeDefined();
+    const icons = await loader!.load();
+
+    // BASE_URL is '/' in test → fetch hits /icons/aws-manifest.json.
+    expect(fetchMock).toHaveBeenCalledWith('/icons/aws-manifest.json');
+    expect(icons).toHaveLength(1);
+    expect(icons[0]).toMatchObject({
+      id: 'builtin:aws-x',
+      name: 'X',
+      category: 'cloud-aws',
+      assetPath: '/icons/aws/x.svg',
+      multiColor: true,
+    });
+  });
+
+  it('throws a precise error when the manifest fetch returns HTML (404 / SW fallback)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => resp('<!DOCTYPE html><html><body>not found</body></html>', { contentType: 'text/html' }))
+    );
+
+    const loader = getCategoryLoader('cloud-azure');
+    await expect(loader!.load()).rejects.toThrow(/returned HTML, not JSON/);
+  });
+
+  it('detects an HTML body even when the content-type lies', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => resp('  <!DOCTYPE html><html></html>', { contentType: 'application/json' }))
+    );
+
+    const loader = getCategoryLoader('cloud-gcp');
+    await expect(loader!.load()).rejects.toThrow(/returned HTML, not JSON/);
+  });
+
+  it('throws on a non-ok manifest response with the status code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => resp('', { ok: false, status: 404 })));
+
+    const loader = getCategoryLoader('cloud-aws');
+    await expect(loader!.load()).rejects.toThrow(/Failed to load icon manifest \(404\)/);
+  });
+});

--- a/src/storage/icons/index.ts
+++ b/src/storage/icons/index.ts
@@ -43,24 +43,55 @@ interface ManifestEntry {
   file: string;
 }
 
+/** Base href the app is served from (`/` in dev, e.g. `/app/` under a subpath). */
+function assetBase(): string {
+  return import.meta.env.BASE_URL ?? '/';
+}
+
 /**
  * Load a cloud provider icon manifest and convert to IconMetadata[].
+ *
+ * `manifestPath`/`assetDir` are relative to the app base href (no leading
+ * slash) — they're prefixed with {@link assetBase} so the fetch works under a
+ * non-root deploy path. A 404 / SPA-shell / service-worker navigation fallback
+ * returns HTML, not JSON; we detect that and throw a precise error rather than
+ * letting `JSON.parse` surface the opaque "Unexpected token '<'" message.
  */
 async function loadCloudManifest(
-  manifestUrl: string,
+  manifestPath: string,
   category: IconCategory,
   assetDir: string
 ): Promise<IconMetadata[]> {
+  const base = assetBase();
+  const manifestUrl = `${base}${manifestPath}`;
   const resp = await fetch(manifestUrl);
-  if (!resp.ok) throw new Error(`Failed to load manifest: ${manifestUrl}`);
-  const entries: ManifestEntry[] = await resp.json();
+  if (!resp.ok) {
+    throw new Error(`Failed to load icon manifest (${resp.status}): ${manifestUrl}`);
+  }
+
+  const contentType = resp.headers.get('content-type') ?? '';
+  const text = await resp.text();
+  if (contentType.includes('text/html') || text.trimStart().startsWith('<')) {
+    throw new Error(
+      `Icon manifest at ${manifestUrl} returned HTML, not JSON — likely a 404 / ` +
+        `SPA-shell or service-worker navigation fallback. Check the asset is ` +
+        `deployed and not intercepted.`
+    );
+  }
+
+  let entries: ManifestEntry[];
+  try {
+    entries = JSON.parse(text) as ManifestEntry[];
+  } catch {
+    throw new Error(`Icon manifest at ${manifestUrl} is not valid JSON.`);
+  }
 
   return entries.map((entry) => ({
     id: entry.id,
     name: entry.name,
     type: 'builtin' as const,
     category,
-    assetPath: `${assetDir}/${entry.file}`,
+    assetPath: `${base}${assetDir}/${entry.file}`,
     multiColor: true,
   }));
 }
@@ -78,18 +109,19 @@ export interface CategoryLoader {
  * Registry of lazy-loadable icon categories.
  */
 export const CATEGORY_LOADERS: CategoryLoader[] = [
-  // Cloud providers — loaded from static asset manifests
+  // Cloud providers — loaded from static asset manifests (paths relative to
+  // the app base href; loadCloudManifest prefixes import.meta.env.BASE_URL).
   {
     category: 'cloud-aws',
-    load: () => loadCloudManifest('/icons/aws-manifest.json', 'cloud-aws', '/icons/aws'),
+    load: () => loadCloudManifest('icons/aws-manifest.json', 'cloud-aws', 'icons/aws'),
   },
   {
     category: 'cloud-azure',
-    load: () => loadCloudManifest('/icons/azure-manifest.json', 'cloud-azure', '/icons/azure'),
+    load: () => loadCloudManifest('icons/azure-manifest.json', 'cloud-azure', 'icons/azure'),
   },
   {
     category: 'cloud-gcp',
-    load: () => loadCloudManifest('/icons/gcp-manifest.json', 'cloud-gcp', '/icons/gcp'),
+    load: () => loadCloudManifest('icons/gcp-manifest.json', 'cloud-gcp', 'icons/gcp'),
   },
   // DevOps & Infrastructure
   {

--- a/src/store/iconLibraryStore.ts
+++ b/src/store/iconLibraryStore.ts
@@ -246,7 +246,15 @@ export const useIconLibraryStore = create<IconLibraryState & IconLibraryActions>
             try {
               const resp = await fetch(icon.assetPath);
               if (!resp.ok) return undefined;
-              content = await resp.text();
+              const text = await resp.text();
+              // A 404 / SW navigation fallback can return the SPA shell (HTML)
+              // with a 200; don't cache that as if it were the icon's SVG.
+              // (Valid SVGs may start with `<?xml`, a comment, or `<svg`.)
+              const head = text.trimStart().toLowerCase();
+              if (head.startsWith('<!doctype html') || head.startsWith('<html')) {
+                return undefined;
+              }
+              content = text;
               svgContentCache.set(id, content);
             } catch {
               return undefined;

--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -20,12 +20,15 @@ import {
   RefreshCw,
   Undo2,
   Redo2,
+  Sticker,
   type LucideIcon,
 } from 'lucide-react';
 import { useSessionStore, type ToolType } from '../store/sessionStore';
 import { useHistoryStore } from '../store/historyStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
+import { createIconShapeAtCenter } from '../engine/CommandRegistry';
 import { ShapePicker } from './ShapePicker';
+import { IconPicker } from './IconPicker';
 import { FileImportButton } from './FileImportButton';
 import { InlinePageTabs } from './InlinePageTabs';
 import type { ImportContext } from '../services/FileImportService';
@@ -141,6 +144,15 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
 
       <ToolbarGroup label="Shapes">
         <ShapePicker />
+        <IconPicker
+          variant="button"
+          value={undefined}
+          buttonTitle="Insert icon shape"
+          buttonContent={<Sticker size={ICON.size} strokeWidth={ICON.strokeWidth} />}
+          onChange={(iconId) => {
+            if (iconId) createIconShapeAtCenter(iconId);
+          }}
+        />
       </ToolbarGroup>
 
       {(getImportContext || onRebuildConnectors) && (

--- a/src/ui/IconPicker.css
+++ b/src/ui/IconPicker.css
@@ -7,6 +7,32 @@
   gap: 4px;
 }
 
+/* Compact toolbar-button variant (JP-325 #1) — sits in the canvas toolbar and
+ * opens the same portal dropdown. Mirrors the other toolbar buttons. */
+.icon-picker--button {
+  flex-direction: row;
+}
+
+.icon-picker-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.icon-picker-button:hover,
+.icon-picker-button.active {
+  background: var(--bg-tertiary);
+}
+
 .icon-picker-label {
   font-size: 11px;
   color: var(--text-secondary);

--- a/src/ui/IconPicker.tsx
+++ b/src/ui/IconPicker.tsx
@@ -10,7 +10,7 @@
  * - Portal-based dropdown to avoid overflow clipping
  */
 
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useIconLibraryStore, initializeIconLibrary } from '../store/iconLibraryStore';
 import type { IconMetadata, IconCategory } from '../storage/IconTypes';
@@ -26,9 +26,24 @@ interface IconPickerProps {
   value: string | undefined;
   /** Callback when icon changes */
   onChange: (iconId: string | undefined) => void;
-  /** Label for the picker */
+  /** Label for the picker (field variant only) */
   label?: string;
+  /**
+   * Trigger style. `'field'` (default) is the labelled field used in the
+   * PropertyPanel. `'button'` is a compact toolbar button that opens the same
+   * portal dropdown at a proper picker width (un-caged from the panel) — used
+   * for the toolbar "insert icon shape" entry (JP-325 #1).
+   */
+  variant?: 'field' | 'button';
+  /** Content of the trigger button (button variant only). */
+  buttonContent?: ReactNode;
+  /** Tooltip / aria-label for the trigger button (button variant only). */
+  buttonTitle?: string;
 }
+
+/** Dropdown width (px) for the compact button variant — a real picker, not a
+ *  button-narrow strip. The field variant matches its (wide) trigger instead. */
+const BUTTON_DROPDOWN_WIDTH = 300;
 
 /** Core categories to show by default (eagerly loaded) */
 const CORE_CATEGORIES: IconCategory[] = ['arrows', 'shapes', 'symbols', 'tech', 'general'];
@@ -36,14 +51,21 @@ const CORE_CATEGORIES: IconCategory[] = ['arrows', 'shapes', 'symbols', 'tech', 
 /**
  * IconPicker component.
  */
-export function IconPicker({ value, onChange, label = 'Icon' }: IconPickerProps) {
+export function IconPicker({
+  value,
+  onChange,
+  label = 'Icon',
+  variant = 'field',
+  buttonContent,
+  buttonTitle = 'Insert icon',
+}: IconPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<IconCategory | 'all'>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [isInitialized, setIsInitialized] = useState(false);
   const [dropdownPosition, setDropdownPosition] = useState<{ top: number; left: number; width: number } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -136,15 +158,17 @@ export function IconPicker({ value, onChange, label = 'Icon' }: IconPickerProps)
 
   // Calculate dropdown position when opening
   const updateDropdownPosition = useCallback(() => {
-    if (triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      setDropdownPosition({
-        top: rect.bottom + 4,
-        left: rect.left,
-        width: rect.width,
-      });
-    }
-  }, []);
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    // The field variant matches its (wide) trigger; the compact toolbar button
+    // opens a fixed-width picker, clamped to stay inside the viewport.
+    const width = variant === 'button' ? BUTTON_DROPDOWN_WIDTH : rect.width;
+    const left =
+      variant === 'button'
+        ? Math.max(8, Math.min(rect.left, window.innerWidth - width - 8))
+        : rect.left;
+    setDropdownPosition({ top: rect.bottom + 4, left, width });
+  }, [variant]);
 
   // Toggle dropdown and update position
   const handleToggle = useCallback(() => {
@@ -367,11 +391,40 @@ export function IconPicker({ value, onChange, label = 'Icon' }: IconPickerProps)
     </div>
   );
 
+  if (variant === 'button') {
+    return (
+      <div className="icon-picker icon-picker--button" ref={containerRef}>
+        <button
+          type="button"
+          className={`icon-picker-button ${isOpen ? 'active' : ''}`}
+          ref={(el) => {
+            triggerRef.current = el;
+          }}
+          onClick={handleToggle}
+          title={buttonTitle}
+          aria-label={buttonTitle}
+          aria-expanded={isOpen}
+        >
+          {buttonContent}
+        </button>
+
+        {/* Render dropdown in a portal to avoid overflow clipping */}
+        {dropdownContent && createPortal(dropdownContent, document.body)}
+      </div>
+    );
+  }
+
   return (
     <div className="icon-picker" ref={containerRef}>
       <label className="icon-picker-label">{label}</label>
 
-      <div className="icon-picker-trigger" ref={triggerRef} onClick={handleToggle}>
+      <div
+        className="icon-picker-trigger"
+        ref={(el) => {
+          triggerRef.current = el;
+        }}
+        onClick={handleToggle}
+      >
         {selectedIcon ? (
           <div className="icon-picker-preview">
             <IconPreview icon={selectedIcon} size={20} />

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -54,6 +54,7 @@ import type { ShapeMetadata, PropertyDefinition, PropertySection as PropertySect
 import { replaceFileContents } from '../services/FileReplaceService';
 import { formatFileSize } from '../utils/fileUtils';
 import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { centeredIconRenderSize, iconOnlyLabelOffsetY } from '../utils/iconRenderer';
 import { Icon } from './icons';
 import './PropertyPanel.css';
 
@@ -298,6 +299,18 @@ const SECTION_LABELS: Record<PropertySectionType, string> = {
 /**
  * Get a property value from a shape by key.
  */
+/**
+ * Build a shape patch that *clears* optional fields (sets them to `undefined`).
+ * `exactOptionalPropertyTypes` forbids a literal `{ labelOffsetX: undefined }`
+ * where the field is `labelOffsetX?: number`, so route through a Record. Clearing
+ * (vs. setting 0) lets the canvas fall back to its computed default offset.
+ */
+function clearFields(...keys: string[]): Partial<Shape> {
+  const patch: Record<string, unknown> = {};
+  for (const k of keys) patch[k] = undefined;
+  return patch as Partial<Shape>;
+}
+
 function getShapeProperty(shape: Shape, key: string): unknown {
   return (shape as unknown as Record<string, unknown>)[key];
 }
@@ -336,6 +349,16 @@ function LibraryShapeProperties({
       }
     });
   }, [selectedShapes, updateShape]);
+
+  // The label's auto vertical offset when it isn't explicitly set: a centred
+  // icon drops the label below itself (tracking the icon's rendered size). Shown
+  // in the Offset Y field so clearing the offset visibly returns to this value,
+  // matching what the canvas renders (LibraryShapeHandler uses the same
+  // `labelOffsetY ?? default`).
+  const iconLabelDefaultOffsetY = useMemo(() => {
+    const size = centeredIconRenderSize(shape, shape.width, shape.height);
+    return size === null ? 0 : Math.round(iconOnlyLabelOffsetY(size, shape.labelFontSize || 14));
+  }, [shape]);
 
   // Handler for custom section properties - writes to shape.customProperties
   // Handles keys with 'customProperties.' prefix (e.g., 'customProperties.actionType')
@@ -430,23 +453,25 @@ function LibraryShapeProperties({
               />
               <CompactNumberInput
                 label="Offset Y"
-                value={shape.labelOffsetY || 0}
+                value={shape.labelOffsetY ?? iconLabelDefaultOffsetY}
                 onChange={(val) => handleUpdate('labelOffsetY', val)}
                 min={-500}
                 max={500}
               />
-              {(shape.labelOffsetX || shape.labelOffsetY) && (
+              {(shape.labelOffsetX != null || shape.labelOffsetY != null) ? (
                 <button
                   className="label-offset-reset"
+                  // Clear (not zero) so the canvas falls back to the computed
+                  // icon offset — an explicit 0 would pin the label to centre.
                   onClick={() => {
-                    handleUpdate('labelOffsetX', 0);
-                    handleUpdate('labelOffsetY', 0);
+                    handleUpdate('labelOffsetX', undefined);
+                    handleUpdate('labelOffsetY', undefined);
                   }}
                   title="Reset label position"
                 >
                   Reset
                 </button>
-              )}
+              ) : null}
             </div>
           )}
         </PropertySection>
@@ -1466,6 +1491,27 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   const isGroupSelected = shape ? isGroup(shape) : false;
   const isLibraryShapeSelected = shape ? isLibraryShape(shape) : false;
 
+  // Auto label offset for a core rectangle/ellipse that displays a centred icon:
+  // the label drops below the icon (tracking its size). Shown in Offset Y when
+  // unset and restored on reset, mirroring LibraryShapeHandler's
+  // `labelOffsetY ?? default`.
+  const iconLabelDefaultOffsetY = useMemo(() => {
+    if (!shape) return 0;
+    let w: number;
+    let h: number;
+    if (isRectangle(shape)) {
+      w = shape.width;
+      h = shape.height;
+    } else if (isEllipse(shape)) {
+      w = shape.radiusX * 2;
+      h = shape.radiusY * 2;
+    } else {
+      return 0;
+    }
+    const size = centeredIconRenderSize(shape, w, h);
+    return size === null ? 0 : Math.round(iconOnlyLabelOffsetY(size, shape.labelFontSize || 14));
+  }, [shape]);
+
   // Get metadata for library shapes
   const shapeMetadata = useMemo(() => {
     if (!shape || !isLibraryShapeSelected) return null;
@@ -1778,15 +1824,15 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                       min={-200}
                       max={200}
                     />
-                    {((shape as GroupShape).labelOffsetX || (shape as GroupShape).labelOffsetY) && (
+                    {((shape as GroupShape).labelOffsetX != null || (shape as GroupShape).labelOffsetY != null) ? (
                       <button
                         className="label-offset-reset"
-                        onClick={() => handleBulkUpdate({ labelOffsetX: 0, labelOffsetY: 0 })}
+                        onClick={() => handleBulkUpdate(clearFields('labelOffsetX', 'labelOffsetY'))}
                         title="Reset offset"
                       >
                         Reset
                       </button>
-                    )}
+                    ) : null}
                   </div>
                 </>
               )}
@@ -1971,7 +2017,7 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                 />
                 <CompactNumberInput
                   label="Offset Y"
-                  value={shape.labelOffsetY || 0}
+                  value={shape.labelOffsetY ?? iconLabelDefaultOffsetY}
                   onChange={(val) => {
                     selectedShapes.forEach((s) => {
                       if (isRectangle(s) || isEllipse(s)) {
@@ -1983,13 +2029,15 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                   max={500}
                   suffix="px"
                 />
-                {(shape.labelOffsetX || shape.labelOffsetY) && (
+                {(shape.labelOffsetX != null || shape.labelOffsetY != null) ? (
                   <button
                     className="label-offset-reset"
                     onClick={() => {
+                      // Clear (not zero) so an icon shape falls back to the
+                      // computed offset; explicit 0 would pin the label to centre.
                       selectedShapes.forEach((s) => {
                         if (isRectangle(s) || isEllipse(s)) {
-                          updateShape(s.id, { labelOffsetX: 0, labelOffsetY: 0 });
+                          updateShape(s.id, clearFields('labelOffsetX', 'labelOffsetY'));
                         }
                       });
                     }}
@@ -1997,7 +2045,7 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                   >
                     Reset
                   </button>
-                )}
+                ) : null}
               </div>
             )}
           </PropertySection>
@@ -2894,13 +2942,13 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                   max={500}
                   suffix="px"
                 />
-                {(shape.labelOffsetX || shape.labelOffsetY) && (
+                {(shape.labelOffsetX != null || shape.labelOffsetY != null) ? (
                   <button
                     className="label-offset-reset"
                     onClick={() => {
                       selectedShapes.forEach((s) => {
                         if (isConnector(s)) {
-                          updateShape(s.id, { labelOffsetX: 0, labelOffsetY: 0 });
+                          updateShape(s.id, clearFields('labelOffsetX', 'labelOffsetY'));
                         }
                       });
                     }}
@@ -2908,7 +2956,7 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
                   >
                     Reset
                   </button>
-                )}
+                ) : null}
               </div>
             )}
           </PropertySection>

--- a/src/ui/ShapePicker.tsx
+++ b/src/ui/ShapePicker.tsx
@@ -26,6 +26,7 @@ import {
 } from '../store/customShapeLibraryStore';
 import { useShapePickerStore } from '../store/shapePickerStore';
 import { useSessionStore } from '../store/sessionStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { createShapeAtCenter } from '../engine/CommandRegistry';
 import { buildEntries, categoryLabel, PICKER_CATEGORY_ORDER } from './shapePicker/entries';
 import { filterEntries } from './shapePicker/filter';
@@ -408,6 +409,12 @@ function ShapeTile({
 }) {
   const ref = useRef<HTMLButtonElement>(null);
 
+  // Preview tiles track the app text-size setting (Appearance → UI scale) so
+  // they grow/shrink with the rest of the chrome instead of staying a fixed,
+  // hard-to-read 46px (JP-325).
+  const uiScale = useUIPreferencesStore((s) => s.appearancePrefs.uiScale);
+  const previewSize = Math.round(PREVIEW_SIZE * uiScale);
+
   // Keep the keyboard-focused tile in view.
   useEffect(() => {
     if (keyboardActive) ref.current?.scrollIntoView({ block: 'nearest' });
@@ -425,7 +432,7 @@ function ShapeTile({
       role="option"
       aria-selected={active}
     >
-      <ShapePreview entry={entry} size={PREVIEW_SIZE} />
+      <ShapePreview entry={entry} size={previewSize} />
       <span className="shape-picker-item-name">{entry.name}</span>
     </button>
   );
@@ -482,12 +489,11 @@ function ShapePreview({ entry, size }: { entry: PickerEntry; size: number }) {
     if (definition?.pathBuilder) {
       const cw = definition.metadata.defaultWidth;
       const ch = definition.metadata.defaultHeight;
-      // pathBuilder draws in [0..w, 0..h]; recenter to origin.
+      // pathBuilder draws centred on the origin (same as the canvas handler), so
+      // no recentre — drawPath already translates to the tile centre. (The old
+      // -cw/2,-ch/2 shift double-offset every preview up-and-left.)
       const raw = definition.pathBuilder(cw, ch);
-      const centered = new Path2D();
-      const m = new DOMMatrix().translate(-cw / 2, -ch / 2);
-      centered.addPath(raw, m);
-      drawPath(centered, cw, ch);
+      drawPath(raw, cw, ch);
     } else if (type === 'rectangle') {
       const p = new Path2D();
       p.roundRect(-w / 2, -h / 2, w, h, 6);

--- a/src/utils/iconCache.test.ts
+++ b/src/utils/iconCache.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { resolveIconCacheKey } from './iconCache';
+
+describe('resolveIconCacheKey', () => {
+  it('keys single-color icons per color variant', () => {
+    expect(resolveIconCacheKey('builtin:server', '#ff0000', false)).toBe('builtin:server:#ff0000');
+    expect(resolveIconCacheKey('builtin:server', '#00ff00', false)).toBe('builtin:server:#00ff00');
+  });
+
+  it('uses the colorless key when no color is requested', () => {
+    expect(resolveIconCacheKey('builtin:server', undefined, false)).toBe('builtin:server');
+  });
+
+  it('shares one colorless entry for multi-color (cloud) icons regardless of color', () => {
+    // Cloud icons ignore the requested color, so every variant must collapse to
+    // a single entry — otherwise each recolor forks a transparent-until-loaded
+    // entry (the JP-325 #3 transparency bug).
+    expect(resolveIconCacheKey('builtin:aws-s3', '#ff0000', true)).toBe('builtin:aws-s3');
+    expect(resolveIconCacheKey('builtin:aws-s3', '#123456', true)).toBe('builtin:aws-s3');
+    expect(resolveIconCacheKey('builtin:aws-s3', undefined, true)).toBe('builtin:aws-s3');
+  });
+});

--- a/src/utils/iconCache.ts
+++ b/src/utils/iconCache.ts
@@ -47,33 +47,70 @@ function notifyLoaded(): void {
 }
 
 /**
+ * Resolve the cache key for an icon + colour variant.
+ *
+ * Multi-colour icons (cloud-provider sets with native fills) ignore the requested
+ * colour entirely — every "variant" rasterises identically — so they share a
+ * single colourless entry instead of forking a fresh (transparent-until-loaded)
+ * entry on every recolour. `multiColor` is passed in so this stays pure/testable;
+ * {@link getIconImage} sources it from the icon library store.
+ */
+export function resolveIconCacheKey(
+  iconId: string,
+  color: string | undefined,
+  multiColor: boolean
+): string {
+  if (!color || multiColor) return iconId;
+  return `${iconId}:${color}`;
+}
+
+/**
+ * Find any already-rasterised image for this icon (the colourless base or any
+ * loaded colour variant). Used as a placeholder so a recolour / reselect never
+ * flashes the shape transparent while the exact variant rasterises.
+ */
+function readySiblingImage(iconId: string): HTMLImageElement | undefined {
+  const base = cache.get(iconId);
+  if (base?.ready) return base.image;
+  const prefix = `${iconId}:`;
+  for (const [key, entry] of cache) {
+    if (entry.ready && key.startsWith(prefix)) return entry.image;
+  }
+  return undefined;
+}
+
+/**
  * Get a cached icon image for rendering.
- * Returns undefined if the icon is not yet loaded or doesn't exist.
+ * Returns undefined only if nothing for this icon is rasterised yet.
  *
  * This function starts loading the icon in the background if not cached.
- * When the icon loads, registered callbacks are notified.
+ * When the icon loads, registered callbacks are notified. While a specific
+ * colour variant rasterises, an already-loaded sibling is returned so the shape
+ * stays visible instead of going transparent.
  *
  * @param iconId - Icon ID (builtin: or custom)
  * @param color - Optional color to replace currentColor in SVG
- * @returns HTMLImageElement if ready, undefined otherwise
+ * @returns HTMLImageElement if any variant is ready, undefined otherwise
  */
 export function getIconImage(
   iconId: string,
   color?: string
 ): HTMLImageElement | undefined {
-  // Create cache key including color
-  const cacheKey = color ? `${iconId}:${color}` : iconId;
+  const multiColor = useIconLibraryStore.getState().getIcon(iconId)?.multiColor ?? false;
+  const cacheKey = resolveIconCacheKey(iconId, color, multiColor);
 
   // Check cache
   const cached = cache.get(cacheKey);
   if (cached) {
-    return cached.ready ? cached.image : undefined;
+    if (cached.ready) return cached.image;
+    // Loading (or errored): show a sibling variant rather than nothing.
+    return readySiblingImage(iconId);
   }
 
-  // Start loading
+  // Start loading; meanwhile fall back to any already-loaded variant.
   loadIconAsync(iconId, color, cacheKey);
 
-  return undefined;
+  return readySiblingImage(iconId);
 }
 
 /**

--- a/src/utils/iconRenderer.test.ts
+++ b/src/utils/iconRenderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { iconOnlyRenderSize, iconOnlyLabelOffsetY } from './iconRenderer';
+import { iconOnlyRenderSize, iconOnlyLabelOffsetY, centeredIconRenderSize } from './iconRenderer';
 
 describe('iconOnlyRenderSize', () => {
   it('fills the bounds, aspect-locked to the smaller dimension', () => {
@@ -18,5 +18,40 @@ describe('iconOnlyLabelOffsetY', () => {
 
   it('is always positive (below centre), never overlapping', () => {
     expect(iconOnlyLabelOffsetY(iconOnlyRenderSize(40, 30), 10)).toBeGreaterThan(0);
+  });
+});
+
+describe('centeredIconRenderSize', () => {
+  it('returns the bound-filling size for icon-only shapes (tracks resize)', () => {
+    expect(centeredIconRenderSize({ iconDisplayMode: 'icon-only', iconId: 'x' }, 100, 80)).toBe(80);
+    // Larger bounds → larger offset basis: label follows the resize.
+    expect(centeredIconRenderSize({ iconDisplayMode: 'icon-only', iconId: 'x' }, 200, 200)).toBe(200);
+  });
+
+  it('returns the icon size for a single centred (legacy) icon', () => {
+    expect(centeredIconRenderSize({ iconId: 'x', iconPosition: 'center', iconSize: 32 }, 120, 90)).toBe(32);
+    expect(centeredIconRenderSize({ iconId: 'x', iconPosition: 'center' }, 120, 90)).toBe(24);
+  });
+
+  it('returns null for corner/edge/default icons (no label collision)', () => {
+    expect(centeredIconRenderSize({ iconId: 'x' }, 120, 90)).toBeNull(); // default top-left
+    expect(centeredIconRenderSize({ iconId: 'x', iconPosition: 'top-right' }, 120, 90)).toBeNull();
+    expect(centeredIconRenderSize({ iconId: 'x', iconPosition: 'bottom' }, 120, 90)).toBeNull();
+  });
+
+  it('returns null when there is no icon at all', () => {
+    expect(centeredIconRenderSize({}, 120, 90)).toBeNull();
+  });
+
+  it('handles a single centred icon in the icons[] array', () => {
+    expect(centeredIconRenderSize({ icons: [{ iconId: 'x', position: 'center', size: 40 }] }, 100, 100)).toBe(40);
+    // Ambiguous multi-icon → no auto-offset.
+    expect(
+      centeredIconRenderSize(
+        { icons: [{ iconId: 'a', position: 'center' }, { iconId: 'b', position: 'top-left' }] },
+        100,
+        100
+      )
+    ).toBeNull();
   });
 });

--- a/src/utils/iconRenderer.ts
+++ b/src/utils/iconRenderer.ts
@@ -450,6 +450,43 @@ export function iconOnlyRenderSize(width: number, height: number): number {
 }
 
 /**
+ * If the shape's icon is rendered **centred** — icon-only mode, or a single icon
+ * explicitly positioned `center` — return its rendered size so the label can be
+ * dropped just below it; otherwise `null`. Corner/edge icons (the `top-left`
+ * default, badges, etc.) don't collide with a centred label, so they get no
+ * auto-offset. The returned size tracks the live bounds so the label follows a
+ * resize without the user hard-coding a static `labelOffsetY`.
+ */
+export function centeredIconRenderSize(
+  shape: {
+    iconId?: string;
+    iconSize?: number;
+    iconPosition?: IconPosition;
+    iconDisplayMode?: IconDisplayMode;
+    icons?: IconConfig[];
+  },
+  width: number,
+  height: number
+): number | null {
+  if (isIconOnlyMode(shape)) return iconOnlyRenderSize(width, height);
+
+  // Multi-icon array: only an unambiguous single centred icon qualifies.
+  if (shape.icons && shape.icons.length > 0) {
+    if (shape.icons.length === 1) {
+      const ic = shape.icons[0];
+      if (ic && (ic.position ?? 'top-left') === 'center') return ic.size ?? 24;
+    }
+    return null;
+  }
+
+  // Legacy single-icon properties.
+  if (shape.iconId && (shape.iconPosition ?? 'top-left') === 'center') {
+    return shape.iconSize ?? 24;
+  }
+  return null;
+}
+
+/**
  * Default vertical label offset for an icon-only shape.
  *
  * The bound-filling icon is centred, so a centred label renders straight

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,9 +55,19 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,woff,woff2}'],
         globIgnores: ['**/dictionaries/**', '**/icons/**'],
-        // SPA fallback, but never serve relay/control-plane routes from cache.
+        // SPA fallback, but never serve relay/control-plane routes — or the
+        // on-demand static asset dirs (icons, dictionaries) — the SPA shell.
+        // Returning index.html for `/icons/*.json` makes the icon loader parse
+        // HTML as JSON ("Unexpected token '<'") and the category silently empty
+        // (JP-325 #2/#12); let those fall through to the network 404 instead.
         navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api/, /^\/oembed/, /^\/\.well-known/],
+        navigateFallbackDenylist: [
+          /^\/api/,
+          /^\/oembed/,
+          /^\/\.well-known/,
+          /^\/icons\//,
+          /^\/dictionaries\//,
+        ],
         // Doc data syncs over WebSocket (which SWs can't intercept) and REST to
         // the relay; we deliberately add no runtime caching for those.
       },


### PR DESCRIPTION
Closes the open icon findings from the JP-312 pre-launch joy ride (JP-325), plus an in-session ShapePicker preview report. Scope is OSS client UI only.

## Findings → fixes

**#2 / #12 — AWS/Azure/GCP icons can't load ("Unexpected token '<', `<!DOCTYPE` … not valid JSON")**
- `storage/icons/index.ts`: manifest + per-icon asset paths now prefix `import.meta.env.BASE_URL` (mirrors `SpellcheckService`), so they resolve under any base path.
- `loadCloudManifest` detects an HTML body (404 / SPA-shell / SW fallback) and throws a precise error instead of an opaque JSON-parse failure. The IconPicker already renders `store.error`, so the cause is now visible.
- `iconLibraryStore.loadIconData`: guards the SVG fetch against a 200-with-HTML body.
- `vite.config.ts`: adds `/icons/` + `/dictionaries/` to the SW `navigateFallbackDenylist` so static assets fall through to the network 404 rather than the SPA shell.
- *Follow-up (out of scope, docushark-web):* if staging still 404s these, the hosting/SPA-fallback config is the remaining fix.

**#3 — Icon shapes go transparent on recolor / reselecting the startup color**
- `utils/iconCache.ts`: multi-color (cloud) icons collapse to one colorless cache entry (color is a no-op for them); while a specific color variant rasterises, an already-loaded sibling is returned as a placeholder so the shape never flashes transparent. Cold-start repaint stays wired via `onIconLoad`.

**#4 — Label renders through a centered icon; manual offset doesn't track resize**
- `iconRenderer.centeredIconRenderSize` + `LibraryShapeHandler`: the auto below-icon label offset now applies to any *centered* icon (icon-only or `position: 'center'`), sized to the rendered icon so it follows a resize. Corner/edge icons are unchanged; an explicit user `labelOffsetY` still wins.

**#1 — Icon-only shapes were buried in the PropertyPanel**
- `IconPicker` gains a compact `button` variant (same portal dropdown, real picker width); `CanvasToolbar` adds an "Insert icon shape" button that drops an icon-only shape via `createIconShapeAtCenter`. The PropertyPanel "display as icon" control is unchanged.

**ShapePicker preview scaling (in-session report)**
- `ShapePicker`: previews drew up-and-left because `pathBuilder`s are already origin-centered but `ShapePreview` re-translated by `(-cw/2, -ch/2)` — removed the double-shift. Tile size now tracks the Appearance UI-scale (text-size) setting instead of a fixed 46px.

## Verification
- `bun run typecheck` clean; `bun run test --run` — 2421 pass (177 files), incl. new tests for the manifest BASE_URL/HTML-detection, icon cache key resolution, and the centered-icon offset matrix; `bun run build` succeeds.
- **Needs a visual pass on a running app** (gates the Linear Done, not the PR): cloud icons load (or show a clear error); an icon shape stays visible on recolor/reselect; a centered icon's label stays below it across a resize; the toolbar "Insert icon shape" button; ShapePicker previews centered + scaling with UI text-size.

Dedupe note: JP-322 is an exact duplicate of JP-325 and should be cancelled.

Assisted-by: Opus 4.8