### PR TITLE
JP-380: Collections fixes — rail/grouped actions, empty-delete, per-card menu stacking + scope icons & picker

### DIFF
--- a/src/store/collectionSync.test.ts
+++ b/src/store/collectionSync.test.ts
@@ -3,10 +3,8 @@ import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 // Mock the relay-facing deps; use the REAL collectionStore.
 vi.mock('./relayDocumentStore', () => ({
   getDocProvider: vi.fn(),
+  isCloudSignedIn: vi.fn(() => true),
   useRelayDocumentStore: { getState: vi.fn() },
-}));
-vi.mock('./connectionStore', () => ({
-  isRelayAuthenticated: vi.fn(() => true),
 }));
 vi.mock('../collaboration/SyncStateManager', () => ({
   getSyncStateManager: vi.fn(() => ({ hasPendingChanges: () => false })),
@@ -25,8 +23,7 @@ import {
   resetWorkspaceSync,
 } from './collectionSync';
 import { useCollectionStore } from './collectionStore';
-import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
-import { isRelayAuthenticated } from './connectionStore';
+import { getDocProvider, isCloudSignedIn, useRelayDocumentStore } from './relayDocumentStore';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { useDocumentRegistry } from './documentRegistry';
 import { useNotificationStore } from './notificationStore';
@@ -35,7 +32,7 @@ import type { RelayCollectionDef } from '../api/relayClient';
 
 const getDocProviderMock = getDocProvider as unknown as Mock;
 const relayGetState = useRelayDocumentStore.getState as unknown as Mock;
-const authedMock = isRelayAuthenticated as unknown as Mock;
+const authedMock = isCloudSignedIn as unknown as Mock;
 const syncMgrMock = getSyncStateManager as unknown as Mock;
 const registryGetState = useDocumentRegistry.getState as unknown as Mock;
 const notifyGetState = useNotificationStore.getState as unknown as Mock;

--- a/src/store/collectionSync.ts
+++ b/src/store/collectionSync.ts
@@ -21,7 +21,6 @@
 import type { RelayCollectionDef } from '../api/relayClient';
 import type { DocumentMetadata } from '../types/Document';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
-import { isRelayAuthenticated } from './connectionStore';
 import {
   useCollectionStore,
   isWorkspaceCollection,
@@ -29,7 +28,7 @@ import {
   type CollectionScope,
 } from './collectionStore';
 import { useNotificationStore } from './notificationStore';
-import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+import { getDocProvider, isCloudSignedIn, useRelayDocumentStore } from './relayDocumentStore';
 import { useDocumentRegistry } from './documentRegistry';
 
 /** Ids of the connected workspace's collections, refreshed on every relay read.
@@ -72,7 +71,7 @@ function mutateRelayDefs(
   return serialize(async () => {
     const provider = getDocProvider();
     if (!provider?.getCollections || !provider.setCollections) return;
-    if (!isRelayAuthenticated()) return;
+    if (!isCloudSignedIn()) return;
     try {
       const current = await provider.getCollections();
       const next = transform(current);
@@ -88,7 +87,7 @@ async function pushMembership(documentId: string, collectionId: string | null): 
   if (!useRelayDocumentStore.getState().isRelayDocument(documentId)) return; // local doc → no relay membership
   const provider = getDocProvider();
   if (!provider?.setDocumentCollection) return;
-  if (!isRelayAuthenticated()) return;
+  if (!isCloudSignedIn()) return;
   // Don't create a dangling reference: if we know this workspace's set and the
   // target isn't in it, it's a local/other-workspace collection — skip.
   if (collectionId !== null && knownCollectionIds.size > 0 && !knownCollectionIds.has(collectionId)) {
@@ -116,7 +115,7 @@ export const syncedActions = {
    * that must match the document's scope).
    */
   createCollection(name: string, color?: string, scope?: CollectionScope): string {
-    const resolvedScope: CollectionScope = scope ?? (isRelayAuthenticated() ? 'workspace' : 'local');
+    const resolvedScope: CollectionScope = scope ?? (isCloudSignedIn() ? 'workspace' : 'local');
     const id = useCollectionStore.getState().createCollection(name, color, resolvedScope);
     if (id && resolvedScope === 'workspace') {
       const col = useCollectionStore.getState().collections[id];

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -26,6 +26,15 @@
   box-shadow: 0 0 0 2px var(--color-primary);
 }
 
+/* While the per-card "move to collection" menu is open, lift the whole card
+   above later sibling cards so the absolutely-positioned dropdown isn't painted
+   underneath the next card (the actions row is opacity<1, which traps the
+   menu's own z-index in a lower stacking context). */
+.document-card--collection-open {
+  position: relative;
+  z-index: 40;
+}
+
 /* Content */
 .document-card__content {
   flex: 1;

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -441,7 +441,7 @@ function DocumentCardImpl({
 
   return (
     <div
-      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''}`}
+      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${collMenuOpen ? 'document-card--collection-open' : ''}`}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
     >

--- a/src/ui/confirm/ConfirmDialog.css
+++ b/src/ui/confirm/ConfirmDialog.css
@@ -71,6 +71,50 @@
   box-shadow: 0 0 0 3px var(--color-primary-alpha);
 }
 
+/* Optional segmented single-select under the input (e.g. collection scope). */
+.confirm-dialog__choice {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.confirm-dialog__choice-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.confirm-dialog__choice-options {
+  display: flex;
+  gap: 4px;
+  padding: 3px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 8px;
+}
+.confirm-dialog__choice-btn {
+  flex: 1 1 0;
+  padding: 7px 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.confirm-dialog__choice-btn:hover {
+  color: var(--text-primary);
+}
+.confirm-dialog__choice-btn--on {
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border-color: var(--border-color);
+}
+.confirm-dialog__choice-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
 .confirm-dialog__btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/src/ui/confirm/ConfirmDialog.tsx
+++ b/src/ui/confirm/ConfirmDialog.tsx
@@ -105,7 +105,7 @@ function ConfirmDialog({ request, onConfirm, onCancel }: ConfirmDialogProps) {
 
 interface PromptDialogProps {
   request: PromptRequest;
-  onSubmit: (value: string) => void;
+  onSubmit: (value: string, choice?: string) => void;
   onCancel: () => void;
 }
 
@@ -113,6 +113,7 @@ function PromptDialog({ request, onSubmit, onCancel }: PromptDialogProps) {
   const dialogRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(request.initialValue ?? '');
+  const [choice, setChoice] = useState(request.choice?.initialValue ?? '');
 
   useEffect(() => {
     // Focus + select the input so the user can type or overwrite immediately.
@@ -124,7 +125,7 @@ function PromptDialog({ request, onSubmit, onCancel }: PromptDialogProps) {
   const trimmed = value.trim();
   const submit = () => {
     if (trimmed.length === 0) return;
-    onSubmit(trimmed);
+    onSubmit(trimmed, request.choice ? choice : undefined);
   };
 
   return (
@@ -163,6 +164,33 @@ function PromptDialog({ request, onSubmit, onCancel }: PromptDialogProps) {
           placeholder={request.placeholder}
           aria-label={request.label ?? request.title}
         />
+        {request.choice && (
+          <div
+            className="confirm-dialog__choice"
+            role="radiogroup"
+            aria-label={request.choice.label ?? 'Choose an option'}
+          >
+            {request.choice.label && (
+              <span className="confirm-dialog__choice-label">{request.choice.label}</span>
+            )}
+            <div className="confirm-dialog__choice-options">
+              {request.choice.options.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={choice === opt.value}
+                  className={`confirm-dialog__choice-btn${
+                    choice === opt.value ? ' confirm-dialog__choice-btn--on' : ''
+                  }`}
+                  onClick={() => setChoice(opt.value)}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
         <div className="confirm-dialog__actions">
           <button
             type="button"
@@ -192,7 +220,10 @@ export function ConfirmDialogHost() {
   const onConfirm = useCallback(() => resolve(true), [resolve]);
   const onCancel = useCallback(() => resolve(false), [resolve]);
   const onPromptCancel = useCallback(() => resolve(null), [resolve]);
-  const onPromptSubmit = useCallback((value: string) => resolve(value), [resolve]);
+  const onPromptSubmit = useCallback(
+    (value: string, choice?: string) => resolve(choice !== undefined ? { value, choice } : value),
+    [resolve],
+  );
 
   if (!current || typeof document === 'undefined') return null;
 

--- a/src/ui/confirm/confirmStore.ts
+++ b/src/ui/confirm/confirmStore.ts
@@ -27,6 +27,28 @@ export interface ConfirmOptions {
   danger?: boolean;
 }
 
+/** One option in a prompt's segmented `choice` control. */
+export interface PromptChoiceOption {
+  value: string;
+  label: string;
+}
+
+/** An optional segmented single-select rendered under a prompt's text input
+ *  (e.g. "save this collection in: Workspace | This device"). */
+export interface PromptChoice {
+  /** Accessible label / small heading for the control. */
+  label?: string;
+  options: PromptChoiceOption[];
+  /** The option selected when the dialog opens. */
+  initialValue: string;
+}
+
+/** Result of a prompt that carried a `choice`: the text plus the picked option. */
+export interface PromptResult {
+  value: string;
+  choice: string;
+}
+
 export interface PromptOptions {
   /** Bold heading. */
   title: string;
@@ -42,12 +64,15 @@ export interface PromptOptions {
   confirmLabel?: string;
   /** Cancel button label (default "Cancel"). */
   cancelLabel?: string;
+  /** Optional segmented choice. When set, the dialog resolves a `PromptResult`
+   *  ({ value, choice }) instead of a bare string. */
+  choice?: PromptChoice;
 }
 
 interface DialogRequestBase {
   id: string;
   /** Internal resolver — narrowed by the wrapper so callers get a clean type. */
-  resolve: (result: boolean | string | null) => void;
+  resolve: (result: boolean | string | PromptResult | null) => void;
 }
 
 export interface ConfirmRequest extends ConfirmOptions, DialogRequestBase {
@@ -64,7 +89,7 @@ interface ConfirmState {
   current: DialogRequest | null;
   queue: DialogRequest[];
   /** @internal */ _enqueue: (req: DialogRequest) => void;
-  /** @internal */ _resolve: (result: boolean | string | null) => void;
+  /** @internal */ _resolve: (result: boolean | string | PromptResult | null) => void;
 }
 
 let seq = 0;
@@ -106,14 +131,25 @@ export function confirmDialog(opts: ConfirmOptions): Promise<boolean> {
  * or `null` on cancel / Esc / backdrop dismiss / empty. Requires
  * `<ConfirmDialogHost />` mounted once.
  */
-export function promptDialog(opts: PromptOptions): Promise<string | null> {
+export function promptDialog(
+  opts: PromptOptions & { choice: PromptChoice },
+): Promise<PromptResult | null>;
+export function promptDialog(opts: PromptOptions): Promise<string | null>;
+export function promptDialog(opts: PromptOptions): Promise<string | PromptResult | null> {
+  const hasChoice = opts.choice !== undefined;
   return new Promise((resolve) => {
     seq += 1;
     useConfirmStore.getState()._enqueue({
       ...opts,
       kind: 'prompt',
       id: `prompt-${seq}`,
-      resolve: (r) => resolve(typeof r === 'string' && r.length > 0 ? r : null),
+      resolve: (r) => {
+        if (hasChoice) {
+          resolve(r !== null && typeof r === 'object' ? r : null);
+        } else {
+          resolve(typeof r === 'string' && r.length > 0 ? r : null);
+        }
+      },
     });
   });
 }

--- a/src/ui/confirm/promptDialog.test.tsx
+++ b/src/ui/confirm/promptDialog.test.tsx
@@ -64,6 +64,64 @@ describe('promptDialog', () => {
     expect(create.disabled).toBe(true);
   });
 
+  it('with a choice: resolves { value, choice } using the initial selection', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({
+      title: 'New collection',
+      confirmLabel: 'Create',
+      choice: {
+        label: 'Save in',
+        initialValue: 'workspace',
+        options: [
+          { value: 'workspace', label: 'Workspace' },
+          { value: 'local', label: 'This device' },
+        ],
+      },
+    });
+
+    const input = (await screen.findByRole('textbox')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Roadmap' } });
+    // Default selection (workspace) is reflected on the radio.
+    expect(screen.getByRole('radio', { name: 'Workspace' }).getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await expect(p).resolves.toEqual({ value: 'Roadmap', choice: 'workspace' });
+  });
+
+  it('with a choice: picking a different option changes the resolved choice', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({
+      title: 'New collection',
+      confirmLabel: 'Create',
+      choice: {
+        initialValue: 'workspace',
+        options: [
+          { value: 'workspace', label: 'Workspace' },
+          { value: 'local', label: 'This device' },
+        ],
+      },
+    });
+
+    const input = (await screen.findByRole('textbox')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Personal notes' } });
+    fireEvent.click(screen.getByRole('radio', { name: 'This device' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await expect(p).resolves.toEqual({ value: 'Personal notes', choice: 'local' });
+  });
+
+  it('with a choice: resolves null on cancel', async () => {
+    render(<ConfirmDialogHost />);
+    const p = promptDialog({
+      title: 'New collection',
+      choice: { initialValue: 'workspace', options: [{ value: 'workspace', label: 'Workspace' }] },
+    });
+    await screen.findByRole('textbox');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await expect(p).resolves.toBeNull();
+  });
+
   it('queues behind a confirm dialog, then shows the prompt', async () => {
     render(<ConfirmDialogHost />);
     const c = confirmDialog({ title: 'First confirm' });

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -203,6 +203,11 @@
   border-radius: var(--radius-full);
   background: var(--text-faint);
 }
+/* Local (HardDrive) vs workspace (Cloud) scope marker on a collection entry. */
+.dh-collection-scope {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
 
 /* A collection rail entry: the filter button plus its actions menu (JP-380).
    The menu trigger is revealed on hover / keyboard focus / while open, so the

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -204,6 +204,33 @@
   background: var(--text-faint);
 }
 
+/* A collection rail entry: the filter button plus its actions menu (JP-380).
+   The menu trigger is revealed on hover / keyboard focus / while open, so the
+   dense rail stays clean but every collection's rename/recolour/delete is one
+   reach away (previously only reachable via group-by-collection). */
+.dh-collection-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.dh-collection-row .dh-nav-item {
+  width: auto;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.dh-collection-row .document-browser__section-menu-wrap {
+  flex: 0 0 auto;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s ease;
+}
+.dh-collection-row:hover .document-browser__section-menu-wrap,
+.dh-collection-row:focus-within .document-browser__section-menu-wrap,
+.dh-collection-row--menu-open .document-browser__section-menu-wrap {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .dh-side-foot {
   flex: 0 0 auto;
   padding: 10px;

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -40,6 +40,7 @@ import {
 import { useDocumentBrowserModel, SORT_LABELS } from '../settings/useDocumentBrowserModel';
 import { DocumentList, SelectionBar } from '../settings/DocumentList';
 import { CollectionActionsMenu } from '../settings/CollectionActionsMenu';
+import { isWorkspaceCollection } from '../../store/collectionStore';
 import { StorageSettings } from '../settings/StorageSettings';
 import { TrashView } from './TrashView';
 import { ShapeLibraryManager } from '../ShapeLibraryManager';
@@ -351,30 +352,44 @@ export function DocumentsHome({
           {collections.length === 0 ? (
             <div className="dh-nav-empty">No collections yet</div>
           ) : (
-            collections.map((c) => (
-              <div
-                key={c.id}
-                className={`dh-collection-row${activeCollectionMenu === c.id ? ' dh-collection-row--menu-open' : ''}`}
-              >
-                <button
-                  className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
-                  onClick={() => selectCollection(c.id)}
+            collections.map((c) => {
+              // Namespace the rail's menu key so it never collides with the
+              // group-by-collection section menu (which keys off the bare
+              // collection id) — otherwise both would open at once and their
+              // outside-click handlers cancel each other (JP-380).
+              const menuKey = `coll-rail:${c.id}`;
+              const isWorkspace = isWorkspaceCollection(c);
+              const ScopeIcon = isWorkspace ? Cloud : HardDrive;
+              return (
+                <div
+                  key={c.id}
+                  className={`dh-collection-row${activeCollectionMenu === menuKey ? ' dh-collection-row--menu-open' : ''}`}
                 >
-                  <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
-                  <span className="dh-nav-label">{c.name}</span>
-                  <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
-                </button>
-                <CollectionActionsMenu
-                  collection={c}
-                  isOpen={activeCollectionMenu === c.id}
-                  onOpen={() => setActiveCollectionMenu(activeCollectionMenu === c.id ? null : c.id)}
-                  onClose={() => setActiveCollectionMenu(null)}
-                  onRename={handleRenameCollection}
-                  onDelete={handleDeleteCollection}
-                  onRecolor={handleRecolor}
-                />
-              </div>
-            ))
+                  <button
+                    className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
+                    onClick={() => selectCollection(c.id)}
+                  >
+                    <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
+                    <ScopeIcon
+                      size={13}
+                      className="dh-collection-scope"
+                      aria-label={isWorkspace ? 'Workspace collection' : 'Local collection'}
+                    />
+                    <span className="dh-nav-label">{c.name}</span>
+                    <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
+                  </button>
+                  <CollectionActionsMenu
+                    collection={c}
+                    isOpen={activeCollectionMenu === menuKey}
+                    onOpen={() => setActiveCollectionMenu(activeCollectionMenu === menuKey ? null : menuKey)}
+                    onClose={() => setActiveCollectionMenu(null)}
+                    onRename={handleRenameCollection}
+                    onDelete={handleDeleteCollection}
+                    onRecolor={handleRecolor}
+                  />
+                </div>
+              );
+            })
           )}
 
           <button

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -39,6 +39,7 @@ import {
 } from 'lucide-react';
 import { useDocumentBrowserModel, SORT_LABELS } from '../settings/useDocumentBrowserModel';
 import { DocumentList, SelectionBar } from '../settings/DocumentList';
+import { CollectionActionsMenu } from '../settings/CollectionActionsMenu';
 import { StorageSettings } from '../settings/StorageSettings';
 import { TrashView } from './TrashView';
 import { ShapeLibraryManager } from '../ShapeLibraryManager';
@@ -99,6 +100,11 @@ export function DocumentsHome({
     groupBy,
     setGroupBy,
     handleCreateCollection,
+    handleRenameCollection,
+    handleDeleteCollection,
+    handleRecolor,
+    activeCollectionMenu,
+    setActiveCollectionMenu,
     isInTeamMode,
     isConnectedToHost,
     relaySessionUsable,
@@ -346,15 +352,28 @@ export function DocumentsHome({
             <div className="dh-nav-empty">No collections yet</div>
           ) : (
             collections.map((c) => (
-              <button
+              <div
                 key={c.id}
-                className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
-                onClick={() => selectCollection(c.id)}
+                className={`dh-collection-row${activeCollectionMenu === c.id ? ' dh-collection-row--menu-open' : ''}`}
               >
-                <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
-                <span className="dh-nav-label">{c.name}</span>
-                <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
-              </button>
+                <button
+                  className={`dh-nav-item dh-collection${collectionFilter === c.id ? ' dh-nav-item--on' : ''}`}
+                  onClick={() => selectCollection(c.id)}
+                >
+                  <span className="dh-collection-dot" style={c.color ? { background: c.color } : undefined} />
+                  <span className="dh-nav-label">{c.name}</span>
+                  <span className="dh-nav-count">{collectionCounts[c.id] ?? 0}</span>
+                </button>
+                <CollectionActionsMenu
+                  collection={c}
+                  isOpen={activeCollectionMenu === c.id}
+                  onOpen={() => setActiveCollectionMenu(activeCollectionMenu === c.id ? null : c.id)}
+                  onClose={() => setActiveCollectionMenu(null)}
+                  onRename={handleRenameCollection}
+                  onDelete={handleDeleteCollection}
+                  onRecolor={handleRecolor}
+                />
+              </div>
             ))
           )}
 

--- a/src/ui/settings/CollectionActionsMenu.tsx
+++ b/src/ui/settings/CollectionActionsMenu.tsx
@@ -1,0 +1,96 @@
+/**
+ * CollectionActionsMenu — the three-dots actions menu for a single collection
+ * (rename / recolour / delete). Shared by the group-by `CollectionSection` in
+ * `DocumentList` and the Collections rail in `DocumentsHome` so both surfaces
+ * stay in lockstep (JP-380). Presentational: the host owns the open state (one
+ * menu open at a time, keyed off the model's `activeCollectionMenu`) and the
+ * action handlers; this component just renders the trigger + dropdown and
+ * closes itself on an outside click.
+ *
+ * Reuses the global `document-browser__*` classes from `DocumentBrowser.css`.
+ */
+
+import { useRef, useEffect } from 'react';
+import { MoreHorizontal, X } from 'lucide-react';
+import { COLLECTION_SWATCHES, type Collection } from '../../store/collectionStore';
+
+interface CollectionActionsMenuProps {
+  collection: Collection;
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onRename: (collection: Collection) => void;
+  onDelete: (collection: Collection) => void;
+  onRecolor: (collection: Collection, color: string | undefined) => void;
+}
+
+export function CollectionActionsMenu({
+  collection,
+  isOpen,
+  onOpen,
+  onClose,
+  onRename,
+  onDelete,
+  onRecolor,
+}: CollectionActionsMenuProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [isOpen, onClose]);
+
+  return (
+    <div className="document-browser__section-menu-wrap" ref={menuRef}>
+      <button
+        className="document-browser__section-menu-btn"
+        onClick={onOpen}
+        title="Collection actions"
+        aria-label="Collection actions"
+        aria-haspopup="menu"
+      >
+        <MoreHorizontal size={16} aria-hidden="true" />
+      </button>
+      {isOpen && (
+        <div className="document-browser__section-menu" role="menu">
+          <button className="document-browser__assign-item" onClick={() => onRename(collection)}>
+            Rename…
+          </button>
+          <div className="document-browser__assign-sep" />
+          <div className="document-browser__swatch-row">
+            {COLLECTION_SWATCHES.map((color) => (
+              <button
+                key={color}
+                className="document-browser__swatch"
+                style={{ background: color }}
+                onClick={() => onRecolor(collection, color)}
+                title={color}
+              />
+            ))}
+            <button
+              className="document-browser__swatch document-browser__swatch--clear"
+              onClick={() => onRecolor(collection, undefined)}
+              title="Clear colour"
+              aria-label="Clear colour"
+            >
+              <X size={12} aria-hidden="true" />
+            </button>
+          </div>
+          <div className="document-browser__assign-sep" />
+          <button
+            className="document-browser__assign-item document-browser__assign-item--danger"
+            onClick={() => onDelete(collection)}
+          >
+            Delete collection
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -569,6 +569,11 @@
   flex-shrink: 0;
 }
 
+.document-browser__section-scope {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
 .document-browser__section-title {
   letter-spacing: 0.2px;
 }

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -7,12 +7,13 @@
  * `DocumentBrowser` chrome and the first-class `DocumentsHome` surface (JP-218).
  */
 
-import { useRef, useEffect, useState } from 'react';
-import { ChevronDown, MoreHorizontal, X } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
 import { DocumentBackupsDrawer } from '../DocumentBackupsDrawer';
 import { DocumentPermissionsDialog } from '../DocumentPermissionsDialog';
-import { COLLECTION_SWATCHES, type Collection } from '../../store/collectionStore';
+import { CollectionActionsMenu } from './CollectionActionsMenu';
+import { type Collection } from '../../store/collectionStore';
 import type { DocumentBrowserView } from '../../store/uiPreferencesStore';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
 import {
@@ -291,19 +292,6 @@ function CollectionSection({
   onDelete,
   onRecolor,
 }: CollectionSectionProps) {
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!isMenuOpen || !onCloseMenu) return;
-    const onDoc = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        onCloseMenu();
-      }
-    };
-    document.addEventListener('mousedown', onDoc);
-    return () => document.removeEventListener('mousedown', onDoc);
-  }, [isMenuOpen, onCloseMenu]);
-
   const isUnassigned = collection === null;
   // Show the collection-actions menu + swatch only for real user-defined
   // collections, never for the unassigned section.
@@ -332,52 +320,16 @@ function CollectionSection({
           <span className="document-browser__section-title">{title}</span>
           <span className="document-browser__section-count">{docs.length}</span>
         </button>
-        {showMenu && collection && (
-          <div className="document-browser__section-menu-wrap" ref={menuRef}>
-            <button
-              className="document-browser__section-menu-btn"
-              onClick={onOpenMenu}
-              title="Collection actions"
-              aria-label="Collection actions"
-              aria-haspopup="menu"
-            >
-              <MoreHorizontal size={16} aria-hidden="true" />
-            </button>
-            {isMenuOpen && (
-              <div className="document-browser__section-menu" role="menu">
-                <button className="document-browser__assign-item" onClick={() => onRename?.(collection)}>
-                  Rename…
-                </button>
-                <div className="document-browser__assign-sep" />
-                <div className="document-browser__swatch-row">
-                  {COLLECTION_SWATCHES.map((color) => (
-                    <button
-                      key={color}
-                      className="document-browser__swatch"
-                      style={{ background: color }}
-                      onClick={() => onRecolor?.(collection, color)}
-                      title={color}
-                    />
-                  ))}
-                  <button
-                    className="document-browser__swatch document-browser__swatch--clear"
-                    onClick={() => onRecolor?.(collection, undefined)}
-                    title="Clear colour"
-                    aria-label="Clear colour"
-                  >
-                    <X size={12} aria-hidden="true" />
-                  </button>
-                </div>
-                <div className="document-browser__assign-sep" />
-                <button
-                  className="document-browser__assign-item document-browser__assign-item--danger"
-                  onClick={() => onDelete?.(collection)}
-                >
-                  Delete collection
-                </button>
-              </div>
-            )}
-          </div>
+        {showMenu && collection && onRename && onDelete && onRecolor && (
+          <CollectionActionsMenu
+            collection={collection}
+            isOpen={isMenuOpen === true}
+            onOpen={() => onOpenMenu?.()}
+            onClose={() => onCloseMenu?.()}
+            onRename={onRename}
+            onDelete={onDelete}
+            onRecolor={onRecolor}
+          />
         )}
       </div>
       {!collapsed && (

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -8,12 +8,12 @@
  */
 
 import { useState } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Cloud, HardDrive } from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
 import { DocumentBackupsDrawer } from '../DocumentBackupsDrawer';
 import { DocumentPermissionsDialog } from '../DocumentPermissionsDialog';
 import { CollectionActionsMenu } from './CollectionActionsMenu';
-import { type Collection } from '../../store/collectionStore';
+import { isWorkspaceCollection, type Collection } from '../../store/collectionStore';
 import type { DocumentBrowserView } from '../../store/uiPreferencesStore';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
 import {
@@ -298,6 +298,7 @@ function CollectionSection({
   const showMenu = collection !== null;
   const showSwatch = !isUnassigned;
   const title = collection !== null ? collection.name : 'Unassigned';
+  const ScopeIcon = collection && isWorkspaceCollection(collection) ? Cloud : HardDrive;
   return (
     <div className="document-browser__section">
       <div className="document-browser__section-header">
@@ -315,6 +316,15 @@ function CollectionSection({
             <span
               className="document-browser__section-swatch"
               style={collection?.color ? { background: collection.color } : undefined}
+            />
+          )}
+          {collection && (
+            <ScopeIcon
+              size={13}
+              className="document-browser__section-scope"
+              aria-label={
+                isWorkspaceCollection(collection) ? 'Workspace collection' : 'Local collection'
+              }
             />
           )}
           <span className="document-browser__section-title">{title}</span>

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -20,7 +20,7 @@ import {
   saveDocumentToStorage,
 } from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
-import { useRelayDocumentStore, useIsCloudSignedIn } from '../../store/relayDocumentStore';
+import { useRelayDocumentStore, useIsCloudSignedIn, isCloudSignedIn } from '../../store/relayDocumentStore';
 import { ensureCollabSessionForDoc } from '../../collaboration/ensureCollabSession';
 import {
   computeOfflineStatus,
@@ -33,7 +33,7 @@ import {
   useUIPreferencesStore,
   type DocumentBrowserSort,
 } from '../../store/uiPreferencesStore';
-import { useCollectionStore, type Collection } from '../../store/collectionStore';
+import { useCollectionStore, type Collection, type CollectionScope } from '../../store/collectionStore';
 import { syncedActions, assignDocumentsScoped, docScopeOf } from '../../store/collectionSync';
 import { exportAndDownloadDocumentArchive, importDocumentArchive } from '../../storage/DocumentArchiveService';
 import { getTransferService, type TransferState } from '../../services/DocumentTransferService';
@@ -850,14 +850,38 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
 
   // Collection management
   const handleCreateCollection = useCallback(async () => {
-    const name = await promptDialog({
-      title: 'New collection',
-      label: 'Collection name',
-      placeholder: 'e.g. Q3 Planning',
-      confirmLabel: 'Create',
-    });
+    let name: string | null;
+    let scope: CollectionScope;
+    // Offer a Workspace/local picker only when signed into a workspace; otherwise
+    // a collection can only be local, so skip the choice and create it local.
+    if (isCloudSignedIn()) {
+      const res = await promptDialog({
+        title: 'New collection',
+        label: 'Collection name',
+        placeholder: 'e.g. Q3 Planning',
+        confirmLabel: 'Create',
+        choice: {
+          label: 'Save in',
+          initialValue: 'workspace',
+          options: [
+            { value: 'workspace', label: 'Workspace' },
+            { value: 'local', label: 'This device' },
+          ],
+        },
+      });
+      name = res?.value ?? null;
+      scope = res?.choice === 'local' ? 'local' : 'workspace';
+    } else {
+      name = await promptDialog({
+        title: 'New collection',
+        label: 'Collection name',
+        placeholder: 'e.g. Q3 Planning',
+        confirmLabel: 'Create',
+      });
+      scope = 'local';
+    }
     if (!name) return;
-    const id = syncedActions.createCollection(name);
+    const id = syncedActions.createCollection(name, undefined, scope);
     // Surface the new (empty) collection so it's immediately visible + manageable.
     if (id) setGroupBy('collection');
   }, [setGroupBy]);


### PR DESCRIPTION
Fixes JP-380 plus the follow-up Collections issues surfaced while testing, all on the same subject (folded in per request — kept as one self-contained Collections PR rather than stacking).

## Bug — collection actions buried
Rename/recolour/delete was only reachable via **group-by collection**. Extracted the inline three-dots menu into a shared, presentational `CollectionActionsMenu` (`src/ui/settings/CollectionActionsMenu.tsx`) reused by both the group-by section and the **Collections rail** in the documents home. Trigger reveals on hover/focus.

## Bug — grouped double-menu (regression in the above)
The rail and the group-by section menus both keyed off `activeCollectionMenu` by the bare collection id, so a grouped collection opened **both** at once and their rival outside-click handlers cancelled each other on mousedown — controls went dead (delete still worked, it's a direct handler). The rail now uses a namespaced `coll-rail:<id>` key, so only one menu is ever open.

## Bug — can't delete an empty *remote* collection
Collection-definition **reads** (`reconcileFromRelay`) hit the relay over REST unconditionally, but **writes** (`mutateRelayDefs`, `pushMembership`, create-scope) were gated on `isRelayAuthenticated()` — a **WebSocket-only** check. Deleting an empty workspace collection from the documents home (REST session, no live WS) dropped the local def but skipped the relay PUT, so the next reconcile re-hydrated it. Both endpoints are plain REST, so gate the whole def/membership lifecycle on `isCloudSignedIn()` (REST-capable, the same gate used for list/refresh/transfer). No relay change.

## Bug — per-card "move to collection" dropdown hidden under the next card
Pre-existing (from JP-365): `.document-card__actions` is `opacity < 1`, creating a stacking context that traps the dropdown's `z-index` below later sibling cards. Lift the whole card (`position: relative; z-index`) while its collection menu is open.

## Feature — scope icons + create picker
- Each collection shows **Cloud** (workspace) or **HardDrive** (local) in the rail and the group-by section header, consistent with the sidebar's type-axis nav icons.
- Extended the shared `promptDialog` with an optional segmented `choice` control (resolves `{ value, choice }`). **New collection** now offers **Workspace vs This device** when signed into a workspace; local-only otherwise.

## Verification
- `bun run typecheck`, full `bun run test --run` (**2678 passing**, incl. new `promptDialog` choice-path + updated `collectionSync` gate tests), and `bun run build` all green.
- **Manual (gates Done):** on staging — (1) delete an empty workspace collection from the home with no doc open (REST-only) → stays gone after refresh; (2) group by collection → rail and section three-dots each work independently; (3) open a card's "move to collection" menu in a list → dropdown floats above the next card; (4) create a collection while signed in → Workspace/This device picker; the chosen scope sticks and shows the right icon.

Assisted-by: Opus 4.8