### PR TITLE
fix(collab): build collab prose editor off-render to stop setState-in-render warning

### DIFF
--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -101,6 +101,14 @@ export function CollaborativeProseEditor({
         ...collaborationCursor,
       ],
       editable: !readOnly,
+      // Build the editor in a commit-phase effect, not during render. Tiptap's
+      // default constructs the editor inside render; here that synchronously sets
+      // local Yjs awareness (via CollaborationCursor), which fires the awareness
+      // listener that writes collaborationStore.remoteUsers — a setState during
+      // render that React flags ("Cannot update FloatingCollabIndicator while
+      // rendering CollaborativeProseEditor"). Deferring construction keeps render
+      // pure. The component already handles `editor === null` on first render.
+      immediatelyRender: false,
       // No initial `content`: the relay is the sole prose seeder (JP-284), so the
       // editor adopts the bound fragment. Passing content would inject a second
       // prose lineage that merges into the fragment and duplicates content.


### PR DESCRIPTION
## Why

In a live collab prose session the console warns:

> Cannot update a component (`FloatingCollabIndicator`) while rendering a different component (`CollaborativeProseEditor`).

### Root cause

`@tiptap/react`'s `useEditor` constructs the editor **during render** by default (`getInitialEditor()` calls `createEditor()` in the `useState` initializer on the client). For `CollaborativeProseEditor` that construction adds the `CollaborationCursor` extension, whose y-prosemirror plugin **synchronously sets local Yjs awareness** on init. That awareness event runs the subscription in `collaborationStore.ts` (`onAwarenessChange → _updateRemoteUsers → set({ remoteUsers })`). Since `FloatingCollabIndicator` subscribes to `collaborationStore` (`isActive` / `remoteUsers`), the store write lands **while `CollaborativeProseEditor` is mid-render** → React's warning.

Harmless at runtime (React applies the update next tick), but it's a genuine impurity: a side-effectful editor that mutates shared awareness is being built during render.

## Fix

Add **`immediatelyRender: false`** to the `useEditor` options. The editor (and its awareness mutation) is then created in a commit-phase effect, where side effects belong, so the store write no longer happens during render. The component already handles `editor === null` on first render (the documented offline state), and the local-only `TiptapEditor` has no awareness, so it was never affected.

(Considered deferring the store propagation with `queueMicrotask` instead — valid defense-in-depth, but it treats the symptom and taxes every presence update, rather than fixing the impure-render cause.)

## Verification

`bun run typecheck` ✓ · full `bun run test --run` (2715 tests, incl. `collaborationStore.test.ts`) ✓. The warning's disappearance is a live-collab check.

Assisted-by: Opus 4.8