### PR TITLE
JP-159: sync collections editor↔relay (the missing half)

### DIFF
--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -1636,6 +1636,29 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
+    fn collection_def_serializes_camelcase() {
+        // Contract guard (JP-159): the wire shape docushark-web + the editor's
+        // RelayCollectionDef mirror. camelCase keys, color omitted when None.
+        let def = CollectionDef {
+            id: "c1".into(),
+            name: "Alpha".into(),
+            color: Some("#fff".into()),
+            order: 2,
+        };
+        let v = serde_json::to_value(&def).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(
+            obj.keys().cloned().collect::<std::collections::BTreeSet<_>>(),
+            ["color", "id", "name", "order"].iter().map(|s| s.to_string()).collect(),
+        );
+        assert!(obj.keys().all(|k| !k.contains('_')), "no snake_case leakage");
+
+        let no_color = CollectionDef { id: "c2".into(), name: "B".into(), color: None, order: 0 };
+        let v2 = serde_json::to_value(&no_color).unwrap();
+        assert!(v2.get("color").is_none(), "color omitted when None");
+    }
+
+    #[test]
     fn test_document_store_lifecycle() {
         let dir = tempdir().unwrap();
         let store = DocumentStore::new(dir.path().to_path_buf());

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1959,6 +1959,35 @@ mod tests {
         assert_eq!(out["references"]["style"], json!("mla"));
     }
 
+    // ---- JP-159: collection membership survives hydrate → flatten ----
+
+    #[test]
+    fn collection_id_survives_hydrate_and_flatten() {
+        // `collectionId` is an inert top-level field: hydrate ignores it and
+        // flatten_into only rewrites pages/metadata/shared types, so a relay
+        // snapshot (JP-36) can't drop a document's collection membership. This is
+        // what lets the editor's stamped membership persist across collab saves.
+        let json = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}},
+            "collectionId": "col-1"
+        });
+        let handle = DocHandle::hydrate(&json, None, false);
+        let mut out = json.clone();
+        assert!(handle.flatten_into(&mut out));
+        assert_eq!(out["collectionId"], json!("col-1"), "membership preserved through flatten");
+
+        // A body with no membership never gains one.
+        let bare = json!({
+            "id": "d", "serverVersion": 1, "activePageId": "p1",
+            "pages": {"p1": {"shapes": {}, "shapeOrder": []}}
+        });
+        let handle2 = DocHandle::hydrate(&bare, None, false);
+        let mut out2 = bare.clone();
+        assert!(handle2.flatten_into(&mut out2));
+        assert!(out2.get("collectionId").is_none(), "no membership invented");
+    }
+
     #[test]
     fn concurrent_mcp_and_author_adds_both_survive() {
         use yrs::updates::decoder::Decode;

--- a/src/api/relayClient.test.ts
+++ b/src/api/relayClient.test.ts
@@ -258,6 +258,40 @@ describe('RelayClient', () => {
     });
   });
 
