### PR TITLE
JP-33: per-shape style-profile adapters

### DIFF
--- a/src/store/styleProfile/capabilities.ts
+++ b/src/store/styleProfile/capabilities.ts
@@ -1,0 +1,60 @@
+/**
+ * Shape style capability resolution for the adapter layer (JP-33).
+ *
+ * Replaces the old hardcoded `SHAPE_CATEGORIES` map + the brittle
+ * `isLibraryShape()` string heuristic in `styleProfileStore`. Capability is now
+ * sourced from registry/metadata truth:
+ *
+ *   1. `shapeRegistry.getMetadata(type)` — authoritative for shapes that
+ *      register metadata (the `file` shape + all library shapes).
+ *   2. A small static fallback for the core shapes, which deliberately register
+ *      no metadata (so they stay out of the library picker). This fallback is
+ *      also what keeps the layer working in unit tests, where the registry and
+ *      shape-library store are empty.
+ *   3. `shapeLibraryStore.isLibraryShape(type)` as a last resort.
+ *
+ * Registry/store reads happen lazily *inside* the functions (never at module
+ * load) so this module imports cleanly and degrades gracefully when those
+ * stores have not been initialized yet.
+ */
+
+import { shapeRegistry } from '../../shapes/ShapeRegistry';
+import { useShapeLibraryStore } from '../shapeLibraryStore';
+
+/**
+ * Core shapes that support labels but register no metadata. Also the source of
+ * truth in the (registry-empty) test environment.
+ */
+const STATIC_LABEL_TYPES = new Set(['rectangle', 'ellipse', 'connector', 'group']);
+
+/** Core shapes that support icons but register no metadata. */
+const STATIC_ICON_TYPES = new Set(['rectangle', 'ellipse']);
+
+/**
+ * Whether `type` is a registered library shape. Wrapped in try/catch so that a
+ * not-yet-initialized store (e.g. in tests) degrades to `false` rather than
+ * throwing.
+ */
+function isLibraryShapeType(type: string): boolean {
+  try {
+    return useShapeLibraryStore.getState().isLibraryShape(type);
+  } catch {
+    return false;
+  }
+}
+
+/** Whether shapes of this type carry a styleable label. */
+export function shapeSupportsLabel(type: string): boolean {
+  const meta = shapeRegistry.getMetadata(type);
+  if (meta) return meta.supportsLabel;
+  if (STATIC_LABEL_TYPES.has(type)) return true;
+  return isLibraryShapeType(type);
+}
+
+/** Whether shapes of this type carry a styleable icon. */
+export function shapeSupportsIcon(type: string): boolean {
+  const meta = shapeRegistry.getMetadata(type);
+  if (meta) return meta.supportsIcon;
+  if (STATIC_ICON_TYPES.has(type)) return true;
+  return isLibraryShapeType(type);
+}

