### PR TITLE
JP-332 Slice 4: mobile prose toolbar + review fixes

### DIFF
--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -14,6 +14,9 @@ import { Icon } from './icons';
 import type { Editor } from '@tiptap/core';
 import { history } from 'prosemirror-history';
 import { DocumentEditorToolbar } from './DocumentEditorToolbar';
+import { MobileProseToolbar } from './mobile/MobileProseToolbar';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { useKeyboardInset } from './mobile/useKeyboardInset';
 import { TiptapEditor } from './TiptapEditor';
 import { TiptapEditorProvider } from './TiptapEditorContext';
 import { RichTextTabBar } from './RichTextTabBar';
@@ -97,6 +100,10 @@ export function DocumentEditorPanel({
   onCustomizeLayout,
   presentation = 'docked',
 }: DocumentEditorPanelProps) {
+  const { mobileActive } = useMobileAdaptation();
+  // Reserve the on-screen keyboard's height as panel padding so the mobile
+  // bottom toolbar (last flex child) rides above the keyboard (JP-332).
+  const keyboardInset = useKeyboardInset();
   const { activePageId, updatePageContent } = useRichTextPagesStore();
   // Reactive content for the read-only ProsePreview, so it reflects edits/sync
   // while shown — instead of an imperative `getState()` read in render.
@@ -555,9 +562,12 @@ export function DocumentEditorPanel({
         className={`document-editor-panel ${isFullscreen ? 'fullscreen' : ''} ${
           presentation === 'reading' ? 'reading' : ''
         }`}
+        style={mobileActive && keyboardInset > 0 ? { paddingBottom: keyboardInset } : undefined}
       >
         <RichTextTabBar trailing={trailing} />
-        <DocumentEditorToolbar />
+        {/* Desktop ribbon sits at the top; on mobile it's replaced by the
+            bottom MobileProseToolbar rendered after the content (JP-332). */}
+        {!mobileActive && <DocumentEditorToolbar />}
         <div className="document-editor-panel-content">
           {/* Never blank (JP-328): a prose render crash degrades to the page's
               read-only HTML projection, not an empty panel; auto-resets on
@@ -589,6 +599,9 @@ export function DocumentEditorPanel({
             )}
           </ProseErrorBoundary>
         </div>
+        {/* Mobile: bottom formatting bar that squeezes the writing area above and
+            rides above the on-screen keyboard (JP-332). */}
+        {mobileActive && <MobileProseToolbar />}
       </div>
     </TiptapEditorProvider>
   );

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -18,6 +18,9 @@
   min-width: 0;
   max-width: none;
   width: 100%;
+  /* Fill the sheet body's height so the panel's own `flex: 1` content region
+     expands (and scrolls) instead of collapsing to its intrinsic height. */
+  height: 100%;
   border: none;
 }
 .property-panel.property-panel--mobile .property-panel-resize-handle {

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -11,6 +11,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen, MoreHorizontal } from 'lucide-react';
 import { Icon, PdfIcon } from './icons';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { MobileDocumentInfo } from './mobile/MobileDocumentInfo';
 import { ToolbarGroup } from './ToolbarGroup';
 import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
@@ -185,14 +186,14 @@ export function UnifiedToolbar({
             <span>Documents</span>
           </button>
         )}
-        <DocumentInfo />
+        {mobileActive ? <MobileDocumentInfo /> : <DocumentInfo />}
       </div>
 
       {/* Right: view controls (the context cluster) + app actions */}
       <div className="unified-toolbar-right">
         <ToolbarGroup label="View" className="unified-toolbar-view">
           {activeLayout === 'relaxed' && <RelaxedFocusControl />}
-          <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} />
+          <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} compact={mobileActive} />
         </ToolbarGroup>
 
         <ToolbarGroup label="Actions" className="unified-toolbar-actions">

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -760,6 +760,15 @@
   .dh-top {
     padding-left: 56px;
   }
+  /* The actions group (sort · group · view · refresh · import · new) is a
+     non-wrapping flex item; on a narrow header it overflowed the row and the
+     trailing buttons (Refresh / Import / New) were clipped by the surface's
+     `overflow: hidden`. Give it a full row and let its controls wrap so they
+     all stay reachable. */
+  .dh-top-actions {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+  }
   .dh-recents {
     /* A single full-width column instead of the 240px-floor track, which could
        itself overflow a very narrow content column. */

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -22,6 +22,15 @@
   transition: background-color 0.12s ease, border-color 0.12s ease;
 }
 