+  describe('collections (JP-159)', () => {
+    it('getCollections GETs /api/collections', async () => {
+      const client = new RelayClient({ baseUrl: 'http://r', token: 'T', fetchImpl: script.fetch });
+      script.pushJson({ collections: [{ id: 'A', name: 'Alpha', order: 0 }] });
+      const out = await client.getCollections();
+      expect(script.calls[0]?.method).toBe('GET');
+      expect(script.calls[0]?.url).toBe('http://r/api/collections');
+      expect(out.collections[0]?.id).toBe('A');
+    });
+
+    it('setCollections PUTs the wrapped set', async () => {
+      const client = new RelayClient({ baseUrl: 'http://r', token: 'T', fetchImpl: script.fetch });
+      script.pushJson({ success: true });
+      await client.setCollections([{ id: 'A', name: 'Alpha', order: 0 }]);
+      const call = script.calls[0]!;
+      expect(call.method).toBe('PUT');
+      expect(call.url).toBe('http://r/api/collections');
+      expect(JSON.parse(call.body!)).toEqual({ collections: [{ id: 'A', name: 'Alpha', order: 0 }] });
+    });
+
+    it('setDocumentCollection PUTs collectionId to /collection (null clears)', async () => {
+      const client = new RelayClient({ baseUrl: 'http://r', token: 'T', fetchImpl: script.fetch });
+      script.pushJson({ success: true });
+      await client.setDocumentCollection('doc-1', 'A');
+      expect(script.calls[0]?.method).toBe('PUT');
+      expect(script.calls[0]?.url).toBe('http://r/api/docs/doc-1/collection');
+      expect(JSON.parse(script.calls[0]!.body!)).toEqual({ collectionId: 'A' });
+
+      script.pushJson({ success: true });
+      await client.setDocumentCollection('doc-1', null);
+      expect(JSON.parse(script.calls[1]!.body!)).toEqual({ collectionId: null });
+    });
+  });
+
   describe('blobs', () => {
     it('uploadBlob POSTs raw bytes with octet-stream content type', async () => {
       const client = new RelayClient({ baseUrl: 'http://r', token: 'T', fetchImpl: script.fetch });

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -87,6 +87,18 @@ export interface RelayShareEntry {
 }
 
 /**
+ * Collection definition as carried on the wire by `GET`/`PUT /api/collections`.
+ * Mirrors the relay's `CollectionDef` struct (`relay/src/server/documents.rs`).
+ * Membership is NOT here — it rides the per-document `collectionId` field.
+ */
+export interface RelayCollectionDef {
+  id: string;
+  name: string;
+  color?: string;
+  order: number;
+}
+
+/**
  * Caller's own workspace usage + effective limits, from `GET /api/v1/usage`.
  * `null` quota/limit means unlimited. Counts only — no doc ids or content.
  */
@@ -206,6 +218,37 @@ export class RelayClient {
     return this.requestJson('POST', `/api/docs/${encodeURIComponent(docId)}/transfer`, {
       auth: true,
       body: { newOwnerId, newOwnerName },
+    });
+  }
+
+  // ============ Collections (JP-159) ============
+
+  /** The connected workspace's collection definitions (`GET /api/collections`). */
+  async getCollections(): Promise<{ collections: RelayCollectionDef[] }> {
+    return this.requestJson('GET', '/api/collections', { auth: true });
+  }
+
+  /**
+   * Replace the connected workspace's collection definitions wholesale
+   * (`PUT /api/collections`). The relay scopes this to the token's workspace;
+   * callers must pass that workspace's full set (read-modify-write), never a
+   * cross-workspace union of the client's global store.
+   */
+  async setCollections(collections: RelayCollectionDef[]): Promise<{ success: boolean }> {
+    return this.requestJson('PUT', '/api/collections', {
+      auth: true,
+      body: { collections },
+    });
+  }
+
+  /** Set (or clear, with `null`) a document's collection membership. */
+  async setDocumentCollection(
+    docId: string,
+    collectionId: string | null,
+  ): Promise<{ success: boolean }> {
+    return this.requestJson('PUT', `/api/docs/${encodeURIComponent(docId)}/collection`, {
+      auth: true,
+      body: { collectionId },
     });
   }
 

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -10,7 +10,7 @@
  */
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
-import type { RelayClient, RelayUsage } from './relayClient';
+import type { RelayClient, RelayCollectionDef, RelayUsage } from './relayClient';
 import {
   BlobSyncService,
   type BlobSyncProgress,
@@ -110,5 +110,20 @@ export class RestDocumentProvider {
     newOwnerName: string,
   ): Promise<void> {
     await this.client.transferDocumentOwnership(docId, newOwnerId, newOwnerName);
+  }
+
+  // ============ Collections (JP-159) ============
+
+  async getCollections(): Promise<RelayCollectionDef[]> {
+    const { collections } = await this.client.getCollections();
+    return collections;
+  }
+
+  async setCollections(collections: RelayCollectionDef[]): Promise<void> {
+    await this.client.setCollections(collections);
+  }
+
+  async setDocumentCollection(docId: string, collectionId: string | null): Promise<void> {
+    await this.client.setDocumentCollection(docId, collectionId);
   }
 }

--- a/src/store/collectionMembership.test.ts
+++ b/src/store/collectionMembership.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { stampCollectionMembership } from './collectionMembership';
+import type { DiagramDocument } from '../types/Document';
+
+function doc(extra: Partial<DiagramDocument> = {}): DiagramDocument {
+  return { id: 'd1', name: 'Doc', ...extra } as DiagramDocument;
+}
+
+describe('stampCollectionMembership (JP-159 clobber guard)', () => {
+  it('stamps collectionId when the doc is assigned', () => {
+    const out = stampCollectionMembership(doc(), 'c1', true);
+    expect(out.collectionId).toBe('c1');
+  });
+
+  it('overrides a stale body collectionId with the store assignment', () => {
+    const out = stampCollectionMembership(doc({ collectionId: 'old' }), 'c2', true);
+    expect(out.collectionId).toBe('c2');
+  });
+
+  it('returns the same object when already matching (no needless clone)', () => {
+    const d = doc({ collectionId: 'c1' });
+    expect(stampCollectionMembership(d, 'c1', true)).toBe(d);
+  });
+
+  it('strips a stale membership when unassigned AND listed (honours unassign)', () => {
+    const out = stampCollectionMembership(doc({ collectionId: 'c1' }), undefined, true);
+    expect(out.collectionId).toBeUndefined();
+  });
+
+  it('preserves body membership when unassigned but NOT listed (pre-reconcile race)', () => {
+    const out = stampCollectionMembership(doc({ collectionId: 'c1' }), undefined, false);
+    expect(out.collectionId).toBe('c1');
+  });
+
+  it('is a no-op for an unassigned doc with no membership', () => {
+    const d = doc();
+    expect(stampCollectionMembership(d, undefined, true)).toBe(d);
+  });
+});

--- a/src/store/collectionMembership.ts
+++ b/src/store/collectionMembership.ts
@@ -1,0 +1,27 @@
+import type { DiagramDocument } from '../types/Document';
+
+/**
+ * Reconcile a relay-save body's `collectionId` to the canonical client store
+ * assignment, so a content-save can't erase the relay's membership (the relay
+ * derives metadata wholesale from the body) (JP-159). Pure + import-free so it's
+ * trivially unit-testable and carries no module-cycle risk.
+ *
+ * - assigned → stamp `collectionId` onto the body.
+ * - unassigned → strip a stale `collectionId` **only when `isListed`** (the doc
+ *   has appeared in a relay list, i.e. reconcile has run), so a save right after
+ *   connect can't drop membership the store hasn't hydrated yet.
+ */
+export function stampCollectionMembership(
+  doc: DiagramDocument,
+  assignment: string | undefined,
+  isListed: boolean,
+): DiagramDocument {
+  if (assignment) {
+    return doc.collectionId === assignment ? doc : { ...doc, collectionId: assignment };
+  }
+  if (doc.collectionId !== undefined && isListed) {
+    const { collectionId: _unassigned, ...rest } = doc;
+    return rest;
+  }
+  return doc;
+}

--- a/src/store/collectionStore.ts
+++ b/src/store/collectionStore.ts
@@ -55,6 +55,18 @@ export interface CollectionActions {
   getCollectionForDocument: (documentId: string) => Collection | undefined;
   /** Returns collections sorted by order asc. */
   listCollections: () => Collection[];
+  /**
+   * Reconcile relay-sourced collections into this store (JP-159). Upserts the
+   * given definitions (preserving local-only ones and any existing `createdAt`)
+   * and applies memberships keyed by RELAY document id only — a `string` sets,
+   * `null` clears. Local-doc assignments are never touched (the caller only
+   * includes relay doc ids it intends to apply). The single atomic entry point
+   * the sync layer uses; this store stays network-free.
+   */
+  hydrateFromRelay: (input: {
+    definitions: Collection[];
+    memberships: Record<string, string | null>;
+  }) => void;
   reset: () => void;
 }
 
@@ -170,6 +182,23 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
       listCollections: () => {
         const { collections } = get();
         return Object.values(collections).sort((a, b) => a.order - b.order);
+      },
+
+      hydrateFromRelay: ({ definitions, memberships }) => {
+        const { collections, assignments } = get();
+        const nextCollections = { ...collections };
+        for (const def of definitions) {
+          nextCollections[def.id] = def;
+        }
+        const nextAssignments = { ...assignments };
+        for (const [documentId, collectionId] of Object.entries(memberships)) {
+          if (collectionId === null) {
+            delete nextAssignments[documentId];
+          } else {
+            nextAssignments[documentId] = collectionId;
+          }
+        }
+        set({ collections: nextCollections, assignments: nextAssignments });
       },
 
       reset: () => set(initialState),

--- a/src/store/collectionSync.test.ts
+++ b/src/store/collectionSync.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+
+// Mock the relay-facing deps; use the REAL collectionStore.
+vi.mock('./relayDocumentStore', () => ({
+  getDocProvider: vi.fn(),
+  useRelayDocumentStore: { getState: vi.fn() },
+}));
+vi.mock('./connectionStore', () => ({
+  isRelayAuthenticated: vi.fn(() => true),
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: vi.fn(() => ({ hasPendingChanges: () => false })),
+}));
+
+import { syncedActions, reconcileFromRelay } from './collectionSync';
+import { useCollectionStore } from './collectionStore';
+import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+import { isRelayAuthenticated } from './connectionStore';
+import { getSyncStateManager } from '../collaboration/SyncStateManager';
+import type { DocumentMetadata } from '../types/Document';
+import type { RelayCollectionDef } from '../api/relayClient';
+
+const getDocProviderMock = getDocProvider as unknown as Mock;
+const relayGetState = useRelayDocumentStore.getState as unknown as Mock;
+const authedMock = isRelayAuthenticated as unknown as Mock;
+const syncMgrMock = getSyncStateManager as unknown as Mock;
+
+function makeProvider(defs: RelayCollectionDef[]) {
+  return {
+    getCollections: vi.fn(async (): Promise<RelayCollectionDef[]> => defs.map((d) => ({ ...d }))),
+    setCollections: vi.fn(async (_defs: RelayCollectionDef[]): Promise<void> => {}),
+    setDocumentCollection: vi.fn(async (_docId: string, _collectionId: string | null): Promise<void> => {}),
+  };
+}
+function meta(id: string, collectionId?: string): DocumentMetadata {
+  return { id, name: id, pageCount: 1, modifiedAt: 1, createdAt: 1, ...(collectionId ? { collectionId } : {}) };
+}
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useCollectionStore.getState().reset();
+  authedMock.mockReturnValue(true);
+  relayGetState.mockReturnValue({ isRelayDocument: () => true });
+  syncMgrMock.mockReturnValue({ hasPendingChanges: () => false });
+});
+
+describe('collectionSync write-through (JP-159)', () => {
+  it('pushes membership for a relay doc, skips a local doc', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+    relayGetState.mockReturnValue({ isRelayDocument: (id: string) => id === 'relayDoc' });
+    await reconcileFromRelay([]); // knownCollectionIds = {A}
+
+    syncedActions.assignDocuments(['relayDoc'], 'A');
+    await vi.waitFor(() => expect(provider.setDocumentCollection).toHaveBeenCalledWith('relayDoc', 'A'));
+
+    syncedActions.assignDocuments(['localDoc'], 'A');
+    await flush();
+    expect(provider.setDocumentCollection).not.toHaveBeenCalledWith('localDoc', 'A');
+  });
+
+  it('pushDefinitions is read-modify-write — never PUTs foreign store collections', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+    // A foreign collection exists in the GLOBAL store (e.g. another workspace).
+    const foreignId = useCollectionStore.getState().createCollection('Foreign');
+
+    const newId = syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+    const putCalls = provider.setCollections.mock.calls;
+    const put = putCalls[putCalls.length - 1]![0] as RelayCollectionDef[];
+    const ids = put.map((d) => d.id);
+    expect(ids).toContain('A'); // the workspace's existing def, from getCollections
+    expect(ids).toContain(newId); // the new one
+    expect(ids).not.toContain(foreignId); // the global-store foreign def is never pushed
+  });
+
+  it('skips a membership push to a collection not in the connected workspace', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+    await reconcileFromRelay([]); // known = {A}
+
+    syncedActions.assignDocuments(['d'], 'B'); // B not in workspace
+    await flush();
+    expect(provider.setDocumentCollection).not.toHaveBeenCalled();
+
+    syncedActions.assignDocuments(['d'], 'A'); // A is known
+    await vi.waitFor(() => expect(provider.setDocumentCollection).toHaveBeenCalledWith('d', 'A'));
+  });
+
+  it('offline (unauthenticated) is a no-op, never throws', async () => {
+    authedMock.mockReturnValue(false);
+    const provider = makeProvider([]);
+    getDocProviderMock.mockReturnValue(provider);
+
+    expect(() => syncedActions.createCollection('X')).not.toThrow();
+    syncedActions.assignDocuments(['d'], 'X');
+    await flush();
+    expect(provider.setCollections).not.toHaveBeenCalled();
+    expect(provider.setDocumentCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe('collectionSync reconcileFromRelay (JP-159)', () => {
+  it('hydrates relay defs + memberships, leaves local-doc assignments untouched', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'Alpha', order: 0, color: '#fff' }]);
+    getDocProviderMock.mockReturnValue(provider);
+    // Seed a local-only collection + assignment that reconcile must NOT touch.
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'localCol', name: 'Local', order: 9, createdAt: 1 }],
+      memberships: { localDoc: 'localCol' },
+    });
+
+    await reconcileFromRelay([meta('d1', 'A'), meta('d2')]);
+
+    const st = useCollectionStore.getState();
+    expect(st.collections['A']?.name).toBe('Alpha');
+    expect(typeof st.collections['A']?.createdAt).toBe('number');
+    expect(st.assignments['d1']).toBe('A'); // relay membership applied
+    expect(st.assignments['d2']).toBeUndefined(); // relay-absent → cleared
+    expect(st.assignments['localDoc']).toBe('localCol'); // local doc untouched
+    expect(st.collections['localCol']).toBeDefined(); // local def preserved
+  });
+
+  it('does NOT clear a relay doc with a pending queued save (clear-guard)', async () => {
+    syncMgrMock.mockReturnValue({ hasPendingChanges: (id: string) => id === 'd2' });
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'A', name: 'A', order: 0, createdAt: 1 }],
+      memberships: { d2: 'A' },
+    });
+
+    await reconcileFromRelay([meta('d2')]); // relay reports no membership for d2
+
+    expect(useCollectionStore.getState().assignments['d2']).toBe('A'); // preserved (pending save)
+  });
+});

