### PR TITLE
JP-237: connection lifecycle — reconnect UX hardening + Remove Workspace

### DIFF
--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -2812,6 +2812,9 @@ async fn handle_message(
             MESSAGE_SYNC_CHUNK => handle_sync_chunk(client_id, data, state).await,
             MESSAGE_AWARENESS => handle_awareness(client_id, data, state).await,
             MESSAGE_JOIN_DOC => handle_join_doc(client_id, data, state).await,
+            // JP-237 liveness heartbeat: echo the bare frame straight back so the
+            // client can detect a silently-dropped socket. Cheap and stateless.
+            MESSAGE_HEARTBEAT => send_to_client(client_id, vec![MESSAGE_HEARTBEAT], state).await,
             _ => {
                 log::warn!("Unknown message type {} from client {}", msg_type, client_id);
             }
@@ -3427,6 +3430,44 @@ mod tests {
         let keep_alive = handle_message(client_id, MESSAGE_SYNC, b"\x00ignored", &state).await;
         assert!(!keep_alive, "panic must drop the connection");
         assert_eq!(state.panic_count(), 1, "panic must increment the counter");
+    }
+
+    /// JP-237: a liveness heartbeat is echoed straight back to the sender so the
+    /// client can detect a silently-dropped socket. Stateless and auth-agnostic.
+    #[tokio::test]
+    async fn handle_message_echoes_heartbeat() {
+        use crate::server::protocol::WorkspaceId;
+
+        let state = test_server_state(TenancyConfig::default()).await;
+
+        let (tx, mut rx) = mpsc::channel(4);
+        let client_id = state.next_client_id();
+        {
+            let mut clients = state.clients.write().await;
+            clients.insert(
+                client_id,
+                ClientState {
+                    id: client_id,
+                    user_id: Some("user-1".to_string()),
+                    username: None,
+                    role: None,
+                    current_doc_id: None,
+                    current_workspace_id: WorkspaceId::single_tenant(),
+                    authenticated: true,
+                    jti: None,
+                    token_exp: None,
+                    tx,
+                    reassembly: chunk::ChunkReassembler::default(),
+                },
+            );
+        }
+
+        let keep_alive =
+            handle_message(client_id, MESSAGE_HEARTBEAT, &[MESSAGE_HEARTBEAT], &state).await;
+        assert!(keep_alive, "heartbeat must keep the connection alive");
+
+        let echoed = rx.recv().await.expect("heartbeat echo");
+        assert_eq!(echoed, vec![MESSAGE_HEARTBEAT]);
     }
 
     /// Build a `ServerState` for inline tenancy/limit tests. Mirrors

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -282,6 +282,13 @@ pub const MESSAGE_SYNC_CHUNK: u8 = 14;
 /// applied. Body (binary): `[msgId: 16 bytes]`.
 pub const MESSAGE_SYNC_CHUNK_ACK: u8 = 15;
 
+/// Liveness heartbeat (bodyless, a bare 1-byte frame). The client sends it on an
+/// interval; the relay echoes it straight back so the client can detect a
+/// silently-dropped socket (wifi off, idle proxy kill) that never fires a WS
+/// close. Additive + client-feature-detected, so no PROTOCOL_VERSION bump (an
+/// older client simply never sends it; an older relay would log it as unknown).
+pub const MESSAGE_HEARTBEAT: u8 = 16;
+
 /// Authentication request with JWT token (sent by client)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/collaboration/UnifiedSyncProvider.test.ts
+++ b/src/collaboration/UnifiedSyncProvider.test.ts
@@ -9,6 +9,7 @@ import {
   MESSAGE_ERROR,
   MESSAGE_SYNC,
   MESSAGE_SYNC_CHUNK,
+  MESSAGE_HEARTBEAT,
   encodeMessage,
   decodeMessageType,
   decodePayload,
@@ -270,6 +271,63 @@ describe('UnifiedSyncProvider', () => {
       mockWebSocket?.simulateError();
 
       expect(provider.getStatus()).toBe('error');
+    });
+  });
+
+  describe('Liveness heartbeat (JP-237)', () => {
+    const HEARTBEAT_INTERVAL_MS = 15000;
+    const PONG_TIMEOUT_MS = 5000;
+
+    it('sends a heartbeat frame on the interval once open', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket?.simulateOpen();
+      mockWebSocket?.clearSentMessages();
+
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+
+      expect(mockWebSocket?.findSentMessage(MESSAGE_HEARTBEAT)).not.toBeNull();
+    });
+
+    it('closes a dead socket when a heartbeat goes unanswered (after the relay echoed once)', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket?.simulateOpen();
+
+      // First heartbeat → relay echoes → enforcement enabled.
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      mockWebSocket?.simulateMessage(new Uint8Array([MESSAGE_HEARTBEAT]));
+
+      // Second heartbeat → no echo → deadline fires → socket closed.
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      vi.advanceTimersByTime(PONG_TIMEOUT_MS);
+      vi.advanceTimersByTime(1); // mock close() schedules its onclose a tick later
+
+      expect(provider.getStatus()).toBe('disconnected');
+    });
+
+    it('does NOT close when the relay never echoes (feature-detect, old relay)', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket?.simulateOpen();
+
+      // Heartbeats sent, but no echo ever → never enforce → stay connected.
+      vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      vi.advanceTimersByTime(PONG_TIMEOUT_MS);
+      vi.advanceTimersByTime(1);
+
+      expect(provider.getStatus()).toBe('connected');
+    });
+
+    it('dropForReconnect closes the socket (navigator offline)', () => {
+      provider = createProvider();
+      provider.connect();
+      mockWebSocket?.simulateOpen();
+
+      provider.dropForReconnect();
+      vi.advanceTimersByTime(1); // mock close() → onclose
+
+      expect(provider.getStatus()).toBe('disconnected');
     });
   });
 

--- a/src/collaboration/UnifiedSyncProvider.ts
+++ b/src/collaboration/UnifiedSyncProvider.ts
@@ -241,6 +241,19 @@ export class UnifiedSyncProvider {
     this.setStatus('disconnected');
   }
 
