### PR TITLE
JP-332: Documents sidebar fly-in/out drawer on narrow

### DIFF
--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -684,12 +684,21 @@
 /* The shared DocumentList renders the editor's existing `.document-browser__*`
    list markup; it inherits global styling. Nothing to override here in Slice 1. */
 
+/* The mobile drawer toggle is hidden until the drawer breakpoint (below). */
+.dh-menu-toggle {
+  display: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .dh-storage-fill,
   .dh-rcard,
   .dh-workspace,
-  .dh-nav-item {
+  .dh-nav-item,
+  .dh-side {
     transition: none;
+  }
+  .dh-side-backdrop {
+    animation: none;
   }
 }
 
@@ -706,13 +715,64 @@
   }
 }
 @media (max-width: 640px) {
+  /* Off-canvas drawer: the rail slides over the content instead of squeezing it,
+     so the main area gets the full width. The parked (translated-out) rail is
+     clipped by `.documents-home`'s `overflow: hidden`, so it never adds a
+     horizontal scrollbar. */
   .dh-side {
-    flex-basis: 168px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 20;
+    flex-basis: auto;
+    width: min(82vw, 300px);
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    box-shadow: var(--shadow-lg);
+  }
+  .dh-side--open {
+    transform: translateX(0);
+  }
+  .dh-side-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 15;
+    background: rgba(0, 0, 0, 0.4);
+    animation: dh-backdrop-in 0.18s ease-out;
+  }
+  .dh-menu-toggle {
+    display: grid;
+    place-items: center;
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    z-index: 10;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+  /* Reserve room at the start of every header for the absolute toggle. */
+  .dh-top {
+    padding-left: 56px;
   }
   .dh-recents {
     /* A single full-width column instead of the 240px-floor track, which could
        itself overflow a very narrow content column. */
     grid-template-columns: 1fr;
+  }
+}
+
+@keyframes dh-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -28,6 +28,7 @@ import {
   Layers,
   LayoutGrid,
   List,
+  Menu,
   Moon,
   RefreshCw,
   Search,
@@ -133,10 +134,35 @@ export function DocumentsHome({
   const trashCount = useTrashStore((s) => s.items.length);
   const refreshTrash = useTrashStore((s) => s.refresh);
 
+  // On narrow viewports the sidebar is an off-canvas drawer (it overlays the
+  // content rather than squeezing it). Open state only matters at <=640px — the
+  // toggle + backdrop are display:none above that, where the rail is docked.
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  // Close the drawer on Escape while it's open.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSidebarOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sidebarOpen]);
+  // Drop any lingering open state when the viewport grows past the drawer
+  // breakpoint, so the docked rail never renders with a stale backdrop.
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 641px)');
+    const sync = () => {
+      if (mq.matches) setSidebarOpen(false);
+    };
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
   const selectNav = (id: NavId) => {
     setNav(id);
     setMainView('documents');
     setCollectionFilter(null);
+    setSidebarOpen(false);
     if (id === 'recents') {
       setFilterMode('all');
       setSort('modified-desc');
@@ -155,6 +181,13 @@ export function DocumentsHome({
     setMainView('documents');
     setFilterMode('all');
     setCollectionFilter(id);
+    setSidebarOpen(false);
+  };
+
+  // Switch the main destination and dismiss the mobile drawer in one go.
+  const goMainView = (v: 'documents' | 'storage' | 'trash' | 'shapes') => {
+    setMainView(v);
+    setSidebarOpen(false);
   };
 
   // Per-collection counts (network-free, from the local assignment map).
@@ -285,8 +318,18 @@ export function DocumentsHome({
 
   return (
     <div className="documents-home" data-theme={resolvedTheme}>
+      {/* Mobile-only drawer toggle — display:none above the drawer breakpoint. */}
+      <button
+        className="dh-menu-toggle"
+        onClick={() => setSidebarOpen((v) => !v)}
+        aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
+        aria-expanded={sidebarOpen}
+      >
+        <Menu size={20} aria-hidden="true" />
+      </button>
+
       {/* ── Sidebar ── */}
-      <aside className="dh-side">
+      <aside className={`dh-side${sidebarOpen ? ' dh-side--open' : ''}`}>
         <div className="dh-identity">
           <button
             className="dh-workspace"
@@ -394,7 +437,7 @@ export function DocumentsHome({
 
           <button
             className={`dh-nav-item${mainView === 'shapes' ? ' dh-nav-item--on' : ''}`}
-            onClick={() => setMainView('shapes')}
+            onClick={() => goMainView('shapes')}
             title="Shape library"
             aria-current={mainView === 'shapes' ? 'page' : undefined}
           >
@@ -404,7 +447,7 @@ export function DocumentsHome({
 
           <button
             className={`dh-nav-item${mainView === 'trash' ? ' dh-nav-item--on' : ''}`}
-            onClick={() => setMainView('trash')}
+            onClick={() => goMainView('trash')}
             title="Trash"
             aria-current={mainView === 'trash' ? 'page' : undefined}
           >
@@ -417,7 +460,7 @@ export function DocumentsHome({
         <div className="dh-side-foot">
           <button
             className={`dh-storage${mainView === 'storage' ? ' dh-storage--on' : ''}`}
-            onClick={() => setMainView('storage')}
+            onClick={() => goMainView('storage')}
             title="Manage storage"
           >
             <div className="dh-storage-top">
@@ -470,6 +513,15 @@ export function DocumentsHome({
           </div>
         </div>
       </aside>
+
+      {/* Drawer backdrop — only rendered (and only styled) while open on narrow. */}
+      {sidebarOpen && (
+        <div
+          className="dh-side-backdrop"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+        />
+      )}
 
       {/* ── Main ── */}
       <div className="dh-main">


### PR DESCRIPTION
Follow-up to the merged Slice 6 (#319). Standalone, off `master`.

## Problem
Slice 6 stopped the Documents browser from *clipping* its top bar on narrow viewports, but the fixed 264px → 168px sidebar still **squeezed the content column** on phones — leaving an unusable sliver for the document list.

## Fix — off-canvas drawer at ≤640px
- **`.dh-side`** becomes `position: absolute`, parked off-canvas (`translateX(-100%)`), and flies in on `.dh-side--open`. Because it's out of flow, `.dh-main` gets the **full width**. The surface's existing `overflow: hidden` clips the parked rail, so it never adds a horizontal scrollbar.
- **`.dh-menu-toggle`** hamburger (absolute, mobile-only — `display:none` above 640) opens it. It closes on: backdrop tap, **Escape**, and **choosing any destination** (nav item, collection, shapes/trash/storage). Crossing back to a wide viewport drops stale open state via a `matchMedia` listener.
- **`.dh-top`** gains left padding at ≤640 so the absolute toggle clears the header content — applied uniformly across every view (documents / storage / shapes / trash all share `.dh-top`).
- Honors `prefers-reduced-motion` (no slide, no backdrop fade).

**Above 640px nothing changes** — the rail stays docked (the ≤1024 narrowing from Slice 6 is untouched).

## Verification
- `bun run typecheck` ✓
- `bun run build` ✓
- Manual: Documents at ≤640 → rail hidden, content full-width, hamburger top-left → tap opens drawer over content → tap a nav item / backdrop / Esc closes it → resize wide → rail docked, toggle gone. Works across documents/storage/shapes/trash headers.

Assisted-by: Opus 4.8