### PR TITLE
docs: Connect an AI Agent guide (MCP) + region picker

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -31,6 +31,7 @@ const guidesSidebar = [
       { text: 'Export & Import', link: '/guide/export-import' },
       { text: 'Whiteboard & Ideas', link: '/guide/whiteboard' },
       { text: 'Collaboration', link: '/guide/collaboration' },
+      { text: 'Connect an AI Agent', link: '/guide/connect-your-agent' },
       { text: 'Keyboard Shortcuts', link: '/guide/keyboard-shortcuts' },
       { text: 'Settings', link: '/guide/settings' },
     ],

--- a/docs-site/.vitepress/theme/RegionSelector.vue
+++ b/docs-site/.vitepress/theme/RegionSelector.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+// DocuShark Cloud relay pods are regional; clients connect by region hostname.
+// Toronto is live today; the rest light up on request.
+const regions = [
+  { id: 'yyz', city: 'Toronto', available: true },
+  { id: 'ord', city: 'Chicago', available: false },
+  { id: 'nrt', city: 'Tokyo', available: false },
+  { id: 'fra', city: 'Frankfurt', available: false },
+]
+
+const selected = ref('yyz')
+const region = computed(() => regions.find((r) => r.id === selected.value)!)
+const url = computed(() => `https://${selected.value}.relay.docushark.app/mcp`)
+const copied = ref(false)
+
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(url.value)
+    copied.value = true
+    setTimeout(() => (copied.value = false), 1500)
+  } catch {
+    // Clipboard blocked (e.g. non-secure context) — the field is selectable instead.
+  }
+}
+</script>
+
+<template>
+  <div class="region-selector">
+    <label class="rs-label" for="rs-region">Your workspace location</label>
+    <div class="rs-row">
+      <select id="rs-region" v-model="selected" class="rs-select">
+        <option v-for="r in regions" :key="r.id" :value="r.id">
+          {{ r.city }} ({{ r.id }}){{ r.available ? '' : ' — on request' }}
+        </option>
+      </select>
+    </div>
+
+    <label class="rs-label" for="rs-url">Your MCP endpoint</label>
+    <div class="rs-row">
+      <input
+        id="rs-url"
+        class="rs-url"
+        :value="url"
+        readonly
+        @focus="($event.target as HTMLInputElement).select()"
+      />
+      <button class="rs-copy" type="button" @click="copy">{{ copied ? 'Copied ✓' : 'Copy' }}</button>
+    </div>
+
+    <p v-if="!region.available" class="rs-note">
+      The <strong>{{ region.city }}</strong> region isn’t live yet — it lights up on request.
+      <a href="https://app.docushark.app" target="_blank" rel="noreferrer">Get in touch</a> to enable
+      it for your workspace. <strong>Toronto (yyz)</strong> is available today.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.region-selector {
+  margin: 1.25rem 0;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+}
+.rs-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  margin: 0.2rem 0 0.35rem;
+}
+.rs-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+.rs-row:last-of-type {
+  margin-bottom: 0;
+}
+.rs-select,
+.rs-url {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 38px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font-size: 0.95rem;
+}
+.rs-url {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.88rem;
+}
+.rs-copy {
+  flex: 0 0 auto;
+  height: 38px;
+  padding: 0 1rem;
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 8px;
+  background: var(--vp-c-brand-1);
+  color: var(--vp-c-bg);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.rs-copy:hover {
+  background: var(--vp-c-brand-2);
+  border-color: var(--vp-c-brand-2);
+}
+.rs-note {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/docs-site/.vitepress/theme/index.ts
+++ b/docs-site/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import Layout from './Layout.vue'
 import Home from './Home.vue'
+import RegionSelector from './RegionSelector.vue'
 
 // Self-hosted JetBrains Mono (offline-safe — bundled by Vite, no network at
 // runtime). Inter is already shipped by VitePress's default theme.
@@ -16,5 +17,6 @@ export default {
   Layout,
   enhanceApp({ app }) {
     app.component('Home', Home)
+    app.component('RegionSelector', RegionSelector)
   },
 } satisfies Theme

--- a/docs-site/developer/mcp-agent-recipes.md
+++ b/docs-site/developer/mcp-agent-recipes.md
@@ -9,6 +9,12 @@ Codex, Cursor, ChatGPT, or your own — rather than learning a new one.
 
 ## Connect your agent
 
+::: tip New here?
+For a step-by-step setup (with a picker that gives you the exact endpoint URL for your
+workspace), start with the [**Connect an AI Agent**](/guide/connect-your-agent) guide. This
+page is the deeper reference.
+:::
+
 1. **Connect your agent** to a relay's MCP endpoint (`/mcp`). The setup differs per
    client — see the connection matrix in the
    [skills/CONNECTING.md](https://github.com/JPE-Net-Technologies/docushark/blob/master/skills/CONNECTING.md)

--- a/docs-site/guide/connect-your-agent.md
+++ b/docs-site/guide/connect-your-agent.md
@@ -1,0 +1,96 @@
+# Connect an AI Agent
+
+DocuShark speaks **[MCP](https://modelcontextprotocol.io)** — an open standard that lets
+an AI agent author real documents for you: write prose, build diagrams, manage references,
+all directly in your live document. You connect the agent you already use — Claude, Cursor,
+ChatGPT, or your own — so there's nothing new to learn.
+
+This guide gets you connected in a few minutes.
+
+## 1. What you'll get
+
+Once connected, you can ask your agent things like *"draft an architecture RFC with a system
+diagram"* or *"turn these notes into an outlined document"* — and it writes them straight into
+a DocuShark document, diagrams and all.
+
+## 2. Get your endpoint
+
+Pick your workspace's location to get the address — your **MCP endpoint** — that you'll paste
+into your agent:
+
+<RegionSelector />
+
+::: tip Which location is mine?
+It's the region you chose when you created your DocuShark Cloud workspace. Not sure? Toronto
+(`yyz`) is the default. Running your own relay instead? See [Self-hosting](#self-hosting) below.
+:::
+
+## 3. Connect your agent
+
+There are two ways to authenticate. Most people use **Option A**.
+
+### Option A — Sign in (recommended)
+
+Add your **MCP endpoint** to your client as a remote / custom MCP server. The first time your
+agent connects, DocuShark walks you through signing in to your workspace — there's no token to
+copy or paste. This is also the **only** option for **claude.ai on the web**.
+
+### Option B — Use a token (advanced / self-host)
+
+Some setups authenticate with a token instead of signing in (handy for a self-hosted relay or
+a headless script). Send it as a header:
+
+```
+Authorization: Bearer <your-token>
+```
+
+For DocuShark Cloud, prefer Option A — signing in is simpler and nothing to manage.
+
+### Per-client setup
+
+::: tip Claude Desktop / Claude Code
+Add DocuShark as a remote MCP server using your endpoint, then approve the sign-in prompt.
+:::
+
+Clients that use a JSON config (Cursor and others) follow this shape — paste your endpoint from
+step 2 in place of the URL:
+
+```json
+{
+  "mcpServers": {
+    "docushark": {
+      "url": "https://yyz.relay.docushark.app/mcp"
+    }
+  }
+}
+```
+
+Your client's exact field names may differ slightly; the endpoint URL is the part that matters.
+DocuShark's tools show up with a `docushark_` prefix (e.g. `docushark_create_document`).
+
+## 4. Check it works
+
+Ask your agent:
+
+> "Create a DocuShark document called **Hello** with a short intro paragraph."
+
+Then open [DocuShark](https://app.docushark.app) — your new document is right there, live.
+
+## 5. Do more with recipes
+
+Ready-made workflows ("skills") cover common jobs — an architecture RFC, a diagram from a
+description, notes → a structured document, and more. On Claude they load automatically; with
+other clients you paste a recipe into your system prompt. See
+[AI Agents (MCP) & Recipes](/developer/mcp-agent-recipes) for the recipe list and the full
+tool reference.
+
+## Self-hosting
+
+Running your own relay? Use its address instead of a Cloud region — for example
+`http://localhost:9877/mcp` for a local relay, or `https://your-host/mcp` for a public one.
+Everything else in this guide is the same.
+
+::: tip Good to know
+Your agent writes to your **workspace** (Cloud) documents. Local, on-device documents are
+read-only over MCP — an agent can read them for context but won't change them.
+:::


### PR DESCRIPTION
An easy, step-by-step **customer** guide for connecting an MCP agent to a DocuShark Cloud workspace — with an interactive **region → URL picker** so people get the endpoint right. Independent of the relay-math work.

## What's here
- **`guide/connect-your-agent.md`** — beginner-first, copy-paste flow: *what you get → pick your endpoint → connect → verify → recipes → self-hosting*. Two auth paths: **sign in (OAuth)** — the only mode for **claude.ai web** — or **a token** for self-host/advanced. Honest about the manual-only bits and what's read-only over MCP.
- **`RegionSelector.vue`** — a region `<select>` → `https://<region>.relay.docushark.app/mcp` + a **Copy** button. **Toronto (`yyz`) is live**; Chicago/Tokyo/Frankfurt are marked **"on request"** (no dead URLs). Registered via `enhanceApp`, mirroring the existing `Home.vue` pattern.
- **Nav + cross-links** — added to **Guides → Using DocuShark**; the deeper `developer/mcp-agent-recipes` page now points newcomers here.

## Notes
- Documents only the **public** connect info (region hostnames are endpoints customers hit). No links to internal/Cloud topology docs.
- `vitepress build` passes — the page, the Vue component, and all internal links resolve (VitePress fails the build on dead links).

> Region availability + the exact hostnames are encoded in `RegionSelector.vue` — easy to flip a region to "live" as pods come online.

Assisted-by: Opus 4.8