### PR TITLE
JP-397: harden JWKS cold-start (readiness gate + 503 + cold-JOIN hydrate)

### DIFF
--- a/relay/src/auth/jwks.rs
+++ b/relay/src/auth/jwks.rs
@@ -27,6 +27,13 @@ pub const REFRESH_INTERVAL: Duration = Duration::from_secs(300);
 pub const FAIL_OPEN_GRACE: Duration = Duration::from_secs(3600);
 /// Floor between debounced on-demand refreshes (unknown-kid path).
 const ON_DEMAND_DEBOUNCE: Duration = Duration::from_secs(5);
+/// Bound on the boot-time JWKS warm-up (JP-397). Must stay under the platform's
+/// boot grace so a slow/unreachable JWKS endpoint can't deadlock startup.
+pub const BOOT_WARMUP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Background-refresh cadence *until the first success* — a pod that booted while
+/// the JWKS endpoint was briefly down recovers in seconds, not a full
+/// `REFRESH_INTERVAL` (JP-397). Switches to `REFRESH_INTERVAL` once warm.
+const COLD_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Deserialize)]
 struct Jwk {
@@ -100,15 +107,54 @@ impl JwksCache {
             // Eagerly attempt one fetch on boot so the first request
             // doesn't have to pay the cold-cache latency.
             let _ = me.refresh_once().await;
-            let mut ticker = tokio::time::interval(REFRESH_INTERVAL);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            // First tick fires immediately; absorb it.
-            ticker.tick().await;
             loop {
-                ticker.tick().await;
+                // JP-397: until the cache has ever succeeded, retry on a short
+                // cadence so a pod that booted while the JWKS endpoint was briefly
+                // down recovers in seconds rather than a full `REFRESH_INTERVAL`.
+                // Once warm, settle into the steady cadence.
+                let interval = if me.is_ready().await {
+                    REFRESH_INTERVAL
+                } else {
+                    COLD_RETRY_INTERVAL
+                };
+                tokio::time::sleep(interval).await;
                 let _ = me.refresh_once().await;
             }
         })
