### PR TITLE
Deletion & Trash UX: stranded→Trash fix + styled confirmation utility

### DIFF
--- a/src/store/relayDocumentStore.strand.test.ts
+++ b/src/store/relayDocumentStore.strand.test.ts
@@ -1,9 +1,9 @@
 /**
  * JP-175 — clients react to a deleted relay document by preserving the user's
  * copy instead of silently dropping it. `strandOrDemoteDeletedDoc` decides:
- *   - open doc        → demote to local + stop relay sync (don't strand)
- *   - other doc, copy → strand into Trash
- *   - self-initiated  → nothing to preserve
+ *   - any doc with a copy → snapshot into Trash (the editor leaves it if open)
+ *   - open doc, no copy   → demote to local (edge-case fallback, keep the work)
+ *   - self-initiated      → nothing to preserve
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   currentDocumentId: null as string | null,
   currentUserId: 'me' as string | undefined,
   demote: vi.fn(),
+  newDocument: vi.fn(),
   leaveDocument: vi.fn(),
   trashStranded: vi.fn(),
   removeDocument: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock('./persistenceStore', () => ({
     getState: () => ({
       currentDocumentId: h.currentDocumentId,
       demoteCurrentDocumentToLocal: h.demote,
+      newDocument: h.newDocument,
     }),
   },
 }));
@@ -98,18 +100,34 @@ describe('strandOrDemoteDeletedDoc (JP-175)', () => {
     expect(useRelayDocumentStore.getState().documentCache[DOC_ID]).toBeUndefined();
   });
 
-  it('demotes the OPEN doc to local instead of stranding it', () => {
+  it('strands the OPEN doc to Trash and resets the editor (no demote)', () => {
     h.currentDocumentId = DOC_ID;
 
     useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(DOC_ID, 'someone-else');
 
-    expect(h.demote).toHaveBeenCalledTimes(1);
-    expect(h.leaveDocument).toHaveBeenCalledTimes(1);
-    expect(h.warning).toHaveBeenCalledTimes(1);
-    expect(h.trashStranded).not.toHaveBeenCalled();
-    // The (now-local) registry entry is preserved — don't remove it.
-    expect(h.removeDocument).not.toHaveBeenCalled();
+    expect(h.trashStranded).toHaveBeenCalledTimes(1);
+    expect(h.info).toHaveBeenCalledTimes(1); // "moved to Trash"
+    expect(h.leaveDocument).toHaveBeenCalledTimes(1); // stop relay sync
+    expect(h.newDocument).toHaveBeenCalledTimes(1); // editor leaves the trashed doc
+    expect(h.demote).not.toHaveBeenCalled();
+    expect(h.warning).not.toHaveBeenCalled();
+    expect(h.removeDocument).toHaveBeenCalledWith(DOC_ID);
     expect(useRelayDocumentStore.getState().relayDocuments[DOC_ID]).toBeUndefined();
+  });
+
+  it('demotes an OPEN doc to local ONLY as a fallback when no copy can be preserved', async () => {
+    h.currentDocumentId = DOC_ID;
+    // No in-memory copy (registry returns undefined) and no cached copy.
+    useRelayDocumentStore.setState({ documentCache: {} });
+    h.cacheGet.mockResolvedValue(null);
+
+    useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(DOC_ID, 'someone-else');
+    await new Promise((r) => setTimeout(r, 0)); // let the async cache lookup settle
+
+    expect(h.trashStranded).not.toHaveBeenCalled();
+    expect(h.demote).toHaveBeenCalledTimes(1);
+    expect(h.warning).toHaveBeenCalledTimes(1); // "now a local document"
+    expect(h.newDocument).not.toHaveBeenCalled(); // keep the user on their work
   });
 
   it('preserves nothing when WE initiated the deletion', () => {

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -786,53 +786,62 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         });
       };
 
-      // Open doc → keep the user editing: demote in place to a local document
-      // (its registry entry becomes local), stop relay sync, and tell them.
-      if (isOpen && !selfInitiated) {
-        persistence.demoteCurrentDocumentToLocal();
-        useCollaborationStore.getState().leaveDocument();
-        useNotificationStore
-          .getState()
-          .warning(
-            'This document was deleted from the relay. Your copy is now a local document.',
-          );
-        // Keep the (now-local) registry entry demote just created; only clear
-        // the relay-side maps + offline cache.
-        clearRelayMaps();
-        void RelayDocumentCache.remove(docId);
-        return;
-      }
-
-      // Capture an in-memory copy before we drop it.
+      // Capture a recoverable copy (in-memory) BEFORE we drop any bookkeeping.
       const copy = get().documentCache[docId] ?? registry.getDocumentContent(docId);
 
+      // Viewing the deleted doc → stop relay sync now; the editor is reset off it
+      // below once we've preserved a copy.
+      if (isOpen) useCollaborationStore.getState().leaveDocument();
       clearRelayMaps();
-      registry.removeDocument(docId);
 
+      // We deleted it on purpose — nothing to preserve, just drop bookkeeping.
       if (selfInitiated) {
-        void RelayDocumentCache.remove(docId); // we deleted it on purpose
+        registry.removeDocument(docId);
+        void RelayDocumentCache.remove(docId);
+        if (isOpen) persistence.newDocument();
         return;
       }
 
-      if (copy) {
-        // trashStranded snapshots the bytes into the trash, so the offline
-        // cache entry is now safe to drop.
-        useTrashStore.getState().trashStranded(copy, origin);
+      // Stranded relay docs go to Trash (recoverable), whether or not they're the
+      // open doc — demotion to local is only the edge-case fallback below when
+      // there's genuinely no copy to snapshot. trashStranded captures the bytes,
+      // so the offline cache entry is then safe to drop.
+      const strandToTrash = (doc: DiagramDocument): void => {
+        useTrashStore.getState().trashStranded(doc, origin);
+        registry.removeDocument(docId);
         void RelayDocumentCache.remove(docId);
         useNotificationStore
           .getState()
-          .info(`“${copy.name}” was deleted from the relay and moved to Trash.`);
+          .info(`“${doc.name}” was deleted from the relay and moved to Trash.`);
+        // Leave the now-trashed doc — the editor resets to a blank document (the
+        // copy is recoverable from Trash).
+        if (isOpen) persistence.newDocument();
+      };
+
+      if (copy) {
+        strandToTrash(copy);
         return;
       }
 
-      // No in-memory copy, but a persistent offline copy may exist — strand it
-      // (read it BEFORE removing) best-effort.
+      // No in-memory copy — try the persistent offline cache (read BEFORE remove).
       void RelayDocumentCache.get(docId).then((cached) => {
         if (cached) {
-          useTrashStore.getState().trashStranded(cached, origin);
+          strandToTrash(cached);
+          return;
+        }
+        // EDGE-CASE FALLBACK: the relay genuinely has no record AND we have no
+        // snapshot to preserve in Trash. If it's the open doc, demote the loaded
+        // copy to a local document so the user keeps their work; otherwise just
+        // drop the stale bookkeeping.
+        if (isOpen) {
+          persistence.demoteCurrentDocumentToLocal();
           useNotificationStore
             .getState()
-            .info(`“${cached.name}” was deleted from the relay and moved to Trash.`);
+            .warning(
+              'This document is no longer on the relay. Your copy is now a local document.',
+            );
+        } else {
+          registry.removeDocument(docId);
         }
         void RelayDocumentCache.remove(docId);
       });

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -24,6 +24,7 @@ import { CanvasToolbar } from './CanvasToolbar';
 import { StatusBar } from './StatusBar';
 import { FloatingCollabIndicator } from './FloatingCollabIndicator';
 import { NotificationToast } from './NotificationToast';
+import { ConfirmDialogHost } from './confirm/ConfirmDialog';
 import { UploadIndicator } from './UploadIndicator';
 import { ErrorBoundary } from './ErrorBoundary';
 import { ConnectionStatusBanner } from './ConnectionStatusBanner';
@@ -604,6 +605,9 @@ function App() {
       {/* Toast notifications */}
       <NotificationToast />
       <UploadIndicator />
