### PR TITLE
JP-375: deleted-doc tombstone + stale-rejoin fence

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -259,6 +259,12 @@ struct SaveQuery {
     /// Caller's expected `serverVersion`. When present, the relay
     /// refuses the write (HTTP 409) if the stored version differs.
     expected_version: Option<u64>,
+    /// JP-375: deliberate resurrection of a tombstoned (deleted) id. When
+    /// `true`, the relay lifts the tombstone before saving — gated to the
+    /// original owner or a workspace admin. The explicit human override of the
+    /// fence that otherwise rejects a re-create with 410.
+    #[serde(default)]
+    override_tombstone: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -804,6 +810,40 @@ async fn save_doc_handler(
         }
     }
 
+    // JP-375: a tombstoned id is normally refused with 410 (resurrection guard).
+    // A returning offline editor's transfer / a stale PUT must not silently
+    // re-create a deleted doc. The deliberate `overrideTombstone=true` lifts it —
+    // but only for the original owner or a workspace admin, since the doc's live
+    // metadata (and ACL) is gone, leaving the recorded tombstone owner as the
+    // only thing to authorize against.
+    if state.doc_store().is_deleted(&ws, &doc_id) {
+        if !query.override_tombstone {
+            return (
+                StatusCode::GONE,
+                ApiError::body(
+                    "document was deleted; pass overrideTombstone=true to restore it",
+                ),
+            )
+                .into_response();
+        }
+        let is_admin = role_str(role) == "admin";
+        let is_owner = state
+            .doc_store()
+            .tombstone_owner(&ws, &doc_id)
+            .map(|owner| owner == claims.sub)
+            .unwrap_or(false);
+        if !is_admin && !is_owner {
+            return (
+                StatusCode::FORBIDDEN,
+                ApiError::body(
+                    "only the document owner or a workspace admin can restore a deleted document",
+                ),
+            )
+                .into_response();
+        }
+        state.doc_store().clear_tombstone(&ws, &doc_id);
+    }
+
     // Storage backpressure (JP-81): once a workspace is at/over its storage
     // quota, refuse *new* writes with 507 — existing data stays readable
     // (GET is unaffected). Doc JSON references blobs (not base64) so its own
