### PR TITLE
JP-350: rename_document + delete_document MCP tools

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -101,6 +101,7 @@ All tools are namespaced `docushark.*`.
 | Tool | Purpose |
 | -- | -- |
 | `create_document` | Create a new document (one blank canvas page + one blank prose page). Returns `{ id, name }`. The starting point for authoring from scratch. |
+| `rename_document` | Rename a document (set its title). Updates the title live for anyone who has the document open. Returns `{ id, name }`. |
 
 ### Prose (write)
 
@@ -144,6 +145,7 @@ icons directly — build those with `add_shape(s)`.
 | `delete_shape` | Delete a shape by id. **Cascade-removes** any connectors attached to it (start or end), so no dangling connectors are left; returns the ids actually deleted. |
 | `delete_prose_page` | Delete a prose page by id. Refuses to delete the **last** remaining prose page. In a connected editor the page's *tab* may persist until reload (the prose page list isn't yet live-synced); its content is cleared immediately. |
 | `delete_canvas_page` | Delete a canvas page by id. Refuses to delete the **last** remaining canvas page. Repoints the active page if the deleted one was active; a connected app reloads. |
+| `delete_document` | **Permanently** delete a whole document and all its pages, prose, and blobs — cannot be undone on the server. Anyone currently viewing it has it moved to their local Trash. Returns `{ deleted: id }`. |
 | `reorder_shapes` | Set a page's z-order. `order` must be a permutation of the page's current shape ids (later ids render on top). |
 | `reorder_prose_pages` | Set the order of a document's prose pages. `order` must be a permutation of the current prose page ids. Tab order may update on reload (page list not yet live-synced). |
 | `reorder_canvas_page` | Set the order of a document's canvas pages. `order` must be a permutation of the current canvas page ids. Tab order updates on reload (page list not live-synced). |
@@ -179,7 +181,7 @@ durably. On a *connected* (resident) document, `set_fields` writes the live CRDT
 library and broadcasts, so collaborators see new values immediately, per item (a
 concurrent editor's field isn't clobbered).
 
