### PR TITLE
Fix collab not starting on active doc after sign-in (JP-392)

### DIFF
--- a/src/api/completeCloudSignIn.test.ts
+++ b/src/api/completeCloudSignIn.test.ts
@@ -8,6 +8,10 @@ const h = vi.hoisted(() => ({
   standUpRestProvider: vi.fn(),
   getRecord: vi.fn((_id: string) => undefined as unknown),
   ensureCollabSessionForDoc: vi.fn(async () => {}),
+  // A live collab engine is itself proof of a relay doc (local docs never get one),
+  // so an already-active session for the doc is a valid sign-in reopen signal even
+  // when the registry record hasn't loaded yet (JP-392 boot-cached path).
+  collabState: { isActive: false, config: null as { documentId: string } | null },
 }));
 
 vi.mock('./relayConnection', () => ({ saveConnection: h.saveConnection }));
@@ -17,6 +21,9 @@ vi.mock('../store/connectionStore', () => ({
 }));
 vi.mock('../store/documentRegistry', () => ({
   useDocumentRegistry: { getState: () => ({ getRecord: h.getRecord }) },
+}));
+vi.mock('../collaboration/collaborationStore', () => ({
+  useCollaborationStore: { getState: () => h.collabState },
 }));
 vi.mock('../collaboration/ensureCollabSession', () => ({
   ensureCollabSessionForDoc: h.ensureCollabSessionForDoc,
@@ -34,6 +41,8 @@ const base = {
 beforeEach(() => {
   vi.clearAllMocks();
   h.getRecord.mockReturnValue(undefined);
+  h.collabState.isActive = false;
+  h.collabState.config = null;
 });
 
 describe('completeCloudSignIn (REST-only sign-in, JP — phantom-join fix)', () => {
@@ -59,6 +68,19 @@ describe('completeCloudSignIn (REST-only sign-in, JP — phantom-join fix)', () 
     h.getRecord.mockReturnValue(undefined);
     await completeCloudSignIn({ ...base, documentId: 'default' });
     expect(h.ensureCollabSessionForDoc).not.toHaveBeenCalled();
+  });
+
+  it('JP-392: opens the live session for the active doc when its registry record is missing', async () => {
+    // Boot-cached doc: warmupCache loaded its content but no record, and the REST
+    // list re-fetch is still async — so getRecord is undefined at sign-in. The live
+    // engine for this exact doc is the reliable signal that it's a relay doc.
+    h.getRecord.mockReturnValue(undefined);
+    h.collabState.isActive = true;
+    h.collabState.config = { documentId: 'doc-9' };
+
+    await completeCloudSignIn({ ...base, documentId: 'doc-9' });
+
+    expect(h.ensureCollabSessionForDoc).toHaveBeenCalledWith('doc-9');
   });
 
   it('opens the live session only for a known relay doc', async () => {

--- a/src/api/completeCloudSignIn.ts
+++ b/src/api/completeCloudSignIn.ts
@@ -80,7 +80,17 @@ export async function completeCloudSignIn(args: CompleteCloudSignInArgs): Promis
   // `restUrlToWsUrl` from here).
   if (documentId) {
     const record = useDocumentRegistry.getState().getRecord(documentId);
-    if (record && (record.type === 'remote' || record.type === 'cached')) {
+    // A live collab engine for this exact doc also makes it a confirmed relay doc:
+    // the engine only ever exists for relay docs (local docs never get one, JP-64),
+    // and an expired-session boot brings the active doc up engine-only BEFORE its
+    // registry record loads (warmupCache stores content, not a record; the REST list
+    // re-fetch is async). Without this the active doc stayed offline until a manual
+    // doc switch (JP-392). Lazy import mirrors the ensureCollabSession import below.
+    const { useCollaborationStore } = await import('../collaboration/collaborationStore');
+    const collab = useCollaborationStore.getState();
+    const engineLiveForDoc = collab.isActive && collab.config?.documentId === documentId;
+    const knownRelayDoc = record !== undefined && (record.type === 'remote' || record.type === 'cached');
+    if (engineLiveForDoc || knownRelayDoc) {
       const { ensureCollabSessionForDoc } = await import('../collaboration/ensureCollabSession');
       await ensureCollabSessionForDoc(documentId);
     }

--- a/src/collaboration/ensureCollabSession.test.ts
+++ b/src/collaboration/ensureCollabSession.test.ts
@@ -60,6 +60,34 @@ describe('ensureCollabSessionForDoc', () => {
     expect(collab.startSession).not.toHaveBeenCalled();
   });
 
+  it('JP-392: restarts a token-less same-doc session once a valid token is available', async () => {
+    // Boot opened the active doc engine-only (expired session → no token, no WS
+    // provider). The user then signs in, so connectionStore now holds a valid
+    // token. Re-running ensure for the SAME doc must force-restart it (carrying the
+    // fresh token via switchDocument) so the WS provider attaches — not no-op,
+    // which is what left the active doc offline until a manual doc switch.
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-9', serverUrl: 'ws://relay.example:9876/ws' }; // no token
+    useConnectionStore.getState().setToken('fresh-token', Date.now() + 60_000);
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.switchDocument).toHaveBeenCalledWith('doc-9');
+  });
+
+  it('JP-392: does NOT restart an already-online same-doc session (provider attached)', async () => {
+    // config.token set → provider already live. Must stay a no-op so we never tear
+    // down a provider whose callback may be running (the on-connect reattach path).
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-9', serverUrl: 'ws://relay.example:9876/ws', token: 'live' };
+    useConnectionStore.getState().setToken('fresh-token', Date.now() + 60_000);
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.switchDocument).not.toHaveBeenCalled();
+    expect(collab.startSession).not.toHaveBeenCalled();
+  });
+
   it('switches the engine when active for a different doc', async () => {
     collab.isActive = true;
     collab.config = { documentId: 'doc-1', serverUrl: 'ws://x/ws', token: 't' };

--- a/src/collaboration/ensureCollabSession.ts
+++ b/src/collaboration/ensureCollabSession.ts
@@ -100,8 +100,22 @@ export async function ensureCollabSessionForDoc(docId: string): Promise<void> {
 
   const collab = useCollaborationStore.getState();
 
-  // Already the live engine for this doc.
-  if (collab.isActive && collab.config?.documentId === docId) return;
+  // Already the live engine for this doc. If it came up engine-only (no WS provider —
+  // started before a token was available, e.g. an expired-session boot) and a valid
+  // token is now available — the user just signed in (JP-392) — force-restart it WITH
+  // the token so the provider attaches, instead of leaving the active doc offline
+  // until a manual doc switch. switchDocument re-keys the same `host:docId` room and
+  // carries the freshest connectionStore token. Otherwise no-op: an already-online
+  // session must not be torn down here (the on-connect reattach calls this for the
+  // doc whose provider callback is running).
+  const active = collab.config;
+  if (collab.isActive && active && active.documentId === docId) {
+    const conn = useConnectionStore.getState();
+    if (!active.token && conn.token && conn.isTokenValid()) {
+      collab.switchDocument(docId);
+    }
+    return;
+  }
 
   // A local-only doc must never get a CRDT engine (it would emit a JOIN_DOC the
   // relay rejects, and risks a cross-client leak — see JP-64). Unknown records


### PR DESCRIPTION
## Problem (JP-392, Urgent)

Open the app, it shows "session expired", you sign in — but the document you're **already looking at** stays offline. You have to switch to another doc and back before it goes online.

## Root cause — two gaps on the sign-in → active-doc path

Boot with an expired token brings the last relay doc up **engine-only** (Y.Doc + `y-indexeddb`, no token → `startSession` skips the WS provider). Then signing in (`completeCloudSignIn({ documentId })`) failed to bring it online because:

1. **`ensureCollabSession.ts`** no-op'd for the same doc (`collab.config?.documentId === docId`) without noticing the live session was token-less and a valid token was now available — so the provider never attached.
2. **`completeCloudSignIn.ts`** only reopened the session when the doc had a `remote`/`cached` registry record. A boot-cached doc registers content but **no record** (`warmupCache`), and the REST list re-fetch is async — so `getRecord` was `undefined` and the reopen was skipped entirely.

Switching docs worked because that path routes through `switchDocument`, which force-restarts carrying the freshest `connectionStore` token. The same-doc path never reached it.

## Fix

- **`ensureCollabSession.ts`**: when the active same-doc session is engine-only (`!config.token`) and a valid token is now available, force-restart via the existing `switchDocument(docId)` so the provider attaches. An already-online session still no-ops (don't tear down a provider mid-callback).
- **`completeCloudSignIn.ts`**: also treat a **live collab engine for the doc** as proof it's a relay doc (local docs never get an engine, JP-64) — reopening even when the registry record hasn't loaded yet. Local/unknown ids with no live engine still skip (no phantom `JOIN_DOC`).

No wire/protocol/document-format change.

## Tests

Repro-first (red → green): added failing unit tests for both gaps before fixing.
- `ensureCollabSession.test.ts`: token-less same-doc session restarts on a fresh token; already-online session does not.
- `completeCloudSignIn.test.ts`: live engine + missing record still reopens.

`bun run typecheck` clean; full suite **2710 passed**.

## Verification (manual E2E, needs deploy)

Boot with an expired token → "session expired" notice → sign in → the currently-open relay doc goes online **without** switching docs.

Assisted-by: Opus 4.8