### PR TITLE
JP-402: per-user "best effort" canvas undo/redo in collaboration

### DIFF
--- a/src/collaboration/CanvasUndoController.ts
+++ b/src/collaboration/CanvasUndoController.ts
@@ -1,0 +1,147 @@
+/**
+ * CanvasUndoController — per-user "best effort" canvas undo/redo in collaboration
+ * (JP-402).
+ *
+ * Snapshot-based history (`historyStore`) is disabled in a collab session (JP-178)
+ * because restoring a local snapshot diverges from the authoritative relay Y.Doc.
+ * This controller is the collab-native answer: a Yjs `UndoManager` per canvas page,
+ * scoped to that page's `shapes:<id>` / `shapeOrder:<id>` shared types and filtered
+ * to a single tracked origin — the owning `YjsDocument` instance.
+ *
+ * Why that origin filter is the whole trick: every LOCAL canvas mutation runs through
+ * `YjsDocument.withLocalUpdate()` → `doc.transact(fn, this)`, so local edits carry the
+ * `YjsDocument` as their transaction origin, while remote edits arrive via the provider
+ * (a different origin) and adopt/load writes never touch these maps. So
+ * `trackedOrigins: {yjsDoc}` captures *only this user's* edits — and an `undo()` is a
+ * real CRDT op (origin = the UndoManager, not `yjsDoc`), so it re-renders through the
+ * existing remote-apply pipeline and broadcasts to peers like any other edit. No
+ * snapshot, no divergence.
+ *
+ * Managers are cached per page (the `shapes:<id>` Y.Map instance is stable for the
+ * Y.Doc's lifetime), so per-page undo stacks survive page switches — matching the
+ * existing per-page history model. Stacks are in-memory and session-scoped (lost on
+ * reload), exactly like the snapshot history they stand in for.
+ */
+
+import * as Y from 'yjs';
+import type { Shape } from '../shapes/Shape';
+
+/**
+ * Coalescing window for un-anchored edit bursts (ms). The real step boundaries come
+ * from `closeStep()` (called at every `pushHistory` action anchor); this timeout only
+ * groups edits with no anchor between them (e.g. rapid property-panel tweaks). It is a
+ * feel knob, NOT a perf lever — undo cost is in observing/inverting ops, independent of
+ * the window.
+ */
+const CAPTURE_TIMEOUT_MS = 1000;
+
+export class CanvasUndoController {
+  /** One UndoManager per page id, created lazily on first visit. */
+  private readonly managers = new Map<string, Y.UndoManager>();
+  /** The manager for the currently-bound page (drives undo/redo/canUndo/canRedo). */
+  private active: Y.UndoManager | null = null;
+  private activePageId: string | null = null;
+  private readonly stackChangeCallbacks = new Set<() => void>();
+
+  /** Fired on any stack mutation of the active manager → notify subscribers. */
+  private readonly onStackEvent = (): void => {
+    this.stackChangeCallbacks.forEach((cb) => cb());
+  };
+
+  /**
+   * Point the controller at a page's shape surface, get-or-creating its manager.
+   * Called from `YjsDocument.rebindActivePage`. Idempotent for the same page.
+   */
+  setActivePage(
+    pageId: string,
+    shapes: Y.Map<Shape>,
+    order: Y.Array<string>,
+    trackedOrigin: object,
+  ): void {
+    if (this.activePageId === pageId && this.active) return;
+
+    this.detachActiveListeners();
+
+    let manager = this.managers.get(pageId);
+    if (!manager) {
+      manager = new Y.UndoManager([shapes, order], {
+        trackedOrigins: new Set([trackedOrigin]),
+        captureTimeout: CAPTURE_TIMEOUT_MS,
+      });
+      this.managers.set(pageId, manager);
+    }
+
+    this.active = manager;
+    this.activePageId = pageId;
+    this.attachActiveListeners();
+    // Availability may differ between pages → let subscribers refresh.
+    this.onStackEvent();
+  }
+
+  undo(): void {
+    this.active?.undo();
+  }
+
+  redo(): void {
+    this.active?.redo();
+  }
+
+  canUndo(): boolean {
+    return (this.active?.undoStack.length ?? 0) > 0;
+  }
+
+  canRedo(): boolean {
+    return (this.active?.redoStack.length ?? 0) > 0;
+  }
+
+  /**
+   * Close the current undo step (action anchor). Called from the `pushHistory`
+   * funnel before each discrete action's mutation, so each action becomes its own
+   * undo step rather than relying on the capture timeout.
+   */
+  closeStep(): void {
+    this.active?.stopCapturing();
+  }
+
+  /**
+   * Drop the active page's undo/redo stacks (the shapes themselves are untouched).
+   * Called once the adopted/seeded Y.Doc is the established baseline, so a user can't
+   * undo into an empty/seed document — including a never-synced `initializeFromState`
+   * seed, which transacts with the tracked origin and would otherwise be captured.
+   */
+  clearActive(): void {
+    this.active?.clear();
+  }
+
+  /** Subscribe to undo/redo stack changes (for button reactivity). */
+  onStackChange(cb: () => void): () => void {
+    this.stackChangeCallbacks.add(cb);
+    return () => this.stackChangeCallbacks.delete(cb);
+  }
+
+  /** Tear down every manager (call before the owning Y.Doc is destroyed). */
+  destroy(): void {
+    this.detachActiveListeners();
+    this.managers.forEach((m) => m.destroy());
+    this.managers.clear();
+    this.active = null;
+    this.activePageId = null;
+    this.stackChangeCallbacks.clear();
+  }
+
+  private attachActiveListeners(): void {
+    if (!this.active) return;
+    this.active.on('stack-item-added', this.onStackEvent);
+    this.active.on('stack-item-popped', this.onStackEvent);
+    this.active.on('stack-cleared', this.onStackEvent);
+  }
+
+  private detachActiveListeners(): void {
+    if (!this.active) return;
+    this.active.off('stack-item-added', this.onStackEvent);
+    this.active.off('stack-item-popped', this.onStackEvent);
+    this.active.off('stack-cleared', this.onStackEvent);
+  }
+}
+
+export default CanvasUndoController;

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -30,6 +30,7 @@ import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle, ReferenceLibrary } from '../types/Citation';
 import type { Field, FieldLibrary } from '../types/Field';
 import { getProseSchema } from './proseSchema';
