### PR TITLE
relay: enforce private-by-default document access (JP-370)

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -199,6 +199,7 @@ override the file but an explicit CLI flag still wins. Malformed values
 | `RELAY_TENANCY_MODE` | `[tenancy].mode` (`shared`/`dedicated`) |
 | `RELAY_TENANCY_WORKSPACE` | `[tenancy].workspace_id` |
 | `RELAY_REGION` | the `--region` value (used to enforce `wsp[].region`) |
+| `RELAY_ENFORCE_PRIVATE_DOCS` | `[permissions].enforce_private_docs` (gate document reads on owner/share set; default off) |
 
 ## What's *not* here
 

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -57,6 +57,14 @@ paths:
     get:
       tags: [docs]
       summary: List documents visible to the caller
+      description: |
+        Lists the workspace's documents. When the relay is configured with
+        `permissions.enforce_private_docs = true`, the listing is filtered to
+        documents the caller may read — those they own, are explicitly shared
+        on (`sharedWith`), or (as a workspace owner/admin) manage. When that
+        setting is off (the default), every document in the caller's workspace
+        is returned. Access is always scoped to the workspace resolved from the
+        token's `wsp` claim.
       security:
         - bearerAuth: []
       responses:
@@ -638,6 +646,15 @@ paths:
         Token verification follows `token-format.md`. Connections whose
         token region does not match the relay's configured region are
         rejected with a 403 close.
+
+        A JOIN_DOC frame is answered with an ERROR frame (the connection stays
+        open) when the document is unknown (`ERR_UNKNOWN_DOC`) or deleted
+        (`ERR_DELETED`). When `permissions.enforce_private_docs = true`, a
+        JOIN_DOC for a document the caller may not read is refused with
+        `ERR_VIEW_FORBIDDEN` and the client is not joined — the same
+        owner/share rules the document listing applies. With that setting off
+        (the default), any authenticated member of the workspace may join any
+        of its documents.
       parameters:
         - name: Sec-WebSocket-Protocol
           in: header

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -406,7 +406,7 @@ async fn list_docs_handler(
         Ok(c) => c,
         Err(resp) => return resp,
     };
-    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
@@ -414,7 +414,18 @@ async fn list_docs_handler(
     // a listing isn't empty after a recycle (best-effort; never clobbers a
     // populated in-memory index).
     state.ensure_workspace_index_local(&ws).await;
-    let docs = state.doc_store().list_documents(&ws);
+    let mut docs = state.doc_store().list_documents(&ws);
+    // JP-370: when private-doc enforcement is on, a member only sees documents
+    // they own, are shared on, or (as workspace owner/admin) manage — the same
+    // owner/share rules the per-document read path applies. Off by default →
+    // the full workspace listing, unchanged.
+    if state.enforce_private_docs() {
+        let role = role_str(role);
+        docs.retain(|m| {
+            crate::server::permissions::get_user_permission(m, &claims.sub, Some(role))
+                != crate::server::permissions::Permission::None
+        });
+    }
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
 }
 

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -578,6 +578,26 @@ impl Default for SyncConfig {
     }
 }
 
+/// Access-control section. Gates whether the relay enforces per-document
+/// access (owner + explicit shares + workspace owner/admin) on the read
+/// paths — the document listing and the WebSocket join. The share metadata
+/// and the permission model are always present; this flag only decides
+/// whether a non-owner, non-shared workspace member is *refused* an unshared
+/// document, versus the legacy behaviour where any workspace member could
+/// read any document in the workspace.
+///
+/// Default **off** so an operator upgrading an existing relay never silently
+/// hides documents from members who could previously see them; a deployment
+/// that wants document-level privacy opts in explicitly.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct PermissionsConfig {
+    /// When true, document reads (REST listing + WebSocket join) are gated by
+    /// the document's owner/share set. When false (the `bool` default), access
+    /// is workspace-scoped only.
+    pub enforce_private_docs: bool,
+}
+
 /// Top-level relay config. All sections optional in the TOML; missing
 /// sections fall back to `Default::default()`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -590,6 +610,7 @@ pub struct RelayConfig {
     pub tenancy: TenancyConfig,
     pub observability: ObservabilityConfig,
     pub sync: SyncConfig,
