### PR TITLE
Fix a live collab doc stuck on the "Idle" sync badge

### DIFF
--- a/src/api/restoreCloudSession.test.ts
+++ b/src/api/restoreCloudSession.test.ts
@@ -6,18 +6,21 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { loadConnection, setToken, setUser, setProvider, setAuthenticated, info } = vi.hoisted(() => ({
-  loadConnection: vi.fn(),
-  setToken: vi.fn(),
-  setUser: vi.fn(),
-  setProvider: vi.fn(),
-  setAuthenticated: vi.fn(),
-  info: vi.fn(),
-}));
+const { loadConnection, setToken, setUser, setHost, setProvider, setAuthenticated, info } = vi.hoisted(
+  () => ({
+    loadConnection: vi.fn(),
+    setToken: vi.fn(),
+    setUser: vi.fn(),
+    setHost: vi.fn(),
+    setProvider: vi.fn(),
+    setAuthenticated: vi.fn(),
+    info: vi.fn(),
+  }),
+);
 
 vi.mock('./relayConnection', () => ({ loadConnection }));
 vi.mock('../store/connectionStore', () => ({
-  useConnectionStore: { getState: () => ({ user: null, setToken, setUser }) },
+  useConnectionStore: { getState: () => ({ user: null, setToken, setUser, setHost }) },
 }));
 vi.mock('../store/relayDocumentStore', () => ({
   useRelayDocumentStore: { getState: () => ({ setProvider, setAuthenticated }) },
@@ -33,7 +36,9 @@ const future = { relayUrl: 'http://relay:9876', jwt: 'tok', jwtExpiresAt: NOW + 
 
 describe('restoreCloudSession', () => {
   beforeEach(() => {
-    [loadConnection, setToken, setUser, setProvider, setAuthenticated, info].forEach((m) => m.mockReset());
+    [loadConnection, setToken, setUser, setHost, setProvider, setAuthenticated, info].forEach((m) =>
+      m.mockReset(),
+    );
   });
 
   it("status 'none' when no connection / no token", async () => {
@@ -82,6 +87,17 @@ describe('restoreCloudSession', () => {
     expect(setToken).toHaveBeenCalledWith('tok', NOW + 60_000);
     expect(setProvider).toHaveBeenCalledTimes(1);
     expect(setAuthenticated).toHaveBeenCalledWith(true, { skipFetch: true });
+  });
+
+  it('records the relay host so the REST list registers a real relayId (not "unknown")', async () => {
+    // Without this, fetchDocumentList runs with connection.host null → every doc
+    // registers as relayId 'unknown' → never matches the live relay → sync badge
+    // stuck on 'idle'.
+    loadConnection.mockResolvedValueOnce(future);
+
+    await restoreCloudSession({ proactiveList: true, now: () => NOW });
+
+    expect(setHost).toHaveBeenCalledWith({ address: 'relay:9876', url: 'http://relay:9876' });
   });
 
   it('populates the user from the token so identity-gated transfer works', async () => {

--- a/src/api/restoreCloudSession.ts
+++ b/src/api/restoreCloudSession.ts
@@ -132,6 +132,23 @@ export function standUpRestProvider(
     },
   });
   relayStore.setProvider(new RestDocumentProvider(client));
+
+  const conn = useConnectionStore.getState();
+
+  // Record the relay identity (host) BEFORE the list fetch. Only `startSession`
+  // (a WS session) otherwise calls `setHost`, so in a REST-only session
+  // `connection.host` is null and `fetchDocumentList` registers every doc with
+  // `relayId: 'unknown'` (relayDocumentStore). That 'unknown' then never matches
+  // the connected relay address once a WS session goes live, leaving the doc's
+  // sync badge stuck on 'idle' even while fully synced. Setting it here = the
+  // same address `startSession` would set (`new URL(serverUrl).host`), so the WS
+  // session later overwrites it with an identical address (+ the ws:// url).
+  try {
+    conn.setHost({ address: new URL(relayUrl).host, url: relayUrl });
+  } catch {
+    /* malformed relayUrl — leave host unset (registration falls back to 'unknown') */
+  }
+
   relayStore.setAuthenticated(true, { skipFetch: !fetchList });
 
   // Populate the authenticated user from the token. The live WS path sets this
@@ -139,7 +156,6 @@ export function standUpRestProvider(
   // `connectionStore.user` null, which silently no-ops identity-gated surfaces
   // (the document-browser transfer bails on `!currentUser?.id`). Don't clobber a
   // richer user a live WS session may already have set.
-  const conn = useConnectionStore.getState();
   if (!conn.user) {
     const user = userFromRelayToken(token);
     if (user) conn.setUser(user);

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -122,3 +122,29 @@ describe('clearRemoteDocuments (JP-324 hard-disconnect keeps cached docs)', () =
     expect(getType('y')).toBeUndefined();
   });
 });
+
+describe("resolveOriginRelayId ('unknown' heal — collab-idle badge)", () => {
+  const relayIdOf = (id: string): string | undefined => {
+    const rec = useDocumentRegistry.getState().getRecord(id);
+    return rec && 'relayId' in rec ? rec.relayId : undefined;
+  };
+
+  it("adopts a real relayId over a stale 'unknown' origin on re-registration", () => {
+    const r = useDocumentRegistry.getState();
+    // Registered during a REST-only list fetch (connection.host was null).
+    r.registerRemote(meta('d', 'Doc'), 'unknown', 'owner', 'synced');
+    expect(relayIdOf('d')).toBe('unknown');
+
+    // A later fetch, now that the relay identity is known, heals it — otherwise
+    // the doc never matches the connected relay and its badge sticks on 'idle'.
+    r.registerRemote(meta('d', 'Doc'), 'relay-a:9876', 'owner', 'synced');
+    expect(relayIdOf('d')).toBe('relay-a:9876');
+  });
+
+  it('still preserves a real origin (never re-homes to a different connected relay)', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('d', 'Doc'), 'relay-a:9876', 'owner', 'synced');
+    r.registerRemote(meta('d', 'Doc'), 'relay-b:9876', 'owner', 'synced');
+    expect(relayIdOf('d')).toBe('relay-a:9876');
+  });
+});

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -36,16 +36,28 @@ import { RelayDocumentCache } from '../storage/RelayDocumentCache';
  * elsewhere) must not re-home it. Priority: an existing record's origin, then
  * the durable cache (cold boot, registry empty), then — only for a genuine
  * first sighting — the passed (connected) relay.
+ *
+ * `'unknown'` is the sentinel for "relay identity wasn't known at registration"
+ * (e.g. a doc registered during a REST-only list fetch, before `connection.host`
+ * was set). It must NOT be treated as a real origin — otherwise a stale 'unknown'
+ * (in memory or in the durable cache) shadows the real connected relayId forever,
+ * so the doc never matches the connected relay and its sync badge sticks on
+ * 'idle'. Skip it and adopt the passed (connected) relay instead.
  */
 function resolveOriginRelayId(
   existing: DocumentRegistryEntry | undefined,
   id: string,
   passedRelayId: string,
 ): string {
-  if (existing && (isRemoteDocument(existing.record) || isCachedDocument(existing.record))) {
-    return existing.record.relayId;
-  }
-  return RelayDocumentCache.getMeta(id)?.relayId ?? passedRelayId;
+  const isReal = (r: string | undefined): r is string => !!r && r !== 'unknown';
+  const existingId =
+    existing && (isRemoteDocument(existing.record) || isCachedDocument(existing.record))
+      ? existing.record.relayId
+      : undefined;
+  if (isReal(existingId)) return existingId;
+  const cachedId = RelayDocumentCache.getMeta(id)?.relayId;
+  if (isReal(cachedId)) return cachedId;
+  return passedRelayId;
 }
 
 // ============ Types ============


### PR DESCRIPTION
A cloud document that's fully signed-in and live-synced showed the **"Idle"** sync badge ("Signed in — not open right now"), on both boot and open-from-browser.

## Root cause (pinned via instrumentation)
The WS session reaches `authenticated` cleanly — confirmed by temporary probe logging through `ensureCollabSessionForDoc` → `startSession` → `UnifiedSyncProvider` (cold-start with a valid token, AUTH success, `status → authenticated`). So this is **stale display state**, not a connection failure.

The sync badge (`getSyncState` → `formatRelayLabel`) resolves to "connected" only when `record.relayId === connectedRelayAddress`. But `fetchDocumentList` registers each doc with `relayId = connection.host?.address ?? 'unknown'`, and a **REST-only sign-in never calls `setHost`** — only a WS `startSession` does. So the REST list fetch (which is how the list loads after the REST-only sign-in refactor, on both boot and mid-session) registers every doc with `relayId: 'unknown'`. Once a WS session later goes live (`host.address = '<relay>'`), the record's `relayId` is still `'unknown'` → never matches → badge stuck idle.

## Fixes
- **`standUpRestProvider`** records the relay host (`new URL(relayUrl).host`) before the list fetch — the same address `startSession` would set, so the later WS session overwrites it identically (no churn). This is the root fix: REST-fetched docs now register with the real `relayId`.
- **`resolveOriginRelayId`** treats `'unknown'` as absent, so a real connected `relayId` wins over a stale `'unknown'` (in memory or in the durable cache). This **self-heals** docs already registered/cached as `'unknown'` before this fix, while still preserving a real origin (never re-homing a doc to a different connected relay).

## Verification
- `bun run typecheck` clean; full suite green (198 files / 2579 tests).
- New regression tests: `restoreCloudSession` sets host with the relay address; the registry adopts a real `relayId` over a stale `'unknown'` and preserves real origins.
- **Live confirmation pending (yours):** rebuild this branch, open/switch to a cloud doc → the sync badge should show **Synced**, not Idle.

Self-contained; second of the three post-#287 polish items (Issue 1 = #288; the reload-cursor bug ships separately).

Assisted-by: Opus 4.8