### PR TITLE
Prose context menu: lucide icons, drop emojis, add Replace image

### DIFF
--- a/src/tiptap/ResizableImageExtension.test.ts
+++ b/src/tiptap/ResizableImageExtension.test.ts
@@ -68,6 +68,33 @@ describe('image float', () => {
     element.remove();
   });
 
+  it('replaceSelectedImage swaps src/alt in place, keeps float, resets size', () => {
+    const { editor, element } = makeEditor('<img src="blob://old" alt="old" data-float="left" width="120" height="80">');
+    editor.commands.setNodeSelection(0);
+
+    expect(editor.commands.replaceSelectedImage({ src: 'blob://new', alt: 'new' })).toBe(true);
+
+    const html = editor.getHTML();
+    expect(html).toContain('blob://new');
+    expect(html).not.toContain('blob://old');
+    expect(html).toContain('alt="new"');
+    // Float (text-wrap) is a layout choice → preserved across the swap.
+    expect(html).toContain('data-float="left"');
+    // Old explicit dimensions are dropped so the new image takes natural size.
+    expect(html).not.toContain('width="120"');
+    expect(html).not.toContain('height="80"');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('replaceSelectedImage is a no-op when no image is selected', () => {
+    const { editor, element } = makeEditor('<p>just text</p>');
+    expect(editor.commands.replaceSelectedImage({ src: 'blob://new' })).toBe(false);
+    editor.destroy();
+    element.remove();
+  });
+
   it('preserves float through a resize (regression: resize reset float to inline)', () => {
     const { editor, element } = makeEditor('<img src="blob://x" alt="x">');
     editor.commands.setNodeSelection(0);

--- a/src/tiptap/ResizableImageExtension.ts
+++ b/src/tiptap/ResizableImageExtension.ts
@@ -33,6 +33,12 @@ declare module '@tiptap/core' {
       }) => ReturnType;
       /** Set float/text-wrap on the currently selected image. */
       setImageFloat: (float: ImageFloat) => ReturnType;
+      /**
+       * Swap the source of the currently selected image in place — preserves its
+       * position (incl. gallery membership) + float, and resets the explicit
+       * width/height so the new image takes its natural size.
+       */
+      replaceSelectedImage: (options: { src: string; alt?: string }) => ReturnType;
       /** Delete the selected image (removes the whole gallery if it was the last). */
       removeSelectedImage: () => ReturnType;
     };
@@ -382,6 +388,27 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
           const node = state.doc.nodeAt(from);
           if (!node || node.type.name !== this.name) return false;
           if (dispatch) dispatch(state.tr.setNodeMarkup(from, undefined, { ...node.attrs, float }));
+          return true;
+        },
+      replaceSelectedImage:
+        (options) =>
+        ({ state, dispatch }) => {
+          const sel = state.selection;
+          if (!(sel instanceof NodeSelection) || sel.node.type.name !== this.name) return false;
+          const { from } = sel;
+          if (dispatch) {
+            dispatch(
+              state.tr.setNodeMarkup(from, undefined, {
+                ...sel.node.attrs,
+                src: options.src,
+                alt: options.alt ?? sel.node.attrs['alt'] ?? null,
+                // Drop the old dimensions so the replacement isn't squeezed into
+                // the previous image's box; float/wrap is kept via the spread.
+                width: null,
+                height: null,
+              }),
+            );
+          }
           return true;
         },
       removeSelectedImage:

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -43,9 +43,11 @@
 }
 
 .doc-editor-context-menu-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 18px;
-  text-align: center;
-  font-weight: 600;
+  flex-shrink: 0;
   color: var(--text-secondary);
 }
 