+  /**
+   * Manual reconnect (user pressed "Reconnect"): clear any pending backoff, reset
+   * the attempt budget so a gave-up state gets a fresh set of retries, and connect
+   * immediately. No-op if a socket is already open/connecting (`connect()` guards
+   * on an existing `ws`).
+   */
+  retryNow(): void {
+    this.clearReconnectTimeout();
+    this.reconnectAttempts = 0;
+    useConnectionStore.getState().resetReconnectAttempts();
+    this.connect();
+  }
+
   /** Destroy the provider and clean up */
   destroy(): void {
     this.disconnect();

--- a/src/collaboration/UnifiedSyncProvider.ts
+++ b/src/collaboration/UnifiedSyncProvider.ts
@@ -30,6 +30,7 @@ import {
   MESSAGE_DOC_EVENT,
   MESSAGE_JOIN_DOC,
   MESSAGE_ERROR,
+  MESSAGE_HEARTBEAT,
   encodeMessage,
   decodePayload,
   type AuthResponse,
@@ -145,6 +146,19 @@ export class UnifiedSyncProvider {
   private reconnectAttempts = 0;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Liveness heartbeat (JP-237). A silently-dropped socket (wifi off, relay
+   * process dies, proxy idle-kill) never fires `onclose`, so without this the
+   * client believes it's still connected for the full TCP timeout (30–120s).
+   * We ping on an interval and expect the relay to echo within a deadline.
+   */
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private pongTimer: ReturnType<typeof setTimeout> | null = null;
+  /** True once the relay has echoed at least one heartbeat — only THEN do we
+   *  enforce the deadline, so an older relay that ignores the frame can't cause
+   *  a false disconnect (feature detection in lieu of a PROTOCOL_VERSION bump). */
+  private heartbeatSupported = false;
+
   /** Current document ID for CRDT routing */
   private currentDocId: string | null = null;
 
@@ -230,6 +244,7 @@ export class UnifiedSyncProvider {
   /** Disconnect from the WebSocket server */
   disconnect(): void {
     this.clearReconnectTimeout();
+    this.stopHeartbeat();
 
     if (this.ws) {
       this.ws.close();
@@ -386,6 +401,9 @@ export class UnifiedSyncProvider {
 
     // Send initial awareness
     this.sendAwarenessUpdate();
+
+    // Begin liveness heartbeats now the socket is open (JP-237).
+    this.startHeartbeat();
   };
 
   private handleMessage = (event: MessageEvent): void => {
@@ -417,6 +435,11 @@ export class UnifiedSyncProvider {
         // local delta lives durably in the Y.Doc/y-indexeddb and the broadcast
         // path already informs peers, so this is just a delivery confirmation.
         break;
+      case MESSAGE_HEARTBEAT:
+        // JP-237: the relay echoed our heartbeat — the socket is alive. Clear the
+        // pong-deadline and (once supported is observed) keep enforcing it.
+        this.handleHeartbeatPong();
+        break;
       default:
         // Unknown message type, ignore
         break;
@@ -427,6 +450,7 @@ export class UnifiedSyncProvider {
     this.ws = null;
     this.synced = false;
     this.authenticated = false;
+    this.stopHeartbeat();
 
     if (this.status !== 'disconnected') {
       this.setStatus('disconnected');
@@ -631,6 +655,74 @@ export class UnifiedSyncProvider {
       this.options.onError(response.error, this.currentDocId);
     } catch (e) {
       console.error('[UnifiedSyncProvider] Failed to parse error frame:', e);
+    }
+  }
+
+  // ============ Liveness heartbeat (JP-237) ============
+
+  /** How often the client pings the relay. */
+  private static readonly HEARTBEAT_INTERVAL_MS = 15000;
+  /** How long to wait for the relay's echo before declaring the socket dead. */
+  private static readonly HEARTBEAT_PONG_TIMEOUT_MS = 5000;
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      this.sendHeartbeat();
+    }, UnifiedSyncProvider.HEARTBEAT_INTERVAL_MS);
+  }
+
+  private sendHeartbeat(): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    // A previous ping is still outstanding when the next interval fires — only
+    // possible if the deadline didn't fire yet; let the deadline handle it.
+    if (this.pongTimer !== null) return;
+    try {
+      this.ws.send(new Uint8Array([MESSAGE_HEARTBEAT]));
+    } catch {
+      return; // send failed — the close/error handlers will take over
+    }
+    this.pongTimer = setTimeout(() => {
+      this.pongTimer = null;
+      // Only treat a missed echo as a dead socket once we know the relay speaks
+      // heartbeat (feature detection) — otherwise an older relay would be wrongly
+      // dropped every interval.
+      if (this.heartbeatSupported && this.ws?.readyState === WebSocket.OPEN) {
+        console.warn('[UnifiedSyncProvider] Heartbeat timed out — closing dead socket');
+        this.ws.close(4000, 'heartbeat timeout');
+      }
+    }, UnifiedSyncProvider.HEARTBEAT_PONG_TIMEOUT_MS);
+  }
+
+  private handleHeartbeatPong(): void {
+    this.heartbeatSupported = true;
+    if (this.pongTimer !== null) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (this.pongTimer !== null) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+  }
+
+  /**
+   * Drop the socket because the OS reported the network went away (JP-237,
+   * `navigator.onLine`). Closing routes through `handleClose` → `disconnected`
+   * → `scheduleReconnect`, so the UI reflects offline immediately and reconnect
+   * resumes when the network returns (or via `retryNow` on the `online` event).
+   * No-op if there's no live socket.
+   */
+  dropForReconnect(): void {
+    if (this.ws) {
+      this.ws.close(4001, 'network offline');
     }
   }
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -22,7 +22,11 @@ import type { ProsePageMeta, CanvasPageMeta } from './YjsDocument';
 import { UnifiedSyncProvider, AwarenessUserState } from './UnifiedSyncProvider';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { registerCollabOwnsActivePageLoad } from '../store/pageStore';
-import { reattachAwaitingTeamDocument, syncCurrentDocToRelayOnConnect } from '../store/persistenceStore';
+import {
+  reattachAwaitingTeamDocument,
+  syncCurrentDocToRelayOnConnect,
+  uploadCollabBlobsOnConnect,
+} from '../store/persistenceStore';
 import { getSyncStateManager } from './SyncStateManager';
 import {
   useConnectionStore,
@@ -149,6 +153,11 @@ interface CollaborationActions {
    * terminal latch + the provider's attempt budget and connects immediately.
    */
   reconnectNow: () => void;
+  /** Network went away (`navigator.onLine`) — drop the (likely dead) socket so the
+   *  offline UI appears immediately and reconnect resumes. */
+  handleNetworkOffline: () => void;
+  /** Network returned — retry the connection immediately. */
+  handleNetworkOnline: () => void;
 
   // Local -> Remote sync
   /** Sync a shape change to remote peers */
@@ -524,6 +533,9 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
                   : undefined,
               )
               .then(() => syncCurrentDocToRelayOnConnect())
+              // JP-237: re-push blobs added while offline (collab docs skip the
+              // upload when disconnected). Server-deduped, so a no-op if present.
+              .then(() => uploadCollabBlobsOnConnect())
               .catch((e) => console.warn('[collab] on-connect relay sync failed:', e));
           }
         },
@@ -685,6 +697,19 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // Manual retry (banner "Reconnect"): un-latch terminal + reset the attempt
       // budget and connect immediately. No-op on the socket if no provider is
       // live — the banner also opens the quick-connect menu for a full re-pair.
+      clearReconnectTerminal();
+      syncProvider?.retryNow();
+    },
+
+    handleNetworkOffline: () => {
+      // The OS reported the network went away (JP-237 navigator.onLine). A dead
+      // socket may not fire `onclose` for 30–120s, so proactively drop it →
+      // disconnected → reconnect, making the offline UI appear immediately.
+      syncProvider?.dropForReconnect();
+    },
+
+    handleNetworkOnline: () => {
+      // Network came back — retry immediately rather than waiting on backoff.
       clearReconnectTerminal();
       syncProvider?.retryNow();
     },

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -31,6 +31,8 @@ import {
   startTokenExpirationMonitor,
   stopTokenExpirationMonitor,
   muteConnectionToasts,
+  markReconnectCancelled,
+  clearReconnectTerminal,
 } from '../store/connectionStore';
 import { attemptTokenRefresh } from '../api/tokenRefresh';
 import { usePresenceStore } from '../store/presenceStore';
@@ -135,6 +137,18 @@ interface CollaborationActions {
    * offline/re-login. Used when navigating from a relay doc to a local one.
    */
   leaveDocument: () => void;
+  /**
+   * Stop the provider's auto-reconnect loop and go offline (JP-237). The user
+   * pressed "Cancel" on the reconnecting toast — they choose to stay offline
+   * (the CRDT keeps working locally); the connection banner offers a manual
+   * Reconnect. Keeps the doc engine + auth intact, only the socket retry stops.
+   */
+  cancelReconnect: () => void;
+  /**
+   * Manually retry the connection (JP-237) — the banner's "Reconnect". Clears the
+   * terminal latch + the provider's attempt budget and connects immediately.
+   */
+  reconnectNow: () => void;
 
   // Local -> Remote sync
   /** Sync a shape change to remote peers */
@@ -656,6 +670,23 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // Leave the doc but stay signed in: same teardown, but keep the relay
       // token/host/user so reopening a relay doc reconnects authenticated.
       teardownSession(set, { preserveAuth: true });
+    },
+
+    cancelReconnect: () => {
+      // User chose to stop retrying (Cancel on the reconnecting toast). Halt the
+      // provider's auto-reconnect loop (clears its backoff timer) and latch the
+      // offline phase so the banner takes over. Engine + auth stay intact; the
+      // CRDT keeps working locally and a manual Reconnect can resume.
+      syncProvider?.disconnect();
+      markReconnectCancelled();
+    },
+
+    reconnectNow: () => {
+      // Manual retry (banner "Reconnect"): un-latch terminal + reset the attempt
+      // budget and connect immediately. No-op on the socket if no provider is
+      // live — the banner also opens the quick-connect menu for a full re-pair.
+      clearReconnectTerminal();
+      syncProvider?.retryNow();
     },
 
     syncShape: (shape: Shape) => {

--- a/src/collaboration/protocol.ts
+++ b/src/collaboration/protocol.ts
@@ -74,6 +74,16 @@ export const MESSAGE_SYNC_CHUNK = 14;
  * Body (binary): `[msgId: 16 bytes]`. */
 export const MESSAGE_SYNC_CHUNK_ACK = 15;
 
+/**
+ * Liveness heartbeat (bodyless, a bare 1-byte frame). The client sends it on an
+ * interval and the relay echoes it straight back; a missed echo within the
+ * pong-deadline means the socket is silently dead (wifi off, relay died) so the
+ * client closes + reconnects. **Additive + feature-detected** — the client only
+ * enforces the deadline once it has seen one echo, so an older relay that ignores
+ * the frame causes no false disconnects (no PROTOCOL_VERSION bump needed).
+ */
+export const MESSAGE_HEARTBEAT = 16;
+
 // ============ Request/Response Types ============
 
 /** Authentication response from server */

--- a/src/services/networkStatusWatcher.test.ts
+++ b/src/services/networkStatusWatcher.test.ts
@@ -1,0 +1,56 @@
+/**
+ * networkStatusWatcher (JP-237): browser online/offline events drive the relay
+ * connection — the fast-path for the common wifi-off case.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const handleNetworkOffline = vi.fn();
+const handleNetworkOnline = vi.fn();
+vi.mock('../collaboration/collaborationStore', () => ({
+  useCollaborationStore: { getState: () => ({ handleNetworkOffline, handleNetworkOnline }) },
+}));
+
+import {
+  registerNetworkStatusWatcher,
+  __resetNetworkStatusWatcherForTests,
+} from './networkStatusWatcher';
+
+describe('registerNetworkStatusWatcher', () => {
+  beforeEach(() => {
+    handleNetworkOffline.mockClear();
+    handleNetworkOnline.mockClear();
+    __resetNetworkStatusWatcherForTests();
+  });
+
+  it('drops the connection on offline', () => {
+    const dispose = registerNetworkStatusWatcher();
+    window.dispatchEvent(new Event('offline'));
+    expect(handleNetworkOffline).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('retries the connection on online', () => {
+    const dispose = registerNetworkStatusWatcher();
+    window.dispatchEvent(new Event('online'));
+    expect(handleNetworkOnline).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it('disposer removes the listeners', () => {
+    const dispose = registerNetworkStatusWatcher();
+    dispose();
+    window.dispatchEvent(new Event('offline'));
+    window.dispatchEvent(new Event('online'));
+    expect(handleNetworkOffline).not.toHaveBeenCalled();
+    expect(handleNetworkOnline).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — a second register while active does not double-bind', () => {
+    const dispose1 = registerNetworkStatusWatcher();
+    const dispose2 = registerNetworkStatusWatcher();
+    window.dispatchEvent(new Event('offline'));
+    expect(handleNetworkOffline).toHaveBeenCalledTimes(1);
+    dispose2();
+    dispose1();
+  });
+});

--- a/src/services/networkStatusWatcher.ts
+++ b/src/services/networkStatusWatcher.ts
@@ -1,0 +1,43 @@
+/**
+ * Network-status watcher (JP-237).
+ *
+ * The browser's `online`/`offline` events are the fastest signal that the device
+ * lost (or regained) network — far quicker than waiting for a silently-dropped
+ * WebSocket to fire `onclose` (30–120s of TCP timeout). On `offline` we proactively
+ * drop the live relay socket so the offline UI (status-bar chip / toast) appears
+ * immediately and reconnect begins; on `online` we retry at once instead of waiting
+ * on the backoff schedule.
+ *
+ * This is the fast-path for the common "wifi went off" case; the WS heartbeat
+ * (UnifiedSyncProvider) covers drops the OS doesn't report (relay process died with
+ * the network still up).
+ */
+import { useCollaborationStore } from '../collaboration/collaborationStore';
+
+let registered = false;
+
+/**
+ * Register `online`/`offline` listeners that drive the relay connection. Idempotent;
+ * returns a disposer that removes them.
+ */
+export function registerNetworkStatusWatcher(): () => void {
+  if (registered || typeof window === 'undefined') return () => {};
+  registered = true;
+
+  const onOffline = (): void => useCollaborationStore.getState().handleNetworkOffline();
+  const onOnline = (): void => useCollaborationStore.getState().handleNetworkOnline();
+
+  window.addEventListener('offline', onOffline);
+  window.addEventListener('online', onOnline);
+
+  return () => {
+    window.removeEventListener('offline', onOffline);
+    window.removeEventListener('online', onOnline);
+    registered = false;
+  };
+}
+
+/** Test-only: re-arm registration after a disposer wasn't called. */
+export function __resetNetworkStatusWatcherForTests(): void {
+  registered = false;
+}

--- a/src/services/removeWorkspace.test.ts
+++ b/src/services/removeWorkspace.test.ts
@@ -1,0 +1,60 @@
+/**
+ * removeCurrentWorkspace (JP-237): the hard purge. Verifies it tears down the
+ * session and deletes the host's registry entries, durable offline copies, local
+ * CRDT rooms, and the persisted connection — all scoped to the current host.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const {
+  stopSession,
+  clearRemoteDocuments,
+  clearForHost,
+  purgeLocalDocRoom,
+  clearConnection,
+  getCachedIdsForHost,
+} = vi.hoisted(() => ({
+  stopSession: vi.fn(),
+  clearRemoteDocuments: vi.fn(),
+  clearForHost: vi.fn(async () => {}),
+  purgeLocalDocRoom: vi.fn(async () => {}),
+  clearConnection: vi.fn(async () => {}),
+  getCachedIdsForHost: vi.fn(() => ['doc-1', 'doc-2']),
+}));
+
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: { getState: () => ({ host: { address: 'relay-a:9876' } }) },
+}));
+vi.mock('../collaboration/collaborationStore', () => ({
+  useCollaborationStore: { getState: () => ({ stopSession }) },
+}));
+vi.mock('../store/documentRegistry', () => ({
+  useDocumentRegistry: { getState: () => ({ clearRemoteDocuments }) },
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({
+  RelayDocumentCache: { getCachedIdsForHost, clearForHost },
+}));
+vi.mock('../collaboration/ensureCollabSession', () => ({ purgeLocalDocRoom }));
+vi.mock('../api/relayConnection', () => ({ clearConnection }));
+
+import { removeCurrentWorkspace } from './removeWorkspace';
+
+describe('removeCurrentWorkspace', () => {
+  beforeEach(() => {
+    [stopSession, clearRemoteDocuments, clearForHost, purgeLocalDocRoom, clearConnection].forEach(
+      (m) => m.mockClear(),
+    );
+    getCachedIdsForHost.mockClear();
+  });
+
+  it('purges the host everywhere and forgets the connection', async () => {
+    await removeCurrentWorkspace();
+
+    expect(stopSession).toHaveBeenCalledTimes(1);
+    expect(clearRemoteDocuments).toHaveBeenCalledWith('relay-a:9876');
+    expect(clearForHost).toHaveBeenCalledWith('relay-a:9876');
+    // One CRDT-room purge per cached doc.
+    expect(purgeLocalDocRoom).toHaveBeenCalledWith('doc-1');
+    expect(purgeLocalDocRoom).toHaveBeenCalledWith('doc-2');
+    expect(clearConnection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/removeWorkspace.ts
+++ b/src/services/removeWorkspace.ts
@@ -1,0 +1,44 @@
+/**
+ * Hard-remove the current relay workspace (JP-237).
+ *
+ * The destructive counterpart to Disconnect: where Disconnect is the *soft* path
+ * (stays signed out but keeps cached team docs browsable offline), Remove
+ * Workspace means the user wants this relay and its local footprint GONE. It
+ * tears down the live session, purges the host's registry entries + durable
+ * offline copies + local CRDT rooms, and forgets the persisted connection.
+ *
+ * Everything is scoped to the host/`relayId`, so when connection management grows
+ * to multiple concurrent workspaces this removes only the targeted relay.
+ */
+import { useConnectionStore } from '../store/connectionStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import { RelayDocumentCache } from '../storage/RelayDocumentCache';
+import { purgeLocalDocRoom } from '../collaboration/ensureCollabSession';
+import { clearConnection } from '../api/relayConnection';
+
+export async function removeCurrentWorkspace(): Promise<void> {
+  const host = useConnectionStore.getState().host?.address ?? null;
+  // Capture the host's doc ids BEFORE any teardown clears the caches — they're
+  // needed to purge the local CRDT rooms below.
+  const docIds = host ? RelayDocumentCache.getCachedIdsForHost(host) : [];
+
+  // 1. Tear down the live session + in-memory relay identity.
+  useCollaborationStore.getState().stopSession();
+
+  if (host) {
+    // 2. Drop ALL registry entries for the host — an explicit full purge (never
+    //    preserve cached entries here; this is the hard path, unlike disconnect).
+    useDocumentRegistry.getState().clearRemoteDocuments(host);
+    // 3. Delete the durable offline copies for the host.
+    await RelayDocumentCache.clearForHost(host);
+  }
+
+  // 4. Purge the local CRDT rooms (y-indexeddb `host:docId`) for those docs.
+  //    Done before step 5 — `purgeLocalDocRoom` derives the room host from the
+  //    still-persisted relay URL.
+  await Promise.all(docIds.map((id) => purgeLocalDocRoom(id)));
+
+  // 5. Forget the relay connection entirely (URLs + token).
+  await clearConnection();
+}

--- a/src/store/connectionController.test.ts
+++ b/src/store/connectionController.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Connection controller (JP-237): the reconnect-phase + single-toast logic in
+ * `initConnectionNotifications`. Verifies an unexpected drop shows ONE updatable
+ * toast (no per-status-flip spam), resolves on reconnect, goes terminal on
+ * give-up, and stays quiet during an intentional (muted) transition.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock the (dynamically-imported) notification store so we can observe toasts.
+const notify = vi.fn(() => 'toast-1');
+const update = vi.fn();
+const dismiss = vi.fn();
+const error = vi.fn();
+vi.mock('./notificationStore', () => ({
+  useNotificationStore: {
+    getState: () => ({ notify, update, dismiss, error, success: vi.fn(), warning: vi.fn() }),
+  },
+}));
+
+import {
+  useConnectionStore,
+  initConnectionNotifications,
+  muteConnectionToasts,
+  markReconnectCancelled,
+  __resetConnectionControllerForTests,
+  type ConnectionStatus,
+} from './connectionStore';
+
+let unsub: (() => void) | null = null;
+
+/** Let the controller's dynamic import('./notificationStore').then(...) resolve. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('connection controller (initConnectionNotifications)', () => {
+  beforeEach(async () => {
+    notify.mockClear();
+    update.mockClear();
+    dismiss.mockClear();
+    error.mockClear();
+    useConnectionStore.getState().reset();
+    __resetConnectionControllerForTests();
+    unsub = initConnectionNotifications();
+    await flush();
+  });
+
+  afterEach(() => {
+    unsub?.();
+    unsub = null;
+  });
+
+  const set = (status: ConnectionStatus, err?: string) =>
+    useConnectionStore.getState().setStatus(status, err);
+
+  it('shows ONE updatable toast across a drop→retry cycle (no spam)', () => {
+    set('authenticated'); // establish a prior session
+    set('disconnected'); // unexpected drop → create toast
+    useConnectionStore.getState().incrementReconnectAttempts();
+    set('connecting'); // retry → UPDATE, not a new toast
+    set('disconnected'); // bounce → still update
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(useConnectionStore.getState().reconnectPhase).toBe('reconnecting');
+  });
+
+  it('resolves to online and dismisses the toast on reconnect', () => {
+    vi.useFakeTimers();
+    set('authenticated');
+    set('disconnected');
+    set('connecting');
+    set('authenticated'); // reconnected
+
+    // The live toast is updated to a success and then auto-dismissed.
+    expect(update).toHaveBeenCalledWith('toast-1', { message: 'Reconnected', severity: 'success' });
+    vi.runAllTimers();
+    expect(dismiss).toHaveBeenCalledWith('toast-1');
+    expect(useConnectionStore.getState().reconnectPhase).toBe('online');
+    vi.useRealTimers();
+  });
+
+  it('goes terminal (offline) when the provider gives up', () => {
+    set('authenticated');
+    set('disconnected'); // reconnecting
+    set('error', 'Max reconnect attempts reached'); // give up
+
+    expect(dismiss).toHaveBeenCalledWith('toast-1');
+    expect(useConnectionStore.getState().reconnectPhase).toBe('offline');
+  });
+
+  it('stays quiet during an intentional (muted) transition', () => {
+    set('authenticated');
+    muteConnectionToasts(8000); // leave/switch/sign-in mutes the churn
+    set('disconnected');
+    set('connecting');
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().reconnectPhase).toBe('online');
+  });
+
+  it('markReconnectCancelled (user Cancel) dismisses the toast and goes offline', () => {
+    set('authenticated');
+    set('disconnected'); // reconnecting → toast-1
+    markReconnectCancelled(); // user pressed Cancel
+
+    expect(dismiss).toHaveBeenCalledWith('toast-1');
+    expect(useConnectionStore.getState().reconnectPhase).toBe('offline');
+
+    // And the latch holds: a further status bounce doesn't re-open the toast.
+    notify.mockClear();
+    set('connecting');
+    expect(notify).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().reconnectPhase).toBe('offline');
+  });
+
+  it('does not treat a first-connect failure as an outage', () => {
+    // Never authenticated — an error surfaces as a toast, no reconnect phase.
+    set('connecting');
+    set('error', 'WebSocket error');
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalled();
+    expect(useConnectionStore.getState().reconnectPhase).toBe('online');
+  });
+});

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -8,6 +8,7 @@
  */
 
 import { create } from 'zustand';
+import type { Notification, NotificationOptions } from './notificationStore';
 
 // ============ Types ============
 
@@ -19,6 +20,19 @@ export type ConnectionStatus =
   | 'authenticating' // Sending credentials/token
   | 'authenticated' // Ready for operations
   | 'error';        // Connection or auth error
+
+/**
+ * High-level reconnect phase for the UI — distinct from the low-level
+ * `ConnectionStatus`. Driven by the connection controller (NOT raw status flips),
+ * so an intentional doc-leave/switch/sign-in never looks like an outage.
+ *
+ * - `online` — authenticated/healthy (or never-connected; no affordance).
+ * - `reconnecting` — an unexpected drop the provider is auto-retrying; show the
+ *   single updatable "reconnecting…" toast.
+ * - `offline` — terminal: retries exhausted, auth rejected, or the user cancelled;
+ *   show the connection banner (the toast is dismissed).
+ */
+export type ReconnectPhase = 'online' | 'reconnecting' | 'offline';
 
 /** Authentication method */
 export type AuthMethod = 'token' | 'credentials' | 'none';
@@ -62,6 +76,8 @@ interface ConnectionState {
   lastConnectedAt: number | null;
   /** Whether auto-reconnect is enabled */
   autoReconnect: boolean;
+  /** High-level reconnect phase for the UI (online/reconnecting/offline). */
+  reconnectPhase: ReconnectPhase;
 }
 
 /** Connection actions */
@@ -82,6 +98,8 @@ interface ConnectionActions {
   resetReconnectAttempts: () => void;
   /** Set auto-reconnect flag */
   setAutoReconnect: (enabled: boolean) => void;
+  /** Set the high-level reconnect phase (driven by the connection controller). */
+  setReconnectPhase: (phase: ReconnectPhase) => void;
   /** Reset all connection state (on disconnect) */
   reset: () => void;
   /** Check if token is still valid */
@@ -101,6 +119,7 @@ const initialState: ConnectionState = {
   reconnectAttempts: 0,
   lastConnectedAt: null,
   autoReconnect: true,
+  reconnectPhase: 'online',
 };
 
 // ============ Store ============
@@ -155,6 +174,10 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
 
     setAutoReconnect: (enabled) => {
       set({ autoReconnect: enabled });
+    },
+
+    setReconnectPhase: (reconnectPhase) => {
+      set({ reconnectPhase });
     },
 
     reset: () => {
@@ -359,63 +382,149 @@ export function stopTokenExpirationMonitor(): void {
   tokenMonitorState.onTokenExpired = undefined;
 }
 
+// ============ Connection controller (reconnect phase + single toast) ============
+
+/** Lazy notification API — avoids a static circular import with notificationStore. */
+type ConnectionNotifApi = {
+  notify: (o: NotificationOptions) => string;
+  update: (id: string, changes: Partial<Pick<Notification, 'message' | 'severity'>>) => void;
+  dismiss: (id: string) => void;
+  error: (message: string, options?: { category?: 'transient' | 'permanent' }) => void;
+};
+let connectionNotif: ConnectionNotifApi | null = null;
+
+/** Id of the live "reconnecting…" toast, reused across a whole drop→retry cycle. */
+let reconnectToastId: string | null = null;
+/** True once we've authenticated at least once (a first-connect failure isn't an "outage"). */
+let everAuthenticated = false;
+/** Latched when reconnect is terminal (gave up / cancelled) until a fresh connect or manual retry. */
+let reconnectTerminal = false;
+
+/** ms a resolved "Reconnected" toast lingers before auto-dismissing. */
+const RECONNECTED_TOAST_MS = 3000;
+
+function dismissReconnectToast(): void {
+  if (reconnectToastId) connectionNotif?.dismiss(reconnectToastId);
+  reconnectToastId = null;
+}
+
 /**
- * Set up notification integration for connection status changes.
- * Call this once at app startup to enable user-facing notifications.
+ * The user cancelled reconnecting (Cancel on the toast). Stop showing the toast
+ * and go `offline` so the banner takes over. Latched until a successful reconnect
+ * or an explicit manual retry (`clearReconnectTerminal`).
+ */
+export function markReconnectCancelled(): void {
+  reconnectTerminal = true;
+  dismissReconnectToast();
+  useConnectionStore.getState().setReconnectPhase('offline');
+}
+
+/** A manual reconnect was requested — un-latch so the reconnecting UI can show again. */
+export function clearReconnectTerminal(): void {
+  reconnectTerminal = false;
+}
+
+/** Test-only: reset the module-level controller latches. */
+export function __resetConnectionControllerForTests(): void {
+  reconnectToastId = null;
+  everAuthenticated = false;
+  reconnectTerminal = false;
+  connectionToastMuteUntil = 0;
+}
+
+/**
+ * Set up connection-status notifications + the high-level reconnect phase. Call
+ * once at app startup.
+ *
+ * An UNEXPECTED drop after we've authenticated shows ONE persistent
+ * "reconnecting…" toast that updates in place (no per-status-flip spam) with a
+ * Cancel action; a successful reconnect resolves it to a brief "Reconnected"; a
+ * terminal give-up (max attempts) or the user cancelling flips the phase to
+ * `offline` (the banner takes over) and dismisses the toast. Intentional
+ * transitions (leave / switch / sign-in) are muted via `muteConnectionToasts`,
+ * so they never enter the reconnecting phase.
  */
 export function initConnectionNotifications(): () => void {
-  // Dynamic import to avoid circular dependencies
-  let notifyError: ((message: string, options?: { category?: 'transient' | 'permanent' }) => void) | null = null;
-  let notifyWarning: ((message: string) => void) | null = null;
-  let notifySuccess: ((message: string) => void) | null = null;
-
-  import('../store/notificationStore').then((module) => {
+  // Dynamic import to avoid a circular dependency with notificationStore.
+  import('./notificationStore').then((module) => {
     const store = module.useNotificationStore.getState();
-    notifyError = (msg, opts) => store.error(msg, opts);
-    notifyWarning = store.warning.bind(store);
-    notifySuccess = store.success.bind(store);
+    connectionNotif = {
+      notify: (o) => store.notify(o),
+      update: (id, changes) => store.update(id, changes),
+      dismiss: (id) => store.dismiss(id),
+      error: (msg, opts) => store.error(msg, opts),
+    };
   });
 
   let previousStatus: ConnectionStatus = 'disconnected';
-  let wasAuthenticated = false;
 
   return useConnectionStore.subscribe((state) => {
     const { status, error, reconnectAttempts } = state;
-
-    // Skip if status hasn't changed
     if (status === previousStatus) return;
-
-    // Errors always surface. The up/down toasts are suppressed during an
-    // intentional session transition (leave / doc-switch / sign-in), which
-    // tears the per-doc WS down and back up — that churn isn't a real outage.
-    const muted = Date.now() < connectionToastMuteUntil;
-
-    if (status === 'error' && error) {
-      notifyError?.(error, { category: 'permanent' });
-    } else if (!muted && status === 'disconnected' && wasAuthenticated) {
-      // Only notify if we were previously connected
-      if (reconnectAttempts > 0) {
-        notifyWarning?.(`Connection lost. Reconnecting (attempt ${reconnectAttempts})...`);
-      } else {
-        notifyWarning?.('Disconnected from server');
-      }
-    } else if (!muted && status === 'authenticated' && previousStatus !== 'authenticated') {
-      // Only show success on reconnection, not initial connection
-      if (wasAuthenticated || reconnectAttempts > 0) {
-        notifySuccess?.('Reconnected to server');
-      }
-    }
-
-    // An intentional transition settles once we're authenticated again — drop
-    // the mute immediately so a genuine drop right after still notifies.
-    if (muted && status === 'authenticated') {
-      connectionToastMuteUntil = 0;
-    }
-
-    // Track state for next comparison
     previousStatus = status;
+
+    const { setReconnectPhase } = useConnectionStore.getState();
+    const muted = Date.now() < connectionToastMuteUntil;
+    const gaveUp = status === 'error' && !!error && /max reconnect/i.test(error);
+
+    // Reconnected (or first successful connect): resolve any live toast.
     if (status === 'authenticated') {
-      wasAuthenticated = true;
+      if (reconnectToastId) {
+        const id = reconnectToastId;
+        reconnectToastId = null;
+        connectionNotif?.update(id, { message: 'Reconnected', severity: 'success' });
+        setTimeout(() => connectionNotif?.dismiss(id), RECONNECTED_TOAST_MS);
+      }
+      reconnectTerminal = false;
+      everAuthenticated = true;
+      if (muted) connectionToastMuteUntil = 0;
+      setReconnectPhase('online');
+      return;
+    }
+
+    // Before the first successful auth, keep legacy behavior: surface errors as a
+    // toast, no reconnect phase/banner (a first-connect failure isn't an outage).
+    if (!everAuthenticated) {
+      if (status === 'error' && error) connectionNotif?.error(error, { category: 'permanent' });
+      return;
+    }
+
+    // Terminal: gave up (max attempts) or the user cancelled. The banner owns it.
+    if (reconnectTerminal || gaveUp) {
+      reconnectTerminal = true;
+      dismissReconnectToast();
+      setReconnectPhase('offline');
+      if (status === 'error' && error) connectionNotif?.error(error, { category: 'permanent' });
+      return;
+    }
+
+    // Intentional-transition churn — stay quiet (don't enter the reconnecting UI).
+    if (muted) return;
+
+    // Transient drop: the provider is auto-retrying. Show/keep ONE updatable toast.
+    if (status === 'disconnected' || status === 'connecting' || status === 'error') {
+      const message =
+        reconnectAttempts > 0
+          ? `Workspace connection lost — reconnecting… (attempt ${reconnectAttempts})`
+          : 'Workspace connection lost — reconnecting…';
+      if (reconnectToastId) {
+        connectionNotif?.update(reconnectToastId, { message });
+      } else {
+        reconnectToastId =
+          connectionNotif?.notify({
+            message,
+            severity: 'warning',
+            category: 'transient',
+            duration: 0,
+            actionLabel: 'Cancel',
+            onAction: () => {
+              void import('../collaboration/collaborationStore').then((m) =>
+                m.useCollaborationStore.getState().cancelReconnect(),
+              );
+            },
+          }) ?? null;
+      }
+      setReconnectPhase('reconnecting');
     }
   });
 }

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -90,12 +90,16 @@ const generateId = (): string => {
   return `notif-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 };
 
-/** Default durations by severity */
+/**
+ * Default durations by severity. Bumped (JP-237) so toasts linger long enough to
+ * read/act on (~10–15s) rather than flashing past; callers can still override per
+ * toast, and a `duration: 0` toast (e.g. the reconnecting toast) never auto-dismisses.
+ */
 const DEFAULT_DURATIONS: Record<NotificationSeverity, number> = {
-  info: 4000,
-  success: 3000,
-  warning: 6000,
-  error: 8000,
+  info: 10000,
+  success: 6000,
+  warning: 15000,
+  error: 12000,
 };
 
 export const useNotificationStore = create<NotificationState>((set, get) => ({

--- a/src/store/persistenceStore.offlineRelaySave.test.ts
+++ b/src/store/persistenceStore.offlineRelaySave.test.ts
@@ -41,6 +41,7 @@ import {
 import { useRelayDocumentStore } from './relayDocumentStore';
 import { useConnectionStore } from './connectionStore';
 import { useNotificationStore } from './notificationStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { VersionConflictError } from '../api/relayClient';
 import type { DiagramDocument } from '../types/Document';
 import type { PDFSettings } from '../types/PDFExport';
@@ -207,6 +208,51 @@ describe('pushRelaySaveOrQueue — connected-save failure handling (JP-127)', ()
     // copy is kept (not dropped), and reattach won't clobber it.
     expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+});
+
+describe('collab blob upload — offline gate (JP-237)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    cacheMock.put.mockClear();
+    useConnectionStore.getState().reset();
+    useRelayDocumentStore.setState({ authenticated: false });
+    // Mark the doc as a live collab session so pushRelaySaveOrQueue takes the
+    // collab branch (relay is sole writer; blobs uploaded out-of-band).
+    useCollaborationStore.setState({ isActive: true } as never);
+  });
+
+  afterEach(() => {
+    useCollaborationStore.setState({ isActive: false, config: null } as never);
+  });
+
+  it('does NOT upload collab blobs while offline (but keeps the local cache)', () => {
+    const uploadCollabBlobs = vi.fn(async () => undefined);
+    useRelayDocumentStore.setState({ authenticated: false, uploadCollabBlobs } as never);
+    useConnectionStore.setState({ status: 'disconnected' });
+    useCollaborationStore.setState({ config: { documentId: 'collab-off' } } as never);
+    saveDocumentToStorage(makeRelayDoc('collab-off'));
+
+    saveDocumentPdfSettings('collab-off', pdfSettings);
+
+    expect(uploadCollabBlobs).not.toHaveBeenCalled();
+    // Bytes stay durable locally so reconnect can push them.
+    expect(cacheMock.put).toHaveBeenCalledTimes(1);
+  });
+
+  it('uploads collab blobs when authenticated', () => {
+    const uploadCollabBlobs = vi.fn(async () => undefined);
+    useRelayDocumentStore.setState({ authenticated: true, uploadCollabBlobs } as never);
+    useConnectionStore.setState({
+      status: 'authenticated',
+      host: { address: 'localhost:9876', url: 'http://localhost:9876' },
+    });
+    useCollaborationStore.setState({ config: { documentId: 'collab-on' } } as never);
+    saveDocumentToStorage(makeRelayDoc('collab-on'));
+
+    saveDocumentPdfSettings('collab-on', pdfSettings);
+
+    expect(uploadCollabBlobs).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -134,6 +134,16 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     // Push just the bytes here: content-addressed + immutable, so no doc save /
     // serverVersion bump / CRDT clobber. Best-effort; debounced by autosave and
     // deduped server-side.
+    //
+    // JP-237: gate on connection — offline, the every-2s autosave would otherwise
+    // retry-storm HEAD/PUTs the relay can't receive, and the failing existence
+    // HEAD makes BlobSyncService conservatively re-queue blobs that already exist
+    // server-side. The local cache `put` above keeps the bytes durable; on
+    // reconnect, `uploadCollabBlobs` re-runs for the active doc (collaborationStore
+    // onAuthenticated) so anything added offline still reaches the relay.
+    if (!isRelayAuthenticated()) {
+      return;
+    }
     console.log('[JP-234] collab branch: triggering uploadCollabBlobs for', doc.id);
     void relayStore
       .uploadCollabBlobs(doc)
@@ -1645,6 +1655,28 @@ export async function reattachAwaitingTeamDocument(): Promise<void> {
  * the queue's reconnect replay (the single writer for those), and a clean
  * doc is a no-op. Called from collaborationStore's onAuthenticated hook.
  */
+/**
+ * On reconnect, re-push the active collab doc's blob bytes (JP-237). The collab
+ * branch of `pushRelaySaveOrQueue` skips blob uploads while offline, so a file
+ * added offline never reached the relay; this re-runs the (server-deduped) upload
+ * once authenticated so it lands without needing a further edit. No-op for
+ * non-collab docs (their bytes ride the REST save) or when still offline.
+ */
+export async function uploadCollabBlobsOnConnect(): Promise<void> {
+  const ps = usePersistenceStore.getState();
+  const docId = ps.currentDocumentId;
+  if (!docId || !isCollabContentDoc(docId) || !isRelayAuthenticated()) return;
+
+  const existing = loadDocumentFromStorage(docId);
+  if (!existing?.isRelayDocument) return;
+
+  try {
+    await useRelayDocumentStore.getState().uploadCollabBlobs(existing);
+  } catch (err) {
+    console.warn('[persistenceStore] on-connect collab blob upload failed:', err);
+  }
+}
+
 export async function syncCurrentDocToRelayOnConnect(): Promise<void> {
   const ps = usePersistenceStore.getState();
   const docId = ps.currentDocumentId;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -80,6 +80,12 @@ function App() {
   // survives the round trip.
   const [appView, setAppView] = useState<'editor' | 'documents'>('editor');
 
+  // Bumped each time something asks to open the relay quick-connect menu (the
+  // connection banner's "Reconnect"). A monotonic nonce — not a boolean — so
+  // repeat requests re-fire even when DocumentsHome is already mounted, and so a
+  // fresh mount (set in the same tick as the event) still picks it up.
+  const [openCloudSignal, setOpenCloudSignal] = useState(0);
+
   // Command palette state (Cmd/Ctrl+K)
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
 
@@ -280,6 +286,18 @@ function App() {
     const open = () => setAppView('documents');
     window.addEventListener('docushark:open-documents', open);
     return () => window.removeEventListener('docushark:open-documents', open);
+  }, []);
+
+  // Open the relay quick-connect menu (Documents → Cloud), e.g. from the
+  // connection banner's "Reconnect" (JP-237). Switch to the Documents surface
+  // and bump the signal so DocumentsHome selects the Cloud view.
+  useEffect(() => {
+    const open = () => {
+      setAppView('documents');
+      setOpenCloudSignal((n) => n + 1);
+    };
+    window.addEventListener('docushark:open-cloud-connect', open);
+    return () => window.removeEventListener('docushark:open-cloud-connect', open);
   }, []);
 
   // Initialize persistence on mount
@@ -544,6 +562,7 @@ function App() {
             <DocumentsHome
               onLeaveToEditor={handleLeaveToEditor}
               onOpenSettings={handleOpenSettings}
+              openCloudSignal={openCloudSignal}
             />
           )}
         </main>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -27,6 +27,7 @@ import { NotificationToast } from './NotificationToast';
 import { UploadIndicator } from './UploadIndicator';
 import { ErrorBoundary } from './ErrorBoundary';
 import { ConnectionStatusBanner } from './ConnectionStatusBanner';
+import { registerNetworkStatusWatcher } from '../services/networkStatusWatcher';
 import { CommandPalette } from './CommandPalette';
 import { ShapeSearchPanel } from './ShapeSearchPanel';
 import { Whiteboard } from './Whiteboard';
@@ -299,6 +300,11 @@ function App() {
     window.addEventListener('docushark:open-cloud-connect', open);
     return () => window.removeEventListener('docushark:open-cloud-connect', open);
   }, []);
+
+  // Drive the relay connection off the browser's online/offline events (JP-237)
+  // so losing/regaining network reflects immediately instead of waiting on the
+  // WebSocket's slow TCP timeout.
+  useEffect(() => registerNetworkStatusWatcher(), []);
 
   // Initialize persistence on mount
   useEffect(() => {

--- a/src/ui/ConnectionStatusBanner.test.tsx
+++ b/src/ui/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * ConnectionStatusBanner (JP-237): renders ONLY in the terminal `offline` phase
+ * (never during normal reconnecting), and "Reconnect" retries + opens the relay
+ * quick-connect menu.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+const reconnectNow = vi.fn();
+vi.mock('../collaboration/collaborationStore', () => ({
+  useCollaborationStore: { getState: () => ({ reconnectNow }) },
+}));
+
+import { ConnectionStatusBanner } from './ConnectionStatusBanner';
+import { useConnectionStore } from '../store/connectionStore';
+
+describe('ConnectionStatusBanner', () => {
+  beforeEach(() => {
+    reconnectNow.mockClear();
+    useConnectionStore.getState().reset();
+    cleanup();
+  });
+
+  it('renders nothing while online', () => {
+    useConnectionStore.getState().setReconnectPhase('online');
+    const { container } = render(<ConnectionStatusBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing while reconnecting (no flashing during recovery)', () => {
+    useConnectionStore.getState().setReconnectPhase('reconnecting');
+    const { container } = render(<ConnectionStatusBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the banner only when offline (terminal)', () => {
+    useConnectionStore.getState().setReconnectPhase('offline');
+    render(<ConnectionStatusBanner />);
+    expect(screen.getByText(/connection lost/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy();
+  });
+
+  it('Reconnect retries and opens the relay quick-connect menu', () => {
+    useConnectionStore.getState().setReconnectPhase('offline');
+    const onEvent = vi.fn();
+    window.addEventListener('docushark:open-cloud-connect', onEvent);
+    render(<ConnectionStatusBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }));
+
+    expect(reconnectNow).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    window.removeEventListener('docushark:open-cloud-connect', onEvent);
+  });
+});

--- a/src/ui/ConnectionStatusBanner.tsx
+++ b/src/ui/ConnectionStatusBanner.tsx
@@ -1,74 +1,55 @@
 import { useEffect, useState } from 'react';
 import { useConnectionStore } from '../store/connectionStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
 import './ConnectionStatusBanner.css';
 
 /**
- * Banner that shows WebSocket connection status to users.
- * Displays when disconnected, reconnecting, or connection failed.
- * Hidden when connected or not in server mode.
+ * Terminal connection banner (JP-237).
+ *
+ * Shows ONLY when reconnection has failed and can't be re-established on its own
+ * — retries exhausted, auth rejected, or the user cancelled
+ * (`reconnectPhase === 'offline'`). Transient reconnects are handled by the
+ * single updatable "reconnecting…" toast, NOT here, so the banner no longer
+ * flashes on every status flip during normal recovery.
+ *
+ * "Reconnect" retries the existing session immediately and opens the relay
+ * quick-connect menu so the user can re-pair if the token/relay needs it.
  */
 export function ConnectionStatusBanner() {
-  const status = useConnectionStore((s) => s.status);
-  const reconnectAttempts = useConnectionStore((s) => s.reconnectAttempts);
-  const autoReconnect = useConnectionStore((s) => s.autoReconnect);
-  const setAutoReconnect = useConnectionStore((s) => s.setAutoReconnect);
+  const phase = useConnectionStore((s) => s.reconnectPhase);
   const [dismissed, setDismissed] = useState(false);
 
-  // Reset dismissed state when status changes
+  // A fresh offline transition re-shows the banner even if a prior one was
+  // dismissed (reset whenever the phase changes).
   useEffect(() => {
     setDismissed(false);
-  }, [status]);
+  }, [phase]);
 
-  // Don't show when connected or in initial disconnected state
-  if (status === 'authenticated' || status === 'connected' || dismissed) {
-    return null;
-  }
+  if (phase !== 'offline' || dismissed) return null;
 
-  // Don't show banner in initial disconnected state (not in server mode)
-  if (status === 'disconnected' && reconnectAttempts === 0) {
-    return null;
-  }
-
-  const isReconnecting = status === 'connecting' && reconnectAttempts > 0;
-  const isFailed = status === 'disconnected' && reconnectAttempts > 0 && !autoReconnect;
-
-  let message: string;
-  let variant: string;
-
-  if (isReconnecting) {
-    message = `Reconnecting... (attempt ${reconnectAttempts})`;
-    variant = 'warning';
-  } else if (isFailed) {
-    message = 'Connection lost. Changes are saved locally.';
-    variant = 'error';
-  } else if (status === 'disconnected' && reconnectAttempts > 0) {
-    message = `Connection lost. Retrying... (attempt ${reconnectAttempts})`;
-    variant = 'warning';
-  } else if (status === 'connecting') {
-    message = 'Connecting to server...';
-    variant = 'info';
-  } else {
-    return null;
-  }
+  const handleReconnect = () => {
+    useCollaborationStore.getState().reconnectNow();
+    // Open the relay quick-connect menu (Documents → Cloud) so the user can
+    // re-pair if the immediate retry can't restore the session on its own.
+    window.dispatchEvent(new CustomEvent('docushark:open-cloud-connect'));
+  };
 
   return (
-    <div className={`connection-banner connection-banner--${variant}`}>
-      <span className="connection-banner__icon">
-        {variant === 'error' ? '⚠' : '⟳'}
+    <div className="connection-banner connection-banner--error" role="status">
+      <span className="connection-banner__icon" aria-hidden="true">
+        ⚠
       </span>
-      <span className="connection-banner__message">{message}</span>
+      <span className="connection-banner__message">
+        Workspace connection lost. Your changes are saved locally.
+      </span>
       <div className="connection-banner__actions">
-        {isFailed && (
-          <button
-            className="connection-banner__retry"
-            onClick={() => setAutoReconnect(true)}
-          >
-            Retry
-          </button>
-        )}
+        <button className="connection-banner__retry" onClick={handleReconnect}>
+          Reconnect
+        </button>
         <button
           className="connection-banner__dismiss"
           onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
         >
           ✕
         </button>

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -1,8 +1,19 @@
 /**
  * Notification Toast Styles
  *
- * Phase 14.9.2 - Error Handling & Resilience
+ * Phase 14.9.2 — Error Handling & Resilience.
+ * JP-237 polish: rounded toasts, rich per-severity coloring + haloed icons, and
+ * a rotating glow ring on appearance that pauses on hover/focus.
  */
+
+/* Animatable angle for the rotating glow ring. Registered so the custom prop
+   actually interpolates; where @property is unsupported the ring stays static
+   (graceful degradation). */
+@property --toast-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
 
 .notification-container {
   position: fixed;
@@ -11,74 +22,123 @@
   z-index: 9999;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   max-width: 400px;
   pointer-events: none;
 }
 
 .notification-toast {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 12px 16px;
-  border-radius: 8px;
-  box-shadow: var(--shadow-lg);
+  padding: 13px 16px;
+  /* Round, not square. */
+  border-radius: 16px;
+  /* Drop shadow + a soft severity-tinted glow. */
+  box-shadow: var(--shadow-lg), 0 0 18px -6px var(--toast-glow, transparent);
   pointer-events: auto;
-  animation: toast-slide-in 0.2s ease-out;
+  animation: toast-enter 0.22s ease-out;
+  /* Subtle severity tint over the surface (falls back to plain surface where
+     color-mix is unsupported — the preceding declaration wins there). */
   background: var(--color-surface, #fff);
-  border-left: 4px solid;
+  background: color-mix(in srgb, var(--toast-glow, transparent) 7%, var(--color-surface, #fff));
+  border: 1px solid color-mix(in srgb, var(--toast-glow, transparent) 22%, transparent);
 }
 
-@keyframes toast-slide-in {
+/* Rotating glow ring drawn just outside the toast, masked to a thin border. */
+.notification-toast::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--toast-angle, 0deg),
+    transparent 0deg,
+    var(--toast-glow, transparent) 70deg,
+    transparent 150deg,
+    transparent 210deg,
+    var(--toast-glow, transparent) 290deg,
+    transparent 360deg
+  );
+  /* Show only the 1.5px ring (exclude the filled centre). */
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  animation: toast-glow-rotate 3.2s linear infinite;
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+/* The user reads/interacts — settle the rotation. */
+.notification-toast:hover::before,
+.notification-toast:focus-within::before {
+  animation-play-state: paused;
+}
+
+@keyframes toast-glow-rotate {
+  to {
+    --toast-angle: 360deg;
+  }
+}
+
+@keyframes toast-enter {
   from {
     opacity: 0;
-    transform: translateX(100%);
+    transform: translateX(16px) scale(0.98);
   }
   to {
     opacity: 1;
-    transform: translateX(0);
+    transform: translateX(0) scale(1);
   }
 }
 
-/* Severity variants */
+/* Reduced motion: no rotation, no slide — just a gentle fade and a static glow. */
+@media (prefers-reduced-motion: reduce) {
+  .notification-toast {
+    animation: toast-fade 0.2s ease-out;
+  }
+  .notification-toast::before {
+    animation: none;
+    /* Even, static halo. */
+    background: var(--toast-glow, transparent);
+    opacity: 0.5;
+  }
+  @keyframes toast-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+/* Severity → glow color (drives the ring, the box-shadow halo, the tint, and the
+   icon). One variable per severity keeps the treatment consistent. */
 .notification-toast--info {
-  border-left-color: var(--color-info, #3b82f6);
+  --toast-glow: var(--color-info, #3b82f6);
 }
-
-.notification-toast--info .notification-toast__icon {
-  color: var(--color-info, #3b82f6);
-}
-
 .notification-toast--success {
-  border-left-color: var(--success);
+  --toast-glow: var(--success);
 }
-
-.notification-toast--success .notification-toast__icon {
-  color: var(--success);
-}
-
 .notification-toast--warning {
-  border-left-color: var(--warning);
+  --toast-glow: var(--warning);
 }
-
-.notification-toast--warning .notification-toast__icon {
-  color: var(--warning);
-}
-
 .notification-toast--error {
-  border-left-color: var(--danger);
+  --toast-glow: var(--danger);
 }
 
-.notification-toast--error .notification-toast__icon {
-  color: var(--danger);
-}
-
-/* Icon */
+/* Icon — colored to the severity with a soft halo so it reads rich, not flat. */
 .notification-toast__icon {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: var(--toast-glow, var(--color-info, #3b82f6));
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--toast-glow, transparent) 55%, transparent));
 }
 
 /* Content */
@@ -117,7 +177,7 @@
   color: var(--color-primary);
   background: transparent;
   border: 1px solid var(--color-primary);
-  border-radius: 4px;
+  border-radius: 999px; /* pill, matching the rounded toast */
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
@@ -136,7 +196,7 @@
   padding: 0;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: 999px;
   color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
@@ -150,7 +210,8 @@
 /* Dark theme support */
 [data-theme='dark'] .notification-toast {
   background: var(--color-surface, #1f2937);
-  box-shadow: var(--shadow-lg);
+  background: color-mix(in srgb, var(--toast-glow, transparent) 12%, var(--color-surface, #1f2937));
+  box-shadow: var(--shadow-lg), 0 0 20px -6px var(--toast-glow, transparent);
 }
 
 [data-theme='dark'] .notification-toast__message {

--- a/src/ui/StatusBar.connchip.test.tsx
+++ b/src/ui/StatusBar.connchip.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * StatusBar ambient connection chip (JP-237): a persistent Offline/Reconnecting
+ * indicator for relay-backed docs that aren't synced — visible even when no
+ * provider is attached and no toast can fire.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+let offline = false;
+vi.mock('../collaboration/offlinePageGuard', () => ({
+  useSharedDocOffline: () => offline,
+}));
+
+import { StatusBar } from './StatusBar';
+import { useConnectionStore } from '../store/connectionStore';
+
+describe('StatusBar connection chip', () => {
+  beforeEach(() => {
+    cleanup();
+    useConnectionStore.getState().reset();
+    offline = false;
+  });
+
+  it('hides the chip when not offline (local doc / online)', () => {
+    offline = false;
+    render(<StatusBar />);
+    expect(screen.queryByText('Offline')).toBeNull();
+    expect(screen.queryByText('Reconnecting…')).toBeNull();
+  });
+
+  it('shows "Offline" when a relay doc is offline and idle', () => {
+    offline = true;
+    useConnectionStore.getState().setStatus('disconnected');
+    render(<StatusBar />);
+    expect(screen.getByText('Offline')).toBeTruthy();
+  });
+
+  it('shows "Reconnecting…" while connecting', () => {
+    offline = true;
+    useConnectionStore.getState().setStatus('connecting');
+    render(<StatusBar />);
+    expect(screen.getByText('Reconnecting…')).toBeTruthy();
+  });
+});

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -102,6 +102,45 @@
   }
 }
 
+/* Connection status (offline / reconnecting) — ambient, always-on while offline */
+.status-bar-conn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 1px var(--space-1-5);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: 10px;
+}
+
+.status-bar-conn--offline {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning) 35%, transparent);
+}
+
+.status-bar-conn--reconnecting {
+  color: var(--text-secondary);
+  background: var(--color-surface-hover, rgba(0, 0, 0, 0.04));
+  border: 1px solid var(--border-color);
+}
+
+.status-bar-conn--reconnecting svg {
+  animation: status-bar-conn-spin 1s linear infinite;
+}
+
+@keyframes status-bar-conn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-bar-conn--reconnecting svg {
+    animation: none;
+  }
+}
+
 /* Divider */
 .status-bar-divider {
   width: 1px;

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -8,9 +8,13 @@
  */
 
 import { useCallback, useMemo } from 'react';
+import { WifiOff, RefreshCw } from 'lucide-react';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
+import { useConnectionStore } from '../store/connectionStore';
+import { useSharedDocOffline } from '../collaboration/offlinePageGuard';
 import { calculateCombinedBounds } from '../shapes/utils/bounds';
+import { Icon } from './icons';
 import './StatusBar.css';
 
 /**
@@ -44,6 +48,18 @@ export function StatusBar() {
   const editingGroupId = useSessionStore((state) => state.editingGroupId);
   const setEditingGroupId = useSessionStore((state) => state.setEditingGroupId);
   const shapeCount = useDocumentStore((state) => state.shapeOrder.length);
+
+  // Ambient connection indicator (JP-237): a relay-backed doc that isn't fully
+  // synced is "offline". Driven by connection state (not a transient event), so
+  // it stays visible the whole time you're offline — including a doc opened
+  // offline-from-start where no provider ever attaches and no toast can fire.
+  const sharedOffline = useSharedDocOffline();
+  const connStatus = useConnectionStore((s) => s.status);
+  const reconnectPhase = useConnectionStore((s) => s.reconnectPhase);
+  const reconnecting =
+    connStatus === 'connecting' ||
+    connStatus === 'authenticating' ||
+    reconnectPhase === 'reconnecting';
 
   // Memoize sync status text
   const syncStatusText = useMemo(() => {
@@ -143,6 +159,23 @@ export function StatusBar() {
 
       {/* Right Section: Info */}
       <div className="status-bar-section status-bar-right">
+        {/* Ambient connection status — offline / reconnecting */}
+        {sharedOffline && (
+          <>
+            <span
+              className={`status-bar-conn status-bar-conn--${reconnecting ? 'reconnecting' : 'offline'}`}
+              title={
+                reconnecting
+                  ? 'Reconnecting to the workspace…'
+                  : "You're offline. Changes are saved on this device and will sync when you reconnect."
+              }
+            >
+              <Icon icon={reconnecting ? RefreshCw : WifiOff} size={13} />
+              <span>{reconnecting ? 'Reconnecting…' : 'Offline'}</span>
+            </span>
+            <div className="status-bar-divider" />
+          </>
+        )}
         {/* Drill-down badge */}
         {editingGroupId && (
           <>

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -60,6 +60,11 @@ export interface DocumentsHomeProps {
   onLeaveToEditor: () => void;
   /** Open the (preferences) Settings modal. Cloud + storage now live in-surface. */
   onOpenSettings?: () => void;
+  /**
+   * Monotonic nonce: when it increments, jump to the Cloud (relay quick-connect)
+   * view. Driven by the connection banner's "Reconnect" (JP-237). 0 = no request.
+   */
+  openCloudSignal?: number;
 }
 
 type NavId = 'all' | 'recents' | 'local' | 'cloud' | 'cached';
@@ -72,7 +77,11 @@ const NAV_LABELS: Record<NavId, string> = {
   cached: 'Offline',
 };
 
-export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHomeProps) {
+export function DocumentsHome({
+  onLeaveToEditor,
+  onOpenSettings,
+  openCloudSignal,
+}: DocumentsHomeProps) {
   const model = useDocumentBrowserModel();
   const {
     documentList,
@@ -113,6 +122,13 @@ export function DocumentsHome({ onLeaveToEditor, onOpenSettings }: DocumentsHome
   );
   const trashCount = useTrashStore((s) => s.items.length);
   const refreshTrash = useTrashStore((s) => s.refresh);
+
+  // Jump to the Cloud (relay quick-connect) view when asked — the connection
+  // banner's "Reconnect". Depends on the nonce so repeat requests re-fire; a
+  // fresh mount with a non-zero signal also lands here (JP-237).
+  useEffect(() => {
+    if (openCloudSignal && openCloudSignal > 0) setMainView('cloud');
+  }, [openCloudSignal]);
 
   const selectNav = (id: NavId) => {
     setNav(id);

--- a/src/ui/settings/RelaySettings.css
+++ b/src/ui/settings/RelaySettings.css
@@ -271,3 +271,42 @@
     transform: rotate(360deg);
   }
 }
+
+/* Remove Workspace (JP-237) — destructive zone, set apart from Disconnect. */
+.relay-settings__danger {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.relay-settings__btn--danger {
+  color: var(--danger-text, #fff);
+  background: var(--danger-bg, #dc2626);
+  align-self: flex-start;
+}
+
+.relay-settings__btn--danger:not(:disabled):hover {
+  filter: brightness(0.95);
+}
+
+.relay-settings__confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--color-surface-hover, rgba(0, 0, 0, 0.03));
+}
+
+.relay-settings__confirm-text {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.relay-settings__confirm-actions {
+  display: flex;
+  gap: 8px;
+}

--- a/src/ui/settings/RelaySettings.tsx
+++ b/src/ui/settings/RelaySettings.tsx
@@ -18,10 +18,12 @@
  */
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { Cloud, LogIn, LogOut, AlertCircle, ExternalLink, Loader2, KeyRound } from 'lucide-react';
+import { Cloud, LogIn, LogOut, AlertCircle, ExternalLink, Loader2, KeyRound, Trash2 } from 'lucide-react';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useCollaborationStore, useIsRelaySessionLive } from '../../collaboration';
 import { usePersistenceStore } from '../../store/persistenceStore';
+import { useNotificationStore } from '../../store/notificationStore';
+import { removeCurrentWorkspace } from '../../services/removeWorkspace';
 import {
   loadConnection,
   clearJwt,
@@ -159,6 +161,31 @@ export function RelaySettings() {
     void clearJwt();
   }, [stopSession]);
 
+  // Remove Workspace (JP-237) — the destructive counterpart to Disconnect. Uses
+  // an inline two-step confirm (mirrors the document browser's delete confirm)
+  // rather than a bare window.confirm.
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const handleRemoveWorkspace = useCallback(async () => {
+    setRemoving(true);
+    try {
+      await removeCurrentWorkspace();
+      useNotificationStore
+        .getState()
+        .success('Workspace removed. Its documents and offline copies were deleted from this device.');
+    } catch (err) {
+      console.error('[RelaySettings] Remove workspace failed:', err);
+      useNotificationStore
+        .getState()
+        .error('Could not fully remove the workspace. Some local data may remain.', {
+          category: 'permanent',
+        });
+    } finally {
+      setRemoving(false);
+      setConfirmRemove(false);
+    }
+  }, []);
+
   return (
     <div className="relay-settings">
       <h3 className="settings-section-title">
@@ -209,6 +236,46 @@ export function RelaySettings() {
             <LogOut size={16} />
             Disconnect
           </button>
+
+          <div className="relay-settings__danger">
+            {!confirmRemove ? (
+              <button
+                type="button"
+                className="relay-settings__btn relay-settings__btn--danger"
+                onClick={() => setConfirmRemove(true)}
+              >
+                <Trash2 size={16} />
+                Remove workspace…
+              </button>
+            ) : (
+              <div className="relay-settings__confirm" role="alertdialog" aria-label="Remove workspace">
+                <p className="relay-settings__confirm-text">
+                  Remove this workspace from <strong>this device</strong>? Its documents
+                  and downloaded offline copies will be deleted locally and the relay
+                  forgotten. Documents on the server are not affected.
+                </p>
+                <div className="relay-settings__confirm-actions">
+                  <button
+                    type="button"
+                    className="relay-settings__btn relay-settings__btn--danger"
+                    onClick={() => void handleRemoveWorkspace()}
+                    disabled={removing}
+                  >
+                    {removing ? <Loader2 size={16} className="relay-settings__spin" /> : <Trash2 size={16} />}
+                    {removing ? 'Removing…' : 'Remove everything'}
+                  </button>
+                  <button
+                    type="button"
+                    className="relay-settings__btn relay-settings__btn--secondary"
+                    onClick={() => setConfirmRemove(false)}
+                    disabled={removing}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       ) : (
         <div className="relay-settings__panel">


### PR DESCRIPTION
Hardens the WebSocket reconnection lifecycle (the "reconnect-UX half" of JP-237) plus a Remove Workspace button and a toast quality pass. Client-side only; off master, independent of #260.

## What changed

**Reconnect controller (no more spam).** A lost connection mid-edit used to fire a fresh toast on *every* status flip. Introduced one explicit `reconnectPhase` (`online`/`reconnecting`/`offline`) on `connectionStore`, driven by a controller — not raw status flips — so intentional transitions (leave/switch/sign-in) stay muted (preserves JP-123/188/190). The controller owns ONE updatable "Workspace connection lost — reconnecting…" toast with **Cancel**, resolves it to "Reconnected", and flips to `offline` only on a terminal give-up (max attempts) or user Cancel. Added `collaborationStore.cancelReconnect`/`reconnectNow` driving the provider, and `UnifiedSyncProvider.retryNow()` (fresh attempt budget + immediate connect).

**Banner is terminal-only.** `ConnectionStatusBanner` now renders **only** in the `offline` phase (no flashing during normal recovery). "Reconnect" retries the session and opens the relay quick-connect menu via a new `docushark:open-cloud-connect` event (App → Documents → Cloud, via a monotonic nonce that survives the mount race).

**Toast polish.** Rounded (16px) toasts with a **rotating conic-gradient glow that pauses on hover/focus** (static halo under `prefers-reduced-motion`), **rich per-severity coloring + haloed icons** off the semantic tokens, gentler enter animation, and longer default dwell (~10–15s). Cancel + the always-present X give the Cancel/Dismiss pair.

**Remove Workspace.** Destructive counterpart to Disconnect (which keeps cached docs), with an inline two-step confirm in `RelaySettings`. `removeCurrentWorkspace()` tears down the session and purges the host everywhere: registry entries (full purge), durable offline copies (`RelayDocumentCache.clearForHost`), local CRDT rooms (`purgeLocalDocRoom`), and the persisted connection (`clearConnection`). Host-scoped → generalizes to multi-workspace.

## Deferred (JP-237's other half, per the user)
Boot **auto-connect / auto-sign-in** so you never re-pair on startup ("we have the mechanics, just need integration + hardening + tests") — a follow-up; **JP-237 stays open**. Also the web "don't ask again" pairing page (proprietary docushark-web).

## Verification
- `bun run typecheck` ✓, `bun run test --run` ✓ (2434; +11 new: controller, banner, removeWorkspace), `bun run build` ✓.
- Manual E2E (founder gate): edit a collab doc, kill the relay → ONE reconnecting toast (no spam), no banner; restart → "Reconnected". Cancel → retries stop, offline banner, Reconnect opens cloud quick-connect. Exhaust retries → banner. Remove Workspace → its docs + offline copies gone, relay forgotten; other workspaces untouched.

Assisted-by: Opus 4.8