### PR TITLE
Keep canvas keyboard focus on unbound keys (#4 focus isolation)

### DIFF
--- a/src/engine/InputHandler.test.ts
+++ b/src/engine/InputHandler.test.ts
@@ -28,6 +28,7 @@ function createMockCanvas(): MockCanvas {
     setPointerCapture: vi.fn(),
     releasePointerCapture: vi.fn(),
     focus: vi.fn(),
+    blur: vi.fn(),
     getBoundingClientRect: vi.fn(() => ({
       left: 0,
       top: 0,
@@ -741,6 +742,58 @@ describe('InputHandler', () => {
       // a normal pointer move; the camera is untouched.
       expect(camera.x).toBe(startX);
       expect(camera.y).toBe(startY);
+    });
+  });
+
+  describe('keyboard focus isolation (#4)', () => {
+    // Pretend the canvas is the focused element (the keydown listener only fires
+    // on it when it is, but the handler also asserts activeElement).
+    beforeEach(() => {
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => canvas,
+      });
+    });
+    afterEach(() => {
+      delete (document as unknown as { activeElement?: unknown }).activeElement;
+    });
+
+    function keydown(key: string, mods: Partial<KeyboardEventInit> = {}): KeyboardEvent {
+      // Real keydown events are cancelable — required for defaultPrevented to flip.
+      const e = new KeyboardEvent('keydown', { key, cancelable: true, ...mods });
+      vi.spyOn(e, 'preventDefault');
+      canvas._dispatch('keydown', e);
+      return e;
+    }
+
+    it('swallows an un-consumed bare key so canvas keeps focus', () => {
+      // keyCallback (the engine) does not preventDefault → key is "unbound".
+      const e = keydown('x');
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(canvas.blur).not.toHaveBeenCalled();
+    });
+
+    it('swallows Tab so focus does not move out of the canvas', () => {
+      const e = keydown('Tab');
+      expect(e.preventDefault).toHaveBeenCalled();
+    });
+
+    it('does NOT swallow a key a handler already consumed (preventDefault)', () => {
+      keyCallback.mockImplementationOnce((ev: KeyboardEvent) => ev.preventDefault());
+      const e = keydown('ArrowUp'); // e.g. a pan key the engine consumes
+      // preventDefault was called once (by the handler), not a second time here.
+      expect((e.preventDefault as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    });
+
+    it('leaves Ctrl/Meta combos alone so global/browser shortcuts still fire', () => {
+      const e = keydown('k', { ctrlKey: true });
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('Escape with nothing to consume blurs the canvas (accessible exit)', () => {
+      const e = keydown('Escape');
+      expect(canvas.blur).toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/engine/InputHandler.ts
+++ b/src/engine/InputHandler.ts
@@ -411,6 +411,24 @@ export class InputHandler {
   private handleKeyDown(e: KeyboardEvent): void {
     if (this.destroyed) return;
     this.onKeyEvent(e);
+
+    // Keep keyboard focus on the canvas. The handler chain above calls
+    // preventDefault() on keys it consumes, so an un-prevented bare key here is
+    // "unbound" — and its browser default (Tab/Space/"/" etc.) would move focus
+    // to the next focusable element. In split layouts that's the prose editor,
+    // so the keystroke leaks into the document (JP focus-isolation). Swallow
+    // un-consumed bare keys so focus stays on the canvas. Real browser/OS combos
+    // (Ctrl/Meta/Alt) are left alone. Escape with nothing left to consume is the
+    // deliberate, accessible way out: blur the canvas so keyboard-only users are
+    // not trapped (this is last in the Escape precedence — selection-clear and
+    // tool-cancel run inside onKeyEvent and preventDefault first).
+    if (e.defaultPrevented || e.ctrlKey || e.metaKey || e.altKey) return;
+    if (document.activeElement !== this.canvas) return;
+    if (e.key === 'Escape') {
+      this.canvas.blur();
+      return;
+    }
+    e.preventDefault();
   }
 
   /**


### PR DESCRIPTION
## Problem
In split layouts, pressing an **unbound key** while the canvas was focused let the browser's default action (**Tab** especially — the canvas has `tabIndex=0` — plus `/`, Space, …) move focus to the next focusable element, which is the **prose contenteditable**. Keystrokes then leaked into the document. Root cause: the canvas keydown chain never `preventDefault()`s keys it doesn't consume.

## Fix
At the canvas keydown boundary (`InputHandler.handleKeyDown`): the handler chain already `preventDefault()`s keys it consumes, so an **un-prevented bare key is "unbound"**. When `document.activeElement === canvas` and there's **no Ctrl/Meta/Alt**, swallow it (`preventDefault`) so focus stays on the canvas. Real browser/OS combos pass through untouched.

**Accessibility:** `Escape` with nothing left to consume **blurs the canvas** — a deliberate keyboard exit so users aren't trapped. It's last in the Escape precedence (selection-clear / tool-cancel run first inside the handler and `preventDefault`, so this only fires when nothing else consumed Esc).

## Tests
5 new cases in `InputHandler.test.ts`: swallows a bare key + Tab; does not double-handle an already-consumed key; leaves Ctrl combos alone; Escape blurs. `bun run typecheck` + full suite (2522) green.

## Notes
This is the targeted fix (shipping first). A follow-up PR unifies all keyboard dispatch into a central registry and folds this preventDefault discipline into the canvas-scope dispatcher.

Assisted-by: Opus 4.8