### PR TITLE
feat(pwa): one-time "Install DocuShark" hint in the browser

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './ui/App';
 import { registerPwa } from './pwa/registerPwa';
+import { initInstallPrompt } from './pwa/installPrompt';
 import { handleAuthCallbackIfPresent } from './api/authCallback';
 import './index.css';
 // Adaptive motion budget (JP-101): also boots adaptiveBudget's device sampling
@@ -37,6 +38,10 @@ function mountApp(authCallbackConsumed: boolean): void {
   // Register the service worker. No-op in the Tauri build, where the PWA plugin
   // is disabled and `registerSW` is a stub.
   registerPwa();
+
+  // Offer a one-time "Install DocuShark" hint when the browser reports the app
+  // as installable. No-op in the Tauri build and once installed/dismissed.
+  initInstallPrompt();
 }
 
 // Intercept the PWA web one-click handoff (`/auth/callback?handoff_code=…`)

--- a/src/pwa/installPrompt.test.ts
+++ b/src/pwa/installPrompt.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the PWA install hint (src/pwa/installPrompt.ts).
+ *
+ * Verifies the one-time toast surfaces only when the browser reports the app as
+ * installable, is suppressed once seen / when already installed standalone, and
+ * that its action fires the browser's native install prompt.
+ */
+
+import { initInstallPrompt } from './installPrompt';
+import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+interface FakePromptEvent extends Event {
+  prompt: ReturnType<typeof vi.fn>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+/** Dispatch a fake `beforeinstallprompt` and return the event (with its spy). */
+function fireBeforeInstallPrompt(outcome: 'accepted' | 'dismissed' = 'accepted'): FakePromptEvent {
+  const event = new Event('beforeinstallprompt') as FakePromptEvent;
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome, platform: 'web' });
+  window.dispatchEvent(event);
+  return event;
+}
+
+/** Toggle the legacy iOS standalone flag (matchMedia is stubbed always-false). */
+function setStandalone(value: boolean): void {
+  Object.defineProperty(window.navigator, 'standalone', { value, configurable: true });
+}
+
+describe('installPrompt', () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    useNotificationStore.getState().dismissAll();
+    useUIPreferencesStore.setState({ installAppHintSeen: false });
+    setStandalone(false);
+    dispose = initInstallPrompt();
+  });
+
+  afterEach(() => {
+    dispose();
+    setStandalone(false);
+  });
+
+  it('surfaces a one-time Install toast when the browser reports installable', () => {
+    fireBeforeInstallPrompt();
+
+    const notes = useNotificationStore.getState().notifications;
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.actionLabel).toBe('Install');
+    expect(notes[0]?.message).toContain('Install DocuShark');
+    expect(notes[0]?.duration).toBe(0); // manual dismiss only
+    // Marked seen so it won't nag again.
+    expect(useUIPreferencesStore.getState().installAppHintSeen).toBe(true);
+  });
+
+  it('does not re-show after it has been seen', () => {
+    useUIPreferencesStore.setState({ installAppHintSeen: true });
+    fireBeforeInstallPrompt();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it('does not show when already running as an installed standalone PWA', () => {
+    setStandalone(true);
+    fireBeforeInstallPrompt();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    // Not marked seen — the user never saw a hint.
+    expect(useUIPreferencesStore.getState().installAppHintSeen).toBe(false);
+  });
+
+  it('suppresses repeat prompts within a session', () => {
+    fireBeforeInstallPrompt();
+    fireBeforeInstallPrompt();
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it('fires the native prompt when the Install action is invoked', async () => {
+    const event = fireBeforeInstallPrompt();
+    const note = useNotificationStore.getState().notifications[0];
+    expect(note?.onAction).toBeTypeOf('function');
+
+    note?.onAction?.();
+    // onAction kicks off promptInstall() asynchronously.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(event.prompt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pwa/installPrompt.ts
+++ b/src/pwa/installPrompt.ts
@@ -1,0 +1,101 @@
+/**
+ * "Install DocuShark" PWA hint — web build only.
+ *
+ * Chromium-family browsers fire `beforeinstallprompt` once the app meets the
+ * installability criteria. We intercept it, stash the deferred event, and offer
+ * a one-time, dismissible toast with an **Install** action that triggers the
+ * browser's native install prompt. This is the in-app counterpart to the
+ * "install it in a click" copy on the marketing site.
+ *
+ * Shown at most once per browser (a persisted flag), never when already running
+ * as an installed standalone PWA, and never in the Tauri build (desktop has no
+ * install concept — it tree-shakes out via `IS_TAURI`).
+ *
+ * iOS Safari doesn't fire `beforeinstallprompt` (install is a manual
+ * Share → Add to Home Screen), so those users get no toast here; an iOS
+ * instructions hint is a possible follow-up.
+ */
+
+import { IS_TAURI } from '../platform/runtime';
+import { readBreakpointState } from '../ui/layout/useBreakpoint';
+import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+/**
+ * Minimal type for the non-standard install-prompt event — it isn't in TS's DOM
+ * lib, and the codebase bans `any`.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt(): Promise<void>;
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+/** The most recent deferred prompt, captured until the user acts on it. */
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+
+/** Fire the stashed native install prompt, then forget it (single-use). */
+async function promptInstall(): Promise<void> {
+  const event = deferredPrompt;
+  deferredPrompt = null;
+  if (!event) return;
+  await event.prompt();
+  // `userChoice` resolves once the user accepts/dismisses. We don't branch on it
+  // (the `appinstalled` listener covers the accepted case); awaiting just avoids
+  // an unhandled rejection if the browser rejects the prompt.
+  await event.userChoice.catch(() => undefined);
+}
+
+/** Surface the hint once, if eligible. */
+function maybeShowHint(): void {
+  if (!deferredPrompt) return;
+  if (readBreakpointState().standalone) return; // already installed
+  // The persisted flag is the cross-load + re-fire guard: it's set synchronously
+  // below, so a second `beforeinstallprompt` in the same session is suppressed.
+  if (useUIPreferencesStore.getState().installAppHintSeen) return;
+
+  // Mark seen on show so the nudge appears at most once per browser, whether the
+  // user installs or simply dismisses it.
+  useUIPreferencesStore.getState().markInstallAppHintSeen();
+  useNotificationStore
+    .getState()
+    .info('Install DocuShark — it opens in its own window and works offline.', {
+      category: 'permanent',
+      duration: 0,
+      actionLabel: 'Install',
+      onAction: () => {
+        void promptInstall();
+      },
+    });
+}
+
+/**
+ * Attach the install-prompt listeners. Call once at boot (web build only).
+ * Returns a disposer that detaches them (used by tests; the app ignores it).
+ * Safe under jsdom — it only registers `window` listeners.
+ */
+export function initInstallPrompt(): () => void {
+  if (IS_TAURI || typeof window === 'undefined') return () => {};
+
+  const onBeforeInstallPrompt = (event: Event): void => {
+    // Suppress Chrome's default mini-infobar so our toast is the single entry point.
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    maybeShowHint();
+  };
+  const onAppInstalled = (): void => {
+    deferredPrompt = null;
+    // Never nag after a successful install.
+    if (!useUIPreferencesStore.getState().installAppHintSeen) {
+      useUIPreferencesStore.getState().markInstallAppHintSeen();
+    }
+  };
+
+  window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+  window.addEventListener('appinstalled', onAppInstalled);
+
+  return () => {
+    window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    window.removeEventListener('appinstalled', onAppInstalled);
+  };
+}

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -129,6 +129,11 @@ export interface UIPreferencesState {
    * Cloud workspace connect. Persisted so it fires at most once per browser.
    */
   storageInfoToastSeen: boolean;
+  /**
+   * Whether the one-time "install DocuShark" PWA hint has been shown/dismissed.
+   * Persisted so the install toast nags at most once per browser. Web-only.
+   */
+  installAppHintSeen: boolean;
   /** Layout manager slice — modes, per-doc memory, per-mode overrides, chrome. */
   layout: LayoutState;
   /** Appearance slice — accent + motion (theme is in `themeStore`). */
@@ -182,6 +187,8 @@ export interface UIPreferencesActions {
   toggleDocumentBrowserGroupCollapsed: (collectionId: string) => void;
   /** Record that the one-time storage-info toast has been shown. */
   markStorageInfoToastSeen: () => void;
+  /** Record that the one-time install-app PWA hint has been shown/dismissed. */
+  markInstallAppHintSeen: () => void;
   /** Accept (or clear) the experimental mobile-preview layout. */
   setMobilePreviewAccepted: (accepted: boolean) => void;
   /** Force the desktop layout on a touch device (mobile-preview opt-out). */
@@ -311,6 +318,7 @@ const initialState: UIPreferencesState = {
   documentBrowserGroupBy: 'none',
   documentBrowserCollapsed: {},
   storageInfoToastSeen: false,
+  installAppHintSeen: false,
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
   collabIndicatorPos: null,
@@ -456,6 +464,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       markStorageInfoToastSeen: () => set({ storageInfoToastSeen: true }),
 
+      markInstallAppHintSeen: () => set({ installAppHintSeen: true }),
+
       setMobilePreviewAccepted: (accepted) => set({ mobilePreviewAccepted: accepted }),
       setForceDesktopSite: (force) => set({ forceDesktopSite: force }),
 
@@ -593,7 +603,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 11,
+      version: 12,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -604,6 +614,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         documentBrowserGroupBy: state.documentBrowserGroupBy,
         documentBrowserCollapsed: state.documentBrowserCollapsed,
         storageInfoToastSeen: state.storageInfoToastSeen,
+        installAppHintSeen: state.installAppHintSeen,
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
         collabIndicatorPos: state.collabIndicatorPos,
@@ -738,6 +749,11 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         if (fromVersion < 11) {
           next['mobilePreviewAccepted'] = next['mobilePreviewAccepted'] ?? false;
           next['forceDesktopSite'] = next['forceDesktopSite'] ?? false;
+        }
+        // v11 → v12: added the one-time install-app PWA hint flag. Default false
+        // (never shown) so existing users get the hint once, like a new install.
+        if (fromVersion < 12) {
+          next['installAppHintSeen'] = next['installAppHintSeen'] ?? false;
         }
         return next as unknown as UIPreferencesState;
       },


### PR DESCRIPTION
## Why

The marketing site already tells users they can *"install it in a click,"* but the editor had **zero** install handling — no `beforeinstallprompt`, no install button. Now that we're steering users to the PWA over the (unreleased) desktop app, browser users should have a clear, non-nagging way to install it.

## What

- **`src/pwa/installPrompt.ts`** — intercepts the Chromium `beforeinstallprompt` event, stashes the deferred prompt, and surfaces a dismissible toast (via the existing `notificationStore`, mirroring the SW-update toast) with an **Install** action that fires the browser's native prompt.
  - Web-only (`IS_TAURI` guard — tree-shaken on desktop).
  - Suppressed when already running standalone (`readBreakpointState().standalone`) and at most **once per browser** (persisted flag).
  - `appinstalled` clears state. Returns a disposer.
- **`main.tsx`** — init alongside `registerPwa()`.
- **`uiPreferencesStore`** — `installAppHintSeen` + `markInstallAppHintSeen`, persisted; store **v11 → v12** with an idempotent migration (defaults false).
- **`installPrompt.test.ts`** — shows once; suppressed when seen / standalone; the action fires the native prompt.

## Notes / scope

- iOS Safari doesn't fire `beforeinstallprompt` (install is a manual Share → Add to Home Screen) — not handled here; a manual iOS hint is a possible follow-up.

## Verification

`bun run typecheck` ✓ · full `bun run test --run` (2715 tests) ✓ · `bun run build` ✓ (SW generated). Forcing the prompt via DevTools → Application is the user's browser-side check.

Assisted-by: Opus 4.8