### PR TITLE
JP-378: relay endpoint to purge a member's document shares

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -236,6 +236,10 @@ fn parse_doc_path(id: String) -> Result<DocId, axum::response::Response> {
 pub fn routes() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/api/v1/internal/revoke", post(revoke_handler))
+        .route(
+            "/api/v1/internal/workspace/:ws/purge-member",
+            post(purge_member_handler),
+        )
         .route("/api/v1/usage", get(usage_handler))
         .route("/api/v1/blobs/:hash/upload-url", post(blob_upload_url_handler))
         .route("/api/v1/blobs/:hash/finalize", post(blob_finalize_handler))
@@ -432,6 +436,82 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
         diff |= x ^ y;
     }
     diff == 0
+}
+
+/// Body for `POST /api/v1/internal/workspace/:ws/purge-member`.
+#[derive(Deserialize)]
+struct PurgeMemberRequest {
+    user_id: String,
+}
+
+/// `POST /api/v1/internal/workspace/:ws/purge-member` — drop a single user's
+/// share grants (`sharedWith`) from every document in the workspace. A generic
+/// control-plane hook: the relay is handed a workspace id + user id and knows
+/// nothing about *why* the grants are being dropped. Gated by the same shared
+/// bearer as the revocation push (`revocation_push_bearer`), constant-time
+/// compared. Idempotent — re-running for the same user is a no-op.
+async fn purge_member_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(ws): Path<String>,
+    Json(body): Json<PurgeMemberRequest>,
+) -> impl IntoResponse {
+    let expected = match state.revocation_push_bearer() {
+        Some(s) => s.to_string(),
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiError::body("internal control-plane transport disabled"),
+            )
+                .into_response();
+        }
+    };
+    let presented = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::trim)
+        .unwrap_or("");
+    if !constant_time_eq(presented.as_bytes(), expected.as_bytes()) {
+        return (StatusCode::UNAUTHORIZED, ApiError::body("unauthorized")).into_response();
+    }
+
+    // Same path-traversal validation the OIDC workspace claim goes through —
+    // a forged `"../etc"` is rejected here rather than reaching `doc_path`.
+    let ws = match WorkspaceId::from_configured(&ws) {
+        Some(w) => w,
+        None => {
+            return (StatusCode::BAD_REQUEST, ApiError::body("invalid workspace id"))
+                .into_response();
+        }
+    };
+
+    // Cold-pod safety: a recycled machine may hold an empty in-memory index —
+    // repopulate from R2 first so the purge sees the workspace's documents.
+    state.ensure_workspace_index_local(&ws).await;
+
+    let purged = match state
+        .doc_store()
+        .purge_user_from_workspace_shares(&ws, &body.user_id)
+    {
+        Ok(ids) => ids,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
+    };
+
+    // Notify connected clients (e.g. a workspace owner with the doc or list
+    // open) so the dropped grant disappears without a manual refresh. No JWT
+    // subject on an internal call → actor `None`.
+    for doc_id in &purged {
+        state.emit_doc_event(&ws, doc_id, DocEventType::Updated, None);
+    }
+
+    log::info!(
+        "purge-member: workspace {} purged user from {} document(s)",
+        ws.as_str(),
+        purged.len()
+    );
+
+    (StatusCode::OK, Json(json!({ "purged": purged.len() }))).into_response()
 }
 
 // ============ Document CRUD handlers ============

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -1813,6 +1813,80 @@ impl DocumentStore {
         Ok(())
     }
 
