### PR TITLE
fix: confirm/prompt dialog + collection menu ignore theme tokens

### DIFF
--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -278,10 +278,10 @@ button.document-card__offline--action:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  background: var(--color-surface, #fff);
+  background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 10px;
-  box-shadow: var(--shadow-lg, 0 12px 40px rgba(14, 28, 48, 0.25));
+  box-shadow: var(--shadow-lg);
   transform-origin: top right;
   animation: document-card__collection-menu-in 0.14s ease-out;
 }
@@ -315,14 +315,14 @@ button.document-card__offline--action:focus-visible {
   cursor: pointer;
 }
 .document-card__collection-item:hover {
-  background: var(--bg-secondary);
+  background: var(--bg-hover);
 }
 .document-card__collection-item svg {
   flex: 0 0 auto;
-  color: var(--color-primary, #2563eb);
+  color: var(--color-primary);
 }
 .document-card__collection-item--new {
-  color: var(--color-primary, #2563eb);
+  color: var(--color-primary);
   font-weight: 500;
 }
 .document-card__collection-name {

--- a/src/ui/confirm/ConfirmDialog.css
+++ b/src/ui/confirm/ConfirmDialog.css
@@ -24,8 +24,8 @@
   gap: 10px;
   padding: 20px;
   border-radius: 16px;
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
   box-shadow: var(--shadow-lg, 0 12px 40px rgba(14, 28, 48, 0.25));
   animation: confirm-dialog-in 0.18s ease-out;
 }
@@ -35,14 +35,14 @@
   font-size: 16px;
   font-weight: 600;
   line-height: 1.3;
-  color: var(--color-text, #1f2937);
+  color: var(--text-primary);
 }
 
 .confirm-dialog__message {
   margin: 0;
   font-size: 14px;
   line-height: 1.5;
-  color: var(--color-text, #1f2937);
+  color: var(--text-primary);
 }
 
 .confirm-dialog__details {
@@ -59,16 +59,16 @@
   padding: 9px 12px;
   font-size: 14px;
   line-height: 1.4;
-  color: var(--color-text, #1f2937);
-  background: var(--color-bg, #f8fafc);
-  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.15));
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color-input);
   border-radius: 8px;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .confirm-dialog__input:focus {
   outline: none;
-  border-color: var(--color-primary, #2563eb);
-  box-shadow: 0 0 0 3px var(--color-primary-soft, rgba(37, 99, 235, 0.2));
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-alpha);
 }
 
 .confirm-dialog__btn:disabled {
@@ -99,32 +99,32 @@
 }
 
 .confirm-dialog__btn--cancel {
-  color: var(--color-text, #1f2937);
-  background: var(--color-bg, #f1f5f9);
-  border-color: var(--border-color, rgba(0, 0, 0, 0.1));
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
 }
 .confirm-dialog__btn--cancel:hover {
-  background: var(--color-bg-hover, #e2e8f0);
+  background: var(--bg-hover);
 }
 
 .confirm-dialog__btn--confirm {
-  color: var(--color-cta-text, #fff);
-  background: var(--color-cta, #1f3354);
+  color: var(--color-cta-text);
+  background: var(--color-cta);
 }
 .confirm-dialog__btn--confirm:hover {
-  background: var(--color-cta-hover, #16243d);
+  background: var(--color-cta-hover);
 }
 
 .confirm-dialog__btn--danger {
-  color: var(--danger-text, #fff);
-  background: var(--danger-bg, #dc2626);
+  color: #fff;
+  background: var(--danger);
 }
 .confirm-dialog__btn--danger:hover {
-  filter: brightness(0.95);
+  filter: brightness(1.08);
 }
 
 .confirm-dialog__btn:focus-visible {
-  outline: 2px solid var(--color-primary, #2563eb);
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -187,8 +187,8 @@
   transition: background 0.15s ease, color 0.15s ease;
 }
 .dh-nav-add:hover {
-  background: var(--color-bg-hover, rgba(0, 0, 0, 0.06));
-  color: var(--text-primary, inherit);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 .dh-nav-empty {
   padding: 2px 12px 6px;


### PR DESCRIPTION
## Problem

The confirm/prompt dialogs and the per-card "Move to collection" dropdown **ignored the theme** — bright white in dark mode — because they referenced a token namespace that doesn't exist in `index.css` (`--color-surface`, `--color-bg`, `--color-bg-hover`, `--color-text`, `--color-primary-soft`) with **hardcoded light fallbacks**, so the fallback always won. The destructive button additionally used `--danger-bg` (a soft translucent wash) as if it were a solid fill.

## Fix

Switch to the real semantic tokens defined for **both** light and dark in `index.css`:

- **ConfirmDialog.css** — dialog surface → `--bg-primary`; title/message → `--text-primary`; cancel button → `--bg-tertiary` / `--bg-hover`; input → `--bg-secondary` / `--border-color-input`; focus ring → `--color-primary-alpha`; danger button → solid `--danger` with white text.
- **DocumentCard.css** (per-card collection menu) — surface → `--bg-primary`; item hover → `--bg-hover`; accent/check → `--color-primary`.
- **DocumentsHome.css** — `.dh-nav-add` hover → `--bg-hover`.

CSS-only; no logic change. Affects the dialogs shipped/used by JP-365/366.

## Verification

Open a confirm (e.g. delete) and a prompt (new/rename collection) in **dark** and **light** themes → dialog surface, input, and buttons follow the theme; the per-card "Move to collection" dropdown matches panel surfaces in both.

Assisted-by: Opus 4.8