-(Renames: `rename_prose_page`.)
+(Renames: `rename_document`, `rename_prose_page`, `rename_canvas_page`.)
 
 ## Concurrency
 

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -900,17 +900,9 @@ async fn delete_doc_handler(
 
     match state.doc_store().delete_document(&ws, &doc_id) {
         Ok(true) => {
-            state.emit_doc_event(&ws, &doc_id, DocEventType::Deleted, Some(claims.sub.clone()));
-            // Release this doc's blob references; GC anything the workspace
-            // no longer references (JP-120).
-            if let Err(e) = state.blob_store().release_doc_refs(&ws, doc_id.as_str()) {
-                log::warn!(
-                    "blob doc-ref release failed for {}/{}: {}",
-                    ws.as_str(),
-                    doc_id.as_str(),
-                    e
-                );
-            }
+            // Broadcast Deleted + release blob refs (JP-120). Shared with the MCP
+            // delete_document tool via ServerState::after_doc_deleted (JP-350).
+            state.after_doc_deleted(&ws, &doc_id, Some(claims.sub.clone()));
             (StatusCode::OK, Json(WriteAck { success: true })).into_response()
         }
         Ok(false) => (

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -319,6 +319,7 @@ async fn run_serve(
         let mount = PublicMount::new(
             config.storage.path.clone(),
             make_doc_changed(&server),
+            make_doc_deleted(&server),
             mcp_read_limiter.clone(),
         )
         .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
@@ -349,6 +350,7 @@ async fn run_serve(
     // public path was wired before `start()` above and rides the main listener.
     let mcp = if config.mcp.enabled && config.mcp.expose == McpExpose::Local {
         let on_doc_changed = make_doc_changed(&server);
+        let on_doc_deleted = make_doc_deleted(&server);
 
         let panic_counter = server.panic_counter_handle();
         let rate_limit_rejections = server.rate_limit_rejections_handle();
@@ -373,6 +375,7 @@ async fn run_serve(
             Some(shared_doc_store) => match McpServer::new(
                 config.storage.path.clone(),
                 on_doc_changed,
+                on_doc_deleted,
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,
@@ -467,6 +470,22 @@ fn make_doc_changed(server: &Arc<WebSocketServer>) -> Arc<docushark_relay::mcp::
             server
                 .broadcast_doc_event(&ws, &doc_id, DocEventType::Updated, None)
                 .await;
+        });
+    })
+}
+
+/// JP-350: the MCP `delete_document` post-delete sink. Runs the same Deleted-event
+/// broadcast + blob release the REST delete does (via the shared
+/// `ServerState::after_doc_deleted`), so the tool and the HTTP handler behave
+/// identically. Mirrors [`make_doc_changed`].
+fn make_doc_deleted(server: &Arc<WebSocketServer>) -> Arc<docushark_relay::mcp::DocDeletedSink> {
+    let server_for_mcp = server.clone();
+    Arc::new(move |workspace: &WorkspaceId, doc_id: &DocId| {
+        let server = server_for_mcp.clone();
+        let ws = workspace.clone();
+        let doc_id = doc_id.clone();
+        tokio::spawn(async move {
+            server.after_mcp_doc_deleted(&ws, &doc_id).await;
         });
     })
 }

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -42,6 +42,14 @@ use tools::OnDocUpdate;
 /// workspace. Carrying the workspace (rather than assuming `single_tenant()`)
 /// is what makes the nudge correct on a multi-tenant public pod — JP-235.
 pub type DocChangedSink = dyn Fn(&WorkspaceId, DocId) + Send + Sync;
+
+/// The post-delete sink (JP-350). Invoked by the `delete_document` tool after it
+/// removes the doc from the store, with the writing workspace + deleted doc id,
+/// so the caller can broadcast a `DocEvent::Deleted` (clients leave/Trash the
+/// doc) and release its blob references — the same follow-up the REST delete
+/// runs. Distinct from [`DocChangedSink`], whose `DocEvent::Updated` would tell
+/// clients to *reload* a now-missing doc.
+pub type DocDeletedSink = dyn Fn(&WorkspaceId, &DocId) + Send + Sync;
 use config::McpFeatureConfigStore;
 use local_mirror::LocalDocumentMirror;
 use token::TokenStore;
@@ -78,6 +86,8 @@ pub struct McpServer {
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
     on_doc_changed: Arc<DocChangedSink>,
+    /// Post-delete sink: Deleted-event broadcast + blob release (JP-350).
+    on_doc_deleted: Arc<DocDeletedSink>,
     /// Shared panic counter — same atomic as `ServerState.panic_count`
     /// so the WS `/metrics` endpoint reflects MCP-side panics too.
     /// Phase 21.2.
@@ -117,6 +127,8 @@ pub struct PublicMount {
     local_mirror: Arc<LocalDocumentMirror>,
     feature_config: Arc<McpFeatureConfigStore>,
     on_doc_changed: Arc<DocChangedSink>,
+    /// Post-delete sink: Deleted-event broadcast + blob release (JP-350).
+    on_doc_deleted: Arc<DocDeletedSink>,
     /// Per-workspace MCP read limiter (JP-249). `None` = unlimited. MCP-local,
     /// so it's carried on the mount rather than `McpSharedHandles`.
     read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
@@ -145,6 +157,7 @@ impl PublicMount {
     pub fn new(
         app_data_dir: PathBuf,
         on_doc_changed: Arc<DocChangedSink>,
+        on_doc_deleted: Arc<DocDeletedSink>,
         read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
     ) -> Result<Self, String> {
         Ok(Self {
@@ -152,6 +165,7 @@ impl PublicMount {
             local_mirror: Arc::new(LocalDocumentMirror::new(app_data_dir.clone())),
             feature_config: Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir)),
             on_doc_changed,
+            on_doc_deleted,
             read_limiter,
         })
     }
@@ -173,6 +187,7 @@ impl PublicMount {
             feature_config: self.feature_config,
             token: self.token,
             on_doc_changed: self.on_doc_changed,
+            on_doc_deleted: self.on_doc_deleted,
             panic_counter: shared.panic_counter,
             rate_limit_rejections: shared.rate_limit_rejections,
             write_limiter: shared.write_limiter,
@@ -204,6 +219,7 @@ impl McpServer {
     pub fn new(
         app_data_dir: PathBuf,
         on_doc_changed: Arc<DocChangedSink>,
+        on_doc_deleted: Arc<DocDeletedSink>,
         panic_counter: Arc<AtomicU64>,
         rate_limit_rejections: Arc<AtomicU64>,
         write_limiter: Arc<WorkspaceWriteLimiter>,
@@ -231,6 +247,7 @@ impl McpServer {
             local_mirror,
             feature_config,
             on_doc_changed,
+            on_doc_deleted,
             panic_counter,
             rate_limit_rejections,
             write_limiter,
@@ -308,6 +325,7 @@ impl McpServer {
             feature_config: self.feature_config.clone(),
             token: self.token.clone(),
             on_doc_changed: self.on_doc_changed.clone(),
+            on_doc_deleted: self.on_doc_deleted.clone(),
             panic_counter: self.panic_counter.clone(),
             rate_limit_rejections: self.rate_limit_rejections.clone(),
             write_limiter: self.write_limiter.clone(),

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -3,6 +3,7 @@
 //! Reads:   list_documents, get_document, get_page, get_shape, get_prose,
 //!          get_outline
 //! Authoring (JP-93 "publish target"): create_document
+//! Document manage (JP-350): rename_document, delete_document
 //! Diagram writes: add_shape, add_shapes, connect, update_shape,
 //!                 generate_diagram
 //! Prose writes:   add_prose_page, set_prose, rename_prose_page,
@@ -26,6 +27,7 @@ use crate::server::documents::{DocumentStore, SaveOutcome};
 use crate::server::protocol::{DocId, WorkspaceId};
 use crate::sync::{DocHandle, DocRegistry};
 
+use super::DocDeletedSink;
 use super::adapter::{apply_dsl_patch, dsl_to_shape_json, shape_json_to_dsl, DslPatch, DslShape};
 use super::local_mirror::LocalDocumentMirror;
 use super::outline::{clamp_level, escape_html, Outline, Section};
@@ -57,6 +59,9 @@ pub struct ToolContext<'a> {
     pub registry: &'a Arc<DocRegistry>,
     /// Sink for live-path CRDT deltas. See [`OnDocUpdate`].
     pub on_doc_update: &'a OnDocUpdate,
+    /// Sink invoked by `delete_document` after the store delete to run the
+    /// Deleted-event broadcast + blob release (JP-350). See [`DocDeletedSink`].
+    pub on_doc_deleted: &'a Arc<DocDeletedSink>,
 }
 
 /// Callback the MCP write path invokes to push a framed CRDT sync update to
@@ -147,6 +152,33 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                         "description": "Title for the new document. Defaults to \"Untitled Document\"."
                     }
                 },
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.rename_document",
+            description:
+                "Rename a document (set its title). Updates the document name live for anyone who has it open. Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "name": {"type": "string", "description": "New document title. Must not be empty."}
+                },
+                "required": ["docId", "name"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark.delete_document",
+            description:
+                "Permanently delete a document and all its pages, prose, and blobs. This cannot be undone on the server; anyone currently viewing it has it moved to their local Trash. Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"}
+                },
+                "required": ["docId"],
                 "additionalProperties": false
             }),
         },
@@ -710,6 +742,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark.get_page" => get_page(ctx, args),
         "docushark.get_shape" => get_shape(ctx, args),
         "docushark.create_document" => create_document(ctx, args),
+        "docushark.rename_document" => rename_document(ctx, args),
+        "docushark.delete_document" => delete_document(ctx, args),
         "docushark.get_prose" => get_prose(ctx, args),
         "docushark.add_prose_page" => add_prose_page(ctx, args),
         "docushark.set_prose" => set_prose(ctx, args),
@@ -1152,6 +1186,93 @@ fn create_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
     Ok(ToolOutcome {
         result: json!({"id": id_str, "name": name}),
         changed_doc_id: Some(doc_id),
+        change_detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Document-level manage tools (JP-350): rename + delete a whole document, the
+// MCP companions to `create_document`. The document title is CRDT-native (it
+// lives in the Y.Doc `metadata.title`), so rename writes the JSON `name` AND —
+// for a resident doc — the live `metadata` map so an open editor retitles
+// without a reload. Delete mirrors the REST `DELETE /api/docs/:id` path exactly
+// (store delete → Deleted event → blob release) via the `on_doc_deleted` sink.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct RenameDocumentArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    name: String,
+}
+
+fn rename_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: RenameDocumentArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+    let name = parsed.name.trim().to_string();
+    if name.is_empty() {
+        return Err("Document name must not be empty".into());
+    }
+
+    // Persist the JSON `name` + bump `modifiedAt` under optimistic concurrency.
+    // The same `now` is reused for the live Y.Doc `updatedAt` below so the flatten
+    // title-adoption guard (adopt `metadata.title` only when `updatedAt >=
+    // modifiedAt`) keeps this title rather than reverting it on the next snapshot.
+    let now = now_ms();
+    mutate_with_retry(ctx, &parsed.doc_id, |doc| {
+        let obj = doc.as_object_mut().ok_or("Document is not an object")?;
+        obj.insert("name".into(), json!(name.clone()));
+        stamp_doc_modified(doc, now);
+        Ok(())
+    })?;
+
+    // Fully live (JP-350): when the doc is resident, push the title into the live
+    // `metadata` map so open editors retitle immediately — no reload. Cold docs
+    // rely on the `changed_doc_id` nudge below to refresh the doc list.
+    if let Some(handle) = resident_handle(ctx, &parsed.doc_id) {
+        let framed = handle.set_metadata_title(&name, now);
+        ctx.broadcast_update(&parsed.doc_id, framed);
+    }
+
+    Ok(ToolOutcome {
+        result: json!({"id": parsed.doc_id.as_str(), "name": name}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct DeleteDocumentArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+}
+
+fn delete_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: DeleteDocumentArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+
+    // Evict the resident Y.Doc FIRST, without snapshotting (raw registry evict),
+    // so no live handle can re-flatten the JSON we're about to delete and
+    // resurrect the doc. Unsaved CRDT edits are intentionally dropped — the doc
+    // is being deleted. No-op when the doc isn't resident.
+    ctx.registry.evict(&ctx.workspace_id, &parsed.doc_id);
+
+    let existed = ctx.team.delete_document(&ctx.workspace_id, &parsed.doc_id)?;
+    if !existed {
+        return Err(format!("Document '{}' not found", parsed.doc_id.as_str()));
+    }
+
+    // Same follow-up as the REST delete (JP-350): broadcast a Deleted event so
+    // connected clients leave/Trash the doc, and release its blob refs (JP-120).
+    // Deliberately NOT `changed_doc_id`, whose `Updated` event would tell clients
+    // to reload a now-missing doc.
+    (ctx.on_doc_deleted)(&ctx.workspace_id, &parsed.doc_id);
+
+    Ok(ToolOutcome {
+        result: json!({"deleted": parsed.doc_id.as_str()}),
+        changed_doc_id: None,
         change_detail: None,
     })
 }
@@ -3343,6 +3464,8 @@ mod tests {
         registry: Arc<DocRegistry>,
         broadcasts: Arc<std::sync::Mutex<Vec<(WorkspaceId, DocId, Vec<u8>)>>>,
         on_doc_update: Arc<OnDocUpdate>,
+        deletions: Arc<std::sync::Mutex<Vec<(WorkspaceId, DocId)>>>,
+        on_doc_deleted: Arc<DocDeletedSink>,
     }
 
     impl Fixture {
@@ -3354,6 +3477,7 @@ mod tests {
                 workspace_id: WorkspaceId::single_tenant(),
                 registry: &self.registry,
                 on_doc_update: &*self.on_doc_update,
+                on_doc_deleted: &self.on_doc_deleted,
             }
         }
 
@@ -3369,6 +3493,11 @@ mod tests {
         /// (ws, doc, framed) updates pushed on the live broadcast path.
         fn broadcasts(&self) -> Vec<(WorkspaceId, DocId, Vec<u8>)> {
             self.broadcasts.lock().unwrap().clone()
+        }
+
+        /// (ws, doc) ids the `delete_document` post-delete sink fired for.
+        fn deletions(&self) -> Vec<(WorkspaceId, DocId)> {
+            self.deletions.lock().unwrap().clone()
         }
     }
 
@@ -3405,7 +3534,13 @@ mod tests {
             Arc::new(move |ws: &WorkspaceId, doc: &DocId, framed: Vec<u8>| {
                 sink.lock().unwrap().push((ws.clone(), doc.clone(), framed));
             });
-        Fixture { team, local, registry, broadcasts, on_doc_update }
+        let deletions = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let del_sink = deletions.clone();
+        let on_doc_deleted: Arc<DocDeletedSink> =
+            Arc::new(move |ws: &WorkspaceId, doc: &DocId| {
+                del_sink.lock().unwrap().push((ws.clone(), doc.clone()));
+            });
+        Fixture { team, local, registry, broadcasts, on_doc_update, deletions, on_doc_deleted }
     }
 
     // ---- JP-35: live Y.Doc write path ----
@@ -4615,6 +4750,228 @@ mod tests {
             let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();
             assert!(err.contains("read-only"), "{} -> {}", tool, err);
         }
+    }
+
+    // ---- JP-350: document-level rename / delete ----
+
+    #[test]
+    fn rename_document_updates_name_in_get_and_list_and_bumps_modified() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.rename_document",
+            &json!({"docId": "doc1", "name": "Renamed Doc"}),
+        )
+        .unwrap();
+        assert_eq!(out.result["id"], "doc1");
+        assert_eq!(out.result["name"], "Renamed Doc");
+
+        let got = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(got.result["name"], "Renamed Doc");
+        // The seed doc starts at modifiedAt = 1; a rename stamps wall-clock now.
+        assert!(
+            got.result["modifiedAt"].as_u64().unwrap() > 1,
+            "modifiedAt bumped: {:?}",
+            got.result["modifiedAt"]
+        );
+
+        let list = dispatch(&f.ctx(true), "docushark.list_documents", &json!({})).unwrap();
+        let doc = list.result["documents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|d| d["id"] == "doc1")
+            .expect("doc1 listed");
+        assert_eq!(doc["name"], "Renamed Doc");
+    }
+
+    #[test]
+    fn rename_document_validates_name_and_target() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        // Empty / whitespace-only names are rejected (no write).
+        for bad in ["", "   "] {
+            let err = dispatch(
+                &f.ctx(true),
+                "docushark.rename_document",
+                &json!({"docId": "doc1", "name": bad}),
+            )
+            .unwrap_err();
+            assert!(err.contains("must not be empty"), "name {bad:?}: {err}");
+        }
+        // The original name is untouched after the rejected writes.
+        let got = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(got.result["name"], "Team Doc");
+
+        // Unknown document id → not-found error (via the read in mutate_with_retry).
+        let err = dispatch(
+            &f.ctx(true),
+            "docushark.rename_document",
+            &json!({"docId": "nope", "name": "X"}),
+        )
+        .unwrap_err();
+        assert!(err.contains("not found"), "{err}");
+
+        // Surrounding whitespace is trimmed.
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark.rename_document",
+            &json!({"docId": "doc1", "name": "  Trimmed  "}),
+        )
+        .unwrap();
+        assert_eq!(out.result["name"], "Trimmed");
+    }
+
+    #[test]
+    fn rename_document_is_idempotent_for_same_name() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        for _ in 0..2 {
+            dispatch(
+                &f.ctx(true),
+                "docushark.rename_document",
+                &json!({"docId": "doc1", "name": "Same"}),
+            )
+            .unwrap();
+        }
+        let got = dispatch(&f.ctx(true), "docushark.get_document", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(got.result["name"], "Same");
+    }
+
+    #[test]
+    fn rename_document_resident_broadcasts_title_nonresident_does_not() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".into()).unwrap();
+        let handle = f.make_resident("doc1");
+        assert!(f.broadcasts().is_empty(), "no broadcast before rename");
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.rename_document",
+            &json!({"docId": "doc1", "name": "Renamed"}),
+        )
+        .unwrap();
+
+        // Resident → a live metadata-title frame was broadcast (no reload needed).
+        assert!(!f.broadcasts().is_empty(), "resident rename broadcasts a frame");
+
+        // The live Y.Doc's metadata.title is now "Renamed": flatten adopts it over
+        // a deliberately-wrong probe name (its updatedAt == the stamped modifiedAt,
+        // so the flatten title-adoption guard fires). This would NOT happen if
+        // set_metadata_title hadn't updated the resident Y.Doc.
+        let mut probe = f.team.get_document(&ws, &doc_id).unwrap();
+        probe["name"] = json!("PROBE-WRONG");
+        assert!(handle.flatten_into(&mut probe), "flatten wrote");
+        assert_eq!(probe["name"], "Renamed", "resident Y.Doc title updated live");
+
+        // A non-resident rename persists but broadcasts nothing.
+        let f2 = seed(&dir.path().join("nr").to_path_buf());
+        dispatch(
+            &f2.ctx(true),
+            "docushark.rename_document",
+            &json!({"docId": "doc1", "name": "Standalone"}),
+        )
+        .unwrap();
+        assert!(f2.broadcasts().is_empty(), "non-resident rename does not broadcast");
+        let got = dispatch(&f2.ctx(true), "docushark.get_document", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(got.result["name"], "Standalone");
+    }
+
+    #[test]
+    fn rename_document_title_survives_save_evict_rejoin() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".into()).unwrap();
+        let _ = f.make_resident("doc1");
+
+        dispatch(
+            &f.ctx(true),
+            "docushark.rename_document",
+            &json!({"docId": "doc1", "name": "RoundTrip"}),
+        )
+        .unwrap();
+
+        // Evict (drop the live Y.Doc) and re-hydrate from the persisted JSON —
+        // the save→evict→rejoin cycle a real client triggers. The rehydrated
+        // Y.Doc must carry the new title (JP-326 round-trip guard).
+        f.registry.evict(&ws, &doc_id);
+        let handle2 = f.make_resident("doc1");
+        let mut probe = f.team.get_document(&ws, &doc_id).unwrap();
+        probe["name"] = json!("PROBE");
+        assert!(handle2.flatten_into(&mut probe), "flatten wrote");
+        assert_eq!(probe["name"], "RoundTrip", "title survived save→evict→rejoin");
+    }
+
+    #[test]
+    fn document_manage_tools_refuse_local_docs() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        f.local.mirror(&WorkspaceId::single_tenant(), make_doc("local1", "p1", "Local")).unwrap();
+        for (tool, args) in [
+            ("docushark.rename_document", json!({"docId": "local1", "name": "y"})),
+            ("docushark.delete_document", json!({"docId": "local1"})),
+        ] {
+            let err = dispatch(&f.ctx(true), tool, &args).unwrap_err();
+            assert!(err.contains("read-only"), "{tool} -> {err}");
+        }
+    }
+
+    #[test]
+    fn delete_document_removes_doc_and_fires_sink() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".into()).unwrap();
+
+        let out = dispatch(&f.ctx(true), "docushark.delete_document", &json!({"docId": "doc1"})).unwrap();
+        assert_eq!(out.result["deleted"], "doc1");
+        // A delete must NOT set changed_doc_id (that broadcasts Updated → reload).
+        assert!(out.changed_doc_id.is_none(), "delete sets no changed_doc_id");
+
+        // Gone from the store + list.
+        assert!(f.team.get_document(&ws, &doc_id).is_err(), "doc deleted from store");
+        let list = dispatch(&f.ctx(true), "docushark.list_documents", &json!({})).unwrap();
+        assert!(
+            !list.result["documents"].as_array().unwrap().iter().any(|d| d["id"] == "doc1"),
+            "doc1 no longer listed"
+        );
+
+        // The post-delete sink fired (Deleted event + blob release in production).
+        let dels = f.deletions();
+        assert!(dels.iter().any(|(w, d)| *w == ws && *d == doc_id), "delete sink fired: {dels:?}");
+    }
+
+    #[test]
+    fn delete_document_missing_errors_and_skips_sink() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let err = dispatch(&f.ctx(true), "docushark.delete_document", &json!({"docId": "nope"}))
+            .unwrap_err();
+        assert!(err.contains("not found"), "{err}");
+        assert!(f.deletions().is_empty(), "no delete sink for a missing doc");
+    }
+
+    #[test]
+    fn delete_document_evicts_resident_without_resurrecting() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("doc1".into()).unwrap();
+        let _ = f.make_resident("doc1");
+        assert!(f.registry.get(&ws, &doc_id).is_some(), "resident before delete");
+
+        dispatch(&f.ctx(true), "docushark.delete_document", &json!({"docId": "doc1"})).unwrap();
+
+        // Evicted (no live handle can re-snapshot) and the file stays gone.
+        assert!(f.registry.get(&ws, &doc_id).is_none(), "resident handle evicted");
+        assert!(f.team.get_document(&ws, &doc_id).is_err(), "doc stays deleted");
+        assert!(f.deletions().iter().any(|(_, d)| *d == doc_id), "delete sink fired");
     }
 
     /// Seed a prose page with Markdown and return (docId, pageId).

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -54,6 +54,11 @@ pub struct McpAppState {
     /// the writing workspace so the coarse `DocEvent` reaches the right clients
     /// on a multi-tenant public pod (JP-235).
     pub on_doc_changed: Arc<super::DocChangedSink>,
+    /// Called by `delete_document` after the store delete: broadcasts a
+    /// `DocEvent::Deleted` + releases blob refs, the same follow-up the REST
+    /// delete runs (JP-350). Separate from `on_doc_changed` because a delete
+    /// must not tell clients to *reload* a now-missing doc.
+    pub on_doc_deleted: Arc<super::DocDeletedSink>,
     /// Shared with `ServerState.panic_count` so MCP tool panics
     /// surface at the WS `/metrics` counter. Phase 21.2.
     pub panic_counter: Arc<AtomicU64>,
@@ -375,6 +380,8 @@ fn is_mcp_write_tool(name: &str) -> bool {
             | "docushark.reorder_shapes"
             | "docushark.reorder_prose_pages"
             | "docushark.add_reference"
+            | "docushark.rename_document"
+            | "docushark.delete_document"
     )
 }
 
