### PR TITLE
relay: round-trip LaTeX math in prose (MCP-authorable equations)

### DIFF
--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -26,9 +26,17 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
 - Pass Markdown by default, or well-formed HTML with format:"html".
 - Allowed block types only: paragraph, heading (h1-h6), bulletList/orderedList
   (with listItem), blockquote, codeBlock, table, horizontalRule, image, figure
-  (with figcaption), callout, gallery. Anything else is unwrapped to its text.
+  (with figcaption), callout, gallery, math block. Anything else is unwrapped to
+  its text.
 - Atoms carry NO children: image, horizontalRule, hardBreak, an inline citation,
-  a field reference. Never nest content inside them.
+  a field reference, an inline/block math node. Never nest content inside them.
+- LaTeX math: write `$$ … $$` on its own line for a block (display) equation, or
+  `$ … $` for inline math, e.g. `$$E = mc^2$$` or "cost is $O(n \log n)$". `$$…$$`
+  is the reliable form. To avoid turning prose into math, an inline `$` only opens
+  before a non-space, non-digit and closes after a non-space — so "$5 and $10"
+  stays literal; `$` inside code stays literal. (HTML form, if you pass
+  format:"html": `<div data-math-block data-latex="…"></div>` /
+  `<span data-math-inline data-latex="…"></span>`.)
 - Every <img> needs a real src (a blob:, https:, or data: URL). A src-less image
   is dropped — it would crash the editor.
 - Tables must be rectangular: a <table> of <tr> rows, each row the same number of

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1447,42 +1447,104 @@ fn delete_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
 // ---------------------------------------------------------------------------
 
 /// Render Markdown to the HTML TipTap persists. GFM tables / strikethrough /
-/// task-lists are enabled to match the editor's extension set. `{{name}}` tokens
-/// in prose text become live field placeholders (Phase 3c) — see
-/// [`expand_field_tokens`].
+/// task-lists are enabled to match the editor's extension set. In prose text
+/// (never inside code), `{{name}}` tokens become live field placeholders
+/// (Phase 3c) and `$…$` / `$$…$$` become LaTeX math nodes — see
+/// [`expand_inline_tokens`] (inline `{{}}`/`$…$`) and [`sole_block_math`]
+/// (a paragraph that is solely a `$$…$$` block formula → a `mathBlock`).
 fn markdown_to_html(md: &str) -> String {
-    use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
+    use pulldown_cmark::{html, CowStr, Event, Options, Parser, Tag, TagEnd};
     let mut opts = Options::empty();
     opts.insert(Options::ENABLE_TABLES);
     opts.insert(Options::ENABLE_STRIKETHROUGH);
     opts.insert(Options::ENABLE_TASKLISTS);
 
-    // Filter the event stream: transform `{{name}}` inside plain text into a
-    // `<span data-field …>` (a live field reference), but NEVER inside a code
-    // block (where `{{` must stay literal). Inline code is a separate
-    // `Event::Code`, so it's left untouched by only matching `Event::Text`.
+    // Filter the event stream. Code is untouched: a code *block* is gated by
+    // `in_code_block`, and inline code is a separate `Event::Code` (we only
+    // rewrite `Event::Text`). A paragraph is buffered so one that is solely a
+    // `$$…$$` block formula can be replaced by a `<div data-math-block>` — a
+    // block `<div>` inside a `<p>` would be dropped by the inline collector, so
+    // block math must be lifted out of the paragraph.
     let mut in_code_block = 0u32;
     let mut events: Vec<Event> = Vec::new();
+    let mut para: Option<Vec<Event>> = None;
+
     for ev in Parser::new_ext(md, opts) {
         match ev {
             Event::Start(Tag::CodeBlock(kind)) => {
                 in_code_block += 1;
-                events.push(Event::Start(Tag::CodeBlock(kind)));
+                sink(&mut events, &mut para, Event::Start(Tag::CodeBlock(kind)));
             }
             Event::End(TagEnd::CodeBlock) => {
                 in_code_block = in_code_block.saturating_sub(1);
-                events.push(Event::End(TagEnd::CodeBlock));
+                sink(&mut events, &mut para, Event::End(TagEnd::CodeBlock));
             }
-            Event::Text(t) if in_code_block == 0 && t.contains("{{") => {
-                expand_field_tokens(&t, &mut events);
+            Event::Start(Tag::Paragraph) if in_code_block == 0 && para.is_none() => {
+                para = Some(Vec::new());
             }
-            other => events.push(other),
+            Event::End(TagEnd::Paragraph) if para.is_some() => {
+                let buf = para.take().unwrap();
+                if let Some(latex) = sole_block_math(&buf) {
+                    let div = format!(
+                        "<div data-math-block data-latex=\"{}\"></div>",
+                        escape_field_attr(&latex)
+                    );
+                    events.push(Event::Html(CowStr::from(div)));
+                } else {
+                    events.push(Event::Start(Tag::Paragraph));
+                    events.extend(buf);
+                    events.push(Event::End(TagEnd::Paragraph));
+                }
+            }
+            Event::Text(t) if in_code_block == 0 => {
+                let mut tmp = Vec::new();
+                expand_inline_tokens(&t, &mut tmp);
+                for e in tmp {
+                    sink(&mut events, &mut para, e);
+                }
+            }
+            other => sink(&mut events, &mut para, other),
         }
     }
 
     let mut out = String::new();
     html::push_html(&mut out, events.into_iter());
     out
+}
+
+/// Route an event to the buffered paragraph if one is open, else the main stream.
+fn sink<'a>(
+    events: &mut Vec<pulldown_cmark::Event<'a>>,
+    para: &mut Option<Vec<pulldown_cmark::Event<'a>>>,
+    ev: pulldown_cmark::Event<'a>,
+) {
+    match para {
+        Some(buf) => buf.push(ev),
+        None => events.push(ev),
+    }
+}
+
+/// If a buffered paragraph's content is solely a `$$…$$` block formula (only text
+/// + line breaks, trimming to `$$ … $$` with no interior `$$`), return its LaTeX.
+/// Otherwise `None` (any mark/code/field/inline-math makes it a normal paragraph).
+fn sole_block_math(buf: &[pulldown_cmark::Event]) -> Option<String> {
+    use pulldown_cmark::Event;
+    let mut text = String::new();
+    for ev in buf {
+        match ev {
+            Event::Text(t) => text.push_str(t),
+            Event::SoftBreak | Event::HardBreak => text.push('\n'),
+            _ => return None,
+        }
+    }
+    let t = text.trim();
+    if t.len() >= 5 && t.starts_with("$$") && t.ends_with("$$") {
+        let inner = t[2..t.len() - 2].trim();
+        if !inner.is_empty() && !inner.contains("$$") {
+            return Some(inner.to_string());
+        }
+    }
+    None
 }
 
 /// Escape a string for an HTML double-quoted attribute value.