+    pub permissions: PermissionsConfig,
 }
 
 impl RelayConfig {
@@ -752,6 +773,15 @@ impl RelayConfig {
                 "0" | "false" | "no" | "off" => false,
                 other => anyhow::bail!(
                     "RELAY_POISON_GUARD must be a boolean (got {other:?})"
+                ),
+            };
+        }
+        if let Some(v) = get("RELAY_ENFORCE_PRIVATE_DOCS") {
+            self.permissions.enforce_private_docs = match v.to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => true,
+                "0" | "false" | "no" | "off" => false,
+                other => anyhow::bail!(
+                    "RELAY_ENFORCE_PRIVATE_DOCS must be a boolean (got {other:?})"
                 ),
             };
         }

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -276,6 +276,7 @@ async fn run_serve(
     server.set_tenancy(config.tenancy.clone()).await;
     server.set_sync_config(config.sync.clone()).await;
     server.set_metering_debug_log(config.observability.metering_debug_log);
+    server.set_enforce_private_docs(config.permissions.enforce_private_docs);
     log::info!(
         "tenancy: mode={:?} workspace_id={:?} region={}",
         config.tenancy.mode,
@@ -385,6 +386,7 @@ async fn run_serve(
                 sync_registry,
                 on_doc_update,
                 shared_doc_store,
+                config.permissions.enforce_private_docs,
             ) {
                 Ok(mcp) => {
                     let mcp = Arc::new(mcp);

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -114,6 +114,10 @@ pub struct McpServer {
     /// Broadcast sink for live-path CRDT deltas, wired to the WS server's
     /// `broadcast_to_doc`. JP-35.
     on_doc_update: Arc<OnDocUpdate>,
+    /// JP-370: per-document access enforcement for JWT callers. Mirrors
+    /// `config.permissions.enforce_private_docs`; the static loopback token
+    /// always bypasses.
+    enforce_private_docs: bool,
 }
 
 /// The MCP-owned pieces needed to fold the endpoint onto the relay's public
@@ -148,6 +152,9 @@ pub struct McpSharedHandles {
     pub relay_region: String,
     pub sync_registry: Arc<DocRegistry>,
     pub on_doc_update: Arc<OnDocUpdate>,
+    /// JP-370: per-document access enforcement for JWT callers on the public
+    /// pod. Mirrors `config.permissions.enforce_private_docs`.
+    pub enforce_private_docs: bool,
 }
 
 impl PublicMount {
@@ -203,6 +210,7 @@ impl PublicMount {
             // the catch-all `single_tenant` local layout unreachable over the
             // network regardless of `feature_config`. JP-235.
             allow_local: false,
+            enforce_private_docs: shared.enforce_private_docs,
         };
         transport::public_router(state)
     }
@@ -229,6 +237,7 @@ impl McpServer {
         sync_registry: Arc<DocRegistry>,
         on_doc_update: Arc<OnDocUpdate>,
         doc_store: Arc<DocumentStore>,
+        enforce_private_docs: bool,
     ) -> Result<Self, String> {
         let token = Arc::new(TokenStore::load_or_create(&app_data_dir)?);
         let feature_config = Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir));
@@ -256,6 +265,7 @@ impl McpServer {
             relay_region,
             sync_registry,
             on_doc_update,
+            enforce_private_docs,
         })
     }
 
@@ -339,6 +349,7 @@ impl McpServer {
             // Desktop / self-host: the local mirror is the whole point — it lets
             // the renderer expose personal documents read-only to MCP. JP-235.
             allow_local: true,
+            enforce_private_docs: self.enforce_private_docs,
         };
         let app = transport::router(state);
 

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -103,6 +103,17 @@ pub struct ToolContext<'a> {
     /// (→ `single_tenant()`) or a relay JWT's `wsp` claim. Threaded
     /// through every team/local storage call.
     pub workspace_id: WorkspaceId,
+    /// JP-370: the authenticated caller's user id, for the per-document access
+    /// gate. `None` for the static loopback MCP token (no user identity →
+    /// treated as workspace admin; the desktop / self-host flow is unaffected).
+    pub user_id: Option<String>,
+    /// JP-370: the caller's workspace role string (`"owner"` short-circuits to
+    /// full access). Paired with `user_id`.
+    pub user_role: Option<String>,
+    /// JP-370: whether to enforce per-document access for JWT callers. Mirrors
+    /// `config.permissions.enforce_private_docs`; `false` (default) keeps the
+    /// legacy workspace-scoped behaviour.
+    pub enforce_private_docs: bool,
     /// Authoritative Y.Doc registry (JP-34). When a shape write targets a
     /// doc that's resident here *and* the doc's hydrated active page, the
     /// write applies to the live Y.Doc (JP-35) and is broadcast to peers,
@@ -126,6 +137,71 @@ impl ToolContext<'_> {
     /// workspace + `doc_id`.
     fn broadcast_update(&self, doc_id: &DocId, framed: Vec<u8>) {
         (self.on_doc_update)(&self.workspace_id, doc_id, framed);
+    }
+
+    /// JP-370: enforce per-document access for a JWT caller. Returns the
+    /// permission error string when the caller lacks `required` on a *team*
+    /// document, else `Ok`. Bypassed entirely when enforcement is off or the
+    /// caller is the static loopback token (`user_id == None`, treated as
+    /// admin). A doc that isn't a team document (unknown id, or a local-mirror
+    /// doc) is left to the tool's own not-found / `reject_if_local` handling —
+    /// we only gate documents the team store actually owns.
+    fn ensure_doc_permission(
+        &self,
+        doc_id: &DocId,
+        required: crate::server::permissions::Permission,
+    ) -> Result<(), String> {
+        let Some(user_id) = self.user_id.as_deref() else {
+            return Ok(()); // static loopback token → workspace admin
+        };
+        if !self.enforce_private_docs {
+            return Ok(());
+        }
+        // Only gate team documents; absence here means "not a team doc" and the
+        // caller's normal path reports not-found / handles the local mirror.
+        if self.team.get_metadata(&self.workspace_id, doc_id).is_none() {
+            return Ok(());
+        }
+        match crate::server::permissions::check_permission(
+            self.team,
+            &self.workspace_id,
+            doc_id,
+            Some(user_id),
+            self.user_role.as_deref(),
+            required,
+        ) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(crate::server::permissions::to_error_string(&e)),
+        }
+    }
+}
+
+/// JP-370: classify an MCP tool by the per-document access it requires.
+/// `None` means the tool isn't gated by a single document (creation, the
+/// catalogue/skills/icons tools, and `list_documents`, which filters its own
+/// output). Reads require Viewer; writes require Editor; `delete_document`
+/// requires Owner, matching the REST surface.
+fn tool_required_permission(name: &str) -> Option<crate::server::permissions::Permission> {
+    use crate::server::permissions::Permission;
+    match name {
+        // No specific target document.
+        "docushark_list_documents"
+        | "docushark_create_document"
+        | "docushark_get_skills"
+        | "docushark_list_icons"
+        | "docushark_resolve_doi" => None,
+        // Owner-only (matches REST DELETE /api/docs/:id).
+        "docushark_delete_document" => Some(Permission::Owner),
+        // Read-only tools.
+        "docushark_get_document"
+        | "docushark_get_page"
+        | "docushark_get_shape"
+        | "docushark_get_prose"
+        | "docushark_get_outline"
+        | "docushark_list_references"
+        | "docushark_list_fields" => Some(Permission::Viewer),
+        // Everything else mutates a specific existing document → Editor.
+        _ => Some(Permission::Editor),
     }
 }
 