@@ -453,6 +460,7 @@ async fn handle_tools_call(
         workspace_id: workspace.clone(),
         registry: &state.sync_registry,
         on_doc_update: state.on_doc_update.as_ref(),
+        on_doc_deleted: &state.on_doc_deleted,
     };
 
     // Per-workspace rate limit. Writes draw from the shared write bucket (same
@@ -612,6 +620,7 @@ mod tests {
             feature_config: cfg,
             token,
             on_doc_changed: Arc::new(|_, _| {}),
+            on_doc_deleted: Arc::new(|_, _| {}),
             panic_counter: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             write_limiter: Arc::new(crate::server::build_workspace_limiter(1000, 1000)),
@@ -751,6 +760,8 @@ mod tests {
         let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
         assert!(names.contains(&"docushark.list_documents"));
         assert!(names.contains(&"docushark.create_document"));
+        assert!(names.contains(&"docushark.rename_document"));
+        assert!(names.contains(&"docushark.delete_document"));
         assert!(names.contains(&"docushark.add_shape"));
         assert!(names.contains(&"docushark.add_shapes"));
         assert!(names.contains(&"docushark.connect"));
@@ -779,7 +790,7 @@ mod tests {
         assert!(names.contains(&"docushark.set_fields"));
         assert!(names.contains(&"docushark.get_skills"));
         assert!(names.contains(&"docushark.list_icons"));
-        assert_eq!(tools.len(), 32);
+        assert_eq!(tools.len(), 34);
     }
 
     #[tokio::test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1450,6 +1450,29 @@ impl ServerState {
             self.broadcast_to_workspace(ws, data, None);
         }
     }
