### PR TITLE
Promote master → staging (PWA stale-chunk recovery)

### DIFF
--- a/src/pwa/registerPwa.ts
+++ b/src/pwa/registerPwa.ts
@@ -13,7 +13,32 @@
 import { registerSW } from 'virtual:pwa-register';
 import { useNotificationStore } from '../store/notificationStore';
 
+/** Loop guard key — the timestamp of the last stale-chunk auto-reload. */
+const STALE_CHUNK_KEY = 'ds:stale-chunk-reload';
+
+/**
+ * Recover an open tab after a deploy. When a lazy chunk's hashed file was
+ * replaced by a newer build, the old URL 404s — and on a SPA host that 404
+ * comes back as the `index.html` shell, so the dynamic import fails with
+ * "Failed to load module script … text/html". Vite emits `vite:preloadError`
+ * for exactly this; the old chunk is gone, so the only fix is to reload to the
+ * current build. Guarded so a genuinely-missing chunk can't loop (reload at
+ * most once per ~10s). Collab-safe: it only fires once an import has already
+ * failed (the tab is broken anyway), never mid-edit on a healthy page — which
+ * is why this complements, rather than replaces, the soft 'prompt' update flow.
+ */
+function installStaleChunkReload(): void {
+  window.addEventListener('vite:preloadError', () => {
+    const last = Number(sessionStorage.getItem(STALE_CHUNK_KEY) ?? '0');
+    if (Date.now() - last < 10_000) return; // already reloaded recently — don't loop
+    sessionStorage.setItem(STALE_CHUNK_KEY, String(Date.now()));
+    window.location.reload();
+  });
+}
+
 export function registerPwa(): void {
+  installStaleChunkReload();
+
   const updateSW = registerSW({
     onNeedRefresh() {
       useNotificationStore.getState().info('A new version of DocuShark is available.', {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,woff,woff2}'],
         globIgnores: ['**/dictionaries/**', '**/icons/**'],
+        // Purge precache entries from prior builds when the new SW activates, so
+        // a stale tab can't keep serving (or 404-ing on) old hashed chunks after
+        // a deploy. Pairs with the `vite:preloadError` reload in registerPwa.ts.
+        cleanupOutdatedCaches: true,
         // SPA fallback, but never serve relay/control-plane routes — or the
         // on-demand static asset dirs (icons, dictionaries) — the SPA shell.
         // Returning index.html for `/icons/*.json` makes the icon loader parse


### PR DESCRIPTION
**master → staging** promotion to redeploy the editor PWA.

**Carries:** **#331** — auto-recover open tabs from stale chunks after a deploy (`vite:preloadError` → guarded reload + `cleanupOutdatedCaches`). Collab-safe; `registerType` unchanged.

Together with the already-promoted **#329** (committed cloud icon sets), this staging build serves the PWA with: the icon picker's AWS/Azure/GCP manifests + SVGs present (no more "manifest returned HTML"), and future deploys self-healing instead of throwing the "module script … text/html" MIME error.

## After merge
- This is a **PWA** change only (no relay change) — the staging.yml deploy rebuilds + pushes to Cloudflare Pages automatically; **no Fly relay redeploy needed**.
- Verify on `app-staging.docushark.app`: the icon picker loads all three cloud categories, and a deploy no longer wedges an open tab (it reloads to the new build).

Assisted-by: Opus 4.8