### PR TITLE
JP-399: style profiles as non-corrupting master memory + swimlane adapter

### DIFF
--- a/src/store/styleProfile/facets.ts
+++ b/src/store/styleProfile/facets.ts
@@ -17,12 +17,70 @@
  */
 
 import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../../shapes/Shape';
-import type { IconPosition, StyleFacet } from './types';
+import type { IconPosition, StyleFacet, StyleProfileProperties } from './types';
 import { shapeSupportsIcon, shapeSupportsLabel } from './capabilities';
 
 /** Index-signature view for guarded subtype probing. */
 function asRecord(shape: BaseShape): Record<string, unknown> {
   return shape as unknown as Record<string, unknown>;
+}
+
+/**
+ * Descriptor for a {@link makeCustomPropsFacet} field: a profile key whose value
+ * lives in `shape.customProperties` under the same name.
+ */
+interface CustomPropField {
+  /** Key on both the profile and the shape's customProperties. */
+  readonly key: keyof StyleProfileProperties & string;
+  /** Runtime kind used to guard extraction. */
+  readonly kind: 'string' | 'number';
+}
+
+interface CustomPropsFacetConfig {
+  readonly id: string;
+  readonly names: readonly string[];
+  readonly types: readonly string[];
+  readonly fields: readonly CustomPropField[];
+}
+
+/**
+ * Build a facet for a shape whose styleable fields live in
+ * `shape.customProperties` (ERD entities, swimlanes, …). `extract` reads the
+ * configured keys off customProperties; `apply` folds the set values back into a
+ * *merged* customProperties copy (preserving unrelated custom data) and is a
+ * no-op when the profile carries none of them. Adding the next such shape is
+ * pure config — no new logic.
+ */
+function makeCustomPropsFacet(config: CustomPropsFacetConfig): StyleFacet {
+  const typeSet = new Set(config.types);
+  return {
+    id: config.id,
+    names: config.names,
+    appliesTo: (type) => typeSet.has(type),
+    extract: (shape) => {
+      const raw = asRecord(shape)['customProperties'];
+      if (!raw || typeof raw !== 'object') return {};
+      const cp = raw as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const field of config.fields) {
+        const value = cp[field.key];
+        if (typeof value === field.kind) out[field.key] = value;
+      }
+      return out as Partial<StyleProfileProperties>;
+    },
+    apply: (props, shape) => {
+      const bag = props as unknown as Record<string, unknown>;
+      const values: Record<string, unknown> = {};
+      for (const field of config.fields) {
+        const value = bag[field.key];
+        if (value !== undefined) values[field.key] = value;
+      }
+      if (Object.keys(values).length === 0) return {};
+      const raw = asRecord(shape)['customProperties'];
+      const existing = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+      return { customProperties: { ...existing, ...values } };
+    },
+  };
 }
 
 /** Universal fill/stroke/strokeWidth/opacity — applies to every shape. */
@@ -152,43 +210,38 @@ const groupFacet: StyleFacet = {
 };
 
 /**
- * ERD table styling — entity shapes. These profile values live on the shape's
- * `customProperties`, so this facet reads from / writes to that object. `apply`
- * folds the values into a *merged* `customProperties` copy (the merge the call
- * site used to do by hand), and is a no-op when the profile carries none.
+ * ERD table styling — entity shapes. Row colors + attribute padding live on the
+ * shape's `customProperties`.
  */