+
+    /// Shared post-delete side effects (JP-350): broadcast a `Deleted` doc event
+    /// (so connected clients leave/Trash the doc) and release the doc's blob
+    /// references for GC (JP-120). The store delete itself is the caller's
+    /// responsibility — this runs the identical follow-up for both the REST
+    /// `delete_doc_handler` and the MCP `delete_document` tool so the two paths
+    /// can't drift.
+    pub(crate) fn after_doc_deleted(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        user_id: Option<String>,
+    ) {
+        self.emit_doc_event(ws, doc_id, DocEventType::Deleted, user_id);
+        if let Err(e) = self.blob_store.release_doc_refs(ws, doc_id.as_str()) {
+            log::warn!(
+                "blob doc-ref release failed for {}/{}: {}",
+                ws.as_str(),
+                doc_id.as_str(),
+                e
+            );
+        }
+    }
 }
 
 /// WebSocket server manager
@@ -2095,6 +2118,17 @@ impl WebSocketServer {
                     doc_id.as_str()
                 );
             }
+        }
+    }
+
+    /// MCP-side wrapper for [`ServerState::after_doc_deleted`] (JP-350): locks the
+    /// running server state and runs the same Deleted-event broadcast + blob
+    /// release the REST delete does. The MCP `on_doc_deleted` sink (wired in
+    /// `main.rs`) spawns this after the tool deletes the doc from the store.
+    pub async fn after_mcp_doc_deleted(&self, ws: &WorkspaceId, doc_id: &DocId) {
+        let state_guard = self.state.read().await;
+        if let Some(state) = state_guard.as_ref() {
+            state.after_doc_deleted(ws, doc_id, None);
         }
     }
 }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -583,6 +583,26 @@ impl DocHandle {
         }
     }
 
