### PR TITLE
JP-327: semantic versioning + build-identity observability (relay + editor)

### DIFF
--- a/.github/workflows/relay-image.yml
+++ b/.github/workflows/relay-image.yml
@@ -35,6 +35,13 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      # Build identity stamped into the binary (JP-327). The commit comes from
+      # the event; the timestamp is computed here as RFC3339 UTC. Surfaced at
+      # the relay's `/version` endpoint + the `relay_build_info` metric.
+      - name: Compute build time
+        id: buildtime
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Derive tags
         id: meta
         uses: docker/metadata-action@v5
@@ -64,6 +71,9 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.buildtime.outputs.value }}
           # Only trusted `staging` pushes WRITE the shared build cache. PR
           # build-checks read it but never write, so an untrusted PR can't
           # poison the cache the published `:edge` image is built from (JP-176).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,17 +15,19 @@ All trademarks and rights remain with their respective owners.
 
 ## Backwards Compatibility & Document Safety
 
-DocuShark is currently **pre-GA** on the `v2` branch — there are no shipped v2 releases or users with v2 documents in the wild. The v1 Diagrammer GitHub releases were retired with the brand collapse and are not part of the v2 compatibility surface.
+DocuShark is currently **pre-GA** on `master` — there are no shipped stable releases or users with v2-format documents in the wild. The v1 Diagrammer GitHub releases were retired with the brand collapse and are not part of the current compatibility surface.
 
-### What this means right now (pre-GA, v2.0.0-beta.N)
+The distributable artifacts carry **independent SemVer** — they ship and version on their own cadence, not in lockstep: the editor/desktop app (`package.json` / `tauri.conf.json`, currently `1.x-beta`) and the relay crate (`relay/Cargo.toml`, currently `1.x-beta`, whose major tracks the `/api/vN` REST major). Each build self-reports its identity (version + git SHA + build time); the relay exposes this at `/version` + the `relay_build_info` metric, the editor in Settings → About. "v2" elsewhere refers to the **document-format generation** (Diagrammer v1 → DocuShark v2), not an app version.
+
+### What this means right now (pre-GA, `-beta` pre-releases)
 
 - **Breaking changes are allowed** if a tested document migration in `/src/migrations/` lands in the same change. The bar is "no developer or future user is surprised by silent data loss," not "the wire/storage format is frozen."
 - Migrations must be **idempotent**, **logged**, and **tested** against a fixture of the pre-change format. See `src/migrations/teamDocumentMigration.ts` + its tests as the canonical pattern.
 - Wire-protocol changes still bump `PROTOCOL_VERSION` in both `src/collaboration/protocol.ts` and `relay/src/server/protocol.rs`, with matching fixtures under `relay/tests/protocol-fixtures/`.
 
-### What this means at GA (v2.0.0 and after)
+### What this means at GA (the first stable release and after)
 
-Once v2.0.0 ships:
+Once a stable (non-`-beta`) release ships:
 
 - **Document format**, **wire protocol**, and **storage keys** are frozen within a major version. Breaking changes require a major-version bump.
 - Deprecated APIs stay functional for at least one major-version cycle, with `Deprecation` warnings in code and release notes.

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "docushark-relay"
-version = "0.1.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "docushark-relay"
-version = "0.1.0"
+# SemVer. The crate major coincides with the REST surface major (`/api/v1` ⇒
+# 1.x); the published image is pinned at `:1` by consumers. The binary
+# self-reports its build identity (this version + git SHA + build time) via the
+# `/version` endpoint and the `relay_build_info` metric — see `src/build_info.rs`.
+version = "1.0.0-beta.1"
 description = "DocuShark Relay — standalone collaboration / MCP / auth server for DocuShark clients."
 authors = ["DocuShark Team"]
 license = "AGPL-3.0-or-later"

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -31,8 +31,19 @@ RUN mkdir -p src \
  && cargo fetch --locked \
  && rm -rf src
 
