### PR TITLE
JP-363: resolve blob:// prose images on the read-only preview surface

### DIFF
--- a/src/ui/ProsePreview.test.tsx
+++ b/src/ui/ProsePreview.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ProsePreview — the read-only prose surface shown for a relay document while
+ * its collaboration engine comes up. It must resolve embedded `blob://` images
+ * to object URLs just like the editable surfaces; before JP-363 it didn't, so
+ * prose images flashed broken during a sign-in / document-switch transition and
+ * only healed once the editable editor mounted.
+ *
+ * This is the automated repro: on the pre-fix code the rendered <img> keeps its
+ * `blob://` src; after the fix it resolves to the (mocked) object URL.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { blobStorage } from '../storage/BlobStorage';
+import { registerBlobDownloader, resetBlobCache } from '../storage/blobResolver';
+import { ProsePreview } from './ProsePreview';
+
+const HASH = 'c'.repeat(64);
+
+function pngBlob(): Blob {
+  return new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' });
+}
+
+describe('ProsePreview blob image resolution (JP-363)', () => {
+  let loadBlobSpy: MockInstance<[id: string], Promise<Blob | null>>;
+  let urlCounter: number;
+
+  beforeEach(() => {
+    urlCounter = 0;
+    globalThis.URL.createObjectURL = vi.fn(() => `blob:mock-${urlCounter++}`);
+    globalThis.URL.revokeObjectURL = vi.fn();
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  afterEach(() => {
+    loadBlobSpy?.mockRestore();
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  it('resolves an embedded blob:// image to an object URL', async () => {
+    loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob').mockResolvedValue(pngBlob());
+
+    const { container } = render(
+      <ProsePreview html={`<p>caption</p><img src="blob://${HASH}">`} />,
+    );
+
+    await waitFor(() => {
+      const img = container.querySelector('img');
+      expect(img).not.toBeNull();
+      expect(img!.getAttribute('src')).toBe('blob:mock-0');
+    });
+
+    expect(loadBlobSpy).toHaveBeenCalledWith(HASH);
+  });
+});

--- a/src/ui/ProsePreview.tsx
+++ b/src/ui/ProsePreview.tsx
@@ -14,6 +14,7 @@
 
 import { useEditor, EditorContent } from '@tiptap/react';
 import { extensions } from './TiptapEditor';
+import { useResolveBlobImages } from './useProseBlobImages';
 import './TiptapEditor.css';
 
 export interface ProsePreviewProps {
@@ -32,6 +33,11 @@ export function ProsePreview({ html, className }: ProsePreviewProps) {
     },
     [html],
   );
+
+  // Resolve embedded `blob://` images to object URLs — the read-only preview is
+  // shown for a relay doc while its collab engine comes up, and without this its
+  // images render broken until the editable surface mounts (JP-363).
+  useResolveBlobImages(editor);
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`}>

--- a/src/ui/proseBlobImages.test.ts
+++ b/src/ui/proseBlobImages.test.ts
@@ -1,0 +1,98 @@
+/**
+ * resolveBlobImagesIn — resolves `blob://<hash>` rich-text images in an editor
+ * DOM subtree to object URLs, and shows a *non-sticky* placeholder on a genuine
+ * miss so the self-heal path (resolve succeeds on a later pass, e.g. after a
+ * local↔collab mode flip) renders the healed image clean (JP-363).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
+import { blobStorage } from '../storage/BlobStorage';
+import { registerBlobDownloader, resetBlobCache } from '../storage/blobResolver';
+import { resolveBlobImagesIn } from './proseBlobImages';
+
+const HASH = 'a'.repeat(64);
+
+function pngBlob(): Blob {
+  return new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' });
+}
+
+function subtreeWithBlobImage(): { dom: HTMLElement; img: HTMLImageElement } {
+  const dom = document.createElement('div');
+  dom.innerHTML = `<p>before</p><img src="blob://${HASH}"><p>after</p>`;
+  return { dom, img: dom.querySelector('img')! };
+}
+
+describe('resolveBlobImagesIn', () => {
+  let loadBlobSpy: MockInstance<[id: string], Promise<Blob | null>>;
+  let urlCounter: number;
+
+  beforeEach(() => {
+    urlCounter = 0;
+    globalThis.URL.createObjectURL = vi.fn(() => `blob:mock-${urlCounter++}`);
+    globalThis.URL.revokeObjectURL = vi.fn();
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  afterEach(() => {
+    loadBlobSpy?.mockRestore();
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  it('resolves a blob:// image to an object URL', async () => {
+    loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob').mockResolvedValue(pngBlob());
+    const { dom, img } = subtreeWithBlobImage();
+
+    await resolveBlobImagesIn(dom);
+
+    expect(img.getAttribute('src')).toBe('blob:mock-0');
+    expect(img.hasAttribute('data-blob-missing')).toBe(false);
+  });
+
+  it('shows a marked placeholder for a blob that genuinely cannot resolve', async () => {
+    loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob').mockResolvedValue(null);
+    const { dom, img } = subtreeWithBlobImage();
+
+    await resolveBlobImagesIn(dom);
+
+    // src is left as the blob:// ref so a later pass can retry it.
+    expect(img.getAttribute('src')).toBe(`blob://${HASH}`);
+    expect(img.hasAttribute('data-blob-missing')).toBe(true);
+    expect(img.getAttribute('alt')).toBe('(Image not found)');
+    expect(img.style.border).toContain('dashed');
+  });
+
+  it('clears the placeholder when a later pass resolves the blob (self-heal)', async () => {
+    // First pass misses (e.g. mid mode-transition), second pass succeeds — the
+    // JP-363 flip-then-heal sequence.
+    loadBlobSpy = vi
+      .spyOn(blobStorage, 'loadBlob')
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(pngBlob());
+    const { dom, img } = subtreeWithBlobImage();
+
+    await resolveBlobImagesIn(dom);
+    expect(img.hasAttribute('data-blob-missing')).toBe(true);
+
+    await resolveBlobImagesIn(dom);
+
+    expect(img.getAttribute('src')).toBe('blob:mock-0');
+    expect(img.hasAttribute('data-blob-missing')).toBe(false);
+    expect(img.getAttribute('alt')).toBeNull();
+    expect(img.style.border).toBe('');
+    expect(img.style.padding).toBe('');
+  });
+
+  it('leaves directly-loadable srcs untouched (only blob:// is rewritten)', async () => {
+    loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob');
+    const dom = document.createElement('div');
+    dom.innerHTML = '<img src="https://x/y.png"><img src="data:image/png;base64,AAAA">';
+
+    await resolveBlobImagesIn(dom);
+
+    expect(dom.querySelectorAll('img')[0]!.getAttribute('src')).toBe('https://x/y.png');
+    expect(dom.querySelectorAll('img')[1]!.getAttribute('src')).toBe('data:image/png;base64,AAAA');
+    expect(loadBlobSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/proseBlobImages.ts
+++ b/src/ui/proseBlobImages.ts
@@ -24,8 +24,19 @@ export async function resolveBlobImagesIn(dom: HTMLElement): Promise<void> {
     const objectUrl = await resolveBlobUrl(blobUrl);
     if (objectUrl && objectUrl !== blobUrl) {
       img.setAttribute('src', objectUrl);
+      // A blob that previously missed (e.g. resolved mid mode-transition) and is
+      // now available: clear the placeholder so the healed image renders clean
+      // instead of keeping a stale dashed border (JP-363).
+      if (img.hasAttribute('data-blob-missing')) {
+        img.removeAttribute('data-blob-missing');
+        img.removeAttribute('alt');
+        img.style.border = '';
+        img.style.padding = '';
+      }
     } else if (!objectUrl) {
-      // Show a placeholder for a blob we genuinely can't resolve.
+      // Show a placeholder for a blob we genuinely can't resolve. Marked so a
+      // later successful resolve (the self-heal path) can clear it.
+      img.setAttribute('data-blob-missing', '');
       img.setAttribute('alt', '(Image not found)');
       img.style.border = '2px dashed var(--border-color)';
       img.style.padding = '8px';

--- a/src/ui/useProseBlobImages.ts
+++ b/src/ui/useProseBlobImages.ts
@@ -1,0 +1,45 @@
+/**
+ * useResolveBlobImages — resolve `blob://<hash>` images inside a Tiptap editor's
+ * DOM to displayable object URLs, on mount and on every update.
+ *
+ * Shared by every prose render surface — the local `TiptapEditor`, the relay
+ * `CollaborativeProseEditor` (both via `useProseEditorChrome`), and the
+ * read-only `ProsePreview` shown while a relay doc's collab engine is still
+ * coming up. Keeping the resolution in one hook is what stops the surfaces from
+ * drifting: a surface that forgets to resolve renders raw `blob://` srcs the
+ * browser can't load, which is exactly the transient broken-image flash when a
+ * doc flips between local and collab mode (JP-363 — `ProsePreview` used to miss
+ * this).
+ *
+ * JP-319: a collab/MCP update re-renders the image node view, which resets the
+ * DOM `<img>` back to the unresolved `blob://` src from the node attrs. Running
+ * the resolver only synchronously can lose that race (the node view re-renders
+ * after we resolve), leaving a broken-image icon until the next interaction (the
+ * "toggle float to make it reappear" symptom). So also re-resolve on the next
+ * frame, after the node view has settled. The resolver is idempotent — it only
+ * touches remaining `blob://` srcs, never object/http/data URLs. A read-only
+ * surface never fires `update`, but it recreates its editor when its content
+ * changes, so the `[editor]` effect re-runs and still covers it.
+ */
+
+import { useEffect } from 'react';
+import type { Editor } from '@tiptap/core';
+import { resolveBlobImagesIn } from './proseBlobImages';
+
+export function useResolveBlobImages(editor: Editor | null): void {
+  useEffect(() => {
+    if (!editor) return;
+    let raf = 0;
+    const convert = () => {
+      void resolveBlobImagesIn(editor.view.dom);
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => void resolveBlobImagesIn(editor.view.dom));
+    };
+    convert();
+    editor.on('update', convert);
+    return () => {
+      cancelAnimationFrame(raf);
+      editor.off('update', convert);
+    };
+  }, [editor]);
+}

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -23,7 +23,7 @@ import { rebuildSpellcheck } from '../tiptap/SpellcheckExtension';
 import { SpellcheckService } from '../services/SpellcheckService';
 import { SpellcheckPopover } from './SpellcheckPopover';
 import { DocumentEditorContextMenu } from './DocumentEditorContextMenu';
-import { resolveBlobImagesIn } from './proseBlobImages';
+import { useResolveBlobImages } from './useProseBlobImages';
 
 interface ContextMenuState {
   isOpen: boolean;
@@ -172,30 +172,9 @@ export function useProseEditorChrome(
   }, [editor, headingAnchors]);
 
   // Resolve blob:// images to object URLs (initial + on every update) —
-  // collaborators on other devices embed images we must load.
-  //
-  // JP-319: a collab/MCP update re-renders the image node view, which resets the
-  // DOM <img> back to the unresolved `blob://` src from the node attrs. Running
-  // the resolver only synchronously can lose that race (the node view re-renders
-  // after we resolve), leaving a broken-image icon until the next interaction
-  // (the "toggle float to make it reappear" symptom). So also re-resolve on the
-  // next frame, after the node view has settled. The resolver is idempotent —
-  // it only touches remaining `blob://` srcs, never object/http/data URLs.
-  useEffect(() => {
-    if (!editor) return;
-    let raf = 0;
-    const convert = () => {
-      void resolveBlobImagesIn(editor.view.dom);
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(() => void resolveBlobImagesIn(editor.view.dom));
-    };
-    convert();
-    editor.on('update', convert);
-    return () => {
-      cancelAnimationFrame(raf);
-      editor.off('update', convert);
-    };
-  }, [editor]);
+  // collaborators on other devices embed images we must load. Shared with the
+  // read-only `ProsePreview` surface so they can't drift (see the hook).
+  useResolveBlobImages(editor);
 
   const overlay = (
     <>


### PR DESCRIPTION
## Problem

Prose-page images (mostly local-origin) flash **broken / de-referenced** when a document flips between **local** and **collaborative** mode — signing in, or switching documents — then **self-heal** a moment later. The bytes are in storage the whole time; it's a render-surface bug, not data loss. Closes JP-363.

## Root cause

The editor panel renders prose through **three** surfaces depending on collab state:

| Surface | When | Resolved `blob://` images? |
|---|---|---|
| `TiptapEditor` (local) | local-only doc | ✅ via `useProseEditorChrome` |
| `CollaborativeProseEditor` | relay doc, engine ready | ✅ via `useProseEditorChrome` |
| `ProsePreview` (read-only) | **relay doc, engine not yet ready** | ❌ **no resolution** |

`ProsePreview` rendered the page HTML through a read-only Tiptap instance but never called `resolveBlobImagesIn`, so the image node-view's raw `<img src="blob://…">` (unloadable by the browser) was shown as-is. During sign-in / doc-switch the panel transitions to `ProsePreview` for the sub-second window while the collab engine comes up — exactly the "flip at the wrong time" window — then heals once `CollaborativeProseEditor` mounts.

## Fix

- Extract the JP-319 two-stage resolver (sync + `requestAnimationFrame` retry, re-run on `update`) out of `useProseEditorChrome` into a shared **`useResolveBlobImages`** hook, and use it on **all three** surfaces so they can't drift. `ProsePreview` adopting it is the actual fix.
- Make the `(Image not found)` placeholder **non-sticky**: mark it with `data-blob-missing` and clear the marker + dashed border when a later pass resolves the blob, so a healed image renders clean instead of keeping a stale border.

Scope is the prose render path only — canvas `FileShape` images use a separate (working) `requestBlobThumbnail` path. No store / wire / document-format changes; no migration.

## Tests

- `src/ui/ProsePreview.test.tsx` — **red→green repro**: renders `ProsePreview` with an embedded `blob://` image and asserts it resolves to an object URL (verified failing on pre-fix code: `expected 'blob://cccc…' to be 'blob:mock-0'`).
- `src/ui/proseBlobImages.test.ts` — placeholder set on a genuine miss, and cleared on the self-heal pass.

Typecheck clean; full `src/ui` + `src/tiptap` suites green (260 tests).

## Manual verification (staging, post-deploy)

Open a local doc with a prose image → **sign in** → confirm no broken-image flash during the transition; then **switch documents** between two relay docs with prose images and confirm no transient de-ref.

Assisted-by: Opus 4.8