### PR TITLE
Add relay location switcher; adopt server-resolved relay URL

### DIFF
--- a/src/api/cloudAuth.test.ts
+++ b/src/api/cloudAuth.test.ts
@@ -82,6 +82,55 @@ describe('beginCloudSignIn', () => {
     });
   });
 
+  it('surfaces the region-resolved relay_url (and workspace identity) when present', async () => {
+    const { fetchImpl } = mockFetch({
+      tokenQueue: [
+        jsonRes({
+          token: 'RELAY.JWT',
+          jti: 'j1',
+          expires_at: 1000,
+          token_type: 'Bearer',
+          relay_url: 'https://relay.example.com',
+          workspace_name: 'Acme',
+          workspace_slug: 'acme',
+        }),
+      ],
+    });
+
+    const handle = await beginCloudSignIn('http://web', {
+      fetchImpl,
+      openExternal: async () => {},
+      sleep: noopSleep,
+    });
+
+    const result = await handle.result;
+    expect(result).toEqual({
+      token: 'RELAY.JWT',
+      expiresAt: 1000 * 1000,
+      relayUrl: 'https://relay.example.com',
+      workspaceName: 'Acme',
+      workspaceSlug: 'acme',
+    });
+  });
+
+  it('omits relayUrl when the response has none (older relay)', async () => {
+    const { fetchImpl } = mockFetch({
+      tokenQueue: [
+        jsonRes({ token: 'T', jti: 'j', expires_at: 5, token_type: 'Bearer' }),
+      ],
+    });
+
+    const handle = await beginCloudSignIn('http://web', {
+      fetchImpl,
+      openExternal: async () => {},
+      sleep: noopSleep,
+    });
+
+    const result = await handle.result;
+    expect(result).toEqual({ token: 'T', expiresAt: 5000 });
+    expect('relayUrl' in result).toBe(false);
+  });
+
   it('keeps polling through slow_down and still resolves', async () => {
     const { fetchImpl, tokenCallCount } = mockFetch({
       tokenQueue: [

--- a/src/api/cloudAuth.ts
+++ b/src/api/cloudAuth.ts
@@ -26,6 +26,13 @@ export const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
 export interface CloudSignInResult {
   token: string;
   expiresAt: number;
+  /**
+   * Region-resolved relay origin from the device-token response. The session
+   * adopts this as the authoritative relay URL (it overrides the form/switcher
+   * default), so a hosted sign-in always lands on the workspace's region relay
+   * rather than the local-dev default. Absent on older relays.
+   */
+  relayUrl?: string;
   /** Cloud workspace display identity from the device-token response (JP-343);
    *  for the relay page. Persisted in the connection record, never the JWT claim. */
   workspaceName?: string;
@@ -84,6 +91,8 @@ interface DeviceTokenSuccess {
   /** Epoch *seconds* (relay token `exp`). */
   expires_at: number;
   token_type: string;
+  /** Region-resolved relay origin (docushark-web computes it from the workspace). */
+  relay_url?: string;
   workspace_name?: string;
   workspace_slug?: string;
 }
@@ -180,6 +189,7 @@ async function pollForToken(args: PollArgs): Promise<CloudSignInResult> {
       return {
         token: body.token,
         expiresAt: body.expires_at * 1000,
+        ...(typeof body.relay_url === 'string' ? { relayUrl: body.relay_url } : {}),
         ...(typeof body.workspace_name === 'string' ? { workspaceName: body.workspace_name } : {}),
         ...(typeof body.workspace_slug === 'string' ? { workspaceSlug: body.workspace_slug } : {}),
       };

--- a/src/api/relayLocations.test.ts
+++ b/src/api/relayLocations.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RELAY_LOCATIONS,
+  DEFAULT_RELAY_LOCATION,
+  DEFAULT_RELAY_BASE_URL,
+  locationForUrl,
+} from './relayLocations';
+
+describe('relayLocations', () => {
+  it('defaults the primary region to Toronto (yyz)', () => {
+    expect(DEFAULT_RELAY_LOCATION.id).toBe('yyz');
+    expect(RELAY_LOCATIONS).toContain(DEFAULT_RELAY_LOCATION);
+  });
+
+  it('falls back to the local dev relay when VITE_RELAY_BASE_URL is unset', () => {
+    // No build var is injected in the test env, so the default is the OSS dev relay.
+    expect(DEFAULT_RELAY_BASE_URL).toBe('http://localhost:9876');
+    expect(DEFAULT_RELAY_LOCATION.relayUrl).toBe('http://localhost:9876');
+  });
+
+  describe('locationForUrl', () => {
+    it('matches a known origin exactly', () => {
+      expect(locationForUrl(DEFAULT_RELAY_LOCATION.relayUrl)).toBe(DEFAULT_RELAY_LOCATION);
+    });
+
+    it('normalizes trailing slashes and surrounding whitespace', () => {
+      expect(locationForUrl(`  ${DEFAULT_RELAY_LOCATION.relayUrl}/  `)).toBe(DEFAULT_RELAY_LOCATION);
+    });
+
+    it('returns undefined for a custom/self-host origin', () => {
+      expect(locationForUrl('https://relay.example.com')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string', () => {
+      expect(locationForUrl('')).toBeUndefined();
+    });
+  });
+});

--- a/src/api/relayLocations.ts
+++ b/src/api/relayLocations.ts
@@ -1,0 +1,65 @@
+/**
+ * Relay location registry — the location → relay-origin mapping that backs the
+ * Cloud connect modal's location switcher.
+ *
+ * The relay origin for a given location differs per environment (localhost in
+ * dev, the staging Fly app, the prod custom domain), so the primary region's
+ * origin is injected at **build time** via `VITE_RELAY_BASE_URL` — mirroring
+ * `VITE_CLOUD_BASE_URL` (see `relayConnection.ts`). A hosted build pairs with
+ * its environment's relay; the OSS source keeps a generic `localhost` default so
+ * no deployment origin lands in the public tree.
+ *
+ * Region-resolution is ultimately a server concern: the relay app-token response
+ * already carries the workspace's region-resolved `relay_url`, which the session
+ * adopts as authoritative (see `cloudAuth.ts` / `completeCloudSignIn.ts`). This
+ * registry governs the *pre-sign-in default* the user sees + a self-host override.
+ */
+
+/**
+ * Build-time relay origin for the primary region; `http://localhost:9876` for
+ * OSS/dev. Injected per-environment in the editor build (docushark-web CI),
+ * exactly like `VITE_CLOUD_BASE_URL`. Just an origin (not a secret).
+ */
+export const DEFAULT_RELAY_BASE_URL =
+  import.meta.env.VITE_RELAY_BASE_URL ?? 'http://localhost:9876';
+
+export interface RelayLocation {
+  /** Region code, e.g. `yyz`. */
+  id: string;
+  /** Human label shown in the switcher, e.g. `Toronto, Canada`. */
+  label: string;
+  /** Relay REST origin for this location (e.g. `http://localhost:9876`). */
+  relayUrl: string;
+}
+
+// Declare the location const first, then build the list + default from it — so
+// DEFAULT_RELAY_LOCATION is `RelayLocation`, not `RelayLocation | undefined`
+// (RELAY_LOCATIONS[0] would be `| undefined` under noUncheckedIndexedAccess).
+//
+// Only Toronto (`yyz`) is live today. ord/nrt/fra light up on demand; each will
+// get its own `VITE_RELAY_BASE_URL_<region>` build var when it does (YAGNI now).
+const TORONTO: RelayLocation = {
+  id: 'yyz',
+  label: 'Toronto, Canada',
+  relayUrl: DEFAULT_RELAY_BASE_URL,
+};
+
+export const RELAY_LOCATIONS: RelayLocation[] = [TORONTO];
+
+/** The location selected by default before the user picks one. */
+export const DEFAULT_RELAY_LOCATION: RelayLocation = TORONTO;
+
+/** Trim trailing slashes so `http://host/` and `http://host` compare equal. */
+function normalizeOrigin(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+/**
+ * The known location whose relay origin matches `url` (slash-normalized), or
+ * `undefined` when none does — in which case the switcher shows "Custom" (a
+ * self-host / Advanced-override URL).
+ */
+export function locationForUrl(url: string): RelayLocation | undefined {
+  const target = normalizeOrigin(url);
+  return RELAY_LOCATIONS.find((loc) => normalizeOrigin(loc.relayUrl) === target);
+}

--- a/src/ui/cloud/CloudConnectPanel.tsx
+++ b/src/ui/cloud/CloudConnectPanel.tsx
@@ -48,10 +48,13 @@ import {
 } from '../../api/relayConnection';
 import { completeCloudSignIn } from '../../api/completeCloudSignIn';
 import { beginCloudSignIn, CloudAuthError, type CloudSignInHandle } from '../../api/cloudAuth';
+import {
+  RELAY_LOCATIONS,
+  DEFAULT_RELAY_LOCATION,
+  locationForUrl,
+} from '../../api/relayLocations';
 import { WorkspaceMembersSection } from './WorkspaceMembersSection';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
-
-const DEFAULT_RELAY_URL = 'http://localhost:9876';
 
 /** Local sign-in phase, distinct from the connection-store status. */
 type SignInPhase = 'idle' | 'starting' | 'awaiting' | 'error';
@@ -75,8 +78,12 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
   // modal shows "Signed in" (not "Disconnected") and doesn't prompt a re-pair.
   const cloudSignedIn = useIsCloudSignedIn();
 
-  const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
+  const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_LOCATION.relayUrl);
   const [cloudUrl, setCloudUrl] = useState(DEFAULT_CLOUD_BASE_URL);
+  // Controlled Advanced disclosure: force-opened when the relay URL is a custom
+  // (non-location) origin so the override field isn't hidden; otherwise the user
+  // toggles it freely (tracked via onToggle).
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const [hasStoredToken, setHasStoredToken] = useState(false);
   const [wsName, setWsName] = useState<string | null>(null);
@@ -150,6 +157,18 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
   const isAwaiting = phase === 'starting' || phase === 'awaiting';
   const isBusy = isConnecting || isAwaiting;
 
+  // The location currently selected in the switcher is derived from the relay
+  // URL (no separate state to keep in sync). Undefined → a custom/self-host URL,
+  // shown as "Custom" in the switcher.
+  const selectedLocation = locationForUrl(relayUrl);
+
+  // Reveal the Advanced override whenever the relay URL is a custom origin (e.g.
+  // a persisted self-host URL on mount) so it's never stranded behind a closed
+  // disclosure. Manual toggles still work via onToggle.
+  useEffect(() => {
+    if (locationForUrl(relayUrl) === undefined) setAdvancedOpen(true);
+  }, [relayUrl]);
+
   const handleSignIn = useCallback(async () => {
     const trimmedRelay = relayUrl.trim();
     const trimmedCloud = cloudUrl.trim().replace(/\/+$/, '');
@@ -187,11 +206,23 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
       setVerificationUri(handle.verificationUriComplete);
       setPhase('awaiting');
 
-      const { token, expiresAt, workspaceName, workspaceSlug } = await handle.result;
+      const {
+        token,
+        expiresAt,
+        relayUrl: serverRelayUrl,
+        workspaceName,
+        workspaceSlug,
+      } = await handle.result;
       handleRef.current = null;
 
+      // The relay's device-token response carries the workspace's region-resolved
+      // relay origin; adopt it as authoritative so a hosted sign-in lands on the
+      // right region relay regardless of the switcher/form default. Fall back to
+      // the form value for older relays / self-hosts that don't return one.
+      const effectiveRelay = serverRelayUrl?.trim() || trimmedRelay;
+
       await completeCloudSignIn({
-        relayUrl: trimmedRelay,
+        relayUrl: effectiveRelay,
         cloudBaseUrl: trimmedCloud,
         token,
         expiresAt,
@@ -452,6 +483,33 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
         </div>
       ) : (
         <>
+          <div className="cloud-connect__field cloud-connect__field--location">
+            <label htmlFor="relay-location">Location</label>
+            <select
+              id="relay-location"
+              className="cloud-connect__location-select"
+              value={selectedLocation?.id ?? 'custom'}
+              onChange={(e) => {
+                const loc = RELAY_LOCATIONS.find((l) => l.id === e.target.value);
+                if (loc) setRelayUrl(loc.relayUrl);
+              }}
+              disabled={isBusy}
+            >
+              {RELAY_LOCATIONS.map((loc) => (
+                <option key={loc.id} value={loc.id}>
+                  {loc.label}
+                </option>
+              ))}
+              {/* Only present when the relay URL was overridden under Advanced —
+                  not directly selectable, just reflects the custom state. */}
+              {!selectedLocation ? <option value="custom">Custom (Advanced)</option> : null}
+            </select>
+            <p className="cloud-connect__hint">
+              Connects to the relay region nearest you. Override the URL under
+              Advanced for self-hosting.
+            </p>
+          </div>
+
           <button
             type="button"
             className="cloud-connect__btn cloud-connect__btn--primary cloud-connect__btn--block"
@@ -468,8 +526,13 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
               : 'Sign in with DocuShark Cloud'}
           </button>
 
-          {/* Advanced: only self-hosters / testing / enterprise change these. */}
-          <details className="cloud-connect__advanced">
+          {/* Advanced: only self-hosters / testing / enterprise change these.
+              Controlled so a custom relay URL force-opens it (see effect). */}
+          <details
+            className="cloud-connect__advanced"
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+          >
             <summary className="cloud-connect__advanced-summary">
               <ChevronRight size={14} className="cloud-connect__advanced-caret" />
               Advanced
@@ -482,7 +545,7 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
                   type="url"
                   value={relayUrl}
                   onChange={(e) => setRelayUrl(e.target.value)}
-                  placeholder={DEFAULT_RELAY_URL}
+                  placeholder={DEFAULT_RELAY_LOCATION.relayUrl}
                   disabled={isBusy}
                   autoComplete="url"
                   required

--- a/src/ui/cloud/CloudSignInModal.css
+++ b/src/ui/cloud/CloudSignInModal.css
@@ -148,7 +148,8 @@
   color: var(--text-secondary);
 }
 
-.cloud-connect__field input {
+.cloud-connect__field input,
+.cloud-connect__field select {
   padding: 10px 12px;
   font-size: 14px;
   color: var(--text-primary);
@@ -158,14 +159,23 @@
   transition: border-color 0.15s ease;
 }
 
-.cloud-connect__field input:focus {
+.cloud-connect__field input:focus,
+.cloud-connect__field select:focus {
   outline: none;
   border-color: var(--color-primary);
 }
 
-.cloud-connect__field input:disabled {
+.cloud-connect__field input:disabled,
+.cloud-connect__field select:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.cloud-connect__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
 }
 
 .cloud-connect__btn {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -23,6 +23,12 @@ interface ImportMetaEnv {
    * Optional — falls back to the local dev origin in `relayConnection.ts`.
    */
   readonly VITE_CLOUD_BASE_URL?: string;
+  /**
+   * Relay origin for the primary region, used as the default location's URL in
+   * the Cloud connect switcher. Optional — falls back to the local dev relay
+   * (`http://localhost:9876`) in `relayLocations.ts`.
+   */
+  readonly VITE_RELAY_BASE_URL?: string;
 }
 
 declare module 'nspell' {


### PR DESCRIPTION
## Problem

The production editor's relay URL defaulted to `http://localhost:9876`. The Cloud connect modal seeded its Relay URL field from a hardcoded localhost const and used it verbatim on the **device-code** sign-in path — so a hosted (PWA/desktop) sign-in tried to reach localhost unless the user hand-edited the Advanced field. Unlike the web one-click handoff, the device-code path also **ignored the region-resolved `relay_url`** the relay already returns in its device-token response.

## Changes

- **`src/api/relayLocations.ts`** (new): a small pure registry mapping location → relay origin. The primary region (Toronto / `yyz`) origin is injected at build time via `VITE_RELAY_BASE_URL` (mirrors `VITE_CLOUD_BASE_URL`), defaulting to the local dev relay so **no deployment origin lands in OSS source**.
- **`CloudConnectPanel`**: a **Location** switcher above the sign-in button. The selected location is *derived* from the relay URL (no extra state); a custom/self-host URL force-opens the Advanced override.
- **`cloudAuth.ts`**: surfaces the device-token `relay_url`; `handleSignIn` adopts it as the **authoritative** session relay URL, falling back to the form value for older relays / self-hosts.

## Verification

- `bun run typecheck` clean; `relayLocations` + `cloudAuth` tests pass (15) plus cloud/api regression (32).
- `VITE_RELAY_BASE_URL=… bun run build` → the env origin is baked in and `localhost:9876` is absent from the bundle.

> The build var is set per environment in the companion `docushark-web` PR (`relay-base-url-editor-build`). This PR is self-contained: with no env it defaults to localhost, so it's safe to merge independently.

Assisted-by: Opus 4.8