### PR TITLE
docs: PWA-first install/intro, stop advertising unreleased desktop binaries

### DIFF
--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -1,42 +1,39 @@
 ---
 title: Installation
-description: Install DocuShark as a desktop app (Windows, macOS, Linux) or run it directly in your browser.
+description: Run DocuShark right in your browser, or build the desktop app from source.
 ---
 
 # Installation
 
-DocuShark can be installed as a desktop application or run directly in your browser.
+DocuShark runs right in your browser — no installation required — and can also be built as a
+desktop application from source. Both share the same editor and the same features.
 
-## Desktop Application (Recommended)
+## Run in Your Browser (Recommended)
 
-The desktop version provides the best performance and full feature access including native file system integration.
+Open [app.docushark.app](https://app.docushark.app) and start working immediately — there's
+nothing to install, and you always have the latest version. Local documents stay in your
+browser and keep working offline.
 
-### Windows
+Most browsers also let you **install** DocuShark so it opens in its own window and lives in your
+dock, taskbar, or home screen:
 
-1. Download the latest `.msi` or `.exe` installer from the [releases page](https://github.com/JPE-Net-Technologies/docushark/releases)
-2. Run the installer and follow the prompts
-3. Launch DocuShark from the Start menu
+- **Chrome / Edge** — click the install icon in the address bar, or use the in-app **Install** prompt.
+- **Safari (macOS)** — File → Add to Dock.
+- **iOS / Android** — Share → Add to Home Screen.
 
-### Linux
+## Desktop Application
 
-**AppImage (Universal)**
-```bash
-chmod +x DocuShark-*.AppImage
-./DocuShark-*.AppImage
-```
+DocuShark can also run as a native desktop application (Windows, Linux, macOS) built with Tauri,
+with native file-system integration. It has the same features as the browser version.
 
-**Debian/Ubuntu (.deb)**
-```bash
-sudo dpkg -i docushark_*.deb
-```
-
-### macOS
-
-There are no pre-built macOS binaries yet. You can build from source — it only takes a few minutes. See the instructions below.
+Pre-built signed installers aren't published yet, so the desktop app is currently built from
+source — it only takes a few minutes on any platform. See [Building from Source](#building-from-source)
+below.
 
 ## Building from Source
 
-Building from source is straightforward on all platforms. macOS users — this is your primary installation path.
+Building from source is straightforward on all platforms, and is currently the way to get the
+desktop app.
 
 ### Prerequisites
 

--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -19,9 +19,9 @@ Many browser-based diagram tools start to struggle as a diagram grows. DocuShark
 - Instant shape selection and manipulation
 - No lag, no waiting, no frustration
 
-### Desktop & Web
+### Web & Desktop
 
-DocuShark runs as a **native desktop application** (Windows, Linux, macOS) using Tauri, giving you native file system access and system-level performance. It also works right in your browser for quick access without installation.
+DocuShark runs right in your browser — open it, install it as a PWA, and you always have the latest version. It also builds as a **native desktop application** (Windows, Linux, macOS) using Tauri, with native file-system access. You get the same editor and the same features either way.
 
 ### Real-time Collaboration
 
@@ -64,7 +64,7 @@ Plus, you can create and share your own **custom shape libraries**.
 
 This documentation is organized to help you get productive quickly:
 
-1. **[Installation](./installation)** — Download or build DocuShark
+1. **[Installation](./installation)** — Run DocuShark in your browser, or build it
 2. **[Quick Start](./quick-start)** — Create your first diagram in under five minutes
 3. **[Interface Tour](./interface-tour)** — Learn what every part of the screen does
 


### PR DESCRIPTION
## Why

The Getting Started docs led with **"Desktop Application (Recommended)"**, claimed the desktop build gives **"best performance and full feature access"**, and handed out `.msi`/`.exe`/`.deb`/AppImage **download links for binaries that aren't published**. The native desktop app isn't shipped as a signed/pre-built artifact yet, and the browser PWA has the same features (and, without WebKitGTK, is actually quicker).

## What

- **`installation.md`** — leads with **"Run in Your Browser (Recommended)"** (`app.docushark.app`, installable as a PWA with per-browser instructions). Removes the "best performance / full feature access" claim and the dead pre-built download steps. Desktop is now framed as build-from-source for all platforms (pre-built signed installers aren't published yet).
- **`introduction.md`** — reframes the "Desktop & Web" section as web-first, drops "system-level performance", and states feature parity either way.

Pure docs/content; no commercial/pricing leakage (OSS leak grep clean). VitePress build passes.

Assisted-by: Opus 4.8