### PR TITLE
Boot auto-sign-in: use the saved relay token on restart

### DIFF
--- a/src/api/restoreCloudSession.test.ts
+++ b/src/api/restoreCloudSession.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Boot auto-sign-in (Lean): restoreCloudSession reuses the saved token on
+ * restart — asserts it into the connection store and (for a local/no-doc boot)
+ * stands up a REST-only provider to load the live cloud list. Expired → no
+ * connect.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { loadConnection, setToken, setProvider, setAuthenticated, info } = vi.hoisted(() => ({
+  loadConnection: vi.fn(),
+  setToken: vi.fn(),
+  setProvider: vi.fn(),
+  setAuthenticated: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock('./relayConnection', () => ({ loadConnection }));
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: { getState: () => ({ setToken }) },
+}));
+vi.mock('../store/relayDocumentStore', () => ({
+  useRelayDocumentStore: { getState: () => ({ setProvider, setAuthenticated }) },
+}));
+vi.mock('../store/notificationStore', () => ({
+  useNotificationStore: { getState: () => ({ info }) },
+}));
+
+import { restoreCloudSession } from './restoreCloudSession';
+
+const NOW = 1_000_000;
+const future = { relayUrl: 'http://relay:9876', jwt: 'tok', jwtExpiresAt: NOW + 60_000, cloudBaseUrl: null };
+
+describe('restoreCloudSession', () => {
+  beforeEach(() => {
+    [loadConnection, setToken, setProvider, setAuthenticated, info].forEach((m) => m.mockReset());
+  });
+
+  it("status 'none' when no connection / no token", async () => {
+    loadConnection.mockResolvedValueOnce(null);
+    expect(await restoreCloudSession({ proactiveList: true, now: () => NOW })).toEqual({ status: 'none' });
+
+    loadConnection.mockResolvedValueOnce({ relayUrl: 'http://relay:9876', jwt: null, jwtExpiresAt: null });
+    expect(await restoreCloudSession({ proactiveList: true, now: () => NOW })).toEqual({ status: 'none' });
+
+    expect(setToken).not.toHaveBeenCalled();
+    expect(setProvider).not.toHaveBeenCalled();
+  });
+
+  it("status 'expired' (no connect) when the token has expired", async () => {
+    loadConnection.mockResolvedValueOnce({ ...future, jwtExpiresAt: NOW - 1 });
+
+    const r = await restoreCloudSession({ proactiveList: true, now: () => NOW });
+
+    expect(r).toEqual({ status: 'expired' });
+    expect(setToken).not.toHaveBeenCalled();
+    expect(setProvider).not.toHaveBeenCalled();
+    expect(setAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('restored + proactiveList: asserts token AND loads the live list', async () => {
+    loadConnection.mockResolvedValueOnce(future);
+
+    const r = await restoreCloudSession({ proactiveList: true, now: () => NOW });
+
+    expect(r).toEqual({ status: 'restored' });
+    expect(setToken).toHaveBeenCalledWith('tok', NOW + 60_000);
+    expect(setProvider).toHaveBeenCalledTimes(1); // a REST provider was stood up
+    expect(setAuthenticated).toHaveBeenCalledWith(true); // → fetchDocumentList
+  });
+
+  it('restored without proactiveList: asserts token only (relay-doc boot — Slice 1 lists)', async () => {
+    loadConnection.mockResolvedValueOnce(future);
+
+    const r = await restoreCloudSession({ proactiveList: false, now: () => NOW });
+
+    expect(r).toEqual({ status: 'restored' });
+    expect(setToken).toHaveBeenCalledWith('tok', NOW + 60_000);
+    expect(setProvider).not.toHaveBeenCalled();
+    expect(setAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('treats a null expiry as valid (matches isTokenValid)', async () => {
+    loadConnection.mockResolvedValueOnce({ ...future, jwtExpiresAt: null });
+
+    const r = await restoreCloudSession({ proactiveList: false, now: () => NOW });
+
+    expect(r).toEqual({ status: 'restored' });
+    expect(setToken).toHaveBeenCalledWith('tok', null);
+  });
+});

--- a/src/api/restoreCloudSession.ts
+++ b/src/api/restoreCloudSession.ts
@@ -1,0 +1,105 @@
+/**
+ * Boot auto-sign-in (Lean) — actually USE the saved relay token on app restart.
+ *
+ * On boot the persisted relay token (a 30-day JWT) is loaded but otherwise idle.
+ * Reopening a *cloud doc* already auto-signs-in (JP-324 `chooseRelaySessionToken`
+ * restores the persisted token into the WS session). This covers the other boot
+ * surfaces — a local doc or the Documents home — by:
+ *   1. asserting the saved token into the in-memory connection store, and
+ *   2. (when asked) standing up a REST-only document provider to load the LIVE
+ *      cloud doc list so Documents→Cloud is fresh on startup.
+ *
+ * Deliberately REST-only: NO WebSocket session, NO Y.Doc engine, NO view binding.
+ * That sidesteps the JP-340/341 corruption class (the collab view-bind has no
+ * doc-id guard) and the auth-timing race a placeholder WS session would hit. The
+ * full live-sync session still comes up the moment the user opens a cloud doc.
+ *
+ * Multi-workspace (future, light): this operates on the singleton connection
+ * record from `loadConnection()`. An enterprise multi-workspace variant would map
+ * a `restoreCloudSessions()` over N persisted records — a mechanical lift; not
+ * built here.
+ */
+
+import { loadConnection } from './relayConnection';
+import { RelayClient } from './relayClient';
+import { RestDocumentProvider } from './restDocumentProvider';
+import { relayFetch } from '../platform/relayFetch';
+import { useConnectionStore } from '../store/connectionStore';
+import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { useNotificationStore } from '../store/notificationStore';
+
+export type RestoreCloudSessionStatus = 'none' | 'expired' | 'restored';
+
+export interface RestoreCloudSessionOptions {
+  /**
+   * When true, proactively stand up a REST-only provider and load the live cloud
+   * doc list. Pass `false` for a relay-doc boot — JP-324 Slice 1's `startSession`
+   * loads the list itself (its `onAuthenticated → fetchDocumentList`), so a REST
+   * provider here would just churn — and `true` for a local/no-doc boot.
+   */
+  proactiveList: boolean;
+  /** Injectable clock for expiry checks (tests). Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Friendly "your Cloud session expired — sign in again" notice. Reused for a
+ * boot-time expiry and a REST 401. Opens the relay quick-connect surface (the
+ * JP-237 `docushark:open-cloud-connect` event) rather than auto-launching the
+ * device-code flow — the user chooses to re-pair.
+ */
+export function notifyCloudSessionExpired(): void {
+  useNotificationStore.getState().info(
+    'Your Cloud session expired. Sign in again to reconnect your workspace.',
+    {
+      category: 'permanent',
+      actionLabel: 'Sign in',
+      onAction: () => window.dispatchEvent(new CustomEvent('docushark:open-cloud-connect')),
+    },
+  );
+}
+
+export async function restoreCloudSession(
+  opts: RestoreCloudSessionOptions,
+): Promise<{ status: RestoreCloudSessionStatus }> {
+  const now = opts.now ?? Date.now;
+
+  const conn = await loadConnection();
+  if (!conn?.relayUrl || !conn.jwt) return { status: 'none' };
+
+  // Expiry semantics match `connectionStore.isTokenValid`: a null expiry is
+  // treated as "no known expiry → assume valid".
+  if (conn.jwtExpiresAt !== null && now() >= conn.jwtExpiresAt) {
+    return { status: 'expired' };
+  }
+
+  // The literal "the app actually uses the saved token on restart": put it into
+  // the in-memory connection store so it's live immediately (and so
+  // `chooseRelaySessionToken` prefers it for any subsequent relay-doc reopen).
+  useConnectionStore.getState().setToken(conn.jwt, conn.jwtExpiresAt);
+
+  if (opts.proactiveList) {
+    const relayStore = useRelayDocumentStore.getState();
+    const client = new RelayClient({
+      baseUrl: conn.relayUrl,
+      token: conn.jwt,
+      fetchImpl: relayFetch,
+      onUnauthorized: () => {
+        // The saved token was rejected — drop the REST provider and prompt a
+        // friendly re-sign-in instead of failing silently.
+        const s = useRelayDocumentStore.getState();
+        s.setProvider(null);
+        s.setAuthenticated(false);
+        notifyCloudSessionExpired();
+      },
+    });
+    relayStore.setProvider(new RestDocumentProvider(client));
+    // `setAuthenticated(true)` fires `fetchDocumentList` (+ stale-cache refresh,
+    // JP-324) so the live list loads. It reflects "the relay accepted our token"
+    // (REST-verified); the WS `connectionStore.status` stays disconnected until
+    // the user opens a cloud doc and Slice 1 starts the real session.
+    relayStore.setAuthenticated(true);
+  }
+
+  return { status: 'restored' };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,7 +22,7 @@ import './platform/adaptiveBudget';
 // boot, before first paint — see applyAppearance (Abstraction A).
 import './ui/appearance/applyAppearance';
 
-function mountApp(): void {
+function mountApp(authCallbackConsumed: boolean): void {
   const root = document.getElementById('root');
   if (!root) {
     throw new Error('Root element not found');
@@ -30,7 +30,7 @@ function mountApp(): void {
 
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
-      <App />
+      <App authCallbackConsumed={authCallbackConsumed} />
     </React.StrictMode>
   );
 
@@ -41,5 +41,7 @@ function mountApp(): void {
 
 // Intercept the PWA web one-click handoff (`/auth/callback?handoff_code=…`)
 // before mounting: consume the code, connect the relay, then mount. A no-op on
-// every other route (and in the Tauri build).
+// every other route (and in the Tauri build). The boolean it resolves with
+// (`true` = it signed in on this load) is threaded to App so boot auto-sign-in
+// doesn't double-connect on the callback route.
 void handleAuthCallbackIfPresent().then(mountApp);

--- a/src/store/persistenceStore.isRelayDocId.test.ts
+++ b/src/store/persistenceStore.isRelayDocId.test.ts
@@ -1,0 +1,45 @@
+/**
+ * isRelayDocId (JP boot auto-sign-in): classify a doc as relay/cloud via the
+ * durable `isRelayDocument` metadata flag (primary) or a registry `remote` record.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isRelayDocId, usePersistenceStore } from './persistenceStore';
+import { useDocumentRegistry } from './documentRegistry';
+import type { DocumentMetadata } from '../types/Document';
+
+function meta(id: string, isRelayDocument = false): DocumentMetadata {
+  return {
+    id,
+    name: id,
+    createdAt: 0,
+    modifiedAt: 0,
+    ...(isRelayDocument ? { isRelayDocument: true } : {}),
+  } as DocumentMetadata;
+}
+
+describe('isRelayDocId', () => {
+  beforeEach(() => {
+    usePersistenceStore.setState({ documents: {} } as never);
+    useDocumentRegistry.getState().reset();
+  });
+
+  it('false for null or an unknown id', () => {
+    expect(isRelayDocId(null)).toBe(false);
+    expect(isRelayDocId('nope')).toBe(false);
+  });
+
+  it('true via the durable isRelayDocument metadata flag', () => {
+    usePersistenceStore.setState({ documents: { d: meta('d', true) } } as never);
+    expect(isRelayDocId('d')).toBe(true);
+  });
+
+  it('false for a plain local doc', () => {
+    usePersistenceStore.setState({ documents: { l: meta('l', false) } } as never);
+    expect(isRelayDocId('l')).toBe(false);
+  });
+
+  it('true via a registry remote record', () => {
+    useDocumentRegistry.getState().registerRemote(meta('r'), 'relay-a:9876', 'owner', 'synced');
+    expect(isRelayDocId('r')).toBe(true);
+  });
+});

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -1491,6 +1491,26 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
 );
 
 /**
+ * True when `docId` is a relay/cloud document. Classified by the durable
+ * `isRelayDocument` metadata flag (primary — it survives a cold boot, whereas the
+ * registry's `remote` entries hydrate asynchronously via `warmupCache`) or the
+ * registry record type. Shared by `initializePersistence` and the boot
+ * auto-sign-in (`restoreCloudSession`).
+ */
+export function isRelayDocId(docId: string | null): boolean {
+  if (!docId) return false;
+  return (
+    usePersistenceStore.getState().documents[docId]?.isRelayDocument === true ||
+    useDocumentRegistry.getState().entries[docId]?.record.type === 'remote'
+  );
+}
+
+/** The last-opened document id persisted across restarts, or null. */
+export function getLastOpenedDocId(): string | null {
+  return localStorage.getItem(STORAGE_KEYS.CURRENT_DOCUMENT);
+}
+
+/**
  * Initialize persistence on app startup.
  * Loads the last opened document or creates a new one.
  * Also migrates existing documents to the document registry.
@@ -1517,6 +1537,8 @@ export function initializePersistence(): void {
     const metadata = store.documents[lastDocId];
     const isTeamMetadata = metadata?.isRelayDocument === true;
     const isTeamRegistryEntry = registry.entries[lastDocId]?.record.type === 'remote';
+    // (classification mirrors `isRelayDocId`; kept inline here for the name/metadata
+    // lookups the branches below reuse.)
 
     if (store.documentExists(lastDocId)) {
       const success = store.loadDocument(lastDocId);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -33,7 +33,13 @@ import { ShapeSearchPanel } from './ShapeSearchPanel';
 import { Whiteboard } from './Whiteboard';
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
-import { initializePersistence, usePersistenceStore } from '../store/persistenceStore';
+import {
+  initializePersistence,
+  usePersistenceStore,
+  isRelayDocId,
+  getLastOpenedDocId,
+} from '../store/persistenceStore';
+import { restoreCloudSession, notifyCloudSessionExpired } from '../api/restoreCloudSession';
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
@@ -68,7 +74,7 @@ const DocumentEditorPanel = lazy(() =>
 // Initialize connection notifications (runs once at module load)
 initConnectionNotifications();
 
-function App() {
+function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean } = {}) {
   const initializeDefault = usePageStore((state) => state.initializeDefault);
   const persistenceInitializedRef = useRef(false);
 
@@ -403,25 +409,44 @@ function App() {
       }
     })();
 
-    // Check if we have any saved documents
-    const documents = usePersistenceStore.getState().documents;
-    const hasDocuments = Object.keys(documents).length > 0;
-
-    if (hasDocuments) {
-      // Initialize from persistence (loads last document or creates new)
-      initializePersistence();
-    } else {
-      // First time use: create default page (blank canvas)
-      initializeDefault();
-
-      // Set history active page
-      const pageId = usePageStore.getState().activePageId;
-      if (pageId) {
-        useHistoryStore.getState().setActivePage(pageId);
+    // Boot auto-sign-in (Lean): actually USE the saved relay token on restart.
+    // Run BEFORE opening the last doc so the token is live in the connection
+    // store first. For a relay-doc boot, JP-324 Slice 1 brings up the full WS
+    // session (and loads the list) when the doc reopens, so we only assert the
+    // token (proactiveList: false). For a local/no-doc boot we additionally load
+    // the live cloud list over REST (race-free — no WS/engine). Skipped on the
+    // web-OAuth callback load, which already signed in.
+    void (async () => {
+      if (!authCallbackConsumed) {
+        try {
+          const bootRelay = isRelayDocId(getLastOpenedDocId());
+          const result = await restoreCloudSession({ proactiveList: !bootRelay });
+          if (result.status === 'expired') notifyCloudSessionExpired();
+        } catch (err) {
+          console.error('[App] Boot cloud-session restore failed:', err);
+        }
       }
-    }
 
-  }, [initializeDefault]);
+      // Check if we have any saved documents
+      const documents = usePersistenceStore.getState().documents;
+      const hasDocuments = Object.keys(documents).length > 0;
+
+      if (hasDocuments) {
+        // Initialize from persistence (loads last document or creates new)
+        initializePersistence();
+      } else {
+        // First time use: create default page (blank canvas)
+        initializeDefault();
+
+        // Set history active page
+        const pageId = usePageStore.getState().activePageId;
+        if (pageId) {
+          useHistoryStore.getState().setActivePage(pageId);
+        }
+      }
+    })();
+
+  }, [initializeDefault, authCallbackConsumed]);
 
   return (
     <div className="app">


### PR DESCRIPTION
Makes the app **actually use the saved relay token on restart**, so you don't re-do the device-code pairing. Off fresh master (has JP-324 + JP-237). Client-side only.

## What changed
Reopening a cloud doc already auto-signs-in (merged JP-324 `chooseRelaySessionToken`). This covers the **other boot surfaces** — starting on a local doc or the Documents home:

- **`restoreCloudSession()`** at boot: asserts the still-valid persisted token into the connection store and, for a **local/no-doc boot**, stands up a **REST-only** document provider to load the **live** cloud list (Documents→Cloud is fresh on startup; opening any cloud doc then connects with no re-pair via Slice 1).
- **REST-only by design** — no WebSocket session, no Y.Doc engine, no view binding. That sidesteps the JP-340/341 bind-corruption class (the collab view-bind has no doc-id guard) and the auth-timing race a placeholder WS session would hit.
- **Expired token** → a gentle "Sign in" toast that opens the relay quick-connect (the JP-237 `open-cloud-connect` event); never auto-launches device-code, never clears the saved URLs.
- Wiring: `isRelayDocId`/`getLastOpenedDocId` helpers; App runs the restore **before** `initializePersistence` (`proactiveList` only for a non-relay boot, to avoid churning Slice 1's session); `main.tsx` threads `handleAuthCallbackIfPresent()`'s boolean so restore is skipped on the web-OAuth callback load.

## Deferred (intentional)
Full proactive **"Signed in" status** on a *local-doc* boot needs a doc-id guard in `useCollaborationSync` (core-collab change) so an auth-only session can coexist with a displayed local doc. Out of scope for this Lean PR; the live list + token reuse + expired notice ship here.

## Verification
- `bun run typecheck` ✓, `bun run test --run` ✓ (2479; +9 new across `restoreCloudSession`, `isRelayDocId`), `bun run build` ✓.
- Manual: restart on a cloud doc → signed in, syncing, no re-pair; restart on a local doc with a valid token → live cloud list loads, opening a cloud doc connects with no re-pair, no corruption; expired token → friendly "Sign in" toast, stays offline.

Assisted-by: Opus 4.8