### PR TITLE
JP-370 review hardening (app): collection-list filter + MCP gate tests + cache-helper tests

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1308,17 +1308,30 @@ async fn list_collection_docs_handler(
         Ok(c) => c,
         Err(resp) => return resp,
     };
-    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
     // Repopulate the workspace index from R2 on a cold machine first (best-effort).
     state.ensure_workspace_index_local(&ws).await;
+    // JP-370: when private-doc enforcement is on, this browse listing is filtered
+    // to documents the caller may read — the same owner/share rule as
+    // GET /api/docs. Without it, the collection view leaked every private doc's
+    // metadata (including its share list) to any workspace member.
+    let enforce = state.enforce_private_docs();
     let docs: Vec<_> = state
         .doc_store()
         .list_documents(&ws)
         .into_iter()
         .filter(|d| d.collection_id.as_deref() == Some(collection_id.as_str()))
+        .filter(|d| {
+            !enforce
+                || crate::server::permissions::get_user_permission(
+                    d,
+                    &claims.sub,
+                    Some(role_str(role)),
+                ) != crate::server::permissions::Permission::None
+        })
         .collect();
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
 }

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -3796,6 +3796,23 @@ mod tests {
             }
         }
 
+        /// JP-370: a ToolContext as a specific JWT-authed user with the
+        /// per-document gate enabled (vs `ctx`'s static-token, gate-off shape).
+        fn ctx_as(&self, user_id: &str, role: &str, enforce: bool) -> ToolContext<'_> {
+            ToolContext {
+                team: &self.team,
+                local: &self.local,
+                local_enabled: false,
+                workspace_id: WorkspaceId::single_tenant(),
+                user_id: Some(user_id.to_string()),
+                user_role: Some(role.to_string()),
+                enforce_private_docs: enforce,
+                registry: &self.registry,
+                on_doc_update: &*self.on_doc_update,
+                on_doc_deleted: &self.on_doc_deleted,
+            }
+        }
+
         /// Hydrate a team doc into the registry so it counts as "live"
         /// (resident on its active page) — exercises the JP-35 Y.Doc path.
         fn make_resident(&self, doc_id: &str) -> Arc<DocHandle> {
@@ -6250,5 +6267,131 @@ mod tests {
         assert!(markdown_to_html("- a\n  b\n").contains("a\nb"));
         // Loose list (blank line between items) → newline inside an explicit <p>.
         assert!(markdown_to_html("- a\n  b\n\n- c\n").contains("<p>a\nb</p>"));
+    }
+
+    // ───────────────────── JP-370: MCP per-document gate ─────────────────────
+
+    /// Every advertised tool must have an explicit permission classification —
+    /// and no doc-mutating tool may fall into the read/none buckets. This is the
+    /// guard against a future tool silently shipping with no write-gate: add a
+    /// tool to `descriptors()` without classifying it and (because the catch-all
+    /// is Editor) it's gated as a write — this test pins the intended mapping so
+    /// a *read* tool added to the write bucket (or vice-versa) is caught.
+    #[test]
+    fn every_tool_has_an_intended_permission_classification() {
+        use crate::server::permissions::Permission;
+        let reads = [
+            "docushark_get_document",
+            "docushark_get_page",
+            "docushark_get_shape",
+            "docushark_get_prose",
+            "docushark_get_outline",
+            "docushark_list_references",
+            "docushark_list_fields",
+        ];
+        let no_doc = [
+            "docushark_list_documents",
+            "docushark_create_document",
+            "docushark_get_skills",
+            "docushark_list_icons",
+            "docushark_resolve_doi",
+        ];
+        for d in descriptors() {
+            let got = tool_required_permission(d.name);
+            if reads.contains(&d.name) {
+                assert_eq!(got, Some(Permission::Viewer), "{} should be a read", d.name);
+            } else if no_doc.contains(&d.name) {
+                assert_eq!(got, None, "{} targets no single doc", d.name);
+            } else if d.name == "docushark_delete_document" {
+                assert_eq!(got, Some(Permission::Owner), "delete is owner-only");
+            } else {
+                // Every other advertised tool mutates a document → Editor.
+                assert_eq!(got, Some(Permission::Editor), "{} should require Editor", d.name);
+            }
+        }
+    }
+
+    /// Seed a doc owned by someone else (no shares) and confirm the gate denies a
+    /// plain workspace member's read AND write via `dispatch`, then a `view`
+    /// share lets the read through.
+    #[tokio::test]
+    async fn jwt_caller_is_gated_on_a_private_doc() {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let f = seed(&dir);
+        let ws = WorkspaceId::single_tenant();
+        // An owned, unshared doc (distinct from the fixture's owner-less doc1).
+        f.team
+            .save_document(
+                &ws,
+                json!({
+                    "id": "owned1", "name": "Owner's doc", "ownerId": "owner-1",
+                    "version": 1, "createdAt": 1u64, "modifiedAt": 1u64,
+                    "activePageId": "p1", "pageOrder": ["p1"],
+                    "pages": { "p1": { "id": "p1", "name": "P", "shapes": {}, "shapeOrder": [] } },
+                }),
+            )
+            .unwrap();
+
+        let member = f.ctx_as("member-2", "member", true);
+        let args = json!({ "docId": "owned1" });
+
+        assert!(
+            dispatch(&member, "docushark_get_document", &args).is_err(),
+            "unshared member must be denied read"
+        );
+        assert!(
+            dispatch(&member, "docushark_rename_document", &json!({ "docId": "owned1", "name": "x" }))
+                .is_err(),
+            "unshared member must be denied write"
+        );
+
+        // Owner-role caller (workspace owner/admin) is allowed by the role short-circuit.
+        let owner = f.ctx_as("someone", "owner", true);
+        assert!(dispatch(&owner, "docushark_get_document", &args).is_ok());
+
+        // Grant member-2 a view share → read now allowed, write still denied.
+        f.team
+            .update_document_shares(
+                &ws,
+                &DocId::from_http_path("owned1".into()).unwrap(),
+                &[crate::server::protocol::ShareEntry {
+                    user_id: "member-2".into(),
+                    user_name: "Member".into(),
+                    permission: "view".into(),
+                }],
+            )
+            .unwrap();
+        assert!(dispatch(&member, "docushark_get_document", &args).is_ok(), "view share allows read");
+        assert!(
+            dispatch(&member, "docushark_rename_document", &json!({ "docId": "owned1", "name": "x" }))
+                .is_err(),
+            "a viewer still can't write"
+        );
+    }
+
+    /// The static loopback token (no user identity) bypasses the gate even with
+    /// enforcement on — preserving the desktop / self-host flow.
+    #[tokio::test]
+    async fn static_token_bypasses_the_gate() {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let f = seed(&dir);
+        f.team
+            .save_document(
+                &WorkspaceId::single_tenant(),
+                json!({
+                    "id": "owned1", "name": "Owner's doc", "ownerId": "owner-1",
+                    "version": 1, "createdAt": 1u64, "modifiedAt": 1u64,
+                    "activePageId": "p1", "pageOrder": ["p1"],
+                    "pages": { "p1": { "id": "p1", "name": "P", "shapes": {}, "shapeOrder": [] } },
+                }),
+            )
+            .unwrap();
+        // ctx() has user_id = None (static token) — enforcement is irrelevant.
+        let mut ctx = f.ctx(false);
+        ctx.enforce_private_docs = true;
+        assert!(
+            dispatch(&ctx, "docushark_get_document", &json!({ "docId": "owned1" })).is_ok(),
+            "static loopback token must bypass the per-doc gate"
+        );
     }
 }

