### PR TITLE
JP-366: local vs workspace collection semantics hardening

### DIFF
--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -45,6 +45,7 @@ import { RestDocumentProvider } from '../api/restDocumentProvider';
 import { clearJwt, saveConnection } from '../api/relayConnection';
 import { useNotificationStore } from '../store/notificationStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
+import { useCollectionStore } from '../store/collectionStore';
 import { isRemoteDocument, isForeignRelayDoc } from '../types/DocumentRegistry';
 import { mutateDocument } from '../store/writeProvenance';
 import type { JSONContent } from '@tiptap/core';
@@ -680,6 +681,12 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     stopSession: () => {
       // Full sign-out: tear down the doc engine AND drop the relay identity.
       teardownSession(set, { preserveAuth: false });
+      // Leaving the workspace: drop its collections + forget its synced id set so
+      // they don't bleed into the next session or local-only use (JP-366). Local
+      // (personal) collections are kept. Dynamic import for collectionSync avoids
+      // a module cycle (it pulls in SyncStateManager).
+      useCollectionStore.getState().dropWorkspaceCollections();
+      void import('../store/collectionSync').then((m) => m.resetWorkspaceSync());
     },
 
     leaveDocument: () => {

--- a/src/services/DocumentTransferService.ts
+++ b/src/services/DocumentTransferService.ts
@@ -354,6 +354,10 @@ export class DocumentTransferService {
         lastModifiedByName: currentUser.displayName,
       } : {}),
     };
+    // Promoting to a workspace clears local collection membership (JP-366) — never
+    // carry a local `collectionId` onto the relay body, where it would dangle
+    // against a collection the workspace doesn't have.
+    delete updatedDoc.collectionId;
 
     // Save locally first
     this.deps.saveDocument(updatedDoc);

--- a/src/store/collectionStore.test.ts
+++ b/src/store/collectionStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { useCollectionStore } from './collectionStore';
+import { useCollectionStore, migrateCollections } from './collectionStore';
 
 function reset() {
   useCollectionStore.getState().reset();
@@ -93,5 +93,72 @@ describe('collectionStore', () => {
     useCollectionStore.getState().reorderCollections([c, a, b]);
     const ordered = useCollectionStore.getState().listCollections().map((x) => x.id);
     expect(ordered).toEqual([c, a, b]);
+  });
+});
+
+describe('collectionStore scope (JP-366)', () => {
+  beforeEach(reset);
+
+  it('defaults new collections to local scope; honours an explicit workspace scope', () => {
+    const local = useCollectionStore.getState().createCollection('Personal');
+    const ws = useCollectionStore.getState().createCollection('Team', undefined, 'workspace');
+    expect(useCollectionStore.getState().collections[local]?.scope).toBe('local');
+    expect(useCollectionStore.getState().collections[ws]?.scope).toBe('workspace');
+  });
+
+  it('hydrateFromRelay tags every upserted definition workspace-scoped', () => {
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'A', name: 'Alpha', order: 0, createdAt: 1 }],
+      memberships: {},
+    });
+    expect(useCollectionStore.getState().collections['A']?.scope).toBe('workspace');
+  });
+
+  it('dropWorkspaceCollections removes workspace defs + their memberships, keeps local', () => {
+    const local = useCollectionStore.getState().createCollection('Personal'); // local
+    useCollectionStore.getState().assignDocument('localDoc', local);
+    // Workspace collection + a relay-doc membership (via the relay hydrate path).
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'WS', name: 'Team', order: 1, createdAt: 1 }],
+      memberships: { relayDoc: 'WS' },
+    });
+
+    useCollectionStore.getState().dropWorkspaceCollections();
+
+    const st = useCollectionStore.getState();
+    expect(st.collections['WS']).toBeUndefined(); // workspace def dropped
+    expect(st.assignments['relayDoc']).toBeUndefined(); // its membership pruned
+    expect(st.collections[local]?.scope).toBe('local'); // local def kept
+    expect(st.assignments['localDoc']).toBe(local); // local membership kept
+  });
+
+  it('dropWorkspaceCollections is a no-op when there are no workspace collections', () => {
+    const local = useCollectionStore.getState().createCollection('Personal');
+    useCollectionStore.getState().assignDocument('d', local);
+    useCollectionStore.getState().dropWorkspaceCollections();
+    expect(useCollectionStore.getState().collections[local]).toBeDefined();
+    expect(useCollectionStore.getState().assignments['d']).toBe(local);
+  });
+});
+
+describe('migrateCollections v1→v2 (JP-366)', () => {
+  it('stamps scope=local on untagged v1 collections, preserving assignments', () => {
+    const v1 = {
+      collections: {
+        a: { id: 'a', name: 'A', order: 0, createdAt: 1 }, // no scope
+        b: { id: 'b', name: 'B', order: 1, createdAt: 2, scope: 'workspace' as const },
+      },
+      assignments: { d1: 'a' },
+    };
+    const out = migrateCollections(v1, 1);
+    expect(out.collections['a']?.scope).toBe('local'); // stamped
+    expect(out.collections['b']?.scope).toBe('workspace'); // already tagged, kept
+    expect(out.assignments).toEqual({ d1: 'a' });
+  });
+
+  it('leaves v2 state untouched and tolerates empty/garbage input', () => {
+    const v2 = { collections: { a: { id: 'a', name: 'A', order: 0, createdAt: 1, scope: 'local' as const } }, assignments: {} };
+    expect(migrateCollections(v2, 2)).toEqual(v2);
+    expect(migrateCollections(undefined, 1).collections).toEqual({});
   });
 });

