### PR TITLE
Make the cached (REST-only) Cloud session first-class — transfer, refresh, connect menu (JP-364)

### DIFF
--- a/src/store/isCloudSignedIn.test.ts
+++ b/src/store/isCloudSignedIn.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { isCloudSignedIn, useRelayDocumentStore } from './relayDocumentStore';
+import { useConnectionStore } from './connectionStore';
+
+// The single "signed in to cloud (REST or live)" gate behind transfer / refresh /
+// connect-menu. A cached REST-only session (authenticated + valid token, WS
+// disconnected) must count as signed in; a stale/absent token must not.
+beforeEach(() => {
+  useConnectionStore.getState().reset();
+  useRelayDocumentStore.getState().setAuthenticated(false);
+});
+
+describe('isCloudSignedIn', () => {
+  it('false when a valid token exists but the provider is not authenticated', () => {
+    useConnectionStore.getState().setToken('jwt', Date.now() + 60_000);
+    expect(isCloudSignedIn()).toBe(false);
+  });
+
+  it('false when authenticated but there is no token', () => {
+    useRelayDocumentStore.getState().setAuthenticated(true);
+    expect(isCloudSignedIn()).toBe(false);
+  });
+
+  it('false when the token is expired', () => {
+    useRelayDocumentStore.getState().setAuthenticated(true);
+    useConnectionStore.getState().setToken('jwt', Date.now() - 1);
+    expect(isCloudSignedIn()).toBe(false);
+  });
+
+  it('true for a REST-only session (authenticated + unexpired token, WS disconnected)', () => {
+    useRelayDocumentStore.getState().setAuthenticated(true);
+    useConnectionStore.getState().setToken('jwt', Date.now() + 60_000);
+    expect(useConnectionStore.getState().status).toBe('disconnected'); // no live WS
+    expect(isCloudSignedIn()).toBe(true);
+  });
+
+  it('true with a null-expiry token (no known expiry)', () => {
+    useRelayDocumentStore.getState().setAuthenticated(true);
+    useConnectionStore.getState().setToken('jwt', null);
+    expect(isCloudSignedIn()).toBe(true);
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -1094,4 +1094,35 @@ export function getDocProvider(): DocumentProvider | null {
   return docProvider;
 }
 
+/**
+ * True when there's a usable Cloud session: a REST/live-authenticated provider
+ * AND a present, unexpired relay token. This is the single "signed in to cloud"
+ * gate for list / refresh / transfer / connected-UI — it counts a REST-only
+ * (cached) session as well as a live WS one, unlike `isRelayAuthenticated()`
+ * (`connectionStore.status`, WS-only). Mirrors the gate `refreshDocumentList`
+ * already uses (`docProvider && authenticated`), now shared so the manual
+ * refresh, the transfer execution gate, and the connect menu agree.
+ *
+ * Imperative variant for closures (e.g. the transfer-service `isAuthenticated`).
+ */
+export function isCloudSignedIn(): boolean {
+  if (!useRelayDocumentStore.getState().authenticated) return false;
+  const conn = useConnectionStore.getState();
+  return conn.token !== null && (conn.tokenExpiresAt === null || Date.now() < conn.tokenExpiresAt);
+}
+
+/**
+ * Reactive hook for `isCloudSignedIn` — subscribes to BOTH the relay-doc auth
+ * flag and the connection token/expiry so components re-render on change.
+ * (Expiry-by-elapsed-time isn't reactive, same as the prior `relaySessionUsable`;
+ * a real expiry surfaces via the 401 → `onUnauthorized` path that clears auth.)
+ */
+export function useIsCloudSignedIn(): boolean {
+  const authed = useRelayDocumentStore((s) => s.authenticated);
+  const tokenUsable = useConnectionStore(
+    (s) => s.token !== null && (s.tokenExpiresAt === null || Date.now() < s.tokenExpiresAt),
+  );
+  return authed && tokenUsable;
+}
+
 export default useRelayDocumentStore;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -42,7 +42,7 @@ import {
 import { restoreCloudSession, notifyCloudSessionExpired } from '../api/restoreCloudSession';
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
-import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { useRelayDocumentStore, isCloudSignedIn } from '../store/relayDocumentStore';
 import { registerRelayListAutoRefresh } from '../services/relayListAutoRefresh';
 import { useTrashStore } from '../store/trashStore';
 import { ensureDocBlobsLocal } from '../store/offlineAvailability';
@@ -92,6 +92,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   // repeat requests re-fire even when DocumentsHome is already mounted, and so a
   // fresh mount (set in the same tick as the event) still picks it up.
   const [openCloudSignal, setOpenCloudSignal] = useState(0);
+  // One-shot: DocumentsHome calls this after consuming the signal so a later
+  // remount (each Documents-area open) doesn't re-jump to the Cloud connect view.
+  const consumeCloudSignal = useCallback(() => setOpenCloudSignal(0), []);
 
   // Command palette state (Cmd/Ctrl+K)
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -357,9 +360,10 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
       },
       deleteFromHost: (id) => useRelayDocumentStore.getState().deleteFromHost(id),
       ensureBlobsAvailableLocally: (doc) => ensureDocBlobsLocal(doc),
-      isAuthenticated: () =>
-        useConnectionStore.getState().status === 'authenticated' &&
-        useRelayDocumentStore.getState().authenticated,
+      // Transfer runs over the REST `saveToHost`, so a usable cloud session
+      // (REST-only cached OR live WS) is sufficient — gating on the live WS
+      // status blocked the first transfer after a REST-only sign-in.
+      isAuthenticated: () => isCloudSignedIn(),
       updateMetadata: (docId, metadata) => {
         usePersistenceStore.setState((state) => ({
           documents: { ...state.documents, [docId]: metadata },
@@ -583,6 +587,7 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
               onLeaveToEditor={handleLeaveToEditor}
               onOpenSettings={handleOpenSettings}
               openCloudSignal={openCloudSignal}
+              onCloudConnectConsumed={consumeCloudSignal}
             />
           )}
         </main>

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -65,6 +65,10 @@ export interface DocumentsHomeProps {
    * view. Driven by the connection banner's "Reconnect" (JP-237). 0 = no request.
    */
   openCloudSignal?: number;
+  /** Called once the cloud-connect signal has been consumed so App can reset it
+   *  (one-shot). Without this, every DocumentsHome remount re-jumps to the Cloud
+   *  connect view because the signal stays non-zero. */
+  onCloudConnectConsumed?: () => void;
 }
 
 type NavId = 'all' | 'recents' | 'local' | 'cloud' | 'cached';
@@ -81,6 +85,7 @@ export function DocumentsHome({
   onLeaveToEditor,
   onOpenSettings,
   openCloudSignal,
+  onCloudConnectConsumed,
 }: DocumentsHomeProps) {
   const model = useDocumentBrowserModel();
   const {
@@ -120,6 +125,7 @@ export function DocumentsHome({
   const [mainView, setMainView] = useState<'documents' | 'storage' | 'cloud' | 'trash' | 'shapes'>(
     'documents'
   );
+  const [refreshSpin, setRefreshSpin] = useState(false);
   const trashCount = useTrashStore((s) => s.items.length);
   const refreshTrash = useTrashStore((s) => s.refresh);
 
@@ -127,8 +133,11 @@ export function DocumentsHome({
   // banner's "Reconnect". Depends on the nonce so repeat requests re-fire; a
   // fresh mount with a non-zero signal also lands here (JP-237).
   useEffect(() => {
-    if (openCloudSignal && openCloudSignal > 0) setMainView('cloud');
-  }, [openCloudSignal]);
+    if (openCloudSignal && openCloudSignal > 0) {
+      setMainView('cloud');
+      onCloudConnectConsumed?.(); // one-shot: reset so a later remount doesn't re-jump
+    }
+  }, [openCloudSignal, onCloudConnectConsumed]);
 
   const selectNav = (id: NavId) => {
     setNav(id);
@@ -507,14 +516,18 @@ export function DocumentsHome({
             </div>
             <button
               className="dh-refresh"
-              onClick={handleRefresh}
+              onClick={() => {
+                setRefreshSpin(true);
+                handleRefresh();
+                window.setTimeout(() => setRefreshSpin(false), 600);
+              }}
               title="Refresh document list"
               aria-label="Refresh document list"
             >
               <RefreshCw
                 size={16}
                 aria-hidden="true"
-                className={isFetchingRemote ? 'dh-refresh-spin' : undefined}
+                className={isFetchingRemote || refreshSpin ? 'dh-refresh-spin' : undefined}
               />
             </button>
             <button

--- a/src/ui/settings/RelaySettings.tsx
+++ b/src/ui/settings/RelaySettings.tsx
@@ -20,6 +20,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Cloud, LogIn, LogOut, AlertCircle, ExternalLink, Loader2, KeyRound, Trash2 } from 'lucide-react';
 import { useConnectionStore } from '../../store/connectionStore';
+import { useIsCloudSignedIn } from '../../store/relayDocumentStore';
 import { useCollaborationStore, useIsRelaySessionLive } from '../../collaboration';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
@@ -48,6 +49,9 @@ export function RelaySettings() {
   // Token-accepted ("Signed in") vs the active doc actually live-synced — the
   // JP-123 distinction made first-class (JP-199).
   const sessionLive = useIsRelaySessionLive();
+  // A cached REST-only session counts as signed in even with no live WS, so the
+  // menu shows "Signed in" (not "Disconnected") and doesn't prompt a re-pair.
+  const cloudSignedIn = useIsCloudSignedIn();
 
   const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
   const [cloudUrl, setCloudUrl] = useState(DEFAULT_CLOUD_BASE_URL);
@@ -99,7 +103,7 @@ export function RelaySettings() {
     return () => handleRef.current?.cancel();
   }, []);
 
-  const isAuthenticated = status === 'authenticated';
+  const isAuthenticated = status === 'authenticated' || cloudSignedIn;
   const isConnecting = status === 'connecting' || status === 'authenticating';
   const isAwaiting = phase === 'starting' || phase === 'awaiting';
   const isBusy = isConnecting || isAwaiting;
@@ -115,6 +119,26 @@ export function RelaySettings() {
     setPhase('starting');
 
     try {
+      // "Use the key": if a valid token for this relay is already cached, reuse
+      // it (REST-only sign-in) instead of re-running the device-code flow. Only
+      // re-pair when there's no usable cached token (or it's a different relay).
+      const persisted = await loadConnection();
+      if (
+        persisted?.jwt &&
+        persisted.relayUrl === trimmedRelay &&
+        (persisted.jwtExpiresAt === null || persisted.jwtExpiresAt > Date.now())
+      ) {
+        await completeCloudSignIn({
+          relayUrl: trimmedRelay,
+          cloudBaseUrl: trimmedCloud,
+          token: persisted.jwt,
+          expiresAt: persisted.jwtExpiresAt,
+          documentId: currentDocumentId,
+        });
+        setPhase('idle');
+        return;
+      }
+
       const handle = await beginCloudSignIn(trimmedCloud);
       handleRef.current = handle;
       setUserCode(handle.userCode);

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -15,7 +15,8 @@ import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useDocumentRegistry } from '../../store/documentRegistry';
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
-import { useRelayDocumentStore } from '../../store/relayDocumentStore';
+import { useRelayDocumentStore, useIsCloudSignedIn } from '../../store/relayDocumentStore';
+import { ensureCollabSessionForDoc } from '../../collaboration/ensureCollabSession';
 import {
   computeOfflineStatus,
   makeAvailableOffline,
@@ -32,7 +33,7 @@ import { syncedActions } from '../../store/collectionSync';
 import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
 import { getTransferService } from '../../services/DocumentTransferService';
 import { useTransferStore, isTransferRunning } from '../../store/transferStore';
-import { useCollaborationStore, purgeLocalDocRoom } from '../../collaboration';
+import { purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
 import { confirmDialog } from '../confirm/confirmStore';
@@ -195,6 +196,10 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   // Relay stores
   const isRelayLive = useIsRelayAuthenticated();
   const authenticated = useRelayDocumentStore((s) => s.authenticated);
+  // "Signed in to cloud" — a usable session (REST-only cached OR live WS). Gates
+  // list/refresh/transfer, distinct from `isConnectedToHost` (live WS), which
+  // stays the source for the "Connected" vs "Signed in" label in DocumentsHome.
+  const signedIn = useIsCloudSignedIn();
   const isLoadingList = useRelayDocumentStore((s) => s.isLoadingList);
   const teamStoreError = useRelayDocumentStore((s) => s.error);
   const fetchDocumentList = useRelayDocumentStore((s) => s.fetchDocumentList);
@@ -408,8 +413,8 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     useDocumentRegistry
       .getState()
       .reconcileLocalDocuments(usePersistenceStore.getState().getDocumentList());
-    if (isConnectedToHost || isHost) fetchDocumentList();
-  }, [fetchDocumentList, isConnectedToHost, isHost]);
+    if (signedIn || isHost) fetchDocumentList();
+  }, [fetchDocumentList, signedIn, isHost]);
 
   const handleOpen = useCallback(
     async (docId: string) => {
@@ -535,12 +540,17 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       // immediately (convert-in-place keeps the same id). This is what turns
       // the post-sign-in "JOIN_DOC for unknown doc" rejection into a real
       // synced session.
-      if (docId === currentDocumentId && isConnectedToHost) {
-        useCollaborationStore.getState().switchDocument(docId);
+      if (docId === currentDocumentId && signedIn) {
+        // Open the just-promoted (now relay) doc live. `ensureCollabSessionForDoc`
+        // handles both a REST-only sign-in (cold start → `startSession`) and an
+        // already-active session (→ `switchDocument`); calling `switchDocument`
+        // directly assumes an active session config, which a REST-only sign-in
+        // doesn't have.
+        await ensureCollabSessionForDoc(docId);
       }
       useTransferStore.getState().reset();
     },
-    [currentDocumentId, saveDocument, fetchDocumentList, currentUser, isConnectedToHost]
+    [currentDocumentId, saveDocument, fetchDocumentList, currentUser, signedIn]
   );
 
   const handleMoveToPersonal = useCallback(
@@ -704,7 +714,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     const hasRelay = deletable.some((id) => entries[id]?.record.type === 'remote');
     const n = deletable.length;
     const detail = hasRelay
-      ? isConnectedToHost
+      ? signedIn
         ? 'Cloud documents are removed from the workspace for everyone; a recoverable copy is kept in your Trash.'
         : 'You’re offline — cloud documents move to your Trash now and leave the workspace once you reconnect.'
       : undefined;
@@ -720,7 +730,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       await handleDelete(id);
     }
     clearSelection();
-  }, [selectedIds, entries, currentUser, handleDelete, clearSelection, isConnectedToHost]);
+  }, [selectedIds, entries, currentUser, handleDelete, clearSelection, signedIn]);
 
   const handleBulkExport = useCallback(async () => {
     const ids = Array.from(selectedIds);


### PR DESCRIPTION
## What

After the REST-only sign-in (#285), a cached Cloud session has `relayDocumentStore.authenticated === true` + a valid token but **no WebSocket** (`connectionStore.status` stays `'disconnected'`) until a cloud doc is opened. Several "are we online" gates keyed off that WS status, so a valid cached session read as **offline**:

- **First transfer** of a local doc → cloud failed (transfer gate required live WS).
- **Refresh button did nothing** (gated on the WS-live `isConnectedToHost`) — this is **JP-364**.
- **Connect menu** showed "Disconnected" and re-ran the **device-code** flow instead of using the cached key; reopening Documents kept re-popping the connect screen.

## Fix — one "signed in to cloud" predicate

- `relayDocumentStore`: **`isCloudSignedIn()` / `useIsCloudSignedIn()`** = `authenticated` (REST **or** live) AND an unexpired token. This is the gate the focus/connectivity auto-refresh (`refreshDocumentList`) already used — the manual paths just weren't consistent with it.
- **Transfer** (`App.tsx`): gate → `isCloudSignedIn()`. Saves over REST; the existing post-transfer `fetchDocumentList` makes the new cloud doc appear **without a reload**.
- **Browser** (`useDocumentBrowserModel`): a new `signedIn` (`useIsCloudSignedIn`) drives the manual-refresh gate, the post-transfer live-join, and the delete-copy. **`isConnectedToHost` stays = live WS** for DocumentsHome's "Connected" vs "Signed in" label (audited — don't mislabel REST as "Connected"). Post-transfer join uses `ensureCollabSessionForDoc` (handles REST-only cold start) instead of `switchDocument`.
- **DocumentsHome**: refresh button animates on click (brief min-spin + fetch spinner). **One-shot** the cloud-connect quick-open — `openCloudSignal` resets after consume, so reopening Documents no longer re-jumps to the Cloud connect view each time.
- **RelaySettings**: shows "Signed in" for a cached/REST session, and `handleSignIn` **reuses a valid cached token** (no device-code) when present for the target relay.

Disconnect already flips the predicate false (`teardownSession` → `connectionStore.reset()` nulls the token + drops the REST provider). **No relay change.**

## Tests
- `isCloudSignedIn` REST-only / expired / absent / null-expiry matrix.
- `typecheck` clean; full editor suite green (**2564**).

## Verification (local stack)
- Connect with a cached session → menu shows **Signed in** (no device code; reuses the key).
- Refresh button animates and lists cloud docs (REST-only, WS disconnected).
- **First transfer** of a local doc → cloud succeeds, appears **without a reload**, and live-syncs if it was the open doc (relay log: save + legit join, no `ERR_UNKNOWN_DOC`).
- Reopen Documents repeatedly → no re-pop of the Cloud connect screen.
- Disconnect → menu returns to signed-out; refresh/transfer gate off.

Builds on merged #285. Closes the root cause behind **JP-364**.

Follow-up (out of scope, per request): broader "relay page more intelligent" connection-menu redesign.

Assisted-by: Opus 4.8