--- a/src/store/activeWorkspace.test.ts
+++ b/src/store/activeWorkspace.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { activeWorkspaceId, DEFAULT_WORKSPACE_ID } from './activeWorkspace';
+import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
+import { useConnectionStore } from './connectionStore';
+
+/** Build an unsigned JWT (header.payload.sig) — the decoder never verifies. */
+function tokenWith(payload: Record<string, unknown>): string {
+  const b64url = (o: unknown) =>
+    btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${b64url({ alg: 'RS256' })}.${b64url(payload)}.sig`;
+}
+
+describe('workspaceIdFromRelayToken', () => {
+  it('returns the first workspace claim id', () => {
+    expect(workspaceIdFromRelayToken(tokenWith({ wsp: [{ id: 'ws-a', role: 'owner' }] }))).toBe('ws-a');
+  });
+
+  it('returns null when there is no usable wsp claim', () => {
+    expect(workspaceIdFromRelayToken(tokenWith({ sub: 'u1' }))).toBeNull(); // no wsp
+    expect(workspaceIdFromRelayToken(tokenWith({ wsp: [] }))).toBeNull(); // empty
+    expect(workspaceIdFromRelayToken(tokenWith({ wsp: [{ role: 'owner' }] }))).toBeNull(); // no id
+  });
+
+  it('returns null for a malformed / missing token', () => {
+    expect(workspaceIdFromRelayToken('not-a-jwt')).toBeNull();
+    expect(workspaceIdFromRelayToken('')).toBeNull();
+    expect(workspaceIdFromRelayToken(null)).toBeNull();
+    expect(workspaceIdFromRelayToken(undefined)).toBeNull();
+  });
+});
+
+describe('activeWorkspaceId', () => {
+  beforeEach(() => {
+    useConnectionStore.getState().reset();
+  });
+
+  it('resolves the workspace id from the live token', () => {
+    useConnectionStore.getState().setToken(tokenWith({ wsp: [{ id: 'ws-live', role: 'member' }] }));
+    expect(activeWorkspaceId()).toBe('ws-live');
+  });
+
+  it('falls back to the single-tenant default when there is no token / no claim', () => {
+    expect(activeWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID);
+    useConnectionStore.getState().setToken(tokenWith({ sub: 'u1' })); // no wsp
+    expect(activeWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID);
+  });
+});


### PR DESCRIPTION
Post-review hardening for the merged JP-370 app-side work (relay enforcement #302, cache scoping #303). From the session's adversarial code review.

## Changes
- **relay — collection-listing leak (was High).** `GET /api/collections/:id/documents` filtered only by `collection_id`, **not** by read permission — so with `enforce_private_docs` ON it returned every private doc's metadata (including its `sharedWith` list) to any workspace member. Now filtered with the same `get_user_permission != None` rule as `GET /api/docs`. (The sibling listing was missed when the flag landed.)
- **relay — MCP gate test coverage (was a real gap).** The MCP per-document gate had **zero** tests. Added:
  - a **classification guard**: every advertised tool maps to its intended permission (reads=Viewer, delete=Owner, no-doc=None, everything else=Editor) — so a future *write* tool can't silently ship in the read/none bucket;
  - a **gate test** via `dispatch`: an unshared member is denied read **and** write, an owner-role caller is allowed, and a `view` share allows read but still denies write;
  - the **static-loopback-token bypass** (no user identity → admin, preserving desktop/self-host).
- **editor — cache-helper tests.** Unit tests for `workspaceIdFromRelayToken` + `activeWorkspaceId`, covering the load-bearing `'default'` single-tenant fallback that was untested.

## Note (intentionally not changed)
The WS-join role string (`"member"`) differs from the REST permission-input `role_str` (`"user"`). The reviewer flagged unifying them, but they're isolated vocabularies and `get_user_permission` only elevates `owner`/`admin`, so they're behaviorally identical — and the WS spelling matches the JWT claim the REST-only sign-in surfaces to the client, so unifying would *diverge* the client-visible role. Left as-is + documented.

## Verification
`cargo test --lib` (543) + `cargo build --bin relay` + `cargo clippy` clean; editor `tsc` + full `vitest` green.

## Still tracked (not in this PR)
- **C1 (blob bytes under enforcement)** — a private doc's images/attachments are workspace-scoped, not doc-scoped, so they stay readable by any member when the flag is ON. Not live (flag default OFF). Assessment in progress; must close before enabling `enforce_private_docs` in Cloud.

Assisted-by: Opus 4.8