### PR TITLE
JP-324: session/auth lifecycle hardening

### DIFF
--- a/src/api/relayConnection.ts
+++ b/src/api/relayConnection.ts
@@ -5,10 +5,13 @@
  * slice the record also carries the `docushark-web` (Cloud) base URL —
  * which pre-fills the sign-in form — and the relay token's expiry.
  *
- * Decision (carried over): only the URLs are silently re-applied on boot
- * (they pre-fill the form). The cached JWT is loaded but *not* silently
- * re-asserted — the user must click "Connect," at which point we try it
- * once; a 401 drops it and forces a fresh sign-in (or, once a token
+ * Decision (JP-324, supersedes the original): the cached JWT is now silently
+ * re-asserted on boot when it's still unexpired, so reopening a relay doc on
+ * startup is authenticated/online without forcing a manual "Connect" every
+ * launch. The restore happens at the session chokepoint
+ * (`ensureCollabSessionForDoc` → `chooseRelaySessionToken`), which already loads
+ * this record; an expired/absent token still starts engine-only. A 401 on a
+ * genuinely-rejected token drops it and forces a fresh sign-in (or, once a token
  * refresher is registered, a silent re-exchange — see `tokenRefresh.ts`).
  *
  * JP-100: the relay token now lives in IndexedDB via `platform.secureStore`

--- a/src/collaboration/ensureCollabSession.test.ts
+++ b/src/collaboration/ensureCollabSession.test.ts
@@ -24,7 +24,9 @@ vi.mock('../store/documentRegistry', () => ({
   useDocumentRegistry: { getState: () => ({ getRecord: () => record }) },
 }));
 
-let connection: { relayUrl: string } | null;
+let connection:
+  | { relayUrl: string; jwt?: string | null; jwtExpiresAt?: number | null }
+  | null;
 vi.mock('../api/relayConnection', () => ({
   loadConnection: () => Promise.resolve(connection),
 }));
@@ -32,7 +34,7 @@ vi.mock('../api/relayConnection', () => ({
 // Use the real restUrlToWsUrl (pure string transform) and the real
 // connectionStore (a plain zustand store, no import side effects) so the
 // token-aware reopen reads a realistic in-memory relay identity.
-import { ensureCollabSessionForDoc } from './ensureCollabSession';
+import { ensureCollabSessionForDoc, chooseRelaySessionToken } from './ensureCollabSession';
 import { useConnectionStore } from '../store/connectionStore';
 
 describe('ensureCollabSessionForDoc', () => {
@@ -126,6 +128,42 @@ describe('ensureCollabSessionForDoc', () => {
     expect(arg.token).toBe('live-token');
   });
 
+  it('restores the PERSISTED token on cold boot and asserts it into the store (JP-324)', async () => {
+    // connectionStore is empty (fresh process), but a still-valid token survives
+    // on disk from a previous run — reopening a relay doc must reconnect
+    // authenticated WITHOUT a fresh sign-in.
+    connection = {
+      relayUrl: 'http://relay.example:9876',
+      jwt: 'disk-token',
+      jwtExpiresAt: Date.now() + 60_000,
+    };
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.startSession).toHaveBeenCalledTimes(1);
+    const arg = collab.startSession.mock.calls[0]![0] as { token?: string };
+    expect(arg.token).toBe('disk-token');
+    // The restored token is asserted back into connectionStore so the
+    // expiry monitor + REST subscription stay coherent.
+    expect(useConnectionStore.getState().token).toBe('disk-token');
+    expect(useConnectionStore.getState().isTokenValid()).toBe(true);
+  });
+
+  it('does NOT restore an EXPIRED persisted token (stays engine-only)', async () => {
+    connection = {
+      relayUrl: 'http://relay.example:9876',
+      jwt: 'stale-token',
+      jwtExpiresAt: Date.now() - 1_000,
+    };
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.startSession).toHaveBeenCalledTimes(1);
+    const arg = collab.startSession.mock.calls[0]![0] as { token?: string };
+    expect(arg.token).toBeUndefined();
+    expect(useConnectionStore.getState().token).toBeNull();
+  });
+
   it('respects the kill-switch for cold starts', async () => {
     flagEnabled = false;
 
@@ -150,5 +188,54 @@ describe('ensureCollabSessionForDoc', () => {
     await ensureCollabSessionForDoc('doc-9');
 
     expect(collab.startSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('chooseRelaySessionToken', () => {
+  const NOW = 1_000_000;
+
+  it('prefers a valid in-memory token (no disk restore)', () => {
+    const r = chooseRelaySessionToken(
+      { token: 'live', expiresAt: NOW + 5_000, valid: true },
+      { jwt: 'disk', jwtExpiresAt: NOW + 5_000 },
+      NOW,
+    );
+    expect(r).toEqual({ token: 'live', expiresAt: NOW + 5_000, restoredFromDisk: false });
+  });
+
+  it('restores an unexpired persisted token when memory is empty', () => {
+    const r = chooseRelaySessionToken(
+      { token: null, expiresAt: null, valid: false },
+      { jwt: 'disk', jwtExpiresAt: NOW + 5_000 },
+      NOW,
+    );
+    expect(r).toEqual({ token: 'disk', expiresAt: NOW + 5_000, restoredFromDisk: true });
+  });
+
+  it('treats a persisted token with null expiry as valid (matches isTokenValid)', () => {
+    const r = chooseRelaySessionToken(
+      { token: null, expiresAt: null, valid: false },
+      { jwt: 'disk', jwtExpiresAt: null },
+      NOW,
+    );
+    expect(r).toEqual({ token: 'disk', expiresAt: null, restoredFromDisk: true });
+  });
+
+  it('does not restore an expired persisted token', () => {
+    const r = chooseRelaySessionToken(
+      { token: null, expiresAt: null, valid: false },
+      { jwt: 'disk', jwtExpiresAt: NOW - 1 },
+      NOW,
+    );
+    expect(r).toEqual({ token: null, expiresAt: null, restoredFromDisk: false });
+  });
+
+  it('yields engine-only when neither token is present', () => {
+    const r = chooseRelaySessionToken(
+      { token: null, expiresAt: null, valid: false },
+      { jwt: null, jwtExpiresAt: null },
+      NOW,
+    );
+    expect(r).toEqual({ token: null, expiresAt: null, restoredFromDisk: false });
   });
 });

--- a/src/collaboration/ensureCollabSession.ts
+++ b/src/collaboration/ensureCollabSession.ts
@@ -42,14 +42,19 @@ const PLACEHOLDER_USER = { id: 'pending', name: 'You', color: '#4a90d9' };
  *   engine restart that re-keys the `y-indexeddb` room — see
  *   `collaborationStore.switchDocument`), preserving the live token so an online
  *   collaborator stays connected across the switch.
- * - If no session is active, start a session from the persisted relay URL. When
- *   `connectionStore` holds a still-valid token — i.e. the user signed in this
- *   run and then left a doc (JP-190) — reconnect **with** it so reopening a
- *   relay doc is authenticated/online. Otherwise (cold boot: `connectionStore`
- *   is empty until `completeCloudSignIn` runs) start **engine-only** (no token),
- *   so offline editing works immediately without auto-asserting an on-disk
- *   token. The distinction is safe because `connectionStore` is in-memory: a
- *   non-null token there means an actual sign-in happened this session.
+ * - If no session is active, start a session from the persisted relay URL with
+ *   the best available token (JP-324):
+ *     1. the live in-memory token when still valid — the user signed in this run
+ *        and then left a doc (JP-190); or
+ *     2. the **persisted** token from `loadConnection()` when it's still
+ *        unexpired — a cold boot where `connectionStore` is empty but a prior
+ *        sign-in's token survives on disk. Restoring it means reopening a relay
+ *        doc on startup is authenticated/online (and the REST doc-list loads)
+ *        instead of forcing a fresh sign-in every launch.
+ *   When neither is available (no token / expired), start **engine-only** so
+ *   offline editing still works immediately. A restored token is asserted back
+ *   into `connectionStore` after `startSession` so the auth/expiry/REST paths
+ *   stay coherent (mirrors `completeCloudSignIn`).
  *
  * Callers must only pass relay-backed doc ids; local-only docs are
  * renderer-owned and never get an engine (guarded here as a safety net).
@@ -136,16 +141,57 @@ export async function ensureCollabSessionForDoc(docId: string): Promise<void> {
     return;
   }
 
-  // Reconnect with the live in-session token when we have a valid one (the
-  // signed-in-then-left-a-doc case, JP-190) so reopening a relay doc is
-  // authenticated/online; otherwise start engine-only (cold boot — no token —
-  // brings up the Y.Doc + y-indexeddb + view binding without the WS provider).
+  // Pick the session token: live in-memory first (signed-in-then-left, JP-190),
+  // else the still-valid persisted token (cold-boot restore, JP-324). Engine-only
+  // when neither is available — brings up the Y.Doc + y-indexeddb + view binding
+  // without the WS provider.
   const connStore = useConnectionStore.getState();
-  const token = connStore.isTokenValid() ? connStore.token : null;
+  const { token, expiresAt, restoredFromDisk } = chooseRelaySessionToken(
+    { token: connStore.token, expiresAt: connStore.tokenExpiresAt, valid: connStore.isTokenValid() },
+    { jwt: conn.jwt, jwtExpiresAt: conn.jwtExpiresAt },
+    Date.now(),
+  );
+
   latest.startSession({
     serverUrl: restUrlToWsUrl(conn.relayUrl),
     documentId: docId,
     ...(token ? { token } : {}),
     user: { ...PLACEHOLDER_USER },
   });
+
+  // Re-assert a disk-restored token into connectionStore so the token-expiry
+  // monitor and REST sync subscription read a coherent value. The session's REST
+  // client is seeded from `config.token` directly; this keeps the store in sync.
+  // Safe to set after startSession: a cold-start start (nothing was active) does
+  // NOT reset the store, so the assertion sticks — mirroring completeCloudSignIn.
+  if (restoredFromDisk && token) {
+    useConnectionStore.getState().setToken(token, expiresAt);
+  }
+}
+
+/**
+ * Choose the token a (re)started relay session should use, given the in-memory
+ * connection state and the persisted connection record. Pure so it can be unit
+ * tested without the stores.
+ *
+ * - A valid in-memory token wins (the user signed in this run; JP-190).
+ * - Otherwise fall back to a persisted token that hasn't expired (cold-boot
+ *   restore; JP-324) and flag it so the caller re-asserts it into the store.
+ * - A null/expired token in both yields an engine-only start.
+ *
+ * Expiry semantics match `connectionStore.isTokenValid`: a null expiry is
+ * treated as "no known expiry → assume valid".
+ */
+export function chooseRelaySessionToken(
+  inMemory: { token: string | null; expiresAt: number | null; valid: boolean },
+  persisted: { jwt: string | null; jwtExpiresAt: number | null },
+  now: number,
+): { token: string | null; expiresAt: number | null; restoredFromDisk: boolean } {
+  if (inMemory.valid && inMemory.token) {
+    return { token: inMemory.token, expiresAt: inMemory.expiresAt, restoredFromDisk: false };
+  }
+  if (persisted.jwt && (persisted.jwtExpiresAt === null || now < persisted.jwtExpiresAt)) {
+    return { token: persisted.jwt, expiresAt: persisted.jwtExpiresAt, restoredFromDisk: true };
+  }
+  return { token: null, expiresAt: null, restoredFromDisk: false };
 }

--- a/src/services/relayListAutoRefresh.test.ts
+++ b/src/services/relayListAutoRefresh.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const refreshDocumentList = vi.fn();
+vi.mock('../store/relayDocumentStore', () => ({
+  useRelayDocumentStore: { getState: () => ({ refreshDocumentList }) },
+}));
+
+import {
+  registerRelayListAutoRefresh,
+  __resetRelayListAutoRefreshForTests,
+} from './relayListAutoRefresh';
+
+describe('registerRelayListAutoRefresh', () => {
+  beforeEach(() => {
+    refreshDocumentList.mockReset();
+    __resetRelayListAutoRefreshForTests();
+  });
+
+  it('refreshes on window focus', () => {
+    const dispose = registerRelayListAutoRefresh(() => 0);
+    window.dispatchEvent(new Event('focus'));
+    expect(refreshDocumentList).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('refreshes on coming back online', () => {
+    const dispose = registerRelayListAutoRefresh(() => 0);
+    window.dispatchEvent(new Event('online'));
+    expect(refreshDocumentList).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('refreshes on visibilitychange only when visible', () => {
+    const dispose = registerRelayListAutoRefresh(() => 0);
+
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(refreshDocumentList).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(refreshDocumentList).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('throttles the focus + visibility double-fire on a single tab return', () => {
+    let clock = 1000;
+    const dispose = registerRelayListAutoRefresh(() => clock);
+
+    // visibility → visible, then focus, within the same instant: one refresh.
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('focus'));
+    expect(refreshDocumentList).toHaveBeenCalledTimes(1);
+
+    // After the throttle window, another return refreshes again.
+    clock += 2_500;
+    window.dispatchEvent(new Event('focus'));
+    expect(refreshDocumentList).toHaveBeenCalledTimes(2);
+    dispose();
+  });
+
+  it('disposer removes the listeners (no refresh after dispose)', () => {
+    const dispose = registerRelayListAutoRefresh(() => 0);
+    dispose();
+    window.dispatchEvent(new Event('focus'));
+    window.dispatchEvent(new Event('online'));
+    expect(refreshDocumentList).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — a second register while active does not double-bind', () => {
+    const dispose1 = registerRelayListAutoRefresh(() => 0);
+    const dispose2 = registerRelayListAutoRefresh(() => 0); // no-op, returns a noop disposer
+    window.dispatchEvent(new Event('focus'));
+    expect(refreshDocumentList).toHaveBeenCalledTimes(1);
+    dispose2();
+    dispose1();
+  });
+});

--- a/src/services/relayListAutoRefresh.ts
+++ b/src/services/relayListAutoRefresh.ts
@@ -1,0 +1,69 @@
+/**
+ * Auto-refresh the team document list when the app regains focus or comes back
+ * online (JP-324 #10).
+ *
+ * While a relay WS session is live the list already refreshes on its own: the
+ * relay re-authenticates on every reconnect → `setAuthenticated(true)` →
+ * `fetchDocumentList()`. The gap this closes is the *idle* case — the user is
+ * signed in but sitting on a local/offline document, so there's no live WS and
+ * no reconnect event. A document transferred from another session (e.g. their
+ * first cloud doc, promoted elsewhere) would otherwise stay invisible until a
+ * manual reload.
+ *
+ * `refreshDocumentList` is guarded (no-ops unless authenticated with a live
+ * provider), so these listeners are cheap when signed out. A short throttle
+ * collapses the focus + visibilitychange double-fire on a single tab return.
+ *
+ * Scope note (multi-workspace): this drives the single active relay's list via
+ * the store's current provider. When connection management grows to multiple
+ * workspaces, the refresh action — not this listener wiring — becomes the place
+ * to fan out per `relayId`.
+ */
+import { useRelayDocumentStore } from '../store/relayDocumentStore';
+
+let registered = false;
+
+/** Minimum gap between auto-refreshes, to collapse focus + visibility double-fires. */
+const MIN_INTERVAL_MS = 2_000;
+
+/**
+ * Register window/document listeners that refresh the relay document list on
+ * regained focus / visibility / connectivity. Idempotent — a second call while
+ * already registered is a no-op. Returns a disposer that removes the listeners.
+ */
+export function registerRelayListAutoRefresh(now: () => number = Date.now): () => void {
+  if (registered || typeof window === 'undefined' || typeof document === 'undefined') {
+    return () => {};
+  }
+  registered = true;
+
+  // Start in the distant past so the first refresh always passes the throttle,
+  // regardless of the clock's origin.
+  let lastRefresh = Number.NEGATIVE_INFINITY;
+  const refresh = (): void => {
+    const t = now();
+    if (t - lastRefresh < MIN_INTERVAL_MS) return;
+    lastRefresh = t;
+    useRelayDocumentStore.getState().refreshDocumentList();
+  };
+
+  const onVisibilityChange = (): void => {
+    if (document.visibilityState === 'visible') refresh();
+  };
+
+  window.addEventListener('focus', refresh);
+  window.addEventListener('online', refresh);
+  document.addEventListener('visibilitychange', onVisibilityChange);
+
+  return () => {
+    window.removeEventListener('focus', refresh);
+    window.removeEventListener('online', refresh);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+    registered = false;
+  };
+}
+
+/** Test-only: re-arm registration after a disposer wasn't called. */
+export function __resetRelayListAutoRefreshForTests(): void {
+  registered = false;
+}

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -61,3 +61,64 @@ describe('reconcileLocalDocuments', () => {
     expect(useDocumentRegistry.getState().entries).toBe(before);
   });
 });
+
+describe('clearRemoteDocuments (JP-324 hard-disconnect keeps cached docs)', () => {
+  const RELAY = 'relay-a:9876';
+  const OTHER = 'relay-b:9876';
+
+  function getType(id: string) {
+    return useDocumentRegistry.getState().getRecord(id)?.type;
+  }
+
+  it('demotes an offline-available remote doc to cached instead of dropping it', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('keep', 'Keep'), RELAY, 'owner', 'synced');
+    r.registerRemote(meta('drop', 'Drop'), RELAY, 'owner', 'synced');
+
+    // Only 'keep' has an offline copy.
+    r.clearRemoteDocuments(RELAY, new Set(['keep']));
+
+    expect(getType('keep')).toBe('cached'); // demoted, still browsable offline
+    expect(getType('drop')).toBeUndefined(); // no offline copy → dropped
+  });
+
+  it('keeps an already-cached doc that is offline-available', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('c', 'Cached'), RELAY, 'owner', 'synced');
+    r.convertToCached('c');
+    expect(getType('c')).toBe('cached');
+
+    r.clearRemoteDocuments(RELAY, new Set(['c']));
+
+    expect(getType('c')).toBe('cached');
+  });
+
+  it('leaves docs from a different relay untouched', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('other', 'Other'), OTHER, 'owner', 'synced');
+
+    r.clearRemoteDocuments(RELAY, new Set());
+
+    expect(getType('other')).toBe('remote');
+  });
+
+  it('keeps local documents', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerLocal(meta('loc', 'Local'));
+
+    r.clearRemoteDocuments(RELAY, new Set());
+
+    expect(getType('loc')).toBe('local');
+  });
+
+  it('drops everything for the relay when no preserve set is given (legacy purge)', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('x', 'X'), RELAY, 'owner', 'synced');
+    r.registerRemote(meta('y', 'Y'), RELAY, 'owner', 'synced');
+
+    r.clearRemoteDocuments(RELAY);
+
+    expect(getType('x')).toBeUndefined();
+    expect(getType('y')).toBeUndefined();
+  });
+});

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -104,8 +104,15 @@ interface DocumentRegistryActions {
   /** Remove a document from the registry */
   removeDocument: (id: string) => void;
 
-  /** Clear all remote documents for a host */
-  clearRemoteDocuments: (relayId: string) => void;
+  /**
+   * Clear a host's relay documents from the registry. Entries listed in
+   * `preserveOfflineIds` are kept as `cached` (a live `remote` entry is demoted)
+   * so a hard-disconnect doesn't make offline-available team docs vanish
+   * (JP-324); everything else for that relay is dropped. Omitting
+   * `preserveOfflineIds` drops them all (legacy behavior). Scoped by `relayId`,
+   * so other workspaces are untouched.
+   */
+  clearRemoteDocuments: (relayId: string, preserveOfflineIds?: ReadonlySet<string>) => void;
 
   /** Clear all documents */
   clearAll: () => void;
@@ -328,23 +335,32 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
         });
       },
 
