### PR TITLE
Promote master → staging (relay LaTeX math + JP-332 mobile)

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -31,6 +31,7 @@ const guidesSidebar = [
       { text: 'Export & Import', link: '/guide/export-import' },
       { text: 'Whiteboard & Ideas', link: '/guide/whiteboard' },
       { text: 'Collaboration', link: '/guide/collaboration' },
+      { text: 'Connect an AI Agent', link: '/guide/connect-your-agent' },
       { text: 'Keyboard Shortcuts', link: '/guide/keyboard-shortcuts' },
       { text: 'Settings', link: '/guide/settings' },
     ],

--- a/docs-site/.vitepress/theme/RegionSelector.vue
+++ b/docs-site/.vitepress/theme/RegionSelector.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+// DocuShark Cloud relay pods are regional; clients connect by region hostname.
+// Toronto is live today; the rest light up on request.
+const regions = [
+  { id: 'yyz', city: 'Toronto', available: true },
+  { id: 'ord', city: 'Chicago', available: false },
+  { id: 'nrt', city: 'Tokyo', available: false },
+  { id: 'fra', city: 'Frankfurt', available: false },
+]
+
+const selected = ref('yyz')
+const region = computed(() => regions.find((r) => r.id === selected.value)!)
+const url = computed(() => `https://${selected.value}.relay.docushark.app/mcp`)
+const copied = ref(false)
+
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(url.value)
+    copied.value = true
+    setTimeout(() => (copied.value = false), 1500)
+  } catch {
+    // Clipboard blocked (e.g. non-secure context) — the field is selectable instead.
+  }
+}
+</script>
+
+<template>
+  <div class="region-selector">
+    <label class="rs-label" for="rs-region">Your workspace location</label>
+    <div class="rs-row">
+      <select id="rs-region" v-model="selected" class="rs-select">
+        <option v-for="r in regions" :key="r.id" :value="r.id">
+          {{ r.city }} ({{ r.id }}){{ r.available ? '' : ' — on request' }}
+        </option>
+      </select>
+    </div>
+
+    <label class="rs-label" for="rs-url">Your MCP endpoint</label>
+    <div class="rs-row">
+      <input
+        id="rs-url"
+        class="rs-url"
+        :value="url"
+        readonly
+        @focus="($event.target as HTMLInputElement).select()"
+      />
+      <button class="rs-copy" type="button" @click="copy">{{ copied ? 'Copied ✓' : 'Copy' }}</button>
+    </div>
+
+    <p v-if="!region.available" class="rs-note">
+      The <strong>{{ region.city }}</strong> region isn’t live yet — it lights up on request.
+      <a href="https://app.docushark.app" target="_blank" rel="noreferrer">Get in touch</a> to enable
+      it for your workspace. <strong>Toronto (yyz)</strong> is available today.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.region-selector {
+  margin: 1.25rem 0;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+}
+.rs-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  margin: 0.2rem 0 0.35rem;
+}
+.rs-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+.rs-row:last-of-type {
+  margin-bottom: 0;
+}
+.rs-select,
+.rs-url {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 38px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font-size: 0.95rem;
+}
+.rs-url {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.88rem;
+}
+.rs-copy {
+  flex: 0 0 auto;
+  height: 38px;
+  padding: 0 1rem;
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 8px;
+  background: var(--vp-c-brand-1);
+  color: var(--vp-c-bg);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.rs-copy:hover {
+  background: var(--vp-c-brand-2);
+  border-color: var(--vp-c-brand-2);
+}
+.rs-note {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/docs-site/.vitepress/theme/index.ts
+++ b/docs-site/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import Layout from './Layout.vue'
 import Home from './Home.vue'
+import RegionSelector from './RegionSelector.vue'
 
 // Self-hosted JetBrains Mono (offline-safe — bundled by Vite, no network at
 // runtime). Inter is already shipped by VitePress's default theme.
@@ -16,5 +17,6 @@ export default {
   Layout,
   enhanceApp({ app }) {
     app.component('Home', Home)
+    app.component('RegionSelector', RegionSelector)
   },
 } satisfies Theme

--- a/docs-site/developer/mcp-agent-recipes.md
+++ b/docs-site/developer/mcp-agent-recipes.md
@@ -9,6 +9,12 @@ Codex, Cursor, ChatGPT, or your own — rather than learning a new one.
 
 ## Connect your agent
 
+::: tip New here?
+For a step-by-step setup (with a picker that gives you the exact endpoint URL for your
+workspace), start with the [**Connect an AI Agent**](/guide/connect-your-agent) guide. This
+page is the deeper reference.
+:::
+
 1. **Connect your agent** to a relay's MCP endpoint (`/mcp`). The setup differs per
    client — see the connection matrix in the
    [skills/CONNECTING.md](https://github.com/JPE-Net-Technologies/docushark/blob/master/skills/CONNECTING.md)

--- a/docs-site/guide/connect-your-agent.md
+++ b/docs-site/guide/connect-your-agent.md
@@ -1,0 +1,96 @@
+# Connect an AI Agent
+
+DocuShark speaks **[MCP](https://modelcontextprotocol.io)** — an open standard that lets
+an AI agent author real documents for you: write prose, build diagrams, manage references,
+all directly in your live document. You connect the agent you already use — Claude, Cursor,
+ChatGPT, or your own — so there's nothing new to learn.
+
+This guide gets you connected in a few minutes.
+
+## 1. What you'll get
+
+Once connected, you can ask your agent things like *"draft an architecture RFC with a system
+diagram"* or *"turn these notes into an outlined document"* — and it writes them straight into
+a DocuShark document, diagrams and all.
+
+## 2. Get your endpoint
+
+Pick your workspace's location to get the address — your **MCP endpoint** — that you'll paste
+into your agent:
+
+<RegionSelector />
+
+::: tip Which location is mine?
+It's the region you chose when you created your DocuShark Cloud workspace. Not sure? Toronto
+(`yyz`) is the default. Running your own relay instead? See [Self-hosting](#self-hosting) below.
+:::
+
+## 3. Connect your agent
+
+There are two ways to authenticate. Most people use **Option A**.
+
+### Option A — Sign in (recommended)
+
+Add your **MCP endpoint** to your client as a remote / custom MCP server. The first time your
+agent connects, DocuShark walks you through signing in to your workspace — there's no token to
+copy or paste. This is also the **only** option for **claude.ai on the web**.
+
+### Option B — Use a token (advanced / self-host)
+
+Some setups authenticate with a token instead of signing in (handy for a self-hosted relay or
+a headless script). Send it as a header:
+
+```
+Authorization: Bearer <your-token>
+```
+
+For DocuShark Cloud, prefer Option A — signing in is simpler and nothing to manage.
+
+### Per-client setup
+
+::: tip Claude Desktop / Claude Code
+Add DocuShark as a remote MCP server using your endpoint, then approve the sign-in prompt.
+:::
+
+Clients that use a JSON config (Cursor and others) follow this shape — paste your endpoint from
+step 2 in place of the URL:
+
+```json
+{
+  "mcpServers": {
+    "docushark": {
+      "url": "https://yyz.relay.docushark.app/mcp"
+    }
+  }
+}
+```
+
+Your client's exact field names may differ slightly; the endpoint URL is the part that matters.
+DocuShark's tools show up with a `docushark_` prefix (e.g. `docushark_create_document`).
+
+## 4. Check it works
+
+Ask your agent:
+
+> "Create a DocuShark document called **Hello** with a short intro paragraph."
+
+Then open [DocuShark](https://app.docushark.app) — your new document is right there, live.
+
+## 5. Do more with recipes
+
+Ready-made workflows ("skills") cover common jobs — an architecture RFC, a diagram from a
+description, notes → a structured document, and more. On Claude they load automatically; with
+other clients you paste a recipe into your system prompt. See
+[AI Agents (MCP) & Recipes](/developer/mcp-agent-recipes) for the recipe list and the full
+tool reference.
+
+## Self-hosting
+
+Running your own relay? Use its address instead of a Cloud region — for example
+`http://localhost:9877/mcp` for a local relay, or `https://your-host/mcp` for a public one.
+Everything else in this guide is the same.
+
+::: tip Good to know
+Your agent writes to your **workspace** (Cloud) documents. Local, on-device documents are
+read-only over MCP — an agent can read them for context but won't change them.
+:::

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -26,9 +26,17 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
 - Pass Markdown by default, or well-formed HTML with format:"html".
 - Allowed block types only: paragraph, heading (h1-h6), bulletList/orderedList
   (with listItem), blockquote, codeBlock, table, horizontalRule, image, figure
-  (with figcaption), callout, gallery. Anything else is unwrapped to its text.
+  (with figcaption), callout, gallery, math block. Anything else is unwrapped to
+  its text.
 - Atoms carry NO children: image, horizontalRule, hardBreak, an inline citation,
-  a field reference. Never nest content inside them.
+  a field reference, an inline/block math node. Never nest content inside them.
+- LaTeX math: write `$$ … $$` on its own line for a block (display) equation, or
+  `$ … $` for inline math, e.g. `$$E = mc^2$$` or "cost is $O(n \log n)$". `$$…$$`
+  is the reliable form. To avoid turning prose into math, an inline `$` only opens
+  before a non-space, non-digit and closes after a non-space — so "$5 and $10"
+  stays literal; `$` inside code stays literal. (HTML form, if you pass
+  format:"html": `<div data-math-block data-latex="…"></div>` /
+  `<span data-math-inline data-latex="…"></span>`.)
 - Every <img> needs a real src (a blob:, https:, or data: URL). A src-less image
   is dropped — it would crash the editor.
 - Tables must be rectangular: a <table> of <tr> rows, each row the same number of

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1447,42 +1447,104 @@ fn delete_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
 // ---------------------------------------------------------------------------
 
 /// Render Markdown to the HTML TipTap persists. GFM tables / strikethrough /
-/// task-lists are enabled to match the editor's extension set. `{{name}}` tokens
-/// in prose text become live field placeholders (Phase 3c) — see
-/// [`expand_field_tokens`].
+/// task-lists are enabled to match the editor's extension set. In prose text
+/// (never inside code), `{{name}}` tokens become live field placeholders
+/// (Phase 3c) and `$…$` / `$$…$$` become LaTeX math nodes — see
+/// [`expand_inline_tokens`] (inline `{{}}`/`$…$`) and [`sole_block_math`]
+/// (a paragraph that is solely a `$$…$$` block formula → a `mathBlock`).
 fn markdown_to_html(md: &str) -> String {
-    use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
+    use pulldown_cmark::{html, CowStr, Event, Options, Parser, Tag, TagEnd};
     let mut opts = Options::empty();
     opts.insert(Options::ENABLE_TABLES);
     opts.insert(Options::ENABLE_STRIKETHROUGH);
     opts.insert(Options::ENABLE_TASKLISTS);
 
-    // Filter the event stream: transform `{{name}}` inside plain text into a
-    // `<span data-field …>` (a live field reference), but NEVER inside a code
-    // block (where `{{` must stay literal). Inline code is a separate
-    // `Event::Code`, so it's left untouched by only matching `Event::Text`.
+    // Filter the event stream. Code is untouched: a code *block* is gated by
+    // `in_code_block`, and inline code is a separate `Event::Code` (we only
+    // rewrite `Event::Text`). A paragraph is buffered so one that is solely a
+    // `$$…$$` block formula can be replaced by a `<div data-math-block>` — a
+    // block `<div>` inside a `<p>` would be dropped by the inline collector, so
+    // block math must be lifted out of the paragraph.
     let mut in_code_block = 0u32;
     let mut events: Vec<Event> = Vec::new();
+    let mut para: Option<Vec<Event>> = None;
+
     for ev in Parser::new_ext(md, opts) {
         match ev {
             Event::Start(Tag::CodeBlock(kind)) => {
                 in_code_block += 1;
-                events.push(Event::Start(Tag::CodeBlock(kind)));
+                sink(&mut events, &mut para, Event::Start(Tag::CodeBlock(kind)));
             }
             Event::End(TagEnd::CodeBlock) => {
                 in_code_block = in_code_block.saturating_sub(1);
-                events.push(Event::End(TagEnd::CodeBlock));
+                sink(&mut events, &mut para, Event::End(TagEnd::CodeBlock));
             }
-            Event::Text(t) if in_code_block == 0 && t.contains("{{") => {
-                expand_field_tokens(&t, &mut events);
+            Event::Start(Tag::Paragraph) if in_code_block == 0 && para.is_none() => {
+                para = Some(Vec::new());
             }
-            other => events.push(other),
+            Event::End(TagEnd::Paragraph) if para.is_some() => {
+                let buf = para.take().unwrap();
+                if let Some(latex) = sole_block_math(&buf) {
+                    let div = format!(
+                        "<div data-math-block data-latex=\"{}\"></div>",
+                        escape_field_attr(&latex)
+                    );
+                    events.push(Event::Html(CowStr::from(div)));
+                } else {
+                    events.push(Event::Start(Tag::Paragraph));
+                    events.extend(buf);
+                    events.push(Event::End(TagEnd::Paragraph));
+                }
+            }
+            Event::Text(t) if in_code_block == 0 => {
+                let mut tmp = Vec::new();
+                expand_inline_tokens(&t, &mut tmp);
+                for e in tmp {
+                    sink(&mut events, &mut para, e);
+                }
+            }
+            other => sink(&mut events, &mut para, other),
         }
     }
 
     let mut out = String::new();
     html::push_html(&mut out, events.into_iter());
     out
+}
+
+/// Route an event to the buffered paragraph if one is open, else the main stream.
+fn sink<'a>(
+    events: &mut Vec<pulldown_cmark::Event<'a>>,
+    para: &mut Option<Vec<pulldown_cmark::Event<'a>>>,
+    ev: pulldown_cmark::Event<'a>,
+) {
+    match para {
+        Some(buf) => buf.push(ev),
+        None => events.push(ev),
+    }
+}
+
+/// If a buffered paragraph's content is solely a `$$…$$` block formula (only text
+/// + line breaks, trimming to `$$ … $$` with no interior `$$`), return its LaTeX.
+/// Otherwise `None` (any mark/code/field/inline-math makes it a normal paragraph).
+fn sole_block_math(buf: &[pulldown_cmark::Event]) -> Option<String> {
+    use pulldown_cmark::Event;
+    let mut text = String::new();
+    for ev in buf {
+        match ev {
+            Event::Text(t) => text.push_str(t),
+            Event::SoftBreak | Event::HardBreak => text.push('\n'),
+            _ => return None,
+        }
+    }
+    let t = text.trim();
+    if t.len() >= 5 && t.starts_with("$$") && t.ends_with("$$") {
+        let inner = t[2..t.len() - 2].trim();
+        if !inner.is_empty() && !inner.contains("$$") {
+            return Some(inner.to_string());
+        }
+    }
+    None
 }
 
 /// Escape a string for an HTML double-quoted attribute value.
@@ -1517,21 +1579,23 @@ fn try_parse_field_token(s: &str) -> Option<(&str, usize)> {
     None
 }
 
-/// Split `text` on `{{name}}` tokens, pushing literal stretches as `Event::Text`
-/// and each token as an `Event::InlineHtml` `<span data-field data-name="name">`
-/// (no `data-label` — the editor's nodeView fills the live value). A malformed
-/// `{{…` with no valid close stays literal.
-fn expand_field_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>) {
+/// Split `text` on inline tokens, pushing literal stretches as `Event::Text` and
+/// each token as an `Event::InlineHtml`:
+/// - `{{name}}` → `<span data-field data-name="name">` (no `data-label` — the
+///   editor's nodeView fills the live value).
+/// - `$…$`      → `<span data-math-inline data-latex="…">` (inline LaTeX; block
+///   `$$…$$` is handled at the paragraph level by [`sole_block_math`]).
+/// Malformed/literal forms (`{{…` with no close, `$5`, an escaped `\$`) stay text.
+fn expand_inline_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>) {
     use pulldown_cmark::{CowStr, Event};
     let bytes = text.as_bytes();
     let mut i = 0;
     let mut literal_start = 0;
-    while i + 1 < bytes.len() {
-        if bytes[i] == b'{' && bytes[i + 1] == b'{' {
+    while i < bytes.len() {
+        // `{{name}}` field token.
+        if bytes[i] == b'{' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
             if let Some((name, consumed)) = try_parse_field_token(&text[i + 2..]) {
-                if literal_start < i {
-                    out.push(Event::Text(CowStr::from(text[literal_start..i].to_string())));
-                }
+                flush_literal(text, literal_start, i, out);
                 let span = format!("<span data-field data-name=\"{}\"></span>", escape_field_attr(name));
                 out.push(Event::InlineHtml(CowStr::from(span)));
                 i += 2 + consumed;
@@ -1539,11 +1603,68 @@ fn expand_field_tokens<'a>(text: &str, out: &mut Vec<pulldown_cmark::Event<'a>>)
                 continue;
             }
         }
+        // `$…$` inline math — skip an escaped `\$`.
+        if bytes[i] == b'$' && !(i > 0 && bytes[i - 1] == b'\\') {
+            if let Some((latex, consumed)) = try_parse_inline_math(&text[i..]) {
+                flush_literal(text, literal_start, i, out);
+                let span = format!(
+                    "<span data-math-inline data-latex=\"{}\"></span>",
+                    escape_field_attr(latex)
+                );
+                out.push(Event::InlineHtml(CowStr::from(span)));
+                i += consumed;
+                literal_start = i;
+                continue;
+            }
+        }
         i += 1;
     }
-    if literal_start < text.len() {
-        out.push(Event::Text(CowStr::from(text[literal_start..].to_string())));
+    flush_literal(text, literal_start, text.len(), out);
+}
+
+/// Push `text[start..end]` as an `Event::Text` if non-empty.
+fn flush_literal<'a>(text: &str, start: usize, end: usize, out: &mut Vec<pulldown_cmark::Event<'a>>) {
+    use pulldown_cmark::{CowStr, Event};
+    if start < end {
+        out.push(Event::Text(CowStr::from(text[start..end].to_string())));
     }
+}
+
+/// Parse an inline `$…$` math span at the start of `s` (`s[0] == '$'`). Returns
+/// the LaTeX + total bytes consumed (both `$` included), or `None`. Conservative
+/// delimiters (markdown-it-texmath style) so prose dollars don't become math:
+/// the opening `$` must be followed by a non-space, non-digit; the closing `$`
+/// must be preceded by a non-space and not be escaped; `$$` is not inline (it's
+/// block); and inline math can't cross a newline. `$` is ASCII so byte scanning
+/// is char-boundary safe.
+fn try_parse_inline_math(s: &str) -> Option<(&str, usize)> {
+    let bytes = s.as_bytes();
+    // Need at least `$x$`, and `$$` is the block form (handled elsewhere).
+    if bytes.len() < 3 || bytes[1] == b'$' {
+        return None;
+    }
+    let first = bytes[1];
+    if first == b' ' || first == b'\t' || first == b'\n' || first.is_ascii_digit() {
+        return None;
+    }
+    let mut j = 2;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'\n' => return None, // inline math doesn't cross a line
+            b'$' if bytes[j - 1] != b'\\' => {
+                if bytes[j - 1] == b' ' || bytes[j - 1] == b'\t' {
+                    return None; // closing `$` can't follow whitespace
+                }
+                if j + 1 < bytes.len() && bytes[j + 1] == b'$' {
+                    return None; // `$$` — not an inline close
+                }
+                let latex = &s[1..j];
+                return if latex.is_empty() { None } else { Some((latex, j + 1)) };
+            }
+            _ => j += 1,
+        }
+    }
+    None
 }
 
 /// Hard cap on a single prose write's content size, in bytes (JP-248). A safety
@@ -6254,6 +6375,50 @@ mod tests {
         assert!(html.contains("{{unclosed and "), "got: {html}");
         // The well-formed `{{x}}` after the junk still converts.
         assert!(html.contains(r#"<span data-field data-name="x"></span>"#), "got: {html}");
+    }
+
+    // ---- LaTeX math markdown adapter ----
+
+    #[test]
+    fn markdown_block_math_becomes_div() {
+        // A paragraph that is solely `$$…$$` lifts to a block math node (not a <p>).
+        let html = markdown_to_html("$$E = mc^2$$");
+        assert!(html.contains(r#"<div data-math-block data-latex="E = mc^2"></div>"#), "got: {html}");
+        assert!(!html.contains("<p>"), "block math is not wrapped in a paragraph: {html}");
+    }
+
+    #[test]
+    fn markdown_inline_math_becomes_span() {
+        let html = markdown_to_html(r"cost is $O(n \log n)$ here");
+        assert!(html.contains(r#"<span data-math-inline data-latex="O(n \log n)"></span>"#), "got: {html}");
+        assert!(html.contains("cost is "), "literal text preserved");
+    }
+
+    #[test]
+    fn markdown_math_left_literal_in_code() {
+        let inline = markdown_to_html("use `$x$` here");
+        assert!(inline.contains("$x$"), "inline code untouched: {inline}");
+        assert!(!inline.contains("data-math"));
+
+        let fenced = markdown_to_html("```\n$$y$$\n```");
+        assert!(fenced.contains("$$y$$"), "code block untouched: {fenced}");
+        assert!(!fenced.contains("data-math"));
+    }
+
+    #[test]
+    fn markdown_prose_dollars_stay_literal() {
+        // Conservative delimiters: a `$` before a digit / a space isn't math.
+        let html = markdown_to_html("pay $5 and $10 to me");
+        assert!(!html.contains("data-math"), "prose dollars are not math: {html}");
+        assert!(html.contains("$5 and $10"), "got: {html}");
+    }
+
+    #[test]
+    fn markdown_inline_dollar_dollar_is_not_inline_math() {
+        // `$$…$$` mid-paragraph (not a sole block) stays literal — block math goes
+        // on its own line.
+        let html = markdown_to_html("see $$x$$ here");
+        assert!(!html.contains("data-math"), "got: {html}");
     }
 
     /// JP-356: the markdown a `set_prose` author writes for a soft-wrapped /

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -148,6 +148,8 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         "citationInline" => Block::Void(citation_html(el, txn)),
         "bibliography" => Block::Void(bibliography_html(el, txn)),
         "fieldRef" => Block::Void(field_html(el, txn)),
+        "mathInline" => Block::Void(math_inline_html(el, txn)),
+        "mathBlock" => Block::Void(math_block_html(el, txn)),
         // Structural custom blocks (round-trip with the relay parser). `variant`/
         // `layout` are PM attr names → emitted as `data-variant`/`data-layout`.
         "callout" => {
@@ -303,6 +305,21 @@ fn bibliography_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
         Some(bib) => format!("<div data-bibliography data-bib-html=\"{}\"></div>", escape_attr(&bib)),
         None => "<div data-bibliography></div>".to_string(),
     }
+}
+
+/// Serialize a `mathInline` element to `<span data-math-inline data-latex=…>`.
+/// Childless; the LaTeX source lives in `data-latex`. The editor re-adds the
+/// `class`/`contenteditable` presentation on render. Mirrors `LatexExtension.ts`.
+fn math_inline_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let latex = str_attr(el, txn, "latex").unwrap_or_default();
+    format!("<span data-math-inline data-latex=\"{}\"></span>", escape_attr(&latex))
+}
+
+/// Serialize a `mathBlock` element to `<div data-math-block data-latex=…>`.
+/// Childless; the LaTeX source lives in `data-latex`.
+fn math_block_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let latex = str_attr(el, txn, "latex").unwrap_or_default();
+    format!("<div data-math-block data-latex=\"{}\"></div>", escape_attr(&latex))
 }
 
 fn write_text<T: ReadTxn>(t: &XmlTextRef, txn: &T, out: &mut String) {
@@ -600,6 +617,26 @@ mod tests {
             // no label
         });
         assert_eq!(html, "<p><span data-field data-name=\"Version\"></span></p>");
+    }
+
+    #[test]
+    fn math_inline_serializes_with_latex() {
+        let html = render(|_doc, frag, txn| {
+            let p = frag.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("where "));
+            let m = p.push_back(txn, XmlElementPrelim::empty("mathInline"));
+            m.insert_attribute(txn, "latex", "x^2");
+        });
+        assert_eq!(html, "<p>where <span data-math-inline data-latex=\"x^2\"></span></p>");
+    }
+
+    #[test]
+    fn math_block_serializes_with_latex() {
+        let html = render(|_doc, frag, txn| {
+            let m = frag.push_back(txn, XmlElementPrelim::empty("mathBlock"));
+            m.insert_attribute(txn, "latex", "E = mc^2");
+        });
+        assert_eq!(html, "<div data-math-block data-latex=\"E = mc^2\"></div>");
     }
 
     #[test]

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -351,7 +351,7 @@ fn is_inline_member(n: &HtmlNode) -> bool {
                 || tag == "br"
                 || matches!(
                     prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)),
-                    Some("fieldRef") | Some("citationInline")
+                    Some("fieldRef") | Some("citationInline") | Some("mathInline")
                 )
         }
     }
@@ -394,8 +394,32 @@ fn field_node(attrs: &[(String, String)]) -> PmNode {
     PmNode { node_type: "fieldRef".to_string(), attrs: a, children: vec![] }
 }
 
+/// Build a `mathInline` PM node from a `<span data-math-inline data-latex=…>`
+/// element. Caller guarantees `data-latex` is present. The LaTeX source ↔ the
+/// `latex` PM attr, symmetric with the editor's `renderHTML`
+/// (`src/tiptap/LatexExtension.ts`). It's an atom — no children.
+fn math_inline_node(attrs: &[(String, String)]) -> PmNode {
+    let latex = get_attr(attrs, "data-latex").unwrap_or("").to_string();
+    PmNode { node_type: "mathInline".to_string(), attrs: vec![("latex".to_string(), latex)], children: vec![] }
+}
+
+/// Build a childless `mathBlock` PM node from a `<div data-math-block
+/// data-latex=…>` element. Caller guarantees `data-latex` is present.
+fn math_block_node(attrs: &[(String, String)]) -> PmNode {
+    let latex = get_attr(attrs, "data-latex").unwrap_or("").to_string();
+    PmNode { node_type: "mathBlock".to_string(), attrs: vec![("latex".to_string(), latex)], children: vec![] }
+}
+
 /// Map a known block-level HTML element to a PM node, else `None`.
 fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode]) -> Option<PmNode> {
+    // Math block atom: `<div data-math-block data-latex=…>`. Childless — the
+    // LaTeX source lives in `data-latex`. A latex-less block is useless, so let
+    // it fall through to the generic unwrap (keeping any text) instead.
+    if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)) == Some("mathBlock")
+        && has_attr(attrs, "data-latex")
+    {
+        return Some(math_block_node(attrs));
+    }
     // Bibliography block atom (JP-89): `<div data-bibliography data-bib-html=…>`.
     // Childless — the rendered entries live (escaped) in `bibHtml`.
     if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m)) == Some("bibliography") {
@@ -595,6 +619,13 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                     // — a nameless field reference is useless, so fall through to
                     // the unwrap below and keep the text instead.
                     out.push(PmChild::Node(field_node(attrs)));
+                } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
+                    == Some("mathInline")
+                    && has_attr(attrs, "data-latex")
+                {
+                    // Inline math atom. Require `data-latex` — a latex-less math
+                    // span is useless, so fall through to the unwrap and keep text.
+                    out.push(PmChild::Node(math_inline_node(attrs)));
                 } else if let Some(mark) = prose_schema::mark_pm(tag) {
                     let mut m = marks.to_vec();
                     m.push(PmMark { name: mark.to_string(), href: None });
@@ -867,6 +898,42 @@ mod tests {
         assert_eq!(f.node_type, "fieldRef");
         assert_eq!(attr(f, "name"), Some("Version"));
         assert_eq!(attr(f, "label"), None);
+    }
+
+    #[test]
+    fn math_inline_span_parses_to_inline_atom() {
+        let b = html_to_blocks(
+            r#"<p>where <span data-math-inline data-latex="x^2"></span> holds</p>"#,
+        );
+        assert_eq!(b[0].node_type, "paragraph");
+        assert_eq!(b[0].children[0], text("where "));
+        let PmChild::Node(m) = &b[0].children[1] else { panic!("math not a node") };
+        assert_eq!(m.node_type, "mathInline");
+        assert!(m.children.is_empty(), "math is an atom");
+        assert_eq!(attr(m, "latex"), Some("x^2"));
+    }
+
+    #[test]
+    fn math_block_div_parses_to_block_atom() {
+        let b = html_to_blocks(r#"<div data-math-block data-latex="E = mc^2"></div>"#);
+        assert_eq!(b[0].node_type, "mathBlock");
+        assert!(b[0].children.is_empty(), "math block is an atom");
+        assert_eq!(attr(&b[0], "latex"), Some("E = mc^2"));
+    }
+
+    #[test]
+    fn math_without_latex_degrades_to_text() {
+        // A latex-less math span keeps its text rather than producing a useless atom.
+        let b = html_to_blocks(r#"<p>a <span data-math-inline>kept</span> b</p>"#);
+        let all: String = b[0]
+            .children
+            .iter()
+            .filter_map(|c| match c {
+                PmChild::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(all.contains("kept"), "latex-less math span keeps its text");
     }
 
     #[test]

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -68,8 +68,8 @@ pub fn mark_pm(html_tag: &str) -> Option<&'static str> {
 /// `(pm type, html tag, marker attribute)` triple so the two sides can't drift.
 /// Mirrors the editor extensions in `src/tiptap/CitationExtension.ts`.
 ///
-/// `mathInline`/`mathBlock` are the next entries (same mechanism) when math
-/// round-trips through the relay.
+/// Mirrors `src/tiptap/CitationExtension.ts`, `src/tiptap/FieldExtension.ts`,
+/// and `src/tiptap/LatexExtension.ts`.
 pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
     ("citationInline", "span", "data-citation"),
     ("bibliography", "div", "data-bibliography"),
@@ -78,6 +78,12 @@ pub const CUSTOM_PROSE_NODES: &[(&str, &str, &str)] = &[
     // any reserialize/flatten, dropping the field node. Mirrors
     // `src/tiptap/FieldExtension.ts`.
     ("fieldRef", "span", "data-field"),
+    // LaTeX math: an inline atom (`<span data-math-inline data-latex>`) and a
+    // childless block atom (`<div data-math-block data-latex>`). The LaTeX source
+    // lives in `data-latex`; both are round-tripped explicitly like the citation/
+    // field atoms so a flatten doesn't unwrap them. Mirrors `LatexExtension.ts`.
+    ("mathInline", "span", "data-math-inline"),
+    ("mathBlock", "div", "data-math-block"),
 ];
 
 /// PM node type for an HTML element that matches a custom prose-helper node:

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -71,6 +71,8 @@ fn is_known_type(t: &str) -> bool {
             | "gallery"
             | "citationInline"
             | "fieldRef"
+            | "mathInline"
+            | "mathBlock"
             | "hardBreak"
     )
 }
@@ -81,7 +83,14 @@ fn is_known_type(t: &str) -> bool {
 fn is_atom(t: &str) -> bool {
     matches!(
         t,
-        "image" | "citationInline" | "fieldRef" | "horizontalRule" | "bibliography" | "hardBreak"
+        "image"
+            | "citationInline"
+            | "fieldRef"
+            | "mathInline"
+            | "mathBlock"
+            | "horizontalRule"
+            | "bibliography"
+            | "hardBreak"
     )
 }
 

--- a/src/engine/CommandRegistry.test.ts
+++ b/src/engine/CommandRegistry.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getPaletteCommands, findShortcutConflicts } from './CommandRegistry';
+
+describe('CommandRegistry palette', () => {
+  it('exposes the PDF export and import commands (reachable from the mobile palette)', () => {
+    const ids = getPaletteCommands().map((c) => c.id);
+    expect(ids).toContain('file.exportPdf');
+    expect(ids).toContain('import.diagram');
+    expect(ids).toContain('view.toggleWhiteboard');
+    expect(ids).toContain('view.docs');
+  });
+
+  it('import.diagram carries a read-only guard (mirrors the toolbar button)', () => {
+    const importCmd = getPaletteCommands().find((c) => c.id === 'import.diagram');
+    expect(importCmd?.canExecute).toBeTypeOf('function');
+  });
+
+  it('has no conflicting keyboard bindings', () => {
+    expect(findShortcutConflicts()).toEqual([]);
+  });
+});

--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -170,6 +170,18 @@ function buildCommands(): Command[] {
       category: 'File',
       // The palette can't reach the engine; CanvasContainer opens the picker.
       execute: () => window.dispatchEvent(new CustomEvent('docushark:import-diagram')),
+      // JP-370: import writes into the active doc → unavailable view-only (mirror
+      // the toolbar button's guard, which the palette path otherwise bypasses).
+      canExecute: () => !isActiveDocReadOnly(),
+    },
+
+    // --- Export (PDF) --- the dialog lives in UnifiedToolbar's local state, so
+    // the palette opens it by event, mirroring the import bridge above.
+    {
+      id: 'file.exportPdf',
+      label: 'Export to PDF…',
+      category: 'File',
+      execute: () => window.dispatchEvent(new CustomEvent('docushark:open-pdf-export')),
     },
 
     // --- Documents surface (JP-218) ---

--- a/src/engine/Renderer.test.ts
+++ b/src/engine/Renderer.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Renderer, RendererOptions } from './Renderer';
+import { Renderer, RendererOptions, scaleHandleSize } from './Renderer';
 import { Camera } from './Camera';
+import { device } from '../platform/device';
+import { refreshAdaptiveBudget } from '../platform/adaptiveBudget';
 import { Vec2 } from '../math/Vec2';
 import type { ConnectorShape, Shape } from '../shapes/Shape';
 // Register the connector handler (self-registers on import) for the JP-353 test.
@@ -145,6 +147,47 @@ describe('Renderer', () => {
       const renderer = new Renderer(canvas, camera, options);
 
       expect(renderer).toBeInstanceOf(Renderer);
+    });
+  });
+
+  describe('handle sizing (JP-332)', () => {
+    afterEach(() => {
+      // Restore the device mock, then re-derive so the global budget snapshot
+      // returns to the real (jsdom = fine-pointer) value for other tests.
+      vi.restoreAllMocks();
+      refreshAdaptiveBudget();
+    });
+
+    it('scaleHandleSize enlarges the handle on coarse pointers (grab-zone parity)', () => {
+      expect(scaleHandleSize(8, 1.6)).toBe(13);
+    });
+
+    it('scaleHandleSize leaves the handle unchanged on a fine pointer', () => {
+      expect(scaleHandleSize(8, 1)).toBe(8);
+    });
+
+    it('defaults the drawn handle to the touch-scaled size on a coarse pointer', () => {
+      vi.spyOn(device, 'isTouch').mockReturnValue(true);
+      refreshAdaptiveBudget();
+      const renderer = new Renderer(createMockCanvas(), new Camera());
+      const opts = (renderer as unknown as { options: Required<RendererOptions> }).options;
+      expect(opts.handleSize).toBe(13);
+    });
+
+    it('keeps the 8px handle on a fine pointer', () => {
+      vi.spyOn(device, 'isTouch').mockReturnValue(false);
+      refreshAdaptiveBudget();
+      const renderer = new Renderer(createMockCanvas(), new Camera());
+      const opts = (renderer as unknown as { options: Required<RendererOptions> }).options;
+      expect(opts.handleSize).toBe(8);
+    });
+
+    it('still honors an explicit handleSize override on touch', () => {
+      vi.spyOn(device, 'isTouch').mockReturnValue(true);
+      refreshAdaptiveBudget();
+      const renderer = new Renderer(createMockCanvas(), new Camera(), { handleSize: 6 });
+      const opts = (renderer as unknown as { options: Required<RendererOptions> }).options;
+      expect(opts.handleSize).toBe(6);
     });
   });
 

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -65,6 +65,17 @@ export interface RenderMetrics {
  */
 export type ToolOverlayCallback = (ctx: CanvasRenderingContext2D) => void;
 
+/**
+ * Resolve the rendered resize-handle edge length (screen px) for a pointer type.
+ * Scales the base size up on coarse pointers so the *drawn* handle matches the
+ * already-enlarged touch grab zone (SelectTool keys off the same
+ * `hitTargetScale`), instead of staying an 8px square that's hard to grab with a
+ * finger. (JP-332)
+ */
+export function scaleHandleSize(base: number, hitTargetScale: number): number {
+  return Math.round(base * hitTargetScale);
+}
+
 const DEFAULT_OPTIONS: Required<RendererOptions> = {
   showGrid: true,
   gridSpacing: 50,
@@ -176,7 +187,13 @@ export class Renderer {
   ) {
     this.canvas = canvas;
     this.camera = camera;
-    this.options = { ...DEFAULT_OPTIONS, ...options };
+    // When the caller doesn't pin a handle size, scale the default by the touch
+    // grab-zone factor so the drawn handle stays finger-sized on coarse pointers
+    // (JP-332). An explicit `options.handleSize` always wins.
+    const handleSize =
+      options?.handleSize ??
+      scaleHandleSize(DEFAULT_OPTIONS.handleSize, getAdaptiveBudget().hitTargetScale);
+    this.options = { ...DEFAULT_OPTIONS, ...options, handleSize };
 
     const ctx = canvas.getContext('2d');
     if (!ctx) {

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -393,6 +393,42 @@ describe('uiPreferencesStore — migration', () => {
 
     expect(useUIPreferencesStore.getState().relaxedSplitCanvasWidth).toBe(640);
   });
+
+  it('v10 → v11 defaults the mobile-preview flags to false (existing users unaffected)', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          // v10 payload predates the mobile-preview flags.
+        },
+        version: 10,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    const state = useUIPreferencesStore.getState();
+    expect(state.mobilePreviewAccepted).toBe(false);
+    expect(state.forceDesktopSite).toBe(false);
+  });
+
+  it('v10 → v11 preserves an explicit mobile-preview acceptance', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          layout: { defaultMode: 'relaxed', modeOverrides: { relaxed: {}, designer: {}, technician: {}, power: {} }, customChrome: false },
+          mobilePreviewAccepted: true,
+        },
+        version: 10,
+      })
+    );
+
+    await useUIPreferencesStore.persist.rehydrate();
+
+    expect(useUIPreferencesStore.getState().mobilePreviewAccepted).toBe(true);
+  });
 });
 
 describe('uiPreferencesStore — collab indicator position', () => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -139,6 +139,17 @@ export interface UIPreferencesState {
    * App-level (not per-doc), clamped into the viewport at render time.
    */
   collabIndicatorPos: { x: number; y: number } | null;
+  /**
+   * Whether the user accepted the experimental mobile-preview layout (JP-332).
+   * Persisted so the one-time prompt fires at most once per browser. Gates the
+   * mobile chrome together with `forceDesktopSite` — see `useMobileAdaptation`.
+   */
+  mobilePreviewAccepted: boolean;
+  /**
+   * Whether the user opted out of the mobile preview — force the desktop layout
+   * even on a small touch screen. Re-enabled from Settings → Appearance.
+   */
+  forceDesktopSite: boolean;
 }
 
 /**
@@ -171,6 +182,10 @@ export interface UIPreferencesActions {
   toggleDocumentBrowserGroupCollapsed: (collectionId: string) => void;
   /** Record that the one-time storage-info toast has been shown. */
   markStorageInfoToastSeen: () => void;
+  /** Accept (or clear) the experimental mobile-preview layout. */
+  setMobilePreviewAccepted: (accepted: boolean) => void;
+  /** Force the desktop layout on a touch device (mobile-preview opt-out). */
+  setForceDesktopSite: (force: boolean) => void;
 
   // ── Layout actions (low-level; the `useLayout` hook composes ergonomic
   // "infer current mode" wrappers on top of these for normal call sites.)
@@ -299,6 +314,8 @@ const initialState: UIPreferencesState = {
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
   collabIndicatorPos: null,
+  mobilePreviewAccepted: false,
+  forceDesktopSite: false,
 };
 
 /**
@@ -439,6 +456,9 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       markStorageInfoToastSeen: () => set({ storageInfoToastSeen: true }),
 
+      setMobilePreviewAccepted: (accepted) => set({ mobilePreviewAccepted: accepted }),
+      setForceDesktopSite: (force) => set({ forceDesktopSite: force }),
+
       setDefaultLayout: (mode) => {
         set({ layout: { ...get().layout, defaultMode: mode } });
       },
@@ -573,7 +593,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 10,
+      version: 11,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -587,6 +607,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
         collabIndicatorPos: state.collabIndicatorPos,
+        mobilePreviewAccepted: state.mobilePreviewAccepted,
+        forceDesktopSite: state.forceDesktopSite,
       }),
       migrate: (persisted, fromVersion) => {
         // Cast away the loose persisted-state typing — older payloads carry
@@ -707,6 +729,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
             ...initialAppearancePrefs,
             ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
           };
+        }
+        // v10 → v11: added the experimental mobile-preview flags (JP-332).
+        // Default both to false (never prompted, not opted out) so existing
+        // users are unaffected until they hit the gate. An explicit persisted
+        // value is preserved. (The `merge` below also backstops these top-level
+        // booleans.)
+        if (fromVersion < 11) {
+          next['mobilePreviewAccepted'] = next['mobilePreviewAccepted'] ?? false;
+          next['forceDesktopSite'] = next['forceDesktopSite'] ?? false;
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { isFlyoutLayout, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { MobilePreviewGate } from './mobile/MobilePreviewGate';
+import { MobilePropertySheet } from './mobile/MobilePropertySheet';
 import { FlyoutPanel } from './layout/FlyoutPanel';
 import { PanelChromeWrapper } from './layout/PanelChromeWrapper';
 import { DockedPanel } from './layout/DockedPanel';
@@ -484,8 +485,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             )
           )}
 
-          {/* Properties on left */}
-          {renderProperties && propertiesPanelState.dock === 'left' && (
+          {/* Properties on left (suppressed on mobile — the full-screen
+              MobilePropertySheet below takes over). */}
+          {!mobileActive && renderProperties && propertiesPanelState.dock === 'left' && (
             <PanelChromeWrapper panelId="properties">
               <ErrorBoundary sectionName="Properties">
                 {propertiesUsesFlyout || relaxedTransientProps ? (
@@ -542,8 +544,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             )}
           </div>
 
-          {/* Properties on right */}
-          {renderProperties && propertiesPanelState.dock === 'right' && (
+          {/* Properties on right (suppressed on mobile — see sheet below). */}
+          {!mobileActive && renderProperties && propertiesPanelState.dock === 'right' && (
             <PanelChromeWrapper panelId="properties">
               <ErrorBoundary sectionName="Properties">
                 {propertiesUsesFlyout || relaxedTransientProps ? (
@@ -604,6 +606,12 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
           onClose={handleCloseSettings}
           initialTab={settingsInitialTab}
         />
+
+        {/* Mobile: properties become a selection-driven full-screen sheet
+            (JP-332) instead of a docked panel that would eat the small screen. */}
+        {appView === 'editor' && mobileActive && selectionCount > 0 && (
+          <MobilePropertySheet onClose={() => useSessionStore.getState().clearSelection()} />
+        )}
 
         {/* Command Palette (Cmd/Ctrl+K) */}
         <CommandPalette isOpen={isPaletteOpen} onClose={() => setIsPaletteOpen(false)} />

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState, useCallback, lazy, Suspense } from 'react';
 import './App.css';
+import './mobile/mobile.css';
 import { CanvasContainer } from './CanvasContainer';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
 import { isFlyoutLayout, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { MobilePreviewGate } from './mobile/MobilePreviewGate';
 import { FlyoutPanel } from './layout/FlyoutPanel';
 import { PanelChromeWrapper } from './layout/PanelChromeWrapper';
 import { DockedPanel } from './layout/DockedPanel';
@@ -143,6 +146,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   const renderProperties = isPropertiesVisible || relaxedTransientProps;
 
   const { band } = useBreakpoint();
+  // Experimental mobile chrome (JP-332): inert until the user opts in on a small
+  // touch screen. Slices hang their mobile overrides off `data-mobile` + this flag.
+  const { mobileActive } = useMobileAdaptation();
   const regions = resolveRegions(activeMode, relaxedFocus, band);
   const isRelaxed = activeMode === 'relaxed';
   // The canvas wrapper is rendered once for every layout (so the engine never
@@ -419,7 +425,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   }, [initializeDefault, authCallbackConsumed]);
 
   return (
-    <div className="app">
+    <div className="app" data-mobile={mobileActive ? 'true' : undefined}>
+      <MobilePreviewGate />
       <ConnectionStatusBanner />
         {/* Custom-chrome title bar stays in the document browser — it carries the
             desktop window controls. The editor app bar (document title, layouts,

--- a/src/ui/CommandPalette.tsx
+++ b/src/ui/CommandPalette.tsx
@@ -10,6 +10,7 @@ import {
   getRecentCommandIds,
   type Command,
 } from '../engine/CommandRegistry';
+import { device } from '../platform/device';
 import './CommandPalette.css';
 
 export interface CommandPaletteProps {
@@ -66,8 +67,13 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     if (isOpen) {
       setQuery('');
       setSelectedIndex(0);
-      // Focus input after render
-      requestAnimationFrame(() => inputRef.current?.focus());
+      // Focus the search input after render — but NOT on touch, where it would
+      // pop the on-screen keyboard and shove the layout up. On touch the palette
+      // opens straight to the tappable command list (it doubles as the mobile
+      // action menu); tapping the field still focuses it to type.
+      if (!device.isTouch()) {
+        requestAnimationFrame(() => inputRef.current?.focus());
+      }
     }
   }, [isOpen]);
 

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -14,6 +14,9 @@ import { Icon } from './icons';
 import type { Editor } from '@tiptap/core';
 import { history } from 'prosemirror-history';
 import { DocumentEditorToolbar } from './DocumentEditorToolbar';
+import { MobileProseToolbar } from './mobile/MobileProseToolbar';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { useKeyboardInset } from './mobile/useKeyboardInset';
 import { TiptapEditor } from './TiptapEditor';
 import { TiptapEditorProvider } from './TiptapEditorContext';
 import { RichTextTabBar } from './RichTextTabBar';
@@ -97,6 +100,10 @@ export function DocumentEditorPanel({
   onCustomizeLayout,
   presentation = 'docked',
 }: DocumentEditorPanelProps) {
+  const { mobileActive } = useMobileAdaptation();
+  // Reserve the on-screen keyboard's height as panel padding so the mobile
+  // bottom toolbar (last flex child) rides above the keyboard (JP-332).
+  const keyboardInset = useKeyboardInset();
   const { activePageId, updatePageContent } = useRichTextPagesStore();
   // Reactive content for the read-only ProsePreview, so it reflects edits/sync
   // while shown — instead of an imperative `getState()` read in render.
@@ -555,9 +562,12 @@ export function DocumentEditorPanel({
         className={`document-editor-panel ${isFullscreen ? 'fullscreen' : ''} ${
           presentation === 'reading' ? 'reading' : ''
         }`}
+        style={mobileActive && keyboardInset > 0 ? { paddingBottom: keyboardInset } : undefined}
       >
         <RichTextTabBar trailing={trailing} />
-        <DocumentEditorToolbar />
+        {/* Desktop ribbon sits at the top; on mobile it's replaced by the
+            bottom MobileProseToolbar rendered after the content (JP-332). */}
+        {!mobileActive && <DocumentEditorToolbar />}
         <div className="document-editor-panel-content">
           {/* Never blank (JP-328): a prose render crash degrades to the page's
               read-only HTML projection, not an empty panel; auto-resets on
@@ -589,6 +599,9 @@ export function DocumentEditorPanel({
             )}
           </ProseErrorBoundary>
         </div>
+        {/* Mobile: bottom formatting bar that squeezes the writing area above and
+            rides above the on-screen keyboard (JP-332). */}
+        {mobileActive && <MobileProseToolbar />}
       </div>
     </TiptapEditorProvider>
   );

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -12,6 +12,18 @@
   overflow: hidden;
 }
 
+/* Full-screen mobile sheet variant (JP-332): fill the sheet body. The docked
+ * width clamps, border, and resize handle don't apply inside the sheet. */
+.property-panel.property-panel--mobile {
+  min-width: 0;
+  max-width: none;
+  width: 100%;
+  border: none;
+}
+.property-panel.property-panel--mobile .property-panel-resize-handle {
+  display: none;
+}
+
 /* When the panel is docked on the left of the canvas, swap the border side
  * and put the resize handle on the right edge instead of the left. */
 .property-panel.property-panel-left-dock {

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -18,6 +18,9 @@
   min-width: 0;
   max-width: none;
   width: 100%;
+  /* Fill the sheet body's height so the panel's own `flex: 1` content region
+     expands (and scrolls) instead of collapsing to its intrinsic height. */
+  height: 100%;
   border: none;
 }
 .property-panel.property-panel--mobile .property-panel-resize-handle {

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -55,6 +55,25 @@
   }
 }
 
+/* Mobile preview (JP-332): the app bar goes icon-only regardless of the exact
+   width (the gate can hold through the medium band) — Documents + Settings drop
+   their labels — and the bar honors the horizontal safe-area insets. */
+.app[data-mobile='true'] .unified-toolbar {
+  padding-left: max(var(--space-3), var(--safe-area-left));
+  padding-right: max(var(--space-3), var(--safe-area-right));
+}
+.app[data-mobile='true'] .toolbar-documents-btn span,
+.app[data-mobile='true'] .toolbar-settings-btn span {
+  display: none;
+}
+.app[data-mobile='true'] .toolbar-documents-btn,
+.app[data-mobile='true'] .toolbar-settings-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+}
+
 /* Divider */
 .toolbar-divider {
   width: 1px;

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -11,6 +11,7 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen, MoreHorizontal } from 'lucide-react';
 import { Icon, PdfIcon } from './icons';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { MobileDocumentInfo } from './mobile/MobileDocumentInfo';
 import { ToolbarGroup } from './ToolbarGroup';
 import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
@@ -185,14 +186,14 @@ export function UnifiedToolbar({
             <span>Documents</span>
           </button>
         )}
-        <DocumentInfo />
+        {mobileActive ? <MobileDocumentInfo /> : <DocumentInfo />}
       </div>
 
       {/* Right: view controls (the context cluster) + app actions */}
       <div className="unified-toolbar-right">
         <ToolbarGroup label="View" className="unified-toolbar-view">
           {activeLayout === 'relaxed' && <RelaxedFocusControl />}
-          <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} />
+          <LayoutSelector onOpenLayoutSettings={onOpenLayoutSettings} compact={mobileActive} />
         </ToolbarGroup>
 
         <ToolbarGroup label="Actions" className="unified-toolbar-actions">

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -8,8 +8,9 @@
  */
 
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen } from 'lucide-react';
+import { StickyNote, CircleHelp, Settings, FileInput, FolderOpen, MoreHorizontal } from 'lucide-react';
 import { Icon, PdfIcon } from './icons';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { ToolbarGroup } from './ToolbarGroup';
 import { PDFExportDialog } from './PDFExportDialog';
 import { usePersistenceStore } from '../store/persistenceStore';
@@ -156,6 +157,17 @@ export function UnifiedToolbar({
   // JP-370: import writes into the active doc → disable it on a view-only doc.
   // Whiteboard (scratch overlay), Export, Help and Settings stay read-safe.
   const isReadOnly = useActiveDocReadOnly();
+  // On mobile the low-frequency actions collapse into the command palette; the
+  // bar keeps just Documents, the doc identity, the view cluster, and Settings.
+  const { mobileActive } = useMobileAdaptation();
+
+  // The PDF export dialog lives in this component's local state, so the palette
+  // (and any other caller) opens it via an event — mirroring the import bridge.
+  useEffect(() => {
+    const open = () => setShowPdfExport(true);
+    window.addEventListener('docushark:open-pdf-export', open);
+    return () => window.removeEventListener('docushark:open-pdf-export', open);
+  }, []);
 
   return (
     <>
@@ -184,42 +196,59 @@ export function UnifiedToolbar({
         </ToolbarGroup>
 
         <ToolbarGroup label="Actions" className="unified-toolbar-actions">
-          <button
-            className="toolbar-help-btn"
-            onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
-            disabled={isReadOnly}
-            title={
-              isReadOnly
-                ? 'Import is unavailable on a view-only document'
-                : 'Import diagram (Excalidraw, drawio, Mermaid)'
-            }
-            aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
-          >
-            <Icon icon={FileInput} />
-          </button>
-          <button
-            className="toolbar-whiteboard-btn"
-            onClick={() => useWhiteboardStore.getState().toggleVisibility()}
-            title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
-            aria-label="Whiteboard"
-          >
-            <Icon icon={StickyNote} />
-          </button>
-          <button
-            className="toolbar-export-btn"
-            onClick={() => setShowPdfExport(true)}
-            title="Export to PDF"
-            aria-label="Export to PDF"
-          >
-            <PdfIcon />
-          </button>
-          <button
-            className="toolbar-help-btn"
-            onClick={() => void openDocsHandler()}
-            title="Open documentation (F1)"
-          >
-            <Icon icon={CircleHelp} />
-          </button>
+          {mobileActive ? (
+            // Collapse Import / Whiteboard / Export / Help into the command
+            // palette (which doubles as the touch action menu). One affordance.
+            <button
+              className="toolbar-help-btn"
+              onClick={() =>
+                window.dispatchEvent(new CustomEvent('docushark:toggle-command-palette'))
+              }
+              title="More actions"
+              aria-label="More actions"
+            >
+              <Icon icon={MoreHorizontal} />
+            </button>
+          ) : (
+            <>
+              <button
+                className="toolbar-help-btn"
+                onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
+                disabled={isReadOnly}
+                title={
+                  isReadOnly
+                    ? 'Import is unavailable on a view-only document'
+                    : 'Import diagram (Excalidraw, drawio, Mermaid)'
+                }
+                aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
+              >
+                <Icon icon={FileInput} />
+              </button>
+              <button
+                className="toolbar-whiteboard-btn"
+                onClick={() => useWhiteboardStore.getState().toggleVisibility()}
+                title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
+                aria-label="Whiteboard"
+              >
+                <Icon icon={StickyNote} />
+              </button>
+              <button
+                className="toolbar-export-btn"
+                onClick={() => setShowPdfExport(true)}
+                title="Export to PDF"
+                aria-label="Export to PDF"
+              >
+                <PdfIcon />
+              </button>
+              <button
+                className="toolbar-help-btn"
+                onClick={() => void openDocsHandler()}
+                title="Open documentation (F1)"
+              >
+                <Icon icon={CircleHelp} />
+              </button>
+            </>
+          )}
           {onOpenSettings && (
             <button
               className="toolbar-settings-btn"

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -684,12 +684,21 @@
 /* The shared DocumentList renders the editor's existing `.document-browser__*`
    list markup; it inherits global styling. Nothing to override here in Slice 1. */
 
+/* The mobile drawer toggle is hidden until the drawer breakpoint (below). */
+.dh-menu-toggle {
+  display: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .dh-storage-fill,
   .dh-rcard,
   .dh-workspace,
-  .dh-nav-item {
+  .dh-nav-item,
+  .dh-side {
     transition: none;
+  }
+  .dh-side-backdrop {
+    animation: none;
   }
 }
 
@@ -706,13 +715,64 @@
   }
 }
 @media (max-width: 640px) {
+  /* Off-canvas drawer: the rail slides over the content instead of squeezing it,
+     so the main area gets the full width. The parked (translated-out) rail is
+     clipped by `.documents-home`'s `overflow: hidden`, so it never adds a
+     horizontal scrollbar. */
   .dh-side {
-    flex-basis: 168px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 20;
+    flex-basis: auto;
+    width: min(82vw, 300px);
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    box-shadow: var(--shadow-lg);
+  }
+  .dh-side--open {
+    transform: translateX(0);
+  }
+  .dh-side-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 15;
+    background: rgba(0, 0, 0, 0.4);
+    animation: dh-backdrop-in 0.18s ease-out;
+  }
+  .dh-menu-toggle {
+    display: grid;
+    place-items: center;
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    z-index: 10;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+  /* Reserve room at the start of every header for the absolute toggle. */
+  .dh-top {
+    padding-left: 56px;
   }
   .dh-recents {
     /* A single full-width column instead of the 240px-floor track, which could
        itself overflow a very narrow content column. */
     grid-template-columns: 1fr;
+  }
+}
+
+@keyframes dh-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -398,6 +398,11 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  /* Wrap when the row can't fit, so the search + actions drop to a second row
+     instead of being clipped by the surface's `overflow: hidden` on a narrow
+     viewport. No effect on wide screens, where everything fits one row. The
+     `gap` doubles as the wrapped row-gap. */
+  flex-wrap: wrap;
   gap: 14px;
   padding: 14px 22px;
   border-bottom: 1px solid var(--border-color);
@@ -431,6 +436,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  /* A floor (rather than the default content-based min-width) so the search is
+     the elastic element: it shrinks toward this width, then the row wraps the
+     actions to a second line rather than overflowing. 180px clears a 320px
+     viewport. */
+  min-width: 180px;
   max-width: 460px;
   padding: 8px 12px;
   border: 1px solid var(--border-color-input);
@@ -680,6 +690,29 @@
   .dh-workspace,
   .dh-nav-item {
     transition: none;
+  }
+}
+
+/* Responsive: keep the surface free of lateral cutoff on small/medium viewports
+   (a narrowed desktop window, or the editor on a small screen). Scope is "no
+   horizontal overflow at any width >= 320px", not a full mobile redesign. The
+   literals mirror the --bp-regular (1024px) / --bp-compact (640px) tokens in
+   index.css (CSS @media can't read custom properties). */
+@media (max-width: 1024px) {
+  .dh-side {
+    /* Reclaim width for the content area; the fixed 264px crowds it on a
+       narrow window. */
+    flex-basis: 208px;
+  }
+}
+@media (max-width: 640px) {
+  .dh-side {
+    flex-basis: 168px;
+  }
+  .dh-recents {
+    /* A single full-width column instead of the 240px-floor track, which could
+       itself overflow a very narrow content column. */
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -760,6 +760,15 @@
   .dh-top {
     padding-left: 56px;
   }
+  /* The actions group (sort · group · view · refresh · import · new) is a
+     non-wrapping flex item; on a narrow header it overflowed the row and the
+     trailing buttons (Refresh / Import / New) were clipped by the surface's
+     `overflow: hidden`. Give it a full row and let its controls wrap so they
+     all stay reachable. */
+  .dh-top-actions {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+  }
   .dh-recents {
     /* A single full-width column instead of the 240px-floor track, which could
        itself overflow a very narrow content column. */

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -28,6 +28,7 @@ import {
   Layers,
   LayoutGrid,
   List,
+  Menu,
   Moon,
   RefreshCw,
   Search,
@@ -133,10 +134,35 @@ export function DocumentsHome({
   const trashCount = useTrashStore((s) => s.items.length);
   const refreshTrash = useTrashStore((s) => s.refresh);
 
+  // On narrow viewports the sidebar is an off-canvas drawer (it overlays the
+  // content rather than squeezing it). Open state only matters at <=640px — the
+  // toggle + backdrop are display:none above that, where the rail is docked.
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  // Close the drawer on Escape while it's open.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSidebarOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sidebarOpen]);
+  // Drop any lingering open state when the viewport grows past the drawer
+  // breakpoint, so the docked rail never renders with a stale backdrop.
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 641px)');
+    const sync = () => {
+      if (mq.matches) setSidebarOpen(false);
+    };
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
   const selectNav = (id: NavId) => {
     setNav(id);
     setMainView('documents');
     setCollectionFilter(null);
+    setSidebarOpen(false);
     if (id === 'recents') {
       setFilterMode('all');
       setSort('modified-desc');
@@ -155,6 +181,13 @@ export function DocumentsHome({
     setMainView('documents');
     setFilterMode('all');
     setCollectionFilter(id);
+    setSidebarOpen(false);
+  };
+
+  // Switch the main destination and dismiss the mobile drawer in one go.
+  const goMainView = (v: 'documents' | 'storage' | 'trash' | 'shapes') => {
+    setMainView(v);
+    setSidebarOpen(false);
   };
 
   // Per-collection counts (network-free, from the local assignment map).
@@ -285,8 +318,18 @@ export function DocumentsHome({
 
   return (
     <div className="documents-home" data-theme={resolvedTheme}>
+      {/* Mobile-only drawer toggle — display:none above the drawer breakpoint. */}
+      <button
+        className="dh-menu-toggle"
+        onClick={() => setSidebarOpen((v) => !v)}
+        aria-label={sidebarOpen ? 'Close navigation' : 'Open navigation'}
+        aria-expanded={sidebarOpen}
+      >
+        <Menu size={20} aria-hidden="true" />
+      </button>
+
       {/* ── Sidebar ── */}
-      <aside className="dh-side">
+      <aside className={`dh-side${sidebarOpen ? ' dh-side--open' : ''}`}>
         <div className="dh-identity">
           <button
             className="dh-workspace"
@@ -394,7 +437,7 @@ export function DocumentsHome({
 
           <button
             className={`dh-nav-item${mainView === 'shapes' ? ' dh-nav-item--on' : ''}`}
-            onClick={() => setMainView('shapes')}
+            onClick={() => goMainView('shapes')}
             title="Shape library"
             aria-current={mainView === 'shapes' ? 'page' : undefined}
           >
@@ -404,7 +447,7 @@ export function DocumentsHome({
 
           <button
             className={`dh-nav-item${mainView === 'trash' ? ' dh-nav-item--on' : ''}`}
-            onClick={() => setMainView('trash')}
+            onClick={() => goMainView('trash')}
             title="Trash"
             aria-current={mainView === 'trash' ? 'page' : undefined}
           >
@@ -417,7 +460,7 @@ export function DocumentsHome({
         <div className="dh-side-foot">
           <button
             className={`dh-storage${mainView === 'storage' ? ' dh-storage--on' : ''}`}
-            onClick={() => setMainView('storage')}
+            onClick={() => goMainView('storage')}
             title="Manage storage"
           >
             <div className="dh-storage-top">
@@ -470,6 +513,15 @@ export function DocumentsHome({
           </div>
         </div>
       </aside>
+
+      {/* Drawer backdrop — only rendered (and only styled) while open on narrow. */}
+      {sidebarOpen && (
+        <div
+          className="dh-side-backdrop"
+          onClick={() => setSidebarOpen(false)}
+          aria-hidden="true"
+        />
+      )}
 
       {/* ── Main ── */}
       <div className="dh-main">

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -22,6 +22,15 @@
   transition: background-color 0.12s ease, border-color 0.12s ease;
 }
 
+/* Compact (mobile) trigger: a square icon button, no label/chevron. */
+.layout-selector-chip.compact {
+  gap: 0;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+}
+
 .layout-selector-chip:hover,
 .layout-selector-chip.open,
 .layout-selector-chip:focus-visible {

--- a/src/ui/layout/LayoutSelector.tsx
+++ b/src/ui/layout/LayoutSelector.tsx
@@ -10,6 +10,8 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { PanelsTopLeft } from 'lucide-react';
+import { Icon } from '../icons';
 import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS } from './modes';
 import { useActiveLayoutMode, useLayoutActions } from './useLayout';
 import { LAYOUT_MODES, type LayoutMode } from './types';
@@ -19,9 +21,11 @@ import './LayoutSelector.css';
 export interface LayoutSelectorProps {
   /** Called when the user clicks "Customize layout…" — wires to Settings. */
   onOpenLayoutSettings?: (() => void) | undefined;
+  /** Collapse the trigger to a single icon (mobile) — the dropdown is unchanged. */
+  compact?: boolean;
 }
 
-export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
+export function LayoutSelector({ onOpenLayoutSettings, compact = false }: LayoutSelectorProps) {
   const activeMode = useActiveLayoutMode();
   const { setActiveLayout } = useLayoutActions();
 
@@ -61,16 +65,22 @@ export function LayoutSelector({ onOpenLayoutSettings }: LayoutSelectorProps) {
     <div className="layout-selector-wrapper" ref={wrapperRef}>
       <button
         type="button"
-        className={`layout-selector-chip ${isOpen ? 'open' : ''}`}
+        className={`layout-selector-chip ${compact ? 'compact' : ''} ${isOpen ? 'open' : ''}`}
         onClick={() => setIsOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-label={`Layout: ${LAYOUT_LABELS[activeMode]}. Click to change.`}
         title={`Layout: ${LAYOUT_LABELS[activeMode]} (Cmd+Shift+1..4)`}
       >
-        <LayoutThumbnail mode={activeMode} width={22} height={14} />
-        <span className="layout-selector-chip-label">{LAYOUT_LABELS[activeMode]}</span>
-        <span className="layout-selector-chip-chevron" aria-hidden="true">▾</span>
+        {compact ? (
+          <Icon icon={PanelsTopLeft} />
+        ) : (
+          <>
+            <LayoutThumbnail mode={activeMode} width={22} height={14} />
+            <span className="layout-selector-chip-label">{LAYOUT_LABELS[activeMode]}</span>
+            <span className="layout-selector-chip-chevron" aria-hidden="true">▾</span>
+          </>
+        )}
       </button>
 
       {isOpen && (

--- a/src/ui/layout/useMobileAdaptation.test.ts
+++ b/src/ui/layout/useMobileAdaptation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { isMobileViewport, shouldAdaptToMobile } from './useMobileAdaptation';
+import type { BreakpointState } from './useBreakpoint';
+
+/** A touch + narrow baseline; override per case. */
+function bp(partial: Partial<BreakpointState> = {}): BreakpointState {
+  return { band: 'narrow', isTouch: true, standalone: false, ...partial };
+}
+
+describe('isMobileViewport', () => {
+  it('is true only for a touch device at a narrow viewport', () => {
+    expect(isMobileViewport(bp({ isTouch: true, band: 'narrow' }))).toBe(true);
+    expect(isMobileViewport(bp({ isTouch: false, band: 'narrow' }))).toBe(false);
+    expect(isMobileViewport(bp({ isTouch: true, band: 'medium' }))).toBe(false);
+    expect(isMobileViewport(bp({ isTouch: true, band: 'wide' }))).toBe(false);
+  });
+});
+
+describe('shouldAdaptToMobile', () => {
+  it('does not render mobile chrome until accepted', () => {
+    expect(shouldAdaptToMobile(bp(), false, false)).toBe(false);
+    expect(shouldAdaptToMobile(bp(), true, false)).toBe(true);
+  });
+
+  it('opting out (forceDesktop) wins over acceptance', () => {
+    expect(shouldAdaptToMobile(bp(), true, true)).toBe(false);
+  });
+
+  it('requires a touch device (a narrowed desktop window never adapts)', () => {
+    expect(shouldAdaptToMobile(bp({ isTouch: false }), true, false)).toBe(false);
+  });
+
+  it('holds through narrow and medium but not wide (no orientation thrash)', () => {
+    expect(shouldAdaptToMobile(bp({ band: 'narrow' }), true, false)).toBe(true);
+    expect(shouldAdaptToMobile(bp({ band: 'medium' }), true, false)).toBe(true);
+    expect(shouldAdaptToMobile(bp({ band: 'wide' }), true, false)).toBe(false);
+  });
+});

--- a/src/ui/layout/useMobileAdaptation.ts
+++ b/src/ui/layout/useMobileAdaptation.ts
@@ -1,0 +1,65 @@
+/**
+ * useMobileAdaptation — the single seam gating the experimental mobile chrome
+ * (JP-332). Builds on `useBreakpoint` (touch + viewport band) and two persisted
+ * flags on `uiPreferencesStore` (`mobilePreviewAccepted`, `forceDesktopSite`).
+ *
+ * Two derived booleans, deliberately distinct:
+ *
+ * - `isMobile`     — a touch device at a `narrow` viewport. The gate uses this
+ *                    to decide whether to *prompt*: real phones, not a narrowed
+ *                    desktop window (desktop has no coarse pointer).
+ * - `mobileActive` — render the mobile chrome *now*: accepted, not opted out, on
+ *                    a touch device, and not a `wide` viewport. Slices 2–5
+ *                    consume only this. It holds through the `medium` band too,
+ *                    so a phone rotating portrait↔landscape (which crosses the
+ *                    640px boundary) keeps one consistent shell instead of
+ *                    thrashing between mobile and desktop chrome mid-session.
+ *
+ * The predicate is a pure function (`shouldAdaptToMobile`) so it is unit-tested
+ * without React, alongside `useBreakpoint.test.ts` / `modes.test.ts`.
+ */
+
+import { useBreakpoint, type BreakpointState } from './useBreakpoint';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+
+export interface MobileAdaptation {
+  /** Touch device at a narrow viewport — the prompt trigger. */
+  isMobile: boolean;
+  /** Render the mobile chrome now (gated by acceptance + opt-out). */
+  mobileActive: boolean;
+  /** The user accepted the experimental mobile preview. */
+  accepted: boolean;
+  /** The user opted out — force the desktop layout on touch. */
+  forceDesktop: boolean;
+}
+
+/** A touch device at a narrow viewport (the prompt trigger). Pure. */
+export function isMobileViewport(bp: BreakpointState): boolean {
+  return bp.isTouch && bp.band === 'narrow';
+}
+
+/**
+ * Should the mobile chrome render? Accepted + not opted out, on a touch device,
+ * and not a `wide` viewport. Holds through `medium` (phone/tablet landscape) so
+ * an orientation change doesn't swap the whole shell mid-session. Pure.
+ */
+export function shouldAdaptToMobile(
+  bp: BreakpointState,
+  accepted: boolean,
+  forceDesktop: boolean,
+): boolean {
+  return accepted && !forceDesktop && bp.isTouch && bp.band !== 'wide';
+}
+
+/** Reactive mobile-adaptation state — the single seam every mobile slice reads. */
+export function useMobileAdaptation(): MobileAdaptation {
+  const bp = useBreakpoint();
+  const accepted = useUIPreferencesStore((s) => s.mobilePreviewAccepted);
+  const forceDesktop = useUIPreferencesStore((s) => s.forceDesktopSite);
+  return {
+    isMobile: isMobileViewport(bp),
+    mobileActive: shouldAdaptToMobile(bp, accepted, forceDesktop),
+    accepted,
+    forceDesktop,
+  };
+}

--- a/src/ui/mobile/MobileDocumentInfo.css
+++ b/src/ui/mobile/MobileDocumentInfo.css
@@ -1,0 +1,106 @@
+/* MobileDocumentInfo — ⓘ button + rename/status popover for mobile (JP-332). */
+
+.mobile-doc-info {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.mobile-doc-info-btn {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.mobile-doc-info-btn:hover {
+  background: var(--bg-hover);
+}
+/* Glanceable unsaved indicator so the status isn't lost behind the popover. */
+.mobile-doc-info-btn.is-dirty::after {
+  content: '';
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-cta, var(--brand-gold-deep));
+}
+
+.mobile-doc-info-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 100;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+.mobile-doc-info-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.mobile-doc-info-label {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+.mobile-doc-info-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border-color-input);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+}
+
+.mobile-doc-info-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+.mobile-doc-info-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.mobile-doc-info-dot.saved {
+  background: var(--color-success, #3aaf6a);
+}
+.mobile-doc-info-dot.dirty {
+  background: var(--color-cta, var(--brand-gold-deep));
+}
+.mobile-doc-info-dot.saving {
+  background: var(--text-muted);
+}
+.mobile-doc-info-save {
+  margin-left: auto;
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--color-primary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+.mobile-doc-info-save:hover {
+  background: var(--bg-hover);
+}

--- a/src/ui/mobile/MobileDocumentInfo.tsx
+++ b/src/ui/mobile/MobileDocumentInfo.tsx
@@ -1,0 +1,115 @@
+/**
+ * MobileDocumentInfo — the document identity (name + rename + save status) as a
+ * compact info popover for mobile (JP-332).
+ *
+ * On a narrow bar the inline document name collided with the Write/Split/Diagram
+ * focus tabs on the right. Here the name moves behind an ⓘ button next to
+ * Documents; tapping it opens a small popover to read the status and rename the
+ * doc. The button keeps a dirty dot so unsaved state is still glanceable without
+ * opening it.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Info } from 'lucide-react';
+import { Icon } from '../icons';
+import { usePersistenceStore } from '../../store/persistenceStore';
+import { useAutoSave } from '../../hooks/useAutoSave';
+import './MobileDocumentInfo.css';
+
+export function MobileDocumentInfo() {
+  const currentDocumentName = usePersistenceStore((s) => s.currentDocumentName);
+  const renameDocument = usePersistenceStore((s) => s.renameDocument);
+  const { isDirty, status, saveNow } = useAutoSave();
+
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(currentDocumentName);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Keep the field in sync with external renames while the popover is closed.
+  useEffect(() => {
+    if (!open) setName(currentDocumentName);
+  }, [currentDocumentName, open]);
+
+  const commit = useCallback(() => {
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== currentDocumentName) renameDocument(trimmed);
+  }, [name, currentDocumentName, renameDocument]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (t && !wrapRef.current?.contains(t)) {
+        commit();
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setName(currentDocumentName);
+        setOpen(false);
+      }
+    };
+    window.addEventListener('pointerdown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('pointerdown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, commit, currentDocumentName]);
+
+  const statusLabel = status === 'saving' ? 'Saving…' : isDirty ? 'Unsaved changes' : 'Saved';
+  const statusState = status === 'saving' ? 'saving' : isDirty ? 'dirty' : 'saved';
+
+  return (
+    <div className="mobile-doc-info" ref={wrapRef}>
+      <button
+        type="button"
+        className={`mobile-doc-info-btn${isDirty ? ' is-dirty' : ''}`}
+        onClick={() => setOpen((v) => !v)}
+        title={currentDocumentName}
+        aria-label={`Document: ${currentDocumentName}. ${statusLabel}.`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <Icon icon={Info} />
+      </button>
+
+      {open && (
+        <div className="mobile-doc-info-pop" role="dialog" aria-label="Document info">
+          <label className="mobile-doc-info-field">
+            <span className="mobile-doc-info-label">Name</span>
+            <input
+              type="text"
+              className="mobile-doc-info-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  commit();
+                  setOpen(false);
+                }
+              }}
+            />
+          </label>
+          <div className="mobile-doc-info-status">
+            <span className={`mobile-doc-info-dot ${statusState}`} aria-hidden="true" />
+            <span>{statusLabel}</span>
+            {isDirty && status !== 'saving' && (
+              <button
+                type="button"
+                className="mobile-doc-info-save"
+                onClick={() => {
+                  commit();
+                  saveNow();
+                }}
+              >
+                Save now
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/mobile/MobilePreviewGate.tsx
+++ b/src/ui/mobile/MobilePreviewGate.tsx
@@ -1,0 +1,48 @@
+/**
+ * MobilePreviewGate — the one-time opt-in to the experimental mobile layout
+ * (JP-332). On a touch device at a narrow viewport, the first load offers the
+ * (early, incomplete) mobile chrome behind a confirmation. Acceptance persists
+ * (`mobilePreviewAccepted`) so the prompt fires at most once per browser;
+ * "Not now" simply re-prompts on a future load.
+ *
+ * The *durable* opt-out ("use the desktop layout") lives in Settings →
+ * Appearance, not in this dialog: `confirmDialog` collapses an explicit decline
+ * and an Esc/backdrop dismissal into the same `false`, so the dialog only ever
+ * commits on accept — declining is always non-committal.
+ *
+ * Renders nothing; it's an effect host mounted once at the app root (next to
+ * `ConfirmDialogHost`, which actually draws the queued dialog).
+ */
+
+import { useEffect, useRef } from 'react';
+import { confirmDialog } from '../confirm/confirmStore';
+import { useMobileAdaptation } from '../layout/useMobileAdaptation';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+
+export function MobilePreviewGate(): null {
+  const { isMobile, accepted, forceDesktop } = useMobileAdaptation();
+  const setMobilePreviewAccepted = useUIPreferencesStore((s) => s.setMobilePreviewAccepted);
+  // Offer the prompt at most once per app session, even as the effect re-runs
+  // on resize/orientation changes. Persisted flags handle suppression across
+  // reloads; this ref handles it within a session.
+  const promptedThisSession = useRef(false);
+
+  useEffect(() => {
+    if (!isMobile || accepted || forceDesktop) return;
+    if (promptedThisSession.current) return;
+    promptedThisSession.current = true;
+    void (async () => {
+      const ok = await confirmDialog({
+        title: 'Mobile preview (experimental)',
+        message:
+          'The editor on a small screen is early-access and may be missing some features.',
+        details: 'You can switch back to the desktop layout anytime in Settings → Appearance.',
+        confirmLabel: 'Try mobile preview',
+        cancelLabel: 'Not now',
+      });
+      if (ok) setMobilePreviewAccepted(true);
+    })();
+  }, [isMobile, accepted, forceDesktop, setMobilePreviewAccepted]);
+
+  return null;
+}

--- a/src/ui/mobile/MobilePropertySheet.tsx
+++ b/src/ui/mobile/MobilePropertySheet.tsx
@@ -1,0 +1,22 @@
+/**
+ * MobilePropertySheet — the property panel as a full-screen sheet on mobile
+ * (JP-332 Slice 3). Composes the reusable MobileSheet around the existing
+ * PropertyPanel, which fills the sheet (its docked width clamps + border are
+ * dropped via `property-panel--mobile`).
+ *
+ * `onClose` is wired by App to clear the selection — so the sheet is purely
+ * selection-driven on mobile: select a shape → sheet; Done / Escape / deselect →
+ * gone. This keeps the property panel from permanently covering a small screen
+ * the way a docked panel would.
+ */
+
+import { MobileSheet } from './MobileSheet';
+import { PropertyPanel } from '../PropertyPanel';
+
+export function MobilePropertySheet({ onClose }: { onClose: () => void }) {
+  return (
+    <MobileSheet title="Properties" onClose={onClose} className="mobile-property-sheet">
+      <PropertyPanel className="property-panel--mobile" />
+    </MobileSheet>
+  );
+}

--- a/src/ui/mobile/MobileProseToolbar.css
+++ b/src/ui/mobile/MobileProseToolbar.css
@@ -1,0 +1,78 @@
+/* MobileProseToolbar — bottom-anchored prose formatting bar for mobile (JP-332).
+ *
+ * Rendered as the last flex child of the editor panel: the slim bar sits at the
+ * bottom (above the keyboard, via the panel's reserved keyboard inset), and the
+ * expandable Format panel grows *upward*, squeezing the `flex: 1` writing area
+ * rather than overlaying it. */
+
+.mobile-prose-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
+}
+
+/* The full ribbon, hosted inline above the slim bar — bounded so it never eats
+   the whole writing area; scrolls if the ribbon is taller. */
+.mpt-panel {
+  flex: 0 1 auto;
+  max-height: 42vh;
+  overflow-y: auto;
+  border-bottom: 1px solid var(--border-color);
+}
+.mpt-panel .document-editor-toolbar {
+  border-bottom: none;
+}
+
+.mpt-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 4px 8px;
+}
+
+.mpt-btn {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.mpt-btn:hover {
+  background: var(--bg-hover);
+}
+.mpt-btn.is-active {
+  background: var(--color-primary-light);
+  color: var(--text-primary);
+}
+
+.mpt-format {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: var(--font-size-base);
+  cursor: pointer;
+}
+.mpt-format:hover {
+  background: var(--bg-hover);
+}
+.mpt-format.is-open {
+  background: var(--color-primary-light);
+  color: var(--text-primary);
+  border-color: var(--color-primary);
+}

--- a/src/ui/mobile/MobileProseToolbar.tsx
+++ b/src/ui/mobile/MobileProseToolbar.tsx
@@ -1,0 +1,115 @@
+/**
+ * MobileProseToolbar — the prose ribbon, partitioned for mobile (JP-332).
+ *
+ * The full DocumentEditorToolbar is a tabbed ribbon that wraps to several rows
+ * on a narrow viewport, cramping the writing column. On mobile we render a slim
+ * one-row bar of the highest-frequency marks plus a "Format" button. Tapping
+ * Format expands the complete ribbon *inline above the bar* (bounded height,
+ * scrollable) rather than as an overlay — so it squeezes the writing area
+ * instead of drawing over the text.
+ *
+ * This component is mounted as the LAST flex child of the editor panel (a flex
+ * column), so expanding the panel shrinks the `flex: 1` content above it. The
+ * panel reserves the keyboard inset (see DocumentEditorPanel + useKeyboardInset),
+ * which keeps this bar sitting directly above the on-screen keyboard.
+ *
+ * It hosts the real DocumentEditorToolbar verbatim (so every dialog keeps
+ * working); because it lives inside the panel's TiptapEditorProvider it shares
+ * the same editor without any re-providing, and the slim bar is the only toolbar
+ * mounted when collapsed (no duplicate shortcut listeners).
+ */
+
+import { useEffect, useState } from 'react';
+import { Bold, Italic, Underline, List, Heading2, Type, X } from 'lucide-react';
+import { Icon } from '../icons';
+import { useTiptapEditor } from '../TiptapEditorContext';
+import * as cmd from '../editorCommands';
+import { DocumentEditorToolbar } from '../DocumentEditorToolbar';
+import './MobileProseToolbar.css';
+
+export function MobileProseToolbar() {
+  const editor = useTiptapEditor();
+  const [, force] = useState({});
+  const [showFormat, setShowFormat] = useState(false);
+
+  // Re-render the slim bar's active states as the selection/content changes
+  // (same subscription the full ribbon uses).
+  useEffect(() => {
+    if (!editor) return;
+    const handle = () => force({});
+    editor.on('selectionUpdate', handle);
+    editor.on('transaction', handle);
+    return () => {
+      editor.off('selectionUpdate', handle);
+      editor.off('transaction', handle);
+    };
+  }, [editor]);
+
+  // No live editor (e.g. a read-only ProsePreview) → nothing to format.
+  if (!editor) return null;
+
+  const isH2 = editor.isActive('heading', { level: 2 });
+
+  return (
+    <div className="mobile-prose-toolbar">
+      {showFormat && (
+        <div className="mpt-panel" role="region" aria-label="Formatting">
+          <DocumentEditorToolbar />
+        </div>
+      )}
+
+      <div className="mpt-bar">
+        <button
+          className={`mpt-btn${editor.isActive('bold') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleBold(editor)}
+          aria-label="Bold"
+          aria-pressed={editor.isActive('bold')}
+        >
+          <Icon icon={Bold} />
+        </button>
+        <button
+          className={`mpt-btn${editor.isActive('italic') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleItalic(editor)}
+          aria-label="Italic"
+          aria-pressed={editor.isActive('italic')}
+        >
+          <Icon icon={Italic} />
+        </button>
+        <button
+          className={`mpt-btn${editor.isActive('underline') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleUnderline(editor)}
+          aria-label="Underline"
+          aria-pressed={editor.isActive('underline')}
+        >
+          <Icon icon={Underline} />
+        </button>
+        <button
+          className={`mpt-btn${isH2 ? ' is-active' : ''}`}
+          onClick={() => (isH2 ? cmd.setParagraph(editor) : cmd.setHeading(editor, 2))}
+          aria-label="Heading"
+          aria-pressed={isH2}
+        >
+          <Icon icon={Heading2} />
+        </button>
+        <button
+          className={`mpt-btn${editor.isActive('bulletList') ? ' is-active' : ''}`}
+          onClick={() => cmd.toggleBulletList(editor)}
+          aria-label="Bullet list"
+          aria-pressed={editor.isActive('bulletList')}
+        >
+          <Icon icon={List} />
+        </button>
+
+        <button
+          className={`mpt-format${showFormat ? ' is-open' : ''}`}
+          onClick={() => setShowFormat((v) => !v)}
+          aria-pressed={showFormat}
+          aria-label={showFormat ? 'Close formatting' : 'More formatting'}
+        >
+          <Icon icon={showFormat ? X : Type} />
+          <span>Format</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/mobile/MobileSheet.css
+++ b/src/ui/mobile/MobileSheet.css
@@ -1,0 +1,71 @@
+/* MobileSheet — full-screen sheet shell for the mobile preview (JP-332). */
+
+.mobile-sheet {
+  position: fixed;
+  inset: 0;
+  /* Above the editor chrome, below the picker portals (z 10000) and the
+     confirm-dialog host so those layer over the sheet. */
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  /* Clear notches / home indicator inside a standalone PWA (0 elsewhere). */
+  padding-top: var(--safe-area-top);
+  padding-bottom: var(--safe-area-bottom);
+  animation: mobile-sheet-in 0.2s ease-out;
+}
+
+.mobile-sheet-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.mobile-sheet-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.mobile-sheet-done {
+  flex: 0 0 auto;
+  padding: 7px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--color-primary);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+}
+.mobile-sheet-done:hover {
+  background: var(--bg-hover);
+}
+
+.mobile-sheet-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+@keyframes mobile-sheet-in {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-sheet {
+    animation: none;
+  }
+}

--- a/src/ui/mobile/MobileSheet.tsx
+++ b/src/ui/mobile/MobileSheet.tsx
@@ -1,0 +1,61 @@
+/**
+ * MobileSheet — a reusable full-screen sheet for the mobile preview (JP-332).
+ *
+ * A presentational overlay shell: a fixed, full-viewport panel (portaled to
+ * `document.body` so no editor-layout ancestor can clip or mis-stack it) with a
+ * safe-area-aware header (title + Done) and a scrollable body slot. Dismissal is
+ * the caller's Done handler plus Escape.
+ *
+ * It sits at a modest z-index (above the editor chrome, below the picker portals
+ * and the confirm-dialog host) so panel-owned popovers — the property panel's
+ * color/icon/pattern pickers, which portal to `document.body` at a higher
+ * z-index — render *over* the sheet and stay interactive. Because the sheet
+ * never installs an outside-click/focus trap, those `[data-flyout-keep-open]`
+ * portals need no special-casing here.
+ *
+ * Slice 3 uses it for the full-screen property panel; Slice 4's prose toolbar
+ * sheet composes the same primitive.
+ */
+
+import { ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import './MobileSheet.css';
+
+export interface MobileSheetProps {
+  /** Header title + ARIA label. */
+  title: string;
+  /** Called by the Done button and Escape. */
+  onClose: () => void;
+  /** Sheet body. */
+  children: ReactNode;
+  /** Extra class on the sheet root for per-use styling. */
+  className?: string;
+}
+
+export function MobileSheet({ title, onClose, children, className }: MobileSheetProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className={`mobile-sheet${className ? ` ${className}` : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <header className="mobile-sheet-header">
+        <span className="mobile-sheet-title">{title}</span>
+        <button type="button" className="mobile-sheet-done" onClick={onClose}>
+          Done
+        </button>
+      </header>
+      <div className="mobile-sheet-body">{children}</div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/mobile/mobile.css
+++ b/src/ui/mobile/mobile.css
@@ -1,0 +1,21 @@
+/*
+ * Mobile preview chrome — shared shell rules (JP-332).
+ *
+ * Everything here is scoped to `[data-mobile="true"]`, which App sets on the
+ * root `.app` element only when the experimental mobile layout is active
+ * (`useMobileAdaptation().mobileActive`). Later slices hang their mobile chrome
+ * (collapsed toolbar, full-screen property sheet, partitioned prose toolbar) off
+ * this hook.
+ *
+ * The `--safe-area-*` tokens (declared in index.css) resolve to 0 outside a
+ * notched standalone PWA, so the inset padding below is a no-op on desktop and
+ * in an ordinary browser tab. The global `box-sizing: border-box` reset keeps
+ * the inset from growing the 100%-height root past the viewport.
+ */
+
+.app[data-mobile='true'] {
+  padding-top: var(--safe-area-top);
+  padding-right: var(--safe-area-right);
+  padding-bottom: var(--safe-area-bottom);
+  padding-left: var(--safe-area-left);
+}

--- a/src/ui/mobile/useKeyboardInset.ts
+++ b/src/ui/mobile/useKeyboardInset.ts
@@ -1,0 +1,35 @@
+/**
+ * useKeyboardInset — the height (px) the on-screen keyboard currently occupies,
+ * derived from `window.visualViewport` (JP-332).
+ *
+ * On mobile the soft keyboard shrinks the visual viewport without changing the
+ * layout viewport, so a bottom-anchored toolbar would otherwise be hidden behind
+ * it. Reserving this inset as padding lifts the editing column above the
+ * keyboard. Returns 0 where `visualViewport` is unavailable (desktop, older
+ * browsers, jsdom).
+ */
+
+import { useEffect, useState } from 'react';
+
+export function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    const vv = typeof window !== 'undefined' ? window.visualViewport : null;
+    if (!vv) return;
+    const update = () => {
+      // Keyboard height ≈ layout viewport minus the visible (visual) viewport.
+      const kb = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+      setInset(Math.round(kb));
+    };
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+    update();
+    return () => {
+      vv.removeEventListener('resize', update);
+      vv.removeEventListener('scroll', update);
+    };
+  }, []);
+
+  return inset;
+}

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -383,12 +383,63 @@ export function AppearanceSettings() {
       {/* Title bar — desktop-only; renders nothing on the web app. */}
       <TitleBarSection />
 
+      {/* Mobile preview — the experimental small-screen layout (JP-332). */}
+      <MobilePreviewSection />
+
       {/* Reset */}
       <div className="settings-group">
         <h4 className="settings-group-title">Reset</h4>
         <button type="button" className="settings-reset-btn" onClick={handleReset}>
           Reset appearance to defaults
         </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mobile preview opt-in/out (JP-332). A single switch over the two persisted
+ * flags: turning it on accepts the preview and clears any opt-out; turning it
+ * off forces the desktop layout. Only takes visible effect on a small touch
+ * screen — `useMobileAdaptation` requires a coarse pointer — but it's shown
+ * everywhere so an opted-out user (or a desktop user testing a narrow window)
+ * has a discoverable, non-nagging way back in.
+ */
+function MobilePreviewSection() {
+  const accepted = useUIPreferencesStore((s) => s.mobilePreviewAccepted);
+  const forceDesktop = useUIPreferencesStore((s) => s.forceDesktopSite);
+  const setMobilePreviewAccepted = useUIPreferencesStore((s) => s.setMobilePreviewAccepted);
+  const setForceDesktopSite = useUIPreferencesStore((s) => s.setForceDesktopSite);
+
+  const enabled = accepted && !forceDesktop;
+  const handleToggle = (next: boolean) => {
+    if (next) {
+      setForceDesktopSite(false);
+      setMobilePreviewAccepted(true);
+    } else {
+      setMobilePreviewAccepted(false);
+      setForceDesktopSite(true);
+    }
+  };
+
+  return (
+    <div className="settings-group">
+      <h4 className="settings-group-title">Mobile preview</h4>
+      <div className="settings-row settings-row-switch">
+        <label className="settings-switch-label" htmlFor="docushark-mobile-preview">
+          <Switch
+            id="docushark-mobile-preview"
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            ariaLabel="Use the mobile preview layout"
+          />
+          <span className="settings-switch-text">Use the mobile preview layout</span>
+        </label>
+        <span className="settings-hint">
+          An experimental, early-access layout for small touch screens. Only takes
+          effect on a touch device with a small screen; turn it off to always use the
+          desktop layout.
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
Routine **master → staging** promotion so the staging relay + editor pick up everything merged to master since the last sync (#317).

**Primary goal:** deploy the **relay LaTeX-math support** (#325) so the staging MCP can author equations (`$$…$$` / `$…$` round-trip instead of being stripped). Merging this builds the `:edge` relay image; the staging relay (`dsk-relay-staging-yyz`) is then redeployed to pick it up.

## Included (16 commits)
- **#325** — relay: round-trip LaTeX math in prose (the reason for this promotion).
- **JP-332 mobile preview** — gate+seam (#318), Documents overflow (#319) + sidebar drawer (#320), full-screen property sheet (#321), canvas handles (#322), top-bar palette (#323), prose toolbar + review fixes (#324).

## After merge
1. Wait for the relay `:edge` image build (CI).
2. Redeploy `dsk-relay-staging-yyz`.
3. Verify: `set_prose` `$$…$$` → `get_prose` returns `data-math-block`.

Assisted-by: Opus 4.8