### PR TITLE
Fix: Cloud sign-in started a phantom `default` collab session

### DIFF
--- a/src/api/completeCloudSignIn.test.ts
+++ b/src/api/completeCloudSignIn.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Seams: assert sign-in stands up the REST-only provider and never starts a WS
+// collab session for a placeholder doc (the JOIN_DOC=default bug).
+const h = vi.hoisted(() => ({
+  saveConnection: vi.fn(async () => {}),
+  setToken: vi.fn(),
+  standUpRestProvider: vi.fn(),
+  getRecord: vi.fn((_id: string) => undefined as unknown),
+  ensureCollabSessionForDoc: vi.fn(async () => {}),
+}));
+
+vi.mock('./relayConnection', () => ({ saveConnection: h.saveConnection }));
+vi.mock('./restoreCloudSession', () => ({ standUpRestProvider: h.standUpRestProvider }));
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: { getState: () => ({ setToken: h.setToken }) },
+}));
+vi.mock('../store/documentRegistry', () => ({
+  useDocumentRegistry: { getState: () => ({ getRecord: h.getRecord }) },
+}));
+vi.mock('../collaboration/ensureCollabSession', () => ({
+  ensureCollabSessionForDoc: h.ensureCollabSessionForDoc,
+}));
+
+import { completeCloudSignIn } from './completeCloudSignIn';
+
+const base = {
+  relayUrl: 'http://localhost:9876',
+  cloudBaseUrl: 'https://cloud.test',
+  token: 'JWT',
+  expiresAt: 123,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getRecord.mockReturnValue(undefined);
+});
+
+describe('completeCloudSignIn (REST-only sign-in, JP — phantom-join fix)', () => {
+  it('persists, sets token, and stands up the REST provider — no doc id', async () => {
+    await completeCloudSignIn(base);
+    expect(h.saveConnection).toHaveBeenCalledWith('http://localhost:9876', 'JWT', {
+      cloudBaseUrl: 'https://cloud.test',
+      jwtExpiresAt: 123,
+    });
+    expect(h.setToken).toHaveBeenCalledWith('JWT', 123);
+    expect(h.standUpRestProvider).toHaveBeenCalledWith('http://localhost:9876', 'JWT');
+    expect(h.ensureCollabSessionForDoc).not.toHaveBeenCalled();
+  });
+
+  it('does NOT open a session for a local doc (no phantom JOIN)', async () => {
+    h.getRecord.mockReturnValue({ type: 'local' });
+    await completeCloudSignIn({ ...base, documentId: 'default' });
+    expect(h.standUpRestProvider).toHaveBeenCalled();
+    expect(h.ensureCollabSessionForDoc).not.toHaveBeenCalled();
+  });
+
+  it('does NOT open a session for an unknown doc id (e.g. the scratch default)', async () => {
+    h.getRecord.mockReturnValue(undefined);
+    await completeCloudSignIn({ ...base, documentId: 'default' });
+    expect(h.ensureCollabSessionForDoc).not.toHaveBeenCalled();
+  });
+
+  it('opens the live session only for a known relay doc', async () => {
+    h.getRecord.mockReturnValue({ type: 'remote' });
+    await completeCloudSignIn({ ...base, documentId: 'doc-42' });
+    expect(h.ensureCollabSessionForDoc).toHaveBeenCalledWith('doc-42');
+
+    h.getRecord.mockReturnValue({ type: 'cached' });
+    await completeCloudSignIn({ ...base, documentId: 'doc-7' });
+    expect(h.ensureCollabSessionForDoc).toHaveBeenCalledWith('doc-7');
+  });
+});

