### PR TITLE
pwa: auto-recover open tabs from stale chunks after a deploy

### DIFF
--- a/src/pwa/registerPwa.ts
+++ b/src/pwa/registerPwa.ts
@@ -13,7 +13,32 @@
 import { registerSW } from 'virtual:pwa-register';
 import { useNotificationStore } from '../store/notificationStore';
 
+/** Loop guard key — the timestamp of the last stale-chunk auto-reload. */
+const STALE_CHUNK_KEY = 'ds:stale-chunk-reload';
+
+/**
+ * Recover an open tab after a deploy. When a lazy chunk's hashed file was
+ * replaced by a newer build, the old URL 404s — and on a SPA host that 404
+ * comes back as the `index.html` shell, so the dynamic import fails with
+ * "Failed to load module script … text/html". Vite emits `vite:preloadError`
+ * for exactly this; the old chunk is gone, so the only fix is to reload to the
+ * current build. Guarded so a genuinely-missing chunk can't loop (reload at
+ * most once per ~10s). Collab-safe: it only fires once an import has already
+ * failed (the tab is broken anyway), never mid-edit on a healthy page — which
+ * is why this complements, rather than replaces, the soft 'prompt' update flow.
+ */
+function installStaleChunkReload(): void {
+  window.addEventListener('vite:preloadError', () => {
+    const last = Number(sessionStorage.getItem(STALE_CHUNK_KEY) ?? '0');
+    if (Date.now() - last < 10_000) return; // already reloaded recently — don't loop
+    sessionStorage.setItem(STALE_CHUNK_KEY, String(Date.now()));
+    window.location.reload();
+  });
+}
+
 export function registerPwa(): void {
+  installStaleChunkReload();
+
   const updateSW = registerSW({
     onNeedRefresh() {
       useNotificationStore.getState().info('A new version of DocuShark is available.', {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,woff,woff2}'],
         globIgnores: ['**/dictionaries/**', '**/icons/**'],
+        // Purge precache entries from prior builds when the new SW activates, so
+        // a stale tab can't keep serving (or 404-ing on) old hashed chunks after
+        // a deploy. Pairs with the `vite:preloadError` reload in registerPwa.ts.
+        cleanupOutdatedCaches: true,
         // SPA fallback, but never serve relay/control-plane routes — or the
         // on-demand static asset dirs (icons, dictionaries) — the SPA shell.
         // Returning index.html for `/icons/*.json` makes the icon loader parse


### PR DESCRIPTION
The "Failed to load module script … MIME type 'text/html'" error on the staging PWA after a deploy. A hard reload fixes it, which confirms the cause: a deploy replaces the hashed chunks, but an open tab (or a stale precached `index.html`) still requests an **old chunk URL** → 404 → the SPA host returns the `index.html` shell (`text/html`) → the module load fails. The app uses `registerType: 'prompt'` (deliberately, to never yank a live collab session), so the old SW lingers until the user takes the update prompt — and a stale lazy chunk hard-fails before then.

## Fix (collab-safe, no `skipWaiting`)
- **`registerPwa.ts`** — listen for Vite's **`vite:preloadError`** (emitted exactly when a dynamic import's chunk can't load) and **reload to the current build**, guarded against a loop (at most once per ~10s via `sessionStorage`). It only fires once an import has **already failed** (the tab is broken anyway), so it never reloads a healthy page mid-edit. This complements the existing soft "New version — Reload" toast; it doesn't replace it.
- **`vite.config.ts`** — workbox `cleanupOutdatedCaches: true`, so the new SW purges prior-build precache entries on activate (verified present in `dist/sw.js`).

## Scope / notes
- The lazy-chunk case is the common one and is now self-healing. The rarer **entry-script** case (a very stale tab whose cached `index.html` references a removed entry chunk) is inherently hard-reload territory for a `prompt`-mode PWA — the existing update toast remains the intended path there; we keep `prompt` to protect live collab.
- `registerType` unchanged on purpose.

## Verification
- `bun run typecheck` ✓ · `bun run build` ✓ · `cleanupOutdatedCaches` present in the generated SW.

Assisted-by: Opus 4.8