### PR TITLE
Fix the prose caret (collab line-offset + scroll drift) + caret color

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -268,6 +268,7 @@ describe('uiPreferencesStore — migration', () => {
       proseBackground: 'default',
       caretStyle: 'bar',
       smoothCaret: true,
+      caretColor: null,
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -296,6 +297,7 @@ describe('uiPreferencesStore — migration', () => {
       proseBackground: 'default',
       caretStyle: 'bar',
       smoothCaret: true,
+      caretColor: null,
     });
   });
 
@@ -321,6 +323,7 @@ describe('uiPreferencesStore — migration', () => {
       proseBackground: 'default',
       caretStyle: 'bar',
       smoothCaret: true,
+      caretColor: null,
     });
   });
 
@@ -394,6 +397,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       proseBackground: 'default',
       caretStyle: 'bar',
       smoothCaret: true,
+      caretColor: null,
     });
   });
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -80,6 +80,10 @@ export interface AppearancePrefs {
   /** Smooth (gliding) caret in the prose editor. Opt-out — on by default;
    *  forced off when `motion` resolves to reduced. */
   smoothCaret: boolean;
+  /** Custom prose caret color — any CSS color (incl. `var(--token)` so it can
+   *  track the theme). `null` follows the default (theme text color). Applies to
+   *  the custom caret (block / smooth). */
+  caretColor: string | null;
 }
 
 /**
@@ -182,6 +186,8 @@ export interface UIPreferencesActions {
   resetThemeBuild: () => void;
   /** Set the interface motion preference. */
   setMotion: (motion: MotionPreference) => void;
+  /** Set the custom prose caret color (`null` = follow the theme). */
+  setCaretColor: (caretColor: string | null) => void;
   /** Set the spacing density. */
   setDensity: (density: Density) => void;
   /** Set the prose caret shape. */
@@ -252,6 +258,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   proseBackground: 'default',
   caretStyle: 'bar',
   smoothCaret: true,