@@ -784,6 +860,22 @@ pub struct ToolOutcome {
 /// Dispatch a `tools/call` request. `name` is the tool name as advertised
 /// in `descriptors()`; `args` is the `arguments` object from the call.
 pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutcome, String> {
+    // JP-370: per-document access gate. For tools that target a specific
+    // document, enforce the caller's owner/share permission before dispatch —
+    // the single chokepoint that also covers the resident-Y.Doc read paths that
+    // bypass `fetch_doc`. No-op for the static loopback token and when
+    // enforcement is off (see `ensure_doc_permission`). `list_documents`
+    // filters its own output below; creation/catalogue tools target no doc.
+    if let Some(required) = tool_required_permission(name) {
+        if let Some(doc_id) = args
+            .get("docId")
+            .and_then(|v| v.as_str())
+            .and_then(|s| DocId::from_http_path(s.to_string()).ok())
+        {
+            ctx.ensure_doc_permission(&doc_id, required)?;
+        }
+    }
+
     // JP-230: MCP and the WS/REST path now share one `DocumentStore`, so reads
     // already see every write through the shared in-memory index — no per-call
     // reload-from-disk needed (it was a band-aid for the old two-store split).
@@ -909,9 +1001,20 @@ fn fetch_doc(ctx: &ToolContext, doc_id: &DocId) -> Result<(Value, &'static str),
 }
 
 fn list_documents(ctx: &ToolContext) -> Result<ToolOutcome, String> {
-    let mut payload: Vec<Value> = ctx
-        .team
-        .list_documents(&ctx.workspace_id)
+    let mut team_docs = ctx.team.list_documents(&ctx.workspace_id);
+    // JP-370: a JWT caller only lists team docs they may read (owner / shared /
+    // workspace owner-admin), mirroring the REST listing. The static loopback
+    // token (user_id None) and enforcement-off keep the full listing.
+    if ctx.enforce_private_docs {
+        if let Some(user_id) = ctx.user_id.as_deref() {
+            let role = ctx.user_role.as_deref();
+            team_docs.retain(|m| {
+                crate::server::permissions::get_user_permission(m, user_id, role)
+                    != crate::server::permissions::Permission::None
+            });
+        }
+    }
+    let mut payload: Vec<Value> = team_docs
         .into_iter()
         .map(|m| {
             // JP-349: pageCount is the canvas + prose total; the split lets an
@@ -3681,6 +3784,12 @@ mod tests {
                 local: &self.local,
                 local_enabled,
                 workspace_id: WorkspaceId::single_tenant(),
+                // JP-370: tool tests run as the static/local context (no user
+                // identity, enforcement off) → the gate is a no-op, matching
+                // the loopback-token semantics.
+                user_id: None,
+                user_role: None,
+                enforce_private_docs: false,
                 registry: &self.registry,
                 on_doc_update: &*self.on_doc_update,
                 on_doc_deleted: &self.on_doc_deleted,

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -29,7 +29,7 @@ use axum::{
 use futures_util::stream;
 use serde_json::{json, Value};
 
-use crate::auth::OidcAuthState;
+use crate::auth::{OidcAuthState, WorkspaceRole};
 use crate::server::documents::DocumentStore;
 use crate::server::protocol::WorkspaceId;
 use crate::server::WorkspaceWriteLimiter;
@@ -105,6 +105,11 @@ pub struct McpAppState {
     /// would be the catch-all `single_tenant` one — so local access is forced off
     /// for defense-in-depth, independent of `feature_config`.
     pub allow_local: bool,
+    /// JP-370: when true, JWT-authed MCP callers are gated by per-document
+    /// access (owner + shares + workspace owner/admin), mirroring the WS/REST
+    /// read paths. The static loopback token (no user identity) always
+    /// bypasses. Mirrors `config.permissions.enforce_private_docs`.
+    pub enforce_private_docs: bool,
 }
 
 /// Build the Axum router for the MCP endpoint.
@@ -282,7 +287,7 @@ async fn handle_rpc(
     match method.as_str() {
         "initialize" => Json(rpc_result(id, initialize_result())).into_response(),
         "tools/list" => Json(rpc_result(id, tools_list_result())).into_response(),
-        "tools/call" => handle_tools_call(&state, &auth.workspace, id, &params).await,
+        "tools/call" => handle_tools_call(&state, &auth, id, &params).await,
         // Spec-defined no-op notifications we may receive from the client.
         "notifications/initialized" | "ping" => {
             (StatusCode::OK, Json(json!({"jsonrpc": "2.0", "id": id, "result": {}}))).into_response()
@@ -297,6 +302,24 @@ async fn handle_rpc(
 /// for relay-issued JWTs (Cloud / multi-tenant). Phase 21.6.
 struct AuthOutcome {
     workspace: WorkspaceId,
+    /// JP-370: the authenticated user's id + role for JWT callers, used by the
+    /// per-document access gate. `None` for the static loopback MCP token —
+    /// which has no user identity and is treated as a workspace admin so the
+    /// desktop / self-host flow is unaffected.
+    user_id: Option<String>,
+    role: Option<String>,
+}
+
+/// Stringified workspace role, matching the values the permissions layer
+/// recognises (`"owner"` short-circuits to full access; api.rs uses the same
+/// mapping). JP-370.
+fn role_str(role: WorkspaceRole) -> String {
+    match role {
+        WorkspaceRole::Owner => "owner",
+        WorkspaceRole::Member => "user",
+        WorkspaceRole::Viewer => "viewer",
+    }
+    .to_string()
 }
 
 fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
@@ -328,11 +351,17 @@ async fn authenticate(
     if allow_static_token && token.validate(presented) {
         return Some(AuthOutcome {
             workspace: WorkspaceId::single_tenant(),
+            user_id: None,
+            role: None,
         });
     }
     if let Ok(claims) = auth.validate(presented).await {
-        if let Ok((ws, _role, _limits)) = WorkspaceId::from_oidc_array(&claims, None, relay_region) {
-            return Some(AuthOutcome { workspace: ws });
+        if let Ok((ws, role, _limits)) = WorkspaceId::from_oidc_array(&claims, None, relay_region) {
+            return Some(AuthOutcome {
+                workspace: ws,
+                user_id: Some(claims.sub.clone()),
+                role: Some(role_str(role)),
+            });
         }
     }
     None
@@ -441,10 +470,11 @@ async fn resolve_citation_doi(name: &str, args: &mut Value) -> DoiPreflight {
 
 async fn handle_tools_call(
     state: &McpAppState,
-    workspace: &WorkspaceId,
+    auth: &AuthOutcome,
     id: Value,
     params: &Value,
 ) -> Response {
+    let workspace = &auth.workspace;
     let name = match params.get("name").and_then(|v| v.as_str()) {
         Some(n) => n,
         None => return rpc_error(id, -32602, "Invalid params: missing tool name"),
@@ -458,6 +488,12 @@ async fn handle_tools_call(
         // false`) regardless of the persisted feature flag.
         local_enabled: state.allow_local && state.feature_config.local_access_enabled(),
         workspace_id: workspace.clone(),
+        // JP-370: per-document access gate. `user_id == None` (static loopback
+        // token) bypasses, treated as workspace admin; a JWT caller is gated by
+        // the doc's owner/share set when enforcement is on.
+        user_id: auth.user_id.clone(),
+        user_role: auth.role.clone(),
+        enforce_private_docs: state.enforce_private_docs,
         registry: &state.sync_registry,
         on_doc_update: state.on_doc_update.as_ref(),
         on_doc_deleted: &state.on_doc_deleted,
@@ -631,6 +667,7 @@ mod tests {
             on_doc_update: Arc::new(|_, _, _| {}),
             allow_static_token: true,
             allow_local: true,
+            enforce_private_docs: false,
         };
         (state, token_str)
     }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -502,6 +502,10 @@ pub struct ServerState {
     /// binary-vs-JSON hydrate sanity check + self-heal and the N→0 persist
     /// backup so a single bad client can't permanently zero a document.
     poison_guard: bool,
+    /// Snapshot of `config.permissions.enforce_private_docs` (JP-370). When
+    /// true, the document listing and the WS join are gated by the document's
+    /// owner/share set; when false (default) access is workspace-scoped only.
+    enforce_private_docs: bool,
     /// DEBUG-only trigger: when set, any WS handler that observes a
     /// client with this workspace id will panic on entry. Compiled out
     /// of release builds. Phase 21.2.
@@ -545,6 +549,7 @@ impl ServerState {
         metering_debug_log: bool,
         binary_persistence: bool,
         poison_guard: bool,
+        enforce_private_docs: bool,
         #[cfg(debug_assertions)] panic_tenant_trigger: Option<WorkspaceId>,
     ) -> Self {
         let (broadcast_tx, _) = broadcast::channel(100);
@@ -644,6 +649,7 @@ impl ServerState {
             metering_debug_log,
             binary_persistence,
             poison_guard,
+            enforce_private_docs,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
             blob_recovery_done: std::sync::Mutex::new(HashSet::new()),
@@ -1063,6 +1069,12 @@ impl ServerState {
 
     pub(crate) fn poison_guard(&self) -> bool {
         self.poison_guard
+    }
+
+    /// JP-370: whether per-document access is enforced on the read paths
+    /// (document listing + WS join). When false, access is workspace-scoped.
+    pub(crate) fn enforce_private_docs(&self) -> bool {
+        self.enforce_private_docs
     }
 
     /// Accessor for the blob store — used by `/metrics` to read storage
@@ -1554,6 +1566,10 @@ pub struct WebSocketServer {
     /// metering snapshot at debug level. Mirrors
     /// `config.observability.metering_debug_log`; set before `start()`.
     metering_debug_log: AtomicBool,
+    /// When true, the document listing + WS join enforce per-document access
+    /// (JP-370). Mirrors `config.permissions.enforce_private_docs`; set before
+    /// `start()`. Default off (workspace-scoped access).
+    enforce_private_docs: AtomicBool,
     /// MCP-owned state for folding `/mcp` onto this public listener
     /// (JP-210, `[mcp] expose = "public"`). Set via
     /// [`set_mcp_public_mount`] before `start()`; `start()` takes it and
@@ -1592,6 +1608,7 @@ impl WebSocketServer {
             panic_count: Arc::new(AtomicU64::new(0)),
             rate_limit_rejections: Arc::new(AtomicU64::new(0)),
             metering_debug_log: AtomicBool::new(false),
+            enforce_private_docs: AtomicBool::new(false),
             mcp_public_mount: RwLock::new(None),
             #[cfg(debug_assertions)]
             panic_tenant_trigger: RwLock::new(None),
@@ -1611,6 +1628,12 @@ impl WebSocketServer {
     /// `config.observability.metering_debug_log`. Must precede `start()`.
     pub fn set_metering_debug_log(&self, enabled: bool) {
         self.metering_debug_log.store(enabled, Ordering::Relaxed);
+    }
+
+    /// JP-370: enable per-document access enforcement on the read paths.
+    /// Mirrors `config.permissions.enforce_private_docs`; call before `start()`.
+    pub fn set_enforce_private_docs(&self, enabled: bool) {
+        self.enforce_private_docs.store(enabled, Ordering::Relaxed);
     }
 
     /// Replace the tenancy config (called during startup from
@@ -1850,6 +1873,7 @@ impl WebSocketServer {
         let metering_debug_log = self.metering_debug_log.load(Ordering::Relaxed);
         let binary_persistence = self.sync_config.read().await.binary_persistence;
         let poison_guard = self.sync_config.read().await.poison_guard;
+        let enforce_private_docs = self.enforce_private_docs.load(Ordering::Relaxed);
         let tenancy = self.tenancy.read().await.clone();
         let storage = self.storage.read().await.clone();
         // Reuse the cached limiter so MCP and WS share one bucket.
@@ -1871,6 +1895,7 @@ impl WebSocketServer {
             metering_debug_log,
             binary_persistence,
             poison_guard,
+            enforce_private_docs,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
         ));
@@ -1967,6 +1992,7 @@ impl WebSocketServer {
                     relay_region: server_state.relay_region.clone(),
                     sync_registry: server_state.sync_registry.clone(),
                     on_doc_update,
+                    enforce_private_docs: server_state.enforce_private_docs(),
                 };
                 log::info!("MCP endpoint folded onto the public HTTP listener at /mcp (expose=public)");
                 Some(mount.into_public_router(shared))
@@ -3286,13 +3312,18 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
         }
     };
 
-    // Snapshot the client's workspace for the doc-store lookup. The
-    // join is rejected (without setting current_doc_id) if the client
-    // record disappeared (race) or the doc isn't a team document.
-    let workspace_id = {
+    // Snapshot the client's workspace + identity for the doc-store lookup and
+    // the JP-370 per-document read gate. The join is rejected (without setting
+    // current_doc_id) if the client record disappeared (race) or the doc isn't
+    // a team document.
+    let (workspace_id, user_id, role) = {
         let clients = state.clients.read().await;
         match clients.get(&client_id) {
-            Some(c) => c.current_workspace_id.clone(),
+            Some(c) => (
+                c.current_workspace_id.clone(),
+                c.user_id.clone(),
+                c.role.clone(),
+            ),
             None => return,
         }
     };
@@ -3347,6 +3378,38 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
             send_to_client(client_id, data, state).await;
         }
         return;
+    }
+
+    // JP-370: per-document read gate. When enforcement is on, a workspace
+    // member who is neither the owner, an explicit share, nor a workspace
+    // owner/admin is refused the join — the same owner/share rules the REST
+    // read path applies, now closing the WS-sync path that previously trusted
+    // any authenticated member of the workspace. Off by default → unchanged
+    // workspace-scoped behaviour. The error frame mirrors the ERR_UNKNOWN_DOC
+    // branch so the client strands its local copy rather than syncing blind.
+    if state.enforce_private_docs() {
+        if let Err(e) = crate::server::permissions::check_read_permission(
+            state.doc_store(),
+            &workspace_id,
+            &request.doc_id,
+            user_id.as_deref(),
+            role.as_deref(),
+        ) {
+            log::info!(
+                "rejecting JOIN_DOC (access denied) client_id={} workspace_id={} doc_id={}",
+                client_id,
+                workspace_id.as_str(),
+                request.doc_id.as_str(),
+            );
+            let err = ErrorResponse {
+                request_id: None,
+                error: crate::server::permissions::to_error_string(&e),
+            };
+            if let Ok(data) = encode_message(MESSAGE_ERROR, &err) {
+                send_to_client(client_id, data, state).await;
+            }
+            return;
+        }
     }
 
     let previous_doc_id = {
@@ -3507,6 +3570,7 @@ mod tests {
             false,
             true,
             true,
+            false,
             trigger,
         ));
 
@@ -3585,6 +3649,16 @@ mod tests {
     /// `WebSocketServer::start`'s wiring at the minimum needed to call
     /// `check_tenancy` and the workspace-cap methods.
     async fn test_server_state(tenancy: TenancyConfig) -> Arc<ServerState> {
+        test_server_state_with(tenancy, false).await
+    }
+
+    /// As [`test_server_state`] but lets a test enable the JP-370 private-doc
+    /// enforcement gate (off in the default helper to keep existing tests on
+    /// the legacy workspace-scoped behaviour).
+    async fn test_server_state_with(
+        tenancy: TenancyConfig,
+        enforce_private_docs: bool,
+    ) -> Arc<ServerState> {
         let temp_dir = tempfile::tempdir().unwrap().keep();
         let write_limiter = Arc::new(build_workspace_limiter(
             tenancy.limits.writes_per_sec,
@@ -3603,6 +3677,7 @@ mod tests {
             false,
             true,
             true,
+            enforce_private_docs,
             #[cfg(debug_assertions)]
             None,
         ))
@@ -3649,6 +3724,7 @@ mod tests {
             false,
             true,
             true,
+            false,
             #[cfg(debug_assertions)]
             None,
         ));
@@ -3860,6 +3936,99 @@ mod tests {
                 .map(|d| d.as_str().to_string())
         };
         assert_eq!(cur.as_deref(), Some("real-doc"));
+    }
+
+    /// JP-370: with private-doc enforcement on, a workspace member who is
+    /// neither the owner nor an explicit share is refused the JOIN_DOC
+    /// (`current_doc_id` stays `None`, an ERR_VIEW_FORBIDDEN frame is sent) —
+    /// closing the WS-sync path. Adding a `view` share then lets them join.
+    #[tokio::test]
+    async fn handle_join_doc_enforces_per_document_read_access() {
+        let state = test_server_state_with(TenancyConfig::default(), true).await;
+        let ws = WorkspaceId::single_tenant();
+
+        // Seed a team document owned by `owner-1` with no shares.
+        let doc = serde_json::json!({
+            "id": "private-doc",
+            "name": "Private",
+            "ownerId": "owner-1",
+            "ownerName": "Owner",
+            "pageOrder": ["p1"],
+            "pages": {},
+            "createdAt": 1u64,
+            "modifiedAt": 1u64,
+        });
+        state.doc_store.save_document(&ws, doc).expect("save");
+
+        // A different member of the same workspace (role "user", not owner/admin).
+        let (tx, mut rx) = mpsc::channel(4);
+        let client_id = state.next_client_id();
+        {
+            let mut clients = state.clients.write().await;
+            clients.insert(
+                client_id,
+                ClientState {
+                    id: client_id,
+                    user_id: Some("member-2".to_string()),
+                    username: None,
+                    role: Some("user".to_string()),
+                    current_doc_id: None,
+                    current_workspace_id: ws.clone(),
+                    authenticated: true,
+                    jti: None,
+                    token_exp: None,
+                    tx,
+                    reassembly: chunk::ChunkReassembler::default(),
+                },
+            );
+        }
+
+        let req = JoinDocRequest {
+            doc_id: DocId::from_http_path("private-doc".to_string()).unwrap(),
+        };
+        let frame = encode_message(MESSAGE_JOIN_DOC, &req).expect("encode");
+        handle_join_doc(client_id, &frame, &state).await;
+
+        // Denied: no current_doc_id, and a permission error frame was sent.
+        let cur = {
+            let clients = state.clients.read().await;
+            clients.get(&client_id).and_then(|c| c.current_doc_id.clone())
+        };
+        assert!(cur.is_none(), "unshared member must not join; got {cur:?}");
+        let err_frame = rx.try_recv().expect("expected an error frame");
+        assert_eq!(decode_message_type(&err_frame), Some(MESSAGE_ERROR));
+        let err: ErrorResponse = decode_payload(&err_frame).expect("decode error frame");
+        assert!(
+            err.error.starts_with("ERR_VIEW_FORBIDDEN"),
+            "expected a view-forbidden denial, got {:?}",
+            err.error
+        );
+
+        // Grant `member-2` a `view` share, then the join succeeds.
+        let doc_id = DocId::from_http_path("private-doc".to_string()).unwrap();
+        state
+            .doc_store
+            .update_document_shares(
+                &ws,
+                &doc_id,
+                &[crate::server::protocol::ShareEntry {
+                    user_id: "member-2".to_string(),
+                    user_name: "Member".to_string(),
+                    permission: "view".to_string(),
+                }],
+            )
+            .expect("share");
+
+        let frame = encode_message(MESSAGE_JOIN_DOC, &req).expect("encode");
+        handle_join_doc(client_id, &frame, &state).await;
+        let cur = {
+            let clients = state.clients.read().await;
+            clients
+                .get(&client_id)
+                .and_then(|c| c.current_doc_id.clone())
+                .map(|d| d.as_str().to_string())
+        };
+        assert_eq!(cur.as_deref(), Some("private-doc"), "shared member must join");
     }
 
     /// Phase 21.3: per-workspace connection cap is enforced atomically

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -167,6 +167,7 @@ impl Harness {
                 sync_registry,
                 on_doc_update,
                 shared_doc_store,
+                false, // JP-370: private-doc enforcement off in this test
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -65,6 +65,7 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
             server.sync_registry_handle().await,
             on_doc_update,
             shared_doc_store,
+            false, // JP-370: private-doc enforcement off in this test
         )
         .expect("McpServer::new"),
     );

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -98,6 +98,7 @@ impl Harness {
                 sync_registry,
                 on_doc_update,
                 shared_doc_store,
+                false, // JP-370: private-doc enforcement off in this test
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -659,6 +659,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             sync_registry,
             on_doc_update,
             shared_doc_store,
+            false, // JP-370: private-doc enforcement off in this test
         )
         .expect("McpServer::new"),
     );


### PR DESCRIPTION
Part of **JP-370 — Document Access Logic + UX** (the relay slice; PR-1 of the cross-repo set). Standalone off `master`.

## What & why
The relay already modeled per-document permissions (`owner_id` + `shared_with` + workspace owner/admin) and enforced them on the REST single-doc read/write, but two paths trusted *any* authenticated member of the workspace:

- **WS `JOIN_DOC` had no per-doc check** — a member could open + edit any document's CRDT over the socket, bypassing the REST read gate.
- **`GET /api/docs` returned every workspace document**, regardless of share state.

This PR closes both, plus the MCP read-around, behind an **opt-in** flag.

## Changes
- **New config** `[permissions] enforce_private_docs` (env `RELAY_ENFORCE_PRIVATE_DOCS`), **default OFF**. With it off, behavior is unchanged (workspace-scoped). With it on, reads are gated by the document's owner/share set.
- **WS join gate** — `handle_join_doc` now runs `check_read_permission`; denial emits `ERR_VIEW_FORBIDDEN` and the client is not joined (mirrors the existing `ERR_UNKNOWN_DOC`/`ERR_DELETED` branches; `handle_sync` already drops frames for an un-joined client).
- **Doc-list filter** — `GET /api/docs` returns only readable docs when enforcement is on.
- **MCP gate** — the caller's identity (`sub` + role) is threaded from the JWT through `AuthOutcome` → `ToolContext`; `dispatch` gates per-document tools (reads = Viewer, writes = Editor, `delete_document` = Owner) and `list_documents` is filtered. The **static loopback token has no user identity and is treated as workspace admin**, so the desktop/self-host flow is unchanged.

## Compatibility
Additive only — wire frames unchanged, `PROTOCOL_VERSION` not moved. Not a breaking wire change. Default-off means a self-hoster upgrade never silently locks members out; Cloud opts in. No multi-member workspaces predate this feature, so there is no live-data migration.

## Verification
- `cargo build --bin relay`, `cargo clippy --all-targets` (no new warnings)
- `cargo test --all-targets` — 540 lib + all integration tests green, incl. a new `handle_join_doc_enforces_per_document_read_access` test (unshared member denied → `view` share → joins)
- `openapi.yaml` (`GET /api/docs` + `/ws`) and `relay/README.md` updated; OSS-leak grep clean

Assisted-by: Opus 4.8