@@ -833,6 +873,14 @@ async fn save_doc_handler(
     };
 
     match outcome {
+        // JP-375: the store also guards resurrection; the handler clears the
+        // tombstone above when overriding, so this is a safety net (e.g. a race
+        // re-tombstoned between the check and the save).
+        SaveOutcome::Tombstoned => (
+            StatusCode::GONE,
+            ApiError::body("document was deleted; pass overrideTombstone=true to restore it"),
+        )
+            .into_response(),
         SaveOutcome::VersionConflict { current } => (
             StatusCode::CONFLICT,
             Json(VersionConflictBody {

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -2789,6 +2789,15 @@ fn mutate_with_retry<R>(
                 last_seen = current;
                 continue;
             }
+            // JP-375: the doc was deleted out from under this write. MCP edits an
+            // existing doc (read-then-save), so a tombstone mid-write means it's
+            // gone — surface it rather than resurrecting it.
+            SaveOutcome::Tombstoned => {
+                return Err(format!(
+                    "document '{}' was deleted during the write — re-read and try again",
+                    doc_id.as_str()
+                ));
+            }
         }
     }
     Err(format!(

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -139,6 +139,14 @@ impl S3Backend {
         format!("{}docs/{}/collections.json", self.config.key_prefix, ws.as_str())
     }
 
+    /// Object key for a workspace's **deleted-id tombstone registry** (JP-375):
+    /// `{prefix}docs/{ws}/deleted-ids.json`. Sits beside the doc index so a cold
+    /// machine restoring from R2 knows which ids are dead and refuses to
+    /// resurrect them via restore-on-miss.
+    pub fn workspace_deleted_ids_key(&self, ws: &WorkspaceId) -> String {
+        format!("{}docs/{}/deleted-ids.json", self.config.key_prefix, ws.as_str())
+    }
+
     /// Object key for a workspace's **blob ledger** (JP-232):
     /// `{prefix}docs/{ws}/blob_ledger.json`. Durable per-workspace projection of
     /// the blob bookkeeping (ACLs + per-doc refs + size/mime) so a recycled
@@ -419,6 +427,13 @@ pub trait DocObjectStore: Send + Sync {
         &self,
         ws: &WorkspaceId,
     ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
+
+    /// Fetch a workspace's deleted-id tombstone registry (JP-375; best-effort
+    /// restore so a cold machine won't resurrect tombstoned ids).
+    fn get_workspace_deleted_ids(
+        &self,
+        ws: &WorkspaceId,
+    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
 }
 
 impl DocObjectStore for S3Backend {
@@ -437,6 +452,10 @@ impl DocObjectStore for S3Backend {
 
     async fn get_workspace_collections(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
         self.get_object_at(&self.workspace_collections_key(ws)).await
+    }
+
+    async fn get_workspace_deleted_ids(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
+        self.get_object_at(&self.workspace_deleted_ids_key(ws)).await
     }
 }
 

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -29,6 +29,9 @@ pub enum MirrorOp {
     PutIndex { ws: WorkspaceId },
     /// Upload a workspace's `collections.json` (collection definitions registry).
     PutCollections { ws: WorkspaceId },
+    /// Upload a workspace's `deleted-ids.json` tombstone registry (JP-375) so a
+    /// cold machine knows which ids are dead and won't resurrect them from R2.
+    PutDeleted { ws: WorkspaceId },
     /// Delete a doc's objects (`json` + `ydoc`) from R2.
     Delete { ws: WorkspaceId, doc_id: DocId },
     /// Drain marker: the worker acks once every prior op has been processed.
@@ -138,6 +141,43 @@ pub struct RecoveryPoint {
 /// captures a copy on each suspicious zeroing, not every snapshot).
 const RECOVERY_RING: usize = 5;
 
+/// Default tombstone retention window (JP-375). A deleted id is fenced for this
+/// long so a returning offline editor's stale state can't merge back into a
+/// re-created/restored doc; after the window the record is pruned so
+/// `deleted-ids.json` stays bounded. Override with `RELAY_TOMBSTONE_TTL_DAYS`.
+const DEFAULT_TOMBSTONE_TTL_DAYS: u64 = 30;
+
+/// One tombstone entry (JP-375): a document id that was deleted, with enough
+/// context to fence stale rejoins and to prune the record once it ages out.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletedRecord {
+    /// Wall-clock millis when the id was tombstoned (prune key).
+    pub deleted_at_ms: u64,
+    /// The `serverVersion` the doc carried at deletion (diagnostic / future
+    /// version-fence use).
+    #[serde(default)]
+    pub last_server_version: u64,
+    /// The doc's owner at deletion. The deliberate resurrection override is
+    /// gated on this (the doc's metadata is gone, so there's nothing else to
+    /// authorize against): only the original owner — or a workspace admin —
+    /// may lift the tombstone. `None` if the doc had no recorded owner.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_id: Option<String>,
+}
+
+/// Drop tombstone records older than `ttl_ms` relative to `now_ms`. Pure (no IO)
+/// so the prune policy is unit-testable. Returns whether anything was removed.
+fn prune_deleted_records(
+    map: &mut std::collections::BTreeMap<String, DeletedRecord>,
+    now_ms: u64,
+    ttl_ms: u64,
+) -> bool {
+    let before = map.len();
+    map.retain(|_, rec| now_ms.saturating_sub(rec.deleted_at_ms) < ttl_ms);
+    map.len() != before
+}
+
 /// Outcome of a save attempt with optimistic-concurrency support.
 /// IO and validation errors continue to surface via the `Result::Err`
 /// channel; this enum carries only application-level outcomes.
@@ -150,6 +190,10 @@ pub enum SaveOutcome {
     /// Caller's `expected_version` did not match the stored version.
     /// `current` is the server's view; clients should refetch + retry.
     VersionConflict { current: u64 },
+    /// The id is tombstoned (JP-375): it was deleted and the write would
+    /// resurrect it. Refused unless the caller first clears the tombstone via
+    /// an explicit, permission-gated override (`clear_tombstone`).
+    Tombstoned,
 }
 
 /// Wall-clock millis since the epoch (0 if the clock is before 1970).
@@ -260,6 +304,14 @@ pub struct DocumentStore {
     /// without this, two interleaved writers could land a stale snapshot after a
     /// fresher one and drop an entry. Held across snapshot+write.
     index_write_lock: std::sync::Mutex<()>,
+    /// JP-375 tombstone registry: deleted document ids per workspace, persisted to
+    /// `workspaces/<ws>/deleted-ids.json` (and mirrored to R2). Fences stale
+    /// offline rejoins / blind re-creates so a deleted (or restored) doc can't be
+    /// silently resurrected. Loaded on boot like `index`; pruned by TTL.
+    deleted_ids: RwLock<HashMap<WorkspaceId, std::collections::BTreeMap<String, DeletedRecord>>>,
+    /// JP-375 tombstone retention window in millis (from `RELAY_TOMBSTONE_TTL_DAYS`,
+    /// default [`DEFAULT_TOMBSTONE_TTL_DAYS`]). Records older than this are pruned.
+    tombstone_ttl_ms: u64,
 }
 
 impl DocumentStore {
@@ -275,6 +327,12 @@ impl DocumentStore {
         // One-shot migration from the pre-21.5 flat layout.
         Self::migrate_legacy_layout(&documents_dir);
 
+        let tombstone_ttl_ms = std::env::var("RELAY_TOMBSTONE_TTL_DAYS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_TOMBSTONE_TTL_DAYS)
+            .saturating_mul(24 * 60 * 60 * 1000);
+
         let store = Self {
             documents_dir: documents_dir.clone(),
             index: RwLock::new(HashMap::new()),
@@ -282,6 +340,8 @@ impl DocumentStore {
             mirror_tx: None,
             cache: RwLock::new(HashMap::new()),
             index_write_lock: std::sync::Mutex::new(()),
+            deleted_ids: RwLock::new(HashMap::new()),
+            tombstone_ttl_ms,
         };
 
         // Eagerly preload every workspace index (and collection registry) so
@@ -901,6 +961,7 @@ impl DocumentStore {
             let Some(ws) = WorkspaceId::from_configured(&name) else { continue };
             self.load_workspace_index(&ws);
             self.load_workspace_collections(&ws);
+            self.load_workspace_deleted_ids(&ws);
         }
     }
 
@@ -1080,6 +1141,165 @@ impl DocumentStore {
         }
     }
 
+    // ── Deleted-doc tombstones (`deleted-ids.json`, JP-375) ────────────────────
+
+    /// Path to a workspace's tombstone registry file.
+    fn deleted_ids_path(&self, ws: &WorkspaceId) -> PathBuf {
+        self.workspace_root(ws).join("deleted-ids.json")
+    }
+
+    /// Load a workspace's tombstone registry from disk into memory, pruning any
+    /// records that have aged past the TTL. No-op (leaves the in-memory entry
+    /// untouched) if the file is missing or unparseable.
+    fn load_workspace_deleted_ids(&self, ws: &WorkspaceId) {
+        let path = self.deleted_ids_path(ws);
+        let Ok(data) = std::fs::read_to_string(&path) else { return };
+        let Ok(mut parsed) =
+            serde_json::from_str::<std::collections::BTreeMap<String, DeletedRecord>>(&data)
+        else {
+            log::warn!("deleted-ids for workspace {} are malformed — leaving empty", ws.as_str());
+            return;
+        };
+        let pruned = prune_deleted_records(&mut parsed, now_ms(), self.tombstone_ttl_ms);
+        if let Ok(mut current) = self.deleted_ids.write() {
+            current.insert(ws.clone(), parsed);
+        }
+        // Persist back if the load-time prune removed anything (raw write, no
+        // mirror — boot housekeeping).
+        if pruned {
+            if let Err(e) = self.write_deleted_ids_file(ws) {
+                log::warn!("JP-375 tombstone prune persist failed for {}: {}", ws.as_str(), e);
+            }
+        }
+    }
+
+    /// Read a workspace's `deleted-ids.json` bytes off the local volume for the
+    /// mirror worker. `None` if absent/unreadable.
+    pub fn read_workspace_deleted_ids_bytes(&self, ws: &WorkspaceId) -> Option<Vec<u8>> {
+        std::fs::read(self.deleted_ids_path(ws)).ok()
+    }
+
+    /// Snapshot the in-memory tombstones for a workspace and write them to disk
+    /// (raw, no mirror enqueue). Serialized with the other sidecar writes.
+    fn write_deleted_ids_file(&self, ws: &WorkspaceId) -> Result<(), String> {
+        let _guard = self
+            .index_write_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let snapshot = {
+            let map = self.deleted_ids.read().map_err(|e| e.to_string())?;
+            map.get(ws).cloned().unwrap_or_default()
+        };
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| format!("Serialize error: {}", e))?;
+        let _ = std::fs::create_dir_all(self.workspace_root(ws));
+        std::fs::write(self.deleted_ids_path(ws), json)
+            .map_err(|e| format!("Write error: {}", e))?;
+        Ok(())
+    }
+
+    /// Persist a workspace's tombstones locally and mirror to R2 (JP-375).
+    fn save_deleted_ids(&self, ws: &WorkspaceId) -> Result<(), String> {
+        self.write_deleted_ids_file(ws)?;
+        self.enqueue_mirror(MirrorOp::PutDeleted { ws: ws.clone() });
+        Ok(())
+    }
+
+    /// Whether a document id is tombstoned in this workspace (JP-375). Stale
+    /// records past the TTL are treated as absent (the load-time prune reclaims
+    /// them lazily).
+    pub fn is_deleted(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        let now = now_ms();
+        self.deleted_ids
+            .read()
+            .ok()
+            .and_then(|m| {
+                m.get(ws)
+                    .and_then(|t| t.get(doc_id.as_str()))
+                    .map(|rec| now.saturating_sub(rec.deleted_at_ms) < self.tombstone_ttl_ms)
+            })
+            .unwrap_or(false)
+    }
+
+    /// Tombstone a document id (JP-375), recording the version + owner it
+    /// carried. Called from `delete_document`; persists + mirrors. Best-effort —
+    /// a failure to persist is logged, never fatal to the delete.
+    fn tombstone(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        last_server_version: u64,
+        owner_id: Option<String>,
+    ) {
+        {
+            let mut map = match self.deleted_ids.write() {
+                Ok(m) => m,
+                Err(_) => return,
+            };
+            map.entry(ws.clone()).or_default().insert(
+                doc_id.as_str().to_string(),
+                DeletedRecord { deleted_at_ms: now_ms(), last_server_version, owner_id },
+            );
+        }
+        if let Err(e) = self.save_deleted_ids(ws) {
+            log::warn!("JP-375 tombstone persist failed for {}/{}: {}", ws.as_str(), doc_id.as_str(), e);
+        }
+    }
+
+    /// The recorded owner of a tombstoned id, if any (JP-375). `None` when the id
+    /// isn't tombstoned or had no owner. Used to authorize the resurrection
+    /// override, since the doc's live metadata is already gone.
+    pub fn tombstone_owner(&self, ws: &WorkspaceId, doc_id: &DocId) -> Option<String> {
+        self.deleted_ids
+            .read()
+            .ok()
+            .and_then(|m| m.get(ws).and_then(|t| t.get(doc_id.as_str())).and_then(|r| r.owner_id.clone()))
+    }
+
+    /// Clear a document id's tombstone (JP-375) — the deliberate,
+    /// permission-gated override that lets an explicit human re-create a deleted
+    /// doc. Persists + mirrors. Returns whether a record was present.
+    pub fn clear_tombstone(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
+        let removed = {
+            let mut map = match self.deleted_ids.write() {
+                Ok(m) => m,
+                Err(_) => return false,
+            };
+            map.get_mut(ws).map(|t| t.remove(doc_id.as_str()).is_some()).unwrap_or(false)
+        };
+        if removed {
+            if let Err(e) = self.save_deleted_ids(ws) {
+                log::warn!(
+                    "JP-375 tombstone clear persist failed for {}/{}: {}",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+            }
+        }
+        removed
+    }
+
+    /// Restore a workspace's tombstone registry from R2 on a cold machine
+    /// (best-effort), paralleling `restore_workspace_index_from`. Pruned on load.
+    pub async fn restore_workspace_deleted_ids_from<S: DocObjectStore>(
+        &self,
+        store: &S,
+        ws: &WorkspaceId,
+    ) {
+        match store.get_workspace_deleted_ids(ws).await {
+            Ok(Some(bytes)) => {
+                let _ = std::fs::create_dir_all(self.workspace_root(ws));
+                if std::fs::write(self.deleted_ids_path(ws), &bytes).is_ok() {
+                    self.load_workspace_deleted_ids(ws);
+                    log::info!("restored tombstones for workspace {} from R2", ws.as_str());
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!("restore: R2 get deleted-ids {}: {}", ws.as_str(), e),
+        }
+    }
+
     /// List all documents for a single workspace.
     pub fn list_documents(&self, ws: &WorkspaceId) -> Vec<DocumentMetadata> {
         self.index
@@ -1154,6 +1374,9 @@ impl DocumentStore {
                 "unexpected version conflict (current={})",
                 current
             )),
+            // This non-versioned helper is used for internal writes to existing
+            // docs (locks, shares); a tombstoned id here is a logic error.
+            SaveOutcome::Tombstoned => Err("document is tombstoned (deleted)".to_string()),
         }
     }
 
@@ -1250,6 +1473,14 @@ impl DocumentStore {
         let doc_id = DocId::from_body_id(id_str.clone())
             .map_err(|e| format!("Invalid document id: {}", e))?;
         let id = id_str;
+
+        // JP-375: refuse to resurrect a tombstoned id. A blind re-create (a
+        // returning offline editor's transfer, a stale PUT) would undo a delete
+        // or a restore and re-introduce the old state. The deliberate override
+        // path (`clear_tombstone`, Owner-gated) lifts the tombstone first.
+        if self.is_deleted(ws, &doc_id) {
+            return Ok(SaveOutcome::Tombstoned);
+        }
 
         // Read current stored version (if any) for the concurrency
         // check. Holding the read lock briefly is fine; the rest of
@@ -1379,17 +1610,15 @@ impl DocumentStore {
     /// `Ok(false)` if the doc isn't in this workspace's index — even
     /// when another workspace holds a doc with the same id.
     pub fn delete_document(&self, ws: &WorkspaceId, doc_id: &DocId) -> Result<bool, String> {
-        // Check if document exists in this workspace.
-        {
+        // Check if document exists in this workspace, and capture its version +
+        // owner for the tombstone record.
+        let (last_server_version, owner_id) = {
             let index = self.index.read().map_err(|e| e.to_string())?;
-            let in_workspace = index
-                .get(ws)
-                .map(|m| m.contains_key(doc_id.as_str()))
-                .unwrap_or(false);
-            if !in_workspace {
-                return Ok(false);
+            match index.get(ws).and_then(|m| m.get(doc_id.as_str())) {
+                Some(meta) => (meta.server_version.unwrap_or(0), meta.owner_id.clone()),
+                None => return Ok(false),
             }
-        }
+        };
 
         // Remove document file.
         let path = self.doc_path(ws, doc_id);
@@ -1430,6 +1659,10 @@ impl DocumentStore {
             ws: ws.clone(),
             doc_id: doc_id.clone(),
         });
+
+        // JP-375: record the tombstone so the id can't be silently resurrected
+        // by a stale offline rejoin or a blind re-create.
+        self.tombstone(ws, doc_id, last_server_version, owner_id);
 
         log::info!("Deleted relay document: {}/{}", ws.as_str(), doc_id.as_str());
         Ok(true)
@@ -1781,6 +2014,101 @@ mod tests {
         );
     }
 
+    #[test]
+    fn prune_deleted_records_drops_only_aged() {
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(
+            "fresh".to_string(),
+            DeletedRecord { deleted_at_ms: 9_000, last_server_version: 1, owner_id: None },
+        );
+        map.insert(
+            "old".to_string(),
+            DeletedRecord { deleted_at_ms: 1_000, last_server_version: 1, owner_id: None },
+        );
+        // now=10_000, ttl=5_000 ⇒ "old" (age 9_000) pruned, "fresh" (age 1_000) kept.
+        let removed = prune_deleted_records(&mut map, 10_000, 5_000);
+        assert!(removed);
+        assert!(map.contains_key("fresh"));
+        assert!(!map.contains_key("old"));
+    }
+
+    #[test]
+    fn tombstone_blocks_resave_and_override_clears_it() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("t-doc".to_string()).unwrap();
+
+        store
+            .save_document(&ws, serde_json::json!({ "id": "t-doc", "name": "T", "ownerId": "u1" }))
+            .unwrap();
+        assert!(!store.is_deleted(&ws, &doc_id));
+
+        // Delete → tombstoned (owner recorded for the override gate).
+        assert!(store.delete_document(&ws, &doc_id).unwrap());
+        assert!(store.is_deleted(&ws, &doc_id));
+        assert_eq!(store.tombstone_owner(&ws, &doc_id).as_deref(), Some("u1"));
+
+        // A blind re-create is refused (resurrection guard).
+        let outcome = store
+            .save_document_with_expected_version(
+                &ws,
+                serde_json::json!({ "id": "t-doc", "name": "T again" }),
+                None,
+            )
+            .unwrap();
+        assert_eq!(outcome, SaveOutcome::Tombstoned);
+
+        // Deliberate override: clear the tombstone, then the save creates it anew.
+        assert!(store.clear_tombstone(&ws, &doc_id));
+        assert!(!store.is_deleted(&ws, &doc_id));
+        let outcome = store
+            .save_document_with_expected_version(
+                &ws,
+                serde_json::json!({ "id": "t-doc", "name": "T restored" }),
+                None,
+            )
+            .unwrap();
+        assert!(matches!(outcome, SaveOutcome::Created { .. }));
+    }
+
+    #[test]
+    fn tombstone_persists_across_store_reload() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("p-doc".to_string()).unwrap();
+        {
+            let store = DocumentStore::new(dir.path().to_path_buf());
+            store
+                .save_document(&ws, serde_json::json!({ "id": "p-doc", "name": "P" }))
+                .unwrap();
+            store.delete_document(&ws, &doc_id).unwrap();
+            assert!(store.is_deleted(&ws, &doc_id));
+        }
+        // A fresh store over the same dir preloads the persisted tombstones.
+        let reloaded = DocumentStore::new(dir.path().to_path_buf());
+        assert!(reloaded.is_deleted(&ws, &doc_id));
+    }
+
+    #[tokio::test]
+    async fn restore_tombstones_from_object_store() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("r-doc".to_string()).unwrap();
+        assert!(!store.is_deleted(&ws, &doc_id));
+
+        // A cold machine restores the tombstone registry from R2 and honours it.
+        let fake = FakeObjectStore {
+            deleted_ids: Some(
+                br#"{"r-doc":{"deletedAtMs":9999999999999,"lastServerVersion":3}}"#.to_vec(),
+            ),
+            ..Default::default()
+        };
+        store.restore_workspace_deleted_ids_from(&fake, &ws).await;
+        assert!(store.is_deleted(&ws, &doc_id));
+    }
+
     #[tokio::test]
     async fn restore_collections_from_object_store() {
         let dir = tempdir().unwrap();
@@ -1826,6 +2154,7 @@ mod tests {
                 MirrorOp::Put { .. } => {}
                 MirrorOp::PutIndex { .. } => put_index += 1,
                 MirrorOp::PutCollections { .. } => {}
+                MirrorOp::PutDeleted { .. } => {}
                 MirrorOp::Delete { .. } => deletes += 1,
                 MirrorOp::Flush(_) => {}
             }
@@ -1858,6 +2187,7 @@ mod tests {
         ydoc: Option<Vec<u8>>,
         index: Option<Vec<u8>>,
         collections: Option<Vec<u8>>,
+        deleted_ids: Option<Vec<u8>>,
     }
 
     impl DocObjectStore for FakeObjectStore {
@@ -1886,6 +2216,13 @@ mod tests {
             _ws: &WorkspaceId,
         ) -> Result<Option<Vec<u8>>, String> {
             Ok(self.collections.clone())
+        }
+
+        async fn get_workspace_deleted_ids(
+            &self,
+            _ws: &WorkspaceId,
+        ) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.deleted_ids.clone())
         }
     }
 

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -215,6 +215,15 @@ async fn run_doc_mirror_worker(
                     log::warn!("R2 collections mirror PUT failed for {}: {}", key, e);
                 }
             }
+            MirrorOp::PutDeleted { ws } => {
+                let Some(bytes) = doc_store.read_workspace_deleted_ids_bytes(&ws) else {
+                    continue;
+                };
+                let key = s3.workspace_deleted_ids_key(&ws);
+                if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                    log::warn!("R2 deleted-ids mirror PUT failed for {}: {}", key, e);
+                }
+            }
             MirrorOp::Delete { ws, doc_id } => {
                 for ext in ["json", "ydoc"] {
                     let key = s3.doc_object_key(&ws, &doc_id, ext);
@@ -705,8 +714,15 @@ impl ServerState {
     /// normal not-found handling).
     pub(crate) async fn ensure_doc_local(&self, ws: &WorkspaceId, doc_id: &DocId) -> bool {
         // JP-232: recover this workspace's blob bookkeeping before any restore.
-        // No-op (O(1)) on a healthy/already-recovered pod.
+        // No-op (O(1)) on a healthy/already-recovered pod. Also restores the
+        // JP-375 tombstone registry on a cold machine, so the gate below is real.
         self.ensure_blob_bookkeeping(ws).await;
+        // JP-375: never resurrect a tombstoned id from R2 by-id restore. A
+        // deleted doc's bytes are already gone from R2 (delete mirrors a Delete),
+        // but this is the explicit fence for the race where they linger.
+        if self.doc_store.is_deleted(ws, doc_id) {
+            return false;
+        }
         // JP-279: gate on **body presence**, not index/metadata presence. After a
         // JP-200 index restore (index eager, bodies lazy-by-id) or a JP-231
         // eviction, a doc is listed in the index but its body isn't on the volume
@@ -797,6 +813,14 @@ impl ServerState {
             self.blob_recovery_done.lock().unwrap().insert(ws.clone());
             return;
         }
+
+        // JP-375: this machine's volume is cold — restore the deleted-id
+        // tombstones from R2 before any save/restore can resurrect a dead id.
+        // (When the volume is intact the tombstones were loaded at boot, so the
+        // early-return above already has them.) Best-effort; absent = none.
+        self.doc_store
+            .restore_workspace_deleted_ids_from(s3.as_ref(), ws)
+            .await;
 
         // Ledger-first.
         match s3.get_object_at(&s3.blob_ledger_key(ws)).await {
@@ -3142,6 +3166,15 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
 
     let Some(doc_id) = doc_id else { return };
 
+    // JP-375: drop SYNC frames for a tombstoned id — this is the anti-corruption
+    // gate. A returning offline editor still holding a session for a since-deleted
+    // (or restored-under-new-id) doc must not have its stale Y.Doc updates merged
+    // back into the authoritative state. The client gets ERR_DELETED on its
+    // (re)JOIN and strands its copy; any in-flight SYNC frames are simply dropped.
+    if state.doc_store().is_deleted(&workspace_id, &doc_id) {
+        return;
+    }
+
     // JP-34: apply the frame to the authoritative Y.Doc, then answer/broadcast.
     // The handle should already exist (created on JOIN_DOC); hydrate on demand
     // to cover the JOIN→SYNC race or a join-time body-load failure.
@@ -3268,6 +3301,28 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
     // doc from R2 by id before the existence gate, so durability survives volume
     // loss. No-op when already local or on the filesystem backend.
     state.ensure_doc_local(&workspace_id, &request.doc_id).await;
+
+    // JP-375: a tombstoned id is dead. Tell the client explicitly (ERR_DELETED)
+    // so it strands its stale local copy to Trash and stops, rather than letting
+    // a returning offline editor's Y.Doc merge back into a re-created/restored
+    // doc. Checked before the unknown-doc gate (ensure_doc_local restored the
+    // tombstones on a cold machine).
+    if state.doc_store().is_deleted(&workspace_id, &request.doc_id) {
+        log::info!(
+            "rejecting JOIN_DOC for deleted doc client_id={} workspace_id={} doc_id={}",
+            client_id,
+            workspace_id.as_str(),
+            request.doc_id.as_str(),
+        );
+        let err = ErrorResponse {
+            request_id: None,
+            error: "ERR_DELETED".to_string(),
+        };
+        if let Ok(data) = encode_message(MESSAGE_ERROR, &err) {
+            send_to_client(client_id, data, state).await;
+        }
+        return;
+    }
 
     if state
         .doc_store()

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -21,8 +21,8 @@ use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::config::{TenancyConfig, TenancyMode};
 use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer};
 use docushark_relay::server::protocol::{
-    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
-    PROTOCOL_VERSION,
+    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_ERROR, MESSAGE_JOIN_DOC,
+    MESSAGE_SYNC, PROTOCOL_VERSION,
 };
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
 use docushark_relay::test_support::OidcTestIssuer;
@@ -100,6 +100,36 @@ async fn put_doc(http: &str, token: &str, body: Value) {
         .await
         .expect("PUT doc");
     assert!(resp.status().is_success(), "seed PUT: {}", resp.status());
+}
+
+/// DELETE a document over REST (JP-375 fence tests). Returns the HTTP status.
+async fn delete_doc(http: &str, token: &str, id: &str) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .delete(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("DELETE doc")
+        .status()
+}
+
+/// PUT a document over REST returning the raw status (JP-375 — used to assert a
+/// tombstoned re-create is refused with 410, and that the override restores it).
+async fn put_doc_status(
+    http: &str,
+    token: &str,
+    body: Value,
+    query: &str,
+) -> reqwest::StatusCode {
+    let id = body["id"].as_str().expect("doc id").to_string();
+    reqwest::Client::new()
+        .put(format!("{http}/api/docs/{id}{query}"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("PUT doc")
+        .status()
 }
 
 type WsStream =
@@ -1598,5 +1628,81 @@ async fn jp342_list_icons_and_icon_apply_round_trip() {
     assert!(shape2["iconDisplayMode"].is_null(), "bogus mode dropped: {shape2}");
 
     mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
+// ----------------------------------------------------------------------
+// JP-375 — deleted-doc tombstone + stale-rejoin fence
+// ----------------------------------------------------------------------
+
+/// Once a doc is deleted, a JOIN_DOC for its id is rejected with `ERR_DELETED`
+/// (not silently dropped) so the client strands its local copy instead of
+/// merging a stale Y.Doc back into a re-created / restored doc.
+#[tokio::test]
+async fn join_on_deleted_doc_is_rejected_with_err_deleted() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+    let body = json!({
+        "id": "doc-del", "name": "Doomed", "pageOrder": ["p1"],
+        "activePageId": "p1", "createdAt": 1, "modifiedAt": 2,
+        "ownerId": "alice", "ownerName": "alice",
+        "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+    });
+    put_doc(&relay.http, &token, body).await;
+    assert!(delete_doc(&relay.http, &token, "doc-del").await.is_success());
+
+    let mut client = WsClient::connect(&relay.ws_base).await;
+    client.auth(&token).await;
+    client.join_doc("doc-del").await;
+
+    let mut saw_err_deleted = false;
+    for _ in 0..10 {
+        if let Some((ty, bytes)) = client.recv_within(300).await {
+            if ty == MESSAGE_ERROR {
+                let err: Value = serde_json::from_slice(&bytes[1..]).expect("err json");
+                if err["error"].as_str() == Some("ERR_DELETED") {
+                    saw_err_deleted = true;
+                    break;
+                }
+            }
+        }
+    }
+    assert!(saw_err_deleted, "JOIN_DOC on a deleted doc must return ERR_DELETED");
+
+    relay.server.stop().await.expect("stop");
+}
+
+/// A blind re-create (PUT) of a tombstoned id is refused with 410; the
+/// deliberate owner override (`overrideTombstone=true`) lifts the tombstone and
+/// restores it. This is the transfer-resurrection guard + its escape hatch.
+#[tokio::test]
+async fn tombstoned_recreate_is_410_until_owner_override() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+    let body = json!({
+        "id": "doc-res", "name": "Res", "pageOrder": ["p1"],
+        "activePageId": "p1", "createdAt": 1, "modifiedAt": 2,
+        "ownerId": "alice", "ownerName": "alice",
+        "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+    });
+    put_doc(&relay.http, &token, body.clone()).await;
+    assert!(delete_doc(&relay.http, &token, "doc-res").await.is_success());
+
+    // Blind re-create → 410 Gone.
+    let status = put_doc_status(&relay.http, &token, body.clone(), "").await;
+    assert_eq!(status.as_u16(), 410, "tombstoned re-create must be 410");
+
+    // Owner override → restored, and readable again.
+    let status = put_doc_status(&relay.http, &token, body, "?overrideTombstone=true").await;
+    assert!(status.is_success(), "owner override should restore: {status}");
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-res", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("GET");
+    assert!(resp.status().is_success(), "restored doc should be readable");
+
     relay.server.stop().await.expect("stop");
 }

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -185,11 +185,21 @@ export class RelayClient {
     docId: string,
     document: DiagramDocument,
     expectedVersion?: number,
+    overrideTombstone?: boolean,
   ): Promise<{ success: boolean; newVersion: number }> {
-    const path =
-      expectedVersion !== undefined
-        ? `/api/docs/${encodeURIComponent(docId)}?expectedVersion=${expectedVersion}`
-        : `/api/docs/${encodeURIComponent(docId)}`;
+    // JP-375: `overrideTombstone` deliberately resurrects a deleted id (relay
+    // refuses a blind re-create with 410); Owner/admin-gated server-side.
+    const params = new URLSearchParams();
+    if (expectedVersion !== undefined) {
+      params.set('expectedVersion', String(expectedVersion));
+    }
+    if (overrideTombstone) {
+      params.set('overrideTombstone', 'true');
+    }
+    const qs = params.toString();
+    const path = qs
+      ? `/api/docs/${encodeURIComponent(docId)}?${qs}`
+      : `/api/docs/${encodeURIComponent(docId)}`;
     return this.requestJson('PUT', path, {
       auth: true,
       body: document,

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -63,8 +63,14 @@ export class RestDocumentProvider {
   async saveDocument(
     doc: DiagramDocument,
     expectedVersion?: number,
+    opts?: { overrideTombstone?: boolean },
   ): Promise<{ newVersion?: number }> {
-    const { newVersion } = await this.client.saveDocument(doc.id, doc, expectedVersion);
+    const { newVersion } = await this.client.saveDocument(
+      doc.id,
+      doc,
+      expectedVersion,
+      opts?.overrideTombstone,
+    );
     return typeof newVersion === 'number' ? { newVersion } : {};
   }
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -53,7 +53,7 @@ import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import type { Field } from '../types/Field';
 import type { DocEvent } from './protocol';
-import { isUnknownDocError } from './protocol';
+import { isDeletedDocError, isUnknownDocError } from './protocol';
 import { throttle } from '../utils/requestUtils';
 import { getAdaptiveBudget } from '../platform/adaptiveBudget';
 import { relayFetch } from '../platform/relayFetch';
@@ -544,6 +544,18 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
           useRelayDocumentStore.getState().handleDocumentEvent(event);
         },
         onError: (error: string, docId: string | null) => {
+          // JP-375: ERR_DELETED is a definitive tombstone — the doc was deleted
+          // (or restored under a new id) on the relay. Strand our local copy to
+          // Trash and leave, so a returning offline editor never merges its stale
+          // Y.Doc back. Only act when we actually hold a copy; a bare unknown id
+          // is a no-op (strandOrDemoteDeletedDoc handles a missing record).
+          if (isDeletedDocError(error) && docId) {
+            const record = useDocumentRegistry.getState().getRecord(docId);
+            if (record) {
+              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+            }
+            return;
+          }
           // A rejected JOIN_DOC means the relay has no record of this doc in
           // our workspace (never promoted, deleted, or a diverged local-only
           // id). Mark it as not-syncing and tell the user their edits are

--- a/src/collaboration/protocol.test.ts
+++ b/src/collaboration/protocol.test.ts
@@ -25,6 +25,7 @@ import {
   hasErrorCode,
   isPermissionError,
   isUnknownDocError,
+  isDeletedDocError,
   isCRDTMessage,
   getMessageTypeName,
   validateMessageSize,
@@ -264,6 +265,19 @@ describe('Error Code Helpers', () => {
       expect(isUnknownDocError('ERR_DOC_NOT_FOUND')).toBe(false);
       expect(isUnknownDocError('ERR_ACCESS_DENIED')).toBe(false);
       expect(isUnknownDocError('')).toBe(false);
+    });
+  });
+
+  describe('isDeletedDocError', () => {
+    it('detects a tombstoned-doc rejection (ERR_DELETED)', () => {
+      expect(isDeletedDocError('ERR_DELETED')).toBe(true);
+      expect(isDeletedDocError('ERR_DELETED: tombstoned')).toBe(true);
+    });
+
+    it('returns false for other errors (incl. the unknown-doc code)', () => {
+      expect(isDeletedDocError('ERR_UNKNOWN_DOC')).toBe(false);
+      expect(isDeletedDocError('ERR_ACCESS_DENIED')).toBe(false);
+      expect(isDeletedDocError('')).toBe(false);
     });
   });
 });

--- a/src/collaboration/protocol.ts
+++ b/src/collaboration/protocol.ts
@@ -157,6 +157,19 @@ export function isUnknownDocError(error: string): boolean {
   return hasErrorCode(error, ERR_UNKNOWN_DOC);
 }
 
+/**
+ * Sent by the relay (JP-375) when a JOIN_DOC / SYNC targets a **tombstoned**
+ * id — one that was deleted (or restored under a new id). Unlike
+ * {@link ERR_UNKNOWN_DOC} this is a definitive deletion: the client must
+ * strand its local copy to Trash and stop, never merge its stale Y.Doc back.
+ */
+export const ERR_DELETED = 'ERR_DELETED';
+
+/** True for a tombstoned-doc rejection (see {@link ERR_DELETED}). */
+export function isDeletedDocError(error: string): boolean {
+  return hasErrorCode(error, ERR_DELETED);
+}
+
 // ============ Message Size Limits ============
 
 /** Maximum message size in bytes (16 MB) */

--- a/src/services/DocumentTransferService.test.ts
+++ b/src/services/DocumentTransferService.test.ts
@@ -111,10 +111,31 @@ describe('DocumentTransferService', () => {
       await service.transferToTeam(testDoc.id);
 
       expect(deps.saveToHost).toHaveBeenCalledTimes(1);
-      expect(deps.saveToHost).toHaveBeenCalledWith(expect.objectContaining({
-        id: testDoc.id,
-        isRelayDocument: true,
-      }));
+      expect(deps.saveToHost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: testDoc.id,
+          isRelayDocument: true,
+        }),
+        // JP-375: saveToHost now carries the tombstone-override flag.
+        expect.objectContaining({ overrideTombstone: false }),
+      );
+    });
+
+    it('surfaces a tombstoned result when the relay returns 410 (JP-375)', async () => {
+      deps.saveToHost = vi.fn().mockRejectedValue(
+        Object.assign(new Error('gone'), { status: 410 }),
+      );
+      const result = await service.transferToTeam(testDoc.id);
+      expect(result.success).toBe(false);
+      expect(result.tombstoned).toBe(true);
+    });
+
+    it('forwards overrideTombstone to saveToHost when restoring (JP-375)', async () => {
+      await service.transferToTeam(testDoc.id, { overrideTombstone: true });
+      expect(deps.saveToHost).toHaveBeenCalledWith(
+        expect.objectContaining({ id: testDoc.id }),
+        expect.objectContaining({ overrideTombstone: true }),
+      );
     });
 
     it('skips server sync when not authenticated', async () => {

--- a/src/services/DocumentTransferService.ts
+++ b/src/services/DocumentTransferService.ts
@@ -64,6 +64,13 @@ export interface TransferResult {
   error?: string;
   /** Whether rollback was performed */
   rolledBack?: boolean;
+  /**
+   * JP-375: the relay refused the upload because this id is tombstoned
+   * (deleted, or restored under a new id). The caller should prompt the user to
+   * either restore the original (retry with `overrideTombstone`) or upload a
+   * fresh copy under a new id — never a silent failure.
+   */
+  tombstoned?: boolean;
 }
 
 /** Transfer options */
@@ -74,6 +81,12 @@ export interface TransferOptions {
   timeout?: number;
   /** Skip server sync (for testing) */
   skipServerSync?: boolean;
+  /**
+   * JP-375: deliberately resurrect a tombstoned id on the relay (the explicit
+   * "restore the original" choice after a tombstone prompt). Owner/admin-gated
+   * server-side.
+   */
+  overrideTombstone?: boolean;
 }
 
 /** Dependencies for transfer service */
@@ -84,8 +97,8 @@ export interface TransferServiceDeps {
   saveDocument: (doc: DiagramDocument) => void;
   /** Get current user info */
   getCurrentUser: () => { id: string; displayName: string } | null;
-  /** Save to team host */
-  saveToHost: (doc: DiagramDocument) => Promise<void>;
+  /** Save to team host (JP-375: `overrideTombstone` resurrects a deleted id). */
+  saveToHost: (doc: DiagramDocument, opts?: { overrideTombstone?: boolean }) => Promise<void>;
   /** Delete from team host */
   deleteFromHost: (docId: string) => Promise<void>;
   /** Check if authenticated with host */
@@ -105,6 +118,20 @@ export interface TransferServiceDeps {
 
 const TRANSFER_STORAGE_KEY = 'docushark-pending-transfer';
 const DEFAULT_TIMEOUT = 30000;
+
+/**
+ * JP-375: detect the relay's 410 Gone — the doc id is tombstoned (deleted, or
+ * restored under a new id). Structural check so the service stays decoupled from
+ * the relay client's `RelayError` class.
+ */
+function isTombstonedError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    (error as { status?: unknown }).status === 410
+  );
+}
 
 // ============ Transfer Service ============
 
@@ -221,7 +248,12 @@ export class DocumentTransferService {
     direction: TransferDirection,
     options: TransferOptions
   ): Promise<TransferResult> {
-    const { onProgress, timeout = DEFAULT_TIMEOUT, skipServerSync = false } = options;
+    const {
+      onProgress,
+      timeout = DEFAULT_TIMEOUT,
+      skipServerSync = false,
+      overrideTombstone = false,
+    } = options;
 
     // Prevent concurrent transfers
     if (this.isTransferInProgress()) {
@@ -244,13 +276,21 @@ export class DocumentTransferService {
     this.updateTransferState('executing');
 
     try {
-      const executeResult = await this.execute(record, skipServerSync, timeout);
+      const executeResult = await this.execute(record, skipServerSync, timeout, overrideTombstone);
       if (!executeResult.success) {
         // Carry the reason into the record so rollback surfaces *why* (e.g. blobs
         // couldn't be secured) instead of a generic failure.
         if (executeResult.error !== undefined) record.error = executeResult.error;
         onProgress?.('rolling-back');
-        return this.rollback(record);
+        const rolled = await this.rollback(record);
+        // JP-375: preserve the tombstoned signal through rollback so the caller
+        // can prompt (restore original / upload as new copy) rather than dead-end.
+        if (executeResult.tombstoned) {
+          const out: TransferResult = { ...rolled, tombstoned: true };
+          if (executeResult.error !== undefined) out.error = executeResult.error;
+          return out;
+        }
+        return rolled;
       }
 
       // PHASE 3: COMMIT
@@ -315,7 +355,8 @@ export class DocumentTransferService {
   private async execute(
     record: TransferRecord,
     skipServerSync: boolean,
-    timeout: number
+    timeout: number,
+    overrideTombstone: boolean
   ): Promise<TransferResult> {
     const doc = this.deps.loadDocument(record.documentId);
     if (!doc) {
@@ -323,7 +364,7 @@ export class DocumentTransferService {
     }
 
     if (record.direction === 'to-relay') {
-      return this.executeToTeam(doc, skipServerSync, timeout);
+      return this.executeToTeam(doc, skipServerSync, timeout, overrideTombstone);
     } else {
       return this.executeToPersonal(doc, skipServerSync, timeout);
     }
@@ -335,7 +376,8 @@ export class DocumentTransferService {
   private async executeToTeam(
     doc: DiagramDocument,
     skipServerSync: boolean,
-    timeout: number
+    timeout: number,
+    overrideTombstone: boolean
   ): Promise<TransferResult> {
     // Get current user for ownership
     const currentUser = this.deps.getCurrentUser();
@@ -366,10 +408,22 @@ export class DocumentTransferService {
     if (!skipServerSync && this.deps.isAuthenticated()) {
       try {
         await Promise.race([
-          this.deps.saveToHost(updatedDoc),
+          this.deps.saveToHost(updatedDoc, { overrideTombstone }),
           this.timeoutPromise(timeout, 'Server sync timed out'),
         ]);
       } catch (error) {
+        // JP-375: the relay tombstoned this id (deleted, or restored under a new
+        // id) and refused the blind re-create with 410. Surface it as a distinct
+        // outcome so the caller can prompt (restore original / upload as new copy)
+        // instead of a confusing generic failure.
+        if (isTombstonedError(error)) {
+          return {
+            success: false,
+            tombstoned: true,
+            error:
+              'This document was deleted on the relay. Restore the original, or upload it as a new copy.',
+          };
+        }
         const message = error instanceof Error ? error.message : 'Server sync failed';
         return { success: false, error: message };
       }

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -120,7 +120,11 @@ interface RelayDocumentState {
 export interface DocumentProvider {
   listDocuments(): Promise<DocumentMetadata[]>;
   getDocument(docId: string): Promise<DiagramDocument | { document: DiagramDocument; serverVersion?: number }>;
-  saveDocument(doc: DiagramDocument, expectedVersion?: number): Promise<void | { newVersion?: number }>;
+  saveDocument(
+    doc: DiagramDocument,
+    expectedVersion?: number,
+    opts?: { overrideTombstone?: boolean },
+  ): Promise<void | { newVersion?: number }>;
   deleteDocument(docId: string): Promise<void>;
   updateDocumentShares?(
     docId: string,
@@ -170,7 +174,11 @@ interface RelayDocumentActions {
    * Uses optimistic locking if expectedVersion is provided.
    * @throws VersionConflictError if version mismatch detected
    */
-  saveToHost: (doc: DiagramDocument, expectedVersion?: number) => Promise<{ newVersion?: number }>;
+  saveToHost: (
+    doc: DiagramDocument,
+    expectedVersion?: number,
+    opts?: { overrideTombstone?: boolean },
+  ) => Promise<{ newVersion?: number }>;
 
   /**
    * JP-234: upload the blob bytes a document references to the relay blob
@@ -503,7 +511,7 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       }
     },
 
-    saveToHost: async (doc, expectedVersion) => {
+    saveToHost: async (doc, expectedVersion, opts) => {
       if (!docProvider) {
         throw new Error('Not connected to host');
       }
@@ -566,8 +574,8 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           console.log(`[relayDocumentStore] Bundled ${bundleResult.assetCount} assets (${bundleResult.totalSize} bytes)`);
         }
 
-        // Save with optional version check
-        const saveResult = await docProvider.saveDocument(docToSave, expectedVersion);
+        // Save with optional version check (+ JP-375 tombstone override)
+        const saveResult = await docProvider.saveDocument(docToSave, expectedVersion, opts);
         const newVersion = saveResult && typeof saveResult === 'object' && 'newVersion' in saveResult
           ? saveResult.newVersion
           : undefined;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -345,8 +345,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
           displayName: user.displayName || user.username || 'Unknown',
         };
       },
-      saveToHost: async (doc) => {
-        await useRelayDocumentStore.getState().saveToHost(doc);
+      saveToHost: async (doc, opts) => {
+        await useRelayDocumentStore.getState().saveToHost(doc, undefined, opts);
       },
       deleteFromHost: (id) => useRelayDocumentStore.getState().deleteFromHost(id),
       ensureBlobsAvailableLocally: (doc) => ensureDocBlobsLocal(doc),

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -13,7 +13,11 @@
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useDocumentRegistry } from '../../store/documentRegistry';
-import { usePersistenceStore } from '../../store/persistenceStore';
+import {
+  usePersistenceStore,
+  loadDocumentFromStorage,
+  saveDocumentToStorage,
+} from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
 import { useRelayDocumentStore, useIsCloudSignedIn } from '../../store/relayDocumentStore';
 import { ensureCollabSessionForDoc } from '../../collaboration/ensureCollabSession';
@@ -31,7 +35,7 @@ import {
 import { useCollectionStore, type Collection } from '../../store/collectionStore';
 import { syncedActions, assignDocumentsScoped, docScopeOf } from '../../store/collectionSync';
 import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
-import { getTransferService } from '../../services/DocumentTransferService';
+import { getTransferService, type TransferState } from '../../services/DocumentTransferService';
 import { useTransferStore, isTransferRunning } from '../../store/transferStore';
 import { purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
@@ -78,6 +82,33 @@ export function friendlyTransferError(raw: string | undefined): string {
   if (lower.includes('network') || lower.includes('fetch') || lower.includes('timed out'))
     return "Couldn't reach the relay. Check your connection and try again.";
   return raw;
+}
+
+/**
+ * JP-375 tombstone prompt: the relay refused the upload because the id is
+ * deleted/tombstoned. The dialog layer is yes/no only, so this is two-step —
+ * "Upload as a new copy" is the one-click, non-destructive default; "Restore
+ * original" is a deliberate second confirm (it resurrects the doc for everyone
+ * and is Owner/admin-gated server-side).
+ */
+async function promptTombstonedPublish(): Promise<'new-copy' | 'restore-original' | 'cancel'> {
+  const uploadCopy = await confirmDialog({
+    title: 'This document was deleted on the relay',
+    message: 'Upload your copy as a new document?',
+    details: 'Choose “Restore original” instead to bring the deleted document back for everyone.',
+    confirmLabel: 'Upload as new copy',
+    cancelLabel: 'Restore original…',
+  });
+  if (uploadCopy) return 'new-copy';
+  const restore = await confirmDialog({
+    title: 'Restore the original document?',
+    message:
+      'This brings the deleted document back for everyone, replacing the deleted version.',
+    confirmLabel: 'Restore original',
+    cancelLabel: 'Cancel',
+    danger: true,
+  });
+  return restore ? 'restore-original' : 'cancel';
 }
 
 export const SORT_LABELS: Record<DocumentBrowserSort, string> = {
@@ -514,9 +545,60 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       }
 
       useTransferStore.getState().begin(docId, 'to-relay');
-      const result = await service.transferToTeam(docId, {
-        onProgress: (phase) => useTransferStore.getState().setPhase(phase),
-      });
+      const onProgress = (phase: TransferState) =>
+        useTransferStore.getState().setPhase(phase);
+      let result = await service.transferToTeam(docId, { onProgress });
+
+      // JP-375: the relay tombstoned this id (deleted, or restored under a new
+      // id) and refused the blind re-create. Offer the two safe paths instead of
+      // dead-ending: upload the local copy as a NEW document (non-destructive
+      // default), or deliberately restore the original for everyone.
+      if (result.tombstoned) {
+        const choice = await promptTombstonedPublish();
+        if (choice === 'cancel') {
+          useTransferStore.getState().reset();
+          return;
+        }
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        if (choice === 'new-copy') {
+          const original = loadDocumentFromStorage(docId);
+          if (!original) {
+            useTransferStore.getState().fail('Document not found locally');
+            useNotificationStore.getState().error('Move to Relay failed: document not found locally.');
+            return;
+          }
+          const copy = {
+            ...original,
+            id: crypto.randomUUID(),
+            name: `${original.name} (Copy)`,
+            isRelayDocument: false,
+          };
+          delete copy.ownerId;
+          delete copy.ownerName;
+          delete copy.collectionId;
+          saveDocumentToStorage(copy);
+          useDocumentRegistry.getState().registerLocal(getDocumentMetadata(copy));
+          useTransferStore.getState().begin(copy.id, 'to-relay');
+          const copyResult = await service.transferToTeam(copy.id, { onProgress });
+          if (!copyResult.success) {
+            useTransferStore.getState().fail(friendlyTransferError(copyResult.error));
+            useNotificationStore
+              .getState()
+              .error(`Move to Relay failed: ${friendlyTransferError(copyResult.error)}`);
+            return;
+          }
+          useDocumentRegistry.getState().removeDocument(copy.id);
+          await fetchDocumentList();
+          useTransferStore.getState().reset();
+          useNotificationStore.getState().success('Uploaded as a new document on the relay.');
+          return;
+        }
+        // 'restore-original' — deliberate, Owner/admin-gated resurrection of the
+        // same id; falls through to the normal in-place post-promotion steps.
+        useTransferStore.getState().begin(docId, 'to-relay');
+        result = await service.transferToTeam(docId, { onProgress, overrideTombstone: true });
+      }
+
       if (!result.success) {
         useTransferStore.getState().fail(friendlyTransferError(result.error));
         const { useNotificationStore } = await import('../../store/notificationStore');


### PR DESCRIPTION
## Why

Scoping JP-183 (document restore) surfaced a **confirmed data-corruption vector** that pre-exists restore and affects plain **DELETE** today:

- The relay kept **no record of deleted documents** — `delete_document` erased everything and remembered nothing.
- A deleted id was **freely re-creatable** — the save path had no tombstone check.
- The **WS/CRDT sync path never version-fenced** — `handle_sync` merged inbound Y.Doc updates unconditionally.

So a deleted (or restored) doc could be **silently resurrected / re-corrupted** by an editor that was offline and comes back online with a stale local Y.Doc. This is the foundational fence that **unblocks JP-183** (which will restore-under-a-new-id + tombstone the old id).

## What

**Relay**
- Persisted, **TTL-trimmed** tombstone registry (`deleted-ids.json`, mirrored to R2; `RELAY_TOMBSTONE_TTL_DAYS`, default 30). `delete_document` records a tombstone (owner + version).
- **Resurrection guard:** the save path returns **410** for a tombstoned id; `JOIN_DOC` and `SYNC` reject/drop tombstoned ids (`ERR_DELETED`); `ensure_doc_local` refuses to restore a tombstoned id from R2 on a cold machine.
- **Deliberate override:** `PUT ?overrideTombstone=true` lifts the tombstone, gated to the original **owner or a workspace admin** (the doc's live ACL is gone, so the tombstone records the owner).

**Client (`docushark-app`)**
- `ERR_DELETED` → strand the local copy to **Trash** + leave the session (only when a copy is actually held) — a returning offline editor never merges stale state back.
- Transfer detects **410** and prompts: **Upload as a new copy** (safe, non-destructive default) or **Restore the original** (override), instead of a dead-end "Move to Relay failed" toast.

## Tests
- Relay unit: tombstone persist-across-reload, resave→`Tombstoned`/clear→`Created`, TTL prune, restore-from-R2.
- Relay WS+HTTP **contract tests** (`yjs_authority.rs`): `JOIN_DOC` on a deleted doc → `ERR_DELETED`; blind re-create → 410, owner override → restored + readable.
- Client: `isDeletedDocError` units; transfer 410→`tombstoned` + `overrideTombstone` forwarding.
- `cargo build --bin relay`, full `cargo test` (539 lib + integration), `bun run typecheck`, full client suite (2631) — all green.

## Notes
- **Blocks JP-183.** The follow-up restore PR will build on this (new-id restore + tombstone the old id).
- The live restore-during-collab repro remains the manual E2E gate.

Assisted-by: Opus 4.8