@@ -60,8 +62,10 @@
 }
 
 .doc-editor-context-menu-arrow {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
   color: var(--text-muted);
-  font-size: 12px;
 }
 
 .doc-editor-context-menu-hint {

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -14,8 +14,46 @@ import { useEffect, useCallback, useState, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import type { Editor } from '@tiptap/core';
 import { NodeSelection } from '@tiptap/pm/state';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Trash2,
+  Type,
+  Heading,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  List,
+  ListOrdered,
+  ListTodo,
+  TextQuote,
+  Minus,
+  Table,
+  Shapes,
+  Bold,
+  Italic,
+  Underline,
+  Strikethrough,
+  Code,
+  Subscript,
+  Superscript,
+  RemoveFormatting,
+  Pilcrow,
+  ArrowUpToLine,
+  ArrowDownToLine,
+  ArrowLeftToLine,
+  ArrowRightToLine,
+  Rows3,
+  Columns3,
+  TableCellsMerge,
+  TableCellsSplit,
+} from 'lucide-react';
 import { useDocumentStore } from '../store/documentStore';
 import { isGroup, type GroupShape } from '../shapes/Shape';
+import { Icon } from './icons';
 import * as cmd from './editorCommands';
 import './DocumentEditorContextMenu.css';
 
@@ -28,6 +66,18 @@ export interface DocumentEditorContextMenuProps {
   onClose: () => void;
   /** Tiptap editor instance */
   editor: Editor | null;
+}
+
+/** Heading-level glyphs, indexed by `level - 1`. */
+const HEADING_ICONS = [Heading1, Heading2, Heading3, Heading4, Heading5, Heading6] as const;
+
+/** Submenu caret — a small muted chevron shown on items that open a submenu. */
+function SubmenuArrow() {
+  return (
+    <span className="doc-editor-context-menu-arrow">
+      <Icon icon={ChevronRight} size={14} />
+    </span>
+  );
 }
 
 /**
@@ -68,7 +118,7 @@ export function DocumentEditorContextMenu({
   const shapes = useDocumentStore((state) => state.shapes);
   const shapeOrder = useDocumentStore((state) => state.shapeOrder);
   const groups = getAvailableGroups(shapes, shapeOrder);
-  
+
   // Check if cursor is in a table
   const isInTable = editor?.isActive('table') ?? false;
 
@@ -237,7 +287,7 @@ export function DocumentEditorContextMenu({
                     onClose();
                   }}
                 >
-                  <span className="doc-editor-context-menu-icon">‹</span>
+                  <span className="doc-editor-context-menu-icon"><Icon icon={ChevronLeft} /></span>
                   <span className="doc-editor-context-menu-label">Move image left</span>
                   <span className="doc-editor-context-menu-shortcut">←</span>
                 </div>
@@ -248,7 +298,7 @@ export function DocumentEditorContextMenu({
                     onClose();
                   }}
                 >
-                  <span className="doc-editor-context-menu-icon">›</span>
+                  <span className="doc-editor-context-menu-icon"><Icon icon={ChevronRight} /></span>
                   <span className="doc-editor-context-menu-label">Move image right</span>
                   <span className="doc-editor-context-menu-shortcut">→</span>
                 </div>
@@ -261,7 +311,7 @@ export function DocumentEditorContextMenu({
                 onClose();
               }}
             >
-              <span className="doc-editor-context-menu-icon">×</span>
+              <span className="doc-editor-context-menu-icon"><Icon icon={Trash2} /></span>
               <span className="doc-editor-context-menu-label">Remove image</span>
               <span className="doc-editor-context-menu-shortcut">⌫</span>
             </div>
@@ -275,9 +325,9 @@ export function DocumentEditorContextMenu({
           onMouseEnter={(e) => handleSubmenuEnter('format', e)}
           onMouseLeave={handleMenuItemLeave}
         >
-          <span className="doc-editor-context-menu-icon">A</span>
+          <span className="doc-editor-context-menu-icon"><Icon icon={Type} /></span>
           <span className="doc-editor-context-menu-label">Format</span>
-          <span className="doc-editor-context-menu-arrow">›</span>
+          <SubmenuArrow />
         </div>
 
         {/* Heading submenu */}