--- a/src/store/styleProfile/facets.ts
+++ b/src/store/styleProfile/facets.ts
@@ -1,0 +1,247 @@
+/**
+ * The style facets (JP-33).
+ *
+ * Each facet owns one style axis and is a faithful port of the corresponding
+ * branch from the old `extractStyleFromShape` / `getProfileUpdates` if-ladders.
+ * Two behavioral contracts are preserved verbatim:
+ *
+ *  - Subtype fields are probed via an index-signature view of the shape, each
+ *    read guarded by a `typeof` runtime check (so the `unknown` cast never
+ *    widens a value that actually lands in the result).
+ *  - The pre-existing `startArrow`/`endArrow` quirk (profile stores them as
+ *    `string`, shapes store them as `boolean`) is left exactly as-is — extract
+ *    only captures string values. Not "fixed" here; out of scope.
+ *
+ * Facets only ever conditionally assign optional fields (never assign
+ * `undefined`), satisfying `exactOptionalPropertyTypes`.
+ */
+
+import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../../shapes/Shape';
+import type { IconPosition, StyleFacet } from './types';
+import { shapeSupportsIcon, shapeSupportsLabel } from './capabilities';
+
+/** Index-signature view for guarded subtype probing. */
+function asRecord(shape: BaseShape): Record<string, unknown> {
+  return shape as unknown as Record<string, unknown>;
+}
+
+/** Universal fill/stroke/strokeWidth/opacity — applies to every shape. */
+const universalFacet: StyleFacet = {
+  id: 'universal',
+  names: ['Fill', 'Stroke', 'Stroke Width', 'Opacity'],
+  appliesTo: () => true,
+  extract: (shape) => ({
+    fill: shape.fill ?? null,
+    stroke: shape.stroke ?? null,
+    strokeWidth: shape.strokeWidth ?? 2,
+    opacity: shape.opacity ?? 1,
+  }),
+  apply: (props) => ({
+    fill: props.fill,
+    stroke: props.stroke,
+    strokeWidth: props.strokeWidth,
+    opacity: props.opacity,
+  }),
+};
+
+/** Corner radius — rectangles and groups. */
+const cornerRadiusFacet: StyleFacet = {
+  id: 'cornerRadius',
+  names: ['Corner Radius'],
+  appliesTo: (type) => type === 'rectangle' || type === 'group',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    return typeof extra['cornerRadius'] === 'number' ? { cornerRadius: extra['cornerRadius'] } : {};
+  },
+  apply: (props) => (props.cornerRadius !== undefined ? { cornerRadius: props.cornerRadius } : {}),
+};
+
+/** Label font size + color — any shape whose metadata says it carries a label. */
+const labelFacet: StyleFacet = {
+  id: 'label',
+  names: ['Label Font Size', 'Label Color'],
+  appliesTo: shapeSupportsLabel,
+  extract: (shape, opts) => {
+    if (!opts.includeLabelStyle) return {};
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['labelFontSize'] === 'number') out.labelFontSize = extra['labelFontSize'];
+    if (typeof extra['labelColor'] === 'string') out.labelColor = extra['labelColor'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.labelFontSize !== undefined) out.labelFontSize = props.labelFontSize;
+    if (props.labelColor !== undefined) out.labelColor = props.labelColor;
+    return out;
+  },
+};
+
+/** Font size + family — text shapes (fill doubles as text color via universal). */
+const textFacet: StyleFacet = {
+  id: 'text',
+  names: ['Font Size', 'Font Family'],
+  appliesTo: (type) => type === 'text',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['fontSize'] === 'number') out.fontSize = extra['fontSize'];
+    if (typeof extra['fontFamily'] === 'string') out.fontFamily = extra['fontFamily'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.fontSize !== undefined) out.fontSize = props.fontSize;
+    if (props.fontFamily !== undefined) out.fontFamily = props.fontFamily;
+    return out;
+  },
+};
+
+/** Start/end arrow style — lines and connectors. */
+const arrowsFacet: StyleFacet = {
+  id: 'arrows',
+  names: ['Start Arrow', 'End Arrow'],
+  appliesTo: (type) => type === 'line' || type === 'connector',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['startArrow'] === 'string') out.startArrow = extra['startArrow'];
+    if (typeof extra['endArrow'] === 'string') out.endArrow = extra['endArrow'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.startArrow !== undefined) out.startArrow = props.startArrow;
+    if (props.endArrow !== undefined) out.endArrow = props.endArrow;
+    return out;
+  },
+};
+
+/** Line style (solid/dashed) — connectors. */
+const lineStyleFacet: StyleFacet = {
+  id: 'lineStyle',
+  names: ['Line Style'],
+  appliesTo: (type) => type === 'connector',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    return typeof extra['lineStyle'] === 'string' ? { lineStyle: extra['lineStyle'] } : {};
+  },
+  apply: (props) => (props.lineStyle !== undefined ? { lineStyle: props.lineStyle } : {}),
+};
+
+/** Background/border styling — groups. */
+const groupFacet: StyleFacet = {
+  id: 'group',
+  names: ['Background Color', 'Border Color', 'Border Width'],
+  appliesTo: (type) => type === 'group',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['backgroundColor'] === 'string') out.backgroundColor = extra['backgroundColor'];
+    if (typeof extra['borderColor'] === 'string') out.borderColor = extra['borderColor'];
+    if (typeof extra['borderWidth'] === 'number') out.borderWidth = extra['borderWidth'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.backgroundColor !== undefined) out.backgroundColor = props.backgroundColor;
+    if (props.borderColor !== undefined) out.borderColor = props.borderColor;
+    if (props.borderWidth !== undefined) out.borderWidth = props.borderWidth;
+    return out;
+  },
+};
+
+/**
+ * ERD table styling — entity shapes. These profile values live on the shape's
+ * `customProperties`, so this facet reads from / writes to that object. `apply`
+ * folds the values into a *merged* `customProperties` copy (the merge the call
+ * site used to do by hand), and is a no-op when the profile carries none.
+ */
+const erdFacet: StyleFacet = {
+  id: 'erd',
+  names: ['Row Colors', 'Padding', 'Separator Inset'],
+  appliesTo: (type) => type === 'erd-entity' || type === 'erd-weak-entity',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const customPropsRaw = extra['customProperties'];
+    if (!customPropsRaw || typeof customPropsRaw !== 'object') return {};
+    const customProps = customPropsRaw as Record<string, unknown>;
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof customProps['rowSeparatorColor'] === 'string') out.rowSeparatorColor = customProps['rowSeparatorColor'];
+    if (typeof customProps['rowBackgroundColor'] === 'string') out.rowBackgroundColor = customProps['rowBackgroundColor'];
+    if (typeof customProps['rowAlternateColor'] === 'string') out.rowAlternateColor = customProps['rowAlternateColor'];
+    if (typeof customProps['attributePaddingHorizontal'] === 'number') out.attributePaddingHorizontal = customProps['attributePaddingHorizontal'];
+    if (typeof customProps['attributePaddingVertical'] === 'number') out.attributePaddingVertical = customProps['attributePaddingVertical'];
+    return out;
+  },
+  apply: (props, shape) => {
+    const erdValues: Record<string, unknown> = {};
+    if (props.rowSeparatorColor !== undefined) erdValues['rowSeparatorColor'] = props.rowSeparatorColor;
+    if (props.rowBackgroundColor !== undefined) erdValues['rowBackgroundColor'] = props.rowBackgroundColor;
+    if (props.rowAlternateColor !== undefined) erdValues['rowAlternateColor'] = props.rowAlternateColor;
+    if (props.attributePaddingHorizontal !== undefined) erdValues['attributePaddingHorizontal'] = props.attributePaddingHorizontal;
+    if (props.attributePaddingVertical !== undefined) erdValues['attributePaddingVertical'] = props.attributePaddingVertical;
+
+    if (Object.keys(erdValues).length === 0) return {};
+
+    const existingRaw = asRecord(shape)['customProperties'];
+    const existing = existingRaw && typeof existingRaw === 'object' ? (existingRaw as Record<string, unknown>) : {};
+    return { customProperties: { ...existing, ...erdValues } };
+  },
+};
+
+/** Icon styling (all 8 icon fields) — any shape whose metadata supports icons. */
+const iconFacet: StyleFacet = {
+  id: 'icon',
+  names: ['Icon', 'Icon Size', 'Icon Position'],
+  appliesTo: shapeSupportsIcon,
+  extract: (shape, opts) => {
+    if (!opts.includeIconStyle) return {};
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['iconId'] === 'string') out.iconId = extra['iconId'];
+    if (typeof extra['iconSize'] === 'number') out.iconSize = extra['iconSize'];
+    if (typeof extra['iconPadding'] === 'number') out.iconPadding = extra['iconPadding'];
+    if (typeof extra['iconColor'] === 'string') out.iconColor = extra['iconColor'];
+    if (typeof extra['iconPosition'] === 'string') out.iconPosition = extra['iconPosition'] as IconPosition;
+    if (typeof extra['iconDisplayMode'] === 'string') out.iconDisplayMode = extra['iconDisplayMode'] as IconDisplayMode;
+    const iconBadge = extra['iconBadge'];
+    if (iconBadge && typeof iconBadge === 'object') {
+      // Shallow copy so later shape mutations don't bleed into the profile.
+      out.iconBadge = { ...(iconBadge as IconBadgeConfig) };
+    }
+    const icons = extra['icons'];
+    if (Array.isArray(icons)) {
+      out.icons = icons.map((icon) => ({ ...(icon as IconConfig) }));
+    }
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.iconId !== undefined) out.iconId = props.iconId;
+    if (props.iconSize !== undefined) out.iconSize = props.iconSize;
+    if (props.iconPadding !== undefined) out.iconPadding = props.iconPadding;
+    if (props.iconColor !== undefined) out.iconColor = props.iconColor;
+    if (props.iconPosition !== undefined) out.iconPosition = props.iconPosition;
+    if (props.iconDisplayMode !== undefined) out.iconDisplayMode = props.iconDisplayMode;
+    if (props.iconBadge !== undefined) out.iconBadge = props.iconBadge;
+    if (props.icons !== undefined) out.icons = props.icons;
+    return out;
+  },
+};
+
+/**
+ * All facets, in application order. Order matters only for `apply` precedence
+ * (later facets win on key collisions — none currently collide).
+ */
+export const STYLE_FACETS: readonly StyleFacet[] = [
+  universalFacet,
+  cornerRadiusFacet,
+  labelFacet,
+  textFacet,
+  arrowsFacet,
+  lineStyleFacet,
+  groupFacet,
+  erdFacet,
+  iconFacet,
+];

--- a/src/store/styleProfile/index.ts
+++ b/src/store/styleProfile/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-shape style-profile adapter layer (JP-33).
+ *
+ * Translates a flat style profile to/from concrete shape fields via composable
+ * facets resolved per shape type. See {@link resolveStyleAdapter} and the
+ * {@link StyleFacet} contract.
+ */
+
+export type {
+  IconPosition,
+  StyleProfileProperties,
+  ShapeStyleUpdate,
+  ResolvedExtractOptions,
+  StyleFacet,
+  ErdProfileKey,
+} from './types';
+export { resolveStyleAdapter } from './registry';
+export { STYLE_FACETS } from './facets';
+export { shapeSupportsLabel, shapeSupportsIcon } from './capabilities';

