### PR TITLE
JP-384: stop duplicating empty Untitled docs on reload

### DIFF
--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -15,6 +15,7 @@ import {
   getDocumentMetadata,
 } from '../types/Document';
 import { validateDocumentJSON } from '../types/DocumentValidation';
+import { isRichTextEmpty } from '../types/RichText';
 import { migrateDocument, DocumentVersionError } from '../migrations/documentMigrations';
 import { usePageStore, PageStoreSnapshot } from './pageStore';
 import { useNotificationStore } from './notificationStore';
@@ -509,6 +510,81 @@ export class DocumentIntegrityError extends Error {
 }
 
 /**
+ * The default name a brand-new, never-named document carries. Used both as the
+ * `newDocument()` default and as the JP-384 guard's gate: a doc still wearing
+ * this name and holding no content has never been touched, so it must not be
+ * persisted (see `isPristineUntitled`).
+ */
+export const UNTITLED_DOCUMENT_NAME = 'Untitled Document';
+
+/**
+ * Is this HTML prose page effectively empty? Conservative: any embedded media
+ * or block structure (image, table, list, heading, rule, embed, quote, code)
+ * counts as content even with no text, so we never misjudge a real page as
+ * empty. Only plain whitespace-or-empty-paragraph markup reads as empty.
+ */
+function isProseHtmlEmpty(html: string): boolean {
+  if (!html) return true;
+  if (/<(img|table|hr|iframe|video|audio|pre|blockquote|figure|ul|ol|h[1-6])\b/i.test(html)) {
+    return false;
+  }
+  const text = html.replace(/<[^>]*>/g, '').replace(/&nbsp;/gi, ' ').trim();
+  return text.length === 0;
+}
+
+/**
+ * Is `doc` devoid of all user content across every surface — canvas shapes,
+ * prose (legacy single-content + per-page), citations, fields, whiteboard, and
+ * extra pages? Biased toward returning `false` (treat as having content) so the
+ * JP-384 skip-persist guard can never drop a document that holds anything.
+ */
+function isDocumentContentEmpty(doc: DiagramDocument): boolean {
+  // More than one canvas/prose page is itself a deliberate edit.
+  if (doc.pageOrder.length > 1) return false;
+  if ((doc.richTextPages?.pageOrder.length ?? 0) > 1) return false;
+
+  // Canvas shapes on any page.
+  for (const page of Object.values(doc.pages)) {
+    if (page.shapeOrder.length > 0 || Object.keys(page.shapes).length > 0) return false;
+  }
+
+  // Legacy single-document prose.
+  if (doc.richTextContent && !isRichTextEmpty(doc.richTextContent)) return false;
+
+  // Per-page prose (HTML).
+  for (const page of Object.values(doc.richTextPages?.pages ?? {})) {
+    if (!isProseHtmlEmpty(page.content)) return false;
+  }
+
+  // Citations / fields.
+  if ((doc.references?.itemOrder.length ?? 0) > 0) return false;
+  if ((doc.fields?.order.length ?? 0) > 0) return false;
+
+  // Whiteboard notes.
+  for (const board of Object.values(doc.whiteboard?.boards ?? {})) {
+    if (board.noteOrder.length > 0 || Object.keys(board.notes).length > 0) return false;
+  }
+
+  return true;
+}
+
+/**
+ * A pristine untitled doc is one that has never been saved (no id), still wears
+ * the default {@link UNTITLED_DOCUMENT_NAME}, and holds no content. JP-384: such
+ * a doc must never be persisted — otherwise the unload / boot-flush save mints a
+ * fresh empty "Untitled Document" on every close/reload. A rename routes through
+ * `saveDocument` only after setting a non-default name, so renamed-but-empty
+ * docs still persist (the name no longer matches this gate).
+ */
+function isPristineUntitled(currentDocumentId: string | null, doc: DiagramDocument): boolean {
+  return (
+    !currentDocumentId &&
+    doc.name === UNTITLED_DOCUMENT_NAME &&
+    isDocumentContentEmpty(doc)
+  );
+}
+
+/**
  * Create a DiagramDocument from current page store state.
  *
  * Throws `DocumentIntegrityError` if any page's shapes/shapeOrder are
@@ -680,7 +756,7 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
 
       // Create a new empty document
       newDocument: (name?: string) => {
-        const docName = name ?? 'Untitled Document';
+        const docName = name ?? UNTITLED_DOCUMENT_NAME;
 
         // These store resets are a programmatic reset, NOT user edits — suppress
         // autosave so their subscriptions (and any nodeView reaction to
@@ -767,6 +843,17 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
             return;
           }
           throw err;
+        }
+
+        // JP-384: never persist a pristine, never-saved "Untitled Document"
+        // (default name + no content). The unload / boot-flush save would
+        // otherwise mint a fresh empty Untitled on every close/reload, piling
+        // up duplicates. It earns storage only once it gains content or is
+        // renamed (renameDocument sets a non-default name before saving, so it
+        // fails this gate and persists). `state.currentDocumentId` — not the
+        // freshly-minted `docId` — is the "never saved" signal.
+        if (isPristineUntitled(state.currentDocumentId, doc)) {
+          return;
         }
 
         // Extract blob references from rich text content and shapes

--- a/src/store/persistenceStore.untitledDuplication.test.ts
+++ b/src/store/persistenceStore.untitledDuplication.test.ts
@@ -1,0 +1,102 @@
+/**
+ * JP-384: closing/reloading the app while on an empty "Untitled Document" used
+ * to mint a NEW empty Untitled doc every time, because `saveDocument()` invents
+ * a fresh nanoid whenever `currentDocumentId` is null with no guard against
+ * persisting a pristine, never-named document. The unload / boot-flush save
+ * (useAutoSave `beforeunload` + `loadDocument`'s `flushAutoSaveNow`) is what
+ * fired the bug while the untitled doc's id was still null.
+ *
+ * Fix: a pristine untitled (default name + no content + never saved) is never
+ * persisted. It earns storage only once it gains content OR is renamed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  put: vi.fn(async () => {}),
+  getMeta: vi.fn(() => null),
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+
+const syncManagerMock = vi.hoisted(() => ({
+  queueSave: vi.fn(() => ({ id: 'op-1' })),
+  hasPendingChanges: vi.fn(() => false),
+  processQueueForHost: vi.fn(async () => []),
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => syncManagerMock,
+}));
+
+import { usePersistenceStore, UNTITLED_DOCUMENT_NAME } from './persistenceStore';
+import { useRichTextStore } from './richTextStore';
+
+/** Count locally-stored docs whose name is the default Untitled name. */
+function untitledDocCount(): number {
+  const docs = usePersistenceStore.getState().documents;
+  return Object.values(docs).filter((d) => d.name === UNTITLED_DOCUMENT_NAME).length;
+}
+
+function totalDocCount(): number {
+  return Object.keys(usePersistenceStore.getState().documents).length;
+}
+
+describe('JP-384 — Untitled duplication on reload', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    usePersistenceStore.setState({
+      currentDocumentId: null,
+      currentDocumentName: UNTITLED_DOCUMENT_NAME,
+      documents: {},
+    } as never);
+    vi.restoreAllMocks();
+  });
+
+  it('never persists a pristine untitled doc across repeated reload cycles', () => {
+    const store = usePersistenceStore.getState();
+
+    // Three "open app on a fresh untitled page, then close/reload" cycles.
+    // Each cycle: newDocument() (id=null, empty) then the unload/boot save
+    // fires while the id is still null.
+    for (let i = 0; i < 3; i++) {
+      store.newDocument();
+      usePersistenceStore.getState().saveDocument();
+    }
+
+    // The pristine untitled never earns storage — no duplicates, no doc at all.
+    expect(untitledDocCount()).toBe(0);
+    expect(totalDocCount()).toBe(0);
+    expect(usePersistenceStore.getState().currentDocumentId).toBeNull();
+  });
+
+  it('persists exactly one doc once content is added, and reload does not duplicate it', () => {
+    const store = usePersistenceStore.getState();
+    store.newDocument();
+
+    // User types prose — the doc now has content (still named "Untitled").
+    useRichTextStore.getState().setContent({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+    });
+
+    usePersistenceStore.getState().saveDocument();
+    const firstId = usePersistenceStore.getState().currentDocumentId;
+    expect(firstId).not.toBeNull();
+    expect(totalDocCount()).toBe(1);
+
+    // Simulate a reload-time save: same id, no duplicate.
+    usePersistenceStore.getState().saveDocument();
+    expect(totalDocCount()).toBe(1);
+    expect(usePersistenceStore.getState().currentDocumentId).toBe(firstId);
+  });
+
+  it('persists a renamed-but-empty doc (the rename gate keeps working)', () => {
+    usePersistenceStore.getState().newDocument();
+    // Post-rename state: non-default name, still no content, never saved.
+    usePersistenceStore.setState({ currentDocumentName: 'My Renamed Doc' } as never);
+
+    usePersistenceStore.getState().saveDocument();
+
+    expect(totalDocCount()).toBe(1);
+    const docs = usePersistenceStore.getState().documents;
+    expect(Object.values(docs)[0]?.name).toBe('My Renamed Doc');
+  });
+});

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -19,7 +19,11 @@
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  justify-content: center;
+  /* Left-align so a long document name reads from its (recognizable) start
+   * and runs the full width up to the window controls, instead of centering
+   * and ellipsizing the middle. Matches the Windows/Linux right-controls
+   * style WindowControls already uses. */
+  justify-content: flex-start;
   gap: var(--space-2);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);

