### PR TITLE
Fix JP-390: cached relay docs vanish from the list after token expiry

### DIFF
--- a/src/api/restoreCloudSession.test.ts
+++ b/src/api/restoreCloudSession.test.ts
@@ -30,6 +30,10 @@ vi.mock('../store/notificationStore', () => ({
 }));
 
 import { restoreCloudSession } from './restoreCloudSession';
+import { activeWorkspaceId, clearRememberedWorkspaceId } from '../store/activeWorkspace';
+
+const b64url = (o: unknown) =>
+  btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 
 const NOW = 1_000_000;
 const future = { relayUrl: 'http://relay:9876', jwt: 'tok', jwtExpiresAt: NOW + 60_000, cloudBaseUrl: null };
@@ -39,6 +43,7 @@ describe('restoreCloudSession', () => {
     [loadConnection, setToken, setUser, setHost, setProvider, setAuthenticated, info].forEach((m) =>
       m.mockReset(),
     );
+    clearRememberedWorkspaceId();
   });
 
   it("status 'none' when no connection / no token", async () => {
@@ -61,6 +66,19 @@ describe('restoreCloudSession', () => {
     expect(setToken).not.toHaveBeenCalled();
     expect(setProvider).not.toHaveBeenCalled();
     expect(setAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("JP-390: recovers the workspace scope from an expired token (no connect)", async () => {
+    // The token is dead (no auth), but it still names the workspace this session
+    // belonged to — recover that scope so the cached relay docs stay listed.
+    const jwt = `h.${b64url({ sub: 'u1', wsp: [{ id: 'ws-expired', role: 'owner' }] })}.s`;
+    loadConnection.mockResolvedValueOnce({ ...future, jwt, jwtExpiresAt: NOW - 1 });
+
+    const r = await restoreCloudSession({ proactiveList: true, now: () => NOW });
+
+    expect(r).toEqual({ status: 'expired' });
+    expect(setToken).not.toHaveBeenCalled(); // still never authenticates
+    expect(activeWorkspaceId()).toBe('ws-expired'); // but the scope survives
   });
 
   it('restored + proactiveList: asserts token, stands up provider AND loads the live list', async () => {

--- a/src/api/restoreCloudSession.ts
+++ b/src/api/restoreCloudSession.ts
@@ -23,8 +23,9 @@
 import { loadConnection } from './relayConnection';
 import { RelayClient } from './relayClient';
 import { RestDocumentProvider } from './restDocumentProvider';
-import { userFromRelayToken } from './relayTokenUser';
+import { userFromRelayToken, workspaceIdFromRelayToken } from './relayTokenUser';
 import { relayFetch } from '../platform/relayFetch';
+import { rememberWorkspaceId } from '../store/activeWorkspace';
 import { useConnectionStore } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { useNotificationStore } from '../store/notificationStore';
@@ -71,6 +72,12 @@ export async function restoreCloudSession(
   // Expiry semantics match `connectionStore.isTokenValid`: a null expiry is
   // treated as "no known expiry → assume valid".
   if (conn.jwtExpiresAt !== null && now() >= conn.jwtExpiresAt) {
+    // JP-390: the token is expired, so we never authenticate — but it still
+    // carries the workspace this session belonged to. Recover that scope from
+    // the (unverified) payload so the cached relay docs stay correctly scoped
+    // and listed offline. Covers a first boot after upgrade where no prior
+    // in-app `setToken` recorded the workspace. Decoding never verifies `exp`.
+    rememberWorkspaceId(workspaceIdFromRelayToken(conn.jwt));
     return { status: 'expired' };
   }
 

--- a/src/services/removeWorkspace.ts
+++ b/src/services/removeWorkspace.ts
@@ -14,7 +14,7 @@ import { useConnectionStore } from '../store/connectionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
-import { activeWorkspaceId } from '../store/activeWorkspace';
+import { activeWorkspaceId, clearRememberedWorkspaceId } from '../store/activeWorkspace';
 import { purgeLocalDocRoom } from '../collaboration/ensureCollabSession';
 import { clearConnection } from '../api/relayConnection';
 
@@ -45,4 +45,9 @@ export async function removeCurrentWorkspace(): Promise<void> {
 
   // 5. Forget the relay connection entirely (URLs + token).
   await clearConnection();
+
+  // 6. JP-390: forget the durable workspace-scope fallback last — after the
+  //    workspace-scoped teardown above has consumed it — so we never restore
+  //    into a workspace whose caches we just purged.
+  clearRememberedWorkspaceId();
 }

--- a/src/store/activeWorkspace.test.ts
+++ b/src/store/activeWorkspace.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { activeWorkspaceId, DEFAULT_WORKSPACE_ID } from './activeWorkspace';
+import { activeWorkspaceId, DEFAULT_WORKSPACE_ID, clearRememberedWorkspaceId } from './activeWorkspace';
 import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
 import { useConnectionStore } from './connectionStore';
 
@@ -32,6 +32,7 @@ describe('workspaceIdFromRelayToken', () => {
 describe('activeWorkspaceId', () => {
   beforeEach(() => {
     useConnectionStore.getState().reset();
+    clearRememberedWorkspaceId();
   });
 
   it('resolves the workspace id from the live token', () => {
@@ -43,5 +44,15 @@ describe('activeWorkspaceId', () => {
     expect(activeWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID);
     useConnectionStore.getState().setToken(tokenWith({ sub: 'u1' })); // no wsp
     expect(activeWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID);
+  });
+
+  // JP-390: once a real workspace has been seen, it must survive token loss so
+  // an expired-token cold boot still scopes the cached relay docs correctly.
+  it('falls back to the last real workspace after the token is lost', () => {
+    useConnectionStore.getState().setToken(tokenWith({ wsp: [{ id: 'ws-abc', role: 'owner' }] }));
+    expect(activeWorkspaceId()).toBe('ws-abc');
+
+    useConnectionStore.getState().reset(); // expired-token cold boot: token gone
+    expect(activeWorkspaceId()).toBe('ws-abc');
   });
 });

--- a/src/store/activeWorkspace.ts
+++ b/src/store/activeWorkspace.ts
@@ -19,10 +19,58 @@ import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
 export const DEFAULT_WORKSPACE_ID = 'default';
 
 /**
- * The workspace id the editor is currently authenticated to, for cache keying.
- * Resolved from the live relay token's first `wsp` claim; falls back to
- * `DEFAULT_WORKSPACE_ID`.
+ * localStorage key for the last real workspace id we authenticated to. This is
+ * the durable fallback scope (JP-390): the in-memory relay token is gone on
+ * every cold boot, and an EXPIRED token is never re-asserted into the store, so
+ * without a remembered scope `activeWorkspaceId()` would collapse to
+ * `DEFAULT_WORKSPACE_ID` — and the registry's workspace-scope filter would hide
+ * every cached relay doc that was stamped with the real workspace id (the doc
+ * still opens directly, but vanishes from the list).
+ */
+const LAST_WORKSPACE_KEY = 'docushark-last-workspace-id';
+
+/**
+ * Remember the last real workspace id so cloud-doc scoping survives token loss
+ * (JP-390). No-op for the single-tenant default / absent id. Called from the
+ * token choke point (`connectionStore.setToken`) and the expired-boot recovery
+ * (`restoreCloudSession`), so every real session records its workspace.
+ */
+export function rememberWorkspaceId(id: string | null | undefined): void {
+  if (!id || id === DEFAULT_WORKSPACE_ID) return;
+  try {
+    if (localStorage.getItem(LAST_WORKSPACE_KEY) !== id) {
+      localStorage.setItem(LAST_WORKSPACE_KEY, id);
+    }
+  } catch {
+    // localStorage unavailable (private mode / SSR) — fallback just degrades to
+    // DEFAULT_WORKSPACE_ID, never throws into an auth flow.
+  }
+}
+
+/**
+ * Forget the remembered workspace id. Called on a full workspace removal so we
+ * don't restore into a workspace whose caches were just purged.
+ */
+export function clearRememberedWorkspaceId(): void {
+  try {
+    localStorage.removeItem(LAST_WORKSPACE_KEY);
+  } catch {
+    // ignore — see rememberWorkspaceId
+  }
+}
+
+/**
+ * The workspace id the editor is currently scoped to, for cache keying.
+ * Resolved from the live relay token's first `wsp` claim; on a cold/expired
+ * boot (no in-memory token) falls back to the last real workspace we saw
+ * (JP-390), then to `DEFAULT_WORKSPACE_ID`.
  */
 export function activeWorkspaceId(): string {
-  return workspaceIdFromRelayToken(useConnectionStore.getState().token) ?? DEFAULT_WORKSPACE_ID;
+  const live = workspaceIdFromRelayToken(useConnectionStore.getState().token);
+  if (live) return live;
+  try {
+    return localStorage.getItem(LAST_WORKSPACE_KEY) ?? DEFAULT_WORKSPACE_ID;
+  } catch {
+    return DEFAULT_WORKSPACE_ID;
+  }
 }

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -9,6 +9,8 @@
 
 import { create } from 'zustand';
 import type { Notification, NotificationOptions } from './notificationStore';
+import { rememberWorkspaceId } from './activeWorkspace';
+import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
 
 // ============ Types ============
 
@@ -162,6 +164,10 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
 
     setToken: (token, expiresAt = null) => {
       set({ token, tokenExpiresAt: expiresAt });
+      // JP-390: setToken is the universal token sink (live WS auth + cold-boot
+      // restore), so record the workspace here. It survives token loss as the
+      // scope fallback so an expired-token boot still lists cached relay docs.
+      if (token) rememberWorkspaceId(workspaceIdFromRelayToken(token));
     },
 
     incrementReconnectAttempts: () => {

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -12,6 +12,7 @@ import {
   isActiveDocReadOnly,
 } from './documentRegistry';
 import { useConnectionStore } from './connectionStore';
+import { clearRememberedWorkspaceId } from './activeWorkspace';
 import type { DocumentMetadata } from '../types/Document';
 
 /** Unsigned JWT carrying a single `wsp[].id` — sets the active workspace for
@@ -36,6 +37,7 @@ function meta(id: string, name = 'Doc', isRelayDocument = false): DocumentMetada
 beforeEach(() => {
   useDocumentRegistry.getState().reset();
   useConnectionStore.getState().reset();
+  clearRememberedWorkspaceId();
 });
 
 // JP-370: the browser is scoped to the active workspace — two workspaces on one
@@ -71,6 +73,23 @@ describe('workspace scoping (JP-370)', () => {
     useDocumentRegistry.getState().registerRemote(meta('d', 'D'), RELAY, 'owner', 'synced');
     const rec = useDocumentRegistry.getState().getRecord('d');
     expect(rec && 'workspaceId' in rec ? rec.workspaceId : null).toBe('ws-x');
+  });
+
+  // JP-390: on an expired-token cold boot the in-memory token is null, so
+  // `activeWorkspaceId()` must fall back to the last real workspace — otherwise
+  // it collapses to `default` and the scope filter hides every cached relay doc
+  // (the doc still opens directly, but vanishes from the list).
+  it('keeps cached relay docs listed after the token is lost (expired-boot)', () => {
+    const r = useDocumentRegistry.getState();
+    useConnectionStore.getState().setToken(tokenForWs('ws-abc'));
+    r.registerRemote(meta('doc-x', 'X'), RELAY, 'owner', 'synced');
+
+    // Simulate the expired-token cold boot: the persisted token is never
+    // re-asserted into the store, so the in-memory token is gone.
+    useConnectionStore.getState().reset();
+
+    const ids = useDocumentRegistry.getState().getFilteredDocuments().map((d) => d.id);
+    expect(ids).toContain('doc-x');
   });
 });
 


### PR DESCRIPTION
## Problem (JP-390, Urgent, PWA-only)

A signed-in user with cached collab (relay) docs closes the PWA. The relay token expires while it's closed. On return, the document list shows **no cached collab docs** — yet the last-opened doc the PWA boots into, if it's a cached relay doc, is still fully functional in the editor.

## Root cause

A **workspace-scope filter** that collapses to the wrong scope when there is no live token:

1. The registry **persists** `remote`/`cached` entries across a cold boot, each stamped with the real workspace id via `registerRemote` (`documentRegistry.ts`).
2. `getFilteredDocuments()` drops any relay record whose `workspaceId !== activeWorkspaceId()` (`documentRegistry.ts:613–614`) — the "guard." No auth gate.
3. `activeWorkspaceId()` derives scope **only from the live in-memory token**. `connectionStore` is not persisted, so `token` is `null` on every cold boot until `setToken` runs.
4. On an **expired-token boot**, `restoreCloudSession()` returns early at the expiry check and **never calls `setToken`**; the booted-doc path also yields no token. So `token` stays `null` → `activeWorkspaceId()` returns `'default'` → the filter hides every cached relay doc.
5. The last-opened doc still works because `initializePersistence` opens it **directly** (offline-first), bypassing the list filter.

## Fix

Make cloud-doc scoping survive token loss by remembering the last real workspace id durably:

- **`activeWorkspace.ts`** — localStorage-backed `lastWorkspaceId`; `activeWorkspaceId()` resolves live token → remembered workspace → `DEFAULT`. Adds `rememberWorkspaceId` / `clearRememberedWorkspaceId`.
- **`connectionStore.setToken`** — record the workspace at the universal token sink (live WS auth + cold-boot restore).
- **`restoreCloudSession`** — expired branch recovers scope from the (unverified) expired jwt payload (covers a first boot after upgrade).
- **`removeWorkspace`** — clear the remembered id last, after the workspace-scoped teardown consumes it.

Fixing `activeWorkspaceId()` (the true root) also corrects the parallel `RelayDocumentCache` / `registerRemote` mis-scoping, rather than patching the list filter (which would re-leak the JP-370 cross-workspace bug).

## Tests (red → green)

- `documentRegistry.test.ts` — registry-filter-level repro: cached relay doc stays listed after token loss (was `[]`).
- `activeWorkspace.test.ts` — unit: falls back to the last real workspace after the token is lost.
- `restoreCloudSession.test.ts` — expired branch recovers the workspace scope without authenticating.

Verified: `bun run typecheck` clean; full suite green (214 files / 2707 tests).

Manual E2E (PWA) still recommended: sign in with cached collab docs → close → let token expire → reopen → list still shows cached relay docs; re-sign-in promotes them back to live `remote`.

Assisted-by: Opus 4.8