-const erdFacet: StyleFacet = {
+const erdFacet: StyleFacet = makeCustomPropsFacet({
   id: 'erd',
   names: ['Row Colors', 'Padding', 'Separator Inset'],
-  appliesTo: (type) => type === 'erd-entity' || type === 'erd-weak-entity',
-  extract: (shape) => {
-    const extra = asRecord(shape);
-    const customPropsRaw = extra['customProperties'];
-    if (!customPropsRaw || typeof customPropsRaw !== 'object') return {};
-    const customProps = customPropsRaw as Record<string, unknown>;
-    const out: ReturnType<StyleFacet['extract']> = {};
-    if (typeof customProps['rowSeparatorColor'] === 'string') out.rowSeparatorColor = customProps['rowSeparatorColor'];
-    if (typeof customProps['rowBackgroundColor'] === 'string') out.rowBackgroundColor = customProps['rowBackgroundColor'];
-    if (typeof customProps['rowAlternateColor'] === 'string') out.rowAlternateColor = customProps['rowAlternateColor'];
-    if (typeof customProps['attributePaddingHorizontal'] === 'number') out.attributePaddingHorizontal = customProps['attributePaddingHorizontal'];
-    if (typeof customProps['attributePaddingVertical'] === 'number') out.attributePaddingVertical = customProps['attributePaddingVertical'];
-    return out;
-  },
-  apply: (props, shape) => {
-    const erdValues: Record<string, unknown> = {};
-    if (props.rowSeparatorColor !== undefined) erdValues['rowSeparatorColor'] = props.rowSeparatorColor;
-    if (props.rowBackgroundColor !== undefined) erdValues['rowBackgroundColor'] = props.rowBackgroundColor;
-    if (props.rowAlternateColor !== undefined) erdValues['rowAlternateColor'] = props.rowAlternateColor;
-    if (props.attributePaddingHorizontal !== undefined) erdValues['attributePaddingHorizontal'] = props.attributePaddingHorizontal;
-    if (props.attributePaddingVertical !== undefined) erdValues['attributePaddingVertical'] = props.attributePaddingVertical;
+  types: ['erd-entity', 'erd-weak-entity'],
+  fields: [
+    { key: 'rowSeparatorColor', kind: 'string' },
+    { key: 'rowBackgroundColor', kind: 'string' },
+    { key: 'rowAlternateColor', kind: 'string' },
+    { key: 'attributePaddingHorizontal', kind: 'number' },
+    { key: 'attributePaddingVertical', kind: 'number' },
+  ],
+});
 
-    if (Object.keys(erdValues).length === 0) return {};
-
-    const existingRaw = asRecord(shape)['customProperties'];
-    const existing = existingRaw && typeof existingRaw === 'object' ? (existingRaw as Record<string, unknown>) : {};
-    return { customProperties: { ...existing, ...erdValues } };
-  },
-};
+/**
+ * Swimlane chrome — header band color + lane separator color/width, stored on
+ * `customProperties`. First explicit-keys pilot of the adapter on a complex
+ * library shape (JP-399). `headerSize` is intentionally excluded — it is
+ * structural (layout), not style, so applying a profile never resizes chrome.
+ */
+const swimlaneFacet: StyleFacet = makeCustomPropsFacet({
+  id: 'swimlane',
+  names: ['Header Color', 'Separator Color', 'Separator Width'],
+  types: ['activity-swimlane'],
+  fields: [
+    { key: 'headerBackground', kind: 'string' },
+    { key: 'separatorColor', kind: 'string' },
+    { key: 'separatorWidth', kind: 'number' },
+  ],
+});
 
 /** Icon styling (all 8 icon fields) — any shape whose metadata supports icons. */
 const iconFacet: StyleFacet = {
@@ -243,5 +296,6 @@ export const STYLE_FACETS: readonly StyleFacet[] = [
   lineStyleFacet,
   groupFacet,
   erdFacet,
+  swimlaneFacet,
   iconFacet,
 ];

--- a/src/store/styleProfile/index.ts
+++ b/src/store/styleProfile/index.ts
@@ -13,6 +13,8 @@ export type {
   ResolvedExtractOptions,
   StyleFacet,
   ErdProfileKey,
+  SwimlaneProfileKey,
+  CustomPropertyProfileKey,
 } from './types';
 export { resolveStyleAdapter } from './registry';
 export { STYLE_FACETS } from './facets';

--- a/src/store/styleProfile/registry.test.ts
+++ b/src/store/styleProfile/registry.test.ts
@@ -166,6 +166,47 @@ describe('extractStyleFromShape — adapter dispatch', () => {
   });
 });
 