--- a/src/store/styleProfile/registry.test.ts
+++ b/src/store/styleProfile/registry.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Coverage for the per-shape style-profile adapter layer (JP-33).
+ *
+ * Validates that:
+ *  - the registry dispatches the right facets per shape type;
+ *  - capability resolution falls back to the static table when the shape
+ *    registry is empty (the case in this test environment, and the case for
+ *    core shapes at runtime since they register no metadata);
+ *  - capability resolution honors shape metadata when present;
+ *  - the ERD facet folds its values into a *merged* customProperties object;
+ *  - metadata-truth coverage gains label styling for groups.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveStyleAdapter, shapeSupportsLabel, shapeSupportsIcon } from './index';
+import {
+  extractStyleFromShape,
+  getProfileUpdates,
+  type StyleProfile,
+  type StyleProfileProperties,
+} from '../styleProfileStore';
+import type { BaseShape } from '../../shapes/Shape';
+import type { ShapeHandler } from '../../shapes/ShapeRegistry';
+import { shapeRegistry } from '../../shapes/ShapeRegistry';
+import type { ShapeMetadata } from '../../shapes/ShapeMetadata';
+
+/** Loosely-typed shape factory — the adapter reads fields dynamically. */
+function makeShape(type: string, extra: Record<string, unknown> = {}): BaseShape {
+  return {
+    id: `${type}-1`,
+    type,
+    x: 0,
+    y: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#ffffff',
+    stroke: '#000000',
+    strokeWidth: 2,
+    ...extra,
+  } as unknown as BaseShape;
+}
+
+function makeProfile(properties: StyleProfileProperties): StyleProfile {
+  return { id: 'p', name: 'p', properties, createdAt: 0, favorite: false };
+}
+
+const BASE_PROPS: StyleProfileProperties = {
+  fill: '#abcdef',
+  stroke: '#123456',
+  strokeWidth: 3,
+  opacity: 0.5,
+};
+
+const facetIds = (type: string): string[] => resolveStyleAdapter(type).map((f) => f.id);
+
+describe('resolveStyleAdapter — dispatch', () => {
+  it('gives a rectangle universal + cornerRadius + label + icon', () => {
+    const ids = facetIds('rectangle');
+    expect(ids).toEqual(expect.arrayContaining(['universal', 'cornerRadius', 'label', 'icon']));
+  });
+
+  it('gives a line universal + arrows, but not icon/label/cornerRadius', () => {
+    const ids = facetIds('line');
+    expect(ids).toEqual(expect.arrayContaining(['universal', 'arrows']));
+    expect(ids).not.toContain('icon');
+    expect(ids).not.toContain('label');
+    expect(ids).not.toContain('cornerRadius');
+  });
+
+  it('gives a text shape the text facet but no icon', () => {
+    const ids = facetIds('text');
+    expect(ids).toContain('text');
+    expect(ids).not.toContain('icon');
+  });
+
+  it('gives a group the group + label + cornerRadius facets but no icon', () => {
+    const ids = facetIds('group');
+    expect(ids).toEqual(expect.arrayContaining(['universal', 'group', 'label', 'cornerRadius']));
+    expect(ids).not.toContain('icon');
+  });
+
+  it('gives a connector arrows + lineStyle + label', () => {
+    const ids = facetIds('connector');
+    expect(ids).toEqual(expect.arrayContaining(['arrows', 'lineStyle', 'label']));
+  });
+
+  it('gives an unknown type only the universal facet', () => {
+    expect(facetIds('totally-unknown-shape')).toEqual(['universal']);
+  });
+});
+
+describe('empty-registry static fallback', () => {
+  it('resolves core-shape capabilities without registered metadata', () => {
+    // No shapes are registered in the test environment — these come from the
+    // static fallback table, which is load-bearing for the JP-7 icon tests.
+    expect(shapeSupportsLabel('rectangle')).toBe(true);
+    expect(shapeSupportsIcon('rectangle')).toBe(true);
+    expect(shapeSupportsLabel('line')).toBe(false);
+    expect(shapeSupportsIcon('line')).toBe(false);
+    expect(shapeSupportsLabel('group')).toBe(true);
+    expect(shapeSupportsIcon('group')).toBe(false);
+  });
+});
+
+describe('getProfileUpdates — translation', () => {
+  it('applies universal fields to every shape, including markerless ones', () => {
+    const updates = getProfileUpdates(makeProfile(BASE_PROPS), makeShape('line'));
+    expect(updates.fill).toBe('#abcdef');
+    expect(updates.stroke).toBe('#123456');
+    expect(updates.strokeWidth).toBe(3);
+    expect(updates.opacity).toBe(0.5);
+  });
+
+  it('grants label styling to groups (metadata-truth coverage gain)', () => {
+    const profile = makeProfile({ ...BASE_PROPS, labelFontSize: 18, labelColor: '#654321' });
+    const updates = getProfileUpdates(profile, makeShape('group'));
+    expect(updates.labelFontSize).toBe(18);
+    expect(updates.labelColor).toBe('#654321');
+  });
+
+  it('does not write label fields onto shapes that do not support them', () => {
+    const profile = makeProfile({ ...BASE_PROPS, labelFontSize: 18, labelColor: '#654321' });
+    const updates = getProfileUpdates(profile, makeShape('line'));
+    expect(updates.labelFontSize).toBeUndefined();
+    expect(updates.labelColor).toBeUndefined();
+  });
+
+  it('merges ERD row styling into existing customProperties without clobbering', () => {
+    const profile = makeProfile({
+      ...BASE_PROPS,
+      rowSeparatorColor: '#ff0000',
+      attributePaddingHorizontal: 12,
+    });
+    const shape = makeShape('erd-entity', { customProperties: { foo: 1, rowSeparatorColor: '#000' } });
+
+    const updates = getProfileUpdates(profile, shape);
+
+    expect(updates.customProperties).toEqual({
+      foo: 1,
+      rowSeparatorColor: '#ff0000',
+      attributePaddingHorizontal: 12,
+    });
+    // Raw ERD keys must never leak onto the top-level update.
+    expect((updates as Record<string, unknown>)['rowSeparatorColor']).toBeUndefined();
+  });
+
+  it('leaves customProperties untouched when the profile has no ERD styling', () => {
+    const updates = getProfileUpdates(makeProfile(BASE_PROPS), makeShape('erd-entity', { customProperties: { foo: 1 } }));
+    expect(updates.customProperties).toBeUndefined();
+  });
+});
+
+describe('extractStyleFromShape — adapter dispatch', () => {
+  it('always captures the four universal fields', () => {
+    const props = extractStyleFromShape(makeShape('totally-unknown-shape', { fill: '#aaa', stroke: '#bbb', strokeWidth: 4, opacity: 0.3 }));
+    expect(props).toMatchObject({ fill: '#aaa', stroke: '#bbb', strokeWidth: 4, opacity: 0.3 });
+  });
+
+  it('captures ERD row styling from customProperties on entity shapes', () => {
+    const shape = makeShape('erd-entity', { customProperties: { rowAlternateColor: '#eee', attributePaddingVertical: 6 } });
+    const props = extractStyleFromShape(shape);
+    expect(props.rowAlternateColor).toBe('#eee');
+    expect(props.attributePaddingVertical).toBe(6);
+  });
+});
+
+describe('metadata-driven capability resolution', () => {
+  afterEach(() => {
+    // The registry is a shared singleton; the test env starts empty, so a full
+    // clear is the safe teardown (unregister alone leaves metadata behind).
+    shapeRegistry.clear();
+  });
+
+  function registerDummy(supportsLabel: boolean, supportsIcon: boolean): void {
+    const metadata: ShapeMetadata = {
+      type: 'dummy-style-shape',
+      name: 'Dummy',
+      category: 'custom',
+      icon: '?',
+      properties: [],
+      supportsLabel,
+      supportsIcon,
+      defaultWidth: 100,
+      defaultHeight: 100,
+    };
+    const stubHandler = {
+      render: () => {},
+      hitTest: () => false,
+      getBounds: () => ({ x: 0, y: 0, width: 0, height: 0 }),
+      getHandles: () => [],
+      create: (_pos: unknown, id: string) => makeShape('dummy-style-shape', { id }),
+    } as unknown as ShapeHandler;
+    shapeRegistry.register('dummy-style-shape', stubHandler, metadata);
+  }
+
+  it('honors supportsLabel:true / supportsIcon:false from metadata', () => {
+    registerDummy(true, false);
+    expect(shapeSupportsLabel('dummy-style-shape')).toBe(true);
+    expect(shapeSupportsIcon('dummy-style-shape')).toBe(false);
+    const ids = facetIds('dummy-style-shape');
+    expect(ids).toContain('label');
+    expect(ids).not.toContain('icon');
+  });
+
+  it('honors supportsIcon:true from metadata', () => {
+    registerDummy(false, true);
+    expect(shapeSupportsLabel('dummy-style-shape')).toBe(false);
+    expect(shapeSupportsIcon('dummy-style-shape')).toBe(true);
+    const ids = facetIds('dummy-style-shape');
+    expect(ids).toContain('icon');
+    expect(ids).not.toContain('label');
+  });
+});

