### PR TITLE
JP-183: document recovery — restore endpoint + editor backups drawer

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -226,6 +226,10 @@ pub fn routes() -> Router<Arc<ServerState>> {
         )
         .route("/api/docs/:id/recovery", get(list_recovery_handler))
         .route(
+            "/api/docs/:id/recovery/:pointId",
+            get(recovery_point_content_handler),
+        )
+        .route(
             "/api/docs/:id/recovery/:pointId/restore",
             post(restore_recovery_handler),
         )
@@ -694,6 +698,94 @@ async fn get_doc_handler(
     }
 }
 
+/// Validate a recovery point id (`<createdAtMs>-v<serverVersion>`) before it
+/// indexes a file path — both halves must be numeric, which rejects any `/` or
+/// `..` traversal (JP-183).
+fn is_valid_recovery_point_id(id: &str) -> bool {
+    match id.split_once("-v") {
+        Some((ts, ver)) => ts.parse::<u64>().is_ok() && ver.parse::<u64>().is_ok(),
+        None => false,
+    }
+}
+
+/// Decode a recovery point and flatten its CRDT state over the document's
+/// current JSON body, yielding `(restored_json, handle)` (JP-183). The handle
+/// retains the decoded `Y.Doc` so the restore path can re-encode it as the new
+/// doc's binary sidecar. Shared by the non-destructive content GET and the
+/// restore POST; `Err` is a ready-to-return error response.
+fn reconstruct_recovery_point(
+    state: &Arc<ServerState>,
+    ws: &WorkspaceId,
+    doc_id: &DocId,
+    point_id: &str,
+) -> Result<(Value, crate::sync::DocHandle), axum::response::Response> {
+    if !is_valid_recovery_point_id(point_id) {
+        return Err((StatusCode::BAD_REQUEST, ApiError::body("invalid recovery point id")).into_response());
+    }
+    let bytes = state
+        .doc_store()
+        .read_recovery_point(ws, doc_id, point_id)
+        .ok_or_else(|| {
+            (StatusCode::NOT_FOUND, ApiError::body("recovery point not found")).into_response()
+        })?;
+    // Scaffold from the current body so non-CRDT metadata + page structure are
+    // preserved; the recovery point only carries the CRDT shared types.
+    let mut json = state.doc_store().get_document(ws, doc_id).map_err(|_| {
+        (StatusCode::NOT_FOUND, ApiError::body("document not found")).into_response()
+    })?;
+    let page_id = json.get("activePageId").and_then(Value::as_str).map(str::to_string);
+    let handle = crate::sync::DocHandle::from_sidecar_bytes(&bytes, page_id).map_err(|e| {
+        (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            ApiError::body(format!("recovery point is corrupt: {e}")),
+        )
+            .into_response()
+    })?;
+    if !handle.flatten_into(&mut json) {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ApiError::body("recovery point is incompatible with the current document structure"),
+        )
+            .into_response());
+    }
+    Ok((json, handle))
+}
+
+/// `GET /api/docs/:id/recovery/:pointId` — a recovery point's content as a
+/// document JSON (JP-183), **without mutating live state**. Read-scoped exactly
+/// like `GET /api/docs/:id`. Backs the editor's "download to local".
+async fn recovery_point_content_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path((id, point_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = check_read_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+    match reconstruct_recovery_point(&state, &ws, &doc_id, &point_id) {
+        Ok((json, _handle)) => (StatusCode::OK, Json(json)).into_response(),
+        Err(resp) => resp,
+    }
+}
+
 /// `GET /api/docs/:id/recovery` — list a document's recovery points (JP-180),
 /// newest first. Read-scoped exactly like `GET /api/docs/:id`. The backups are
 /// written by the relay's poison guard before a suspicious N→0 zeroing; this is
@@ -729,13 +821,15 @@ async fn list_recovery_handler(
 }
 
 /// `POST /api/docs/:id/recovery/:pointId/restore` — restore a recovery point as
-/// the live document. **Stub (JP-180):** authed + workspace-scoped, but the
-/// actual restore (decode sidecar → flatten to JSON → versioned save + DocEvent
-/// broadcast) and the web-interface surface are tracked in JP-183.
+/// a **new document** (JP-183), then delete + tombstone the source id. A fresh
+/// id sidesteps the stale-sidecar hydration hazard and gives connected clients a
+/// clean break: the source's `Deleted` broadcast kicks them (they strand their
+/// pre-restore copy to Trash via JP-375), and the new doc surfaces via `Created`.
+/// Owner-gated, since it deletes the source. Returns `{ newDocId, serverVersion }`.
 async fn restore_recovery_handler(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
-    Path((id, _point_id)): Path<(String, String)>,
+    Path((id, point_id)): Path<(String, String)>,
 ) -> impl IntoResponse {
     let claims = match require_auth(&state, &headers).await {
         Ok(c) => c,
@@ -745,21 +839,104 @@ async fn restore_recovery_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
-        Ok(ws) => ws,
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
         Err(resp) => return resp,
     };
-    // Don't leak existence across tenants: 404 if the doc isn't in this
-    // workspace before advertising the not-yet-implemented restore.
+    state.ensure_blob_bookkeeping(&ws).await;
+
+    // Don't leak existence across tenants: 404 if the source isn't in this ws.
     if state.doc_store().get_metadata(&ws, &doc_id).is_none() {
         return (StatusCode::NOT_FOUND, ApiError::body("document not found")).into_response();
     }
+    // Restore deletes the source doc → require delete-level (owner) permission.
+    if let Err(e) = check_delete_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    // Reconstruct the restored content from the recovery point.
+    let (mut json, handle) = match reconstruct_recovery_point(&state, &ws, &doc_id, &point_id) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // Re-id into a fresh document (the source id is retired below).
+    let new_id = format!("doc-{}", nanoid::nanoid!(12));
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    if let Some(obj) = json.as_object_mut() {
+        let base = obj.get("name").and_then(Value::as_str).unwrap_or("Document").to_string();
+        obj.insert("id".into(), json!(new_id));
+        obj.insert("name".into(), json!(format!("{base} (Restored)")));
+        obj.insert("createdAt".into(), json!(now));
+        obj.insert("modifiedAt".into(), json!(now));
+        obj.remove("serverVersion"); // the save assigns v1
+    }
+    let new_doc_id = match DocId::from_body_id(new_id.clone()) {
+        Ok(d) => d,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(format!("mint id: {e}")))
+                .into_response()
+        }
+    };
+
+    // Blob refs the restored doc references — registered after the save and
+    // before releasing the source's, so blobs shared by both stay alive.
+    let new_refs = save_blob_refs(&json);
+
+    match state.doc_store().save_document_with_expected_version(&ws, json, None) {
+        Ok(SaveOutcome::Created { .. }) | Ok(SaveOutcome::Updated { .. }) => {}
+        Ok(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiError::body("restore: unexpected save outcome"),
+            )
+                .into_response()
+        }
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
+    }
+
+    // Seed the new doc's binary sidecar from the recovery Y.Doc (CRDT fidelity),
+    // tagged at the new doc's version (1).
+    let bytes = handle.encode_binary(1);
+    if let Err(e) = state.doc_store().persist_ydoc_binary(&ws, &new_doc_id, &bytes) {
+        log::warn!(
+            "restore: persist new sidecar {}/{}: {}",
+            ws.as_str(),
+            new_doc_id.as_str(),
+            e
+        );
+    }
+    // Inherit the source's recovery ring before the source (and its ring) is deleted.
+    state.doc_store().copy_recovery_ring(&ws, &doc_id, &new_doc_id);
+
+    // Blob accounting: register the new doc's refs, then release the source's.
+    if let Err(e) = state.blob_store().sync_doc_refs(&ws, new_doc_id.as_str(), new_refs) {
+        log::warn!("restore: sync new-doc blob refs: {e}");
+    }
+
+    // Retire the source: delete + tombstone (the store records the tombstone),
+    // release its blob refs, and broadcast Deleted so connected clients strand
+    // their pre-restore copy to Trash and leave (no merge-back), then Created so
+    // the new doc surfaces in browsers.
+    let _ = state.doc_store().delete_document(&ws, &doc_id);
+    if let Err(e) = state.blob_store().release_doc_refs(&ws, doc_id.as_str()) {
+        log::warn!("restore: release source blob refs: {e}");
+    }
+    state.emit_doc_event(&ws, &doc_id, DocEventType::Deleted, Some(claims.sub.clone()));
+    state.emit_doc_event(&ws, &new_doc_id, DocEventType::Created, Some(claims.sub.clone()));
+
     (
-        StatusCode::NOT_IMPLEMENTED,
-        Json(json!({
-            "error": "recovery restore not yet implemented",
-            "issue": "JP-183",
-        })),
+        StatusCode::OK,
+        Json(json!({ "newDocId": new_id, "serverVersion": 1 })),
     )
         .into_response()
 }

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -907,6 +907,43 @@ impl DocumentStore {
         }
     }
 
