### PR TITLE
Fix docs-site base path for apex domain (JP-314)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build documentation
         working-directory: docs-site
-        run: bun run build:gh-pages
+        run: bun run build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,8 +1,6 @@
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
-const isGitHubPages = process.env['GITHUB_PAGES'] === 'true'
-
 // The Guides area spans two folders: /getting-started/ (the onboarding group)
 // and /guide/ (the using-DocuShark group). Both routes share one sidebar.
 const guidesSidebar = [
@@ -42,18 +40,20 @@ export default withMermaid(
   defineConfig({
     title: 'DocuShark',
     description: 'DocuShark — diagramming and docs in one offline-first editor',
-    base: isGitHubPages ? '/docushark/' : '/',
+    // Served from the apex domain docs.docushark.app, so assets are root-relative.
+    // (Was '/docushark/' for the old github.io project-path host — JP-314.)
+    base: '/',
 
     head: [
       ['link', { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
       ['meta', { property: 'og:type', content: 'website' }],
       ['meta', { property: 'og:title', content: 'DocuShark Docs' }],
       ['meta', { property: 'og:description', content: 'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.' }],
-      ['meta', { property: 'og:image', content: 'https://jpe-net-technologies.github.io/docushark/docushark-badge.png' }],
+      ['meta', { property: 'og:image', content: 'https://docs.docushark.app/docushark-badge.png' }],
       ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
       ['meta', { name: 'twitter:title', content: 'DocuShark Docs' }],
       ['meta', { name: 'twitter:description', content: 'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.' }],
-      ['meta', { name: 'twitter:image', content: 'https://jpe-net-technologies.github.io/docushark/docushark-badge.png' }],
+      ['meta', { name: 'twitter:image', content: 'https://docs.docushark.app/docushark-badge.png' }],
     ],
 
     themeConfig: {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "cross-env ONLINE_MODE=true vitepress dev",
     "build": "cross-env ONLINE_MODE=true vitepress build",
-    "build:gh-pages": "cross-env ONLINE_MODE=true GITHUB_PAGES=true vitepress build",
     "build:offline": "vitepress build",
     "preview": "cross-env ONLINE_MODE=true vitepress preview"
   },

--- a/docs-site/public/CNAME
+++ b/docs-site/public/CNAME
@@ -1,0 +1,1 @@
+docs.docushark.app


### PR DESCRIPTION
## What

`docs.docushark.app` was moved off the old `jpe-net-technologies.github.io/docushark` project-path host onto its own apex domain, but the VitePress `base` still resolved to `/docushark/` (via the `GITHUB_PAGES=true` build), so every asset 404'd under the stale subpath. JP-314.

## Changes

- **`.vitepress/config.mts`**: `base: '/'` (apex-relative); removed the now-unused `isGitHubPages` env switch.
- **`.github/workflows/docs.yml`**: build with `bun run build` instead of `build:gh-pages`.
- **`docs-site/package.json`**: removed the `build:gh-pages` script so the `/docushark/` subpath base can't be reintroduced.
- Fixed stale `og:image` / `twitter:image` URLs (`github.io/docushark` → `docs.docushark.app`).
- Added `public/CNAME` (`docs.docushark.app`) so the custom domain survives Pages deploys.

## Verification

`bun run build` succeeds; built `index.html` references root-relative `/assets/...` (no `/docushark/`), `CNAME` is present in `dist`, and the OG image resolves to `docs.docushark.app`. Full end-to-end confirmation is the live Pages deploy after merge.

Assisted-by: Opus 4.8