### PR TITLE
Fix document shares not reflecting after save (revoke/add) + de-emoji the dialog

### DIFF
--- a/src/store/relayDocumentStore.test.ts
+++ b/src/store/relayDocumentStore.test.ts
@@ -148,3 +148,64 @@ describe('relayDocumentStore.setAuthenticated skipFetch (transfer no-op fix)', (
     expect(listDocuments).not.toHaveBeenCalled();
   });
 });
+
+// JP-370: a share revoke/add persists on the relay but the share dialog reads
+// from relayDocuments[docId].sharedWith — so the store must reflect the change
+// locally after a successful save, or the UI shows the stale (pre-save) list
+// and the edit "appears to do nothing".
+describe('relayDocumentStore.updateDocumentShares local reflection', () => {
+  const seedDoc = (sharedWith: unknown[]) =>
+    useRelayDocumentStore.setState({
+      relayDocuments: {
+        'doc-1': { id: 'doc-1', name: 'Doc', sharedWith } as never,
+      },
+    });
+
+  beforeEach(() => {
+    useRelayDocumentStore.getState().setProvider(null);
+    useRelayDocumentStore.setState({ relayDocuments: {} });
+  });
+
+  it('updates sharedWith after the relay save resolves', async () => {
+    const updateDocumentShares = vi.fn(async () => undefined);
+    useRelayDocumentStore.getState().setProvider({ updateDocumentShares } as unknown as DocumentProvider);
+    seedDoc([{ userId: 'old', userName: 'Old', permission: 'view', sharedAt: 1 }]);
+
+    await useRelayDocumentStore
+      .getState()
+      .updateDocumentShares('doc-1', [{ userId: 'alice', userName: 'Alice', permission: 'edit' }]);
+
+    expect(updateDocumentShares).toHaveBeenCalledTimes(1);
+    const sw = useRelayDocumentStore.getState().relayDocuments['doc-1']?.sharedWith ?? [];
+    expect(sw.map((s) => s.userId)).toEqual(['alice']);
+    expect(sw[0]?.permission).toBe('edit');
+  });
+
+  it('revokes (empty list) reflect locally too', async () => {
+    useRelayDocumentStore
+      .getState()
+      .setProvider({ updateDocumentShares: vi.fn(async () => undefined) } as unknown as DocumentProvider);
+    seedDoc([{ userId: 'old', userName: 'Old', permission: 'view', sharedAt: 1 }]);
+
+    await useRelayDocumentStore.getState().updateDocumentShares('doc-1', []);
+
+    expect(useRelayDocumentStore.getState().relayDocuments['doc-1']?.sharedWith).toEqual([]);
+  });
+
+  it('leaves local metadata untouched when the relay save throws', async () => {
+    const updateDocumentShares = vi.fn(async () => {
+      throw new Error('relay down');
+    });
+    useRelayDocumentStore.getState().setProvider({ updateDocumentShares } as unknown as DocumentProvider);
+    seedDoc([{ userId: 'old', userName: 'Old', permission: 'view', sharedAt: 1 }]);
+
+    await expect(
+      useRelayDocumentStore
+        .getState()
+        .updateDocumentShares('doc-1', [{ userId: 'alice', userName: 'Alice', permission: 'edit' }]),
+    ).rejects.toThrow('relay down');
+
+    const sw = useRelayDocumentStore.getState().relayDocuments['doc-1']?.sharedWith ?? [];
+    expect(sw.map((s) => s.userId)).toEqual(['old']);
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -740,6 +740,27 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
 
       try {
         await docProvider.updateDocumentShares(docId, shares);
+        // Reflect the saved shares in local metadata so the share dialog (which
+        // derives its list from relayDocuments[docId].sharedWith) updates
+        // immediately — without this, a revoke/add persists on the relay but the
+        // UI keeps showing the pre-save list (looks like it did nothing). The
+        // relay is canonical; a later DocEvent::Updated reconciles sharedAt.
+        set((state) => {
+          const meta = state.relayDocuments[docId];
+          if (!meta) return {};
+          const now = Date.now();
+          const relayDocuments = { ...state.relayDocuments };
+          relayDocuments[docId] = {
+            ...meta,
+            sharedWith: shares.map((s) => ({
+              userId: s.userId,
+              userName: s.userName,
+              permission: s.permission as 'view' | 'edit',
+              sharedAt: now,
+            })),
+          };
+          return { relayDocuments };
+        });
       } catch (e) {
         const error = e instanceof Error ? e.message : 'Failed to update shares';
         set({ error });

--- a/src/ui/DocumentPermissionsDialog.css
+++ b/src/ui/DocumentPermissionsDialog.css
@@ -258,6 +258,19 @@
   border-radius: 3px;
 }
 
+/* A sharee who is no longer a workspace member (JP-370) — their grant lingers
+   and the owner can revoke it. Warning-toned so it reads as "needs attention". */
+.document-permissions-dialog__former-badge {
+  font-size: 10px;
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--warning);
+  background: var(--warning-bg);
+  padding: 1px var(--space-1-5);
+  border-radius: 3px;
+}
+
 .document-permissions-dialog__member-controls {
   display: flex;
   align-items: center;
@@ -313,9 +326,16 @@
 }
 
 .document-permissions-dialog__transfer-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
   color: var(--warning);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+}
+.document-permissions-dialog__transfer-warning svg {
+  flex-shrink: 0;
+  margin-top: 1px;
 }
 
 .document-permissions-dialog__transfer-actions {

--- a/src/ui/DocumentPermissionsDialog.tsx
+++ b/src/ui/DocumentPermissionsDialog.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useState, useCallback, useEffect, useMemo, FormEvent } from 'react';
+import { Crown, AlertTriangle } from 'lucide-react';
 import { useUserStore } from '../store/userStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
@@ -105,6 +106,16 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
       cancelled = true;
     };
   }, [record]);
