### PR TITLE
relay: gate blob reads on per-document access under enforcement (JP-370 C1)

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -158,6 +158,44 @@ fn is_valid_blob_hash(hash: &str) -> bool {
     hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
+/// JP-370 (C1): may this caller read the bytes of `hash`? When private-doc
+/// enforcement is off, blob access stays workspace-scoped (legacy). When on, the
+/// caller must be able to read at least one document in the workspace that
+/// references the blob — otherwise a member denied a private doc could still
+/// fetch its images/attachments by content hash (blob hashes are derivable and
+/// shared workspace-wide). An orphan blob (no referencing doc) is readable only
+/// by a workspace owner/admin, mirroring the unowned-doc rule.
+fn caller_can_read_blob(
+    state: &Arc<ServerState>,
+    ws: &WorkspaceId,
+    hash: &str,
+    sub: &str,
+    role: WorkspaceRole,
+) -> bool {
+    if !state.enforce_private_docs() {
+        return true;
+    }
+    let role = role_str(role);
+    // Owner/admin can always read (manages the whole workspace).
+    if role == "owner" || role == "admin" {
+        return true;
+    }
+    let referencing = state.blob_store().docs_referencing(ws, hash);
+    referencing.iter().any(|doc_id| {
+        match DocId::from_http_path(doc_id.clone()) {
+            Ok(doc_id) => state
+                .doc_store()
+                .get_metadata(ws, &doc_id)
+                .map(|m| {
+                    crate::server::permissions::get_user_permission(&m, sub, Some(role))
+                        != crate::server::permissions::Permission::None
+                })
+                .unwrap_or(false),
+            Err(_) => false,
+        }
+    })
+}
+
 /// Stringified role value used by the permissions layer.
 fn role_str(role: WorkspaceRole) -> &'static str {
     match role {
@@ -644,7 +682,7 @@ async fn blob_download_url_handler(
         Ok(c) => c,
         Err(resp) => return resp,
     };
-    let (ws, _role, _limits) = match resolve_workspace(&state, &claims) {
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
         Ok(v) => v,
         Err(resp) => return resp,
     };
@@ -664,6 +702,15 @@ async fn blob_download_url_handler(
     // reads as a plain 404 (never leaks that the blob exists elsewhere) — the
     // same gate the 302 download handler uses.
     if !state.blob_store().exists(&ws, &hash) {
+        return (StatusCode::NOT_FOUND, ApiError::body("blob not found")).into_response();
+    }
+
+    // JP-370 (C1): when private-doc enforcement is on, gate the read on the
+    // caller being able to read at least one document that references this blob —
+    // otherwise a member denied a private doc could still fetch its images /
+    // attachments by content hash. Opaque 404 (same shape as the ACL miss above),
+    // so it never reveals the blob exists for docs the caller can't see.
+    if !caller_can_read_blob(&state, &ws, &hash, &claims.sub, role) {
         return (StatusCode::NOT_FOUND, ApiError::body("blob not found")).into_response();
     }
 

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -450,6 +450,23 @@ impl BlobStore {
             .unwrap_or_default()
     }
 
+    /// The ids of documents in `ws` that reference `hash` (JP-370). Reverse of
+    /// the `doc_refs` map; used by the blob read gate to decide whether a caller
+    /// who may read at least one referencing document may fetch the bytes. An
+    /// empty result means no document references it (an orphan, or unknown hash).
+    pub fn docs_referencing(&self, ws: &WorkspaceId, hash: &str) -> Vec<String> {
+        self.doc_refs
+            .read()
+            .ok()
+            .map(|refs| {
+                refs.iter()
+                    .filter(|((w, _doc), hashes)| w == ws && hashes.contains(hash))
+                    .map(|((_w, doc), _hashes)| doc.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Load the per-document blob-reference map from disk (JP-120). Absent
     /// sidecar = empty map; `ServerState` seeds it from existing docs at
     /// startup, so a cold boot still ends up with a complete map.
@@ -1371,6 +1388,34 @@ impl BlobStore {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    // JP-370 (C1): the reverse lookup powering the blob read gate — which docs
+    // in a workspace reference a given hash, scoped to that workspace.
+    #[test]
+    fn docs_referencing_is_workspace_scoped_reverse_of_doc_refs() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let alpha = WorkspaceId::from_configured("alpha").unwrap();
+        let beta = WorkspaceId::from_configured("beta").unwrap();
+        let h = "a".repeat(64);
+        let other = "b".repeat(64);
+
+        // alpha: doc1 + doc2 reference h; doc3 references only `other`.
+        store.sync_doc_refs(&alpha, "doc1", HashSet::from([h.clone()])).unwrap();
+        store.sync_doc_refs(&alpha, "doc2", HashSet::from([h.clone(), other.clone()])).unwrap();
+        store.sync_doc_refs(&alpha, "doc3", HashSet::from([other.clone()])).unwrap();
+        // beta references h from its own doc — must NOT bleed into alpha's result.
+        store.sync_doc_refs(&beta, "bdoc", HashSet::from([h.clone()])).unwrap();
+
+        let mut got = store.docs_referencing(&alpha, &h);
+        got.sort();
+        assert_eq!(got, vec!["doc1".to_string(), "doc2".to_string()]);
+
+        // An orphan / unknown hash → no referencing docs.
+        assert!(store.docs_referencing(&alpha, &"c".repeat(64)).is_empty());
+        // Cross-workspace isolation: beta's reference is invisible to alpha.
+        assert_eq!(store.docs_referencing(&beta, &h), vec!["bdoc".to_string()]);
+    }
 
     #[test]
     fn test_compute_hash() {


### PR DESCRIPTION
Closes the one **Critical-if-enabled** finding from the session's security review. Standalone off `master`.

## The leak
With `enforce_private_docs` ON, the document *body* became private (WS-join + REST + MCP gated by #302/#305) — but its **blob bytes** (images, file attachments) stayed workspace-scoped. A member denied a private doc could still fetch its blobs via `POST /api/v1/blobs/:hash/download-url`, because blob hashes are content-derived and shared workspace-wide. The doc was private; its pictures weren't.

Not live (the flag is default-OFF and not yet enabled in Cloud), but a hard blocker before turning enforcement on.

## Fix
- `BlobStore::docs_referencing(ws, hash)` — reverse of the per-doc `doc_refs` map: which documents in a workspace reference a hash (workspace-scoped).
- `download-url` now gates the presigned GET on the caller being able to read **at least one referencing document** (owner/admin always; otherwise `get_user_permission != None`). Orphan/unknown hash → opaque 404, the same shape as the existing ACL miss, so it never reveals the blob exists for docs the caller can't see.
- Flag OFF (default) → unchanged workspace-scoped behavior. The write paths (`upload-url`/`finalize`) and `ingest-from-url` aren't read-leaks and are untouched.

## Verification
`cargo build --bin relay` + `cargo clippy` clean; relay lib suite green; new `docs_referencing` unit test (workspace-scoped reverse lookup, orphan-empty, cross-workspace isolation).

## Note
This is the last of the review's blocking items before `enforce_private_docs` can be enabled in Cloud. The presigned-GET path is the only blob **read** route in the relay router; the filesystem self-host path has no GET proxy here.

Assisted-by: Opus 4.8