@@ -1517,21 +1579,23 @@ fn try_parse_field_token(s: &str) -> Option<(&str, usize)> {
     None
 }
 
-/// Split `text` on `{{name}}` tokens, pushing literal stretches as `Event::Text`
-/// and each token as an `Event::InlineHtml` `<span data-field data-name="name">`
-/// (no `data-label` — the editor's nodeView fills the live value). A malformed
-/// `{{…` with no valid close stays literal.
-fn expand_field_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>) {
+/// Split `text` on inline tokens, pushing literal stretches as `Event::Text` and
+/// each token as an `Event::InlineHtml`:
+/// - `{{name}}` → `<span data-field data-name="name">` (no `data-label` — the
+///   editor's nodeView fills the live value).
+/// - `$…$`      → `<span data-math-inline data-latex="…">` (inline LaTeX; block
+///   `$$…$$` is handled at the paragraph level by [`sole_block_math`]).
+/// Malformed/literal forms (`{{…` with no close, `$5`, an escaped `\$`) stay text.
+fn expand_inline_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>) {
     use pulldown_cmark::{CowStr, Event};
     let bytes = text.as_bytes();
     let mut i = 0;
     let mut literal_start = 0;
-    while i + 1 < bytes.len() {
-        if bytes[i] == b'{' && bytes[i + 1] == b'{' {
+    while i < bytes.len() {
+        // `{{name}}` field token.
+        if bytes[i] == b'{' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
             if let Some((name, consumed)) = try_parse_field_token(&text[i + 2..]) {
-                if literal_start < i {
-                    out.push(Event::Text(CowStr::from(text[literal_start..i].to_string())));
-                }
+                flush_literal(text, literal_start, i, out);
                 let span = format!("<span data-field data-name=\"{}\"></span>", escape_field_attr(name));
                 out.push(Event::InlineHtml(CowStr::from(span)));
                 i += 2 + consumed;
@@ -1539,11 +1603,68 @@ fn expand_field_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>)
                 continue;
             }
         }
+        // `$…$` inline math — skip an escaped `\$`.
+        if bytes[i] == b'$' && !(i > 0 && bytes[i - 1] == b'\\') {
+            if let Some((latex, consumed)) = try_parse_inline_math(&text[i..]) {
+                flush_literal(text, literal_start, i, out);
+                let span = format!(
+                    "<span data-math-inline data-latex=\"{}\"></span>",
+                    escape_field_attr(latex)
+                );
+                out.push(Event::InlineHtml(CowStr::from(span)));
+                i += consumed;
+                literal_start = i;
+                continue;
+            }
+        }
         i += 1;
     }
-    if literal_start < text.len() {
-        out.push(Event::Text(CowStr::from(text[literal_start..].to_string())));
+    flush_literal(text, literal_start, text.len(), out);
+}
+
+/// Push `text[start..end]` as an `Event::Text` if non-empty.
+fn flush_literal<'a>(text: &str, start: usize, end: usize, out: &mut Vec<pulldown_cmark::Event<'a>>) {
+    use pulldown_cmark::{CowStr, Event};
+    if start < end {
+        out.push(Event::Text(CowStr::from(text[start..end].to_string())));
     }
+}
+
+/// Parse an inline `$…$` math span at the start of `s` (`s[0] == '$'`). Returns
+/// the LaTeX + total bytes consumed (both `$` included), or `None`. Conservative
+/// delimiters (markdown-it-texmath style) so prose dollars don't become math:
+/// the opening `$` must be followed by a non-space, non-digit; the closing `$`
+/// must be preceded by a non-space and not be escaped; `$$` is not inline (it's
+/// block); and inline math can't cross a newline. `$` is ASCII so byte scanning
+/// is char-boundary safe.
+fn try_parse_inline_math(s: &str) -> Option<(&str, usize)> {
+    let bytes = s.as_bytes();
+    // Need at least `$x$`, and `$$` is the block form (handled elsewhere).
+    if bytes.len() < 3 || bytes[1] == b'$' {
+        return None;
+    }
+    let first = bytes[1];
+    if first == b' ' || first == b'\t' || first == b'\n' || first.is_ascii_digit() {
+        return None;
+    }
+    let mut j = 2;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'\n' => return None, // inline math doesn't cross a line
+            b'$' if bytes[j - 1] != b'\\' => {
+                if bytes[j - 1] == b' ' || bytes[j - 1] == b'\t' {
+                    return None; // closing `$` can't follow whitespace
+                }
+                if j + 1 < bytes.len() && bytes[j + 1] == b'$' {
+                    return None; // `$$` — not an inline close
+                }
+                let latex = &s[1..j];
+                return if latex.is_empty() { None } else { Some((latex, j + 1)) };
+            }
+            _ => j += 1,
+        }
+    }
+    None
 }
 
 /// Hard cap on a single prose write's content size, in bytes (JP-248). A safety