+describe('swimlane facet (JP-399)', () => {
+  it('dispatches the swimlane facet for activity-swimlane only', () => {
+    expect(facetIds('activity-swimlane')).toContain('swimlane');
+    expect(facetIds('rectangle')).not.toContain('swimlane');
+  });
+
+  it('extracts header/separator chrome from customProperties', () => {
+    const shape = makeShape('activity-swimlane', {
+      customProperties: { headerBackground: '#222', separatorColor: '#0ff', separatorWidth: 2, orientation: 'horizontal' },
+    });
+    const props = extractStyleFromShape(shape);
+    expect(props.headerBackground).toBe('#222');
+    expect(props.separatorColor).toBe('#0ff');
+    expect(props.separatorWidth).toBe(2);
+  });
+
+  it('merges chrome into existing customProperties without clobbering non-style data', () => {
+    const profile = makeProfile({ ...BASE_PROPS, headerBackground: '#222', separatorWidth: 3 });
+    const shape = makeShape('activity-swimlane', {
+      customProperties: { orientation: 'vertical', separatorColor: '#000' },
+    });
+
+    const updates = getProfileUpdates(profile, shape);
+
+    expect(updates.customProperties).toEqual({
+      orientation: 'vertical',
+      separatorColor: '#000',
+      headerBackground: '#222',
+      separatorWidth: 3,
+    });
+    expect((updates as Record<string, unknown>)['headerBackground']).toBeUndefined();
+  });
+
+  it('does not leak swimlane keys onto a non-swimlane shape', () => {
+    const profile = makeProfile({ ...BASE_PROPS, headerBackground: '#222', separatorColor: '#0ff' });
+    const updates = getProfileUpdates(profile, makeShape('rectangle'));
+    expect((updates as Record<string, unknown>)['headerBackground']).toBeUndefined();
+    expect(updates.customProperties).toBeUndefined();
+  });
+});
+
 describe('metadata-driven capability resolution', () => {
   afterEach(() => {
     // The registry is a shared singleton; the test env starts empty, so a full

--- a/src/store/styleProfile/types.ts
+++ b/src/store/styleProfile/types.ts
@@ -68,7 +68,7 @@ export interface StyleProfileProperties {
   /** Optional - border width for groups */
   borderWidth?: number;
 
-  // ERD entity styling properties
+  // ERD entity styling properties (applied into customProperties)
   /** Optional - row separator color */
   rowSeparatorColor?: string;
   /** Optional - row background color */
@@ -79,6 +79,14 @@ export interface StyleProfileProperties {
   attributePaddingHorizontal?: number;
   /** Optional - vertical padding for attributes */
   attributePaddingVertical?: number;
+
+  // Swimlane styling properties (applied into customProperties)
+  /** Optional - swimlane header band color */
+  headerBackground?: string;
+  /** Optional - swimlane lane separator color */
+  separatorColor?: string;
+  /** Optional - swimlane lane separator width */
+  separatorWidth?: number;
 
   // Icon properties (Rectangle, Ellipse, LibraryShape)
   /** Optional - icon ID reference */
@@ -100,10 +108,7 @@ export interface StyleProfileProperties {
 }
 
 /**
- * The ERD-specific profile keys. They are stored flat on a profile but applied
- * into `shape.customProperties` rather than onto the shape directly, so they are
- * stripped from {@link ShapeStyleUpdate} (the ERD facet folds them into
- * `customProperties`).
+ * ERD-specific profile keys (applied into `shape.customProperties`).
  */
 export type ErdProfileKey =
   | 'rowSeparatorColor'
@@ -113,13 +118,27 @@ export type ErdProfileKey =
   | 'attributePaddingVertical';
 
 /**
+ * Swimlane-specific profile keys (applied into `shape.customProperties`).
+ */
+export type SwimlaneProfileKey = 'headerBackground' | 'separatorColor' | 'separatorWidth';
+
+/**
+ * Profile keys that are stored flat on a profile but applied into
+ * `shape.customProperties` rather than onto the shape directly. They are stripped
+ * from {@link ShapeStyleUpdate} because their owning facet folds them into a
+ * merged `customProperties` object instead.
+ */
+export type CustomPropertyProfileKey = ErdProfileKey | SwimlaneProfileKey;
+
+/**
  * Concrete shape-field updates produced by applying a profile to a shape.
  *
- * Structurally a `Partial<Shape>`: the raw ERD keys are replaced by a single
- * (already-merged) `customProperties` object, so the result can be handed
- * straight to `updateShape(id, update)` with no special-casing at the call site.
+ * Structurally a `Partial<Shape>`: the raw customProperties-backed keys are
+ * replaced by a single (already-merged) `customProperties` object, so the result
+ * can be handed straight to `updateShape(id, update)` with no special-casing at
+ * the call site.
  */
-export type ShapeStyleUpdate = Omit<Partial<StyleProfileProperties>, ErdProfileKey> & {
+export type ShapeStyleUpdate = Omit<Partial<StyleProfileProperties>, CustomPropertyProfileKey> & {
   customProperties?: Record<string, unknown>;
 };
 

--- a/src/store/styleProfileStore.test.ts
+++ b/src/store/styleProfileStore.test.ts
@@ -13,10 +13,11 @@ import { describe, it, expect } from 'vitest';
 import {
   extractStyleFromShape,
   getProfileUpdates,
+  mergeProfileProperties,
   type StyleProfile,
   type StyleProfileProperties,
 } from './styleProfileStore';
-import type { RectangleShape, LineShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
+import type { BaseShape, RectangleShape, LineShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
 
 function makeRectangle(overrides: Partial<RectangleShape> = {}): RectangleShape {
   return {
@@ -59,6 +60,23 @@ function makeLine(overrides: Partial<LineShape> = {}): LineShape {
   };
 }
 
+function makeFile(overrides: Record<string, unknown> = {}): BaseShape {
+  return {
+    id: 'file-1',
+    type: 'file',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#f8fafc',
+    stroke: '#cbd5e1',
+    strokeWidth: 1,
+    ...overrides,
+  } as unknown as BaseShape;
+}
+
 function makeProfile(name: string, properties: StyleProfileProperties): StyleProfile {
   return {
     id: `profile-${name}`,
@@ -68,6 +86,33 @@ function makeProfile(name: string, properties: StyleProfileProperties): StylePro
     favorite: false,
   };
 }
+
+describe('mergeProfileProperties — non-destructive master memory (JP-399)', () => {
+  it('keeps a rectangle cornerRadius when later updating the profile from a file', () => {
+    // Save a rectangle's style into a profile.
+    const rectProps = extractStyleFromShape(makeRectangle({ cornerRadius: 8, fill: '#ffffff' }));
+    expect(rectProps.cornerRadius).toBe(8);
+
+    // Later "Update with current" from a file shape, which has no cornerRadius.
+    const fileProps = extractStyleFromShape(makeFile({ fill: '#f8fafc' }));
+    expect(fileProps.cornerRadius).toBeUndefined();
+
+    const merged = mergeProfileProperties(rectProps, fileProps);
+
+    // The file's universal fill wins (the freshly-saved look)…
+    expect(merged.fill).toBe('#f8fafc');
+    // …but the rectangle's radius is preserved, not clobbered. This was the bug:
+    // a full replace deleted it.
+    expect(merged.cornerRadius).toBe(8);
+  });
+
+  it('unions fields across shapes so one profile can style many shape types', () => {
+    const a: StyleProfileProperties = { fill: '#111', stroke: '#222', strokeWidth: 2, opacity: 1, cornerRadius: 4 };
+    const b: StyleProfileProperties = { fill: '#333', stroke: '#444', strokeWidth: 3, opacity: 1, fontSize: 18 };
+    const merged = mergeProfileProperties(a, b);
+    expect(merged).toMatchObject({ fill: '#333', stroke: '#444', strokeWidth: 3, cornerRadius: 4, fontSize: 18 });
+  });
+});
 
 describe('extractStyleFromShape — icon coverage (JP-7)', () => {
   it('captures all 8 icon fields when includeIconStyle is true', () => {

--- a/src/store/styleProfileStore.ts
+++ b/src/store/styleProfileStore.ts
@@ -297,3 +297,21 @@ export function getProfileUpdates(profile: StyleProfile, shape: BaseShape): Shap
 export function getApplicablePropertyNames(shapeType: string): string[] {
   return resolveStyleAdapter(shapeType).flatMap((facet) => [...facet.names]);
 }
+
+/**
+ * Non-destructively merge freshly-extracted style into a profile's existing
+ * properties — the "master memory" union.
+ *
+ * Keys absent from `incoming` are preserved from `existing`, so saving a shape
+ * that lacks a field (e.g. a file has no `cornerRadius`) never deletes another
+ * shape's saved value. This relies on `extractStyleFromShape` only emitting keys
+ * the shape actually has, which is what makes a plain union correct: across shape
+ * families there are no semantic collisions, and `getProfileUpdates` gates apply
+ * per shape, so a unioned profile hands each shape back only its own fields.
+ */
+export function mergeProfileProperties(
+  existing: StyleProfileProperties,
+  incoming: StyleProfileProperties
+): StyleProfileProperties {
+  return { ...existing, ...incoming };
+}

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -7,6 +7,7 @@ import {
   StyleProfile,
   extractStyleFromShape,
   getProfileUpdates,
+  mergeProfileProperties,
   ExtractStyleOptions,
 } from '../store/styleProfileStore';
 import { useSettingsStore } from '../store/settingsStore';
@@ -107,7 +108,14 @@ export function StyleProfilePanel() {
     setIsCreating(false);
   }, [firstShape, newProfileName, addProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
 
-  // Overwrite a profile with current shape's style
+  // Update an existing profile from the current shape's style.
+  //
+  // Merges (non-destructively unions) the extracted style into the profile's
+  // existing properties rather than replacing them — so a profile becomes a
+  // "master memory" across the shapes saved into it, and saving a shape that
+  // lacks a field (e.g. a file has no cornerRadius) never wipes another shape's
+  // saved value. Apply is gated per shape, so the unioned profile only ever
+  // hands each shape back its own fields.
   const handleOverwriteProfile = useCallback((profileId: string) => {
     if (!firstShape) return;
 
@@ -115,11 +123,15 @@ export function StyleProfilePanel() {
       includeIconStyle: saveIconStyleToProfile,
       includeLabelStyle: saveLabelStyleToProfile,
     };
-    const properties = extractStyleFromShape(firstShape, extractOptions);
+    const extracted = extractStyleFromShape(firstShape, extractOptions);
+    const existing = storeProfiles.find((p) => p.id === profileId);
+    const properties = existing
+      ? mergeProfileProperties(existing.properties, extracted)
+      : extracted;
 
     updateProfile(profileId, { properties });
     setConfirmOverwriteId(null);
-  }, [firstShape, updateProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
+  }, [firstShape, storeProfiles, updateProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
 
   // Start editing a profile name
   const handleStartEdit = useCallback((profile: StyleProfile) => {
@@ -410,7 +422,7 @@ export function StyleProfilePanel() {
                 )}
                 {isOverwriting && (
                   <div className="style-profile-grid-confirm overwrite">
-                    <span>Overwrite?</span>
+                    <span>Update?</span>
                     <div className="style-profile-grid-confirm-actions">
                       <button onClick={(e) => { e.stopPropagation(); handleOverwriteProfile(profile.id); }}>Yes</button>
                       <button onClick={(e) => { e.stopPropagation(); handleCancelOverwrite(); }}>No</button>
@@ -486,7 +498,7 @@ export function StyleProfilePanel() {
                       e.stopPropagation();
                       handleRequestOverwrite(profile.id);
                     }}
-                    title="Overwrite with current style"
+                    title="Update profile with this shape's style (merges; keeps other shapes' saved fields)"
                   >
                     <OverwriteIcon />
                   </button>
@@ -523,7 +535,7 @@ export function StyleProfilePanel() {
                           e.stopPropagation();
                           handleOverwriteProfile(profile.id);
                         }}
-                        title="Confirm overwrite"
+                        title="Confirm update"
                       >
                         <ApplyIcon />
                       </button>
@@ -616,7 +628,7 @@ export function StyleProfilePanel() {
                       closeContextMenu();
                     }}
                   >
-                    Overwrite with Current
+                    Update with Current
                   </button>
                 )}
                 <div className="style-profile-context-menu-separator" />


### PR DESCRIPTION
## What

Two coupled changes, both building on the JP-33 adapter layer (#347):

1. **Style profiles become a non-corrupting "master memory."** Saving a shape into a profile did a full **replace** — so overwriting a rectangle-derived profile from a *file* (no `cornerRadius`) **deleted** the saved radius. Now `Overwrite` **merges** (unions) the freshly-extracted style into the profile's existing properties via `mergeProfileProperties`. A profile accumulates every shape saved into it; applying it to any shape pulls back only that shape's slice.
2. **Swimlane adapter pilot** — the first explicit-keys per-shape adapter on a complex `customProperties`-backed library shape (header band + lane separators).

## Why merge-on-save is sufficient (not a band-aid)

Audited every profile key against every shape family: the only fields shared across families are the four universal ones (same semantic everywhere) and `cornerRadius` (rectangle + group); everything else is owned by exactly one family. So a union flat bag has **no semantic collisions**, and JP-33's gated `apply` already returns each shape only its own fields. The corruption was purely *replace-on-save* clobbering — merge fixes it with **no localStorage/archive migration**.

## Notable

- **`makeCustomPropsFacet` factory** — ERD + swimlane are now two `customProperties`-backed facets with identical structure, so they're expressed as declarative config (`{ id, names, types, fields }`). The ERD facet is re-expressed through it; the next such shape is pure config, no new logic.
- New optional keys (`headerBackground`/`separatorColor`/`separatorWidth`) are **additive** → no migration; `ErdProfileKey` generalized to `CustomPropertyProfileKey` for the `ShapeStyleUpdate` omit. `headerSize` excluded (structural, not style — applying a profile never resizes chrome).
- The "Overwrite" affordance is relabeled **"Update with current"** (+ explanatory tooltip) since it now enriches rather than replaces. `StyleProfileSettings` has no save path — nothing to change there.

## Trade-offs (intentional)

- `cornerRadius` shares one slot for rectangle + group (last-saved value wins) — the only thing the heavier layered model would separate; not worth a migration.
- A profile only themes a shape's *chrome* (swimlane header, ERD rows) if that shape type was saved into it — explicit-keys means no auto-derivation. The future AI "style studio" (imputing per-shape sections) is the long-term fill; the union/merge model is its foundation.

## Testing

- `typecheck` clean; full suite **2749 passed**; `build` green.
- **Corruption regression** (`styleProfileStore.test.ts`): rectangle `cornerRadius: 8` survives an `Update` from a file shape, which takes over the universal fill.
- **Swimlane facet** (`styleProfile/registry.test.ts`): dispatch is swimlane-only; extract from `customProperties`; apply merges into `customProperties` preserving non-style data (`orientation`); no `headerBackground` leak onto a rectangle.
- Manual smoke (deploy): build one profile by saving a rectangle then a swimlane; confirm updating it from a file no longer wipes the radius; apply to rectangle / swimlane / ERD entity and confirm each gets only its own fields.

Closes JP-399. Related: JP-33 (#347), JP-301.

Assisted-by: Opus 4.8