### PR TITLE
JP-332 Slice 5: scale canvas resize handles for touch

### DIFF
--- a/src/engine/Renderer.test.ts
+++ b/src/engine/Renderer.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Renderer, RendererOptions } from './Renderer';
+import { Renderer, RendererOptions, scaleHandleSize } from './Renderer';
 import { Camera } from './Camera';
+import { device } from '../platform/device';
+import { refreshAdaptiveBudget } from '../platform/adaptiveBudget';
 import { Vec2 } from '../math/Vec2';
 import type { ConnectorShape, Shape } from '../shapes/Shape';
 // Register the connector handler (self-registers on import) for the JP-353 test.
@@ -145,6 +147,47 @@ describe('Renderer', () => {
       const renderer = new Renderer(canvas, camera, options);
 
       expect(renderer).toBeInstanceOf(Renderer);
+    });
+  });
+
+  describe('handle sizing (JP-332)', () => {
+    afterEach(() => {
+      // Restore the device mock, then re-derive so the global budget snapshot
+      // returns to the real (jsdom = fine-pointer) value for other tests.
+      vi.restoreAllMocks();
+      refreshAdaptiveBudget();
+    });
+
+    it('scaleHandleSize enlarges the handle on coarse pointers (grab-zone parity)', () => {
+      expect(scaleHandleSize(8, 1.6)).toBe(13);
+    });
+
+    it('scaleHandleSize leaves the handle unchanged on a fine pointer', () => {
+      expect(scaleHandleSize(8, 1)).toBe(8);
+    });
+
+    it('defaults the drawn handle to the touch-scaled size on a coarse pointer', () => {
+      vi.spyOn(device, 'isTouch').mockReturnValue(true);
+      refreshAdaptiveBudget();
+      const renderer = new Renderer(createMockCanvas(), new Camera());
+      const opts = (renderer as unknown as { options: Required<RendererOptions> }).options;
+      expect(opts.handleSize).toBe(13);
+    });
+
+    it('keeps the 8px handle on a fine pointer', () => {
+      vi.spyOn(device, 'isTouch').mockReturnValue(false);
+      refreshAdaptiveBudget();
+      const renderer = new Renderer(createMockCanvas(), new Camera());
+      const opts = (renderer as unknown as { options: Required<RendererOptions> }).options;
+      expect(opts.handleSize).toBe(8);
+    });
+
+    it('still honors an explicit handleSize override on touch', () => {
+      vi.spyOn(device, 'isTouch').mockReturnValue(true);
+      refreshAdaptiveBudget();
+      const renderer = new Renderer(createMockCanvas(), new Camera(), { handleSize: 6 });
+      const opts = (renderer as unknown as { options: Required<RendererOptions> }).options;
+      expect(opts.handleSize).toBe(6);
     });
   });
 

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -65,6 +65,17 @@ export interface RenderMetrics {
  */
 export type ToolOverlayCallback = (ctx: CanvasRenderingContext2D) => void;
 
+/**
+ * Resolve the rendered resize-handle edge length (screen px) for a pointer type.
+ * Scales the base size up on coarse pointers so the *drawn* handle matches the
+ * already-enlarged touch grab zone (SelectTool keys off the same
+ * `hitTargetScale`), instead of staying an 8px square that's hard to grab with a
+ * finger. (JP-332)
+ */
+export function scaleHandleSize(base: number, hitTargetScale: number): number {
+  return Math.round(base * hitTargetScale);
+}
+
 const DEFAULT_OPTIONS: Required<RendererOptions> = {
   showGrid: true,
   gridSpacing: 50,
@@ -176,7 +187,13 @@ export class Renderer {
   ) {
     this.canvas = canvas;
     this.camera = camera;
-    this.options = { ...DEFAULT_OPTIONS, ...options };
+    // When the caller doesn't pin a handle size, scale the default by the touch
+    // grab-zone factor so the drawn handle stays finger-sized on coarse pointers
+    // (JP-332). An explicit `options.handleSize` always wins.
+    const handleSize =
+      options?.handleSize ??
+      scaleHandleSize(DEFAULT_OPTIONS.handleSize, getAdaptiveBudget().hitTargetScale);
+    this.options = { ...DEFAULT_OPTIONS, ...options, handleSize };
 
     const ctx = canvas.getContext('2d');
     if (!ctx) {


### PR DESCRIPTION
Engine-isolated slice of JP-332. Independent of the rest (keys off `isTouch`, not the mobile-preview gate).

## Problem
The selection **grab zone** already scales 1.6× on coarse pointers (`SelectTool` reads `adaptiveBudget.hitTargetScale`), but the **drawn** handle stayed a fixed 8px square — easy to grab, hard to *aim at* with a finger. The visual and the hit target were inconsistent.

## Fix
- `Renderer` default `handleSize` is now `scaleHandleSize(8, getAdaptiveBudget().hitTargetScale)` → ~**13px on touch**, **8px** on a fine pointer. An explicit `options.handleSize` still wins. The rotation handle derives from the same `halfHandle`, so it scales automatically.
- New pure **`scaleHandleSize`** helper (rounded) — "test the math".

## Why `isTouch`, not `mobileActive`
Matches how the hit side already scales, keeps drawn/grab sizes aligned, and benefits a touch laptop at any width — no coupling of engine rendering to the React breakpoint hook.

## Verification
- `bun run test --run src/engine/Renderer.test.ts` ✓ — 43 (5 new): `scaleHandleSize` math + constructor wiring via the `refreshAdaptiveBudget` seam (touch → 13, fine → 8, explicit override preserved).
- Full suite ✓ 2690 · `typecheck` ✓ · `build` ✓
- Manual caveat: `adaptiveBudget` samples touch **once at module load**, so enable DevTools touch emulation **before reload** to see the larger handles.

Assisted-by: Opus 4.8