### PR TITLE
JP-349: count canvas + prose pages, with a split for AIs

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -84,7 +84,7 @@ All tools are namespaced `docushark.*`.
 
 | Tool | Purpose |
 | -- | -- |
-| `list_documents` | List documents in the workspace (`id`, `name`, `pageCount`, `modifiedAt`, `source`). |
+| `list_documents` | List documents in the workspace (`id`, `name`, `modifiedAt`, `source`, and page counts). `pageCount` is the **canvas + prose total**; `canvasPageCount` and `prosePageCount` give the breakdown (a document has a diagram canvas and a separate prose body). |
 | `get_document` | Document metadata + canvas `pages` summary + `prosePages` summary + `fields` (the document's `{{name}}` values). The map of what exists. |
 | `get_page` | The shapes on one canvas page, as DSL objects. |
 | `get_shape` | One shape on a page, by id, as a DSL object (the read-one companion to `get_page`). |

--- a/relay/src/mcp/local_mirror.rs
+++ b/relay/src/mcp/local_mirror.rs
@@ -32,7 +32,11 @@ use crate::server::protocol::WorkspaceId;
 pub struct MirroredDocumentMetadata {
     pub id: String,
     pub name: String,
+    /// Combined canvas + prose total (JP-349), matching the team store.
     pub page_count: usize,
+    /// Prose pages only, for the MCP doc-list canvas/prose split (JP-349).
+    #[serde(default)]
+    pub prose_page_count: usize,
     pub modified_at: u64,
 }
 
@@ -250,11 +254,10 @@ fn extract_metadata(doc: &Value) -> Option<MirroredDocumentMetadata> {
         .and_then(|v| v.as_str())
         .unwrap_or("Untitled")
         .to_string();
-    let page_count = doc
-        .get("pageOrder")
-        .and_then(|v| v.as_array())
-        .map(|a| a.len())
-        .unwrap_or(1);
+    // JP-349: combined canvas + prose total + the prose split, via the team
+    // store's shared derivation so the two can't drift.
+    let (canvas, prose) = crate::server::documents::DocumentStore::page_counts_of(doc);
+    let page_count = (canvas + prose).max(1);
     let modified_at = doc
         .get("modifiedAt")
         .and_then(|v| v.as_u64())
@@ -263,6 +266,7 @@ fn extract_metadata(doc: &Value) -> Option<MirroredDocumentMetadata> {
         id,
         name,
         page_count,
+        prose_page_count: prose,
         modified_at,
     })
 }

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -91,7 +91,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark.list_documents",
             description:
-                "List DocuShark team documents stored on this host. Returns id, name, pageCount, modifiedAt for each.",
+                "List DocuShark team documents stored on this host. Returns id, name, modifiedAt, and page counts for each: pageCount (canvas + prose total), with canvasPageCount and prosePageCount giving the breakdown (a document has a diagram canvas and a separate prose body).",
             input_schema: json!({
                 "type": "object",
                 "properties": {},
@@ -863,10 +863,17 @@ fn list_documents(ctx: &ToolContext) -> Result<ToolOutcome, String> {
         .list_documents(&ctx.workspace_id)
         .into_iter()
         .map(|m| {
+            // JP-349: pageCount is the canvas + prose total; the split lets an
+            // agent see at a glance that prose pages exist (a canvas-only count
+            // read as if they'd vanished). `prose_page_count` is `None` only on
+            // an un-backfilled cold doc — fall back to 0 (canvas == total).
+            let prose = m.prose_page_count.unwrap_or(0);
             json!({
                 "id": m.id,
                 "name": m.name,
                 "pageCount": m.page_count,
+                "canvasPageCount": m.page_count.saturating_sub(prose),
+                "prosePageCount": prose,
                 "modifiedAt": m.modified_at,
                 "source": SOURCE_TEAM,
             })
@@ -878,6 +885,8 @@ fn list_documents(ctx: &ToolContext) -> Result<ToolOutcome, String> {
                 "id": m.id,
                 "name": m.name,
                 "pageCount": m.page_count,
+                "canvasPageCount": m.page_count.saturating_sub(m.prose_page_count),
+                "prosePageCount": m.prose_page_count,
                 "modifiedAt": m.modified_at,
                 "source": SOURCE_LOCAL,
             }));
@@ -4972,6 +4981,39 @@ mod tests {
         assert!(f.registry.get(&ws, &doc_id).is_none(), "resident handle evicted");
         assert!(f.team.get_document(&ws, &doc_id).is_err(), "doc stays deleted");
         assert!(f.deletions().iter().any(|(_, d)| *d == doc_id), "delete sink fired");
+    }
+
+    // ---- JP-349: canvas + prose page-count split in list_documents ----
+
+    #[test]
+    fn list_documents_reports_canvas_and_prose_split() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        // seed's doc1 is canvas-only (no richTextPages). Add one with prose.
+        f.team
+            .save_document(
+                &WorkspaceId::single_tenant(),
+                json!({
+                    "id": "d2",
+                    "name": "D2",
+                    "pageOrder": ["c1", "c2"],
+                    "richTextPages": {"pages": {}, "pageOrder": ["r1", "r2", "r3"], "activePageId": "r1"},
+                }),
+            )
+            .unwrap();
+
+        let out = dispatch(&f.ctx(true), "docushark.list_documents", &json!({})).unwrap();
+        let docs = out.result["documents"].as_array().unwrap();
+
+        let d1 = docs.iter().find(|d| d["id"] == "doc1").unwrap();
+        assert_eq!(d1["pageCount"], 1);
+        assert_eq!(d1["canvasPageCount"], 1);
+        assert_eq!(d1["prosePageCount"], 0);
+
+        let d2 = docs.iter().find(|d| d["id"] == "d2").unwrap();
+        assert_eq!(d2["pageCount"], 5, "2 canvas + 3 prose");
+        assert_eq!(d2["canvasPageCount"], 2);
+        assert_eq!(d2["prosePageCount"], 3);
     }
 
     /// Seed a prose page with Markdown and return (docId, pageId).

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -67,7 +67,18 @@ pub struct CollectionDef {
 pub struct DocumentMetadata {
     pub id: DocId,
     pub name: String,
+    /// Total pages across BOTH collections — canvas (`pageOrder`) + prose
+    /// (`richTextPages.pageOrder`). Was canvas-only, which made the MCP doc
+    /// list read as if prose pages had vanished (JP-349). Derived in
+    /// `metadata_from_body`; the canvas/prose split is recoverable as
+    /// `page_count - prose_page_count`.
     pub page_count: usize,
+    /// Number of prose pages, so the MCP doc list can report a canvas/prose
+    /// breakdown (JP-349). `None` on entries written before JP-349 — backfilled
+    /// from the body in `load_workspace_index`. `#[serde(default)]` keeps a
+    /// pre-JP-349 `index.json` loadable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prose_page_count: Option<usize>,
     pub modified_at: u64,
     pub created_at: u64,
 
@@ -899,13 +910,43 @@ impl DocumentStore {
     fn load_workspace_index(&self, ws: &WorkspaceId) {
         let path = self.index_path(ws);
         let Ok(data) = std::fs::read_to_string(&path) else { return };
-        let Ok(parsed) = serde_json::from_str::<HashMap<String, DocumentMetadata>>(&data) else {
+        let Ok(mut parsed) = serde_json::from_str::<HashMap<String, DocumentMetadata>>(&data) else {
             log::warn!("index for workspace {} is malformed — leaving empty", ws.as_str());
             return;
         };
+        // JP-349 backfill: pre-JP-349 entries lack `prose_page_count` and their
+        // `page_count` is canvas-only — so without this an existing (cold) doc
+        // would keep reporting the canvas-only count, the very thing JP-349
+        // fixes. Re-derive both from the local body. Best-effort: an
+        // evicted-to-R2 body that isn't local stays `None` until its next save
+        // (acceptable pre-GA). `meta.id` is the doc's `DocId`, so no key parse.
+        let mut backfilled = false;
+        for meta in parsed.values_mut() {
+            if meta.prose_page_count.is_some() {
+                continue;
+            }
+            let path = self.doc_path(ws, &meta.id);
+            if let Some(body) = std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|d| serde_json::from_str::<serde_json::Value>(&d).ok())
+            {
+                let (canvas, prose) = Self::page_counts_of(&body);
+                meta.page_count = (canvas + prose).max(1);
+                meta.prose_page_count = Some(prose);
+                backfilled = true;
+            }
+        }
         let ids: Vec<String> = parsed.keys().cloned().collect();
         if let Ok(mut current) = self.index.write() {
             current.insert(ws.clone(), parsed);
+        }
+        // Persist the backfilled counts once (raw file write, no R2 enqueue) so
+        // subsequent boots skip the re-derive. Best-effort — a failure just
+        // means we re-derive next boot.
+        if backfilled {
+            if let Err(e) = self.write_workspace_index_file(ws) {
+                log::warn!("JP-349 index backfill persist failed for {}: {}", ws.as_str(), e);
+            }
         }
         // JP-231: seed working-set cache state for these docs (idempotent).
         self.seed_cache_for_workspace(ws, &ids);
@@ -1119,6 +1160,26 @@ impl DocumentStore {
     /// Build [`DocumentMetadata`] from a document body at a given server
     /// version. Shared by the save / snapshot / restore write paths so the
     /// derived index fields can't drift between them (JP-200 de-dup).
+    /// Count a document body's two independent page collections (JP-349):
+    /// canvas pages (top-level `pageOrder`) and prose pages
+    /// (`richTextPages.pageOrder`). Either is 0 when its array is absent. The
+    /// single derivation shared by `metadata_from_body` and the local-mirror
+    /// extractor so the two can't drift.
+    pub(crate) fn page_counts_of(doc: &serde_json::Value) -> (usize, usize) {
+        let canvas = doc
+            .get("pageOrder")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.len())
+            .unwrap_or(0);
+        let prose = doc
+            .get("richTextPages")
+            .and_then(|rtp| rtp.get("pageOrder"))
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.len())
+            .unwrap_or(0);
+        (canvas, prose)
+    }
+
     fn metadata_from_body(
         doc: &serde_json::Value,
         doc_id: DocId,
@@ -1131,14 +1192,15 @@ impl DocumentStore {
                 .unwrap_or(0)
         });
         let created_at = doc.get("createdAt").and_then(|v| v.as_u64()).unwrap_or(modified_at);
+        let (canvas, prose) = Self::page_counts_of(doc);
         DocumentMetadata {
             id: doc_id,
             name: doc.get("name").and_then(|v| v.as_str()).unwrap_or("Untitled").to_string(),
-            page_count: doc
-                .get("pageOrder")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.len())
-                .unwrap_or(1),
+            // Combined total, floored to 1 so a doc never reports 0 pages (the
+            // historical canvas-only `unwrap_or(1)` floor, now applied to the
+            // total). JP-349.
+            page_count: (canvas + prose).max(1),
+            prose_page_count: Some(prose),
             modified_at,
             created_at,
             is_relay_document: doc
@@ -2027,6 +2089,7 @@ mod tests {
             id: DocId::from_http_path("legacy-doc".into()).unwrap(),
             name: "legacy".into(),
             page_count: 1,
+            prose_page_count: None,
             modified_at: 1,
             created_at: 1,
             is_relay_document: Some(true),
@@ -2077,6 +2140,80 @@ mod tests {
 
         let result = store.get_document(&ws, &doc_id);
         assert!(result.is_err());
+    }
+
+    // ---- JP-349: canvas + prose page counts ----
+
+    #[test]
+    fn page_counts_of_counts_both_collections() {
+        let two_canvas_three_prose = serde_json::json!({
+            "pageOrder": ["c1", "c2"],
+            "richTextPages": { "pageOrder": ["r1", "r2", "r3"] },
+        });
+        assert_eq!(DocumentStore::page_counts_of(&two_canvas_three_prose), (2, 3));
+
+        // Absent richTextPages → 0 prose (not a panic / default-1).
+        let canvas_only = serde_json::json!({ "pageOrder": ["c1"] });
+        assert_eq!(DocumentStore::page_counts_of(&canvas_only), (1, 0));
+
+        // Absent everything → (0, 0); the floor lives in metadata_from_body.
+        assert_eq!(DocumentStore::page_counts_of(&serde_json::json!({})), (0, 0));
+    }
+
+    #[test]
+    fn metadata_page_count_is_canvas_plus_prose() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({
+                    "id": "d",
+                    "name": "D",
+                    "pageOrder": ["c1"],
+                    "richTextPages": { "pageOrder": ["r1", "r2", "r3"] },
+                }),
+            )
+            .unwrap();
+
+        let doc_id = DocId::from_http_path("d".into()).unwrap();
+        let meta = store.get_metadata(&ws, &doc_id).unwrap();
+        assert_eq!(meta.page_count, 4, "1 canvas + 3 prose");
+        assert_eq!(meta.prose_page_count, Some(3));
+        // canvasPageCount is derived as page_count - prose at the MCP edge.
+        assert_eq!(meta.page_count - meta.prose_page_count.unwrap(), 1);
+    }
+
+    #[test]
+    fn load_workspace_index_backfills_legacy_entry_prose_count() {
+        // A pre-JP-349 index.json: canvas-only `pageCount`, no `prosePageCount`.
+        let dir = tempdir().unwrap();
+        let ws_dir = dir
+            .path()
+            .join("relay_documents")
+            .join("workspaces")
+            .join("default");
+        std::fs::create_dir_all(ws_dir.join("docs")).unwrap();
+        std::fs::write(
+            ws_dir.join("index.json"),
+            r#"{"legacy-doc":{"id":"legacy-doc","name":"L","pageCount":1,"modifiedAt":1,"createdAt":1}}"#,
+        )
+        .unwrap();
+        // The body it points at has 1 canvas + 3 prose pages.
+        std::fs::write(
+            ws_dir.join("docs").join("legacy-doc.json"),
+            r#"{"id":"legacy-doc","name":"L","pageOrder":["c1"],"richTextPages":{"pages":{},"pageOrder":["r1","r2","r3"],"activePageId":"r1"}}"#,
+        )
+        .unwrap();
+
+        // Boot re-derives from the body — the cold doc is fixed, not stuck at 1.
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("legacy-doc".into()).unwrap();
+        let meta = store.get_metadata(&ws, &doc_id).unwrap();
+        assert_eq!(meta.page_count, 4, "backfilled to canvas + prose");
+        assert_eq!(meta.prose_page_count, Some(3));
     }
 
     // ---- JP-231 working-set cache / eviction --------------------------------

--- a/relay/src/server/permissions.rs
+++ b/relay/src/server/permissions.rs
@@ -250,6 +250,7 @@ mod tests {
             id: DocId::from_http_path("doc-1".to_string()).unwrap(),
             name: "Test".to_string(),
             page_count: 1,
+            prose_page_count: None,
             modified_at: 0,
             created_at: 0,
             is_relay_document: Some(true),

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -406,6 +406,7 @@ mod tests {
                 id: DocId::from_http_path("doc-1".to_string()).unwrap(),
                 name: "Test Doc".to_string(),
                 page_count: 1,
+                prose_page_count: None,
                 modified_at: 1000,
                 created_at: 1000,
                 is_relay_document: Some(true),

--- a/src/types/Document.test.ts
+++ b/src/types/Document.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { createDocument, getDocumentMetadata } from './Document';
+
+describe('getDocumentMetadata pageCount (JP-349)', () => {
+  it('counts canvas-only documents as before', () => {
+    const doc = createDocument('Doc', 'd1', 'p1');
+    expect(getDocumentMetadata(doc).pageCount).toBe(1);
+  });
+
+  it('counts canvas + prose pages combined', () => {
+    const doc = createDocument('Doc', 'd1', 'p1');
+    doc.richTextPages = {
+      pages: {},
+      pageOrder: ['r1', 'r2', 'r3'],
+      activePageId: 'r1',
+    };
+    // 1 canvas + 3 prose
+    expect(getDocumentMetadata(doc).pageCount).toBe(4);
+  });
+
+  it('treats absent richTextPages as zero prose pages', () => {
+    const doc = createDocument('Doc', 'd1', 'p1');
+    doc.pageOrder = ['p1', 'p2'];
+    delete doc.richTextPages;
+    expect(getDocumentMetadata(doc).pageCount).toBe(2);
+  });
+});

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -143,7 +143,7 @@ export interface DocumentMetadata {
   id: string;
   /** Display name of the document */
   name: string;
-  /** Number of pages in the document */
+  /** Total pages across both collections — canvas pages + prose pages (JP-349). */
   pageCount: number;
   /** Timestamp when document was last modified */
   modifiedAt: number;
@@ -238,7 +238,9 @@ export function getDocumentMetadata(doc: DiagramDocument): DocumentMetadata {
   const metadata: DocumentMetadata = {
     id: doc.id,
     name: doc.name,
-    pageCount: doc.pageOrder.length,
+    // JP-349: canvas + prose total, matching the relay's metadata derivation so
+    // the "N pages" UI and the server-listed count agree.
+    pageCount: doc.pageOrder.length + (doc.richTextPages?.pageOrder.length ?? 0),
     modifiedAt: doc.modifiedAt,
     createdAt: doc.createdAt,
   };


### PR DESCRIPTION
Closes JP-349. From JP-312's joy-ride agent feedback: a document has two page collections — **canvas** (`pageOrder`) and **prose** (`richTextPages.pageOrder`) — but `page_count` counted canvas only, so on the MCP doc list the agent saw `pageCount: 5` and *"briefly thought 8 prose pages had vanished,"* asking for *"separate proseCount/canvasCount."*

## What

- **`page_count` is now the canvas + prose total**, derived via one shared `DocumentStore::page_counts_of(doc) -> (canvas, prose)` helper reused by the team store (`metadata_from_body`) and the local mirror — no drift.
- **MCP `list_documents`** additionally emits `canvasPageCount` + `prosePageCount` (the breakdown the agent asked for), alongside the combined `pageCount`. Descriptor + MCP README updated.
- **Client** `getDocumentMetadata` mirrors the combined total so the human "N pages" UI agrees with the server. The split stays MCP-only (no new client type/registry plumbing).

## Precompute + back-compat

The count is precomputed into the metadata index at write time (the same path `page_count` already used), so `list_documents` stays cheap — important since cold docs are evicted (JP-231). `DocumentMetadata` gains `prose_page_count: Option<usize>` with `#[serde(default)]` so a pre-JP-349 `index.json` still deserializes. Crucially, `load_workspace_index` (which trusts `index.json` as-is) **backfills** the count from the doc body for legacy entries — otherwise existing cold docs would keep reporting the canvas-only count, i.e. the bug would persist for every doc already on staging. The serde default is just the safety net; the backfill is the fix.

## Tests (all green)

- Relay: `page_counts_of` (both collections / absent prose / empty), metadata combined total, **legacy-index backfill** (old canvas-only entry → correct combined + prose after boot), MCP `list_documents` split.
- Client: `getDocumentMetadata` combined total (canvas-only / canvas+prose / absent prose).
- `cargo test --lib` (514), `cargo build --bin relay`, `cargo check --all-targets`, `bun run typecheck`, vitest — all clean. OSS leak grep clean.

Live staging check (MCP `list_documents` shows `canvasPageCount`/`prosePageCount`/`pageCount` on a multi-prose doc, and an existing cold doc reports the right total after the relay restart) is the remaining manual gate.

Assisted-by: Opus 4.8