+    /// Drop a single user's share grant (`sharedWith`) from every document in a
+    /// workspace. For each document that currently shares with `user_id`, the
+    /// entry is removed and the remaining grants are kept verbatim — including
+    /// their original `sharedAt` (unlike [`update_document_shares`], which
+    /// rebuilds the whole list with a fresh timestamp). Documents the user was
+    /// never shared on are left untouched (no version bump, no R2 write).
+    /// Ownership (`owner_id`) is never affected. Returns the ids of the
+    /// documents actually modified.
+    pub fn purge_user_from_workspace_shares(
+        &self,
+        ws: &WorkspaceId,
+        user_id: &str,
+    ) -> Result<Vec<DocId>, String> {
+        // Narrow to candidates using the in-memory index: only documents whose
+        // metadata already lists this user are worth loading from disk.
+        let candidates: Vec<DocId> = self
+            .list_documents(ws)
+            .into_iter()
+            .filter(|m| {
+                m.shared_with
+                    .as_ref()
+                    .map(|s| s.iter().any(|e| e.user_id == user_id))
+                    .unwrap_or(false)
+            })
+            .map(|m| m.id)
+            .collect();
+
+        let mut purged = Vec::new();
+        for doc_id in candidates {
+            let mut doc = match self.get_document(ws, &doc_id) {
+                Ok(d) => d,
+                Err(e) => {
+                    log::warn!(
+                        "purge-member: skip {}/{}: {}",
+                        ws.as_str(),
+                        doc_id.as_str(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            // Re-read the body's shares (authoritative over the index snapshot)
+            // and drop the target user, keeping every other grant verbatim.
+            let existing: Vec<DocumentShare> = doc
+                .get("sharedWith")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            let before = existing.len();
+            let kept: Vec<DocumentShare> = existing
+                .into_iter()
+                .filter(|e| e.user_id != user_id)
+                .collect();
+            // Index said this doc shared with the user but the body disagrees
+            // (stale index) — nothing to write, skip to avoid a needless bump.
+            if kept.len() == before {
+                continue;
+            }
+
+            doc["sharedWith"] = serde_json::to_value(&kept)
+                .map_err(|e| format!("Failed to serialize shares: {}", e))?;
+            self.save_document(ws, doc)?;
+            log::info!(
+                "purge-member: dropped a share grant from {}/{} ({} grants remain)",
+                ws.as_str(),
+                doc_id.as_str(),
+                kept.len()
+            );
+            purged.push(doc_id);
+        }
+
+        Ok(purged)
+    }
+
     /// Set (or clear, with `None`) a document's collection membership. A document
     /// belongs to at most one collection; passing a new id reassigns it, `None`
     /// unassigns it. Writes `collectionId` onto the body and saves through the

--- a/relay/tests/purge_member_shares.rs
+++ b/relay/tests/purge_member_shares.rs
@@ -1,0 +1,223 @@
+//! JP-378 — auto-revoke a member's document shares, over the real REST surface.
+//!
+//! `POST /api/v1/internal/workspace/:ws/purge-member` drops a single user's
+//! `sharedWith` grant from every document in the workspace. It is a generic,
+//! membership-agnostic control-plane hook gated by the same shared bearer as the
+//! revocation push (`revocation_push_bearer`). These tests exercise:
+//!
+//!   * the user is removed from every doc that shared with them, while other
+//!     grants are kept verbatim — including their original `sharedAt`;
+//!   * a doc the user was never shared on is left untouched (no version bump);
+//!   * the bearer gate: wrong bearer → 401, transport disabled → 503;
+//!   * a malformed workspace id → 400 (the path-traversal guard).
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const PUSH_BEARER: &str = "test-purge-bearer";
+
+/// In-process relay in shared-tenancy mode. `bearer` is the control-plane push
+/// secret — set *before* `start()` so it's captured into `ServerState`. Pass
+/// `None` to leave the internal transport disabled (503 path).
+async fn start_relay(
+    bearer: Option<&str>,
+) -> (Arc<WebSocketServer>, String, OidcTestIssuer, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_revocation_push_bearer(bearer.map(str::to_string))
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+
+    (server, http, issuer, tmp)
+}
+
+/// One share grant in `sharedWith` (camelCase, matching `DocumentShare`).
+fn share(user_id: &str, permission: &str, shared_at: u64) -> Value {
+    json!({
+        "userId": user_id,
+        "userName": user_id,
+        "permission": permission,
+        "sharedAt": shared_at,
+    })
+}
+
+/// Seed a document via the REST save handler with the given `sharedWith` array.
+async fn save_doc(http: &str, token: &str, id: &str, shares: Vec<Value>) {
+    let status = reqwest::Client::new()
+        .put(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .json(&json!({
+            "id": id,
+            "name": id,
+            "ownerId": "owner-1",
+            "sharedWith": shares,
+        }))
+        .send()
+        .await
+        .expect("save request")
+        .status();
+    assert_eq!(status, reqwest::StatusCode::OK, "seed save for {id} failed");
+}
+
+/// Fetch a document body.
+async fn get_doc(http: &str, token: &str, id: &str) -> Value {
+    reqwest::Client::new()
+        .get(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("get request")
+        .json()
+        .await
+        .expect("get json")
+}
+
+/// The set of user ids currently in a doc's `sharedWith`.
+fn shared_user_ids(doc: &Value) -> Vec<String> {
+    doc.get("sharedWith")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e.get("userId").and_then(|u| u.as_str()).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn purge(
+    http: &str,
+    bearer: &str,
+    ws: &str,
+    user_id: &str,
+) -> (reqwest::StatusCode, Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("{http}/api/v1/internal/workspace/{ws}/purge-member"))
+        .bearer_auth(bearer)
+        .json(&json!({ "user_id": user_id }))
+        .send()
+        .await
+        .expect("purge request");
+    let status = resp.status();
+    let body = resp.json().await.unwrap_or(Value::Null);
+    (status, body)
+}
+
+#[tokio::test]
+async fn purge_removes_user_everywhere_and_keeps_other_grants_verbatim() {
+    let (_server, http, issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    let owner = issuer.mint("owner-1", "alpha", WorkspaceRole::Owner);
+
+    // doc1: shared with X (edit) and Y (view, sharedAt=222); doc2: X only;
+    // doc3: Y only (X never on it → must be left untouched, no version bump).
+    save_doc(&http, &owner, "doc1", vec![
+        share("user-x", "edit", 111),
+        share("user-y", "view", 222),
+    ]).await;
+    save_doc(&http, &owner, "doc2", vec![share("user-x", "view", 333)]).await;
+    save_doc(&http, &owner, "doc3", vec![share("user-y", "edit", 444)]).await;
+
+    let doc3_before = get_doc(&http, &owner, "doc3").await;
+    let doc3_ver_before = doc3_before.get("serverVersion").cloned();
+
+    let (status, body) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["purged"], json!(2), "should have touched exactly doc1 + doc2");
+
+    // doc1: X gone, Y retained with its ORIGINAL sharedAt (not rebuilt to `now`).
+    let doc1 = get_doc(&http, &owner, "doc1").await;
+    assert_eq!(shared_user_ids(&doc1), vec!["user-y".to_string()]);
+    let y = &doc1["sharedWith"][0];
+    assert_eq!(y["sharedAt"], json!(222), "remaining grant's timestamp must be preserved");
+    assert_eq!(y["permission"], json!("view"));
+
+    // doc2: X was the only grant → now empty.
+    let doc2 = get_doc(&http, &owner, "doc2").await;
+    assert!(shared_user_ids(&doc2).is_empty());
+
+    // doc3: untouched — Y still present and serverVersion unchanged (no save).
+    let doc3 = get_doc(&http, &owner, "doc3").await;
+    assert_eq!(shared_user_ids(&doc3), vec!["user-y".to_string()]);
+    assert_eq!(
+        doc3.get("serverVersion").cloned(),
+        doc3_ver_before,
+        "a doc the user was never shared on must not be re-saved"
+    );
+}
+
+#[tokio::test]
+async fn purge_is_idempotent() {
+    let (_server, http, issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    let owner = issuer.mint("owner-1", "alpha", WorkspaceRole::Owner);
+    save_doc(&http, &owner, "doc1", vec![share("user-x", "edit", 111)]).await;
+
+    let (s1, b1) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(s1, reqwest::StatusCode::OK);
+    assert_eq!(b1["purged"], json!(1));
+
+    // Second run: nothing left to drop.
+    let (s2, b2) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(s2, reqwest::StatusCode::OK);
+    assert_eq!(b2["purged"], json!(0));
+}
+
+#[tokio::test]
+async fn purge_rejects_wrong_bearer() {
+    let (_server, http, issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    let owner = issuer.mint("owner-1", "alpha", WorkspaceRole::Owner);
+    save_doc(&http, &owner, "doc1", vec![share("user-x", "edit", 111)]).await;
+
+    let (status, _) = purge(&http, "not-the-bearer", "alpha", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+
+    // The grant is untouched after the rejected call.
+    let doc1 = get_doc(&http, &owner, "doc1").await;
+    assert_eq!(shared_user_ids(&doc1), vec!["user-x".to_string()]);
+}
+
+#[tokio::test]
+async fn purge_returns_503_when_transport_disabled() {
+    // No push bearer configured → the internal endpoint is unavailable.
+    let (_server, http, _issuer, _tmp) = start_relay(None).await;
+    let (status, _) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn purge_rejects_malformed_workspace_id() {
+    let (_server, http, _issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    // "a..b" is a single valid URL segment but fails workspace-id validation
+    // (contains ".."), so it never reaches the document store as a path.
+    let (status, _) = purge(&http, PUSH_BEARER, "a..b", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## What

Adds `POST /api/v1/internal/workspace/:ws/purge-member` — a generic, bearer-gated control-plane endpoint that drops a single user's `sharedWith` grant from **every** document in a workspace.

Per-document share grants were never cleaned up when a user's access to a workspace ended, leaving the grant orphaned to a now-external user. This is the relay half of that cleanup (the caller drives *when*; the relay knows only a workspace id + a user id — no membership concept baked in).

## How

- **`documents.rs` — `purge_user_from_workspace_shares`**: narrows to candidate docs via the in-memory index, then for each one re-reads the body's `sharedWith` and retains-out the target user. Preserves the remaining grants' **original `sharedAt`** (unlike `update_document_shares`, which rebuilds the whole list with a fresh timestamp), and skips docs the user was never on (no needless version bump / R2 write). Ownership (`owner_id`) is never touched.
- **`api.rs` — `purge_member_handler`**: mirrors `revoke_handler` — constant-time compare against the existing `revocation_push_bearer` secret (503 when unset, 401 on mismatch), `WorkspaceId::from_configured` path-traversal validation (400), cold-pod index repopulation, emits `DocEvent::Updated` per touched doc so a connected owner refreshes, returns `{ "purged": N }`.
- Reuses the existing `revocation_push_bearer` / `RELAY_REVOCATION_BEARER` secret — **no new config**.

## Tests

`relay/tests/purge_member_shares.rs` — purge-everywhere + grant retention (original `sharedAt` preserved), untouched-doc has no version bump, idempotency, and the 401 / 503 / 400 gates. All green; `cargo build --bin relay` clean.

Assisted-by: Opus 4.8