+COPY build.rs ./
 COPY src ./src
 COPY tests ./tests
+
+# Build identity (JP-327). CI passes the commit + an RFC3339 UTC timestamp;
+# `build.rs` stamps them into the binary (surfaced at `/version` + the
+# `relay_build_info` metric). There's no `.git` in the build context, so without
+# these the git fallback reports "unknown". Placed after `COPY src` (the build
+# already recompiles on any source change — the warm-up above only caches the
+# dep *download*, not a pre-compile — so a changing SHA costs nothing extra).
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+ENV GIT_SHA=$GIT_SHA BUILD_TIME=$BUILD_TIME
 
 # Release build. `--locked` enforces Cargo.lock so the image is
 # reproducible against the committed lockfile.

--- a/relay/build.rs
+++ b/relay/build.rs
@@ -1,0 +1,73 @@
+//! Build script: stamps the relay binary with its build identity.
+//!
+//! Emits two compile-time env vars (read via `env!` in `src/build_info.rs`):
+//!   - `RELAY_GIT_SHA`    — the commit the binary was built from.
+//!   - `RELAY_BUILD_TIME` — when it was built (RFC3339 UTC, or epoch seconds).
+//!
+//! Both prefer a value passed in by the build environment (`GIT_SHA` /
+//! `BUILD_TIME`, set by the Docker build-arg → ENV in `Dockerfile`, fed by CI),
+//! falling back to a local `git` invocation / the wall clock so plain
+//! `cargo build` still produces something useful. Neither var is ever unset,
+//! so `env!` (not `option_env!`) is safe at the call site.
+//!
+//! Deliberately std-only — no `vergen`/`chrono` build-dep, matching the relay's
+//! small-dep-tree house style (hand-rolled SigV4, no `prometheus` crate, etc.).
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    // Re-run when the injected values change, or when this script is edited.
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-env-changed=BUILD_TIME");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    println!("cargo:rustc-env=RELAY_GIT_SHA={}", resolve_git_sha());
+    println!("cargo:rustc-env=RELAY_BUILD_TIME={}", resolve_build_time());
+}
+
+/// `GIT_SHA` env (CI / Docker build-arg) → local `git rev-parse --short HEAD`
+/// → `"unknown"`.
+fn resolve_git_sha() -> String {
+    if let Some(sha) = non_empty_env("GIT_SHA") {
+        // Normalize to a short SHA for display parity with the `sha-<short>`
+        // image tag, while tolerating a value that's already short.
+        return short_sha(&sha);
+    }
+
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// `BUILD_TIME` env (CI passes RFC3339 UTC) → wall-clock epoch seconds →
+/// `"unknown"`.
+fn resolve_build_time() -> String {
+    if let Some(t) = non_empty_env("BUILD_TIME") {
+        return t;
+    }
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| format!("epoch:{}", d.as_secs()))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
+fn short_sha(sha: &str) -> String {
+    let sha = sha.trim();
+    if sha.len() > 12 {
+        sha[..12].to_string()
+    } else {
+        sha.to_string()
+    }
+}

--- a/relay/src/build_info.rs
+++ b/relay/src/build_info.rs
@@ -1,0 +1,16 @@
+//! Build identity for the running relay binary.
+//!
+//! Single source of truth for "what build is this?" — surfaced at runtime via
+//! the `/version` endpoint, the `relay_build_info` Prometheus metric, the MCP
+//! `GET /` info response, and `relay --version` (Clap reads `CARGO_PKG_VERSION`
+//! directly). `GIT_SHA` / `BUILD_TIME` are stamped by `build.rs` and are always
+//! set (it falls back to `"unknown"`), so `env!` never fails to compile.
+
+/// The crate SemVer (e.g. `1.0.0-beta.1`). Major coincides with the REST major.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Short git SHA the binary was built from, or `"unknown"`.
+pub const GIT_SHA: &str = env!("RELAY_GIT_SHA");
+
+/// Build timestamp (RFC3339 UTC from CI, or `epoch:<secs>` locally), or `"unknown"`.
+pub const BUILD_TIME: &str = env!("RELAY_BUILD_TIME");

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod api;
 pub mod auth;
+pub mod build_info;
 pub mod config;
 pub mod mcp;
 pub mod server;

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -210,7 +210,8 @@ fn unauthorized(headers: &HeaderMap) -> Response {
 async fn root_info() -> Response {
     Json(json!({
         "server": "docushark-mcp",
-        "version": env!("CARGO_PKG_VERSION"),
+        "version": crate::build_info::VERSION,
+        "commit": crate::build_info::GIT_SHA,
         "endpoint": "/mcp",
         "transport": "streamable-http",
         "protocolVersion": MCP_PROTOCOL_VERSION,
@@ -340,7 +341,7 @@ fn initialize_result() -> Value {
         },
         "serverInfo": {
             "name": "docushark",
-            "version": env!("CARGO_PKG_VERSION")
+            "version": crate::build_info::VERSION
         }
     })
 }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1932,6 +1932,7 @@ impl WebSocketServer {
         let mut app = Router::new()
             .route("/ws", get(ws_handler))
             .route("/health", get(health_handler))
+            .route("/version", get(version_handler))
             .route("/metrics", get(metrics_handler))
             // RB-1: the proxy upload buffers the body inline with an explicit
             // `max_blob_bytes` cap + the RB-1b concurrency gate (see
@@ -2098,9 +2099,25 @@ impl WebSocketServer {
     }
 }
 
-/// Health check endpoint
+/// Health check endpoint. Intentionally a bare `OK` (not JSON) — Fly/LB
+/// liveness checks match on it; build identity lives at `/version`.
 async fn health_handler() -> impl IntoResponse {
     "OK"
+}
+
+/// Build-identity endpoint. Unauthenticated (like `/health`) so an operator can
+/// curl which build a pod is running. Reports the crate SemVer + the git SHA /
+/// build time stamped in by `build.rs`. Under promote-don't-rebuild the binary
+/// keeps its build-time identity (a `-beta.N` pre-release); the clean `X.Y.Z` is
+/// the registry promotion tag, not something the binary re-stamps.
+async fn version_handler() -> impl IntoResponse {
+    axum::Json(serde_json::json!({
+        "server": "docushark-relay",
+        "version": crate::build_info::VERSION,
+        "commit": crate::build_info::GIT_SHA,
+        "built": crate::build_info::BUILD_TIME,
+        "protocolVersion": PROTOCOL_VERSION,
+    }))
 }
 
 /// Prometheus metrics endpoint. Hand-rolled exposition format — no
@@ -2149,7 +2166,10 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
     }
 
     let body = format!(
-        "# HELP relay_handler_panics_total Total handler panics caught at the per-message boundary.\n\
+        "# HELP relay_build_info Relay build identity (always 1; read the labels).\n\
+         # TYPE relay_build_info gauge\n\
+         relay_build_info{{version=\"{version}\",commit=\"{commit}\"}} 1\n\
+         # HELP relay_handler_panics_total Total handler panics caught at the per-message boundary.\n\
          # TYPE relay_handler_panics_total counter\n\
          relay_handler_panics_total {panics}\n\
          # HELP relay_jwks_cache_age_seconds Seconds since the last successful JWKS fetch (-1 = never).\n\
@@ -2176,6 +2196,8 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
          # HELP relay_rate_limit_rejections_total Write frames (CRDT + MCP) throttled by the per-workspace fair-use limiter.\n\
          # TYPE relay_rate_limit_rejections_total counter\n\
          relay_rate_limit_rejections_total {rate_limit_rejections}\n",
+        version = crate::build_info::VERSION,
+        commit = crate::build_info::GIT_SHA,
         panics = state.panic_count(),
         jwks_failures = jwks.refresh_failures_total,
         jwks_keys = jwks.key_count,

--- a/relay/tests/smoke.rs
+++ b/relay/tests/smoke.rs
@@ -129,13 +129,43 @@ async fn relay_docs_crud_roundtrip() {
         .expect("delete");
     assert_eq!(res.status().as_u16(), 200);
 
-    // /health
+    // /health stays a bare 200 (Fly/LB liveness depends on it).
     let res = client
         .get(format!("{}/health", harness.base))
         .send()
         .await
         .expect("health");
     assert_eq!(res.status().as_u16(), 200);
+
+    // /version exposes build identity, unauthenticated (JP-327).
+    let res = client
+        .get(format!("{}/version", harness.base))
+        .send()
+        .await
+        .expect("version");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.expect("version json");
+    assert_eq!(body["server"], "docushark-relay");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+    assert!(body["commit"].is_string(), "version reports a commit");
+    assert!(body["built"].is_string(), "version reports a build time");
+
+    // /metrics carries the build_info gauge with the version label (JP-327).
+    let body = client
+        .get(format!("{}/metrics", harness.base))
+        .send()
+        .await
+        .expect("metrics")
+        .text()
+        .await
+        .expect("metrics body");
+    assert!(
+        body.contains(&format!(
+            "relay_build_info{{version=\"{}\"",
+            env!("CARGO_PKG_VERSION")
+        )),
+        "metrics expose relay_build_info; got:\n{body}"
+    );
 
     harness.stop().await;
 }

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -16,6 +16,7 @@ import {
   Package,
   Palette,
   SwatchBook,
+  Info,
   Maximize2,
   Minimize2,
 } from 'lucide-react';
@@ -23,6 +24,7 @@ import { GeneralSettings } from './settings/GeneralSettings';
 import { StyleProfileSettings } from './settings/StyleProfileSettings';
 import { BackupSettings } from './settings/BackupSettings';
 import { AppearanceSettings } from './settings/AppearanceSettings';
+import { AboutSettings } from './settings/AboutSettings';
 import './SettingsModal.css';
 
 /**
@@ -30,7 +32,7 @@ import './SettingsModal.css';
  * library manager moved to the first-class Documents surface (JP-218); Settings
  * is now true preferences.
  */
-type SettingsTab = 'general' | 'appearance' | 'style-profiles' | 'backup';
+type SettingsTab = 'general' | 'appearance' | 'style-profiles' | 'backup' | 'about';
 
 /**
  * Tab configuration.
@@ -49,6 +51,7 @@ const TABS: TabConfig[] = [
   { id: 'appearance', label: 'Appearance', icon: SwatchBook },
   { id: 'style-profiles', label: 'Style Profiles', icon: Palette },
   { id: 'backup', label: 'Backup & Restore', icon: Package },
+  { id: 'about', label: 'About', icon: Info },
 ];
 
 export interface SettingsModalProps {
@@ -146,6 +149,7 @@ export function SettingsModal({ isOpen, onClose, initialTab = 'general' }: Setti
             {activeTab === 'appearance' && <AppearanceSettings />}
             {activeTab === 'style-profiles' && <StyleProfileSettings />}
             {activeTab === 'backup' && <BackupSettings />}
+            {activeTab === 'about' && <AboutSettings />}
           </div>
         </div>
       </div>

--- a/src/ui/settings/AboutSettings.css
+++ b/src/ui/settings/AboutSettings.css
@@ -1,0 +1,23 @@
+/* About settings tab (JP-327). Two-column key/value list for build identity. */
+
+.about-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+.about-label {
+  color: var(--text-secondary, #6b7280);
+  font-size: 13px;
+}
+
+.about-value {
+  margin: 0;
+  font-size: 13px;
+  word-break: break-word;
+}
+
+.about-value-mono {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}

--- a/src/ui/settings/AboutSettings.tsx
+++ b/src/ui/settings/AboutSettings.tsx
@@ -1,0 +1,113 @@
+/**
+ * About settings tab (JP-327).
+ *
+ * Surfaces the build identity that was previously only embedded in archive ZIP
+ * metadata: app semver, the short git SHA the build came from, build time, and
+ * platform. When connected to a relay it also shows the relay's own version
+ * (best-effort — a failed/blocked fetch degrades silently; the relay's
+ * `/version` is unauthenticated, like `/health`).
+ */
+
+import { useEffect, useState } from 'react';
+import { useConnectionStore } from '../../store/connectionStore';
+import './AboutSettings.css';
+
+const PLATFORM = __IS_TAURI__ ? 'Desktop (Tauri)' : 'Web (PWA)';
+
+/** Map a relay WebSocket URL to its HTTP origin (ws→http, wss→https). */
+function relayHttpOrigin(wsUrl: string): string | null {
+  try {
+    const u = new URL(wsUrl);
+    const proto = u.protocol === 'wss:' ? 'https:' : u.protocol === 'ws:' ? 'http:' : u.protocol;
+    return `${proto}//${u.host}`;
+  } catch {
+    return null;
+  }
+}
+
+interface RelayVersion {
+  version: string;
+  commit?: string;
+}
+
+export function AboutSettings() {
+  const status = useConnectionStore((s) => s.status);
+  const hostUrl = useConnectionStore((s) => s.host?.url ?? null);
+  const [relay, setRelay] = useState<RelayVersion | null>(null);
+
+  const connected = status === 'authenticated' || status === 'connected';
+
+  useEffect(() => {
+    setRelay(null);
+    if (!connected || !hostUrl) return;
+    const origin = relayHttpOrigin(hostUrl);
+    if (!origin) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(`${origin}/version`, { signal: controller.signal });
+        if (!res.ok) return;
+        const body = (await res.json()) as Partial<RelayVersion>;
+        if (typeof body.version === 'string') {
+          const next: RelayVersion = { version: body.version };
+          if (typeof body.commit === 'string') next.commit = body.commit;
+          setRelay(next);
+        }
+      } catch {
+        // Best-effort: offline, CORS, or an older relay without /version.
+        // The app-only rows below still render.
+      }
+    })();
+    return () => controller.abort();
+  }, [connected, hostUrl]);
+
+  return (
+    <div className="about-settings">
+      <h3 className="settings-section-title">About</h3>
+
+      <div className="settings-group">
+        <h4 className="settings-group-title">DocuShark</h4>
+        <dl className="about-list">
+          <AboutRow label="Version" value={__APP_VERSION__} mono />
+          <AboutRow label="Commit" value={__GIT_SHA__} mono />
+          <AboutRow label="Built" value={formatBuildTime(__BUILD_TIME__)} />
+          <AboutRow label="Platform" value={PLATFORM} />
+        </dl>
+      </div>
+
+      <div className="settings-group">
+        <h4 className="settings-group-title">Relay</h4>
+        {relay ? (
+          <dl className="about-list">
+            <AboutRow label="Version" value={relay.version} mono />
+            {relay.commit ? <AboutRow label="Commit" value={relay.commit} mono /> : null}
+            <AboutRow label="Status" value="Connected" />
+          </dl>
+        ) : (
+          <p className="settings-hint">
+            {connected ? 'Relay version unavailable.' : 'Not connected to a relay.'}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AboutRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <>
+      <dt className="about-label">{label}</dt>
+      <dd className={`about-value${mono ? ' about-value-mono' : ''}`}>{value}</dd>
+    </>
+  );
+}
+
+/** Render the ISO build timestamp in the user's locale; pass through if unparseable. */
+function formatBuildTime(raw: string): string {
+  if (!raw || raw === 'unknown') return 'unknown';
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? raw : d.toLocaleString();
+}
+
+export default AboutSettings;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,6 +10,10 @@
  * unreachable branch and any module that was only imported from it.
  */
 declare const __APP_VERSION__: string;
+/** Short git SHA of the build, or "unknown" (JP-327). Shown in Settings → About. */
+declare const __GIT_SHA__: string;
+/** ISO-8601 UTC build timestamp (JP-327). */
+declare const __BUILD_TIME__: string;
 declare const __IS_TAURI__: boolean;
 
 interface ImportMetaEnv {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import { execSync } from 'child_process';
 import path from 'path';
 import pkg from './package.json';
 
@@ -10,6 +11,21 @@ import pkg from './package.json';
 // not a service worker, so the PWA plugin is disabled for those builds.
 const isTauriBuild =
   process.env.TAURI_ENV_PLATFORM != null || process.env.TAURI_PLATFORM != null;
+
+// Build identity (JP-327). `__APP_VERSION__` is the package semver; the short
+// git SHA pins which build it actually is (shown in Settings → About). Prefer a
+// local `git` read, fall back to CI's GITHUB_SHA, then "unknown" — never fail
+// the build over missing VCS metadata.
+const gitSha = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return (process.env.GITHUB_SHA ?? '').slice(0, 12) || 'unknown';
+  }
+})();
+const buildTime = new Date().toISOString();
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -75,6 +91,8 @@ export default defineConfig({
   ],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __GIT_SHA__: JSON.stringify(gitSha),
+    __BUILD_TIME__: JSON.stringify(buildTime),
     // Build-time platform flag for tree-shaking Tauri impls out of PWA
     // bundles. Tauri sets TAURI_ENV_PLATFORM (and the older TAURI_PLATFORM)
     // when invoking the renderer build; treat either as desktop.


### PR DESCRIPTION
Closes JP-327.

None of the apps reported a meaningful, observable version. This adds **independent per-app SemVer** plus build-identity surfacing so ops can answer *"which build is running in this pod?"* and users can see *"what version am I on?"*.

## Relay (`docushark-app/relay`)
- Bump crate `0.1.0` → **`1.0.0-beta.1`**. Major stays **1** to coincide with the `/api/v1` REST surface and the image `:1` pin — a coordinated cross-repo major is intentionally out of scope here.
- `build.rs` (std-only — no `vergen`/`chrono`, matching the relay's small-dep-tree style) stamps `RELAY_GIT_SHA` + `RELAY_BUILD_TIME`; `src/build_info.rs` is the single source of truth.
- New unauthenticated `GET /version` (JSON) + a `relay_build_info{version,commit}` Prometheus gauge. `/health` stays a bare `OK` (Fly/LB liveness). MCP `serverInfo` / `GET /` now read `build_info` (`GET /` also reports the commit).
- `Dockerfile` copies `build.rs` and accepts `GIT_SHA`/`BUILD_TIME` build-args; `relay-image.yml` passes the commit + an RFC3339 build time.
- The Docker-Hub **promotion workflow stays deferred** (promote-don't-rebuild: the binary keeps its build-time `-beta` identity; the clean `X.Y.Z` is the registry promotion tag).

## Editor (`docushark-app`)
- vite injects `__GIT_SHA__` / `__BUILD_TIME__` alongside `__APP_VERSION__` (editor stays `1.3.1-beta.1`).
- New **Settings → About** tab: version + commit + build time + platform, plus the connected relay's version (best-effort; degrades silently on offline/CORS/older relay).

## Docs
- `AGENTS.md` version-scheme claims corrected: `master` (not a "v2 branch"); independent per-app SemVer; "v2" clarified as the **document-format generation**, not an app semver.

## Verification
- Relay: `cargo build --bin relay`, `cargo check --all-targets`, full `cargo test` green; `smoke.rs` asserts `/version` JSON + the `relay_build_info` gauge; build-arg injection path verified via `strings`.
- Editor: `bun run typecheck` + `bun run build` clean; all 2487 tests pass; confirmed the git SHA lands in the built bundle.
- Both OSS leak greps (commercial + one-way-link) clean on touched files.

> Note: full image build/promotion + the live staging round-trip need the deploy pipeline; in-repo gates are all green.

Assisted-by: Opus 4.8