+import { CanvasUndoController } from './CanvasUndoController';
 
 /**
  * Document metadata stored in Yjs
@@ -205,6 +206,13 @@ export class YjsDocument {
 
   private isLocalUpdate = false;
 
+  /**
+   * Per-user collab undo/redo (JP-402). Owns a per-page Yjs `UndoManager` filtered
+   * to this document's local-edit origin (`this`); re-pointed on every
+   * `rebindActivePage`. See {@link CanvasUndoController}.
+   */
+  private readonly undoController = new CanvasUndoController();
+
   constructor() {
     // NOTE (JP-172): the Y.Doc clientID is intentionally left as Yjs's random
     // per-instance default. An earlier version pinned it deterministically to
@@ -274,10 +282,59 @@ export class YjsDocument {
       this.boundShapes.observe(this.handleShapeChange);
       this.boundShapeOrder.observe(this.handleOrderChange);
     }
+    // JP-402: re-point the per-page undo controller at this page's surface, so
+    // undo/redo act on the page the user is editing.
+    if (this.boundShapes && this.boundShapeOrder) {
+      this.undoController.setActivePage(pageId, this.boundShapes, this.boundShapeOrder, this);
+    }
     return {
       shapes: Array.from(this.getAllShapes().values()),
       order: this.getShapeOrder(),
     };
+  }
+
+  // ============ Canvas undo/redo (JP-402) ============
+
+  /** Undo this user's last tracked canvas edit on the active page. */
+  undo(): void {
+    this.undoController.undo();
+  }
+
+  /** Redo this user's last undone canvas edit on the active page. */
+  redo(): void {
+    this.undoController.redo();
+  }
+
+  /** Whether an undo is available on the active page. */
+  canUndo(): boolean {
+    return this.undoController.canUndo();
+  }
+
+  /** Whether a redo is available on the active page. */
+  canRedo(): boolean {
+    return this.undoController.canRedo();
+  }
+
+  /**
+   * Close the current undo step (action anchor) — called from the `pushHistory`
+   * funnel so each discrete action is its own undo step.
+   */
+  closeUndoStep(): void {
+    this.undoController.closeStep();
+  }
+
+  /**
+   * Drop the active page's undo/redo history (shapes untouched). Called once the
+   * adopted/seeded Y.Doc is the established baseline, so the user can't undo into an
+   * empty/seed document.
+   */
+  clearUndoHistory(): void {
+    this.undoController.clearActive();
+  }
+
+  /** Subscribe to undo/redo stack changes (for button reactivity). */
+  onUndoStackChange(cb: () => void): () => void {
+    return this.undoController.onStackChange(cb);
   }
 
   /** The shapes on `pageId` (its own surface), regardless of the bound page. */
