### PR TITLE
JP-332 Slice 1: mobile-preview gate + adaptation seam

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -393,6 +393,42 @@ describe('uiPreferencesStore — migration', () => {
 
     expect(useUIPreferencesStore.getState().relaxedSplitCanvasWidth).toBe(640);
   });
+
+  it('v10 → v11 defaults the mobile-preview flags to false (existing users unaffected)', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          // v10 payload predates the mobile-preview flags.
+        },
+        version: 10,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    const state = useUIPreferencesStore.getState();
+    expect(state.mobilePreviewAccepted).toBe(false);
+    expect(state.forceDesktopSite).toBe(false);
+  });
+
+  it('v10 → v11 preserves an explicit mobile-preview acceptance', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          mobilePreviewAccepted: true,
+        },
+        version: 10,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().mobilePreviewAccepted).toBe(true);
+  });
 });
 
 describe('uiPreferencesStore — collab indicator position', () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -139,6 +139,17 @@ export interface UIPreferencesState {
    * App-level (not per-doc), clamped into the viewport at render time.
    */
   collabIndicatorPos: { x: number; y: number } | null;
+  /**
+   * Whether the user accepted the experimental mobile-preview layout (JP-332).
+   * Persisted so the one-time prompt fires at most once per browser. Gates the
+   * mobile chrome together with `forceDesktopSite` — see `useMobileAdaptation`.
+   */
+  mobilePreviewAccepted: boolean;
+  /**
+   * Whether the user opted out of the mobile preview — force the desktop layout
+   * even on a small touch screen. Re-enabled from Settings → Appearance.
+   */
+  forceDesktopSite: boolean;
 }
 
 /**
@@ -171,6 +182,10 @@ export interface UIPreferencesActions {
   toggleDocumentBrowserGroupCollapsed: (collectionId: string) => void;
   /** Record that the one-time storage-info toast has been shown. */
   markStorageInfoToastSeen: () => void;
+  /** Accept (or clear) the experimental mobile-preview layout. */
+  setMobilePreviewAccepted: (accepted: boolean) => void;
+  /** Force the desktop layout on a touch device (mobile-preview opt-out). */
+  setForceDesktopSite: (force: boolean) => void;
 
   // ── Layout actions (low-level; the `useLayout` hook composes ergonomic
   // "infer current mode" wrappers on top of these for normal call sites.)
@@ -299,6 +314,8 @@ const initialState: UIPreferencesState = {
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
   collabIndicatorPos: null,
+  mobilePreviewAccepted: false,
+  forceDesktopSite: false,
 };
 
 /**
@@ -439,6 +456,9 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       markStorageInfoToastSeen: () => set({ storageInfoToastSeen: true }),
 
+      setMobilePreviewAccepted: (accepted) => set({ mobilePreviewAccepted: accepted }),
+      setForceDesktopSite: (force) => set({ forceDesktopSite: force }),
+
       setDefaultLayout: (mode) => {
         set({ layout: { ...get().layout, defaultMode: mode } });
       },
@@ -573,7 +593,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 10,
+      version: 11,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -587,6 +607,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
         collabIndicatorPos: state.collabIndicatorPos,
+        mobilePreviewAccepted: state.mobilePreviewAccepted,
+        forceDesktopSite: state.forceDesktopSite,
       }),
       migrate: (persisted, fromVersion) => {
         // Cast away the loose persisted-state typing — older payloads carry
@@ -707,6 +729,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...initialAppearancePrefs,
             ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
           };
+        }
+        // v10 → v11: added the experimental mobile-preview flags (JP-332).
+        // Default both to false (never prompted, not opted out) so existing
+        // users are unaffected until they hit the gate. An explicit persisted
+        // value is preserved. (The `merge` below also backstops these top-level
+        // booleans.)
+        if (fromVersion < 11) {
+          next['mobilePreviewAccepted'] = next['mobilePreviewAccepted'] ?? false;
+          next['forceDesktopSite'] = next['forceDesktopSite'] ?? false;
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState, useCallback, lazy, Suspense } from 'react';
 import './App.css';
+import './mobile/mobile.css';
 import { CanvasContainer } from './CanvasContainer';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
 import { isFlyoutLayout, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { MobilePreviewGate } from './mobile/MobilePreviewGate';
 import { FlyoutPanel } from './layout/FlyoutPanel';
 import { PanelChromeWrapper } from './layout/PanelChromeWrapper';
 import { DockedPanel } from './layout/DockedPanel';
@@ -143,6 +146,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   const renderProperties = isPropertiesVisible || relaxedTransientProps;
 
   const { band } = useBreakpoint();
+  // Experimental mobile chrome (JP-332): inert until the user opts in on a small
+  // touch screen. Slices hang their mobile overrides off `data-mobile` + this flag.
+  const { mobileActive } = useMobileAdaptation();
   const regions = resolveRegions(activeMode, relaxedFocus, band);
   const isRelaxed = activeMode === 'relaxed';
   // The canvas wrapper is rendered once for every layout (so the engine never
@@ -419,7 +425,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   }, [initializeDefault, authCallbackConsumed]);
 
   return (
-    <div className="app">
+    <div className="app" data-mobile={mobileActive ? 'true' : undefined}>
+      <MobilePreviewGate />
       <ConnectionStatusBanner />
         {/* Custom-chrome title bar stays in the document browser — it carries the
             desktop window controls. The editor app bar (document title, layouts,

--- a/src/ui/layout/useMobileAdaptation.test.ts
+++ b/src/ui/layout/useMobileAdaptation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { isMobileViewport, shouldAdaptToMobile } from './useMobileAdaptation';
+import type { BreakpointState } from './useBreakpoint';
+
+/** A touch + narrow baseline; override per case. */
+function bp(partial: Partial<BreakpointState> = {}): BreakpointState {
+  return { band: 'narrow', isTouch: true, standalone: false, ...partial };
+}
+
+describe('isMobileViewport', () => {
+  it('is true only for a touch device at a narrow viewport', () => {
+    expect(isMobileViewport(bp({ isTouch: true, band: 'narrow' }))).toBe(true);
+    expect(isMobileViewport(bp({ isTouch: false, band: 'narrow' }))).toBe(false);
+    expect(isMobileViewport(bp({ isTouch: true, band: 'medium' }))).toBe(false);
+    expect(isMobileViewport(bp({ isTouch: true, band: 'wide' }))).toBe(false);
+  });
+});
+
+describe('shouldAdaptToMobile', () => {
+  it('does not render mobile chrome until accepted', () => {
+    expect(shouldAdaptToMobile(bp(), false, false)).toBe(false);
+    expect(shouldAdaptToMobile(bp(), true, false)).toBe(true);
+  });
+
+  it('opting out (forceDesktop) wins over acceptance', () => {
+    expect(shouldAdaptToMobile(bp(), true, true)).toBe(false);
+  });
+
+  it('requires a touch device (a narrowed desktop window never adapts)', () => {
+    expect(shouldAdaptToMobile(bp({ isTouch: false }), true, false)).toBe(false);
+  });
+
+  it('holds through narrow and medium but not wide (no orientation thrash)', () => {
+    expect(shouldAdaptToMobile(bp({ band: 'narrow' }), true, false)).toBe(true);
+    expect(shouldAdaptToMobile(bp({ band: 'medium' }), true, false)).toBe(true);
+    expect(shouldAdaptToMobile(bp({ band: 'wide' }), true, false)).toBe(false);
+  });
+});

--- a/src/ui/layout/useMobileAdaptation.ts
+++ b/src/ui/layout/useMobileAdaptation.ts
@@ -1,0 +1,65 @@
+/**
+ * useMobileAdaptation — the single seam gating the experimental mobile chrome
+ * (JP-332). Builds on `useBreakpoint` (touch + viewport band) and two persisted
+ * flags on `uiPreferencesStore` (`mobilePreviewAccepted`, `forceDesktopSite`).
+ *
+ * Two derived booleans, deliberately distinct:
+ *
+ * - `isMobile`     — a touch device at a `narrow` viewport. The gate uses this
+ *                    to decide whether to *prompt*: real phones, not a narrowed
+ *                    desktop window (desktop has no coarse pointer).
+ * - `mobileActive` — render the mobile chrome *now*: accepted, not opted out, on
+ *                    a touch device, and not a `wide` viewport. Slices 2–5
+ *                    consume only this. It holds through the `medium` band too,
+ *                    so a phone rotating portrait↔landscape (which crosses the
+ *                    640px boundary) keeps one consistent shell instead of
+ *                    thrashing between mobile and desktop chrome mid-session.
+ *
+ * The predicate is a pure function (`shouldAdaptToMobile`) so it is unit-tested
+ * without React, alongside `useBreakpoint.test.ts` / `modes.test.ts`.
+ */
+
+import { useBreakpoint, type BreakpointState } from './useBreakpoint';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+
+export interface MobileAdaptation {
+  /** Touch device at a narrow viewport — the prompt trigger. */
+  isMobile: boolean;
+  /** Render the mobile chrome now (gated by acceptance + opt-out). */
+  mobileActive: boolean;
+  /** The user accepted the experimental mobile preview. */
+  accepted: boolean;
+  /** The user opted out — force the desktop layout on touch. */
+  forceDesktop: boolean;
+}
+
+/** A touch device at a narrow viewport (the prompt trigger). Pure. */
+export function isMobileViewport(bp: BreakpointState): boolean {
+  return bp.isTouch && bp.band === 'narrow';
+}
+
+/**
+ * Should the mobile chrome render? Accepted + not opted out, on a touch device,
+ * and not a `wide` viewport. Holds through `medium` (phone/tablet landscape) so
+ * an orientation change doesn't swap the whole shell mid-session. Pure.
+ */
+export function shouldAdaptToMobile(
+  bp: BreakpointState,
+  accepted: boolean,
+  forceDesktop: boolean,
+): boolean {
+  return accepted && !forceDesktop && bp.isTouch && bp.band !== 'wide';
+}
+
+/** Reactive mobile-adaptation state — the single seam every mobile slice reads. */
+export function useMobileAdaptation(): MobileAdaptation {
+  const bp = useBreakpoint();
+  const accepted = useUIPreferencesStore((s) => s.mobilePreviewAccepted);
+  const forceDesktop = useUIPreferencesStore((s) => s.forceDesktopSite);
+  return {
+    isMobile: isMobileViewport(bp),
+    mobileActive: shouldAdaptToMobile(bp, accepted, forceDesktop),
+    accepted,
+    forceDesktop,
+  };
+}

--- a/src/ui/mobile/MobilePreviewGate.tsx
+++ b/src/ui/mobile/MobilePreviewGate.tsx
@@ -1,0 +1,48 @@
+/**
+ * MobilePreviewGate — the one-time opt-in to the experimental mobile layout
+ * (JP-332). On a touch device at a narrow viewport, the first load offers the
+ * (early, incomplete) mobile chrome behind a confirmation. Acceptance persists
+ * (`mobilePreviewAccepted`) so the prompt fires at most once per browser;
+ * "Not now" simply re-prompts on a future load.
+ *
+ * The *durable* opt-out ("use the desktop layout") lives in Settings →
+ * Appearance, not in this dialog: `confirmDialog` collapses an explicit decline
+ * and an Esc/backdrop dismissal into the same `false`, so the dialog only ever
+ * commits on accept — declining is always non-committal.
+ *
+ * Renders nothing; it's an effect host mounted once at the app root (next to
+ * `ConfirmDialogHost`, which actually draws the queued dialog).
+ */
+
+import { useEffect, useRef } from 'react';
+import { confirmDialog } from '../confirm/confirmStore';
+import { useMobileAdaptation } from '../layout/useMobileAdaptation';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+
+export function MobilePreviewGate(): null {
+  const { isMobile, accepted, forceDesktop } = useMobileAdaptation();
+  const setMobilePreviewAccepted = useUIPreferencesStore((s) => s.setMobilePreviewAccepted);
+  // Offer the prompt at most once per app session, even as the effect re-runs
+  // on resize/orientation changes. Persisted flags handle suppression across
+  // reloads; this ref handles it within a session.
+  const promptedThisSession = useRef(false);
+
+  useEffect(() => {
+    if (!isMobile || accepted || forceDesktop) return;
+    if (promptedThisSession.current) return;
+    promptedThisSession.current = true;
+    void (async () => {
+      const ok = await confirmDialog({
+        title: 'Mobile preview (experimental)',
+        message:
+          'The editor on a small screen is early-access and may be missing some features.',
+        details: 'You can switch back to the desktop layout anytime in Settings → Appearance.',
+        confirmLabel: 'Try mobile preview',
+        cancelLabel: 'Not now',
+      });
+      if (ok) setMobilePreviewAccepted(true);
+    })();
+  }, [isMobile, accepted, forceDesktop, setMobilePreviewAccepted]);
+
+  return null;
+}

--- a/src/ui/mobile/mobile.css
+++ b/src/ui/mobile/mobile.css
@@ -1,0 +1,21 @@
+/*
+ * Mobile preview chrome — shared shell rules (JP-332).
+ *
+ * Everything here is scoped to `[data-mobile="true"]`, which App sets on the
+ * root `.app` element only when the experimental mobile layout is active
+ * (`useMobileAdaptation().mobileActive`). Later slices hang their mobile chrome
+ * (collapsed toolbar, full-screen property sheet, partitioned prose toolbar) off
+ * this hook.
+ *
+ * The `--safe-area-*` tokens (declared in index.css) resolve to 0 outside a
+ * notched standalone PWA, so the inset padding below is a no-op on desktop and
+ * in an ordinary browser tab. The global `box-sizing: border-box` reset keeps
+ * the inset from growing the 100%-height root past the viewport.
+ */
+
+.app[data-mobile='true'] {
+  padding-top: var(--safe-area-top);
+  padding-right: var(--safe-area-right);
+  padding-bottom: var(--safe-area-bottom);
+  padding-left: var(--safe-area-left);
+}

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -383,12 +383,63 @@ export function AppearanceSettings() {
       {/* Title bar — desktop-only; renders nothing on the web app. */}
       <TitleBarSection />
 
+      {/* Mobile preview — the experimental small-screen layout (JP-332). */}
+      <MobilePreviewSection />
+
       {/* Reset */}
       <div className="settings-group">
         <h4 className="settings-group-title">Reset</h4>
         <button type="button" className="settings-reset-btn" onClick={handleReset}>
           Reset appearance to defaults
         </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mobile preview opt-in/out (JP-332). A single switch over the two persisted
+ * flags: turning it on accepts the preview and clears any opt-out; turning it
+ * off forces the desktop layout. Only takes visible effect on a small touch
+ * screen — `useMobileAdaptation` requires a coarse pointer — but it's shown
+ * everywhere so an opted-out user (or a desktop user testing a narrow window)
+ * has a discoverable, non-nagging way back in.
+ */
+function MobilePreviewSection() {
+  const accepted = useUIPreferencesStore((s) => s.mobilePreviewAccepted);
+  const forceDesktop = useUIPreferencesStore((s) => s.forceDesktopSite);
+  const setMobilePreviewAccepted = useUIPreferencesStore((s) => s.setMobilePreviewAccepted);
+  const setForceDesktopSite = useUIPreferencesStore((s) => s.setForceDesktopSite);
+
+  const enabled = accepted && !forceDesktop;
+  const handleToggle = (next: boolean) => {
+    if (next) {
+      setForceDesktopSite(false);
+      setMobilePreviewAccepted(true);
+    } else {
+      setMobilePreviewAccepted(false);
+      setForceDesktopSite(true);
+    }
+  };
+
+  return (
+    <div className="settings-group">
+      <h4 className="settings-group-title">Mobile preview</h4>
+      <div className="settings-row settings-row-switch">
+        <label className="settings-switch-label" htmlFor="docushark-mobile-preview">
+          <Switch
+            id="docushark-mobile-preview"
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            ariaLabel="Use the mobile preview layout"
+          />
+          <span className="settings-switch-text">Use the mobile preview layout</span>
+        </label>
+        <span className="settings-hint">
+          An experimental, early-access layout for small touch screens. Only takes
+          effect on a touch device with a small screen; turn it off to always use the
+          desktop layout.
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
First slice of JP-332 (experimental mobile layout). Lays the foundation every later slice builds on; **nothing visible changes yet** beyond a one-time opt-in dialog — the editor stays in Relaxed mode.

## Architecture
Per the approved plan, the mobile layout **adapts Relaxed in place** — no new `LayoutMode`, no `LAYOUT_PRESETS`/`resolveRegions` change. It's an additive chrome-override layer keyed off a single new seam and two persisted flags.

## What's here
- **`useMobileAdaptation`** (`src/ui/layout/useMobileAdaptation.ts`) — the single seam. Pure `shouldAdaptToMobile` predicate (unit-tested) + hook. `isMobile` (touch + `narrow`) drives *whether to prompt*; `mobileActive` drives *the chrome* and deliberately holds through the `medium` band so a phone rotating portrait↔landscape (which crosses 640px) keeps one consistent shell instead of thrashing.
- **`MobilePreviewGate`** — one-time "Mobile preview (experimental)" confirm on touch+narrow; acceptance persists so it fires at most once per browser. "Not now" re-prompts next load; the **durable opt-out lives in Settings → Appearance** (`confirmDialog` can't tell an explicit decline from an Esc/backdrop dismissal, so the dialog only ever commits on accept).
- **`uiPreferencesStore`** — persisted `mobilePreviewAccepted` + `forceDesktopSite` (v10→v11 migration defaulting both `false`) + setters. Migration + predicate tests included.
- **App shell** — `data-mobile` on the root + mounts the gate. `mobile.css` applies the reserved `--safe-area-*` insets under the hook (no-op outside a notched standalone PWA).
- **Settings → Appearance** — a "Use the mobile preview layout" switch (re-enable / opt-out home).

## Verification
- `bun run typecheck` ✓
- `bun run test` (touched: `useMobileAdaptation`, `uiPreferencesStore`, `AppearanceSettings`) ✓ — 40 passed incl. new v11 migration + predicate matrix
- `bun run build` ✓
- Manual: DevTools device toolbar (narrow + touch) → reload → dialog once → accept → `data-mobile="true"`; mouse + narrow window does **not** prompt.

Assisted-by: Opus 4.8