### PR TITLE
JP-401: Style Profile area TLC — refactor, responsive, live preview, default hardening

### DIFF
--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -161,6 +161,12 @@ export class Renderer {
   // Emphasis animation
   private emphasizedShapeId: string | null = null;
   private emphasisStartTime: number = 0;
+  /**
+   * Ephemeral per-shape style overrides for live preview (e.g. hovering a style
+   * profile). Applied on top of the real shape at render time ONLY — never
+   * persisted, never synced, never in the document/CRDT/history.
+   */
+  private stylePreviewOverrides: Record<string, Partial<Shape>> = {};
 
   // Contrast resolution cache for AUTO colours. Persisted across frames and
   // cleared only when the inputs that affect resolution change (shape data,
@@ -326,6 +332,15 @@ export class Renderer {
         this.requestRender();
       }
     }
+  }
+
+  /**
+   * Set ephemeral per-shape style overrides for live preview. Each entry is
+   * applied on top of the real shape (before AUTO-colour resolution) at render
+   * time only. Pass `{}` to clear. Caller is responsible for requesting a render.
+   */
+  setStylePreviewOverrides(overrides: Record<string, Partial<Shape>>): void {
+    this.stylePreviewOverrides = overrides;
   }
 
   /**
@@ -683,8 +698,11 @@ export class Renderer {
         } else {
           // Render the shape. Resolve AUTO colours once and reuse the result
           // for both the body and any deferred overlay (avoids a second
-          // contrast-cache resolve).
-          const resolved = this.resolveAutoFillStroke(shape);
+          // contrast-cache resolve). A live-preview override (if any) is layered
+          // on BEFORE resolution so 'auto'/contrast resolve against it.
+          const override = this.stylePreviewOverrides[id];
+          const previewed = override ? ({ ...shape, ...override } as Shape) : shape;
+          const resolved = this.resolveAutoFillStroke(previewed);
           ctx.save();
           handler.render(ctx, resolved);
           ctx.restore();
@@ -780,7 +798,9 @@ export class Renderer {
           // and reuse for the deferred overlay (JP-353) — without collecting
           // here, a group-child connector's label would render nowhere, since
           // the label moved out of `render` into `renderOverlay`.
-          const resolved = this.resolveAutoFillStroke(child);
+          const childOverride = this.stylePreviewOverrides[child.id];
+          const previewedChild = childOverride ? ({ ...child, ...childOverride } as Shape) : child;
+          const resolved = this.resolveAutoFillStroke(previewedChild);
           ctx.save();
           ctx.globalAlpha = child.opacity * effectiveOpacity;
           handler.render(ctx, resolved);

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { useDocumentStore } from './documentStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
+import type { Shape } from '../shapes/Shape';
 import type { RelaxedFocus } from '../ui/layout/types';
 
 /**
@@ -132,6 +133,13 @@ export interface SessionState {
   snapGuides: SnapGuides;
   /** ID of shape that should be visually emphasized (for focus animation) */
   emphasizedShapeId: string | null;
+  /**
+   * Ephemeral per-shape style overrides for live preview (e.g. hovering a style
+   * profile in the panel). Keyed by shape id. Applied by the renderer on top of
+   * the real shape — never written to the document, CRDT, or history, so peers
+   * in a collab session never see it.
+   */
+  stylePreviewOverrides: Record<string, Partial<Shape>>;
   /** Current cursor position in world coordinates (for status bar display) */
   cursorWorldPosition: { x: number; y: number } | null;
   /** Blob sync progress (for status bar display during file sync) */
@@ -197,6 +205,12 @@ export interface SessionActions {
   setSnapSettings: (settings: Partial<SnapSettings>) => void;
   setSnapGuides: (guides: SnapGuides) => void;
   clearSnapGuides: () => void;
+
+  // Ephemeral style preview (collab-safe; render-only)
+  /** Set per-shape style overrides for live preview. Replaces the whole map. */
+  setStylePreview: (overrides: Record<string, Partial<Shape>>) => void;
+  /** Clear all live-preview overrides. */
+  clearStylePreview: () => void;
 
   // Focus/Emphasis
   /** Focus camera on a shape and trigger emphasis animation */
@@ -277,6 +291,7 @@ const initialState: SessionState = {
   snapSettings: { ...DEFAULT_SNAP_SETTINGS },
   snapGuides: {},
   emphasizedShapeId: null,
+  stylePreviewOverrides: {},
   cursorWorldPosition: null,
   blobSyncProgress: null,
   editingGroupId: null,
@@ -424,6 +439,16 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
 
   clearSnapGuides: () => {
     set({ snapGuides: {} });
+  },
+
+  setStylePreview: (overrides: Record<string, Partial<Shape>>) => {
+    set({ stylePreviewOverrides: overrides });
+  },
+
+  clearStylePreview: () => {
+    // Avoid a needless render churn when already empty.
+    if (Object.keys(get().stylePreviewOverrides).length === 0) return;
+    set({ stylePreviewOverrides: {} });
   },
 
   // Focus/Emphasis

--- a/src/store/stylePreview.test.ts
+++ b/src/store/stylePreview.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Collab-safety proof for the ephemeral style preview (JP-401).
+ *
+ * The live preview (hovering a style profile) must NEVER mutate the document —
+ * if it did, a collaboration session would broadcast the temporary restyle to
+ * every peer. This test pins that the override lives only in `sessionStore` and
+ * leaves `documentStore` completely untouched.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore } from './sessionStore';
+import { useDocumentStore } from './documentStore';
+import type { Shape } from '../shapes/Shape';
+
+describe('ephemeral style preview is collab-safe', () => {
+  beforeEach(() => {
+    useSessionStore.getState().clearStylePreview();
+  });
+
+  it('setStylePreview writes only sessionStore and never the document', () => {
+    const shapesBefore = useDocumentStore.getState().shapes;
+    const overrides: Record<string, Partial<Shape>> = { 's1': { fill: '#ff0000', strokeWidth: 9 } };
+
+    useSessionStore.getState().setStylePreview(overrides);
+
+    // Override is held in the ephemeral session store…
+    expect(useSessionStore.getState().stylePreviewOverrides).toBe(overrides);
+    // …and the document is byte-for-byte untouched (no updateShape → no CRDT
+    // broadcast, no history). Reference equality proves no mutation happened.
+    expect(useDocumentStore.getState().shapes).toBe(shapesBefore);
+  });
+
+  it('clearStylePreview empties the overrides', () => {
+    useSessionStore.getState().setStylePreview({ 's1': { fill: '#00ff00' } });
+    useSessionStore.getState().clearStylePreview();
+    expect(useSessionStore.getState().stylePreviewOverrides).toEqual({});
+  });
+});

--- a/src/store/styleProfileStore.test.ts
+++ b/src/store/styleProfileStore.test.ts
@@ -14,6 +14,9 @@ import {
   extractStyleFromShape,
   getProfileUpdates,
   mergeProfileProperties,
+  seedProfiles,
+  migrateStyleProfiles,
+  useStyleProfileStore,
   type StyleProfile,
   type StyleProfileProperties,
 } from './styleProfileStore';
@@ -86,6 +89,69 @@ function makeProfile(name: string, properties: StyleProfileProperties): StylePro
     favorite: false,
   };
 }
