### PR TITLE
JP-332 Slice 3: full-screen property panel on mobile + MobileSheet

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { isFlyoutLayout, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { MobilePreviewGate } from './mobile/MobilePreviewGate';
+import { MobilePropertySheet } from './mobile/MobilePropertySheet';
 import { FlyoutPanel } from './layout/FlyoutPanel';
 import { PanelChromeWrapper } from './layout/PanelChromeWrapper';
 import { DockedPanel } from './layout/DockedPanel';
@@ -484,8 +485,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             )
           )}
 
-          {/* Properties on left */}
-          {renderProperties && propertiesPanelState.dock === 'left' && (
+          {/* Properties on left (suppressed on mobile — the full-screen
+              MobilePropertySheet below takes over). */}
+          {!mobileActive && renderProperties && propertiesPanelState.dock === 'left' && (
             <PanelChromeWrapper panelId="properties">
               <ErrorBoundary sectionName="Properties">
                 {propertiesUsesFlyout || relaxedTransientProps ? (
@@ -542,8 +544,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             )}
           </div>
 
-          {/* Properties on right */}
-          {renderProperties && propertiesPanelState.dock === 'right' && (
+          {/* Properties on right (suppressed on mobile — see sheet below). */}
+          {!mobileActive && renderProperties && propertiesPanelState.dock === 'right' && (
             <PanelChromeWrapper panelId="properties">
               <ErrorBoundary sectionName="Properties">
                 {propertiesUsesFlyout || relaxedTransientProps ? (
@@ -604,6 +606,12 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
           onClose={handleCloseSettings}
           initialTab={settingsInitialTab}
         />
+
+        {/* Mobile: properties become a selection-driven full-screen sheet
+            (JP-332) instead of a docked panel that would eat the small screen. */}
+        {appView === 'editor' && mobileActive && selectionCount > 0 && (
+          <MobilePropertySheet onClose={() => useSessionStore.getState().clearSelection()} />
+        )}
 
         {/* Command Palette (Cmd/Ctrl+K) */}
         <CommandPalette isOpen={isPaletteOpen} onClose={() => setIsPaletteOpen(false)} />

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -12,6 +12,18 @@
   overflow: hidden;
 }
 
+/* Full-screen mobile sheet variant (JP-332): fill the sheet body. The docked
+ * width clamps, border, and resize handle don't apply inside the sheet. */
+.property-panel.property-panel--mobile {
+  min-width: 0;
+  max-width: none;
+  width: 100%;
+  border: none;
+}
+.property-panel.property-panel--mobile .property-panel-resize-handle {
+  display: none;
+}
+
 /* When the panel is docked on the left of the canvas, swap the border side
  * and put the resize handle on the right edge instead of the left. */
 .property-panel.property-panel-left-dock {

--- a/src/ui/mobile/MobilePropertySheet.tsx
+++ b/src/ui/mobile/MobilePropertySheet.tsx
@@ -1,0 +1,22 @@
+/**
+ * MobilePropertySheet — the property panel as a full-screen sheet on mobile
+ * (JP-332 Slice 3). Composes the reusable MobileSheet around the existing
+ * PropertyPanel, which fills the sheet (its docked width clamps + border are
+ * dropped via `property-panel--mobile`).
+ *
+ * `onClose` is wired by App to clear the selection — so the sheet is purely
+ * selection-driven on mobile: select a shape → sheet; Done / Escape / deselect →
+ * gone. This keeps the property panel from permanently covering a small screen
+ * the way a docked panel would.
+ */
+
+import { MobileSheet } from './MobileSheet';
+import { PropertyPanel } from '../PropertyPanel';
+
+export function MobilePropertySheet({ onClose }: { onClose: () => void }) {
+  return (
+    <MobileSheet title="Properties" onClose={onClose} className="mobile-property-sheet">
+      <PropertyPanel className="property-panel--mobile" />
+    </MobileSheet>
+  );
+}

--- a/src/ui/mobile/MobileSheet.css
+++ b/src/ui/mobile/MobileSheet.css
@@ -1,0 +1,71 @@
+/* MobileSheet — full-screen sheet shell for the mobile preview (JP-332). */
+
+.mobile-sheet {
+  position: fixed;
+  inset: 0;
+  /* Above the editor chrome, below the picker portals (z 10000) and the
+     confirm-dialog host so those layer over the sheet. */
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  /* Clear notches / home indicator inside a standalone PWA (0 elsewhere). */
+  padding-top: var(--safe-area-top);
+  padding-bottom: var(--safe-area-bottom);
+  animation: mobile-sheet-in 0.2s ease-out;
+}
+
+.mobile-sheet-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.mobile-sheet-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.mobile-sheet-done {
+  flex: 0 0 auto;
+  padding: 7px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--color-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+.mobile-sheet-done:hover {
+  background: var(--bg-hover);
+}
+
+.mobile-sheet-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+@keyframes mobile-sheet-in {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-sheet {
+    animation: none;
+  }
+}

--- a/src/ui/mobile/MobileSheet.tsx
+++ b/src/ui/mobile/MobileSheet.tsx
@@ -1,0 +1,61 @@
+/**
+ * MobileSheet — a reusable full-screen sheet for the mobile preview (JP-332).
+ *
+ * A presentational overlay shell: a fixed, full-viewport panel (portaled to
+ * `document.body` so no editor-layout ancestor can clip or mis-stack it) with a
+ * safe-area-aware header (title + Done) and a scrollable body slot. Dismissal is
+ * the caller's Done handler plus Escape.
+ *
+ * It sits at a modest z-index (above the editor chrome, below the picker portals
+ * and the confirm-dialog host) so panel-owned popovers — the property panel's
+ * color/icon/pattern pickers, which portal to `document.body` at a higher
+ * z-index — render *over* the sheet and stay interactive. Because the sheet
+ * never installs an outside-click/focus trap, those `[data-flyout-keep-open]`
+ * portals need no special-casing here.
+ *
+ * Slice 3 uses it for the full-screen property panel; Slice 4's prose toolbar
+ * sheet composes the same primitive.
+ */
+
+import { ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import './MobileSheet.css';
+
+export interface MobileSheetProps {
+  /** Header title + ARIA label. */
+  title: string;
+  /** Called by the Done button and Escape. */
+  onClose: () => void;
+  /** Sheet body. */
+  children: ReactNode;
+  /** Extra class on the sheet root for per-use styling. */
+  className?: string;
+}
+
+export function MobileSheet({ title, onClose, children, className }: MobileSheetProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className={`mobile-sheet${className ? ` ${className}` : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <header className="mobile-sheet-header">
+        <span className="mobile-sheet-title">{title}</span>
+        <button type="button" className="mobile-sheet-done" onClick={onClose}>
+          Done
+        </button>
+      </header>
+      <div className="mobile-sheet-body">{children}</div>
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
Third slice of JP-332. Introduces the reusable **`MobileSheet`** primitive and uses it to make the property panel a **selection-driven full-screen sheet** on mobile. Builds on the Slice 1 seam (merged). **Desktop is untouched** — all behavior gates on `mobileActive`.

## What's here
- **`MobileSheet`** (`src/ui/mobile/MobileSheet.tsx` + `.css`) — a portaled, full-viewport sheet shell: safe-area-aware header (title + Done), scrollable body, Escape-to-close. It sits at `z-index: 1000` — above the editor chrome but **below the picker portals (z 10000) and the confirm-dialog host** — so the property panel's color/icon/pattern pickers render *over* the sheet and stay interactive. Because the sheet installs **no outside-click/focus trap**, the `[data-flyout-keep-open]` portals need no special-casing (the trap the plan flagged is sidestepped by design). Slice 4's prose-toolbar sheet will compose this same primitive.
- **`MobilePropertySheet`** — wraps the existing `PropertyPanel` (`property-panel--mobile` fills the sheet; docked width clamps, border, and resize handle dropped).
- **App** — on mobile the two docked Properties sites are suppressed; a single sheet renders gated on `appView === 'editor' && mobileActive && selectionCount > 0`. Select a shape → sheet; **Done / Escape / deselect → gone**. `onClose` clears the selection, so properties never permanently cover a small screen.

## Why selection-driven
A docked/pinned property panel would consume a phone's whole width. Making it selection-driven full-screen is both the right mobile UX and robust across layouts (works the same whether the active layout is Relaxed or a docked persona).

## Verification
- `bun run typecheck` ✓
- `bun run test --run` ✓ — **2685 passed**, no regressions
- `bun run build` ✓
- Manual (narrow + touch, after opting into the preview): select a shape → Properties fills the screen → open a color/icon picker → it layers **over** the sheet and doesn't dismiss it → Done / Escape / deselect all close it. Wide/desktop: docked + flyout properties unchanged.

> Visual checkpoint: this is the first slice with on-screen output — worth a look on a device/emulator before Slice 4.

Assisted-by: Opus 4.8