--- a/src/store/collectionSync.ts
+++ b/src/store/collectionSync.ts
@@ -1,0 +1,205 @@
+/**
+ * collectionSync — the seam between the client `collectionStore` (canonical,
+ * network-free) and the relay's per-workspace collection registry (JP-159).
+ *
+ * Two directions:
+ *  - **Write-through** (`syncedActions`): after a local collection mutation,
+ *    push it to the connected workspace. Definitions use **read-modify-write**
+ *    against the relay's current set (`GET` → mutate → `PUT`) so we only ever
+ *    touch ids that belong to that workspace — the global client store is never
+ *    PUT wholesale (all Cloud workspaces share a relay origin, so that would
+ *    corrupt other workspaces' registries). Membership uses the per-doc endpoint.
+ *  - **Reconcile** (`reconcileFromRelay`): on doc-list fetch, pull the relay's
+ *    definitions + each relay doc's `collectionId` and hydrate them in — the
+ *    relay is authoritative for relay-hosted docs; local-only docs are untouched.
+ *
+ * All network calls are best-effort: offline/errors are swallowed+logged and
+ * self-heal on the next reconcile (definitions) or the queued content-save,
+ * which carries `collectionId` in its body (persistenceStore stamp).
+ */
+
+import type { RelayCollectionDef } from '../api/relayClient';
+import type { DocumentMetadata } from '../types/Document';
+import { getSyncStateManager } from '../collaboration/SyncStateManager';
+import { isRelayAuthenticated } from './connectionStore';
+import { useCollectionStore, type Collection } from './collectionStore';
+import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+
+/** Ids of the connected workspace's collections, refreshed on every relay read.
+ *  Used to skip pushing a membership to a collection the workspace doesn't have
+ *  (which would leave a dangling `collectionId`). */
+let knownCollectionIds = new Set<string>();
+
+/** Serialize relay-definition read-modify-writes so concurrent mutations can't
+ *  interleave their GET/PUT and clobber each other. */
+let chain: Promise<unknown> = Promise.resolve();
+function serialize<T>(fn: () => Promise<T>): Promise<T> {
+  const run = chain.then(fn, fn);
+  chain = run.catch(() => undefined);
+  return run;
+}
+
+function toDef(col: Collection): RelayCollectionDef {
+  return {
+    id: col.id,
+    name: col.name,
+    order: col.order,
+    ...(col.color !== undefined ? { color: col.color } : {}),
+  };
+}
+
+/**
+ * Read the connected workspace's definition set, apply `transform`, write it
+ * back. Best-effort + serialized + auth-gated. Refreshes `knownCollectionIds`.
+ */
+function mutateRelayDefs(
+  transform: (defs: RelayCollectionDef[]) => RelayCollectionDef[],
+): Promise<void> {
+  return serialize(async () => {
+    const provider = getDocProvider();
+    if (!provider?.getCollections || !provider.setCollections) return;
+    if (!isRelayAuthenticated()) return;
+    try {
+      const current = await provider.getCollections();
+      const next = transform(current);
+      knownCollectionIds = new Set(next.map((d) => d.id));
+      await provider.setCollections(next);
+    } catch (e) {
+      console.warn('[collectionSync] definitions push failed (best-effort):', e);
+    }
+  });
+}
+
+async function pushMembership(documentId: string, collectionId: string | null): Promise<void> {
+  if (!useRelayDocumentStore.getState().isRelayDocument(documentId)) return; // local doc → no relay membership
+  const provider = getDocProvider();
+  if (!provider?.setDocumentCollection) return;
+  if (!isRelayAuthenticated()) return;
+  // Don't create a dangling reference: if we know this workspace's set and the
+  // target isn't in it, it's a local/other-workspace collection — skip.
+  if (collectionId !== null && knownCollectionIds.size > 0 && !knownCollectionIds.has(collectionId)) {
+    console.warn(
+      `[collectionSync] skipping membership push for ${documentId}: collection ${collectionId} not in connected workspace`,
+    );
+    return;
+  }
+  try {
+    await provider.setDocumentCollection(documentId, collectionId);
+  } catch (e) {
+    console.warn('[collectionSync] membership push failed (best-effort):', e);
+  }
+}
+
+/**
+ * Sync-wrapped collection actions. UI should call these instead of the raw
+ * store so every mutation (incl. future slice-4 UI) writes through to the relay.
+ */
+export const syncedActions = {
+  createCollection(name: string, color?: string): string {
+    const id = useCollectionStore.getState().createCollection(name, color);
+    if (id) {
+      const col = useCollectionStore.getState().collections[id];
+      if (col) {
+        void mutateRelayDefs((defs) =>
+          defs.some((d) => d.id === col.id) ? defs : [...defs, toDef(col)],
+        );
+      }
+    }
+    return id;
+  },
+
+  renameCollection(id: string, name: string): void {
+    useCollectionStore.getState().renameCollection(id, name);
+    void reprojectDefinition(id);
+  },
+
+  recolorCollection(id: string, color: string | undefined): void {
+    useCollectionStore.getState().recolorCollection(id, color);
+    void reprojectDefinition(id);
+  },
+
+  reorderCollections(orderedIds: string[]): void {
+    useCollectionStore.getState().reorderCollections(orderedIds);
+    // Refresh order/content for the workspace's ids from the store; leave ids
+    // this client doesn't know (another client's collections) untouched.
+    void mutateRelayDefs((defs) =>
+      defs.map((d) => {
+        const col = useCollectionStore.getState().collections[d.id];
+        return col ? toDef(col) : d;
+      }),
+    );
+  },
+
+  deleteCollection(id: string): void {
+    useCollectionStore.getState().deleteCollection(id);
+    void mutateRelayDefs((defs) => defs.filter((d) => d.id !== id));
+  },
+
+  /** Assign/unassign documents; pushes membership for relay docs only. */
+  assignDocuments(documentIds: string[], collectionId: string | null): void {
+    useCollectionStore.getState().assignMany(documentIds, collectionId);
+    for (const documentId of documentIds) {
+      void pushMembership(documentId, collectionId);
+    }
+  },
+};
+
+/** Push a single definition's current store content to the workspace set, only
+ *  if it already exists there (rename/recolor never re-adds a deleted/foreign id). */
+function reprojectDefinition(id: string): Promise<void> {
+  return mutateRelayDefs((defs) =>
+    defs.map((d) => {
+      if (d.id !== id) return d;
+      const col = useCollectionStore.getState().collections[id];
+      return col ? toDef(col) : d;
+    }),
+  );
+}
+
+/**
+ * Pull the connected workspace's collections + relay-doc memberships and
+ * reconcile them into the store. Called from `fetchDocumentList`. Best-effort:
+ * a failure here must not fail the doc-list fetch.
+ */
+export async function reconcileFromRelay(relayDocs: DocumentMetadata[]): Promise<void> {
+  const provider = getDocProvider();
+  if (!provider?.getCollections) return;
+
+  let relaySet: RelayCollectionDef[];
+  try {
+    relaySet = await provider.getCollections();
+  } catch (e) {
+    console.warn('[collectionSync] reconcile getCollections failed (best-effort):', e);
+    return;
+  }
+  knownCollectionIds = new Set(relaySet.map((d) => d.id));
+
+  const store = useCollectionStore.getState();
+  const definitions: Collection[] = relaySet.map((d) => {
+    const existing = store.collections[d.id];
+    return {
+      id: d.id,
+      name: d.name,
+      order: d.order,
+      createdAt: existing?.createdAt ?? Date.now(),
+      ...(d.color !== undefined ? { color: d.color } : {}),
+    };
+  });
+
+  // Membership: relay is authoritative for relay docs. Clear an absent
+  // membership only when there's no pending queued save for that doc — an
+  // offline assign that reconnects before its content-save replays would
+  // otherwise be reverted by a stale reconcile.
+  const sync = getSyncStateManager();
+  const memberships: Record<string, string | null> = {};
+  for (const doc of relayDocs) {
+    const cid = doc.collectionId;
+    if (typeof cid === 'string') {
+      memberships[doc.id] = cid;
+    } else if (!sync.hasPendingChanges(doc.id)) {
+      memberships[doc.id] = null;
+    }
+  }
+
+  store.hydrateFromRelay({ definitions, memberships });
+}

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -25,6 +25,8 @@ import { useFieldStore } from './fieldStore';
 import { useUserStore } from './userStore';
 import { isRelayAuthenticated, useConnectionStore } from './connectionStore';
 import { useRelayDocumentStore } from './relayDocumentStore';
