### PR TITLE
editor: document share UX + workspace members panel (JP-370)

### DIFF
--- a/src/api/webClient.test.ts
+++ b/src/api/webClient.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { webClient, WebClientError } from './webClient';
+
+const BASE = 'https://cloud.test';
+const TOKEN = 'relay.jwt.token';
+const WS = 'ws-123';
+
+/** A fetch stub that records the last call and returns a canned JSON response. */
+function stubFetch(status: number, body: unknown) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const deps = (impl: typeof fetch) => ({ fetchImpl: impl, baseUrl: BASE, token: TOKEN });
+
+describe('webClient', () => {
+  it('getWorkspaceMembers hits /members with the bearer token and unwraps the list', async () => {
+    const { impl, calls } = stubFetch(200, {
+      members: [{ userId: 'u1', email: 'a@b.c', displayName: 'Alice', role: 'owner' }],
+    });
+    const members = await webClient.getWorkspaceMembers(WS, deps(impl));
+
+    expect(members).toHaveLength(1);
+    expect(members[0]?.displayName).toBe('Alice');
+    expect(calls[0]?.url).toBe(`${BASE}/api/v1/workspace/${WS}/members`);
+    expect((calls[0]?.init.headers as Record<string, string>)['authorization']).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('createInvite POSTs the role and returns the invite', async () => {
+    const { impl, calls } = stubFetch(201, {
+      id: 'inv1',
+      url: `${BASE}/invite/abc`,
+      role: 'viewer',
+      expiresAt: 'x',
+      createdAt: 'y',
+    });
+    const invite = await webClient.createInvite('viewer', WS, deps(impl));
+
+    expect(invite.url).toBe(`${BASE}/invite/abc`);
+    expect(calls[0]?.url).toBe(`${BASE}/api/v1/workspace/${WS}/invites`);
+    expect(calls[0]?.init.method).toBe('POST');
+    expect(JSON.parse(calls[0]?.init.body as string)).toEqual({ role: 'viewer' });
+  });
+
+  it('listWorkspaces unwraps the workspaces array', async () => {
+    const { impl } = stubFetch(200, {
+      workspaces: [{ id: WS, name: 'Acme', slug: 'acme', region: 'yyz', role: 'owner' }],
+    });
+    const out = await webClient.listWorkspaces(deps(impl));
+    expect(out[0]?.name).toBe('Acme');
+  });
+
+  it('throws WebClientError with the server error code on a non-2xx', async () => {
+    const { impl } = stubFetch(403, { error: 'owner_required' });
+    await expect(webClient.createInvite('member', WS, deps(impl))).rejects.toMatchObject({
+      name: 'WebClientError',
+      status: 403,
+      code: 'owner_required',
+    });
+  });
+
+  it('refuses to call without a token', async () => {
+    const { impl, calls } = stubFetch(200, { members: [] });
+    await expect(
+      webClient.getWorkspaceMembers(WS, { fetchImpl: impl, baseUrl: BASE, token: null }),
+    ).rejects.toBeInstanceOf(WebClientError);
+    expect(calls).toHaveLength(0); // never hit the network
+  });
+
+  it('revokeInvite issues a DELETE to the token path', async () => {
+    const { impl, calls } = stubFetch(200, { ok: true });
+    await webClient.revokeInvite('tok-xyz', WS, deps(impl));
+    expect(calls[0]?.init.method).toBe('DELETE');
+    expect(calls[0]?.url).toBe(`${BASE}/api/v1/workspace/${WS}/invites/tok-xyz`);
+  });
+});

--- a/src/api/webClient.ts
+++ b/src/api/webClient.ts
@@ -1,0 +1,192 @@
+/**
+ * Cloud control-plane client (JP-370).
+ *
+ * The editor's HTTP client for the proprietary `docushark-web` workspace +
+ * invite endpoints — the membership roster that feeds the document-share
+ * picker, the shareable invite links, and (later, for the switcher) the list of
+ * workspaces a user belongs to. Parallel to `relayClient` (which talks to the
+ * relay); this talks to `docushark-web` and authenticates with the SAME relay
+ * app token (the only credential the editor holds — there is no Supabase
+ * session here). The web verifies that token against its own JWKS.
+ *
+ * Functional + injectable (mirrors `cloudAuth`) so tests can stub `fetch`,
+ * the cloud origin, and the token without touching global state.
+ */
+import { useConnectionStore } from '../store/connectionStore';
+import { loadConnection, DEFAULT_CLOUD_BASE_URL } from './relayConnection';
+import { activeWorkspaceId } from '../store/activeWorkspace';
+
+export type WorkspaceRole = 'owner' | 'member' | 'viewer';
+
+export interface WorkspaceMember {
+  userId: string;
+  email: string | null;
+  displayName: string;
+  role: WorkspaceRole;
+}
+
+export interface WorkspaceInvite {
+  id: string;
+  /** Shareable accept link (`https://<app>/invite/<token>`). */
+  url: string;
+  role: WorkspaceRole;
+  expiresAt: string;
+  createdAt: string;
+}
+
+export interface WorkspaceSummary {
+  id: string;
+  name: string;
+  slug: string | null;
+  region: string;
+  role: WorkspaceRole;
+}
+
+/** A failed control-plane call. `status` is the HTTP status (0 = network/no-auth). */
+export class WebClientError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message?: string,
+  ) {
+    super(message ?? code);
+    this.name = 'WebClientError';
+  }
+}
+
+export interface WebClientDeps {
+  fetchImpl?: typeof fetch;
+  /** Cloud origin override (defaults to the persisted connection's, then the build default). */
+  baseUrl?: string;
+  /** Token override (defaults to the live connection token). */
+  token?: string | null;
+}
+
+async function resolveBase(deps: WebClientDeps): Promise<string> {
+  if (deps.baseUrl) return deps.baseUrl.replace(/\/+$/, '');
+  const conn = await loadConnection();
+  return (conn?.cloudBaseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/+$/, '');
+}
+
+function resolveToken(deps: WebClientDeps): string | null {
+  return deps.token !== undefined ? deps.token : useConnectionStore.getState().token;
+}
+
+async function request<T>(
+  method: 'GET' | 'POST' | 'DELETE',
+  path: string,
+  deps: WebClientDeps,
+  body?: unknown,
+): Promise<T> {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const token = resolveToken(deps);
+  if (!token) throw new WebClientError(0, 'not_signed_in', 'Not signed in to the cloud');
+  const base = await resolveBase(deps);
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${base}${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (e) {
+    throw new WebClientError(0, 'network_error', e instanceof Error ? e.message : String(e));
+  }
+
+  if (!res.ok) {
+    let code = `http_${res.status}`;
+    try {
+      const errBody = (await res.json()) as { error?: string };
+      if (errBody?.error) code = errBody.error;
+    } catch {
+      /* non-JSON error body — keep the http_<status> code */
+    }
+    throw new WebClientError(res.status, code);
+  }
+
+  // 204 / empty bodies → undefined.
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export const webClient = {
+  /** Roster of the workspace's members (feeds the share picker). */
+  async getWorkspaceMembers(
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<WorkspaceMember[]> {
+    const { members } = await request<{ members: WorkspaceMember[] }>(
+      'GET',
+      `/api/v1/workspace/${encodeURIComponent(workspaceId)}/members`,
+      deps,
+    );
+    return members ?? [];
+  },
+
+  /** The workspaces the caller belongs to (switcher source, PR-3c). */
+  async listWorkspaces(deps: WebClientDeps = {}): Promise<WorkspaceSummary[]> {
+    const { workspaces } = await request<{ workspaces: WorkspaceSummary[] }>(
+      'GET',
+      `/api/v1/workspaces`,
+      deps,
+    );
+    return workspaces ?? [];
+  },
+
+  /** Mint a shareable invite link (owner-only). */
+  async createInvite(
+    role: 'member' | 'viewer',
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<WorkspaceInvite> {
+    return request<WorkspaceInvite>(
+      'POST',
+      `/api/v1/workspace/${encodeURIComponent(workspaceId)}/invites`,
+      deps,
+      { role },
+    );
+  },
+
+  /** Active (pending) invites for the workspace (owner-only). */
+  async listInvites(
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<WorkspaceInvite[]> {
+    const { invites } = await request<{ invites: WorkspaceInvite[] }>(
+      'GET',
+      `/api/v1/workspace/${encodeURIComponent(workspaceId)}/invites`,
+      deps,
+    );
+    return invites ?? [];
+  },
+
+  /** Revoke a pending invite by its token (owner-only). */
+  async revokeInvite(
+    token: string,
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<void> {
+    await request<void>(
+      'DELETE',
+      `/api/v1/workspace/${encodeURIComponent(workspaceId)}/invites/${encodeURIComponent(token)}`,
+      deps,
+    );
+  },
+
+  /** Remove a member from the workspace (owner-only). */
+  async removeMember(
+    userId: string,
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<void> {
+    await request<void>(
+      'DELETE',
+      `/api/v1/workspace/${encodeURIComponent(workspaceId)}/members/${encodeURIComponent(userId)}`,
+      deps,
+    );
+  },
+};

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -53,7 +53,7 @@ import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import type { Field } from '../types/Field';
 import type { DocEvent } from './protocol';
-import { isDeletedDocError, isUnknownDocError } from './protocol';
+import { isDeletedDocError, isUnknownDocError, isPermissionError } from './protocol';
 import { throttle } from '../utils/requestUtils';
 import { getAdaptiveBudget } from '../platform/adaptiveBudget';
 import { relayFetch } from '../platform/relayFetch';
@@ -553,6 +553,24 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
             const record = useDocumentRegistry.getState().getRecord(docId);
             if (record) {
               useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+            }
+            return;
+          }
+          // JP-370: the relay refused the JOIN_DOC because we no longer have
+          // read access — un-shared, or removed from the workspace, while
+          // private-doc enforcement is on. The doc isn't deleted globally, but
+          // it's inaccessible to us now: keep our local copy (strand to Trash,
+          // same as a deletion) so we stop syncing into a doc we can't read, and
+          // tell the user plainly rather than leaving a silently-dead session.
+          if (isPermissionError(error) && docId) {
+            const record = useDocumentRegistry.getState().getRecord(docId);
+            if (record) {
+              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+              useNotificationStore
+                .getState()
+                .warning(
+                  'You no longer have access to this document. Your local copy has been moved to Trash.',
+                );
             }
             return;
           }

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -53,7 +53,7 @@ import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle } from '../types/Citation';
 import type { Field } from '../types/Field';
 import type { DocEvent } from './protocol';
-import { isDeletedDocError, isUnknownDocError, isPermissionError } from './protocol';
+import { isDeletedDocError, isUnknownDocError, isViewForbiddenError } from './protocol';
 import { throttle } from '../utils/requestUtils';
 import { getAdaptiveBudget } from '../platform/adaptiveBudget';
 import { relayFetch } from '../platform/relayFetch';
@@ -556,21 +556,21 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
             }
             return;
           }
-          // JP-370: the relay refused the JOIN_DOC because we no longer have
-          // read access — un-shared, or removed from the workspace, while
-          // private-doc enforcement is on. The doc isn't deleted globally, but
-          // it's inaccessible to us now: keep our local copy (strand to Trash,
-          // same as a deletion) so we stop syncing into a doc we can't read, and
-          // tell the user plainly rather than leaving a silently-dead session.
-          if (isPermissionError(error) && docId) {
+          // JP-370: the relay refused the JOIN_DOC with a VIEW denial — we no
+          // longer have read access (un-shared, or removed from the workspace)
+          // while private-doc enforcement is on. The doc isn't deleted globally,
+          // but it's inaccessible to us: keep our local copy (strand to Trash)
+          // so we stop syncing into a doc we can't read. Deliberately narrow to
+          // a view denial — a transient ERR_NOT_AUTHENTICATED (token race) or an
+          // ERR_EDIT_FORBIDDEN (read-only viewer who can still SEE the doc) must
+          // NOT strand a doc the user still legitimately holds. The strand path
+          // owns the single 'access-revoked' toast (no duplicate here).
+          if (isViewForbiddenError(error) && docId) {
             const record = useDocumentRegistry.getState().getRecord(docId);
             if (record) {
-              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
-              useNotificationStore
+              useRelayDocumentStore
                 .getState()
-                .warning(
-                  'You no longer have access to this document. Your local copy has been moved to Trash.',
-                );
+                .strandOrDemoteDeletedDoc(docId, undefined, 'access-revoked');
             }
             return;
           }

--- a/src/collaboration/protocol.test.ts
+++ b/src/collaboration/protocol.test.ts
@@ -26,6 +26,7 @@ import {
   isPermissionError,
   isUnknownDocError,
   isDeletedDocError,
+  isViewForbiddenError,
   isCRDTMessage,
   getMessageTypeName,
   validateMessageSize,
@@ -278,6 +279,25 @@ describe('Error Code Helpers', () => {
       expect(isDeletedDocError('ERR_UNKNOWN_DOC')).toBe(false);
       expect(isDeletedDocError('ERR_ACCESS_DENIED')).toBe(false);
       expect(isDeletedDocError('')).toBe(false);
+    });
+  });
+
+  // JP-370: the strand-to-Trash on access loss keys off this NARROW matcher,
+  // not isPermissionError — guarding against stranding a doc the user still
+  // holds on a transient auth race or a read-only viewer join.
+  describe('isViewForbiddenError', () => {
+    it('detects a view/read denial', () => {
+      expect(isViewForbiddenError('ERR_VIEW_FORBIDDEN: Cannot view')).toBe(true);
+      expect(isViewForbiddenError('ERR_ACCESS_DENIED: No access')).toBe(true);
+    });
+
+    it('does NOT match a transient auth error or an edit-only denial', () => {
+      // The whole point of the fix: these must not strand an owned/readable doc.
+      expect(isViewForbiddenError('ERR_NOT_AUTHENTICATED: token expired')).toBe(false);
+      expect(isViewForbiddenError('ERR_EDIT_FORBIDDEN: read-only')).toBe(false);
+      expect(isViewForbiddenError('ERR_DELETE_FORBIDDEN')).toBe(false);
+      expect(isViewForbiddenError('ERR_DELETED')).toBe(false);
+      expect(isViewForbiddenError('')).toBe(false);
     });
   });
 });

--- a/src/collaboration/protocol.ts
+++ b/src/collaboration/protocol.ts
@@ -170,6 +170,17 @@ export function isDeletedDocError(error: string): boolean {
   return hasErrorCode(error, ERR_DELETED);
 }
 
+/**
+ * True ONLY for a view/read denial (JP-370 private-doc enforcement on JOIN_DOC):
+ * the caller may not read this document. Deliberately narrower than
+ * {@link isPermissionError} — a transient {@link ERR_NOT_AUTHENTICATED} (token
+ * race) or an {@link ERR_EDIT_FORBIDDEN} (read-only viewer) must NOT be treated
+ * as a permanent access loss, or we'd strand a doc the user still holds.
+ */
+export function isViewForbiddenError(error: string): boolean {
+  return hasErrorCode(error, ERR_VIEW_FORBIDDEN) || hasErrorCode(error, ERR_ACCESS_DENIED);
+}
+
 // ============ Message Size Limits ============
 
 /** Maximum message size in bytes (16 MB) */

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -244,7 +244,16 @@ interface RelayDocumentActions {
    *  - clean up the relay bookkeeping either way.
    * Skips preservation when *we* initiated the deletion (`deletedByUserId` is us).
    */
-  strandOrDemoteDeletedDoc: (docId: string, deletedByUserId?: string) => void;
+  strandOrDemoteDeletedDoc: (
+    docId: string,
+    deletedByUserId?: string,
+    /**
+     * Why the doc is being stranded — drives the user-facing copy. `'deleted'`
+     * (default): the relay removed it. `'access-revoked'` (JP-370): the doc
+     * still exists but we lost read access (un-shared / removed from workspace).
+     */
+    reason?: 'deleted' | 'access-revoked',
+  ) => void;
 
   /** Set host connection status */
   setHostConnected: (connected: boolean) => void;
@@ -796,7 +805,7 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
       });
     },
 
