### PR TITLE
JP-347: document version gate + v1→v2 schema hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,9 +188,10 @@ relay the source of truth (removing whole-document last-write-wins) — it is a
 each dirty Y.Doc back to its JSON snapshot on a configurable interval
 (`[sync] snapshot_interval_secs`, default 10), on last-client eviction, and on
 graceful shutdown (SIGINT/SIGTERM) — keeping `serverVersion` and emitting no
-`DocEvent`, so durability no longer depends on a client REST save. The flatten
-targets the page the doc was hydrated from (`activePageId`); a live page-switch
-mid-session is the known active-page-only limitation.
+`DocEvent`, so durability no longer depends on a client REST save. Since JP-340
+the flatten writes **every** page's shape surface back to its `pages[id]` object
+(not just the hydrated `activePageId`), so a live page-switch mid-session no
+longer risks dropping the other pages' edits.
 
 **Offline-first architecture**:
 - **OfflineQueue**: Queues save/delete operations when disconnected, processes on reconnect

--- a/src/migrations/documentMigrations.test.ts
+++ b/src/migrations/documentMigrations.test.ts
@@ -1,9 +1,47 @@
 import { describe, it, expect } from 'vitest';
 import { migrateDocument, DocumentVersionError } from './documentMigrations';
 import { createDocument, DOCUMENT_VERSION, type DiagramDocument } from '../types/Document';
+import type { GroupShape, RectangleShape } from '../shapes/Shape';
 
 function sampleDoc(overrides: Partial<DiagramDocument> = {}): DiagramDocument {
   return { ...createDocument('Sample', 'doc-1', 'page-1'), ...overrides };
+}
+
+function group(id: string, ownerId?: string | null): GroupShape {
+  const base: GroupShape = {
+    id,
+    type: 'group',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: null,
+    stroke: null,
+    strokeWidth: 0,
+    childIds: [],
+  };
+  return ownerId === undefined ? base : { ...base, ownerId };
+}
+
+function rect(id: string): RectangleShape {
+  return {
+    id,
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#fff',
+    stroke: '#000',
+    strokeWidth: 1,
+    cornerRadius: 0,
+  };
 }
 
 describe('migrateDocument — version gate', () => {
@@ -43,5 +81,66 @@ describe('migrateDocument — version gate', () => {
     expect(out.pages).toEqual(doc.pages);
     expect(out.pageOrder).toEqual(doc.pageOrder);
     expect(out.activePageId).toBe(doc.activePageId);
+  });
+});
+
+describe('migrateDocument — v2 invariants (JP-347)', () => {
+  it('stamps ownerId: null on a group missing it, preserving set owners', () => {
+    const doc = sampleDoc();
+    doc.pages['page-1']!.shapes = {
+      g1: group('g1'), // ownerId undefined
+      g2: group('g2', 'user-7'), // explicit owner kept
+      g3: group('g3', null), // already null
+    };
+    doc.pages['page-1']!.shapeOrder = ['g1', 'g2', 'g3'];
+
+    const out = migrateDocument(doc);
+    const shapes = out.pages['page-1']!.shapes;
+    expect((shapes['g1'] as GroupShape).ownerId).toBeNull();
+    expect((shapes['g2'] as GroupShape).ownerId).toBe('user-7');
+    expect((shapes['g3'] as GroupShape).ownerId).toBeNull();
+  });
+
+  it('does not touch non-group shapes', () => {
+    const doc = sampleDoc();
+    doc.pages['page-1']!.shapes = { r1: rect('r1') };
+    const out = migrateDocument(doc);
+    expect(out.pages['page-1']!.shapes['r1']).toEqual(rect('r1'));
+  });
+
+  it('repoints a dangling canvas activePageId to a real page', () => {
+    const doc = sampleDoc({ activePageId: 'ghost-page' });
+    const out = migrateDocument(doc);
+    expect(out.activePageId).toBe('page-1');
+  });
+
+  it('repoints a dangling prose activePageId; nulls it when there are no prose pages', () => {
+    const withDangling = sampleDoc({
+      richTextPages: { pages: { p1: { id: 'p1', name: 'A', content: '<p/>', order: 0, createdAt: 0, modifiedAt: 0 } }, pageOrder: ['p1'], activePageId: 'ghost' },
+    });
+    expect(migrateDocument(withDangling).richTextPages!.activePageId).toBe('p1');
+
+    const empty = sampleDoc({ richTextPages: { pages: {}, pageOrder: [], activePageId: 'ghost' } });
+    expect(migrateDocument(empty).richTextPages!.activePageId).toBeNull();
+  });
+
+  it('round-trips a v1 document to v2 with no data loss', () => {
+    const v1 = sampleDoc({ version: 1 });
+    v1.pages['page-1']!.shapes = { g1: group('g1'), r1: rect('r1') };
+    v1.pages['page-1']!.shapeOrder = ['g1', 'r1'];
+    v1.references = { items: {}, itemOrder: [] };
+    v1.fields = { fields: {}, order: [] };
+
+    const out = migrateDocument(v1);
+    expect(out.version).toBe(DOCUMENT_VERSION);
+    // content preserved
+    expect(out.pages['page-1']!.shapeOrder).toEqual(['g1', 'r1']);
+    expect(out.pages['page-1']!.shapes['r1']).toEqual(rect('r1'));
+    expect(out.references).toEqual(v1.references);
+    expect(out.fields).toEqual(v1.fields);
+    // invariant applied
+    expect((out.pages['page-1']!.shapes['g1'] as GroupShape).ownerId).toBeNull();
+    // idempotent
+    expect(migrateDocument(out)).toEqual(out);
   });
 });