+
+      {/* Styled confirmation prompts (replaces window.confirm) */}
+      <ConfirmDialogHost />
     </div>
   );
 }

--- a/src/ui/confirm/ConfirmDialog.css
+++ b/src/ui/confirm/ConfirmDialog.css
@@ -1,0 +1,163 @@
+/* Styled confirmation dialog — overlay + centered card. Responsive + themed. */
+
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10050; /* above settings modals (10000) + toasts (9999) */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(14, 28, 48, 0.45);
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
+  animation: confirm-overlay-in 0.16s ease-out;
+}
+
+.confirm-dialog {
+  width: 100%;
+  max-width: 420px;
+  max-height: 90vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
+  box-shadow: var(--shadow-lg, 0 12px 40px rgba(14, 28, 48, 0.25));
+  animation: confirm-dialog-in 0.18s ease-out;
+}
+
+.confirm-dialog__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-text, #1f2937);
+}
+
+.confirm-dialog__message {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text, #1f2937);
+}
+
+.confirm-dialog__details {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary, #6b7280);
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.confirm-dialog__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 84px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, filter 0.15s ease;
+}
+
+.confirm-dialog__btn--cancel {
+  color: var(--color-text, #1f2937);
+  background: var(--color-bg, #f1f5f9);
+  border-color: var(--border-color, rgba(0, 0, 0, 0.1));
+}
+.confirm-dialog__btn--cancel:hover {
+  background: var(--color-bg-hover, #e2e8f0);
+}
+
+.confirm-dialog__btn--confirm {
+  color: var(--color-cta-text, #fff);
+  background: var(--color-cta, #1f3354);
+}
+.confirm-dialog__btn--confirm:hover {
+  background: var(--color-cta-hover, #16243d);
+}
+
+.confirm-dialog__btn--danger {
+  color: var(--danger-text, #fff);
+  background: var(--danger-bg, #dc2626);
+}
+.confirm-dialog__btn--danger:hover {
+  filter: brightness(0.95);
+}
+
+.confirm-dialog__btn:focus-visible {
+  outline: 2px solid var(--color-primary, #2563eb);
+  outline-offset: 2px;
+}
+
+/* Narrow viewports: full-width buttons, dialog hugs the bottom-safe area. */
+@media (max-width: 480px) {
+  .confirm-overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+  .confirm-dialog {
+    max-width: 100%;
+    border-radius: 16px 16px 0 0;
+    padding: 20px 16px calc(20px + env(safe-area-inset-bottom, 0px));
+    animation: confirm-sheet-in 0.2s ease-out;
+  }
+  .confirm-dialog__actions {
+    flex-direction: column-reverse;
+  }
+  .confirm-dialog__btn {
+    width: 100%;
+  }
+}
+
+@keyframes confirm-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes confirm-dialog-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes confirm-sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confirm-overlay,
+  .confirm-dialog {
+    animation: confirm-overlay-in 0.12s ease-out;
+  }
+}
+
+[data-theme='dark'] .confirm-overlay {
+  background: rgba(0, 0, 0, 0.55);
+}

--- a/src/ui/confirm/ConfirmDialog.test.tsx
+++ b/src/ui/confirm/ConfirmDialog.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ConfirmDialogHost } from './ConfirmDialog';
+import { confirmDialog, useConfirmStore } from './confirmStore';
+
+describe('ConfirmDialogHost', () => {
+  beforeEach(() => {
+    cleanup();
+    useConfirmStore.setState({ current: null, queue: [] });
+  });
+
+  it('renders nothing when idle', () => {
+    const { container } = render(<ConfirmDialogHost />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+  });
+
+  it('shows the active prompt (title, message, details) and resolves true on confirm', async () => {
+    render(<ConfirmDialogHost />);
+    const p = confirmDialog({
+      title: 'Delete 3 documents?',
+      message: 'They’ll be moved to Trash.',
+      details: 'Cloud documents are removed from the workspace.',
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+
+    expect(await screen.findByText('Delete 3 documents?')).toBeTruthy();
+    expect(screen.getByText('They’ll be moved to Trash.')).toBeTruthy();
+    expect(screen.getByText('Cloud documents are removed from the workspace.')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('resolves false on Cancel', async () => {
+    render(<ConfirmDialogHost />);
+    const p = confirmDialog({ title: 'Question?' });
+    await screen.findByText('Question?');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('resolves false on Escape', async () => {
+    render(<ConfirmDialogHost />);
+    const p = confirmDialog({ title: 'Escape me' });
+    await screen.findByText('Escape me');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('uses the default labels when none are given', async () => {
+    render(<ConfirmDialogHost />);
+    void confirmDialog({ title: 'Defaults' });
+    await screen.findByText('Defaults');
+
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+});

--- a/src/ui/confirm/ConfirmDialog.tsx
+++ b/src/ui/confirm/ConfirmDialog.tsx
@@ -1,0 +1,112 @@
+/**
+ * Styled confirmation dialog + host. Driven by `confirmStore` / `confirmDialog()`.
+ * Render <ConfirmDialogHost /> once at the app root.
+ */
+import { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { useConfirmStore, type ConfirmRequest } from './confirmStore';
+import './ConfirmDialog.css';
+
+interface ConfirmDialogProps {
+  request: ConfirmRequest;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // Focus the safe (cancel) button by default — important for destructive prompts.
+    cancelRef.current?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+      if (e.key === 'Tab') {
+        // Minimal focus trap across the dialog's focusable controls.
+        const focusables = dialogRef.current?.querySelectorAll<HTMLElement>('button');
+        if (!focusables || focusables.length === 0) return;
+        const first = focusables[0]!;
+        const last = focusables[focusables.length - 1]!;
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKey, true);
+    return () => document.removeEventListener('keydown', handleKey, true);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="confirm-overlay"
+      onMouseDown={(e) => {
+        // Backdrop click (not a drag from inside) cancels.
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="confirm-dialog"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby={request.message ? 'confirm-dialog-message' : undefined}
+      >
+        <h2 id="confirm-dialog-title" className="confirm-dialog__title">
+          {request.title}
+        </h2>
+        {request.message && (
+          <p id="confirm-dialog-message" className="confirm-dialog__message">
+            {request.message}
+          </p>
+        )}
+        {request.details && <p className="confirm-dialog__details">{request.details}</p>}
+        <div className="confirm-dialog__actions">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="confirm-dialog__btn confirm-dialog__btn--cancel"
+            onClick={onCancel}
+          >
+            {request.cancelLabel ?? 'Cancel'}
+          </button>
+          <button
+            type="button"
+            className={`confirm-dialog__btn ${
+              request.danger ? 'confirm-dialog__btn--danger' : 'confirm-dialog__btn--confirm'
+            }`}
+            onClick={onConfirm}
+          >
+            {request.confirmLabel ?? 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Mount once at the app root — renders the active confirmation prompt. */
+export function ConfirmDialogHost() {
+  const current = useConfirmStore((s) => s.current);
+  const resolve = useConfirmStore((s) => s._resolve);
+
+  const onConfirm = useCallback(() => resolve(true), [resolve]);
+  const onCancel = useCallback(() => resolve(false), [resolve]);
+
+  if (!current || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <ConfirmDialog key={current.id} request={current} onConfirm={onConfirm} onCancel={onCancel} />,
+    document.body,
+  );
+}

--- a/src/ui/confirm/confirmStore.test.ts
+++ b/src/ui/confirm/confirmStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useConfirmStore, confirmDialog } from './confirmStore';
+
+describe('confirmDialog store', () => {
+  beforeEach(() => useConfirmStore.setState({ current: null, queue: [] }));
+
+  it('enqueues a request and resolves with the confirm result', async () => {
+    const p = confirmDialog({ title: 'Delete it?' });
+    expect(useConfirmStore.getState().current?.title).toBe('Delete it?');
+
+    useConfirmStore.getState()._resolve(true);
+
+    await expect(p).resolves.toBe(true);
+    expect(useConfirmStore.getState().current).toBeNull();
+  });
+
+  it('queues concurrent requests and advances to the next on resolve', async () => {
+    const p1 = confirmDialog({ title: 'A' });
+    const p2 = confirmDialog({ title: 'B' });
+
+    expect(useConfirmStore.getState().current?.title).toBe('A');
+    expect(useConfirmStore.getState().queue).toHaveLength(1);
+
+    useConfirmStore.getState()._resolve(false);
+    await expect(p1).resolves.toBe(false);
+    expect(useConfirmStore.getState().current?.title).toBe('B');
+
+    useConfirmStore.getState()._resolve(true);
+    await expect(p2).resolves.toBe(true);
+    expect(useConfirmStore.getState().current).toBeNull();
+  });
+});

--- a/src/ui/confirm/confirmStore.ts
+++ b/src/ui/confirm/confirmStore.ts
@@ -1,0 +1,67 @@
+/**
+ * Imperative styled-confirmation utility — a drop-in replacement for the gross
+ * vanilla `window.confirm`. Call `await confirmDialog({...})` from anywhere
+ * (event handlers, hooks, stores) and get back a `Promise<boolean>`; a single
+ * `<ConfirmDialogHost />` mounted at the app root renders the styled dialog.
+ *
+ * Customizable per call: title, message, an extra `details` line (e.g. exactly
+ * what happens to a relay doc online vs offline), button labels, and a `danger`
+ * (destructive) treatment. Concurrent requests queue.
+ */
+import { create } from 'zustand';
+
+export interface ConfirmOptions {
+  /** Bold heading — the question. */
+  title: string;
+  /** Primary explanatory line. */
+  message?: string;
+  /** Secondary line for consequences/behavior (e.g. "kept in Trash for 7 days"). */
+  details?: string;
+  /** Confirm button label (default "Confirm"). */
+  confirmLabel?: string;
+  /** Cancel button label (default "Cancel"). */
+  cancelLabel?: string;
+  /** Destructive (red) confirm button — for deletes/removals. */
+  danger?: boolean;
+}
+
+export interface ConfirmRequest extends ConfirmOptions {
+  id: string;
+  resolve: (confirmed: boolean) => void;
+}
+
+interface ConfirmState {
+  current: ConfirmRequest | null;
+  queue: ConfirmRequest[];
+  /** @internal */ _enqueue: (req: ConfirmRequest) => void;
+  /** @internal */ _resolve: (confirmed: boolean) => void;
+}
+
+let seq = 0;
+
+export const useConfirmStore = create<ConfirmState>((set, get) => ({
+  current: null,
+  queue: [],
+  _enqueue: (req) => {
+    const { current, queue } = get();
+    if (current) set({ queue: [...queue, req] });
+    else set({ current: req });
+  },
+  _resolve: (confirmed) => {
+    const { current, queue } = get();
+    current?.resolve(confirmed);
+    const [next, ...rest] = queue;
+    set({ current: next ?? null, queue: rest });
+  },
+}));
+
+/**
+ * Show a styled confirmation prompt. Resolves `true` on confirm, `false` on
+ * cancel / Esc / backdrop dismiss. Requires `<ConfirmDialogHost />` mounted once.
+ */
+export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    seq += 1;
+    useConfirmStore.getState()._enqueue({ ...opts, id: `confirm-${seq}`, resolve });
+  });
+}

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -34,6 +34,7 @@ import { useTransferStore, isTransferRunning } from '../../store/transferStore';
 import { useCollaborationStore, purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
+import { confirmDialog } from '../confirm/confirmStore';
 
 /** Document type axis the nav rail / filter row toggles. */
 export type FilterMode = 'all' | 'local' | 'team' | 'cached';
@@ -701,12 +702,26 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       return canDelete(entry.record, currentUser?.id, currentUser?.role);
     });
     if (deletable.length === 0) return;
-    if (!window.confirm(`Delete ${deletable.length} document(s)? This cannot be undone.`)) return;
+    const hasRelay = deletable.some((id) => entries[id]?.record.type === 'remote');
+    const n = deletable.length;
+    const detail = hasRelay
+      ? isConnectedToHost
+        ? 'Cloud documents are removed from the workspace for everyone; a recoverable copy is kept in your Trash.'
+        : 'You’re offline — cloud documents move to your Trash now and leave the workspace once you reconnect.'
+      : undefined;
+    const ok = await confirmDialog({
+      title: `Delete ${n} document${n === 1 ? '' : 's'}?`,
+      message: 'They’ll be moved to Trash and removed after 7 days.',
+      ...(detail ? { details: detail } : {}),
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
     for (const id of deletable) {
       await handleDelete(id);
     }
     clearSelection();
-  }, [selectedIds, entries, currentUser, handleDelete, clearSelection]);
+  }, [selectedIds, entries, currentUser, handleDelete, clearSelection, isConnectedToHost]);
 
   const handleBulkExport = useCallback(async () => {
     const ids = Array.from(selectedIds);
@@ -737,8 +752,14 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   );
 
   const handleDeleteCollection = useCallback(
-    (collection: Collection) => {
-      if (!window.confirm(`Delete collection "${collection.name}"? Documents in it will become Unassigned.`)) return;
+    async (collection: Collection) => {
+      const ok = await confirmDialog({
+        title: `Delete collection “${collection.name}”?`,
+        message: 'The collection is removed. The documents inside it aren’t deleted — they become Unassigned.',
+        confirmLabel: 'Delete collection',
+        danger: true,
+      });
+      if (!ok) return;
       deleteCollectionAction(collection.id);
       setActiveCollectionMenu(null);
     },


### PR DESCRIPTION
Two cohesive deletion/trash UX improvements. Off fresh master, client-side only.

## 1. Stranded relay docs go to Trash (not "now a local document")
When a relay doc was deleted from the relay **while open**, the legacy path demoted it to a local document and toasted *"now a local document"* — but stranded docs belong in **Trash** (where the non-open ones already go). Unified: any deleted relay doc (open or not) is snapshotted into Trash with the correct "moved to Trash" toast, and the editor leaves the now-trashed doc when it's open. Demotion-to-local is kept only as the **edge-case fallback** when there's genuinely no copy to preserve.

## 2. Styled confirmation-prompt utility (replaces `window.confirm`)
`confirmDialog({ title, message, details?, confirmLabel?, cancelLabel?, danger? }): Promise<boolean>` — a drop-in for the gross vanilla `window.confirm`, backed by a queueable store + one `<ConfirmDialogHost />` portal at the app root. Styled/themed, **responsive** (centered card → bottom sheet on narrow viewports), focus-trapped, Esc + backdrop dismiss, destructive `danger` treatment, and a `details` line for explaining consequences.

Migrated the deletion `window.confirm` sites with accurate, **behavior-aware** copy (the old bulk-delete text even wrongly claimed "cannot be undone" — it's a soft delete to Trash):
- **Bulk delete** — explains cloud docs leave the workspace for everyone + stay recoverable in your Trash; **offline** variant notes the workspace removal syncs on reconnect.
- **Delete collection** — clarifies the documents aren't deleted, just Unassigned.

**Deferred** (per founder): the "don't ask again" option (needs a `uiPreferencesStore` v8→v9 migration). `DocumentCard` already uses a styled inline confirm, so single-doc delete was already non-vanilla. Remaining non-deletion `window.confirm`/`prompt` sites (settings resets, storage, collection rename/create) can be migrated to the same utility incrementally.

## Verification
- `bun run typecheck` ✓, `bun run test --run` ✓ (2478; +12 new across the confirm utility + the reworked strand test), `bun run build` ✓.

Assisted-by: Opus 4.8