### PR TITLE
JP-357: page-nav shortcuts, palette entries, button-icon polish

### DIFF
--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -26,6 +26,7 @@ import type { ShortcutCategory } from './KeyboardShortcuts';
 import { LAYOUT_LABELS } from '../ui/layout/modes';
 import { LAYOUT_MODES, type LayoutMode } from '../ui/layout/types';
 import { parseCombo, eventMatchesAny, formatCombo, type KeyScope } from './keybindings';
+import { navigateActivePage } from './pageNavigation';
 
 export interface Command {
   /** Unique identifier */
@@ -178,6 +179,22 @@ function buildCommands(): Command[] {
       keys: 'Mod+Shift+O', scope: 'global', whileTyping: true,
       // The palette can't reach React state; App listens for this event.
       execute: () => window.dispatchEvent(new CustomEvent('docushark:open-documents')),
+    },
+
+    // --- Page navigation (JP-357) --- steps the focused surface's pages (prose
+    // when the editor is focused, canvas otherwise). Literal Ctrl (not Mod):
+    // Ctrl+Tab is the cross-platform tab-cycle even on macOS. whileTyping so it
+    // works while the prose editor is focused. The keys are browser-reserved in
+    // the web PWA (work in desktop); the palette entries are the web path.
+    {
+      id: 'page.next', label: 'Next page', category: 'Navigation',
+      keys: 'Ctrl+PageDown | Ctrl+Tab', scope: 'global', whileTyping: true,
+      execute: () => navigateActivePage('next'),
+    },
+    {
+      id: 'page.prev', label: 'Previous page', category: 'Navigation',
+      keys: 'Ctrl+PageUp | Ctrl+Shift+Tab', scope: 'global', whileTyping: true,
+      execute: () => navigateActivePage('prev'),
     },
 
     // --- Editing (canvas scope — active when the canvas owns focus) ---

--- a/src/engine/keybindings.ts
+++ b/src/engine/keybindings.ts
@@ -100,6 +100,7 @@ export function eventMatchesAny(e: KeyboardEvent, combos: KeyCombo[]): boolean {
 const KEY_DISPLAY: Record<string, string> = {
   arrowup: '↑', arrowdown: '↓', arrowleft: '←', arrowright: '→',
   escape: 'Esc', delete: 'Del', backspace: 'Backspace', enter: 'Enter', ' ': 'Space',
+  pageup: 'PgUp', pagedown: 'PgDn', tab: 'Tab',
 };
 
 /** Human-readable label for the first combo of a spec (for the help panel + palette). */

--- a/src/engine/pageNavigation.test.ts
+++ b/src/engine/pageNavigation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { navigateActivePage } from './pageNavigation';
+import { usePageStore } from '../store/pageStore';
+import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { useHistoryStore } from '../store/historyStore';
+
+const canvasFocus = () => false;
+const proseFocus = () => true;
+
+describe('navigateActivePage', () => {
+  const canvasSet = vi.fn();
+  const proseSet = vi.fn();
+  const historySet = vi.fn();
+
+  beforeEach(() => {
+    canvasSet.mockReset();
+    proseSet.mockReset();
+    historySet.mockReset();
+    // Override the action fields with spies so we assert routing/clamping without
+    // exercising the stores' real mutation internals.
+    usePageStore.setState({ pageOrder: ['c1', 'c2', 'c3'], activePageId: 'c2', setActivePage: canvasSet } as never);
+    useRichTextPagesStore.setState({ pageOrder: ['p1', 'p2', 'p3'], activePageId: 'p2', setActivePage: proseSet } as never);
+    useHistoryStore.setState({ setActivePage: historySet } as never);
+  });
+
+  it('moves to the next canvas page and mirrors history', () => {
+    navigateActivePage('next', canvasFocus);
+    expect(canvasSet).toHaveBeenCalledWith('c3');
+    expect(historySet).toHaveBeenCalledWith('c3');
+    expect(proseSet).not.toHaveBeenCalled();
+  });
+
+  it('moves to the previous canvas page', () => {
+    navigateActivePage('prev', canvasFocus);
+    expect(canvasSet).toHaveBeenCalledWith('c1');
+  });
+
+  it('routes to the prose store when the editor is focused (no history mirror)', () => {
+    navigateActivePage('next', proseFocus);
+    expect(proseSet).toHaveBeenCalledWith('p3');
+    expect(canvasSet).not.toHaveBeenCalled();
+    expect(historySet).not.toHaveBeenCalled();
+  });
+
+  it('clamps at the last page', () => {
+    usePageStore.setState({ activePageId: 'c3' } as never);
+    navigateActivePage('next', canvasFocus);
+    expect(canvasSet).not.toHaveBeenCalled();
+  });
+
+  it('clamps at the first page', () => {
+    usePageStore.setState({ activePageId: 'c1' } as never);
+    navigateActivePage('prev', canvasFocus);
+    expect(canvasSet).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op with a single page', () => {
+    usePageStore.setState({ pageOrder: ['c1'], activePageId: 'c1' } as never);
+    navigateActivePage('next', canvasFocus);
+    expect(canvasSet).not.toHaveBeenCalled();
+  });
+});

--- a/src/engine/pageNavigation.ts
+++ b/src/engine/pageNavigation.ts
@@ -1,0 +1,57 @@
+/**
+ * Keyboard page navigation (JP-357).
+ *
+ * Steps the active page of whichever surface currently has focus: the prose
+ * editor's pages when the Tiptap editable owns focus, otherwise the canvas
+ * pages. Bound to Ctrl+PageUp/PageDown and Ctrl+Tab/Ctrl+Shift+Tab in the
+ * command registry, and surfaced as "Next/Previous page" palette commands — the
+ * web-reliable path, since those keys are browser-reserved in the PWA and only
+ * reach us in the Tauri desktop webview.
+ */
+
+import { usePageStore } from '../store/pageStore';
+import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { useHistoryStore } from '../store/historyStore';
+
+/** True when the Tiptap prose editor (its `.ProseMirror` editable) owns focus. */
+function defaultIsProseFocused(): boolean {
+  const el = typeof document !== 'undefined' ? document.activeElement : null;
+  return !!el && !!(el as Element).closest?.('.ProseMirror');
+}
+
+/** The page id one step away, or null when there's nothing to move to. */
+function neighbor(order: readonly string[], activeId: string | null, step: number): string | null {
+  if (order.length < 2 || !activeId) return null;
+  const idx = order.indexOf(activeId);
+  if (idx === -1) return null;
+  const next = idx + step;
+  if (next < 0 || next >= order.length) return null;
+  return order[next] ?? null;
+}
+
+/**
+ * Move the focused surface's active page by one step. Clamps at both ends (no
+ * wrap) and no-ops when there are fewer than two pages. `isProseFocused` is
+ * injectable for testing.
+ */
+export function navigateActivePage(
+  dir: 'next' | 'prev',
+  isProseFocused: () => boolean = defaultIsProseFocused,
+): void {
+  const step = dir === 'next' ? 1 : -1;
+
+  if (isProseFocused()) {
+    const { pageOrder, activePageId, setActivePage } = useRichTextPagesStore.getState();
+    const target = neighbor(pageOrder, activePageId, step);
+    if (target) setActivePage(target);
+    return;
+  }
+
+  const { pageOrder, activePageId, setActivePage } = usePageStore.getState();
+  const target = neighbor(pageOrder, activePageId, step);
+  if (target) {
+    setActivePage(target);
+    // Mirror the tab-click path (InlinePageTabs) so history tracks the switch.
+    useHistoryStore.getState().setActivePage(target);
+  }
+}

--- a/src/services/importPipeline.ts
+++ b/src/services/importPipeline.ts
@@ -21,14 +21,17 @@ import { pushHistory } from '../store/historyStore';
 import type { Vec2 } from '../math/Vec2';
 import { importFiles, type ImportContext } from './FileImportService';
 
-/** File extensions that route to diagram import rather than file-embed. */
+/**
+ * File extensions that route to diagram import rather than file-embed. Only the
+ * formats with a registered adapter (see registerImportAdapters.ts) belong here;
+ * an extension without an adapter would hit a dead import path, so unsupported
+ * formats (e.g. PlantUML .puml) fall through to the normal file-embed instead.
+ */
 export const DIAGRAM_EXTENSIONS = [
   '.excalidraw',
   '.drawio',
   '.mmd',
   '.mermaid',
-  '.puml',
-  '.plantuml',
 ];
 
 export interface ImportReport {

--- a/src/ui/FileImportButton.tsx
+++ b/src/ui/FileImportButton.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback } from 'react';
-import { Import } from 'lucide-react';
+import { Paperclip } from 'lucide-react';
 import { Icon } from './icons';
 import { importFiles, ImportContext } from '../services/FileImportService';
 import './FileImportButton.css';
@@ -59,7 +59,7 @@ export function FileImportButton({ getImportContext }: FileImportButtonProps) {
               </path>
             </svg>
           ) : (
-            <Icon icon={Import} />
+            <Icon icon={Paperclip} />
           )}
         </span>
       </button>

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -8,8 +8,8 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StickyNote, CircleHelp, Settings, Import, FolderOpen, FileDown } from 'lucide-react';
-import { Icon } from './icons';
+import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen } from 'lucide-react';
+import { Icon, PdfIcon } from './icons';
 import { ToolbarGroup } from './ToolbarGroup';
 import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