--- a/src/migrations/documentMigrations.test.ts
+++ b/src/migrations/documentMigrations.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { migrateDocument, DocumentVersionError } from './documentMigrations';
+import { createDocument, DOCUMENT_VERSION, type DiagramDocument } from '../types/Document';
+
+function sampleDoc(overrides: Partial<DiagramDocument> = {}): DiagramDocument {
+  return { ...createDocument('Sample', 'doc-1', 'page-1'), ...overrides };
+}
+
+describe('migrateDocument — version gate', () => {
+  it('returns a current-version document unchanged (idempotent)', () => {
+    const doc = sampleDoc();
+    const out = migrateDocument(doc);
+    expect(out.version).toBe(DOCUMENT_VERSION);
+    // Running it again is a no-op.
+    expect(migrateDocument(out)).toEqual(out);
+  });
+
+  it('stamps the current version onto a document with a missing version', () => {
+    // Force an old/missing stamp the way a pre-versioning document on disk would look.
+    const doc = sampleDoc({ version: undefined as unknown as number });
+    const out = migrateDocument(doc);
+    expect(out.version).toBe(DOCUMENT_VERSION);
+  });
+
+  it('throws DocumentVersionError for a document newer than this build', () => {
+    const doc = sampleDoc({ version: DOCUMENT_VERSION + 1 });
+    expect(() => migrateDocument(doc)).toThrow(DocumentVersionError);
+    try {
+      migrateDocument(doc);
+    } catch (e) {
+      expect(e).toBeInstanceOf(DocumentVersionError);
+      const err = e as DocumentVersionError;
+      expect(err.documentVersion).toBe(DOCUMENT_VERSION + 1);
+      expect(err.supportedVersion).toBe(DOCUMENT_VERSION);
+    }
+  });
+
+  it('preserves document content through the gate (no data loss)', () => {
+    const doc = sampleDoc();
+    const out = migrateDocument(doc);
+    expect(out.id).toBe(doc.id);
+    expect(out.name).toBe(doc.name);
+    expect(out.pages).toEqual(doc.pages);
+    expect(out.pageOrder).toEqual(doc.pageOrder);
+    expect(out.activePageId).toBe(doc.activePageId);
+  });
+});