--- a/src/store/styleProfile/registry.ts
+++ b/src/store/styleProfile/registry.ts
@@ -1,0 +1,25 @@
+/**
+ * Style-adapter registry (JP-33).
+ *
+ * A shape's "adapter" is emergent: it is exactly the subset of {@link STYLE_FACETS}
+ * whose {@link StyleFacet.appliesTo} is true for the shape type. There are no
+ * hand-written per-type adapter objects to keep in sync.
+ *
+ * The result is intentionally not cached: capability sources (shape metadata,
+ * the shape-library store) can register after the first call, and filtering a
+ * handful of cheap predicates per user-triggered apply is negligible.
+ */
+
+import type { StyleFacet } from './types';
+import { STYLE_FACETS } from './facets';
+
+/**
+ * Resolve the ordered list of facets that apply to a shape type.
+ *
+ * Unknown types fall through to just the universal facet (fill/stroke/
+ * strokeWidth/opacity), since every non-universal facet returns `false` for an
+ * unrecognized type — so there is no separate "default adapter" to maintain.
+ */
+export function resolveStyleAdapter(type: string): readonly StyleFacet[] {
+  return STYLE_FACETS.filter((facet) => facet.appliesTo(type));
+}

--- a/src/store/styleProfile/types.ts
+++ b/src/store/styleProfile/types.ts
@@ -1,0 +1,163 @@
+/**
+ * Core contracts for the per-shape style-profile adapter layer (JP-33).
+ *
+ * A style profile is a flat bag of concrete style values
+ * ({@link StyleProfileProperties}). Translating that bag onto a concrete shape —
+ * and reading it back off a shape — used to be three hand-written `if`-ladders
+ * gated by a brittle string heuristic. It is now a set of composable
+ * {@link StyleFacet}s, each owning one style axis (fill/stroke, label, icon,
+ * ERD rows, …). A shape's "adapter" is simply the facets whose
+ * {@link StyleFacet.appliesTo} is true for its type — resolved by the registry.
+ *
+ * This module is the dependency root: it imports only shape *types*, so the
+ * facet/registry/capability modules can depend on it without forming a cycle
+ * back through `styleProfileStore`.
+ */
+
+import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../../shapes/Shape';
+
+/**
+ * Icon position options persisted in a style profile.
+ *
+ * Intentionally narrower than the shape-level `IconPosition` in `Shape.ts`
+ * (profiles only ever round-trip the corner/center positions). Kept verbatim
+ * from the original `styleProfileStore` definition to preserve behavior.
+ */
+export type IconPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center';
+
+/**
+ * Style properties that can be saved in a profile.
+ * These are the common style properties across all shape types.
+ */
+export interface StyleProfileProperties {
+  // Universal properties
+  fill: string | null;
+  stroke: string | null;
+  strokeWidth: number;
+  opacity: number;
+
+  // Rectangle/Group properties
+  /** Optional - only applies to rectangles and groups */
+  cornerRadius?: number;
+
+  // Label properties
+  /** Optional - label font size for shapes with labels */
+  labelFontSize?: number;
+  /** Optional - label color for shapes with labels */
+  labelColor?: string;
+
+  // Text shape properties
+  /** Optional - font size for text shapes */
+  fontSize?: number;
+  /** Optional - font family for text shapes */
+  fontFamily?: string;
+
+  // Line/Connector properties
+  /** Optional - start arrow style */
+  startArrow?: string;
+  /** Optional - end arrow style */
+  endArrow?: string;
+  /** Optional - line style (solid, dashed) */
+  lineStyle?: string;
+
+  // Group-specific properties
+  /** Optional - background color for groups */
+  backgroundColor?: string;
+  /** Optional - border color for groups */
+  borderColor?: string;
+  /** Optional - border width for groups */
+  borderWidth?: number;
+
+  // ERD entity styling properties
+  /** Optional - row separator color */
+  rowSeparatorColor?: string;
+  /** Optional - row background color */
+  rowBackgroundColor?: string;
+  /** Optional - alternate row color for zebra striping */
+  rowAlternateColor?: string;
+  /** Optional - horizontal padding for attribute text */
+  attributePaddingHorizontal?: number;
+  /** Optional - vertical padding for attributes */
+  attributePaddingVertical?: number;
+
+  // Icon properties (Rectangle, Ellipse, LibraryShape)
+  /** Optional - icon ID reference */
+  iconId?: string;
+  /** Optional - icon size in pixels */
+  iconSize?: number;
+  /** Optional - icon padding from corner */
+  iconPadding?: number;
+  /** Optional - icon color override */
+  iconColor?: string;
+  /** Optional - icon position */
+  iconPosition?: IconPosition;
+  /** Optional - icon display mode ('inside' | 'badge' | 'icon-only') */
+  iconDisplayMode?: IconDisplayMode;
+  /** Optional - badge configuration when iconDisplayMode = 'badge' */
+  iconBadge?: IconBadgeConfig;
+  /** Optional - multi-icon configuration (overrides single-icon props when present) */
+  icons?: IconConfig[];
+}
+
+/**
+ * The ERD-specific profile keys. They are stored flat on a profile but applied
+ * into `shape.customProperties` rather than onto the shape directly, so they are
+ * stripped from {@link ShapeStyleUpdate} (the ERD facet folds them into
+ * `customProperties`).
+ */
+export type ErdProfileKey =
+  | 'rowSeparatorColor'
+  | 'rowBackgroundColor'
+  | 'rowAlternateColor'
+  | 'attributePaddingHorizontal'
+  | 'attributePaddingVertical';
+
+/**
+ * Concrete shape-field updates produced by applying a profile to a shape.
+ *
+ * Structurally a `Partial<Shape>`: the raw ERD keys are replaced by a single
+ * (already-merged) `customProperties` object, so the result can be handed
+ * straight to `updateShape(id, update)` with no special-casing at the call site.
+ */
+export type ShapeStyleUpdate = Omit<Partial<StyleProfileProperties>, ErdProfileKey> & {
+  customProperties?: Record<string, unknown>;
+};
+
+/**
+ * Fully-resolved extraction options (every flag concrete). The public
+ * `ExtractStyleOptions` is the partial form; the store resolves it before
+ * dispatching to facets.
+ */
+export interface ResolvedExtractOptions {
+  /** Include icon properties (iconId, iconSize, …). */
+  includeIconStyle: boolean;
+  /** Include label properties (labelFontSize, labelColor). */
+  includeLabelStyle: boolean;
+}
+
+/**
+ * One reusable style axis (universal fill/stroke, label, icon, ERD rows, …).
+ *
+ * A facet knows which shape *types* it applies to, how to read its fields off a
+ * shape into the flat profile bag ({@link extract}), and how to translate
+ * profile values into concrete shape-field updates ({@link apply}).
+ *
+ * `apply(props, shape)` is deliberately the same primitive a future "Dynamic
+ * Style Profiles" `styleProfileRef` would call to resolve/merge a referenced
+ * profile onto a shape — no separate code path needed.
+ */
+export interface StyleFacet {
+  /** Stable id for ordering/debugging. */
+  readonly id: string;
+  /** Human-readable property names this facet contributes (drives the UI hint). */
+  readonly names: readonly string[];
+  /** Whether this facet applies to the given shape type. */
+  appliesTo(type: string): boolean;
+  /** Pull this facet's concrete fields off a shape into the flat profile bag. */
+  extract(shape: BaseShape, opts: ResolvedExtractOptions): Partial<StyleProfileProperties>;
+  /**
+   * Translate profile values into concrete shape-field updates, merging with
+   * the existing shape where a field is a sub-object (ERD `customProperties`).
+   */
+  apply(props: StyleProfileProperties, shape: BaseShape): ShapeStyleUpdate;
+}