+/* Compact (mobile) trigger: a square icon button, no label/chevron. */
+.layout-selector-chip.compact {
+  gap: 0;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+}
+
 .layout-selector-chip:hover,
 .layout-selector-chip.open,
 .layout-selector-chip:focus-visible {

--- a/src/ui/layout/LayoutSelector.tsx
+++ b/src/ui/layout/LayoutSelector.tsx
@@ -10,6 +10,8 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { PanelsTopLeft } from 'lucide-react';
+import { Icon } from '../icons';
 import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS } from './modes';
 import { useActiveLayoutMode, useLayoutActions } from './useLayout';
 import { LAYOUT_MODES, type LayoutMode } from './types';
@@ -19,9 +21,11 @@ import './LayoutSelector.css';
 export interface LayoutSelectorProps {
   /** Called when the user clicks "Customize layout…" — wires to Settings. */
   onOpenLayoutSettings?: (() => void) | undefined;
+  /** Collapse the trigger to a single icon (mobile) — the dropdown is unchanged. */
+  compact?: boolean;
 }
 
-export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
+export function LayoutSelector({ onOpenLayoutSettings, compact = false }: LayoutSelectorProps) {
   const activeMode = useActiveLayoutMode();
   const { setActiveLayout } = useLayoutActions();
 
@@ -61,16 +65,22 @@ export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
     <div className="layout-selector-wrapper" ref={wrapperRef}>
       <button
         type="button"
-        className={`layout-selector-chip ${isOpen ? 'open' : ''}`}
+        className={`layout-selector-chip ${compact ? 'compact' : ''} ${isOpen ? 'open' : ''}`}
         onClick={() => setIsOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-label={`Layout: ${LAYOUT_LABELS[activeMode]}. Click to change.`}
         title={`Layout: ${LAYOUT_LABELS[activeMode]} (Cmd+Shift+1..4)`}
       >
-        <LayoutThumbnail mode={activeMode} width={22} height={14} />
-        <span className="layout-selector-chip-label">{LAYOUT_LABELS[activeMode]}</span>
-        <span className="layout-selector-chip-chevron" aria-hidden="true">▾</span>
+        {compact ? (
+          <Icon icon={PanelsTopLeft} />
+        ) : (
+          <>
+            <LayoutThumbnail mode={activeMode} width={22} height={14} />
+            <span className="layout-selector-chip-label">{LAYOUT_LABELS[activeMode]}</span>
+            <span className="layout-selector-chip-chevron" aria-hidden="true">▾</span>
+          </>
+        )}
       </button>
 
       {isOpen && (

--- a/src/ui/mobile/MobileDocumentInfo.css
+++ b/src/ui/mobile/MobileDocumentInfo.css
@@ -1,0 +1,106 @@
+/* MobileDocumentInfo — ⓘ button + rename/status popover for mobile (JP-332). */
+
+.mobile-doc-info {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.mobile-doc-info-btn {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.mobile-doc-info-btn:hover {
+  background: var(--bg-hover);
+}
+/* Glanceable unsaved indicator so the status isn't lost behind the popover. */
+.mobile-doc-info-btn.is-dirty::after {
+  content: '';
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-cta, var(--brand-gold-deep));
+}
+
+.mobile-doc-info-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 100;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+.mobile-doc-info-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.mobile-doc-info-label {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+.mobile-doc-info-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+}
+
+.mobile-doc-info-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+.mobile-doc-info-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.mobile-doc-info-dot.saved {
+  background: var(--color-success, #3aaf6a);
+}
+.mobile-doc-info-dot.dirty {
+  background: var(--color-cta, var(--brand-gold-deep));
+}
+.mobile-doc-info-dot.saving {
+  background: var(--text-muted);
+}
+.mobile-doc-info-save {
+  margin-left: auto;
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--color-primary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+.mobile-doc-info-save:hover {
+  background: var(--bg-hover);
+}

--- a/src/ui/mobile/MobileDocumentInfo.tsx
+++ b/src/ui/mobile/MobileDocumentInfo.tsx
@@ -1,0 +1,115 @@
+/**
+ * MobileDocumentInfo — the document identity (name + rename + save status) as a
+ * compact info popover for mobile (JP-332).
+ *
+ * On a narrow bar the inline document name collided with the Write/Split/Diagram
+ * focus tabs on the right. Here the name moves behind an ⓘ button next to
+ * Documents; tapping it opens a small popover to read the status and rename the
+ * doc. The button keeps a dirty dot so unsaved state is still glanceable without
+ * opening it.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Info } from 'lucide-react';
+import { Icon } from '../icons';
+import { usePersistenceStore } from '../../store/persistenceStore';
+import { useAutoSave } from '../../hooks/useAutoSave';
+import './MobileDocumentInfo.css';
+
+export function MobileDocumentInfo() {
+  const currentDocumentName = usePersistenceStore((s) => s.currentDocumentName);
+  const renameDocument = usePersistenceStore((s) => s.renameDocument);
+  const { isDirty, status, saveNow } = useAutoSave();
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(currentDocumentName);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Keep the field in sync with external renames while the popover is closed.
+  useEffect(() => {
+    if (!open) setName(currentDocumentName);
+  }, [currentDocumentName, open]);
+
+  const commit = useCallback(() => {
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== currentDocumentName) renameDocument(trimmed);
+  }, [name, currentDocumentName, renameDocument]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (t && !wrapRef.current?.contains(t)) {
+        commit();
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setName(currentDocumentName);
+        setOpen(false);
+      }
+    };
+    window.addEventListener('pointerdown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, commit, currentDocumentName]);
+
+  const statusLabel = status === 'saving' ? 'Saving…' : isDirty ? 'Unsaved changes' : 'Saved';
+  const statusState = status === 'saving' ? 'saving' : isDirty ? 'dirty' : 'saved';
+
+  return (
+    <div className="mobile-doc-info" ref={wrapRef}>
+      <button
+        type="button"
+        className={`mobile-doc-info-btn${isDirty ? ' is-dirty' : ''}`}
+        onClick={() => setOpen((v) => !v)}
+        title={currentDocumentName}
+        aria-label={`Document: ${currentDocumentName}. ${statusLabel}.`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <Icon icon={Info} />
+      </button>
+
+      {open && (
+        <div className="mobile-doc-info-pop" role="dialog" aria-label="Document info">
+          <label className="mobile-doc-info-field">
+            <span className="mobile-doc-info-label">Name</span>
+            <input
+              type="text"
+              className="mobile-doc-info-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  commit();
+                  setOpen(false);
+                }
+              }}
+            />
+          </label>
+          <div className="mobile-doc-info-status">
+            <span className={`mobile-doc-info-dot ${statusState}`} aria-hidden="true" />
+            <span>{statusLabel}</span>
+            {isDirty && status !== 'saving' && (
+              <button
+                type="button"
+                className="mobile-doc-info-save"
+                onClick={() => {
+                  commit();
+                  saveNow();
+                }}
+              >
+                Save now
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/mobile/MobileProseToolbar.css
+++ b/src/ui/mobile/MobileProseToolbar.css
@@ -1,0 +1,78 @@
+/* MobileProseToolbar — bottom-anchored prose formatting bar for mobile (JP-332).
+ *
+ * Rendered as the last flex child of the editor panel: the slim bar sits at the
+ * bottom (above the keyboard, via the panel's reserved keyboard inset), and the
+ * expandable Format panel grows *upward*, squeezing the `flex: 1` writing area
+ * rather than overlaying it. */
+
+.mobile-prose-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
+}
+
+/* The full ribbon, hosted inline above the slim bar — bounded so it never eats
+   the whole writing area; scrolls if the ribbon is taller. */
+.mpt-panel {
+  flex: 0 1 auto;
+  max-height: 42vh;
+  overflow-y: auto;
+  border-bottom: 1px solid var(--border-color);
+}
+.mpt-panel .document-editor-toolbar {
+  border-bottom: none;
+}
+
+.mpt-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 4px 8px;
+}
+
+.mpt-btn {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.mpt-btn:hover {
+  background: var(--bg-hover);
+}
+.mpt-btn.is-active {
+  background: var(--color-primary-light);
+  color: var(--text-primary);
+}
+
+.mpt-format {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+}
+.mpt-format:hover {
+  background: var(--bg-hover);
+}
+.mpt-format.is-open {
+  background: var(--color-primary-light);
+  color: var(--text-primary);
+  border-color: var(--color-primary);
+}

--- a/src/ui/mobile/MobileProseToolbar.tsx
+++ b/src/ui/mobile/MobileProseToolbar.tsx
@@ -1,0 +1,115 @@
+/**
+ * MobileProseToolbar — the prose ribbon, partitioned for mobile (JP-332).
+ *
+ * The full DocumentEditorToolbar is a tabbed ribbon that wraps to several rows
+ * on a narrow viewport, cramping the writing column. On mobile we render a slim
+ * one-row bar of the highest-frequency marks plus a "Format" button. Tapping
+ * Format expands the complete ribbon *inline above the bar* (bounded height,
+ * scrollable) rather than as an overlay — so it squeezes the writing area
+ * instead of drawing over the text.
+ *
+ * This component is mounted as the LAST flex child of the editor panel (a flex
+ * column), so expanding the panel shrinks the `flex: 1` content above it. The
+ * panel reserves the keyboard inset (see DocumentEditorPanel + useKeyboardInset),
+ * which keeps this bar sitting directly above the on-screen keyboard.
+ *
+ * It hosts the real DocumentEditorToolbar verbatim (so every dialog keeps
+ * working); because it lives inside the panel's TiptapEditorProvider it shares
+ * the same editor without any re-providing, and the slim bar is the only toolbar
+ * mounted when collapsed (no duplicate shortcut listeners).
+ */
+
+import { useEffect, useState } from 'react';
+import { Bold, Italic, Underline, List, Heading2, Type, X } from 'lucide-react';
+import { Icon } from '../icons';
+import { useTiptapEditor } from '../TiptapEditorContext';
+import * as cmd from '../editorCommands';
+import { DocumentEditorToolbar } from '../DocumentEditorToolbar';
+import './MobileProseToolbar.css';
+
+export function MobileProseToolbar() {
+  const editor = useTiptapEditor();
+  const [, force] = useState({});
+  const [showFormat, setShowFormat] = useState(false);
+
+  // Re-render the slim bar's active states as the selection/content changes
+  // (same subscription the full ribbon uses).
+  useEffect(() => {
+    if (!editor) return;
+    const handle = () => force({});
+    editor.on('selectionUpdate', handle);
+    editor.on('transaction', handle);
+    return () => {
+      editor.off('selectionUpdate', handle);
+      editor.off('transaction', handle);
+    };
+  }, [editor]);
+
+  // No live editor (e.g. a read-only ProsePreview) → nothing to format.
+  if (!editor) return null;
+
+  const isH2 = editor.isActive('heading', { level: 2 });
+
+  return (
+    <div className="mobile-prose-toolbar">
+      {showFormat && (
+        <div className="mpt-panel" role="region" aria-label="Formatting">
+          <DocumentEditorToolbar />
+        </div>
+      )}
+
+      <div className="mpt-bar">
+        <button
+          className={`mpt-btn${editor.isActive('bold') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleBold(editor)}
+          aria-label="Bold"
+          aria-pressed={editor.isActive('bold')}
+        >
+          <Icon icon={Bold} />
+        </button>
+        <button
+          className={`mpt-btn${editor.isActive('italic') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleItalic(editor)}
+          aria-label="Italic"
+          aria-pressed={editor.isActive('italic')}
+        >
+          <Icon icon={Italic} />
+        </button>
+        <button
+          className={`mpt-btn${editor.isActive('underline') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleUnderline(editor)}
+          aria-label="Underline"
+          aria-pressed={editor.isActive('underline')}
+        >
+          <Icon icon={Underline} />
+        </button>
+        <button
+          className={`mpt-btn${isH2 ? ' is-active' : ''}`}
+          onClick={() => (isH2 ? cmd.setParagraph(editor) : cmd.setHeading(editor, 2))}
+          aria-label="Heading"
+          aria-pressed={isH2}
+        >
+          <Icon icon={Heading2} />
+        </button>
+        <button
+          className={`mpt-btn${editor.isActive('bulletList') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleBulletList(editor)}
+          aria-label="Bullet list"
+          aria-pressed={editor.isActive('bulletList')}
+        >
+          <Icon icon={List} />
+        </button>
+
+        <button
+          className={`mpt-format${showFormat ? ' is-open' : ''}`}
+          onClick={() => setShowFormat((v) => !v)}
+          aria-pressed={showFormat}
+          aria-label={showFormat ? 'Close formatting' : 'More formatting'}
+        >
+          <Icon icon={showFormat ? X : Type} />
+          <span>Format</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/mobile/useKeyboardInset.ts
+++ b/src/ui/mobile/useKeyboardInset.ts
@@ -1,0 +1,35 @@
+/**
+ * useKeyboardInset — the height (px) the on-screen keyboard currently occupies,
+ * derived from `window.visualViewport` (JP-332).
+ *
+ * On mobile the soft keyboard shrinks the visual viewport without changing the
+ * layout viewport, so a bottom-anchored toolbar would otherwise be hidden behind
+ * it. Reserving this inset as padding lifts the editing column above the
+ * keyboard. Returns 0 where `visualViewport` is unavailable (desktop, older
+ * browsers, jsdom).
+ */
+
+import { useEffect, useState } from 'react';
+
+export function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    const vv = typeof window !== 'undefined' ? window.visualViewport : null;
+    if (!vv) return;
+    const update = () => {
+      // Keyboard height ≈ layout viewport minus the visible (visual) viewport.
+      const kb = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+      setInset(Math.round(kb));
+    };
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+    update();
+    return () => {
+      vv.removeEventListener('resize', update);
+      vv.removeEventListener('scroll', update);
+    };
+  }, []);
+
+  return inset;
+}


### PR DESCRIPTION
Final mobile slice of JP-332 — the prose-toolbar partitioning — plus the mobile-preview regressions found in review (folded in at your request). All behavior gates on `mobileActive`; **desktop is unchanged**.

## Prose toolbar (the slice)
- On mobile the multi-row tabbed ribbon is replaced by a **slim bottom bar** (Bold / Italic / Underline / Heading / Bullets) + a **Format** button.
- **Format expands the full `DocumentEditorToolbar` inline, above the bar** (bounded `42vh`, scrollable) — it **squeezes the writing area instead of drawing over the text** (the previous full-screen sheet was wrong).
- The bar is the editor panel's **last flex child**, and the panel **reserves the on-screen keyboard's height** (`useKeyboardInset`, via `visualViewport`) as padding so the bar **rides above the keyboard**. The hosted ribbon shares the panel's `TiptapEditorProvider` (no re-provide), and the slim bar is the only toolbar mounted when collapsed (no duplicate shortcut listeners).

## Review fixes (folded in)
1. **Property sheet didn't fill** — `property-panel--mobile` now `height: 100%`, so the panel's `flex: 1` content expands/scrolls instead of collapsing to its intrinsic height.
2. **Documents header clipped buttons** — `.dh-top-actions` was a non-wrapping group, so on a narrow header the trailing **Refresh / Import / New** overflowed behind the sort select and were clipped. It now takes a full row and wraps.
3. **Title/status collided with the focus tabs** (real regression) — the document identity moved into a **`MobileDocumentInfo`** popover (ⓘ button next to Documents) with rename + save status + a **glanceable dirty dot** on the button; the **`LayoutSelector` chip collapses to a lucide icon** on mobile. The left stops carrying a long title and the right shrinks, so nothing overlaps the Write/Split/Diagram tabs.

## Verification
- `bun run typecheck` ✓ · full suite ✓ **2693** · `build` ✓
- ⚠️ **Needs device verification:** the keyboard-inset behavior depends on `visualViewport` and can't be exercised in jsdom/desktop DevTools — please confirm on real iOS Safari + Android Chrome that the Format bar sits above the keyboard and the writing area squeezes (doesn't hide text).

> Scope note: this PR is broader than a single concern because the review fixes were folded onto this branch by request. Happy to split if you'd prefer.

Assisted-by: Opus 4.8