--- a/src/migrations/documentMigrations.ts
+++ b/src/migrations/documentMigrations.ts
@@ -1,0 +1,102 @@
+/**
+ * Document version gate + migration dispatcher (JP-347).
+ *
+ * Pre-GA, the document format is still allowed to evolve, but once a stable
+ * release ships the format freezes within a major version (see AGENTS.md
+ * "Backwards Compatibility & Document Safety"). For that freeze to be
+ * meaningful, *every* document entering the app must pass through a single,
+ * ordered migration funnel:
+ *
+ *   1. A document whose `version` is **newer** than this build can support is
+ *      rejected loudly (`DocumentVersionError`) instead of being silently
+ *      mis-interpreted — the caller surfaces a notice rather than crashing or
+ *      dropping data.
+ *   2. A document whose `version` is **older** is walked up through the ordered
+ *      `MIGRATIONS` registry to the current `DOCUMENT_VERSION`.
+ *   3. The result is stamped with the current `DOCUMENT_VERSION`.
+ *
+ * `migrateDocument` is pure and idempotent: re-running it on an
+ * already-current document is a no-op (no migration step matches, the version
+ * stamp is unchanged). This is the chokepoint wired into every loader
+ * (local-storage, relay fetch, cached, imported, restored-from-backup) so the
+ * migration ceremony can never be forgotten on one path — a contract test
+ * guards that.
+ *
+ * Adding a new format version (vN -> vN+1):
+ *   - bump `DOCUMENT_VERSION` in `types/Document.ts`,
+ *   - write a pure `migrateVNToVN1(doc)` that preserves all data,
+ *   - append `{ to: N+1, migrate: migrateVNToVN1 }` to `MIGRATIONS`,
+ *   - add a fixture of the old format + a round-trip "no data loss" test.
+ */
+
+import type { DiagramDocument } from '../types/Document';
+import { DOCUMENT_VERSION } from '../types/Document';
+
+/**
+ * Thrown when a document declares a `version` greater than this build's
+ * `DOCUMENT_VERSION`. Loaders should catch this and surface a user-facing
+ * "created by a newer version of DocuShark" notice rather than attempting to
+ * load (and risk silently mangling) a format they don't understand.
+ */
+export class DocumentVersionError extends Error {
+  constructor(
+    /** The document's declared schema version. */
+    readonly documentVersion: number,
+    /** The highest schema version this build supports. */
+    readonly supportedVersion: number,
+  ) {
+    super(
+      `This document was created by a newer version of DocuShark ` +
+        `(document format v${documentVersion}; this app supports up to v${supportedVersion}). ` +
+        `Update DocuShark to open it.`,
+    );
+    this.name = 'DocumentVersionError';
+  }
+}
+
+/** A single ordered step: bring a document up to schema version `to`. */
+interface Migration {
+  /** The schema version this step produces. */
+  to: number;
+  /** Pure, data-preserving transform from the previous version to `to`. */
+  migrate: (doc: DiagramDocument) => DiagramDocument;
+}
+
+/**
+ * Ordered registry of format migrations, ascending by `to`. Empty until the
+ * first format bump lands (the gate is useful on its own — it rejects
+ * newer-than-supported documents and normalizes the version stamp).
+ */
+const MIGRATIONS: Migration[] = [];
+
+/** Read a document's declared version, defaulting a missing/invalid one to 1. */
+function readVersion(doc: DiagramDocument): number {
+  return typeof doc.version === 'number' && Number.isFinite(doc.version) ? doc.version : 1;
+}
+
+/**
+ * Run a raw, already-parsed document through the version gate + migration
+ * chain and return it at the current `DOCUMENT_VERSION`.
+ *
+ * @throws {DocumentVersionError} if the document is newer than this build.
+ */
+export function migrateDocument(doc: DiagramDocument): DiagramDocument {
+  const from = readVersion(doc);
+
+  if (from > DOCUMENT_VERSION) {
+    throw new DocumentVersionError(from, DOCUMENT_VERSION);
+  }
+
+  let result = doc;
+  let current = from;
+  for (const step of MIGRATIONS) {
+    if (step.to > current && step.to <= DOCUMENT_VERSION) {
+      result = step.migrate(result);
+      current = step.to;
+    }
+  }
+
+  // Stamp the current version (also normalizes a missing/old stamp on an
+  // already-structurally-current document).
+  return result.version === DOCUMENT_VERSION ? result : { ...result, version: DOCUMENT_VERSION };
+}

