### PR TITLE
JP-395: don't fake-delete docs on transient ERR_UNKNOWN_DOC

### DIFF
--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -543,76 +543,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         onDocumentEvent: (event: DocEvent) => {
           useRelayDocumentStore.getState().handleDocumentEvent(event);
         },
-        onError: (error: string, docId: string | null) => {
-          // JP-375: ERR_DELETED is a definitive tombstone — the doc was deleted
-          // (or restored under a new id) on the relay. Strand our local copy to
-          // Trash and leave, so a returning offline editor never merges its stale
-          // Y.Doc back. Only act when we actually hold a copy; a bare unknown id
-          // is a no-op (strandOrDemoteDeletedDoc handles a missing record).
-          if (isDeletedDocError(error) && docId) {
-            const record = useDocumentRegistry.getState().getRecord(docId);
-            if (record) {
-              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
-            }
-            return;
-          }
-          // JP-370: the relay refused the JOIN_DOC with a VIEW denial — we no
-          // longer have read access (un-shared, or removed from the workspace)
-          // while private-doc enforcement is on. The doc isn't deleted globally,
-          // but it's inaccessible to us: keep our local copy (strand to Trash)
-          // so we stop syncing into a doc we can't read. Deliberately narrow to
-          // a view denial — a transient ERR_NOT_AUTHENTICATED (token race) or an
-          // ERR_EDIT_FORBIDDEN (read-only viewer who can still SEE the doc) must
-          // NOT strand a doc the user still legitimately holds. The strand path
-          // owns the single 'access-revoked' toast (no duplicate here).
-          if (isViewForbiddenError(error) && docId) {
-            const record = useDocumentRegistry.getState().getRecord(docId);
-            if (record) {
-              useRelayDocumentStore
-                .getState()
-                .strandOrDemoteDeletedDoc(docId, undefined, 'access-revoked');
-            }
-            return;
-          }
-          // A rejected JOIN_DOC means the relay has no record of this doc in
-          // our workspace (never promoted, deleted, or a diverged local-only
-          // id). Mark it as not-syncing and tell the user their edits are
-          // local-only, rather than letting them edit into the void.
-          if (isUnknownDocError(error) && docId) {
-            const record = useDocumentRegistry.getState().getRecord(docId);
-            const connectedRelayAddress = useConnectionStore.getState().host?.address;
-            if (record && isForeignRelayDoc(record, connectedRelayAddress)) {
-              // JP-308: the doc belongs to a DIFFERENT relay than the one we're
-              // connected to. This relay rejecting the JOIN is expected — the doc
-              // lives on its home relay, it is NOT deleted. Do nothing destructive:
-              // keep the remote record intact (the card derives idle/offline from
-              // the relay mismatch, and edits queue under the doc's home relay for
-              // replay on return — JP-117). Demoting here was the bug.
-            } else if (record && (record.type === 'remote' || record.type === 'cached')) {
-              // The doc's OWN home relay has no record of it — it was deleted,
-              // possibly while we were offline. Converge on the same strand/demote
-              // path as a live Deleted event (JP-175) so the user keeps their copy
-              // instead of editing a ghost into the void. No deleter id (this is
-              // our own rejected JOIN), so it's treated as a foreign deletion
-              // (never self-skipped).
-              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
-            } else if (record?.type === 'local') {
-              // A local-only doc was never meant to sync; a JOIN reject for it is
-              // expected (and should have been gated upstream by shouldJoinDocument
-              // / sign-in staying REST-only). Don't scare the user with a warning.
-            } else {
-              // Diverged / never-promoted id — not a deletion. Keep the gentler
-              // "saved locally only" hint.
-              useDocumentRegistry.getState().setSyncState(docId, 'error');
-              useNotificationStore
-                .getState()
-                .warning(
-                  'This document isn’t syncing — the relay has no record of it. ' +
-                    'Your changes are saved locally only.',
-                );
-            }
-          }
-        },
+        onError: (error: string, docId: string | null) => handleRelayJoinError(error, docId),
         shouldJoinDocument: (docId: string) => {
           // Don't fire a JOIN_DOC for a local-only document; the relay will
           // reject it. Relay docs ('remote') and offline-cached relay docs
@@ -979,6 +910,77 @@ export function useIsRelaySessionLive(): boolean {
   const isActive = useCollaborationStore((s) => s.isActive);
   const isSynced = useCollaborationStore((s) => s.isSynced);
   return authed && isActive && isSynced;
+}
+
+/**
+ * Handle a relay JOIN_DOC error frame. Extracted from the inline provider
+ * `onError` so it's unit-testable (the UnifiedSyncProvider mock discards the
+ * options object). The relay gives three distinct signals:
+ *
+ *   - ERR_DELETED (JP-375): a definitive tombstone — the doc was really deleted
+ *     (or restored under a new id). Strand our local copy to Trash so a returning
+ *     offline editor never merges a stale Y.Doc back.
+ *   - ERR_VIEW_FORBIDDEN (JP-370): read access was revoked (un-shared / removed
+ *     from the workspace). The doc still exists globally but is inaccessible to
+ *     us — strand it, with the single 'access-revoked' toast.
+ *   - ERR_UNKNOWN_DOC: the relay's in-memory index has no record. This is
+ *     AMBIGUOUS and frequently TRANSIENT — a cold/un-hydrated workspace index, or
+ *     a JWKS cold-start auth blip after a relay redeploy, emits it for a doc that
+ *     still exists. JP-395: never strand on it (doing so fake-deleted live docs
+ *     and evicted the cache). A genuine deletion arrives as ERR_DELETED, above.
+ */
+export function handleRelayJoinError(error: string, docId: string | null): void {
+  if (isDeletedDocError(error) && docId) {
+    const record = useDocumentRegistry.getState().getRecord(docId);
+    if (record) {
+      useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+    }
+    return;
+  }
+  if (isViewForbiddenError(error) && docId) {
+    const record = useDocumentRegistry.getState().getRecord(docId);
+    if (record) {
+      useRelayDocumentStore
+        .getState()
+        .strandOrDemoteDeletedDoc(docId, undefined, 'access-revoked');
+    }
+    return;
+  }
+  if (isUnknownDocError(error) && docId) {
+    const record = useDocumentRegistry.getState().getRecord(docId);
+    const connectedRelayAddress = useConnectionStore.getState().host?.address;
+    if (record && isForeignRelayDoc(record, connectedRelayAddress)) {
+      // JP-308: the doc belongs to a DIFFERENT relay than the one we're connected
+      // to — this relay rejecting the JOIN is expected and NOT a deletion. Keep
+      // the remote record intact (edits queue under the doc's home relay, JP-117).
+      return;
+    }
+    if (record?.type === 'local') {
+      // A local-only doc was never meant to sync; a JOIN reject is expected (and
+      // should have been gated upstream by shouldJoinDocument). Stay silent.
+      return;
+    }
+    if (record && (record.type === 'remote' || record.type === 'cached')) {
+      // JP-395: ERR_UNKNOWN_DOC on the doc's OWN home relay is ambiguous and
+      // usually transient (a cold/un-hydrated index, or a JWKS cold-start blip
+      // after a relay redeploy) — it self-heals once auth/the index recovers.
+      // Do NOT strand/trash the doc (that was the fake-deletion bug). Mark the
+      // card not-syncing; it clears when the next JOIN syncs. No toast — a
+      // transient blip shouldn't alarm the user. A real deletion would have
+      // arrived as ERR_DELETED (handled above).
+      useDocumentRegistry.getState().setSyncState(docId, 'error');
+      return;
+    }
+    // No record at all (a diverged / never-promoted id) — a persistent condition,
+    // so keep the gentle non-destructive hint that edits are local-only.
+    useDocumentRegistry.getState().setSyncState(docId, 'error');
+    useNotificationStore
+      .getState()
+      .warning(
+        'This document isn’t syncing — the relay has no record of it. ' +
+          'Your changes are saved locally only.',
+      );
+  }
 }
 
 /**

--- a/src/collaboration/handleRelayJoinError.test.ts
+++ b/src/collaboration/handleRelayJoinError.test.ts
@@ -1,0 +1,156 @@
+/**
+ * JP-395 — `handleRelayJoinError` must NOT treat a transient `ERR_UNKNOWN_DOC`
+ * as a deletion. The relay emits `ERR_UNKNOWN_DOC` whenever its in-memory index
+ * misses (a cold/un-hydrated index, or a JWKS cold-start auth blip after a
+ * redeploy) — which fake-deleted live docs (trash + cache evict + "deleted"
+ * toast). A genuine deletion arrives as `ERR_DELETED` (JP-375) and must still
+ * strand. This drives the extracted handler directly (the UnifiedSyncProvider
+ * mock discards the inline `onError`, so it's otherwise unreachable).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Heavy collab deps — mock so importing collaborationStore stays lightweight
+// (mirrors collaborationStore.test.ts).
+vi.mock('./YjsDocument', () => ({
+  YjsDocument: vi.fn().mockImplementation(() => ({ getDoc: vi.fn(), destroy: vi.fn() })),
+}));
+vi.mock('./UnifiedSyncProvider', () => ({
+  UnifiedSyncProvider: vi.fn().mockImplementation(() => ({})),
+}));
+
+const hoisted = vi.hoisted(() => ({
+  strandOrDemoteDeletedDoc: vi.fn(),
+  getRecord: vi.fn(),
+  setSyncState: vi.fn(),
+  warning: vi.fn(),
+  host: { address: 'home-relay:443' } as { address: string } | null,
+}));
+
+vi.mock('../store/relayDocumentStore', () => ({
+  useRelayDocumentStore: {
+    getState: () => ({ strandOrDemoteDeletedDoc: hoisted.strandOrDemoteDeletedDoc }),
+  },
+}));
+vi.mock('../store/documentRegistry', () => ({
+  useDocumentRegistry: {
+    getState: () => ({ getRecord: hoisted.getRecord, setSyncState: hoisted.setSyncState }),
+  },
+}));
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: {
+    getState: () => ({ host: hoisted.host }),
+    subscribe: () => () => {},
+  },
+  // collaborationStore imports several named exports from this module at load.
+  isRelayAuthenticated: vi.fn(() => false),
+  startTokenExpirationMonitor: vi.fn(),
+  stopTokenExpirationMonitor: vi.fn(),
+  muteConnectionToasts: vi.fn(),
+  markReconnectCancelled: vi.fn(),
+  clearReconnectTerminal: vi.fn(),
+}));
+vi.mock('../store/presenceStore', () => ({ usePresenceStore: { getState: () => ({}) } }));
+vi.mock('../store/notificationStore', () => ({
+  useNotificationStore: { getState: () => ({ warning: hoisted.warning }) },
+}));
+
+import { handleRelayJoinError } from './collaborationStore';
+
+const HOME = 'home-relay:443';
+const DOC = 'doc-1';
+const base = { id: DOC, name: 'Doc', pageCount: 1, createdAt: 0, modifiedAt: 0 };
+const remote = (relayId = HOME) => ({
+  ...base,
+  type: 'remote' as const,
+  relayId,
+  workspaceId: 'ws-1',
+  ownerId: 'u1',
+  ownerName: 'U',
+  permission: 'owner' as const,
+  syncState: 'synced' as const,
+  lastSyncedAt: 0,
+});
+const cached = (relayId = HOME) => ({
+  ...base,
+  type: 'cached' as const,
+  relayId,
+  workspaceId: 'ws-1',
+  originalDocId: DOC,
+  cachedAt: 0,
+  pendingChanges: 0,
+  permission: 'editor' as const,
+});
+const localDoc = { ...base, type: 'local' as const };
+
+beforeEach(() => {
+  hoisted.strandOrDemoteDeletedDoc.mockClear();
+  hoisted.getRecord.mockReset();
+  hoisted.setSyncState.mockClear();
+  hoisted.warning.mockClear();
+  hoisted.host = { address: HOME };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('handleRelayJoinError — JP-395', () => {
+  it('does NOT strand a CACHED doc on ERR_UNKNOWN_DOC (the fake-deletion bug)', () => {
+    hoisted.getRecord.mockReturnValue(cached());
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).toHaveBeenCalledWith(DOC, 'error');
+    expect(hoisted.warning).not.toHaveBeenCalled(); // transient → no alarming toast
+  });
+
+  it('does NOT strand a REMOTE doc on ERR_UNKNOWN_DOC', () => {
+    hoisted.getRecord.mockReturnValue(remote());
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).toHaveBeenCalledWith(DOC, 'error');
+    expect(hoisted.warning).not.toHaveBeenCalled();
+  });
+
+  it('STILL strands on ERR_DELETED (definitive tombstone, JP-375)', () => {
+    hoisted.getRecord.mockReturnValue(remote());
+    handleRelayJoinError('ERR_DELETED', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).toHaveBeenCalledWith(DOC);
+  });
+
+  it('strands with access-revoked on ERR_VIEW_FORBIDDEN (JP-370)', () => {
+    hoisted.getRecord.mockReturnValue(remote());
+    handleRelayJoinError('ERR_VIEW_FORBIDDEN', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).toHaveBeenCalledWith(DOC, undefined, 'access-revoked');
+  });
+
+  it('is a silent no-op for a foreign-relay doc on ERR_UNKNOWN_DOC (JP-308)', () => {
+    hoisted.getRecord.mockReturnValue(remote('other-relay:443')); // != connected HOME
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).not.toHaveBeenCalled();
+    expect(hoisted.warning).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op for a local-only doc on ERR_UNKNOWN_DOC', () => {
+    hoisted.getRecord.mockReturnValue(localDoc);
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).not.toHaveBeenCalled();
+    expect(hoisted.warning).not.toHaveBeenCalled();
+  });
+
+  it('warns (non-destructive) for an unknown id with NO local record', () => {
+    hoisted.getRecord.mockReturnValue(undefined);
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).toHaveBeenCalledWith(DOC, 'error');
+    expect(hoisted.warning).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## The bug

After reinstalling the production PWA and signing in, the user got a **"document was deleted … moved to Trash"** toast and the doc vanished — yet it was still on the relay and reappeared on the next successful auth.

From the console trace:
1. The freshly-redeployed relay returns **401 `invalid token: jwks unavailable (fail-open grace expired)`** on `/api/docs` — a JWKS cold-start window (`last_success == None` → fail-closed for a few seconds until the background fetch lands).
2. The JOIN_DOC then gets an **`ERR_UNKNOWN_DOC`** frame.
3. `collaborationStore.onError` treated `ERR_UNKNOWN_DOC` on a `remote`/`cached` doc as a deletion → `strandOrDemoteDeletedDoc` → Trash + **`RelayDocumentCache` evict** + "deleted" toast.
4. Auth recovers; the doc reappears (it was never deleted).

## Root cause

`ERR_UNKNOWN_DOC` is **ambiguous and usually transient** — the relay emits it whenever its in-memory index misses (a cold/un-hydrated workspace index, or the JWKS cold-start auth blip after a redeploy), not just for real deletions. A genuine deletion arrives as **`ERR_DELETED`** (JP-375 tombstone), already handled. Stranding on `ERR_UNKNOWN_DOC` is a data-loss-prone false positive.

## Fix

- Extract the inline provider `onError` into an exported, unit-testable **`handleRelayJoinError(error, docId)`** (the `UnifiedSyncProvider` mock discards the options object, so the inline callback was otherwise unreachable).
- For a `remote`/`cached` doc on its **own home relay**, `ERR_UNKNOWN_DOC` now sets a **silent sync-error** (the doc card reflects it; it clears when sync resumes) instead of stranding — **no toast**, since the blip self-heals. The gentle "saved locally only" warning is reserved for the persistent **no-record / diverged** case.
- `ERR_DELETED` (strand, JP-375) and `ERR_VIEW_FORBIDDEN` (strand access-revoked, JP-370) are **unchanged** — those are the authoritative signals. JP-308 foreign-relay and `local` paths stay silent no-ops.

Aligns with the "never lose data" rule: a real deletion still strands via `ERR_DELETED`; an ambiguous `ERR_UNKNOWN_DOC` keeps the local copy.

## Tests (red → green)

`src/collaboration/handleRelayJoinError.test.ts` — verified the two "does NOT strand cached/remote" cases fail against the pre-fix branch and pass after, while `ERR_DELETED` / `ERR_VIEW_FORBIDDEN` still strand and foreign-relay / local stay no-ops. Full `src/collaboration` sweep green (303 tests); `tsc --noEmit` clean.

## Note: the relay-side trigger

This fixes the **client** (the guard against acting destructively on an ambiguous signal). The underlying triggers live on the relay — the JWKS cold-start fail-closed window after a redeploy, and JOIN_DOC emitting `ERR_UNKNOWN_DOC` before the workspace index is restored from R2. Filing a separate relay-side issue to harden the source.

Assisted-by: Opus 4.8