+import { useCollectionStore } from './collectionStore';
+import { stampCollectionMembership } from './collectionMembership';
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { useSessionStore } from './sessionStore';
@@ -98,7 +100,19 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
   // ref made the relay release the ACL and GC the bytes (orphaned the asset).
   // saveToHost recomputes the same set; this guarantees the *queued* copy matches.
   doc = { ...doc, blobReferences: collectBlobReferences(doc) };
+
+  // JP-159: stamp collection membership from the canonical client store so a
+  // content-save can't erase the relay's `collectionId` (the relay derives
+  // metadata wholesale from the body). Stamp the queued + offline-replay copies
+  // too (this runs before every branch below). Strip a stale body membership
+  // only for docs we've already listed (reconcile has run), so a save right
+  // after connect can't drop membership the store hasn't hydrated yet.
   const relayStore = useRelayDocumentStore.getState();
+  doc = stampCollectionMembership(
+    doc,
+    useCollectionStore.getState().assignments[doc.id],
+    relayStore.relayDocuments[doc.id] !== undefined,
+  );
 
   // JP-234 diagnostics (temporary): trace the blob-upload trigger on the relay
   // save path. If you don't see this line on a collab edit, the autosave isn't

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -35,7 +35,7 @@ import { useNotificationStore } from './notificationStore';
 import { useTrashStore } from './trashStore';
 import type { TrashOrigin } from '../storage/TrashStorage';
 import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
