### PR TITLE
docs-site: improve SEO/discoverability + link docushark.app homepage

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,5 +1,15 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig, type HeadConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
+import { generateLlmsTxt } from './plugins/llms'
+
+const SITE_TITLE = 'DocuShark Docs'
+const SITE_DESCRIPTION =
+  'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.'
+
+// Canonical host for the published docs (GitHub Pages, apex CNAME). Used for
+// canonical/og:url tags and JSON-LD. SiteData has no `url` field, so we keep
+// the hostname here as the single source of truth.
+const HOSTNAME = 'https://docs.docushark.app'
 
 // The Guides area spans two folders: /getting-started/ (the onboarding group)
 // and /guide/ (the using-DocuShark group). Both routes share one sidebar.
@@ -38,6 +48,93 @@ const guidesSidebar = [
   },
 ]
 
+const developerSidebar = [
+  {
+    text: 'Getting Set Up',
+    items: [
+      { text: 'Architecture Overview', link: '/developer/architecture' },
+      { text: 'Project Setup', link: '/developer/project-setup' },
+      { text: 'Core Systems', link: '/developer/core-systems' },
+      { text: 'State Management', link: '/developer/state-management' },
+    ],
+  },
+  {
+    text: 'Extending DocuShark',
+    items: [
+      { text: 'Creating Custom Shapes', link: '/developer/creating-shapes' },
+      { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
+      { text: 'Creating Prose Helpers', link: '/developer/creating-prose-helpers' },
+      { text: 'Shape Properties', link: '/developer/shape-properties' },
+      { text: 'Plugin Development', link: '/developer/plugin-development' },
+      { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
+      { text: 'Utility Modules', link: '/developer/utilities' },
+      { text: 'AI Agents (MCP) & Recipes', link: '/developer/mcp-agent-recipes' },
+    ],
+  },
+  {
+    text: 'Contributing',
+    items: [
+      { text: 'Contributing', link: '/developer/contributing' },
+      { text: 'Roadmap', link: '/developer/roadmap' },
+    ],
+  },
+]
+
+// `transformHead` receives the source markdown path (e.g. "guide/connectors.md",
+// "index.md"). We derive two things from it:
+//
+//  - canonicalUrl: the absolute URL matching what VitePress emits in the sitemap
+//    and internal links. With cleanUrls off (the default here), interior pages
+//    are served at "<path>.html" and the home page at "/".
+//  - routeKey: an extensionless, slash-prefixed key ("/guide/connectors") used
+//    to match sidebar `link` values when resolving the breadcrumb trail.
+function canonicalUrlOf(page: string): string {
+  if (page === 'index.md') return `${HOSTNAME}/`
+  const nested = page.match(/^(.*)\/index\.md$/)
+  if (nested) return `${HOSTNAME}/${nested[1]}/`
+  return `${HOSTNAME}/${page.replace(/\.md$/, '.html')}`
+}
+
+function routeKeyOf(page: string): string {
+  if (page === 'index.md') return '/'
+  const nested = page.match(/^(.*)\/index\.md$/)
+  if (nested) return `/${nested[1]}`
+  return `/${page.replace(/\.md$/, '')}`
+}
+
+// Convert a sidebar link ("/getting-started/introduction") to its canonical
+// absolute URL, matching the sitemap's ".html" form so breadcrumb ancestor
+// items stay consistent with the leaf's canonical URL.
+function linkToUrl(link: string): string {
+  const clean = link.replace(/^\/+/, '').replace(/\/$/, '')
+  return clean === '' ? `${HOSTNAME}/` : `${HOSTNAME}/${clean}.html`
+}
+
+// Resolve a route to its breadcrumb trail (area + group + title) from the
+// sidebar definitions, so the JSON-LD BreadcrumbList mirrors the visual one.
+function resolveBreadcrumb(
+  route: string,
+  pageTitle: string,
+): { areaLabel: string; areaLink: string; group: string; title: string } | null {
+  let area: { label: string; link: string; sidebar: typeof guidesSidebar } | null = null
+  if (route.startsWith('/developer/')) {
+    area = { label: 'Developer', link: '/developer/architecture', sidebar: developerSidebar }
+  } else if (route.startsWith('/guide/') || route.startsWith('/getting-started/')) {
+    area = { label: 'Guides', link: '/getting-started/introduction', sidebar: guidesSidebar }
+  }
+  if (!area) return null
+
+  for (const grp of area.sidebar) {
+    for (const item of grp.items) {
+      if (item.link === route) {
+        return { areaLabel: area.label, areaLink: area.link, group: grp.text, title: item.text }
+      }
+    }
+  }
+  // Page not found in sidebar (shouldn't happen) — still emit a 2-level trail.
+  return { areaLabel: area.label, areaLink: area.link, group: '', title: pageTitle }
+}
+
 export default withMermaid(
   defineConfig({
     title: 'DocuShark',
@@ -48,6 +145,8 @@ export default withMermaid(
 
     head: [
       ['link', { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+      ['meta', { property: 'og:site_name', content: 'DocuShark' }],
+      ['meta', { property: 'og:locale', content: 'en_US' }],
       ['meta', { property: 'og:type', content: 'website' }],
       ['meta', { property: 'og:title', content: 'DocuShark Docs' }],
       ['meta', { property: 'og:description', content: 'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.' }],
@@ -58,6 +157,99 @@ export default withMermaid(
       ['meta', { name: 'twitter:image', content: 'https://docs.docushark.app/docushark-badge.png' }],
     ],
 
+    // Native VitePress sitemap — no extra dep. See node_modules/vitepress SitemapOptions.
+    sitemap: {
+      hostname: HOSTNAME,
+    },
+
+    // Emit /llms.txt + /llms-full.txt into the build output. Runs for both
+    // `build` and `build:offline`, so a local `preview` serves them too.
+    // Sections mirror the sidebar IA defined above.
+    buildEnd(siteConfig) {
+      generateLlmsTxt(siteConfig, {
+        hostname: HOSTNAME,
+        siteTitle: SITE_TITLE,
+        siteDescription: SITE_DESCRIPTION,
+        sections: [
+          ...guidesSidebar.map((g) => ({ title: g.text, items: g.items })),
+          { title: 'Developer', items: developerSidebar.flatMap((g) => g.items) },
+        ],
+      })
+    },
+
+    // Per-page <head> augmentation, emitted into the static HTML at build time:
+    //  - canonical + og:url/twitter:url derived from the resolved route
+    //  - JSON-LD: WebSite + SearchAction on the home page, BreadcrumbList on
+    //    interior pages (mirrors the visual breadcrumb)
+    // VitePress already injects per-page title/description from frontmatter.
+    transformHead({ page, pageData }) {
+      const routeKey = routeKeyOf(page)
+      const url = canonicalUrlOf(page)
+
+      const head: HeadConfig[] = [
+        ['link', { rel: 'canonical', href: url }],
+        ['meta', { property: 'og:url', content: url }],
+        ['meta', { name: 'twitter:url', content: url }],
+      ]
+
+      if (routeKey === '/') {
+        head.push([
+          'script',
+          { type: 'application/ld+json' },
+          JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            name: 'DocuShark Docs',
+            url: `${HOSTNAME}/`,
+            description:
+              'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.',
+            publisher: {
+              '@type': 'Organization',
+              name: 'JPE-Net Technologies',
+              url: 'https://github.com/JPE-Net-Technologies/docushark',
+            },
+            potentialAction: {
+              '@type': 'SearchAction',
+              target: {
+                '@type': 'EntryPoint',
+                urlTemplate: `${HOSTNAME}/?q={search_term_string}`,
+              },
+              'query-input': 'required name=search_term_string',
+            },
+          }),
+        ])
+      } else {
+        const crumb = resolveBreadcrumb(routeKey, pageData.title)
+        if (crumb) {
+          const items: Array<Record<string, unknown>> = [
+            { '@type': 'ListItem', position: 1, name: 'Docs', item: `${HOSTNAME}/` },
+            {
+              '@type': 'ListItem',
+              position: 2,
+              name: crumb.areaLabel,
+              item: linkToUrl(crumb.areaLink),
+            },
+          ]
+          let pos = 3
+          if (crumb.group) {
+            items.push({ '@type': 'ListItem', position: pos++, name: crumb.group })
+          }
+          items.push({ '@type': 'ListItem', position: pos, name: crumb.title, item: url })
+          head.push([
+            'script',
+            { type: 'application/ld+json' },
+            JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: items,
+            }),
+          ])
+        }
+      }
+
+      return head
+    },
+
     themeConfig: {
       logo: { src: '/docushark-logo.png', alt: 'DocuShark' },
 
@@ -65,43 +257,14 @@ export default withMermaid(
         { text: 'Home', link: '/' },
         { text: 'Guides', link: '/getting-started/introduction', activeMatch: '/getting-started/|/guide/' },
         { text: 'Developer', link: '/developer/architecture', activeMatch: '/developer/' },
+        { text: 'Website', link: 'https://docushark.app' },
         { text: 'Open DocuShark', link: 'https://app.docushark.app' },
       ],
 
       sidebar: {
         '/getting-started/': guidesSidebar,
         '/guide/': guidesSidebar,
-        '/developer/': [
-          {
-            text: 'Getting Set Up',
-            items: [
-              { text: 'Architecture Overview', link: '/developer/architecture' },
-              { text: 'Project Setup', link: '/developer/project-setup' },
-              { text: 'Core Systems', link: '/developer/core-systems' },
-              { text: 'State Management', link: '/developer/state-management' },
-            ],
-          },
-          {
-            text: 'Extending DocuShark',
-            items: [
-              { text: 'Creating Custom Shapes', link: '/developer/creating-shapes' },
-              { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
-              { text: 'Creating Prose Helpers', link: '/developer/creating-prose-helpers' },
-              { text: 'Shape Properties', link: '/developer/shape-properties' },
-              { text: 'Plugin Development', link: '/developer/plugin-development' },
-              { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
-              { text: 'Utility Modules', link: '/developer/utilities' },
-              { text: 'AI Agents (MCP) & Recipes', link: '/developer/mcp-agent-recipes' },
-            ],
-          },
-          {
-            text: 'Contributing',
-            items: [
-              { text: 'Contributing', link: '/developer/contributing' },
-              { text: 'Roadmap', link: '/developer/roadmap' },
-            ],
-          },
-        ],
+        '/developer/': developerSidebar,
       },
 
       socialLinks: [

--- a/docs-site/.vitepress/plugins/llms.ts
+++ b/docs-site/.vitepress/plugins/llms.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Minimal build-time generator for /llms.txt and /llms-full.txt, following the
+// llmstxt.org convention. Runs from VitePress's `buildEnd` hook, so the files
+// land in the build output (dist) on every build — including `build:offline`.
+//
+// We deliberately avoid extra deps: frontmatter is parsed with a small reader
+// (the docs use only single-line `title:` / `description:` keys), and page
+// order + grouping is passed in from config.mts so the output mirrors the
+// sidebar IA without a parallel table.
+
+export interface LlmsItem {
+  text: string
+  link: string
+}
+
+export interface LlmsSection {
+  title: string
+  items: LlmsItem[]
+}
+
+export interface LlmsOptions {
+  hostname: string
+  siteTitle: string
+  siteDescription: string
+  sections: LlmsSection[]
+}
+
+// Subset of VitePress's SiteConfig that we actually need.
+interface BuildConfig {
+  srcDir: string
+  outDir: string
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/
+
+function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
+  const match = raw.match(FRONTMATTER_RE)
+  if (!match || match[1] === undefined) return { data: {}, body: raw }
+  const data: Record<string, string> = {}
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/)
+    if (kv && kv[1] !== undefined && kv[2] !== undefined) {
+      data[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, '')
+    }
+  }
+  return { data, body: raw.slice(match[0].length) }
+}
+
+function firstHeading(body: string): string {
+  const m = body.match(/^#\s+(.+)$/m)
+  return m && m[1] !== undefined ? m[1].trim() : ''
+}
+
+// Resolve a sidebar link ("/guide/connectors") to its source markdown file.
+function sourcePath(srcDir: string, link: string): string {
+  const rel = link.replace(/^\/+/, '').replace(/\/$/, '')
+  const candidate = rel === '' ? 'index.md' : `${rel}.md`
+  return path.join(srcDir, candidate)
+}
+
+function readPage(
+  srcDir: string,
+  item: LlmsItem,
+): { title: string; description: string; body: string } | null {
+  const file = sourcePath(srcDir, item.link)
+  let raw: string
+  try {
+    raw = fs.readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+  const { data, body } = parseFrontmatter(raw)
+  return {
+    title: data['title'] || firstHeading(body) || item.text,
+    description: data['description'] || '',
+    body: body.trim(),
+  }
+}
+
+function absoluteUrl(hostname: string, link: string): string {
+  const clean = link.replace(/\/$/, '')
+  return clean === '' ? `${hostname}/` : `${hostname}${clean}`
+}
+
+export function generateLlmsTxt(config: BuildConfig, opts: LlmsOptions): void {
+  const { srcDir, outDir } = config
+  const { hostname, siteTitle, siteDescription, sections } = opts
+
+  // ---- /llms.txt — curated index ----
+  const indexLines: string[] = [
+    `# ${siteTitle}`,
+    '',
+    `> ${siteDescription}`,
+    '',
+    'This file helps language models navigate the DocuShark documentation. For the full text of every page in a single file, see [/llms-full.txt](' +
+      `${hostname}/llms-full.txt).`,
+    '',
+  ]
+
+  // ---- /llms-full.txt — full page contents ----
+  const fullLines: string[] = [
+    `# ${siteTitle} — Full Documentation`,
+    '',
+    `> ${siteDescription}`,
+    '',
+    `Source: ${hostname}/`,
+    '',
+  ]
+
+  for (const section of sections) {
+    indexLines.push(`## ${section.title}`, '')
+    for (const item of section.items) {
+      const page = readPage(srcDir, item)
+      if (!page) continue
+      const url = absoluteUrl(hostname, item.link)
+      const suffix = page.description ? `: ${page.description}` : ''
+      indexLines.push(`- [${page.title}](${url})${suffix}`)
+
+      fullLines.push('---', '', `# ${page.title}`, '', `Source: ${url}`, '')
+      if (page.description) fullLines.push(`> ${page.description}`, '')
+      fullLines.push(page.body, '')
+    }
+    indexLines.push('')
+  }
+
+  fs.mkdirSync(outDir, { recursive: true })
+  fs.writeFileSync(path.join(outDir, 'llms.txt'), indexLines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n')
+  fs.writeFileSync(path.join(outDir, 'llms-full.txt'), fullLines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n')
+}

--- a/docs-site/.vitepress/theme/Breadcrumb.vue
+++ b/docs-site/.vitepress/theme/Breadcrumb.vue
@@ -3,11 +3,13 @@ import { computed } from 'vue'
 import { useData } from 'vitepress'
 import { useSidebar } from 'vitepress/theme'
 
-const { page, theme } = useData()
+const { page } = useData()
 const { sidebarGroups } = useSidebar()
 
 // "Docs / <Area> / <Group> / <Here>" — derived from the resolved sidebar so it
-// stays in sync with config.mts without a parallel IA table.
+// stays in sync with config.mts without a parallel IA table. The matching
+// JSON-LD BreadcrumbList is emitted into static HTML by the `transformHead`
+// hook in config.mts.
 const area = computed(() => {
   const p = '/' + page.value.relativePath
   if (p.startsWith('/developer/')) return { label: 'Developer', link: '/developer/architecture' }

--- a/docs-site/.vitepress/theme/Home.vue
+++ b/docs-site/.vitepress/theme/Home.vue
@@ -210,6 +210,7 @@ function openSearch() {
           <div>
             <h4>Project</h4>
             <ul>
+              <li><a href="https://docushark.app" target="_blank" rel="noopener">Website</a></li>
               <li><a :href="GH" target="_blank" rel="noopener">GitHub</a></li>
               <li><a :href="withBase('/developer/contributing')">Contributing</a></li>
               <li><a :href="withBase('/developer/roadmap')">Roadmap</a></li>

--- a/docs-site/.vitepress/theme/Layout.vue
+++ b/docs-site/.vitepress/theme/Layout.vue
@@ -11,6 +11,9 @@ const { page } = useData()
 // and an `ds-area-*` hook on the layout root that CSS uses to scope chrome
 // (e.g. GitHub shows only in the developer area). Computed from useData() so it
 // is correct during SSR — no client-side flash.
+//
+// JSON-LD (WebSite on home, BreadcrumbList on interior pages) is emitted into
+// the static HTML by the `transformHead` hook in config.mts, not here.
 const area = computed(() => {
   const p = '/' + page.value.relativePath
   if (p.startsWith('/developer/')) return 'developer'

--- a/docs-site/developer/architecture.md
+++ b/docs-site/developer/architecture.md
@@ -1,3 +1,8 @@
+---
+title: Architecture Overview
+description: Bird's-eye view of DocuShark's architecture — React + Canvas engine on top of Zustand stores, Tauri desktop, and Yjs collaboration.
+---
+
 # Architecture Overview
 
 This page provides a bird's-eye view of DocuShark's architecture. For detailed coverage of specific systems, see the linked pages.

--- a/docs-site/developer/collaboration-protocol.md
+++ b/docs-site/developer/collaboration-protocol.md
@@ -1,3 +1,8 @@
+---
+title: Collaboration Protocol
+description: DocuShark's real-time collaboration protocol — Yjs CRDTs over WebSocket, JWT auth, and the relay message format.
+---
+
 # Collaboration Protocol
 
 DocuShark's real-time collaboration runs through a **standalone relay**

--- a/docs-site/developer/contributing.md
+++ b/docs-site/developer/contributing.md
@@ -1,3 +1,8 @@
+---
+title: Contributing
+description: How to contribute to DocuShark — bug fixes, shape libraries, documentation, and feature work.
+---
+
 # Contributing
 
 We welcome contributions of all kinds — bug fixes, new shape libraries, documentation improvements, and feature work.

--- a/docs-site/developer/core-systems.md
+++ b/docs-site/developer/core-systems.md
@@ -1,3 +1,8 @@
+---
+title: Core Systems
+description: DocuShark's core runtime systems — coordinate pipeline, rendering engine, shape registry, and tool state machines.
+---
+
 # Core Systems
 
 This page covers the core runtime systems that power DocuShark's canvas — the coordinate pipeline, rendering engine, shape registry, and tool state machines.

--- a/docs-site/developer/creating-prose-helpers.md
+++ b/docs-site/developer/creating-prose-helpers.md
@@ -1,3 +1,8 @@
+---
+title: Creating Prose Helpers
+description: Build custom Tiptap/ProseMirror prose helpers — nodes that live alongside diagrams in DocuShark documents.
+---
+
 # Creating Prose Helpers
 
 A **prose helper** is a custom Tiptap/ProseMirror node that lives in the written

--- a/docs-site/developer/creating-shapes.md
+++ b/docs-site/developer/creating-shapes.md
@@ -1,3 +1,8 @@
+---
+title: Creating Custom Shapes
+description: Create custom shapes for DocuShark — register render, hitTest, getBounds, getHandles, and create handlers.
+---
+
 # Creating Custom Shapes
 
 This guide walks through creating custom shapes for DocuShark, from simple library shapes to fully custom handlers.

--- a/docs-site/developer/creating-tools.md
+++ b/docs-site/developer/creating-tools.md
@@ -1,3 +1,8 @@
+---
+title: Creating Custom Tools
+description: Build custom DocuShark tools — state machines that respond to normalized pointer, keyboard, and wheel events.
+---
+
 # Creating Custom Tools
 
 Tools are the primary way users interact with the canvas. Each tool is a **state machine** that responds to normalized input events — pointer down, move, up, keyboard, and wheel. Only one tool is active at a time, managed by the `ToolManager`.

--- a/docs-site/developer/mcp-agent-recipes.md
+++ b/docs-site/developer/mcp-agent-recipes.md
@@ -1,3 +1,8 @@
+---
+title: AI Agents (MCP) & Recipes
+description: DocuShark's MCP server — tools, recipes, and patterns for AI agents that author real documents and diagrams.
+---
+
 # AI Agents (MCP) & Recipes
 
 DocuShark ships an **MCP server** (in the relay) — a precise, high-performance

--- a/docs-site/developer/plugin-development.md
+++ b/docs-site/developer/plugin-development.md
@@ -1,3 +1,8 @@
+---
+title: Plugin Development Guide
+description: Extend DocuShark through the PanelExtensions plugin registry — panels, shape libraries, and UI extensions.
+---
+
 # Plugin Development Guide
 
 DocuShark provides a plugin system through the **PanelExtensions** registry, allowing developers to extend the UI without modifying core components.

--- a/docs-site/developer/project-setup.md
+++ b/docs-site/developer/project-setup.md
@@ -1,3 +1,8 @@
+---
+title: Project Setup
+description: Set up the DocuShark repo locally — prerequisites, install steps, dev commands, and tests.
+---
+
 # Project Setup
 
 This page covers everything you need to start developing DocuShark locally.

--- a/docs-site/developer/roadmap.md
+++ b/docs-site/developer/roadmap.md
@@ -1,3 +1,8 @@
+---
+title: Roadmap
+description: DocuShark's development progress and planned features — what's shipped, what's next, and what's on the horizon.
+---
+
 # Roadmap
 
 This document tracks DocuShark's development progress and planned features.

--- a/docs-site/developer/shape-properties.md
+++ b/docs-site/developer/shape-properties.md
@@ -1,3 +1,8 @@
+---
+title: Shape Properties
+description: Reference for every shape property in DocuShark — appearance, position, behavior, and metadata fields.
+---
+
 # Shape Properties
 
 Every shape in DocuShark has properties that control its appearance and behavior. This reference covers all available properties.

--- a/docs-site/developer/state-management.md
+++ b/docs-site/developer/state-management.md
@@ -1,3 +1,8 @@
+---
+title: State Management
+description: How DocuShark splits state across Zustand stores — document, session, history, pages, persistence, and feature stores.
+---
+
 # State Management
 
 DocuShark uses **Zustand** with **Immer** middleware for state management. Stores are split by responsibility so that changes to ephemeral UI state (cursor position, active tool) don't trigger re-renders on document data, and vice versa.

--- a/docs-site/developer/utilities.md
+++ b/docs-site/developer/utilities.md
@@ -1,3 +1,8 @@
+---
+title: Utility Modules Reference
+description: DocuShark's core utilities — math primitives (Vec2, Mat3, Box), color manipulation, file handling, and export.
+---
+
 # Utility Modules Reference
 
 DocuShark's core utility modules provide math primitives, color manipulation, file handling, and export functionality. All math types are immutable — every operation returns a new instance.

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+description: Install DocuShark as a desktop app (Windows, macOS, Linux) or run it directly in your browser.
+---
+
 # Installation
 
 DocuShark can be installed as a desktop application or run directly in your browser.

--- a/docs-site/getting-started/interface-tour.md
+++ b/docs-site/getting-started/interface-tour.md
@@ -1,3 +1,8 @@
+---
+title: Interface Tour
+description: A quick tour of the DocuShark editor — toolbar, canvas, properties panel, layers, and status bar.
+---
+
 # Interface Tour
 
 Here's a quick overview of everything you see when you open a document in DocuShark.

--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+description: DocuShark is a fast, offline-first diagramming and whiteboard app that stays smooth on large, complex diagrams.
+---
+
 # Introduction
 
 Welcome to **DocuShark** — a fast, offline-first diagramming and whiteboard app that keeps things smooth even on large, complex diagrams.

--- a/docs-site/getting-started/quick-start.md
+++ b/docs-site/getting-started/quick-start.md
@@ -1,3 +1,8 @@
+---
+title: Quick Start
+description: Create your first DocuShark diagram in about five minutes — new document, add shapes, connect them, save.
+---
+
 # Quick Start
 
 Let's create your first diagram. This should take about five minutes.

--- a/docs-site/guide/canvas-navigation.md
+++ b/docs-site/guide/canvas-navigation.md
@@ -1,3 +1,8 @@
+---
+title: Canvas & Navigation
+description: Navigate DocuShark's infinite canvas — pan, zoom, fit-to-screen, minimap, and keyboard navigation.
+---
+
 # Canvas & Navigation
 
 The canvas is your infinite drawing surface. Let's cover how to move around it efficiently.

--- a/docs-site/guide/citations.md
+++ b/docs-site/guide/citations.md
@@ -1,3 +1,8 @@
+---
+title: Citations & References
+description: Cite sources and manage references in DocuShark documents — first-class citations in the rich text editor.
+---
+
 # Citations & References
 
 DocuShark has first-class citations built into the document editor. Cite a source

--- a/docs-site/guide/collaboration.md
+++ b/docs-site/guide/collaboration.md
@@ -1,3 +1,8 @@
+---
+title: Collaboration
+description: Real-time collaboration in DocuShark — connect to a relay and edit diagrams live with your team via CRDTs.
+---
+
 # Collaboration
 
 DocuShark supports real-time collaboration: when your document is connected to a

--- a/docs-site/guide/collections.md
+++ b/docs-site/guide/collections.md
@@ -1,3 +1,8 @@
+---
+title: Collections
+description: Group related DocuShark documents into named, color-coded collections to organize your whole library.
+---
+
 # Collections
 
 Collections are **containers for your documents** — think of them as

--- a/docs-site/guide/connect-your-agent.md
+++ b/docs-site/guide/connect-your-agent.md
@@ -1,3 +1,8 @@
+---
+title: Connect an AI Agent
+description: Connect Claude, Cursor, ChatGPT, or any MCP-compatible AI agent to DocuShark to author documents and diagrams.
+---
+
 # Connect an AI Agent
 
 DocuShark speaks **[MCP](https://modelcontextprotocol.io)** — an open standard that lets

--- a/docs-site/guide/connectors.md
+++ b/docs-site/guide/connectors.md
@@ -1,3 +1,8 @@
+---
+title: Connectors
+description: Smart connectors that link shapes together — route styles, anchor points, and how they follow shape movement.
+---
+
 # Connectors
 
 Connectors are smart lines that link shapes together. Unlike regular lines, connectors stay attached to their shapes — move a shape and the connector follows.

--- a/docs-site/guide/document-fields.md
+++ b/docs-site/guide/document-fields.md
@@ -1,3 +1,8 @@
+---
+title: Document Fields
+description: Reusable values you define once and reference throughout a DocuShark document — version numbers, names, dates, and more.
+---
+
 # Document Fields
 
 Document fields are reusable values you define once and reference throughout your

--- a/docs-site/guide/drawing-tools.md
+++ b/docs-site/guide/drawing-tools.md
@@ -1,3 +1,8 @@
+---
+title: Drawing Tools
+description: DocuShark's drawing tools — select, rectangle, ellipse, line, text, connector, and more — with keyboard shortcuts.
+---
+
 # Drawing Tools
 
 DocuShark gives you a set of drawing tools for creating and manipulating shapes. Switch between them using the toolbar or keyboard shortcuts.

--- a/docs-site/guide/embedded-files.md
+++ b/docs-site/guide/embedded-files.md
@@ -1,3 +1,8 @@
+---
+title: Embedded Files
+description: Embed PDFs, spreadsheets, images, and other files onto your DocuShark canvas as shape cards with previews.
+---
+
 # Embedded Files
 
 DocuShark lets you embed files — PDFs, spreadsheets, images, and more — directly onto your canvas. Files appear as shape cards with thumbnail previews, and you can open them in built-in viewers.

--- a/docs-site/guide/export-import.md
+++ b/docs-site/guide/export-import.md
@@ -1,3 +1,8 @@
+---
+title: Export & Import
+description: Export DocuShark diagrams to PNG, SVG, PDF, or Markdown; import from Mermaid, draw.io, and Excalidraw.
+---
+
 # Export & Import
 
 DocuShark supports multiple ways to export your diagrams and share your work.

--- a/docs-site/guide/keyboard-shortcuts.md
+++ b/docs-site/guide/keyboard-shortcuts.md
@@ -1,3 +1,8 @@
+---
+title: Keyboard Shortcuts
+description: Complete keyboard shortcuts reference for DocuShark — tools, navigation, editing, and clipboard operations.
+---
+
 # Keyboard Shortcuts
 
 Master DocuShark with these keyboard shortcuts.

--- a/docs-site/guide/layout-modes.md
+++ b/docs-site/guide/layout-modes.md
@@ -1,3 +1,8 @@
+---
+title: Layout Modes
+description: Switch between DocuShark's four workspace layouts — Relaxed, Designer, Technician, and Power — for writing or diagramming.
+---
+
 # Layout Modes
 
 DocuShark adapts its workspace to what you're doing. Whether you're heads-down

--- a/docs-site/guide/multi-page-documents.md
+++ b/docs-site/guide/multi-page-documents.md
@@ -1,3 +1,8 @@
+---
+title: Multi-Page Documents
+description: Organize complex diagrams across multiple pages — add, reorder, and navigate pages in a single document.
+---
+
 # Multi-Page Documents
 
 DocuShark documents can contain multiple pages, letting you organize complex projects into logical sections.

--- a/docs-site/guide/rich-text-editor.md
+++ b/docs-site/guide/rich-text-editor.md
@@ -1,3 +1,8 @@
+---
+title: Rich Text & Notes
+description: DocuShark's rich text editor — write documentation, headings, lists, code, and tables alongside your diagrams.
+---
+
 # Rich Text & Notes
 
 DocuShark includes a powerful rich text editor for adding documentation alongside your diagrams.

--- a/docs-site/guide/settings.md
+++ b/docs-site/guide/settings.md
@@ -1,3 +1,8 @@
+---
+title: Settings
+description: DocuShark settings — appearance, theme, collaboration server, storage, and editor preferences.
+---
+
 # Settings
 
 Access settings via the **Settings** button in the toolbar.

--- a/docs-site/guide/shape-libraries.md
+++ b/docs-site/guide/shape-libraries.md
@@ -1,3 +1,8 @@
+---
+title: Shape Libraries
+description: DocuShark's built-in shape libraries — flowchart, UML, ERD, AWS/Azure/GCP icons — plus custom libraries.
+---
+
 # Shape Libraries
 
 DocuShark comes with extensive shape libraries for creating any kind of diagram, plus a large collection of cloud provider icons for architecture diagrams.

--- a/docs-site/guide/styling.md
+++ b/docs-site/guide/styling.md
@@ -1,3 +1,8 @@
+---
+title: Styling & Themes
+description: Style shapes individually with the properties panel, save reusable style profiles, and switch app-wide themes.
+---
+
 # Styling & Themes
 
 DocuShark gives you flexible control over how your diagrams look — from individual shape styles to app-wide themes.

--- a/docs-site/guide/whiteboard.md
+++ b/docs-site/guide/whiteboard.md
@@ -1,3 +1,8 @@
+---
+title: Whiteboard & Ideas
+description: The DocuShark Whiteboard — sticky-note overlay for brainstorming that floats above your canvas.
+---
+
 # Whiteboard & Ideas
 
 The Whiteboard is a sticky-note overlay for quick brainstorming and idea tracking. It floats on top of your canvas and is separate from your diagram content.

--- a/docs-site/public/robots.txt
+++ b/docs-site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.docushark.app/sitemap.xml


### PR DESCRIPTION
- Advertise the marketing homepage (docushark.app): add a "Website" nav item and a footer link in the Home landing, distinct from the existing "Open DocuShark" app link.
- Add title + description frontmatter to all 36 guide/developer pages so each has a unique <title> and meta description.
- Enable VitePress's native sitemap (no new dep) and add public/robots.txt referencing it.
- Add og:site_name/og:locale plus per-page canonical, og:url, and twitter:url via a build-time transformHead hook, matching the sitemap's URL form (home "/", interior "*.html").
- Emit JSON-LD as static HTML: WebSite + SearchAction on the home page, BreadcrumbList mirroring the visual breadcrumb on interior pages.
- Generate /llms.txt and /llms-full.txt at build time via a small in-tree plugin (.vitepress/plugins/llms.ts), grouped to mirror the sidebar IA; runs for both build and build:offline.