--- a/src/store/styleProfileStore.test.ts
+++ b/src/store/styleProfileStore.test.ts
@@ -16,7 +16,7 @@ import {
   type StyleProfile,
   type StyleProfileProperties,
 } from './styleProfileStore';
-import type { RectangleShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
+import type { RectangleShape, LineShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
 
 function makeRectangle(overrides: Partial<RectangleShape> = {}): RectangleShape {
   return {
@@ -34,6 +34,27 @@ function makeRectangle(overrides: Partial<RectangleShape> = {}): RectangleShape 
     stroke: '#000000',
     strokeWidth: 2,
     cornerRadius: 0,
+    ...overrides,
+  };
+}
+
+function makeLine(overrides: Partial<LineShape> = {}): LineShape {
+  return {
+    id: 'line-1',
+    type: 'line',
+    x: 0,
+    y: 0,
+    x2: 50,
+    y2: 50,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: null,
+    stroke: '#000000',
+    strokeWidth: 2,
+    startArrow: false,
+    endArrow: true,
     ...overrides,
   };
 }
@@ -130,7 +151,7 @@ describe('getProfileUpdates — icon coverage (JP-7)', () => {
 
     const props = extractStyleFromShape(source, { includeIconStyle: true });
     const profile = makeProfile('roundtrip', props);
-    const updates = getProfileUpdates(profile, 'rectangle');
+    const updates = getProfileUpdates(profile, source);
 
     expect(updates.iconId).toBe('builtin:typescript');
     expect(updates.iconSize).toBe(32);
@@ -146,7 +167,7 @@ describe('getProfileUpdates — icon coverage (JP-7)', () => {
     // Profile saved with includeIconStyle: false — no icon props.
     const profileProps = extractStyleFromShape(makeRectangle(), { includeIconStyle: false });
     const profile = makeProfile('no-icons', profileProps);
-    const updates = getProfileUpdates(profile, 'rectangle');
+    const updates = getProfileUpdates(profile, makeRectangle());
 
     expect(updates.iconId).toBeUndefined();
     expect(updates.iconSize).toBeUndefined();
@@ -165,8 +186,8 @@ describe('getProfileUpdates — icon coverage (JP-7)', () => {
     );
     const profile = makeProfile('cross-shape', props);
 
-    // 'line' is not in SHAPE_CATEGORIES.withIcons.
-    const updates = getProfileUpdates(profile, 'line');
+    // A line does not support icons, so the icon facet does not apply.
+    const updates = getProfileUpdates(profile, makeLine());
 
     expect(updates.iconId).toBeUndefined();
     expect(updates.iconDisplayMode).toBeUndefined();

--- a/src/store/styleProfileStore.ts
+++ b/src/store/styleProfileStore.ts
@@ -1,86 +1,18 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { nanoid } from 'nanoid';
-import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../shapes/Shape';
+import type { BaseShape } from '../shapes/Shape';
+import { resolveStyleAdapter } from './styleProfile';
+import type {
+  StyleProfileProperties,
+  ShapeStyleUpdate,
+  ResolvedExtractOptions,
+} from './styleProfile';
 
-/**
- * Icon position options for shapes.
- */
-export type IconPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center';
-
-/**
- * Style properties that can be saved in a profile.
- * These are the common style properties across all shape types.
- */
-export interface StyleProfileProperties {
-  // Universal properties
-  fill: string | null;
-  stroke: string | null;
-  strokeWidth: number;
-  opacity: number;
-
-  // Rectangle/Group properties
-  /** Optional - only applies to rectangles and groups */
-  cornerRadius?: number;
-
-  // Label properties
-  /** Optional - label font size for shapes with labels */
-  labelFontSize?: number;
-  /** Optional - label color for shapes with labels */
-  labelColor?: string;
-
-  // Text shape properties
-  /** Optional - font size for text shapes */
-  fontSize?: number;
-  /** Optional - font family for text shapes */
-  fontFamily?: string;
-
-  // Line/Connector properties
-  /** Optional - start arrow style */
-  startArrow?: string;
-  /** Optional - end arrow style */
-  endArrow?: string;
-  /** Optional - line style (solid, dashed) */
-  lineStyle?: string;
-
-  // Group-specific properties
-  /** Optional - background color for groups */
-  backgroundColor?: string;
-  /** Optional - border color for groups */
-  borderColor?: string;
-  /** Optional - border width for groups */
-  borderWidth?: number;
-
-  // ERD entity styling properties
-  /** Optional - row separator color */
-  rowSeparatorColor?: string;
-  /** Optional - row background color */
-  rowBackgroundColor?: string;
-  /** Optional - alternate row color for zebra striping */
-  rowAlternateColor?: string;
-  /** Optional - horizontal padding for attribute text */
-  attributePaddingHorizontal?: number;
-  /** Optional - vertical padding for attributes */
-  attributePaddingVertical?: number;
-
-  // Icon properties (Rectangle, Ellipse, LibraryShape)
-  /** Optional - icon ID reference */
-  iconId?: string;
-  /** Optional - icon size in pixels */
-  iconSize?: number;
-  /** Optional - icon padding from corner */
-  iconPadding?: number;
-  /** Optional - icon color override */
-  iconColor?: string;
-  /** Optional - icon position */
-  iconPosition?: IconPosition;
-  /** Optional - icon display mode ('inside' | 'badge' | 'icon-only') */
-  iconDisplayMode?: IconDisplayMode;
-  /** Optional - badge configuration when iconDisplayMode = 'badge' */
-  iconBadge?: IconBadgeConfig;
-  /** Optional - multi-icon configuration (overrides single-icon props when present) */
-  icons?: IconConfig[];
-}
+// The profile value types now live in `./styleProfile/types` (the dependency
+// root of the adapter layer). Re-export them here so existing import paths
+// (`./styleProfileStore`) keep working unchanged.
+export type { IconPosition, StyleProfileProperties } from './styleProfile';
 
 /**
  * A saved style profile.
@@ -306,20 +238,22 @@ const DEFAULT_EXTRACT_OPTIONS: ExtractStyleOptions = {
 
 /**
  * Extract style properties from a shape for creating a profile.
- * Extracts all applicable properties based on the shape type.
+ *
+ * Dispatches to the per-shape adapter (the facets that apply to `shape.type`):
+ * universal fill/stroke/strokeWidth/opacity are always present, and each facet
+ * layers on the type-specific fields it owns. See `./styleProfile`.
  *
  * @param shape - The shape to extract styles from
  * @param options - Options for what to include (default: include all)
  */
 export function extractStyleFromShape(shape: BaseShape, options?: ExtractStyleOptions): StyleProfileProperties {
-  const opts = { ...DEFAULT_EXTRACT_OPTIONS, ...options };
+  const opts: ResolvedExtractOptions = {
+    includeIconStyle: options?.includeIconStyle ?? DEFAULT_EXTRACT_OPTIONS.includeIconStyle ?? true,
+    includeLabelStyle: options?.includeLabelStyle ?? DEFAULT_EXTRACT_OPTIONS.includeLabelStyle ?? true,
+  };
 
-  // Subtype-specific fields aren't on BaseShape, so probe them via an
-  // index-signature view of the same object. Each access is guarded by a
-  // `typeof` runtime check, so the cast doesn't widen the effective type
-  // of any value that actually lands in `properties`.
-  const extra = shape as unknown as Record<string, unknown>;
-
+  // Seed the four universal (required) fields so the return type is satisfied
+  // even before facets run; the universal facet re-affirms the same values.
   const properties: StyleProfileProperties = {
     fill: shape.fill ?? null,
     stroke: shape.stroke ?? null,
@@ -327,309 +261,33 @@ export function extractStyleFromShape(shape: BaseShape, options?: ExtractStyleOp
     opacity: shape.opacity ?? 1,
   };
 
-  // Rectangle/Group properties
-  if (typeof extra['cornerRadius'] === 'number') {
-    properties.cornerRadius = extra['cornerRadius'];
-  }
-
-  // Label properties (conditionally included)
-  if (opts.includeLabelStyle) {
-    if (typeof extra['labelFontSize'] === 'number') {
-      properties.labelFontSize = extra['labelFontSize'];
-    }
-    if (typeof extra['labelColor'] === 'string') {
-      properties.labelColor = extra['labelColor'];
-    }
-  }
-
-  // Text shape properties
-  if (typeof extra['fontSize'] === 'number') {
-    properties.fontSize = extra['fontSize'];
-  }
-  if (typeof extra['fontFamily'] === 'string') {
-    properties.fontFamily = extra['fontFamily'];
-  }
-
-  // Line/Connector properties
-  if (typeof extra['startArrow'] === 'string') {
-    properties.startArrow = extra['startArrow'];
-  }
-  if (typeof extra['endArrow'] === 'string') {
-    properties.endArrow = extra['endArrow'];
-  }
-  if (typeof extra['lineStyle'] === 'string') {
-    properties.lineStyle = extra['lineStyle'];
-  }
-
-  // Group-specific properties
-  if (typeof extra['backgroundColor'] === 'string') {
-    properties.backgroundColor = extra['backgroundColor'];
-  }
-  if (typeof extra['borderColor'] === 'string') {
-    properties.borderColor = extra['borderColor'];
-  }
-  if (typeof extra['borderWidth'] === 'number') {
-    properties.borderWidth = extra['borderWidth'];
-  }
-
-  // ERD entity properties (from customProperties)
-  const customPropsRaw = extra['customProperties'];
-  if (customPropsRaw && typeof customPropsRaw === 'object') {
-    const customProps = customPropsRaw as Record<string, unknown>;
-    if (typeof customProps['rowSeparatorColor'] === 'string') {
-      properties.rowSeparatorColor = customProps['rowSeparatorColor'];
-    }
-    if (typeof customProps['rowBackgroundColor'] === 'string') {
-      properties.rowBackgroundColor = customProps['rowBackgroundColor'];
-    }
-    if (typeof customProps['rowAlternateColor'] === 'string') {
-      properties.rowAlternateColor = customProps['rowAlternateColor'];
-    }
-    if (typeof customProps['attributePaddingHorizontal'] === 'number') {
-      properties.attributePaddingHorizontal = customProps['attributePaddingHorizontal'];
-    }
-    if (typeof customProps['attributePaddingVertical'] === 'number') {
-      properties.attributePaddingVertical = customProps['attributePaddingVertical'];
-    }
-  }
-
-  // Icon properties (conditionally included)
-  if (opts.includeIconStyle) {
-    if (typeof extra['iconId'] === 'string') {
-      properties.iconId = extra['iconId'];
-    }
-    if (typeof extra['iconSize'] === 'number') {
-      properties.iconSize = extra['iconSize'];
-    }
-    if (typeof extra['iconPadding'] === 'number') {
-      properties.iconPadding = extra['iconPadding'];
-    }
-    if (typeof extra['iconColor'] === 'string') {
-      properties.iconColor = extra['iconColor'];
-    }
-    if (typeof extra['iconPosition'] === 'string') {
-      properties.iconPosition = extra['iconPosition'] as IconPosition;
-    }
-    if (typeof extra['iconDisplayMode'] === 'string') {
-      properties.iconDisplayMode = extra['iconDisplayMode'] as IconDisplayMode;
-    }
-    const iconBadge = extra['iconBadge'];
-    if (iconBadge && typeof iconBadge === 'object') {
-      // Shallow copy so future shape mutations don't bleed into the profile.
-      properties.iconBadge = { ...(iconBadge as IconBadgeConfig) };
-    }
-    const icons = extra['icons'];
-    if (Array.isArray(icons)) {
-      properties.icons = icons.map((icon) => ({ ...(icon as IconConfig) }));
-    }
+  for (const facet of resolveStyleAdapter(shape.type)) {
+    Object.assign(properties, facet.extract(shape, opts));
   }
 
   return properties;
 }
 
 /**
- * Shape type categories for determining applicable properties.
+ * Translate a profile into the concrete field updates to apply to a shape.
+ *
+ * Dispatches to the per-shape adapter. The result is a `Partial<Shape>`-shaped
+ * update (it includes an already-merged `customProperties` object for ERD
+ * entities), so callers hand it straight to `updateShape(id, updates)` with no
+ * shape-type special-casing.
+ *
+ * This is also the primitive a future "Dynamic Style Profiles" `styleProfileRef`
+ * would call to resolve/merge a referenced profile onto a shape.
+ *
+ * Note: the second parameter is the **shape** (not just its type) because the
+ * ERD facet needs the existing `customProperties` to merge rather than clobber.
  */
-const SHAPE_CATEGORIES = {
-  /** Shapes that support labels */
-  withLabels: new Set(['rectangle', 'ellipse', 'connector']),
-  /** Shapes that support corner radius */
-  withCornerRadius: new Set(['rectangle', 'group']),
-  /** Shapes that are text-based */
-  textBased: new Set(['text']),
-  /** Shapes that support arrows */
-  withArrows: new Set(['line', 'connector']),
-  /** Shapes that support line style */
-  withLineStyle: new Set(['connector']),
-  /** Group shapes with background/border */
-  groups: new Set(['group']),
-  /** ERD entity shapes with table styling */
-  erdEntities: new Set(['erd-entity', 'erd-weak-entity']),
-  /** Shapes that support icons */
-  withIcons: new Set(['rectangle', 'ellipse']),
-} as const;
-
-/**
- * Check if a shape type is an ERD entity shape.
- */
-function isERDEntityShape(shapeType: string): boolean {
-  return SHAPE_CATEGORIES.erdEntities.has(shapeType);
-}
-
-/**
- * Check if a shape type is a library shape (flowchart, ERD, UML, etc.)
- */
-function isLibraryShape(shapeType: string): boolean {
-  return shapeType.includes('-') || shapeType.startsWith('flowchart') ||
-         shapeType.startsWith('erd') || shapeType.startsWith('uml') ||
-         shapeType === 'diamond' || shapeType === 'terminator' ||
-         shapeType === 'document' || shapeType === 'data' ||
-         shapeType === 'predefined-process' || shapeType === 'manual-input' ||
-         shapeType === 'preparation' || shapeType === 'connector-circle' ||
-         shapeType === 'off-page-connector' || shapeType === 'actor' ||
-         shapeType === 'use-case' || shapeType === 'system-boundary';
-}
-
-/**
- * Get updates object to apply a profile to a shape.
- * Filters out properties that don't apply to the shape type.
- */
-export function getProfileUpdates(
-  profile: StyleProfile,
-  shapeType: string
-): Partial<StyleProfileProperties> {
-  const props = profile.properties;
-  const updates: Partial<StyleProfileProperties> = {};
-
-  // Universal properties - apply to all shapes
-  updates.fill = props.fill;
-  updates.stroke = props.stroke;
-  updates.strokeWidth = props.strokeWidth;
-  updates.opacity = props.opacity;
-
-  // Corner radius - rectangles and groups
-  if (SHAPE_CATEGORIES.withCornerRadius.has(shapeType) && props.cornerRadius !== undefined) {
-    updates.cornerRadius = props.cornerRadius;
+export function getProfileUpdates(profile: StyleProfile, shape: BaseShape): ShapeStyleUpdate {
+  const updates: ShapeStyleUpdate = {};
+  for (const facet of resolveStyleAdapter(shape.type)) {
+    Object.assign(updates, facet.apply(profile.properties, shape));
   }
-
-  // Label properties - rectangles, ellipses, connectors, and all library shapes
-  const supportsLabels = SHAPE_CATEGORIES.withLabels.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsLabels) {
-    if (props.labelFontSize !== undefined) {
-      updates.labelFontSize = props.labelFontSize;
-    }
-    if (props.labelColor !== undefined) {
-      updates.labelColor = props.labelColor;
-    }
-  }
-
-  // Text shape properties
-  if (SHAPE_CATEGORIES.textBased.has(shapeType)) {
-    if (props.fontSize !== undefined) {
-      updates.fontSize = props.fontSize;
-    }
-    if (props.fontFamily !== undefined) {
-      updates.fontFamily = props.fontFamily;
-    }
-    // For text shapes, fill is the text color (already applied above)
-  }
-
-  // Arrow properties - lines and connectors
-  if (SHAPE_CATEGORIES.withArrows.has(shapeType)) {
-    if (props.startArrow !== undefined) {
-      updates.startArrow = props.startArrow;
-    }
-    if (props.endArrow !== undefined) {
-      updates.endArrow = props.endArrow;
-    }
-  }
-
-  // Line style - connectors
-  if (SHAPE_CATEGORIES.withLineStyle.has(shapeType)) {
-    if (props.lineStyle !== undefined) {
-      updates.lineStyle = props.lineStyle;
-    }
-  }
-
-  // Group-specific properties
-  if (SHAPE_CATEGORIES.groups.has(shapeType)) {
-    if (props.backgroundColor !== undefined) {
-      updates.backgroundColor = props.backgroundColor;
-    }
-    if (props.borderColor !== undefined) {
-      updates.borderColor = props.borderColor;
-    }
-    if (props.borderWidth !== undefined) {
-      updates.borderWidth = props.borderWidth;
-    }
-  }
-
-  // ERD entity properties are applied via customProperties
-  // Note: These are included in the updates object but need special handling
-  // when applying to the shape (see getERDProfileCustomProperties)
-  if (isERDEntityShape(shapeType)) {
-    if (props.rowSeparatorColor !== undefined) {
-      updates.rowSeparatorColor = props.rowSeparatorColor;
-    }
-    if (props.rowBackgroundColor !== undefined) {
-      updates.rowBackgroundColor = props.rowBackgroundColor;
-    }
-    if (props.rowAlternateColor !== undefined) {
-      updates.rowAlternateColor = props.rowAlternateColor;
-    }
-    if (props.attributePaddingHorizontal !== undefined) {
-      updates.attributePaddingHorizontal = props.attributePaddingHorizontal;
-    }
-    if (props.attributePaddingVertical !== undefined) {
-      updates.attributePaddingVertical = props.attributePaddingVertical;
-    }
-  }
-
-  // Icon properties - rectangles, ellipses, and library shapes
-  const supportsIcons = SHAPE_CATEGORIES.withIcons.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsIcons) {
-    if (props.iconId !== undefined) {
-      updates.iconId = props.iconId;
-    }
-    if (props.iconSize !== undefined) {
-      updates.iconSize = props.iconSize;
-    }
-    if (props.iconPadding !== undefined) {
-      updates.iconPadding = props.iconPadding;
-    }
-    if (props.iconColor !== undefined) {
-      updates.iconColor = props.iconColor;
-    }
-    if (props.iconPosition !== undefined) {
-      updates.iconPosition = props.iconPosition;
-    }
-    if (props.iconDisplayMode !== undefined) {
-      updates.iconDisplayMode = props.iconDisplayMode;
-    }
-    if (props.iconBadge !== undefined) {
-      updates.iconBadge = props.iconBadge;
-    }
-    if (props.icons !== undefined) {
-      updates.icons = props.icons;
-    }
-  }
-
   return updates;
-}
-
-/**
- * Get ERD-specific customProperties updates from a profile.
- * These need to be merged with existing customProperties when applying.
- */
-export function getERDProfileCustomProperties(
-  profile: StyleProfile
-): Record<string, unknown> | null {
-  const props = profile.properties;
-  const customProps: Record<string, unknown> = {};
-  let hasProps = false;
-
-  if (props.rowSeparatorColor !== undefined) {
-    customProps['rowSeparatorColor'] = props.rowSeparatorColor;
-    hasProps = true;
-  }
-  if (props.rowBackgroundColor !== undefined) {
-    customProps['rowBackgroundColor'] = props.rowBackgroundColor;
-    hasProps = true;
-  }
-  if (props.rowAlternateColor !== undefined) {
-    customProps['rowAlternateColor'] = props.rowAlternateColor;
-    hasProps = true;
-  }
-  if (props.attributePaddingHorizontal !== undefined) {
-    customProps['attributePaddingHorizontal'] = props.attributePaddingHorizontal;
-    hasProps = true;
-  }
-  if (props.attributePaddingVertical !== undefined) {
-    customProps['attributePaddingVertical'] = props.attributePaddingVertical;
-    hasProps = true;
-  }
-
-  return hasProps ? customProps : null;
 }
 
 /**
@@ -637,41 +295,5 @@ export function getERDProfileCustomProperties(
  * Useful for UI to show what a profile will change.
  */
 export function getApplicablePropertyNames(shapeType: string): string[] {
-  const names: string[] = ['Fill', 'Stroke', 'Stroke Width', 'Opacity'];
-
-  if (SHAPE_CATEGORIES.withCornerRadius.has(shapeType)) {
-    names.push('Corner Radius');
-  }
-
-  const supportsLabels = SHAPE_CATEGORIES.withLabels.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsLabels) {
-    names.push('Label Font Size', 'Label Color');
-  }
-
-  if (SHAPE_CATEGORIES.textBased.has(shapeType)) {
-    names.push('Font Size', 'Font Family');
-  }
-
-  if (SHAPE_CATEGORIES.withArrows.has(shapeType)) {
-    names.push('Start Arrow', 'End Arrow');
-  }
-
-  if (SHAPE_CATEGORIES.withLineStyle.has(shapeType)) {
-    names.push('Line Style');
-  }
-
-  if (SHAPE_CATEGORIES.groups.has(shapeType)) {
-    names.push('Background Color', 'Border Color', 'Border Width');
-  }
-
-  if (isERDEntityShape(shapeType)) {
-    names.push('Row Colors', 'Padding', 'Separator Inset');
-  }
-
-  const supportsIcons = SHAPE_CATEGORIES.withIcons.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsIcons) {
-    names.push('Icon', 'Icon Size', 'Icon Position');
-  }
-
-  return names;
+  return resolveStyleAdapter(shapeType).flatMap((facet) => [...facet.names]);
 }

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -7,7 +7,6 @@ import {
   StyleProfile,
   extractStyleFromShape,
   getProfileUpdates,
-  getERDProfileCustomProperties,
   ExtractStyleOptions,
 } from '../store/styleProfileStore';
 import { useSettingsStore } from '../store/settingsStore';
@@ -83,27 +82,11 @@ export function StyleProfilePanel() {
 
       push('Apply style profile');
 
+      // The adapter translates the profile into concrete shape-field updates,
+      // including a pre-merged `customProperties` for ERD entities — so there is
+      // no shape-type special-casing to do here.
       for (const shape of selectedShapes) {
-        const updates = getProfileUpdates(profile, shape.type);
-
-        // For ERD entity shapes, also apply customProperties
-        if (shape.type === 'erd-entity' || shape.type === 'erd-weak-entity') {
-          const erdProps = getERDProfileCustomProperties(profile);
-          if (erdProps) {
-            // Merge with existing customProperties
-            const existingCustomProps = (shape as unknown as { customProperties?: Record<string, unknown> }).customProperties || {};
-            updateShape(shape.id, {
-              ...updates,
-              customProperties: {
-                ...existingCustomProps,
-                ...erdProps,
-              },
-            } as Record<string, unknown>);
-            continue;
-          }
-        }
-
-        updateShape(shape.id, updates);
+        updateShape(shape.id, getProfileUpdates(profile, shape));
       }
     },
     [selectedShapes, push, updateShape]


### PR DESCRIPTION
## What

Refactors the style-profile **translation layer** (JP-33) from three hand-written `if`-ladders into a composable **per-shape adapter** built from reusable style facets.

Today `extractStyleFromShape` / `getProfileUpdates` / `getApplicablePropertyNames` are gated by a hardcoded `SHAPE_CATEGORIES` map and a brittle `isLibraryShape()` **string heuristic that re-implements knowledge the shape registry already owns**, and ERD styling leaks out as a special-case at the `StyleProfilePanel` call site. This made profiles apply uniformly, miss real coverage (groups/file shapes never got label styling), and require edits in three functions to add a shape.

## How

New `src/store/styleProfile/`:
- **`types.ts`** — the `StyleFacet` contract + `ShapeStyleUpdate`; also the new home of `StyleProfileProperties`/`IconPosition` (re-exported from `styleProfileStore` so import paths are unchanged). Dependency root → no import cycle.
- **`capabilities.ts`** — `shapeSupportsLabel/Icon` resolved from `shapeRegistry.getMetadata(type)` + `shapeLibraryStore`, with a static fallback for the metadata-less core shapes (and the empty test registry). Reads are lazy → graceful when stores aren't initialized.
- **`facets.ts`** — the 9 style axes (universal / cornerRadius / label / text / arrows / lineStyle / group / erd / icon). The ERD facet folds the `customProperties` merge inside `apply`.
- **`registry.ts`** — `resolveStyleAdapter(type)` emergently composes the adapter from the facets whose `appliesTo` is true. Unknown types fall through to universal-only; no per-type adapter objects to maintain.

The four public functions become thin dispatchers. **`getProfileUpdates(profile, shape)`** now takes the shape (needed to merge `customProperties` rather than clobber) and returns concrete `Partial<Shape>`-shaped updates — so `StyleProfilePanel` drops its ERD branch entirely.

## Notable decisions

- **Concrete routing** — `StyleProfileProperties` is unchanged; **no archive/backup migration**. Only the translation layer moved.
- **Coverage via metadata truth** — correctly grants label styling to **groups** and the **file** shape. Audited every library shape's `supportsLabel`/`supportsIcon`: shapes flagged `false` are custom-rendered (ERD/UML class titles live in `customProperties`) or markerless, so there is **no functional regression** — the old heuristic was writing dead fields.
- **Design-for, don't build** Dynamic Style Profiles — `apply(props, shape)` is exactly the future `styleProfileRef` resolve/merge primitive, but no shape-schema change or reference field is added here.

## Testing

- `bun run typecheck` clean (also clears import-cycle risk).
- Full suite **2743 passed**; `bun run build` green.
- Existing JP-7 icon round-trip tests updated for the new `getProfileUpdates` signature.
- New `styleProfile/registry.test.ts`: facet dispatch, static-fallback (empty registry), metadata-driven coverage (registered dummy), group label gain, and ERD `customProperties` merge (no raw-key leak).

Manual smoke recommended on a real deploy: apply a profile to a rectangle, an ERD entity (row colors land + existing custom props preserved), and a group (label styling now lands).

Assisted-by: Opus 4.8