@@ -888,6 +945,8 @@ export class YjsDocument {
    * Destroy the document and clean up observers.
    */
   destroy(): void {
+    // JP-402: tear down the per-page undo managers before the Y.Doc is destroyed.
+    this.undoController.destroy();
     // Per-page shape surfaces are observed only while bound (JP-340).
     this.boundShapes?.unobserve(this.handleShapeChange);
     this.boundShapeOrder?.unobserve(this.handleOrderChange);

--- a/src/collaboration/YjsDocument.undo.test.ts
+++ b/src/collaboration/YjsDocument.undo.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-user canvas undo/redo in collaboration (JP-402).
+ *
+ * Safety properties (the scar-tissue cases from JP-178 / JP-330):
+ *  - Tracked-origin isolation: undo reverts only THIS user's edits; a remote edit
+ *    (applied with a foreign origin) is never on the undo stack and survives undo.
+ *  - Round-trip: an add (shape + order) is one undo step; undo removes both, redo
+ *    restores both — through the same observers a remote edit drives.
+ *  - Baseline not undoable: after the seed/adopt baseline, history is cleared so the
+ *    user can't undo into an empty doc (a never-synced `initializeFromState` seed
+ *    transacts with the tracked origin and would otherwise be captured).
+ *  - Per-page scoping: undo on the active page never touches another page.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+import type { Shape } from '../shapes/Shape';
+
+function shape(id: string): Shape {
+  return {
+    id,
+    type: 'rectangle',
+    position: { x: 0, y: 0 },
+    size: { width: 1, height: 1 },
+    rotation: 0,
+    style: {},
+  } as unknown as Shape;
+}
+
+describe('YjsDocument canvas undo/redo (JP-402)', () => {
+  it('tracks only local edits; a remote edit is not undoable and survives undo', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    // A peer's edit arrives via the provider (foreign transaction origin).
+    const peer = new YjsDocument();
+    peer.rebindActivePage('p1');
+    peer.setShape(shape('remote-1'));
+    peer.setShapeOrder(['remote-1']);
+    Y.applyUpdate(doc.getDoc(), Y.encodeStateAsUpdate(peer.getDoc()));
+
+    // Remote change is not on our undo stack.
+    expect(doc.canUndo()).toBe(false);
+
+    // A local edit IS undoable.
+    doc.setShape(shape('local-1'));
+    expect(doc.canUndo()).toBe(true);
+
+    doc.undo();
+    expect(doc.getShape('local-1')).toBeUndefined(); // our edit reverted
+    expect(doc.getShape('remote-1')).toBeDefined(); // peer's edit untouched
+    expect(doc.canRedo()).toBe(true);
+
+    doc.redo();
+    expect(doc.getShape('local-1')).toBeDefined();
+
+    doc.destroy();
+    peer.destroy();
+  });
+
+  it('add → undo → redo round-trips both shape and order in one step', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    // Two transactions in the same burst (no stopCapturing between) → one step.
+    doc.setShape(shape('s1'));
+    doc.setShapeOrder(['s1']);
+    expect(doc.getShapeOrder()).toEqual(['s1']);
+
+    doc.undo();
+    expect(doc.getAllShapes().has('s1')).toBe(false);
+    expect(doc.getShapeOrder()).toEqual([]); // order reverted too
+
+    doc.redo();
+    expect(doc.getAllShapes().has('s1')).toBe(true);
+    expect(doc.getShapeOrder()).toEqual(['s1']);
+
+    doc.destroy();
+  });
+
+  it('closeUndoStep splits consecutive edits into separate undo steps', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    doc.setShape(shape('s1'));
+    doc.closeUndoStep(); // action anchor between the two edits
+    doc.setShape(shape('s2'));
+
+    // First undo removes only the second edit.
+    doc.undo();
+    expect(doc.getAllShapes().has('s2')).toBe(false);
+    expect(doc.getAllShapes().has('s1')).toBe(true);
+
+    // Second undo removes the first.
+    doc.undo();
+    expect(doc.getAllShapes().has('s1')).toBe(false);
+
+    doc.destroy();
+  });
+
+  it('clearUndoHistory makes the seed baseline non-undoable (shapes kept)', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    // A never-synced seed transacts with the tracked origin → would be captured.
+    doc.initializeFromState([shape('seed')], ['seed']);
+    expect(doc.canUndo()).toBe(true);
+
+    doc.clearUndoHistory();
+    expect(doc.canUndo()).toBe(false);
+    expect(doc.getShape('seed')).toBeDefined(); // baseline preserved, just not undoable
+
+    doc.destroy();
+  });
+
+  it('undo is scoped per page', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+    doc.setShape(shape('s1'));
+
+    doc.rebindActivePage('p2');
+    doc.setShape(shape('s2'));
+
+    // Undo on the active page (p2) removes only p2's shape.
+    doc.undo();
+    expect(doc.getShapesForPage('p2')).toHaveLength(0);
+    expect(doc.getShapesForPage('p1').map((s) => s.id)).toEqual(['s1']);
+
+    // Switching back to p1 keeps its stack — undo there removes p1's shape.
+    doc.rebindActivePage('p1');
+    doc.undo();
+    expect(doc.getShapesForPage('p1')).toHaveLength(0);
+
+    doc.destroy();
+  });
+});

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -26,6 +26,14 @@ vi.mock('./YjsDocument', () => ({
     onOrderChange: vi.fn(() => vi.fn()),
     onMetadataChange: vi.fn(() => vi.fn()),
     initializeFromState: vi.fn(),
+    // JP-402 canvas undo/redo surface.
+    onUndoStackChange: vi.fn(() => vi.fn()),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: vi.fn(() => false),
+    canRedo: vi.fn(() => false),
+    closeUndoStep: vi.fn(),
+    clearUndoHistory: vi.fn(),
   })),
 }));
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -123,6 +123,14 @@ interface CollaborationState {
    * on the old, destroyed Y.Doc and remote changes would never reach the view.
    */
   sessionEpoch: number;
+  /**
+   * Whether the active canvas page has a per-user undo / redo step available
+   * (JP-402). Reactive mirror of the YjsDocument's `UndoManager` stacks so the
+   * toolbar buttons react in collab; refreshed via `onUndoStackChange` and reset on
+   * teardown. False outside a session.
+   */
+  canUndoCanvas: boolean;
+  canRedoCanvas: boolean;
 }
 
 /**
@@ -213,6 +221,12 @@ interface CollaborationActions {
   /** Replace a page's prose with a merge-safe CRDT diff (`programmatic` write). */
   setProse: (pageId: string, docJSON: JSONContent) => void;
 
