### PR TITLE
Hide the editor app bar in the document browser

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -421,12 +421,18 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   return (
     <div className="app">
       <ConnectionStatusBanner />
+        {/* Custom-chrome title bar stays in the document browser — it carries the
+            desktop window controls. The editor app bar (document title, layouts,
+            export…) is editor-only, so it's hidden while the browser is open
+            (DocumentsHome has its own chrome + Back-to-editor). */}
         {customChrome && <TitleBar />}
-        <UnifiedToolbar
-          onOpenSettings={handleOpenSettings}
-          onOpenLayoutSettings={handleOpenLayoutSettings}
-          onOpenDocuments={handleOpenDocuments}
-        />
+        {appView === 'editor' && (
+          <UnifiedToolbar
+            onOpenSettings={handleOpenSettings}
+            onOpenLayoutSettings={handleOpenLayoutSettings}
+            onOpenDocuments={handleOpenDocuments}
+          />
+        )}
         <main className="app-main">
           {/* Document on left. In Relaxed the editor is the primary reading
               column (not a fixed sidebar); the focus switch in the toolbar


### PR DESCRIPTION
## What

Opening the **document browser** (`DocumentsHome`) left the **editor app bar** (`UnifiedToolbar` — current document title, layout selector, export, settings) rendered above it. That's confusing when you're browsing/managing documents rather than editing one.

## Fix

Gate `UnifiedToolbar` on `appView === 'editor'` in `App.tsx`, so it's hidden while the browser is open. `DocumentsHome` already has its own chrome + Back-to-editor, so nothing is stranded.

The custom-chrome `TitleBar` is **intentionally kept** when the browser is open — it carries the desktop window controls (minimize/close/drag), which must stay reachable everywhere.

## Verification

`tsc` clean · full suite **2663 pass** · `bun run build` · OSS-leak grep clean.

Assisted-by: Opus 4.8