+    }
+
+    /// True once the cache has had at least one successful fetch — i.e. it can
+    /// validate tokens. Drives the boot warm-up gate and the cold-retry cadence.
+    pub async fn is_ready(&self) -> bool {
+        self.inner.read().await.last_success.is_some()
+    }
+
+    /// Block (up to `timeout`) until the first successful JWKS fetch lands, so a
+    /// freshly-booted/redeployed pod doesn't serve a cold-cache 401 for a valid
+    /// token (JP-397). Retries `refresh_once` on a short exponential backoff.
+    /// Returns whether the cache became ready; on timeout the caller proceeds
+    /// anyway (fail-open — a down JWKS endpoint must not deadlock boot; the
+    /// background refresher keeps trying and `get()` reports `JwksUnavailable`
+    /// → 503 in the meantime).
+    pub async fn warm_up(&self, timeout: Duration) -> bool {
+        // Already warm (e.g. the background refresher beat us, or a prior call) —
+        // skip a redundant fetch.
+        if self.is_ready().await {
+            return true;
+        }
+        let deadline = Instant::now() + timeout;
+        let mut backoff = Duration::from_millis(250);
+        loop {
+            if self.refresh_once().await.is_ok() {
+                return true;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            tokio::time::sleep(backoff.min(deadline - now)).await;
+            backoff = (backoff * 2).min(Duration::from_secs(1));
+        }
     }
 
     /// Resolve a `kid` for the validation path. Returns `Ok(Some(key))`

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -248,8 +248,32 @@ async fn run_serve(
         revocations.clone(),
     );
 
-    // Spawn the periodic JWKS refresh (5-min cadence + 1-h fail-open
-    // grace; see `token-format.md`).
+    // JP-397: block (bounded) on the first JWKS fetch BEFORE we bind the
+    // listener, so a freshly-booted / just-redeployed pod never rejects a valid
+    // token with a cold-cache 401 (deferring the bind also means the platform's
+    // health check holds traffic / holds the old machine in a rolling deploy
+    // until this pod is truly ready). Skipped when no JWKS URL is configured
+    // (static-token-only deployments). Fail-open: on timeout we log and proceed —
+    // the background refresher keeps trying and `JwksUnavailable` surfaces as a
+    // 503 (not a 401) meanwhile.
+    if !config.auth.jwks_url.trim().is_empty() {
+        let warm_started = std::time::Instant::now();
+        if jwks_cache
+            .warm_up(docushark_relay::auth::jwks::BOOT_WARMUP_TIMEOUT)
+            .await
+        {
+            log::info!("JWKS warm-up complete in {:?}", warm_started.elapsed());
+        } else {
+            log::warn!(
+                "JWKS warm-up timed out after {:?}; serving may 503 until JWKS is reachable at {}",
+                docushark_relay::auth::jwks::BOOT_WARMUP_TIMEOUT,
+                config.auth.jwks_url,
+            );
+        }
+    }
+
+    // Spawn the periodic JWKS refresh (5-min steady cadence, short cold-retry
+    // until the first success, + 1-h fail-open grace; see `token-format.md`).
     let _jwks_refresh_handle = jwks_cache.start_background_refresh();
 
     // Optional polling fallback for revocations. Push transport lives

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -2318,9 +2318,16 @@ async fn extract_jwt_from_headers(
 }
 
 /// Map an `AuthError` to the same opacity contract the WS path uses:
-/// 401 for anything signature/claim-related, 403 for region/workspace.
+/// 401 for anything signature/claim-related, 403 for region/workspace, and
+/// **503 for `JwksUnavailable`** — the relay couldn't *validate* the token right
+/// now (its JWKS isn't loaded yet on a cold/just-redeployed pod), which is a
+/// relay-availability condition, not a token rejection. Surfacing it as 503
+/// (rather than 401) stops a client from mistaking a transient blip for a bad
+/// token and signing the user out (JP-396/JP-397); the token is unchanged and
+/// succeeds once the relay warms.
 pub(crate) fn auth_error_to_http(e: &AuthError) -> (StatusCode, String) {
     let status = match e {
+        AuthError::JwksUnavailable => StatusCode::SERVICE_UNAVAILABLE,
         AuthError::WorkspaceMismatch | AuthError::RegionMismatch => StatusCode::FORBIDDEN,
         _ => StatusCode::UNAUTHORIZED,
     };
@@ -3402,6 +3409,14 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
         return;
     }
 
+    // JP-397: on a cold/recycled pod the in-memory index can be empty even
+    // though the doc exists in R2. The per-doc `ensure_doc_local` above restores
+    // a doc by id; this additionally restores the workspace `index.json` (the
+    // authoritative doc set) — the same R2-restore guard the REST list path uses
+    // — so we don't emit `ERR_UNKNOWN_DOC` for a doc that's merely not-loaded-yet.
+    // Idempotent + cheap: no-op once the index is populated or on a non-S3 backend.
+    state.ensure_workspace_index_local(&workspace_id).await;
+
     if state
         .doc_store()
         .get_metadata(&workspace_id, &request.doc_id)
@@ -3524,6 +3539,28 @@ async fn send_to_client(client_id: u64, data: Vec<u8>, state: &Arc<ServerState>)
 mod tests {
     use super::*;
     use crate::config::{LimitsConfig, TenancyConfig, TenancyMode};
+
+    #[test]
+    fn jwks_unavailable_maps_to_503_not_401() {
+        // JP-397: a relay-availability failure must be a 503 so a client doesn't
+        // mistake it for a token rejection and sign the user out.
+        assert_eq!(
+            auth_error_to_http(&AuthError::JwksUnavailable).0,
+            StatusCode::SERVICE_UNAVAILABLE,
+        );
+        // Genuine token rejections stay 401.
+        for e in [
+            AuthError::MissingKid,
+            AuthError::UnknownKid("k".into()),
+            AuthError::Expired,
+        ] {
+            assert_eq!(auth_error_to_http(&e).0, StatusCode::UNAUTHORIZED, "{e:?}");
+        }
+        // Scope mismatches stay 403.
+        for e in [AuthError::WorkspaceMismatch, AuthError::RegionMismatch] {
+            assert_eq!(auth_error_to_http(&e).0, StatusCode::FORBIDDEN, "{e:?}");
+        }
+    }
 
     #[tokio::test]
     async fn test_server_lifecycle() {

--- a/relay/tests/jwks_cold_start.rs
+++ b/relay/tests/jwks_cold_start.rs
@@ -1,0 +1,99 @@
+//! JP-397 — JWKS cold-start hardening.
+//!
+//! 1. `is_ready` / `warm_up` reflect whether the cache has ever loaded a key.
+//! 2. A relay whose JWKS cache hasn't loaded yet answers an authed REST request
+//!    with **503** (relay can't validate right now), NOT 401 (token rejected) —
+//!    so a client doesn't mistake a cold-pod blip for a bad token and sign out.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use docushark_relay::auth::{
+    JwksCache, OidcAuthState, OidcValidationConfig, RevocationSet, WorkspaceRole,
+};
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+
+/// An unroutable JWKS URL (discard port) so a refresh attempt always fails fast.
+const DEAD_JWKS: &str = "http://127.0.0.1:9/jwks";
+
+#[tokio::test]
+async fn is_ready_and_warm_up_reflect_cache_state() {
+    // Cold cache pointing at an unreachable endpoint is never ready.
+    let cold = JwksCache::new(DEAD_JWKS.to_string());
+    assert!(!cold.is_ready().await);
+
+    // warm_up against a dead endpoint returns false and respects its bound.
+    let t0 = std::time::Instant::now();
+    assert!(!cold.warm_up(Duration::from_millis(300)).await);
+    assert!(t0.elapsed() < Duration::from_secs(5), "warm_up overran its timeout");
+    assert!(!cold.is_ready().await);
+
+    // A preloaded cache (the test issuer's) is ready, and warm_up short-circuits
+    // to true without touching any endpoint.
+    let issuer = OidcTestIssuer::new().await;
+    let warm = issuer.auth_state().jwks;
+    assert!(warm.is_ready().await);
+    assert!(warm.warm_up(Duration::from_millis(1)).await);
+}
+
+#[tokio::test]
+async fn cold_jwks_returns_503_not_401() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Mint a structurally-valid token from a real issuer...
+    let issuer = OidcTestIssuer::new().await;
+    let token = issuer.mint("user-cold", "ws-cold", WorkspaceRole::Owner);
+
+    // ...but give the SERVER a cold cache that can't resolve the kid. Validation
+    // hits the JWKS lookup before any signature/claim check, so it returns
+    // `JwksUnavailable` → 503.
+    let cold_auth = OidcAuthState::new(
+        OidcValidationConfig {
+            issuer: "https://test.docushark.app".to_string(),
+            audience: "docushark-relay".to_string(),
+            resource: None,
+        },
+        JwksCache::new(DEAD_JWKS.to_string()),
+        RevocationSet::new(),
+    );
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(cold_auth).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+
+    let status = reqwest::Client::new()
+        .get(format!("{http}/api/docs"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("request")
+        .status();
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "cold JWKS must surface as 503, not 401",
+    );
+}


### PR DESCRIPTION
Fixes the **relay-side source** of the transient failures that caused JP-395 (fake-deletion) and JP-396 (session stranded). A freshly-booted / just-redeployed (or idle-then-cold) Fly pod rejected *valid* tokens with 401 for a few seconds, because the JWKS cache starts empty (`last_success: None` → `JwksUnavailable`) and the boot fetch was fire-and-forget.

## A — Readiness-gate the boot (`auth/jwks.rs` + `main.rs`)
- `JwksCache::is_ready()` + `warm_up(timeout)`: block (bounded, `BOOT_WARMUP_TIMEOUT = 10s`) on the **first successful JWKS fetch before binding the listener**. The pod never serves a cold 401, and — because the port isn't bound until JWKS is ready — the platform health check holds the old machine in a rolling deploy until the new one is truly ready (no out-of-repo `fly.toml` change needed). Skipped when no `jwks_url` is configured; **fail-open** on timeout (log loudly + proceed — a down web-JWKS must not deadlock boot).
- `start_background_refresh` now retries on a **short cadence (5s) until the first success**, then settles to `REFRESH_INTERVAL` — a pod that booted while web JWKS was briefly down recovers in seconds, not 5 minutes.

## C — `JwksUnavailable` → 503, not 401 (`server/mod.rs` `auth_error_to_http`)
It's a relay-*availability* condition, not a token rejection. 503 is unambiguous and sidesteps the client's `onUnauthorized`/sign-out path entirely — defense in depth with JP-396's `isTransientAuthFailure` guard. Genuine rejections stay 401; scope mismatches stay 403. (`require_auth` routes through this, so the boot `GET /api/docs` is now a 503.)

## B — Hydrate the index on a cold `JOIN_DOC` (`server/mod.rs`)
Call `ensure_workspace_index_local` before the `get_metadata → ERR_UNKNOWN_DOC` gate (mirrors the REST list path), so a cold R2-backed pod doesn't report a doc that exists in R2 as unknown. Idempotent + cheap (no-op when warm / on a non-S3 backend); complements the existing per-doc `ensure_doc_local`.

## Tests
- Unit: `auth_error_to_http` (503 / 401 / 403); `is_ready` + `warm_up` (cold→false within bound; preloaded→true, short-circuits).
- **Wire (JP-326 safety net):** `tests/jwks_cold_start.rs` boots a relay with a cold cache and asserts a valid token gets **503, not 401**.
- `cargo build --bin relay` + `cargo check --all-targets` + 560 lib tests green.

## Closes the loop
Pairs with the already-merged client guards (JP-395 #343, JP-396 #344). Once this ships, the [JP-397 acceptance comment](https://linear.app/justins-awesome-apps/issue/JP-397) re: returning 503 is satisfied; the client's string-match can eventually retire in favour of the status code (noted, not changed here — must stay robust against older relays).

Assisted-by: Opus 4.8