### PR TITLE
Titlebar: online status + workspace (drop duplicated doc title); widen toolbar name

### DIFF
--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -257,7 +257,9 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
-  max-width: 200px;
+  /* Room for longer document names: grows with the viewport but stays bounded
+   * so it can't crowd out the page tabs / actions on a narrow window. */
+  max-width: clamp(220px, 34vw, 460px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -277,7 +279,7 @@
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: var(--radius-sm);
   outline: none;
-  max-width: 200px;
+  max-width: clamp(220px, 34vw, 460px);
 }
 
 .document-status {

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -15,38 +15,61 @@
   flex-shrink: 0;
 }
 
-.title-bar-title {
+.title-bar-info {
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  /* Left-align so a long document name reads from its (recognizable) start
-   * and runs the full width up to the window controls, instead of centering
-   * and ellipsizing the middle. Matches the Windows/Linux right-controls
-   * style WindowControls already uses. */
-  justify-content: flex-start;
   gap: var(--space-2);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-medium);
-  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
   min-width: 0;
   overflow: hidden;
   padding: 0 var(--space-3);
 }
 
-.title-bar-name {
+.title-bar-online {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+  font-weight: var(--font-weight-medium);
+}
+
+.title-bar-online-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.title-bar-online-label {
+  white-space: nowrap;
+}
+
+.title-bar-online-online .title-bar-online-dot {
+  background: var(--success);
+}
+.title-bar-online-connecting .title-bar-online-dot,
+.title-bar-online-reconnecting .title-bar-online-dot {
+  background: var(--warning);
+}
+.title-bar-online-offline .title-bar-online-dot {
+  background: var(--danger);
+}
+
+/* Workspace name, shown only when signed in. Truncates with an ellipsis if the
+ * bar is narrow; the full name is available via its title tooltip. */
+.title-bar-workspace {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+  color: var(--text-primary);
 }
 
-.title-bar-status {
-  flex-shrink: 0;
-  font-size: var(--font-size-2xs);
-  line-height: var(--line-height-tight);
-  display: inline-flex;
-  align-items: center;
+.title-bar-workspace::before {
+  content: '·';
+  margin-right: var(--space-2);
+  color: var(--text-secondary);
 }
-
-.title-bar-status-dirty { color: var(--warning); }
-.title-bar-status-saving { color: var(--text-secondary); }
-.title-bar-status-saved { color: var(--success); }

--- a/src/ui/chrome/TitleBar.tsx
+++ b/src/ui/chrome/TitleBar.tsx
@@ -3,21 +3,37 @@
  * window chrome. Drag region uses `data-tauri-drag-region` so Tauri intercepts
  * mousedown for window dragging; window controls live on the right.
  *
+ * This bar is Tauri window chrome and is intentionally NOT a home for the
+ * document title — that lives in the UnifiedToolbar (showing it here too just
+ * duplicated it). Instead it surfaces the live relay/WebSocket connection
+ * status and, when signed in, the active workspace name.
+ *
  * In a PWA build (no Tauri), the bar still renders if the user opted in, but
- * WindowControls renders nothing — the bar is then just a decorative strip
- * with the doc title and save-status dot.
+ * WindowControls renders nothing — the bar is then just a decorative strip.
  */
 
 import { useEffect, useState } from 'react';
-import { usePersistenceStore } from '../../store/persistenceStore';
-import { useAutoSave } from '../../hooks/useAutoSave';
+import { useConnectionStore } from '../../store/connectionStore';
+import { loadConnection } from '../../api/relayConnection';
 import { WindowControls } from './WindowControls';
 import './TitleBar.css';
 
+type OnlineState = 'online' | 'connecting' | 'reconnecting' | 'offline' | 'local';
+
+const ONLINE_LABELS: Record<OnlineState, string> = {
+  online: 'Online',
+  connecting: 'Connecting…',
+  reconnecting: 'Reconnecting…',
+  offline: 'Offline',
+  local: 'Local',
+};
+
 export function TitleBar() {
-  const docName = usePersistenceStore((s) => s.currentDocumentName);
-  const { isDirty, status } = useAutoSave();
+  const status = useConnectionStore((s) => s.status);
+  const reconnectPhase = useConnectionStore((s) => s.reconnectPhase);
+  const token = useConnectionStore((s) => s.token);
   const [isMac, setIsMac] = useState(false);
+  const [workspaceName, setWorkspaceName] = useState<string | null>(null);
 
   useEffect(() => {
     // Lightweight UA sniff for the macOS traffic-light gap. We don't need
@@ -27,10 +43,35 @@ export function TitleBar() {
     setIsMac(/mac|iphone|ipad|ipod/.test(ua));
   }, []);
 
-  const statusDot =
-    status === 'saving' ? '◐' : isDirty ? '●' : '○';
-  const statusTitle =
-    status === 'saving' ? 'Saving…' : isDirty ? 'Unsaved changes' : 'Saved';
+  // The workspace name lives in the persisted connection record (written by
+  // completeCloudSignIn), not in a reactive store. Re-read it whenever sign-in
+  // state flips — by the time the token is set the name is already persisted.
+  // Cleared when signed out (no token), so a local user shows no workspace.
+  useEffect(() => {
+    if (!token) {
+      setWorkspaceName(null);
+      return undefined;
+    }
+    let cancelled = false;
+    void loadConnection().then((conn) => {
+      if (!cancelled) setWorkspaceName(conn?.workspaceName ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  // WS-live status. No token → purely local (neutral). With a token: authed is
+  // a live session; connecting/reconnecting are transient; anything else is a
+  // dropped connection.
+  let onlineState: OnlineState;
+  if (!token) onlineState = 'local';
+  else if (status === 'authenticated') onlineState = 'online';
+  else if (reconnectPhase === 'reconnecting') onlineState = 'reconnecting';
+  else if (status === 'connecting' || status === 'connected') onlineState = 'connecting';
+  else onlineState = 'offline';
+
+  const label = ONLINE_LABELS[onlineState];
 
   return (
     <div className="title-bar" data-tauri-drag-region>
@@ -40,17 +81,20 @@ export function TitleBar() {
        * empty so users with macOS read the spacing as familiar. */}
       {isMac && <div className="title-bar-mac-gap" data-tauri-drag-region />}
 
-      <div className="title-bar-title" data-tauri-drag-region>
+      <div className="title-bar-info" data-tauri-drag-region>
         <span
-          className={`title-bar-status title-bar-status-${status === 'saving' ? 'saving' : isDirty ? 'dirty' : 'saved'}`}
-          title={statusTitle}
-          aria-label={statusTitle}
+          className={`title-bar-online title-bar-online-${onlineState}`}
+          title={`Connection: ${label}`}
+          aria-label={`Connection: ${label}`}
         >
-          {statusDot}
+          <span className="title-bar-online-dot" aria-hidden="true" />
+          <span className="title-bar-online-label">{label}</span>
         </span>
-        <span className="title-bar-name" title={docName || 'DocuShark'}>
-          {docName || 'DocuShark'}
-        </span>
+        {workspaceName && (
+          <span className="title-bar-workspace" title={workspaceName}>
+            {workspaceName}
+          </span>
+        )}
       </div>
 
       <WindowControls />


### PR DESCRIPTION
## Problem
The Tauri window-chrome `TitleBar` showed the document title — but the title already lives in the `UnifiedToolbar`, so it was duplicated. (The previous left-align tweak in #334 just made the duplication tidier.)

## Changes
**TitleBar (`src/ui/chrome/TitleBar.*`)** — no longer holds the doc title. The window chrome now shows:
- **Live connection status** — `Online` (authenticated WS), `Connecting…` / `Reconnecting…` (transient), `Offline` (dropped), or `Local` (no token / not signed in). Driven reactively by `connectionStore` `status` + `reconnectPhase` + `token`.
- **Workspace name** when signed in — read from the persisted connection record via the existing async `loadConnection()` (no new store interface), cleared on sign-out.

**UnifiedToolbar (`src/ui/UnifiedToolbar.css`)** — the real document title now gets much more room: `max-width` raised from a flat `200px` to `clamp(220px, 34vw, 460px)` (button + edit input), so long names show far more before truncating, without crowding the page tabs/actions on narrow windows.

## Verification
- `bun run typecheck` clean; full suite **214 files / 2704 tests** pass.
- **Desktop visual — please eyeball on the Tauri build:** custom-chrome on, signed in vs local, and a long doc name in the toolbar.

Note: this supersedes the titlebar portion of #334 (which was merged); the doc-title rendering is removed here rather than reverted.

Assisted-by: Opus 4.8