### PR TITLE
Promote master → staging (PWA cold-start stability: JP-395/JP-396)

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -1,5 +1,15 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig, type HeadConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
+import { generateLlmsTxt } from './plugins/llms'
+
+const SITE_TITLE = 'DocuShark Docs'
+const SITE_DESCRIPTION =
+  'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.'
+
+// Canonical host for the published docs (GitHub Pages, apex CNAME). Used for
+// canonical/og:url tags and JSON-LD. SiteData has no `url` field, so we keep
+// the hostname here as the single source of truth.
+const HOSTNAME = 'https://docs.docushark.app'
 
 // The Guides area spans two folders: /getting-started/ (the onboarding group)
 // and /guide/ (the using-DocuShark group). Both routes share one sidebar.
@@ -38,6 +48,93 @@ const guidesSidebar = [
   },
 ]
 
+const developerSidebar = [
+  {
+    text: 'Getting Set Up',
+    items: [
+      { text: 'Architecture Overview', link: '/developer/architecture' },
+      { text: 'Project Setup', link: '/developer/project-setup' },
+      { text: 'Core Systems', link: '/developer/core-systems' },
+      { text: 'State Management', link: '/developer/state-management' },
+    ],
+  },
+  {
+    text: 'Extending DocuShark',
+    items: [
+      { text: 'Creating Custom Shapes', link: '/developer/creating-shapes' },
+      { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
+      { text: 'Creating Prose Helpers', link: '/developer/creating-prose-helpers' },
+      { text: 'Shape Properties', link: '/developer/shape-properties' },
+      { text: 'Plugin Development', link: '/developer/plugin-development' },
+      { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
+      { text: 'Utility Modules', link: '/developer/utilities' },
+      { text: 'AI Agents (MCP) & Recipes', link: '/developer/mcp-agent-recipes' },
+    ],
+  },
+  {
+    text: 'Contributing',
+    items: [
+      { text: 'Contributing', link: '/developer/contributing' },
+      { text: 'Roadmap', link: '/developer/roadmap' },
+    ],
+  },
+]
+
+// `transformHead` receives the source markdown path (e.g. "guide/connectors.md",
+// "index.md"). We derive two things from it:
+//
+//  - canonicalUrl: the absolute URL matching what VitePress emits in the sitemap
+//    and internal links. With cleanUrls off (the default here), interior pages
+//    are served at "<path>.html" and the home page at "/".
+//  - routeKey: an extensionless, slash-prefixed key ("/guide/connectors") used
+//    to match sidebar `link` values when resolving the breadcrumb trail.
+function canonicalUrlOf(page: string): string {
+  if (page === 'index.md') return `${HOSTNAME}/`
+  const nested = page.match(/^(.*)\/index\.md$/)
+  if (nested) return `${HOSTNAME}/${nested[1]}/`
+  return `${HOSTNAME}/${page.replace(/\.md$/, '.html')}`
+}
+
+function routeKeyOf(page: string): string {
+  if (page === 'index.md') return '/'
+  const nested = page.match(/^(.*)\/index\.md$/)
+  if (nested) return `/${nested[1]}`
+  return `/${page.replace(/\.md$/, '')}`
+}
+
+// Convert a sidebar link ("/getting-started/introduction") to its canonical
+// absolute URL, matching the sitemap's ".html" form so breadcrumb ancestor
+// items stay consistent with the leaf's canonical URL.
+function linkToUrl(link: string): string {
+  const clean = link.replace(/^\/+/, '').replace(/\/$/, '')
+  return clean === '' ? `${HOSTNAME}/` : `${HOSTNAME}/${clean}.html`
+}
+
+// Resolve a route to its breadcrumb trail (area + group + title) from the
+// sidebar definitions, so the JSON-LD BreadcrumbList mirrors the visual one.
+function resolveBreadcrumb(
+  route: string,
+  pageTitle: string,
+): { areaLabel: string; areaLink: string; group: string; title: string } | null {
+  let area: { label: string; link: string; sidebar: typeof guidesSidebar } | null = null
+  if (route.startsWith('/developer/')) {
+    area = { label: 'Developer', link: '/developer/architecture', sidebar: developerSidebar }
+  } else if (route.startsWith('/guide/') || route.startsWith('/getting-started/')) {
+    area = { label: 'Guides', link: '/getting-started/introduction', sidebar: guidesSidebar }
+  }
+  if (!area) return null
+
+  for (const grp of area.sidebar) {
+    for (const item of grp.items) {
+      if (item.link === route) {
+        return { areaLabel: area.label, areaLink: area.link, group: grp.text, title: item.text }
+      }
+    }
+  }
+  // Page not found in sidebar (shouldn't happen) — still emit a 2-level trail.
+  return { areaLabel: area.label, areaLink: area.link, group: '', title: pageTitle }
+}
+
 export default withMermaid(
   defineConfig({
     title: 'DocuShark',
@@ -48,6 +145,8 @@ export default withMermaid(
 
     head: [
       ['link', { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+      ['meta', { property: 'og:site_name', content: 'DocuShark' }],
+      ['meta', { property: 'og:locale', content: 'en_US' }],
       ['meta', { property: 'og:type', content: 'website' }],
       ['meta', { property: 'og:title', content: 'DocuShark Docs' }],
       ['meta', { property: 'og:description', content: 'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.' }],
@@ -58,6 +157,99 @@ export default withMermaid(
       ['meta', { name: 'twitter:image', content: 'https://docs.docushark.app/docushark-badge.png' }],
     ],
 
+    // Native VitePress sitemap — no extra dep. See node_modules/vitepress SitemapOptions.
+    sitemap: {
+      hostname: HOSTNAME,
+    },
+
+    // Emit /llms.txt + /llms-full.txt into the build output. Runs for both
+    // `build` and `build:offline`, so a local `preview` serves them too.
+    // Sections mirror the sidebar IA defined above.
+    buildEnd(siteConfig) {
+      generateLlmsTxt(siteConfig, {
+        hostname: HOSTNAME,
+        siteTitle: SITE_TITLE,
+        siteDescription: SITE_DESCRIPTION,
+        sections: [
+          ...guidesSidebar.map((g) => ({ title: g.text, items: g.items })),
+          { title: 'Developer', items: developerSidebar.flatMap((g) => g.items) },
+        ],
+      })
+    },
+
+    // Per-page <head> augmentation, emitted into the static HTML at build time:
+    //  - canonical + og:url/twitter:url derived from the resolved route
+    //  - JSON-LD: WebSite + SearchAction on the home page, BreadcrumbList on
+    //    interior pages (mirrors the visual breadcrumb)
+    // VitePress already injects per-page title/description from frontmatter.
+    transformHead({ page, pageData }) {
+      const routeKey = routeKeyOf(page)
+      const url = canonicalUrlOf(page)
+
+      const head: HeadConfig[] = [
+        ['link', { rel: 'canonical', href: url }],
+        ['meta', { property: 'og:url', content: url }],
+        ['meta', { name: 'twitter:url', content: url }],
+      ]
+
+      if (routeKey === '/') {
+        head.push([
+          'script',
+          { type: 'application/ld+json' },
+          JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebSite',
+            name: 'DocuShark Docs',
+            url: `${HOSTNAME}/`,
+            description:
+              'Guides and developer references for DocuShark — diagramming and docs in one offline-first editor.',
+            publisher: {
+              '@type': 'Organization',
+              name: 'JPE-Net Technologies',
+              url: 'https://github.com/JPE-Net-Technologies/docushark',
+            },
+            potentialAction: {
+              '@type': 'SearchAction',
+              target: {
+                '@type': 'EntryPoint',
+                urlTemplate: `${HOSTNAME}/?q={search_term_string}`,
+              },
+              'query-input': 'required name=search_term_string',
+            },
+          }),
+        ])
+      } else {
+        const crumb = resolveBreadcrumb(routeKey, pageData.title)
+        if (crumb) {
+          const items: Array<Record<string, unknown>> = [
+            { '@type': 'ListItem', position: 1, name: 'Docs', item: `${HOSTNAME}/` },
+            {
+              '@type': 'ListItem',
+              position: 2,
+              name: crumb.areaLabel,
+              item: linkToUrl(crumb.areaLink),
+            },
+          ]
+          let pos = 3
+          if (crumb.group) {
+            items.push({ '@type': 'ListItem', position: pos++, name: crumb.group })
+          }
+          items.push({ '@type': 'ListItem', position: pos, name: crumb.title, item: url })
+          head.push([
+            'script',
+            { type: 'application/ld+json' },
+            JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: items,
+            }),
+          ])
+        }
+      }
+
+      return head
+    },
+
     themeConfig: {
       logo: { src: '/docushark-logo.png', alt: 'DocuShark' },
 
@@ -65,43 +257,14 @@ export default withMermaid(
         { text: 'Home', link: '/' },
         { text: 'Guides', link: '/getting-started/introduction', activeMatch: '/getting-started/|/guide/' },
         { text: 'Developer', link: '/developer/architecture', activeMatch: '/developer/' },
+        { text: 'Website', link: 'https://docushark.app' },
         { text: 'Open DocuShark', link: 'https://app.docushark.app' },
       ],
 
       sidebar: {
         '/getting-started/': guidesSidebar,
         '/guide/': guidesSidebar,
-        '/developer/': [
-          {
-            text: 'Getting Set Up',
-            items: [
-              { text: 'Architecture Overview', link: '/developer/architecture' },
-              { text: 'Project Setup', link: '/developer/project-setup' },
-              { text: 'Core Systems', link: '/developer/core-systems' },
-              { text: 'State Management', link: '/developer/state-management' },
-            ],
-          },
-          {
-            text: 'Extending DocuShark',
-            items: [
-              { text: 'Creating Custom Shapes', link: '/developer/creating-shapes' },
-              { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
-              { text: 'Creating Prose Helpers', link: '/developer/creating-prose-helpers' },
-              { text: 'Shape Properties', link: '/developer/shape-properties' },
-              { text: 'Plugin Development', link: '/developer/plugin-development' },
-              { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
-              { text: 'Utility Modules', link: '/developer/utilities' },
-              { text: 'AI Agents (MCP) & Recipes', link: '/developer/mcp-agent-recipes' },
-            ],
-          },
-          {
-            text: 'Contributing',
-            items: [
-              { text: 'Contributing', link: '/developer/contributing' },
-              { text: 'Roadmap', link: '/developer/roadmap' },
-            ],
-          },
-        ],
+        '/developer/': developerSidebar,
       },
 
       socialLinks: [

--- a/docs-site/.vitepress/plugins/llms.ts
+++ b/docs-site/.vitepress/plugins/llms.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Minimal build-time generator for /llms.txt and /llms-full.txt, following the
+// llmstxt.org convention. Runs from VitePress's `buildEnd` hook, so the files
+// land in the build output (dist) on every build — including `build:offline`.
+//
+// We deliberately avoid extra deps: frontmatter is parsed with a small reader
+// (the docs use only single-line `title:` / `description:` keys), and page
+// order + grouping is passed in from config.mts so the output mirrors the
+// sidebar IA without a parallel table.
+
+export interface LlmsItem {
+  text: string
+  link: string
+}
+
+export interface LlmsSection {
+  title: string
+  items: LlmsItem[]
+}
+
+export interface LlmsOptions {
+  hostname: string
+  siteTitle: string
+  siteDescription: string
+  sections: LlmsSection[]
+}
+
+// Subset of VitePress's SiteConfig that we actually need.
+interface BuildConfig {
+  srcDir: string
+  outDir: string
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/
+
+function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
+  const match = raw.match(FRONTMATTER_RE)
+  if (!match || match[1] === undefined) return { data: {}, body: raw }
+  const data: Record<string, string> = {}
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/)
+    if (kv && kv[1] !== undefined && kv[2] !== undefined) {
+      data[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, '')
+    }
+  }
+  return { data, body: raw.slice(match[0].length) }
+}
+
+function firstHeading(body: string): string {
+  const m = body.match(/^#\s+(.+)$/m)
+  return m && m[1] !== undefined ? m[1].trim() : ''
+}
+
+// Resolve a sidebar link ("/guide/connectors") to its source markdown file.
+function sourcePath(srcDir: string, link: string): string {
+  const rel = link.replace(/^\/+/, '').replace(/\/$/, '')
+  const candidate = rel === '' ? 'index.md' : `${rel}.md`
+  return path.join(srcDir, candidate)
+}
+
+function readPage(
+  srcDir: string,
+  item: LlmsItem,
+): { title: string; description: string; body: string } | null {
+  const file = sourcePath(srcDir, item.link)
+  let raw: string
+  try {
+    raw = fs.readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+  const { data, body } = parseFrontmatter(raw)
+  return {
+    title: data['title'] || firstHeading(body) || item.text,
+    description: data['description'] || '',
+    body: body.trim(),
+  }
+}
+
+function absoluteUrl(hostname: string, link: string): string {
+  const clean = link.replace(/\/$/, '')
+  return clean === '' ? `${hostname}/` : `${hostname}${clean}`
+}
+
+export function generateLlmsTxt(config: BuildConfig, opts: LlmsOptions): void {
+  const { srcDir, outDir } = config
+  const { hostname, siteTitle, siteDescription, sections } = opts
+
+  // ---- /llms.txt — curated index ----
+  const indexLines: string[] = [
+    `# ${siteTitle}`,
+    '',
+    `> ${siteDescription}`,
+    '',
+    'This file helps language models navigate the DocuShark documentation. For the full text of every page in a single file, see [/llms-full.txt](' +
+      `${hostname}/llms-full.txt).`,
+    '',
+  ]
+
+  // ---- /llms-full.txt — full page contents ----
+  const fullLines: string[] = [
+    `# ${siteTitle} — Full Documentation`,
+    '',
+    `> ${siteDescription}`,
+    '',
+    `Source: ${hostname}/`,
+    '',
+  ]
+
+  for (const section of sections) {
+    indexLines.push(`## ${section.title}`, '')
+    for (const item of section.items) {
+      const page = readPage(srcDir, item)
+      if (!page) continue
+      const url = absoluteUrl(hostname, item.link)
+      const suffix = page.description ? `: ${page.description}` : ''
+      indexLines.push(`- [${page.title}](${url})${suffix}`)
+
+      fullLines.push('---', '', `# ${page.title}`, '', `Source: ${url}`, '')
+      if (page.description) fullLines.push(`> ${page.description}`, '')
+      fullLines.push(page.body, '')
+    }
+    indexLines.push('')
+  }
+
+  fs.mkdirSync(outDir, { recursive: true })
+  fs.writeFileSync(path.join(outDir, 'llms.txt'), indexLines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n')
+  fs.writeFileSync(path.join(outDir, 'llms-full.txt'), fullLines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n')
+}

--- a/docs-site/.vitepress/theme/Breadcrumb.vue
+++ b/docs-site/.vitepress/theme/Breadcrumb.vue
@@ -3,11 +3,13 @@ import { computed } from 'vue'
 import { useData } from 'vitepress'
 import { useSidebar } from 'vitepress/theme'
 
-const { page, theme } = useData()
+const { page } = useData()
 const { sidebarGroups } = useSidebar()
 
 // "Docs / <Area> / <Group> / <Here>" — derived from the resolved sidebar so it
-// stays in sync with config.mts without a parallel IA table.
+// stays in sync with config.mts without a parallel IA table. The matching
+// JSON-LD BreadcrumbList is emitted into static HTML by the `transformHead`
+// hook in config.mts.
 const area = computed(() => {
   const p = '/' + page.value.relativePath
   if (p.startsWith('/developer/')) return { label: 'Developer', link: '/developer/architecture' }

--- a/docs-site/.vitepress/theme/Home.vue
+++ b/docs-site/.vitepress/theme/Home.vue
@@ -210,6 +210,7 @@ function openSearch() {
           <div>
             <h4>Project</h4>
             <ul>
+              <li><a href="https://docushark.app" target="_blank" rel="noopener">Website</a></li>
               <li><a :href="GH" target="_blank" rel="noopener">GitHub</a></li>
               <li><a :href="withBase('/developer/contributing')">Contributing</a></li>
               <li><a :href="withBase('/developer/roadmap')">Roadmap</a></li>

--- a/docs-site/.vitepress/theme/Layout.vue
+++ b/docs-site/.vitepress/theme/Layout.vue
@@ -11,6 +11,9 @@ const { page } = useData()
 // and an `ds-area-*` hook on the layout root that CSS uses to scope chrome
 // (e.g. GitHub shows only in the developer area). Computed from useData() so it
 // is correct during SSR — no client-side flash.
+//
+// JSON-LD (WebSite on home, BreadcrumbList on interior pages) is emitted into
+// the static HTML by the `transformHead` hook in config.mts, not here.
 const area = computed(() => {
   const p = '/' + page.value.relativePath
   if (p.startsWith('/developer/')) return 'developer'

--- a/docs-site/developer/architecture.md
+++ b/docs-site/developer/architecture.md
@@ -1,3 +1,8 @@
+---
+title: Architecture Overview
+description: Bird's-eye view of DocuShark's architecture — React + Canvas engine on top of Zustand stores, Tauri desktop, and Yjs collaboration.
+---
+
 # Architecture Overview
 
 This page provides a bird's-eye view of DocuShark's architecture. For detailed coverage of specific systems, see the linked pages.

--- a/docs-site/developer/collaboration-protocol.md
+++ b/docs-site/developer/collaboration-protocol.md
@@ -1,3 +1,8 @@
+---
+title: Collaboration Protocol
+description: DocuShark's real-time collaboration protocol — Yjs CRDTs over WebSocket, JWT auth, and the relay message format.
+---
+
 # Collaboration Protocol
 
 DocuShark's real-time collaboration runs through a **standalone relay**

--- a/docs-site/developer/contributing.md
+++ b/docs-site/developer/contributing.md
@@ -1,3 +1,8 @@
+---
+title: Contributing
+description: How to contribute to DocuShark — bug fixes, shape libraries, documentation, and feature work.
+---
+
 # Contributing
 
 We welcome contributions of all kinds — bug fixes, new shape libraries, documentation improvements, and feature work.

--- a/docs-site/developer/core-systems.md
+++ b/docs-site/developer/core-systems.md
@@ -1,3 +1,8 @@
+---
+title: Core Systems
+description: DocuShark's core runtime systems — coordinate pipeline, rendering engine, shape registry, and tool state machines.
+---
+
 # Core Systems
 
 This page covers the core runtime systems that power DocuShark's canvas — the coordinate pipeline, rendering engine, shape registry, and tool state machines.

--- a/docs-site/developer/creating-prose-helpers.md
+++ b/docs-site/developer/creating-prose-helpers.md
@@ -1,3 +1,8 @@
+---
+title: Creating Prose Helpers
+description: Build custom Tiptap/ProseMirror prose helpers — nodes that live alongside diagrams in DocuShark documents.
+---
+
 # Creating Prose Helpers
 
 A **prose helper** is a custom Tiptap/ProseMirror node that lives in the written

--- a/docs-site/developer/creating-shapes.md
+++ b/docs-site/developer/creating-shapes.md
@@ -1,3 +1,8 @@
+---
+title: Creating Custom Shapes
+description: Create custom shapes for DocuShark — register render, hitTest, getBounds, getHandles, and create handlers.
+---
+
 # Creating Custom Shapes
 
 This guide walks through creating custom shapes for DocuShark, from simple library shapes to fully custom handlers.

--- a/docs-site/developer/creating-tools.md
+++ b/docs-site/developer/creating-tools.md
@@ -1,3 +1,8 @@
+---
+title: Creating Custom Tools
+description: Build custom DocuShark tools — state machines that respond to normalized pointer, keyboard, and wheel events.
+---
+
 # Creating Custom Tools
 
 Tools are the primary way users interact with the canvas. Each tool is a **state machine** that responds to normalized input events — pointer down, move, up, keyboard, and wheel. Only one tool is active at a time, managed by the `ToolManager`.

--- a/docs-site/developer/mcp-agent-recipes.md
+++ b/docs-site/developer/mcp-agent-recipes.md
@@ -1,3 +1,8 @@
+---
+title: AI Agents (MCP) & Recipes
+description: DocuShark's MCP server — tools, recipes, and patterns for AI agents that author real documents and diagrams.
+---
+
 # AI Agents (MCP) & Recipes
 
 DocuShark ships an **MCP server** (in the relay) — a precise, high-performance

--- a/docs-site/developer/plugin-development.md
+++ b/docs-site/developer/plugin-development.md
@@ -1,3 +1,8 @@
+---
+title: Plugin Development Guide
+description: Extend DocuShark through the PanelExtensions plugin registry — panels, shape libraries, and UI extensions.
+---
+
 # Plugin Development Guide
 
 DocuShark provides a plugin system through the **PanelExtensions** registry, allowing developers to extend the UI without modifying core components.

--- a/docs-site/developer/project-setup.md
+++ b/docs-site/developer/project-setup.md
@@ -1,3 +1,8 @@
+---
+title: Project Setup
+description: Set up the DocuShark repo locally — prerequisites, install steps, dev commands, and tests.
+---
+
 # Project Setup
 
 This page covers everything you need to start developing DocuShark locally.

--- a/docs-site/developer/roadmap.md
+++ b/docs-site/developer/roadmap.md
@@ -1,3 +1,8 @@
+---
+title: Roadmap
+description: DocuShark's development progress and planned features — what's shipped, what's next, and what's on the horizon.
+---
+
 # Roadmap
 
 This document tracks DocuShark's development progress and planned features.

--- a/docs-site/developer/shape-properties.md
+++ b/docs-site/developer/shape-properties.md
@@ -1,3 +1,8 @@
+---
+title: Shape Properties
+description: Reference for every shape property in DocuShark — appearance, position, behavior, and metadata fields.
+---
+
 # Shape Properties
 
 Every shape in DocuShark has properties that control its appearance and behavior. This reference covers all available properties.

--- a/docs-site/developer/state-management.md
+++ b/docs-site/developer/state-management.md
@@ -1,3 +1,8 @@
+---
+title: State Management
+description: How DocuShark splits state across Zustand stores — document, session, history, pages, persistence, and feature stores.
+---
+
 # State Management
 
 DocuShark uses **Zustand** with **Immer** middleware for state management. Stores are split by responsibility so that changes to ephemeral UI state (cursor position, active tool) don't trigger re-renders on document data, and vice versa.

--- a/docs-site/developer/utilities.md
+++ b/docs-site/developer/utilities.md
@@ -1,3 +1,8 @@
+---
+title: Utility Modules Reference
+description: DocuShark's core utilities — math primitives (Vec2, Mat3, Box), color manipulation, file handling, and export.
+---
+
 # Utility Modules Reference
 
 DocuShark's core utility modules provide math primitives, color manipulation, file handling, and export functionality. All math types are immutable — every operation returns a new instance.

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -1,42 +1,39 @@
 ---
 title: Installation
-description: Install DocuShark as a desktop app (Windows, macOS, Linux) or run it directly in your browser.
+description: Run DocuShark right in your browser, or build the desktop app from source.
 ---
 
 # Installation
 
-DocuShark can be installed as a desktop application or run directly in your browser.
+DocuShark runs right in your browser — no installation required — and can also be built as a
+desktop application from source. Both share the same editor and the same features.
 
-## Desktop Application (Recommended)
+## Run in Your Browser (Recommended)
 
-The desktop version provides the best performance and full feature access including native file system integration.
+Open [app.docushark.app](https://app.docushark.app) and start working immediately — there's
+nothing to install, and you always have the latest version. Local documents stay in your
+browser and keep working offline.
 
-### Windows
+Most browsers also let you **install** DocuShark so it opens in its own window and lives in your
+dock, taskbar, or home screen:
 
-1. Download the latest `.msi` or `.exe` installer from the [releases page](https://github.com/JPE-Net-Technologies/docushark/releases)
-2. Run the installer and follow the prompts
-3. Launch DocuShark from the Start menu
+- **Chrome / Edge** — click the install icon in the address bar, or use the in-app **Install** prompt.
+- **Safari (macOS)** — File → Add to Dock.
+- **iOS / Android** — Share → Add to Home Screen.
 
-### Linux
+## Desktop Application
 
-**AppImage (Universal)**
-```bash
-chmod +x DocuShark-*.AppImage
-./DocuShark-*.AppImage
-```
+DocuShark can also run as a native desktop application (Windows, Linux, macOS) built with Tauri,
+with native file-system integration. It has the same features as the browser version.
 
-**Debian/Ubuntu (.deb)**
-```bash
-sudo dpkg -i docushark_*.deb
-```
-
-### macOS
-
-There are no pre-built macOS binaries yet. You can build from source — it only takes a few minutes. See the instructions below.
+Pre-built signed installers aren't published yet, so the desktop app is currently built from
+source — it only takes a few minutes on any platform. See [Building from Source](#building-from-source)
+below.
 
 ## Building from Source
 
-Building from source is straightforward on all platforms. macOS users — this is your primary installation path.
+Building from source is straightforward on all platforms, and is currently the way to get the
+desktop app.
 
 ### Prerequisites
 

--- a/docs-site/getting-started/installation.md
+++ b/docs-site/getting-started/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation
+description: Install DocuShark as a desktop app (Windows, macOS, Linux) or run it directly in your browser.
+---
+
 # Installation
 
 DocuShark can be installed as a desktop application or run directly in your browser.

--- a/docs-site/getting-started/interface-tour.md
+++ b/docs-site/getting-started/interface-tour.md
@@ -1,3 +1,8 @@
+---
+title: Interface Tour
+description: A quick tour of the DocuShark editor — toolbar, canvas, properties panel, layers, and status bar.
+---
+
 # Interface Tour
 
 Here's a quick overview of everything you see when you open a document in DocuShark.

--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -19,9 +19,9 @@ Many browser-based diagram tools start to struggle as a diagram grows. DocuShark
 - Instant shape selection and manipulation
 - No lag, no waiting, no frustration
 
-### Desktop & Web
+### Web & Desktop
 
-DocuShark runs as a **native desktop application** (Windows, Linux, macOS) using Tauri, giving you native file system access and system-level performance. It also works right in your browser for quick access without installation.
+DocuShark runs right in your browser — open it, install it as a PWA, and you always have the latest version. It also builds as a **native desktop application** (Windows, Linux, macOS) using Tauri, with native file-system access. You get the same editor and the same features either way.
 
 ### Real-time Collaboration
 
@@ -64,7 +64,7 @@ Plus, you can create and share your own **custom shape libraries**.
 
 This documentation is organized to help you get productive quickly:
 
-1. **[Installation](./installation)** — Download or build DocuShark
+1. **[Installation](./installation)** — Run DocuShark in your browser, or build it
 2. **[Quick Start](./quick-start)** — Create your first diagram in under five minutes
 3. **[Interface Tour](./interface-tour)** — Learn what every part of the screen does
 

--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+description: DocuShark is a fast, offline-first diagramming and whiteboard app that stays smooth on large, complex diagrams.
+---
+
 # Introduction
 
 Welcome to **DocuShark** — a fast, offline-first diagramming and whiteboard app that keeps things smooth even on large, complex diagrams.

--- a/docs-site/getting-started/quick-start.md
+++ b/docs-site/getting-started/quick-start.md
@@ -1,3 +1,8 @@
+---
+title: Quick Start
+description: Create your first DocuShark diagram in about five minutes — new document, add shapes, connect them, save.
+---
+
 # Quick Start
 
 Let's create your first diagram. This should take about five minutes.

--- a/docs-site/guide/canvas-navigation.md
+++ b/docs-site/guide/canvas-navigation.md
@@ -1,3 +1,8 @@
+---
+title: Canvas & Navigation
+description: Navigate DocuShark's infinite canvas — pan, zoom, fit-to-screen, minimap, and keyboard navigation.
+---
+
 # Canvas & Navigation
 
 The canvas is your infinite drawing surface. Let's cover how to move around it efficiently.

--- a/docs-site/guide/citations.md
+++ b/docs-site/guide/citations.md
@@ -1,3 +1,8 @@
+---
+title: Citations & References
+description: Cite sources and manage references in DocuShark documents — first-class citations in the rich text editor.
+---
+
 # Citations & References
 
 DocuShark has first-class citations built into the document editor. Cite a source

--- a/docs-site/guide/collaboration.md
+++ b/docs-site/guide/collaboration.md
@@ -1,3 +1,8 @@
+---
+title: Collaboration
+description: Real-time collaboration in DocuShark — connect to a relay and edit diagrams live with your team via CRDTs.
+---
+
 # Collaboration
 
 DocuShark supports real-time collaboration: when your document is connected to a

--- a/docs-site/guide/collections.md
+++ b/docs-site/guide/collections.md
@@ -1,3 +1,8 @@
+---
+title: Collections
+description: Group related DocuShark documents into named, color-coded collections to organize your whole library.
+---
+
 # Collections
 
 Collections are **containers for your documents** — think of them as

--- a/docs-site/guide/connect-your-agent.md
+++ b/docs-site/guide/connect-your-agent.md
@@ -1,3 +1,8 @@
+---
+title: Connect an AI Agent
+description: Connect Claude, Cursor, ChatGPT, or any MCP-compatible AI agent to DocuShark to author documents and diagrams.
+---
+
 # Connect an AI Agent
 
 DocuShark speaks **[MCP](https://modelcontextprotocol.io)** — an open standard that lets

--- a/docs-site/guide/connectors.md
+++ b/docs-site/guide/connectors.md
@@ -1,3 +1,8 @@
+---
+title: Connectors
+description: Smart connectors that link shapes together — route styles, anchor points, and how they follow shape movement.
+---
+
 # Connectors
 
 Connectors are smart lines that link shapes together. Unlike regular lines, connectors stay attached to their shapes — move a shape and the connector follows.

--- a/docs-site/guide/document-fields.md
+++ b/docs-site/guide/document-fields.md
@@ -1,3 +1,8 @@
+---
+title: Document Fields
+description: Reusable values you define once and reference throughout a DocuShark document — version numbers, names, dates, and more.
+---
+
 # Document Fields
 
 Document fields are reusable values you define once and reference throughout your

--- a/docs-site/guide/drawing-tools.md
+++ b/docs-site/guide/drawing-tools.md
@@ -1,3 +1,8 @@
+---
+title: Drawing Tools
+description: DocuShark's drawing tools — select, rectangle, ellipse, line, text, connector, and more — with keyboard shortcuts.
+---
+
 # Drawing Tools
 
 DocuShark gives you a set of drawing tools for creating and manipulating shapes. Switch between them using the toolbar or keyboard shortcuts.

--- a/docs-site/guide/embedded-files.md
+++ b/docs-site/guide/embedded-files.md
@@ -1,3 +1,8 @@
+---
+title: Embedded Files
+description: Embed PDFs, spreadsheets, images, and other files onto your DocuShark canvas as shape cards with previews.
+---
+
 # Embedded Files
 
 DocuShark lets you embed files — PDFs, spreadsheets, images, and more — directly onto your canvas. Files appear as shape cards with thumbnail previews, and you can open them in built-in viewers.

--- a/docs-site/guide/export-import.md
+++ b/docs-site/guide/export-import.md
@@ -1,3 +1,8 @@
+---
+title: Export & Import
+description: Export DocuShark diagrams to PNG, SVG, PDF, or Markdown; import from Mermaid, draw.io, and Excalidraw.
+---
+
 # Export & Import
 
 DocuShark supports multiple ways to export your diagrams and share your work.

--- a/docs-site/guide/keyboard-shortcuts.md
+++ b/docs-site/guide/keyboard-shortcuts.md
@@ -1,3 +1,8 @@
+---
+title: Keyboard Shortcuts
+description: Complete keyboard shortcuts reference for DocuShark — tools, navigation, editing, and clipboard operations.
+---
+
 # Keyboard Shortcuts
 
 Master DocuShark with these keyboard shortcuts.

--- a/docs-site/guide/layout-modes.md
+++ b/docs-site/guide/layout-modes.md
@@ -1,3 +1,8 @@
+---
+title: Layout Modes
+description: Switch between DocuShark's four workspace layouts — Relaxed, Designer, Technician, and Power — for writing or diagramming.
+---
+
 # Layout Modes
 
 DocuShark adapts its workspace to what you're doing. Whether you're heads-down

--- a/docs-site/guide/multi-page-documents.md
+++ b/docs-site/guide/multi-page-documents.md
@@ -1,3 +1,8 @@
+---
+title: Multi-Page Documents
+description: Organize complex diagrams across multiple pages — add, reorder, and navigate pages in a single document.
+---
+
 # Multi-Page Documents
 
 DocuShark documents can contain multiple pages, letting you organize complex projects into logical sections.

--- a/docs-site/guide/rich-text-editor.md
+++ b/docs-site/guide/rich-text-editor.md
@@ -1,3 +1,8 @@
+---
+title: Rich Text & Notes
+description: DocuShark's rich text editor — write documentation, headings, lists, code, and tables alongside your diagrams.
+---
+
 # Rich Text & Notes
 
 DocuShark includes a powerful rich text editor for adding documentation alongside your diagrams.

--- a/docs-site/guide/settings.md
+++ b/docs-site/guide/settings.md
@@ -1,3 +1,8 @@
+---
+title: Settings
+description: DocuShark settings — appearance, theme, collaboration server, storage, and editor preferences.
+---
+
 # Settings
 
 Access settings via the **Settings** button in the toolbar.

--- a/docs-site/guide/shape-libraries.md
+++ b/docs-site/guide/shape-libraries.md
@@ -1,3 +1,8 @@
+---
+title: Shape Libraries
+description: DocuShark's built-in shape libraries — flowchart, UML, ERD, AWS/Azure/GCP icons — plus custom libraries.
+---
+
 # Shape Libraries
 
 DocuShark comes with extensive shape libraries for creating any kind of diagram, plus a large collection of cloud provider icons for architecture diagrams.

--- a/docs-site/guide/styling.md
+++ b/docs-site/guide/styling.md
@@ -1,3 +1,8 @@
+---
+title: Styling & Themes
+description: Style shapes individually with the properties panel, save reusable style profiles, and switch app-wide themes.
+---
+
 # Styling & Themes
 
 DocuShark gives you flexible control over how your diagrams look — from individual shape styles to app-wide themes.

--- a/docs-site/guide/whiteboard.md
+++ b/docs-site/guide/whiteboard.md
@@ -1,3 +1,8 @@
+---
+title: Whiteboard & Ideas
+description: The DocuShark Whiteboard — sticky-note overlay for brainstorming that floats above your canvas.
+---
+
 # Whiteboard & Ideas
 
 The Whiteboard is a sticky-note overlay for quick brainstorming and idea tracking. It floats on top of your canvas and is separate from your diagram content.

--- a/docs-site/public/robots.txt
+++ b/docs-site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.docushark.app/sitemap.xml

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -236,6 +236,10 @@ fn parse_doc_path(id: String) -> Result<DocId, axum::response::Response> {
 pub fn routes() -> Router<Arc<ServerState>> {
     Router::new()
         .route("/api/v1/internal/revoke", post(revoke_handler))
+        .route(
+            "/api/v1/internal/workspace/:ws/purge-member",
+            post(purge_member_handler),
+        )
         .route("/api/v1/usage", get(usage_handler))
         .route("/api/v1/blobs/:hash/upload-url", post(blob_upload_url_handler))
         .route("/api/v1/blobs/:hash/finalize", post(blob_finalize_handler))
@@ -432,6 +436,82 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
         diff |= x ^ y;
     }
     diff == 0
+}
+
+/// Body for `POST /api/v1/internal/workspace/:ws/purge-member`.
+#[derive(Deserialize)]
+struct PurgeMemberRequest {
+    user_id: String,
+}
+
+/// `POST /api/v1/internal/workspace/:ws/purge-member` — drop a single user's
+/// share grants (`sharedWith`) from every document in the workspace. A generic
+/// control-plane hook: the relay is handed a workspace id + user id and knows
+/// nothing about *why* the grants are being dropped. Gated by the same shared
+/// bearer as the revocation push (`revocation_push_bearer`), constant-time
+/// compared. Idempotent — re-running for the same user is a no-op.
+async fn purge_member_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(ws): Path<String>,
+    Json(body): Json<PurgeMemberRequest>,
+) -> impl IntoResponse {
+    let expected = match state.revocation_push_bearer() {
+        Some(s) => s.to_string(),
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiError::body("internal control-plane transport disabled"),
+            )
+                .into_response();
+        }
+    };
+    let presented = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::trim)
+        .unwrap_or("");
+    if !constant_time_eq(presented.as_bytes(), expected.as_bytes()) {
+        return (StatusCode::UNAUTHORIZED, ApiError::body("unauthorized")).into_response();
+    }
+
+    // Same path-traversal validation the OIDC workspace claim goes through —
+    // a forged `"../etc"` is rejected here rather than reaching `doc_path`.
+    let ws = match WorkspaceId::from_configured(&ws) {
+        Some(w) => w,
+        None => {
+            return (StatusCode::BAD_REQUEST, ApiError::body("invalid workspace id"))
+                .into_response();
+        }
+    };
+
+    // Cold-pod safety: a recycled machine may hold an empty in-memory index —
+    // repopulate from R2 first so the purge sees the workspace's documents.
+    state.ensure_workspace_index_local(&ws).await;
+
+    let purged = match state
+        .doc_store()
+        .purge_user_from_workspace_shares(&ws, &body.user_id)
+    {
+        Ok(ids) => ids,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
+    };
+
+    // Notify connected clients (e.g. a workspace owner with the doc or list
+    // open) so the dropped grant disappears without a manual refresh. No JWT
+    // subject on an internal call → actor `None`.
+    for doc_id in &purged {
+        state.emit_doc_event(&ws, doc_id, DocEventType::Updated, None);
+    }
+
+    log::info!(
+        "purge-member: workspace {} purged user from {} document(s)",
+        ws.as_str(),
+        purged.len()
+    );
+
+    (StatusCode::OK, Json(json!({ "purged": purged.len() }))).into_response()
 }
 
 // ============ Document CRUD handlers ============

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -1813,6 +1813,80 @@ impl DocumentStore {
         Ok(())
     }
 
+    /// Drop a single user's share grant (`sharedWith`) from every document in a
+    /// workspace. For each document that currently shares with `user_id`, the
+    /// entry is removed and the remaining grants are kept verbatim — including
+    /// their original `sharedAt` (unlike [`update_document_shares`], which
+    /// rebuilds the whole list with a fresh timestamp). Documents the user was
+    /// never shared on are left untouched (no version bump, no R2 write).
+    /// Ownership (`owner_id`) is never affected. Returns the ids of the
+    /// documents actually modified.
+    pub fn purge_user_from_workspace_shares(
+        &self,
+        ws: &WorkspaceId,
+        user_id: &str,
+    ) -> Result<Vec<DocId>, String> {
+        // Narrow to candidates using the in-memory index: only documents whose
+        // metadata already lists this user are worth loading from disk.
+        let candidates: Vec<DocId> = self
+            .list_documents(ws)
+            .into_iter()
+            .filter(|m| {
+                m.shared_with
+                    .as_ref()
+                    .map(|s| s.iter().any(|e| e.user_id == user_id))
+                    .unwrap_or(false)
+            })
+            .map(|m| m.id)
+            .collect();
+
+        let mut purged = Vec::new();
+        for doc_id in candidates {
+            let mut doc = match self.get_document(ws, &doc_id) {
+                Ok(d) => d,
+                Err(e) => {
+                    log::warn!(
+                        "purge-member: skip {}/{}: {}",
+                        ws.as_str(),
+                        doc_id.as_str(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            // Re-read the body's shares (authoritative over the index snapshot)
+            // and drop the target user, keeping every other grant verbatim.
+            let existing: Vec<DocumentShare> = doc
+                .get("sharedWith")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+            let before = existing.len();
+            let kept: Vec<DocumentShare> = existing
+                .into_iter()
+                .filter(|e| e.user_id != user_id)
+                .collect();
+            // Index said this doc shared with the user but the body disagrees
+            // (stale index) — nothing to write, skip to avoid a needless bump.
+            if kept.len() == before {
+                continue;
+            }
+
+            doc["sharedWith"] = serde_json::to_value(&kept)
+                .map_err(|e| format!("Failed to serialize shares: {}", e))?;
+            self.save_document(ws, doc)?;
+            log::info!(
+                "purge-member: dropped a share grant from {}/{} ({} grants remain)",
+                ws.as_str(),
+                doc_id.as_str(),
+                kept.len()
+            );
+            purged.push(doc_id);
+        }
+
+        Ok(purged)
+    }
+
     /// Set (or clear, with `None`) a document's collection membership. A document
     /// belongs to at most one collection; passing a new id reassigns it, `None`
     /// unassigns it. Writes `collectionId` onto the body and saves through the

--- a/relay/tests/purge_member_shares.rs
+++ b/relay/tests/purge_member_shares.rs
@@ -1,0 +1,223 @@
+//! JP-378 — auto-revoke a member's document shares, over the real REST surface.
+//!
+//! `POST /api/v1/internal/workspace/:ws/purge-member` drops a single user's
+//! `sharedWith` grant from every document in the workspace. It is a generic,
+//! membership-agnostic control-plane hook gated by the same shared bearer as the
+//! revocation push (`revocation_push_bearer`). These tests exercise:
+//!
+//!   * the user is removed from every doc that shared with them, while other
+//!     grants are kept verbatim — including their original `sharedAt`;
+//!   * a doc the user was never shared on is left untouched (no version bump);
+//!   * the bearer gate: wrong bearer → 401, transport disabled → 503;
+//!   * a malformed workspace id → 400 (the path-traversal guard).
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const PUSH_BEARER: &str = "test-purge-bearer";
+
+/// In-process relay in shared-tenancy mode. `bearer` is the control-plane push
+/// secret — set *before* `start()` so it's captured into `ServerState`. Pass
+/// `None` to leave the internal transport disabled (503 path).
+async fn start_relay(
+    bearer: Option<&str>,
+) -> (Arc<WebSocketServer>, String, OidcTestIssuer, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let issuer = OidcTestIssuer::new().await;
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(issuer.auth_state()).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_revocation_push_bearer(bearer.map(str::to_string))
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+
+    (server, http, issuer, tmp)
+}
+
+/// One share grant in `sharedWith` (camelCase, matching `DocumentShare`).
+fn share(user_id: &str, permission: &str, shared_at: u64) -> Value {
+    json!({
+        "userId": user_id,
+        "userName": user_id,
+        "permission": permission,
+        "sharedAt": shared_at,
+    })
+}
+
+/// Seed a document via the REST save handler with the given `sharedWith` array.
+async fn save_doc(http: &str, token: &str, id: &str, shares: Vec<Value>) {
+    let status = reqwest::Client::new()
+        .put(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .json(&json!({
+            "id": id,
+            "name": id,
+            "ownerId": "owner-1",
+            "sharedWith": shares,
+        }))
+        .send()
+        .await
+        .expect("save request")
+        .status();
+    assert_eq!(status, reqwest::StatusCode::OK, "seed save for {id} failed");
+}
+
+/// Fetch a document body.
+async fn get_doc(http: &str, token: &str, id: &str) -> Value {
+    reqwest::Client::new()
+        .get(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .expect("get request")
+        .json()
+        .await
+        .expect("get json")
+}
+
+/// The set of user ids currently in a doc's `sharedWith`.
+fn shared_user_ids(doc: &Value) -> Vec<String> {
+    doc.get("sharedWith")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e.get("userId").and_then(|u| u.as_str()).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn purge(
+    http: &str,
+    bearer: &str,
+    ws: &str,
+    user_id: &str,
+) -> (reqwest::StatusCode, Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("{http}/api/v1/internal/workspace/{ws}/purge-member"))
+        .bearer_auth(bearer)
+        .json(&json!({ "user_id": user_id }))
+        .send()
+        .await
+        .expect("purge request");
+    let status = resp.status();
+    let body = resp.json().await.unwrap_or(Value::Null);
+    (status, body)
+}
+
+#[tokio::test]
+async fn purge_removes_user_everywhere_and_keeps_other_grants_verbatim() {
+    let (_server, http, issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    let owner = issuer.mint("owner-1", "alpha", WorkspaceRole::Owner);
+
+    // doc1: shared with X (edit) and Y (view, sharedAt=222); doc2: X only;
+    // doc3: Y only (X never on it → must be left untouched, no version bump).
+    save_doc(&http, &owner, "doc1", vec![
+        share("user-x", "edit", 111),
+        share("user-y", "view", 222),
+    ]).await;
+    save_doc(&http, &owner, "doc2", vec![share("user-x", "view", 333)]).await;
+    save_doc(&http, &owner, "doc3", vec![share("user-y", "edit", 444)]).await;
+
+    let doc3_before = get_doc(&http, &owner, "doc3").await;
+    let doc3_ver_before = doc3_before.get("serverVersion").cloned();
+
+    let (status, body) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body["purged"], json!(2), "should have touched exactly doc1 + doc2");
+
+    // doc1: X gone, Y retained with its ORIGINAL sharedAt (not rebuilt to `now`).
+    let doc1 = get_doc(&http, &owner, "doc1").await;
+    assert_eq!(shared_user_ids(&doc1), vec!["user-y".to_string()]);
+    let y = &doc1["sharedWith"][0];
+    assert_eq!(y["sharedAt"], json!(222), "remaining grant's timestamp must be preserved");
+    assert_eq!(y["permission"], json!("view"));
+
+    // doc2: X was the only grant → now empty.
+    let doc2 = get_doc(&http, &owner, "doc2").await;
+    assert!(shared_user_ids(&doc2).is_empty());
+
+    // doc3: untouched — Y still present and serverVersion unchanged (no save).
+    let doc3 = get_doc(&http, &owner, "doc3").await;
+    assert_eq!(shared_user_ids(&doc3), vec!["user-y".to_string()]);
+    assert_eq!(
+        doc3.get("serverVersion").cloned(),
+        doc3_ver_before,
+        "a doc the user was never shared on must not be re-saved"
+    );
+}
+
+#[tokio::test]
+async fn purge_is_idempotent() {
+    let (_server, http, issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    let owner = issuer.mint("owner-1", "alpha", WorkspaceRole::Owner);
+    save_doc(&http, &owner, "doc1", vec![share("user-x", "edit", 111)]).await;
+
+    let (s1, b1) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(s1, reqwest::StatusCode::OK);
+    assert_eq!(b1["purged"], json!(1));
+
+    // Second run: nothing left to drop.
+    let (s2, b2) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(s2, reqwest::StatusCode::OK);
+    assert_eq!(b2["purged"], json!(0));
+}
+
+#[tokio::test]
+async fn purge_rejects_wrong_bearer() {
+    let (_server, http, issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    let owner = issuer.mint("owner-1", "alpha", WorkspaceRole::Owner);
+    save_doc(&http, &owner, "doc1", vec![share("user-x", "edit", 111)]).await;
+
+    let (status, _) = purge(&http, "not-the-bearer", "alpha", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+
+    // The grant is untouched after the rejected call.
+    let doc1 = get_doc(&http, &owner, "doc1").await;
+    assert_eq!(shared_user_ids(&doc1), vec!["user-x".to_string()]);
+}
+
+#[tokio::test]
+async fn purge_returns_503_when_transport_disabled() {
+    // No push bearer configured → the internal endpoint is unavailable.
+    let (_server, http, _issuer, _tmp) = start_relay(None).await;
+    let (status, _) = purge(&http, PUSH_BEARER, "alpha", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn purge_rejects_malformed_workspace_id() {
+    let (_server, http, _issuer, _tmp) = start_relay(Some(PUSH_BEARER)).await;
+    // "a..b" is a single valid URL segment but fails workspace-id validation
+    // (contains ".."), so it never reaches the document store as a path.
+    let (status, _) = purge(&http, PUSH_BEARER, "a..b", "user-x").await;
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+}

--- a/src/api/cloudAuth.test.ts
+++ b/src/api/cloudAuth.test.ts
@@ -82,6 +82,55 @@ describe('beginCloudSignIn', () => {
     });
   });
 
+  it('surfaces the region-resolved relay_url (and workspace identity) when present', async () => {
+    const { fetchImpl } = mockFetch({
+      tokenQueue: [
+        jsonRes({
+          token: 'RELAY.JWT',
+          jti: 'j1',
+          expires_at: 1000,
+          token_type: 'Bearer',
+          relay_url: 'https://relay.example.com',
+          workspace_name: 'Acme',
+          workspace_slug: 'acme',
+        }),
+      ],
+    });
+
+    const handle = await beginCloudSignIn('http://web', {
+      fetchImpl,
+      openExternal: async () => {},
+      sleep: noopSleep,
+    });
+
+    const result = await handle.result;
+    expect(result).toEqual({
+      token: 'RELAY.JWT',
+      expiresAt: 1000 * 1000,
+      relayUrl: 'https://relay.example.com',
+      workspaceName: 'Acme',
+      workspaceSlug: 'acme',
+    });
+  });
+
+  it('omits relayUrl when the response has none (older relay)', async () => {
+    const { fetchImpl } = mockFetch({
+      tokenQueue: [
+        jsonRes({ token: 'T', jti: 'j', expires_at: 5, token_type: 'Bearer' }),
+      ],
+    });
+
+    const handle = await beginCloudSignIn('http://web', {
+      fetchImpl,
+      openExternal: async () => {},
+      sleep: noopSleep,
+    });
+
+    const result = await handle.result;
+    expect(result).toEqual({ token: 'T', expiresAt: 5000 });
+    expect('relayUrl' in result).toBe(false);
+  });
+
   it('keeps polling through slow_down and still resolves', async () => {
     const { fetchImpl, tokenCallCount } = mockFetch({
       tokenQueue: [

--- a/src/api/cloudAuth.ts
+++ b/src/api/cloudAuth.ts
@@ -26,6 +26,13 @@ export const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
 export interface CloudSignInResult {
   token: string;
   expiresAt: number;
+  /**
+   * Region-resolved relay origin from the device-token response. The session
+   * adopts this as the authoritative relay URL (it overrides the form/switcher
+   * default), so a hosted sign-in always lands on the workspace's region relay
+   * rather than the local-dev default. Absent on older relays.
+   */
+  relayUrl?: string;
   /** Cloud workspace display identity from the device-token response (JP-343);
    *  for the relay page. Persisted in the connection record, never the JWT claim. */
   workspaceName?: string;
@@ -84,6 +91,8 @@ interface DeviceTokenSuccess {
   /** Epoch *seconds* (relay token `exp`). */
   expires_at: number;
   token_type: string;
+  /** Region-resolved relay origin (docushark-web computes it from the workspace). */
+  relay_url?: string;
   workspace_name?: string;
   workspace_slug?: string;
 }
@@ -180,6 +189,7 @@ async function pollForToken(args: PollArgs): Promise<CloudSignInResult> {
       return {
         token: body.token,
         expiresAt: body.expires_at * 1000,
+        ...(typeof body.relay_url === 'string' ? { relayUrl: body.relay_url } : {}),
         ...(typeof body.workspace_name === 'string' ? { workspaceName: body.workspace_name } : {}),
         ...(typeof body.workspace_slug === 'string' ? { workspaceSlug: body.workspace_slug } : {}),
       };

--- a/src/api/completeCloudSignIn.test.ts
+++ b/src/api/completeCloudSignIn.test.ts
@@ -8,6 +8,10 @@ const h = vi.hoisted(() => ({
   standUpRestProvider: vi.fn(),
   getRecord: vi.fn((_id: string) => undefined as unknown),
   ensureCollabSessionForDoc: vi.fn(async () => {}),
+  // A live collab engine is itself proof of a relay doc (local docs never get one),
+  // so an already-active session for the doc is a valid sign-in reopen signal even
+  // when the registry record hasn't loaded yet (JP-392 boot-cached path).
+  collabState: { isActive: false, config: null as { documentId: string } | null },
 }));
 
 vi.mock('./relayConnection', () => ({ saveConnection: h.saveConnection }));
@@ -17,6 +21,9 @@ vi.mock('../store/connectionStore', () => ({
 }));
 vi.mock('../store/documentRegistry', () => ({
   useDocumentRegistry: { getState: () => ({ getRecord: h.getRecord }) },
+}));
+vi.mock('../collaboration/collaborationStore', () => ({
+  useCollaborationStore: { getState: () => h.collabState },
 }));
 vi.mock('../collaboration/ensureCollabSession', () => ({
   ensureCollabSessionForDoc: h.ensureCollabSessionForDoc,
@@ -34,6 +41,8 @@ const base = {
 beforeEach(() => {
   vi.clearAllMocks();
   h.getRecord.mockReturnValue(undefined);
+  h.collabState.isActive = false;
+  h.collabState.config = null;
 });
 
 describe('completeCloudSignIn (REST-only sign-in, JP — phantom-join fix)', () => {
@@ -59,6 +68,19 @@ describe('completeCloudSignIn (REST-only sign-in, JP — phantom-join fix)', () 
     h.getRecord.mockReturnValue(undefined);
     await completeCloudSignIn({ ...base, documentId: 'default' });
     expect(h.ensureCollabSessionForDoc).not.toHaveBeenCalled();
+  });
+
+  it('JP-392: opens the live session for the active doc when its registry record is missing', async () => {
+    // Boot-cached doc: warmupCache loaded its content but no record, and the REST
+    // list re-fetch is still async — so getRecord is undefined at sign-in. The live
+    // engine for this exact doc is the reliable signal that it's a relay doc.
+    h.getRecord.mockReturnValue(undefined);
+    h.collabState.isActive = true;
+    h.collabState.config = { documentId: 'doc-9' };
+
+    await completeCloudSignIn({ ...base, documentId: 'doc-9' });
+
+    expect(h.ensureCollabSessionForDoc).toHaveBeenCalledWith('doc-9');
   });
 
   it('opens the live session only for a known relay doc', async () => {

--- a/src/api/completeCloudSignIn.ts
+++ b/src/api/completeCloudSignIn.ts
@@ -80,7 +80,17 @@ export async function completeCloudSignIn(args: CompleteCloudSignInArgs): Promis
   // `restUrlToWsUrl` from here).
   if (documentId) {
     const record = useDocumentRegistry.getState().getRecord(documentId);
-    if (record && (record.type === 'remote' || record.type === 'cached')) {
+    // A live collab engine for this exact doc also makes it a confirmed relay doc:
+    // the engine only ever exists for relay docs (local docs never get one, JP-64),
+    // and an expired-session boot brings the active doc up engine-only BEFORE its
+    // registry record loads (warmupCache stores content, not a record; the REST list
+    // re-fetch is async). Without this the active doc stayed offline until a manual
+    // doc switch (JP-392). Lazy import mirrors the ensureCollabSession import below.
+    const { useCollaborationStore } = await import('../collaboration/collaborationStore');
+    const collab = useCollaborationStore.getState();
+    const engineLiveForDoc = collab.isActive && collab.config?.documentId === documentId;
+    const knownRelayDoc = record !== undefined && (record.type === 'remote' || record.type === 'cached');
+    if (engineLiveForDoc || knownRelayDoc) {
       const { ensureCollabSessionForDoc } = await import('../collaboration/ensureCollabSession');
       await ensureCollabSessionForDoc(documentId);
     }

--- a/src/api/relayClient.test.ts
+++ b/src/api/relayClient.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { RelayClient, RelayError, VersionConflictError } from './relayClient';
+import {
+  RelayClient,
+  RelayError,
+  VersionConflictError,
+  isTransientAuthFailure,
+} from './relayClient';
 
 /** Minimal scriptable fetch mock. Each test queues responses in order. */
 class FetchScript {
@@ -459,5 +464,76 @@ describe('RelayClient — request timeout (JP-127)', () => {
       requestTimeoutMs: 0,
     });
     await expect(client.blobExists('abc')).resolves.toBe(false);
+  });
+});
+
+describe('401 discrimination (JP-396)', () => {
+  let script: FetchScript;
+  beforeEach(() => {
+    script = new FetchScript();
+  });
+
+  it('does NOT call onUnauthorized for a transient jwks-unavailable 401 (still throws)', async () => {
+    let unauthorized = 0;
+    const client = new RelayClient({
+      baseUrl: 'http://r',
+      token: 'T',
+      fetchImpl: script.fetch,
+      onUnauthorized: () => {
+        unauthorized++;
+      },
+    });
+    // The cold-relay 401: a relay-availability failure, not a token rejection.
+    script.pushError(401, 'invalid token: jwks unavailable (fail-open grace expired)');
+
+    await expect(client.listDocuments()).rejects.toBeInstanceOf(RelayError);
+    expect(unauthorized).toBe(0); // session must NOT be torn down
+  });
+
+  it('DOES call onUnauthorized for a genuine token rejection 401', async () => {
+    let unauthorized = 0;
+    const client = new RelayClient({
+      baseUrl: 'http://r',
+      token: 'T',
+      fetchImpl: script.fetch,
+      onUnauthorized: () => {
+        unauthorized++;
+      },
+    });
+    script.pushError(401, 'invalid token: ExpiredSignature');
+
+    await expect(client.listDocuments()).rejects.toBeInstanceOf(RelayError);
+    expect(unauthorized).toBe(1);
+  });
+
+  it('does not call onUnauthorized for a 403 (only 401 triggers it)', async () => {
+    let unauthorized = 0;
+    const client = new RelayClient({
+      baseUrl: 'http://r',
+      token: 'T',
+      fetchImpl: script.fetch,
+      onUnauthorized: () => {
+        unauthorized++;
+      },
+    });
+    script.pushError(403, 'forbidden');
+
+    await expect(client.listDocuments()).rejects.toBeInstanceOf(RelayError);
+    expect(unauthorized).toBe(0);
+  });
+});
+
+describe('isTransientAuthFailure (JP-396)', () => {
+  it('matches the relay cold-start JWKS strings', () => {
+    expect(isTransientAuthFailure('invalid token: jwks unavailable (fail-open grace expired)')).toBe(true);
+    expect(isTransientAuthFailure('JWKS UNAVAILABLE')).toBe(true);
+    expect(isTransientAuthFailure('fail-open grace expired')).toBe(true);
+  });
+
+  it('does not match genuine token rejections', () => {
+    expect(isTransientAuthFailure('invalid token: ExpiredSignature')).toBe(false);
+    expect(isTransientAuthFailure('invalid token: InvalidSignature')).toBe(false);
+    expect(isTransientAuthFailure('forbidden')).toBe(false);
+    expect(isTransientAuthFailure('workspace mismatch')).toBe(false);
   });
 });

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -61,6 +61,23 @@ export class RelayError extends Error {
 }
 
 /**
+ * JP-396: a 401 whose body says the relay couldn't *validate* the token right
+ * now — its JWKS cache isn't populated yet on a cold or just-redeployed pod
+ * (`jwks unavailable (fail-open grace expired)`) — rather than the token being
+ * genuinely rejected. This is **transient**: the *same* token succeeds once the
+ * relay warms, so callers must NOT tear down the signed-in session or prompt a
+ * re-sign-in over it (that stranded a perfectly good session on every PWA
+ * cold-start against a cold prod relay). A genuine rejection (expired/bad
+ * signature/issuer/audience/region/workspace mismatch) is not matched here and
+ * keeps its normal sign-out behavior. (JP-397 will also have the relay return
+ * 503 for this, making it unambiguous at the status-code level.)
+ */
+export function isTransientAuthFailure(message: string): boolean {
+  const m = message.toLowerCase();
+  return m.includes('jwks unavailable') || m.includes('fail-open');
+}
+
+/**
  * Thrown by `saveDocument` when the caller's `expectedVersion` no
  * longer matches the server-side version. Carries `currentVersion` so
  * the caller can refetch, rebase, and retry.
@@ -487,10 +504,14 @@ export class RelayClient {
     const wasAuthed = opts.auth !== false && this.token !== undefined;
     const res = await this.fetchWithTimeout(url, init, opts.timeoutMs ?? this.requestTimeoutMs);
     if (!res.ok) {
-      if (res.status === 401 && wasAuthed) {
+      const err = await buildRelayError(res, url);
+      // JP-396: only a GENUINE token rejection should drop the signed-in
+      // session. A transient relay-validation 401 (a cold-pod JWKS that isn't
+      // loaded yet) must not — the same token succeeds once the relay warms.
+      if (res.status === 401 && wasAuthed && !isTransientAuthFailure(err.message)) {
         this.onUnauthorized?.();
       }
-      throw await buildRelayError(res, url);
+      throw err;
     }
     // 204 No Content -> return empty object cast to T.
     if (res.status === 204) {
@@ -520,10 +541,14 @@ export class RelayClient {
     const wasAuthed = this.token !== undefined;
     const res = await this.fetchWithTimeout(url, init, opts.timeoutMs ?? this.requestTimeoutMs);
     if (!res.ok) {
-      if (res.status === 401 && wasAuthed) {
+      const err = await buildRelayError(res, url);
+      // JP-396: only a GENUINE token rejection should drop the signed-in
+      // session. A transient relay-validation 401 (a cold-pod JWKS that isn't
+      // loaded yet) must not — the same token succeeds once the relay warms.
+      if (res.status === 401 && wasAuthed && !isTransientAuthFailure(err.message)) {
         this.onUnauthorized?.();
       }
-      throw await buildRelayError(res, url);
+      throw err;
     }
     return res;
   }

--- a/src/api/relayLocations.test.ts
+++ b/src/api/relayLocations.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RELAY_LOCATIONS,
+  DEFAULT_RELAY_LOCATION,
+  DEFAULT_RELAY_BASE_URL,
+  locationForUrl,
+} from './relayLocations';
+
+describe('relayLocations', () => {
+  it('defaults the primary region to Toronto (yyz)', () => {
+    expect(DEFAULT_RELAY_LOCATION.id).toBe('yyz');
+    expect(RELAY_LOCATIONS).toContain(DEFAULT_RELAY_LOCATION);
+  });
+
+  it('falls back to the local dev relay when VITE_RELAY_BASE_URL is unset', () => {
+    // No build var is injected in the test env, so the default is the OSS dev relay.
+    expect(DEFAULT_RELAY_BASE_URL).toBe('http://localhost:9876');
+    expect(DEFAULT_RELAY_LOCATION.relayUrl).toBe('http://localhost:9876');
+  });
+
+  describe('locationForUrl', () => {
+    it('matches a known origin exactly', () => {
+      expect(locationForUrl(DEFAULT_RELAY_LOCATION.relayUrl)).toBe(DEFAULT_RELAY_LOCATION);
+    });
+
+    it('normalizes trailing slashes and surrounding whitespace', () => {
+      expect(locationForUrl(`  ${DEFAULT_RELAY_LOCATION.relayUrl}/  `)).toBe(DEFAULT_RELAY_LOCATION);
+    });
+
+    it('returns undefined for a custom/self-host origin', () => {
+      expect(locationForUrl('https://relay.example.com')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string', () => {
+      expect(locationForUrl('')).toBeUndefined();
+    });
+  });
+});

--- a/src/api/relayLocations.ts
+++ b/src/api/relayLocations.ts
@@ -1,0 +1,65 @@
+/**
+ * Relay location registry — the location → relay-origin mapping that backs the
+ * Cloud connect modal's location switcher.
+ *
+ * The relay origin for a given location differs per environment (localhost in
+ * dev, the staging Fly app, the prod custom domain), so the primary region's
+ * origin is injected at **build time** via `VITE_RELAY_BASE_URL` — mirroring
+ * `VITE_CLOUD_BASE_URL` (see `relayConnection.ts`). A hosted build pairs with
+ * its environment's relay; the OSS source keeps a generic `localhost` default so
+ * no deployment origin lands in the public tree.
+ *
+ * Region-resolution is ultimately a server concern: the relay app-token response
+ * already carries the workspace's region-resolved `relay_url`, which the session
+ * adopts as authoritative (see `cloudAuth.ts` / `completeCloudSignIn.ts`). This
+ * registry governs the *pre-sign-in default* the user sees + a self-host override.
+ */
+
+/**
+ * Build-time relay origin for the primary region; `http://localhost:9876` for
+ * OSS/dev. Injected per-environment in the editor build (docushark-web CI),
+ * exactly like `VITE_CLOUD_BASE_URL`. Just an origin (not a secret).
+ */
+export const DEFAULT_RELAY_BASE_URL =
+  import.meta.env.VITE_RELAY_BASE_URL ?? 'http://localhost:9876';
+
+export interface RelayLocation {
+  /** Region code, e.g. `yyz`. */
+  id: string;
+  /** Human label shown in the switcher, e.g. `Toronto, Canada`. */
+  label: string;
+  /** Relay REST origin for this location (e.g. `http://localhost:9876`). */
+  relayUrl: string;
+}
+
+// Declare the location const first, then build the list + default from it — so
+// DEFAULT_RELAY_LOCATION is `RelayLocation`, not `RelayLocation | undefined`
+// (RELAY_LOCATIONS[0] would be `| undefined` under noUncheckedIndexedAccess).
+//
+// Only Toronto (`yyz`) is live today. ord/nrt/fra light up on demand; each will
+// get its own `VITE_RELAY_BASE_URL_<region>` build var when it does (YAGNI now).
+const TORONTO: RelayLocation = {
+  id: 'yyz',
+  label: 'Toronto, Canada',
+  relayUrl: DEFAULT_RELAY_BASE_URL,
+};
+
+export const RELAY_LOCATIONS: RelayLocation[] = [TORONTO];
+
+/** The location selected by default before the user picks one. */
+export const DEFAULT_RELAY_LOCATION: RelayLocation = TORONTO;
+
+/** Trim trailing slashes so `http://host/` and `http://host` compare equal. */
+function normalizeOrigin(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+/**
+ * The known location whose relay origin matches `url` (slash-normalized), or
+ * `undefined` when none does — in which case the switcher shows "Custom" (a
+ * self-host / Advanced-override URL).
+ */
+export function locationForUrl(url: string): RelayLocation | undefined {
+  const target = normalizeOrigin(url);
+  return RELAY_LOCATIONS.find((loc) => normalizeOrigin(loc.relayUrl) === target);
+}

--- a/src/api/restoreCloudSession.test.ts
+++ b/src/api/restoreCloudSession.test.ts
@@ -30,6 +30,10 @@ vi.mock('../store/notificationStore', () => ({
 }));
 
 import { restoreCloudSession } from './restoreCloudSession';
+import { activeWorkspaceId, clearRememberedWorkspaceId } from '../store/activeWorkspace';
+
+const b64url = (o: unknown) =>
+  btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 
 const NOW = 1_000_000;
 const future = { relayUrl: 'http://relay:9876', jwt: 'tok', jwtExpiresAt: NOW + 60_000, cloudBaseUrl: null };
@@ -39,6 +43,7 @@ describe('restoreCloudSession', () => {
     [loadConnection, setToken, setUser, setHost, setProvider, setAuthenticated, info].forEach((m) =>
       m.mockReset(),
     );
+    clearRememberedWorkspaceId();
   });
 
   it("status 'none' when no connection / no token", async () => {
@@ -61,6 +66,19 @@ describe('restoreCloudSession', () => {
     expect(setToken).not.toHaveBeenCalled();
     expect(setProvider).not.toHaveBeenCalled();
     expect(setAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it("JP-390: recovers the workspace scope from an expired token (no connect)", async () => {
+    // The token is dead (no auth), but it still names the workspace this session
+    // belonged to — recover that scope so the cached relay docs stay listed.
+    const jwt = `h.${b64url({ sub: 'u1', wsp: [{ id: 'ws-expired', role: 'owner' }] })}.s`;
+    loadConnection.mockResolvedValueOnce({ ...future, jwt, jwtExpiresAt: NOW - 1 });
+
+    const r = await restoreCloudSession({ proactiveList: true, now: () => NOW });
+
+    expect(r).toEqual({ status: 'expired' });
+    expect(setToken).not.toHaveBeenCalled(); // still never authenticates
+    expect(activeWorkspaceId()).toBe('ws-expired'); // but the scope survives
   });
 
   it('restored + proactiveList: asserts token, stands up provider AND loads the live list', async () => {

--- a/src/api/restoreCloudSession.ts
+++ b/src/api/restoreCloudSession.ts
@@ -23,8 +23,9 @@
 import { loadConnection } from './relayConnection';
 import { RelayClient } from './relayClient';
 import { RestDocumentProvider } from './restDocumentProvider';
-import { userFromRelayToken } from './relayTokenUser';
+import { userFromRelayToken, workspaceIdFromRelayToken } from './relayTokenUser';
 import { relayFetch } from '../platform/relayFetch';
+import { rememberWorkspaceId } from '../store/activeWorkspace';
 import { useConnectionStore } from '../store/connectionStore';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { useNotificationStore } from '../store/notificationStore';
@@ -71,6 +72,12 @@ export async function restoreCloudSession(
   // Expiry semantics match `connectionStore.isTokenValid`: a null expiry is
   // treated as "no known expiry → assume valid".
   if (conn.jwtExpiresAt !== null && now() >= conn.jwtExpiresAt) {
+    // JP-390: the token is expired, so we never authenticate — but it still
+    // carries the workspace this session belonged to. Recover that scope from
+    // the (unverified) payload so the cached relay docs stay correctly scoped
+    // and listed offline. Covers a first boot after upgrade where no prior
+    // in-app `setToken` recorded the workspace. Decoding never verifies `exp`.
+    rememberWorkspaceId(workspaceIdFromRelayToken(conn.jwt));
     return { status: 'expired' };
   }
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -543,76 +543,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         onDocumentEvent: (event: DocEvent) => {
           useRelayDocumentStore.getState().handleDocumentEvent(event);
         },
-        onError: (error: string, docId: string | null) => {
-          // JP-375: ERR_DELETED is a definitive tombstone — the doc was deleted
-          // (or restored under a new id) on the relay. Strand our local copy to
-          // Trash and leave, so a returning offline editor never merges its stale
-          // Y.Doc back. Only act when we actually hold a copy; a bare unknown id
-          // is a no-op (strandOrDemoteDeletedDoc handles a missing record).
-          if (isDeletedDocError(error) && docId) {
-            const record = useDocumentRegistry.getState().getRecord(docId);
-            if (record) {
-              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
-            }
-            return;
-          }
-          // JP-370: the relay refused the JOIN_DOC with a VIEW denial — we no
-          // longer have read access (un-shared, or removed from the workspace)
-          // while private-doc enforcement is on. The doc isn't deleted globally,
-          // but it's inaccessible to us: keep our local copy (strand to Trash)
-          // so we stop syncing into a doc we can't read. Deliberately narrow to
-          // a view denial — a transient ERR_NOT_AUTHENTICATED (token race) or an
-          // ERR_EDIT_FORBIDDEN (read-only viewer who can still SEE the doc) must
-          // NOT strand a doc the user still legitimately holds. The strand path
-          // owns the single 'access-revoked' toast (no duplicate here).
-          if (isViewForbiddenError(error) && docId) {
-            const record = useDocumentRegistry.getState().getRecord(docId);
-            if (record) {
-              useRelayDocumentStore
-                .getState()
-                .strandOrDemoteDeletedDoc(docId, undefined, 'access-revoked');
-            }
-            return;
-          }
-          // A rejected JOIN_DOC means the relay has no record of this doc in
-          // our workspace (never promoted, deleted, or a diverged local-only
-          // id). Mark it as not-syncing and tell the user their edits are
-          // local-only, rather than letting them edit into the void.
-          if (isUnknownDocError(error) && docId) {
-            const record = useDocumentRegistry.getState().getRecord(docId);
-            const connectedRelayAddress = useConnectionStore.getState().host?.address;
-            if (record && isForeignRelayDoc(record, connectedRelayAddress)) {
-              // JP-308: the doc belongs to a DIFFERENT relay than the one we're
-              // connected to. This relay rejecting the JOIN is expected — the doc
-              // lives on its home relay, it is NOT deleted. Do nothing destructive:
-              // keep the remote record intact (the card derives idle/offline from
-              // the relay mismatch, and edits queue under the doc's home relay for
-              // replay on return — JP-117). Demoting here was the bug.
-            } else if (record && (record.type === 'remote' || record.type === 'cached')) {
-              // The doc's OWN home relay has no record of it — it was deleted,
-              // possibly while we were offline. Converge on the same strand/demote
-              // path as a live Deleted event (JP-175) so the user keeps their copy
-              // instead of editing a ghost into the void. No deleter id (this is
-              // our own rejected JOIN), so it's treated as a foreign deletion
-              // (never self-skipped).
-              useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
-            } else if (record?.type === 'local') {
-              // A local-only doc was never meant to sync; a JOIN reject for it is
-              // expected (and should have been gated upstream by shouldJoinDocument
-              // / sign-in staying REST-only). Don't scare the user with a warning.
-            } else {
-              // Diverged / never-promoted id — not a deletion. Keep the gentler
-              // "saved locally only" hint.
-              useDocumentRegistry.getState().setSyncState(docId, 'error');
-              useNotificationStore
-                .getState()
-                .warning(
-                  'This document isn’t syncing — the relay has no record of it. ' +
-                    'Your changes are saved locally only.',
-                );
-            }
-          }
-        },
+        onError: (error: string, docId: string | null) => handleRelayJoinError(error, docId),
         shouldJoinDocument: (docId: string) => {
           // Don't fire a JOIN_DOC for a local-only document; the relay will
           // reject it. Relay docs ('remote') and offline-cached relay docs
@@ -979,6 +910,77 @@ export function useIsRelaySessionLive(): boolean {
   const isActive = useCollaborationStore((s) => s.isActive);
   const isSynced = useCollaborationStore((s) => s.isSynced);
   return authed && isActive && isSynced;
+}
+
+/**
+ * Handle a relay JOIN_DOC error frame. Extracted from the inline provider
+ * `onError` so it's unit-testable (the UnifiedSyncProvider mock discards the
+ * options object). The relay gives three distinct signals:
+ *
+ *   - ERR_DELETED (JP-375): a definitive tombstone — the doc was really deleted
+ *     (or restored under a new id). Strand our local copy to Trash so a returning
+ *     offline editor never merges a stale Y.Doc back.
+ *   - ERR_VIEW_FORBIDDEN (JP-370): read access was revoked (un-shared / removed
+ *     from the workspace). The doc still exists globally but is inaccessible to
+ *     us — strand it, with the single 'access-revoked' toast.
+ *   - ERR_UNKNOWN_DOC: the relay's in-memory index has no record. This is
+ *     AMBIGUOUS and frequently TRANSIENT — a cold/un-hydrated workspace index, or
+ *     a JWKS cold-start auth blip after a relay redeploy, emits it for a doc that
+ *     still exists. JP-395: never strand on it (doing so fake-deleted live docs
+ *     and evicted the cache). A genuine deletion arrives as ERR_DELETED, above.
+ */
+export function handleRelayJoinError(error: string, docId: string | null): void {
+  if (isDeletedDocError(error) && docId) {
+    const record = useDocumentRegistry.getState().getRecord(docId);
+    if (record) {
+      useRelayDocumentStore.getState().strandOrDemoteDeletedDoc(docId);
+    }
+    return;
+  }
+  if (isViewForbiddenError(error) && docId) {
+    const record = useDocumentRegistry.getState().getRecord(docId);
+    if (record) {
+      useRelayDocumentStore
+        .getState()
+        .strandOrDemoteDeletedDoc(docId, undefined, 'access-revoked');
+    }
+    return;
+  }
+  if (isUnknownDocError(error) && docId) {
+    const record = useDocumentRegistry.getState().getRecord(docId);
+    const connectedRelayAddress = useConnectionStore.getState().host?.address;
+    if (record && isForeignRelayDoc(record, connectedRelayAddress)) {
+      // JP-308: the doc belongs to a DIFFERENT relay than the one we're connected
+      // to — this relay rejecting the JOIN is expected and NOT a deletion. Keep
+      // the remote record intact (edits queue under the doc's home relay, JP-117).
+      return;
+    }
+    if (record?.type === 'local') {
+      // A local-only doc was never meant to sync; a JOIN reject is expected (and
+      // should have been gated upstream by shouldJoinDocument). Stay silent.
+      return;
+    }
+    if (record && (record.type === 'remote' || record.type === 'cached')) {
+      // JP-395: ERR_UNKNOWN_DOC on the doc's OWN home relay is ambiguous and
+      // usually transient (a cold/un-hydrated index, or a JWKS cold-start blip
+      // after a relay redeploy) — it self-heals once auth/the index recovers.
+      // Do NOT strand/trash the doc (that was the fake-deletion bug). Mark the
+      // card not-syncing; it clears when the next JOIN syncs. No toast — a
+      // transient blip shouldn't alarm the user. A real deletion would have
+      // arrived as ERR_DELETED (handled above).
+      useDocumentRegistry.getState().setSyncState(docId, 'error');
+      return;
+    }
+    // No record at all (a diverged / never-promoted id) — a persistent condition,
+    // so keep the gentle non-destructive hint that edits are local-only.
+    useDocumentRegistry.getState().setSyncState(docId, 'error');
+    useNotificationStore
+      .getState()
+      .warning(
+        'This document isn’t syncing — the relay has no record of it. ' +
+          'Your changes are saved locally only.',
+      );
+  }
 }
 
 /**

--- a/src/collaboration/ensureCollabSession.test.ts
+++ b/src/collaboration/ensureCollabSession.test.ts
@@ -60,6 +60,34 @@ describe('ensureCollabSessionForDoc', () => {
     expect(collab.startSession).not.toHaveBeenCalled();
   });
 
+  it('JP-392: restarts a token-less same-doc session once a valid token is available', async () => {
+    // Boot opened the active doc engine-only (expired session → no token, no WS
+    // provider). The user then signs in, so connectionStore now holds a valid
+    // token. Re-running ensure for the SAME doc must force-restart it (carrying the
+    // fresh token via switchDocument) so the WS provider attaches — not no-op,
+    // which is what left the active doc offline until a manual doc switch.
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-9', serverUrl: 'ws://relay.example:9876/ws' }; // no token
+    useConnectionStore.getState().setToken('fresh-token', Date.now() + 60_000);
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.switchDocument).toHaveBeenCalledWith('doc-9');
+  });
+
+  it('JP-392: does NOT restart an already-online same-doc session (provider attached)', async () => {
+    // config.token set → provider already live. Must stay a no-op so we never tear
+    // down a provider whose callback may be running (the on-connect reattach path).
+    collab.isActive = true;
+    collab.config = { documentId: 'doc-9', serverUrl: 'ws://relay.example:9876/ws', token: 'live' };
+    useConnectionStore.getState().setToken('fresh-token', Date.now() + 60_000);
+
+    await ensureCollabSessionForDoc('doc-9');
+
+    expect(collab.switchDocument).not.toHaveBeenCalled();
+    expect(collab.startSession).not.toHaveBeenCalled();
+  });
+
   it('switches the engine when active for a different doc', async () => {
     collab.isActive = true;
     collab.config = { documentId: 'doc-1', serverUrl: 'ws://x/ws', token: 't' };

--- a/src/collaboration/ensureCollabSession.ts
+++ b/src/collaboration/ensureCollabSession.ts
@@ -100,8 +100,22 @@ export async function ensureCollabSessionForDoc(docId: string): Promise<void> {
 
   const collab = useCollaborationStore.getState();
 
-  // Already the live engine for this doc.
-  if (collab.isActive && collab.config?.documentId === docId) return;
+  // Already the live engine for this doc. If it came up engine-only (no WS provider —
+  // started before a token was available, e.g. an expired-session boot) and a valid
+  // token is now available — the user just signed in (JP-392) — force-restart it WITH
+  // the token so the provider attaches, instead of leaving the active doc offline
+  // until a manual doc switch. switchDocument re-keys the same `host:docId` room and
+  // carries the freshest connectionStore token. Otherwise no-op: an already-online
+  // session must not be torn down here (the on-connect reattach calls this for the
+  // doc whose provider callback is running).
+  const active = collab.config;
+  if (collab.isActive && active && active.documentId === docId) {
+    const conn = useConnectionStore.getState();
+    if (!active.token && conn.token && conn.isTokenValid()) {
+      collab.switchDocument(docId);
+    }
+    return;
+  }
 
   // A local-only doc must never get a CRDT engine (it would emit a JOIN_DOC the
   // relay rejects, and risks a cross-client leak — see JP-64). Unknown records

--- a/src/collaboration/handleRelayJoinError.test.ts
+++ b/src/collaboration/handleRelayJoinError.test.ts
@@ -1,0 +1,156 @@
+/**
+ * JP-395 — `handleRelayJoinError` must NOT treat a transient `ERR_UNKNOWN_DOC`
+ * as a deletion. The relay emits `ERR_UNKNOWN_DOC` whenever its in-memory index
+ * misses (a cold/un-hydrated index, or a JWKS cold-start auth blip after a
+ * redeploy) — which fake-deleted live docs (trash + cache evict + "deleted"
+ * toast). A genuine deletion arrives as `ERR_DELETED` (JP-375) and must still
+ * strand. This drives the extracted handler directly (the UnifiedSyncProvider
+ * mock discards the inline `onError`, so it's otherwise unreachable).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Heavy collab deps — mock so importing collaborationStore stays lightweight
+// (mirrors collaborationStore.test.ts).
+vi.mock('./YjsDocument', () => ({
+  YjsDocument: vi.fn().mockImplementation(() => ({ getDoc: vi.fn(), destroy: vi.fn() })),
+}));
+vi.mock('./UnifiedSyncProvider', () => ({
+  UnifiedSyncProvider: vi.fn().mockImplementation(() => ({})),
+}));
+
+const hoisted = vi.hoisted(() => ({
+  strandOrDemoteDeletedDoc: vi.fn(),
+  getRecord: vi.fn(),
+  setSyncState: vi.fn(),
+  warning: vi.fn(),
+  host: { address: 'home-relay:443' } as { address: string } | null,
+}));
+
+vi.mock('../store/relayDocumentStore', () => ({
+  useRelayDocumentStore: {
+    getState: () => ({ strandOrDemoteDeletedDoc: hoisted.strandOrDemoteDeletedDoc }),
+  },
+}));
+vi.mock('../store/documentRegistry', () => ({
+  useDocumentRegistry: {
+    getState: () => ({ getRecord: hoisted.getRecord, setSyncState: hoisted.setSyncState }),
+  },
+}));
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: {
+    getState: () => ({ host: hoisted.host }),
+    subscribe: () => () => {},
+  },
+  // collaborationStore imports several named exports from this module at load.
+  isRelayAuthenticated: vi.fn(() => false),
+  startTokenExpirationMonitor: vi.fn(),
+  stopTokenExpirationMonitor: vi.fn(),
+  muteConnectionToasts: vi.fn(),
+  markReconnectCancelled: vi.fn(),
+  clearReconnectTerminal: vi.fn(),
+}));
+vi.mock('../store/presenceStore', () => ({ usePresenceStore: { getState: () => ({}) } }));
+vi.mock('../store/notificationStore', () => ({
+  useNotificationStore: { getState: () => ({ warning: hoisted.warning }) },
+}));
+
+import { handleRelayJoinError } from './collaborationStore';
+
+const HOME = 'home-relay:443';
+const DOC = 'doc-1';
+const base = { id: DOC, name: 'Doc', pageCount: 1, createdAt: 0, modifiedAt: 0 };
+const remote = (relayId = HOME) => ({
+  ...base,
+  type: 'remote' as const,
+  relayId,
+  workspaceId: 'ws-1',
+  ownerId: 'u1',
+  ownerName: 'U',
+  permission: 'owner' as const,
+  syncState: 'synced' as const,
+  lastSyncedAt: 0,
+});
+const cached = (relayId = HOME) => ({
+  ...base,
+  type: 'cached' as const,
+  relayId,
+  workspaceId: 'ws-1',
+  originalDocId: DOC,
+  cachedAt: 0,
+  pendingChanges: 0,
+  permission: 'editor' as const,
+});
+const localDoc = { ...base, type: 'local' as const };
+
+beforeEach(() => {
+  hoisted.strandOrDemoteDeletedDoc.mockClear();
+  hoisted.getRecord.mockReset();
+  hoisted.setSyncState.mockClear();
+  hoisted.warning.mockClear();
+  hoisted.host = { address: HOME };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('handleRelayJoinError — JP-395', () => {
+  it('does NOT strand a CACHED doc on ERR_UNKNOWN_DOC (the fake-deletion bug)', () => {
+    hoisted.getRecord.mockReturnValue(cached());
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).toHaveBeenCalledWith(DOC, 'error');
+    expect(hoisted.warning).not.toHaveBeenCalled(); // transient → no alarming toast
+  });
+
+  it('does NOT strand a REMOTE doc on ERR_UNKNOWN_DOC', () => {
+    hoisted.getRecord.mockReturnValue(remote());
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).toHaveBeenCalledWith(DOC, 'error');
+    expect(hoisted.warning).not.toHaveBeenCalled();
+  });
+
+  it('STILL strands on ERR_DELETED (definitive tombstone, JP-375)', () => {
+    hoisted.getRecord.mockReturnValue(remote());
+    handleRelayJoinError('ERR_DELETED', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).toHaveBeenCalledWith(DOC);
+  });
+
+  it('strands with access-revoked on ERR_VIEW_FORBIDDEN (JP-370)', () => {
+    hoisted.getRecord.mockReturnValue(remote());
+    handleRelayJoinError('ERR_VIEW_FORBIDDEN', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).toHaveBeenCalledWith(DOC, undefined, 'access-revoked');
+  });
+
+  it('is a silent no-op for a foreign-relay doc on ERR_UNKNOWN_DOC (JP-308)', () => {
+    hoisted.getRecord.mockReturnValue(remote('other-relay:443')); // != connected HOME
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).not.toHaveBeenCalled();
+    expect(hoisted.warning).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op for a local-only doc on ERR_UNKNOWN_DOC', () => {
+    hoisted.getRecord.mockReturnValue(localDoc);
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).not.toHaveBeenCalled();
+    expect(hoisted.warning).not.toHaveBeenCalled();
+  });
+
+  it('warns (non-destructive) for an unknown id with NO local record', () => {
+    hoisted.getRecord.mockReturnValue(undefined);
+    handleRelayJoinError('ERR_UNKNOWN_DOC', DOC);
+
+    expect(hoisted.strandOrDemoteDeletedDoc).not.toHaveBeenCalled();
+    expect(hoisted.setSyncState).toHaveBeenCalledWith(DOC, 'error');
+    expect(hoisted.warning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './ui/App';
 import { registerPwa } from './pwa/registerPwa';
+import { initInstallPrompt } from './pwa/installPrompt';
 import { handleAuthCallbackIfPresent } from './api/authCallback';
 import './index.css';
 // Adaptive motion budget (JP-101): also boots adaptiveBudget's device sampling
@@ -37,6 +38,10 @@ function mountApp(authCallbackConsumed: boolean): void {
   // Register the service worker. No-op in the Tauri build, where the PWA plugin
   // is disabled and `registerSW` is a stub.
   registerPwa();
+
+  // Offer a one-time "Install DocuShark" hint when the browser reports the app
+  // as installable. No-op in the Tauri build and once installed/dismissed.
+  initInstallPrompt();
 }
 
 // Intercept the PWA web one-click handoff (`/auth/callback?handoff_code=…`)

--- a/src/pwa/installPrompt.test.ts
+++ b/src/pwa/installPrompt.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the PWA install hint (src/pwa/installPrompt.ts).
+ *
+ * Verifies the one-time toast surfaces only when the browser reports the app as
+ * installable, is suppressed once seen / when already installed standalone, and
+ * that its action fires the browser's native install prompt.
+ */
+
+import { initInstallPrompt } from './installPrompt';
+import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+interface FakePromptEvent extends Event {
+  prompt: ReturnType<typeof vi.fn>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+/** Dispatch a fake `beforeinstallprompt` and return the event (with its spy). */
+function fireBeforeInstallPrompt(outcome: 'accepted' | 'dismissed' = 'accepted'): FakePromptEvent {
+  const event = new Event('beforeinstallprompt') as FakePromptEvent;
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome, platform: 'web' });
+  window.dispatchEvent(event);
+  return event;
+}
+
+/** Toggle the legacy iOS standalone flag (matchMedia is stubbed always-false). */
+function setStandalone(value: boolean): void {
+  Object.defineProperty(window.navigator, 'standalone', { value, configurable: true });
+}
+
+describe('installPrompt', () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    useNotificationStore.getState().dismissAll();
+    useUIPreferencesStore.setState({ installAppHintSeen: false });
+    setStandalone(false);
+    dispose = initInstallPrompt();
+  });
+
+  afterEach(() => {
+    dispose();
+    setStandalone(false);
+  });
+
+  it('surfaces a one-time Install toast when the browser reports installable', () => {
+    fireBeforeInstallPrompt();
+
+    const notes = useNotificationStore.getState().notifications;
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.actionLabel).toBe('Install');
+    expect(notes[0]?.message).toContain('Install DocuShark');
+    expect(notes[0]?.duration).toBe(0); // manual dismiss only
+    // Marked seen so it won't nag again.
+    expect(useUIPreferencesStore.getState().installAppHintSeen).toBe(true);
+  });
+
+  it('does not re-show after it has been seen', () => {
+    useUIPreferencesStore.setState({ installAppHintSeen: true });
+    fireBeforeInstallPrompt();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it('does not show when already running as an installed standalone PWA', () => {
+    setStandalone(true);
+    fireBeforeInstallPrompt();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    // Not marked seen — the user never saw a hint.
+    expect(useUIPreferencesStore.getState().installAppHintSeen).toBe(false);
+  });
+
+  it('suppresses repeat prompts within a session', () => {
+    fireBeforeInstallPrompt();
+    fireBeforeInstallPrompt();
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it('fires the native prompt when the Install action is invoked', async () => {
+    const event = fireBeforeInstallPrompt();
+    const note = useNotificationStore.getState().notifications[0];
+    expect(note?.onAction).toBeTypeOf('function');
+
+    note?.onAction?.();
+    // onAction kicks off promptInstall() asynchronously.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(event.prompt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pwa/installPrompt.ts
+++ b/src/pwa/installPrompt.ts
@@ -1,0 +1,101 @@
+/**
+ * "Install DocuShark" PWA hint — web build only.
+ *
+ * Chromium-family browsers fire `beforeinstallprompt` once the app meets the
+ * installability criteria. We intercept it, stash the deferred event, and offer
+ * a one-time, dismissible toast with an **Install** action that triggers the
+ * browser's native install prompt. This is the in-app counterpart to the
+ * "install it in a click" copy on the marketing site.
+ *
+ * Shown at most once per browser (a persisted flag), never when already running
+ * as an installed standalone PWA, and never in the Tauri build (desktop has no
+ * install concept — it tree-shakes out via `IS_TAURI`).
+ *
+ * iOS Safari doesn't fire `beforeinstallprompt` (install is a manual
+ * Share → Add to Home Screen), so those users get no toast here; an iOS
+ * instructions hint is a possible follow-up.
+ */
+
+import { IS_TAURI } from '../platform/runtime';
+import { readBreakpointState } from '../ui/layout/useBreakpoint';
+import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+/**
+ * Minimal type for the non-standard install-prompt event — it isn't in TS's DOM
+ * lib, and the codebase bans `any`.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt(): Promise<void>;
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+/** The most recent deferred prompt, captured until the user acts on it. */
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+
+/** Fire the stashed native install prompt, then forget it (single-use). */
+async function promptInstall(): Promise<void> {
+  const event = deferredPrompt;
+  deferredPrompt = null;
+  if (!event) return;
+  await event.prompt();
+  // `userChoice` resolves once the user accepts/dismisses. We don't branch on it
+  // (the `appinstalled` listener covers the accepted case); awaiting just avoids
+  // an unhandled rejection if the browser rejects the prompt.
+  await event.userChoice.catch(() => undefined);
+}
+
+/** Surface the hint once, if eligible. */
+function maybeShowHint(): void {
+  if (!deferredPrompt) return;
+  if (readBreakpointState().standalone) return; // already installed
+  // The persisted flag is the cross-load + re-fire guard: it's set synchronously
+  // below, so a second `beforeinstallprompt` in the same session is suppressed.
+  if (useUIPreferencesStore.getState().installAppHintSeen) return;
+
+  // Mark seen on show so the nudge appears at most once per browser, whether the
+  // user installs or simply dismisses it.
+  useUIPreferencesStore.getState().markInstallAppHintSeen();
+  useNotificationStore
+    .getState()
+    .info('Install DocuShark — it opens in its own window and works offline.', {
+      category: 'permanent',
+      duration: 0,
+      actionLabel: 'Install',
+      onAction: () => {
+        void promptInstall();
+      },
+    });
+}
+
+/**
+ * Attach the install-prompt listeners. Call once at boot (web build only).
+ * Returns a disposer that detaches them (used by tests; the app ignores it).
+ * Safe under jsdom — it only registers `window` listeners.
+ */
+export function initInstallPrompt(): () => void {
+  if (IS_TAURI || typeof window === 'undefined') return () => {};
+
+  const onBeforeInstallPrompt = (event: Event): void => {
+    // Suppress Chrome's default mini-infobar so our toast is the single entry point.
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    maybeShowHint();
+  };
+  const onAppInstalled = (): void => {
+    deferredPrompt = null;
+    // Never nag after a successful install.
+    if (!useUIPreferencesStore.getState().installAppHintSeen) {
+      useUIPreferencesStore.getState().markInstallAppHintSeen();
+    }
+  };
+
+  window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+  window.addEventListener('appinstalled', onAppInstalled);
+
+  return () => {
+    window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    window.removeEventListener('appinstalled', onAppInstalled);
+  };
+}

--- a/src/services/removeWorkspace.ts
+++ b/src/services/removeWorkspace.ts
@@ -14,7 +14,7 @@ import { useConnectionStore } from '../store/connectionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { RelayDocumentCache } from '../storage/RelayDocumentCache';
-import { activeWorkspaceId } from '../store/activeWorkspace';
+import { activeWorkspaceId, clearRememberedWorkspaceId } from '../store/activeWorkspace';
 import { purgeLocalDocRoom } from '../collaboration/ensureCollabSession';
 import { clearConnection } from '../api/relayConnection';
 
@@ -45,4 +45,9 @@ export async function removeCurrentWorkspace(): Promise<void> {
 
   // 5. Forget the relay connection entirely (URLs + token).
   await clearConnection();
+
+  // 6. JP-390: forget the durable workspace-scope fallback last — after the
+  //    workspace-scoped teardown above has consumed it — so we never restore
+  //    into a workspace whose caches we just purged.
+  clearRememberedWorkspaceId();
 }

--- a/src/store/activeWorkspace.test.ts
+++ b/src/store/activeWorkspace.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { activeWorkspaceId, DEFAULT_WORKSPACE_ID } from './activeWorkspace';
+import { activeWorkspaceId, DEFAULT_WORKSPACE_ID, clearRememberedWorkspaceId } from './activeWorkspace';
 import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
 import { useConnectionStore } from './connectionStore';
 
@@ -32,6 +32,7 @@ describe('workspaceIdFromRelayToken', () => {
 describe('activeWorkspaceId', () => {
   beforeEach(() => {
     useConnectionStore.getState().reset();
+    clearRememberedWorkspaceId();
   });
 
   it('resolves the workspace id from the live token', () => {
@@ -43,5 +44,15 @@ describe('activeWorkspaceId', () => {
     expect(activeWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID);
     useConnectionStore.getState().setToken(tokenWith({ sub: 'u1' })); // no wsp
     expect(activeWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID);
+  });
+
+  // JP-390: once a real workspace has been seen, it must survive token loss so
+  // an expired-token cold boot still scopes the cached relay docs correctly.
+  it('falls back to the last real workspace after the token is lost', () => {
+    useConnectionStore.getState().setToken(tokenWith({ wsp: [{ id: 'ws-abc', role: 'owner' }] }));
+    expect(activeWorkspaceId()).toBe('ws-abc');
+
+    useConnectionStore.getState().reset(); // expired-token cold boot: token gone
+    expect(activeWorkspaceId()).toBe('ws-abc');
   });
 });

--- a/src/store/activeWorkspace.ts
+++ b/src/store/activeWorkspace.ts
@@ -19,10 +19,58 @@ import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
 export const DEFAULT_WORKSPACE_ID = 'default';
 
 /**
- * The workspace id the editor is currently authenticated to, for cache keying.
- * Resolved from the live relay token's first `wsp` claim; falls back to
- * `DEFAULT_WORKSPACE_ID`.
+ * localStorage key for the last real workspace id we authenticated to. This is
+ * the durable fallback scope (JP-390): the in-memory relay token is gone on
+ * every cold boot, and an EXPIRED token is never re-asserted into the store, so
+ * without a remembered scope `activeWorkspaceId()` would collapse to
+ * `DEFAULT_WORKSPACE_ID` — and the registry's workspace-scope filter would hide
+ * every cached relay doc that was stamped with the real workspace id (the doc
+ * still opens directly, but vanishes from the list).
+ */
+const LAST_WORKSPACE_KEY = 'docushark-last-workspace-id';
+
+/**
+ * Remember the last real workspace id so cloud-doc scoping survives token loss
+ * (JP-390). No-op for the single-tenant default / absent id. Called from the
+ * token choke point (`connectionStore.setToken`) and the expired-boot recovery
+ * (`restoreCloudSession`), so every real session records its workspace.
+ */
+export function rememberWorkspaceId(id: string | null | undefined): void {
+  if (!id || id === DEFAULT_WORKSPACE_ID) return;
+  try {
+    if (localStorage.getItem(LAST_WORKSPACE_KEY) !== id) {
+      localStorage.setItem(LAST_WORKSPACE_KEY, id);
+    }
+  } catch {
+    // localStorage unavailable (private mode / SSR) — fallback just degrades to
+    // DEFAULT_WORKSPACE_ID, never throws into an auth flow.
+  }
+}
+
+/**
+ * Forget the remembered workspace id. Called on a full workspace removal so we
+ * don't restore into a workspace whose caches were just purged.
+ */
+export function clearRememberedWorkspaceId(): void {
+  try {
+    localStorage.removeItem(LAST_WORKSPACE_KEY);
+  } catch {
+    // ignore — see rememberWorkspaceId
+  }
+}
+
+/**
+ * The workspace id the editor is currently scoped to, for cache keying.
+ * Resolved from the live relay token's first `wsp` claim; on a cold/expired
+ * boot (no in-memory token) falls back to the last real workspace we saw
+ * (JP-390), then to `DEFAULT_WORKSPACE_ID`.
  */
 export function activeWorkspaceId(): string {
-  return workspaceIdFromRelayToken(useConnectionStore.getState().token) ?? DEFAULT_WORKSPACE_ID;
+  const live = workspaceIdFromRelayToken(useConnectionStore.getState().token);
+  if (live) return live;
+  try {
+    return localStorage.getItem(LAST_WORKSPACE_KEY) ?? DEFAULT_WORKSPACE_ID;
+  } catch {
+    return DEFAULT_WORKSPACE_ID;
+  }
 }

--- a/src/store/connectionStore.ts
+++ b/src/store/connectionStore.ts
@@ -9,6 +9,8 @@
 
 import { create } from 'zustand';
 import type { Notification, NotificationOptions } from './notificationStore';
+import { rememberWorkspaceId } from './activeWorkspace';
+import { workspaceIdFromRelayToken } from '../api/relayTokenUser';
 
 // ============ Types ============
 
@@ -162,6 +164,10 @@ export const useConnectionStore = create<ConnectionState & ConnectionActions>()(
 
     setToken: (token, expiresAt = null) => {
       set({ token, tokenExpiresAt: expiresAt });
+      // JP-390: setToken is the universal token sink (live WS auth + cold-boot
+      // restore), so record the workspace here. It survives token loss as the
+      // scope fallback so an expired-token boot still lists cached relay docs.
+      if (token) rememberWorkspaceId(workspaceIdFromRelayToken(token));
     },
 
     incrementReconnectAttempts: () => {

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -12,6 +12,7 @@ import {
   isActiveDocReadOnly,
 } from './documentRegistry';
 import { useConnectionStore } from './connectionStore';
+import { clearRememberedWorkspaceId } from './activeWorkspace';
 import type { DocumentMetadata } from '../types/Document';
 
 /** Unsigned JWT carrying a single `wsp[].id` — sets the active workspace for
@@ -36,6 +37,7 @@ function meta(id: string, name = 'Doc', isRelayDocument = false): DocumentMetada
 beforeEach(() => {
   useDocumentRegistry.getState().reset();
   useConnectionStore.getState().reset();
+  clearRememberedWorkspaceId();
 });
 
 // JP-370: the browser is scoped to the active workspace — two workspaces on one
@@ -71,6 +73,23 @@ describe('workspace scoping (JP-370)', () => {
     useDocumentRegistry.getState().registerRemote(meta('d', 'D'), RELAY, 'owner', 'synced');
     const rec = useDocumentRegistry.getState().getRecord('d');
     expect(rec && 'workspaceId' in rec ? rec.workspaceId : null).toBe('ws-x');
+  });
+
+  // JP-390: on an expired-token cold boot the in-memory token is null, so
+  // `activeWorkspaceId()` must fall back to the last real workspace — otherwise
+  // it collapses to `default` and the scope filter hides every cached relay doc
+  // (the doc still opens directly, but vanishes from the list).
+  it('keeps cached relay docs listed after the token is lost (expired-boot)', () => {
+    const r = useDocumentRegistry.getState();
+    useConnectionStore.getState().setToken(tokenForWs('ws-abc'));
+    r.registerRemote(meta('doc-x', 'X'), RELAY, 'owner', 'synced');
+
+    // Simulate the expired-token cold boot: the persisted token is never
+    // re-asserted into the store, so the in-memory token is gone.
+    useConnectionStore.getState().reset();
+
+    const ids = useDocumentRegistry.getState().getFilteredDocuments().map((d) => d.id);
+    expect(ids).toContain('doc-x');
   });
 });
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -15,6 +15,7 @@ import {
   getDocumentMetadata,
 } from '../types/Document';
 import { validateDocumentJSON } from '../types/DocumentValidation';
+import { isRichTextEmpty } from '../types/RichText';
 import { migrateDocument, DocumentVersionError } from '../migrations/documentMigrations';
 import { usePageStore, PageStoreSnapshot } from './pageStore';
 import { useNotificationStore } from './notificationStore';
@@ -509,6 +510,81 @@ export class DocumentIntegrityError extends Error {
 }
 
 /**
+ * The default name a brand-new, never-named document carries. Used both as the
+ * `newDocument()` default and as the JP-384 guard's gate: a doc still wearing
+ * this name and holding no content has never been touched, so it must not be
+ * persisted (see `isPristineUntitled`).
+ */
+export const UNTITLED_DOCUMENT_NAME = 'Untitled Document';
+
+/**
+ * Is this HTML prose page effectively empty? Conservative: any embedded media
+ * or block structure (image, table, list, heading, rule, embed, quote, code)
+ * counts as content even with no text, so we never misjudge a real page as
+ * empty. Only plain whitespace-or-empty-paragraph markup reads as empty.
+ */
+function isProseHtmlEmpty(html: string): boolean {
+  if (!html) return true;
+  if (/<(img|table|hr|iframe|video|audio|pre|blockquote|figure|ul|ol|h[1-6])\b/i.test(html)) {
+    return false;
+  }
+  const text = html.replace(/<[^>]*>/g, '').replace(/&nbsp;/gi, ' ').trim();
+  return text.length === 0;
+}
+
+/**
+ * Is `doc` devoid of all user content across every surface — canvas shapes,
+ * prose (legacy single-content + per-page), citations, fields, whiteboard, and
+ * extra pages? Biased toward returning `false` (treat as having content) so the
+ * JP-384 skip-persist guard can never drop a document that holds anything.
+ */
+function isDocumentContentEmpty(doc: DiagramDocument): boolean {
+  // More than one canvas/prose page is itself a deliberate edit.
+  if (doc.pageOrder.length > 1) return false;
+  if ((doc.richTextPages?.pageOrder.length ?? 0) > 1) return false;
+
+  // Canvas shapes on any page.
+  for (const page of Object.values(doc.pages)) {
+    if (page.shapeOrder.length > 0 || Object.keys(page.shapes).length > 0) return false;
+  }
+
+  // Legacy single-document prose.
+  if (doc.richTextContent && !isRichTextEmpty(doc.richTextContent)) return false;
+
+  // Per-page prose (HTML).
+  for (const page of Object.values(doc.richTextPages?.pages ?? {})) {
+    if (!isProseHtmlEmpty(page.content)) return false;
+  }
+
+  // Citations / fields.
+  if ((doc.references?.itemOrder.length ?? 0) > 0) return false;
+  if ((doc.fields?.order.length ?? 0) > 0) return false;
+
+  // Whiteboard notes.
+  for (const board of Object.values(doc.whiteboard?.boards ?? {})) {
+    if (board.noteOrder.length > 0 || Object.keys(board.notes).length > 0) return false;
+  }
+
+  return true;
+}
+
+/**
+ * A pristine untitled doc is one that has never been saved (no id), still wears
+ * the default {@link UNTITLED_DOCUMENT_NAME}, and holds no content. JP-384: such
+ * a doc must never be persisted — otherwise the unload / boot-flush save mints a
+ * fresh empty "Untitled Document" on every close/reload. A rename routes through
+ * `saveDocument` only after setting a non-default name, so renamed-but-empty
+ * docs still persist (the name no longer matches this gate).
+ */
+function isPristineUntitled(currentDocumentId: string | null, doc: DiagramDocument): boolean {
+  return (
+    !currentDocumentId &&
+    doc.name === UNTITLED_DOCUMENT_NAME &&
+    isDocumentContentEmpty(doc)
+  );
+}
+
+/**
  * Create a DiagramDocument from current page store state.
  *
  * Throws `DocumentIntegrityError` if any page's shapes/shapeOrder are
@@ -680,7 +756,7 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
 
       // Create a new empty document
       newDocument: (name?: string) => {
-        const docName = name ?? 'Untitled Document';
+        const docName = name ?? UNTITLED_DOCUMENT_NAME;
 
         // These store resets are a programmatic reset, NOT user edits — suppress
         // autosave so their subscriptions (and any nodeView reaction to
@@ -767,6 +843,17 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
             return;
           }
           throw err;
+        }
+
+        // JP-384: never persist a pristine, never-saved "Untitled Document"
+        // (default name + no content). The unload / boot-flush save would
+        // otherwise mint a fresh empty Untitled on every close/reload, piling
+        // up duplicates. It earns storage only once it gains content or is
+        // renamed (renameDocument sets a non-default name before saving, so it
+        // fails this gate and persists). `state.currentDocumentId` — not the
+        // freshly-minted `docId` — is the "never saved" signal.
+        if (isPristineUntitled(state.currentDocumentId, doc)) {
+          return;
         }
 
         // Extract blob references from rich text content and shapes

--- a/src/store/persistenceStore.untitledDuplication.test.ts
+++ b/src/store/persistenceStore.untitledDuplication.test.ts
@@ -1,0 +1,102 @@
+/**
+ * JP-384: closing/reloading the app while on an empty "Untitled Document" used
+ * to mint a NEW empty Untitled doc every time, because `saveDocument()` invents
+ * a fresh nanoid whenever `currentDocumentId` is null with no guard against
+ * persisting a pristine, never-named document. The unload / boot-flush save
+ * (useAutoSave `beforeunload` + `loadDocument`'s `flushAutoSaveNow`) is what
+ * fired the bug while the untitled doc's id was still null.
+ *
+ * Fix: a pristine untitled (default name + no content + never saved) is never
+ * persisted. It earns storage only once it gains content OR is renamed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  put: vi.fn(async () => {}),
+  getMeta: vi.fn(() => null),
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+
+const syncManagerMock = vi.hoisted(() => ({
+  queueSave: vi.fn(() => ({ id: 'op-1' })),
+  hasPendingChanges: vi.fn(() => false),
+  processQueueForHost: vi.fn(async () => []),
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => syncManagerMock,
+}));
+
+import { usePersistenceStore, UNTITLED_DOCUMENT_NAME } from './persistenceStore';
+import { useRichTextStore } from './richTextStore';
+
+/** Count locally-stored docs whose name is the default Untitled name. */
+function untitledDocCount(): number {
+  const docs = usePersistenceStore.getState().documents;
+  return Object.values(docs).filter((d) => d.name === UNTITLED_DOCUMENT_NAME).length;
+}
+
+function totalDocCount(): number {
+  return Object.keys(usePersistenceStore.getState().documents).length;
+}
+
+describe('JP-384 — Untitled duplication on reload', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    usePersistenceStore.setState({
+      currentDocumentId: null,
+      currentDocumentName: UNTITLED_DOCUMENT_NAME,
+      documents: {},
+    } as never);
+    vi.restoreAllMocks();
+  });
+
+  it('never persists a pristine untitled doc across repeated reload cycles', () => {
+    const store = usePersistenceStore.getState();
+
+    // Three "open app on a fresh untitled page, then close/reload" cycles.
+    // Each cycle: newDocument() (id=null, empty) then the unload/boot save
+    // fires while the id is still null.
+    for (let i = 0; i < 3; i++) {
+      store.newDocument();
+      usePersistenceStore.getState().saveDocument();
+    }
+
+    // The pristine untitled never earns storage — no duplicates, no doc at all.
+    expect(untitledDocCount()).toBe(0);
+    expect(totalDocCount()).toBe(0);
+    expect(usePersistenceStore.getState().currentDocumentId).toBeNull();
+  });
+
+  it('persists exactly one doc once content is added, and reload does not duplicate it', () => {
+    const store = usePersistenceStore.getState();
+    store.newDocument();
+
+    // User types prose — the doc now has content (still named "Untitled").
+    useRichTextStore.getState().setContent({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }] }],
+    });
+
+    usePersistenceStore.getState().saveDocument();
+    const firstId = usePersistenceStore.getState().currentDocumentId;
+    expect(firstId).not.toBeNull();
+    expect(totalDocCount()).toBe(1);
+
+    // Simulate a reload-time save: same id, no duplicate.
+    usePersistenceStore.getState().saveDocument();
+    expect(totalDocCount()).toBe(1);
+    expect(usePersistenceStore.getState().currentDocumentId).toBe(firstId);
+  });
+
+  it('persists a renamed-but-empty doc (the rename gate keeps working)', () => {
+    usePersistenceStore.getState().newDocument();
+    // Post-rename state: non-default name, still no content, never saved.
+    usePersistenceStore.setState({ currentDocumentName: 'My Renamed Doc' } as never);
+
+    usePersistenceStore.getState().saveDocument();
+
+    expect(totalDocCount()).toBe(1);
+    const docs = usePersistenceStore.getState().documents;
+    expect(Object.values(docs)[0]?.name).toBe('My Renamed Doc');
+  });
+});

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -129,6 +129,11 @@ export interface UIPreferencesState {
    * Cloud workspace connect. Persisted so it fires at most once per browser.
    */
   storageInfoToastSeen: boolean;
+  /**
+   * Whether the one-time "install DocuShark" PWA hint has been shown/dismissed.
+   * Persisted so the install toast nags at most once per browser. Web-only.
+   */
+  installAppHintSeen: boolean;
   /** Layout manager slice — modes, per-doc memory, per-mode overrides, chrome. */
   layout: LayoutState;
   /** Appearance slice — accent + motion (theme is in `themeStore`). */
@@ -182,6 +187,8 @@ export interface UIPreferencesActions {
   toggleDocumentBrowserGroupCollapsed: (collectionId: string) => void;
   /** Record that the one-time storage-info toast has been shown. */
   markStorageInfoToastSeen: () => void;
+  /** Record that the one-time install-app PWA hint has been shown/dismissed. */
+  markInstallAppHintSeen: () => void;
   /** Accept (or clear) the experimental mobile-preview layout. */
   setMobilePreviewAccepted: (accepted: boolean) => void;
   /** Force the desktop layout on a touch device (mobile-preview opt-out). */
@@ -311,6 +318,7 @@ const initialState: UIPreferencesState = {
   documentBrowserGroupBy: 'none',
   documentBrowserCollapsed: {},
   storageInfoToastSeen: false,
+  installAppHintSeen: false,
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
   collabIndicatorPos: null,
@@ -456,6 +464,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       markStorageInfoToastSeen: () => set({ storageInfoToastSeen: true }),
 
+      markInstallAppHintSeen: () => set({ installAppHintSeen: true }),
+
       setMobilePreviewAccepted: (accepted) => set({ mobilePreviewAccepted: accepted }),
       setForceDesktopSite: (force) => set({ forceDesktopSite: force }),
 
@@ -593,7 +603,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 11,
+      version: 12,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -604,6 +614,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         documentBrowserGroupBy: state.documentBrowserGroupBy,
         documentBrowserCollapsed: state.documentBrowserCollapsed,
         storageInfoToastSeen: state.storageInfoToastSeen,
+        installAppHintSeen: state.installAppHintSeen,
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
         collabIndicatorPos: state.collabIndicatorPos,
@@ -738,6 +749,11 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         if (fromVersion < 11) {
           next['mobilePreviewAccepted'] = next['mobilePreviewAccepted'] ?? false;
           next['forceDesktopSite'] = next['forceDesktopSite'] ?? false;
+        }
+        // v11 → v12: added the one-time install-app PWA hint flag. Default false
+        // (never shown) so existing users get the hint once, like a new install.
+        if (fromVersion < 12) {
+          next['installAppHintSeen'] = next['installAppHintSeen'] ?? false;
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -101,6 +101,14 @@ export function CollaborativeProseEditor({
         ...collaborationCursor,
       ],
       editable: !readOnly,
+      // Build the editor in a commit-phase effect, not during render. Tiptap's
+      // default constructs the editor inside render; here that synchronously sets
+      // local Yjs awareness (via CollaborationCursor), which fires the awareness
+      // listener that writes collaborationStore.remoteUsers — a setState during
+      // render that React flags ("Cannot update FloatingCollabIndicator while
+      // rendering CollaborativeProseEditor"). Deferring construction keeps render
+      // pure. The component already handles `editor === null` on first render.
+      immediatelyRender: false,
       // No initial `content`: the relay is the sole prose seeder (JP-284), so the
       // editor adopts the bound fragment. Passing content would inject a second
       // prose lineage that merges into the fragment and duplicates content.

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -257,7 +257,9 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
-  max-width: 200px;
+  /* Room for longer document names: grows with the viewport but stays bounded
+   * so it can't crowd out the page tabs / actions on a narrow window. */
+  max-width: clamp(220px, 34vw, 460px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -277,7 +279,7 @@
   border: 1px solid var(--color-primary, var(--color-primary));
   border-radius: var(--radius-sm);
   outline: none;
-  max-width: 200px;
+  max-width: clamp(220px, 34vw, 460px);
 }
 
 .document-status {

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -15,38 +15,61 @@
   flex-shrink: 0;
 }
 
-.title-bar-title {
+.title-bar-info {
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  /* Left-align so a long document name reads from its (recognizable) start
-   * and runs the full width up to the window controls, instead of centering
-   * and ellipsizing the middle. Matches the Windows/Linux right-controls
-   * style WindowControls already uses. */
-  justify-content: flex-start;
   gap: var(--space-2);
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-medium);
-  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
   min-width: 0;
   overflow: hidden;
   padding: 0 var(--space-3);
 }
 
-.title-bar-name {
+.title-bar-online {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+  font-weight: var(--font-weight-medium);
+}
+
+.title-bar-online-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.title-bar-online-label {
+  white-space: nowrap;
+}
+
+.title-bar-online-online .title-bar-online-dot {
+  background: var(--success);
+}
+.title-bar-online-connecting .title-bar-online-dot,
+.title-bar-online-reconnecting .title-bar-online-dot {
+  background: var(--warning);
+}
+.title-bar-online-offline .title-bar-online-dot {
+  background: var(--danger);
+}
+
+/* Workspace name, shown only when signed in. Truncates with an ellipsis if the
+ * bar is narrow; the full name is available via its title tooltip. */
+.title-bar-workspace {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+  color: var(--text-primary);
 }
 
-.title-bar-status {
-  flex-shrink: 0;
-  font-size: var(--font-size-2xs);
-  line-height: var(--line-height-tight);
-  display: inline-flex;
-  align-items: center;
+.title-bar-workspace::before {
+  content: '·';
+  margin-right: var(--space-2);
+  color: var(--text-secondary);
 }
-
-.title-bar-status-dirty { color: var(--warning); }
-.title-bar-status-saving { color: var(--text-secondary); }
-.title-bar-status-saved { color: var(--success); }

--- a/src/ui/chrome/TitleBar.css
+++ b/src/ui/chrome/TitleBar.css
@@ -19,7 +19,11 @@
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  justify-content: center;
+  /* Left-align so a long document name reads from its (recognizable) start
+   * and runs the full width up to the window controls, instead of centering
+   * and ellipsizing the middle. Matches the Windows/Linux right-controls
+   * style WindowControls already uses. */
+  justify-content: flex-start;
   gap: var(--space-2);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);

--- a/src/ui/chrome/TitleBar.tsx
+++ b/src/ui/chrome/TitleBar.tsx
@@ -48,7 +48,9 @@ export function TitleBar() {
         >
           {statusDot}
         </span>
-        <span className="title-bar-name">{docName || 'DocuShark'}</span>
+        <span className="title-bar-name" title={docName || 'DocuShark'}>
+          {docName || 'DocuShark'}
+        </span>
       </div>
 
       <WindowControls />

--- a/src/ui/chrome/TitleBar.tsx
+++ b/src/ui/chrome/TitleBar.tsx
@@ -3,21 +3,37 @@
  * window chrome. Drag region uses `data-tauri-drag-region` so Tauri intercepts
  * mousedown for window dragging; window controls live on the right.
  *
+ * This bar is Tauri window chrome and is intentionally NOT a home for the
+ * document title — that lives in the UnifiedToolbar (showing it here too just
+ * duplicated it). Instead it surfaces the live relay/WebSocket connection
+ * status and, when signed in, the active workspace name.
+ *
  * In a PWA build (no Tauri), the bar still renders if the user opted in, but
- * WindowControls renders nothing — the bar is then just a decorative strip
- * with the doc title and save-status dot.
+ * WindowControls renders nothing — the bar is then just a decorative strip.
  */
 
 import { useEffect, useState } from 'react';
-import { usePersistenceStore } from '../../store/persistenceStore';
-import { useAutoSave } from '../../hooks/useAutoSave';
+import { useConnectionStore } from '../../store/connectionStore';
+import { loadConnection } from '../../api/relayConnection';
 import { WindowControls } from './WindowControls';
 import './TitleBar.css';
 
+type OnlineState = 'online' | 'connecting' | 'reconnecting' | 'offline' | 'local';
+
+const ONLINE_LABELS: Record<OnlineState, string> = {
+  online: 'Online',
+  connecting: 'Connecting…',
+  reconnecting: 'Reconnecting…',
+  offline: 'Offline',
+  local: 'Local',
+};
+
 export function TitleBar() {
-  const docName = usePersistenceStore((s) => s.currentDocumentName);
-  const { isDirty, status } = useAutoSave();
+  const status = useConnectionStore((s) => s.status);
+  const reconnectPhase = useConnectionStore((s) => s.reconnectPhase);
+  const token = useConnectionStore((s) => s.token);
   const [isMac, setIsMac] = useState(false);
+  const [workspaceName, setWorkspaceName] = useState<string | null>(null);
 
   useEffect(() => {
     // Lightweight UA sniff for the macOS traffic-light gap. We don't need
@@ -27,10 +43,35 @@ export function TitleBar() {
     setIsMac(/mac|iphone|ipad|ipod/.test(ua));
   }, []);
 
-  const statusDot =
-    status === 'saving' ? '◐' : isDirty ? '●' : '○';
-  const statusTitle =
-    status === 'saving' ? 'Saving…' : isDirty ? 'Unsaved changes' : 'Saved';
+  // The workspace name lives in the persisted connection record (written by
+  // completeCloudSignIn), not in a reactive store. Re-read it whenever sign-in
+  // state flips — by the time the token is set the name is already persisted.
+  // Cleared when signed out (no token), so a local user shows no workspace.
+  useEffect(() => {
+    if (!token) {
+      setWorkspaceName(null);
+      return undefined;
+    }
+    let cancelled = false;
+    void loadConnection().then((conn) => {
+      if (!cancelled) setWorkspaceName(conn?.workspaceName ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  // WS-live status. No token → purely local (neutral). With a token: authed is
+  // a live session; connecting/reconnecting are transient; anything else is a
+  // dropped connection.
+  let onlineState: OnlineState;
+  if (!token) onlineState = 'local';
+  else if (status === 'authenticated') onlineState = 'online';
+  else if (reconnectPhase === 'reconnecting') onlineState = 'reconnecting';
+  else if (status === 'connecting' || status === 'connected') onlineState = 'connecting';
+  else onlineState = 'offline';
+
+  const label = ONLINE_LABELS[onlineState];
 
   return (
     <div className="title-bar" data-tauri-drag-region>
@@ -40,17 +81,20 @@ export function TitleBar() {
        * empty so users with macOS read the spacing as familiar. */}
       {isMac && <div className="title-bar-mac-gap" data-tauri-drag-region />}
 
-      <div className="title-bar-title" data-tauri-drag-region>
+      <div className="title-bar-info" data-tauri-drag-region>
         <span
-          className={`title-bar-status title-bar-status-${status === 'saving' ? 'saving' : isDirty ? 'dirty' : 'saved'}`}
-          title={statusTitle}
-          aria-label={statusTitle}
+          className={`title-bar-online title-bar-online-${onlineState}`}
+          title={`Connection: ${label}`}
+          aria-label={`Connection: ${label}`}
         >
-          {statusDot}
+          <span className="title-bar-online-dot" aria-hidden="true" />
+          <span className="title-bar-online-label">{label}</span>
         </span>
-        <span className="title-bar-name" title={docName || 'DocuShark'}>
-          {docName || 'DocuShark'}
-        </span>
+        {workspaceName && (
+          <span className="title-bar-workspace" title={workspaceName}>
+            {workspaceName}
+          </span>
+        )}
       </div>
 
       <WindowControls />

--- a/src/ui/cloud/CloudConnectPanel.tsx
+++ b/src/ui/cloud/CloudConnectPanel.tsx
@@ -48,10 +48,13 @@ import {
 } from '../../api/relayConnection';
 import { completeCloudSignIn } from '../../api/completeCloudSignIn';
 import { beginCloudSignIn, CloudAuthError, type CloudSignInHandle } from '../../api/cloudAuth';
+import {
+  RELAY_LOCATIONS,
+  DEFAULT_RELAY_LOCATION,
+  locationForUrl,
+} from '../../api/relayLocations';
 import { WorkspaceMembersSection } from './WorkspaceMembersSection';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
-
-const DEFAULT_RELAY_URL = 'http://localhost:9876';
 
 /** Local sign-in phase, distinct from the connection-store status. */
 type SignInPhase = 'idle' | 'starting' | 'awaiting' | 'error';
@@ -75,8 +78,12 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
   // modal shows "Signed in" (not "Disconnected") and doesn't prompt a re-pair.
   const cloudSignedIn = useIsCloudSignedIn();
 
-  const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_URL);
+  const [relayUrl, setRelayUrl] = useState(DEFAULT_RELAY_LOCATION.relayUrl);
   const [cloudUrl, setCloudUrl] = useState(DEFAULT_CLOUD_BASE_URL);
+  // Controlled Advanced disclosure: force-opened when the relay URL is a custom
+  // (non-location) origin so the override field isn't hidden; otherwise the user
+  // toggles it freely (tracked via onToggle).
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const [hasStoredToken, setHasStoredToken] = useState(false);
   const [wsName, setWsName] = useState<string | null>(null);
@@ -150,6 +157,18 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
   const isAwaiting = phase === 'starting' || phase === 'awaiting';
   const isBusy = isConnecting || isAwaiting;
 
+  // The location currently selected in the switcher is derived from the relay
+  // URL (no separate state to keep in sync). Undefined → a custom/self-host URL,
+  // shown as "Custom" in the switcher.
+  const selectedLocation = locationForUrl(relayUrl);
+
+  // Reveal the Advanced override whenever the relay URL is a custom origin (e.g.
+  // a persisted self-host URL on mount) so it's never stranded behind a closed
+  // disclosure. Manual toggles still work via onToggle.
+  useEffect(() => {
+    if (locationForUrl(relayUrl) === undefined) setAdvancedOpen(true);
+  }, [relayUrl]);
+
   const handleSignIn = useCallback(async () => {
     const trimmedRelay = relayUrl.trim();
     const trimmedCloud = cloudUrl.trim().replace(/\/+$/, '');
@@ -187,11 +206,23 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
       setVerificationUri(handle.verificationUriComplete);
       setPhase('awaiting');
 
-      const { token, expiresAt, workspaceName, workspaceSlug } = await handle.result;
+      const {
+        token,
+        expiresAt,
+        relayUrl: serverRelayUrl,
+        workspaceName,
+        workspaceSlug,
+      } = await handle.result;
       handleRef.current = null;
 
+      // The relay's device-token response carries the workspace's region-resolved
+      // relay origin; adopt it as authoritative so a hosted sign-in lands on the
+      // right region relay regardless of the switcher/form default. Fall back to
+      // the form value for older relays / self-hosts that don't return one.
+      const effectiveRelay = serverRelayUrl?.trim() || trimmedRelay;
+
       await completeCloudSignIn({
-        relayUrl: trimmedRelay,
+        relayUrl: effectiveRelay,
         cloudBaseUrl: trimmedCloud,
         token,
         expiresAt,
@@ -452,6 +483,33 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
         </div>
       ) : (
         <>
+          <div className="cloud-connect__field cloud-connect__field--location">
+            <label htmlFor="relay-location">Location</label>
+            <select
+              id="relay-location"
+              className="cloud-connect__location-select"
+              value={selectedLocation?.id ?? 'custom'}
+              onChange={(e) => {
+                const loc = RELAY_LOCATIONS.find((l) => l.id === e.target.value);
+                if (loc) setRelayUrl(loc.relayUrl);
+              }}
+              disabled={isBusy}
+            >
+              {RELAY_LOCATIONS.map((loc) => (
+                <option key={loc.id} value={loc.id}>
+                  {loc.label}
+                </option>
+              ))}
+              {/* Only present when the relay URL was overridden under Advanced —
+                  not directly selectable, just reflects the custom state. */}
+              {!selectedLocation ? <option value="custom">Custom (Advanced)</option> : null}
+            </select>
+            <p className="cloud-connect__hint">
+              Connects to the relay region nearest you. Override the URL under
+              Advanced for self-hosting.
+            </p>
+          </div>
+
           <button
             type="button"
             className="cloud-connect__btn cloud-connect__btn--primary cloud-connect__btn--block"
@@ -468,8 +526,13 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
               : 'Sign in with DocuShark Cloud'}
           </button>
 
-          {/* Advanced: only self-hosters / testing / enterprise change these. */}
-          <details className="cloud-connect__advanced">
+          {/* Advanced: only self-hosters / testing / enterprise change these.
+              Controlled so a custom relay URL force-opens it (see effect). */}
+          <details
+            className="cloud-connect__advanced"
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+          >
             <summary className="cloud-connect__advanced-summary">
               <ChevronRight size={14} className="cloud-connect__advanced-caret" />
               Advanced
@@ -482,7 +545,7 @@ export function CloudConnectPanel({ onClose }: CloudConnectPanelProps) {
                   type="url"
                   value={relayUrl}
                   onChange={(e) => setRelayUrl(e.target.value)}
-                  placeholder={DEFAULT_RELAY_URL}
+                  placeholder={DEFAULT_RELAY_LOCATION.relayUrl}
                   disabled={isBusy}
                   autoComplete="url"
                   required

--- a/src/ui/cloud/CloudSignInModal.css
+++ b/src/ui/cloud/CloudSignInModal.css
@@ -148,7 +148,8 @@
   color: var(--text-secondary);
 }
 
-.cloud-connect__field input {
+.cloud-connect__field input,
+.cloud-connect__field select {
   padding: 10px 12px;
   font-size: 14px;
   color: var(--text-primary);
@@ -158,14 +159,23 @@
   transition: border-color 0.15s ease;
 }
 
-.cloud-connect__field input:focus {
+.cloud-connect__field input:focus,
+.cloud-connect__field select:focus {
   outline: none;
   border-color: var(--color-primary);
 }
 
-.cloud-connect__field input:disabled {
+.cloud-connect__field input:disabled,
+.cloud-connect__field select:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.cloud-connect__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
 }
 
 .cloud-connect__btn {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -23,6 +23,12 @@ interface ImportMetaEnv {
    * Optional — falls back to the local dev origin in `relayConnection.ts`.
    */
   readonly VITE_CLOUD_BASE_URL?: string;
+  /**
+   * Relay origin for the primary region, used as the default location's URL in
+   * the Cloud connect switcher. Optional — falls back to the local dev relay
+   * (`http://localhost:9876`) in `relayLocations.ts`.
+   */
+  readonly VITE_RELAY_BASE_URL?: string;
 }
 
 declare module 'nspell' {


### PR DESCRIPTION
Promotes the current `master` to `staging` — headline is the **PWA cold-start stability** fixes for the transient-relay-failure class the user hit on the installed production PWA.

## Headline stability fixes
- **JP-395** (#343) — don't fake-delete docs on a transient `ERR_UNKNOWN_DOC`. A cold/redeployed relay's index-miss no longer trashes + cache-evicts a live doc; only `ERR_DELETED` (tombstone) strands.
- **JP-396** (#344) — don't sign out on a transient relay 401 (`jwks unavailable`). A cold-relay boot `GET /api/docs` 401 no longer tears down a valid signed-in session; only genuine token rejections do.

Both are the same lesson: a transient relay failure must not drive a destructive client action. (Relay-side hardening of the *source* is tracked in JP-397.)

## Also carried (already merged to master)
- JP-378 — relay endpoint to purge a member's document shares (note: rebuilds the relay `:edge` image).
- JP-392 — collab reconnect on the active doc after sign-in.
- JP-390 — cached relay docs no longer vanish from the list after token expiry.
- JP-384 — stop duplicating empty Untitled docs on reload.
- Relay location switcher + server-resolved relay URL; titlebar online-status/workspace; one-time PWA install hint; off-render collab prose editor (setState-in-render fix); docs-site SEO + PWA-first framing.

Full list: 13 non-merge commits (`git log staging..master`).

## Deploy surface
Merging promotes to the staging editor PWA (Cloudflare Pages) and rebuilds the relay `:edge` image (GHCR) per the staging pipeline. No migrations in this set.

Assisted-by: Opus 4.8