### PR TITLE
Workspace identity in the document browser (no UID/email leak)

### DIFF
--- a/src/api/relayConnection.ts
+++ b/src/api/relayConnection.ts
@@ -35,6 +35,15 @@ const STORAGE_KEY = 'docushark-relay-connection';
 export const DEFAULT_CLOUD_BASE_URL =
   import.meta.env.VITE_CLOUD_BASE_URL ?? 'http://localhost:3000';
 
+/**
+ * Display origin for a workspace's symbolic URL (JP-343), e.g.
+ * `space.docushark.app/<slug>`. Editor-local — the web's `workspaceUrl` helper
+ * isn't importable across repos, and there's no resolve route yet, so this is
+ * presentational only. Shared by the Cloud connect modal and the document
+ * browser so they format the workspace URL identically.
+ */
+export const WORKSPACE_URL_BASE = 'space.docushark.app';
+
 export interface RelayConnection {
   /** Origin of the relay (e.g. `http://localhost:9876`). */
   relayUrl: string;

--- a/src/ui/cloud/CloudConnectPanel.tsx
+++ b/src/ui/cloud/CloudConnectPanel.tsx
@@ -37,15 +37,16 @@ import { useCollaborationStore, useIsRelaySessionLive } from '../../collaboratio
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
 import { removeCurrentWorkspace } from '../../services/removeWorkspace';
-import { loadConnection, clearJwt, DEFAULT_CLOUD_BASE_URL } from '../../api/relayConnection';
+import {
+  loadConnection,
+  clearJwt,
+  DEFAULT_CLOUD_BASE_URL,
+  WORKSPACE_URL_BASE,
+} from '../../api/relayConnection';
 import { completeCloudSignIn } from '../../api/completeCloudSignIn';
 import { beginCloudSignIn, CloudAuthError, type CloudSignInHandle } from '../../api/cloudAuth';
 
 const DEFAULT_RELAY_URL = 'http://localhost:9876';
-
-/** Display origin for a workspace's symbolic URL (JP-343). Editor-local — the
- *  web's `workspaceUrl` helper isn't importable across repos; no resolve route yet. */
-const WORKSPACE_URL_BASE = 'space.docushark.app';
 
 /** Local sign-in phase, distinct from the connection-store status. */
 type SignInPhase = 'idle' | 'starting' | 'awaiting' | 'error';

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -78,6 +78,9 @@
 .dh-workspace-meta {
   font-size: var(--font-size-xs);
   color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .dh-manage {
   flex: 0 0 auto;

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -46,7 +46,7 @@ import { useDocumentRegistry } from '../../store/documentRegistry';
 import { useThemeStore } from '../../store/themeStore';
 import { getDocProvider } from '../../store/relayDocumentStore';
 import type { RelayUsage } from '../../api/relayClient';
-import { loadConnection, DEFAULT_CLOUD_BASE_URL } from '../../api/relayConnection';
+import { loadConnection, DEFAULT_CLOUD_BASE_URL, WORKSPACE_URL_BASE } from '../../api/relayConnection';
 import { opener } from '../../platform/opener';
 import { blobStorage } from '../../storage/BlobStorage';
 import type { StorageStats } from '../../storage/BlobTypes';
@@ -214,6 +214,24 @@ export function DocumentsHome({
     void opener.openExternalUrl(`${cloudBaseUrl.replace(/\/+$/, '')}/account`);
   };
 
+  // Cloud workspace identity (name + slug) for the workspace chip — the same
+  // values the connect modal shows (JP-343), read from the persisted connection
+  // record. Keyed on `signedIn`, NOT a status, so a REST-only sign-in (which
+  // leaves connectionStore.status 'disconnected') still refreshes the display.
+  const [wsName, setWsName] = useState<string | null>(null);
+  const [wsSlug, setWsSlug] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void loadConnection().then((c) => {
+      if (cancelled) return;
+      setWsName(c?.workspaceName ?? null);
+      setWsSlug(c?.workspaceSlug ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [signedIn]);
+
   // Keep the Trash nav count accurate on open (other surfaces mutate the bin).
   useEffect(() => {
     refreshTrash();
@@ -266,10 +284,16 @@ export function DocumentsHome({
             </span>
             <span className="dh-workspace-info">
               <span className="dh-workspace-name">
-                {signedIn ? (currentUser?.displayName ?? 'Cloud workspace') : 'Local workspace'}
+                {signedIn ? (wsName ?? currentUser?.displayName ?? 'Cloud workspace') : 'Local workspace'}
               </span>
               <span className="dh-workspace-meta">
-                {signedIn ? (isConnectedToHost ? 'Connected' : 'Signed in') : 'Sign in to sync'}
+                {signedIn
+                  ? wsSlug
+                    ? `${WORKSPACE_URL_BASE}/${wsSlug}`
+                    : isConnectedToHost
+                      ? 'Connected'
+                      : 'Signed in'
+                  : 'Sign in to sync'}
               </span>
             </span>
           </button>

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -94,7 +94,6 @@ export function DocumentsHome({
     isInTeamMode,
     isConnectedToHost,
     relaySessionUsable,
-    currentUser,
     currentDocumentId,
     hasSelection,
     handleNewDocument,
@@ -284,7 +283,7 @@ export function DocumentsHome({
             </span>
             <span className="dh-workspace-info">
               <span className="dh-workspace-name">
-                {signedIn ? (wsName ?? currentUser?.displayName ?? 'Cloud workspace') : 'Local workspace'}
+                {signedIn ? (wsName ?? 'Cloud workspace') : 'Local workspace'}
               </span>
               <span className="dh-workspace-meta">
                 {signedIn
@@ -397,11 +396,14 @@ export function DocumentsHome({
               title="Open your DocuShark Cloud account"
             >
               <span className="dh-user-avatar">
-                {(currentUser?.displayName ?? 'You').slice(0, 1).toUpperCase()}
+                {signedIn ? <Cloud size={16} aria-hidden="true" /> : <HardDrive size={16} aria-hidden="true" />}
               </span>
               <span className="dh-user-info">
-                <span className="dh-user-name">{currentUser?.displayName ?? 'You'}</span>
-                <span className="dh-user-meta">{signedIn ? 'DocuShark Cloud' : 'Local only'}</span>
+                {/* No account id / email here — the relay token's `sub` is an
+                    opaque UID, not a friendly name. Show the account context +
+                    the action; the external-link icon signals it opens the web. */}
+                <span className="dh-user-name">{signedIn ? 'DocuShark Cloud' : 'Local only'}</span>
+                <span className="dh-user-meta">Open web account</span>
               </span>
               <ExternalLink className="dh-user-ext" size={14} aria-hidden="true" />
             </button>


### PR DESCRIPTION
The document browser's identity surfaces showed an ugly opaque account id, and didn't show the workspace name/slug the Cloud connect modal already has.

## Changes
- **Workspace chip (`dh-identity`):** shows the workspace **name** + `space.docushark.app/<slug>` (read from the persisted connection record, keyed on `signedIn` so a REST-only sign-in still refreshes). Falls back to "Cloud workspace" — **never** the account UID.
- **Account card (`dh-user-main`):** no longer renders `currentUser.displayName`. On a REST-only session that value is the relay token's `sub` (an opaque UID / email). Now shows **"DocuShark Cloud"** / "Local only" with an **"Open web account"** action line and a Cloud/HardDrive avatar icon — no id or email leaked. The external-link icon signals it opens the web portal.
- Exported `WORKSPACE_URL_BASE` from `relayConnection.ts` (was a duplicated local const in `CloudConnectPanel`) so both surfaces format the workspace URL from one source.
- Added ellipsis truncation to the chip meta so a long slug doesn't overflow.

## Verification
- `bun run typecheck` clean; full suite green (198 files / 2576 tests).
- Manual (pending): sign in → chip shows the workspace name + slug; account card shows "DocuShark Cloud" / "Open web account" with no UID/email; signed-out shows "Local workspace" / "Local only".

Self-contained; first of the post-#287 polish items (the collab-idle badge shipped as #289).

Assisted-by: Opus 4.8