@@ -183,10 +183,10 @@ export function UnifiedToolbar({
           <button
             className="toolbar-help-btn"
             onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
-            title="Import diagram (Excalidraw)"
-            aria-label="Import diagram"
+            title="Import diagram (Excalidraw, drawio, Mermaid)"
+            aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
           >
-            <Icon icon={Import} />
+            <Icon icon={FileInput} />
           </button>
           <button
             className="toolbar-whiteboard-btn"
@@ -202,7 +202,7 @@ export function UnifiedToolbar({
             title="Export to PDF"
             aria-label="Export to PDF"
           >
-            <Icon icon={FileDown} />
+            <PdfIcon />
           </button>
           <button
             className="toolbar-help-btn"

--- a/src/ui/icons.tsx
+++ b/src/ui/icons.tsx
@@ -24,3 +24,43 @@ export const ICON_SM = { size: 12, strokeWidth: 1.5 } as const;
 export function Icon({ icon: Glyph, ...props }: { icon: LucideIcon } & LucideProps) {
   return <Glyph size={ICON.size} strokeWidth={ICON.strokeWidth} {...props} />;
 }
+
+/**
+ * Custom "PDF" glyph (JP-357) — a page with a folded corner and a knockout
+ * "PDF" label band, so the export button reads literally rather than as a
+ * generic file-down arrow. Matches the lucide chrome aesthetic (currentColor,
+ * 16px / 1.5 stroke). The label letters are filled with the panel background so
+ * they read in both themes against the opaque currentColor band.
+ */
+export function PdfIcon({ size = ICON.size, strokeWidth = ICON.strokeWidth, ...rest }: LucideProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+      <path d="M14 3v5h5" />
+      <rect x="6.5" y="12.5" width="11" height="6" rx="1" fill="currentColor" stroke="none" />
+      <text
+        x="12"
+        y="17.1"
+        textAnchor="middle"
+        fontSize="4.6"
+        fontWeight="700"
+        stroke="none"
+        fill="var(--bg-secondary, #fff)"
+        fontFamily="system-ui, sans-serif"
+      >
+        PDF
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION
Closes JP-357.

## What

### Page navigation shortcuts + palette entries
- New `src/engine/pageNavigation.ts` → `navigateActivePage(dir)` that **follows focus**: prose pages when the Tiptap editor (`.ProseMirror`) is focused, canvas pages otherwise. Clamps at both ends, no-ops on a single page, and mirrors the InlinePageTabs history side-effect on the canvas path.
- Bound to **`Ctrl+PageDown/PageUp`** and **`Ctrl+Tab/Ctrl+Shift+Tab`** (literal `Ctrl` — the correct cross-platform tab-cycle even on macOS, where `Cmd+Tab` is OS app-switching). `whileTyping` so prose-page nav works while the editor is focused.
- Added **"Next page" / "Previous page"** command-palette entries — the web-reliable path, since `Ctrl+Tab`/`Ctrl+PageUp/Down` are browser-reserved in the PWA and only reach us in the Tauri desktop webview.
- `KEY_DISPLAY` gains `PgUp` / `PgDn` / `Tab` so hints read cleanly.

### Button-icon polish
- Custom **`PdfIcon`** glyph that literally reads "PDF" on the export button (knockout label on an opaque `currentColor` band → legible in both themes).
- Import-diagram button → clearer **`FileInput`** icon + accurate tooltip: **"Import diagram (Excalidraw, drawio, Mermaid)"** (was "Excalidraw" only).
- Canvas embed button → **`Paperclip`** to disambiguate from the diagram-import button (both previously shared the generic `Import` icon).

### Correctness
- Dropped `.puml` / `.plantuml` from `DIAGRAM_EXTENSIONS` — no PlantUML adapter is registered, so those files were hitting a dead diagram-import path; they now embed-as-file.

## Out of scope
- Layout-swap shortcuts (`Ctrl+Shift+1–4`): verified they already work (fixed in the prior keyboard PR), so no change.

## Verification
- `bun run typecheck` clean; full suite **2605 tests passing**, including a new `pageNavigation.test.ts` (clamping, single-page no-op, prose-vs-canvas routing via injected focus predicate).
- Desktop key behaviour + icon visuals to confirm on a real run (the keyboard bindings are browser-reserved on web; palette entries cover the web case).

Assisted-by: Opus 4.8