### PR TITLE
Fix connector labels buried by overlapping connectors (JP-353)

### DIFF
--- a/src/engine/RenderContext.ts
+++ b/src/engine/RenderContext.ts
@@ -1,4 +1,5 @@
 import { Shape } from '../shapes/Shape';
+import { Box } from '../math/Box';
 import { ContrastCache } from './ContrastResolver';
 
 /**
@@ -23,6 +24,13 @@ export interface RenderContext {
   pageBackground: string;
   /** Per-frame memoization cache for contrast lookups. */
   contrastCache: ContrastCache;
+  /**
+   * World-space boxes of every connector label without an opaque pill, across
+   * the whole frame. Each connector breaks its line at ALL of these (not just
+   * its own), so no line is drawn through any label's text (JP-353). Computed
+   * once per frame by the renderer/exporter after the context is set.
+   */
+  connectorLabelGapBoxes?: Box[];
 }
 
 let current: RenderContext | null = null;

--- a/src/engine/Renderer.test.ts
+++ b/src/engine/Renderer.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Renderer, RendererOptions } from './Renderer';
 import { Camera } from './Camera';
 import { Vec2 } from '../math/Vec2';
+import type { ConnectorShape, Shape } from '../shapes/Shape';
+// Register the connector handler (self-registers on import) for the JP-353 test.
+import { connectorHandler } from '../shapes/Connector';
 
 /**
  * Create a mock canvas element with a mock 2D context.
@@ -378,6 +381,112 @@ describe('Renderer', () => {
       renderer.renderNow();
 
       expect(clearSpy.mock.calls.length).toBe(afterFirstFrame + 1);
+    });
+  });
+
+  describe('deferred connector-label overlay (JP-353)', () => {
+    /** A canvas whose 2D context records every drawing call (for call-order). */
+    function createRecordingCanvas(): {
+      canvas: HTMLCanvasElement;
+      ctx: { stroke: ReturnType<typeof vi.fn>; fillText: ReturnType<typeof vi.fn> };
+    } {
+      const ctx = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        stroke: vi.fn(),
+        fill: vi.fn(),
+        closePath: vi.fn(),
+        arc: vi.fn(),
+        setLineDash: vi.fn(),
+        clearRect: vi.fn(),
+        fillRect: vi.fn(),
+        strokeRect: vi.fn(),
+        fillText: vi.fn(),
+        strokeText: vi.fn(),
+        measureText: vi.fn().mockReturnValue({ width: 40 }),
+        translate: vi.fn(),
+        rotate: vi.fn(),
+        setTransform: vi.fn(),
+        transform: vi.fn(),
+        canvas: { width: 800, height: 600 },
+        globalAlpha: 1,
+        strokeStyle: '',
+        fillStyle: '',
+        lineWidth: 1,
+        lineCap: 'butt',
+        lineJoin: 'miter',
+        font: '',
+        textAlign: 'left',
+        textBaseline: 'alphabetic',
+      };
+      const canvas = {
+        width: 800,
+        height: 600,
+        getContext: vi.fn().mockReturnValue(ctx),
+        getBoundingClientRect: vi.fn().mockReturnValue({ left: 0, top: 0, width: 800, height: 600 }),
+      } as unknown as HTMLCanvasElement;
+      return { canvas, ctx: ctx as unknown as { stroke: ReturnType<typeof vi.fn>; fillText: ReturnType<typeof vi.fn> } };
+    }
+
+    function connector(id: string, label: string, pts: [number, number, number, number]): ConnectorShape {
+      const [x, y, x2, y2] = pts;
+      return {
+        id, type: 'connector', x, y, x2, y2,
+        rotation: 0, opacity: 1, locked: false, visible: true,
+        fill: null, stroke: '#000000', strokeWidth: 2,
+        startShapeId: null, startAnchor: 'center', endShapeId: null, endAnchor: 'center',
+        startArrow: false, endArrow: false,
+        label,
+      } as ConnectorShape;
+    }
+
+    it('draws both connector lines before either label, so labels are never buried', () => {
+      const { canvas, ctx } = createRecordingCanvas();
+      const camera = new Camera();
+      camera.setViewport(800, 600);
+      const renderer = new Renderer(canvas, camera, { showGrid: false });
+
+      // Two crossing connectors through the origin, each with a label — without
+      // the deferred pass, the second connector's line would paint over the
+      // first connector's label.
+      const a = connector('a', 'AAA', [-100, 0, 100, 0]);
+      const b = connector('b', 'BBB', [0, -100, 0, 100]);
+      const shapes: Record<string, Shape> = { a, b };
+      renderer.setShapes(shapes, ['a', 'b']);
+      renderer.renderNow();
+
+      const strokeOrders = ctx.stroke.mock.invocationCallOrder;
+      const labelOrders = ctx.fillText.mock.invocationCallOrder;
+
+      // Both labels were drawn (deferred overlay ran for both connectors).
+      expect(ctx.fillText).toHaveBeenCalledWith('AAA', expect.any(Number), expect.any(Number));
+      expect(ctx.fillText).toHaveBeenCalledWith('BBB', expect.any(Number), expect.any(Number));
+
+      // Every body line stroke happened before the first label fillText: labels
+      // ride on top of all connector lines (JP-353).
+      expect(strokeOrders.length).toBeGreaterThan(0);
+      expect(labelOrders.length).toBeGreaterThan(0);
+      expect(Math.max(...strokeOrders)).toBeLessThan(Math.min(...labelOrders));
+    });
+
+    it('render() no longer draws the label inline (it is deferred)', () => {
+      const { canvas, ctx } = createRecordingCanvas();
+      const camera = new Camera();
+      camera.setViewport(800, 600);
+      const renderer = new Renderer(canvas, camera, { showGrid: false });
+
+      // Sanity: connectorHandler exposes the deferred hook.
+      expect(typeof connectorHandler.renderOverlay).toBe('function');
+
+      renderer.setShapes({ a: connector('a', 'ONLY', [-50, 0, 50, 0]) }, ['a']);
+      renderer.renderNow();
+
+      // The label is still drawn (in the overlay pass) exactly once.
+      const onlyCalls = ctx.fillText.mock.calls.filter((c) => c[0] === 'ONLY');
+      expect(onlyCalls).toHaveLength(1);
     });
   });
 

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -140,6 +140,12 @@ export class Renderer {
   private shapeOrder: string[] = [];
   private selectedIds: Set<string> = new Set();
 
+  // Deferred "overlay" shapes collected during the z-order pass and drawn on
+  // top afterwards (e.g. connector labels, so they sit above other connectors'
+  // lines instead of being buried — JP-353). Reused across frames (cleared via
+  // `length = 0`) to avoid per-frame allocation; holds already-resolved shapes.
+  private overlays: Shape[] = [];
+
   // Emphasis animation
   private emphasizedShapeId: string | null = null;
   private emphasisStartTime: number = 0;
@@ -613,6 +619,9 @@ export class Renderer {
 
     if (shapeOrder.length === 0) return;
 
+    // Reset the deferred-overlay collector for this frame (reuse the array).
+    this.overlays.length = 0;
+
     // Get visible bounds for culling
     const visibleBounds = camera.getVisibleBounds();
 
@@ -646,10 +655,14 @@ export class Renderer {
           rendered += stats.rendered;
           culled += stats.culled;
         } else {
-          // Render the shape
+          // Render the shape. Resolve AUTO colours once and reuse the result
+          // for both the body and any deferred overlay (avoids a second
+          // contrast-cache resolve).
+          const resolved = this.resolveAutoFillStroke(shape);
           ctx.save();
-          handler.render(ctx, this.resolveAutoFillStroke(shape));
+          handler.render(ctx, resolved);
           ctx.restore();
+          if (handler.renderOverlay) this.overlays.push(resolved);
           rendered++;
         }
       } catch {
@@ -657,9 +670,35 @@ export class Renderer {
       }
     }
 
+    // Deferred overlay pass: draw collected overlays (e.g. connector labels) on
+    // top of every shape body, in z-order amongst themselves (JP-353). Still
+    // inside drawShapes, so the RenderContext set by the caller is live for any
+    // overlay that re-resolves geometry.
+    this.drawOverlays();
+
     // Could expose these stats via getMetrics() if needed
     void rendered;
     void culled;
+  }
+
+  /**
+   * Draw the deferred overlays collected during the z-order pass. Each overlay
+   * shape's handler is guaranteed to have `renderOverlay` (checked at collection
+   * time). See `overlays` and JP-353.
+   */
+  private drawOverlays(): void {
+    const { ctx } = this;
+    for (const shape of this.overlays) {
+      try {
+        const handler = shapeRegistry.getHandler(shape.type);
+        if (!handler.renderOverlay) continue;
+        ctx.save();
+        handler.renderOverlay(ctx, shape);
+        ctx.restore();
+      } catch {
+        // Shape type not registered - skip silently
+      }
+    }
   }
 
   /**
@@ -711,11 +750,16 @@ export class Renderer {
           rendered += stats.rendered;
           culled += stats.culled;
         } else {
-          // Render the child with inherited opacity
+          // Render the child with inherited opacity. Resolve AUTO colours once
+          // and reuse for the deferred overlay (JP-353) — without collecting
+          // here, a group-child connector's label would render nowhere, since
+          // the label moved out of `render` into `renderOverlay`.
+          const resolved = this.resolveAutoFillStroke(child);
           ctx.save();
           ctx.globalAlpha = child.opacity * effectiveOpacity;
-          handler.render(ctx, this.resolveAutoFillStroke(child));
+          handler.render(ctx, resolved);
           ctx.restore();
+          if (handler.renderOverlay) this.overlays.push(resolved);
           rendered++;
         }
       } catch {

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -2,12 +2,13 @@ import { Camera } from './Camera';
 import { Box } from '../math/Box';
 import { Shape, isGroup, GroupShape, Handle, isConnector } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
+import { collectConnectorLabelGapBoxes } from '../shapes/Connector';
 import type { GroupShapeHandler } from '../shapes/Group';
 import { setLatexRenderCallback } from '../utils/textUtils';
 import { onIconLoad } from '../utils/iconCache';
 import { onThumbnailLoad } from '../shapes/FileShape';
 import { ContrastCache, isAutoColor } from './ContrastResolver';
-import { setRenderContext } from './RenderContext';
+import { setRenderContext, type RenderContext } from './RenderContext';
 import { getAdaptiveBudget } from '../platform/adaptiveBudget';
 
 /**
@@ -413,12 +414,20 @@ export class Renderer {
       this.lastContrastShapeOrder = this.shapeOrder;
       this.lastContrastPageBackground = pageBackground;
     }
-    setRenderContext({
+    const renderContext = {
       shapes: this.shapes,
       shapeOrder: this.shapeOrder,
       pageBackground,
       contrastCache: this.contrastCache,
-    });
+    };
+    setRenderContext(renderContext);
+    // Collect every connector label's gap box now that the context is live (so
+    // point resolution clips identically to the draw pass), then publish it so
+    // each connector breaks its line at all labels, not just its own (JP-353).
+    (renderContext as RenderContext).connectorLabelGapBoxes = collectConnectorLabelGapBoxes(
+      this.ctx,
+      this.shapes
+    );
     try {
       this.drawShapes();
     } finally {

--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -132,13 +132,18 @@ describe('connectorHandler', () => {
       expect(ctx.setLineDash).toHaveBeenCalledWith([]);
     });
 
-    it('renders a connector label at midpoint', () => {
-      const ctx = createMockContext();
+    it('renders a connector label at midpoint via the deferred overlay pass (JP-353)', () => {
       const connector = createTestConnector({ label: 'Test Label' });
 
-      connectorHandler.render(ctx, connector);
+      // The label moved out of `render` into `renderOverlay` so it paints above
+      // other connectors instead of being buried by their lines.
+      const bodyCtx = createMockContext();
+      connectorHandler.render(bodyCtx, connector);
+      expect(bodyCtx.fillText).not.toHaveBeenCalledWith('Test Label', expect.any(Number), expect.any(Number));
 
-      expect(ctx.fillText).toHaveBeenCalledWith('Test Label', expect.any(Number), expect.any(Number));
+      const overlayCtx = createMockContext();
+      connectorHandler.renderOverlay?.(overlayCtx, connector);
+      expect(overlayCtx.fillText).toHaveBeenCalledWith('Test Label', expect.any(Number), expect.any(Number));
     });
 
     it('renders guard condition with brackets', () => {
@@ -760,13 +765,15 @@ describe('curved routing mode', () => {
 });
 
 describe('label outline (labelStrokeColor)', () => {
+  // The label is drawn in the deferred overlay pass (JP-353), so the outline is
+  // produced by renderOverlay, not render.
   it('strokes the label text only when an outline colour is set', () => {
     const withOutline = createMockContext();
-    connectorHandler.render(withOutline, createTestConnector({ label: 'Hi', labelStrokeColor: '#ffffff' }));
+    connectorHandler.renderOverlay?.(withOutline, createTestConnector({ label: 'Hi', labelStrokeColor: '#ffffff' }));
     expect(withOutline.strokeText).toHaveBeenCalled();
 
     const without = createMockContext();
-    connectorHandler.render(without, createTestConnector({ label: 'Hi' }));
+    connectorHandler.renderOverlay?.(without, createTestConnector({ label: 'Hi' }));
     expect(without.strokeText).not.toHaveBeenCalled();
   });
 });

--- a/src/shapes/Connector.test.ts
+++ b/src/shapes/Connector.test.ts
@@ -764,6 +764,33 @@ describe('curved routing mode', () => {
   });
 });
 
+describe('breaks all connectors crossing a label (JP-353)', () => {
+  it('breaks a connector line at a foreign label box from the render context', () => {
+    const ctx = createMockContext();
+    // A label box owned by some OTHER connector, centred at x=100 on the line.
+    const foreign = new Box(80, -10, 120, 10);
+    setRenderContext({
+      shapes: {},
+      shapeOrder: [],
+      pageBackground: '#ffffff',
+      contrastCache: new ContrastCache(),
+      connectorLabelGapBoxes: [foreign],
+    });
+    // A connector with NO label of its own, passing straight through the box.
+    connectorHandler.render(
+      ctx,
+      createTestConnector({ stroke: '#000000', x: 0, y: 0, x2: 200, y2: 0, endArrow: false })
+    );
+    setRenderContext(null);
+
+    // The line resumes after the foreign box (x≈120) — i.e. it broke around a
+    // label that belongs to a different connector.
+    const calls = (ctx.moveTo as ReturnType<typeof vi.fn>).mock.calls;
+    const resumes = calls.some((c) => Math.abs(c[0] - 120) < 1e-6 && c[1] === 0);
+    expect(resumes).toBe(true);
+  });
+});
+
 describe('label outline (labelStrokeColor)', () => {
   // The label is drawn in the deferred overlay pass (JP-353), so the outline is
   // produced by renderOverlay, not render.

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -1005,6 +1005,54 @@ function pointToLineDistance(point: Vec2, lineStart: Vec2, lineEnd: Vec2): numbe
 }
 
 /**
+ * Resolve the full set of world-space path points for a connector, applying the
+ * same transforms the renderer uses: endpoint clipping to bound shapes (when a
+ * render context is active), self-message loop routing, and curved-mode
+ * smoothing. Shared by `render` (to draw the line) and `renderOverlay` (to place
+ * the label) so the two stay in lock-step.
+ */
+function resolveConnectorPoints(shape: ConnectorShape): Vec2[] {
+  // Get all path points (handle self-message routing)
+  let points = getPathPoints(shape);
+
+  // Clip endpoints bound to a shape with an interior anchor (the default
+  // 'center') to that shape's edge, so the line/arrowhead touch the boundary
+  // instead of running to the centre. Needs the live shapes from the render
+  // context; outside a frame the raw points are used.
+  const renderCtx = getRenderContext();
+  if (renderCtx) {
+    points = clipConnectorEndpoints(points, shape, renderCtx.shapes);
+  }
+
+  // Self-message routing: when both endpoints connect to the same shape
+  // Route the connector as a loop to the right
+  if (shape.startShapeId && shape.startShapeId === shape.endShapeId && points.length === 2) {
+    const start = points[0]!;
+    const end = points[1]!;
+    const loopWidth = shape.selfMessageWidth ?? 30;
+    const loopHeight = Math.abs(end.y - start.y) || 40;
+
+    // Create a loop that goes to the right and down
+    points = [
+      start,
+      new Vec2(start.x + loopWidth, start.y),
+      new Vec2(start.x + loopWidth, start.y + loopHeight),
+      new Vec2(end.x, end.y),
+    ];
+  }
+
+  // Curved mode: smooth the polyline into a dense Catmull-Rom curve through
+  // its waypoints. Everything downstream (stroke, arrowhead tangent, label
+  // arc-length placement) then operates on the smoothed points with no
+  // special-casing. A 2-point path has nothing to smooth and stays straight.
+  if (shape.routingMode === 'curved' && points.length >= 3) {
+    points = sampleSmoothCurve(points);
+  }
+
+  return points;
+}
+
+/**
  * Connector shape handler implementation.
  */
 export const connectorHandler: ShapeHandler<ConnectorShape> = {
@@ -1021,42 +1069,11 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
     ctx.save();
     ctx.globalAlpha = opacity;
 
-    // Get all path points (handle self-message routing)
-    let points = getPathPoints(shape);
-
-    // Clip endpoints bound to a shape with an interior anchor (the default
-    // 'center') to that shape's edge, so the line/arrowhead touch the boundary
-    // instead of running to the centre. Needs the live shapes from the render
-    // context; outside a frame the raw points are used.
-    const renderCtx = getRenderContext();
-    if (renderCtx) {
-      points = clipConnectorEndpoints(points, shape, renderCtx.shapes);
-    }
-
-    // Self-message routing: when both endpoints connect to the same shape
-    // Route the connector as a loop to the right
-    if (shape.startShapeId && shape.startShapeId === shape.endShapeId && points.length === 2) {
-      const start = points[0]!;
-      const end = points[1]!;
-      const loopWidth = shape.selfMessageWidth ?? 30;
-      const loopHeight = Math.abs(end.y - start.y) || 40;
-
-      // Create a loop that goes to the right and down
-      points = [
-        start,
-        new Vec2(start.x + loopWidth, start.y),
-        new Vec2(start.x + loopWidth, start.y + loopHeight),
-        new Vec2(end.x, end.y),
-      ];
-    }
-
-    // Curved mode: smooth the polyline into a dense Catmull-Rom curve through
-    // its waypoints. Everything downstream (stroke, arrowhead tangent, label
-    // arc-length placement) then operates on the smoothed points with no
-    // special-casing. A 2-point path has nothing to smooth and stays straight.
-    if (shape.routingMode === 'curved' && points.length >= 3) {
-      points = sampleSmoothCurve(points);
-    }
+    // Resolve the routed path (endpoint clipping, self-message loop, curve
+    // smoothing). The connector label is drawn in a deferred overlay pass
+    // (`renderOverlay`) so it sits above other connectors instead of being
+    // buried by their lines — see JP-353.
+    const points = resolveConnectorPoints(shape);
 
     // Draw the line(s)
     if (stroke && strokeWidth > 0 && points.length >= 2) {
@@ -1208,19 +1225,10 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
       ctx.restore();
     }
 
-    // Draw label if present
-    if (shape.label && shape.label.trim()) {
-      const labelPosition = shape.labelPosition ?? 0.5;
-      const { point } = getPointAlongPath(points, labelPosition);
-      const fontSize = shape.labelFontSize ?? 12;
-      const rawColor = shape.labelColor ?? stroke ?? '#000000';
-      const color = resolveStrokeAtPoint(rawColor, point, shape.id) ?? rawColor;
-      const backgroundColor = shape.labelBackground;
-      const offsetX = shape.labelOffsetX ?? 0;
-      const offsetY = shape.labelOffsetY ?? 0;
-
-      renderConnectorLabel(ctx, shape.label, point, fontSize, color, backgroundColor, offsetX, offsetY, shape.labelOverflow, shape.labelStrokeColor);
-    }
+    // The connector label is intentionally NOT drawn here — it is deferred to
+    // `renderOverlay` so it paints above all connector bodies (JP-353). The
+    // line was still broken behind it above via `labelGapBox`, so the own-line
+    // "cut" is preserved.
 
     // Draw guard condition if present (for activity diagrams)
     if (shape.guardCondition && shape.guardCondition.trim()) {
@@ -1254,6 +1262,36 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
       ctx.fillText(guardText, point.x, point.y - 6);
       ctx.restore();
     }
+
+    ctx.restore();
+  },
+
+  /**
+   * Deferred label render (JP-353). Drawn by the Renderer after every shape has
+   * rendered its body, so a connector's label sits above other connectors'
+   * lines instead of being buried by them. The own-line gap behind the label is
+   * still produced in `render` (via `labelGapBox`); only the text moves here.
+   */
+  renderOverlay(ctx: CanvasRenderingContext2D, shape: ConnectorShape): void {
+    if (!shape.label || !shape.label.trim()) return;
+
+    const points = resolveConnectorPoints(shape);
+    if (points.length < 2) return;
+
+    ctx.save();
+    // Match the body's opacity exactly (render() uses shape.opacity).
+    ctx.globalAlpha = shape.opacity;
+
+    const labelPosition = shape.labelPosition ?? 0.5;
+    const { point } = getPointAlongPath(points, labelPosition);
+    const fontSize = shape.labelFontSize ?? 12;
+    const rawColor = shape.labelColor ?? shape.stroke ?? '#000000';
+    const color = resolveStrokeAtPoint(rawColor, point, shape.id) ?? rawColor;
+    const backgroundColor = shape.labelBackground;
+    const offsetX = shape.labelOffsetX ?? 0;
+    const offsetY = shape.labelOffsetY ?? 0;
+
+    renderConnectorLabel(ctx, shape.label, point, fontSize, color, backgroundColor, offsetX, offsetY, shape.labelOverflow, shape.labelStrokeColor);
 
     ctx.restore();
   },