+  caretColor: null,
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -534,6 +541,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setSmoothCaret: (smoothCaret) => {
         set({ appearancePrefs: { ...get().appearancePrefs, smoothCaret } });
+      },
+
+      setCaretColor: (caretColor) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, caretColor } });
       },
 
       reset: () => {

--- a/src/tiptap/CaretExtension.ts
+++ b/src/tiptap/CaretExtension.ts
@@ -129,9 +129,18 @@ class CaretView {
       return;
     }
 
-    const hostRect = this.host.getBoundingClientRect();
-    const left = coords.left - hostRect.left + this.host.scrollLeft;
-    const top = coords.top - hostRect.top + this.host.scrollTop;
+    // Position against the caret's ACTUAL offset parent, not the assumed host.
+    // The caret is absolutely positioned, so the browser resolves its top/left
+    // against the nearest positioned ancestor — which is `.ds-caret-host`
+    // (`.tiptap-editor`) for the local editor, but on a collab doc the host
+    // isn't a positioned box and the offset parent is an outer layout wrapper,
+    // so measuring against the host left the caret a line low. Show the caret
+    // first (a hidden element has no offsetParent), then measure.
+    this.caret.style.display = 'block';
+    const offsetParent = (this.caret.offsetParent as HTMLElement | null) ?? this.host;
+    const opRect = offsetParent.getBoundingClientRect();
+    const left = coords.left - opRect.left + offsetParent.scrollLeft;
+    const top = coords.top - opRect.top + offsetParent.scrollTop;
     const height = Math.max(1, coords.bottom - coords.top);
 
     const isBlock = caretStyle === 'block';
@@ -162,7 +171,6 @@ class CaretView {
         : caretColor
       : '';
 
-    this.caret.style.display = 'block';
     this.caret.style.width = `${width}px`;
     this.caret.style.height = `${height}px`;
 

--- a/src/tiptap/CaretExtension.ts
+++ b/src/tiptap/CaretExtension.ts
@@ -44,6 +44,8 @@ class CaretView {
   private host: HTMLElement;
   private unsub: () => void;
   private onResize: () => void;
+  private onScroll: () => void;
+  private rafId = 0;
 
   constructor(view: EditorView) {
     this.caret = document.createElement('div');
@@ -57,10 +59,40 @@ class CaretView {
     this.host.classList.add('ds-caret-host');
     this.host.appendChild(this.caret);
 
-    // Re-render the caret when caret prefs (or any appearance pref) change.
-    this.unsub = useUIPreferencesStore.subscribe(() => this.render(view));
+    // Re-render only when a CARET-relevant pref changes — not on every appearance
+    // pref (theme, layout, density…), which would re-run the layout reads in
+    // `render` for no reason.
+    this.unsub = useUIPreferencesStore.subscribe((state, prev) => {
+      const a = state.appearancePrefs;
+      const b = prev.appearancePrefs;
+      if (
+        a.caretStyle !== b.caretStyle ||
+        a.smoothCaret !== b.smoothCaret ||
+        a.motion !== b.motion ||
+        a.caretColor !== b.caretColor
+      ) {
+        this.render(view);
+      }
+    });
     this.onResize = () => this.render(view);
     window.addEventListener('resize', this.onResize);
+
+    // Keep the caret glued to its glyph while the prose scrolls. The caret is
+    // positioned from viewport coords (`coordsAtPos`), and the scroll container
+    // isn't necessarily the caret's host, so a scroll must trigger a reposition —
+    // but WITHOUT the smooth glide, or the caret visibly lags/floats chasing the
+    // text (the glide is for caret MOVES while typing, not for scroll tracking).
+    // Capture phase: scroll doesn't bubble and the real scroller may be an
+    // ancestor/descendant. rAF-throttled so a fast scroll coalesces to one
+    // reposition per frame (no layout thrash).
+    this.onScroll = () => {
+      if (this.rafId) return;
+      this.rafId = requestAnimationFrame(() => {
+        this.rafId = 0;
+        this.render(view, { instant: true });
+      });
+    };
+    window.addEventListener('scroll', this.onScroll, { capture: true, passive: true });
 
     this.render(view);
   }
@@ -69,8 +101,8 @@ class CaretView {
     this.render(view);
   }
 
-  private render(view: EditorView): void {
-    const { caretStyle, smoothCaret } = useUIPreferencesStore.getState().appearancePrefs;
+  private render(view: EditorView, opts?: { instant?: boolean }): void {
+    const { caretStyle, smoothCaret, caretColor } = useUIPreferencesStore.getState().appearancePrefs;
 
     // A custom caret is only needed for the block shape or the smooth glide; a
     // plain bar with smooth off is just the native caret.
@@ -121,21 +153,39 @@ class CaretView {
     this.caret.classList.toggle('ds-caret--block', isBlock);
     this.caret.classList.toggle('ds-caret--smooth', smooth);
 
+    // Custom caret color (any CSS color or var). Empty string falls back to the
+    // CSS defaults (.ds-caret / .ds-caret--block). The block caret stays
+    // translucent so the glyph underneath remains legible.
+    this.caret.style.background = caretColor
+      ? isBlock
+        ? `color-mix(in srgb, ${caretColor} 35%, transparent)`
+        : caretColor
+      : '';
+
     this.caret.style.display = 'block';
     this.caret.style.width = `${width}px`;
     this.caret.style.height = `${height}px`;
+
+    // Scroll-driven repositions must be instant — suppress the glide for this
+    // frame so the caret tracks the text exactly instead of floating behind it,
+    // then restore the transition so the next real caret MOVE still glides.
+    if (opts?.instant) this.caret.style.transition = 'none';
     this.caret.style.transform = `translate(${left}px, ${top}px)`;
 
     // Restart the blink so the caret is solid the instant it moves (feels
-    // responsive while typing) and resumes blinking when idle.
+    // responsive while typing) and resumes blinking when idle. The reflow also
+    // commits the (instant) transform before the transition is re-enabled.
     this.caret.style.animation = 'none';
     void this.caret.offsetWidth;
     this.caret.style.animation = '';
+    if (opts?.instant) this.caret.style.transition = '';
   }
 
   destroy(): void {
     this.unsub();
     window.removeEventListener('resize', this.onResize);
+    window.removeEventListener('scroll', this.onScroll, true);
+    if (this.rafId) cancelAnimationFrame(this.rafId);
     this.caret.remove();
   }
 }

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -92,6 +92,8 @@ export function AppearanceSettings() {
   const setCaretStyle = useUIPreferencesStore((s) => s.setCaretStyle);
   const smoothCaret = useUIPreferencesStore((s) => s.appearancePrefs.smoothCaret);
   const setSmoothCaret = useUIPreferencesStore((s) => s.setSmoothCaret);
+  const caretColor = useUIPreferencesStore((s) => s.appearancePrefs.caretColor);
+  const setCaretColor = useUIPreferencesStore((s) => s.setCaretColor);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -252,6 +254,13 @@ export function AppearanceSettings() {
             Automatically off when interface motion is reduced.
           </span>
         </div>
+        <ColorField
+          label="Color"
+          hint="The writing caret's color. Defaults to the theme text color; applies to the block / smooth caret."
+          value={caretColor ?? undefined}
+          defaultSwatch="#0a1525"
+          onChange={(value) => setCaretColor(value ?? null)}
+        />
       </div>
 
       {/* Motion */}


### PR DESCRIPTION
The smooth prose caret (JP-259) was mispositioned on collab docs — rendering ~a line below where it should be, and drifting when scrolling. Diagnosed with temporary instrumentation (since removed) across the prose mount, `healDoubledProse`, and the caret overlay; the real ProseMirror selection was always correct, so both were **overlay positioning** bugs.

## Root causes
1. **Line-offset (collab-only, even offline).** The overlay caret computed its position relative to its host (`.tiptap-editor` / `.ds-caret-host`), but it's absolutely positioned, so the browser resolves it against its nearest **positioned ancestor**. On a local doc that's the host; on a collab doc the host isn't a positioned box, so the true offset parent is an outer layout wrapper (`.document-area-wrapper`) — leaving the caret a constant ~44px (≈ one line) too low. (Offline too: it's the y-prosemirror `Collaboration` binding that differs, not the live cursor.)
2. **Scroll drift.** The caret re-rendered only on ProseMirror updates/resize/pref changes — never on scroll — and the smooth `transform` transition made it float/lag chasing the text.

## Fixes
- **Measure against the caret's actual `offsetParent`** (not the assumed host) — correct in both cases (local's offset parent *is* the host). Show the caret before reading `offsetParent`, since a hidden element reports none.
- **Scroll tracking:** a capture-phase, passive, rAF-throttled scroll listener repositions the caret **instantly** (transition suppressed for that frame). The smooth glide is fully preserved for caret *moves* while typing.
- **Caret color (requested):** a `caretColor` appearance preference + a `ColorField` in Settings → Appearance → Caret. Any CSS color; defaults to the theme text color; the block caret keeps a translucent blend. No store version bump — persist `merge` defaults the new field.
- **Scoped prefs subscription (perf):** the caret re-renders only on caret-relevant pref changes, not every appearance change.

## Verification
- `bun run typecheck` clean; full suite green (198 files / 2579 tests).
- **Live (yours):** on a collab doc (offline is fine) the caret sits exactly on the line; scrolling keeps it glued; the glide still feels right while typing; Settings → Appearance → Caret → Color changes it live.

Assisted-by: Opus 4.8