### PR TITLE
Keyboard-shortcut registry + dispatch unification + hardening

### DIFF
--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -10,7 +10,9 @@ import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore, pushHistory } from '../store/historyStore';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
-import type { RectangleShape } from '../shapes/Shape';
+import { isGroup, type RectangleShape } from '../shapes/Shape';
+import { useWhiteboardStore } from '../store/whiteboardStore';
+import { opener } from '../platform/opener';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
 import { alignHorizontal, alignVertical, distribute } from '../shapes/utils/alignment';
@@ -226,19 +228,70 @@ function buildCommands(): Command[] {
     // --- View ---
     { id: 'view.zoomIn', label: 'Zoom in', category: 'Navigation', keys: 'E', scope: 'canvas', reserved: true, execute: () => {} },
     { id: 'view.zoomOut', label: 'Zoom out', category: 'Navigation', keys: 'Q', scope: 'canvas', reserved: true, execute: () => {} },
-    { id: 'view.toggleWhiteboard', label: 'Toggle whiteboard (Ideas)', category: 'View', keys: 'Mod+I', scope: 'global', reserved: true, execute: () => {} },
 
-    // --- Reference-only rows for the shortcut help panel (dispatched by other
-    // machinery or pure reference; hidden from the palette). ---
-    { id: 'ref.pan', label: 'Pan canvas', category: 'Navigation', keys: 'W', scope: 'canvas', reserved: true, execute: () => {}, },
+    // --- Clipboard + grouping (canvas scope). Copy/paste are engine-coupled
+    // (clipboard + spatial index) so they bridge to the engine via an event;
+    // group/ungroup are pure store ops and run directly. ---
+    {
+      id: 'edit.copy', label: 'Copy', category: 'Editing', keys: 'Mod+C', scope: 'canvas',
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:copy-shapes')),
+      canExecute: () => useSessionStore.getState().hasSelection(),
+    },
+    {
+      id: 'edit.paste', label: 'Paste', category: 'Editing', keys: 'Mod+V', scope: 'canvas',
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:paste-shapes')),
+    },
+    {
+      id: 'edit.group', label: 'Group selected shapes', category: 'Editing', keys: 'Mod+G', scope: 'canvas',
+      execute: () => {
+        const ids = useSessionStore.getState().getSelectedIds();
+        if (ids.length < 2) return;
+        pushHistory('Group shapes');
+        const groupId = nanoid();
+        useDocumentStore.getState().groupShapes(ids, groupId);
+        useSessionStore.getState().select([groupId]);
+      },
+      canExecute: () => getSelectedShapes().length >= 2,
+    },
+    {
+      id: 'edit.ungroup', label: 'Ungroup', category: 'Editing', keys: 'Mod+Shift+G', scope: 'canvas',
+      execute: () => {
+        const ids = useSessionStore.getState().getSelectedIds();
+        if (ids.length !== 1) return;
+        const shape = useDocumentStore.getState().shapes[ids[0]!];
+        if (!shape || !isGroup(shape)) return;
+        pushHistory('Ungroup shapes');
+        const childIds = [...shape.childIds];
+        useDocumentStore.getState().ungroupShape(shape.id);
+        useSessionStore.getState().select(childIds);
+      },
+    },
+
+    // --- View / app (global scope) ---
+    {
+      id: 'view.toggleWhiteboard', label: 'Toggle whiteboard (Ideas)', category: 'View', keys: 'Mod+I', scope: 'global',
+      execute: () => useWhiteboardStore.getState().toggleVisibility(),
+    },
+    {
+      id: 'view.commandPalette', label: 'Command palette', category: 'View', keys: 'Mod+K', scope: 'global', whileTyping: true,
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:toggle-command-palette')),
+    },
+    {
+      // Shape search; suppressed while typing so the prose find (Ctrl+F in the
+      // editor) wins when the editor is focused.
+      id: 'view.searchShapes', label: 'Search shapes', category: 'View', keys: 'Mod+F', scope: 'global',
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:toggle-search')),
+    },
+    {
+      id: 'view.docs', label: 'Open documentation', category: 'View', keys: 'F1', scope: 'global', whileTyping: true,
+      execute: () => { void opener.openDocs(); },
+    },
+
+    // --- Reference-only rows for the help panel (dispatched by other machinery
+    // or pure reference; hidden from the palette). ---
+    { id: 'ref.pan', label: 'Pan canvas', category: 'Navigation', keys: 'W', scope: 'canvas', reserved: true, execute: () => {} },
     { id: 'ref.nudge', label: 'Nudge shapes / pan', category: 'Navigation', keys: 'ArrowUp', scope: 'canvas', reserved: true, execute: () => {} },
     { id: 'ref.scroll', label: 'Zoom at cursor', category: 'Navigation', shortcut: 'Scroll', reserved: true, execute: () => {} },
-    { id: 'ref.copy', label: 'Copy', category: 'Editing', keys: 'Mod+C', scope: 'canvas', reserved: true, execute: () => {} },
-    { id: 'ref.paste', label: 'Paste', category: 'Editing', keys: 'Mod+V', scope: 'canvas', reserved: true, execute: () => {} },
-    { id: 'ref.group', label: 'Group selected shapes', category: 'Editing', keys: 'Mod+G', scope: 'canvas', reserved: true, execute: () => {} },
-    { id: 'ref.ungroup', label: 'Ungroup', category: 'Editing', keys: 'Mod+Shift+G', scope: 'canvas', reserved: true, execute: () => {} },
-    { id: 'ref.commandPalette', label: 'Command palette', category: 'View', keys: 'Mod+K', scope: 'global', whileTyping: true, reserved: true, execute: () => {} },
-    { id: 'ref.searchShapes', label: 'Search shapes', category: 'View', keys: 'Mod+F', scope: 'global', reserved: true, execute: () => {} },
     { id: 'ref.help', label: 'Keyboard shortcuts', category: 'View', keys: 'Shift+/', scope: 'global', reserved: true, execute: () => {} },
 
     // --- Layouts ---

--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -23,6 +23,7 @@ import {
 import type { ShortcutCategory } from './KeyboardShortcuts';
 import { LAYOUT_LABELS } from '../ui/layout/modes';
 import { LAYOUT_MODES, type LayoutMode } from '../ui/layout/types';
+import { parseCombo, eventMatchesAny, formatCombo, type KeyScope } from './keybindings';
 
 export interface Command {
   /** Unique identifier */
@@ -31,11 +32,31 @@ export interface Command {
   label: string;
   /** Category for grouping */
   category: ShortcutCategory;
-  /** Keyboard shortcut hint (display only) */
+  /**
+   * Binding spec — the single source of truth for this command's shortcut, e.g.
+   * `"Mod+Shift+L"` or `"Delete | Backspace"` (`Mod` = ⌘/Ctrl per platform).
+   * The display hint (`shortcut`) is derived from this; don't set both by hand.
+   */
+  keys?: string;
+  /** Where the binding is active / dispatched (default `'global'`). */
+  scope?: KeyScope;
+  /** For `global` bindings: also fire while an input/contenteditable is focused. Default false. */
+  whileTyping?: boolean;
+  /**
+   * Documented for the shortcut help panel but NOT an executable palette action
+   * — dispatched by other machinery (ToolManager, the pan/zoom handler) or pure
+   * reference (scroll wheel). Hidden from the command palette; `dispatchKey`
+   * never runs it.
+   */
+  reserved?: boolean;
+  /**
+   * Keyboard shortcut hint (display only). DERIVED from `keys` at build time —
+   * only set directly for a command with no real binding.
+   */
   shortcut?: string;
   /** Execute the command. Returns true if handled. */
   execute: () => void;
-  /** Optional guard — hide command when it returns false */
+  /** Optional guard — hide command when it returns false / skip dispatch. */
   canExecute?: () => boolean;
 }
 
@@ -120,16 +141,16 @@ export function createIconShapeAtCenter(iconId: string): void {
 // ---------------------------------------------------------------------------
 // All commands
 // ---------------------------------------------------------------------------
-export function getAllCommands(): Command[] {
+function buildCommands(): Command[] {
   return [
-    // --- Tools (activate draw mode) ---
-    { id: 'tool.select', label: 'Select tool', category: 'Tools', shortcut: 'V', execute: () => useSessionStore.getState().setActiveTool('select') },
-    { id: 'tool.rectangle', label: 'Rectangle tool', category: 'Tools', shortcut: 'R', execute: () => useSessionStore.getState().setActiveTool('rectangle') },
-    { id: 'tool.ellipse', label: 'Ellipse tool', category: 'Tools', shortcut: 'O', execute: () => useSessionStore.getState().setActiveTool('ellipse') },
-    { id: 'tool.line', label: 'Line tool', category: 'Tools', shortcut: 'L', execute: () => useSessionStore.getState().setActiveTool('line') },
-    { id: 'tool.text', label: 'Text tool', category: 'Tools', shortcut: 'T', execute: () => useSessionStore.getState().setActiveTool('text') },
-    { id: 'tool.connector', label: 'Connector tool', category: 'Tools', shortcut: 'C', execute: () => useSessionStore.getState().setActiveTool('connector') },
-    { id: 'tool.pan', label: 'Pan (Hand) tool', category: 'Tools', shortcut: 'H', execute: () => useSessionStore.getState().setActiveTool('pan') },
+    // --- Tools (activate draw mode) --- dispatched by ToolManager (scope 'reserved').
+    { id: 'tool.select', label: 'Select tool', category: 'Tools', keys: 'V', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('select') },
+    { id: 'tool.rectangle', label: 'Rectangle tool', category: 'Tools', keys: 'R', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('rectangle') },
+    { id: 'tool.ellipse', label: 'Ellipse tool', category: 'Tools', keys: 'O', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('ellipse') },
+    { id: 'tool.line', label: 'Line tool', category: 'Tools', keys: 'L', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('line') },
+    { id: 'tool.text', label: 'Text tool', category: 'Tools', keys: 'T', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('text') },
+    { id: 'tool.connector', label: 'Connector tool', category: 'Tools', keys: 'C', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('connector') },
+    { id: 'tool.pan', label: 'Pan (Hand) tool', category: 'Tools', keys: 'H', scope: 'canvas', reserved: true, execute: () => useSessionStore.getState().setActiveTool('pan') },
 
     // --- Add shape (instant create at viewport center) ---
     { id: 'add.rectangle', label: 'Add rectangle', category: 'Editing', execute: () => createShapeAtCenter('rectangle') },
@@ -152,27 +173,27 @@ export function getAllCommands(): Command[] {
       id: 'view.documents',
       label: 'Go to Documents',
       category: 'File',
-      shortcut: 'Ctrl+Shift+O',
+      keys: 'Mod+Shift+O', scope: 'global', whileTyping: true,
       // The palette can't reach React state; App listens for this event.
       execute: () => window.dispatchEvent(new CustomEvent('docushark:open-documents')),
     },
 
-    // --- Editing ---
+    // --- Editing (canvas scope — active when the canvas owns focus) ---
     {
-      id: 'edit.undo', label: 'Undo', category: 'Editing', shortcut: 'Ctrl+Z',
+      id: 'edit.undo', label: 'Undo', category: 'Editing', keys: 'Mod+Z', scope: 'canvas',
       execute: () => { if (useHistoryStore.getState().canUndo()) useHistoryStore.getState().undo(); },
     },
     {
-      id: 'edit.redo', label: 'Redo', category: 'Editing', shortcut: 'Ctrl+Shift+Z',
+      id: 'edit.redo', label: 'Redo', category: 'Editing', keys: 'Mod+Shift+Z | Mod+Y', scope: 'canvas',
       execute: () => { if (useHistoryStore.getState().canRedo()) useHistoryStore.getState().redo(); },
     },
-    { id: 'edit.selectAll', label: 'Select all', category: 'Editing', shortcut: 'Ctrl+A', execute: () => useSessionStore.getState().selectAll() },
+    { id: 'edit.selectAll', label: 'Select all', category: 'Editing', keys: 'Mod+A', scope: 'canvas', execute: () => useSessionStore.getState().selectAll() },
     {
-      id: 'edit.delete', label: 'Delete selected', category: 'Editing', shortcut: 'Del',
+      id: 'edit.delete', label: 'Delete selected', category: 'Editing', keys: 'Delete | Backspace', scope: 'canvas',
       execute: () => { pushHistory('Delete shapes'); deleteSelected(); },
       canExecute: () => useSessionStore.getState().hasSelection(),
     },
-    { id: 'edit.clearSelection', label: 'Clear selection', category: 'Editing', shortcut: 'Esc', execute: () => useSessionStore.getState().clearSelection() },
+    { id: 'edit.clearSelection', label: 'Clear selection', category: 'Editing', keys: 'Escape', scope: 'canvas', execute: () => useSessionStore.getState().clearSelection() },
 
     // --- Alignment ---
     ...alignmentCommands(),
@@ -182,7 +203,7 @@ export function getAllCommands(): Command[] {
       id: 'arrange.selectConnected',
       label: 'Select connected shapes',
       category: 'Editing',
-      shortcut: 'Ctrl+Shift+A',
+      keys: 'Mod+Shift+A', scope: 'canvas',
       execute: () => selectConnectedChain(),
       canExecute: canSelectConnectedChain,
     },
@@ -190,7 +211,7 @@ export function getAllCommands(): Command[] {
       id: 'arrange.autoLayoutTB',
       label: 'Auto-layout selection (top to bottom)',
       category: 'Editing',
-      shortcut: 'Ctrl+Shift+L',
+      keys: 'Mod+Shift+L', scope: 'canvas',
       execute: () => autoLayoutSelection('TB'),
       canExecute: canAutoLayoutSelection,
     },
@@ -203,8 +224,22 @@ export function getAllCommands(): Command[] {
     },
 
     // --- View ---
-    { id: 'view.zoomIn', label: 'Zoom in', category: 'Navigation', shortcut: 'E', execute: () => { /* dispatched via Engine key handler */ } },
-    { id: 'view.zoomOut', label: 'Zoom out', category: 'Navigation', shortcut: 'Q', execute: () => { /* dispatched via Engine key handler */ } },
+    { id: 'view.zoomIn', label: 'Zoom in', category: 'Navigation', keys: 'E', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'view.zoomOut', label: 'Zoom out', category: 'Navigation', keys: 'Q', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'view.toggleWhiteboard', label: 'Toggle whiteboard (Ideas)', category: 'View', keys: 'Mod+I', scope: 'global', reserved: true, execute: () => {} },
+
+    // --- Reference-only rows for the shortcut help panel (dispatched by other
+    // machinery or pure reference; hidden from the palette). ---
+    { id: 'ref.pan', label: 'Pan canvas', category: 'Navigation', keys: 'W', scope: 'canvas', reserved: true, execute: () => {}, },
+    { id: 'ref.nudge', label: 'Nudge shapes / pan', category: 'Navigation', keys: 'ArrowUp', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'ref.scroll', label: 'Zoom at cursor', category: 'Navigation', shortcut: 'Scroll', reserved: true, execute: () => {} },
+    { id: 'ref.copy', label: 'Copy', category: 'Editing', keys: 'Mod+C', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'ref.paste', label: 'Paste', category: 'Editing', keys: 'Mod+V', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'ref.group', label: 'Group selected shapes', category: 'Editing', keys: 'Mod+G', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'ref.ungroup', label: 'Ungroup', category: 'Editing', keys: 'Mod+Shift+G', scope: 'canvas', reserved: true, execute: () => {} },
+    { id: 'ref.commandPalette', label: 'Command palette', category: 'View', keys: 'Mod+K', scope: 'global', whileTyping: true, reserved: true, execute: () => {} },
+    { id: 'ref.searchShapes', label: 'Search shapes', category: 'View', keys: 'Mod+F', scope: 'global', reserved: true, execute: () => {} },
+    { id: 'ref.help', label: 'Keyboard shortcuts', category: 'View', keys: 'Shift+/', scope: 'global', reserved: true, execute: () => {} },
 
     // --- Layouts ---
     ...layoutCommands(),
@@ -212,7 +247,7 @@ export function getAllCommands(): Command[] {
       id: 'view.cycleRelaxedFocus',
       label: 'Cycle prose / split / diagram focus',
       category: 'View',
-      shortcut: 'Ctrl+Shift+\\',
+      keys: 'Mod+Shift+\\', scope: 'global', whileTyping: true,
       execute: () => useSessionStore.getState().cycleRelaxedFocus(),
       // Focus only applies to the writing-first Relaxed layout.
       canExecute: () => useUIPreferencesStore.getState().layout.defaultMode === 'relaxed',
@@ -220,12 +255,81 @@ export function getAllCommands(): Command[] {
   ];
 }
 
+/**
+ * The command catalogue — the single source of truth for shortcuts. The display
+ * hint (`shortcut`) is DERIVED here from each command's `keys` spec, so the
+ * palette + help panel can never drift from the real binding.
+ */
+export function getAllCommands(): Command[] {
+  return buildCommands().map((c) =>
+    c.keys ? { ...c, shortcut: formatCombo(c.keys) } : c,
+  );
+}
+
+/** Commands the user can run from the palette (executable, non-reserved). */
+export function getPaletteCommands(): Command[] {
+  return getAllCommands().filter((c) => !c.reserved);
+}
+
+/**
+ * Dispatch a keyboard event against the registry for a given scope. Returns true
+ * if a command matched and ran. `reserved` commands are never dispatched here
+ * (their keys are owned by ToolManager / the pan handler / prose). For `global`
+ * scope, bindings without `whileTyping` are skipped while an input/textarea/
+ * contenteditable is focused.
+ */
+export function dispatchKey(event: KeyboardEvent, scope: KeyScope): boolean {
+  const typing = isTypingContext();
+  for (const cmd of getAllCommands()) {
+    if (cmd.reserved || !cmd.keys || (cmd.scope ?? 'global') !== scope) continue;
+    if (scope === 'global' && typing && !cmd.whileTyping) continue;
+    if (!eventMatchesAny(event, parseCombo(cmd.keys))) continue;
+    if (cmd.canExecute && !cmd.canExecute()) continue;
+    event.preventDefault();
+    cmd.execute();
+    recordRecent(cmd.id);
+    return true;
+  }
+  return false;
+}
+
+function isTypingContext(): boolean {
+  const el = typeof document !== 'undefined' ? document.activeElement : null;
+  if (!el) return false;
+  const tag = el.tagName?.toLowerCase();
+  return tag === 'input' || tag === 'textarea' || (el as HTMLElement).isContentEditable === true;
+}
+
+/**
+ * Dev/test guardrail: return any two bindings that collide on the same combo +
+ * scope. Reserved entries participate (a real binding must not shadow a reserved
+ * one in the same scope); cross-scope duplicates (e.g. Mod+F global vs prose)
+ * are allowed.
+ */
+export function findShortcutConflicts(): Array<{ a: string; b: string; combo: string }> {
+  const seen = new Map<string, string>();
+  const conflicts: Array<{ a: string; b: string; combo: string }> = [];
+  for (const cmd of getAllCommands()) {
+    if (!cmd.keys) continue;
+    const scope = cmd.scope ?? 'global';
+    for (const combo of parseCombo(cmd.keys)) {
+      const sig = `${scope}::${combo.ctrl}${combo.meta}${combo.shift}${combo.alt}:${combo.key}`;
+      const prev = seen.get(sig);
+      if (prev) conflicts.push({ a: prev, b: cmd.id, combo: formatCombo(cmd.keys) });
+      else seen.set(sig, cmd.id);
+    }
+  }
+  return conflicts;
+}
+
 function layoutCommands(): Command[] {
   return LAYOUT_MODES.map((mode, idx) => ({
     id: `view.layout.${mode}`,
     label: `Switch to ${LAYOUT_LABELS[mode]} layout`,
     category: 'View' as const,
-    shortcut: `Ctrl+Shift+${idx + 1}`,
+    keys: `Mod+Shift+${idx + 1}`,
+    scope: 'global' as const,
+    whileTyping: true,
     execute: () => applyLayoutMode(mode),
   }));
 }

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -15,7 +15,7 @@ import { ConnectorTool } from './tools/ConnectorTool';
 import { LibraryShapeTool } from './tools/LibraryShapeTool';
 import { CustomShapeTool } from './tools/CustomShapeTool';
 import { Vec2 } from '../math/Vec2';
-import { Shape, isConnector, isGroup, ConnectorShape } from '../shapes/Shape';
+import { Shape, isConnector, ConnectorShape } from '../shapes/Shape';
 import { updateConnectorEndpoints } from '../shapes/Connector';
 import { calculateConnectorWaypoints } from './OrthogonalRouter';
 import { collectChangedShapes, isConnectorAffected } from './connectorReroute';
@@ -25,7 +25,6 @@ import { pushHistory } from '../store/historyStore';
 import { dispatchKey } from './CommandRegistry';
 import { useShapeLibraryStore } from '../store/shapeLibraryStore';
 import { useCustomShapeLibraryStore } from '../store/customShapeLibraryStore';
-import { useWhiteboardStore } from '../store/whiteboardStore';
 import { nanoid } from 'nanoid';
 
 // Import shape handlers to register them
@@ -168,8 +167,10 @@ export class Engine {
   private pendingPanX = 0;
   private pendingPanY = 0;
 
-  // Global keyboard handler for shortcuts that need to intercept browser defaults
-  private boundGlobalKeyDown: (e: KeyboardEvent) => void;
+  // Clipboard shortcuts are registry commands (canvas scope) that bridge to the
+  // engine via these events — they need the engine clipboard + spatial index.
+  private boundCopy: () => void;
+  private boundPaste: () => void;
 
   constructor(canvas: HTMLCanvasElement, options?: EngineOptions) {
     this.canvas = canvas;
@@ -212,9 +213,11 @@ export class Engine {
     // Set initial tool
     this.toolManager.setActiveTool(this.options.initialTool);
 
-    // Add global keyboard handler for shortcuts that need to intercept browser defaults
-    this.boundGlobalKeyDown = this.handleGlobalKeyDown.bind(this);
-    window.addEventListener('keydown', this.boundGlobalKeyDown);
+    // Clipboard commands (registry, canvas scope) bridge to the engine here.
+    this.boundCopy = () => this.copySelection();
+    this.boundPaste = () => this.pasteClipboard();
+    window.addEventListener('docushark:copy-shapes', this.boundCopy);
+    window.addEventListener('docushark:paste-shapes', this.boundPaste);
 
     // Initial render
     this.syncFromStores();
@@ -333,8 +336,9 @@ export class Engine {
     }
     this.activePanKeys.clear();
 
-    // Remove global keyboard listener
-    window.removeEventListener('keydown', this.boundGlobalKeyDown);
+    // Remove clipboard bridge listeners
+    window.removeEventListener('docushark:copy-shapes', this.boundCopy);
+    window.removeEventListener('docushark:paste-shapes', this.boundPaste);
 
     // Unsubscribe from stores
     this.unsubscribeDocument?.();
@@ -661,73 +665,6 @@ export class Engine {
 
   // Event handlers
 
-  /**
-   * Global keyboard handler to intercept browser defaults like Ctrl+A, Ctrl+G.
-   * This runs on window, not canvas, so it works even when canvas isn't focused.
-   */
-  private handleGlobalKeyDown(event: KeyboardEvent): void {
-    if (this.destroyed) return;
-
-    // Don't intercept shortcuts when focus is on an input/textarea/contenteditable
-    const activeEl = document.activeElement;
-    if (activeEl) {
-      const tagName = activeEl.tagName.toLowerCase();
-      if (
-        tagName === 'input' ||
-        tagName === 'textarea' ||
-        (activeEl as HTMLElement).isContentEditable
-      ) {
-        return;
-      }
-    }
-
-    const isCtrl = event.ctrlKey || event.metaKey;
-    const isShift = event.shiftKey;
-
-    // (Ctrl+A select-all, Ctrl+Shift+A select-connected, Ctrl+Shift+L auto-layout
-    // moved to the central registry, canvas scope — dispatched on the canvas key
-    // path. Group/ungroup/whiteboard stay here until the registry migration's
-    // next slice.)
-
-    // Ctrl+G: Group selected shapes - intercept to prevent browser "Find" dialog
-    if (isCtrl && !isShift && event.key === 'g') {
-      event.preventDefault();
-      const selectedIds = useSessionStore.getState().getSelectedIds();
-      if (selectedIds.length >= 2) {
-        pushHistory('Group shapes');
-        const groupId = nanoid();
-        useDocumentStore.getState().groupShapes(selectedIds, groupId);
-        useSessionStore.getState().select([groupId]);
-        this.renderer.requestRender();
-      }
-      return;
-    }
-
-    // Ctrl+Shift+G: Ungroup selected group
-    if (isCtrl && isShift && (event.key === 'G' || event.key === 'g')) {
-      event.preventDefault();
-      const selectedIds = useSessionStore.getState().getSelectedIds();
-      if (selectedIds.length === 1) {
-        const shape = useDocumentStore.getState().shapes[selectedIds[0]!];
-        if (shape && isGroup(shape)) {
-          pushHistory('Ungroup shapes');
-          const childIds = [...shape.childIds];
-          useDocumentStore.getState().ungroupShape(shape.id);
-          useSessionStore.getState().select(childIds);
-          this.renderer.requestRender();
-        }
-      }
-      return;
-    }
-
-    // Ctrl+I: Toggle whiteboard (Ideas)
-    if (isCtrl && event.key.toLowerCase() === 'i') {
-      event.preventDefault();
-      useWhiteboardStore.getState().toggleVisibility();
-      return;
-    }
-  }
-
   private handlePointerEvent(event: NormalizedPointerEvent): void {
     // Update cursor world position for status bar display
     useSessionStore.getState().setCursorWorldPosition({
@@ -758,13 +695,10 @@ export class Engine {
     // Let the active tool handle it first (tool shortcuts + tool keys).
     if (this.toolManager.handleKeyDown(event)) return;
 
-    // Canvas-scope shortcuts via the central keyboard registry
-    // (undo/redo/select-all/delete/clear/select-connected/auto-layout).
-    if (dispatchKey(event, 'canvas')) return;
-
-    // Engine-internal canvas shortcuts not yet in the registry (copy/paste —
-    // they need the engine clipboard + spatial index).
-    this.handleGlobalShortcuts(event);
+    // Canvas-scope shortcuts via the central keyboard registry — including
+    // copy/paste/group/ungroup (copy/paste bridge back to the engine clipboard
+    // via docushark:copy-shapes / paste-shapes events).
+    dispatchKey(event, 'canvas');
   }
 
   private handleKeyUp(event: KeyboardEvent): void {
@@ -1046,62 +980,41 @@ export class Engine {
   }
 
   /**
-   * Handle global keyboard shortcuts.
+   * Copy the current selection to the engine clipboard. Invoked by the
+   * `edit.copy` registry command via the `docushark:copy-shapes` event (it needs
+   * the engine-held clipboard).
    */
-  private handleGlobalShortcuts(event: KeyboardEvent): void {
-    const isCtrl = event.ctrlKey || event.metaKey;
+  private copySelection(): void {
+    const selectedIds = useSessionStore.getState().getSelectedIds();
+    if (selectedIds.length === 0) return;
+    const shapes = useDocumentStore.getState().shapes;
+    clipboard = selectedIds.map((id) => ({ ...shapes[id]! }));
+  }
 
-    // NOTE: undo/redo/select-all/delete/clear-selection moved to the central
-    // keyboard registry (canvas scope) — dispatched in handleKeyDown before this.
-    // Only copy/paste remain here: they're coupled to the engine clipboard +
-    // spatial index, so they stay until the registry gains CustomEvent bridges.
+  /**
+   * Paste the engine clipboard (offset), select the new shapes, and feed the
+   * spatial index. Invoked by the `edit.paste` registry command via the
+   * `docushark:paste-shapes` event.
+   */
+  private pasteClipboard(): void {
+    if (clipboard.length === 0) return;
+    pushHistory('Paste shapes');
 
-    // Ctrl+C / Cmd+C: Copy selected shapes
-    if (isCtrl && event.key === 'c') {
-      const selectedIds = useSessionStore.getState().getSelectedIds();
-      if (selectedIds.length > 0) {
-        event.preventDefault();
-        const shapes = useDocumentStore.getState().shapes;
-        clipboard = selectedIds.map((id) => ({ ...shapes[id]! }));
-      }
-      return;
+    const newIds: string[] = [];
+    const offset = 20; // Offset pasted shapes slightly
+
+    for (const shape of clipboard) {
+      const newId = nanoid();
+      const newShape: Shape = { ...shape, id: newId, x: shape.x + offset, y: shape.y + offset };
+      useDocumentStore.getState().addShape(newShape);
+      this.spatialIndex.insert(newShape);
+      newIds.push(newId);
     }
 
-    // Ctrl+V / Cmd+V: Paste shapes
-    if (isCtrl && event.key === 'v') {
-      if (clipboard.length > 0) {
-        event.preventDefault();
-        pushHistory('Paste shapes');
-
-        const newIds: string[] = [];
-        const offset = 20; // Offset pasted shapes slightly
-
-        for (const shape of clipboard) {
-          const newId = nanoid();
-          const newShape: Shape = {
-            ...shape,
-            id: newId,
-            x: shape.x + offset,
-            y: shape.y + offset,
-          };
-          useDocumentStore.getState().addShape(newShape);
-          this.spatialIndex.insert(newShape);
-          newIds.push(newId);
-        }
-
-        // Select pasted shapes
-        useSessionStore.getState().select(newIds);
-
-        // Update clipboard with new positions for subsequent pastes
-        clipboard = clipboard.map((s) => ({ ...s, x: s.x + offset, y: s.y + offset }));
-
-        this.renderer.requestRender();
-      }
-      return;
-    }
-
-    // Note: Ctrl+G and Ctrl+Shift+G are handled in handleGlobalKeyDown
-    // to intercept browser defaults
+    useSessionStore.getState().select(newIds);
+    // Update clipboard with new positions for subsequent pastes.
+    clipboard = clipboard.map((s) => ({ ...s, x: s.x + offset, y: s.y + offset }));
+    this.renderer.requestRender();
   }
 
   private handleWheel(event: WheelEvent, screenPoint: Vec2): void {

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -20,9 +20,9 @@ import { updateConnectorEndpoints } from '../shapes/Connector';
 import { calculateConnectorWaypoints } from './OrthogonalRouter';
 import { collectChangedShapes, isConnectorAffected } from './connectorReroute';
 import { useDocumentStore } from '../store/documentStore';
-import { useSessionStore, ToolType, deleteSelected } from '../store/sessionStore';
-import { useHistoryStore, pushHistory } from '../store/historyStore';
-import { selectConnectedChain, autoLayoutSelection } from './selectionLayout';
+import { useSessionStore, ToolType } from '../store/sessionStore';
+import { pushHistory } from '../store/historyStore';
+import { dispatchKey } from './CommandRegistry';
 import { useShapeLibraryStore } from '../store/shapeLibraryStore';
 import { useCustomShapeLibraryStore } from '../store/customShapeLibraryStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
@@ -684,13 +684,10 @@ export class Engine {
     const isCtrl = event.ctrlKey || event.metaKey;
     const isShift = event.shiftKey;
 
-    // Ctrl+A: Select all - must intercept at window level to prevent browser select all
-    if (isCtrl && event.key === 'a') {
-      event.preventDefault();
-      useSessionStore.getState().selectAll();
-      this.renderer.requestRender();
-      return;
-    }
+    // (Ctrl+A select-all, Ctrl+Shift+A select-connected, Ctrl+Shift+L auto-layout
+    // moved to the central registry, canvas scope — dispatched on the canvas key
+    // path. Group/ungroup/whiteboard stay here until the registry migration's
+    // next slice.)
 
     // Ctrl+G: Group selected shapes - intercept to prevent browser "Find" dialog
     if (isCtrl && !isShift && event.key === 'g') {
@@ -720,22 +717,6 @@ export class Engine {
           this.renderer.requestRender();
         }
       }
-      return;
-    }
-
-    // Ctrl+Shift+A: Select the connected chain(s) of the current selection
-    if (isCtrl && isShift && event.key.toLowerCase() === 'a') {
-      event.preventDefault();
-      selectConnectedChain();
-      this.renderer.requestRender();
-      return;
-    }
-
-    // Ctrl+Shift+L: Auto-layout the current selection (top-to-bottom)
-    if (isCtrl && isShift && event.key.toLowerCase() === 'l') {
-      event.preventDefault();
-      autoLayoutSelection('TB');
-      this.renderer.requestRender();
       return;
     }
 
@@ -774,13 +755,16 @@ export class Engine {
       return;
     }
 
-    // Let tool manager handle first
-    const handled = this.toolManager.handleKeyDown(event);
+    // Let the active tool handle it first (tool shortcuts + tool keys).
+    if (this.toolManager.handleKeyDown(event)) return;
 
-    if (!handled) {
-      // Handle global shortcuts
-      this.handleGlobalShortcuts(event);
-    }
+    // Canvas-scope shortcuts via the central keyboard registry
+    // (undo/redo/select-all/delete/clear/select-connected/auto-layout).
+    if (dispatchKey(event, 'canvas')) return;
+
+    // Engine-internal canvas shortcuts not yet in the registry (copy/paste —
+    // they need the engine clipboard + spatial index).
+    this.handleGlobalShortcuts(event);
   }
 
   private handleKeyUp(event: KeyboardEvent): void {
@@ -1066,57 +1050,11 @@ export class Engine {
    */
   private handleGlobalShortcuts(event: KeyboardEvent): void {
     const isCtrl = event.ctrlKey || event.metaKey;
-    const isShift = event.shiftKey;
 
-    // Ctrl+Z / Cmd+Z: Undo
-    if (isCtrl && !isShift && event.key === 'z') {
-      event.preventDefault();
-      if (useHistoryStore.getState().canUndo()) {
-        useHistoryStore.getState().undo();
-        this.renderer.requestRender();
-      }
-      return;
-    }
-
-    // Ctrl+Shift+Z / Cmd+Shift+Z or Ctrl+Y / Cmd+Y: Redo
-    if ((isCtrl && isShift && event.key === 'z') || (isCtrl && event.key === 'y')) {
-      event.preventDefault();
-      if (useHistoryStore.getState().canRedo()) {
-        useHistoryStore.getState().redo();
-        this.renderer.requestRender();
-      }
-      return;
-    }
-
-    // Ctrl+A / Cmd+A: Select All
-    if (isCtrl && event.key === 'a') {
-      event.preventDefault();
-      useSessionStore.getState().selectAll();
-      this.renderer.requestRender();
-      return;
-    }
-
-    // Delete / Backspace: Delete selected shapes
-    if (event.key === 'Delete' || event.key === 'Backspace') {
-      const selectedIds = useSessionStore.getState().getSelectedIds();
-      if (selectedIds.length > 0) {
-        event.preventDefault();
-        pushHistory('Delete shapes');
-        deleteSelected();
-        this.renderer.requestRender();
-      }
-      return;
-    }
-
-    // Escape: Clear selection
-    if (event.key === 'Escape') {
-      if (useSessionStore.getState().hasSelection()) {
-        event.preventDefault();
-        useSessionStore.getState().clearSelection();
-        this.renderer.requestRender();
-      }
-      return;
-    }
+    // NOTE: undo/redo/select-all/delete/clear-selection moved to the central
+    // keyboard registry (canvas scope) — dispatched in handleKeyDown before this.
+    // Only copy/paste remain here: they're coupled to the engine clipboard +
+    // spatial index, so they stay until the registry gains CustomEvent bridges.
 
     // Ctrl+C / Cmd+C: Copy selected shapes
     if (isCtrl && event.key === 'c') {

--- a/src/engine/KeyboardShortcuts.ts
+++ b/src/engine/KeyboardShortcuts.ts
@@ -1,86 +1,15 @@
 /**
- * Central keyboard shortcut registry.
+ * Shortcut category type — the grouping axis shared by the command registry and
+ * the shortcut help panel.
  *
- * Collects all shortcut definitions for display in the shortcut reference panel.
- * Shortcuts are organized by category.
+ * NOTE: the actual shortcut definitions live in the central command registry
+ * (`CommandRegistry.ts`), which is the single source of truth that both the
+ * command palette and the help panel render from. The old hardcoded
+ * `KEYBOARD_SHORTCUTS` array was retired (it drifted from the real handlers).
  */
-
-export interface ShortcutEntry {
-  /** Display label for the key combination */
-  keys: string;
-  /** Description of the action */
-  description: string;
-  /** Category for grouping */
-  category: ShortcutCategory;
-}
-
 export type ShortcutCategory =
   | 'Tools'
   | 'Navigation'
   | 'Editing'
   | 'File'
   | 'View';
-
-/**
- * All registered keyboard shortcuts in the application.
- */
-export const KEYBOARD_SHORTCUTS: ShortcutEntry[] = [
-  // Tools
-  { keys: 'V', description: 'Select tool', category: 'Tools' },
-  { keys: 'R', description: 'Rectangle tool', category: 'Tools' },
-  { keys: 'O', description: 'Ellipse tool', category: 'Tools' },
-  { keys: 'L', description: 'Line tool', category: 'Tools' },
-  { keys: 'C', description: 'Connector tool', category: 'Tools' },
-  { keys: 'T', description: 'Text tool', category: 'Tools' },
-  { keys: 'H', description: 'Pan (Hand) tool', category: 'Tools' },
-
-  // Navigation
-  { keys: 'W / A / S / D', description: 'Pan canvas', category: 'Navigation' },
-  { keys: '↑ / ↓ / ← / →', description: 'Nudge shapes (or pan if none selected)', category: 'Navigation' },
-  { keys: 'Shift + Arrow', description: 'Nudge by 50px', category: 'Navigation' },
-  { keys: 'Q', description: 'Zoom out', category: 'Navigation' },
-  { keys: 'E', description: 'Zoom in', category: 'Navigation' },
-  { keys: 'Scroll wheel', description: 'Zoom at cursor', category: 'Navigation' },
-
-  // Editing
-  { keys: 'Ctrl+Z', description: 'Undo', category: 'Editing' },
-  { keys: 'Ctrl+Shift+Z / Ctrl+Y', description: 'Redo', category: 'Editing' },
-  { keys: 'Ctrl+A', description: 'Select all', category: 'Editing' },
-  { keys: 'Ctrl+C', description: 'Copy', category: 'Editing' },
-  { keys: 'Ctrl+V', description: 'Paste', category: 'Editing' },
-  { keys: 'Ctrl+G', description: 'Group selected shapes', category: 'Editing' },
-  { keys: 'Ctrl+Shift+G', description: 'Ungroup', category: 'Editing' },
-  { keys: 'Ctrl+Shift+A', description: 'Select connected shapes (chain)', category: 'Editing' },
-  { keys: 'Ctrl+Shift+L', description: 'Auto-layout selection', category: 'Editing' },
-  { keys: 'Delete / Backspace', description: 'Delete selected', category: 'Editing' },
-  { keys: 'Escape', description: 'Clear selection', category: 'Editing' },
-
-  // File
-  { keys: 'Ctrl+N', description: 'New document', category: 'File' },
-  { keys: 'Ctrl+O', description: 'Open document', category: 'File' },
-  { keys: 'Ctrl+S', description: 'Save', category: 'File' },
-  { keys: 'Ctrl+Shift+E', description: 'Export as PNG', category: 'File' },
-
-  // View
-  { keys: '?', description: 'Keyboard shortcuts', category: 'View' },
-  { keys: 'Ctrl+K', description: 'Command palette', category: 'View' },
-  { keys: 'Ctrl+F', description: 'Search shapes', category: 'View' },
-  { keys: 'Ctrl+I', description: 'Toggle whiteboard (Ideas)', category: 'View' },
-  { keys: 'Ctrl+Shift+1', description: 'Switch to Relaxed layout', category: 'View' },
-  { keys: 'Ctrl+Shift+2', description: 'Switch to Designer layout', category: 'View' },
-  { keys: 'Ctrl+Shift+3', description: 'Switch to Technician layout', category: 'View' },
-  { keys: 'Ctrl+Shift+4', description: 'Switch to Power layout', category: 'View' },
-];
-
-/**
- * Get shortcuts grouped by category.
- */
-export function getShortcutsByCategory(): Map<ShortcutCategory, ShortcutEntry[]> {
-  const map = new Map<ShortcutCategory, ShortcutEntry[]>();
-  for (const shortcut of KEYBOARD_SHORTCUTS) {
-    const list = map.get(shortcut.category) ?? [];
-    list.push(shortcut);
-    map.set(shortcut.category, list);
-  }
-  return map;
-}

--- a/src/engine/keybindings.test.ts
+++ b/src/engine/keybindings.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseCombo, eventMatchesCombo, eventMatchesAny, formatCombo } from './keybindings';
+import { getAllCommands, getPaletteCommands, dispatchKey, findShortcutConflicts } from './CommandRegistry';
+
+function key(k: string, mods: Partial<KeyboardEventInit> = {}): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key: k, cancelable: true, ...mods });
+}
+
+describe('keybindings — parseCombo', () => {
+  it('maps Mod to Ctrl off macOS and Meta on macOS', () => {
+    expect(parseCombo('Mod+Z', false)[0]).toMatchObject({ key: 'z', ctrl: true, meta: false });
+    expect(parseCombo('Mod+Z', true)[0]).toMatchObject({ key: 'z', ctrl: false, meta: true });
+  });
+
+  it('parses modifiers + alternatives', () => {
+    const combos = parseCombo('Mod+Shift+Z | Mod+Y', false);
+    expect(combos).toHaveLength(2);
+    expect(combos[0]).toMatchObject({ key: 'z', ctrl: true, shift: true });
+    expect(combos[1]).toMatchObject({ key: 'y', ctrl: true, shift: false });
+  });
+
+  it('lowercases named keys (Delete | Backspace, Escape)', () => {
+    expect(parseCombo('Delete | Backspace', false).map((c) => c.key)).toEqual(['delete', 'backspace']);
+    expect(parseCombo('Escape', false)[0]!.key).toBe('escape');
+  });
+});
+
+describe('keybindings — matching', () => {
+  it('matches exact modifier state only', () => {
+    const [combo] = parseCombo('Mod+Z', false);
+    expect(eventMatchesCombo(key('z', { ctrlKey: true }), combo!)).toBe(true);
+    expect(eventMatchesCombo(key('z'), combo!)).toBe(false); // no ctrl
+    expect(eventMatchesCombo(key('z', { ctrlKey: true, shiftKey: true }), combo!)).toBe(false);
+  });
+
+  it('eventMatchesAny matches either alternative', () => {
+    const combos = parseCombo('Delete | Backspace', false);
+    expect(eventMatchesAny(key('Backspace'), combos)).toBe(true);
+    expect(eventMatchesAny(key('x'), combos)).toBe(false);
+  });
+});
+
+describe('keybindings — formatCombo', () => {
+  it('formats for Windows/Linux and macOS', () => {
+    expect(formatCombo('Mod+Shift+L', false)).toBe('Ctrl+Shift+L');
+    expect(formatCombo('Mod+Shift+L', true)).toBe('⇧⌘L'); // Mac order: ⌘ last
+    expect(formatCombo('ArrowUp', false)).toBe('↑');
+  });
+});
+
+describe('CommandRegistry — registry integrity', () => {
+  it('has NO shortcut conflicts (same combo + scope)', () => {
+    expect(findShortcutConflicts()).toEqual([]);
+  });
+
+  it('derives the display hint from keys', () => {
+    const undo = getAllCommands().find((c) => c.id === 'edit.undo')!;
+    expect(undo.shortcut).toBe(formatCombo('Mod+Z'));
+  });
+
+  it('hides reserved bindings from the palette but shows them in the catalogue', () => {
+    expect(getAllCommands().some((c) => c.id === 'tool.select')).toBe(true);
+    expect(getPaletteCommands().some((c) => c.id === 'tool.select')).toBe(false);
+  });
+});
+
+describe('CommandRegistry — dispatchKey', () => {
+  it('runs a matching canvas command and reports handled', () => {
+    const handled = dispatchKey(key('Escape'), 'canvas'); // edit.clearSelection
+    expect(handled).toBe(true);
+  });
+
+  it('does not dispatch a binding in the wrong scope', () => {
+    // edit.clearSelection is canvas-scope; nothing matches Escape in global.
+    expect(dispatchKey(key('Escape'), 'global')).toBe(false);
+  });
+
+  it('never dispatches reserved bindings (tool keys owned by ToolManager)', () => {
+    expect(dispatchKey(key('v'), 'canvas')).toBe(false);
+  });
+});

--- a/src/engine/keybindings.ts
+++ b/src/engine/keybindings.ts
@@ -65,14 +65,32 @@ export function parseCombo(spec: string, mac: boolean = isMacPlatform()): KeyCom
   });
 }
 
+/**
+ * Physical `event.code` for a layout-sensitive `combo.key`. Shifted digits and
+ * punctuation report a different `event.key` per layout (Shift+1 → "!", Shift+\
+ * → "|"), so for those we match the physical code instead. Letters stay
+ * key-based so they remain layout-aware (AZERTY etc.). Null = match by key only.
+ */
+function expectedCode(key: string): string | null {
+  if (/^[0-9]$/.test(key)) return `Digit${key}`;
+  const punct: Record<string, string> = {
+    '\\': 'Backslash', '/': 'Slash', '.': 'Period', ',': 'Comma',
+    ';': 'Semicolon', "'": 'Quote', '[': 'BracketLeft', ']': 'BracketRight',
+    '-': 'Minus', '=': 'Equal', '`': 'Backquote',
+  };
+  return punct[key] ?? null;
+}
+
 /** Does a keyboard event match this combo? `Mod` matched ctrl OR meta per platform. */
 export function eventMatchesCombo(e: KeyboardEvent, combo: KeyCombo): boolean {
-  if (normalizeKey(e.key) !== combo.key) return false;
   if (e.ctrlKey !== combo.ctrl) return false;
   if (e.metaKey !== combo.meta) return false;
   if (e.shiftKey !== combo.shift) return false;
   if (e.altKey !== combo.alt) return false;
-  return true;
+  if (normalizeKey(e.key) === combo.key) return true;
+  // Fall back to the physical code for shifted digits/punctuation.
+  const code = expectedCode(combo.key);
+  return code !== null && e.code === code;
 }
 
 export function eventMatchesAny(e: KeyboardEvent, combos: KeyCombo[]): boolean {

--- a/src/engine/keybindings.ts
+++ b/src/engine/keybindings.ts
@@ -1,0 +1,99 @@
+/**
+ * Key-combo primitives for the central keyboard registry.
+ *
+ * A binding is declared as a string spec (e.g. `"Mod+Shift+L"`, `"Delete | Backspace"`)
+ * and parsed into one or more {@link KeyCombo}s. `Mod` resolves to ⌘ on macOS and
+ * Ctrl elsewhere, so a single declaration is correct cross-platform. These are
+ * pure functions (no DOM/global state) — unit-tested in isolation.
+ */
+
+/** A single parsed key combination. */
+export interface KeyCombo {
+  /** The non-modifier key, lowercased for letters (e.g. `'z'`, `'arrowup'`, `'escape'`, `'/'`). */
+  key: string;
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+  alt: boolean;
+}
+
+/** Where a binding is active / dispatched. */
+export type KeyScope =
+  /** Window-level, app-wide (palette, layout, undo when nothing focused). */
+  | 'global'
+  /** Only when the canvas owns focus (tools, delete, copy/paste shapes). */
+  | 'canvas'
+  /** Owned by the prose editor (Tiptap); reference-only — we never dispatch. */
+  | 'prose';
+
+const isMacPlatform = (): boolean =>
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '');
+
+/** Normalize an `event.key` to the canonical form used by {@link KeyCombo}. */
+function normalizeKey(key: string): string {
+  if (key.length === 1) return key.toLowerCase();
+  return key.toLowerCase();
+}
+
+/**
+ * Parse a binding spec into combos. Multiple alternatives are separated by `|`
+ * (e.g. `"Mod+Shift+Z | Mod+Y"`); modifiers within a combo by `+`. Recognized
+ * modifier tokens: `Mod` (Ctrl/⌘), `Ctrl`, `Meta`/`Cmd`, `Shift`, `Alt`/`Option`.
+ */
+export function parseCombo(spec: string, mac: boolean = isMacPlatform()): KeyCombo[] {
+  return spec.split('|').map((part) => {
+    const tokens = part.trim().split('+').map((t) => t.trim()).filter(Boolean);
+    const combo: KeyCombo = { key: '', ctrl: false, meta: false, shift: false, alt: false };
+    for (const token of tokens) {
+      const t = token.toLowerCase();
+      if (t === 'mod') {
+        if (mac) combo.meta = true;
+        else combo.ctrl = true;
+      } else if (t === 'ctrl' || t === 'control') {
+        combo.ctrl = true;
+      } else if (t === 'meta' || t === 'cmd' || t === 'command') {
+        combo.meta = true;
+      } else if (t === 'shift') {
+        combo.shift = true;
+      } else if (t === 'alt' || t === 'option' || t === 'opt') {
+        combo.alt = true;
+      } else {
+        combo.key = normalizeKey(token);
+      }
+    }
+    return combo;
+  });
+}
+
+/** Does a keyboard event match this combo? `Mod` matched ctrl OR meta per platform. */
+export function eventMatchesCombo(e: KeyboardEvent, combo: KeyCombo): boolean {
+  if (normalizeKey(e.key) !== combo.key) return false;
+  if (e.ctrlKey !== combo.ctrl) return false;
+  if (e.metaKey !== combo.meta) return false;
+  if (e.shiftKey !== combo.shift) return false;
+  if (e.altKey !== combo.alt) return false;
+  return true;
+}
+
+export function eventMatchesAny(e: KeyboardEvent, combos: KeyCombo[]): boolean {
+  return combos.some((c) => eventMatchesCombo(e, c));
+}
+
+const KEY_DISPLAY: Record<string, string> = {
+  arrowup: '↑', arrowdown: '↓', arrowleft: '←', arrowright: '→',
+  escape: 'Esc', delete: 'Del', backspace: 'Backspace', enter: 'Enter', ' ': 'Space',
+};
+
+/** Human-readable label for the first combo of a spec (for the help panel + palette). */
+export function formatCombo(spec: string, mac: boolean = isMacPlatform()): string {
+  const [first] = parseCombo(spec, mac);
+  if (!first) return '';
+  const parts: string[] = [];
+  if (first.ctrl) parts.push(mac ? '⌃' : 'Ctrl');
+  if (first.alt) parts.push(mac ? '⌥' : 'Alt');
+  if (first.shift) parts.push(mac ? '⇧' : 'Shift');
+  if (first.meta) parts.push(mac ? '⌘' : 'Win');
+  const k = first.key;
+  parts.push(KEY_DISPLAY[k] ?? (k.length === 1 ? k.toUpperCase() : k.charAt(0).toUpperCase() + k.slice(1)));
+  return parts.join(mac ? '' : '+');
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -11,8 +11,7 @@ import { PanelChromeWrapper } from './layout/PanelChromeWrapper';
 import { DockedPanel } from './layout/DockedPanel';
 import { DocumentToggleRail } from './layout/DocumentToggleRail';
 import { RelaxedSplitHandle } from './layout/RelaxedSplitHandle';
-import { LAYOUT_MODES } from './layout/types';
-import { applyLayoutMode } from '../engine/CommandRegistry';
+import { dispatchKey } from '../engine/CommandRegistry';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { useSessionStore } from '../store/sessionStore';
 import { isMacOS } from '../utils/platform';
@@ -49,7 +48,6 @@ import { useTrashStore } from '../store/trashStore';
 import { ensureDocBlobsLocal } from '../store/offlineAvailability';
 import { useUserStore } from '../store/userStore';
 import { useConnectionStore } from '../store/connectionStore';
-import { opener } from '../platform/opener';
 import { windowControls } from '../platform/window';
 import {
   initTransferService,
@@ -241,58 +239,29 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
     setIsEditorFullscreen((v) => !v);
   }, []);
 
-  // Global keyboard shortcuts
+  // Global keyboard shortcuts — the single window-level owner. Every global
+  // binding (palette, search, documents, layout 1-4, relaxed focus, F1) lives in
+  // the central registry; this just routes the event through it (the registry
+  // owns preventDefault + the per-binding while-typing rule). React-state actions
+  // (palette/search toggle, documents) are bridged back via CustomEvents below.
   useEffect(() => {
-    const handleKeyDown = async (e: KeyboardEvent) => {
-      // Cmd/Ctrl+K — Command palette
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
-        e.preventDefault();
-        setIsPaletteOpen((v) => !v);
-        return;
-      }
-
-      // Ctrl+F — Shape search
-      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
-        e.preventDefault();
-        setIsSearchOpen((v) => !v);
-        return;
-      }
-
-      // Ctrl/Cmd+Shift+O — Documents surface (JP-218)
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'o' || e.key === 'O')) {
-        e.preventDefault();
-        setAppView('documents');
-        return;
-      }
-
-      // Ctrl/Cmd+Shift+1..4 — Switch layout
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && /^[1-4]$/.test(e.key)) {
-        e.preventDefault();
-        const idx = parseInt(e.key, 10) - 1;
-        const mode = LAYOUT_MODES[idx];
-        if (mode) applyLayoutMode(mode);
-        return;
-      }
-
-      // Ctrl/Cmd+Shift+\ — Cycle Relaxed focus (prose / split / diagram).
-      // `e.code` is layout-independent (Shift+\ produces '|' on US keyboards).
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'Backslash') {
-        e.preventDefault();
-        if (useUIPreferencesStore.getState().layout.defaultMode === 'relaxed') {
-          useSessionStore.getState().cycleRelaxedFocus();
-        }
-        return;
-      }
-
-      // F1 - Open documentation (platform.opener handles desktop vs web).
-      if (e.key === 'F1') {
-        e.preventDefault();
-        await opener.openDocs();
-      }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      dispatchKey(e, 'global');
     };
-
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // Bridge registry commands that need App's React state.
+  useEffect(() => {
+    const togglePalette = () => setIsPaletteOpen((v) => !v);
+    const toggleSearch = () => setIsSearchOpen((v) => !v);
+    window.addEventListener('docushark:toggle-command-palette', togglePalette);
+    window.addEventListener('docushark:toggle-search', toggleSearch);
+    return () => {
+      window.removeEventListener('docushark:toggle-command-palette', togglePalette);
+      window.removeEventListener('docushark:toggle-search', toggleSearch);
+    };
   }, []);
 
   // The command palette can't reach React state directly; "Go to Documents"

--- a/src/ui/CommandPalette.tsx
+++ b/src/ui/CommandPalette.tsx
@@ -4,7 +4,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import {
-  getAllCommands,
+  getPaletteCommands,
   fuzzyMatch,
   recordRecent,
   getRecentCommandIds,
@@ -25,7 +25,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 
   // Get all available commands
   const commands = useMemo(() => {
-    const all = getAllCommands();
+    const all = getPaletteCommands();
     return all.filter((c) => !c.canExecute || c.canExecute());
   }, [isOpen]); // re-evaluate when palette opens
 

--- a/src/ui/KeyboardShortcutPanel.tsx
+++ b/src/ui/KeyboardShortcutPanel.tsx
@@ -1,7 +1,23 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getShortcutsByCategory } from '../engine/KeyboardShortcuts';
+import { getAllCommands } from '../engine/CommandRegistry';
 import type { ShortcutCategory } from '../engine/KeyboardShortcuts';
 import './KeyboardShortcutPanel.css';
+
+/**
+ * Shortcut rows grouped by category, derived from the central command registry
+ * (the single source of truth — no separate hardcoded list to drift). Only
+ * commands with a real binding (`shortcut`) are shown.
+ */
+function getShortcutsByCategory(): Map<ShortcutCategory, Array<{ keys: string; description: string }>> {
+  const map = new Map<ShortcutCategory, Array<{ keys: string; description: string }>>();
+  for (const cmd of getAllCommands()) {
+    if (!cmd.shortcut) continue;
+    const list = map.get(cmd.category) ?? [];
+    list.push({ keys: cmd.shortcut, description: cmd.label });
+    map.set(cmd.category, list);
+  }
+  return map;
+}
 
 interface KeyboardShortcutPanelProps {
   isOpen: boolean;


### PR DESCRIPTION
Unifies the app's scattered keyboard handling into one registry that is the single source of truth, dispatches, and feeds the palette + help panel. Done in three slices (all on this branch).

## Slice 1 — source of truth
- `keybindings.ts`: `KeyCombo` parse/match/format (`Mod` = Ctrl/⌘; `a | b` alternatives; matches shifted digits/punctuation by physical `event.code` so `Mod+Shift+1..4` and `Ctrl+Shift+\` are layout-robust; letters stay `key`-based).
- `CommandRegistry` `Command` gains a real binding: `keys` + `scope` (`global`/`canvas`/`prose`) + `whileTyping` + `reserved`; the display hint is **derived** from `keys`.
- `dispatchKey(event, scope)` matcher + `findShortcutConflicts()` guardrail.
- Palette lists `getPaletteCommands()`; help panel renders from the registry; retired the hardcoded `KEYBOARD_SHORTCUTS` array.

## Slice 2 — canvas dispatch
- `Engine.handleKeyDown` → `dispatchKey(event, 'canvas')` for the store-only canvas commands (undo/redo/select-all/delete/clear/select-connected/auto-layout). Removed the **Ctrl+A double-path** (it lived in two handlers).

## Slice 3 — global + engine-internal
- Removed `Engine.handleGlobalKeyDown` (+ its window listener) and `handleGlobalShortcuts`. group/ungroup/whiteboard are store-direct commands; copy/paste bridge to the engine clipboard/spatial-index via `docushark:copy-shapes` / `paste-shapes` events.
- `App.tsx` window keydown is the **single global dispatch owner** (`dispatchKey(e, 'global')`); palette/search toggle via CustomEvents; layout/focus/documents/F1 are registry commands. **One dispatch per key.**
- `searchShapes` is `whileTyping:false` so the prose find wins while the editor is focused (fixes the old Ctrl+F dual-fire).

## Verify
`bun run typecheck` + full suite (2534) green; `findShortcutConflicts()` empty. Manual: every shortcut still fires once (tools, undo/redo, delete, select-all, group/ungroup, copy/paste, Ctrl+K palette, Ctrl+F search, Ctrl+Shift+1-4 layout, Ctrl+Shift+\\ focus, Ctrl+I whiteboard, F1); help panel matches; prose shortcuts unaffected when the editor is focused.

Supersedes the slice-1-only description. Assisted-by: Opus 4.8