### PR TITLE
Spellcheck mode setting (custom / system / off) — fixes the double underline

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -94,6 +94,19 @@ describe('uiPreferencesStore — document browser grouping', () => {
   });
 });
 
+describe('uiPreferencesStore — spellcheck mode', () => {
+  it('defaults to the custom (built-in) checker', () => {
+    expect(useUIPreferencesStore.getState().appearancePrefs.spellcheck).toBe('custom');
+  });
+
+  it('setSpellcheckMode switches the active checker', () => {
+    useUIPreferencesStore.getState().setSpellcheckMode('system');
+    expect(useUIPreferencesStore.getState().appearancePrefs.spellcheck).toBe('system');
+    useUIPreferencesStore.getState().setSpellcheckMode('off');
+    expect(useUIPreferencesStore.getState().appearancePrefs.spellcheck).toBe('off');
+  });
+});
+
 describe('layout presets', () => {
   it('every layout has an entry for every panel id', () => {
     for (const mode of ['relaxed', 'designer', 'technician', 'power'] as const) {
@@ -269,6 +282,7 @@ describe('uiPreferencesStore — migration', () => {
       caretStyle: 'bar',
       smoothCaret: true,
       caretColor: null,
+      spellcheck: 'custom',
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -298,6 +312,7 @@ describe('uiPreferencesStore — migration', () => {
       caretStyle: 'bar',
       smoothCaret: true,
       caretColor: null,
+      spellcheck: 'custom',
     });
   });
 
@@ -324,6 +339,7 @@ describe('uiPreferencesStore — migration', () => {
       caretStyle: 'bar',
       smoothCaret: true,
       caretColor: null,
+      spellcheck: 'custom',
     });
   });
 
@@ -398,6 +414,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       caretStyle: 'bar',
       smoothCaret: true,
       caretColor: null,
+      spellcheck: 'custom',
     });
   });
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -59,6 +59,16 @@ export type ProseBackground = 'default' | 'flat' | 'glow' | 'aurora';
 /** Text caret shape in the prose editor. `bar` = the default thin I-beam caret. */
 export type CaretStyle = 'bar' | 'block';
 
+/**
+ * Which spellchecker runs in the prose editor.
+ * - `custom`: DocuShark's built-in checker (nspell) + the per-document custom
+ *   dictionary + "Add to dictionary"; the native browser spellcheck is turned OFF.
+ * - `system`: the browser/OS native spellcheck; the custom checker is OFF.
+ * - `off`: no spellchecking.
+ * Exactly one checker is ever active, so a word is never double-underlined.
+ */
+export type SpellcheckMode = 'custom' | 'system' | 'off';
+
 /** Bounds for the interface-size (UI scale) multiplier. */
 export const UI_SCALE_MIN = 0.9;
 export const UI_SCALE_MAX = 1.25;
@@ -84,6 +94,9 @@ export interface AppearancePrefs {
    *  track the theme). `null` follows the default (theme text color). Applies to
    *  the custom caret (block / smooth). */
   caretColor: string | null;
+  /** Which spellchecker runs in the prose editor (custom dictionary / system /
+   *  off). Drives both the custom decorations and the native `spellcheck` attr. */
+  spellcheck: SpellcheckMode;
 }
 
 /**
@@ -188,6 +201,8 @@ export interface UIPreferencesActions {
   setMotion: (motion: MotionPreference) => void;
   /** Set the custom prose caret color (`null` = follow the theme). */
   setCaretColor: (caretColor: string | null) => void;
+  /** Set which spellchecker runs in the prose editor. */
+  setSpellcheckMode: (spellcheck: SpellcheckMode) => void;
   /** Set the spacing density. */
   setDensity: (density: Density) => void;
   /** Set the prose caret shape. */
@@ -259,6 +274,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   caretStyle: 'bar',
   smoothCaret: true,
   caretColor: null,