--- a/src/ui/chrome/TitleBar.tsx
+++ b/src/ui/chrome/TitleBar.tsx
@@ -48,7 +48,9 @@ export function TitleBar() {
         >
           {statusDot}
         </span>
-        <span className="title-bar-name">{docName || 'DocuShark'}</span>
+        <span className="title-bar-name" title={docName || 'DocuShark'}>
+          {docName || 'DocuShark'}
+        </span>
       </div>
 
       <WindowControls />


### PR DESCRIPTION
## JP-384 — Untitled Page Duplication

Closing or reloading the app while on an empty untitled page spawned a new `Untitled Document` every time. They piled up one per close/reload cycle.

### Root cause
`saveDocument()` minted a fresh `nanoid()` whenever `currentDocumentId` was null, with no guard against persisting a pristine untitled doc. The save fired by `beforeunload` and by `loadDocument`'s `flushAutoSaveNow` ran while the id was still null, so each cycle wrote a brand-new empty doc.

### Fix
Guard `saveDocument()`: skip persisting **only** when `currentDocumentId === null` **AND** the name is still the default `"Untitled Document"` **AND** the document has no content (`isPristineUntitled`). A pristine untitled never hits storage; it earns a save once it:
- gains content on any surface (canvas shapes, prose, citations, fields, whiteboard, extra pages), or
- is renamed — `renameDocument` sets a non-default name before saving, so it passes the gate.

The content check (`isDocumentContentEmpty`) is biased toward "has content" so it can never drop a real document. Reuses the existing `isRichTextEmpty()` helper.

### Tests
`persistenceStore.untitledDuplication.test.ts` (red→green; originally reproduced 3 dupes):
- pristine reload cycles persist **0** docs
- content-added persists exactly **1**, reload does not duplicate
- renamed-but-empty still persists

`bun run typecheck` clean; full suite **214 files / 2704 tests** pass.

---

### Also in this PR (bundled at request — separate concern)
**Titlebar long-name handling.** The custom-chrome titlebar centered the doc name and ellipsized the middle, so long names read as cut off. Left-aligned the title (matches the existing Windows/Linux right-controls style) so it reads from its start and uses the full width up to the window controls, plus a native tooltip for the full name on hover. A single-line bar still ellipsizes a name longer than the whole bar, but the start is always visible and the complete name is one hover away. **Desktop visual — please eyeball it on the Tauri build.**

Assisted-by: Opus 4.8