### PR TITLE
JP-332 Slice 2: collapse top controls into icons + command palette

### DIFF
--- a/src/engine/CommandRegistry.test.ts
+++ b/src/engine/CommandRegistry.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getPaletteCommands, findShortcutConflicts } from './CommandRegistry';
+
+describe('CommandRegistry palette', () => {
+  it('exposes the PDF export and import commands (reachable from the mobile palette)', () => {
+    const ids = getPaletteCommands().map((c) => c.id);
+    expect(ids).toContain('file.exportPdf');
+    expect(ids).toContain('import.diagram');
+    expect(ids).toContain('view.toggleWhiteboard');
+    expect(ids).toContain('view.docs');
+  });
+
+  it('import.diagram carries a read-only guard (mirrors the toolbar button)', () => {
+    const importCmd = getPaletteCommands().find((c) => c.id === 'import.diagram');
+    expect(importCmd?.canExecute).toBeTypeOf('function');
+  });
+
+  it('has no conflicting keyboard bindings', () => {
+    expect(findShortcutConflicts()).toEqual([]);
+  });
+});

--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -170,6 +170,18 @@ function buildCommands(): Command[] {
       category: 'File',
       // The palette can't reach the engine; CanvasContainer opens the picker.
       execute: () => window.dispatchEvent(new CustomEvent('docushark:import-diagram')),
+      // JP-370: import writes into the active doc → unavailable view-only (mirror
+      // the toolbar button's guard, which the palette path otherwise bypasses).
+      canExecute: () => !isActiveDocReadOnly(),
+    },
+
+    // --- Export (PDF) --- the dialog lives in UnifiedToolbar's local state, so
+    // the palette opens it by event, mirroring the import bridge above.
+    {
+      id: 'file.exportPdf',
+      label: 'Export to PDF…',
+      category: 'File',
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:open-pdf-export')),
     },
 
     // --- Documents surface (JP-218) ---

--- a/src/ui/CommandPalette.tsx
+++ b/src/ui/CommandPalette.tsx
@@ -10,6 +10,7 @@ import {
   getRecentCommandIds,
   type Command,
 } from '../engine/CommandRegistry';
+import { device } from '../platform/device';
 import './CommandPalette.css';
 
 export interface CommandPaletteProps {
@@ -66,8 +67,13 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     if (isOpen) {
       setQuery('');
       setSelectedIndex(0);
-      // Focus input after render
-      requestAnimationFrame(() => inputRef.current?.focus());
+      // Focus the search input after render — but NOT on touch, where it would
+      // pop the on-screen keyboard and shove the layout up. On touch the palette
+      // opens straight to the tappable command list (it doubles as the mobile
+      // action menu); tapping the field still focuses it to type.
+      if (!device.isTouch()) {
+        requestAnimationFrame(() => inputRef.current?.focus());
+      }
     }
   }, [isOpen]);
 

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -55,6 +55,25 @@
   }
 }
 
+/* Mobile preview (JP-332): the app bar goes icon-only regardless of the exact
+   width (the gate can hold through the medium band) — Documents + Settings drop
+   their labels — and the bar honors the horizontal safe-area insets. */
+.app[data-mobile='true'] .unified-toolbar {
+  padding-left: max(var(--space-3), var(--safe-area-left));
+  padding-right: max(var(--space-3), var(--safe-area-right));
+}
+.app[data-mobile='true'] .toolbar-documents-btn span,
+.app[data-mobile='true'] .toolbar-settings-btn span {
+  display: none;
+}
+.app[data-mobile='true'] .toolbar-documents-btn,
+.app[data-mobile='true'] .toolbar-settings-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+}
+
 /* Divider */
 .toolbar-divider {
   width: 1px;

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -8,8 +8,9 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen } from 'lucide-react';
+import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen, MoreHorizontal } from 'lucide-react';
 import { Icon, PdfIcon } from './icons';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { ToolbarGroup } from './ToolbarGroup';
 import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