-      clearRemoteDocuments: (relayId) => {
+      clearRemoteDocuments: (relayId, preserveOfflineIds) => {
         set((state) => {
           const newEntries: Record<string, DocumentRegistryEntry> = {};
 
           for (const [id, entry] of Object.entries(state.entries)) {
-            if (isRemoteDocument(entry.record)) {
-              if (entry.record.relayId !== relayId) {
-                newEntries[id] = entry;
-              }
-            } else if (isCachedDocument(entry.record)) {
-              if (entry.record.relayId !== relayId) {
-                newEntries[id] = entry;
-              }
-            } else {
-              // Keep local documents
+            const record = entry.record;
+            const isRelayDoc = isRemoteDocument(record) || isCachedDocument(record);
+
+            // Local docs, and relay docs from a different host, are untouched.
+            if (!isRelayDoc || record.relayId !== relayId) {
               newEntries[id] = entry;
+              continue;
             }
+
+            // This relay's docs: keep the offline-available ones so a
+            // hard-disconnect doesn't make cached team docs disappear (JP-324).
+            // A live `remote` entry is demoted to `cached` (still browsable, but
+            // clearly offline); an already-`cached` entry is kept as-is. Entries
+            // with no offline copy are dropped — nothing to show offline, and we
+            // must not retain titles past a full sign-out.
+            if (preserveOfflineIds?.has(id)) {
+              newEntries[id] = isRemoteDocument(record)
+                ? { ...entry, record: toCachedDocument(record) }
+                : entry;
+            }
+            // else: drop (omit from newEntries)
           }
 
           return { entries: newEntries };

--- a/src/store/persistenceStore.rename.test.ts
+++ b/src/store/persistenceStore.rename.test.ts
@@ -76,3 +76,47 @@ describe('applyRemoteDocumentName', () => {
     expect(usePersistenceStore.getState().currentDocumentName).toBe('Old Name');
   });
 });
+
+describe('renameDocument durability (JP-324 #9)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists a fresh untitled doc via saveDocument so the rename sticks', () => {
+    // Fresh untitled doc: no id, no metadata-map entry — the desync repro.
+    usePersistenceStore.setState({
+      currentDocumentId: null,
+      currentDocumentName: 'Untitled Document',
+      documents: {},
+    } as never);
+    const saveSpy = vi
+      .spyOn(usePersistenceStore.getState(), 'saveDocument')
+      .mockImplementation(() => {});
+
+    usePersistenceStore.getState().renameDocument('My Lobby');
+
+    // The rename is committed to display state AND routed through saveDocument
+    // (which mints the id + metadata entry + registry record).
+    expect(usePersistenceStore.getState().currentDocumentName).toBe('My Lobby');
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates metadata in place for an already-saved doc without re-saving', () => {
+    usePersistenceStore.setState({
+      currentDocumentId: 'doc-1',
+      currentDocumentName: 'Old Name',
+      documents: { 'doc-1': meta('doc-1', 'Old Name') },
+    } as never);
+    vi.spyOn(useDocumentRegistry.getState(), 'updateRecord').mockImplementation(() => {});
+    const saveSpy = vi
+      .spyOn(usePersistenceStore.getState(), 'saveDocument')
+      .mockImplementation(() => {});
+
+    usePersistenceStore.getState().renameDocument('New Name');
+
+    const s = usePersistenceStore.getState();
+    expect(s.documents['doc-1']?.name).toBe('New Name');
+    // A saved doc updates the map directly; no implicit save needed.
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -1022,12 +1022,14 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
       renameDocument: (name: string) => {
         const state = get();
         const docId = state.currentDocumentId;
+        const isSaved = !!(docId && state.documents[docId]);
+        const isCollab = !!docId && isCollabContentDoc(docId);
 
         set({ currentDocumentName: name, isDirty: true });
 
         // If document is saved, update metadata
-        if (docId && state.documents[docId]) {
-          const existingMeta = state.documents[docId];
+        if (isSaved) {
+          const existingMeta = state.documents[docId!]!;
           const updatedMeta: DocumentMetadata = {
             ...existingMeta,
             name,
@@ -1035,21 +1037,30 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
           set({
             documents: {
               ...state.documents,
-              [docId]: updatedMeta,
+              [docId!]: updatedMeta,
             },
           });
 
           // Also update the document registry for reactivity
-          useDocumentRegistry.getState().updateRecord(docId, { name });
+          useDocumentRegistry.getState().updateRecord(docId!, { name });
         }
 
-        // CRDT-native rename: when this is the active collab content doc, push
-        // the name through the Y.Doc metadata so it reaches the relay + peers.
-        // The REST save path that would otherwise carry the name is suppressed
-        // for collab docs (isCollabContentDoc), so without this the rename never
-        // leaves the device. Local-only docs stay local (no active session).
-        if (docId && isCollabContentDoc(docId)) {
+        if (isCollab) {
+          // CRDT-native rename: when this is the active collab content doc, push
+          // the name through the Y.Doc metadata so it reaches the relay + peers.
+          // The REST save path that would otherwise carry the name is suppressed
+          // for collab docs (isCollabContentDoc), so without this the rename never
+          // leaves the device.
           useCollaborationStore.getState().syncDocumentName(name);
+        } else if (!isSaved) {
+          // Fresh untitled / not-yet-saved local doc: it has no metadata-map
+          // entry, so the rename would otherwise live only in
+          // `currentDocumentName` and revert (desync) on the next save/reload —
+          // JP-324 #9. Persist now so the rename is durable and the doc gains a
+          // stable id + registry entry. `saveDocument` mints the id, writes the
+          // metadata map, and registers it; it self-guards parked relay docs
+          // (teamDocContentPending) and page-integrity failures.
+          get().saveDocument();
         }
       },
 

--- a/src/store/relayDocumentStore.test.ts
+++ b/src/store/relayDocumentStore.test.ts
@@ -85,3 +85,37 @@ describe('relayDocumentStore.uploadCollabBlobs (JP-234)', () => {
     ).rejects.toThrow('storage quota exceeded');
   });
 });
+
+describe('relayDocumentStore.refreshDocumentList (JP-324 #10)', () => {
+  beforeEach(() => {
+    useRelayDocumentStore.getState().setProvider(null);
+    useRelayDocumentStore.setState({ authenticated: false });
+  });
+
+  it('no-ops when no provider is set', () => {
+    useRelayDocumentStore.setState({ authenticated: true });
+    // No provider → no throw, no fetch attempt.
+    expect(() => useRelayDocumentStore.getState().refreshDocumentList()).not.toThrow();
+  });
+
+  it('no-ops when not authenticated even with a provider', () => {
+    const listDocuments = vi.fn(async () => []);
+    const provider = { listDocuments } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    useRelayDocumentStore.getState().refreshDocumentList();
+
+    expect(listDocuments).not.toHaveBeenCalled();
+  });
+
+  it('fetches the list when authenticated with a live provider', () => {
+    const listDocuments = vi.fn(async () => []);
+    const provider = { listDocuments } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+    useRelayDocumentStore.setState({ authenticated: true });
+
+    useRelayDocumentStore.getState().refreshDocumentList();
+
+    expect(listDocuments).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -248,7 +248,18 @@ interface RelayDocumentActions {
   
   /** Refresh stale cached documents from server (call after reconnect) */
   refreshStaleCachedDocuments: () => Promise<void>;
-  
+
+  /**
+   * Best-effort refresh of the team document list + stale cached docs. No-ops
+   * unless authenticated with a live provider, so it's safe to fire from
+   * focus/visibility/online listeners (JP-324 #10): a doc transferred from
+   * another session shows up without a manual reload, even while the user sits
+   * idle on a local/offline document with no live WS to drive a reconnect
+   * refetch. The reconnect path itself is already covered (the relay re-auths on
+   * every WS reconnect → `setAuthenticated` → `fetchDocumentList`).
+   */
+  refreshDocumentList: () => void;
+
   /** Preload cached documents into memory (call on app start) */
   warmupCache: () => Promise<void>;
 }
@@ -848,6 +859,17 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           .then(() => get().refreshStaleCachedDocuments())
           .catch(console.error);
       }
+    },
+
+    refreshDocumentList: () => {
+      // Guard: nothing to refresh when signed out or without a live provider.
+      // Keeps focus/visibility/online listeners cheap and side-effect-free in
+      // the common signed-out / local-only-doc case.
+      if (!docProvider || !get().authenticated) return;
+      get()
+        .fetchDocumentList()
+        .then(() => get().refreshStaleCachedDocuments())
+        .catch((e) => console.error('[relayDocumentStore] auto-refresh failed:', e));
     },
 
     clearRelayDocuments: () => {

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -873,10 +873,16 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
     },
 
     clearRelayDocuments: () => {
-      // Clear remote documents from registry for the current host
+      // Clear this host's relay docs from the registry, but keep the
+      // offline-available ones visible (as cached) so a hard-disconnect doesn't
+      // make cached team docs disappear (JP-324). Their durable copies in
+      // RelayDocumentCache outlive this clear; reconnect re-promotes them to
+      // live. Scoped by host so other workspaces are untouched.
       const connection = useConnectionStore.getState();
-      if (connection.host?.address) {
-        useDocumentRegistry.getState().clearRemoteDocuments(connection.host.address);
+      const host = connection.host?.address;
+      if (host) {
+        const offlineIds = new Set(RelayDocumentCache.getCachedIdsForHost(host));
+        useDocumentRegistry.getState().clearRemoteDocuments(host, offlineIds);
       }
 
       set({

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -36,6 +36,7 @@ import { initializePersistence, usePersistenceStore } from '../store/persistence
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { registerRelayListAutoRefresh } from '../services/relayListAutoRefresh';
 import { useTrashStore } from '../store/trashStore';
 import { ensureDocBlobsLocal } from '../store/offlineAvailability';
 import { useUserStore } from '../store/userStore';
@@ -281,6 +282,12 @@ function App() {
     window.addEventListener('docushark:open-documents', open);
     return () => window.removeEventListener('docushark:open-documents', open);
   }, []);
+
+  // Refresh the team document list on regained focus / connectivity (JP-324
+  // #10) so a doc transferred from another session appears without a manual
+  // reload while sitting idle on a local/offline doc. Guarded + throttled in the
+  // service; no-ops when signed out.
+  useEffect(() => registerRelayListAutoRefresh(), []);
 
   // Initialize persistence on mount
   useEffect(() => {


### PR DESCRIPTION
Closes JP-324. Client-side only. Four slices, one cohesive PR (commit-per-slice). Surfaced during the JP-312 joy-ride follow-up; several findings share one root cause.

## Slices

**1. Restore the persisted relay token on cold boot** — the "sign in EVERY startup" fix (and #10's cold-boot variant). On a fresh process `connectionStore` was empty, so `ensureCollabSessionForDoc` started engine-only and the REST client came up unauthenticated → the cloud list never loaded and the user was re-prompted. New pure `chooseRelaySessionToken` prefers a valid in-memory token, else a still-unexpired persisted one, else engine-only; a disk-restored token is re-asserted into `connectionStore` after `startSession` (mirrors `completeCloudSignIn`; cold-start `startSession` doesn't reset the store).

**2. Auto-refresh the team doc list on focus/visibility/online (#10 idle variant)** — a guarded `refreshDocumentList` action + a small `registerRelayListAutoRefresh` service (throttled). Covers the gap where the user sits idle on a local/offline doc with no live WS, so a doc transferred elsewhere shows up without a manual reload.

**3. Durable rename of an unsaved doc (#9)** — `renameDocument` now persists a fresh untitled doc via `saveDocument()` (mints id + metadata + registry record) so the name survives reload instead of desyncing.

**4. Hard-disconnect keeps cached team docs visible** — `clearRemoteDocuments` took an optional `preserveOfflineIds` set: offline-available docs are kept (a live `remote` entry is demoted to `cached`), everything else for that relay is dropped, other relays untouched. `clearRelayDocuments` passes the host's `RelayDocumentCache` ids, so disconnect preserves exactly the docs with a durable offline copy (no retained titles past a full sign-out). Reconnect re-promotes them. Scoped by `relayId` throughout to keep multi-workspace a later extension.

## Probe notes — deliberately NOT changed
- The WS provider re-auths on every reconnect, so the reconnect refetch already happens via `setAuthenticated`; a `setHostConnected(true)` refetch would just double-fetch.
- A 401 is a genuine auth rejection; Slice 1 removed the only spurious (no-token-on-boot) 401, so guarding the drop-on-401 would risk wedging on a server-side revocation.
- Pre-test #16 (MCP first-page rename) is already correct in the relay — no code.

Also: updated the stale "must click Connect" decision note in `relayConnection.ts`.

## Verification
- `bun run typecheck` ✓, `bun run test --run` ✓ (2446 tests; +24 new across `ensureCollabSession`, `relayListAutoRefresh`, `relayDocumentStore`, `persistenceStore.rename`, `documentRegistry`), `bun run build` ✓.
- Manual E2E (founder gate): restart on a collab doc → no re-sign-in + list loads; transfer a doc elsewhere → appears on refocus/reconnect; rename a fresh untitled doc → name sticks after reload; hard-disconnect → cached team docs stay visible, reconnect refreshes to live.

Assisted-by: Opus 4.8