+  // Canvas undo/redo (JP-402)
+  /** Undo this user's last canvas edit on the active page (collab). */
+  undoCanvas: () => void;
+  /** Redo this user's last undone canvas edit on the active page (collab). */
+  redoCanvas: () => void;
+
   // Document switching
   /** Switch to a different document for CRDT sync */
   switchDocument: (docId: string) => void;
@@ -257,6 +271,8 @@ let idbPersistence: IndexeddbPersistence | null = null;
 let relayClient: RelayClient | null = null;
 let connectionUnsubscribe: (() => void) | null = null;
 let awarenessUnsubscribe: (() => void) | null = null;
+/** JP-402: unsubscribe from the YjsDocument undo-stack change feed. */
+let undoStackUnsubscribe: (() => void) | null = null;
 
 /**
  * Cursor + selection broadcasts are throttled to the device's collab cadence
@@ -328,6 +344,12 @@ function teardownSession(
     awarenessUnsubscribe = null;
   }
 
+  // JP-402: stop mirroring the (about-to-be-destroyed) Y.Doc's undo stacks.
+  if (undoStackUnsubscribe) {
+    undoStackUnsubscribe();
+    undoStackUnsubscribe = null;
+  }
+
   if (connectionUnsubscribe) {
     connectionUnsubscribe();
     connectionUnsubscribe = null;
@@ -378,6 +400,8 @@ function teardownSession(
     error: null,
     remoteUsers: [],
     config: null,
+    canUndoCanvas: false,
+    canRedoCanvas: false,
   });
 }
 
@@ -395,6 +419,8 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     remoteUsers: [],
     config: null,
     sessionEpoch: 0,
+    canUndoCanvas: false,
+    canRedoCanvas: false,
 
     startSession: (config: CollaborationConfig) => {
       // Bringing a session up is an intentional transition (sign-in / doc-switch
@@ -426,6 +452,18 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // default (JP-172) — NOT keyed off documentId; doc identity is the relay
       // room below, not the clientID.
       yjsDoc = new YjsDocument();
+
+      // JP-402: mirror the per-page UndoManager stacks into reactive state so the
+      // toolbar undo/redo buttons react in collab. A fresh Y.Doc has empty stacks;
+      // the controller fires this on every tracked edit, undo/redo, and page switch.
+      set({ canUndoCanvas: false, canRedoCanvas: false });
+      undoStackUnsubscribe = yjsDoc.onUndoStackChange(() => {
+        const doc = yjsDoc;
+        set({
+          canUndoCanvas: doc ? doc.canUndo() : false,
+          canRedoCanvas: doc ? doc.canRedo() : false,
+        });
+      });
 
       // JP-108 step 3: attach local CRDT persistence BEFORE the provider connects.
       // Room is scoped per relay+doc (matching the cache/queue relay-tagging, JP-117)
@@ -798,6 +836,14 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       const doc = yjsDoc;
       if (!doc) return;
       mutateDocument('programmatic', () => doc.setProse(pageId, docJSON));
+    },
+
+    undoCanvas: () => {
+      yjsDoc?.undo();
+    },
+
+    redoCanvas: () => {
+      yjsDoc?.redo();
     },
 
     switchDocument: (docId: string) => {

--- a/src/collaboration/handleRelayJoinError.test.ts
+++ b/src/collaboration/handleRelayJoinError.test.ts
@@ -12,7 +12,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Heavy collab deps — mock so importing collaborationStore stays lightweight
 // (mirrors collaborationStore.test.ts).
 vi.mock('./YjsDocument', () => ({
-  YjsDocument: vi.fn().mockImplementation(() => ({ getDoc: vi.fn(), destroy: vi.fn() })),
+  YjsDocument: vi.fn().mockImplementation(() => ({
+    getDoc: vi.fn(),
+    destroy: vi.fn(),
+    onUndoStackChange: vi.fn(() => vi.fn()),
+    clearUndoHistory: vi.fn(),
+  })),
 }));
 vi.mock('./UnifiedSyncProvider', () => ({
   UnifiedSyncProvider: vi.fn().mockImplementation(() => ({})),

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -33,6 +33,14 @@ function makeMockYjs() {
     clear: vi.fn(),
     destroy: vi.fn(),
     initializeFromState: vi.fn(),
+    // JP-402 canvas undo/redo surface.
+    onUndoStackChange: vi.fn(() => () => {}),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: vi.fn(() => false),
+    canRedo: vi.fn(() => false),
+    closeUndoStep: vi.fn(),
+    clearUndoHistory: vi.fn(),
     onShapeChange: vi.fn((cb: (a: Shape[], u: Shape[], r: string[]) => void) => {
       shapeCbs.add(cb);
       return () => shapeCbs.delete(cb);

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -307,6 +307,10 @@ export function useCollaborationSync(): void {
     // seed concatenates `body+body`. The collapse is a CRDT delete, so it
     // propagates to the relay + peers and heals everyone. No-op on clean docs.
     if (initializedRef.current) {
+      // JP-402: the adopted/seeded Y.Doc is now the established baseline — drop any
+      // undo steps captured during seed/adopt so the user can't undo into an empty
+      // or seed document.
+      yjsDoc.clearUndoHistory();
       for (const pageId of useRichTextPagesStore.getState().pageOrder) {
         yjsDoc.healDoubledProse(pageId);
       }

--- a/src/store/historyStore.test.ts
+++ b/src/store/historyStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useHistoryStore } from './historyStore';
 import { useDocumentStore } from './documentStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
@@ -186,7 +186,7 @@ describe('History Store', () => {
       expect(useDocumentStore.getState().shapes['rect1']).toBeDefined();
     });
 
-    it('does nothing while a collab session is active (JP-178)', async () => {
+    it('delegates to the collab undo controller while a session is active (JP-178/JP-402)', async () => {
       const store = useHistoryStore.getState();
       const docStore = useDocumentStore.getState();
 
@@ -195,12 +195,17 @@ describe('History Store', () => {
       store.push('Before move');
       docStore.updateShape('rect1', { x: 100, y: 100 });
 
-      // A collab session makes the relay Y.Doc authoritative — snapshot undo is
-      // disabled (it would diverge and be clobbered on sync). Undo must no-op.
-      useCollaborationStore.setState({ isActive: true });
+      // In a collab session the relay Y.Doc is authoritative, so the SNAPSHOT undo
+      // is disabled (it would diverge and be clobbered on sync). Instead undo
+      // delegates to the per-user CRDT UndoManager (JP-402).
+      const undoCanvas = vi.fn();
+      useCollaborationStore.setState({ isActive: true, undoCanvas });
       try {
         store.undo();
+        // The snapshot path did NOT run (no local rollback)…
         expect(useDocumentStore.getState().shapes['rect1']?.x).toBe(100);
+        // …it delegated to the collab controller.
+        expect(undoCanvas).toHaveBeenCalledTimes(1);
       } finally {
         useCollaborationStore.setState({ isActive: false });
       }

--- a/src/store/historyStore.ts
+++ b/src/store/historyStore.ts
@@ -7,11 +7,15 @@ import { useCollaborationStore } from '../collaboration/collaborationStore';
  * Snapshot-based undo/redo is disabled while a collaboration session is active
  * (JP-178). The relay Y.Doc is the authoritative source whenever a collab
  * *engine* session is live — including offline-first relay docs (engine ≠
- * provider) — so restoring a local history snapshot would diverge from the
- * Y.Doc and be silently clobbered on the next sync/reload. Undo/redo therefore
- * apply only to pure local documents (no session); proper per-user collab undo
- * / version history is roadmap work. Read at call time so there is no module
- * eval-order dependency on the collaboration store.
+ * provider) — so restoring a local history *snapshot* would diverge from the
+ * Y.Doc and be silently clobbered on the next sync/reload.
+ *
+ * Instead of no-op'ing in collab, this store now **delegates** to the per-user
+ * Yjs `UndoManager` owned by the YjsDocument (JP-402): a CRDT-native undo that
+ * reverts only this user's edits and broadcasts as a normal op (no snapshot, no
+ * divergence). The snapshot path below still owns pure local documents (no
+ * session). Read at call time so there is no module eval-order dependency on the
+ * collaboration store.
  */
 function isCollabSessionActive(): boolean {
   return useCollaborationStore.getState().isActive;
@@ -252,6 +256,13 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
 
   // Actions
   push: (description?: string) => {
+    // In a collab session the snapshot path is inactive (JP-178). `pushHistory`
+    // is the single action-anchor funnel (Engine.ts → here), so close the current
+    // CRDT undo step (JP-402) — each marked action becomes its own undo step.
+    if (isCollabSessionActive()) {
+      useCollaborationStore.getState().getYjsDocument()?.closeUndoStep();
+      return;
+    }
     const state = get();
     const { activePageId, isTracking } = state;
 
@@ -303,8 +314,12 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   undo: () => {
-    // Disabled in a collab session — see isCollabSessionActive (JP-178).
-    if (isCollabSessionActive()) return;
+    // Collab: delegate to the per-user CRDT UndoManager (JP-402) instead of the
+    // snapshot path (which would diverge from the relay Y.Doc, JP-178).
+    if (isCollabSessionActive()) {
+      useCollaborationStore.getState().undoCanvas();
+      return;
+    }
     const state = get();
     const { activePageId } = state;
 
@@ -384,8 +399,11 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   redo: () => {
-    // Disabled in a collab session — see isCollabSessionActive (JP-178).
-    if (isCollabSessionActive()) return;
+    // Collab: delegate to the per-user CRDT UndoManager (JP-402).
+    if (isCollabSessionActive()) {
+      useCollaborationStore.getState().redoCanvas();
+      return;
+    }
     const state = get();
     const { activePageId } = state;
 
@@ -485,6 +503,8 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   canUndo: () => {
+    // Collab: availability comes from the CRDT UndoManager mirror (JP-402).
+    if (isCollabSessionActive()) return useCollaborationStore.getState().canUndoCanvas;
     const state = get();
     if (!state.activePageId) return false;
     const pageHist = state.pageHistory[state.activePageId];
@@ -492,6 +512,8 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   canRedo: () => {
+    // Collab: availability comes from the CRDT UndoManager mirror (JP-402).
+    if (isCollabSessionActive()) return useCollaborationStore.getState().canRedoCanvas;
     const state = get();
     if (!state.activePageId) return false;
     const pageHist = state.pageHistory[state.activePageId];

--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -113,24 +113,30 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
   const getUndoDescription = useHistoryStore((state) => state.getUndoDescription);
   const getRedoDescription = useHistoryStore((state) => state.getRedoDescription);
 
-  // Undo/redo are disabled in a collaboration session (JP-178): snapshot-based
-  // history would diverge from the authoritative relay Y.Doc. Subscribe so the
-  // buttons react when a session starts/stops.
+  // JP-402: undo/redo now work in a collab session too — backed by a per-user
+  // CRDT UndoManager (not snapshot history, which would diverge, JP-178). In collab
+  // availability comes from the reactive `canUndoCanvas`/`canRedoCanvas` mirror;
+  // subscribe so the buttons react to edits, undo/redo, and page switches.
   const collabActive = useCollaborationStore((state) => state.isActive);
+  const canUndoCanvas = useCollaborationStore((state) => state.canUndoCanvas);
+  const canRedoCanvas = useCollaborationStore((state) => state.canRedoCanvas);
 
   // Derive descriptions reactively (pageHistory triggers re-render)
   const _ph = pageHistory; const _ap = activeHistoryPage; // ensure subscription
   void _ph; void _ap;
   const undoDesc = getUndoDescription();
   const redoDesc = getRedoDescription();
-  const collabUndoNote = 'Undo/redo are unavailable in shared documents';
+  // In collab, undo/redo act on this user's own changes; descriptions come from the
+  // snapshot history, which is inactive there, so use a plain label.
+  const undoEnabled = collabActive ? canUndoCanvas : canUndo();
+  const redoEnabled = collabActive ? canRedoCanvas : canRedo();
   const undoTitle = collabActive
-    ? collabUndoNote
+    ? 'Undo your last change (Ctrl+Z)'
     : undoDesc
       ? `Undo: ${undoDesc} (Ctrl+Z)`
       : 'Undo (Ctrl+Z)';
   const redoTitle = collabActive
-    ? collabUndoNote
+    ? 'Redo your last change (Ctrl+Y)'
     : redoDesc
       ? `Redo: ${redoDesc} (Ctrl+Y)`
       : 'Redo (Ctrl+Y)';
@@ -209,7 +215,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
         <button
           className="toolbar-action-btn"
           onClick={undo}
-          disabled={collabActive || !canUndo()}
+          disabled={!undoEnabled}
           title={undoTitle}
           aria-label={undoTitle}
         >
@@ -218,7 +224,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
         <button
           className="toolbar-action-btn"
           onClick={redo}
-          disabled={collabActive || !canRedo()}
+          disabled={!redoEnabled}
           title={redoTitle}
           aria-label={redoTitle}
         >


### PR DESCRIPTION
## What

Per-user **live** canvas undo/redo that works in a collaboration session. Today canvas undo/redo is fully disabled in collab (JP-178) because the snapshot path would diverge from the authoritative relay Y.Doc — so users doing major rework in a shared doc (e.g. while their team is away) have no Ctrl+Z at all. This makes `Ctrl+Z` / `Ctrl+Shift+Z` (and the toolbar buttons) work in shared docs, reverting **only this user's own** edits.

Closes JP-402.

## How

A per-page Yjs `UndoManager` (`CanvasUndoController`) scoped to each canvas page's `shapes:<id>` / `shapeOrder:<id>` shared types and filtered to a single **tracked origin** — the owning `YjsDocument`. Local canvas edits already transact with that origin (`withLocalUpdate` → `doc.transact(fn, this)`), so only this user's edits are captured; remote edits arrive with a foreign origin and are ignored. An undo is a real CRDT op (origin = the UndoManager, not the doc), so it re-renders through the existing `remote-apply` pipeline and broadcasts to peers like any other edit — **no snapshot, no divergence**. This is the same mechanism collab prose already uses.

- `historyStore` **delegates** `undo/redo/canUndo/canRedo` to the controller in collab (snapshot path still owns pure local docs).
- `pushHistory()` is the single action-anchor funnel → it calls `stopCapturing()` so each discrete action is its own undo step; `captureTimeout` (1000ms) is only the fallback grouping for un-anchored bursts (e.g. property tweaks).
- `collaborationStore` exposes reactive `canUndoCanvas` / `canRedoCanvas`; the `CanvasToolbar` undo/redo buttons are re-enabled in collab.
- Baseline is cleared after adopt/seed so the user can't undo into an empty/seed doc.
- **Redo is intrinsic** to the UndoManager (ships here).

## Granularity

Time-grouped with action anchors. Each `pushHistory`-marked action (move/resize/rotate/delete/create/group/align/paste/import/auto-layout/inline-text) is its own undo step; un-anchored bursts within ~1s coalesce. This matches the coarseness of the old snapshot undo without any sync-architecture change.

## Safety / stability

- Undo only inverts the user's **own** ops — no peer data-loss vector.
- Undo removals update `documentStore` under `remote-apply`, which gates off the local→CRDT diff, so they can't trigger the #59 mass-delete class; the inverse op reaches peers via the provider (the correct channel).
- Reuses the hardened `reorderShapes` permutation guard + JP-330 keep-first dedupe — an undo emits the same event shape as a remote peer edit, not a novel one.
- **No wire/format/migration change** — pure client runtime over existing Y types. Undo stacks are in-memory/session-scoped, like the snapshot history they replace in collab.
- Local-doc snapshot undo is unchanged.

## Out of scope

- JP-185 version-history timeline (complementary coarse-grained recovery; stays on roadmap).
- Per-gesture (explicit edit→op) precision (JP-178's larger someday goal).

## Tests

`bun run typecheck`, full `bun run test --run` (2762 passing), and `bun run build` all green. New/updated TDD coverage:
- tracked-origin isolation (remote edits not undoable, survive undo)
- add → undo → redo round-trip (shape + order in one step)
- step splitting via `closeUndoStep`
- baseline-cleared (seed not undoable)
- per-page scoping
- the collab history test now asserts **delegation** (was: no-op)

## Manual E2E (needs deploy)

Two sessions on a staging relay doc: A adds/moves/deletes shapes; A's Ctrl+Z reverts A's changes live and B sees the revert; A's Ctrl+Z does **not** revert B's edits; verify across a page switch; verify a local (non-collab) doc's undo still works.

Assisted-by: Opus 4.8