### PR TITLE
JP-396: don't sign out on a transient relay 401 (cold-pod JWKS)

### DIFF
--- a/src/api/relayClient.test.ts
+++ b/src/api/relayClient.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { RelayClient, RelayError, VersionConflictError } from './relayClient';
+import {
+  RelayClient,
+  RelayError,
+  VersionConflictError,
+  isTransientAuthFailure,
+} from './relayClient';
 
 /** Minimal scriptable fetch mock. Each test queues responses in order. */
 class FetchScript {
@@ -459,5 +464,76 @@ describe('RelayClient — request timeout (JP-127)', () => {
       requestTimeoutMs: 0,
     });
     await expect(client.blobExists('abc')).resolves.toBe(false);
+  });
+});
+
+describe('401 discrimination (JP-396)', () => {
+  let script: FetchScript;
+  beforeEach(() => {
+    script = new FetchScript();
+  });
+
+  it('does NOT call onUnauthorized for a transient jwks-unavailable 401 (still throws)', async () => {
+    let unauthorized = 0;
+    const client = new RelayClient({
+      baseUrl: 'http://r',
+      token: 'T',
+      fetchImpl: script.fetch,
+      onUnauthorized: () => {
+        unauthorized++;
+      },
+    });
+    // The cold-relay 401: a relay-availability failure, not a token rejection.
+    script.pushError(401, 'invalid token: jwks unavailable (fail-open grace expired)');
+
+    await expect(client.listDocuments()).rejects.toBeInstanceOf(RelayError);
+    expect(unauthorized).toBe(0); // session must NOT be torn down
+  });
+
+  it('DOES call onUnauthorized for a genuine token rejection 401', async () => {
+    let unauthorized = 0;
+    const client = new RelayClient({
+      baseUrl: 'http://r',
+      token: 'T',
+      fetchImpl: script.fetch,
+      onUnauthorized: () => {
+        unauthorized++;
+      },
+    });
+    script.pushError(401, 'invalid token: ExpiredSignature');
+
+    await expect(client.listDocuments()).rejects.toBeInstanceOf(RelayError);
+    expect(unauthorized).toBe(1);
+  });
+
+  it('does not call onUnauthorized for a 403 (only 401 triggers it)', async () => {
+    let unauthorized = 0;
+    const client = new RelayClient({
+      baseUrl: 'http://r',
+      token: 'T',
+      fetchImpl: script.fetch,
+      onUnauthorized: () => {
+        unauthorized++;
+      },
+    });
+    script.pushError(403, 'forbidden');
+
+    await expect(client.listDocuments()).rejects.toBeInstanceOf(RelayError);
+    expect(unauthorized).toBe(0);
+  });
+});
+
+describe('isTransientAuthFailure (JP-396)', () => {
+  it('matches the relay cold-start JWKS strings', () => {
+    expect(isTransientAuthFailure('invalid token: jwks unavailable (fail-open grace expired)')).toBe(true);
+    expect(isTransientAuthFailure('JWKS UNAVAILABLE')).toBe(true);
+    expect(isTransientAuthFailure('fail-open grace expired')).toBe(true);
+  });
+
+  it('does not match genuine token rejections', () => {
+    expect(isTransientAuthFailure('invalid token: ExpiredSignature')).toBe(false);
+    expect(isTransientAuthFailure('invalid token: InvalidSignature')).toBe(false);
+    expect(isTransientAuthFailure('forbidden')).toBe(false);
+    expect(isTransientAuthFailure('workspace mismatch')).toBe(false);
   });
 });

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -61,6 +61,23 @@ export class RelayError extends Error {
 }
 
 /**
+ * JP-396: a 401 whose body says the relay couldn't *validate* the token right
+ * now — its JWKS cache isn't populated yet on a cold or just-redeployed pod
+ * (`jwks unavailable (fail-open grace expired)`) — rather than the token being
+ * genuinely rejected. This is **transient**: the *same* token succeeds once the
+ * relay warms, so callers must NOT tear down the signed-in session or prompt a
+ * re-sign-in over it (that stranded a perfectly good session on every PWA
+ * cold-start against a cold prod relay). A genuine rejection (expired/bad
+ * signature/issuer/audience/region/workspace mismatch) is not matched here and
+ * keeps its normal sign-out behavior. (JP-397 will also have the relay return
+ * 503 for this, making it unambiguous at the status-code level.)
+ */
+export function isTransientAuthFailure(message: string): boolean {
+  const m = message.toLowerCase();
+  return m.includes('jwks unavailable') || m.includes('fail-open');
+}
+
+/**
  * Thrown by `saveDocument` when the caller's `expectedVersion` no
  * longer matches the server-side version. Carries `currentVersion` so
  * the caller can refetch, rebase, and retry.
@@ -487,10 +504,14 @@ export class RelayClient {
     const wasAuthed = opts.auth !== false && this.token !== undefined;
     const res = await this.fetchWithTimeout(url, init, opts.timeoutMs ?? this.requestTimeoutMs);
     if (!res.ok) {
-      if (res.status === 401 && wasAuthed) {
+      const err = await buildRelayError(res, url);
+      // JP-396: only a GENUINE token rejection should drop the signed-in
+      // session. A transient relay-validation 401 (a cold-pod JWKS that isn't
+      // loaded yet) must not — the same token succeeds once the relay warms.
+      if (res.status === 401 && wasAuthed && !isTransientAuthFailure(err.message)) {
         this.onUnauthorized?.();
       }
-      throw await buildRelayError(res, url);
+      throw err;
     }
     // 204 No Content -> return empty object cast to T.
     if (res.status === 204) {
@@ -520,10 +541,14 @@ export class RelayClient {
     const wasAuthed = this.token !== undefined;
     const res = await this.fetchWithTimeout(url, init, opts.timeoutMs ?? this.requestTimeoutMs);
     if (!res.ok) {
-      if (res.status === 401 && wasAuthed) {
+      const err = await buildRelayError(res, url);
+      // JP-396: only a GENUINE token rejection should drop the signed-in
+      // session. A transient relay-validation 401 (a cold-pod JWKS that isn't
+      // loaded yet) must not — the same token succeeds once the relay warms.
+      if (res.status === 401 && wasAuthed && !isTransientAuthFailure(err.message)) {
         this.onUnauthorized?.();
       }
-      throw await buildRelayError(res, url);
+      throw err;
     }
     return res;
   }


### PR DESCRIPTION
## The bug

On the **installed production PWA**, every cold start forced a fresh authorization even though a valid relay JWT was still in `docushark-secure`. Dev (Vite) and Tauri never reproduced it — and it is **not** a service-worker / storage-wipe bug: the token was *stranded* (present but unused), not lost.

On boot, `restoreCloudSession` does a REST `GET /api/docs` to refresh the cloud list. A **cold or just-redeployed production relay** answers that with **`401 invalid token: jwks unavailable (fail-open grace expired)`** — a relay *availability* failure, not a token rejection (the exact 401 is visible in the JP-395 boot log). `RelayClient` called `onUnauthorized()` for **any** authed 401, so the client tore down the signed-in session (`setAuthenticated(false)` + "session expired, sign in again"; `clearJwt()` on the live-session path). Dev/Tauri talk to a warm/local relay → no boot 401 → no false sign-out.

## Fix

Same lesson as JP-395 / JP-397 — a transient relay failure must not drive a destructive client action.

- **`isTransientAuthFailure(message)`** (exported from `relayClient.ts`): matches the relay's cold-start JWKS strings (`jwks unavailable` / `fail-open`).
- In `requestJson` **and** `requestRaw`: build the `RelayError` first (parse the body), then call `onUnauthorized` **only for a genuine 401** — not a transient one. The request still `throw`s (the list fetch fails and retries later), but the **session stays intact**. This single choke point covers both the boot REST provider (`standUpRestProvider`) and the live-session client (`collaborationStore`). Genuine rejections (expired / bad-signature / issuer / audience / region / workspace mismatch) keep their sign-out behavior.
- The WS `AUTH_RESPONSE` failure path was already non-destructive (`error` status + reconnect), so no change there.

## Tests (red → green)

`src/api/relayClient.test.ts` — verified the "transient 401 → no `onUnauthorized`" case fails with the guard removed and passes with it, while "genuine 401 → `onUnauthorized`", "403 → none", and the predicate unit tests stay green. `tsc` clean; full `src/api` + `src/collaboration` sweep green (406 tests).

## Relay companion

Folded a note into **JP-397**: the relay should return **503 (not 401)** for `jwks unavailable`, making "transient" unambiguous at the status-code level (and its readiness-gate removes the cold-start window entirely). This client fix is self-sufficient and does **not** depend on that relay change.

Assisted-by: Opus 4.8