### PR TITLE
JP-365: Collections polishing — manageable, styled, single-card moves

### DIFF
--- a/src/ui/DocumentCard.collections.test.tsx
+++ b/src/ui/DocumentCard.collections.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Per-card "Move to collection" menu (JP-365) — single-document collection
+ * assignment, which used to be possible only via multi-select bulk actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { DocumentCard } from './DocumentCard';
+import type { LocalDocument } from '../types/DocumentRegistry';
+import type { Collection } from '../store/collectionStore';
+
+const record: LocalDocument = {
+  type: 'local',
+  id: 'l1',
+  name: 'My Doc',
+  pageCount: 1,
+  createdAt: 0,
+  modifiedAt: 0,
+};
+
+const collections: Collection[] = [
+  { id: 'c1', name: 'Work', order: 0, createdAt: 0 },
+  { id: 'c2', name: 'Personal', order: 1, createdAt: 0 },
+];
+
+describe('DocumentCard — Move to collection', () => {
+  beforeEach(() => cleanup());
+
+  it('shows no move affordance when onAssignCollection is absent', () => {
+    render(<DocumentCard record={record} collections={collections} />);
+    expect(screen.queryByRole('button', { name: 'Move to collection' })).toBeNull();
+  });
+
+  it('opens the menu and assigns the doc to a chosen collection', () => {
+    const onAssign = vi.fn();
+    render(
+      <DocumentCard
+        record={record}
+        collections={collections}
+        currentCollectionId={null}
+        onAssignCollection={onAssign}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Personal' }));
+
+    expect(onAssign).toHaveBeenCalledWith('l1', 'c2');
+  });
+
+  it('offers "Remove from collection" only when assigned, and passes null', () => {
+    const onAssign = vi.fn();
+    const { rerender } = render(
+      <DocumentCard
+        record={record}
+        collections={collections}
+        currentCollectionId={null}
+        onAssignCollection={onAssign}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    expect(screen.queryByRole('menuitem', { name: 'Remove from collection' })).toBeNull();
+
+    // Now assigned to c1 → the (still-open) menu gains the remove action.
+    rerender(
+      <DocumentCard
+        record={record}
+        collections={collections}
+        currentCollectionId="c1"
+        onAssignCollection={onAssign}
+      />,
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remove from collection' }));
+
+    expect(onAssign).toHaveBeenCalledWith('l1', null);
+  });
+
+  it('routes "+ New collection…" to the create-for-doc handler', () => {
+    const onCreateFor = vi.fn();
+    render(
+      <DocumentCard
+        record={record}
+        collections={collections}
+        currentCollectionId={null}
+        onAssignCollection={vi.fn()}
+        onCreateCollectionFor={onCreateFor}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: '+ New collection…' }));
+
+    expect(onCreateFor).toHaveBeenCalledWith('l1');
+  });
+});

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -260,6 +260,85 @@ button.document-card__offline--action:focus-visible {
   opacity: 0.6;
 }
 
+/* Per-card "Move to collection" menu */
+.document-card__collection-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.document-card__collection-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 30;
+  min-width: 200px;
+  max-width: 260px;
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg, 0 12px 40px rgba(14, 28, 48, 0.25));
+  transform-origin: top right;
+  animation: document-card__collection-menu-in 0.14s ease-out;
+}
+@keyframes document-card__collection-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .document-card__collection-menu {
+    animation: none;
+  }
+}
+.document-card__collection-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 9px;
+  font-size: 13px;
+  text-align: left;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.document-card__collection-item:hover {
+  background: var(--bg-secondary);
+}
+.document-card__collection-item svg {
+  flex: 0 0 auto;
+  color: var(--color-primary, #2563eb);
+}
+.document-card__collection-item--new {
+  color: var(--color-primary, #2563eb);
+  font-weight: 500;
+}
+.document-card__collection-name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.document-card__collection-swatch {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full, 999px);
+  background: var(--text-faint);
+}
+
 .document-card__action--danger:hover {
   background: var(--danger-bg);
   border-color: rgba(239, 68, 68, 0.3);

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -5,7 +5,7 @@
  * Used in the DocumentBrowser for unified document listing.
  */
 
-import { memo, useState, useCallback, useEffect } from 'react';
+import { memo, useState, useCallback, useEffect, useRef } from 'react';
 import {
   Check,
   ChevronDown,
@@ -14,6 +14,7 @@ import {
   CloudDownload,
   CloudOff,
   Download,
+  FolderInput,
   HardDrive,
   Loader2,
   Network,
@@ -24,6 +25,7 @@ import {
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
 import { isForeignRelayDoc, type DocumentRecord, type Permission } from '../types/DocumentRegistry';
+import type { Collection } from '../store/collectionStore';
 import type { OfflineProgress, OfflineStatus } from '../store/offlineAvailability';
 import { useConnectionStore } from '../store/connectionStore';
 import './DocumentCard.css';
@@ -59,6 +61,14 @@ interface DocumentCardProps {
     | undefined;
   /** Optional collection accent (used to surface collection membership in the card). */
   collectionAccent?: { name: string; color?: string | undefined } | undefined;
+  /** All collections, for the per-card "Move to collection" menu. */
+  collections?: Collection[] | undefined;
+  /** The collection this doc currently belongs to (null = unassigned). */
+  currentCollectionId?: string | null | undefined;
+  /** Assign this doc to a collection (or null to remove). Enables the move menu. */
+  onAssignCollection?: ((id: string, collectionId: string | null) => void) | undefined;
+  /** Create a new collection and assign this doc to it (styled prompt). */
+  onCreateCollectionFor?: ((id: string) => void) | undefined;
   /** Address (host:port) of the currently-connected relay, for connected/disconnected badge state. */
   connectedRelayAddress?: string | undefined;
   /** Offline-cache status for relay/cached docs (JP-281). Drives the offline-ready badge. */
@@ -236,6 +246,10 @@ function DocumentCardImpl({
   onMoveToPersonal,
   onSelectToggle,
   collectionAccent,
+  collections,
+  currentCollectionId,
+  onAssignCollection,
+  onCreateCollectionFor,
   connectedRelayAddress,
   offlineStatus,
   offlineProgress,
@@ -248,6 +262,20 @@ function DocumentCardImpl({
   const [isPublishing, setIsPublishing] = useState(false);
   const [isMovingToPersonal, setIsMovingToPersonal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [collMenuOpen, setCollMenuOpen] = useState(false);
+  const collMenuRef = useRef<HTMLDivElement | null>(null);
+
+  // Close the collection menu on an outside click.
+  useEffect(() => {
+    if (!collMenuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (collMenuRef.current && !collMenuRef.current.contains(e.target as Node)) {
+        setCollMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [collMenuOpen]);
 
   // Sync editName when record.name changes externally
   useEffect(() => {
@@ -635,6 +663,73 @@ function DocumentCardImpl({
           >
             <Users size={16} aria-hidden="true" />
           </button>
+        )}
+        {onAssignCollection && (
+          <div className="document-card__collection-wrap" ref={collMenuRef}>
+            <button
+              className="document-card__action"
+              onClick={(e) => {
+                e.stopPropagation();
+                setCollMenuOpen((o) => !o);
+              }}
+              title="Move to collection"
+              aria-label="Move to collection"
+              aria-haspopup="menu"
+              aria-expanded={collMenuOpen}
+            >
+              <FolderInput size={16} aria-hidden="true" />
+            </button>
+            {collMenuOpen && (
+              <div
+                className="document-card__collection-menu"
+                role="menu"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {(collections ?? []).map((c) => (
+                  <button
+                    key={c.id}
+                    className="document-card__collection-item"
+                    role="menuitem"
+                    onClick={() => {
+                      onAssignCollection(record.id, c.id);
+                      setCollMenuOpen(false);
+                    }}
+                  >
+                    <span
+                      className="document-card__collection-swatch"
+                      style={c.color ? { background: c.color } : undefined}
+                    />
+                    <span className="document-card__collection-name">{c.name}</span>
+                    {currentCollectionId === c.id && <Check size={14} aria-hidden="true" />}
+                  </button>
+                ))}
+                {currentCollectionId && (
+                  <button
+                    className="document-card__collection-item"
+                    role="menuitem"
+                    onClick={() => {
+                      onAssignCollection(record.id, null);
+                      setCollMenuOpen(false);
+                    }}
+                  >
+                    Remove from collection
+                  </button>
+                )}
+                {onCreateCollectionFor && (
+                  <button
+                    className="document-card__collection-item document-card__collection-item--new"
+                    role="menuitem"
+                    onClick={() => {
+                      onCreateCollectionFor(record.id);
+                      setCollMenuOpen(false);
+                    }}
+                  >
+                    + New collection…
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
         )}
         {onRename && (
           <button

--- a/src/ui/confirm/ConfirmDialog.css
+++ b/src/ui/confirm/ConfirmDialog.css
@@ -52,6 +52,30 @@
   color: var(--text-secondary, #6b7280);
 }
 
+.confirm-dialog__input {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 2px;
+  padding: 9px 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--color-text, #1f2937);
+  background: var(--color-bg, #f8fafc);
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.15));
+  border-radius: 8px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.confirm-dialog__input:focus {
+  outline: none;
+  border-color: var(--color-primary, #2563eb);
+  box-shadow: 0 0 0 3px var(--color-primary-soft, rgba(37, 99, 235, 0.2));
+}
+
+.confirm-dialog__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .confirm-dialog__actions {
   display: flex;
   justify-content: flex-end;

--- a/src/ui/confirm/ConfirmDialog.tsx
+++ b/src/ui/confirm/ConfirmDialog.tsx
@@ -1,10 +1,11 @@
 /**
- * Styled confirmation dialog + host. Driven by `confirmStore` / `confirmDialog()`.
- * Render <ConfirmDialogHost /> once at the app root.
+ * Styled confirmation + prompt dialog host. Driven by `confirmStore` /
+ * `confirmDialog()` / `promptDialog()`. Render <ConfirmDialogHost /> once at the
+ * app root.
  */
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
-import { useConfirmStore, type ConfirmRequest } from './confirmStore';
+import { useConfirmStore, type ConfirmRequest, type PromptRequest } from './confirmStore';
 import './ConfirmDialog.css';
 
 interface ConfirmDialogProps {
@@ -13,14 +14,12 @@ interface ConfirmDialogProps {
   onCancel: () => void;
 }
 
-function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const cancelRef = useRef<HTMLButtonElement>(null);
-
+/** Minimal focus trap across the dialog's focusable controls (buttons + inputs). */
+function useDialogKeys(
+  dialogRef: RefObject<HTMLElement>,
+  onCancel: () => void,
+): void {
   useEffect(() => {
-    // Focus the safe (cancel) button by default — important for destructive prompts.
-    cancelRef.current?.focus();
-
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -28,8 +27,7 @@ function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
         return;
       }
       if (e.key === 'Tab') {
-        // Minimal focus trap across the dialog's focusable controls.
-        const focusables = dialogRef.current?.querySelectorAll<HTMLElement>('button');
+        const focusables = dialogRef.current?.querySelectorAll<HTMLElement>('button, input');
         if (!focusables || focusables.length === 0) return;
         const first = focusables[0]!;
         const last = focusables[focusables.length - 1]!;
@@ -44,13 +42,23 @@ function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
     };
     document.addEventListener('keydown', handleKey, true);
     return () => document.removeEventListener('keydown', handleKey, true);
-  }, [onCancel]);
+  }, [dialogRef, onCancel]);
+}
+
+function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // Focus the safe (cancel) button by default — important for destructive prompts.
+    cancelRef.current?.focus();
+  }, []);
+  useDialogKeys(dialogRef, onCancel);
 
   return (
     <div
       className="confirm-overlay"
       onMouseDown={(e) => {
-        // Backdrop click (not a drag from inside) cancels.
         if (e.target === e.currentTarget) onCancel();
       }}
     >
@@ -95,18 +103,110 @@ function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
   );
 }
 
-/** Mount once at the app root — renders the active confirmation prompt. */
+interface PromptDialogProps {
+  request: PromptRequest;
+  onSubmit: (value: string) => void;
+  onCancel: () => void;
+}
+
+function PromptDialog({ request, onSubmit, onCancel }: PromptDialogProps) {
+  const dialogRef = useRef<HTMLFormElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(request.initialValue ?? '');
+
+  useEffect(() => {
+    // Focus + select the input so the user can type or overwrite immediately.
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+  useDialogKeys(dialogRef, onCancel);
+
+  const trimmed = value.trim();
+  const submit = () => {
+    if (trimmed.length === 0) return;
+    onSubmit(trimmed);
+  };
+
+  return (
+    <div
+      className="confirm-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <form
+        ref={dialogRef}
+        className="confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby={request.message ? 'confirm-dialog-message' : undefined}
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        <h2 id="confirm-dialog-title" className="confirm-dialog__title">
+          {request.title}
+        </h2>
+        {request.message && (
+          <p id="confirm-dialog-message" className="confirm-dialog__message">
+            {request.message}
+          </p>
+        )}
+        <input
+          ref={inputRef}
+          type="text"
+          className="confirm-dialog__input"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={request.placeholder}
+          aria-label={request.label ?? request.title}
+        />
+        <div className="confirm-dialog__actions">
+          <button
+            type="button"
+            className="confirm-dialog__btn confirm-dialog__btn--cancel"
+            onClick={onCancel}
+          >
+            {request.cancelLabel ?? 'Cancel'}
+          </button>
+          <button
+            type="submit"
+            className="confirm-dialog__btn confirm-dialog__btn--confirm"
+            disabled={trimmed.length === 0}
+          >
+            {request.confirmLabel ?? 'OK'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+/** Mount once at the app root — renders the active confirmation / prompt dialog. */
 export function ConfirmDialogHost() {
   const current = useConfirmStore((s) => s.current);
   const resolve = useConfirmStore((s) => s._resolve);
 
   const onConfirm = useCallback(() => resolve(true), [resolve]);
   const onCancel = useCallback(() => resolve(false), [resolve]);
+  const onPromptCancel = useCallback(() => resolve(null), [resolve]);
+  const onPromptSubmit = useCallback((value: string) => resolve(value), [resolve]);
 
   if (!current || typeof document === 'undefined') return null;
 
   return createPortal(
-    <ConfirmDialog key={current.id} request={current} onConfirm={onConfirm} onCancel={onCancel} />,
+    current.kind === 'prompt' ? (
+      <PromptDialog
+        key={current.id}
+        request={current}
+        onSubmit={onPromptSubmit}
+        onCancel={onPromptCancel}
+      />
+    ) : (
+      <ConfirmDialog key={current.id} request={current} onConfirm={onConfirm} onCancel={onCancel} />
+    ),
     document.body,
   );
 }

--- a/src/ui/confirm/confirmStore.ts
+++ b/src/ui/confirm/confirmStore.ts
@@ -1,12 +1,14 @@
 /**
- * Imperative styled-confirmation utility — a drop-in replacement for the gross
- * vanilla `window.confirm`. Call `await confirmDialog({...})` from anywhere
- * (event handlers, hooks, stores) and get back a `Promise<boolean>`; a single
- * `<ConfirmDialogHost />` mounted at the app root renders the styled dialog.
+ * Imperative styled-dialog utility — a drop-in replacement for the gross vanilla
+ * `window.confirm` / `window.prompt`. Call `await confirmDialog({...})` (yes/no →
+ * `Promise<boolean>`) or `await promptDialog({...})` (text input →
+ * `Promise<string | null>`) from anywhere (event handlers, hooks, stores); a
+ * single `<ConfirmDialogHost />` mounted at the app root renders the styled
+ * dialog. Both kinds share one queue + host so concurrent requests serialize.
  *
- * Customizable per call: title, message, an extra `details` line (e.g. exactly
- * what happens to a relay doc online vs offline), button labels, and a `danger`
- * (destructive) treatment. Concurrent requests queue.
+ * Customizable per call: title, message, an extra `details` line (confirm only),
+ * button labels, a `danger` (destructive) treatment (confirm only), and an input
+ * label/placeholder/initial value (prompt only).
  */
 import { create } from 'zustand';
 
@@ -25,16 +27,44 @@ export interface ConfirmOptions {
   danger?: boolean;
 }
 
-export interface ConfirmRequest extends ConfirmOptions {
-  id: string;
-  resolve: (confirmed: boolean) => void;
+export interface PromptOptions {
+  /** Bold heading. */
+  title: string;
+  /** Optional explanatory line above the input. */
+  message?: string;
+  /** Accessible label for the text field. */
+  label?: string;
+  /** Input placeholder. */
+  placeholder?: string;
+  /** Pre-filled value (e.g. the current name when renaming). */
+  initialValue?: string;
+  /** Confirm button label (default "OK"). */
+  confirmLabel?: string;
+  /** Cancel button label (default "Cancel"). */
+  cancelLabel?: string;
 }
 
+interface DialogRequestBase {
+  id: string;
+  /** Internal resolver — narrowed by the wrapper so callers get a clean type. */
+  resolve: (result: boolean | string | null) => void;
+}
+
+export interface ConfirmRequest extends ConfirmOptions, DialogRequestBase {
+  kind: 'confirm';
+}
+
+export interface PromptRequest extends PromptOptions, DialogRequestBase {
+  kind: 'prompt';
+}
+
+export type DialogRequest = ConfirmRequest | PromptRequest;
+
 interface ConfirmState {
-  current: ConfirmRequest | null;
-  queue: ConfirmRequest[];
-  /** @internal */ _enqueue: (req: ConfirmRequest) => void;
-  /** @internal */ _resolve: (confirmed: boolean) => void;
+  current: DialogRequest | null;
+  queue: DialogRequest[];
+  /** @internal */ _enqueue: (req: DialogRequest) => void;
+  /** @internal */ _resolve: (result: boolean | string | null) => void;
 }
 
 let seq = 0;
@@ -47,9 +77,9 @@ export const useConfirmStore = create<ConfirmState>((set, get) => ({
     if (current) set({ queue: [...queue, req] });
     else set({ current: req });
   },
-  _resolve: (confirmed) => {
+  _resolve: (result) => {
     const { current, queue } = get();
-    current?.resolve(confirmed);
+    current?.resolve(result);
     const [next, ...rest] = queue;
     set({ current: next ?? null, queue: rest });
   },
@@ -62,6 +92,28 @@ export const useConfirmStore = create<ConfirmState>((set, get) => ({
 export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
   return new Promise((resolve) => {
     seq += 1;
-    useConfirmStore.getState()._enqueue({ ...opts, id: `confirm-${seq}`, resolve });
+    useConfirmStore.getState()._enqueue({
+      ...opts,
+      kind: 'confirm',
+      id: `confirm-${seq}`,
+      resolve: (r) => resolve(r === true),
+    });
+  });
+}
+
+/**
+ * Show a styled single-line text prompt. Resolves the trimmed input on confirm,
+ * or `null` on cancel / Esc / backdrop dismiss / empty. Requires
+ * `<ConfirmDialogHost />` mounted once.
+ */
+export function promptDialog(opts: PromptOptions): Promise<string | null> {
+  return new Promise((resolve) => {
+    seq += 1;
+    useConfirmStore.getState()._enqueue({
+      ...opts,
+      kind: 'prompt',
+      id: `prompt-${seq}`,
+      resolve: (r) => resolve(typeof r === 'string' && r.length > 0 ? r : null),
+    });
   });
 }

--- a/src/ui/confirm/promptDialog.test.tsx
+++ b/src/ui/confirm/promptDialog.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ConfirmDialogHost } from './ConfirmDialog';
+import { promptDialog, confirmDialog, useConfirmStore } from './confirmStore';
+
+describe('promptDialog', () => {
+  beforeEach(() => {
+    cleanup();
+    useConfirmStore.setState({ current: null, queue: [] });
+  });
+
+  it('resolves the typed value on submit', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({ title: 'New collection', confirmLabel: 'Create' });
+
+    const input = (await screen.findByRole('textbox')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '  Roadmap  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    // Trimmed.
+    await expect(p).resolves.toBe('Roadmap');
+  });
+
+  it('pre-fills initialValue (rename) and resolves the edited value', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({ title: 'Rename collection', initialValue: 'Old name' });
+
+    const input = (await screen.findByDisplayValue('Old name')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New name' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await expect(p).resolves.toBe('New name');
+  });
+
+  it('resolves null on Cancel', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({ title: 'New collection' });
+    await screen.findByRole('textbox');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await expect(p).resolves.toBeNull();
+  });
+
+  it('resolves null on Escape', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({ title: 'New collection' });
+    await screen.findByRole('textbox');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await expect(p).resolves.toBeNull();
+  });
+
+  it('disables confirm and does not resolve on empty/whitespace input', async () => {
+    render(<ConfirmDialogHost />);
+    promptDialog({ title: 'New collection', confirmLabel: 'Create' });
+    const input = (await screen.findByRole('textbox')) as HTMLInputElement;
+
+    // Empty initial value → confirm disabled.
+    const create = screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement;
+    expect(create.disabled).toBe(true);
+
+    // Whitespace stays disabled.
+    fireEvent.change(input, { target: { value: '   ' } });
+    expect(create.disabled).toBe(true);
+  });
+
+  it('queues behind a confirm dialog, then shows the prompt', async () => {
+    render(<ConfirmDialogHost />);
+    const c = confirmDialog({ title: 'First confirm' });
+    promptDialog({ title: 'Second prompt' });
+
+    // Only the first is visible.
+    await screen.findByText('First confirm');
+    expect(screen.queryByRole('textbox')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await expect(c).resolves.toBe(false);
+
+    // Now the queued prompt surfaces (its title + text input).
+    expect(await screen.findByText('Second prompt')).toBeTruthy();
+    expect(screen.getByRole('textbox')).toBeTruthy();
+  });
+});

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -168,6 +168,34 @@
   letter-spacing: 0.06em;
   color: var(--text-faint);
 }
+.dh-nav-section--with-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+.dh-nav-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.dh-nav-add:hover {
+  background: var(--color-bg-hover, rgba(0, 0, 0, 0.06));
+  color: var(--text-primary, inherit);
+}
+.dh-nav-empty {
+  padding: 2px 12px 6px;
+  font-size: var(--font-size-xs);
+  color: var(--text-faint);
+  font-style: italic;
+}
 .dh-collection-dot {
   flex: 0 0 auto;
   width: 10px;

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -23,6 +23,7 @@ import {
   ExternalLink,
   FilePlus2,
   FolderOpen,
+  FolderPlus,
   HardDrive,
   Layers,
   LayoutGrid,
@@ -52,7 +53,11 @@ import { blobStorage } from '../../storage/BlobStorage';
 import type { StorageStats } from '../../storage/BlobTypes';
 import { formatFileSize } from '../../utils/imageUtils';
 import { openCloudSignIn } from '../cloud/cloudSignInStore';
-import type { DocumentBrowserSort, DocumentBrowserView } from '../../store/uiPreferencesStore';
+import type {
+  DocumentBrowserGroupBy,
+  DocumentBrowserSort,
+  DocumentBrowserView,
+} from '../../store/uiPreferencesStore';
 import './DocumentsHome.css';
 
 export interface DocumentsHomeProps {
@@ -91,6 +96,9 @@ export function DocumentsHome({
     setView,
     sort,
     setSort,
+    groupBy,
+    setGroupBy,
+    handleCreateCollection,
     isInTeamMode,
     isConnectedToHost,
     relaySessionUsable,
@@ -323,21 +331,31 @@ export function DocumentsHome({
             );
           })}
 
-          {collections.length > 0 && (
-            <>
-              <div className="dh-nav-section">Collections</div>
-              {collections.map((c) => (
-                <button
-                  key={c.id}
-                  className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
-                  onClick={() => selectCollection(c.id)}
-                >
-                  <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
-                  <span className="dh-nav-label">{c.name}</span>
-                  <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
-                </button>
-              ))}
-            </>
+          <div className="dh-nav-section dh-nav-section--with-action">
+            <span>Collections</span>
+            <button
+              className="dh-nav-add"
+              onClick={() => void handleCreateCollection()}
+              title="New collection"
+              aria-label="New collection"
+            >
+              <FolderPlus size={14} aria-hidden="true" />
+            </button>
+          </div>
+          {collections.length === 0 ? (
+            <div className="dh-nav-empty">No collections yet</div>
+          ) : (
+            collections.map((c) => (
+              <button
+                key={c.id}
+                className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
+                onClick={() => selectCollection(c.id)}
+              >
+                <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
+                <span className="dh-nav-label">{c.name}</span>
+                <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
+              </button>
+            ))
           )}
 
           <button
@@ -483,6 +501,17 @@ export function DocumentsHome({
                     {label}
                   </option>
                 ))}
+              </select>
+            </label>
+            <label className="dh-sort">
+              <span className="dh-sort-label">Group</span>
+              <select
+                value={groupBy}
+                onChange={(e) => setGroupBy(e.target.value as DocumentBrowserGroupBy)}
+                title="Group documents by collection"
+              >
+                <option value="none">None</option>
+                <option value="collection">Collection</option>
               </select>
             </label>
             <div className="dh-view-toggle" role="group" aria-label="View mode">

--- a/src/ui/settings/DocumentList.test.tsx
+++ b/src/ui/settings/DocumentList.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * DocumentList — guards the collection-management surface stays wired (JP-365).
+ * When grouped by collection, each section's ⋯ menu must invoke the model's
+ * rename / delete handlers. (The Group control that flips on grouping lives in
+ * DocumentsHome; here we feed `groupedSections` directly.)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { DocumentList } from './DocumentList';
+import type { DocumentBrowserModel } from './useDocumentBrowserModel';
+import type { Collection } from '../../store/collectionStore';
+
+const collection: Collection = { id: 'c1', name: 'Work', order: 0, createdAt: 0 };
+
+function stubModel(over: Partial<DocumentBrowserModel> = {}): DocumentBrowserModel {
+  return {
+    // Non-empty so the list (not the empty state) renders; not iterated in the
+    // grouped branch, so a placeholder record is fine.
+    documentList: [{ type: 'local', id: 'l1', name: 'Doc', pageCount: 1, createdAt: 0, modifiedAt: 0 }],
+    groupedSections: [{ key: 'c1', collection, docs: [] }],
+    view: 'list',
+    searchQuery: '',
+    filterMode: 'all',
+    collapsedMap: {},
+    toggleCollapsed: vi.fn(),
+    activeCollectionMenu: 'c1', // pre-open the section menu
+    setActiveCollectionMenu: vi.fn(),
+    handleRenameCollection: vi.fn(),
+    handleDeleteCollection: vi.fn(),
+    handleRecolor: vi.fn(),
+    ...over,
+  } as unknown as DocumentBrowserModel;
+}
+
+describe('DocumentList — collection management menu', () => {
+  beforeEach(() => cleanup());
+
+  it('renders the collection section header', () => {
+    render(<DocumentList model={stubModel()} />);
+    expect(screen.getByText('Work')).toBeTruthy();
+  });
+
+  it('invokes handleDeleteCollection with the collection', () => {
+    const handleDeleteCollection = vi.fn();
+    render(<DocumentList model={stubModel({ handleDeleteCollection })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete collection' }));
+    expect(handleDeleteCollection).toHaveBeenCalledWith(collection);
+  });
+
+  it('invokes handleRenameCollection with the collection', () => {
+    const handleRenameCollection = vi.fn();
+    render(<DocumentList model={stubModel({ handleRenameCollection })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename…' }));
+    expect(handleRenameCollection).toHaveBeenCalledWith(collection);
+  });
+});

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -47,6 +47,10 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
     handleRenameCollection,
     handleDeleteCollection,
     handleRecolor,
+    collections,
+    assignments,
+    handleAssignToCollection,
+    handleAssignNewCollectionFor,
     accentByDoc,
     currentDocumentId,
     selectedIds,
@@ -101,6 +105,10 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
         onPublishToTeam={canPublishToTeam(record, relaySessionUsable) ? handlePublishToTeam : undefined}
         onMoveToPersonal={canMoveToPersonal(record, relaySessionUsable, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
         collectionAccent={accent}
+        collections={collections}
+        currentCollectionId={assignments[record.id] ?? null}
+        onAssignCollection={handleAssignToCollection}
+        onCreateCollectionFor={handleAssignNewCollectionFor}
         connectedRelayAddress={model.connectedRelayAddress}
         offlineStatus={offlineStatuses.get(record.id)}
         offlineProgress={offlineProgress.get(record.id) ?? null}

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -36,7 +36,7 @@ import { useTransferStore, isTransferRunning } from '../../store/transferStore';
 import { purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
-import { confirmDialog } from '../confirm/confirmStore';
+import { confirmDialog, promptDialog } from '../confirm/confirmStore';
 
 /** Document type axis the nav rail / filter row toggles. */
 export type FilterMode = 'all' | 'local' | 'team' | 'cached';
@@ -174,6 +174,8 @@ export interface DocumentBrowserModel {
   handleRenameCollection: (collection: Collection) => void;
   handleDeleteCollection: (collection: Collection) => void;
   handleRecolor: (collection: Collection, color: string | undefined) => void;
+  handleAssignToCollection: (docId: string, collectionId: string | null) => void;
+  handleAssignNewCollectionFor: (docId: string) => void;
 }
 
 export function useDocumentBrowserModel(): DocumentBrowserModel {
@@ -695,9 +697,14 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     [selectedIds]
   );
 
-  const handleBulkAssignNewCollection = useCallback(() => {
-    const name = window.prompt('New collection name');
-    if (!name || !name.trim()) return;
+  const handleBulkAssignNewCollection = useCallback(async () => {
+    const name = await promptDialog({
+      title: 'New collection',
+      label: 'Collection name',
+      placeholder: 'e.g. Q3 Planning',
+      confirmLabel: 'Create',
+    });
+    if (!name) return;
     const id = syncedActions.createCollection(name);
     if (id) syncedActions.assignDocuments(Array.from(selectedIds), id);
     setAssignMenuOpen(false);
@@ -744,15 +751,27 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   }, [selectedIds]);
 
   // Collection management
-  const handleCreateCollection = useCallback(() => {
-    const name = window.prompt('New collection name');
-    if (!name || !name.trim()) return;
-    syncedActions.createCollection(name);
-  }, []);
+  const handleCreateCollection = useCallback(async () => {
+    const name = await promptDialog({
+      title: 'New collection',
+      label: 'Collection name',
+      placeholder: 'e.g. Q3 Planning',
+      confirmLabel: 'Create',
+    });
+    if (!name) return;
+    const id = syncedActions.createCollection(name);
+    // Surface the new (empty) collection so it's immediately visible + manageable.
+    if (id) setGroupBy('collection');
+  }, [setGroupBy]);
 
   const handleRenameCollection = useCallback(
-    (collection: Collection) => {
-      const name = window.prompt('Rename collection', collection.name);
+    async (collection: Collection) => {
+      const name = await promptDialog({
+        title: 'Rename collection',
+        label: 'Collection name',
+        initialValue: collection.name,
+        confirmLabel: 'Rename',
+      });
       if (!name) return;
       syncedActions.renameCollection(collection.id, name);
       setActiveCollectionMenu(null);
@@ -781,6 +800,26 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     },
     []
   );
+
+  // Per-card collection move (single doc) — assignment was previously bulk-only.
+  const handleAssignToCollection = useCallback(
+    (docId: string, collectionId: string | null) => {
+      syncedActions.assignDocuments([docId], collectionId);
+    },
+    []
+  );
+
+  const handleAssignNewCollectionFor = useCallback(async (docId: string) => {
+    const name = await promptDialog({
+      title: 'New collection',
+      label: 'Collection name',
+      placeholder: 'e.g. Q3 Planning',
+      confirmLabel: 'Create',
+    });
+    if (!name) return;
+    const id = syncedActions.createCollection(name);
+    if (id) syncedActions.assignDocuments([docId], id);
+  }, []);
 
   const error = registryError || teamStoreError;
   const isLoading = isFetchingRemote || isLoadingList;
@@ -871,6 +910,8 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     handleBulkDelete,
     handleBulkExport,
     handleCreateCollection,
+    handleAssignToCollection,
+    handleAssignNewCollectionFor,
     handleRenameCollection,
     handleDeleteCollection,
     handleRecolor,


### PR DESCRIPTION
## Problem

Collections had working store + sync logic and a rename/recolor/delete menu, but to the user there was "no way to delete/manage collections," and creating one used an OS prompt. Closes JP-365.

Root cause (verified, not assumed): the management menu lives in `CollectionSection`, which only renders when grouped by collection — but **nothing in the UI ever set `groupBy`**, so `groupedSections` was always `null` and the menu never appeared. `handleCreateCollection` was also exposed by the model but wired to no button. Plus three `window.prompt()` naming sites.

## Changes

**Surface management**
- Add a **Group** control (None / Collection) to the DocumentsHome toolbar — this alone unlocks the existing rename / recolor / delete menu.
- Add a persistent **"Collections +"** nav header wiring the previously-dead `handleCreateCollection`, so a collection can be created without selecting documents first. After a standalone create it auto-switches to grouped view so the new (empty) collection is immediately visible + deletable.

**Styled dialogs**
- Add a `promptDialog(): Promise<string | null>` text-input variant to the existing `src/ui/confirm/` system — same host/queue, `confirmDialog`'s contract unchanged. Input autofocus/select, Enter submits, Esc/backdrop cancels, confirm disabled on empty.
- Migrate the three `window.prompt()` collection-naming sites (create / bulk-create / rename) to it.

**Per-card "Move to collection"** (creative-pass addition)
- Assignment was bulk-only (needed multi-select). Add a single-card menu (assign / change / remove / + new) backed by `assignDocuments([id], cid)` and `promptDialog` for inline create.

**CSS** touch-up: styled prompt input, card collection menu with a subtle reduced-motion-aware entry animation.

No store / schema / sync changes — `collectionStore` + `collectionSync` + `uiPreferencesStore.documentBrowserGroupBy` already did the work; this is wiring + the dialog + the per-card menu.

## Deferred (noted, not filed — 250-issue cap)

Drag-to-assign / drag-to-reorder collections (`reorderCollections` exists but is UI-dead), full `role=menuitem` keyboard nav on the dropdowns, and consolidating card hover actions into a kebab.

## Tests

- `promptDialog.test.tsx` — submit (trimmed) / cancel / Esc / empty-disabled / prefill / queue-behind-confirm.
- `DocumentList.test.tsx` — grouped section ⋯ menu invokes `handleDeleteCollection` / `handleRenameCollection`.
- `DocumentCard.collections.test.tsx` — per-card menu assigns `(id, cid)`, removes `(id, null)`, routes "+ New collection…".

Typecheck clean; full `src/ui` + collection suites green (178 tests).

## Manual verification

Documents → set **Group = Collection** → each collection shows the ⋯ menu with working Rename / recolor / Delete (styled, not OS prompts); create via the **Collections +** header with nothing selected; rename pre-fills the current name; use a card's folder action to move a single doc between collections.

Assisted-by: Opus 4.8