--- a/src/api/completeCloudSignIn.ts
+++ b/src/api/completeCloudSignIn.ts
@@ -1,15 +1,25 @@
 /**
- * Shared tail of a successful Cloud sign-in: commit the relay app token,
- * persist the connection record, and start a collaboration session.
+ * Shared tail of a successful Cloud sign-in: persist the connection record,
+ * commit the relay app token, and establish the **REST-only** signed-in state
+ * (token + live cloud doc list).
  *
- * Extracted from `RelaySettings.handleSignIn` (JP-100) so the device-code flow
- * and the (deferred) web `/auth/callback` redirect drive the *same* proven
- * "token → persist → start session" path rather than duplicating it.
+ * It deliberately does NOT start a WebSocket collab session. Sign-in's job is
+ * connect → authenticate → load the doc list — not open a document. A
+ * placeholder session would emit a `JOIN_DOC` for a doc the relay has no record
+ * of (→ `ERR_UNKNOWN_DOC`, a scary WS error + toasts) and risk the
+ * doc-id-guardless collab view-bind (JP-340/341). The live-sync session for a
+ * specific doc comes up via `ensureCollabSessionForDoc` — invoked here only for a
+ * confirmed relay doc the caller was already viewing.
+ *
+ * Shared by the device-code flow (`RelaySettings`) and the web `/auth/callback`
+ * handoff (`authCallback`) so both drive the same proven path
+ * (mirrors `restoreCloudSession`'s REST-only boot sign-in).
  */
 
 import { useConnectionStore } from '../store/connectionStore';
-import { useCollaborationStore } from '../collaboration';
+import { useDocumentRegistry } from '../store/documentRegistry';
 import { saveConnection } from './relayConnection';