@@ -6254,6 +6375,50 @@ mod tests {
         assert!(html.contains("{{unclosed and "), "got: {html}");
         // The well-formed `{{x}}` after the junk still converts.
         assert!(html.contains(r#"<span data-field data-name="x"></span>"#), "got: {html}");
+    }
+
+    // ---- LaTeX math markdown adapter ----
+
+    #[test]
+    fn markdown_block_math_becomes_div() {
+        // A paragraph that is solely `$$…$$` lifts to a block math node (not a <p>).
+        let html = markdown_to_html("$$E = mc^2$$");
+        assert!(html.contains(r#"<div data-math-block data-latex="E = mc^2"></div>"#), "got: {html}");
+        assert!(!html.contains("<p>"), "block math is not wrapped in a paragraph: {html}");
+    }
+
+    #[test]
+    fn markdown_inline_math_becomes_span() {
+        let html = markdown_to_html(r"cost is $O(n \log n)$ here");
+        assert!(html.contains(r#"<span data-math-inline data-latex="O(n \log n)"></span>"#), "got: {html}");
+        assert!(html.contains("cost is "), "literal text preserved");
+    }
+
+    #[test]
+    fn markdown_math_left_literal_in_code() {
+        let inline = markdown_to_html("use `$x$` here");
+        assert!(inline.contains("$x$"), "inline code untouched: {inline}");
+        assert!(!inline.contains("data-math"));
+
+        let fenced = markdown_to_html("```\n$$y$$\n```");
+        assert!(fenced.contains("$$y$$"), "code block untouched: {fenced}");
+        assert!(!fenced.contains("data-math"));
+    }
+
+    #[test]
+    fn markdown_prose_dollars_stay_literal() {
+        // Conservative delimiters: a `$` before a digit / a space isn't math.
+        let html = markdown_to_html("pay $5 and $10 to me");
+        assert!(!html.contains("data-math"), "prose dollars are not math: {html}");
+        assert!(html.contains("$5 and $10"), "got: {html}");
+    }
+
+    #[test]
+    fn markdown_inline_dollar_dollar_is_not_inline_math() {
+        // `$$…$$` mid-paragraph (not a sole block) stays literal — block math goes
+        // on its own line.
+        let html = markdown_to_html("see $$x$$ here");
+        assert!(!html.contains("data-math"), "got: {html}");
     }
 
     /// JP-356: the markdown a `set_prose` author writes for a soft-wrapped /

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -148,6 +148,8 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         "citationInline" => Block::Void(citation_html(el, txn)),
         "bibliography" => Block::Void(bibliography_html(el, txn)),
         "fieldRef" => Block::Void(field_html(el, txn)),
+        "mathInline" => Block::Void(math_inline_html(el, txn)),
+        "mathBlock" => Block::Void(math_block_html(el, txn)),
         // Structural custom blocks (round-trip with the relay parser). `variant`/
         // `layout` are PM attr names → emitted as `data-variant`/`data-layout`.
         "callout" => {
@@ -303,6 +305,21 @@ fn bibliography_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
         Some(bib) => format!("<div data-bibliography data-bib-html=\"{}\"></div>", escape_attr(&bib)),
         None => "<div data-bibliography></div>".to_string(),
     }
+}
+
+/// Serialize a `mathInline` element to `<span data-math-inline data-latex=…>`.
+/// Childless; the LaTeX source lives in `data-latex`. The editor re-adds the
+/// `class`/`contenteditable` presentation on render. Mirrors `LatexExtension.ts`.
+fn math_inline_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let latex = str_attr(el, txn, "latex").unwrap_or_default();
+    format!("<span data-math-inline data-latex=\"{}\"></span>", escape_attr(&latex))
+}
+
+/// Serialize a `mathBlock` element to `<div data-math-block data-latex=…>`.
+/// Childless; the LaTeX source lives in `data-latex`.
+fn math_block_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let latex = str_attr(el, txn, "latex").unwrap_or_default();
+    format!("<div data-math-block data-latex=\"{}\"></div>", escape_attr(&latex))
 }
 
 fn write_text<T: ReadTxn>(t: &XmlTextRef, txn: &T, out: &mut String) {
@@ -600,6 +617,26 @@ mod tests {
             // no label
         });
         assert_eq!(html, "<p><span data-field data-name=\"Version\"></span></p>");
+    }
+
+    #[test]
+    fn math_inline_serializes_with_latex() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("where "));
+            let m = p.push_back(txn, XmlElementPrelim::empty("mathInline"));
+            m.insert_attribute(txn, "latex", "x^2");
+        });
+        assert_eq!(html, "<p>where <span data-math-inline data-latex=\"x^2\"></span></p>");
+    }
+
+    #[test]
+    fn math_block_serializes_with_latex() {
+        let html = render(|_doc, frag, txn| {
+            let m = frag.push_back(txn, XmlElementPrelim::empty("mathBlock"));
+            m.insert_attribute(txn, "latex", "E = mc^2");
+        });
+        assert_eq!(html, "<div data-math-block data-latex=\"E = mc^2\"></div>");
     }
 
     #[test]

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -351,7 +351,7 @@ fn is_inline_member(n: &HtmlNode) -> bool {
                 || tag == "br"
                 || matches!(
                     prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)),