-    strandOrDemoteDeletedDoc: (docId, deletedByUserId) => {
+    strandOrDemoteDeletedDoc: (docId, deletedByUserId, reason = 'deleted') => {
       const registry = useDocumentRegistry.getState();
       const connection = useConnectionStore.getState();
       const persistence = usePersistenceStore.getState();
@@ -851,7 +860,11 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         void RelayDocumentCache.remove(activeWorkspaceId(), docId);
         useNotificationStore
           .getState()
-          .info(`“${doc.name}” was deleted from the relay and moved to Trash.`);
+          .info(
+            reason === 'access-revoked'
+              ? `You no longer have access to “${doc.name}”. Your local copy was moved to Trash.`
+              : `“${doc.name}” was deleted from the relay and moved to Trash.`,
+          );
         // Leave the now-trashed doc — the editor resets to a blank document (the
         // copy is recoverable from Trash).
         if (isOpen) persistence.newDocument();

--- a/src/ui/DocumentPermissionsDialog.tsx
+++ b/src/ui/DocumentPermissionsDialog.tsx
@@ -4,17 +4,18 @@
  * Modal dialog for managing document ownership and access permissions.
  * Only document owners can access this dialog.
  *
- * Phase 20.3 Slice E.5: dropped the host-mode member picker (the
- * relay no longer exposes a renderer-side user roster). Users now
- * add shares by typing the relay user ID + display name; server-side
- * `POST /api/docs/:id/share` rejects unknown IDs and the error
- * surfaces inline.
+ * JP-370: shares are now chosen from a workspace **member picker** fed by the
+ * Cloud roster (`webClient.getWorkspaceMembers`) — restoring the picker dropped
+ * in Phase 20.3 E.5 (which forced users to hand-type a relay user ID). You can
+ * only share with people already in the workspace; invite them first (the
+ * workspace members panel) to make them appear here.
  */
 
 import { useState, useCallback, useEffect, useMemo, FormEvent } from 'react';
 import { useUserStore } from '../store/userStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
+import { webClient, type WorkspaceMember } from '../api/webClient';
 import type { Permission, RemoteDocument } from '../types/DocumentRegistry';
 import type { DocumentShare } from '../types/Document';
 import './DocumentPermissionsDialog.css';
@@ -47,9 +48,11 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
   const [transferToUserId, setTransferToUserId] = useState<string | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
 
-  // Inline "Add user" form state.
-  const [newUserId, setNewUserId] = useState('');
-  const [newUserName, setNewUserName] = useState('');
+  // Member-picker state (JP-370): the workspace roster + the currently-selected
+  // member to add. Replaces the old hand-typed user-id form.
+  const [roster, setRoster] = useState<WorkspaceMember[]>([]);
+  const [rosterError, setRosterError] = useState<string | null>(null);
+  const [newMemberId, setNewMemberId] = useState('');
   const [newPermission, setNewPermission] = useState<'view' | 'edit'>('view');
 
   const entry = entries[documentId];
@@ -77,6 +80,44 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
     setHasChanges(false);
   }, [currentUser?.id, record, docMetadata]);
 