+import { standUpRestProvider } from './restoreCloudSession';
 
 /** Convert a REST origin (http://host:port) to the matching WS URL (ws://host:port/ws). */
 export function restUrlToWsUrl(restUrl: string): string {
@@ -29,29 +39,36 @@ export interface CompleteCloudSignInArgs {
   token: string;
   /** Absolute token expiry (Unix ms), or null if unknown. */
   expiresAt: number | null;
-  /** Document to open on connect; falls back to `'default'`. */
+  /**
+   * The doc the user is currently viewing, if any. Its live session is opened
+   * ONLY when it's a known relay doc (`remote`/`cached`); a local/scratch/unknown
+   * id stays REST-only (no WS JOIN). Omit for a plain sign-in.
+   */
   documentId?: string | null;
 }
 
 export async function completeCloudSignIn(args: CompleteCloudSignInArgs): Promise<void> {
   const { relayUrl, cloudBaseUrl, token, expiresAt, documentId } = args;
 
-  // Persist the URLs + token before the session starts.
+  // Persist URLs + token, then assert the token into the in-memory connection
+  // store so the token-expiry monitor + any later relay-doc reopen read it.
   await saveConnection(relayUrl, token, { cloudBaseUrl, jwtExpiresAt: expiresAt });
-
-  useCollaborationStore.getState().startSession({
-    serverUrl: restUrlToWsUrl(relayUrl),
-    documentId: documentId ?? 'default',
-    token,
-    user: { id: 'pending', name: 'You', color: '#4a90d9' },
-  });
-
-  // Assert the token into the connection store AFTER `startSession`: it tears
-  // down any prior (Stage 2 engine-only) session first, which RESETS the
-  // connection store — so setting the token *before* would be wiped, leaving
-  // `connectionStore.token` null while authenticated (the token-expiry monitor
-  // would go blind and the REST sync subscription would push a null bearer).
-  // The session's REST client is seeded from `config.token` directly, so this
-  // is purely to keep the connection store coherent for the auth/refresh path.
   useConnectionStore.getState().setToken(token, expiresAt);
+
+  // REST-only signed-in state: token + live cloud doc list. No WS session, no
+  // Y.Doc engine, no view binding — so no phantom JOIN_DOC and no view-bind risk.
+  standUpRestProvider(relayUrl, token);
+
+  // If the user was already viewing a relay doc, bring its live session up now —
+  // correctly gated (local/unknown ids never get a CRDT engine, JP-64). This is
+  // the only path that opens a WS session at sign-in, and only for a real relay
+  // doc. Lazy import avoids a module cycle (ensureCollabSession imports
+  // `restUrlToWsUrl` from here).
+  if (documentId) {
+    const record = useDocumentRegistry.getState().getRecord(documentId);
+    if (record && (record.type === 'remote' || record.type === 'cached')) {
+      const { ensureCollabSessionForDoc } = await import('../collaboration/ensureCollabSession');
+      await ensureCollabSessionForDoc(documentId);
+    }
+  }
 }

--- a/src/api/restoreCloudSession.ts
+++ b/src/api/restoreCloudSession.ts
@@ -79,27 +79,42 @@ export async function restoreCloudSession(
   useConnectionStore.getState().setToken(conn.jwt, conn.jwtExpiresAt);
 
   if (opts.proactiveList) {
-    const relayStore = useRelayDocumentStore.getState();
-    const client = new RelayClient({
-      baseUrl: conn.relayUrl,
-      token: conn.jwt,
-      fetchImpl: relayFetch,
-      onUnauthorized: () => {
-        // The saved token was rejected — drop the REST provider and prompt a
-        // friendly re-sign-in instead of failing silently.
-        const s = useRelayDocumentStore.getState();
-        s.setProvider(null);
-        s.setAuthenticated(false);
-        notifyCloudSessionExpired();
-      },
-    });
-    relayStore.setProvider(new RestDocumentProvider(client));
-    // `setAuthenticated(true)` fires `fetchDocumentList` (+ stale-cache refresh,
-    // JP-324) so the live list loads. It reflects "the relay accepted our token"
-    // (REST-verified); the WS `connectionStore.status` stays disconnected until
-    // the user opens a cloud doc and Slice 1 starts the real session.
-    relayStore.setAuthenticated(true);
+    standUpRestProvider(conn.relayUrl, conn.jwt);
   }
 
   return { status: 'restored' };
+}
+
+/**
+ * Stand up a REST-only document provider for a relay + token and load the live
+ * cloud doc list — **no WebSocket session, no Y.Doc engine, no view binding**.
+ * This is the "signed in, no doc open" state shared by boot auto-sign-in
+ * (`restoreCloudSession`) and an explicit Cloud sign-in (`completeCloudSignIn`).
+ * Deliberately avoids a placeholder WS session, which would emit a JOIN_DOC for
+ * a doc the relay has no record of (→ ERR_UNKNOWN_DOC) and risk the
+ * doc-id-guardless collab view-bind (JP-340/341). The full live-sync session
+ * comes up when the user opens a cloud doc (`ensureCollabSessionForDoc`).
+ *
+ * `setAuthenticated(true)` fires `fetchDocumentList` (+ stale-cache refresh,
+ * JP-324) so the live list loads; it reflects "the relay accepted our token"
+ * (REST-verified). The WS `connectionStore.status` stays disconnected until a
+ * cloud doc is opened.
+ */
+export function standUpRestProvider(relayUrl: string, token: string): void {
+  const relayStore = useRelayDocumentStore.getState();
+  const client = new RelayClient({
+    baseUrl: relayUrl,
+    token,
+    fetchImpl: relayFetch,
+    onUnauthorized: () => {
+      // The token was rejected — drop the REST provider and prompt a friendly
+      // re-sign-in instead of failing silently.
+      const s = useRelayDocumentStore.getState();
+      s.setProvider(null);
+      s.setAuthenticated(false);
+      notifyCloudSessionExpired();
+    },
+  });
+  relayStore.setProvider(new RestDocumentProvider(client));
+  relayStore.setAuthenticated(true);
 }

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -565,9 +565,13 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
               // our own rejected JOIN), so it's treated as a foreign deletion
               // (never self-skipped).
               useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+            } else if (record?.type === 'local') {
+              // A local-only doc was never meant to sync; a JOIN reject for it is
+              // expected (and should have been gated upstream by shouldJoinDocument
+              // / sign-in staying REST-only). Don't scare the user with a warning.
             } else {
-              // Diverged / never-promoted local id — not a deletion. Keep the
-              // gentler "saved locally only" hint.
+              // Diverged / never-promoted id — not a deletion. Keep the gentler
+              // "saved locally only" hint.
               useDocumentRegistry.getState().setSyncState(docId, 'error');
               useNotificationStore
                 .getState()

--- a/src/store/connectionController.test.ts
+++ b/src/store/connectionController.test.ts
@@ -114,13 +114,27 @@ describe('connection controller (initConnectionNotifications)', () => {
     expect(useConnectionStore.getState().reconnectPhase).toBe('offline');
   });
 
-  it('does not treat a first-connect failure as an outage', () => {
-    // Never authenticated — an error surfaces as a toast, no reconnect phase.
+  it('coalesces first-connect failures into ONE dismissible toast (not an outage)', () => {
+    // Never authenticated — errors surface as a single updatable toast (not a
+    // pile of permanent ones, the old 3-toast pre-auth spam) and NO reconnect
+    // phase/banner (a first-connect failure isn't an outage).
+    set('connecting');
+    set('error', 'WebSocket error');
+    set('connecting');
+    set('error', 'WebSocket error again');
+
+    expect(notify).toHaveBeenCalledTimes(1); // one toast, coalesced across flips
+    expect(update.mock.calls.length).toBeGreaterThanOrEqual(1); // later flips update it
+    expect(error).not.toHaveBeenCalled(); // not the old per-flip permanent-error path
+    expect(useConnectionStore.getState().reconnectPhase).toBe('online');
+  });
+
+  it('stays quiet on a first-connect failure during a muted (sign-in) transition', () => {
+    muteConnectionToasts(8000);
     set('connecting');
     set('error', 'WebSocket error');
 
     expect(notify).not.toHaveBeenCalled();
-    expect(error).toHaveBeenCalled();
-    expect(useConnectionStore.getState().reconnectPhase).toBe('online');
+    expect(error).not.toHaveBeenCalled();
   });
 });

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -395,6 +395,8 @@ let connectionNotif: ConnectionNotifApi | null = null;
 
 /** Id of the live "reconnecting…" toast, reused across a whole drop→retry cycle. */
 let reconnectToastId: string | null = null;
+/** Id of the live pre-auth (first-connect) error toast, coalesced across flips. */
+let signInErrorToastId: string | null = null;
 /** True once we've authenticated at least once (a first-connect failure isn't an "outage"). */
 let everAuthenticated = false;
 /** Latched when reconnect is terminal (gave up / cancelled) until a fresh connect or manual retry. */
@@ -427,6 +429,7 @@ export function clearReconnectTerminal(): void {
 /** Test-only: reset the module-level controller latches. */
 export function __resetConnectionControllerForTests(): void {
   reconnectToastId = null;
+  signInErrorToastId = null;
   everAuthenticated = false;
   reconnectTerminal = false;
   connectionToastMuteUntil = 0;
@@ -475,6 +478,11 @@ export function initConnectionNotifications(): () => void {
         connectionNotif?.update(id, { message: 'Reconnected', severity: 'success' });
         setTimeout(() => connectionNotif?.dismiss(id), RECONNECTED_TOAST_MS);
       }
+      // Clear any first-connect error toast — we're authenticated now.
+      if (signInErrorToastId) {
+        connectionNotif?.dismiss(signInErrorToastId);
+        signInErrorToastId = null;
+      }
       reconnectTerminal = false;
       everAuthenticated = true;
       if (muted) connectionToastMuteUntil = 0;
@@ -482,10 +490,26 @@ export function initConnectionNotifications(): () => void {
       return;
     }
 
-    // Before the first successful auth, keep legacy behavior: surface errors as a
-    // toast, no reconnect phase/banner (a first-connect failure isn't an outage).
+    // Before the first successful auth: surface errors, but as ONE dismissible
+    // toast — not a `permanent` toast per error flip (the scary 3-toast pile-up
+    // on a flappy first connect / dev StrictMode connect→close). No reconnect
+    // phase/banner (a first-connect failure isn't an outage).
     if (!everAuthenticated) {
-      if (status === 'error' && error) connectionNotif?.error(error, { category: 'permanent' });
+      // Intentional-transition churn (sign-in connect→auth round trip) — stay quiet.
+      if (muted) return;
+      if (status === 'error' && error) {
+        if (signInErrorToastId) {
+          connectionNotif?.update(signInErrorToastId, { message: error });
+        } else {
+          signInErrorToastId =
+            connectionNotif?.notify({
+              message: error,
+              severity: 'error',
+              category: 'transient',
+              duration: 0,
+            }) ?? null;
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## What

Signing in to Cloud (web handoff or device-code) threw a scary `WebSocket … closed before the connection is established` console error and showed **three toasts**. Repro on the local stack: the relay logged `rejecting JOIN_DOC for unknown doc … doc_id=default` while the user was on a **local** doc in a freshly-provisioned (empty) workspace.

## Root cause

`completeCloudSignIn` started a WS collab session bound to a placeholder doc id — `documentId ?? 'default'`. After auth the provider auto-joined `'default'`; `shouldJoinDocument` lets unknown ids through, so it emitted `JOIN_DOC default` → relay `ERR_UNKNOWN_DOC` → a "not syncing — local only" warning, while the dev-StrictMode connect→close churn tripped the **un-deduped pre-auth toast path** (one `permanent` toast per error flip). The relay was correct (rejects unknown docs, keeps the socket open) — this is editor-side.

Also load-bearing: `useCollaborationSync` rebinds the canvas↔Y.Doc purely on `isActive` (no doc-id guard), and the invariant is *"a local-only doc must never get a CRDT engine"* — so a placeholder session over a local doc was genuinely unsafe.

## Fix — sign-in is connect + authenticate + load the doc list, not open a doc

Converge sign-in on the proven REST-only path that `restoreCloudSession` already uses on boot ("NO WebSocket session, NO Y.Doc engine, NO view binding … sidesteps the JP-340/341 corruption class").

- Extract **`standUpRestProvider`** from `restoreCloudSession` (token + `RestDocumentProvider` + `fetchDocumentList`) and reuse it.
- `completeCloudSignIn` stands up that REST-only state and opens a live session **only** for a doc the user was already viewing that is a known **relay** doc (`remote`/`cached`), via the correctly-gated `ensureCollabSessionForDoc`. A local/scratch/unknown id (incl. the old `'default'`) stays REST-only — **no phantom `JOIN_DOC`**. Opening any relay doc still brings its live session up normally.

**Defense-in-depth:**
- `collaborationStore.onError`: suppress the "not syncing — local only" warning for a `local`-record doc (never meant to sync). JP-308 foreign-relay + JP-175 deleted-doc branches intact.
- `connectionStore` pre-auth branch: coalesce first-connect errors into **one dismissible** toast (was one `permanent` toast per error flip) and honor the sign-in mute window.

**No relay change.** The dev-StrictMode close-before-open becomes harmless once sign-in opens no WS (StrictMode stays on).

## Tests
- `completeCloudSignIn.test.ts` (new): REST-only (no WS session); no session for local/unknown ids; live session only for `remote`/`cached`.
- `connectionController.test.ts`: first-connect failures coalesce to ONE toast (not the old per-flip `error`), and stay quiet while muted.
- `typecheck` clean; full editor suite green (**2559**).

## Verification (local stack)
Sign in to an empty workspace while on a local doc (web handoff + device-code): relay log shows **no** `rejecting JOIN_DOC`, **no** scary WS error, **no** "not syncing" toast, at most one calm toast, doc list loads. Open a real relay doc → exactly one legitimate `JOIN_DOC` succeeds and syncs.

## Follow-up (out of scope)
Auto-creating a first document for an empty Cloud workspace (product decision) — after this fix, sign-in lands the user on their local doc with the Cloud list loaded, the intended calm state.

Assisted-by: Opus 4.8