+    /// Read one recovery point's raw binary `.ydoc` bytes by its filename stem
+    /// (`<createdAtMs>-v<serverVersion>`), JP-183. `None` if the id is malformed,
+    /// absent, or pruned. The caller validates the stem shape (no path
+    /// separators) before calling; the join here also can't escape the recovery
+    /// dir because a stem containing `/` or `..` won't match an actual file.
+    pub fn read_recovery_point(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        point_id: &str,
+    ) -> Option<Vec<u8>> {
+        let path = self.recovery_dir(ws, doc_id).join(format!("{point_id}.ydoc"));
+        std::fs::read(path).ok()
+    }
+
+    /// Copy a document's recovery ring to another doc id (JP-183) so a restored
+    /// doc inherits its source's backup history (you can restore further back
+    /// after a restore). Best-effort: per-file errors are logged, never fatal.
+    pub fn copy_recovery_ring(&self, ws: &WorkspaceId, from: &DocId, to: &DocId) {
+        let src = self.recovery_dir(ws, from);
+        let Ok(entries) = std::fs::read_dir(&src) else {
+            return;
+        };
+        let dest_dir = self.recovery_dir(ws, to);
+        if std::fs::create_dir_all(&dest_dir).is_err() {
+            return;
+        }
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.extension().is_some_and(|x| x == "ydoc") {
+                if let Some(name) = p.file_name() {
+                    let _ = std::fs::copy(&p, dest_dir.join(name));
+                }
+            }
+        }
+    }
+
     /// List a document's recovery points (JP-180), newest first. Empty when the
     /// doc has never been backed up or the directory can't be read.
     pub fn list_recovery_points(&self, ws: &WorkspaceId, doc_id: &DocId) -> Vec<RecoveryPoint> {

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -342,6 +342,31 @@ impl DocHandle {
         binary::encode_snapshot(server_version, &self.doc)
     }
 
+    /// Wrap an already-decoded `Doc` (JP-183 restore) without hydrating from
+    /// JSON. `page_id` is the divergence sentinel `flatten_into` checks against
+    /// the target body — pass the body's `activePageId`. Used to flatten a
+    /// recovery point's CRDT state into a fresh document body and to re-encode it
+    /// as the restored doc's sidecar. The handle is born clean (never persisted
+    /// as a live doc — it's a one-shot reconstruction helper).
+    pub fn from_decoded(doc: Doc, page_id: Option<String>) -> Self {
+        Self {
+            doc,
+            page_id,
+            dirty: AtomicBool::new(false),
+        }
+    }
+
+    /// Build a restore helper handle from a binary `.ydoc` sidecar blob (JP-183):
+    /// decode the header + lib0-v1 state, returning `Err` on a corrupt blob.
+    /// `page_id` is the `flatten_into` divergence sentinel — pass the target
+    /// body's `activePageId`. Keeps the private `binary` module encapsulated.
+    pub fn from_sidecar_bytes(bytes: &[u8], page_id: Option<String>) -> Result<Self, String> {
+        let (_version, update) =
+            binary::decode_header(bytes).ok_or("recovery point header is invalid")?;
+        let doc = binary::doc_from_update(update)?;
+        Ok(Self::from_decoded(doc, page_id))
+    }
+
     /// Apply one inbound sync frame body (bytes *after* the `MESSAGE_SYNC`
     /// prefix) and report what to send back / broadcast. Marks the doc dirty
     /// when the frame actually changed state (an applied update → a broadcast).

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -21,10 +21,11 @@ use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::config::{TenancyConfig, TenancyMode};
 use docushark_relay::mcp::{McpConfig as InternalMcpConfig, McpServer};
 use docushark_relay::server::protocol::{
-    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_ERROR, MESSAGE_JOIN_DOC,
+    encode_message, DocId, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_ERROR, MESSAGE_JOIN_DOC,
     MESSAGE_SYNC, PROTOCOL_VERSION,
 };
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::sync::DocHandle;
 use docushark_relay::test_support::OidcTestIssuer;
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{json, Value};
@@ -1703,6 +1704,115 @@ async fn tombstoned_recreate_is_410_until_owner_override() {
         .await
         .expect("GET");
     assert!(resp.status().is_success(), "restored doc should be readable");
+
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-183: restoring a recovery point creates a NEW document carrying the
+/// recovered shapes, then deletes + tombstones the source id. Exercises the full
+/// HTTP restore over a real relay, with a deterministically-seeded recovery
+/// point (binary sidecar → recovery ring).
+#[tokio::test]
+async fn restore_recovery_point_creates_new_doc_and_tombstones_source() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    // Seed the source doc with an (empty) page p1 — the scaffold the recovery
+    // flatten merges the recovered shapes onto.
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-rec", "name": "Recoverable", "pageOrder": ["p1"],
+            "activePageId": "p1", "createdAt": 1, "modifiedAt": 2,
+            "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}}
+        }),
+    )
+    .await;
+
+    // Manufacture a recovery point: a binary sidecar whose CRDT state carries a
+    // shape on p1, copied into the doc's recovery ring (mirrors the poison-guard
+    // backup, JP-180).
+    let store = relay.server.get_doc_store().await.expect("doc store");
+    let ws = store.known_workspaces().into_iter().next().expect("workspace");
+    let doc_id = DocId::from_body_id("doc-rec".to_string()).unwrap();
+    let rec = Doc::new();
+    {
+        let shapes = rec.get_or_insert_map("shapes:p1");
+        let order = rec.get_or_insert_array("shapeOrder:p1");
+        let mut txn = rec.transact_mut();
+        shapes.insert(&mut txn, "s1", sample_shape("s1"));
+        order.push_back(&mut txn, Any::String("s1".into()));
+    }
+    let blob = DocHandle::from_decoded(rec, Some("p1".to_string())).encode_binary(1);
+    store.persist_ydoc_binary(&ws, &doc_id, &blob).expect("persist sidecar");
+    store.push_recovery_point(&ws, &doc_id);
+
+    // List recovery points over HTTP → point id.
+    let points: Value = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-rec/recovery", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("list")
+        .json()
+        .await
+        .expect("list json");
+    let point_id = points["recoveryPoints"][0]["id"]
+        .as_str()
+        .expect("point id")
+        .to_string();
+
+    // Restore → a fresh doc id.
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/api/docs/doc-rec/recovery/{point_id}/restore",
+            relay.http
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("restore");
+    assert!(resp.status().is_success(), "restore failed: {}", resp.status());
+    let restore: Value = resp.json().await.expect("restore json");
+    let new_id = restore["newDocId"].as_str().expect("newDocId").to_string();
+    assert_ne!(new_id, "doc-rec", "restore mints a fresh id");
+
+    // The new doc carries the recovered shape.
+    let new_doc: Value = reqwest::Client::new()
+        .get(format!("{}/api/docs/{new_id}", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("get new")
+        .json()
+        .await
+        .expect("new json");
+    assert!(
+        new_doc["pages"]["p1"]["shapes"]["s1"].is_object(),
+        "restored doc should carry the recovered shape: {new_doc}"
+    );
+
+    // The source id is gone and tombstoned (re-create → 410).
+    let src_status = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-rec", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("get src")
+        .status();
+    assert_eq!(src_status.as_u16(), 404, "source doc should be deleted");
+
+    let recreate = put_doc_status(
+        &relay.http,
+        &token,
+        json!({"id":"doc-rec","name":"X","pageOrder":["p1"],"activePageId":"p1",
+               "pages":{"p1":{"id":"p1","shapes":{},"shapeOrder":[]}}}),
+        "",
+    )
+    .await;
+    assert_eq!(recreate.as_u16(), 410, "source id should be tombstoned");
 
     relay.server.stop().await.expect("stop");
 }

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -109,6 +109,21 @@ export interface RelayUsage {
   editorLimit: number | null;
 }
 
+/**
+ * One document recovery point (JP-180/JP-183) — a relay-captured backup of a
+ * document's state, addressable for preview/download/restore. Metadata only.
+ */
+export interface RelayRecoveryPoint {
+  /** Opaque id (`<createdAtMs>-v<serverVersion>`). */
+  id: string;
+  /** Wall-clock millis when the backup was captured. */
+  createdAt: number;
+  /** The document `serverVersion` the backup carried. */
+  serverVersion: number;
+  /** On-disk size of the backup (a rough content-size proxy). */
+  sizeBytes: number;
+}
+
 // ============ Client ============
 
 export interface RelayClientOptions {
@@ -208,6 +223,43 @@ export class RelayClient {
 
   async deleteDocument(docId: string): Promise<{ success: boolean }> {
     return this.requestJson('DELETE', `/api/docs/${encodeURIComponent(docId)}`, { auth: true });
+  }
+
+  /** List a document's recovery points (JP-183), newest first. */
+  async listRecoveryPoints(docId: string): Promise<RelayRecoveryPoint[]> {
+    const { recoveryPoints } = await this.requestJson<{ recoveryPoints: RelayRecoveryPoint[] }>(
+      'GET',
+      `/api/docs/${encodeURIComponent(docId)}/recovery`,
+      { auth: true },
+    );
+    return recoveryPoints ?? [];
+  }
+
+  /**
+   * Fetch a recovery point's content as a document (JP-183), **without**
+   * mutating live state — backs "download to local".
+   */
+  async getRecoveryPointContent(docId: string, pointId: string): Promise<DiagramDocument> {
+    return this.requestJson(
+      'GET',
+      `/api/docs/${encodeURIComponent(docId)}/recovery/${encodeURIComponent(pointId)}`,
+      { auth: true },
+    );
+  }
+
+  /**
+   * Restore a recovery point (JP-183). The relay writes it as a NEW document
+   * and tombstones the source id; returns the new doc id.
+   */
+  async restoreRecoveryPoint(
+    docId: string,
+    pointId: string,
+  ): Promise<{ newDocId: string; serverVersion: number }> {
+    return this.requestJson(
+      'POST',
+      `/api/docs/${encodeURIComponent(docId)}/recovery/${encodeURIComponent(pointId)}/restore`,
+      { auth: true },
+    );
   }
 
   async updateDocumentShares(

--- a/src/api/restDocumentProvider.test.ts
+++ b/src/api/restDocumentProvider.test.ts
@@ -38,6 +38,18 @@ function makeStubClient(overrides: Partial<RelayClient> = {}): {
       calls.push({ method: 'transferDocumentOwnership', args: [id, newOwnerId, newOwnerName] });
       return { success: true };
     },
+    async listRecoveryPoints(id: string) {
+      calls.push({ method: 'listRecoveryPoints', args: [id] });
+      return [{ id: 'p1', createdAt: 1, serverVersion: 2, sizeBytes: 3 }];
+    },
+    async getRecoveryPointContent(id: string, pointId: string) {
+      calls.push({ method: 'getRecoveryPointContent', args: [id, pointId] });
+      return { id, name: 'R' } as unknown as DiagramDocument;
+    },
+    async restoreRecoveryPoint(id: string, pointId: string) {
+      calls.push({ method: 'restoreRecoveryPoint', args: [id, pointId] });
+      return { newDocId: 'doc-new', serverVersion: 1 };
+    },
     ...overrides,
   };
   return { client: stub as unknown as RelayClient, calls };
@@ -113,5 +125,25 @@ describe('RestDocumentProvider', () => {
     const provider = new RestDocumentProvider(client);
     await provider.transferDocumentOwnership('doc-1', 'u-2', 'Bob');
     expect(calls[0]?.args).toEqual(['doc-1', 'u-2', 'Bob']);
+  });
+
+  it('recovery methods delegate to the client (JP-183)', async () => {
+    const { client, calls } = makeStubClient();
+    const provider = new RestDocumentProvider(client);
+
+    const points = await provider.listRecoveryPoints('doc-1');
+    expect(points[0]?.id).toBe('p1');
+
+    const content = await provider.getRecoveryPointContent('doc-1', 'p1');
+    expect(content.id).toBe('doc-1');
+
+    const restored = await provider.restoreRecoveryPoint('doc-1', 'p1');
+    expect(restored).toEqual({ newDocId: 'doc-new', serverVersion: 1 });
+
+    expect(calls.map((c) => c.method)).toEqual([
+      'listRecoveryPoints',
+      'getRecoveryPointContent',
+      'restoreRecoveryPoint',
+    ]);
   });
 });

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -10,7 +10,12 @@
  */
 
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
-import type { RelayClient, RelayCollectionDef, RelayUsage } from './relayClient';
+import type {
+  RelayClient,
+  RelayCollectionDef,
+  RelayRecoveryPoint,
+  RelayUsage,
+} from './relayClient';
 import {
   BlobSyncService,
   type BlobSyncProgress,
@@ -76,6 +81,23 @@ export class RestDocumentProvider {
 
   async deleteDocument(docId: string): Promise<void> {
     await this.client.deleteDocument(docId);
+  }
+
+  // ---- Document recovery (JP-183) ----
+
+  async listRecoveryPoints(docId: string): Promise<RelayRecoveryPoint[]> {
+    return this.client.listRecoveryPoints(docId);
+  }
+
+  async getRecoveryPointContent(docId: string, pointId: string): Promise<DiagramDocument> {
+    return this.client.getRecoveryPointContent(docId, pointId);
+  }
+
+  async restoreRecoveryPoint(
+    docId: string,
+    pointId: string,
+  ): Promise<{ newDocId: string; serverVersion: number }> {
+    return this.client.restoreRecoveryPoint(docId, pointId);
   }
 
   async updateDocumentShares(

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -35,7 +35,7 @@ import { useNotificationStore } from './notificationStore';
 import { useTrashStore } from './trashStore';
 import type { TrashOrigin } from '../storage/TrashStorage';
 import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
-import type { RelayCollectionDef, RelayUsage } from '../api/relayClient';
+import type { RelayCollectionDef, RelayRecoveryPoint, RelayUsage } from '../api/relayClient';
 import { useUploadStatusStore } from './uploadStatusStore';
 
 /**
@@ -149,6 +149,17 @@ export interface DocumentProvider {
   downloadBlobs?(hashes: string[]): Promise<BlobSyncResult>;
   /** Caller's own workspace usage + effective limits (`GET /api/v1/usage`). */
   getUsage?(): Promise<RelayUsage>;
+  /**
+   * Document recovery (JP-183). Optional so non-REST providers opt out. List a
+   * doc's recovery points, fetch one's content (non-destructive, for
+   * download-to-local), or restore one (→ a new doc id; tombstones the source).
+   */
+  listRecoveryPoints?(docId: string): Promise<RelayRecoveryPoint[]>;
+  getRecoveryPointContent?(docId: string, pointId: string): Promise<DiagramDocument>;
+  restoreRecoveryPoint?(
+    docId: string,
+    pointId: string,
+  ): Promise<{ newDocId: string; serverVersion: number }>;
   /**
    * Collection sync (JP-159). Optional so non-REST providers opt out. The relay
    * scopes all three to the connected workspace from the bearer token.

--- a/src/ui/DocumentBackupsDrawer.css
+++ b/src/ui/DocumentBackupsDrawer.css
@@ -1,0 +1,156 @@
+/**
+ * DocumentBackupsDrawer styles (JP-183). Mirrors DocumentPermissionsDialog's
+ * modal shell + brand tokens for a consistent look.
+ */
+
+.backups-drawer__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.15s ease;
+}
+
+.backups-drawer {
+  background: var(--bg-primary);
+  border-radius: 12px;
+  width: 90%;
+  max-width: 520px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-xl);
+  animation: slideIn 0.2s ease;
+}
+
+.backups-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color);
+  background: linear-gradient(135deg, var(--navy-900) 0%, var(--navy-700) 100%);
+  border-radius: 12px 12px 0 0;
+}
+
+.backups-drawer__header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: white;
+}
+
+.backups-drawer__close {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  color: white;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.backups-drawer__close:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.backups-drawer__content {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.backups-drawer__hint {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.backups-drawer__error {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--error-color, #dc2626);
+}
+
+.backups-drawer__empty {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.backups-drawer__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.backups-drawer__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.backups-drawer__meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.backups-drawer__time {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.backups-drawer__sub {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.backups-drawer__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.backups-drawer__btn {
+  padding: 6px 12px;
+  font-size: 13px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.backups-drawer__btn:hover:not(:disabled) {
+  background: var(--bg-hover, rgba(0, 0, 0, 0.05));
+}
+
+.backups-drawer__btn--primary {
+  background: var(--navy-700);
+  border-color: var(--navy-700);
+  color: white;
+}
+
+.backups-drawer__btn--primary:hover:not(:disabled) {
+  background: var(--navy-900);
+}
+
+.backups-drawer__btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/src/ui/DocumentBackupsDrawer.tsx
+++ b/src/ui/DocumentBackupsDrawer.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { getDocProvider } from '../store/relayDocumentStore';
+import { getDocProvider, useRelayDocumentStore } from '../store/relayDocumentStore';
 import { useNotificationStore } from '../store/notificationStore';
 import { saveDocumentToStorage } from '../store/persistenceStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
@@ -99,6 +99,10 @@ export function DocumentBackupsDrawer({
       setBusyId(point.id);
       try {
         const { newDocId } = await provider.restoreRecoveryPoint(docId, point.id);
+        // Refetch the list so the new doc appears immediately — don't rely on the
+        // relay's Created broadcast (a REST-only session never receives it, and a
+        // list view may not re-subscribe), which left it hidden until a reload.
+        await useRelayDocumentStore.getState().fetchDocumentList().catch(() => {});
         useNotificationStore.getState().success('Document restored as a new copy.');
         onRestored?.(newDocId);
         onClose();

--- a/src/ui/DocumentBackupsDrawer.tsx
+++ b/src/ui/DocumentBackupsDrawer.tsx
@@ -1,0 +1,209 @@
+/**
+ * DocumentBackupsDrawer (JP-183)
+ *
+ * The editor's "backups" surface for a cloud document — the functional
+ * successor to canvas undo/redo, which is disabled in collab (JP-178). Lists the
+ * relay's recovery points for a document (captured by the poison guard, JP-180)
+ * and offers two actions per point:
+ *
+ *  - **Restore** — POST the recovery point back to the relay. The relay writes
+ *    it as a NEW document and tombstones the source id; connected editors are
+ *    returned to the browser with their pre-restore copy stranded to Trash
+ *    (JP-375). Non-trivial, so it confirms first.
+ *  - **Save to local** — fetch the point's content (non-destructive) and adopt
+ *    it as a fresh LOCAL document, so you keep a copy without touching the cloud
+ *    doc. This is the "download to local" escape hatch.
+ *
+ * All relay access goes through the authed REST provider (`getDocProvider`),
+ * the same path as document CRUD.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { getDocProvider } from '../store/relayDocumentStore';
+import { useNotificationStore } from '../store/notificationStore';
+import { saveDocumentToStorage } from '../store/persistenceStore';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import { getDocumentMetadata } from '../types/Document';
+import { confirmDialog } from './confirm/confirmStore';
+import type { RelayRecoveryPoint } from '../api/relayClient';
+import './DocumentBackupsDrawer.css';
+
+interface DocumentBackupsDrawerProps {
+  /** The cloud document whose backups to show. */
+  docId: string;
+  /** Display name (for the header + restored-copy naming). */
+  docName: string;
+  /** Close the drawer. */
+  onClose: () => void;
+  /** Called after a successful restore with the new document id. */
+  onRestored?: (newDocId: string) => void;
+}
+
+function formatTimestamp(ms: number): string {
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return String(ms);
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function DocumentBackupsDrawer({
+  docId,
+  docName,
+  onClose,
+  onRestored,
+}: DocumentBackupsDrawerProps) {
+  const [points, setPoints] = useState<RelayRecoveryPoint[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    const provider = getDocProvider();
+    if (!provider?.listRecoveryPoints) {
+      setError('Backups are only available for cloud documents.');
+      setPoints([]);
+      return;
+    }
+    setError(null);
+    provider
+      .listRecoveryPoints(docId)
+      .then((p) => setPoints(p))
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : 'Failed to load backups.');
+        setPoints([]);
+      });
+  }, [docId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleRestore = useCallback(
+    async (point: RelayRecoveryPoint) => {
+      const provider = getDocProvider();
+      if (!provider?.restoreRecoveryPoint) return;
+      const ok = await confirmDialog({
+        title: 'Restore this version?',
+        message: `Restore "${docName}" to its state from ${formatTimestamp(point.createdAt)}.`,
+        details:
+          'This restores as a new document. Anyone currently in the document is returned to the browser, and their current copy is saved to their Trash.',
+        confirmLabel: 'Restore',
+      });
+      if (!ok) return;
+      setBusyId(point.id);
+      try {
+        const { newDocId } = await provider.restoreRecoveryPoint(docId, point.id);
+        useNotificationStore.getState().success('Document restored as a new copy.');
+        onRestored?.(newDocId);
+        onClose();
+      } catch (e) {
+        useNotificationStore
+          .getState()
+          .error(`Restore failed: ${e instanceof Error ? e.message : 'unknown error'}`);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [docId, docName, onClose, onRestored],
+  );
+
+  const handleSaveLocal = useCallback(
+    async (point: RelayRecoveryPoint) => {
+      const provider = getDocProvider();
+      if (!provider?.getRecoveryPointContent) return;
+      setBusyId(point.id);
+      try {
+        const content = await provider.getRecoveryPointContent(docId, point.id);
+        const copy = {
+          ...content,
+          id: crypto.randomUUID(),
+          name: `${docName} (Restored ${new Date(point.createdAt).toLocaleDateString()})`,
+          isRelayDocument: false,
+        };
+        delete copy.ownerId;
+        delete copy.ownerName;
+        delete copy.sharedWith;
+        delete copy.collectionId;
+        delete copy.serverVersion;
+        saveDocumentToStorage(copy);
+        useDocumentRegistry.getState().registerLocal(getDocumentMetadata(copy));
+        useNotificationStore.getState().success('Saved a local copy of this version.');
+      } catch (e) {
+        useNotificationStore
+          .getState()
+          .error(`Couldn't save a local copy: ${e instanceof Error ? e.message : 'unknown error'}`);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [docId, docName],
+  );
+
+  return (
+    <div className="backups-drawer__overlay" onClick={onClose}>
+      <div
+        className="backups-drawer"
+        role="dialog"
+        aria-label={`Backups for ${docName}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="backups-drawer__header">
+          <h3>Backups — {docName}</h3>
+          <button className="backups-drawer__close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="backups-drawer__content">
+          <p className="backups-drawer__hint">
+            Saved versions of this document, newest first. Restore replaces the live
+            document (as a new copy); Save to local keeps a copy on this device.
+          </p>
+          {error && <p className="backups-drawer__error">{error}</p>}
+          {points === null ? (
+            <p className="backups-drawer__empty">Loading…</p>
+          ) : points.length === 0 ? (
+            <p className="backups-drawer__empty">
+              No backups yet. They&rsquo;re captured automatically when a document is at risk
+              of losing content.
+            </p>
+          ) : (
+            <ul className="backups-drawer__list">
+              {points.map((point) => (
+                <li key={point.id} className="backups-drawer__row">
+                  <div className="backups-drawer__meta">
+                    <span className="backups-drawer__time">{formatTimestamp(point.createdAt)}</span>
+                    <span className="backups-drawer__sub">
+                      v{point.serverVersion} · {formatSize(point.sizeBytes)}
+                    </span>
+                  </div>
+                  <div className="backups-drawer__actions">
+                    <button
+                      className="backups-drawer__btn"
+                      disabled={busyId !== null}
+                      onClick={() => handleSaveLocal(point)}
+                    >
+                      Save to local
+                    </button>
+                    <button
+                      className="backups-drawer__btn backups-drawer__btn--primary"
+                      disabled={busyId !== null}
+                      onClick={() => handleRestore(point)}
+                    >
+                      Restore
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -16,6 +16,7 @@ import {
   Download,
   FolderInput,
   HardDrive,
+  History,
   Loader2,
   Network,
   Pencil,
@@ -51,6 +52,8 @@ interface DocumentCardProps {
   onRename?: ((id: string, newName: string) => void) | undefined;
   /** Callback to edit permissions (ownership/access) */
   onEditPermissions?: ((id: string) => void) | undefined;
+  /** Callback to open the document's backups/recovery drawer (JP-183). */
+  onViewBackups?: ((id: string) => void) | undefined;
   /** Callback to publish local document to relay */
   onPublishToTeam?: ((id: string) => void | Promise<void>) | undefined;
   /** Callback to move a relay document back to personal */
@@ -254,6 +257,7 @@ function DocumentCardImpl({
   onPermanentDelete,
   onRename,
   onEditPermissions,
+  onViewBackups,
   onPublishToTeam,
   onMoveToPersonal,
   onSelectToggle,
@@ -674,6 +678,19 @@ function DocumentCardImpl({
             aria-label="Manage access"
           >
             <Users size={16} aria-hidden="true" />
+          </button>
+        )}
+        {onViewBackups && (
+          <button
+            className="document-card__action"
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewBackups(record.id);
+            }}
+            title="Backups"
+            aria-label="Backups"
+          >
+            <History size={16} aria-hidden="true" />
           </button>
         )}
         {onAssignCollection && (

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -7,9 +7,10 @@
  * `DocumentBrowser` chrome and the first-class `DocumentsHome` surface (JP-218).
  */
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { ChevronDown, MoreHorizontal, X } from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
+import { DocumentBackupsDrawer } from '../DocumentBackupsDrawer';
 import { COLLECTION_SWATCHES, type Collection } from '../../store/collectionStore';
 import type { DocumentBrowserView } from '../../store/uiPreferencesStore';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
@@ -75,6 +76,13 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
   const cardMode: 'compact' | 'full' | 'grid' =
     view === 'grid' ? 'grid' : compact ? 'compact' : 'full';
 
+  // JP-183 backups drawer — opened from a cloud doc's card; rendered here so it
+  // works in both browser chromes (Settings + DocumentsHome).
+  const [backupsDocId, setBackupsDocId] = useState<string | null>(null);
+  const backupsDoc = backupsDocId
+    ? documentList.find((r) => r.id === backupsDocId)
+    : undefined;
+
   const onOpen = async (id: string) => {
     await handleOpen(id);
     onOpened?.(id);
@@ -102,6 +110,9 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
             ? setPermissionsDocId
             : undefined
         }
+        onViewBackups={
+          record.type !== 'local' && relaySessionUsable ? setBackupsDocId : undefined
+        }
         onPublishToTeam={canPublishToTeam(record, relaySessionUsable) ? handlePublishToTeam : undefined}
         onMoveToPersonal={canMoveToPersonal(record, relaySessionUsable, currentUser?.id, currentUser?.role) ? handleMoveToPersonal : undefined}
         collectionAccent={accent}
@@ -119,6 +130,7 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
   };
 
   return (
+    <>
     <div className={`document-browser__list ${view === 'grid' ? 'document-browser__list--grid' : ''}`}>
       {documentList.length === 0 ? (
         <div className="document-browser__empty">
@@ -156,6 +168,14 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
         documentList.map((record) => renderCard(record))
       )}
     </div>
+      {backupsDocId && (
+        <DocumentBackupsDrawer
+          docId={backupsDocId}
+          docName={backupsDoc?.name ?? 'Document'}
+          onClose={() => setBackupsDocId(null)}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Why

JP-180 already captures **recovery points** (bounded ring, on a suspicious N→0 zeroing) and self-heals on hydrate, but they were not user-recoverable: the restore endpoint was a `501` stub and there was no UI. This makes them recoverable end-to-end — the **functional successor to canvas undo/redo**, which is disabled in collab (tombstone poisoning, JP-178). Builds on the JP-375 tombstone fence (merged).

## What

**Relay**
- `DocumentStore::read_recovery_point` + `copy_recovery_ring`; `DocHandle::from_decoded` / `from_sidecar_bytes` so a recovery point's CRDT state flattens into a document body (private `binary` module stays encapsulated).
- **`GET /api/docs/:id/recovery/:pointId`** — a recovery point's content as document JSON, **non-destructive** (read-gated). Backs "Save to local".
- **`POST /api/docs/:id/recovery/:pointId/restore`** — replaces the stub. Restores as a **NEW document** (a fresh id sidesteps the stale-sidecar hydration hazard), then **deletes + tombstones the source id**. **Owner-gated** (it deletes the source). Connected clients get the source's `Deleted` broadcast → strand their pre-restore copy to Trash (JP-375); the new doc surfaces via `Created`. Blob refs: register the new doc's, then release the source's.

**Editor**
- `RelayClient` + `RestDocumentProvider`: `listRecoveryPoints` / `getRecoveryPointContent` / `restoreRecoveryPoint`.
- **`DocumentBackupsDrawer`**: lists recovery points (timestamp · version · size) with **Restore** (confirm → opens the new doc) and **Save to local** (non-destructive local copy). Opened from a History affordance on **cloud-document** cards in the shared document browser (Settings + DocumentsHome).

## Tests
- Relay WS+HTTP **restore round-trip** (`yjs_authority.rs`): a deterministically-seeded recovery point → restore → the new id carries the recovered shape; the source is deleted **and** tombstoned (re-create → 410).
- `RestDocumentProvider` recovery-method delegation units.
- `cargo build --bin relay`, full `cargo test` (539 lib + integration), `bun run typecheck`, full client suite (2632) — all green.

## Notes
- Depends on **JP-375** (merged) — standalone PR off `master`, not stacked.
- The restore-during-collab repro (two editors → select-all-delete → restore → both strand to Trash, new `(Restored)` doc appears) remains the manual E2E gate before flipping JP-183 to Done.

Assisted-by: Opus 4.8