--- a/src/migrations/documentMigrations.ts
+++ b/src/migrations/documentMigrations.ts
@@ -29,8 +29,9 @@
  *   - add a fixture of the old format + a round-trip "no data loss" test.
  */
 
-import type { DiagramDocument } from '../types/Document';
+import type { DiagramDocument, Page } from '../types/Document';
 import { DOCUMENT_VERSION } from '../types/Document';
+import type { Shape, GroupShape } from '../shapes/Shape';
 
 /**
  * Thrown when a document declares a `version` greater than this build's
@@ -63,9 +64,90 @@ interface Migration {
 }
 
 /**
- * Ordered registry of format migrations, ascending by `to`. Empty until the
- * first format bump lands (the gate is useful on its own — it rejects
- * newer-than-supported documents and normalizes the version stamp).
+ * Always-on, version-independent document invariants (JP-347, pre-GA posture
+ * hardening). Idempotent and data-preserving — applied to *every* document on
+ * the way in (not just on a version bump), so freshly-authored content is held
+ * to the same shape as migrated content:
+ *
+ * - **Group ownership normalized**: a group whose `ownerId` is `undefined`
+ *   (created before ownership was tracked, or by a path that omits it) is
+ *   stamped `ownerId: null` — the explicit "SYSTEM-owned, no restrictions"
+ *   value. This removes the `undefined`-vs-`null` ambiguity from documents so
+ *   future migrations can reason about ownership unambiguously. Behaviour is
+ *   unchanged: `permissionStore` already treats a missing owner and `null`
+ *   identically (everyone may edit).
+ * - **Active page ids self-healed**: the canvas `activePageId` (required) is
+ *   repointed to a real page if it dangles, and the prose
+ *   `richTextPages.activePageId` to a real prose page or `null`. Canvas and
+ *   prose stay independent (separate tab strips, JP-339) — this only repairs
+ *   dangling references, it does not unify them.
+ */
+function normalizeInvariants(doc: DiagramDocument): DiagramDocument {
+  return healActivePageIds(backfillGroupOwnership(doc));
+}
+
+/** Stamp `ownerId: null` on any group shape missing it. Pure; returns the same
+ * reference when nothing changed. */
+function backfillGroupOwnership(doc: DiagramDocument): DiagramDocument {
+  let docChanged = false;
+  const pages: Record<string, Page> = {};
+
+  for (const [pageId, page] of Object.entries(doc.pages)) {
+    let pageChanged = false;
+    const shapes: Record<string, Shape> = {};
+
+    for (const [shapeId, shape] of Object.entries(page.shapes)) {
+      // `type === 'group'` alone doesn't exclude LibraryShape (its `type` is a
+      // dynamic string), so narrow to the real GroupShape before touching owner.
+      const grp = shape.type === 'group' ? (shape as GroupShape) : undefined;
+      if (grp && grp.ownerId === undefined) {
+        shapes[shapeId] = { ...grp, ownerId: null };
+        pageChanged = true;
+      } else {
+        shapes[shapeId] = shape;
+      }
+    }
+
+    pages[pageId] = pageChanged ? { ...page, shapes } : page;
+    docChanged ||= pageChanged;
+  }
+
+  return docChanged ? { ...doc, pages } : doc;
+}
+
+/** Repoint dangling canvas + prose active page ids to a real page. Pure. */
+function healActivePageIds(doc: DiagramDocument): DiagramDocument {
+  let result = doc;
+
+  // Canvas: activePageId is required and must reference an existing page.
+  const canvasIds = Object.keys(result.pages);
+  if (canvasIds.length > 0 && !result.pages[result.activePageId]) {
+    const next = result.pageOrder.find((id) => result.pages[id]) ?? canvasIds[0]!;
+    result = { ...result, activePageId: next };
+  }
+
+  // Prose: activePageId may be null, but if set must reference a real page.
+  const rtp = result.richTextPages;
+  if (rtp) {
+    const active = rtp.activePageId;
+    const proseValid = active != null && rtp.pages[active] !== undefined;
+    if (!proseValid) {
+      const proseIds = Object.keys(rtp.pages);
+      const next = proseIds.length > 0 ? (rtp.pageOrder.find((id) => rtp.pages[id]) ?? proseIds[0]!) : null;
+      if (next !== active) {
+        result = { ...result, richTextPages: { ...rtp, activePageId: next } };
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Ordered registry of *structural* format migrations, ascending by `to`. Empty
+ * today — the v2 bump (JP-347) is carried entirely by the always-on
+ * `normalizeInvariants` below rather than a one-shot transform. Structural,
+ * version-specific reshapes (field renames, moves) go here.
  */
 const MIGRATIONS: Migration[] = [];
 
@@ -95,6 +177,11 @@ export function migrateDocument(doc: DiagramDocument): DiagramDocument {
       current = step.to;
     }
   }
+
+  // Always-on, version-independent invariants (idempotent) — applied to every
+  // document regardless of its declared version, so freshly-authored content is
+  // held to the same shape as migrated content.
+  result = normalizeInvariants(result);
 
   // Stamp the current version (also normalizes a missing/old stamp on an
   // already-structurally-current document).

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -15,6 +15,7 @@ import {
   getDocumentMetadata,
 } from '../types/Document';
 import { validateDocumentJSON } from '../types/DocumentValidation';
+import { migrateDocument, DocumentVersionError } from '../migrations/documentMigrations';
 import { usePageStore, PageStoreSnapshot } from './pageStore';
 import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
@@ -592,7 +593,13 @@ function createDocumentFromPageStore(
 /**
  * Load a DiagramDocument into the page store and rich text store.
  */
-function loadDocumentToPageStore(doc: DiagramDocument): void {
+function loadDocumentToPageStore(input: DiagramDocument): void {
+  // Version gate + migration funnel (JP-347): every document entering the live
+  // stores is brought up to the current DOCUMENT_VERSION here, so no load path
+  // can operate on an unmigrated document. Throws DocumentVersionError if the
+  // document is newer than this build supports — callers surface a notice.
+  const doc = migrateDocument(input);
+
   // Switching documents: drop the previous doc's FileShape thumbnail caches
   // (revoking minted object URLs) so this doc re-resolves its blob:// thumbnails
   // and never shows a stale image or a stale missing-blob overlay.
@@ -871,8 +878,16 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
           return false;
         }
 
-        // Load into page store
-        loadDocumentToPageStore(doc);
+        // Load into page store (migration-gated)
+        try {
+          loadDocumentToPageStore(doc);
+        } catch (e) {
+          if (e instanceof DocumentVersionError) {
+            useNotificationStore.getState().error(e.message);
+            return false;
+          }
+          throw e;
+        }
 
         set({
           currentDocumentId: id,
@@ -1444,8 +1459,16 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
           isRelayDocument: true,
         };
 
-        // Load into page store
-        loadDocumentToPageStore(docWithTeamFlag);
+        // Load into page store (migration-gated)
+        try {
+          loadDocumentToPageStore(docWithTeamFlag);
+        } catch (e) {
+          if (e instanceof DocumentVersionError) {
+            useNotificationStore.getState().error(e.message);
+            return;
+          }
+          throw e;
+        }
 
         // Also save to localStorage so it's cached locally
         saveDocumentToStorage(docWithTeamFlag);

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -1161,6 +1161,12 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
           doc.id = newId;
           doc.modifiedAt = Date.now();
 
+          // JP-347: a `collectionId` in an imported/hand-edited file is a stale
+          // transport stamp from another workspace — drop it so the import opens
+          // Unassigned and the relay re-stamps membership on first save (the body
+          // copy is transport-only; see DiagramDocument.collectionId).
+          delete doc.collectionId;
+
           // Increment usage counts for referenced blobs
           if (doc.blobReferences) {
             doc.blobReferences.forEach((blobId) => {

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -197,8 +197,14 @@ export interface PageSnapshot {
 /**
  * Current document schema version.
  * Increment when making breaking changes to the document structure.
+ *
+ * History:
+ * - v1: original DocuShark (v2) document format.
+ * - v2 (JP-347): pre-GA posture hardening — group `ownerId` is normalized to an
+ *   explicit `null` (never `undefined`) and the active page ids (canvas + prose)
+ *   are self-healed to reference a real page. See `migrations/documentMigrations.ts`.
  */
-export const DOCUMENT_VERSION = 1;
+export const DOCUMENT_VERSION = 2;
 
 /**
  * localStorage keys for document persistence.


### PR DESCRIPTION
**JP-347 — Pre-Launch Schema Review.** Establishes the document migration system and uses it for a small, data-preserving v1→v2 hardening pass. Pre-GA with **no live data yet**, so this is the last cheap moment to make persisted documents unambiguous before the format freezes.

Backed by a 3-agent schema/migration/whiteboard review + a 2-agent TS/Rust blast-radius map. Headline finding: **the relay treats document content as opaque `serde_json::Value`**, so this needs **no `PROTOCOL_VERSION` bump** and zero relay changes.

## Slice 1 — version gate + migration dispatcher (additive)
`src/migrations/documentMigrations.ts`: `migrateDocument(doc)` — pure, idempotent — reads the doc version, **throws `DocumentVersionError` if it's newer than this build** (so a future-format doc surfaces a notice instead of silently mis-loading), walks an ordered `MIGRATIONS` registry, and stamps the version. Wired as the gate at the top of `loadDocumentToPageStore`, so **every** load path (local, relay, import, restore) is covered; `loadDocument`/`loadRemoteDocument` surface the notice, `importJSON`'s existing catch already does.

## Slice 2 — `DOCUMENT_VERSION = 2`, hardening invariants
The v2 work is carried by **always-on, idempotent invariants** in the funnel (applied to every doc regardless of version, so freshly-authored content matches migrated content):
- **Group `ownerId` → explicit `null`** when absent — removes the `undefined`-vs-`null` ambiguity from persisted docs. Behaviour unchanged (`permissionStore` already treats missing owner and `null` identically).
- **Active page ids self-healed** — canvas `activePageId` (required) and prose `richTextPages.activePageId` (real-or-`null`) are repointed if they dangle. Canvas + prose stay **independent** (JP-339) — repaired, not merged.
- **Import strip (#3)** — drop a stale body `collectionId` on import so a hand-edited/exported file can't smuggle membership past the relay re-stamp.

## Tests (JP-326 discipline)
Version gate (idempotency, newer-than-app throws, stamp-normalize, no-data-loss) + invariants (ownerId backfill preserving set owners, dangling canvas/prose activePageId heal incl. empty-prose→null) + a **v1→v2 round-trip with no data loss + idempotency**.

## Verification
`bun run typecheck` clean · full suite **2675 passing** · no `PROTOCOL_VERSION`/relay change.

## Scope notes (from the blast-radius review)
- **Deferred:** the icon builtin/blob discriminator is already covered in practice by `isBuiltinIcon()` — a single canonical helper is a small standalone refactor, not this format PR.
- **Dropped:** `iconId`→`icons[]` consolidation (≈10 renderer sites, low value; the dual model already self-heals at read time).
- **Reframed:** `activePageId` is made consistent/crash-safe, **not** merged (merging would regress the intentional dual tab strips).
- Whiteboard local-only collab guard ships as a **separate** PR.

Corrects a stale `AGENTS.md` note in passing (JP-340 made the relay flatten all pages, not just the active one).

Assisted-by: Opus 4.8