+
+describe('default-profile hardening (JP-401)', () => {
+  it('seedProfiles seeds canonical built-ins, appends user profiles, applies favorites', () => {
+    const user = makeProfile('mine', { fill: '#111', stroke: '#222', strokeWidth: 1, opacity: 1 });
+    const seeded = seedProfiles([user], ['default-blue']);
+
+    expect(seeded.filter((p) => p.id.startsWith('default-')).length).toBe(5);
+    expect(seeded[seeded.length - 1]?.id).toBe(user.id);
+    expect(seeded.find((p) => p.id === 'default-blue')?.favorite).toBe(true);
+    expect(seeded.find((p) => p.id === 'default-green')?.favorite).toBe(false);
+  });
+
+  it('seedProfiles drops stray default- entries from user profiles (no duplicates)', () => {
+    const stray: StyleProfile = {
+      ...makeProfile('x', { fill: '#0', stroke: '#0', strokeWidth: 1, opacity: 1 }),
+      id: 'default-blue',
+    };
+    const seeded = seedProfiles([stray], []);
+    expect(seeded.filter((p) => p.id === 'default-blue').length).toBe(1);
+  });
+
+  it('migrateStyleProfiles v1 strips baked-in defaults and lifts favorited built-ins', () => {
+    const v1 = {
+      profiles: [
+        { id: 'default-blue', name: 'Default Blue', properties: { fill: '#x', stroke: '#y', strokeWidth: 2, opacity: 1 }, createdAt: 0, favorite: true },
+        { id: 'user-1', name: 'Mine', properties: { fill: '#a', stroke: '#b', strokeWidth: 1, opacity: 1 }, createdAt: 1, favorite: false },
+      ],
+    };
+    const out = migrateStyleProfiles(v1, 1);
+    expect(out.profiles.map((p) => p.id)).toEqual(['user-1']);
+    expect(out.favoriteDefaultIds).toEqual(['default-blue']);
+  });
+
+  it('migrateStyleProfiles is idempotent on v2 data', () => {
+    const v2 = {
+      profiles: [{ id: 'user-1', name: 'Mine', properties: { fill: null, stroke: null, strokeWidth: 1, opacity: 1 }, createdAt: 1, favorite: false }],
+      favoriteDefaultIds: ['default-green'],
+    };
+    expect(migrateStyleProfiles(v2, 2)).toEqual(v2);
+  });
+
+  it('updateProfile is a no-op on a built-in (immutable)', () => {
+    const before = useStyleProfileStore.getState().getProfile('default-blue');
+    useStyleProfileStore.getState().updateProfile('default-blue', {
+      name: 'HACKED',
+      properties: { fill: '#000', stroke: '#000', strokeWidth: 9, opacity: 0.1 },
+    });
+    const after = useStyleProfileStore.getState().getProfile('default-blue');
+    expect(after?.name).toBe(before?.name);
+    expect(after?.properties).toEqual(before?.properties);
+  });
+
+  it('toggleFavorite on a built-in tracks it in the favoriteDefaultIds overlay', () => {
+    const start = useStyleProfileStore.getState().favoriteDefaultIds.includes('default-subtle');
+    useStyleProfileStore.getState().toggleFavorite('default-subtle');
+    const s1 = useStyleProfileStore.getState();
+    expect(s1.favoriteDefaultIds.includes('default-subtle')).toBe(!start);
+    expect(s1.getProfile('default-subtle')?.favorite).toBe(!start);
+    // restore
+    useStyleProfileStore.getState().toggleFavorite('default-subtle');
+    expect(useStyleProfileStore.getState().favoriteDefaultIds.includes('default-subtle')).toBe(start);
+  });
+});
 
 describe('mergeProfileProperties — non-destructive master memory (JP-399)', () => {
   it('keeps a rectangle cornerRadius when later updating the profile from a file', () => {

--- a/src/store/styleProfileStore.ts
+++ b/src/store/styleProfileStore.ts
@@ -37,6 +37,18 @@ export interface StyleProfile {
  */
 interface StyleProfileState {
   profiles: StyleProfile[];
+  /**
+   * Ids of built-in default profiles the user has favorited. Built-ins are
+   * immutable and seeded from code (not persisted), so their one allowed
+   * mutation — the favorite flag — is tracked here as an overlay.
+   */
+  favoriteDefaultIds: string[];
+}
+
+/** Shape persisted to localStorage: user profiles only + the favorite overlay. */
+interface PersistedStyleProfiles {
+  profiles: StyleProfile[];
+  favoriteDefaultIds: string[];
 }
 
 /**
@@ -131,6 +143,46 @@ const DEFAULT_PROFILES: StyleProfile[] = [
   },
 ];
 
+/** Whether an id refers to a built-in default profile. */
+function isDefaultProfileId(id: string): boolean {
+  return id.startsWith('default-');
+}
+
+/**
+ * Build the runtime profile list: the canonical built-ins (seeded fresh from
+ * code so they can never drift or be clobbered) followed by the user's saved
+ * profiles. `favoriteDefaultIds` re-applies the user's favorite flags onto the
+ * built-ins — the one mutation allowed on a default.
+ */
+export function seedProfiles(userProfiles: StyleProfile[], favoriteDefaultIds: readonly string[]): StyleProfile[] {
+  const favSet = new Set(favoriteDefaultIds);
+  const defaults = DEFAULT_PROFILES.map((d) => ({ ...d, favorite: favSet.has(d.id) }));
+  const users = userProfiles.filter((p) => !isDefaultProfileId(p.id));
+  return [...defaults, ...users];
+}
+
+/**
+ * Migrate persisted style-profile state to the current persisted shape (user
+ * profiles + favorite overlay). v1 baked the built-ins into the array; strip
+ * them, lifting any favorited built-ins into the overlay. Idempotent — running
+ * it on an already-v2 blob is a no-op beyond defensive normalization.
+ */
+export function migrateStyleProfiles(persisted: unknown, version: number): PersistedStyleProfiles {
+  const prev = (persisted ?? {}) as Partial<PersistedStyleProfiles>;
+  const all = Array.isArray(prev.profiles) ? prev.profiles : [];
+  const userProfiles = all.filter((p) => !isDefaultProfileId(p.id));
+  if (version < 2) {
+    const favoriteDefaultIds = all
+      .filter((p) => isDefaultProfileId(p.id) && p.favorite)
+      .map((p) => p.id);
+    return { profiles: userProfiles, favoriteDefaultIds };
+  }
+  return {
+    profiles: userProfiles,
+    favoriteDefaultIds: Array.isArray(prev.favoriteDefaultIds) ? prev.favoriteDefaultIds : [],
+  };
+}
+
 /**
  * Style profile store for managing reusable style presets.
  * Persisted to localStorage.
@@ -138,7 +190,8 @@ const DEFAULT_PROFILES: StyleProfile[] = [
 export const useStyleProfileStore = create<StyleProfileState & StyleProfileActions>()(
   persist(
     (set, get) => ({
-      profiles: DEFAULT_PROFILES,
+      profiles: seedProfiles([], []),
+      favoriteDefaultIds: [],
 
       addProfile: (name: string, properties: StyleProfileProperties) => {
         const profile: StyleProfile = {
@@ -157,6 +210,10 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
       },
 
       updateProfile: (id: string, updates: Partial<Omit<StyleProfile, 'id' | 'createdAt'>>) => {
+        // Built-in defaults are immutable (seeded from code) — never let Update /
+        // merge / Reset rewrite them.
+        if (isDefaultProfileId(id)) return;
+
         set((state) => ({
           profiles: state.profiles.map((p) =>
             p.id === id ? { ...p, ...updates } : p
@@ -166,7 +223,7 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
 
       deleteProfile: (id: string) => {
         // Don't allow deleting default profiles
-        if (id.startsWith('default-')) return;
+        if (isDefaultProfileId(id)) return;
 
         set((state) => ({
           profiles: state.profiles.filter((p) => p.id !== id),
@@ -175,7 +232,7 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
 
       renameProfile: (id: string, name: string) => {
         // Don't allow renaming default profiles
-        if (id.startsWith('default-')) return;
+        if (isDefaultProfileId(id)) return;
 
         set((state) => ({
           profiles: state.profiles.map((p) =>
@@ -185,6 +242,24 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
       },
 
       toggleFavorite: (id: string) => {
+        if (isDefaultProfileId(id)) {
+          // Favorite is the only allowed mutation on a built-in; track it in the
+          // persisted overlay rather than mutating the (non-persisted) default.
+          set((state) => {
+            const isFav = state.favoriteDefaultIds.includes(id);
+            const favoriteDefaultIds = isFav
+              ? state.favoriteDefaultIds.filter((x) => x !== id)
+              : [...state.favoriteDefaultIds, id];
+            return {
+              favoriteDefaultIds,
+              profiles: state.profiles.map((p) =>
+                p.id === id ? { ...p, favorite: !isFav } : p
+              ),
+            };
+          });
+          return;
+        }
+
         set((state) => ({
           profiles: state.profiles.map((p) =>
             p.id === id ? { ...p, favorite: !p.favorite } : p
@@ -197,8 +272,8 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
       },
 
       clearProfiles: () => {
-        // Reset to default profiles only
-        set({ profiles: DEFAULT_PROFILES });
+        // Drop user profiles + the favorite overlay; reseed canonical built-ins.
+        set({ profiles: seedProfiles([], []), favoriteDefaultIds: [] });
       },
 
       getSortedProfiles: () => {
@@ -213,7 +288,25 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
     }),
     {
       name: 'docushark-style-profiles',
-      version: 1,
+      version: 2,
+      // Persist only user profiles + the default-favorite overlay; built-ins are
+      // seeded from code at runtime (see merge) so they never drift or get
+      // clobbered by a stale persisted copy.
+      partialize: (state): PersistedStyleProfiles => ({
+        profiles: state.profiles.filter((p) => !isDefaultProfileId(p.id)),
+        favoriteDefaultIds: state.favoriteDefaultIds,
+      }),
+      migrate: (persisted, version): PersistedStyleProfiles => migrateStyleProfiles(persisted, version),
+      merge: (persisted, current) => {
+        const prev = (persisted ?? {}) as Partial<PersistedStyleProfiles>;
+        const favoriteDefaultIds = Array.isArray(prev.favoriteDefaultIds) ? prev.favoriteDefaultIds : [];
+        const userProfiles = Array.isArray(prev.profiles) ? prev.profiles : [];
+        return {
+          ...current,
+          favoriteDefaultIds,
+          profiles: seedProfiles(userProfiles, favoriteDefaultIds),
+        };
+      },
     }
   )
 );

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -257,29 +257,40 @@ export function CanvasContainer({
   }, []);
 
   /**
-   * Subscribe to emphasis changes for focus animation.
+   * Subscribe to ephemeral render state (focus emphasis + live style preview).
+   * Both are pushed into the renderer and never touch the document.
    */
   useEffect(() => {
     const engine = engineRef.current;
     if (!engine) return;
 
     let lastEmphasis: string | null = null;
+    let lastPreview: Record<string, unknown> | null = null;
 
-    // Update renderer with emphasis state
-    const updateEmphasis = () => {
-      const { emphasizedShapeId } = useSessionStore.getState();
+    const updateEphemeral = () => {
+      const { emphasizedShapeId, stylePreviewOverrides } = useSessionStore.getState();
+      let dirty = false;
+
       if (emphasizedShapeId !== lastEmphasis) {
         lastEmphasis = emphasizedShapeId;
         engine.renderer.setEmphasis(emphasizedShapeId);
-        engine.requestRender();
+        dirty = true;
       }
+
+      if (stylePreviewOverrides !== lastPreview) {
+        lastPreview = stylePreviewOverrides;
+        engine.renderer.setStylePreviewOverrides(stylePreviewOverrides);
+        dirty = true;
+      }
+
+      if (dirty) engine.requestRender();
     };
 
     // Initial update
-    updateEmphasis();
+    updateEphemeral();
 
     // Subscribe to session store changes
-    const unsubscribe = useSessionStore.subscribe(updateEmphasis);
+    const unsubscribe = useSessionStore.subscribe(updateEphemeral);
 
     return () => {
       unsubscribe();

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -1,6 +1,9 @@
 .style-profile-panel {
-  padding: 8px 0;
+  padding: var(--space-2) 0;
   border-top: 1px solid var(--border-color);
+  /* Establish a query context so the grid + controls reflow with panel width
+     (the panel is content-width-constrained, 180–640px, not viewport-based). */
+  container-type: inline-size;
 }
 
 .style-profile-header {
@@ -25,11 +28,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -50,16 +53,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
-  margin-left: 4px;
+  margin-left: var(--space-1);
 }
 
 .style-profile-add-btn:hover {
@@ -215,19 +218,32 @@
 
 /* Profile container - handles both grid and list modes */
 .style-profile-container {
-  padding: 0 8px;
+  padding: 0 var(--space-2);
 }
 
 .style-profile-container.grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: var(--space-2);
+}
+
+/* Fluid columns: tighter cells in a narrow panel, roomier when docked wide. */
+@container (max-width: 260px) {
+  .style-profile-container.grid {
+    grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+  }
+}
+
+@container (min-width: 440px) {
+  .style-profile-container.grid {
+    grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+  }
 }
 
 .style-profile-container.list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
 }
 
 /* Grid view items */
@@ -259,12 +275,13 @@
 }
 
 .style-profile-grid-preview {
-  width: 36px;
-  height: 36px;
-  border-radius: 4px;
+  width: 100%;
+  max-width: 48px;
+  aspect-ratio: 1;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .style-profile-grid-star {
@@ -276,7 +293,7 @@
 }
 
 .style-profile-grid-name {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
   max-width: 100%;
   text-align: center;
@@ -290,73 +307,43 @@
 }
 
 
-/* Grid confirmation overlay */
-.style-profile-grid-confirm {
+/* Grid ⋯ actions button (revealed on hover) */
+.style-profile-grid-menu {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  top: var(--space-1);
+  right: var(--space-1);
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  border-radius: 6px;
-  font-size: 10px;
-  font-weight: 500;
-}
-
-.style-profile-grid-confirm.delete {
-  background: rgba(229, 62, 62, 0.95);
-  color: white;
-}
-
-.style-profile-grid-confirm.overwrite {
-  background: rgba(74, 144, 217, 0.95);
-  color: white;
-}
-
-.style-profile-grid-confirm-actions {
-  display: flex;
-  gap: 4px;
-}
-
-.style-profile-grid-confirm-actions button {
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 500;
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  padding: 0;
   border: none;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: all 0.15s ease;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
 }
 
-.style-profile-grid-confirm.delete .style-profile-grid-confirm-actions button {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
+.style-profile-grid-item:hover .style-profile-grid-menu {
+  opacity: 0.85;
 }
 
-.style-profile-grid-confirm.delete .style-profile-grid-confirm-actions button:hover {
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.style-profile-grid-confirm.overwrite .style-profile-grid-confirm-actions button {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-}
-
-.style-profile-grid-confirm.overwrite .style-profile-grid-confirm-actions button:hover {
-  background: rgba(255, 255, 255, 0.3);
+.style-profile-grid-menu:hover {
+  opacity: 1;
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 /* List view items */
 .style-profile-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: 4px;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   transition: background 0.15s ease;
 }
 
@@ -370,17 +357,18 @@
 
 /* Color preview swatch */
 .style-profile-preview {
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
 /* Profile name */
 .style-profile-name {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -420,15 +408,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
+}
+
+.style-profile-action.menu:hover:not(:disabled) {
+  color: var(--text-primary);
 }
 
 .style-profile-action:hover:not(:disabled) {

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -1,310 +1,170 @@
-import { useState, useCallback, useEffect, useRef, useLayoutEffect } from 'react';
-import { useDocumentStore } from '../store/documentStore';
-import { getSelectedShapes } from '../store/sessionStore';
-import { useHistoryStore } from '../store/historyStore';
-import {
-  useStyleProfileStore,
-  StyleProfile,
-  extractStyleFromShape,
-  getProfileUpdates,
-  mergeProfileProperties,
-  ExtractStyleOptions,
-} from '../store/styleProfileStore';
+import { useState, useCallback, useEffect, useRef, useMemo, type CSSProperties } from 'react';
+import { Search, LayoutGrid, List, Plus, X } from 'lucide-react';
+import { getSelectedShapes, useSessionStore } from '../store/sessionStore';
+import { useStyleProfileStore, type StyleProfile } from '../store/styleProfileStore';
 import { useSettingsStore } from '../store/settingsStore';
+import { clampToViewport, MENU_SIZE_ESTIMATES } from './contextMenuUtils';
+import { useProfileActions } from './styleProfile/useProfileActions';
+import { ProfileCard, type MenuAnchor } from './styleProfile/ProfileCard';
 import './StyleProfilePanel.css';
 
 type ViewMode = 'grid' | 'list';
 
 interface ContextMenuState {
-  x: number;
-  y: number;
+  pos: { x: number; y: number };
   profileId: string;
 }
 
-/**
- * Panel for managing and applying style profiles.
- * Features compact grid/list views and profile management.
- */
-export function StyleProfilePanel() {
-  // Subscribe to profiles array directly so changes trigger re-renders
-  const storeProfiles = useStyleProfileStore((state) => state.profiles);
-  const addProfile = useStyleProfileStore((state) => state.addProfile);
-  const updateProfile = useStyleProfileStore((state) => state.updateProfile);
-  const deleteProfile = useStyleProfileStore((state) => state.deleteProfile);
-  const renameProfile = useStyleProfileStore((state) => state.renameProfile);
-  const toggleFavorite = useStyleProfileStore((state) => state.toggleFavorite);
+/** Preview swatch style for a profile (the universal dimensions). */
+function getPreviewStyle(profile: StyleProfile): CSSProperties {
+  return {
+    backgroundColor: profile.properties.fill || 'transparent',
+    borderColor: profile.properties.stroke || 'transparent',
+    borderWidth: Math.min(profile.properties.strokeWidth, 3),
+    borderStyle: 'solid',
+    opacity: profile.properties.opacity,
+    borderRadius: profile.properties.cornerRadius || 0,
+  };
+}
 
-  const updateShape = useDocumentStore((state) => state.updateShape);
-  const push = useHistoryStore((state) => state.push);
+export function StyleProfilePanel() {
+  const profilesRaw = useStyleProfileStore((state) => state.profiles);
+  const hideDefaultStyleProfiles = useSettingsStore((state) => state.hideDefaultStyleProfiles);
+
+  // Selection (reactive) → the shapes profiles act on.
+  const selectedIds = useSessionStore((state) => state.selectedIds);
+  const selectedShapes = useMemo(() => getSelectedShapes(), [selectedIds]);
+  const actions = useProfileActions(selectedShapes);
+  const { hasSelection, endPreview } = actions;
 
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [isCreating, setIsCreating] = useState(false);
   const [newProfileName, setNewProfileName] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [confirmOverwriteId, setConfirmOverwriteId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const [adjustedContextMenuPos, setAdjustedContextMenuPos] = useState<{ x: number; y: number } | null>(null);
-  const contextMenuRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const hideDefaultStyleProfiles = useSettingsStore((state) => state.hideDefaultStyleProfiles);
-  const saveIconStyleToProfile = useSettingsStore((state) => state.saveIconStyleToProfile);
-  const saveLabelStyleToProfile = useSettingsStore((state) => state.saveLabelStyleToProfile);
-
-  // Filter and sort profiles: optionally hide defaults, apply search, favorites first (alphabetically), then non-favorites (alphabetically)
-  const profiles = [...storeProfiles]
-    .filter((profile) => !hideDefaultStyleProfiles || !profile.id.startsWith('default-'))
-    .filter((profile) => !searchQuery || profile.name.toLowerCase().includes(searchQuery.toLowerCase()))
-    .sort((a, b) => {
-      if (a.favorite && !b.favorite) return -1;
-      if (!a.favorite && b.favorite) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-  // Focus search input when search opens
-  useEffect(() => {
-    if (isSearching && searchInputRef.current) {
-      searchInputRef.current.focus();
-    }
-  }, [isSearching]);
-
-  const selectedShapes = getSelectedShapes();
-  const hasSelection = selectedShapes.length > 0;
-  const firstShape = selectedShapes[0];
-
-  // Apply a profile to selected shapes
-  const handleApplyProfile = useCallback(
-    (profile: StyleProfile) => {
-      if (selectedShapes.length === 0) return;
-
-      push('Apply style profile');
-
-      // The adapter translates the profile into concrete shape-field updates,
-      // including a pre-merged `customProperties` for ERD entities — so there is
-      // no shape-type special-casing to do here.
-      for (const shape of selectedShapes) {
-        updateShape(shape.id, getProfileUpdates(profile, shape));
-      }
-    },
-    [selectedShapes, push, updateShape]
+  // Sorted (favorites first) via the store's own comparator; filtered locally.
+  const sorted = useMemo(() => useStyleProfileStore.getState().getSortedProfiles(), [profilesRaw]);
+  const visible = useMemo(
+    () =>
+      sorted
+        .filter((p) => !hideDefaultStyleProfiles || !p.id.startsWith('default-'))
+        .filter((p) => !searchQuery || p.name.toLowerCase().includes(searchQuery.toLowerCase())),
+    [sorted, hideDefaultStyleProfiles, searchQuery]
   );
 
-  // Save current shape's style as a new profile
-  const handleSaveProfile = useCallback(() => {
-    if (!firstShape || !newProfileName.trim()) return;
+  useEffect(() => {
+    if (isSearching && searchInputRef.current) searchInputRef.current.focus();
+  }, [isSearching]);
 
-    const extractOptions: ExtractStyleOptions = {
-      includeIconStyle: saveIconStyleToProfile,
-      includeLabelStyle: saveLabelStyleToProfile,
+  // Clear any live preview when the selection changes or the panel unmounts.
+  useEffect(() => endPreview, [selectedIds, endPreview]);
+
+  const closeMenu = useCallback(() => setContextMenu(null), []);
+
+  const openMenu = useCallback((profileId: string, anchor: MenuAnchor) => {
+    const est = MENU_SIZE_ESTIMATES.medium;
+    const pos = clampToViewport(anchor.x, anchor.y, est.width, est.height);
+    setContextMenu({ pos, profileId });
+  }, []);
+
+  // Dismiss the context menu on outside click / Escape.
+  useEffect(() => {
+    if (!contextMenu) return;
+    const onDown = () => closeMenu();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu();
     };
-    const properties = extractStyleFromShape(firstShape, extractOptions);
-
-    addProfile(newProfileName.trim(), properties);
-    setNewProfileName('');
-    setIsCreating(false);
-  }, [firstShape, newProfileName, addProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
-
-  // Update an existing profile from the current shape's style.
-  //
-  // Merges (non-destructively unions) the extracted style into the profile's
-  // existing properties rather than replacing them — so a profile becomes a
-  // "master memory" across the shapes saved into it, and saving a shape that
-  // lacks a field (e.g. a file has no cornerRadius) never wipes another shape's
-  // saved value. Apply is gated per shape, so the unioned profile only ever
-  // hands each shape back its own fields.
-  const handleOverwriteProfile = useCallback((profileId: string) => {
-    if (!firstShape) return;
-
-    const extractOptions: ExtractStyleOptions = {
-      includeIconStyle: saveIconStyleToProfile,
-      includeLabelStyle: saveLabelStyleToProfile,
+    const t = setTimeout(() => {
+      document.addEventListener('click', onDown);
+      document.addEventListener('keydown', onKey);
+    }, 0);
+    return () => {
+      clearTimeout(t);
+      document.removeEventListener('click', onDown);
+      document.removeEventListener('keydown', onKey);
     };
-    const extracted = extractStyleFromShape(firstShape, extractOptions);
-    const existing = storeProfiles.find((p) => p.id === profileId);
-    const properties = existing
-      ? mergeProfileProperties(existing.properties, extracted)
-      : extracted;
+  }, [contextMenu, closeMenu]);
 
-    updateProfile(profileId, { properties });
-    setConfirmOverwriteId(null);
-  }, [firstShape, storeProfiles, updateProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
-
-  // Start editing a profile name
-  const handleStartEdit = useCallback((profile: StyleProfile) => {
-    if (profile.id.startsWith('default-')) return;
+  const startEditFromMenu = useCallback((profile: StyleProfile) => {
+    setViewMode('list');
     setEditingId(profile.id);
     setEditingName(profile.name);
   }, []);
 
-  // Save edited name
-  const handleSaveEdit = useCallback(() => {
-    if (editingId && editingName.trim()) {
-      renameProfile(editingId, editingName.trim());
-    }
+  const commitEdit = useCallback(() => {
+    if (editingId && editingName.trim()) actions.renameProfile(editingId, editingName.trim());
     setEditingId(null);
     setEditingName('');
-  }, [editingId, editingName, renameProfile]);
+  }, [editingId, editingName, actions]);
 
-  // Cancel editing
-  const handleCancelEdit = useCallback(() => {
+  const cancelEdit = useCallback(() => {
     setEditingId(null);
     setEditingName('');
   }, []);
 
-  // Request delete confirmation
-  const handleRequestDelete = useCallback((id: string) => {
-    setConfirmDeleteId(id);
-    setConfirmOverwriteId(null);
-  }, []);
+  const handleSaveNew = useCallback(() => {
+    actions.saveNewProfile(newProfileName);
+    setNewProfileName('');
+    setIsCreating(false);
+  }, [actions, newProfileName]);
 
-  // Confirm and delete a profile
-  const handleConfirmDelete = useCallback(() => {
-    if (confirmDeleteId) {
-      deleteProfile(confirmDeleteId);
-      setConfirmDeleteId(null);
-    }
-  }, [confirmDeleteId, deleteProfile]);
+  const applicableHint = actions.applicableNames.length ? `Applies: ${actions.applicableNames.join(', ')}` : '';
+  const titleFor = useCallback(
+    (profile: StyleProfile) => {
+      const parts = [profile.name];
+      if (!hasSelection) parts.push('(select a shape to apply)');
+      else if (applicableHint) parts.push(applicableHint);
+      parts.push('Right-click for options');
+      return parts.join('\n');
+    },
+    [hasSelection, applicableHint]
+  );
 
-  // Cancel delete
-  const handleCancelDelete = useCallback(() => {
-    setConfirmDeleteId(null);
-  }, []);
-
-  // Request overwrite confirmation
-  const handleRequestOverwrite = useCallback((id: string) => {
-    setConfirmOverwriteId(id);
-    setConfirmDeleteId(null);
-  }, []);
-
-  // Cancel overwrite
-  const handleCancelOverwrite = useCallback(() => {
-    setConfirmOverwriteId(null);
-  }, []);
-
-  // Toggle favorite status
-  const handleToggleFavorite = useCallback((id: string) => {
-    toggleFavorite(id);
-  }, [toggleFavorite]);
-
-  // Context menu handlers
-  const handleContextMenu = useCallback((e: React.MouseEvent, profileId: string) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setContextMenu({ x: e.clientX, y: e.clientY, profileId });
-  }, []);
-
-  const closeContextMenu = useCallback(() => {
-    setContextMenu(null);
-    setAdjustedContextMenuPos(null);
-  }, []);
-
-  // Adjust context menu position to stay within viewport
-  useLayoutEffect(() => {
-    if (!contextMenu || !contextMenuRef.current) {
-      setAdjustedContextMenuPos(null);
-      return;
-    }
-
-    const menu = contextMenuRef.current;
-    const rect = menu.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    const padding = 8;
-
-    let newX = contextMenu.x;
-    let newY = contextMenu.y;
-
-    // Check if menu overflows right edge
-    if (contextMenu.x + rect.width > viewportWidth - padding) {
-      newX = Math.max(padding, viewportWidth - rect.width - padding);
-    }
-
-    // Check if menu overflows bottom edge
-    if (contextMenu.y + rect.height > viewportHeight - padding) {
-      newY = Math.max(padding, viewportHeight - rect.height - padding);
-    }
-
-    setAdjustedContextMenuPos({ x: newX, y: newY });
-  }, [contextMenu]);
-
-  // Close context menu on click outside or escape
-  useEffect(() => {
-    if (!contextMenu) return;
-
-    const handleClick = () => closeContextMenu();
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeContextMenu();
-    };
-
-    const timeoutId = setTimeout(() => {
-      document.addEventListener('click', handleClick);
-      document.addEventListener('keydown', handleEscape);
-    }, 0);
-
-    return () => {
-      clearTimeout(timeoutId);
-      document.removeEventListener('click', handleClick);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [contextMenu, closeContextMenu]);
-
-  // Get preview style for a profile
-  const getPreviewStyle = (profile: StyleProfile): React.CSSProperties => {
-    return {
-      backgroundColor: profile.properties.fill || 'transparent',
-      borderColor: profile.properties.stroke || 'transparent',
-      borderWidth: Math.min(profile.properties.strokeWidth, 3),
-      borderStyle: 'solid',
-      opacity: profile.properties.opacity,
-      borderRadius: profile.properties.cornerRadius || 0,
-    };
-  };
+  const menuProfile = contextMenu ? sorted.find((p) => p.id === contextMenu.profileId) : undefined;
 
   return (
     <div className="style-profile-panel">
       <div className="style-profile-header">
         <span>Style Profiles</span>
         <div className="style-profile-header-actions">
-          {/* Search button */}
           <button
             className={`style-profile-view-btn ${isSearching || searchQuery ? 'active' : ''}`}
-            onClick={() => setIsSearching(!isSearching)}
+            onClick={() => setIsSearching((v) => !v)}
             title="Search profiles"
           >
-            <SearchIcon />
+            <Search size={15} />
           </button>
-          {/* View mode toggle */}
           <button
             className={`style-profile-view-btn ${viewMode === 'grid' ? 'active' : ''}`}
             onClick={() => setViewMode('grid')}
             title="Grid view"
           >
-            <GridIcon />
+            <LayoutGrid size={15} />
           </button>
           <button
             className={`style-profile-view-btn ${viewMode === 'list' ? 'active' : ''}`}
             onClick={() => setViewMode('list')}
             title="List view"
           >
-            <ListIcon />
+            <List size={15} />
           </button>
           {hasSelection && (
             <button
               className="style-profile-add-btn"
               onClick={() => setIsCreating(true)}
-              title="Save current style as profile"
+              title="Save current style as a new profile"
             >
-              <PlusIcon />
+              <Plus size={15} />
             </button>
           )}
         </div>
       </div>
 
-      {/* Search bar */}
       {isSearching && (
         <div className="style-profile-search">
           <input
@@ -322,18 +182,13 @@ export function StyleProfilePanel() {
             }}
           />
           {searchQuery && (
-            <button
-              className="style-profile-search-clear"
-              onClick={() => setSearchQuery('')}
-              title="Clear search"
-            >
-              <CloseIcon />
+            <button className="style-profile-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
+              <X size={14} />
             </button>
           )}
         </div>
       )}
 
-      {/* Active filter indicator */}
       {searchQuery && !isSearching && (
         <div className="style-profile-filter-active">
           <span>Filtered: "{searchQuery}"</span>
@@ -345,13 +200,12 @@ export function StyleProfilePanel() {
             }}
             title="Clear filter"
           >
-            <CloseIcon />
+            <X size={13} />
           </button>
         </div>
       )}
 
-      {/* Create new profile form */}
-      {isCreating && firstShape && (
+      {isCreating && hasSelection && (
         <div className="style-profile-create">
           <input
             type="text"
@@ -361,16 +215,12 @@ export function StyleProfilePanel() {
             className="style-profile-input"
             autoFocus
             onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSaveProfile();
+              if (e.key === 'Enter') handleSaveNew();
               if (e.key === 'Escape') setIsCreating(false);
             }}
           />
           <div className="style-profile-create-actions">
-            <button
-              className="style-profile-btn save"
-              onClick={handleSaveProfile}
-              disabled={!newProfileName.trim()}
-            >
+            <button className="style-profile-btn save" onClick={handleSaveNew} disabled={!newProfileName.trim()}>
               Save
             </button>
             <button
@@ -386,355 +236,117 @@ export function StyleProfilePanel() {
         </div>
       )}
 
-      {/* Profile grid/list */}
       <div className={`style-profile-container ${viewMode}`}>
-        {profiles.map((profile) => {
-          const isDeleting = confirmDeleteId === profile.id;
-          const isOverwriting = confirmOverwriteId === profile.id;
-          const isDefault = profile.id.startsWith('default-');
-
-          if (viewMode === 'grid') {
-            return (
-              <div
-                key={profile.id}
-                className={`style-profile-grid-item ${!hasSelection ? 'disabled' : ''} ${profile.favorite ? 'favorite' : ''}`}
-                onClick={() => hasSelection && handleApplyProfile(profile)}
-                onContextMenu={(e) => handleContextMenu(e, profile.id)}
-                title={`${profile.name}${!hasSelection ? ' (select a shape to apply)' : ''}\nRight-click for options`}
-              >
-                <div
-                  className="style-profile-grid-preview"
-                  style={getPreviewStyle(profile)}
-                />
-                {profile.favorite && (
-                  <span className="style-profile-grid-star">★</span>
-                )}
-                <span className="style-profile-grid-name">{profile.name}</span>
-                {/* Confirmation overlays */}
-                {isDeleting && (
-                  <div className="style-profile-grid-confirm delete">
-                    <span>Delete?</span>
-                    <div className="style-profile-grid-confirm-actions">
-                      <button onClick={(e) => { e.stopPropagation(); handleConfirmDelete(); }}>Yes</button>
-                      <button onClick={(e) => { e.stopPropagation(); handleCancelDelete(); }}>No</button>
-                    </div>
-                  </div>
-                )}
-                {isOverwriting && (
-                  <div className="style-profile-grid-confirm overwrite">
-                    <span>Update?</span>
-                    <div className="style-profile-grid-confirm-actions">
-                      <button onClick={(e) => { e.stopPropagation(); handleOverwriteProfile(profile.id); }}>Yes</button>
-                      <button onClick={(e) => { e.stopPropagation(); handleCancelOverwrite(); }}>No</button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          }
-
-          // List view
-          return (
-            <div
-              key={profile.id}
-              className={`style-profile-item ${!hasSelection ? 'disabled' : ''}`}
-            >
-              {/* Color preview */}
-              <div
-                className="style-profile-preview"
-                style={getPreviewStyle(profile)}
-              />
-
-              {/* Favorite star */}
-              <button
-                className={`style-profile-action favorite ${profile.favorite ? 'active' : ''}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleToggleFavorite(profile.id);
-                }}
-                title={profile.favorite ? 'Remove from favorites' : 'Add to favorites'}
-              >
-                <StarIcon filled={profile.favorite} />
-              </button>
-
-              {/* Name (editable for custom profiles) */}
-              {editingId === profile.id ? (
-                <input
-                  type="text"
-                  value={editingName}
-                  onChange={(e) => setEditingName(e.target.value)}
-                  className="style-profile-edit-input"
-                  autoFocus
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSaveEdit();
-                    if (e.key === 'Escape') handleCancelEdit();
-                  }}
-                  onBlur={handleSaveEdit}
-                />
-              ) : (
-                <span
-                  className="style-profile-name"
-                  onDoubleClick={() => handleStartEdit(profile)}
-                  title={isDefault ? 'Built-in profile' : 'Double-click to rename'}
-                >
-                  {profile.name}
-                </span>
-              )}
-
-              {/* Actions */}
-              <div className="style-profile-actions">
-                <button
-                  className="style-profile-action apply"
-                  onClick={() => handleApplyProfile(profile)}
-                  disabled={!hasSelection}
-                  title="Apply to selected shapes"
-                >
-                  <ApplyIcon />
-                </button>
-                {!isDefault && hasSelection && !isDeleting && !isOverwriting && (
-                  <button
-                    className="style-profile-action overwrite"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleRequestOverwrite(profile.id);
-                    }}
-                    title="Update profile with this shape's style (merges; keeps other shapes' saved fields)"
-                  >
-                    <OverwriteIcon />
-                  </button>
-                )}
-                {!isDefault && (
-                  isDeleting ? (
-                    <>
-                      <button
-                        className="style-profile-action confirm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleConfirmDelete();
-                        }}
-                        title="Confirm delete"
-                      >
-                        <ApplyIcon />
-                      </button>
-                      <button
-                        className="style-profile-action cancel"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCancelDelete();
-                        }}
-                        title="Cancel"
-                      >
-                        <DeleteIcon />
-                      </button>
-                    </>
-                  ) : isOverwriting ? (
-                    <>
-                      <button
-                        className="style-profile-action confirm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleOverwriteProfile(profile.id);
-                        }}
-                        title="Confirm update"
-                      >
-                        <ApplyIcon />
-                      </button>
-                      <button
-                        className="style-profile-action cancel"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCancelOverwrite();
-                        }}
-                        title="Cancel"
-                      >
-                        <DeleteIcon />
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      className="style-profile-action delete"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRequestDelete(profile.id);
-                      }}
-                      title="Delete profile"
-                    >
-                      <DeleteIcon />
-                    </button>
-                  )
-                )}
-              </div>
-            </div>
-          );
-        })}
+        {visible.map((profile) => (
+          <ProfileCard
+            key={profile.id}
+            profile={profile}
+            viewMode={viewMode}
+            hasSelection={hasSelection}
+            isEditing={editingId === profile.id}
+            editingName={editingName}
+            previewStyle={getPreviewStyle(profile)}
+            titleText={titleFor(profile)}
+            onApply={() => actions.applyProfile(profile)}
+            onToggleFavorite={() => actions.toggleFavorite(profile.id)}
+            onOpenMenu={(anchor) => openMenu(profile.id, anchor)}
+            onStartEdit={() => {
+              setEditingId(profile.id);
+              setEditingName(profile.name);
+            }}
+            onEditNameChange={setEditingName}
+            onCommitEdit={commitEdit}
+            onCancelEdit={cancelEdit}
+            onPreviewEnter={() => actions.previewProfile(profile)}
+            onPreviewLeave={endPreview}
+          />
+        ))}
       </div>
 
-      {!hasSelection && (
-        <div className="style-profile-hint">
-          Select a shape to apply or save styles
-        </div>
-      )}
+      {!hasSelection && <div className="style-profile-hint">Select a shape to apply or save styles</div>}
 
-      {/* Context menu for grid items */}
-      {contextMenu && (() => {
-        const profile = profiles.find((p) => p.id === contextMenu.profileId);
-        if (!profile) return null;
-        const isDefault = profile.id.startsWith('default-');
-        const menuPos = adjustedContextMenuPos ?? { x: contextMenu.x, y: contextMenu.y };
-
-        return (
-          <div
-            ref={contextMenuRef}
-            className="style-profile-context-menu"
-            style={{ left: menuPos.x, top: menuPos.y }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {hasSelection && (
-              <button
-                className="style-profile-context-menu-item"
-                onClick={() => {
-                  handleApplyProfile(profile);
-                  closeContextMenu();
-                }}
-              >
-                Apply Style
-              </button>
-            )}
+      {contextMenu && menuProfile && (
+        <div
+          className="style-profile-context-menu"
+          style={{ left: contextMenu.pos.x, top: contextMenu.pos.y }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {hasSelection && (
             <button
               className="style-profile-context-menu-item"
               onClick={() => {
-                handleToggleFavorite(profile.id);
-                closeContextMenu();
+                actions.applyProfile(menuProfile);
+                closeMenu();
               }}
             >
-              {profile.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+              Apply Style
             </button>
-            {!isDefault && (
-              <>
+          )}
+          <button
+            className="style-profile-context-menu-item"
+            onClick={() => {
+              actions.toggleFavorite(menuProfile.id);
+              closeMenu();
+            }}
+          >
+            {menuProfile.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+          </button>
+          <button
+            className="style-profile-context-menu-item"
+            onClick={() => {
+              actions.duplicateProfile(menuProfile);
+              closeMenu();
+            }}
+          >
+            Duplicate
+          </button>
+          {!menuProfile.id.startsWith('default-') && (
+            <>
+              <button
+                className="style-profile-context-menu-item"
+                onClick={() => {
+                  startEditFromMenu(menuProfile);
+                  closeMenu();
+                }}
+              >
+                Rename
+              </button>
+              {hasSelection && (
                 <button
                   className="style-profile-context-menu-item"
                   onClick={() => {
-                    handleStartEdit(profile);
-                    closeContextMenu();
+                    actions.updateProfileFromShape(menuProfile.id);
+                    closeMenu();
                   }}
                 >
-                  Rename
+                  Update with Current
                 </button>
-                {hasSelection && (
-                  <button
-                    className="style-profile-context-menu-item"
-                    onClick={() => {
-                      handleRequestOverwrite(profile.id);
-                      closeContextMenu();
-                    }}
-                  >
-                    Update with Current
-                  </button>
-                )}
-                <div className="style-profile-context-menu-separator" />
+              )}
+              {hasSelection && (
                 <button
-                  className="style-profile-context-menu-item danger"
+                  className="style-profile-context-menu-item"
                   onClick={() => {
-                    handleRequestDelete(profile.id);
-                    closeContextMenu();
+                    closeMenu();
+                    void actions.resetProfileFromShape(menuProfile);
                   }}
                 >
-                  Delete
+                  Reset to Shape
                 </button>
-              </>
-            )}
-          </div>
-        );
-      })()}
+              )}
+              <div className="style-profile-context-menu-separator" />
+              <button
+                className="style-profile-context-menu-item danger"
+                onClick={() => {
+                  closeMenu();
+                  void actions.deleteProfileById(menuProfile);
+                }}
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </div>
-  );
-}
-
-// SVG Icons
-
-function PlusIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M7 2v10M2 7h10" />
-    </svg>
-  );
-}
-
-function ApplyIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 7l4 4 6-8" />
-    </svg>
-  );
-}
-
-function DeleteIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M3 3l8 8M11 3l-8 8" />
-    </svg>
-  );
-}
-
-function StarIcon({ filled }: { filled: boolean }) {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 14 14"
-      fill={filled ? 'currentColor' : 'none'}
-      stroke="currentColor"
-      strokeWidth="1.5"
-    >
-      <path d="M7 1l1.8 3.6 4 .6-2.9 2.8.7 4-3.6-1.9-3.6 1.9.7-4-2.9-2.8 4-.6L7 1z" />
-    </svg>
-  );
-}
-
-function GridIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <rect x="1" y="1" width="5" height="5" rx="1" />
-      <rect x="8" y="1" width="5" height="5" rx="1" />
-      <rect x="1" y="8" width="5" height="5" rx="1" />
-      <rect x="8" y="8" width="5" height="5" rx="1" />
-    </svg>
-  );
-}
-
-function ListIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M4 3h9M4 7h9M4 11h9" />
-      <circle cx="1.5" cy="3" r="0.75" fill="currentColor" />
-      <circle cx="1.5" cy="7" r="0.75" fill="currentColor" />
-      <circle cx="1.5" cy="11" r="0.75" fill="currentColor" />
-    </svg>
-  );
-}
-
-function OverwriteIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 10v2h2l6-6-2-2-6 6z" />
-      <path d="M9 3l2 2" />
-    </svg>
-  );
-}
-
-function SearchIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <circle cx="6" cy="6" r="4" />
-      <path d="M9 9l3 3" />
-    </svg>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 2l8 8M10 2l-8 8" />
-    </svg>
   );
 }

--- a/src/ui/settings/GeneralSettings.tsx
+++ b/src/ui/settings/GeneralSettings.tsx
@@ -10,8 +10,10 @@
  * canvas toolbar's connector dropdown — there's no knob for it here anymore.)
  */
 
+import { useMemo } from 'react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useStyleProfileStore } from '../../store/styleProfileStore';
+import { RichSelect, type RichSelectItem } from '../components/RichSelect';
 import './GeneralSettings.css';
 
 export function GeneralSettings() {
@@ -29,10 +31,19 @@ export function GeneralSettings() {
 
   const profiles = useStyleProfileStore((state) => state.profiles);
 
-  const handleStyleProfileChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
+  const handleStyleProfileChange = (value: string) => {
     setDefaultStyleProfileId(value === '' ? null : value);
   };
+
+  const styleProfileItems = useMemo<RichSelectItem<string>[]>(
+    () => [
+      { value: '', label: 'None (Use Tool Defaults)' },
+      ...profiles
+        .filter((profile) => !hideDefaultStyleProfiles || !profile.id.startsWith('default-'))
+        .map((profile) => ({ value: profile.id, label: profile.name })),
+    ],
+    [profiles, hideDefaultStyleProfiles]
+  );
 
   return (
     <div className="general-settings">
@@ -43,24 +54,17 @@ export function GeneralSettings() {
         <h4 className="settings-group-title">Shapes</h4>
 
         <div className="settings-row">
-          <label className="settings-label" htmlFor="default-style-profile">
+          <label className="settings-label">
             Default Style Profile
           </label>
-          <select
-            id="default-style-profile"
-            className="settings-select"
+          <RichSelect
             value={defaultStyleProfileId ?? ''}
             onChange={handleStyleProfileChange}
-          >
-            <option value="">None (Use Tool Defaults)</option>
-            {profiles
-              .filter((profile) => !hideDefaultStyleProfiles || !profile.id.startsWith('default-'))
-              .map((profile) => (
-                <option key={profile.id} value={profile.id}>
-                  {profile.name}
-                </option>
-              ))}
-          </select>
+            items={styleProfileItems}
+            ariaLabel="Default Style Profile"
+            className="settings-select"
+            align="end"
+          />
           <span className="settings-hint">
             New shapes will be created with this style applied
           </span>

--- a/src/ui/styleProfile/ProfileCard.tsx
+++ b/src/ui/styleProfile/ProfileCard.tsx
@@ -1,0 +1,142 @@
+/**
+ * A single style-profile card, shared by the grid and list views (collapsing
+ * what used to be two near-duplicate renderings). Click applies; hover previews
+ * live on the canvas; the ⋯ button / right-click opens the actions menu.
+ */
+
+import type { CSSProperties, MouseEvent } from 'react';
+import { Star, MoreHorizontal } from 'lucide-react';
+import type { StyleProfile } from '../../store/styleProfileStore';
+
+export interface MenuAnchor {
+  x: number;
+  y: number;
+}
+
+interface ProfileCardProps {
+  profile: StyleProfile;
+  viewMode: 'grid' | 'list';
+  hasSelection: boolean;
+  isEditing: boolean;
+  editingName: string;
+  previewStyle: CSSProperties;
+  /** Tooltip describing what applying this profile affects on the selection. */
+  titleText: string;
+  onApply: () => void;
+  onToggleFavorite: () => void;
+  onOpenMenu: (anchor: MenuAnchor) => void;
+  onStartEdit: () => void;
+  onEditNameChange: (value: string) => void;
+  onCommitEdit: () => void;
+  onCancelEdit: () => void;
+  onPreviewEnter: () => void;
+  onPreviewLeave: () => void;
+}
+
+export function ProfileCard(props: ProfileCardProps) {
+  const {
+    profile, viewMode, hasSelection, isEditing, editingName, previewStyle, titleText,
+    onApply, onToggleFavorite, onOpenMenu, onStartEdit, onEditNameChange,
+    onCommitEdit, onCancelEdit, onPreviewEnter, onPreviewLeave,
+  } = props;
+
+  const handleContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onOpenMenu({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMenuButton = (e: MouseEvent) => {
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    onOpenMenu({ x: rect.left, y: rect.bottom });
+  };
+
+  const apply = () => {
+    if (hasSelection) onApply();
+  };
+
+  if (viewMode === 'grid') {
+    return (
+      <div
+        className={`style-profile-grid-item ${!hasSelection ? 'disabled' : ''} ${profile.favorite ? 'favorite' : ''}`}
+        onClick={apply}
+        onContextMenu={handleContextMenu}
+        onMouseEnter={() => hasSelection && onPreviewEnter()}
+        onMouseLeave={onPreviewLeave}
+        title={titleText}
+      >
+        <div className="style-profile-grid-preview" style={previewStyle} />
+        {profile.favorite && <span className="style-profile-grid-star">★</span>}
+        <span className="style-profile-grid-name">{profile.name}</span>
+        <button
+          className="style-profile-grid-menu"
+          onClick={handleMenuButton}
+          title="More options"
+          aria-label="More options"
+        >
+          <MoreHorizontal size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`style-profile-item ${!hasSelection ? 'disabled' : ''}`}
+      onContextMenu={handleContextMenu}
+      onMouseEnter={() => hasSelection && onPreviewEnter()}
+      onMouseLeave={onPreviewLeave}
+    >
+      <div
+        className="style-profile-preview"
+        style={previewStyle}
+        onClick={apply}
+        role="button"
+        title={hasSelection ? 'Apply to selection' : titleText}
+      />
+
+      <button
+        className={`style-profile-action favorite ${profile.favorite ? 'active' : ''}`}
+        onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}
+        title={profile.favorite ? 'Remove from favorites' : 'Add to favorites'}
+      >
+        <Star size={15} fill={profile.favorite ? 'currentColor' : 'none'} />
+      </button>
+
+      {isEditing ? (
+        <input
+          type="text"
+          value={editingName}
+          onChange={(e) => onEditNameChange(e.target.value)}
+          className="style-profile-edit-input"
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onCommitEdit();
+            if (e.key === 'Escape') onCancelEdit();
+          }}
+          onBlur={onCommitEdit}
+        />
+      ) : (
+        <span
+          className="style-profile-name"
+          onDoubleClick={onStartEdit}
+          title={titleText}
+        >
+          {profile.name}
+        </span>
+      )}
+
+      <div className="style-profile-actions">
+        <button
+          className="style-profile-action menu"
+          onClick={handleMenuButton}
+          title="More options"
+          aria-label="More options"
+        >
+          <MoreHorizontal size={15} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/styleProfile/useProfileActions.ts
+++ b/src/ui/styleProfile/useProfileActions.ts
@@ -1,0 +1,153 @@
+/**
+ * Actions for the Style Profile panel — apply, save/update/reset, duplicate,
+ * delete, rename, favorite, and the collab-safe live preview.
+ *
+ * Keeping these out of the panel component centralizes the profile↔shape logic
+ * (and the JP-399 Update=merge vs Reset=replace distinction) and keeps the panel
+ * focused on layout/state.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useDocumentStore } from '../../store/documentStore';
+import { useHistoryStore } from '../../store/historyStore';
+import { useSessionStore } from '../../store/sessionStore';
+import { useSettingsStore } from '../../store/settingsStore';
+import {
+  useStyleProfileStore,
+  extractStyleFromShape,
+  getProfileUpdates,
+  getApplicablePropertyNames,
+  mergeProfileProperties,
+  type StyleProfile,
+  type ExtractStyleOptions,
+} from '../../store/styleProfileStore';
+import { confirmDialog } from '../confirm/confirmStore';
+import type { Shape } from '../../shapes/Shape';
+
+export function useProfileActions(selectedShapes: Shape[]) {
+  const updateShape = useDocumentStore((s) => s.updateShape);
+  const push = useHistoryStore((s) => s.push);
+  const addProfile = useStyleProfileStore((s) => s.addProfile);
+  const updateProfile = useStyleProfileStore((s) => s.updateProfile);
+  const deleteProfile = useStyleProfileStore((s) => s.deleteProfile);
+  const renameProfile = useStyleProfileStore((s) => s.renameProfile);
+  const toggleFavorite = useStyleProfileStore((s) => s.toggleFavorite);
+  const getProfile = useStyleProfileStore((s) => s.getProfile);
+  const setStylePreview = useSessionStore((s) => s.setStylePreview);
+  const clearStylePreview = useSessionStore((s) => s.clearStylePreview);
+  const saveIconStyleToProfile = useSettingsStore((s) => s.saveIconStyleToProfile);
+  const saveLabelStyleToProfile = useSettingsStore((s) => s.saveLabelStyleToProfile);
+
+  const firstShape = selectedShapes[0];
+  const hasSelection = selectedShapes.length > 0;
+
+  const extractOptions = useMemo<ExtractStyleOptions>(
+    () => ({ includeIconStyle: saveIconStyleToProfile, includeLabelStyle: saveLabelStyleToProfile }),
+    [saveIconStyleToProfile, saveLabelStyleToProfile]
+  );
+
+  /** Style dimensions a profile can affect on the current selection (for the hint tooltip). */
+  const applicableNames = useMemo(
+    () => (firstShape ? getApplicablePropertyNames(firstShape.type) : []),
+    [firstShape]
+  );
+
+  const applyProfile = useCallback(
+    (profile: StyleProfile) => {
+      if (selectedShapes.length === 0) return;
+      clearStylePreview();
+      push('Apply style profile');
+      for (const shape of selectedShapes) {
+        updateShape(shape.id, getProfileUpdates(profile, shape));
+      }
+    },
+    [selectedShapes, push, updateShape, clearStylePreview]
+  );
+
+  /** Live, collab-safe preview: render-only overrides, never the document. */
+  const previewProfile = useCallback(
+    (profile: StyleProfile) => {
+      if (selectedShapes.length === 0) return;
+      const overrides: Record<string, Partial<Shape>> = {};
+      for (const shape of selectedShapes) {
+        overrides[shape.id] = getProfileUpdates(profile, shape);
+      }
+      setStylePreview(overrides);
+    },
+    [selectedShapes, setStylePreview]
+  );
+
+  const endPreview = useCallback(() => clearStylePreview(), [clearStylePreview]);
+
+  const saveNewProfile = useCallback(
+    (name: string) => {
+      if (!firstShape || !name.trim()) return;
+      addProfile(name.trim(), extractStyleFromShape(firstShape, extractOptions));
+    },
+    [firstShape, addProfile, extractOptions]
+  );
+
+  /** Update = non-destructive merge into the existing profile (master memory). */
+  const updateProfileFromShape = useCallback(
+    (profileId: string) => {
+      if (!firstShape) return;
+      const existing = getProfile(profileId);
+      const extracted = extractStyleFromShape(firstShape, extractOptions);
+      updateProfile(profileId, {
+        properties: existing ? mergeProfileProperties(existing.properties, extracted) : extracted,
+      });
+    },
+    [firstShape, getProfile, updateProfile, extractOptions]
+  );
+
+  /** Reset = replace the profile from this shape (counterpart to Update/merge). */
+  const resetProfileFromShape = useCallback(
+    async (profile: StyleProfile) => {
+      if (!firstShape) return;
+      const ok = await confirmDialog({
+        title: `Reset "${profile.name}"?`,
+        message: "Replace this profile entirely with the selected shape's current style.",
+        details: 'Unlike Update, this discards any styles previously saved into the profile from other shapes.',
+        confirmLabel: 'Reset',
+      });
+      if (!ok) return;
+      updateProfile(profile.id, { properties: extractStyleFromShape(firstShape, extractOptions) });
+    },
+    [firstShape, updateProfile, extractOptions]
+  );
+
+  const duplicateProfile = useCallback(
+    (profile: StyleProfile) => {
+      addProfile(`${profile.name} copy`, { ...profile.properties });
+    },
+    [addProfile]
+  );
+
+  const deleteProfileById = useCallback(
+    async (profile: StyleProfile) => {
+      const ok = await confirmDialog({
+        title: `Delete "${profile.name}"?`,
+        confirmLabel: 'Delete',
+        danger: true,
+      });
+      if (ok) deleteProfile(profile.id);
+    },
+    [deleteProfile]
+  );
+
+  return {
+    firstShape,
+    hasSelection,
+    applicableNames,
+    applyProfile,
+    previewProfile,
+    endPreview,
+    saveNewProfile,
+    updateProfileFromShape,
+    resetProfileFromShape,
+    duplicateProfile,
+    deleteProfileById,
+    renameProfile,
+    toggleFavorite,
+  };
+}


### PR DESCRIPTION
Follow-on UI polish after JP-33 (#347) / JP-399 (#348). The store/adapter layer was clean; the panel was a 740-line god-component, cramped and non-responsive.

## Refactor / abstraction
- 9 hand-rolled inline SVGs → **lucide-react**.
- Inline confirm flows (two `confirm*Id` states + grid/list-duplicated Yes/No overlays) → async **`confirmDialog()`**.
- Bespoke context-menu viewport math (`useLayoutEffect` + `adjustedContextMenuPos`) → **`clampToViewport()`**.
- Decomposed into **`ProfileCard`** (collapses the grid/list duplication) + **`useProfileActions`** hook. The ⋯ / right-click menu is the single action surface; uses the store's **`getSortedProfiles`** instead of an inline re-sort.

## Responsive / fluid panel
- The panel is now a **container-query** context (`PropertySection.css` model); grid columns + control sizes reflow across the 180–640px range. Controls/spacing/fonts adopt the **token system** (`--control-height-*`, `--space-*`, `--font-size-*`, `--radius-*`) instead of hardcoded px. Dead confirm-overlay CSS removed.

## Live ephemeral preview (collab-safe — the careful part)
- Hovering a profile restyles the selection on canvas; mouse-out reverts. Implemented as a **render-only** `sessionStore` override applied in the Renderer draw loop **before** auto-colour resolution, pushed in via `CanvasContainer`'s existing emphasis subscription.
- It **never** calls `updateShape`/DocumentStore → no CRDT broadcast, no relay Y.Doc write, no undo history. A unit test pins that `documentStore.shapes` is byte-for-byte untouched, so **collab peers see nothing**. The override is computed via `getProfileUpdates`, so the preview is faithful (incl. the ERD/swimlane `customProperties` merge).

## Extras
- **"What it changes" tooltip** — revives the unused `getApplicablePropertyNames`.
- **Duplicate** profile; **Reset to shape** (replace — the deliberate counterpart to Update/merge).

## Default-profile hardening (both fixes)
- **Built-ins immutable**: `updateProfile` guards `default-` ids, so Update/merge/Reset can't silently rewrite a built-in.
- **Defaults no longer persisted**: `partialize` to user profiles + a `favoriteDefaultIds` overlay; canonical built-ins seeded at runtime; persist **v1→v2 migrate** strips legacy baked-in defaults (lifting favorited ones into the overlay). They can't drift with code changes or be clobbered.

## Settings
- Default Style Profile picker: native `<select>` → custom **`RichSelect`**.

## Testing
- `typecheck` clean; full suite **2757 passed**; `build` green; OSS leak-grep clean.
- New: preview collab-safety (document untouched), default hardening (immutability + migrate idempotency + favorite overlay), and the JP-399 Update=merge vs Reset=replace distinction stays pinned.
- **Manual gate (yours):** in a 2-client collab session, confirm the previewing client sees the live restyle and the peer sees no flicker; and a visual pass of the responsive panel (drag 180↔640px) + the new menu/preview interactions.

Closes JP-401. Related: JP-33 (#347), JP-399 (#348).

Assisted-by: Opus 4.8