@@ -156,6 +157,17 @@ export function UnifiedToolbar({
   // JP-370: import writes into the active doc → disable it on a view-only doc.
   // Whiteboard (scratch overlay), Export, Help and Settings stay read-safe.
   const isReadOnly = useActiveDocReadOnly();
+  // On mobile the low-frequency actions collapse into the command palette; the
+  // bar keeps just Documents, the doc identity, the view cluster, and Settings.
+  const { mobileActive } = useMobileAdaptation();
+
+  // The PDF export dialog lives in this component's local state, so the palette
+  // (and any other caller) opens it via an event — mirroring the import bridge.
+  useEffect(() => {
+    const open = () => setShowPdfExport(true);
+    window.addEventListener('docushark:open-pdf-export', open);
+    return () => window.removeEventListener('docushark:open-pdf-export', open);
+  }, []);
 
   return (
     <>
@@ -184,42 +196,59 @@ export function UnifiedToolbar({
         </ToolbarGroup>
 
         <ToolbarGroup label="Actions" className="unified-toolbar-actions">
-          <button
-            className="toolbar-help-btn"
-            onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
-            disabled={isReadOnly}
-            title={
-              isReadOnly
-                ? 'Import is unavailable on a view-only document'
-                : 'Import diagram (Excalidraw, drawio, Mermaid)'
-            }
-            aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
-          >
-            <Icon icon={FileInput} />
-          </button>
-          <button
-            className="toolbar-whiteboard-btn"
-            onClick={() => useWhiteboardStore.getState().toggleVisibility()}
-            title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
-            aria-label="Whiteboard"
-          >
-            <Icon icon={StickyNote} />
-          </button>
-          <button
-            className="toolbar-export-btn"
-            onClick={() => setShowPdfExport(true)}
-            title="Export to PDF"
-            aria-label="Export to PDF"
-          >
-            <PdfIcon />
-          </button>
-          <button
-            className="toolbar-help-btn"
-            onClick={() => void openDocsHandler()}
-            title="Open documentation (F1)"
-          >
-            <Icon icon={CircleHelp} />
-          </button>
+          {mobileActive ? (
+            // Collapse Import / Whiteboard / Export / Help into the command
+            // palette (which doubles as the touch action menu). One affordance.
+            <button
+              className="toolbar-help-btn"
+              onClick={() =>
+                window.dispatchEvent(new CustomEvent('docushark:toggle-command-palette'))
+              }
+              title="More actions"
+              aria-label="More actions"
+            >
+              <Icon icon={MoreHorizontal} />
+            </button>
+          ) : (
+            <>
+              <button
+                className="toolbar-help-btn"
+                onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
+                disabled={isReadOnly}
+                title={
+                  isReadOnly
+                    ? 'Import is unavailable on a view-only document'
+                    : 'Import diagram (Excalidraw, drawio, Mermaid)'
+                }
+                aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
+              >
+                <Icon icon={FileInput} />
+              </button>
+              <button
+                className="toolbar-whiteboard-btn"
+                onClick={() => useWhiteboardStore.getState().toggleVisibility()}
+                title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
+                aria-label="Whiteboard"
+              >
+                <Icon icon={StickyNote} />
+              </button>
+              <button
+                className="toolbar-export-btn"
+                onClick={() => setShowPdfExport(true)}
+                title="Export to PDF"
+                aria-label="Export to PDF"
+              >
+                <PdfIcon />
+              </button>
+              <button
+                className="toolbar-help-btn"
+                onClick={() => void openDocsHandler()}
+                title="Open documentation (F1)"
+              >
+                <Icon icon={CircleHelp} />
+              </button>
+            </>
+          )}
           {onOpenSettings && (
             <button
               className="toolbar-settings-btn"


### PR DESCRIPTION
Fourth mobile slice of JP-332. On mobile the app bar's low-frequency actions collapse into the **existing** command palette, freeing the cramped 44px bar. Builds on the merged Slice 1 seam. **Desktop is unchanged** (all gated on `mobileActive`).

## What's here
- **`UnifiedToolbar`** — on `mobileActive`, Import / Whiteboard / PDF export / Help collapse into a single **"More actions"** button that opens the command palette (which doubles as the touch action menu). **Documents + Settings go icon-only** (labels dropped) and the bar honors the horizontal `--safe-area-*` insets. Works regardless of exact width (the gate can hold through the medium band).
- **`CommandRegistry`** — adds a `file.exportPdf` palette command that opens the PDF dialog via a new `docushark:open-pdf-export` event (the dialog lives in `UnifiedToolbar` local state, so this mirrors the existing import bridge); `UnifiedToolbar` now listens for it. Also gives `import.diagram` the **read-only guard** the toolbar button had — the palette path previously bypassed it. Whiteboard + Docs were already palette commands.
- **`CommandPalette`** — **skips autofocusing** the search input on touch, so opening it doesn't pop the on-screen keyboard and shove the layout; it opens straight to the tappable command list. Tapping the field still focuses to type.

## Verification
- `bun run typecheck` ✓
- New `CommandRegistry.test.ts` ✓ — palette exposes the demoted actions, `import.diagram` keeps its guard, no shortcut conflicts.
- Full suite ✓ **2688** · `build` ✓
- Manual (narrow + touch, preview on): right cluster is icon-only + a ⋯ button → opens the palette → Import / Whiteboard / Export / Help all fire from it; palette opens without the keyboard popping. Desktop bar unchanged.

Assisted-by: Opus 4.8