@@ -286,9 +336,9 @@ export function DocumentEditorContextMenu({
           onMouseEnter={(e) => handleSubmenuEnter('heading', e)}
           onMouseLeave={handleMenuItemLeave}
         >
-          <span className="doc-editor-context-menu-icon">H</span>
+          <span className="doc-editor-context-menu-icon"><Icon icon={Heading} /></span>
           <span className="doc-editor-context-menu-label">Heading</span>
-          <span className="doc-editor-context-menu-arrow">›</span>
+          <SubmenuArrow />
         </div>
 
         {/* List submenu */}
@@ -297,9 +347,9 @@ export function DocumentEditorContextMenu({
           onMouseEnter={(e) => handleSubmenuEnter('list', e)}
           onMouseLeave={handleMenuItemLeave}
         >
-          <span className="doc-editor-context-menu-icon">≡</span>
+          <span className="doc-editor-context-menu-icon"><Icon icon={List} /></span>
           <span className="doc-editor-context-menu-label">List</span>
-          <span className="doc-editor-context-menu-arrow">›</span>
+          <SubmenuArrow />
         </div>
 
         <div className="doc-editor-context-menu-divider" />
@@ -312,7 +362,7 @@ export function DocumentEditorContextMenu({
             onClose();
           }}
         >
-          <span className="doc-editor-context-menu-icon">❝</span>
+          <span className="doc-editor-context-menu-icon"><Icon icon={TextQuote} /></span>
           <span className="doc-editor-context-menu-label">Block Quote</span>
         </div>
 
@@ -324,7 +374,7 @@ export function DocumentEditorContextMenu({
             onClose();
           }}
         >
-          <span className="doc-editor-context-menu-icon">—</span>
+          <span className="doc-editor-context-menu-icon"><Icon icon={Minus} /></span>
           <span className="doc-editor-context-menu-label">Horizontal Rule</span>
         </div>
 
@@ -337,9 +387,9 @@ export function DocumentEditorContextMenu({
               onMouseEnter={(e) => handleSubmenuEnter('table', e)}
               onMouseLeave={handleMenuItemLeave}
             >
-              <span className="doc-editor-context-menu-icon">⊞</span>
+              <span className="doc-editor-context-menu-icon"><Icon icon={Table} /></span>
               <span className="doc-editor-context-menu-label">Table</span>
-              <span className="doc-editor-context-menu-arrow">›</span>
+              <SubmenuArrow />
             </div>
           </>
         )}
@@ -352,9 +402,9 @@ export function DocumentEditorContextMenu({
           onMouseEnter={(e) => groups.length > 0 && handleSubmenuEnter('group', e)}
           onMouseLeave={handleMenuItemLeave}
         >
-          <span className="doc-editor-context-menu-icon">📊</span>
+          <span className="doc-editor-context-menu-icon"><Icon icon={Shapes} /></span>
           <span className="doc-editor-context-menu-label">Insert Group</span>
-          {groups.length > 0 && <span className="doc-editor-context-menu-arrow">›</span>}
+          {groups.length > 0 && <SubmenuArrow />}
           {groups.length === 0 && (
             <span className="doc-editor-context-menu-hint">No groups</span>
           )}
@@ -374,7 +424,7 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('bold') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleBold(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon" style={{ fontWeight: 'bold' }}>B</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Bold} /></span>
             <span className="doc-editor-context-menu-label">Bold</span>
             <span className="doc-editor-context-menu-shortcut">Ctrl+B</span>
           </div>
@@ -382,7 +432,7 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('italic') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleItalic(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon" style={{ fontStyle: 'italic' }}>I</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Italic} /></span>
             <span className="doc-editor-context-menu-label">Italic</span>
             <span className="doc-editor-context-menu-shortcut">Ctrl+I</span>
           </div>
@@ -390,7 +440,7 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('underline') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleUnderline(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon" style={{ textDecoration: 'underline' }}>U</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Underline} /></span>
             <span className="doc-editor-context-menu-label">Underline</span>
             <span className="doc-editor-context-menu-shortcut">Ctrl+U</span>
           </div>
@@ -398,7 +448,7 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('strike') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleStrike(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon" style={{ textDecoration: 'line-through' }}>S</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Strikethrough} /></span>
             <span className="doc-editor-context-menu-label">Strikethrough</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -406,21 +456,21 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('code') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleCode(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">&lt;/&gt;</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Code} /></span>
             <span className="doc-editor-context-menu-label">Code</span>
           </div>
           <div
             className={`doc-editor-context-menu-item ${editor?.isActive('subscript') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleSubscript(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">X<sub>2</sub></span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Subscript} /></span>
             <span className="doc-editor-context-menu-label">Subscript</span>
           </div>
           <div
             className={`doc-editor-context-menu-item ${editor?.isActive('superscript') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleSuperscript(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">X<sup>2</sup></span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Superscript} /></span>
             <span className="doc-editor-context-menu-label">Superscript</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -428,7 +478,7 @@ export function DocumentEditorContextMenu({
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.clearFormatting(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">⌫</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={RemoveFormatting} /></span>
             <span className="doc-editor-context-menu-label">Clear Formatting</span>
           </div>
         </div>
@@ -447,7 +497,7 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('paragraph') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.setParagraph(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">¶</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Pilcrow} /></span>
             <span className="doc-editor-context-menu-label">Paragraph</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -457,7 +507,7 @@ export function DocumentEditorContextMenu({
               className={`doc-editor-context-menu-item ${editor?.isActive('heading', { level }) ? 'active' : ''}`}
               onClick={() => { if (editor) cmd.setHeading(editor, level); onClose(); }}
             >
-              <span className="doc-editor-context-menu-icon" style={{ fontSize: `${1.2 - level * 0.1}rem`, fontWeight: 'bold' }}>H{level}</span>
+              <span className="doc-editor-context-menu-icon"><Icon icon={HEADING_ICONS[level - 1]!} /></span>
               <span className="doc-editor-context-menu-label">Heading {level}</span>
             </div>
           ))}
@@ -477,21 +527,21 @@ export function DocumentEditorContextMenu({
             className={`doc-editor-context-menu-item ${editor?.isActive('bulletList') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleBulletList(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">•</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={List} /></span>
             <span className="doc-editor-context-menu-label">Bullet List</span>
           </div>
           <div
             className={`doc-editor-context-menu-item ${editor?.isActive('orderedList') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleOrderedList(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">1.</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={ListOrdered} /></span>
             <span className="doc-editor-context-menu-label">Numbered List</span>
           </div>
           <div
             className={`doc-editor-context-menu-item ${editor?.isActive('taskList') ? 'active' : ''}`}
             onClick={() => { if (editor) cmd.toggleTaskList(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">☑</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={ListTodo} /></span>
             <span className="doc-editor-context-menu-label">Task List</span>
           </div>
         </div>
@@ -510,28 +560,28 @@ export function DocumentEditorContextMenu({
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.addRowBefore(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">↑+</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowUpToLine} /></span>
             <span className="doc-editor-context-menu-label">Insert Row Above</span>
           </div>
           <div
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.addRowAfter(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">↓+</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowDownToLine} /></span>
             <span className="doc-editor-context-menu-label">Insert Row Below</span>
           </div>
           <div
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.addColumnBefore(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">←+</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowLeftToLine} /></span>
             <span className="doc-editor-context-menu-label">Insert Column Left</span>
           </div>
           <div
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.addColumnAfter(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">→+</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowRightToLine} /></span>
             <span className="doc-editor-context-menu-label">Insert Column Right</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -539,14 +589,14 @@ export function DocumentEditorContextMenu({
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.deleteRow(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">↕✕</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Rows3} /></span>
             <span className="doc-editor-context-menu-label">Delete Row</span>
           </div>
           <div
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.deleteColumn(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">↔✕</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Columns3} /></span>
             <span className="doc-editor-context-menu-label">Delete Column</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -554,14 +604,14 @@ export function DocumentEditorContextMenu({
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.toggleHeaderRow(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">▤</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Rows3} /></span>
             <span className="doc-editor-context-menu-label">Toggle Header Row</span>
           </div>
           <div
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.toggleHeaderColumn(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">▥</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Columns3} /></span>
             <span className="doc-editor-context-menu-label">Toggle Header Column</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -569,14 +619,14 @@ export function DocumentEditorContextMenu({
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.mergeCells(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">⊞</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={TableCellsMerge} /></span>
             <span className="doc-editor-context-menu-label">Merge Cells</span>
           </div>
           <div
             className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.splitCell(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">⊟</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={TableCellsSplit} /></span>
             <span className="doc-editor-context-menu-label">Split Cell</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
@@ -584,7 +634,7 @@ export function DocumentEditorContextMenu({
             className="doc-editor-context-menu-item danger"
             onClick={() => { if (editor) cmd.deleteTable(editor); onClose(); }}
           >
-            <span className="doc-editor-context-menu-icon">🗑</span>
+            <span className="doc-editor-context-menu-icon"><Icon icon={Trash2} /></span>
             <span className="doc-editor-context-menu-label">Delete Table</span>
           </div>
         </div>

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -17,6 +17,7 @@ import { NodeSelection } from '@tiptap/pm/state';
 import {
   ChevronLeft,
   ChevronRight,
+  ImageUp,
   Trash2,
   Type,
   Heading,
@@ -54,6 +55,7 @@ import {
 import { useDocumentStore } from '../store/documentStore';
 import { isGroup, type GroupShape } from '../shapes/Shape';
 import { Icon } from './icons';
+import { uploadProseImage, IMAGE_FILE_ACCEPT } from './proseImageUpload';
 import * as cmd from './editorCommands';
 import './DocumentEditorContextMenu.css';
 
@@ -108,6 +110,7 @@ export function DocumentEditorContextMenu({
   const menuRef = useRef<HTMLDivElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const replaceInputRef = useRef<HTMLInputElement>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [activeSubmenu, setActiveSubmenu] = useState<'format' | 'heading' | 'list' | 'table' | 'group' | null>(null);
@@ -226,6 +229,33 @@ export function DocumentEditorContextMenu({
     [editor, onClose]
   );
 
+  // Replace image: open the file picker (keeps the menu mounted so the hidden
+  // input survives until the file is chosen). The image NodeSelection persists
+  // in editor state across the picker, so the swap targets the right node.
+  const handleReplaceImageClick = useCallback(() => {
+    replaceInputRef.current?.click();
+  }, []);
+
+  const handleReplaceImageSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = '';
+      if (!file || !editor) {
+        onClose();
+        return;
+      }
+      try {
+        const { src, alt } = await uploadProseImage(file);
+        editor.chain().focus().replaceSelectedImage({ src, alt }).run();
+      } catch (err) {
+        console.error('Failed to replace image:', err);
+      } finally {
+        onClose();
+      }
+    },
+    [editor, onClose]
+  );
+
   // Generic submenu hover handler
   const handleSubmenuEnter = useCallback(
     (submenu: typeof activeSubmenu, e: React.MouseEvent<HTMLDivElement>) => {
@@ -305,6 +335,13 @@ export function DocumentEditorContextMenu({
               </>
             )}
             <div
+              className="doc-editor-context-menu-item"
+              onClick={handleReplaceImageClick}
+            >
+              <span className="doc-editor-context-menu-icon"><Icon icon={ImageUp} /></span>
+              <span className="doc-editor-context-menu-label">Replace image…</span>
+            </div>
+            <div
               className="doc-editor-context-menu-item danger"
               onClick={() => {
                 if (editor) editor.commands.removeSelectedImage();
@@ -315,6 +352,15 @@ export function DocumentEditorContextMenu({
               <span className="doc-editor-context-menu-label">Remove image</span>
               <span className="doc-editor-context-menu-shortcut">⌫</span>
             </div>
+            <input
+              ref={replaceInputRef}
+              type="file"
+              accept={IMAGE_FILE_ACCEPT}
+              onChange={handleReplaceImageSelect}
+              style={{ display: 'none' }}
+              aria-hidden="true"
+              tabIndex={-1}
+            />
             <div className="doc-editor-context-menu-divider" />
           </>
         )}

--- a/src/ui/ImageUploadButton.tsx
+++ b/src/ui/ImageUploadButton.tsx
@@ -12,8 +12,8 @@ import { useEffect, useRef, useState } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
 import { Icon } from './icons';
 import { useTiptapEditor } from './TiptapEditorContext';
-import { blobStorage } from '../storage/BlobStorage';
-import { processImageForUpload, formatFileSize } from '../utils/imageUtils';
+import { formatFileSize } from '../utils/imageUtils';
+import { uploadProseImage, IMAGE_FILE_ACCEPT } from './proseImageUpload';
 import { registerSlashUiHandler } from '../tiptap/slashCommands';
 
 export interface ImageUploadButtonProps {
@@ -30,21 +30,12 @@ export function ImageUploadButton({ className }: ImageUploadButtonProps) {
     setIsUploading(true);
 
     try {
-      // Process image (validate, resize if needed)
-      const { blob, name, originalSize, processedSize, wasResized } = await processImageForUpload(
-        file
-      );
-
-      // Save to blob storage
-      const blobId = await blobStorage.saveBlob(blob, name);
+      // Process (validate, resize) + persist to blob storage.
+      const { src, alt, wasResized, originalSize, processedSize } = await uploadProseImage(file);
 
       // Insert into editor with blob:// URL
       if (editor) {
-        editor
-          .chain()
-          .focus()
-          .setImage({ src: `blob://${blobId}`, alt: name })
-          .run();
+        editor.chain().focus().setImage({ src, alt }).run();
 
         // Log if image was resized
         if (wasResized) {
@@ -118,7 +109,7 @@ export function ImageUploadButton({ className }: ImageUploadButtonProps) {
       <input
         ref={inputRef}
         type="file"
-        accept="image/jpeg,image/jpg,image/png,image/gif,image/webp,image/svg+xml"
+        accept={IMAGE_FILE_ACCEPT}
         onChange={handleChange}
         style={{ display: 'none' }}
         aria-hidden="true"

--- a/src/ui/proseImageUpload.ts
+++ b/src/ui/proseImageUpload.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared prose-image upload pipeline.
+ *
+ * Both the toolbar/slash "Upload image" button and the context-menu "Replace
+ * image" action funnel a picked File through the same flow: validate + resize,
+ * persist to content-addressed blob storage, and hand back a `blob://` src ready
+ * to drop into the Tiptap image node.
+ */
+
+import { blobStorage } from '../storage/BlobStorage';
+import { processImageForUpload } from '../utils/imageUtils';
+
+/** `accept` attribute for image file inputs — the formats we can process. */
+export const IMAGE_FILE_ACCEPT = 'image/jpeg,image/jpg,image/png,image/gif,image/webp,image/svg+xml';
+
+export interface UploadedProseImage {
+  /** `blob://<id>` src for the image node. */
+  src: string;
+  /** Suggested alt text (the processed file name). */
+  alt: string;
+  /** Whether the source image was downscaled to fit the size limits. */
+  wasResized: boolean;
+  originalSize: number;
+  processedSize: number;
+}
+
+/**
+ * Process and store an image file, returning its `blob://` src + metadata.
+ * Throws if the file is invalid or storage fails (callers surface the error).
+ */
+export async function uploadProseImage(file: File): Promise<UploadedProseImage> {
+  const { blob, name, originalSize, processedSize, wasResized } = await processImageForUpload(file);
+  const blobId = await blobStorage.saveBlob(blob, name);
+  return { src: `blob://${blobId}`, alt: name, wasResized, originalSize, processedSize };
+}


### PR DESCRIPTION
Polishes the rich-text editor's right-click context menu (`DocumentEditorContextMenu`) and adds a long-missing **Replace image** action.

## 1. Icon polish (no emojis)
- Replaced the ad-hoc text glyphs (`A`, `H`, `≡`, `❝`, `¶`, `•`, `↑+`, `▤`, …) and **emojis** (`📊` Insert Group, `🗑` Delete Table) with proper **lucide-react** icons via the shared `Icon` wrapper, so the menu matches the rest of the editor chrome (16px / 1.5 stroke, `currentColor`).
- Active and danger item states keep working unchanged (they drive `currentColor` through the existing CSS).
- The icon and submenu-arrow spans now flex-center their SVG; the submenu caret is a lucide `ChevronRight`.

| Area | Icons |
|---|---|
| Parents | `Type` (Format), `Heading`, `List`, `Table`, `Shapes` (Insert Group) |
| Format | Bold / Italic / Underline / Strikethrough / Code / Subscript / Superscript / RemoveFormatting |
| Heading | Pilcrow + Heading1..6 |
| List | List / ListOrdered / ListTodo |
| Table | Arrow{Up,Down,Left,Right}ToLine inserts · Rows3 / Columns3 · TableCellsMerge / TableCellsSplit · Trash2 |
| Image | ChevronLeft / ChevronRight · **ImageUp (Replace)** · Trash2 |

## 2. Replace image
Replacing an image used to mean deleting + re-inserting, which loses its position — painful for an image buried in long prose or inside a gallery. New **"Replace image…"** item opens the file picker and swaps the source in place.

- New `resizableImage` command **`replaceSelectedImage({ src, alt })`**: `setNodeMarkup` on the selected image, preserving its position + gallery membership + float, and resetting width/height so the replacement takes its natural size.
- Extracted the upload-to-blob pipeline into **`proseImageUpload.ts`** (`uploadProseImage` + `IMAGE_FILE_ACCEPT`), now shared by `ImageUploadButton` (refactored) and the context menu — no duplication.
- The image `NodeSelection` persists in editor state across the OS file picker, so the swap targets the right node even though the menu loses DOM focus.

## Verification
- `bun run typecheck` clean; tiptap + UI suites **275 tests passing**, incl. new `replaceSelectedImage` tests (swaps src/alt, keeps float, drops old dimensions; no-op when no image selected).
- Visual check of the menu (table + image submenus, gallery, dark mode) to confirm on a real run.

Part of the lucide icon-unification effort (JP-147).

Assisted-by: Opus 4.8