+  // JP-370: load the workspace roster so shares are picked from real members
+  // (not hand-typed ids). Best-effort: a failure (self-host, offline, web
+  // unreachable) leaves the picker empty with an inline note rather than
+  // breaking the dialog.
+  useEffect(() => {
+    if (!record || record.type !== 'remote') return;
+    let cancelled = false;
+    webClient
+      .getWorkspaceMembers()
+      .then((members) => {
+        if (!cancelled) {
+          setRoster(members);
+          setRosterError(null);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setRoster([]);
+          setRosterError(err instanceof Error ? err.message : 'Could not load workspace members');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [record]);
+
+  // Members who can still be added: everyone in the workspace except the owner,
+  // the current user, and anyone already in the access list.
+  const availableMembers = useMemo(() => {
+    const taken = new Set(accessList.map((m) => m.userId));
+    return roster.filter(
+      (m) =>
+        m.userId !== record?.ownerId &&
+        m.userId !== currentUser?.id &&
+        !taken.has(m.userId),
+    );
+  }, [roster, accessList, record?.ownerId, currentUser?.id]);
+
   const accessCounts = useMemo(() => {
     const editors = accessList.filter((m) => m.permission === 'edit').length;
     const viewers = accessList.filter((m) => m.permission === 'view').length;
@@ -101,22 +142,20 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
   const handleAddUser = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      const id = newUserId.trim();
-      const name = newUserName.trim();
-      if (!id || !name) return;
-      if (accessList.some((m) => m.userId === id)) {
-        setError(`User ${id} is already in the access list`);
-        return;
-      }
-      setAccessList((prev) => [...prev, { userId: id, username: name, permission: newPermission }]);
+      const member = roster.find((m) => m.userId === newMemberId);
+      if (!member) return;
+      if (accessList.some((m) => m.userId === member.userId)) return;
+      setAccessList((prev) => [
+        ...prev,
+        { userId: member.userId, username: member.displayName, permission: newPermission },
+      ]);
       setHasChanges(true);
       setError(null);
       setSuccessMessage(null);
-      setNewUserId('');
-      setNewUserName('');
+      setNewMemberId('');
       setNewPermission('view');
     },
-    [newUserId, newUserName, newPermission, accessList],
+    [newMemberId, newPermission, accessList, roster],
   );
 
   const handleTransferOwnership = useCallback((userId: string) => {
@@ -249,29 +288,27 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
           {!transferToUserId && (
             <>
               <div className="document-permissions-dialog__section">
-                <h4>Add User</h4>
+                <h4>Add a workspace member</h4>
                 <form
                   className="document-permissions-dialog__add-form"
                   onSubmit={handleAddUser}
                 >
-                  <input
-                    type="text"
+                  <select
                     className="document-permissions-dialog__permission-select"
-                    placeholder="User ID"
-                    value={newUserId}
-                    onChange={(e) => setNewUserId(e.target.value)}
-                    disabled={isSaving}
-                    required
-                  />
-                  <input
-                    type="text"
-                    className="document-permissions-dialog__permission-select"
-                    placeholder="Display name"
-                    value={newUserName}
-                    onChange={(e) => setNewUserName(e.target.value)}
-                    disabled={isSaving}
-                    required
-                  />
+                    value={newMemberId}
+                    onChange={(e) => setNewMemberId(e.target.value)}
+                    disabled={isSaving || availableMembers.length === 0}
+                  >
+                    <option value="">
+                      {availableMembers.length === 0 ? 'No members to add' : 'Select a member…'}
+                    </option>
+                    {availableMembers.map((m) => (
+                      <option key={m.userId} value={m.userId}>
+                        {m.displayName}
+                        {m.email ? ` (${m.email})` : ''}
+                      </option>
+                    ))}
+                  </select>
                   <select
                     className="document-permissions-dialog__permission-select"
                     value={newPermission}
@@ -284,14 +321,22 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
                   <button
                     type="submit"
                     className="document-permissions-dialog__btn"
-                    disabled={isSaving || !newUserId.trim() || !newUserName.trim()}
+                    disabled={isSaving || !newMemberId}
                   >
                     Add
                   </button>
                 </form>
-                <p className="document-permissions-dialog__hint">
-                  The relay validates user IDs on save. Unknown IDs will be rejected.
-                </p>
+                {rosterError ? (
+                  <p className="document-permissions-dialog__hint">
+                    Couldn&apos;t load workspace members ({rosterError}). You can still adjust
+                    existing shares below.
+                  </p>
+                ) : (
+                  <p className="document-permissions-dialog__hint">
+                    Only people in this workspace appear here. To add someone new, invite them to
+                    the workspace first.
+                  </p>
+                )}
               </div>
 
               <div className="document-permissions-dialog__quick-actions">

--- a/src/ui/cloud/CloudConnectPanel.tsx
+++ b/src/ui/cloud/CloudConnectPanel.tsx
@@ -45,6 +45,7 @@ import {
 } from '../../api/relayConnection';
 import { completeCloudSignIn } from '../../api/completeCloudSignIn';
 import { beginCloudSignIn, CloudAuthError, type CloudSignInHandle } from '../../api/cloudAuth';
+import { WorkspaceMembersSection } from './WorkspaceMembersSection';
 
 const DEFAULT_RELAY_URL = 'http://localhost:9876';
 
@@ -290,6 +291,12 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
             </dd>
           </div>
         </dl>
+
+        {/* JP-370: workspace members + invite links. Renders for a Cloud
+            session; self-hosts/offline show an inline "couldn't load" note. */}
+        {cloudSignedIn ? (
+          <WorkspaceMembersSection isOwner={user.role === 'owner'} currentUserId={user.id} />
+        ) : null}
 
         <button
           type="button"

--- a/src/ui/cloud/CloudSignInModal.css
+++ b/src/ui/cloud/CloudSignInModal.css
@@ -388,3 +388,125 @@
   display: flex;
   gap: 8px;
 }
+
+/* ── Workspace members + invites (JP-370) ───────────────────────────── */
+.cloud-connect__members {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  margin-top: 4px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-tertiary);
+}
+.cloud-connect__members--loading {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.cloud-connect__members-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.cloud-connect__members-header h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+.cloud-connect__members-note {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+.cloud-connect__member-list,
+.cloud-connect__invite-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.cloud-connect__member,
+.cloud-connect__invite {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cloud-connect__member-id {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.cloud-connect__member-name {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cloud-connect__member-email {
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cloud-connect__member-role,
+.cloud-connect__invite-role-tag {
+  font-size: 11px;
+  text-transform: capitalize;
+  color: var(--text-secondary);
+  padding: 1px 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+}
+.cloud-connect__icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.cloud-connect__icon-btn:hover {
+  background: var(--bg-hover, rgba(0, 0, 0, 0.06));
+  color: var(--text-primary);
+}
+.cloud-connect__icon-btn--danger:hover {
+  color: var(--color-danger, #d23);
+}
+.cloud-connect__invites {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color);
+}
+.cloud-connect__invite-create {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.cloud-connect__invite-role {
+  flex: 1;
+  min-width: 0;
+}
+.cloud-connect__invite-url {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-secondary);
+}

--- a/src/ui/cloud/WorkspaceMembersSection.test.tsx
+++ b/src/ui/cloud/WorkspaceMembersSection.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { inviteToken } from './WorkspaceMembersSection';
+
+// JP-370: revoking an invite parses the opaque token out of the invite URL.
+// A naive last-segment split breaks when the URL carries a query/fragment —
+// the token would then carry `?...`/`#...` and the server-side revoke misses.
+describe('inviteToken', () => {
+  it('extracts the token from a plain invite URL', () => {
+    expect(inviteToken('https://app.docushark.app/invite/abc123')).toBe('abc123');
+  });
+
+  it('ignores a query string and fragment', () => {
+    expect(inviteToken('https://app.docushark.app/invite/abc123?ref=x')).toBe('abc123');
+    expect(inviteToken('https://app.docushark.app/invite/abc123#frag')).toBe('abc123');
+    expect(inviteToken('https://app.docushark.app/invite/abc123?a=1#b')).toBe('abc123');
+  });
+
+  it('url-decodes a percent-encoded token', () => {
+    expect(inviteToken('https://app.docushark.app/invite/a%2Bb')).toBe('a+b');
+  });
+
+  it('falls back to a path split for a non-absolute URL', () => {
+    expect(inviteToken('/invite/tok-9?x=1')).toBe('tok-9');
+  });
+
+  it('returns empty for a URL with no path', () => {
+    expect(inviteToken('https://app.docushark.app')).toBe('');
+  });
+});

--- a/src/ui/cloud/WorkspaceMembersSection.tsx
+++ b/src/ui/cloud/WorkspaceMembersSection.tsx
@@ -220,9 +220,20 @@ export function WorkspaceMembersSection({ isOwner, currentUserId }: WorkspaceMem
   );
 }
 
-/** The opaque token is the last path segment of the invite URL. */
-function inviteToken(url: string): string {
-  const parts = url.split('/').filter(Boolean);
+/**
+ * The opaque token is the last PATH segment of the invite URL. Parse via the
+ * URL API so a query string or fragment (`/invite/<tok>?x=1#y`) never bleeds
+ * into the token — a naive split would yield `<tok>?x=1` and the revoke would
+ * silently miss. Falls back to a path-only split for a non-absolute URL.
+ */
+export function inviteToken(url: string): string {
+  let path = url;
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    path = url.split(/[?#]/)[0] ?? url;
+  }
+  const parts = path.split('/').filter(Boolean);
   return parts.length ? decodeURIComponent(parts[parts.length - 1]!) : '';
 }
 

--- a/src/ui/cloud/WorkspaceMembersSection.tsx
+++ b/src/ui/cloud/WorkspaceMembersSection.tsx
@@ -1,0 +1,229 @@
+/**
+ * Workspace members + invites (JP-370).
+ *
+ * Rendered inside the signed-in Cloud panel. Any member sees the roster; the
+ * workspace **owner** additionally gets shareable invite links (create / copy /
+ * revoke) and can remove members. Talks to `docushark-web` via `webClient` with
+ * the cached relay token. Best-effort: a load failure shows an inline note
+ * rather than breaking the panel (self-host / offline have no control plane).
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Copy, Loader2, RefreshCw, Trash2, UserPlus } from 'lucide-react';
+import {
+  webClient,
+  type WorkspaceMember,
+  type WorkspaceInvite,
+} from '../../api/webClient';
+import { useNotificationStore } from '../../store/notificationStore';
+import { confirmDialog } from '../../ui/confirm/confirmStore';
+
+interface WorkspaceMembersSectionProps {
+  /** True when the signed-in user is the workspace owner (invite/remove gating). */
+  isOwner: boolean;
+  /** The signed-in user's id (so they can't remove themselves). */
+  currentUserId: string | undefined;
+}
+
+export function WorkspaceMembersSection({ isOwner, currentUserId }: WorkspaceMembersSectionProps) {
+  const [members, setMembers] = useState<WorkspaceMember[]>([]);
+  const [invites, setInvites] = useState<WorkspaceInvite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [inviteRole, setInviteRole] = useState<'member' | 'viewer'>('member');
+  const [creating, setCreating] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const roster = await webClient.getWorkspaceMembers();
+      setMembers(roster);
+      // Pending invites are owner-only on the server; only fetch them if owner.
+      if (isOwner) {
+        setInvites(await webClient.listInvites());
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load members');
+    } finally {
+      setLoading(false);
+    }
+  }, [isOwner]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const copyLink = useCallback((url: string) => {
+    void navigator.clipboard?.writeText(url).then(
+      () => useNotificationStore.getState().success('Invite link copied to clipboard'),
+      () => useNotificationStore.getState().info(`Invite link: ${url}`),
+    );
+  }, []);
+
+  const handleCreateInvite = useCallback(async () => {
+    setCreating(true);
+    try {
+      const invite = await webClient.createInvite(inviteRole);
+      setInvites((prev) => [invite, ...prev]);
+      copyLink(invite.url);
+    } catch (err) {
+      useNotificationStore
+        .getState()
+        .error(err instanceof Error ? err.message : 'Could not create an invite link');
+    } finally {
+      setCreating(false);
+    }
+  }, [inviteRole, copyLink]);
+
+  const handleRevokeInvite = useCallback(async (token: string) => {
+    // Extract the token from the invite URL's last path segment.
+    try {
+      await webClient.revokeInvite(token);
+      setInvites((prev) => prev.filter((i) => inviteToken(i.url) !== token));
+    } catch (err) {
+      useNotificationStore
+        .getState()
+        .error(err instanceof Error ? err.message : 'Could not revoke the invite');
+    }
+  }, []);
+
+  const handleRemoveMember = useCallback(async (member: WorkspaceMember) => {
+    const ok = await confirmDialog({
+      title: `Remove ${member.displayName}?`,
+      message: 'They lose access to this workspace and its shared documents.',
+      details: 'They keep any local copies already on their device. You can re-invite them later.',
+      confirmLabel: 'Remove member',
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await webClient.removeMember(member.userId);
+      setMembers((prev) => prev.filter((m) => m.userId !== member.userId));
+    } catch (err) {
+      useNotificationStore
+        .getState()
+        .error(err instanceof Error ? err.message : 'Could not remove the member');
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="cloud-connect__members cloud-connect__members--loading">
+        <Loader2 size={14} className="cloud-connect__spin" /> Loading members…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="cloud-connect__members">
+        <div className="cloud-connect__members-header">
+          <h4>Members</h4>
+          <button type="button" className="cloud-connect__icon-btn" onClick={() => void load()} title="Retry">
+            <RefreshCw size={14} />
+          </button>
+        </div>
+        <p className="cloud-connect__members-note">Couldn’t load workspace members ({error}).</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="cloud-connect__members">
+      <div className="cloud-connect__members-header">
+        <h4>Members ({members.length})</h4>
+        <button type="button" className="cloud-connect__icon-btn" onClick={() => void load()} title="Refresh">
+          <RefreshCw size={14} />
+        </button>
+      </div>
+
+      <ul className="cloud-connect__member-list">
+        {members.map((m) => (
+          <li key={m.userId} className="cloud-connect__member">
+            <div className="cloud-connect__member-id">
+              <span className="cloud-connect__member-name">{m.displayName}</span>
+              {m.email ? <span className="cloud-connect__member-email">{m.email}</span> : null}
+            </div>
+            <span className="cloud-connect__member-role">{m.role}</span>
+            {isOwner && m.role !== 'owner' && m.userId !== currentUserId ? (
+              <button
+                type="button"
+                className="cloud-connect__icon-btn cloud-connect__icon-btn--danger"
+                onClick={() => void handleRemoveMember(m)}
+                title={`Remove ${m.displayName}`}
+              >
+                <Trash2 size={14} />
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+
+      {isOwner ? (
+        <div className="cloud-connect__invites">
+          <div className="cloud-connect__invite-create">
+            <select
+              className="cloud-connect__invite-role"
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as 'member' | 'viewer')}
+              disabled={creating}
+              aria-label="Invite role"
+            >
+              <option value="member">Member (can edit shared docs)</option>
+              <option value="viewer">Viewer (read-only)</option>
+            </select>
+            <button
+              type="button"
+              className="cloud-connect__btn cloud-connect__btn--secondary"
+              onClick={() => void handleCreateInvite()}
+              disabled={creating}
+            >
+              {creating ? <Loader2 size={14} className="cloud-connect__spin" /> : <UserPlus size={14} />}
+              Create invite link
+            </button>
+          </div>
+
+          {invites.length > 0 ? (
+            <ul className="cloud-connect__invite-list">
+              {invites.map((inv) => (
+                <li key={inv.id} className="cloud-connect__invite">
+                  <span className="cloud-connect__invite-role-tag">{inv.role}</span>
+                  <code className="cloud-connect__invite-url" title={inv.url}>
+                    {inv.url}
+                  </code>
+                  <button
+                    type="button"
+                    className="cloud-connect__icon-btn"
+                    onClick={() => copyLink(inv.url)}
+                    title="Copy link"
+                  >
+                    <Copy size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    className="cloud-connect__icon-btn cloud-connect__icon-btn--danger"
+                    onClick={() => void handleRevokeInvite(inviteToken(inv.url))}
+                    title="Revoke invite"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          <p className="cloud-connect__members-note">
+            Anyone with an invite link can join this workspace until it expires or is revoked.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** The opaque token is the last path segment of the invite URL. */
+function inviteToken(url: string): string {
+  const parts = url.split('/').filter(Boolean);
+  return parts.length ? decodeURIComponent(parts[parts.length - 1]!) : '';
+}
+
+export default WorkspaceMembersSection;

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -11,6 +11,7 @@ import { useRef, useEffect, useState } from 'react';
 import { ChevronDown, MoreHorizontal, X } from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
 import { DocumentBackupsDrawer } from '../DocumentBackupsDrawer';
+import { DocumentPermissionsDialog } from '../DocumentPermissionsDialog';
 import { COLLECTION_SWATCHES, type Collection } from '../../store/collectionStore';
 import type { DocumentBrowserView } from '../../store/uiPreferencesStore';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
@@ -66,6 +67,7 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
     handleDelete,
     handlePermanentDelete,
     handleRename,
+    permissionsDocId,
     setPermissionsDocId,
     isInTeamMode,
     relaySessionUsable,
@@ -173,6 +175,12 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
           docId={backupsDocId}
           docName={backupsDoc?.name ?? 'Document'}
           onClose={() => setBackupsDocId(null)}
+        />
+      )}
+      {permissionsDocId && (
+        <DocumentPermissionsDialog
+          documentId={permissionsDocId}
+          onClose={() => setPermissionsDocId(null)}
         />
       )}
     </>


### PR DESCRIPTION
Part of **JP-370 — Document Access Logic + UX** (editor slice PR-3b). Standalone off `master`. Builds on relay #302, web #60, cache #303 (all merged).

## What
Wires the actual share/access UX onto the relay + web backends.

- **`src/api/webClient.ts` (new)** — the editor's client for the `docushark-web` workspace/invite endpoints (roster, invites CRUD, `listWorkspaces`), authenticating with the **cached relay token** (the only credential the editor holds; the web verifies it via its own JWKS). Parallel to `relayClient`; injectable `fetch`/`baseUrl`/`token` for tests.
- **`DocumentPermissionsDialog`** — replaces the hand-typed user-id form (the "super buggy" path the issue calls out) with a **workspace-member picker** fed by `webClient.getWorkspaceMembers`, filtered to members not already on the doc. And it's **actually rendered now**: `DocumentList` mounts it from the existing `onEditPermissions`/`permissionsDocId` seam (it was orphaned).
- **`CloudConnectPanel`** — new **`WorkspaceMembersSection`** (Cloud sessions): the roster, and for the **owner**, create/copy/revoke **shareable invite links** + remove members (`confirmDialog`-gated). + CSS.
- **`collaborationStore.onError`** — handles the relay's `ERR_VIEW_FORBIDDEN` (private-doc denial from #302): strands the local copy to Trash like a deletion and toasts "you no longer have access," instead of a silently-dead sync session.

## Verification
`tsc` + full `vitest` (**2639 tests**, +6 new `webClient` tests) + `bun run build` — all green. `importBoundary` clean (webClient imports no platform/Tauri code).

## Follow-up
The workspace **switcher** (multi-workspace) + the `documentRegistry`/`TrashStorage` workspace-scoping land in **PR-3c**, gated before the switcher is wired.

Assisted-by: Opus 4.8