### PR TITLE
JP-323: Layout & panel UX papercuts

### DIFF
--- a/src/engine/tools/SelectTool.ts
+++ b/src/engine/tools/SelectTool.ts
@@ -1572,7 +1572,9 @@ export class SelectTool extends BaseTool {
    * Get the anchor point (opposite corner/edge) for a resize handle.
    */
   private getAnchorPoint(shape: Shape, handleType: HandleType): Vec2 {
-    if (isRectangle(shape)) {
+    // File shapes are rectangular cards (x/y/width/height/rotation) and use the
+    // identical opposite-corner anchor math as rectangles.
+    if (isRectangle(shape) || isFile(shape)) {
       const halfWidth = shape.width / 2;
       const halfHeight = shape.height / 2;
 
@@ -1693,7 +1695,8 @@ export class SelectTool extends BaseTool {
     anchor: Vec2,
     maintainAspectRatio: boolean
   ): Partial<Shape> | null {
-    if (isRectangle(original)) {
+    if (isRectangle(original) || isFile(original)) {
+      // File shapes resize with the same width/height box math as rectangles.
       return this.calculateRectangleResize(original, handleType, currentPoint, anchor, maintainAspectRatio);
     }
 
@@ -1731,7 +1734,9 @@ export class SelectTool extends BaseTool {
     anchor: Vec2,
     maintainAspectRatio: boolean
   ): Partial<Shape> {
-    if (!isRectangle(original)) return {};
+    // Accepts rectangles and file cards — both are width/height boxes with the
+    // same resize geometry (only x/y/width/height/rotation are read below).
+    if (!isRectangle(original) && !isFile(original)) return {};
 
     // Transform current point to local space (un-rotate around original center)
     const toLocal = (p: Vec2): Vec2 => {

--- a/src/shapes/FileShape.ts
+++ b/src/shapes/FileShape.ts
@@ -336,6 +336,38 @@ export const fileShapeHandler: ShapeHandler<FileShape> = {
       ctx.fillText(truncatedName, nameStartX, barCenterY);
     }
 
+    // --- Tag badges (top-left of the thumbnail area) ---
+    // A single legible row of chips over the thumbnail; stops drawing when it
+    // runs out of card width rather than wrapping.
+    const tags = shape.tags;
+    if (tags && tags.length > 0) {
+      const badgeFont = Math.max(9, Math.min(12, fontSize));
+      ctx.font = `${badgeFont}px sans-serif`;
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'left';
+      const badgePadX = 6;
+      const badgePadY = 3;
+      const badgeGap = 4;
+      const badgeH = badgeFont + badgePadY * 2;
+      const badgeMaxX = halfWidth - 8;
+      const badgeY = thumbAreaTop + 8;
+      let badgeX = -halfWidth + 8;
+      for (const tag of tags) {
+        const text = tag.trim();
+        if (!text) continue;
+        const badgeW = ctx.measureText(text).width + badgePadX * 2;
+        if (badgeX + badgeW > badgeMaxX) break;
+        ctx.beginPath();
+        roundedRectPath(ctx, badgeX, badgeY, badgeW, badgeH, Math.min(6, badgeH / 2));
+        ctx.closePath();
+        ctx.fillStyle = 'rgba(15, 23, 42, 0.82)';
+        ctx.fill();
+        ctx.fillStyle = '#ffffff';
+        ctx.fillText(text, badgeX + badgePadX, badgeY + badgeH / 2);
+        badgeX += badgeW + badgeGap;
+      }
+    }
+
     // --- Missing blob indicator ---
     // Show warning overlay if the file blob OR its thumbnail blob is known to be
     // missing. FileViewerModal marks the file `blobRef` when opened; the canvas

--- a/src/shapes/Shape.ts
+++ b/src/shapes/Shape.ts
@@ -674,6 +674,11 @@ export interface FileShape extends BaseShape {
   labelFontSize?: number;
   /** Label text color */
   labelColor?: string;
+  /**
+   * Free-text tags shown as badges on the card (e.g. "Latest", "Archive").
+   * Optional/additive — absent on older documents (no migration needed).
+   */
+  tags?: string[];
 }
 
 /**

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -334,6 +334,40 @@ describe('uiPreferencesStore — migration', () => {
 
     expect(useUIPreferencesStore.getState().collabIndicatorPos).toBeNull();
   });
+
+  it('v8 → v9 resets the legacy 480px split width to the responsive null default', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          relaxedSplitCanvasWidth: 480, // the old hard default
+        },
+        version: 8,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().relaxedSplitCanvasWidth).toBeNull();
+  });
+
+  it('v8 → v9 preserves a deliberately-dragged split width', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          relaxedSplitCanvasWidth: 640, // a value the user dragged to
+        },
+        version: 8,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().relaxedSplitCanvasWidth).toBe(640);
+  });
 });
 
 describe('uiPreferencesStore — collab indicator position', () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -87,8 +87,10 @@ export interface UIPreferencesState {
   /**
    * Width (px) of the secondary canvas pane in the Relaxed `split` focus — the
    * draggable divider between the prose editor and the canvas. App-level.
+   * `null` means "no explicit width yet" — a responsive ~50/50 CSS default
+   * governs until the user drags the divider (which stores a concrete px).
    */
-  relaxedSplitCanvasWidth: number;
+  relaxedSplitCanvasWidth: number | null;
   /** Document browser layout */
   documentBrowserView: DocumentBrowserView;
   /** Document browser sort key */
@@ -131,7 +133,7 @@ export interface UIPreferencesActions {
   /** Set property panel width */
   setPropertyPanelWidth: (width: number) => void;
   /** Set the Relaxed split secondary-canvas width (px). */
-  setRelaxedSplitCanvasWidth: (width: number) => void;
+  setRelaxedSplitCanvasWidth: (width: number | null) => void;
   /** Pin the floating collaboration indicator's top-left (viewport px). */
   setCollabIndicatorPos: (pos: { x: number; y: number }) => void;
   /** Set the document browser view (list/grid) */
@@ -251,7 +253,7 @@ const initialState: UIPreferencesState = {
   expandedSections: { ...DEFAULT_EXPANDED },
   rotationUnit: 'degrees',
   propertyPanelWidth: 240,
-  relaxedSplitCanvasWidth: 480,
+  relaxedSplitCanvasWidth: null,
   documentBrowserView: 'list',
   documentBrowserSort: 'modified-desc',
   documentBrowserGroupBy: 'none',
@@ -377,7 +379,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ propertyPanelWidth: width });
       },
 
-      setRelaxedSplitCanvasWidth: (width: number) => {
+      setRelaxedSplitCanvasWidth: (width: number | null) => {
         set({ relaxedSplitCanvasWidth: width });
       },
 
@@ -518,7 +520,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 8,
+      version: 9,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -633,6 +635,16 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // they first drag it. (The `merge` below also backstops this.)
         if (fromVersion < 8) {
           next['collabIndicatorPos'] = next['collabIndicatorPos'] ?? null;
+        }
+        // v8 → v9: the Relaxed split-canvas width became responsive-by-default
+        // (`null` = use the ~50/50 CSS clamp). The old hard default was 480px,
+        // which rendered as a cramped ~33% pane on wide screens. Reset that
+        // exact legacy default to `null` so existing users get the responsive
+        // split; any other value is a deliberate drag and is preserved.
+        if (fromVersion < 9) {
+          if (next['relaxedSplitCanvasWidth'] === 480) {
+            next['relaxedSplitCanvasWidth'] = null;
+          }
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -118,9 +118,11 @@
 }
 
 /* In Relaxed split focus the canvas becomes a secondary pane beside the prose.
- * Fluid width so it adapts to the viewport (and the future mobile layout). */
+ * Fluid ~50/50 width so it adapts to the viewport (and the future mobile
+ * layout). Used until the user drags the divider, after which an explicit px
+ * flex-basis is applied inline (see App.tsx / RelaxedSplitHandle). */
 .canvas-area-wrapper--secondary {
-  flex: 0 0 clamp(320px, 40%, 640px);
+  flex: 0 0 clamp(360px, 50%, 760px);
 }
 
 /* A region collapsed by the active focus (e.g. canvas in write focus, prose in

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -118,11 +118,20 @@
 }
 
 /* In Relaxed split focus the canvas becomes a secondary pane beside the prose.
- * Fluid ~50/50 width so it adapts to the viewport (and the future mobile
- * layout). Used until the user drags the divider, after which an explicit px
- * flex-basis is applied inline (see App.tsx / RelaxedSplitHandle). */
+ * Both panes share the row equally (`flex: 1 1 0`) for a true ~50/50 at any
+ * viewport — until the user drags the divider, after which an explicit px
+ * flex-basis is applied inline to the canvas (see App.tsx / RelaxedSplitHandle),
+ * which overrides this and lets the prose flex to fill the rest. */
 .canvas-area-wrapper--secondary {
-  flex: 0 0 clamp(360px, 50%, 760px);
+  flex: 1 1 0;
+  min-width: 320px;
+}
+
+/* The prose primary pane matches the canvas's equal flex in split focus so the
+ * default (undragged) split is a genuine 50/50, not content-sized. */
+.document-area-wrapper--split {
+  flex: 1 1 0;
+  min-width: 320px;
 }
 
 /* A region collapsed by the active focus (e.g. canvas in write focus, prose in

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -474,7 +474,7 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
               <div
                 className={`document-area-wrapper${
                   regions.primary === 'canvas' ? ' is-collapsed' : ''
-                }`}
+                }${canvasIsSecondary ? ' document-area-wrapper--split' : ''}`}
               >
                 <ErrorBoundary sectionName="Document Editor">
                   <Suspense fallback={<div className="document-editor-loading" />}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -130,18 +130,24 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   const propertiesUsesFlyout =
     isPropertiesVisible && isFlyoutLayout(activeMode) && !propertiesPanelState.pinned;
 
-  // Relaxed gets a railless, selection-triggered Properties overlay. The
-  // selection size subscription drives mounting; FlyoutPanel's own
-  // expandOnSelection then handles the slide-in/out within the mounted node.
-  const selectionCount = useSessionStore((s) => s.selectedIds.size);
-  const relaxedTransientProps =
-    activeMode === 'relaxed' && !isPropertiesVisible && selectionCount > 0;
-  const renderProperties = isPropertiesVisible || relaxedTransientProps;
-
   // Relaxed writing-first layout: the prose editor is the primary region and
   // `relaxedFocus` (plus the viewport band) decides how the canvas appears.
   // Other layouts ignore this and use the docked panel machinery below.
   const relaxedFocus = useSessionStore((s) => s.relaxedFocus);
+
+  // Relaxed gets a railless, selection-triggered Properties overlay. The
+  // selection size subscription drives mounting; FlyoutPanel's own
+  // expandOnSelection then handles the slide-in/out within the mounted node.
+  // Suppressed in `write` focus — the canvas is hidden there, so a lingering
+  // selection must not pop the Properties overlay over the prose.
+  const selectionCount = useSessionStore((s) => s.selectedIds.size);
+  const relaxedTransientProps =
+    activeMode === 'relaxed' &&
+    relaxedFocus !== 'write' &&
+    !isPropertiesVisible &&
+    selectionCount > 0;
+  const renderProperties = isPropertiesVisible || relaxedTransientProps;
+
   const { band } = useBreakpoint();
   const regions = resolveRegions(activeMode, relaxedFocus, band);
   const isRelaxed = activeMode === 'relaxed';
@@ -529,7 +535,13 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
               split focus the explicit width is user-draggable. */}
           <div
             className={canvasWrapperClass}
-            style={canvasIsSecondary ? { flex: `0 0 ${relaxedSplitCanvasWidth}px` } : undefined}
+            // An explicit (dragged) width wins; when null the responsive
+            // `.canvas-area-wrapper--secondary` CSS clamp owns the ~50/50 split.
+            style={
+              canvasIsSecondary && relaxedSplitCanvasWidth != null
+                ? { flex: `0 0 ${relaxedSplitCanvasWidth}px` }
+                : undefined
+            }
           >
             {canvasIsSecondary && <RelaxedSplitHandle />}
             <ErrorBoundary sectionName="Canvas Toolbar">

--- a/src/ui/ColorPalette.css
+++ b/src/ui/ColorPalette.css
@@ -210,6 +210,8 @@
   gap: 6px;
 }
 
+/* Custom-color swatch preview (a button, not a native color input — no OS
+   dialog). Shows the current custom color; click opens the hex field. */
 .color-palette-picker {
   width: 28px;
   height: 28px;
@@ -218,15 +220,6 @@
   border-radius: 4px;
   cursor: pointer;
   background: transparent;
-}
-
-.color-palette-picker::-webkit-color-swatch-wrapper {
-  padding: 2px;
-}
-
-.color-palette-picker::-webkit-color-swatch {
-  border: none;
-  border-radius: 2px;
 }
 
 .color-palette-custom-toggle {

--- a/src/ui/ColorPalette.tsx
+++ b/src/ui/ColorPalette.tsx
@@ -102,19 +102,6 @@ export function ColorPalette({
     }
   }, [customInputValue, setCustomColor, handleColorSelect]);
 
-  const handleNativePickerChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const color = e.target.value;
-      setCustomInputValue(color);
-      setCustomColor(color);
-      // Apply immediately — picking a colour in the native picker should take
-      // effect right away, not wait for the user to open the hex field and hit
-      // Apply.
-      handleColorSelect(color);
-    },
-    [setCustomColor, handleColorSelect]
-  );
-
   const handleCustomInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       let val = e.target.value;
@@ -220,12 +207,19 @@ export function ColorPalette({
       <div className="color-palette-section">
         {!compact && <div className="color-palette-label">Custom</div>}
         <div className="color-palette-custom">
-          <input
-            type="color"
-            value={customColor}
-            onChange={handleNativePickerChange}
+          {/* Swatch preview of the current custom color. Clicking it opens the
+              hex field (below) — we deliberately avoid a native
+              `<input type="color">` here so no OS color dialog is invoked. */}
+          <button
+            type="button"
             className="color-palette-picker"
-            title="Pick a custom color"
+            style={HEX_REGEX.test(customColor) ? { backgroundColor: customColor } : undefined}
+            onClick={() => {
+              setShowCustomInput(true);
+              setCustomInputValue(customColor);
+            }}
+            title="Enter hex color"
+            aria-label="Enter a custom hex color"
           />
           {showCustomInput ? (
             <div className="color-palette-custom-input-group">

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -2,7 +2,9 @@
 .property-panel {
   position: relative;
   min-width: 180px;
-  max-width: 400px;
+  /* Keep in sync with MAX_WIDTH in PropertyPanel.tsx and the flyout body cap in
+     FlyoutPanel.css — the lowest of the three binds the docked panel. */
+  max-width: 640px;
   background-color: var(--bg-primary);
   border-left: 1px solid var(--border-color);
   display: flex;
@@ -1469,6 +1471,53 @@
 
 [data-theme="dark"] .file-info-card {
   background: var(--bg-secondary);
+}
+
+/* File-shape tag editor (free-text chips) */
+.file-tags-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.file-tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1-5);
+}
+
+.file-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  font-size: var(--font-size-2xs, 10px);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+}
+
+.file-tag-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.file-tag-remove:hover {
+  color: var(--danger, #ef4444);
+  background: var(--bg-hover);
 }
 
 /* Swimlane Lanes List */

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -74,9 +74,11 @@ function getSharedValue<T>(shapes: Shape[], getter: (s: Shape) => T): T | typeof
   return first;
 }
 
-/** Constraints for panel width */
+/** Constraints for panel width. MAX must stay in sync with the
+ *  `.flyout-panel-body` max-width in layout/FlyoutPanel.css — the flyout body
+ *  sizes from the same store slot, so a lower cap on either side wins. */
 const MIN_WIDTH = 180;
-const MAX_WIDTH = 400;
+const MAX_WIDTH = 560;
 
 /**
  * A small colour chip used in a collapsed section's header summary so the user

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -78,7 +78,7 @@ function getSharedValue<T>(shapes: Shape[], getter: (s: Shape) => T): T | typeof
  *  `.flyout-panel-body` max-width in layout/FlyoutPanel.css — the flyout body
  *  sizes from the same store slot, so a lower cap on either side wins. */
 const MIN_WIDTH = 180;
-const MAX_WIDTH = 560;
+const MAX_WIDTH = 640;
 
 /**
  * A small colour chip used in a collapsed section's header summary so the user
@@ -1290,6 +1290,24 @@ function FileShapeProperties({
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isReplacing, setIsReplacing] = useState(false);
+  const [tagInput, setTagInput] = useState('');
+
+  const tags = shape.tags ?? [];
+  const addTag = useCallback(
+    (raw: string) => {
+      const t = raw.trim();
+      setTagInput('');
+      if (!t || tags.includes(t)) return;
+      updateShape(shape.id, { tags: [...tags, t] });
+    },
+    [tags, shape.id, updateShape]
+  );
+  const removeTag = useCallback(
+    (t: string) => {
+      updateShape(shape.id, { tags: tags.filter((x) => x !== t) });
+    },
+    [tags, shape.id, updateShape]
+  );
 
   const handleReplaceClick = useCallback(() => {
     fileInputRef.current?.click();
@@ -1366,6 +1384,43 @@ function FileShapeProperties({
           onChange={(color) => updateShape(shape.id, { labelColor: color })}
           showAuto
         />
+      </PropertySection>
+
+      <PropertySection id="file-tags" title="Tags" defaultExpanded={false}>
+        <div className="file-tags-editor">
+          {tags.length > 0 && (
+            <div className="file-tags-list">
+              {tags.map((tag) => (
+                <span key={tag} className="file-tag-chip">
+                  {tag}
+                  <button
+                    type="button"
+                    className="file-tag-remove"
+                    onClick={() => removeTag(tag)}
+                    aria-label={`Remove tag ${tag}`}
+                    title={`Remove ${tag}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addTag(tagInput);
+              }
+            }}
+            onBlur={() => addTag(tagInput)}
+            className="property-text-input"
+            placeholder="Add a tag…"
+          />
+        </div>
       </PropertySection>
     </>
   );

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -539,9 +539,19 @@
   margin: 0;
 }
 
-/* Resize handles */
+/* Resize handles.
+   NOTE: `.resize-handle` is a SHARED class name — the docked-panel / split
+   divider rule in `layout/resizeHandle.css` also matches it and sets
+   `top: 0; bottom: 0`. Reset all four offsets to `auto` here (this selector's
+   specificity outranks that global rule) so the per-direction rules below own
+   positioning; otherwise the leaked `top: 0` pins the bottom handles
+   (sw/s/se) to the top of the image. */
 .tiptap-editor .ProseMirror .resize-handle {
   position: absolute;
+  top: auto;
+  bottom: auto;
+  left: auto;
+  right: auto;
   width: 10px;
   height: 10px;
   background-color: var(--color-primary);

--- a/src/ui/Tooltip.css
+++ b/src/ui/Tooltip.css
@@ -1,0 +1,32 @@
+/* Reusable app-styled tooltip popup (see Tooltip.tsx). Portaled to body with
+   fixed positioning; never receives pointer events. Mirrors the toolbar tooltip
+   look (tertiary surface, soft shadow) so tooltips read consistently. */
+.ds-tooltip {
+  z-index: 1000;
+  max-width: 260px;
+  padding: var(--space-1, 4px) var(--space-2, 8px);
+  background: var(--bg-tertiary, #1f2937);
+  color: var(--text-primary, #fff);
+  font-size: var(--font-size-sm, 12px);
+  line-height: 1.35;
+  white-space: nowrap;
+  border-radius: var(--radius-sm, 4px);
+  box-shadow: var(--shadow-md, 0 2px 8px rgba(0, 0, 0, 0.18));
+  pointer-events: none;
+  animation: ds-tooltip-in 0.12s ease;
+}
+
+@keyframes ds-tooltip-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-tooltip {
+    animation: none;
+  }
+}

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tooltip — a small reusable, app-styled hover/focus tooltip.
+ *
+ * Wraps a single trigger element and shows a styled popup on hover or keyboard
+ * focus. The popup is **portaled to `document.body` with fixed positioning** so
+ * it is never clipped by an ancestor `overflow: hidden` (e.g. the canvas pane
+ * that hosts the relaxed split divider). The trigger is cloned (not wrapped in
+ * an extra DOM box) so it keeps its own layout/positioning — handlers are
+ * composed with any the child already declares.
+ *
+ * Prefer this over native `title=""` when the tooltip should match app styling.
+ */
+
+import {
+  Children,
+  cloneElement,
+  type FocusEvent as ReactFocusEvent,
+  isValidElement,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import './Tooltip.css';
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+/** Gap (px) between the trigger and the tooltip. */
+const GAP = 8;
+
+interface TriggerHandlers {
+  onMouseEnter?: (e: ReactMouseEvent) => void;
+  onMouseLeave?: (e: ReactMouseEvent) => void;
+  onFocus?: (e: ReactFocusEvent) => void;
+  onBlur?: (e: ReactFocusEvent) => void;
+}
+
+export interface TooltipProps {
+  /** Tooltip body — text or nodes. When nullish, the tooltip is disabled. */
+  content: ReactNode;
+  /** Side of the trigger the tooltip appears on (default: top). */
+  placement?: TooltipPlacement;
+  /** The single trigger element (cloned to attach hover/focus handlers). */
+  children: ReactElement<TriggerHandlers>;
+}
+
+function call(handler: ((e: never) => void) | undefined, e: unknown): void {
+  handler?.(e as never);
+}
+
+function popupStyle(rect: DOMRect, placement: TooltipPlacement): React.CSSProperties {
+  switch (placement) {
+    case 'bottom':
+      return { top: rect.bottom + GAP, left: rect.left + rect.width / 2, transform: 'translate(-50%, 0)' };
+    case 'left':
+      return { top: rect.top + rect.height / 2, left: rect.left - GAP, transform: 'translate(-100%, -50%)' };
+    case 'right':
+      return { top: rect.top + rect.height / 2, left: rect.right + GAP, transform: 'translate(0, -50%)' };
+    case 'top':
+    default:
+      return { top: rect.top - GAP, left: rect.left + rect.width / 2, transform: 'translate(-50%, -100%)' };
+  }
+}
+
+export function Tooltip({ content, placement = 'top', children }: TooltipProps) {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  const child = Children.only(children);
+  const childProps: TriggerHandlers = isValidElement(child) ? child.props : {};
+
+  const show = useCallback((e: ReactMouseEvent | ReactFocusEvent) => {
+    setRect(e.currentTarget.getBoundingClientRect());
+  }, []);
+  const hide = useCallback(() => setRect(null), []);
+
+  const cloned = cloneElement(child, {
+    onMouseEnter: (e: ReactMouseEvent) => {
+      call(childProps.onMouseEnter, e);
+      show(e);
+    },
+    onMouseLeave: (e: ReactMouseEvent) => {
+      call(childProps.onMouseLeave, e);
+      hide();
+    },
+    onFocus: (e: ReactFocusEvent) => {
+      call(childProps.onFocus, e);
+      show(e);
+    },
+    onBlur: (e: ReactFocusEvent) => {
+      call(childProps.onBlur, e);
+      hide();
+    },
+  });
+
+  return (
+    <>
+      {cloned}
+      {rect != null &&
+        content != null &&
+        content !== false &&
+        createPortal(
+          <div className="ds-tooltip" role="tooltip" style={{ position: 'fixed', ...popupStyle(rect, placement) }}>
+            {content}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
+export default Tooltip;

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -117,7 +117,7 @@
   overflow: hidden;
   min-width: 180px;
   /* Keep in sync with PropertyPanel's MAX_WIDTH — the lower cap wins. */
-  max-width: 560px;
+  max-width: 640px;
   z-index: 6;
 }
 

--- a/src/ui/layout/FlyoutPanel.css
+++ b/src/ui/layout/FlyoutPanel.css
@@ -116,7 +116,8 @@
   background: var(--bg-primary);
   overflow: hidden;
   min-width: 180px;
-  max-width: 480px;
+  /* Keep in sync with PropertyPanel's MAX_WIDTH — the lower cap wins. */
+  max-width: 560px;
   z-index: 6;
 }
 

--- a/src/ui/layout/FlyoutPanel.tsx
+++ b/src/ui/layout/FlyoutPanel.tsx
@@ -76,10 +76,22 @@ export function FlyoutPanel({
 
   const scheduleCollapse = useCallback(() => {
     cancelCollapseTimer();
-    collapseTimerRef.current = window.setTimeout(() => {
-      collapseTimerRef.current = null;
-      setIsExpanded(false);
-    }, AUTO_COLLAPSE_DELAY_MS);
+    // A panel-owned popover (color/icon/pattern/border picker) mounts its
+    // `[data-flyout-keep-open]` portal asynchronously, so a focusout that races
+    // ahead of the mount could schedule a collapse while the popover is open.
+    // If one is open when the timer fires, the panel is in use — re-arm instead
+    // of collapsing, so we still close once the popover goes away.
+    const arm = () => {
+      collapseTimerRef.current = window.setTimeout(() => {
+        collapseTimerRef.current = null;
+        if (document.querySelector('[data-flyout-keep-open]')) {
+          arm();
+          return;
+        }
+        setIsExpanded(false);
+      }, AUTO_COLLAPSE_DELAY_MS);
+    };
+    arm();
   }, [cancelCollapseTimer]);
 
   const expand = useCallback(() => {

--- a/src/ui/layout/RelaxedSplitHandle.tsx
+++ b/src/ui/layout/RelaxedSplitHandle.tsx
@@ -12,6 +12,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { Tooltip } from '../Tooltip';
 import './resizeHandle.css';
 
 const MIN_CANVAS = 280;
@@ -104,21 +105,23 @@ export function RelaxedSplitHandle() {
   );
 
   return (
-    <div
-      ref={handleRef}
-      className={`resize-handle resize-handle--edge-left ${isDragging ? 'dragging' : ''}`}
-      onMouseDown={handleMouseDown}
-      onDoubleClick={handleDoubleClick}
-      onKeyDown={handleKeyDown}
-      role="separator"
-      aria-orientation="vertical"
-      aria-label="Resize prose editor"
-      aria-valuenow={Math.round(effectiveWidth)}
-      aria-valuemin={MIN_CANVAS}
-      aria-valuemax={MAX_CANVAS}
-      tabIndex={0}
-    >
-      <span className="resize-handle-grip" aria-hidden="true" />
-    </div>
+    <Tooltip content="Drag to resize · Double-click to reset" placement="left">
+      <div
+        ref={handleRef}
+        className={`resize-handle resize-handle--edge-left ${isDragging ? 'dragging' : ''}`}
+        onMouseDown={handleMouseDown}
+        onDoubleClick={handleDoubleClick}
+        onKeyDown={handleKeyDown}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize prose editor"
+        aria-valuenow={Math.round(effectiveWidth)}
+        aria-valuemin={MIN_CANVAS}
+        aria-valuemax={MAX_CANVAS}
+        tabIndex={0}
+      >
+        <span className="resize-handle-grip" aria-hidden="true" />
+      </div>
+    </Tooltip>
   );
 }

--- a/src/ui/layout/RelaxedSplitHandle.tsx
+++ b/src/ui/layout/RelaxedSplitHandle.tsx
@@ -4,15 +4,20 @@
  * canvas pane; dragging resizes the prose editor (the canvas takes a fixed
  * width, the prose flexes to fill the rest). Width persists app-level in
  * `uiPreferencesStore.relaxedSplitCanvasWidth`.
+ *
+ * That width is `null` by default — a responsive ~50/50 CSS clamp owns the
+ * split until the user drags (or arrow-keys) the divider, which captures a
+ * concrete px width. Double-click resets back to the responsive default.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
 import './resizeHandle.css';
 
 const MIN_CANVAS = 280;
 const MAX_CANVAS = 960;
-const DEFAULT_CANVAS = 480;
+/** aria/fallback width used before the pane has been measured. */
+const FALLBACK_CANVAS = 480;
 /** Keyboard nudge step for arrow-key resizing (px). */
 const KEY_STEP = 16;
 
@@ -22,17 +27,37 @@ export function RelaxedSplitHandle() {
   const width = useUIPreferencesStore((s) => s.relaxedSplitCanvasWidth);
   const setWidth = useUIPreferencesStore((s) => s.setRelaxedSplitCanvasWidth);
   const [isDragging, setIsDragging] = useState(false);
+  // Live width of the secondary canvas pane (the handle's parent). Tracked so a
+  // drag/nudge starting from the responsive (`null`) default seeds from the
+  // actual rendered width, and so aria-valuenow stays accurate while responsive.
+  const [measuredWidth, setMeasuredWidth] = useState(FALLBACK_CANVAS);
+  const handleRef = useRef<HTMLDivElement>(null);
   const startXRef = useRef(0);
-  const startWidthRef = useRef(width);
+  const startWidthRef = useRef(FALLBACK_CANVAS);
+
+  // Keep `measuredWidth` in sync with the pane's rendered width.
+  useLayoutEffect(() => {
+    const el = handleRef.current?.parentElement;
+    if (!el) return;
+    const update = () => setMeasuredWidth(el.offsetWidth || FALLBACK_CANVAS);
+    update();
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Effective width as a number, whether explicit (dragged) or responsive.
+  const effectiveWidth = width ?? measuredWidth;
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       startXRef.current = e.clientX;
-      startWidthRef.current = width;
+      startWidthRef.current = effectiveWidth;
       setIsDragging(true);
     },
-    [width]
+    [effectiveWidth]
   );
 
   useEffect(() => {
@@ -55,29 +80,32 @@ export function RelaxedSplitHandle() {
     };
   }, [isDragging, setWidth]);
 
-  // Double-click resets the split to the default canvas width.
+  // Double-click resets the split to the responsive ~50/50 default.
   const handleDoubleClick = useCallback(() => {
-    setWidth(DEFAULT_CANVAS);
+    setWidth(null);
   }, [setWidth]);
 
   // Keyboard resize (a11y). Canvas is docked right, so ArrowLeft widens it
-  // (and narrows the prose), matching the leftward drag.
+  // (and narrows the prose), matching the leftward drag. Nudges from the
+  // current effective width, so the first keypress off the responsive default
+  // captures a sensible px value.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       let next: number | null = null;
-      if (e.key === 'ArrowLeft') next = width + KEY_STEP;
-      else if (e.key === 'ArrowRight') next = width - KEY_STEP;
+      if (e.key === 'ArrowLeft') next = effectiveWidth + KEY_STEP;
+      else if (e.key === 'ArrowRight') next = effectiveWidth - KEY_STEP;
       else if (e.key === 'Home') next = MIN_CANVAS;
       else if (e.key === 'End') next = MAX_CANVAS;
       if (next === null) return;
       e.preventDefault();
       setWidth(clampCanvas(next));
     },
-    [width, setWidth]
+    [effectiveWidth, setWidth]
   );
 
   return (
     <div
+      ref={handleRef}
       className={`resize-handle resize-handle--edge-left ${isDragging ? 'dragging' : ''}`}
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
@@ -85,7 +113,7 @@ export function RelaxedSplitHandle() {
       role="separator"
       aria-orientation="vertical"
       aria-label="Resize prose editor"
-      aria-valuenow={Math.round(width)}
+      aria-valuenow={Math.round(effectiveWidth)}
       aria-valuemin={MIN_CANVAS}
       aria-valuemax={MAX_CANVAS}
       tabIndex={0}

--- a/src/ui/layout/resizeHandle.css
+++ b/src/ui/layout/resizeHandle.css
@@ -7,6 +7,10 @@
  * never clipped by an ancestor `overflow: hidden` — the bug behind the
  * docked-panel resize feeling ungrabbable (JP-310). */
 
+/* NOTE: `.resize-handle` is also used (with different per-direction modifiers)
+ * by the prose image NodeView — see `ui/TiptapEditor.css`, which resets these
+ * `top`/`bottom` offsets to `auto`. Keep that in mind before changing the
+ * offsets here. */
 .resize-handle {
   position: absolute;
   top: 0;

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -143,6 +143,9 @@
   border-radius: 6px;
   max-height: 300px;
   overflow-y: auto;
+  /* Narrow modal widths scroll the table sideways instead of crushing the
+     columns (the rows carry a min-width below). */
+  overflow-x: auto;
 }
 
 .storage-empty {
@@ -155,11 +158,18 @@
 /* List */
 .storage-list {
   font-size: 12px;
+  /* Single source of truth for the column track sizing — header + rows both
+     reference this so they can never drift out of alignment. The name column
+     has a floor, and the formerly-cramped "Used by"/"Created" columns get more
+     room. */
+  --storage-grid-cols: minmax(150px, 2fr) 64px 72px minmax(96px, 1fr) 88px 64px;
+  /* Keep usable widths in a narrow modal; the container scrolls sideways. */
+  min-width: 560px;
 }
 
 .storage-list-header {
   display: grid;
-  grid-template-columns: 1fr 60px 70px 60px 80px 60px;
+  grid-template-columns: var(--storage-grid-cols);
   gap: 8px;
   padding: 10px 12px;
   background: var(--bg-secondary);
@@ -172,7 +182,7 @@
 
 .storage-list-item {
   display: grid;
-  grid-template-columns: 1fr 60px 70px 60px 80px 60px;
+  grid-template-columns: var(--storage-grid-cols);
   gap: 8px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--border-color);

--- a/src/ui/settings/StorageSettings.css
+++ b/src/ui/settings/StorageSettings.css
@@ -137,15 +137,10 @@
   font-weight: 500;
 }
 
-/* List container */
+/* List container — scrolls vertically; cards reflow, so no horizontal scroll. */
 .storage-list-container {
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  max-height: 300px;
+  max-height: 320px;
   overflow-y: auto;
-  /* Narrow modal widths scroll the table sideways instead of crushing the
-     columns (the rows carry a min-width below). */
-  overflow-x: auto;
 }
 
 .storage-empty {
@@ -153,55 +148,97 @@
   text-align: center;
   color: var(--text-muted);
   font-size: 13px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
 }
 
-/* List */
-.storage-list {
-  font-size: 12px;
-  /* Single source of truth for the column track sizing — header + rows both
-     reference this so they can never drift out of alignment. The name column
-     has a floor, and the formerly-cramped "Used by"/"Created" columns get more
-     room. */
-  --storage-grid-cols: minmax(150px, 2fr) 64px 72px minmax(96px, 1fr) 88px 64px;
-  /* Keep usable widths in a narrow modal; the container scrolls sideways. */
-  min-width: 560px;
+/* Immersive card list (mirrors DocumentCard) — replaces the cramped fixed-px
+   table grid that collided/clipped columns in a narrow modal. */
+.storage-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 8px);
+  padding: var(--space-1, 4px) 0;
 }
 
-.storage-list-header {
-  display: grid;
-  grid-template-columns: var(--storage-grid-cols);
-  gap: 8px;
-  padding: 10px 12px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
-  font-weight: 600;
-  color: var(--text-secondary);
-  position: sticky;
-  top: 0;
-}
-
-.storage-list-item {
-  display: grid;
-  grid-template-columns: var(--storage-grid-cols);
-  gap: 8px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border-color);
+.storage-card {
+  display: flex;
   align-items: center;
-  color: var(--text-primary);
+  justify-content: space-between;
+  gap: var(--space-3, 12px);
+  padding: var(--space-3, 12px) var(--space-4, 16px);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.storage-list-item:last-child {
-  border-bottom: none;
-}
-
-.storage-list-item:hover {
+.storage-card:hover {
   background: var(--bg-hover);
+  border-color: var(--color-primary);
 }
 
-.storage-col-name {
+.storage-card__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5, 6px);
+}
+
+.storage-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+}
+
+.storage-card__name {
+  font-size: var(--font-size-md, 13px);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.storage-card__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2, 8px);
+  font-size: var(--font-size-sm, 12px);
+  color: var(--text-secondary);
+}
+
+.storage-card__type {
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.storage-card__sep {
+  color: var(--text-muted);
+}
+
+.storage-card__usage {
+  display: inline-flex;
+  align-items: center;
+}
+
+.storage-usage-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.storage-usage-docs {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+}
+
+.storage-card__actions {
+  flex-shrink: 0;
 }
 
 .storage-orphan-badge {
@@ -440,23 +477,15 @@
   background: var(--bg-hover);
 }
 
-:root[data-theme='dark'] .storage-list-container {
-  border-color: var(--border-color);
-}
-
-:root[data-theme='dark'] .storage-list-header {
+:root[data-theme='dark'] .storage-card {
   background: var(--bg-secondary);
-  border-color: var(--border-color);
-  color: var(--text-secondary);
-}
-
-:root[data-theme='dark'] .storage-list-item {
   border-color: var(--border-color);
   color: var(--text-primary);
 }
 
-:root[data-theme='dark'] .storage-list-item:hover {
+:root[data-theme='dark'] .storage-card:hover {
   background: var(--bg-hover);
+  border-color: var(--color-primary);
 }
 
 :root[data-theme='dark'] .storage-icon-item {

--- a/src/ui/settings/StorageSettings.tsx
+++ b/src/ui/settings/StorageSettings.tsx
@@ -414,15 +414,7 @@ export function StorageSettings() {
             ) : blobs.length === 0 ? (
               <div className="storage-empty">No images stored</div>
             ) : (
-              <div className="storage-list">
-                <div className="storage-list-header">
-                  <span className="storage-col-name">Name</span>
-                  <span className="storage-col-type">Type</span>
-                  <span className="storage-col-size">Size</span>
-                  <span className="storage-col-usage">Used by</span>
-                  <span className="storage-col-date">Created</span>
-                  <span className="storage-col-actions">Actions</span>
-                </div>
+              <div className="storage-card-list">
                 {blobs.map((blob) => {
                   const isIcon = blob.type === 'image/svg+xml';
                   const own = ownership[blob.id];
@@ -431,57 +423,64 @@ export function StorageSettings() {
                   // Held alive only by the Trash → reclaimable by emptying it.
                   const trashOnly = owners.length === 0 && trashedOwners.length > 0;
                   return (
-                    <div key={blob.id} className="storage-list-item">
-                      <span className="storage-col-name" title={blob.name}>
-                        {blob.name}
-                        {isIcon && <span className="storage-icon-tag">Icon</span>}
-                      </span>
-                      <span className="storage-col-type">{blob.type.replace('image/', '')}</span>
-                      <span className="storage-col-size">{formatFileSize(blob.size)}</span>
-                      <span className="storage-col-usage">
-                        {blob.usageCount === 0 ? (
-                          <span className={`storage-orphan-badge ${isIcon ? 'protected' : ''}`}>
-                            {isIcon ? 'Protected' : 'Orphaned'}
+                    <div key={blob.id} className="storage-card">
+                      <div className="storage-card__body">
+                        <div className="storage-card__name-row">
+                          <span className="storage-card__name" title={blob.name}>
+                            {blob.name}
                           </span>
-                        ) : trashOnly ? (
-                          <span
-                            className="storage-orphan-badge storage-trash-badge"
-                            title={`Only referenced from the Trash: ${trashedOwners
-                              .map((o) => o.name)
-                              .join(', ')}. Emptying the Trash frees this.`}
-                          >
-                            In Trash
+                          {isIcon && <span className="storage-icon-tag">Icon</span>}
+                        </div>
+                        <div className="storage-card__meta">
+                          <span className="storage-card__type">{blob.type.replace('image/', '')}</span>
+                          <span className="storage-card__sep" aria-hidden="true">·</span>
+                          <span>{formatFileSize(blob.size)}</span>
+                          <span className="storage-card__sep" aria-hidden="true">·</span>
+                          <span title={formatDate(blob.createdAt)}>
+                            {new Date(blob.createdAt).toLocaleDateString()}
                           </span>
-                        ) : (
-                          <span
-                            className="storage-usage-cell"
-                            style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                            title={
-                              owners.length
-                                ? `Used by: ${owners.map((o) => o.name).join(', ')}`
-                                : `${blob.usageCount} document(s)`
-                            }
-                          >
-                            <SyncStatusBadge state={own?.sync ?? 'local'} size="small" />
-                            <span className="storage-usage-docs">
-                              {owners.length === 1
-                                ? (owners[0]?.name ?? '1 doc')
-                                : `${blob.usageCount} docs`}
-                            </span>
+                          <span className="storage-card__usage">
+                            {blob.usageCount === 0 ? (
+                              <span className={`storage-orphan-badge ${isIcon ? 'protected' : ''}`}>
+                                {isIcon ? 'Protected' : 'Orphaned'}
+                              </span>
+                            ) : trashOnly ? (
+                              <span
+                                className="storage-orphan-badge storage-trash-badge"
+                                title={`Only referenced from the Trash: ${trashedOwners
+                                  .map((o) => o.name)
+                                  .join(', ')}. Emptying the Trash frees this.`}
+                              >
+                                In Trash
+                              </span>
+                            ) : (
+                              <span
+                                className="storage-usage-cell"
+                                title={
+                                  owners.length
+                                    ? `Used by: ${owners.map((o) => o.name).join(', ')}`
+                                    : `${blob.usageCount} document(s)`
+                                }
+                              >
+                                <SyncStatusBadge state={own?.sync ?? 'local'} size="small" />
+                                <span className="storage-usage-docs">
+                                  {owners.length === 1
+                                    ? (owners[0]?.name ?? '1 doc')
+                                    : `${blob.usageCount} docs`}
+                                </span>
+                              </span>
+                            )}
                           </span>
-                        )}
-                      </span>
-                      <span className="storage-col-date" title={formatDate(blob.createdAt)}>
-                        {new Date(blob.createdAt).toLocaleDateString()}
-                      </span>
-                      <span className="storage-col-actions">
+                        </div>
+                      </div>
+                      <div className="storage-card__actions">
                         <button
                           className="storage-delete-btn"
                           onClick={() => handleDeleteBlob(blob.id, blob.name)}
                         >
                           Delete
                         </button>
-                      </span>
+                      </div>
                     </div>
                   );
                 })}


### PR DESCRIPTION
Clears the JP-323 batch of layout/panel papercuts from the JP-312 pre-launch joy ride, plus a round of review-feedback refinements and related file-shape fixes. All client-only — no relay/wire-protocol or document-format changes.

## Batch 1 — papercuts
- **Image bottom resize handles** rendered at the top — a global `.resize-handle` rule (docked panels) leaked `top:0; bottom:0` onto the prose image handles via the shared class name. Reset offsets on the image base rule; cross-reference comments at both rules.
- **Properties overlay** no longer appears in Relaxed `write` focus (guarded on `relaxedFocus !== 'write'`).
- **Relaxed split** got a responsive default (nullable `relaxedSplitCanvasWidth`, v8→v9 migration mapping the legacy `480`→`null`), with tests.
- **Storage table** first pass + **flyout** no longer collapses while an async color/icon popover is open.

## Batch 2 — review feedback + file shapes
- **Property panel** now expands to 640px — the binding cap was `PropertyPanel.css .property-panel { max-width: 400px }` (batch 1 only raised the JS/flyout caps, which govern flyout layouts). All three aligned.
- **True 50/50 split** — the `clamp(…,760px)` cap made the canvas ~40% on wide monitors. Both panes now `flex: 1 1 0` for a genuine ~50/50; a dragged px width still overrides; `<640px` stays single-pane.
- **Native OS color dialog removed** — `ColorPalette` always rendered a native `<input type="color">` in its shared "Custom Color" section. Replaced with a swatch that opens the existing hex field; swatches/ramps/recent unchanged. Dead handler + webkit pseudo-element CSS removed.
- **File shapes resizable** — `SelectTool.calculateResize`/`getAnchorPoint` had no `file` case, so drags were dropped. File cards reuse the rectangle box math (`x/y/width/height/rotation`).
- **File shape tags** — new optional `tags?: string[]` (additive, **no migration**); rendered as a legible badge row on the canvas card + a free-text add/remove editor in the property panel.
- **Reusable styled Tooltip** — new portal-positioned `Tooltip` (clones the trigger, no layout wrapper, reduced-motion aware). The split divider now shows "Drag to resize · Double-click to reset".
- **Storage panel redesign** — replaced the cramped fixed-px table (dead space + mid-table column collisions in a narrow modal) with an immersive card list mirroring `DocumentCard`, reusing `SyncStatusBadge`; every field preserved.

## Verification
- `bun run typecheck` — clean.
- `bun run test --run` — **2489 passed** (188 files), incl. the v8→v9 migration tests.
- OSS-leak grep on touched files — clean.

Behavioral/visual items still want a live E2E pass: 50/50 split tracking on resize, property-panel width, storage cards, file-shape resize + tag badges, the divider tooltip, and that no color control opens an OS dialog.

Assisted-by: Opus 4.8