+
+  // Sharees no longer in the workspace (e.g. they left or were removed): their
+  // share lingers on the doc but they're not in the roster. Flag them so the
+  // owner understands the orphaned grant and can revoke it. Only meaningful when
+  // the roster actually loaded (otherwise everyone would look "former").
+  const rosterIds = useMemo(() => new Set(roster.map((m) => m.userId)), [roster]);
+  const isFormerMember = useCallback(
+    (userId: string) => roster.length > 0 && !rosterError && !rosterIds.has(userId),
+    [rosterIds, roster.length, rosterError],
+  );
 
   // Members who can still be added: everyone in the workspace except the owner,
   // the current user, and anyone already in the access list.
@@ -246,7 +257,9 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
           <div className="document-permissions-dialog__doc-info">
             <div className="document-permissions-dialog__doc-name">{record.name}</div>
             <div className="document-permissions-dialog__doc-meta">
-              <span className="document-permissions-dialog__owner-badge">👑 {record.ownerName}</span>
+              <span className="document-permissions-dialog__owner-badge">
+                <Crown size={13} strokeWidth={1.75} /> {record.ownerName}
+              </span>
               <span className="document-permissions-dialog__access-count">
                 {accessCounts.total} user{accessCounts.total !== 1 ? 's' : ''} with access
                 {accessCounts.editors > 0 && ` (${accessCounts.editors} editor${accessCounts.editors !== 1 ? 's' : ''})`}
@@ -264,7 +277,8 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
                 <strong>{accessList.find((m) => m.userId === transferToUserId)?.username}</strong>?
               </p>
               <p className="document-permissions-dialog__transfer-warning">
-                ⚠️ You will lose owner privileges and become an editor. This action cannot be undone.
+                <AlertTriangle size={14} strokeWidth={1.75} /> You will lose owner privileges and become
+                an editor. This action cannot be undone.
               </p>
               <div className="document-permissions-dialog__transfer-actions">
                 <button
@@ -364,6 +378,11 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
                         <div className="document-permissions-dialog__member-info">
                           <span className="document-permissions-dialog__member-name">
                             {member.username}
+                            {isFormerMember(member.userId) && (
+                              <span className="document-permissions-dialog__former-badge" title="No longer in this workspace — you can revoke their access">
+                                former member
+                              </span>
+                            )}
                             <span className="document-permissions-dialog__offline-badge">{member.userId}</span>
                           </span>
                         </div>
@@ -387,8 +406,9 @@ export function DocumentPermissionsDialog({ documentId, onClose }: DocumentPermi
                               className="document-permissions-dialog__transfer-btn"
                               onClick={() => handleTransferOwnership(member.userId)}
                               title="Transfer ownership to this user"
+                              aria-label="Transfer ownership to this user"
                             >
-                              👑
+                              <Crown size={15} strokeWidth={1.75} />
                             </button>
                           )}
                         </div>


### PR DESCRIPTION
## What

Revoking or adding a document share **appeared to do nothing** — most visibly when revoking a grant held by someone who had **left the workspace**.

## Root cause

`relayDocumentStore.updateDocumentShares` saved to the relay (which *did* persist — the `POST /api/docs/:id/share` handler is owner-gated and wholesale-replaces `sharedWith`) but **never updated the local `relayDocuments[docId].sharedWith`**. The share dialog derives its list from that metadata, so it kept rendering the pre-save state → the edit looked like a no-op. It affected *all* share edits; a member leaving is just when an owner first hits it (revoking the now-orphaned share). Not a relay bug — a local-state sync gap.

## Changes (editor-only)

- **`relayDocumentStore`** — after a successful relay save, reflect the new shares in `relayDocuments[docId].sharedWith`, so the dialog re-renders immediately. The relay stays canonical (a later `DocEvent::Updated` reconciles `sharedAt`); on failure local metadata is left untouched.
- **`DocumentPermissionsDialog`** — flag a sharee no longer in the workspace roster with a **"former member"** badge, so the owner understands the lingering grant and revokes it confidently. (Add-path unchanged — still picks current members.)
- **De-emoji** (founder note): the owner badge + transfer-ownership button now use lucide **`Crown`**, and the transfer warning uses **`AlertTriangle`** — no emoji glyphs.

Scope is the contained fix; auto-revoking a member's shares when they leave (a cross-repo relay endpoint + web trigger) is a deliberate follow-up, not included.

## Verification

`tsc` clean · full suite **2666 pass** (incl. 3 new `relayDocumentStore` reflection tests: add/revoke reflect locally, untouched on relay error) · `bun run build` · OSS-leak grep clean.

## Manual E2E (local stack)

Owner shares a doc with a member → member leaves → owner opens the dialog: the share shows **"former member"**; set **No Access** → Save → it disappears immediately and stays gone on reopen. Adding a current member appears immediately. No emojis remain.

Assisted-by: Opus 4.8