-                    Some("fieldRef") | Some("citationInline")
+                    Some("fieldRef") | Some("citationInline") | Some("mathInline")
                 )
         }
     }
@@ -394,8 +394,32 @@ fn field_node(attrs: &[(String, String)]) -> PmNode {
     PmNode { node_type: "fieldRef".to_string(), attrs: a, children: vec![] }
 }
 
+/// Build a `mathInline` PM node from a `<span data-math-inline data-latex=…>`
+/// element. Caller guarantees `data-latex` is present. The LaTeX source ↔ the
+/// `latex` PM attr, symmetric with the editor's `renderHTML`
+/// (`src/tiptap/LatexExtension.ts`). It's an atom — no children.
+fn math_inline_node(attrs: &[(String, String)]) -> PmNode {
+    let latex = get_attr(attrs, "data-latex").unwrap_or("").to_string();
+    PmNode { node_type: "mathInline".to_string(), attrs: vec![("latex".to_string(), latex)], children: vec![] }
+}
+
+/// Build a childless `mathBlock` PM node from a `<div data-math-block
+/// data-latex=…>` element. Caller guarantees `data-latex` is present.
+fn math_block_node(attrs: &[(String, String)]) -> PmNode {
+    let latex = get_attr(attrs, "data-latex").unwrap_or("").to_string();
+    PmNode { node_type: "mathBlock".to_string(), attrs: vec![("latex".to_string(), latex)], children: vec![] }
+}
+
 /// Map a known block-level HTML element to a PM node, else `None`.
 fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode]) -> Option<PmNode> {
+    // Math block atom: `<div data-math-block data-latex=…>`. Childless — the
+    // LaTeX source lives in `data-latex`. A latex-less block is useless, so let
+    // it fall through to the generic unwrap (keeping any text) instead.
+    if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)) == Some("mathBlock")
+        && has_attr(attrs, "data-latex")
+    {
+        return Some(math_block_node(attrs));
+    }
     // Bibliography block atom (JP-89): `<div data-bibliography data-bib-html=…>`.
     // Childless — the rendered entries live (escaped) in `bibHtml`.
     if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)) == Some("bibliography") {
@@ -595,6 +619,13 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                     // — a nameless field reference is useless, so fall through to
                     // the unwrap below and keep the text instead.
                     out.push(PmChild::Node(field_node(attrs)));
+                } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
+                    == Some("mathInline")
+                    && has_attr(attrs, "data-latex")
+                {
+                    // Inline math atom. Require `data-latex` — a latex-less math
+                    // span is useless, so fall through to the unwrap and keep text.
+                    out.push(PmChild::Node(math_inline_node(attrs)));
                 } else if let Some(mark) = prose_schema::mark_pm(tag) {
                     let mut m = marks.to_vec();
                     m.push(PmMark { name: mark.to_string(), href: None });
@@ -867,6 +898,42 @@ mod tests {
         assert_eq!(f.node_type, "fieldRef");
         assert_eq!(attr(f, "name"), Some("Version"));
         assert_eq!(attr(f, "label"), None);
+    }
+
+    #[test]
+    fn math_inline_span_parses_to_inline_atom() {
+        let b = html_to_blocks(
+            r#"<p>where <span data-math-inline data-latex="x^2"></span> holds</p>"#,
+        );
+        assert_eq!(b[0].node_type, "paragraph");
+        assert_eq!(b[0].children[0], text("where "));
+        let PmChild::Node(m) = &b[0].children[1] else { panic!("math not a node") };
+        assert_eq!(m.node_type, "mathInline");
+        assert!(m.children.is_empty(), "math is an atom");
+        assert_eq!(attr(m, "latex"), Some("x^2"));
+    }
+
+    #[test]
+    fn math_block_div_parses_to_block_atom() {
+        let b = html_to_blocks(r#"<div data-math-block data-latex="E = mc^2"></div>"#);
+        assert_eq!(b[0].node_type, "mathBlock");
+        assert!(b[0].children.is_empty(), "math block is an atom");
+        assert_eq!(attr(&b[0], "latex"), Some("E = mc^2"));
+    }
+
+    #[test]
+    fn math_without_latex_degrades_to_text() {
+        // A latex-less math span keeps its text rather than producing a useless atom.
+        let b = html_to_blocks(r#"<p>a <span data-math-inline>kept</span> b</p>"#);
+        let all: String = b[0]
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                PmChild::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(all.contains("kept"), "latex-less math span keeps its text");
     }
 
     #[test]

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -68,8 +68,8 @@ pub fn mark_pm(html_tag: &str) -> Option<&'static str> {
 /// `(pm type, html tag, marker attribute)` triple so the two sides can't drift.
 /// Mirrors the editor extensions in `src/tiptap/CitationExtension.ts`.
 ///
-/// `mathInline`/`mathBlock` are the next entries (same mechanism) when math
-/// round-trips through the relay.
+/// Mirrors `src/tiptap/CitationExtension.ts`, `src/tiptap/FieldExtension.ts`,
+/// and `src/tiptap/LatexExtension.ts`.
 pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
     ("citationInline", "span", "data-citation"),
     ("bibliography", "div", "data-bibliography"),
@@ -78,6 +78,12 @@ pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
     // any reserialize/flatten, dropping the field node. Mirrors
     // `src/tiptap/FieldExtension.ts`.
     ("fieldRef", "span", "data-field"),
+    // LaTeX math: an inline atom (`<span data-math-inline data-latex>`) and a
+    // childless block atom (`<div data-math-block data-latex>`). The LaTeX source
+    // lives in `data-latex`; both are round-tripped explicitly like the citation/
+    // field atoms so a flatten doesn't unwrap them. Mirrors `LatexExtension.ts`.
+    ("mathInline", "span", "data-math-inline"),
+    ("mathBlock", "div", "data-math-block"),
 ];
 
 /// PM node type for an HTML element that matches a custom prose-helper node:

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -71,6 +71,8 @@ fn is_known_type(t: &str) -> bool {
             | "gallery"
             | "citationInline"
             | "fieldRef"
+            | "mathInline"
+            | "mathBlock"
             | "hardBreak"
     )
 }
@@ -81,7 +83,14 @@ fn is_known_type(t: &str) -> bool {
 fn is_atom(t: &str) -> bool {
     matches!(
         t,
-        "image" | "citationInline" | "fieldRef" | "horizontalRule" | "bibliography" | "hardBreak"
+        "image"
+            | "citationInline"
+            | "fieldRef"
+            | "mathInline"
+            | "mathBlock"
+            | "horizontalRule"
+            | "bibliography"
+            | "hardBreak"
     )
 }
 


### PR DESCRIPTION
Lets MCP agents author **live LaTeX/KaTeX equations** in prose. Today the relay's prose whitelist has no `mathInline`/`mathBlock`, so any `$$…$$` or `<div data-math-block>` from `set_prose` is silently **unwrapped/stripped** — math only works when typed in the editor. This adds math round-tripping following the `citationInline`/`fieldRef` precedent the `prose_schema.rs` TODO literally anticipated (*"mathInline/mathBlock are the next entries (same mechanism)"*).

The client `src/tiptap/LatexExtension.ts` already parses the `data-math-*` HTML, so this is **purely relay-side** preservation + emission — perfectly symmetric with what the editor itself serializes.

## Changes
- **`prose_schema`** — `mathInline` (`span`/`data-math-inline`) + `mathBlock` (`div`/`data-math-block`) in `CUSTOM_PROSE_NODES`.
- **`prose_validate`** — both are known **childless atoms** (a stray child is stripped, like `fieldRef` — keeps NodeView reconciliation crash-safe).
- **`prose_parse`** — parse `<span data-math-inline data-latex>` (inline atom) + `<div data-math-block data-latex>` (block atom); a latex-less node degrades to its text.
- **`prose_html`** — emit the `data-math-*` HTML on flatten, so it round-trips to the editor + `get_prose`.
- **`tools` (markdown)** — code-aware **`$$…$$`** (block; a paragraph that is *solely* a block formula is lifted to a `<div>`, since a block `<div>` inside a `<p>` would be dropped by the inline collector) and **`$…$`** (inline) pre-pass with **conservative delimiters** (markdown-it-texmath style): `$` only opens before a non-space/non-digit and closes after a non-space, so `"$5 and $10"` and `$` inside code stay literal.
- **`skills`** — the `get_skills` content contract now documents math (`$$`/`$` + the HTML fallback).

## Safety / compat
- **Additive prose content** — `PROTOCOL_VERSION` unchanged, **no migration** (old docs simply have no math nodes).
- Atom-with-children is stripped (existing `atom_with_children_is_stripped` invariant extended to math), so a malformed math node can't crash the editor's node-view.

## Tests / verification
- New round-trip tests both directions (`prose_parse`: HTML→PM; `prose_html`: PM→HTML) + markdown-adapter tests (block / inline / code-skip / prose-dollars-stay-literal).
- `cargo build --bin relay` ✓ · full `cargo test` suite ✓ · OSS leak grep clean.
- After merge + staging deploy, the staging MCP can author equations (a `$$…$$` `set_prose` → `get_prose` shows `data-math-block`).

Assisted-by: Opus 4.8