-import type { RelayUsage } from '../api/relayClient';
+import type { RelayCollectionDef, RelayUsage } from '../api/relayClient';
 import { useUploadStatusStore } from './uploadStatusStore';
 
 /**
@@ -145,6 +145,13 @@ export interface DocumentProvider {
   downloadBlobs?(hashes: string[]): Promise<BlobSyncResult>;
   /** Caller's own workspace usage + effective limits (`GET /api/v1/usage`). */
   getUsage?(): Promise<RelayUsage>;
+  /**
+   * Collection sync (JP-159). Optional so non-REST providers opt out. The relay
+   * scopes all three to the connected workspace from the bearer token.
+   */
+  getCollections?(): Promise<RelayCollectionDef[]>;
+  setCollections?(collections: RelayCollectionDef[]): Promise<void>;
+  setDocumentCollection?(docId: string, collectionId: string | null): Promise<void>;
 }
 
 /** Team document store actions */
@@ -336,6 +343,13 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           const permission = getEffectivePermission(doc, userId, userRole);
           registry.registerRemote(doc, relayId, permission, 'synced');
         }
+
+        // JP-159: reconcile this workspace's collection definitions + per-doc
+        // membership into the client store. Lazy import breaks the module cycle
+        // (collectionSync imports this store); best-effort — never fails the list.
+        void import('./collectionSync')
+          .then((m) => m.reconcileFromRelay(documents))
+          .catch((err) => console.warn('[relayDocumentStore] collection reconcile failed:', err));
       } catch (e) {
         const error = e instanceof Error ? e.message : 'Failed to fetch documents';
         set({ error, isLoadingList: false });

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -82,6 +82,18 @@ export interface DiagramDocument {
    */
   fields?: FieldLibrary;
 
+  // Collection membership (JP-159)
+  /**
+   * The id of the collection this document belongs to ("workspace inside your
+   * workspace"), or absent for unassigned. Additive/optional like `references`/
+   * `fields` — no `version` bump, no migration. This is a **transport-only
+   * membership stamp**: the relay-save boundary stamps it from `collectionStore`
+   * (the canonical client model) so a content-save can't erase the relay's
+   * `collectionId`; the relay lifts it into `DocumentMetadata`. The editor's
+   * document-construction path does not author it.
+   */
+  collectionId?: string;
+
   // Team document fields (Phase 14.1)
   /** Whether this is a relay document (stored on host, synced via CRDT) */
   isRelayDocument?: boolean;
@@ -169,6 +181,9 @@ export interface DocumentMetadata {
   lastModifiedBy?: string;
   /** Display name of who last modified */
   lastModifiedByName?: string;
+  /** Collection membership (JP-159); absent = unassigned. Lifted by the relay
+   *  from the document body's `collectionId`. */
+  collectionId?: string;
 }
 
 /**

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -28,6 +28,7 @@ import {
   type DocumentBrowserSort,
 } from '../../store/uiPreferencesStore';
 import { useCollectionStore, type Collection } from '../../store/collectionStore';
+import { syncedActions } from '../../store/collectionSync';
 import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
 import { getTransferService } from '../../services/DocumentTransferService';
 import { useTransferStore, isTransferRunning } from '../../store/transferStore';
@@ -244,11 +245,9 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   // Collection store
   const collectionsMap = useCollectionStore((s) => s.collections);
   const assignments = useCollectionStore((s) => s.assignments);
-  const createCollection = useCollectionStore((s) => s.createCollection);
-  const renameCollectionAction = useCollectionStore((s) => s.renameCollection);
-  const recolorCollectionAction = useCollectionStore((s) => s.recolorCollection);
-  const deleteCollectionAction = useCollectionStore((s) => s.deleteCollection);
-  const assignMany = useCollectionStore((s) => s.assignMany);
+  // Mutations route through `syncedActions` (collectionSync) so each change
+  // writes through to the relay for relay-hosted docs (JP-159). The store stays
+  // network-free; `syncedActions` is a stable module import (no dep needed).
 
   const collections = useMemo<Collection[]>(
     () => Object.values(collectionsMap).sort((a, b) => a.order - b.order),
@@ -680,19 +679,19 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
 
   const handleBulkAssign = useCallback(
     (collectionId: string | null) => {
-      assignMany(Array.from(selectedIds), collectionId);
+      syncedActions.assignDocuments(Array.from(selectedIds), collectionId);
       setAssignMenuOpen(false);
     },
-    [assignMany, selectedIds]
+    [selectedIds]
   );
 
   const handleBulkAssignNewCollection = useCallback(() => {
     const name = window.prompt('New collection name');
     if (!name || !name.trim()) return;
-    const id = createCollection(name);
-    if (id) assignMany(Array.from(selectedIds), id);
+    const id = syncedActions.createCollection(name);
+    if (id) syncedActions.assignDocuments(Array.from(selectedIds), id);
     setAssignMenuOpen(false);
-  }, [assignMany, createCollection, selectedIds]);
+  }, [selectedIds]);
 
   const handleBulkDelete = useCallback(async () => {
     const ids = Array.from(selectedIds);
@@ -738,17 +737,17 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const handleCreateCollection = useCallback(() => {
     const name = window.prompt('New collection name');
     if (!name || !name.trim()) return;
-    createCollection(name);
-  }, [createCollection]);
+    syncedActions.createCollection(name);
+  }, []);
 
   const handleRenameCollection = useCallback(
     (collection: Collection) => {
       const name = window.prompt('Rename collection', collection.name);
       if (!name) return;
-      renameCollectionAction(collection.id, name);
+      syncedActions.renameCollection(collection.id, name);
       setActiveCollectionMenu(null);
     },
-    [renameCollectionAction]
+    []
   );
 
   const handleDeleteCollection = useCallback(
@@ -760,17 +759,17 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
         danger: true,
       });
       if (!ok) return;
-      deleteCollectionAction(collection.id);
+      syncedActions.deleteCollection(collection.id);
       setActiveCollectionMenu(null);
     },
-    [deleteCollectionAction]
+    []
   );
 
   const handleRecolor = useCallback(
     (collection: Collection, color: string | undefined) => {
-      recolorCollectionAction(collection.id, color);
+      syncedActions.recolorCollection(collection.id, color);
     },
-    [recolorCollectionAction]
+    []
   );
 
   const error = registryError || teamStoreError;


### PR DESCRIPTION
## What

Finishes JP-159. Collections created in the editor never reached the relay — the editor kept them **only in localStorage** — so the new docushark-web collections view (web PR #49) showed every document under "Unassigned". This wires the editor to push collection **definitions** + per-document **membership** through to the relay's per-workspace registry, and to hydrate them back on load.

## How

- **`relayClient`** — `getCollections` / `setCollections` / `setDocumentCollection` (+ `RelayCollectionDef`), surfaced via `RestDocumentProvider` and the optional `DocumentProvider` methods.
- **`collectionSync`** (new) — the write-through + reconcile seam; the store stays network-free.
  - **Definitions push is read-modify-write** against the connected workspace's set (`GET` → mutate only the touched ids → `PUT`), **never the global store**. All Cloud workspaces share a relay origin, so PUTing the whole client store would corrupt other workspaces' registries; RMW makes each push workspace-self-contained.
  - **Membership** uses the per-doc endpoint and is **skipped when the target collection isn't in the connected workspace** (no dangling `collectionId`).
  - **`reconcileFromRelay`** hydrates relay defs + each relay doc's `collectionId`, leaves **local-doc assignments untouched**, and won't clear a doc that has a **pending queued save** (offline-assign → reconnect race).
- **`persistenceStore`** stamps `collectionId` from the store onto every relay-save body (pure `stampCollectionMembership` helper) so a content-save can't erase membership — the relay's `metadata_from_body` lifts it and the Y.Doc flatten preserves it.
- **`collectionId`** is additive-optional on `DiagramDocument` + `DocumentMetadata` — no migration, no `DOCUMENT_VERSION` bump.
- **`useDocumentBrowserModel`** routes every collection mutation through `syncedActions` so future UI inherits sync.

## Tests (JP-326 seams)

- Relay: `collectionId` survives hydrate→flatten round-trip; `CollectionDef` camelCase contract.
- Editor: `stampCollectionMembership` (assign/strip/race), `collectionSync` (RMW excludes foreign store defs, membership guard, reconcile incl. clear-guard, offline no-throw), `relayClient` method coverage.
- Full editor suite green (2554), `tsc --noEmit` clean, relay `cargo test` green.

## Scope / follow-ups

- **Known follow-up (not corruption):** the editor's collection list is still global, so a relay session can *display* other workspaces' collections; assigning to a collection not in the connected workspace is skipped. Full per-workspace isolation (workspace-keyed store + display scoping) is deferred.
- Slice-4 polish (create/edit modal, color, reorder, pinning) deferred.
- Pairs with docushark-web PR #49 (web view + orphan-bucketing fix).

Verified in-repo; live local-stack E2E to confirm on staging/local.

Assisted-by: Opus 4.8