+  spellcheck: 'custom',
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -545,6 +561,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setCaretColor: (caretColor) => {
         set({ appearancePrefs: { ...get().appearancePrefs, caretColor } });
+      },
+
+      setSpellcheckMode: (spellcheck) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, spellcheck } });
       },
 
       reset: () => {

--- a/src/tiptap/SpellcheckExtension.ts
+++ b/src/tiptap/SpellcheckExtension.ts
@@ -2,6 +2,7 @@ import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { SpellcheckService } from '../services/SpellcheckService';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import type { Node as PMNode } from '@tiptap/pm/model';
 
 export const SPELLCHECK_PLUGIN_KEY = new PluginKey<DecorationSet>('spellcheck');
@@ -9,6 +10,12 @@ const WORD_RE = /\p{L}[\p{L}\p{M}'’-]*/gu;
 const RECHECK_DEBOUNCE_MS = 500;
 
 function buildDecorations(doc: PMNode): DecorationSet {
+  // Only the built-in checker draws decorations. In `system` mode the native
+  // browser spellcheck does the work; `off` disables spelling entirely. (Gating
+  // here — not in SpellcheckService — keeps the service pure for the popover.)
+  if (useUIPreferencesStore.getState().appearancePrefs.spellcheck !== 'custom') {
+    return DecorationSet.empty;
+  }
   if (!SpellcheckService.isReady()) return DecorationSet.empty;
   const decorations: Decoration[] = [];
   doc.descendants((node, pos) => {

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -14,6 +14,7 @@ import {
   useUIPreferencesStore,
   type Density,
   type CaretStyle,
+  type SpellcheckMode,
   type ProseBackground,
   type ThemeBase,
   type ThemeColorSlot,
@@ -66,6 +67,12 @@ const CARET_OPTIONS = [
   { value: 'block' as const, label: 'Block', title: 'Block caret over the character' },
 ];
 
+const SPELLCHECK_OPTIONS = [
+  { value: 'custom' as const, label: 'Custom', title: "DocuShark's dictionary + Add to dictionary" },
+  { value: 'system' as const, label: 'System', title: "Your browser / OS spellchecker" },
+  { value: 'off' as const, label: 'Off', title: 'No spellchecking' },
+];
+
 /** WCAG thresholds for the inline contrast warnings. */
 const AA_TEXT = 4.5;
 const UI_MIN = 3;
@@ -94,6 +101,8 @@ export function AppearanceSettings() {
   const setSmoothCaret = useUIPreferencesStore((s) => s.setSmoothCaret);
   const caretColor = useUIPreferencesStore((s) => s.appearancePrefs.caretColor);
   const setCaretColor = useUIPreferencesStore((s) => s.setCaretColor);
+  const spellcheck = useUIPreferencesStore((s) => s.appearancePrefs.spellcheck);
+  const setSpellcheckMode = useUIPreferencesStore((s) => s.setSpellcheckMode);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -261,6 +270,25 @@ export function AppearanceSettings() {
           defaultSwatch="#0a1525"
           onChange={(value) => setCaretColor(value ?? null)}
         />
+      </div>
+
+      {/* Spelling */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Spelling</h4>
+        <div className="settings-row">
+          <span className="settings-label">Spellcheck</span>
+          <SegmentedControl
+            ariaLabel="Spellcheck"
+            value={spellcheck}
+            onValueChange={(v: SpellcheckMode) => setSpellcheckMode(v)}
+            options={SPELLCHECK_OPTIONS}
+          />
+          <span className="settings-hint">
+            <strong>Custom</strong> uses DocuShark's dictionary and “Add to dictionary”.
+            <strong> System</strong> uses your browser/OS spellchecker.
+            <strong> Off</strong> disables spellchecking. Only one runs at a time.
+          </span>
+        </div>
       </div>
 
       {/* Motion */}

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { Editor } from '@tiptap/core';
 import { useRichTextStore } from '../store/richTextStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { rebuildSpellcheck } from '../tiptap/SpellcheckExtension';
 import { SpellcheckService } from '../services/SpellcheckService';
 import { SpellcheckPopover } from './SpellcheckPopover';
@@ -60,6 +61,7 @@ export function useProseEditorChrome(
 ): ProseEditorChrome {
   const { headingAnchors = false } = opts;
   const customDictionary = useRichTextStore((s) => s.content.customDictionary);
+  const spellcheckMode = useUIPreferencesStore((s) => s.appearancePrefs.spellcheck);
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     isOpen: false,
@@ -106,6 +108,18 @@ export function useProseEditorChrome(
       });
     }
   }, [editor, customDictionary]);
+
+  // Spellcheck mode (custom / system / off). Toggle the contenteditable's NATIVE
+  // browser spellcheck — only `system` wants it on; `custom`/`off` turn it off so
+  // the native red squiggle doesn't stack on the built-in checker's underline (the
+  // double-underline bug). `spellcheck` isn't a ProseMirror-managed attribute, so
+  // an imperative setAttribute sticks. Then rebuild the custom decorations so they
+  // clear when leaving `custom` and re-appear when returning to it.
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return;
+    editor.view.dom.setAttribute('spellcheck', spellcheckMode === 'system' ? 'true' : 'false');
+    rebuildSpellcheck(editor.view);
+  }, [editor, spellcheckMode]);
 
   // DOM-level click handler so inline link clicks reliably fire (handleClickOn
   // doesn't trigger consistently for inline marks in all browsers). Opens


### PR DESCRIPTION
A misspelled word showed what looked like **two underlines**, and adding it to the custom dictionary left it still flagged — even though the app's right-click menu agreed it was fine.

## Root cause
Two spellcheckers were running at once:
- The app's **built-in** checker — `SpellcheckExtension` (nspell + the per-document custom dictionary) draws a wavy `var(--danger)` underline via a ProseMirror decoration.
- The **browser's native** contenteditable spellcheck — on by default for any `contenteditable`, never disabled, drawing its own red squiggle.

"Add to dictionary" clears the *built-in* underline (the popover calls `rebuildSpellcheck`), but the **native** squiggle stays because the browser doesn't know the app's dictionary → the word still looks flagged, with a second underline.

## Fix — one app-level `spellcheck` preference, so exactly one checker ever runs
- **`custom`** (default): built-in checker + custom dictionary + "Add to dictionary"; native spellcheck turned **off** (no more double underline).
- **`system`**: native browser/OS spellcheck; built-in checker off (for anyone the built-in dictionary gives trouble).
- **`off`**: neither.

Wiring (mirrors the `caretStyle`/`caretColor` pattern):
- `uiPreferencesStore`: `SpellcheckMode` + `appearancePrefs.spellcheck` + `setSpellcheckMode`. No persist version bump — the `merge` defaults the new field (like `caretColor`).
- `SpellcheckExtension.buildDecorations` returns empty unless mode is `custom`.
- `useProseEditorChrome` (shared by the local + collab editors) toggles the contenteditable's native `spellcheck` attribute (only `system` → `'true'`) and rebuilds the custom pass on mode change, so the two never coexist.
- `AppearanceSettings`: a **Spelling** group (SegmentedControl).

## Notes
- In `system` mode the app's right-click formatting menu still opens; native spell *suggestions* use the browser's own gesture. The per-document custom dictionary is unchanged (an app-level dictionary is a possible follow-up).

## Verification
- `bun run typecheck` clean; full suite green (198 files / 2581 tests); migration assertions updated for the new field + a default/setter test.
- **Live (yours):** Custom = one wavy underline, "Add to dictionary" clears it for good; System = native squiggle only (no double line); Off = nothing; persists across reload; applies to local + collab docs.

Assisted-by: Opus 4.8