+    /// Set the document title in the live `metadata` Y.Map (keys `title` +
+    /// `updatedAt`), in one transaction — the CRDT-native document rename for a
+    /// resident doc, mirroring the client's `setMetadata({ title })`. Returns the
+    /// framed delta to broadcast so open editors update their title without a
+    /// reload; marks dirty. `updated_at` should match the JSON `modifiedAt` the
+    /// caller stamped on the same rename, so the flatten title-adoption guard
+    /// (adopt `metadata.title` only when `updatedAt >= modifiedAt`) keeps the new
+    /// title rather than reverting it.
+    pub fn set_metadata_title(&self, title: &str, updated_at: u64) -> Vec<u8> {
+        let metadata = self.doc.get_or_insert_map("metadata");
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        metadata.insert(&mut txn, "title", Any::String(title.into()));
+        metadata.insert(&mut txn, "updatedAt", Any::Number(updated_at as f64));
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        protocol::frame_update(update)
+    }
+
     /// Insert reference(s) into the live `references` `Y.Map` and append any new
     /// ids to `referenceOrder`, in one transaction (INVARIANT A: strictly
     /// per-item `set` — never a whole-map rewrite, so a concurrent writer's

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -137,6 +137,7 @@ impl Harness {
         let rate_limit_rejections = self.server.rate_limit_rejections_handle();
         let write_limiter = self.server.build_write_limiter().await;
         let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
+        let on_doc_deleted: Arc<docushark_relay::mcp::DocDeletedSink> = Arc::new(|_, _| {});
         // This harness deliberately hands MCP a *standalone* Y.Doc registry +
         // noop broadcaster (not the server's): a separate registry never resolves
         // a live handle, so MCP writes take the JSON path, which already enforces
@@ -156,6 +157,7 @@ impl Harness {
             McpServer::new(
                 self.data_dir.clone(),
                 on_doc_changed,
+                on_doc_deleted,
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -48,12 +48,14 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
         .await
         .expect("doc store available after start");
     let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
+    let on_doc_deleted: Arc<docushark_relay::mcp::DocDeletedSink> = Arc::new(|_, _| {});
     let on_doc_update: Arc<dyn Fn(&WorkspaceId, &DocId, Vec<u8>) + Send + Sync> =
         Arc::new(|_, _, _| {});
     let mcp = Arc::new(
         McpServer::new(
             tmp.path().to_path_buf(),
             on_doc_changed,
+            on_doc_deleted,
             server.panic_counter_handle(),
             server.rate_limit_rejections_handle(),
             server.build_write_limiter().await,

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -41,7 +41,9 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
         Arc::new(move |ws: &WorkspaceId, _doc| {
             routed_sink.lock().unwrap().push(ws.as_str().to_string());
         });
-    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed, None).expect("mount");
+    let on_doc_deleted: Arc<docushark_relay::mcp::DocDeletedSink> = Arc::new(|_, _| {});
+    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed, on_doc_deleted, None)
+        .expect("mount");
     let static_token = mount.token();
     server.set_mcp_public_mount(mount).await;
 

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -61,6 +61,7 @@ impl Harness {
         let rate_limit_rejections = server.rate_limit_rejections_handle();
         let write_limiter = server.build_write_limiter().await;
         let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
+        let on_doc_deleted: Arc<docushark_relay::mcp::DocDeletedSink> = Arc::new(|_, _| {});
 
         // Start the server first so MCP can share its single `DocumentStore`
         // (JP-230). The write limiter is already built + cached above, so this
@@ -87,6 +88,7 @@ impl Harness {
             McpServer::new(
                 data_dir,
                 on_doc_changed,
+                on_doc_deleted,
                 panic_counter,
                 rate_limit_rejections,
                 write_limiter,

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -602,6 +602,7 @@ async fn snapshot_skips_when_active_page_diverged() {
 /// post-`start()`. Returns the server handle + its `http://host:port` base.
 async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
     let on_doc_changed: Arc<docushark_relay::mcp::DocChangedSink> = Arc::new(|_, _| {});
+    let on_doc_deleted: Arc<docushark_relay::mcp::DocDeletedSink> = Arc::new(|_, _| {});
     let panic_counter = relay.server.panic_counter_handle();
     let rate_limit_rejections = relay.server.rate_limit_rejections_handle();
     let write_limiter = relay.server.build_write_limiter().await;
@@ -617,6 +618,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
         McpServer::new(
             relay._tmp.path().to_path_buf(),
             on_doc_changed,
+            on_doc_deleted,
             panic_counter,
             rate_limit_rejections,
             write_limiter,


### PR DESCRIPTION
Closes JP-350. Adds the two document-level MCP lifecycle tools that were missing — `create_document` existed, but agents had no way to rename or delete a whole document over MCP.

## What

- **`rename_document`** `{ docId, name }` — sets the document title. Persists the JSON `name` + bumps `modifiedAt` under optimistic concurrency, and for a **resident** doc pushes the title into the live Y.Doc `metadata` map (new `DocHandle::set_metadata_title`) + broadcasts, so an open editor retitles **without a reload**. The doc name is CRDT-native, so the same timestamp on `updatedAt`/`modifiedAt` keeps the flatten title-adoption guard from reverting it.
- **`delete_document`** `{ docId }` — mirrors the REST `DELETE /api/docs/:id` path exactly: evict the resident Y.Doc first (raw, no snapshot — so no live handle can re-flatten and resurrect it), delete from the store, then run the shared `ServerState::after_doc_deleted` (Deleted event so clients move it to Trash + blob-ref release, JP-120) via a new `on_doc_deleted` MCP sink. Deliberately does **not** set `changed_doc_id` (its `Updated` event would tell clients to reload a now-missing doc).

The REST delete handler is refactored onto the same `after_doc_deleted` method so the two paths can't drift. Both tools refuse local (renderer-owned) docs and are write-gated for rate limiting.

## Tests

Strict unit coverage (all green, `cargo test --lib`, 510 passing):

- **rename**: name reflected in `get_document`/`list_documents` + `modifiedAt` bump; empty/whitespace/unknown-id validation; local-doc rejection; resident broadcasts a title frame **and** the live Y.Doc title updates, non-resident broadcasts nothing but still persists; **save→evict→rejoin flatten round-trip** (JP-326 guard); idempotence.
- **delete**: removal from store + list + post-delete sink fired + no `changed_doc_id`; missing-id error with no sink; local-doc rejection; resident eviction without resurrection.

## Verification done

- `cargo test --lib` (510 pass), `cargo build --bin relay`, `cargo check --all-targets` — all clean.
- OSS leak grep on touched files — clean.
- MCP README tool reference updated.

Live staging E2E (rename retitles an open editor live; delete moves the doc to a second client's Trash) is the remaining manual gate.

Assisted-by: Opus 4.8