### PR TITLE
Enforce + reflect viewer read-only on shared documents (JP-370)

### DIFF
--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -283,6 +283,18 @@ async fn run_serve(
         config.tenancy.workspace_id.as_deref().unwrap_or(""),
         region,
     );
+    // JP-370: make the access-control posture loud at boot. OFF (the default) is
+    // the correct self-host story, but on a multi-tenant/Cloud pod it means any
+    // workspace member can read AND write any document — easy to forget to flip.
+    if config.permissions.enforce_private_docs {
+        log::info!("permissions: per-document access enforcement ENABLED (private-by-default)");
+    } else {
+        log::warn!(
+            "permissions: per-document access enforcement is DISABLED — any workspace member \
+             can read and write any document (owner/editor/viewer shares are NOT enforced). \
+             Set [permissions] enforce_private_docs = true (or RELAY_ENFORCE_PRIVATE_DOCS=1) to enable."
+        );
+    }
     #[cfg(debug_assertions)]
     if let Some(trigger) = panic_tenant {
         log::warn!(

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -3171,12 +3171,25 @@ async fn handle_sync_chunk(client_id: u64, data: &[u8], state: &Arc<ServerState>
 /// broadcast. Over-quota frames are silently dropped (the sender gets
 /// an ERROR frame); the connection isn't closed.
 async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
-    let (doc_id, workspace_id): (Option<DocId>, WorkspaceId) = {
+    #[allow(clippy::type_complexity)]
+    let (doc_id, workspace_id, user_id, role): (
+        Option<DocId>,
+        WorkspaceId,
+        Option<String>,
+        Option<String>,
+    ) = {
         let clients = state.clients.read().await;
         clients
             .get(&client_id)
-            .map(|c| (c.current_doc_id.clone(), c.current_workspace_id.clone()))
-            .unwrap_or_else(|| (None, WorkspaceId::single_tenant()))
+            .map(|c| {
+                (
+                    c.current_doc_id.clone(),
+                    c.current_workspace_id.clone(),
+                    c.user_id.clone(),
+                    c.role.clone(),
+                )
+            })
+            .unwrap_or_else(|| (None, WorkspaceId::single_tenant(), None, None))
     };
 
     if state.write_limiter().check_key(&workspace_id).is_err() {
@@ -3199,6 +3212,40 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
     // (re)JOIN and strands its copy; any in-flight SYNC frames are simply dropped.
     if state.doc_store().is_deleted(&workspace_id, &doc_id) {
         return;
+    }
+
+    // JP-370: write gate on the LIVE edit path. The JOIN_DOC read gate lets a
+    // viewer in (they may read), but live edits flow here as Yjs SYNC frames —
+    // and a viewer must not mutate the doc. Gate only WRITE-bearing frames: the
+    // Yjs sync sub-type is `data[1]` (0 = SyncStep1, a read/state-vector request
+    // we must always allow so a viewer can receive state; 1 = SyncStep2, 2 =
+    // Update — both carry the client's updates). A non-editor's write frame is
+    // dropped before it touches the authoritative Y.Doc, and the client is told
+    // it's view-only (ERR_EDIT_FORBIDDEN). Behind `enforce_private_docs` to match
+    // the read gate — flag-off keeps the legacy open-editing behavior.
+    if state.enforce_private_docs() && data.len() > 1 && data[1] != 0 {
+        if let Err(e) = crate::server::permissions::check_write_permission(
+            state.doc_store(),
+            &workspace_id,
+            &doc_id,
+            user_id.as_deref(),
+            role.as_deref(),
+        ) {
+            log::info!(
+                "dropping SYNC write (edit forbidden) client_id={} workspace_id={} doc_id={}",
+                client_id,
+                workspace_id.as_str(),
+                doc_id.as_str(),
+            );
+            let err = ErrorResponse {
+                request_id: None,
+                error: crate::server::permissions::to_error_string(&e),
+            };
+            if let Ok(data) = encode_message(MESSAGE_ERROR, &err) {
+                send_to_client(client_id, data, state).await;
+            }
+            return;
+        }
     }
 
     // JP-34: apply the frame to the authoritative Y.Doc, then answer/broadcast.
@@ -4029,6 +4076,107 @@ mod tests {
                 .map(|d| d.as_str().to_string())
         };
         assert_eq!(cur.as_deref(), Some("private-doc"), "shared member must join");
+    }
+
+    /// JP-370: the LIVE edit path (WS SYNC) gates writes too — a viewer who can
+    /// read (and join) must not be able to mutate via SYNC frames. A
+    /// write-bearing frame (Yjs sub-type ≠ 0) from a non-editor is dropped with
+    /// ERR_EDIT_FORBIDDEN; a SyncStep1 (sub-type 0, a read) is always allowed;
+    /// an editor's write passes.
+    #[tokio::test]
+    async fn handle_sync_gates_writes_by_permission() {
+        let state = test_server_state_with(TenancyConfig::default(), true).await;
+        let ws = WorkspaceId::single_tenant();
+        // Doc owned by owner-1, shared with viewer-2 (view) and editor-3 (edit).
+        // Shares go through update_document_shares (the share API) — that's what
+        // populates metadata.shared_with that the permission check reads.
+        state
+            .doc_store
+            .save_document(
+                &ws,
+                serde_json::json!({
+                    "id": "doc1", "name": "Doc", "ownerId": "owner-1",
+                    "pageOrder": ["p1"], "pages": {}, "createdAt": 1u64, "modifiedAt": 1u64,
+                }),
+            )
+            .expect("save");
+        state
+            .doc_store
+            .update_document_shares(
+                &ws,
+                &DocId::from_http_path("doc1".to_string()).unwrap(),
+                &[
+                    crate::server::protocol::ShareEntry {
+                        user_id: "viewer-2".into(),
+                        user_name: "V".into(),
+                        permission: "view".into(),
+                    },
+                    crate::server::protocol::ShareEntry {
+                        user_id: "editor-3".into(),
+                        user_name: "E".into(),
+                        permission: "edit".into(),
+                    },
+                ],
+            )
+            .expect("share");
+
+        // Helper: register a joined client and return its id + receiver.
+        async fn join(state: &Arc<ServerState>, uid: &str) -> (u64, mpsc::Receiver<Vec<u8>>) {
+            let (tx, rx) = mpsc::channel(8);
+            let client_id = state.next_client_id();
+            let mut clients = state.clients.write().await;
+            clients.insert(
+                client_id,
+                ClientState {
+                    id: client_id,
+                    user_id: Some(uid.to_string()),
+                    username: None,
+                    role: Some("user".to_string()),
+                    current_doc_id: Some(DocId::from_http_path("doc1".to_string()).unwrap()),
+                    current_workspace_id: WorkspaceId::single_tenant(),
+                    authenticated: true,
+                    jti: None,
+                    token_exp: None,
+                    tx,
+                    reassembly: chunk::ChunkReassembler::default(),
+                },
+            );
+            (client_id, rx)
+        }
+
+        // A write-bearing Yjs frame (sub-type 2 = Update) — dummy bytes; the gate
+        // runs on data[1] BEFORE any decode, so validity doesn't matter here.
+        let write_frame = vec![MESSAGE_SYNC, 2u8, 0u8, 0u8];
+        // A SyncStep1 read frame (sub-type 0).
+        let read_frame = vec![MESSAGE_SYNC, 0u8, 0u8];
+
+        let is_edit_forbidden = |frame: &[u8]| -> bool {
+            decode_message_type(frame) == Some(MESSAGE_ERROR)
+                && decode_payload::<ErrorResponse>(frame)
+                    .map(|e| e.error.starts_with("ERR_EDIT_FORBIDDEN"))
+                    .unwrap_or(false)
+        };
+
+        // Viewer write → dropped with ERR_EDIT_FORBIDDEN.
+        let (viewer, mut vrx) = join(&state, "viewer-2").await;
+        handle_sync(viewer, &write_frame, &state).await;
+        let got = vrx.try_recv().expect("viewer write should get an error frame");
+        assert!(is_edit_forbidden(&got), "expected ERR_EDIT_FORBIDDEN, got {got:?}");
+
+        // Viewer SyncStep1 (read) → allowed (no error frame).
+        handle_sync(viewer, &read_frame, &state).await;
+        assert!(
+            vrx.try_recv().map(|f| !is_edit_forbidden(&f)).unwrap_or(true),
+            "a viewer's SyncStep1 must not be edit-forbidden",
+        );
+
+        // Editor write → passes the gate (no ERR_EDIT_FORBIDDEN).
+        let (editor, mut erx) = join(&state, "editor-3").await;
+        handle_sync(editor, &write_frame, &state).await;
+        assert!(
+            erx.try_recv().map(|f| !is_edit_forbidden(&f)).unwrap_or(true),
+            "an editor's write must not be edit-forbidden",
+        );
     }
 
     /// Phase 21.3: per-workspace connection cap is enforced atomically

--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -12,6 +12,7 @@ import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { isGroup, type RectangleShape } from '../shapes/Shape';
 import { useWhiteboardStore } from '../store/whiteboardStore';
+import { isActiveDocReadOnly } from '../store/documentRegistry';
 import { opener } from '../platform/opener';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
@@ -201,10 +202,14 @@ function buildCommands(): Command[] {
     {
       id: 'edit.undo', label: 'Undo', category: 'Editing', keys: 'Mod+Z', scope: 'canvas',
       execute: () => { if (useHistoryStore.getState().canUndo()) useHistoryStore.getState().undo(); },
+      // JP-370: undo/redo aren't selection-gated, so the read-only clear-selection
+      // trick doesn't cover them — block them on a view-only doc.
+      canExecute: () => !isActiveDocReadOnly() && useHistoryStore.getState().canUndo(),
     },
     {
       id: 'edit.redo', label: 'Redo', category: 'Editing', keys: 'Mod+Shift+Z | Mod+Y', scope: 'canvas',
       execute: () => { if (useHistoryStore.getState().canRedo()) useHistoryStore.getState().redo(); },
+      canExecute: () => !isActiveDocReadOnly() && useHistoryStore.getState().canRedo(),
     },
     { id: 'edit.selectAll', label: 'Select all', category: 'Editing', keys: 'Mod+A', scope: 'canvas', execute: () => useSessionStore.getState().selectAll() },
     {
@@ -257,6 +262,8 @@ function buildCommands(): Command[] {
     {
       id: 'edit.paste', label: 'Paste', category: 'Editing', keys: 'Mod+V', scope: 'canvas',
       execute: () => window.dispatchEvent(new CustomEvent('docushark:paste-shapes')),
+      // JP-370: paste isn't selection-gated either (the engine also guards).
+      canExecute: () => !isActiveDocReadOnly(),
     },
     {
       id: 'edit.group', label: 'Group selected shapes', category: 'Editing', keys: 'Mod+G', scope: 'canvas',

--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -140,6 +140,16 @@ export class Engine {
   readonly spatialIndex: SpatialIndex;
   readonly hitTester: HitTester;
   readonly toolManager: ToolManager;
+  /**
+   * JP-370: read-only mode (the active doc is view-only for this user). Forces
+   * the 'pan' tool and blocks switching to any mutating tool, so pointer input
+   * can pan/zoom but never create/move/delete. Pan-only also means nothing is
+   * selectable, so keyboard mutations (delete/paste) have no target. The relay
+   * is the real guard; this is the UX layer.
+   */
+  private isReadOnly = false;
+  /** Tool to restore when leaving read-only. */
+  private toolBeforeReadOnly: ToolType = 'select';
 
   // State
   private canvas: HTMLCanvasElement;
@@ -251,10 +261,38 @@ export class Engine {
    * Set the active tool.
    */
   setActiveTool(type: ToolType): void {
+    // JP-370: read-only docs are pan-only — ignore any switch to a mutating tool.
+    if (this.isReadOnly && type !== 'pan') return;
     // Handle dynamic custom shape tools
     this.ensureCustomShapeToolRegistered(type);
     this.toolManager.setActiveTool(type);
     useSessionStore.getState().setActiveTool(type);
+  }
+
+  /**
+   * JP-370: toggle read-only (the active doc is view-only for this user). In
+   * read-only the canvas is forced to the 'pan' tool and tool switches are
+   * blocked, so no pointer/keyboard interaction can mutate the document.
+   */
+  setReadOnly(readOnly: boolean): void {
+    if (readOnly === this.isReadOnly) return;
+    if (readOnly) {
+      this.toolBeforeReadOnly = this.toolManager.getActiveToolType() ?? 'select';
+      this.isReadOnly = true;
+      // Force pan directly (the public setActiveTool now blocks non-pan).
+      this.toolManager.setActiveTool('pan');
+      const session = useSessionStore.getState();
+      session.setActiveTool('pan');
+      // JP-370: drop the selection (pan-only can't re-select) so every
+      // selection-gated mutation command goes inert via its existing
+      // `canExecute: hasSelection()`, and end any in-flight text edit so a
+      // mid-edit demotion can't leave an editable box open.
+      session.clearSelection();
+      session.stopTextEdit();
+    } else {
+      this.isReadOnly = false;
+      this.setActiveTool(this.toolBeforeReadOnly);
+    }
   }
 
   /**
@@ -475,8 +513,11 @@ export class Engine {
       // Sync tool changes from sessionStore to toolManager
       if (state.activeTool !== previousTool) {
         previousTool = state.activeTool;
+        // JP-370: in read-only, the canvas stays pan-only — ignore tool changes
+        // driven through sessionStore (e.g. a toolbar click) too.
+        const blockedByReadOnly = this.isReadOnly && state.activeTool !== 'pan';
         // Only update if different from current tool manager state
-        if (this.toolManager.getActiveToolType() !== state.activeTool) {
+        if (!blockedByReadOnly && this.toolManager.getActiveToolType() !== state.activeTool) {
           // Handle dynamic custom shape tools
           this.ensureCustomShapeToolRegistered(state.activeTool);
           this.toolManager.setActiveTool(state.activeTool);
@@ -997,6 +1038,9 @@ export class Engine {
    * `docushark:paste-shapes` event.
    */
   private pasteClipboard(): void {
+    // JP-370: paste needs no selection, so the clear-selection read-only trick
+    // doesn't cover it — guard explicitly (the registry command is also gated).
+    if (this.isReadOnly) return;
     if (clipboard.length === 0) return;
     pushHistory('Paste shapes');
 

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -5,7 +5,12 @@
  * changed.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useDocumentRegistry } from './documentRegistry';
+import { renderHook } from '@testing-library/react';
+import {
+  useDocumentRegistry,
+  useActiveDocReadOnly,
+  isActiveDocReadOnly,
+} from './documentRegistry';
 import { useConnectionStore } from './connectionStore';
 import type { DocumentMetadata } from '../types/Document';
 
@@ -192,5 +197,81 @@ describe("resolveOriginRelayId ('unknown' heal — collab-idle badge)", () => {
     r.registerRemote(meta('d', 'Doc'), 'relay-a:9876', 'owner', 'synced');
     r.registerRemote(meta('d', 'Doc'), 'relay-b:9876', 'owner', 'synced');
     expect(relayIdOf('d')).toBe('relay-a:9876');
+  });
+});
+
+// JP-370: the active doc is read-only iff it's a relay doc (remote/cached) on
+// which this user holds only `viewer`. This selector is the single gate the
+// editor's canvas + prose read-only UX hangs off, so the matrix is worth
+// pinning — the relay is the real security guard, but a wrong answer here means
+// a viewer makes edits that just get reverted (bad UX).
+describe('useActiveDocReadOnly (JP-370)', () => {
+  const readOnlyFor = (setup: () => string) => {
+    const id = setup();
+    useDocumentRegistry.getState().setActiveDocument(id);
+    return renderHook(() => useActiveDocReadOnly()).result.current;
+  };
+
+  it('is true for a remote doc with viewer permission', () => {
+    expect(
+      readOnlyFor(() => {
+        useDocumentRegistry.getState().registerRemote(meta('rv'), 'relay-a:9876', 'viewer', 'synced');
+        return 'rv';
+      }),
+    ).toBe(true);
+  });
+
+  it('is true for a cached (offline) doc with viewer permission', () => {
+    expect(
+      readOnlyFor(() => {
+        const r = useDocumentRegistry.getState();
+        r.registerRemote(meta('cv'), 'relay-a:9876', 'viewer', 'synced');
+        r.convertToCached('cv');
+        return 'cv';
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for a relay doc with editor or owner permission', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('re'), 'relay-a:9876', 'editor', 'synced');
+    r.registerRemote(meta('ro'), 'relay-a:9876', 'owner', 'synced');
+    r.setActiveDocument('re');
+    expect(renderHook(() => useActiveDocReadOnly()).result.current).toBe(false);
+    r.setActiveDocument('ro');
+    expect(renderHook(() => useActiveDocReadOnly()).result.current).toBe(false);
+  });
+
+  it('is false for a local document (no viewer concept)', () => {
+    expect(
+      readOnlyFor(() => {
+        useDocumentRegistry.getState().registerLocal(meta('local'));
+        return 'local';
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when no document is active', () => {
+    useDocumentRegistry.getState().setActiveDocument(null);
+    expect(renderHook(() => useActiveDocReadOnly()).result.current).toBe(false);
+  });
+
+  it('the non-hook isActiveDocReadOnly() agrees with the hook across the matrix', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('viewer'), 'relay-a:9876', 'viewer', 'synced');
+    r.registerRemote(meta('editor'), 'relay-a:9876', 'editor', 'synced');
+    r.registerLocal(meta('local'));
+
+    for (const [id, expected] of [
+      ['viewer', true],
+      ['editor', false],
+      ['local', false],
+      [null, false],
+    ] as const) {
+      useDocumentRegistry.getState().setActiveDocument(id);
+      const hook = renderHook(() => useActiveDocReadOnly()).result.current;
+      expect(isActiveDocReadOnly()).toBe(expected);
+      expect(isActiveDocReadOnly()).toBe(hook);
+    }
   });
 });

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -774,6 +774,33 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
 // ============ Selectors ============
 
 /**
+ * JP-370: whether the active document is read-only for this user — a relay doc
+ * (remote/cached) on which they hold only `viewer` permission. The relay is the
+ * authority (it drops a non-editor's writes on the live path); this drives the
+ * editor's read-only UX so a viewer doesn't make edits that just get reverted.
+ * Local documents and owner/editor docs are editable.
+ *
+ * Non-hook form for imperative call-sites (the canvas Engine, CommandRegistry
+ * keyboard guards) that need the same answer outside React render. The hook
+ * below delegates to it so there's a single source of truth.
+ */
+export function isActiveDocReadOnly(): boolean {
+  const state = useDocumentRegistry.getState();
+  const rec = state.activeDocumentId ? state.entries[state.activeDocumentId]?.record : undefined;
+  if (!rec) return false;
+  return (rec.type === 'remote' || rec.type === 'cached') && rec.permission === 'viewer';
+}
+
+/** Reactive hook form of {@link isActiveDocReadOnly} for React components. */
+export function useActiveDocReadOnly(): boolean {
+  return useDocumentRegistry((state) => {
+    const rec = state.activeDocumentId ? state.entries[state.activeDocumentId]?.record : undefined;
+    if (!rec) return false;
+    return (rec.type === 'remote' || rec.type === 'cached') && rec.permission === 'viewer';
+  });
+}
+
+/**
  * Get the active document ID.
  */
 export function useActiveDocumentId(): string | null {

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -13,6 +13,7 @@ import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore } from '../store/historyStore';
 import { useThemeStore } from '../store/themeStore';
 import { useSessionStore } from '../store/sessionStore';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import { useSettingsStore } from '../store/settingsStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
@@ -67,6 +68,9 @@ export function CanvasContainer({
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<Engine | null>(null);
+  // JP-370: the active doc is view-only for this user → canvas read-only.
+  const isReadOnly = useActiveDocReadOnly();
+  const isReadOnlyRef = useRef(isReadOnly);
 
   // State for camera reference (for TextEditor positioning)
   const [camera, setCamera] = useState<Camera | null>(null);
@@ -143,12 +147,23 @@ export function CanvasContainer({
     // Set initial canvas size
     updateCanvasSize();
 
+    // JP-370: apply the current read-only state to the freshly-created engine
+    // (covers opening straight into a view-only doc).
+    engine.setReadOnly(isReadOnlyRef.current);
+
     // Cleanup on unmount
     return () => {
       engine.destroy();
       engineRef.current = null;
     };
   }, []); // Only run on mount/unmount
+
+  // JP-370: flip the canvas to/from read-only when the active doc's permission
+  // changes (viewer → pan-only, editor/owner → full tools).
+  useEffect(() => {
+    isReadOnlyRef.current = isReadOnly;
+    engineRef.current?.setReadOnly(isReadOnly);
+  }, [isReadOnly]);
 
   /**
    * Publish the local cursor to collaboration awareness on pointer move (JP/

--- a/src/ui/CanvasToolbar.css
+++ b/src/ui/CanvasToolbar.css
@@ -15,6 +15,22 @@
   flex-shrink: 0;
 }
 
+/* JP-370: view-only marker shown in place of the editing tools when the active
+ * doc is read-only for this user. */
+.canvas-toolbar-viewonly {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+}
+
 /* Page-tabs group fills the remaining width on a single row, and wraps to its
  * own row in a narrow pane instead of squeezing the tool groups. */
 .canvas-toolbar-pages {

--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { useSessionStore, type ToolType } from '../store/sessionStore';
 import { useHistoryStore } from '../store/historyStore';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { createIconShapeAtCenter } from '../engine/CommandRegistry';
 import { ShapePicker } from './ShapePicker';
@@ -97,6 +98,10 @@ interface CanvasToolbarProps {
 export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasToolbarProps) {
   const activeTool = useSessionStore((state) => state.activeTool);
   const setActiveTool = useSessionStore((state) => state.setActiveTool);
+  // JP-370: on a view-only doc the canvas is pan-only — hide the editing tools
+  // (drawing, shapes, insert, history) entirely and show a "View only" marker.
+  // The relay drops a viewer's writes regardless; this removes the dead UI.
+  const isReadOnly = useActiveDocReadOnly();
 
   // Subscribe to history state for undo/redo button updates
   const pageHistory = useHistoryStore((state) => state.pageHistory);
@@ -129,6 +134,21 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
     : redoDesc
       ? `Redo: ${redoDesc} (Ctrl+Y)`
       : 'Redo (Ctrl+Y)';
+
+  if (isReadOnly) {
+    return (
+      <div className="canvas-toolbar">
+        <ToolbarGroup label="Access">
+          <span className="canvas-toolbar-viewonly" title="You have view-only access to this document">
+            View only
+          </span>
+        </ToolbarGroup>
+        <ToolbarGroup label="Pages" className="canvas-toolbar-pages">
+          <InlinePageTabs />
+        </ToolbarGroup>
+      </div>
+    );
+  }
 
   return (
     <div className="canvas-toolbar">

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -35,6 +35,7 @@ import { sharedProseExtensions } from './TiptapEditor';
 import { handleCitationDoiPaste } from '../tiptap/citationPaste';
 import { useRichTextStore } from '../store/richTextStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import './TiptapEditor.css';
 import './collaborationCursor.css';
@@ -73,6 +74,10 @@ export function CollaborativeProseEditor({
   user,
   onEditorReady,
 }: CollaborativeProseEditorProps) {
+  // JP-370: view-only for this user → the prose editor is non-editable (the
+  // relay also drops a viewer's writes; this is the UX layer).
+  const readOnly = useActiveDocReadOnly();
+
   // Remote-caret extension, added only when an awareness channel + identity are
   // available (i.e. an active collab session). y-prosemirror stores the caret in
   // the awareness `cursor` field — disjoint from the canvas `user.cursor`.
@@ -95,6 +100,7 @@ export function CollaborativeProseEditor({
         Collaboration.configure({ document: ydoc, field }),
         ...collaborationCursor,
       ],
+      editable: !readOnly,
       // No initial `content`: the relay is the sole prose seeder (JP-284), so the
       // editor adopts the bound fragment. Passing content would inject a second
       // prose lineage that merges into the fragment and duplicates content.
@@ -134,6 +140,12 @@ export function CollaborativeProseEditor({
     onEditorReady?.(editor, pageId);
     return () => onEditorReady?.(null, pageId);
   }, [editor, onEditorReady, pageId]);
+
+  // JP-370: keep editability in sync if the doc's permission flips in place
+  // (e.g. demoted to viewer mid-session) without remounting the editor.
+  useEffect(() => {
+    editor?.setEditable(!readOnly);
+  }, [editor, readOnly]);
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={onContextMenu}>

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { ChevronsDownUp, ChevronsUpDown, MousePointerClick, ArrowRight, GitFork, Square } from 'lucide-react';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { useActivePanelState, useLayoutActions } from './layout/useLayout';
 import {
@@ -1452,6 +1453,11 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   const selectedIds = useSessionStore((state) => state.selectedIds);
   const shapes = useDocumentStore((state) => state.shapes);
   const updateShape = useDocumentStore((state) => state.updateShape);
+  // JP-370: read-only entry clears the selection (so this normally renders the
+  // empty state), but if a selection lingers a frame, neutralize edit controls
+  // defensively — pointer-events:none over the `inert` attribute, which is
+  // unreliable on WebKitGTK/Tauri.
+  const isReadOnly = useActiveDocReadOnly();
 
   // Width is sourced from the layout store now — single source of truth so
   // both PropertyPanel and FlyoutPanel (when wrapping it) stay in sync.
@@ -1655,7 +1661,7 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
   return (
     <div
       className={`property-panel ${className ?? ''}`}
-      style={{ width }}
+      style={isReadOnly ? { width, pointerEvents: 'none', opacity: 0.6 } : { width }}
     >
       <div
         className={`property-panel-resize-handle ${isResizing ? 'resizing' : ''}`}

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -36,6 +36,7 @@ import Color from '@tiptap/extension-color';
 import TextAlign from '@tiptap/extension-text-align';
 import Link from '@tiptap/extension-link';
 import { useRichTextStore } from '../store/richTextStore';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import { EmbeddedGroup } from '../tiptap/EmbeddedGroupExtension';
 import { ResizableImage } from '../tiptap/ResizableImageExtension';
 import { MathInline, MathBlock } from '../tiptap/LatexExtension';
@@ -236,10 +237,14 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
   const content = useRichTextStore((state) => state.content);
   const setContent = useRichTextStore((state) => state.setContent);
   const setContentSilently = useRichTextStore((state) => state.setContentSilently);
+  // JP-370: a view-only (shared, demoted) doc is non-editable. Local docs
+  // always resolve to false, so this is a no-op outside the shared-cloud path.
+  const readOnly = useActiveDocReadOnly();
 
   const editor = useEditor({
     extensions,
     content: content.content,
+    editable: !readOnly,
     onUpdate: ({ editor, transaction }) => {
       // Defer the Zustand write so it doesn't run inside Tiptap's
       // transaction dispatch (which itself is wrapped in flushSync under
@@ -315,6 +320,11 @@ export function TiptapEditor({ className, onEditorReady }: TiptapEditorProps) {
       }
     };
   }, [editor, onEditorReady]);
+
+  // JP-370: react to in-place permission flips without remounting the editor.
+  useEffect(() => {
+    editor?.setEditable(!readOnly);
+  }, [editor, readOnly]);
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`} onContextMenu={onContextMenu}>

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -14,6 +14,7 @@ import { ToolbarGroup } from './ToolbarGroup';
 import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
 import { useWhiteboardStore } from '../store/whiteboardStore';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import { useAutoSave } from '../hooks/useAutoSave';
 import { opener } from '../platform/opener';
 import { LayoutSelector } from './layout/LayoutSelector';
@@ -152,6 +153,9 @@ export function UnifiedToolbar({
 }: UnifiedToolbarProps) {
   const activeLayout = useActiveLayoutMode();
   const [showPdfExport, setShowPdfExport] = useState(false);
+  // JP-370: import writes into the active doc → disable it on a view-only doc.
+  // Whiteboard (scratch overlay), Export, Help and Settings stay read-safe.
+  const isReadOnly = useActiveDocReadOnly();
 
   return (
     <>
@@ -183,7 +187,12 @@ export function UnifiedToolbar({
           <button
             className="toolbar-help-btn"
             onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
-            title="Import diagram (Excalidraw, drawio, Mermaid)"
+            disabled={isReadOnly}
+            title={
+              isReadOnly
+                ? 'Import is unavailable on a view-only document'
+                : 'Import diagram (Excalidraw, drawio, Mermaid)'
+            }
             aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
           >
             <Icon icon={FileInput} />


### PR DESCRIPTION
## What

Closes the last enforcement gap from the JP-370 access work: a demoted **viewer could still edit** a shared document. Only the WebSocket `JOIN_DOC` *read* path was gated — the live-edit (`SYNC`) *write* path had no permission check, and the editor still showed full editing tools to a viewer.

This PR folds the read-only **enforcement** (relay) and the read-only **UX hardening** (editor) into one coherent subject.

## Relay — write gate (behind `enforce_private_docs`, default OFF)

- `handle_sync` now gates write-bearing Yjs frames (sub-type `!= 0`) by permission, dropping a non-editor's write **before** it touches the authoritative Y.Doc and replying `ERR_EDIT_FORBIDDEN`. `SyncStep1` reads always pass. Mirrors the existing `JOIN_DOC` read gate; flag-off preserves legacy open-editing.
- Startup now logs the access-control posture loudly (`warn` when OFF — a multi-tenant pod with it off lets any member read **and** write any doc).

## Editor — read-only UX

So a viewer never makes local "ghost" edits the relay silently rejects:

- `isActiveDocReadOnly()` / `useActiveDocReadOnly()` — active doc is a relay doc (remote/cached) on which the user holds only `viewer`.
- **Canvas:** `Engine.setReadOnly()` forces pan-only, **clears the selection** and ends any text edit. With nothing selectable, selection-gated mutation commands go inert via their existing `canExecute`; **paste + undo/redo** are guarded explicitly (engine + `CommandRegistry`).
- **Prose:** Tiptap `editable: !readOnly` on both editors, kept in sync on in-place permission flips.
- **Tools UI:** `CanvasToolbar` hides the editing clusters and shows a "View only" marker; `UnifiedToolbar` disables Import (the only active-doc mutation there — Whiteboard/Export/Help/Settings stay); `PropertyPanel` neutralized defensively.

## Tests

- Relay: `handle_sync_gates_writes_by_permission` (viewer write → `ERR_EDIT_FORBIDDEN`, viewer read allowed, editor write allowed).
- Editor: `isActiveDocReadOnly` hook/non-hook parity + a read-only selector matrix (remote-viewer, cached-viewer, editor/owner, local, none).

## Verification

`cargo build --bin relay` + relay tests green · editor `tsc` clean · `bun run test --run` (2663) · `bun run build` · OSS-leak grep clean.

The flag flip (`enforce_private_docs = true`) is config/ops — enabled locally and on staging; not a code change here.

Assisted-by: Opus 4.8
