### PR TITLE
Publish local cursor + selection to collab awareness (canvas presence)

### DIFF
--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -14,6 +14,7 @@ import { useHistoryStore } from '../store/historyStore';
 import { useThemeStore } from '../store/themeStore';
 import { useSessionStore } from '../store/sessionStore';
 import { useSettingsStore } from '../store/settingsStore';
+import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
@@ -148,6 +149,41 @@ export function CanvasContainer({
       engineRef.current = null;
     };
   }, []); // Only run on mount/unmount
+
+  /**
+   * Publish the local cursor to collaboration awareness on pointer move (JP/
+   * awareness local-publish — the one wire that was never connected, so remote
+   * peers never saw each other's cursors). The store throttles the broadcast and
+   * gates on an active collab session; we only convert screen→world here.
+   */
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const handlePointerMove = (e: PointerEvent) => {
+      const engine = engineRef.current;
+      if (!engine || !useCollaborationStore.getState().isActive) return;
+      const rect = canvas.getBoundingClientRect();
+      const world = engine.camera.screenToWorld(
+        new Vec2(e.clientX - rect.left, e.clientY - rect.top)
+      );
+      useCollaborationStore.getState().updateCursor(world.x, world.y);
+    };
+
+    canvas.addEventListener('pointermove', handlePointerMove);
+    return () => canvas.removeEventListener('pointermove', handlePointerMove);
+  }, []);
+
+  /**
+   * Publish the local selection to collaboration awareness whenever it changes
+   * (so remote peers see what this user has selected). Store-gated on an active
+   * collab session.
+   */
+  const selectedIds = useSessionStore((state) => state.selectedIds);
+  useEffect(() => {
+    if (!useCollaborationStore.getState().isActive) return;
+    useCollaborationStore.getState().updateSelection([...selectedIds]);
+  }, [selectedIds]);
 
   /**
    * Update renderer options when props change.

--- a/src/ui/CollaborativeCursors.tsx
+++ b/src/ui/CollaborativeCursors.tsx
@@ -40,9 +40,13 @@ function Cursor({ user, cameraX, cameraY, cameraZoom, containerWidth, containerH
 
   const color = user.color || getUserColor(user.userId);
 
-  // Transform world coordinates to screen coordinates
-  const screenX = (user.cursor.x - cameraX) * cameraZoom;
-  const screenY = (user.cursor.y - cameraY) * cameraZoom;
+  // Transform world → screen. Must mirror Camera.worldToScreen exactly (the
+  // inverse of the screenToWorld used to capture the cursor): screen = viewport
+  // center + (world − camera) * zoom. The container size IS the camera viewport,
+  // so its half is the center offset. (Omitting this term shifted every remote
+  // cursor by half the viewport — the off-by-half-screen bug.)
+  const screenX = containerWidth / 2 + (user.cursor.x - cameraX) * cameraZoom;
+  const screenY = containerHeight / 2 + (user.cursor.y - cameraY) * cameraZoom;
 
   // Skip if cursor is off-screen (with some margin)
   if (screenX < -50 || screenY < -50) return null;


### PR DESCRIPTION
## Problem
Remote collaborators' cursors haven't shown on the canvas since the *Diagrammer* era. An audit found the awareness pipeline is **5/6 wired and working** — encode/transport (`UnifiedSyncProvider.sendAwarenessUpdate`), relay rebroadcast (`relay handle_awareness`), remote consume (`collaborationStore._updateRemoteUsers` → `presenceStore`), and the `CollaborativeCursors` overlay (mounted in `CanvasContainer`) are all live. **The one dead link was local publish:** nothing ever called `collaborationStore.updateCursor()/updateSelection()`, so the local cursor/selection was never broadcast → everyone's overlay was starved.

## Fix
Reconnect the wire from `CanvasContainer`:
- **pointermove** → `updateCursor(worldX, worldY)` (screen→world via `engine.camera`). The store already **throttles** the broadcast and **gates on an active collab session**, so we only do the coordinate conversion here.
- **selection change** → `updateSelection([...selectedIds])`.

Both are no-ops outside an active collaboration session.

## Verify
- In-repo: `bun run typecheck` + full suite (2517) green.
- **End-to-end (needs your two-client check):** open the same relay doc in two sessions → moving one cursor renders a live remote cursor + name label on the other; selecting shapes shows the remote selection.

Assisted-by: Opus 4.8