--- a/src/store/collectionStore.ts
+++ b/src/store/collectionStore.ts
@@ -29,12 +29,28 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { nanoid } from 'nanoid';
 
+/**
+ * Where a collection lives:
+ * - `local` — a personal, client-only collection; applies to local documents,
+ *   never pushed to a relay, and survives signing out of / removing a workspace.
+ * - `workspace` — belongs to the connected relay workspace (reconciled from its
+ *   per-workspace registry); applies to that workspace's documents and is
+ *   dropped from the client when you leave the workspace.
+ *
+ * A document and its collection must share scope (enforced in the assign path):
+ * a workspace doc can only join a workspace collection and a local doc only a
+ * local collection. Absence is treated as `local` (forward-compatible default).
+ */
+export type CollectionScope = 'local' | 'workspace';
+
 export interface Collection {
   id: string;
   name: string;
   color?: string;
   order: number;
   createdAt: number;
+  /** Local (personal) vs workspace (relay-backed). Absent = local. */
+  scope?: CollectionScope;
 }
 
 export interface CollectionState {
@@ -45,7 +61,7 @@ export interface CollectionState {
 }
 
 export interface CollectionActions {
-  createCollection: (name: string, color?: string) => string;
+  createCollection: (name: string, color?: string, scope?: CollectionScope) => string;
   renameCollection: (id: string, name: string) => void;
   recolorCollection: (id: string, color: string | undefined) => void;
   reorderCollections: (orderedIds: string[]) => void;
@@ -67,7 +83,38 @@ export interface CollectionActions {
     definitions: Collection[];
     memberships: Record<string, string | null>;
   }) => void;
+  /**
+   * Drop every `workspace`-scoped collection and prune assignments that point at
+   * a removed one. Local (personal) collections + their memberships are kept.
+   * Called when leaving a workspace (full sign-out / Remove Workspace) so a
+   * workspace's collections don't bleed into the next session or local-only use.
+   */
+  dropWorkspaceCollections: () => void;
   reset: () => void;
+}
+
+/** A collection is workspace-scoped only when explicitly tagged; absent = local. */
+export function isWorkspaceCollection(c: Collection): boolean {
+  return c.scope === 'workspace';
+}
+
+/**
+ * Persist migration. v2 adds `Collection.scope` — stamp existing defs `local`
+ * (the safe default: a workspace collection mislabelled local is re-tagged on
+ * the next relay reconcile, whereas the reverse could wrongly drop a personal
+ * collection on sign-out). Pure + exported so it's unit-testable.
+ */
+export function migrateCollections(persisted: unknown, version: number): CollectionState {
+  const state = persisted as Partial<CollectionState> | undefined;
+  if (!state?.collections) return initialState;
+  if (version < 2) {
+    const collections: Record<string, Collection> = {};
+    for (const [id, col] of Object.entries(state.collections)) {
+      collections[id] = col.scope ? col : { ...col, scope: 'local' };
+    }
+    return { collections, assignments: state.assignments ?? {} };
+  }
+  return { collections: state.collections, assignments: state.assignments ?? {} };
 }
 
 const initialState: CollectionState = {
@@ -80,7 +127,7 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
     (set, get) => ({
       ...initialState,
 
-      createCollection: (name, color) => {
+      createCollection: (name, color, scope = 'local') => {
         const trimmed = name.trim();
         if (!trimmed) return '';
         const id = nanoid();
@@ -91,6 +138,7 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
           name: trimmed,
           order: maxOrder + 1,
           createdAt: Date.now(),
+          scope,
           ...(color !== undefined ? { color } : {}),
         };
         set({ collections: { ...collections, [id]: collection } });
@@ -188,7 +236,9 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
         const { collections, assignments } = get();
         const nextCollections = { ...collections };
         for (const def of definitions) {
-          nextCollections[def.id] = def;
+          // Relay-sourced defs are always workspace-scoped — stamp it so a leave
+          // can drop them and the scope guard treats them correctly.
+          nextCollections[def.id] = { ...def, scope: 'workspace' };
         }
         const nextAssignments = { ...assignments };
         for (const [documentId, collectionId] of Object.entries(memberships)) {
@@ -201,11 +251,28 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
         set({ collections: nextCollections, assignments: nextAssignments });
       },
 
+      dropWorkspaceCollections: () => {
+        const { collections, assignments } = get();
+        const removed = new Set<string>();
+        const nextCollections: Record<string, Collection> = {};
+        for (const [id, col] of Object.entries(collections)) {
+          if (isWorkspaceCollection(col)) removed.add(id);
+          else nextCollections[id] = col;
+        }
+        if (removed.size === 0) return;
+        const nextAssignments: Record<string, string> = {};
+        for (const [docId, cid] of Object.entries(assignments)) {
+          if (!removed.has(cid)) nextAssignments[docId] = cid;
+        }
+        set({ collections: nextCollections, assignments: nextAssignments });
+      },
+
       reset: () => set(initialState),
     }),
     {
       name: 'docushark-collections',
-      version: 1,
+      version: 2,
+      migrate: (persisted, version) => migrateCollections(persisted, version),
       partialize: (state) => ({
         collections: state.collections,
         assignments: state.assignments,

--- a/src/store/collectionSync.test.ts
+++ b/src/store/collectionSync.test.ts
@@ -11,12 +11,25 @@ vi.mock('./connectionStore', () => ({
 vi.mock('../collaboration/SyncStateManager', () => ({
   getSyncStateManager: vi.fn(() => ({ hasPendingChanges: () => false })),
 }));
+vi.mock('./documentRegistry', () => ({
+  useDocumentRegistry: { getState: vi.fn() },
+}));
+vi.mock('./notificationStore', () => ({
+  useNotificationStore: { getState: vi.fn() },
+}));
 
-import { syncedActions, reconcileFromRelay } from './collectionSync';
+import {
+  syncedActions,
+  reconcileFromRelay,
+  assignDocumentsScoped,
+  resetWorkspaceSync,
+} from './collectionSync';
 import { useCollectionStore } from './collectionStore';
 import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
 import { isRelayAuthenticated } from './connectionStore';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
+import { useDocumentRegistry } from './documentRegistry';
+import { useNotificationStore } from './notificationStore';
 import type { DocumentMetadata } from '../types/Document';
 import type { RelayCollectionDef } from '../api/relayClient';
 
@@ -24,6 +37,9 @@ const getDocProviderMock = getDocProvider as unknown as Mock;
 const relayGetState = useRelayDocumentStore.getState as unknown as Mock;
 const authedMock = isRelayAuthenticated as unknown as Mock;
 const syncMgrMock = getSyncStateManager as unknown as Mock;
+const registryGetState = useDocumentRegistry.getState as unknown as Mock;
+const notifyGetState = useNotificationStore.getState as unknown as Mock;
+const warningSpy = vi.fn();
 
 function makeProvider(defs: RelayCollectionDef[]) {
   return {
@@ -43,6 +59,10 @@ beforeEach(() => {
   authedMock.mockReturnValue(true);
   relayGetState.mockReturnValue({ isRelayDocument: () => true });
   syncMgrMock.mockReturnValue({ hasPendingChanges: () => false });
+  warningSpy.mockClear();
+  notifyGetState.mockReturnValue({ warning: warningSpy });
+  // Default: no registry record (docScopeOf falls back to isRelayDocument).
+  registryGetState.mockReturnValue({ getRecord: () => undefined });
 });
 
 describe('collectionSync write-through (JP-159)', () => {
@@ -135,5 +155,99 @@ describe('collectionSync reconcileFromRelay (JP-159)', () => {
     await reconcileFromRelay([meta('d2')]); // relay reports no membership for d2
 
     expect(useCollectionStore.getState().assignments['d2']).toBe('A'); // preserved (pending save)
+  });
+
+  it('tags reconciled definitions workspace-scoped', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+    await reconcileFromRelay([]);
+    expect(useCollectionStore.getState().collections['A']?.scope).toBe('workspace');
+  });
+});
+
+describe('collectionSync scope (JP-366)', () => {
+  function registryOf(scopeById: Record<string, 'local' | 'remote' | 'cached'>) {
+    registryGetState.mockReturnValue({
+      getRecord: (id: string) => (scopeById[id] ? { type: scopeById[id] } : undefined),
+    });
+  }
+
+  it('createCollection scope follows auth: workspace when signed in, local when not', () => {
+    authedMock.mockReturnValue(true);
+    getDocProviderMock.mockReturnValue(makeProvider([]));
+    const ws = syncedActions.createCollection('Team');
+    expect(useCollectionStore.getState().collections[ws]?.scope).toBe('workspace');
+
+    authedMock.mockReturnValue(false);
+    const local = syncedActions.createCollection('Personal');
+    expect(useCollectionStore.getState().collections[local]?.scope).toBe('local');
+  });
+
+  it('assigns when document and collection scopes match (no warning)', () => {
+    const ws = syncedActions.createCollection('Team', undefined, 'workspace');
+    registryOf({ wsDoc: 'remote' });
+
+    assignDocumentsScoped(['wsDoc'], ws);
+
+    expect(useCollectionStore.getState().assignments['wsDoc']).toBe(ws);
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it('blocks a local doc from a workspace collection, with a warning', () => {
+    const ws = syncedActions.createCollection('Team', undefined, 'workspace');
+    registryOf({ localDoc: 'local' });
+
+    assignDocumentsScoped(['localDoc'], ws);
+
+    expect(useCollectionStore.getState().assignments['localDoc']).toBeUndefined();
+    expect(warningSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks a workspace doc from a local collection, with a warning', () => {
+    const local = syncedActions.createCollection('Personal', undefined, 'local');
+    registryOf({ wsDoc: 'cached' }); // cached relay doc = workspace scope
+
+    assignDocumentsScoped(['wsDoc'], local);
+
+    expect(useCollectionStore.getState().assignments['wsDoc']).toBeUndefined();
+    expect(warningSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('partitions a mixed selection: assigns matches, skips + warns on the rest', () => {
+    const ws = syncedActions.createCollection('Team', undefined, 'workspace');
+    registryOf({ wsDoc: 'remote', localDoc: 'local' });
+
+    assignDocumentsScoped(['wsDoc', 'localDoc'], ws);
+
+    const st = useCollectionStore.getState();
+    expect(st.assignments['wsDoc']).toBe(ws); // matched
+    expect(st.assignments['localDoc']).toBeUndefined(); // skipped
+    expect(warningSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('removal (null) bypasses the guard regardless of scope', () => {
+    const ws = syncedActions.createCollection('Team', undefined, 'workspace');
+    useCollectionStore.getState().assignDocument('localDoc', ws); // force a (cross-scope) membership
+    registryOf({ localDoc: 'local' });
+
+    assignDocumentsScoped(['localDoc'], null);
+
+    expect(useCollectionStore.getState().assignments['localDoc']).toBeUndefined();
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it('resetWorkspaceSync forgets the known workspace set so the membership gate reopens', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+    await reconcileFromRelay([]); // known = {A}
+
+    syncedActions.assignDocuments(['d'], 'B'); // B not in workspace → gated out
+    await flush();
+    expect(provider.setDocumentCollection).not.toHaveBeenCalled();
+
+    resetWorkspaceSync(); // forget {A}
+
+    syncedActions.assignDocuments(['d'], 'B'); // gate empty now → push allowed
+    await vi.waitFor(() => expect(provider.setDocumentCollection).toHaveBeenCalledWith('d', 'B'));
   });
 });

--- a/src/store/collectionSync.ts
+++ b/src/store/collectionSync.ts
@@ -22,13 +22,27 @@ import type { RelayCollectionDef } from '../api/relayClient';
 import type { DocumentMetadata } from '../types/Document';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { isRelayAuthenticated } from './connectionStore';
-import { useCollectionStore, type Collection } from './collectionStore';
+import {
+  useCollectionStore,
+  isWorkspaceCollection,
+  type Collection,
+  type CollectionScope,
+} from './collectionStore';
+import { useNotificationStore } from './notificationStore';
 import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+import { useDocumentRegistry } from './documentRegistry';
 
 /** Ids of the connected workspace's collections, refreshed on every relay read.
  *  Used to skip pushing a membership to a collection the workspace doesn't have
  *  (which would leave a dangling `collectionId`). */
 let knownCollectionIds = new Set<string>();
+
+/** Forget the connected workspace's collection set. Called when leaving a
+ *  workspace (full sign-out / Remove Workspace) so a stale set can't gate the
+ *  next workspace's membership pushes. */
+export function resetWorkspaceSync(): void {
+  knownCollectionIds = new Set();
+}
 
 /** Serialize relay-definition read-modify-writes so concurrent mutations can't
  *  interleave their GET/PUT and clobber each other. */
@@ -95,9 +109,16 @@ async function pushMembership(documentId: string, collectionId: string | null): 
  * store so every mutation (incl. future slice-4 UI) writes through to the relay.
  */
 export const syncedActions = {
-  createCollection(name: string, color?: string): string {
-    const id = useCollectionStore.getState().createCollection(name, color);
-    if (id) {
+  /**
+   * Create a collection. Scope follows where it's born: connected to a workspace
+   * → `workspace` (pushed to the relay registry); otherwise `local` (personal,
+   * client-only). Pass an explicit `scope` to override (e.g. a per-card create
+   * that must match the document's scope).
+   */
+  createCollection(name: string, color?: string, scope?: CollectionScope): string {
+    const resolvedScope: CollectionScope = scope ?? (isRelayAuthenticated() ? 'workspace' : 'local');
+    const id = useCollectionStore.getState().createCollection(name, color, resolvedScope);
+    if (id && resolvedScope === 'workspace') {
       const col = useCollectionStore.getState().collections[id];
       if (col) {
         void mutateRelayDefs((defs) =>
@@ -143,6 +164,58 @@ export const syncedActions = {
     }
   },
 };
+
+/**
+ * A document's scope from its registry record: `local` for personal docs,
+ * `workspace` for relay docs (remote *or* cached-offline — a cached doc is still
+ * a workspace doc). Falls back to live relay membership when the record is
+ * unknown. Kept in lockstep with the per-card menu's `record.type` derivation.
+ */
+export function docScopeOf(documentId: string): CollectionScope {
+  const rec = useDocumentRegistry.getState().getRecord(documentId);
+  if (rec) return rec.type === 'local' ? 'local' : 'workspace';
+  return useRelayDocumentStore.getState().isRelayDocument(documentId) ? 'workspace' : 'local';
+}
+
+/**
+ * The single choke point for assigning documents to a collection. Enforces that
+ * a document and its collection share scope — a workspace document can only join
+ * a workspace collection and a local document only a local collection. Matching
+ * documents are assigned (and synced); mismatched ones are skipped with a
+ * warning toast. Removal (`null`) is scope-agnostic and always applies.
+ *
+ * Every assign entry point (per-card, bulk, new-collection-for-doc) must go
+ * through here — calling `syncedActions.assignDocuments` with a non-null target
+ * directly would bypass the guard.
+ */
+export function assignDocumentsScoped(documentIds: string[], collectionId: string | null): void {
+  if (collectionId === null) {
+    syncedActions.assignDocuments(documentIds, null);
+    return;
+  }
+  const collection = useCollectionStore.getState().collections[collectionId];
+  if (!collection) return;
+  const target: CollectionScope = isWorkspaceCollection(collection) ? 'workspace' : 'local';
+
+  const matched: string[] = [];
+  let skipped = 0;
+  for (const id of documentIds) {
+    if (docScopeOf(id) === target) matched.push(id);
+    else skipped += 1;
+  }
+
+  if (matched.length > 0) syncedActions.assignDocuments(matched, collectionId);
+
+  if (skipped > 0) {
+    useNotificationStore
+      .getState()
+      .warning(
+        target === 'workspace'
+          ? "Local documents can't be added to a workspace collection."
+          : "Workspace documents can't be added to a local collection.",
+      );
+  }
+}
 
 /** Push a single definition's current store content to the workspace set, only
  *  if it already exists there (rename/recolor never re-adds a deleted/foreign id). */

--- a/src/ui/DocumentCard.collections.test.tsx
+++ b/src/ui/DocumentCard.collections.test.tsx
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { DocumentCard } from './DocumentCard';
-import type { LocalDocument } from '../types/DocumentRegistry';
+import type { LocalDocument, RemoteDocument } from '../types/DocumentRegistry';
 import type { Collection } from '../store/collectionStore';
 
 const record: LocalDocument = {
@@ -18,9 +18,30 @@ const record: LocalDocument = {
   modifiedAt: 0,
 };
 
+const remoteRecord: RemoteDocument = {
+  type: 'remote',
+  id: 'r1',
+  name: 'Team Doc',
+  pageCount: 1,
+  createdAt: 0,
+  modifiedAt: 0,
+  relayId: 'localhost:9876',
+  ownerId: 'u1',
+  ownerName: 'A',
+  permission: 'owner',
+  syncState: 'synced',
+  lastSyncedAt: 0,
+};
+
 const collections: Collection[] = [
   { id: 'c1', name: 'Work', order: 0, createdAt: 0 },
   { id: 'c2', name: 'Personal', order: 1, createdAt: 0 },
+];
+
+// One local + one workspace collection, for scope-filter tests.
+const mixedCollections: Collection[] = [
+  { id: 'loc', name: 'My Local', order: 0, createdAt: 0, scope: 'local' },
+  { id: 'team', name: 'Team Space', order: 1, createdAt: 0, scope: 'workspace' },
 ];
 
 describe('DocumentCard — Move to collection', () => {
@@ -92,5 +113,35 @@ describe('DocumentCard — Move to collection', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: '+ New collection…' }));
 
     expect(onCreateFor).toHaveBeenCalledWith('l1');
+  });
+
+  it('lists only local collections for a local document (JP-366)', () => {
+    render(
+      <DocumentCard
+        record={record}
+        collections={mixedCollections}
+        currentCollectionId={null}
+        onAssignCollection={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+
+    expect(screen.getByRole('menuitem', { name: 'My Local' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Team Space' })).toBeNull();
+  });
+
+  it('lists only workspace collections for a workspace document (JP-366)', () => {
+    render(
+      <DocumentCard
+        record={remoteRecord}
+        collections={mixedCollections}
+        currentCollectionId={null}
+        onAssignCollection={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+
+    expect(screen.getByRole('menuitem', { name: 'Team Space' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'My Local' })).toBeNull();
   });
 });

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -231,6 +231,18 @@ export function formatRelayLabel(
   };
 }
 
+/**
+ * A collection may hold a document only when their scopes match: a local
+ * (personal) document → local collections; a workspace document (remote or
+ * cached-offline) → workspace collections. Mirrors `docScopeOf` in collectionSync
+ * so the menu only offers collections the assign guard will actually accept.
+ */
+function collectionMatchesDocScope(c: Collection, record: DocumentRecord): boolean {
+  const docScope = record.type === 'local' ? 'local' : 'workspace';
+  const colScope = c.scope === 'workspace' ? 'workspace' : 'local';
+  return docScope === colScope;
+}
+
 function DocumentCardImpl({
   record,
   isActive = false,
@@ -685,7 +697,9 @@ function DocumentCardImpl({
                 role="menu"
                 onClick={(e) => e.stopPropagation()}
               >
-                {(collections ?? []).map((c) => (
+                {(collections ?? [])
+                  .filter((c) => collectionMatchesDocScope(c, record))
+                  .map((c) => (
                   <button
                     key={c.id}
                     className="document-card__collection-item"

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -29,7 +29,7 @@ import {
   type DocumentBrowserSort,
 } from '../../store/uiPreferencesStore';
 import { useCollectionStore, type Collection } from '../../store/collectionStore';
-import { syncedActions } from '../../store/collectionSync';
+import { syncedActions, assignDocumentsScoped, docScopeOf } from '../../store/collectionSync';
 import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
 import { getTransferService } from '../../services/DocumentTransferService';
 import { useTransferStore, isTransferRunning } from '../../store/transferStore';
@@ -527,6 +527,12 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       }
       useDocumentRegistry.getState().removeDocument(docId);
 
+      // The doc is now a workspace doc; drop any LOCAL collection membership so it
+      // lands Unassigned in the workspace (a local collection can't hold a
+      // workspace doc — JP-366) instead of leaving a dangling `collectionId` the
+      // workspace doesn't know. The user re-files it into a workspace collection.
+      useCollectionStore.getState().assignDocument(docId, null);
+
       // Purge any stale local prose CRDT room BEFORE the doc re-joins as a relay
       // doc. A doc previously moved Cloud→Personal keeps its `host:docId`
       // y-indexeddb room on disk; without this, re-promote reloads that stale
@@ -691,7 +697,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
 
   const handleBulkAssign = useCallback(
     (collectionId: string | null) => {
-      syncedActions.assignDocuments(Array.from(selectedIds), collectionId);
+      assignDocumentsScoped(Array.from(selectedIds), collectionId);
       setAssignMenuOpen(false);
     },
     [selectedIds]
@@ -706,7 +712,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     });
     if (!name) return;
     const id = syncedActions.createCollection(name);
-    if (id) syncedActions.assignDocuments(Array.from(selectedIds), id);
+    if (id) assignDocumentsScoped(Array.from(selectedIds), id);
     setAssignMenuOpen(false);
   }, [selectedIds]);
 
@@ -804,7 +810,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   // Per-card collection move (single doc) — assignment was previously bulk-only.
   const handleAssignToCollection = useCallback(
     (docId: string, collectionId: string | null) => {
-      syncedActions.assignDocuments([docId], collectionId);
+      assignDocumentsScoped([docId], collectionId);
     },
     []
   );
@@ -817,8 +823,10 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       confirmLabel: 'Create',
     });
     if (!name) return;
-    const id = syncedActions.createCollection(name);
-    if (id) syncedActions.assignDocuments([docId], id);
+    // Create the collection in the document's own scope so it can hold it
+    // (a workspace doc → workspace collection, a local doc → local collection).
+    const id = syncedActions.createCollection(name, undefined, docScopeOf(docId));
+    if (id) assignDocumentsScoped([docId], id);
   }, []);
 
   const error = registryError || teamStoreError;


### PR DESCRIPTION
## Problem

Collections are **server-backed and per-workspace** on the relay (`/api/collections` → `workspaces/<ws>/collections.json`, JWT `wsp`-scoped; per-doc `collectionId`). But the client `collectionStore` was a **global singleton** that merged local + workspace collections and **never reset** on leave — so:

- **Tenant bleed**: `removeCurrentWorkspace()` / `stopSession()` tore down docs/cache/connection but never the collection store → a workspace's collections + memberships persisted into the next session / local-only view.
- **Promote-to-Cloud dangling**: a local doc in a *local* collection kept its membership, stamping a `collectionId` the workspace doesn't know onto the relay body.
- **No scope separation**: nothing stopped a workspace doc being filed in a local collection (or vice-versa).

Closes JP-366. Follows JP-365 (collections polishing) and JP-159 (relay registry).

## Approach

**Scope tag (keystone).** `Collection.scope: 'local' | 'workspace'` (absent = local). `createCollection` takes a scope; `collectionSync` tags by auth (workspace when signed in); `reconcile`/`hydrateFromRelay` tag relay defs `workspace`. Persist **v1→v2 migration** stamps existing defs `local` (safe default; reconcile re-tags) — extracted as a pure `migrateCollections` for testability.

**Scope-match guard.** `assignDocumentsScoped` is the **single choke point** for every assign path (per-card, bulk, new-for-doc): a workspace doc can only join a workspace collection and a local doc only a local one; mismatches are skipped with a warning toast (lean — no blocking dialog). The per-card "Move to collection" menu lists only same-scope collections; "+ New collection" for a doc inherits the doc's scope. `docScopeOf` derives scope from the registry record type (remote/cached = workspace), kept in lockstep with the card's `record.type` filter.

**Drop on leave.** `stopSession` (full sign-out / Remove Workspace, which calls it) drops `workspace`-scoped collections + their memberships and resets the synced-id set (`resetWorkspaceSync`); local collections + memberships are kept.

**Promote clears membership.** `handlePublishToTeam` clears the local membership and `executeToTeam` strips the body `collectionId` — a promoted doc lands **Unassigned** in the workspace, no dangling reference.

No relay/wire changes — the relay already implements the per-workspace registry; this aligns the client to it.

## Notion

Canonical model captured in **DocuShark Docs → "Collections — local vs workspace semantics"** (Design / Canonical / Public-safe / Tenancy).

## Tests

`collectionStore` (scope default/explicit, `dropWorkspaceCollections`, v1→v2 migration), `collectionSync` (reconcile tagging, the scope guard: match / block-local→ws / block-ws→local / mixed-partition / removal-bypass, `resetWorkspaceSync` gate reopen), `DocumentCard` (menu lists only same-scope collections). Typecheck clean; **full suite green (1062 tests)**.

## Manual verification (staging)

Sign into a workspace → create a workspace collection + assign; **sign out → workspace collections gone, local collections remain**; try to file a workspace doc into a local collection and vice-versa → **blocked + toast**; promote a local doc that's in a local collection → **Unassigned in the workspace, no dangling `collectionId`**.

Assisted-by: Opus 4.8
