### PR TITLE
Collaborative carets in the prose editor (CollaborationCursor)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@tiptap/core": "^2.1.0",
         "@tiptap/extension-code-block-lowlight": "^2",
         "@tiptap/extension-collaboration": "2.27.1",
+        "@tiptap/extension-collaboration-cursor": "^2.26.2",
         "@tiptap/extension-color": "^2.1.0",
         "@tiptap/extension-highlight": "^2.1.0",
         "@tiptap/extension-image": "^2.1.0",
@@ -546,6 +547,8 @@
     "@tiptap/extension-code-block-lowlight": ["@tiptap/extension-code-block-lowlight@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/extension-code-block": "^2.7.0", "@tiptap/pm": "^2.7.0", "highlight.js": "^11", "lowlight": "^2 || ^3" } }, "sha512-v6NKStBbQ/XCc1NnCi3ObsL1DsxadSIBtUQNA/B+urkPgn5LEy72HAGlf0xwjRaNkAGSaTASLKmc84L5q5zlGQ=="],
 
     "@tiptap/extension-collaboration": ["@tiptap/extension-collaboration@2.27.1", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0", "y-prosemirror": "^1.2.11" } }, "sha512-fR35dIYDHM9870zl2sHaA2ytSVcjASv8Nfnb1Mgslt/F3Lqsu9TOv/oJWi9nYBvjjrfK0RNaoGFVH7p2z7FR3w=="],
+
+    "@tiptap/extension-collaboration-cursor": ["@tiptap/extension-collaboration-cursor@2.26.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "y-prosemirror": "^1.2.11" } }, "sha512-FdRb27mZ5Kr18hN6cbfBj1e9F0DOoHB1Gv3IYeic+g4h1C9BjDVMN0+JRBQc+4lamNA8TsHO0oKWRwaPe4sSlA=="],
 
     "@tiptap/extension-color": ["@tiptap/extension-color@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/extension-text-style": "^2.7.0" } }, "sha512-sOKCP8/2V3sRM3FdWgMe1lFE5ewsWNCRafiVoujS1+TTHGCj4jw6W+LiumBUk7cRI8kXW/rqGWVC4RVdknYUCA=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tiptap/core": "^2.1.0",
     "@tiptap/extension-code-block-lowlight": "^2",
     "@tiptap/extension-collaboration": "2.27.1",
+    "@tiptap/extension-collaboration-cursor": "^2.26.2",
     "@tiptap/extension-color": "^2.1.0",
     "@tiptap/extension-highlight": "^2.1.0",
     "@tiptap/extension-image": "^2.1.0",

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -27,13 +27,17 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import type { Editor } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import Collaboration from '@tiptap/extension-collaboration';
+import CollaborationCursor from '@tiptap/extension-collaboration-cursor';
 import type { Doc as YDoc } from 'yjs';
+import type { Awareness } from 'y-protocols/awareness';
+import type { AnyExtension } from '@tiptap/core';
 import { sharedProseExtensions } from './TiptapEditor';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { useRichTextStore } from '../store/richTextStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import './TiptapEditor.css';
+import './collaborationCursor.css';
 
 export interface CollaborativeProseEditorProps {
   /** Shared collaboration Y.Doc (from `collaborationStore.getYjsDocument()`). */
@@ -44,6 +48,17 @@ export interface CollaborativeProseEditorProps {
   pageId: string;
   /** Optional class name. */
   className?: string;
+  /**
+   * Live Yjs awareness (from `getSyncProvider()?.getAwareness()`). When present
+   * with `user`, remote collaborators' carets render in the prose via
+   * CollaborationCursor. Shares the awareness channel with canvas presence — the
+   * caret state lives in the top-level `cursor` field; canvas cursors live under
+   * `user.cursor`, so they coexist (the shared `user` name/color is the same
+   * identity). Null offline / before the provider connects → no carets.
+   */
+  awareness?: Awareness | null;
+  /** Local user identity for the caret label (from presence `localUser`). */
+  user?: { name: string; color: string } | null;
   /** Editor instance callback (the panel keeps it for autosave/toolbar). The
    *  `pageId` lets the panel pair the editor with its page (JP-334). */
   onEditorReady?: (editor: Editor | null, pageId: string | null) => void;
@@ -54,8 +69,18 @@ export function CollaborativeProseEditor({
   field,
   pageId,
   className,
+  awareness,
+  user,
   onEditorReady,
 }: CollaborativeProseEditorProps) {
+  // Remote-caret extension, added only when an awareness channel + identity are
+  // available (i.e. an active collab session). y-prosemirror stores the caret in
+  // the awareness `cursor` field — disjoint from the canvas `user.cursor`.
+  const collaborationCursor: AnyExtension[] =
+    awareness && user
+      ? [CollaborationCursor.configure({ provider: { awareness }, user })]
+      : [];
+
   const editor = useEditor(
     {
       extensions: [
@@ -68,6 +93,7 @@ export function CollaborativeProseEditor({
         }),
         ...sharedProseExtensions,
         Collaboration.configure({ document: ydoc, field }),
+        ...collaborationCursor,
       ],
       // No initial `content`: the relay is the sole prose seeder (JP-284), so the
       // editor adopts the bound fragment. Passing content would inject a second
@@ -93,7 +119,9 @@ export function CollaborativeProseEditor({
     },
     // Rebind when the bound fragment changes (page/doc switch via the key also
     // remounts, but this keeps the editor correct if props change in place).
-    [ydoc, field],
+    // `awareness` is included so the editor picks up CollaborationCursor once the
+    // provider connects (it may be null on first mount when offline-first).
+    [ydoc, field, awareness],
   );
 
   // Shared editor chrome: right-click formatting menu, spellcheck popover,

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -23,6 +23,7 @@ import { useSessionStore } from '../store/sessionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
+import { usePresenceStore } from '../store/presenceStore';
 import { shouldPersistLeavingPage } from './proseLeavingPageGuard';
 import { CollaborativeProseEditor } from './CollaborativeProseEditor';
 import { ProseErrorBoundary } from './ProseErrorBoundary';
@@ -120,6 +121,8 @@ export function DocumentEditorPanel({
   const collabSessionEpoch = useCollaborationStore((s) => s.sessionEpoch);
   const collabDocId = useCollaborationStore((s) => s.config?.documentId ?? null);
   const getYjsDocument = useCollaborationStore((s) => s.getYjsDocument);
+  const getSyncProvider = useCollaborationStore((s) => s.getSyncProvider);
+  const localUser = usePresenceStore((s) => s.localUser);
   const currentDocId = usePersistenceStore((s) => s.currentDocumentId);
 
   // Relay-backed doc → collab editor; local-only → legacy editor. An active
@@ -136,6 +139,10 @@ export function DocumentEditorPanel({
   const engineReady =
     collabActive && collabIdbSynced && !!currentDocId && currentDocId === collabDocId;
   const collabYdoc = engineReady ? getYjsDocument()?.getDoc() ?? null : null;
+  // Awareness + identity for live prose carets (CollaborationCursor). Shares the
+  // awareness channel with canvas presence; null until the provider connects.
+  const collabAwareness = engineReady ? getSyncProvider()?.getAwareness() ?? null : null;
+  const collabUser = localUser ? { name: localUser.name, color: localUser.color } : null;
   const proseField = activePageId ? `prose:${activePageId}` : null;
   // Whether the fragment is the *established truth*. Use `getXmlFragment` (not
   // `share.get`) so it reflects content reliably even before the editor has
@@ -569,6 +576,8 @@ export function DocumentEditorPanel({
                 ydoc={collabYdoc!}
                 field={proseField!}
                 pageId={activePageId!}
+                awareness={collabAwareness}
+                user={collabUser}
                 onEditorReady={handleEditorReady}
               />
             ) : (

--- a/src/ui/collaborationCursor.css
+++ b/src/ui/collaborationCursor.css
@@ -1,0 +1,28 @@
+/* Remote collaborator carets in the prose editor (CollaborationCursor).
+ * The extension's default builder sets the per-user colour inline (caret border
+ * + label background); this provides layout only. */
+
+.collaboration-cursor__caret {
+  border-left: 1px solid #0d0d0d;
+  border-right: 1px solid #0d0d0d;
+  margin-left: -1px;
+  margin-right: -1px;
+  pointer-events: none;
+  position: relative;
+  word-break: normal;
+}
+
+.collaboration-cursor__label {
+  border-radius: 3px 3px 3px 0;
+  color: #0d0d0d;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 600;
+  left: -1px;
+  line-height: normal;
+  padding: 0.1rem 0.3rem;
+  position: absolute;
+  top: -1.4em;
+  user-select: none;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## What
Live remote-collaborator carets in the prose editor via `@tiptap/extension-collaboration-cursor`, reusing the existing Yjs awareness channel (now that local publish is wired in #274) and the presence identity for a single consistent name/color.

## How
- `DocumentEditorPanel` passes the live awareness (`getSyncProvider()?.getAwareness()`) + `localUser` `{name,color}` to `CollaborativeProseEditor`.
- The editor adds `CollaborationCursor` **only when both awareness + user are present** (an active collab session), and lists `awareness` in the `useEditor` deps so it picks up carets once the provider connects (offline-first case).
- **Coexistence with canvas presence (#5):** the prose caret state lives in the top-level awareness `cursor` field; canvas cursors live under `user.cursor`. The shared `user` name/color is the same identity, and canvas `updateCursor` spreads the existing `user`, so prose carets and canvas cursors don't clobber each other.
- `collaborationCursor.css` provides caret/label layout (per-user colour is set inline by the extension's default builder).

## Verify
- In-repo: `bun run typecheck` + full suite (2517) green.
- **Two-client (needs your check), on a shared relay doc:** each session sees the other's caret + name label move in the prose pane; **and** canvas cursors (from #274) still work — test the two together since they share the awareness channel.

Depends on #274 (awareness local publish). Assisted-by: Opus 4.8