--- a/src/shapes/Connector.ts
+++ b/src/shapes/Connector.ts
@@ -15,7 +15,7 @@ import {
   resolveArrowStyle,
 } from './Shape';
 import { isAutoColor } from '../engine/ContrastResolver';
-import { getRenderContext } from '../engine/RenderContext';
+import { getRenderContext, type RenderContext } from '../engine/RenderContext';
 import { renderLabel } from './label/renderLabel';
 import { CONNECTOR_LABEL_SPEC, CONNECTOR_LABEL_MAX_WIDTH } from './label/specs';
 import type { LabelOverflow } from './label/LabelSpec';
@@ -856,26 +856,56 @@ export function segmentBoxOverlap(a: Vec2, b: Vec2, box: Box): [number, number] 
   return t0 <= t1 ? [t0, t1] : null;
 }
 
-/** Stroke a→b but skip the portion inside `box` (the gap behind a label). */
-function strokeSegmentWithGap(ctx: CanvasRenderingContext2D, a: Vec2, b: Vec2, box: Box | null): void {
-  const overlap = box ? segmentBoxOverlap(a, b, box) : null;
-  if (!overlap) {
+/**
+ * Stroke a→b but skip every portion that falls inside one of `boxes` (the gaps
+ * behind labels). A connector breaks at ALL label boxes in the frame — its own
+ * and every other connector's — so no line is ever drawn through a label's text
+ * (JP-353). Overlapping boxes are merged before stroking the complement.
+ */
+function strokeSegmentWithGaps(ctx: CanvasRenderingContext2D, a: Vec2, b: Vec2, boxes: Box[]): void {
+  // Collect the [t0,t1] sub-intervals of this segment covered by any box.
+  const intervals: Array<[number, number]> = [];
+  for (const box of boxes) {
+    const overlap = segmentBoxOverlap(a, b, box);
+    if (overlap) intervals.push(overlap);
+  }
+
+  if (intervals.length === 0) {
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
     return;
   }
-  const [t0, t1] = overlap;
-  if (t0 > 0) {
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(a.x + t0 * (b.x - a.x), a.y + t0 * (b.y - a.y));
-    ctx.stroke();
+
+  // Merge the covered intervals so adjacent/overlapping gaps don't create
+  // zero-length stubs, then stroke the complement within [0,1].
+  intervals.sort((p, q) => p[0] - q[0]);
+  const merged: Array<[number, number]> = [];
+  for (const iv of intervals) {
+    const last = merged[merged.length - 1];
+    if (last && iv[0] <= last[1]) {
+      last[1] = Math.max(last[1], iv[1]);
+    } else {
+      merged.push([iv[0], iv[1]]);
+    }
   }
-  if (t1 < 1) {
+
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  let cursor = 0;
+  for (const [start, end] of merged) {
+    if (start > cursor) {
+      ctx.beginPath();
+      ctx.moveTo(a.x + cursor * dx, a.y + cursor * dy);
+      ctx.lineTo(a.x + start * dx, a.y + start * dy);
+      ctx.stroke();
+    }
+    cursor = Math.max(cursor, end);
+  }
+  if (cursor < 1) {
     ctx.beginPath();
-    ctx.moveTo(a.x + t1 * (b.x - a.x), a.y + t1 * (b.y - a.y));
+    ctx.moveTo(a.x + cursor * dx, a.y + cursor * dy);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
@@ -1004,14 +1034,32 @@ function pointToLineDistance(point: Vec2, lineStart: Vec2, lineEnd: Vec2): numbe
   return Vec2.distance(point, projection);
 }
 
+// Per-frame memoization of resolved path points. A labeled connector resolves
+// its points up to three times a frame (gap-box collection, line draw, label
+// overlay); caching collapses that to one compute. Keyed by shape id and scoped
+// to the active RenderContext object — a new frame brings a new context, which
+// invalidates the cache. Bypassed entirely outside a frame (no context).
+let pointsCacheToken: RenderContext | null = null;
+const pointsCache = new Map<string, Vec2[]>();
+
 /**
  * Resolve the full set of world-space path points for a connector, applying the
  * same transforms the renderer uses: endpoint clipping to bound shapes (when a
  * render context is active), self-message loop routing, and curved-mode
- * smoothing. Shared by `render` (to draw the line) and `renderOverlay` (to place
- * the label) so the two stay in lock-step.
+ * smoothing. Shared by `render` (to draw the line), `renderOverlay` (to place
+ * the label), and gap-box collection so they all stay in lock-step.
  */
 function resolveConnectorPoints(shape: ConnectorShape): Vec2[] {
+  const renderCtx = getRenderContext();
+  if (renderCtx) {
+    if (renderCtx !== pointsCacheToken) {
+      pointsCacheToken = renderCtx;
+      pointsCache.clear();
+    }
+    const cached = pointsCache.get(shape.id);
+    if (cached) return cached;
+  }
+
   // Get all path points (handle self-message routing)
   let points = getPathPoints(shape);
 
@@ -1019,7 +1067,6 @@ function resolveConnectorPoints(shape: ConnectorShape): Vec2[] {
   // 'center') to that shape's edge, so the line/arrowhead touch the boundary
   // instead of running to the centre. Needs the live shapes from the render
   // context; outside a frame the raw points are used.
-  const renderCtx = getRenderContext();
   if (renderCtx) {
     points = clipConnectorEndpoints(points, shape, renderCtx.shapes);
   }
@@ -1049,7 +1096,56 @@ function resolveConnectorPoints(shape: ConnectorShape): Vec2[] {
     points = sampleSmoothCurve(points);
   }
 
+  if (renderCtx) pointsCache.set(shape.id, points);
   return points;
+}
+
+/**
+ * Compute the world-space gap box for a connector's label — the rectangle the
+ * line is broken behind so the text reads cleanly. Returns null when the
+ * connector has no label, or when its label has an opaque pill (the pill is its
+ * own background, so the line is not broken). Mutates `ctx.font` for measuring.
+ */
+function computeConnectorLabelBox(
+  ctx: CanvasRenderingContext2D,
+  shape: ConnectorShape,
+  points: Vec2[]
+): Box | null {
+  if (!shape.label || !shape.label.trim() || points.length < 2) return null;
+  const labelBg = shape.labelBackground;
+  const labelHasPill = labelBg !== undefined && labelBg !== '' && labelBg !== 'transparent';
+  if (labelHasPill) return null;
+
+  const { point } = getPointAlongPath(points, shape.labelPosition ?? 0.5);
+  const labelFontSize = shape.labelFontSize ?? 12;
+  ctx.font = `${labelFontSize}px sans-serif`;
+  const textWidth = ctx.measureText(shape.label).width;
+  const cx = point.x + (shape.labelOffsetX ?? 0);
+  const cy = point.y + (shape.labelOffsetY ?? 0);
+  const halfW = textWidth / 2 + 6;
+  const halfH = labelFontSize / 2 + 4;
+  return new Box(cx - halfW, cy - halfH, cx + halfW, cy + halfH);
+}
+
+/**
+ * Collect the label gap boxes for every connector in `shapes` (JP-353). The
+ * renderer/exporter publishes the result on the RenderContext so each connector
+ * can break its line at all of them, not just its own. Hidden connectors are
+ * skipped (their lines are not drawn).
+ */
+export function collectConnectorLabelGapBoxes(
+  ctx: CanvasRenderingContext2D,
+  shapes: Record<string, Shape>
+): Box[] {
+  const boxes: Box[] = [];
+  for (const id in shapes) {
+    const shape = shapes[id];
+    if (!shape || shape.type !== 'connector' || !shape.visible) continue;
+    const connector = shape as ConnectorShape;
+    const box = computeConnectorLabelBox(ctx, connector, resolveConnectorPoints(connector));
+    if (box) boxes.push(box);
+  }
+  return boxes;
 }
 
 /**
@@ -1089,22 +1185,20 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
         ctx.setLineDash([]);
       }
 
-      // When the label has no opaque pill, break the line behind its text so
-      // it reads cleanly without a box (the line is otherwise transparent
-      // through the label). Compute the label's box once, in world space.
-      let labelGapBox: Box | null = null;
-      const labelBg = shape.labelBackground;
-      const labelHasPill = labelBg !== undefined && labelBg !== '' && labelBg !== 'transparent';
-      if (shape.label && shape.label.trim() && !labelHasPill) {
-        const { point } = getPointAlongPath(points, shape.labelPosition ?? 0.5);
-        const labelFontSize = shape.labelFontSize ?? 12;
-        ctx.font = `${labelFontSize}px sans-serif`;
-        const textWidth = ctx.measureText(shape.label).width;
-        const cx = point.x + (shape.labelOffsetX ?? 0);
-        const cy = point.y + (shape.labelOffsetY ?? 0);
-        const halfW = textWidth / 2 + 6;
-        const halfH = labelFontSize / 2 + 4;
-        labelGapBox = new Box(cx - halfW, cy - halfH, cx + halfW, cy + halfH);
+      // Break the line behind label text so it reads cleanly without a box (the
+      // line is otherwise transparent through the label). A connector breaks at
+      // EVERY connector label's box in the frame — not just its own — so an
+      // overlapping connector never draws a line through another's label
+      // (JP-353). The frame's box set is published on the render context; with
+      // no context (standalone render / tests) we fall back to this connector's
+      // own label box only.
+      const rc = getRenderContext();
+      let gapBoxes: Box[];
+      if (rc?.connectorLabelGapBoxes) {
+        gapBoxes = rc.connectorLabelGapBoxes;
+      } else {
+        const ownBox = computeConnectorLabelBox(ctx, shape, points);
+        gapBoxes = ownBox ? [ownBox] : [];
       }
 
       if (isAutoColor(stroke)) {
@@ -1114,12 +1208,12 @@ export const connectorHandler: ShapeHandler<ConnectorShape> = {
           const a = points[i - 1]!;
           const b = points[i]!;
           ctx.strokeStyle = resolveSegmentStroke(stroke, a, b, shape.id);
-          strokeSegmentWithGap(ctx, a, b, labelGapBox);
+          strokeSegmentWithGaps(ctx, a, b, gapBoxes);
         }
       } else {
         ctx.strokeStyle = stroke;
         for (let i = 1; i < points.length; i++) {
-          strokeSegmentWithGap(ctx, points[i - 1]!, points[i]!, labelGapBox);
+          strokeSegmentWithGaps(ctx, points[i - 1]!, points[i]!, gapBoxes);
         }
       }
 

--- a/src/shapes/ShapeRegistry.ts
+++ b/src/shapes/ShapeRegistry.ts
@@ -98,6 +98,19 @@ export interface ShapeHandler<T extends Shape = Shape> {
    * @returns The label edit target, or null if not label-editable
    */
   getLabelEditTarget?(shape: T): LabelEditTarget | null;
+
+  /**
+   * Optional deferred "overlay" render, drawn after all shapes have rendered in
+   * z-order. Used for annotations (e.g. connector labels) that must sit above
+   * other shapes' bodies rather than be buried by a later shape's body in the
+   * same pass. The context is in world space with the camera applied, exactly as
+   * for `render`. Implementers should set `globalAlpha` themselves to match the
+   * shape body's opacity.
+   *
+   * @param ctx - Canvas 2D rendering context
+   * @param shape - The shape whose overlay to draw
+   */
+  renderOverlay?(ctx: CanvasRenderingContext2D, shape: T): void;
 }
 
 /**

--- a/src/utils/exportUtils.test.ts
+++ b/src/utils/exportUtils.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   getExportBounds,
   exportToSvg,
+  exportToPng,
   resolveExportInk,
   ExportData,
   ExportOptions,
@@ -478,6 +479,69 @@ describe('exportUtils', () => {
       const svg = exportToSvg(makeExportData([conn]), defaultOptions());
 
       expect(svg).toContain('stroke-dasharray=');
+    });
+  });
+
+  describe('PNG export connector labels (JP-353)', () => {
+    /** A recording 2D context for asserting which draw calls a PNG export makes. */
+    function recordingCtx() {
+      return {
+        scale: vi.fn(), translate: vi.fn(), save: vi.fn(), restore: vi.fn(),
+        beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(),
+        fill: vi.fn(), closePath: vi.fn(), arc: vi.fn(), setLineDash: vi.fn(),
+        clearRect: vi.fn(), fillRect: vi.fn(), strokeRect: vi.fn(),
+        fillText: vi.fn(), strokeText: vi.fn(),
+        measureText: vi.fn().mockReturnValue({ width: 40 }),
+        rotate: vi.fn(), setTransform: vi.fn(), transform: vi.fn(),
+        globalAlpha: 1, strokeStyle: '', fillStyle: '', lineWidth: 1,
+        lineCap: 'butt', lineJoin: 'miter', font: '',
+        textAlign: 'left', textBaseline: 'alphabetic',
+      };
+    }
+
+    /** Stub document.createElement so the offscreen export canvas is recordable. */
+    function withMockCanvas<T>(ctx: ReturnType<typeof recordingCtx>, run: () => T): T {
+      const fakeCanvas = {
+        width: 0, height: 0, parentNode: null,
+        getContext: vi.fn().mockReturnValue(ctx),
+        toBlob: (cb: (b: Blob | null) => void) => cb(new Blob(['x'], { type: 'image/png' })),
+      } as unknown as HTMLCanvasElement;
+      const orig = document.createElement.bind(document);
+      const spy = vi.spyOn(document, 'createElement').mockImplementation(
+        (tag: string) => (tag === 'canvas' ? fakeCanvas : orig(tag)) as HTMLElement
+      );
+      try {
+        return run();
+      } finally {
+        spy.mockRestore();
+      }
+    }
+
+    it('draws the connector label text (regression: PNG had no labels)', async () => {
+      const ctx = recordingCtx();
+      const conn = makeConnector('c1', 0, 0, 100, 0, { label: 'imports', stroke: '#333333' });
+      await withMockCanvas(ctx, () => exportToPng(makeExportData([conn]), defaultOptions({ format: 'png' })));
+
+      expect(ctx.fillText).toHaveBeenCalledWith('imports', expect.any(Number), expect.any(Number));
+    });
+
+    it('breaks a connector line at another connector\'s label box (gap-all-connectors)', async () => {
+      const ctx = recordingCtx();
+      // A vertical connector through the origin, and a labeled horizontal
+      // connector whose label sits at the origin. The vertical line must break
+      // around the horizontal connector's label box.
+      const labeled = makeConnector('h', -100, 0, 100, 0, { label: 'X', stroke: '#333333' });
+      const crossing = makeConnector('v', 0, -100, 0, 100, { stroke: '#333333' });
+      await withMockCanvas(ctx, () =>
+        exportToPng(makeExportData([labeled, crossing]), defaultOptions({ format: 'png' }))
+      );
+
+      // measureText→40 ⇒ label box half-height = 12/2+4 = 10 ⇒ the crossing line
+      // resumes at y≈10 after the gap (a moveTo at the box exit on x=0).
+      const resumes = ctx.moveTo.mock.calls.some(
+        ([x, y]: [number, number]) => x === 0 && Math.abs(y - 10) < 1e-6
+      );
+      expect(resumes).toBe(true);
     });
   });
 

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -20,9 +20,14 @@ import {
   isGroup,
 } from '../shapes/Shape';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
-import { normalizeAutoColorsForExport, preResolveAutoColors } from '../engine/ContrastResolver';
+import { ContrastCache, normalizeAutoColorsForExport, preResolveAutoColors } from '../engine/ContrastResolver';
+import { setRenderContext, type RenderContext } from '../engine/RenderContext';
 import { calculateCombinedBounds } from '../shapes/utils/bounds';
-import { getConnectorStartPoint, getConnectorEndPoint } from '../shapes/Connector';
+import {
+  getConnectorStartPoint,
+  getConnectorEndPoint,
+  collectConnectorLabelGapBoxes,
+} from '../shapes/Connector';
 import { groupHandler } from '../shapes/Group';
 import type { GroupLabelPosition } from '../shapes/GroupStyles';
 
@@ -308,9 +313,41 @@ export async function exportToPng(
     // Get shapes to render
     const shapes = getShapesToExport(resolvedData, options.scope);
 
-    // Render shapes in z-order
-    for (const shape of shapes) {
-      renderShapeForExport(ctx, shape, resolvedData.shapes, 1, options.flattenGroups);
+    // Publish a render context so connectors clip their endpoints and break
+    // their lines at every connector label box — and so the deferred label
+    // overlay runs at all — exactly as the on-canvas renderer does (JP-353).
+    const exportContext = {
+      shapes: resolvedData.shapes,
+      shapeOrder: Object.keys(resolvedData.shapes),
+      pageBackground: background ?? '#ffffff',
+      contrastCache: new ContrastCache(),
+    };
+    setRenderContext(exportContext);
+    try {
+      (exportContext as RenderContext).connectorLabelGapBoxes = collectConnectorLabelGapBoxes(
+        ctx,
+        resolvedData.shapes
+      );
+
+      // Pass 1: render bodies in z-order, collecting deferred overlays
+      // (connector labels) so they can be drawn on top afterwards.
+      const overlays: Shape[] = [];
+      for (const shape of shapes) {
+        renderShapeForExport(ctx, shape, resolvedData.shapes, 1, options.flattenGroups, overlays);
+      }
+
+      // Pass 2: deferred overlays (connector labels) on top of all bodies.
+      // Without this, connector labels are missing from PNG export entirely.
+      for (const shape of overlays) {
+        const handler = shapeRegistry.getHandler(shape.type);
+        if (handler?.renderOverlay) {
+          ctx.save();
+          handler.renderOverlay(ctx, shape);
+          ctx.restore();
+        }
+      }
+    } finally {
+      setRenderContext(null);
     }
 
     // Convert to blob and cleanup
@@ -345,7 +382,8 @@ function renderShapeForExport(
   shape: Shape,
   allShapes: Record<string, Shape>,
   parentOpacity: number,
-  flattenGroups?: boolean
+  flattenGroups?: boolean,
+  overlays?: Shape[]
 ): void {
   if (!shape.visible) return;
 
@@ -364,7 +402,7 @@ function renderShapeForExport(
     for (const childId of shape.childIds) {
       const child = allShapes[childId];
       if (child) {
-        renderShapeForExport(ctx, child, allShapes, effectiveOpacity, flattenGroups);
+        renderShapeForExport(ctx, child, allShapes, effectiveOpacity, flattenGroups, overlays);
       }
     }
 
@@ -385,6 +423,9 @@ function renderShapeForExport(
       renderUnknownShapeFallback(ctx, shape);
     }
     ctx.restore();
+    // Defer overlay-capable shapes (e.g. connector labels) to a top pass so
+    // they are not buried — and so they appear in PNG export at all (JP-353).
+    if (overlays && handler?.renderOverlay) overlays.push(shape);
   }
 }
 


### PR DESCRIPTION
## Problem (JP-353)

Connector labels were **buried when connectors overlap**, and the line of *another* connector would draw straight through a label's text. The renderer drew each connector's line + label inline in z-order, and a label only "cut" a gap in **its own** line — so a crossing connector's line clobbered the text.

Separately, **PNG export rendered no connector labels at all**.

## Fix

**1. Deferred label overlay pass**
- New optional `renderOverlay?(ctx, shape)` hook on `ShapeHandler` (a deferred top pass, mirroring the group-label deferral).
- Connector label draw moved from `render` into `renderOverlay`. `Renderer.drawShapes` collects overlay-capable shapes during the z-order pass (top-level **and** group children, resolving AUTO colours once) and draws them after all bodies → labels are never buried.

**2. Labels break *all* crossing connectors (the core of JP-353)**
- Each connector now breaks its line at **every** connector label box in the frame, not just its own — so no line is ever drawn through any label's text.
- The renderer/exporter collects all no-pill label boxes once per frame (`collectConnectorLabelGapBoxes`) and publishes them on the render context (`connectorLabelGapBoxes`). `strokeSegmentWithGap` → `strokeSegmentWithGaps` (merges intervals, strokes the complement).
- `resolveConnectorPoints` gains a per-frame points cache (keyed to the render-context object) so the now-triple resolution — gap-box collect, line draw, label overlay — computes once per connector.

**3. PNG export connector labels**
- `exportToPng` called `handler.render` directly and never `renderOverlay`, so labels were missing. It now sets a render context (connectors clip endpoints + break at label boxes, matching on-canvas) and runs the deferred overlay pass after the bodies.

The own-line "cut" semantics are preserved; pill-backed labels still rely on the pill (drawn on top in the overlay) rather than a gap.

## Tests
- `Connector.test.ts`: label drawn via `renderOverlay` (not `render`); a connector breaks its line at a **foreign** label box published on the context; JP-303 own-line gap tests unchanged.
- `Renderer.test.ts`: ordering test — every body `stroke` before any label `fillText`.
- `exportUtils.test.ts`: PNG export draws the connector label text (regression); a crossing line breaks at another connector's label box.
- `bun run typecheck` clean; full suite (2522 tests) green.

## Follow-up
JP-352 (SVG-export label collision-avoidance / nudging) is a separate code path and ships on its own branch. SVG export keeps its legibility halo in the meantime.

Assisted-by: Opus 4.8