### PR TITLE
Deploy to staging: JP-402 collab undo + JP-401/399/33 style profiles + JP-397 JWKS

### DIFF
--- a/relay/src/auth/jwks.rs
+++ b/relay/src/auth/jwks.rs
@@ -27,6 +27,13 @@ pub const REFRESH_INTERVAL: Duration = Duration::from_secs(300);
 pub const FAIL_OPEN_GRACE: Duration = Duration::from_secs(3600);
 /// Floor between debounced on-demand refreshes (unknown-kid path).
 const ON_DEMAND_DEBOUNCE: Duration = Duration::from_secs(5);
+/// Bound on the boot-time JWKS warm-up (JP-397). Must stay under the platform's
+/// boot grace so a slow/unreachable JWKS endpoint can't deadlock startup.
+pub const BOOT_WARMUP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Background-refresh cadence *until the first success* — a pod that booted while
+/// the JWKS endpoint was briefly down recovers in seconds, not a full
+/// `REFRESH_INTERVAL` (JP-397). Switches to `REFRESH_INTERVAL` once warm.
+const COLD_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Deserialize)]
 struct Jwk {
@@ -100,15 +107,54 @@ impl JwksCache {
             // Eagerly attempt one fetch on boot so the first request
             // doesn't have to pay the cold-cache latency.
             let _ = me.refresh_once().await;
-            let mut ticker = tokio::time::interval(REFRESH_INTERVAL);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            // First tick fires immediately; absorb it.
-            ticker.tick().await;
             loop {
-                ticker.tick().await;
+                // JP-397: until the cache has ever succeeded, retry on a short
+                // cadence so a pod that booted while the JWKS endpoint was briefly
+                // down recovers in seconds rather than a full `REFRESH_INTERVAL`.
+                // Once warm, settle into the steady cadence.
+                let interval = if me.is_ready().await {
+                    REFRESH_INTERVAL
+                } else {
+                    COLD_RETRY_INTERVAL
+                };
+                tokio::time::sleep(interval).await;
                 let _ = me.refresh_once().await;
             }
         })
+    }
+
+    /// True once the cache has had at least one successful fetch — i.e. it can
+    /// validate tokens. Drives the boot warm-up gate and the cold-retry cadence.
+    pub async fn is_ready(&self) -> bool {
+        self.inner.read().await.last_success.is_some()
+    }
+
+    /// Block (up to `timeout`) until the first successful JWKS fetch lands, so a
+    /// freshly-booted/redeployed pod doesn't serve a cold-cache 401 for a valid
+    /// token (JP-397). Retries `refresh_once` on a short exponential backoff.
+    /// Returns whether the cache became ready; on timeout the caller proceeds
+    /// anyway (fail-open — a down JWKS endpoint must not deadlock boot; the
+    /// background refresher keeps trying and `get()` reports `JwksUnavailable`
+    /// → 503 in the meantime).
+    pub async fn warm_up(&self, timeout: Duration) -> bool {
+        // Already warm (e.g. the background refresher beat us, or a prior call) —
+        // skip a redundant fetch.
+        if self.is_ready().await {
+            return true;
+        }
+        let deadline = Instant::now() + timeout;
+        let mut backoff = Duration::from_millis(250);
+        loop {
+            if self.refresh_once().await.is_ok() {
+                return true;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            tokio::time::sleep(backoff.min(deadline - now)).await;
+            backoff = (backoff * 2).min(Duration::from_secs(1));
+        }
     }
 
     /// Resolve a `kid` for the validation path. Returns `Ok(Some(key))`

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -248,8 +248,32 @@ async fn run_serve(
         revocations.clone(),
     );
 
-    // Spawn the periodic JWKS refresh (5-min cadence + 1-h fail-open
-    // grace; see `token-format.md`).
+    // JP-397: block (bounded) on the first JWKS fetch BEFORE we bind the
+    // listener, so a freshly-booted / just-redeployed pod never rejects a valid
+    // token with a cold-cache 401 (deferring the bind also means the platform's
+    // health check holds traffic / holds the old machine in a rolling deploy
+    // until this pod is truly ready). Skipped when no JWKS URL is configured
+    // (static-token-only deployments). Fail-open: on timeout we log and proceed —
+    // the background refresher keeps trying and `JwksUnavailable` surfaces as a
+    // 503 (not a 401) meanwhile.
+    if !config.auth.jwks_url.trim().is_empty() {
+        let warm_started = std::time::Instant::now();
+        if jwks_cache
+            .warm_up(docushark_relay::auth::jwks::BOOT_WARMUP_TIMEOUT)
+            .await
+        {
+            log::info!("JWKS warm-up complete in {:?}", warm_started.elapsed());
+        } else {
+            log::warn!(
+                "JWKS warm-up timed out after {:?}; serving may 503 until JWKS is reachable at {}",
+                docushark_relay::auth::jwks::BOOT_WARMUP_TIMEOUT,
+                config.auth.jwks_url,
+            );
+        }
+    }
+
+    // Spawn the periodic JWKS refresh (5-min steady cadence, short cold-retry
+    // until the first success, + 1-h fail-open grace; see `token-format.md`).
     let _jwks_refresh_handle = jwks_cache.start_background_refresh();
 
     // Optional polling fallback for revocations. Push transport lives

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -2318,9 +2318,16 @@ async fn extract_jwt_from_headers(
 }
 
 /// Map an `AuthError` to the same opacity contract the WS path uses:
-/// 401 for anything signature/claim-related, 403 for region/workspace.
+/// 401 for anything signature/claim-related, 403 for region/workspace, and
+/// **503 for `JwksUnavailable`** — the relay couldn't *validate* the token right
+/// now (its JWKS isn't loaded yet on a cold/just-redeployed pod), which is a
+/// relay-availability condition, not a token rejection. Surfacing it as 503
+/// (rather than 401) stops a client from mistaking a transient blip for a bad
+/// token and signing the user out (JP-396/JP-397); the token is unchanged and
+/// succeeds once the relay warms.
 pub(crate) fn auth_error_to_http(e: &AuthError) -> (StatusCode, String) {
     let status = match e {
+        AuthError::JwksUnavailable => StatusCode::SERVICE_UNAVAILABLE,
         AuthError::WorkspaceMismatch | AuthError::RegionMismatch => StatusCode::FORBIDDEN,
         _ => StatusCode::UNAUTHORIZED,
     };
@@ -3402,6 +3409,14 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
         return;
     }
 
+    // JP-397: on a cold/recycled pod the in-memory index can be empty even
+    // though the doc exists in R2. The per-doc `ensure_doc_local` above restores
+    // a doc by id; this additionally restores the workspace `index.json` (the
+    // authoritative doc set) — the same R2-restore guard the REST list path uses
+    // — so we don't emit `ERR_UNKNOWN_DOC` for a doc that's merely not-loaded-yet.
+    // Idempotent + cheap: no-op once the index is populated or on a non-S3 backend.
+    state.ensure_workspace_index_local(&workspace_id).await;
+
     if state
         .doc_store()
         .get_metadata(&workspace_id, &request.doc_id)
@@ -3524,6 +3539,28 @@ async fn send_to_client(client_id: u64, data: Vec<u8>, state: &Arc<ServerState>)
 mod tests {
     use super::*;
     use crate::config::{LimitsConfig, TenancyConfig, TenancyMode};
+
+    #[test]
+    fn jwks_unavailable_maps_to_503_not_401() {
+        // JP-397: a relay-availability failure must be a 503 so a client doesn't
+        // mistake it for a token rejection and sign the user out.
+        assert_eq!(
+            auth_error_to_http(&AuthError::JwksUnavailable).0,
+            StatusCode::SERVICE_UNAVAILABLE,
+        );
+        // Genuine token rejections stay 401.
+        for e in [
+            AuthError::MissingKid,
+            AuthError::UnknownKid("k".into()),
+            AuthError::Expired,
+        ] {
+            assert_eq!(auth_error_to_http(&e).0, StatusCode::UNAUTHORIZED, "{e:?}");
+        }
+        // Scope mismatches stay 403.
+        for e in [AuthError::WorkspaceMismatch, AuthError::RegionMismatch] {
+            assert_eq!(auth_error_to_http(&e).0, StatusCode::FORBIDDEN, "{e:?}");
+        }
+    }
 
     #[tokio::test]
     async fn test_server_lifecycle() {

--- a/relay/tests/jwks_cold_start.rs
+++ b/relay/tests/jwks_cold_start.rs
@@ -1,0 +1,99 @@
+//! JP-397 — JWKS cold-start hardening.
+//!
+//! 1. `is_ready` / `warm_up` reflect whether the cache has ever loaded a key.
+//! 2. A relay whose JWKS cache hasn't loaded yet answers an authed REST request
+//!    with **503** (relay can't validate right now), NOT 401 (token rejected) —
+//!    so a client doesn't mistake a cold-pod blip for a bad token and sign out.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use docushark_relay::auth::{
+    JwksCache, OidcAuthState, OidcValidationConfig, RevocationSet, WorkspaceRole,
+};
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+
+/// An unroutable JWKS URL (discard port) so a refresh attempt always fails fast.
+const DEAD_JWKS: &str = "http://127.0.0.1:9/jwks";
+
+#[tokio::test]
+async fn is_ready_and_warm_up_reflect_cache_state() {
+    // Cold cache pointing at an unreachable endpoint is never ready.
+    let cold = JwksCache::new(DEAD_JWKS.to_string());
+    assert!(!cold.is_ready().await);
+
+    // warm_up against a dead endpoint returns false and respects its bound.
+    let t0 = std::time::Instant::now();
+    assert!(!cold.warm_up(Duration::from_millis(300)).await);
+    assert!(t0.elapsed() < Duration::from_secs(5), "warm_up overran its timeout");
+    assert!(!cold.is_ready().await);
+
+    // A preloaded cache (the test issuer's) is ready, and warm_up short-circuits
+    // to true without touching any endpoint.
+    let issuer = OidcTestIssuer::new().await;
+    let warm = issuer.auth_state().jwks;
+    assert!(warm.is_ready().await);
+    assert!(warm.warm_up(Duration::from_millis(1)).await);
+}
+
+#[tokio::test]
+async fn cold_jwks_returns_503_not_401() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Mint a structurally-valid token from a real issuer...
+    let issuer = OidcTestIssuer::new().await;
+    let token = issuer.mint("user-cold", "ws-cold", WorkspaceRole::Owner);
+
+    // ...but give the SERVER a cold cache that can't resolve the kid. Validation
+    // hits the JWKS lookup before any signature/claim check, so it returns
+    // `JwksUnavailable` → 503.
+    let cold_auth = OidcAuthState::new(
+        OidcValidationConfig {
+            issuer: "https://test.docushark.app".to_string(),
+            audience: "docushark-relay".to_string(),
+            resource: None,
+        },
+        JwksCache::new(DEAD_JWKS.to_string()),
+        RevocationSet::new(),
+    );
+
+    let server = Arc::new(WebSocketServer::new());
+    server.set_app_data_dir(tmp.path().to_path_buf()).await;
+    server.set_auth(cold_auth).await;
+    server
+        .set_tenancy(TenancyConfig {
+            mode: TenancyMode::Shared,
+            workspace_id: None,
+            ..TenancyConfig::default()
+        })
+        .await;
+    server
+        .set_config(ServerConfig {
+            port: 0,
+            network_mode: NetworkMode::Localhost,
+            max_connections: 0,
+        })
+        .await
+        .expect("set_config");
+    let bound = server.start(0).await.expect("start");
+    let http = bound
+        .strip_prefix("ws://")
+        .map(|rest| format!("http://{rest}"))
+        .unwrap_or(bound);
+
+    let status = reqwest::Client::new()
+        .get(format!("{http}/api/docs"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("request")
+        .status();
+
+    assert_eq!(
+        status,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "cold JWKS must surface as 503, not 401",
+    );
+}

--- a/src/collaboration/CanvasUndoController.ts
+++ b/src/collaboration/CanvasUndoController.ts
@@ -1,0 +1,147 @@
+/**
+ * CanvasUndoController — per-user "best effort" canvas undo/redo in collaboration
+ * (JP-402).
+ *
+ * Snapshot-based history (`historyStore`) is disabled in a collab session (JP-178)
+ * because restoring a local snapshot diverges from the authoritative relay Y.Doc.
+ * This controller is the collab-native answer: a Yjs `UndoManager` per canvas page,
+ * scoped to that page's `shapes:<id>` / `shapeOrder:<id>` shared types and filtered
+ * to a single tracked origin — the owning `YjsDocument` instance.
+ *
+ * Why that origin filter is the whole trick: every LOCAL canvas mutation runs through
+ * `YjsDocument.withLocalUpdate()` → `doc.transact(fn, this)`, so local edits carry the
+ * `YjsDocument` as their transaction origin, while remote edits arrive via the provider
+ * (a different origin) and adopt/load writes never touch these maps. So
+ * `trackedOrigins: {yjsDoc}` captures *only this user's* edits — and an `undo()` is a
+ * real CRDT op (origin = the UndoManager, not `yjsDoc`), so it re-renders through the
+ * existing remote-apply pipeline and broadcasts to peers like any other edit. No
+ * snapshot, no divergence.
+ *
+ * Managers are cached per page (the `shapes:<id>` Y.Map instance is stable for the
+ * Y.Doc's lifetime), so per-page undo stacks survive page switches — matching the
+ * existing per-page history model. Stacks are in-memory and session-scoped (lost on
+ * reload), exactly like the snapshot history they stand in for.
+ */
+
+import * as Y from 'yjs';
+import type { Shape } from '../shapes/Shape';
+
+/**
+ * Coalescing window for un-anchored edit bursts (ms). The real step boundaries come
+ * from `closeStep()` (called at every `pushHistory` action anchor); this timeout only
+ * groups edits with no anchor between them (e.g. rapid property-panel tweaks). It is a
+ * feel knob, NOT a perf lever — undo cost is in observing/inverting ops, independent of
+ * the window.
+ */
+const CAPTURE_TIMEOUT_MS = 1000;
+
+export class CanvasUndoController {
+  /** One UndoManager per page id, created lazily on first visit. */
+  private readonly managers = new Map<string, Y.UndoManager>();
+  /** The manager for the currently-bound page (drives undo/redo/canUndo/canRedo). */
+  private active: Y.UndoManager | null = null;
+  private activePageId: string | null = null;
+  private readonly stackChangeCallbacks = new Set<() => void>();
+
+  /** Fired on any stack mutation of the active manager → notify subscribers. */
+  private readonly onStackEvent = (): void => {
+    this.stackChangeCallbacks.forEach((cb) => cb());
+  };
+
+  /**
+   * Point the controller at a page's shape surface, get-or-creating its manager.
+   * Called from `YjsDocument.rebindActivePage`. Idempotent for the same page.
+   */
+  setActivePage(
+    pageId: string,
+    shapes: Y.Map<Shape>,
+    order: Y.Array<string>,
+    trackedOrigin: object,
+  ): void {
+    if (this.activePageId === pageId && this.active) return;
+
+    this.detachActiveListeners();
+
+    let manager = this.managers.get(pageId);
+    if (!manager) {
+      manager = new Y.UndoManager([shapes, order], {
+        trackedOrigins: new Set([trackedOrigin]),
+        captureTimeout: CAPTURE_TIMEOUT_MS,
+      });
+      this.managers.set(pageId, manager);
+    }
+
+    this.active = manager;
+    this.activePageId = pageId;
+    this.attachActiveListeners();
+    // Availability may differ between pages → let subscribers refresh.
+    this.onStackEvent();
+  }
+
+  undo(): void {
+    this.active?.undo();
+  }
+
+  redo(): void {
+    this.active?.redo();
+  }
+
+  canUndo(): boolean {
+    return (this.active?.undoStack.length ?? 0) > 0;
+  }
+
+  canRedo(): boolean {
+    return (this.active?.redoStack.length ?? 0) > 0;
+  }
+
+  /**
+   * Close the current undo step (action anchor). Called from the `pushHistory`
+   * funnel before each discrete action's mutation, so each action becomes its own
+   * undo step rather than relying on the capture timeout.
+   */
+  closeStep(): void {
+    this.active?.stopCapturing();
+  }
+
+  /**
+   * Drop the active page's undo/redo stacks (the shapes themselves are untouched).
+   * Called once the adopted/seeded Y.Doc is the established baseline, so a user can't
+   * undo into an empty/seed document — including a never-synced `initializeFromState`
+   * seed, which transacts with the tracked origin and would otherwise be captured.
+   */
+  clearActive(): void {
+    this.active?.clear();
+  }
+
+  /** Subscribe to undo/redo stack changes (for button reactivity). */
+  onStackChange(cb: () => void): () => void {
+    this.stackChangeCallbacks.add(cb);
+    return () => this.stackChangeCallbacks.delete(cb);
+  }
+
+  /** Tear down every manager (call before the owning Y.Doc is destroyed). */
+  destroy(): void {
+    this.detachActiveListeners();
+    this.managers.forEach((m) => m.destroy());
+    this.managers.clear();
+    this.active = null;
+    this.activePageId = null;
+    this.stackChangeCallbacks.clear();
+  }
+
+  private attachActiveListeners(): void {
+    if (!this.active) return;
+    this.active.on('stack-item-added', this.onStackEvent);
+    this.active.on('stack-item-popped', this.onStackEvent);
+    this.active.on('stack-cleared', this.onStackEvent);
+  }
+
+  private detachActiveListeners(): void {
+    if (!this.active) return;
+    this.active.off('stack-item-added', this.onStackEvent);
+    this.active.off('stack-item-popped', this.onStackEvent);
+    this.active.off('stack-cleared', this.onStackEvent);
+  }
+}
+
+export default CanvasUndoController;

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -30,6 +30,7 @@ import type { Shape } from '../shapes/Shape';
 import type { CSLItem, CitationStyle, ReferenceLibrary } from '../types/Citation';
 import type { Field, FieldLibrary } from '../types/Field';
 import { getProseSchema } from './proseSchema';
+import { CanvasUndoController } from './CanvasUndoController';
 
 /**
  * Document metadata stored in Yjs
@@ -205,6 +206,13 @@ export class YjsDocument {
 
   private isLocalUpdate = false;
 
+  /**
+   * Per-user collab undo/redo (JP-402). Owns a per-page Yjs `UndoManager` filtered
+   * to this document's local-edit origin (`this`); re-pointed on every
+   * `rebindActivePage`. See {@link CanvasUndoController}.
+   */
+  private readonly undoController = new CanvasUndoController();
+
   constructor() {
     // NOTE (JP-172): the Y.Doc clientID is intentionally left as Yjs's random
     // per-instance default. An earlier version pinned it deterministically to
@@ -274,10 +282,59 @@ export class YjsDocument {
       this.boundShapes.observe(this.handleShapeChange);
       this.boundShapeOrder.observe(this.handleOrderChange);
     }
+    // JP-402: re-point the per-page undo controller at this page's surface, so
+    // undo/redo act on the page the user is editing.
+    if (this.boundShapes && this.boundShapeOrder) {
+      this.undoController.setActivePage(pageId, this.boundShapes, this.boundShapeOrder, this);
+    }
     return {
       shapes: Array.from(this.getAllShapes().values()),
       order: this.getShapeOrder(),
     };
+  }
+
+  // ============ Canvas undo/redo (JP-402) ============
+
+  /** Undo this user's last tracked canvas edit on the active page. */
+  undo(): void {
+    this.undoController.undo();
+  }
+
+  /** Redo this user's last undone canvas edit on the active page. */
+  redo(): void {
+    this.undoController.redo();
+  }
+
+  /** Whether an undo is available on the active page. */
+  canUndo(): boolean {
+    return this.undoController.canUndo();
+  }
+
+  /** Whether a redo is available on the active page. */
+  canRedo(): boolean {
+    return this.undoController.canRedo();
+  }
+
+  /**
+   * Close the current undo step (action anchor) — called from the `pushHistory`
+   * funnel so each discrete action is its own undo step.
+   */
+  closeUndoStep(): void {
+    this.undoController.closeStep();
+  }
+
+  /**
+   * Drop the active page's undo/redo history (shapes untouched). Called once the
+   * adopted/seeded Y.Doc is the established baseline, so the user can't undo into an
+   * empty/seed document.
+   */
+  clearUndoHistory(): void {
+    this.undoController.clearActive();
+  }
+
+  /** Subscribe to undo/redo stack changes (for button reactivity). */
+  onUndoStackChange(cb: () => void): () => void {
+    return this.undoController.onStackChange(cb);
   }
 
   /** The shapes on `pageId` (its own surface), regardless of the bound page. */
@@ -888,6 +945,8 @@ export class YjsDocument {
    * Destroy the document and clean up observers.
    */
   destroy(): void {
+    // JP-402: tear down the per-page undo managers before the Y.Doc is destroyed.
+    this.undoController.destroy();
     // Per-page shape surfaces are observed only while bound (JP-340).
     this.boundShapes?.unobserve(this.handleShapeChange);
     this.boundShapeOrder?.unobserve(this.handleOrderChange);

--- a/src/collaboration/YjsDocument.undo.test.ts
+++ b/src/collaboration/YjsDocument.undo.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-user canvas undo/redo in collaboration (JP-402).
+ *
+ * Safety properties (the scar-tissue cases from JP-178 / JP-330):
+ *  - Tracked-origin isolation: undo reverts only THIS user's edits; a remote edit
+ *    (applied with a foreign origin) is never on the undo stack and survives undo.
+ *  - Round-trip: an add (shape + order) is one undo step; undo removes both, redo
+ *    restores both — through the same observers a remote edit drives.
+ *  - Baseline not undoable: after the seed/adopt baseline, history is cleared so the
+ *    user can't undo into an empty doc (a never-synced `initializeFromState` seed
+ *    transacts with the tracked origin and would otherwise be captured).
+ *  - Per-page scoping: undo on the active page never touches another page.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+import type { Shape } from '../shapes/Shape';
+
+function shape(id: string): Shape {
+  return {
+    id,
+    type: 'rectangle',
+    position: { x: 0, y: 0 },
+    size: { width: 1, height: 1 },
+    rotation: 0,
+    style: {},
+  } as unknown as Shape;
+}
+
+describe('YjsDocument canvas undo/redo (JP-402)', () => {
+  it('tracks only local edits; a remote edit is not undoable and survives undo', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    // A peer's edit arrives via the provider (foreign transaction origin).
+    const peer = new YjsDocument();
+    peer.rebindActivePage('p1');
+    peer.setShape(shape('remote-1'));
+    peer.setShapeOrder(['remote-1']);
+    Y.applyUpdate(doc.getDoc(), Y.encodeStateAsUpdate(peer.getDoc()));
+
+    // Remote change is not on our undo stack.
+    expect(doc.canUndo()).toBe(false);
+
+    // A local edit IS undoable.
+    doc.setShape(shape('local-1'));
+    expect(doc.canUndo()).toBe(true);
+
+    doc.undo();
+    expect(doc.getShape('local-1')).toBeUndefined(); // our edit reverted
+    expect(doc.getShape('remote-1')).toBeDefined(); // peer's edit untouched
+    expect(doc.canRedo()).toBe(true);
+
+    doc.redo();
+    expect(doc.getShape('local-1')).toBeDefined();
+
+    doc.destroy();
+    peer.destroy();
+  });
+
+  it('add → undo → redo round-trips both shape and order in one step', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    // Two transactions in the same burst (no stopCapturing between) → one step.
+    doc.setShape(shape('s1'));
+    doc.setShapeOrder(['s1']);
+    expect(doc.getShapeOrder()).toEqual(['s1']);
+
+    doc.undo();
+    expect(doc.getAllShapes().has('s1')).toBe(false);
+    expect(doc.getShapeOrder()).toEqual([]); // order reverted too
+
+    doc.redo();
+    expect(doc.getAllShapes().has('s1')).toBe(true);
+    expect(doc.getShapeOrder()).toEqual(['s1']);
+
+    doc.destroy();
+  });
+
+  it('closeUndoStep splits consecutive edits into separate undo steps', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    doc.setShape(shape('s1'));
+    doc.closeUndoStep(); // action anchor between the two edits
+    doc.setShape(shape('s2'));
+
+    // First undo removes only the second edit.
+    doc.undo();
+    expect(doc.getAllShapes().has('s2')).toBe(false);
+    expect(doc.getAllShapes().has('s1')).toBe(true);
+
+    // Second undo removes the first.
+    doc.undo();
+    expect(doc.getAllShapes().has('s1')).toBe(false);
+
+    doc.destroy();
+  });
+
+  it('clearUndoHistory makes the seed baseline non-undoable (shapes kept)', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+
+    // A never-synced seed transacts with the tracked origin → would be captured.
+    doc.initializeFromState([shape('seed')], ['seed']);
+    expect(doc.canUndo()).toBe(true);
+
+    doc.clearUndoHistory();
+    expect(doc.canUndo()).toBe(false);
+    expect(doc.getShape('seed')).toBeDefined(); // baseline preserved, just not undoable
+
+    doc.destroy();
+  });
+
+  it('undo is scoped per page', () => {
+    const doc = new YjsDocument();
+    doc.rebindActivePage('p1');
+    doc.setShape(shape('s1'));
+
+    doc.rebindActivePage('p2');
+    doc.setShape(shape('s2'));
+
+    // Undo on the active page (p2) removes only p2's shape.
+    doc.undo();
+    expect(doc.getShapesForPage('p2')).toHaveLength(0);
+    expect(doc.getShapesForPage('p1').map((s) => s.id)).toEqual(['s1']);
+
+    // Switching back to p1 keeps its stack — undo there removes p1's shape.
+    doc.rebindActivePage('p1');
+    doc.undo();
+    expect(doc.getShapesForPage('p1')).toHaveLength(0);
+
+    doc.destroy();
+  });
+});

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -26,6 +26,14 @@ vi.mock('./YjsDocument', () => ({
     onOrderChange: vi.fn(() => vi.fn()),
     onMetadataChange: vi.fn(() => vi.fn()),
     initializeFromState: vi.fn(),
+    // JP-402 canvas undo/redo surface.
+    onUndoStackChange: vi.fn(() => vi.fn()),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: vi.fn(() => false),
+    canRedo: vi.fn(() => false),
+    closeUndoStep: vi.fn(),
+    clearUndoHistory: vi.fn(),
   })),
 }));
 

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -123,6 +123,14 @@ interface CollaborationState {
    * on the old, destroyed Y.Doc and remote changes would never reach the view.
    */
   sessionEpoch: number;
+  /**
+   * Whether the active canvas page has a per-user undo / redo step available
+   * (JP-402). Reactive mirror of the YjsDocument's `UndoManager` stacks so the
+   * toolbar buttons react in collab; refreshed via `onUndoStackChange` and reset on
+   * teardown. False outside a session.
+   */
+  canUndoCanvas: boolean;
+  canRedoCanvas: boolean;
 }
 
 /**
@@ -213,6 +221,12 @@ interface CollaborationActions {
   /** Replace a page's prose with a merge-safe CRDT diff (`programmatic` write). */
   setProse: (pageId: string, docJSON: JSONContent) => void;
 
+  // Canvas undo/redo (JP-402)
+  /** Undo this user's last canvas edit on the active page (collab). */
+  undoCanvas: () => void;
+  /** Redo this user's last undone canvas edit on the active page (collab). */
+  redoCanvas: () => void;
+
   // Document switching
   /** Switch to a different document for CRDT sync */
   switchDocument: (docId: string) => void;
@@ -257,6 +271,8 @@ let idbPersistence: IndexeddbPersistence | null = null;
 let relayClient: RelayClient | null = null;
 let connectionUnsubscribe: (() => void) | null = null;
 let awarenessUnsubscribe: (() => void) | null = null;
+/** JP-402: unsubscribe from the YjsDocument undo-stack change feed. */
+let undoStackUnsubscribe: (() => void) | null = null;
 
 /**
  * Cursor + selection broadcasts are throttled to the device's collab cadence
@@ -328,6 +344,12 @@ function teardownSession(
     awarenessUnsubscribe = null;
   }
 
+  // JP-402: stop mirroring the (about-to-be-destroyed) Y.Doc's undo stacks.
+  if (undoStackUnsubscribe) {
+    undoStackUnsubscribe();
+    undoStackUnsubscribe = null;
+  }
+
   if (connectionUnsubscribe) {
     connectionUnsubscribe();
     connectionUnsubscribe = null;
@@ -378,6 +400,8 @@ function teardownSession(
     error: null,
     remoteUsers: [],
     config: null,
+    canUndoCanvas: false,
+    canRedoCanvas: false,
   });
 }
 
@@ -395,6 +419,8 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     remoteUsers: [],
     config: null,
     sessionEpoch: 0,
+    canUndoCanvas: false,
+    canRedoCanvas: false,
 
     startSession: (config: CollaborationConfig) => {
       // Bringing a session up is an intentional transition (sign-in / doc-switch
@@ -426,6 +452,18 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // default (JP-172) — NOT keyed off documentId; doc identity is the relay
       // room below, not the clientID.
       yjsDoc = new YjsDocument();
+
+      // JP-402: mirror the per-page UndoManager stacks into reactive state so the
+      // toolbar undo/redo buttons react in collab. A fresh Y.Doc has empty stacks;
+      // the controller fires this on every tracked edit, undo/redo, and page switch.
+      set({ canUndoCanvas: false, canRedoCanvas: false });
+      undoStackUnsubscribe = yjsDoc.onUndoStackChange(() => {
+        const doc = yjsDoc;
+        set({
+          canUndoCanvas: doc ? doc.canUndo() : false,
+          canRedoCanvas: doc ? doc.canRedo() : false,
+        });
+      });
 
       // JP-108 step 3: attach local CRDT persistence BEFORE the provider connects.
       // Room is scoped per relay+doc (matching the cache/queue relay-tagging, JP-117)
@@ -798,6 +836,14 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       const doc = yjsDoc;
       if (!doc) return;
       mutateDocument('programmatic', () => doc.setProse(pageId, docJSON));
+    },
+
+    undoCanvas: () => {
+      yjsDoc?.undo();
+    },
+
+    redoCanvas: () => {
+      yjsDoc?.redo();
     },
 
     switchDocument: (docId: string) => {

--- a/src/collaboration/handleRelayJoinError.test.ts
+++ b/src/collaboration/handleRelayJoinError.test.ts
@@ -12,7 +12,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Heavy collab deps — mock so importing collaborationStore stays lightweight
 // (mirrors collaborationStore.test.ts).
 vi.mock('./YjsDocument', () => ({
-  YjsDocument: vi.fn().mockImplementation(() => ({ getDoc: vi.fn(), destroy: vi.fn() })),
+  YjsDocument: vi.fn().mockImplementation(() => ({
+    getDoc: vi.fn(),
+    destroy: vi.fn(),
+    onUndoStackChange: vi.fn(() => vi.fn()),
+    clearUndoHistory: vi.fn(),
+  })),
 }));
 vi.mock('./UnifiedSyncProvider', () => ({
   UnifiedSyncProvider: vi.fn().mockImplementation(() => ({})),

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -33,6 +33,14 @@ function makeMockYjs() {
     clear: vi.fn(),
     destroy: vi.fn(),
     initializeFromState: vi.fn(),
+    // JP-402 canvas undo/redo surface.
+    onUndoStackChange: vi.fn(() => () => {}),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: vi.fn(() => false),
+    canRedo: vi.fn(() => false),
+    closeUndoStep: vi.fn(),
+    clearUndoHistory: vi.fn(),
     onShapeChange: vi.fn((cb: (a: Shape[], u: Shape[], r: string[]) => void) => {
       shapeCbs.add(cb);
       return () => shapeCbs.delete(cb);

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -307,6 +307,10 @@ export function useCollaborationSync(): void {
     // seed concatenates `body+body`. The collapse is a CRDT delete, so it
     // propagates to the relay + peers and heals everyone. No-op on clean docs.
     if (initializedRef.current) {
+      // JP-402: the adopted/seeded Y.Doc is now the established baseline — drop any
+      // undo steps captured during seed/adopt so the user can't undo into an empty
+      // or seed document.
+      yjsDoc.clearUndoHistory();
       for (const pageId of useRichTextPagesStore.getState().pageOrder) {
         yjsDoc.healDoubledProse(pageId);
       }

--- a/src/engine/Renderer.ts
+++ b/src/engine/Renderer.ts
@@ -161,6 +161,12 @@ export class Renderer {
   // Emphasis animation
   private emphasizedShapeId: string | null = null;
   private emphasisStartTime: number = 0;
+  /**
+   * Ephemeral per-shape style overrides for live preview (e.g. hovering a style
+   * profile). Applied on top of the real shape at render time ONLY — never
+   * persisted, never synced, never in the document/CRDT/history.
+   */
+  private stylePreviewOverrides: Record<string, Partial<Shape>> = {};
 
   // Contrast resolution cache for AUTO colours. Persisted across frames and
   // cleared only when the inputs that affect resolution change (shape data,
@@ -326,6 +332,15 @@ export class Renderer {
         this.requestRender();
       }
     }
+  }
+
+  /**
+   * Set ephemeral per-shape style overrides for live preview. Each entry is
+   * applied on top of the real shape (before AUTO-colour resolution) at render
+   * time only. Pass `{}` to clear. Caller is responsible for requesting a render.
+   */
+  setStylePreviewOverrides(overrides: Record<string, Partial<Shape>>): void {
+    this.stylePreviewOverrides = overrides;
   }
 
   /**
@@ -683,8 +698,11 @@ export class Renderer {
         } else {
           // Render the shape. Resolve AUTO colours once and reuse the result
           // for both the body and any deferred overlay (avoids a second
-          // contrast-cache resolve).
-          const resolved = this.resolveAutoFillStroke(shape);
+          // contrast-cache resolve). A live-preview override (if any) is layered
+          // on BEFORE resolution so 'auto'/contrast resolve against it.
+          const override = this.stylePreviewOverrides[id];
+          const previewed = override ? ({ ...shape, ...override } as Shape) : shape;
+          const resolved = this.resolveAutoFillStroke(previewed);
           ctx.save();
           handler.render(ctx, resolved);
           ctx.restore();
@@ -780,7 +798,9 @@ export class Renderer {
           // and reuse for the deferred overlay (JP-353) — without collecting
           // here, a group-child connector's label would render nowhere, since
           // the label moved out of `render` into `renderOverlay`.
-          const resolved = this.resolveAutoFillStroke(child);
+          const childOverride = this.stylePreviewOverrides[child.id];
+          const previewedChild = childOverride ? ({ ...child, ...childOverride } as Shape) : child;
+          const resolved = this.resolveAutoFillStroke(previewedChild);
           ctx.save();
           ctx.globalAlpha = child.opacity * effectiveOpacity;
           handler.render(ctx, resolved);

--- a/src/store/historyStore.test.ts
+++ b/src/store/historyStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useHistoryStore } from './historyStore';
 import { useDocumentStore } from './documentStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
@@ -186,7 +186,7 @@ describe('History Store', () => {
       expect(useDocumentStore.getState().shapes['rect1']).toBeDefined();
     });
 
-    it('does nothing while a collab session is active (JP-178)', async () => {
+    it('delegates to the collab undo controller while a session is active (JP-178/JP-402)', async () => {
       const store = useHistoryStore.getState();
       const docStore = useDocumentStore.getState();
 
@@ -195,12 +195,17 @@ describe('History Store', () => {
       store.push('Before move');
       docStore.updateShape('rect1', { x: 100, y: 100 });
 
-      // A collab session makes the relay Y.Doc authoritative — snapshot undo is
-      // disabled (it would diverge and be clobbered on sync). Undo must no-op.
-      useCollaborationStore.setState({ isActive: true });
+      // In a collab session the relay Y.Doc is authoritative, so the SNAPSHOT undo
+      // is disabled (it would diverge and be clobbered on sync). Instead undo
+      // delegates to the per-user CRDT UndoManager (JP-402).
+      const undoCanvas = vi.fn();
+      useCollaborationStore.setState({ isActive: true, undoCanvas });
       try {
         store.undo();
+        // The snapshot path did NOT run (no local rollback)…
         expect(useDocumentStore.getState().shapes['rect1']?.x).toBe(100);
+        // …it delegated to the collab controller.
+        expect(undoCanvas).toHaveBeenCalledTimes(1);
       } finally {
         useCollaborationStore.setState({ isActive: false });
       }

--- a/src/store/historyStore.ts
+++ b/src/store/historyStore.ts
@@ -7,11 +7,15 @@ import { useCollaborationStore } from '../collaboration/collaborationStore';
  * Snapshot-based undo/redo is disabled while a collaboration session is active
  * (JP-178). The relay Y.Doc is the authoritative source whenever a collab
  * *engine* session is live — including offline-first relay docs (engine ≠
- * provider) — so restoring a local history snapshot would diverge from the
- * Y.Doc and be silently clobbered on the next sync/reload. Undo/redo therefore
- * apply only to pure local documents (no session); proper per-user collab undo
- * / version history is roadmap work. Read at call time so there is no module
- * eval-order dependency on the collaboration store.
+ * provider) — so restoring a local history *snapshot* would diverge from the
+ * Y.Doc and be silently clobbered on the next sync/reload.
+ *
+ * Instead of no-op'ing in collab, this store now **delegates** to the per-user
+ * Yjs `UndoManager` owned by the YjsDocument (JP-402): a CRDT-native undo that
+ * reverts only this user's edits and broadcasts as a normal op (no snapshot, no
+ * divergence). The snapshot path below still owns pure local documents (no
+ * session). Read at call time so there is no module eval-order dependency on the
+ * collaboration store.
  */
 function isCollabSessionActive(): boolean {
   return useCollaborationStore.getState().isActive;
@@ -252,6 +256,13 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
 
   // Actions
   push: (description?: string) => {
+    // In a collab session the snapshot path is inactive (JP-178). `pushHistory`
+    // is the single action-anchor funnel (Engine.ts → here), so close the current
+    // CRDT undo step (JP-402) — each marked action becomes its own undo step.
+    if (isCollabSessionActive()) {
+      useCollaborationStore.getState().getYjsDocument()?.closeUndoStep();
+      return;
+    }
     const state = get();
     const { activePageId, isTracking } = state;
 
@@ -303,8 +314,12 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   undo: () => {
-    // Disabled in a collab session — see isCollabSessionActive (JP-178).
-    if (isCollabSessionActive()) return;
+    // Collab: delegate to the per-user CRDT UndoManager (JP-402) instead of the
+    // snapshot path (which would diverge from the relay Y.Doc, JP-178).
+    if (isCollabSessionActive()) {
+      useCollaborationStore.getState().undoCanvas();
+      return;
+    }
     const state = get();
     const { activePageId } = state;
 
@@ -384,8 +399,11 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   redo: () => {
-    // Disabled in a collab session — see isCollabSessionActive (JP-178).
-    if (isCollabSessionActive()) return;
+    // Collab: delegate to the per-user CRDT UndoManager (JP-402).
+    if (isCollabSessionActive()) {
+      useCollaborationStore.getState().redoCanvas();
+      return;
+    }
     const state = get();
     const { activePageId } = state;
 
@@ -485,6 +503,8 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   canUndo: () => {
+    // Collab: availability comes from the CRDT UndoManager mirror (JP-402).
+    if (isCollabSessionActive()) return useCollaborationStore.getState().canUndoCanvas;
     const state = get();
     if (!state.activePageId) return false;
     const pageHist = state.pageHistory[state.activePageId];
@@ -492,6 +512,8 @@ export const useHistoryStore = create<HistoryState & HistoryActions>()((set, get
   },
 
   canRedo: () => {
+    // Collab: availability comes from the CRDT UndoManager mirror (JP-402).
+    if (isCollabSessionActive()) return useCollaborationStore.getState().canRedoCanvas;
     const state = get();
     if (!state.activePageId) return false;
     const pageHist = state.pageHistory[state.activePageId];

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { useDocumentStore } from './documentStore';
 import { shapeRegistry } from '../shapes/ShapeRegistry';
+import type { Shape } from '../shapes/Shape';
 import type { RelaxedFocus } from '../ui/layout/types';
 
 /**
@@ -132,6 +133,13 @@ export interface SessionState {
   snapGuides: SnapGuides;
   /** ID of shape that should be visually emphasized (for focus animation) */
   emphasizedShapeId: string | null;
+  /**
+   * Ephemeral per-shape style overrides for live preview (e.g. hovering a style
+   * profile in the panel). Keyed by shape id. Applied by the renderer on top of
+   * the real shape — never written to the document, CRDT, or history, so peers
+   * in a collab session never see it.
+   */
+  stylePreviewOverrides: Record<string, Partial<Shape>>;
   /** Current cursor position in world coordinates (for status bar display) */
   cursorWorldPosition: { x: number; y: number } | null;
   /** Blob sync progress (for status bar display during file sync) */
@@ -197,6 +205,12 @@ export interface SessionActions {
   setSnapSettings: (settings: Partial<SnapSettings>) => void;
   setSnapGuides: (guides: SnapGuides) => void;
   clearSnapGuides: () => void;
+
+  // Ephemeral style preview (collab-safe; render-only)
+  /** Set per-shape style overrides for live preview. Replaces the whole map. */
+  setStylePreview: (overrides: Record<string, Partial<Shape>>) => void;
+  /** Clear all live-preview overrides. */
+  clearStylePreview: () => void;
 
   // Focus/Emphasis
   /** Focus camera on a shape and trigger emphasis animation */
@@ -277,6 +291,7 @@ const initialState: SessionState = {
   snapSettings: { ...DEFAULT_SNAP_SETTINGS },
   snapGuides: {},
   emphasizedShapeId: null,
+  stylePreviewOverrides: {},
   cursorWorldPosition: null,
   blobSyncProgress: null,
   editingGroupId: null,
@@ -424,6 +439,16 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
 
   clearSnapGuides: () => {
     set({ snapGuides: {} });
+  },
+
+  setStylePreview: (overrides: Record<string, Partial<Shape>>) => {
+    set({ stylePreviewOverrides: overrides });
+  },
+
+  clearStylePreview: () => {
+    // Avoid a needless render churn when already empty.
+    if (Object.keys(get().stylePreviewOverrides).length === 0) return;
+    set({ stylePreviewOverrides: {} });
   },
 
   // Focus/Emphasis

--- a/src/store/stylePreview.test.ts
+++ b/src/store/stylePreview.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Collab-safety proof for the ephemeral style preview (JP-401).
+ *
+ * The live preview (hovering a style profile) must NEVER mutate the document —
+ * if it did, a collaboration session would broadcast the temporary restyle to
+ * every peer. This test pins that the override lives only in `sessionStore` and
+ * leaves `documentStore` completely untouched.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionStore } from './sessionStore';
+import { useDocumentStore } from './documentStore';
+import type { Shape } from '../shapes/Shape';
+
+describe('ephemeral style preview is collab-safe', () => {
+  beforeEach(() => {
+    useSessionStore.getState().clearStylePreview();
+  });
+
+  it('setStylePreview writes only sessionStore and never the document', () => {
+    const shapesBefore = useDocumentStore.getState().shapes;
+    const overrides: Record<string, Partial<Shape>> = { 's1': { fill: '#ff0000', strokeWidth: 9 } };
+
+    useSessionStore.getState().setStylePreview(overrides);
+
+    // Override is held in the ephemeral session store…
+    expect(useSessionStore.getState().stylePreviewOverrides).toBe(overrides);
+    // …and the document is byte-for-byte untouched (no updateShape → no CRDT
+    // broadcast, no history). Reference equality proves no mutation happened.
+    expect(useDocumentStore.getState().shapes).toBe(shapesBefore);
+  });
+
+  it('clearStylePreview empties the overrides', () => {
+    useSessionStore.getState().setStylePreview({ 's1': { fill: '#00ff00' } });
+    useSessionStore.getState().clearStylePreview();
+    expect(useSessionStore.getState().stylePreviewOverrides).toEqual({});
+  });
+});

--- a/src/store/styleProfile/capabilities.ts
+++ b/src/store/styleProfile/capabilities.ts
@@ -1,0 +1,60 @@
+/**
+ * Shape style capability resolution for the adapter layer (JP-33).
+ *
+ * Replaces the old hardcoded `SHAPE_CATEGORIES` map + the brittle
+ * `isLibraryShape()` string heuristic in `styleProfileStore`. Capability is now
+ * sourced from registry/metadata truth:
+ *
+ *   1. `shapeRegistry.getMetadata(type)` — authoritative for shapes that
+ *      register metadata (the `file` shape + all library shapes).
+ *   2. A small static fallback for the core shapes, which deliberately register
+ *      no metadata (so they stay out of the library picker). This fallback is
+ *      also what keeps the layer working in unit tests, where the registry and
+ *      shape-library store are empty.
+ *   3. `shapeLibraryStore.isLibraryShape(type)` as a last resort.
+ *
+ * Registry/store reads happen lazily *inside* the functions (never at module
+ * load) so this module imports cleanly and degrades gracefully when those
+ * stores have not been initialized yet.
+ */
+
+import { shapeRegistry } from '../../shapes/ShapeRegistry';
+import { useShapeLibraryStore } from '../shapeLibraryStore';
+
+/**
+ * Core shapes that support labels but register no metadata. Also the source of
+ * truth in the (registry-empty) test environment.
+ */
+const STATIC_LABEL_TYPES = new Set(['rectangle', 'ellipse', 'connector', 'group']);
+
+/** Core shapes that support icons but register no metadata. */
+const STATIC_ICON_TYPES = new Set(['rectangle', 'ellipse']);
+
+/**
+ * Whether `type` is a registered library shape. Wrapped in try/catch so that a
+ * not-yet-initialized store (e.g. in tests) degrades to `false` rather than
+ * throwing.
+ */
+function isLibraryShapeType(type: string): boolean {
+  try {
+    return useShapeLibraryStore.getState().isLibraryShape(type);
+  } catch {
+    return false;
+  }
+}
+
+/** Whether shapes of this type carry a styleable label. */
+export function shapeSupportsLabel(type: string): boolean {
+  const meta = shapeRegistry.getMetadata(type);
+  if (meta) return meta.supportsLabel;
+  if (STATIC_LABEL_TYPES.has(type)) return true;
+  return isLibraryShapeType(type);
+}
+
+/** Whether shapes of this type carry a styleable icon. */
+export function shapeSupportsIcon(type: string): boolean {
+  const meta = shapeRegistry.getMetadata(type);
+  if (meta) return meta.supportsIcon;
+  if (STATIC_ICON_TYPES.has(type)) return true;
+  return isLibraryShapeType(type);
+}

--- a/src/store/styleProfile/facets.ts
+++ b/src/store/styleProfile/facets.ts
@@ -17,12 +17,70 @@
  */
 
 import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../../shapes/Shape';
-import type { IconPosition, StyleFacet } from './types';
+import type { IconPosition, StyleFacet, StyleProfileProperties } from './types';
 import { shapeSupportsIcon, shapeSupportsLabel } from './capabilities';
 
 /** Index-signature view for guarded subtype probing. */
 function asRecord(shape: BaseShape): Record<string, unknown> {
   return shape as unknown as Record<string, unknown>;
+}
+
+/**
+ * Descriptor for a {@link makeCustomPropsFacet} field: a profile key whose value
+ * lives in `shape.customProperties` under the same name.
+ */
+interface CustomPropField {
+  /** Key on both the profile and the shape's customProperties. */
+  readonly key: keyof StyleProfileProperties & string;
+  /** Runtime kind used to guard extraction. */
+  readonly kind: 'string' | 'number';
+}
+
+interface CustomPropsFacetConfig {
+  readonly id: string;
+  readonly names: readonly string[];
+  readonly types: readonly string[];
+  readonly fields: readonly CustomPropField[];
+}
+
+/**
+ * Build a facet for a shape whose styleable fields live in
+ * `shape.customProperties` (ERD entities, swimlanes, …). `extract` reads the
+ * configured keys off customProperties; `apply` folds the set values back into a
+ * *merged* customProperties copy (preserving unrelated custom data) and is a
+ * no-op when the profile carries none of them. Adding the next such shape is
+ * pure config — no new logic.
+ */
+function makeCustomPropsFacet(config: CustomPropsFacetConfig): StyleFacet {
+  const typeSet = new Set(config.types);
+  return {
+    id: config.id,
+    names: config.names,
+    appliesTo: (type) => typeSet.has(type),
+    extract: (shape) => {
+      const raw = asRecord(shape)['customProperties'];
+      if (!raw || typeof raw !== 'object') return {};
+      const cp = raw as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const field of config.fields) {
+        const value = cp[field.key];
+        if (typeof value === field.kind) out[field.key] = value;
+      }
+      return out as Partial<StyleProfileProperties>;
+    },
+    apply: (props, shape) => {
+      const bag = props as unknown as Record<string, unknown>;
+      const values: Record<string, unknown> = {};
+      for (const field of config.fields) {
+        const value = bag[field.key];
+        if (value !== undefined) values[field.key] = value;
+      }
+      if (Object.keys(values).length === 0) return {};
+      const raw = asRecord(shape)['customProperties'];
+      const existing = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+      return { customProperties: { ...existing, ...values } };
+    },
+  };
 }
 
 /** Universal fill/stroke/strokeWidth/opacity — applies to every shape. */
@@ -152,43 +210,38 @@ const groupFacet: StyleFacet = {
 };
 
 /**
- * ERD table styling — entity shapes. These profile values live on the shape's
- * `customProperties`, so this facet reads from / writes to that object. `apply`
- * folds the values into a *merged* `customProperties` copy (the merge the call
- * site used to do by hand), and is a no-op when the profile carries none.
+ * ERD table styling — entity shapes. Row colors + attribute padding live on the
+ * shape's `customProperties`.
  */
-const erdFacet: StyleFacet = {
+const erdFacet: StyleFacet = makeCustomPropsFacet({
   id: 'erd',
   names: ['Row Colors', 'Padding', 'Separator Inset'],
-  appliesTo: (type) => type === 'erd-entity' || type === 'erd-weak-entity',
-  extract: (shape) => {
-    const extra = asRecord(shape);
-    const customPropsRaw = extra['customProperties'];
-    if (!customPropsRaw || typeof customPropsRaw !== 'object') return {};
-    const customProps = customPropsRaw as Record<string, unknown>;
-    const out: ReturnType<StyleFacet['extract']> = {};
-    if (typeof customProps['rowSeparatorColor'] === 'string') out.rowSeparatorColor = customProps['rowSeparatorColor'];
-    if (typeof customProps['rowBackgroundColor'] === 'string') out.rowBackgroundColor = customProps['rowBackgroundColor'];
-    if (typeof customProps['rowAlternateColor'] === 'string') out.rowAlternateColor = customProps['rowAlternateColor'];
-    if (typeof customProps['attributePaddingHorizontal'] === 'number') out.attributePaddingHorizontal = customProps['attributePaddingHorizontal'];
-    if (typeof customProps['attributePaddingVertical'] === 'number') out.attributePaddingVertical = customProps['attributePaddingVertical'];
-    return out;
-  },
-  apply: (props, shape) => {
-    const erdValues: Record<string, unknown> = {};
-    if (props.rowSeparatorColor !== undefined) erdValues['rowSeparatorColor'] = props.rowSeparatorColor;
-    if (props.rowBackgroundColor !== undefined) erdValues['rowBackgroundColor'] = props.rowBackgroundColor;
-    if (props.rowAlternateColor !== undefined) erdValues['rowAlternateColor'] = props.rowAlternateColor;
-    if (props.attributePaddingHorizontal !== undefined) erdValues['attributePaddingHorizontal'] = props.attributePaddingHorizontal;
-    if (props.attributePaddingVertical !== undefined) erdValues['attributePaddingVertical'] = props.attributePaddingVertical;
+  types: ['erd-entity', 'erd-weak-entity'],
+  fields: [
+    { key: 'rowSeparatorColor', kind: 'string' },
+    { key: 'rowBackgroundColor', kind: 'string' },
+    { key: 'rowAlternateColor', kind: 'string' },
+    { key: 'attributePaddingHorizontal', kind: 'number' },
+    { key: 'attributePaddingVertical', kind: 'number' },
+  ],
+});
 
-    if (Object.keys(erdValues).length === 0) return {};
-
-    const existingRaw = asRecord(shape)['customProperties'];
-    const existing = existingRaw && typeof existingRaw === 'object' ? (existingRaw as Record<string, unknown>) : {};
-    return { customProperties: { ...existing, ...erdValues } };
-  },
-};
+/**
+ * Swimlane chrome — header band color + lane separator color/width, stored on
+ * `customProperties`. First explicit-keys pilot of the adapter on a complex
+ * library shape (JP-399). `headerSize` is intentionally excluded — it is
+ * structural (layout), not style, so applying a profile never resizes chrome.
+ */
+const swimlaneFacet: StyleFacet = makeCustomPropsFacet({
+  id: 'swimlane',
+  names: ['Header Color', 'Separator Color', 'Separator Width'],
+  types: ['activity-swimlane'],
+  fields: [
+    { key: 'headerBackground', kind: 'string' },
+    { key: 'separatorColor', kind: 'string' },
+    { key: 'separatorWidth', kind: 'number' },
+  ],
+});
 
 /** Icon styling (all 8 icon fields) — any shape whose metadata supports icons. */
 const iconFacet: StyleFacet = {
@@ -243,5 +296,6 @@ export const STYLE_FACETS: readonly StyleFacet[] = [
   lineStyleFacet,
   groupFacet,
   erdFacet,
+  swimlaneFacet,
   iconFacet,
 ];

--- a/src/store/styleProfile/facets.ts
+++ b/src/store/styleProfile/facets.ts
@@ -1,0 +1,247 @@
+/**
+ * The style facets (JP-33).
+ *
+ * Each facet owns one style axis and is a faithful port of the corresponding
+ * branch from the old `extractStyleFromShape` / `getProfileUpdates` if-ladders.
+ * Two behavioral contracts are preserved verbatim:
+ *
+ *  - Subtype fields are probed via an index-signature view of the shape, each
+ *    read guarded by a `typeof` runtime check (so the `unknown` cast never
+ *    widens a value that actually lands in the result).
+ *  - The pre-existing `startArrow`/`endArrow` quirk (profile stores them as
+ *    `string`, shapes store them as `boolean`) is left exactly as-is — extract
+ *    only captures string values. Not "fixed" here; out of scope.
+ *
+ * Facets only ever conditionally assign optional fields (never assign
+ * `undefined`), satisfying `exactOptionalPropertyTypes`.
+ */
+
+import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../../shapes/Shape';
+import type { IconPosition, StyleFacet } from './types';
+import { shapeSupportsIcon, shapeSupportsLabel } from './capabilities';
+
+/** Index-signature view for guarded subtype probing. */
+function asRecord(shape: BaseShape): Record<string, unknown> {
+  return shape as unknown as Record<string, unknown>;
+}
+
+/** Universal fill/stroke/strokeWidth/opacity — applies to every shape. */
+const universalFacet: StyleFacet = {
+  id: 'universal',
+  names: ['Fill', 'Stroke', 'Stroke Width', 'Opacity'],
+  appliesTo: () => true,
+  extract: (shape) => ({
+    fill: shape.fill ?? null,
+    stroke: shape.stroke ?? null,
+    strokeWidth: shape.strokeWidth ?? 2,
+    opacity: shape.opacity ?? 1,
+  }),
+  apply: (props) => ({
+    fill: props.fill,
+    stroke: props.stroke,
+    strokeWidth: props.strokeWidth,
+    opacity: props.opacity,
+  }),
+};
+
+/** Corner radius — rectangles and groups. */
+const cornerRadiusFacet: StyleFacet = {
+  id: 'cornerRadius',
+  names: ['Corner Radius'],
+  appliesTo: (type) => type === 'rectangle' || type === 'group',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    return typeof extra['cornerRadius'] === 'number' ? { cornerRadius: extra['cornerRadius'] } : {};
+  },
+  apply: (props) => (props.cornerRadius !== undefined ? { cornerRadius: props.cornerRadius } : {}),
+};
+
+/** Label font size + color — any shape whose metadata says it carries a label. */
+const labelFacet: StyleFacet = {
+  id: 'label',
+  names: ['Label Font Size', 'Label Color'],
+  appliesTo: shapeSupportsLabel,
+  extract: (shape, opts) => {
+    if (!opts.includeLabelStyle) return {};
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['labelFontSize'] === 'number') out.labelFontSize = extra['labelFontSize'];
+    if (typeof extra['labelColor'] === 'string') out.labelColor = extra['labelColor'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.labelFontSize !== undefined) out.labelFontSize = props.labelFontSize;
+    if (props.labelColor !== undefined) out.labelColor = props.labelColor;
+    return out;
+  },
+};
+
+/** Font size + family — text shapes (fill doubles as text color via universal). */
+const textFacet: StyleFacet = {
+  id: 'text',
+  names: ['Font Size', 'Font Family'],
+  appliesTo: (type) => type === 'text',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['fontSize'] === 'number') out.fontSize = extra['fontSize'];
+    if (typeof extra['fontFamily'] === 'string') out.fontFamily = extra['fontFamily'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.fontSize !== undefined) out.fontSize = props.fontSize;
+    if (props.fontFamily !== undefined) out.fontFamily = props.fontFamily;
+    return out;
+  },
+};
+
+/** Start/end arrow style — lines and connectors. */
+const arrowsFacet: StyleFacet = {
+  id: 'arrows',
+  names: ['Start Arrow', 'End Arrow'],
+  appliesTo: (type) => type === 'line' || type === 'connector',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['startArrow'] === 'string') out.startArrow = extra['startArrow'];
+    if (typeof extra['endArrow'] === 'string') out.endArrow = extra['endArrow'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.startArrow !== undefined) out.startArrow = props.startArrow;
+    if (props.endArrow !== undefined) out.endArrow = props.endArrow;
+    return out;
+  },
+};
+
+/** Line style (solid/dashed) — connectors. */
+const lineStyleFacet: StyleFacet = {
+  id: 'lineStyle',
+  names: ['Line Style'],
+  appliesTo: (type) => type === 'connector',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    return typeof extra['lineStyle'] === 'string' ? { lineStyle: extra['lineStyle'] } : {};
+  },
+  apply: (props) => (props.lineStyle !== undefined ? { lineStyle: props.lineStyle } : {}),
+};
+
+/** Background/border styling — groups. */
+const groupFacet: StyleFacet = {
+  id: 'group',
+  names: ['Background Color', 'Border Color', 'Border Width'],
+  appliesTo: (type) => type === 'group',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['backgroundColor'] === 'string') out.backgroundColor = extra['backgroundColor'];
+    if (typeof extra['borderColor'] === 'string') out.borderColor = extra['borderColor'];
+    if (typeof extra['borderWidth'] === 'number') out.borderWidth = extra['borderWidth'];
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.backgroundColor !== undefined) out.backgroundColor = props.backgroundColor;
+    if (props.borderColor !== undefined) out.borderColor = props.borderColor;
+    if (props.borderWidth !== undefined) out.borderWidth = props.borderWidth;
+    return out;
+  },
+};
+
+/**
+ * ERD table styling — entity shapes. These profile values live on the shape's
+ * `customProperties`, so this facet reads from / writes to that object. `apply`
+ * folds the values into a *merged* `customProperties` copy (the merge the call
+ * site used to do by hand), and is a no-op when the profile carries none.
+ */
+const erdFacet: StyleFacet = {
+  id: 'erd',
+  names: ['Row Colors', 'Padding', 'Separator Inset'],
+  appliesTo: (type) => type === 'erd-entity' || type === 'erd-weak-entity',
+  extract: (shape) => {
+    const extra = asRecord(shape);
+    const customPropsRaw = extra['customProperties'];
+    if (!customPropsRaw || typeof customPropsRaw !== 'object') return {};
+    const customProps = customPropsRaw as Record<string, unknown>;
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof customProps['rowSeparatorColor'] === 'string') out.rowSeparatorColor = customProps['rowSeparatorColor'];
+    if (typeof customProps['rowBackgroundColor'] === 'string') out.rowBackgroundColor = customProps['rowBackgroundColor'];
+    if (typeof customProps['rowAlternateColor'] === 'string') out.rowAlternateColor = customProps['rowAlternateColor'];
+    if (typeof customProps['attributePaddingHorizontal'] === 'number') out.attributePaddingHorizontal = customProps['attributePaddingHorizontal'];
+    if (typeof customProps['attributePaddingVertical'] === 'number') out.attributePaddingVertical = customProps['attributePaddingVertical'];
+    return out;
+  },
+  apply: (props, shape) => {
+    const erdValues: Record<string, unknown> = {};
+    if (props.rowSeparatorColor !== undefined) erdValues['rowSeparatorColor'] = props.rowSeparatorColor;
+    if (props.rowBackgroundColor !== undefined) erdValues['rowBackgroundColor'] = props.rowBackgroundColor;
+    if (props.rowAlternateColor !== undefined) erdValues['rowAlternateColor'] = props.rowAlternateColor;
+    if (props.attributePaddingHorizontal !== undefined) erdValues['attributePaddingHorizontal'] = props.attributePaddingHorizontal;
+    if (props.attributePaddingVertical !== undefined) erdValues['attributePaddingVertical'] = props.attributePaddingVertical;
+
+    if (Object.keys(erdValues).length === 0) return {};
+
+    const existingRaw = asRecord(shape)['customProperties'];
+    const existing = existingRaw && typeof existingRaw === 'object' ? (existingRaw as Record<string, unknown>) : {};
+    return { customProperties: { ...existing, ...erdValues } };
+  },
+};
+
+/** Icon styling (all 8 icon fields) — any shape whose metadata supports icons. */
+const iconFacet: StyleFacet = {
+  id: 'icon',
+  names: ['Icon', 'Icon Size', 'Icon Position'],
+  appliesTo: shapeSupportsIcon,
+  extract: (shape, opts) => {
+    if (!opts.includeIconStyle) return {};
+    const extra = asRecord(shape);
+    const out: ReturnType<StyleFacet['extract']> = {};
+    if (typeof extra['iconId'] === 'string') out.iconId = extra['iconId'];
+    if (typeof extra['iconSize'] === 'number') out.iconSize = extra['iconSize'];
+    if (typeof extra['iconPadding'] === 'number') out.iconPadding = extra['iconPadding'];
+    if (typeof extra['iconColor'] === 'string') out.iconColor = extra['iconColor'];
+    if (typeof extra['iconPosition'] === 'string') out.iconPosition = extra['iconPosition'] as IconPosition;
+    if (typeof extra['iconDisplayMode'] === 'string') out.iconDisplayMode = extra['iconDisplayMode'] as IconDisplayMode;
+    const iconBadge = extra['iconBadge'];
+    if (iconBadge && typeof iconBadge === 'object') {
+      // Shallow copy so later shape mutations don't bleed into the profile.
+      out.iconBadge = { ...(iconBadge as IconBadgeConfig) };
+    }
+    const icons = extra['icons'];
+    if (Array.isArray(icons)) {
+      out.icons = icons.map((icon) => ({ ...(icon as IconConfig) }));
+    }
+    return out;
+  },
+  apply: (props) => {
+    const out: ReturnType<StyleFacet['apply']> = {};
+    if (props.iconId !== undefined) out.iconId = props.iconId;
+    if (props.iconSize !== undefined) out.iconSize = props.iconSize;
+    if (props.iconPadding !== undefined) out.iconPadding = props.iconPadding;
+    if (props.iconColor !== undefined) out.iconColor = props.iconColor;
+    if (props.iconPosition !== undefined) out.iconPosition = props.iconPosition;
+    if (props.iconDisplayMode !== undefined) out.iconDisplayMode = props.iconDisplayMode;
+    if (props.iconBadge !== undefined) out.iconBadge = props.iconBadge;
+    if (props.icons !== undefined) out.icons = props.icons;
+    return out;
+  },
+};
+
+/**
+ * All facets, in application order. Order matters only for `apply` precedence
+ * (later facets win on key collisions — none currently collide).
+ */
+export const STYLE_FACETS: readonly StyleFacet[] = [
+  universalFacet,
+  cornerRadiusFacet,
+  labelFacet,
+  textFacet,
+  arrowsFacet,
+  lineStyleFacet,
+  groupFacet,
+  erdFacet,
+  iconFacet,
+];

--- a/src/store/styleProfile/index.ts
+++ b/src/store/styleProfile/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-shape style-profile adapter layer (JP-33).
+ *
+ * Translates a flat style profile to/from concrete shape fields via composable
+ * facets resolved per shape type. See {@link resolveStyleAdapter} and the
+ * {@link StyleFacet} contract.
+ */
+
+export type {
+  IconPosition,
+  StyleProfileProperties,
+  ShapeStyleUpdate,
+  ResolvedExtractOptions,
+  StyleFacet,
+  ErdProfileKey,
+} from './types';
+export { resolveStyleAdapter } from './registry';
+export { STYLE_FACETS } from './facets';
+export { shapeSupportsLabel, shapeSupportsIcon } from './capabilities';

--- a/src/store/styleProfile/index.ts
+++ b/src/store/styleProfile/index.ts
@@ -13,6 +13,8 @@ export type {
   ResolvedExtractOptions,
   StyleFacet,
   ErdProfileKey,
+  SwimlaneProfileKey,
+  CustomPropertyProfileKey,
 } from './types';
 export { resolveStyleAdapter } from './registry';
 export { STYLE_FACETS } from './facets';

--- a/src/store/styleProfile/registry.test.ts
+++ b/src/store/styleProfile/registry.test.ts
@@ -166,6 +166,47 @@ describe('extractStyleFromShape — adapter dispatch', () => {
   });
 });
 
+describe('swimlane facet (JP-399)', () => {
+  it('dispatches the swimlane facet for activity-swimlane only', () => {
+    expect(facetIds('activity-swimlane')).toContain('swimlane');
+    expect(facetIds('rectangle')).not.toContain('swimlane');
+  });
+
+  it('extracts header/separator chrome from customProperties', () => {
+    const shape = makeShape('activity-swimlane', {
+      customProperties: { headerBackground: '#222', separatorColor: '#0ff', separatorWidth: 2, orientation: 'horizontal' },
+    });
+    const props = extractStyleFromShape(shape);
+    expect(props.headerBackground).toBe('#222');
+    expect(props.separatorColor).toBe('#0ff');
+    expect(props.separatorWidth).toBe(2);
+  });
+
+  it('merges chrome into existing customProperties without clobbering non-style data', () => {
+    const profile = makeProfile({ ...BASE_PROPS, headerBackground: '#222', separatorWidth: 3 });
+    const shape = makeShape('activity-swimlane', {
+      customProperties: { orientation: 'vertical', separatorColor: '#000' },
+    });
+
+    const updates = getProfileUpdates(profile, shape);
+
+    expect(updates.customProperties).toEqual({
+      orientation: 'vertical',
+      separatorColor: '#000',
+      headerBackground: '#222',
+      separatorWidth: 3,
+    });
+    expect((updates as Record<string, unknown>)['headerBackground']).toBeUndefined();
+  });
+
+  it('does not leak swimlane keys onto a non-swimlane shape', () => {
+    const profile = makeProfile({ ...BASE_PROPS, headerBackground: '#222', separatorColor: '#0ff' });
+    const updates = getProfileUpdates(profile, makeShape('rectangle'));
+    expect((updates as Record<string, unknown>)['headerBackground']).toBeUndefined();
+    expect(updates.customProperties).toBeUndefined();
+  });
+});
+
 describe('metadata-driven capability resolution', () => {
   afterEach(() => {
     // The registry is a shared singleton; the test env starts empty, so a full

--- a/src/store/styleProfile/registry.test.ts
+++ b/src/store/styleProfile/registry.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Coverage for the per-shape style-profile adapter layer (JP-33).
+ *
+ * Validates that:
+ *  - the registry dispatches the right facets per shape type;
+ *  - capability resolution falls back to the static table when the shape
+ *    registry is empty (the case in this test environment, and the case for
+ *    core shapes at runtime since they register no metadata);
+ *  - capability resolution honors shape metadata when present;
+ *  - the ERD facet folds its values into a *merged* customProperties object;
+ *  - metadata-truth coverage gains label styling for groups.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveStyleAdapter, shapeSupportsLabel, shapeSupportsIcon } from './index';
+import {
+  extractStyleFromShape,
+  getProfileUpdates,
+  type StyleProfile,
+  type StyleProfileProperties,
+} from '../styleProfileStore';
+import type { BaseShape } from '../../shapes/Shape';
+import type { ShapeHandler } from '../../shapes/ShapeRegistry';
+import { shapeRegistry } from '../../shapes/ShapeRegistry';
+import type { ShapeMetadata } from '../../shapes/ShapeMetadata';
+
+/** Loosely-typed shape factory — the adapter reads fields dynamically. */
+function makeShape(type: string, extra: Record<string, unknown> = {}): BaseShape {
+  return {
+    id: `${type}-1`,
+    type,
+    x: 0,
+    y: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#ffffff',
+    stroke: '#000000',
+    strokeWidth: 2,
+    ...extra,
+  } as unknown as BaseShape;
+}
+
+function makeProfile(properties: StyleProfileProperties): StyleProfile {
+  return { id: 'p', name: 'p', properties, createdAt: 0, favorite: false };
+}
+
+const BASE_PROPS: StyleProfileProperties = {
+  fill: '#abcdef',
+  stroke: '#123456',
+  strokeWidth: 3,
+  opacity: 0.5,
+};
+
+const facetIds = (type: string): string[] => resolveStyleAdapter(type).map((f) => f.id);
+
+describe('resolveStyleAdapter — dispatch', () => {
+  it('gives a rectangle universal + cornerRadius + label + icon', () => {
+    const ids = facetIds('rectangle');
+    expect(ids).toEqual(expect.arrayContaining(['universal', 'cornerRadius', 'label', 'icon']));
+  });
+
+  it('gives a line universal + arrows, but not icon/label/cornerRadius', () => {
+    const ids = facetIds('line');
+    expect(ids).toEqual(expect.arrayContaining(['universal', 'arrows']));
+    expect(ids).not.toContain('icon');
+    expect(ids).not.toContain('label');
+    expect(ids).not.toContain('cornerRadius');
+  });
+
+  it('gives a text shape the text facet but no icon', () => {
+    const ids = facetIds('text');
+    expect(ids).toContain('text');
+    expect(ids).not.toContain('icon');
+  });
+
+  it('gives a group the group + label + cornerRadius facets but no icon', () => {
+    const ids = facetIds('group');
+    expect(ids).toEqual(expect.arrayContaining(['universal', 'group', 'label', 'cornerRadius']));
+    expect(ids).not.toContain('icon');
+  });
+
+  it('gives a connector arrows + lineStyle + label', () => {
+    const ids = facetIds('connector');
+    expect(ids).toEqual(expect.arrayContaining(['arrows', 'lineStyle', 'label']));
+  });
+
+  it('gives an unknown type only the universal facet', () => {
+    expect(facetIds('totally-unknown-shape')).toEqual(['universal']);
+  });
+});
+
+describe('empty-registry static fallback', () => {
+  it('resolves core-shape capabilities without registered metadata', () => {
+    // No shapes are registered in the test environment — these come from the
+    // static fallback table, which is load-bearing for the JP-7 icon tests.
+    expect(shapeSupportsLabel('rectangle')).toBe(true);
+    expect(shapeSupportsIcon('rectangle')).toBe(true);
+    expect(shapeSupportsLabel('line')).toBe(false);
+    expect(shapeSupportsIcon('line')).toBe(false);
+    expect(shapeSupportsLabel('group')).toBe(true);
+    expect(shapeSupportsIcon('group')).toBe(false);
+  });
+});
+
+describe('getProfileUpdates — translation', () => {
+  it('applies universal fields to every shape, including markerless ones', () => {
+    const updates = getProfileUpdates(makeProfile(BASE_PROPS), makeShape('line'));
+    expect(updates.fill).toBe('#abcdef');
+    expect(updates.stroke).toBe('#123456');
+    expect(updates.strokeWidth).toBe(3);
+    expect(updates.opacity).toBe(0.5);
+  });
+
+  it('grants label styling to groups (metadata-truth coverage gain)', () => {
+    const profile = makeProfile({ ...BASE_PROPS, labelFontSize: 18, labelColor: '#654321' });
+    const updates = getProfileUpdates(profile, makeShape('group'));
+    expect(updates.labelFontSize).toBe(18);
+    expect(updates.labelColor).toBe('#654321');
+  });
+
+  it('does not write label fields onto shapes that do not support them', () => {
+    const profile = makeProfile({ ...BASE_PROPS, labelFontSize: 18, labelColor: '#654321' });
+    const updates = getProfileUpdates(profile, makeShape('line'));
+    expect(updates.labelFontSize).toBeUndefined();
+    expect(updates.labelColor).toBeUndefined();
+  });
+
+  it('merges ERD row styling into existing customProperties without clobbering', () => {
+    const profile = makeProfile({
+      ...BASE_PROPS,
+      rowSeparatorColor: '#ff0000',
+      attributePaddingHorizontal: 12,
+    });
+    const shape = makeShape('erd-entity', { customProperties: { foo: 1, rowSeparatorColor: '#000' } });
+
+    const updates = getProfileUpdates(profile, shape);
+
+    expect(updates.customProperties).toEqual({
+      foo: 1,
+      rowSeparatorColor: '#ff0000',
+      attributePaddingHorizontal: 12,
+    });
+    // Raw ERD keys must never leak onto the top-level update.
+    expect((updates as Record<string, unknown>)['rowSeparatorColor']).toBeUndefined();
+  });
+
+  it('leaves customProperties untouched when the profile has no ERD styling', () => {
+    const updates = getProfileUpdates(makeProfile(BASE_PROPS), makeShape('erd-entity', { customProperties: { foo: 1 } }));
+    expect(updates.customProperties).toBeUndefined();
+  });
+});
+
+describe('extractStyleFromShape — adapter dispatch', () => {
+  it('always captures the four universal fields', () => {
+    const props = extractStyleFromShape(makeShape('totally-unknown-shape', { fill: '#aaa', stroke: '#bbb', strokeWidth: 4, opacity: 0.3 }));
+    expect(props).toMatchObject({ fill: '#aaa', stroke: '#bbb', strokeWidth: 4, opacity: 0.3 });
+  });
+
+  it('captures ERD row styling from customProperties on entity shapes', () => {
+    const shape = makeShape('erd-entity', { customProperties: { rowAlternateColor: '#eee', attributePaddingVertical: 6 } });
+    const props = extractStyleFromShape(shape);
+    expect(props.rowAlternateColor).toBe('#eee');
+    expect(props.attributePaddingVertical).toBe(6);
+  });
+});
+
+describe('metadata-driven capability resolution', () => {
+  afterEach(() => {
+    // The registry is a shared singleton; the test env starts empty, so a full
+    // clear is the safe teardown (unregister alone leaves metadata behind).
+    shapeRegistry.clear();
+  });
+
+  function registerDummy(supportsLabel: boolean, supportsIcon: boolean): void {
+    const metadata: ShapeMetadata = {
+      type: 'dummy-style-shape',
+      name: 'Dummy',
+      category: 'custom',
+      icon: '?',
+      properties: [],
+      supportsLabel,
+      supportsIcon,
+      defaultWidth: 100,
+      defaultHeight: 100,
+    };
+    const stubHandler = {
+      render: () => {},
+      hitTest: () => false,
+      getBounds: () => ({ x: 0, y: 0, width: 0, height: 0 }),
+      getHandles: () => [],
+      create: (_pos: unknown, id: string) => makeShape('dummy-style-shape', { id }),
+    } as unknown as ShapeHandler;
+    shapeRegistry.register('dummy-style-shape', stubHandler, metadata);
+  }
+
+  it('honors supportsLabel:true / supportsIcon:false from metadata', () => {
+    registerDummy(true, false);
+    expect(shapeSupportsLabel('dummy-style-shape')).toBe(true);
+    expect(shapeSupportsIcon('dummy-style-shape')).toBe(false);
+    const ids = facetIds('dummy-style-shape');
+    expect(ids).toContain('label');
+    expect(ids).not.toContain('icon');
+  });
+
+  it('honors supportsIcon:true from metadata', () => {
+    registerDummy(false, true);
+    expect(shapeSupportsLabel('dummy-style-shape')).toBe(false);
+    expect(shapeSupportsIcon('dummy-style-shape')).toBe(true);
+    const ids = facetIds('dummy-style-shape');
+    expect(ids).toContain('icon');
+    expect(ids).not.toContain('label');
+  });
+});

--- a/src/store/styleProfile/registry.ts
+++ b/src/store/styleProfile/registry.ts
@@ -1,0 +1,25 @@
+/**
+ * Style-adapter registry (JP-33).
+ *
+ * A shape's "adapter" is emergent: it is exactly the subset of {@link STYLE_FACETS}
+ * whose {@link StyleFacet.appliesTo} is true for the shape type. There are no
+ * hand-written per-type adapter objects to keep in sync.
+ *
+ * The result is intentionally not cached: capability sources (shape metadata,
+ * the shape-library store) can register after the first call, and filtering a
+ * handful of cheap predicates per user-triggered apply is negligible.
+ */
+
+import type { StyleFacet } from './types';
+import { STYLE_FACETS } from './facets';
+
+/**
+ * Resolve the ordered list of facets that apply to a shape type.
+ *
+ * Unknown types fall through to just the universal facet (fill/stroke/
+ * strokeWidth/opacity), since every non-universal facet returns `false` for an
+ * unrecognized type — so there is no separate "default adapter" to maintain.
+ */
+export function resolveStyleAdapter(type: string): readonly StyleFacet[] {
+  return STYLE_FACETS.filter((facet) => facet.appliesTo(type));
+}

--- a/src/store/styleProfile/types.ts
+++ b/src/store/styleProfile/types.ts
@@ -68,7 +68,7 @@ export interface StyleProfileProperties {
   /** Optional - border width for groups */
   borderWidth?: number;
 
-  // ERD entity styling properties
+  // ERD entity styling properties (applied into customProperties)
   /** Optional - row separator color */
   rowSeparatorColor?: string;
   /** Optional - row background color */
@@ -79,6 +79,14 @@ export interface StyleProfileProperties {
   attributePaddingHorizontal?: number;
   /** Optional - vertical padding for attributes */
   attributePaddingVertical?: number;
+
+  // Swimlane styling properties (applied into customProperties)
+  /** Optional - swimlane header band color */
+  headerBackground?: string;
+  /** Optional - swimlane lane separator color */
+  separatorColor?: string;
+  /** Optional - swimlane lane separator width */
+  separatorWidth?: number;
 
   // Icon properties (Rectangle, Ellipse, LibraryShape)
   /** Optional - icon ID reference */
@@ -100,10 +108,7 @@ export interface StyleProfileProperties {
 }
 
 /**
- * The ERD-specific profile keys. They are stored flat on a profile but applied
- * into `shape.customProperties` rather than onto the shape directly, so they are
- * stripped from {@link ShapeStyleUpdate} (the ERD facet folds them into
- * `customProperties`).
+ * ERD-specific profile keys (applied into `shape.customProperties`).
  */
 export type ErdProfileKey =
   | 'rowSeparatorColor'
@@ -113,13 +118,27 @@ export type ErdProfileKey =
   | 'attributePaddingVertical';
 
 /**
+ * Swimlane-specific profile keys (applied into `shape.customProperties`).
+ */
+export type SwimlaneProfileKey = 'headerBackground' | 'separatorColor' | 'separatorWidth';
+
+/**
+ * Profile keys that are stored flat on a profile but applied into
+ * `shape.customProperties` rather than onto the shape directly. They are stripped
+ * from {@link ShapeStyleUpdate} because their owning facet folds them into a
+ * merged `customProperties` object instead.
+ */
+export type CustomPropertyProfileKey = ErdProfileKey | SwimlaneProfileKey;
+
+/**
  * Concrete shape-field updates produced by applying a profile to a shape.
  *
- * Structurally a `Partial<Shape>`: the raw ERD keys are replaced by a single
- * (already-merged) `customProperties` object, so the result can be handed
- * straight to `updateShape(id, update)` with no special-casing at the call site.
+ * Structurally a `Partial<Shape>`: the raw customProperties-backed keys are
+ * replaced by a single (already-merged) `customProperties` object, so the result
+ * can be handed straight to `updateShape(id, update)` with no special-casing at
+ * the call site.
  */
-export type ShapeStyleUpdate = Omit<Partial<StyleProfileProperties>, ErdProfileKey> & {
+export type ShapeStyleUpdate = Omit<Partial<StyleProfileProperties>, CustomPropertyProfileKey> & {
   customProperties?: Record<string, unknown>;
 };
 

--- a/src/store/styleProfile/types.ts
+++ b/src/store/styleProfile/types.ts
@@ -1,0 +1,163 @@
+/**
+ * Core contracts for the per-shape style-profile adapter layer (JP-33).
+ *
+ * A style profile is a flat bag of concrete style values
+ * ({@link StyleProfileProperties}). Translating that bag onto a concrete shape —
+ * and reading it back off a shape — used to be three hand-written `if`-ladders
+ * gated by a brittle string heuristic. It is now a set of composable
+ * {@link StyleFacet}s, each owning one style axis (fill/stroke, label, icon,
+ * ERD rows, …). A shape's "adapter" is simply the facets whose
+ * {@link StyleFacet.appliesTo} is true for its type — resolved by the registry.
+ *
+ * This module is the dependency root: it imports only shape *types*, so the
+ * facet/registry/capability modules can depend on it without forming a cycle
+ * back through `styleProfileStore`.
+ */
+
+import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../../shapes/Shape';
+
+/**
+ * Icon position options persisted in a style profile.
+ *
+ * Intentionally narrower than the shape-level `IconPosition` in `Shape.ts`
+ * (profiles only ever round-trip the corner/center positions). Kept verbatim
+ * from the original `styleProfileStore` definition to preserve behavior.
+ */
+export type IconPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center';
+
+/**
+ * Style properties that can be saved in a profile.
+ * These are the common style properties across all shape types.
+ */
+export interface StyleProfileProperties {
+  // Universal properties
+  fill: string | null;
+  stroke: string | null;
+  strokeWidth: number;
+  opacity: number;
+
+  // Rectangle/Group properties
+  /** Optional - only applies to rectangles and groups */
+  cornerRadius?: number;
+
+  // Label properties
+  /** Optional - label font size for shapes with labels */
+  labelFontSize?: number;
+  /** Optional - label color for shapes with labels */
+  labelColor?: string;
+
+  // Text shape properties
+  /** Optional - font size for text shapes */
+  fontSize?: number;
+  /** Optional - font family for text shapes */
+  fontFamily?: string;
+
+  // Line/Connector properties
+  /** Optional - start arrow style */
+  startArrow?: string;
+  /** Optional - end arrow style */
+  endArrow?: string;
+  /** Optional - line style (solid, dashed) */
+  lineStyle?: string;
+
+  // Group-specific properties
+  /** Optional - background color for groups */
+  backgroundColor?: string;
+  /** Optional - border color for groups */
+  borderColor?: string;
+  /** Optional - border width for groups */
+  borderWidth?: number;
+
+  // ERD entity styling properties
+  /** Optional - row separator color */
+  rowSeparatorColor?: string;
+  /** Optional - row background color */
+  rowBackgroundColor?: string;
+  /** Optional - alternate row color for zebra striping */
+  rowAlternateColor?: string;
+  /** Optional - horizontal padding for attribute text */
+  attributePaddingHorizontal?: number;
+  /** Optional - vertical padding for attributes */
+  attributePaddingVertical?: number;
+
+  // Icon properties (Rectangle, Ellipse, LibraryShape)
+  /** Optional - icon ID reference */
+  iconId?: string;
+  /** Optional - icon size in pixels */
+  iconSize?: number;
+  /** Optional - icon padding from corner */
+  iconPadding?: number;
+  /** Optional - icon color override */
+  iconColor?: string;
+  /** Optional - icon position */
+  iconPosition?: IconPosition;
+  /** Optional - icon display mode ('inside' | 'badge' | 'icon-only') */
+  iconDisplayMode?: IconDisplayMode;
+  /** Optional - badge configuration when iconDisplayMode = 'badge' */
+  iconBadge?: IconBadgeConfig;
+  /** Optional - multi-icon configuration (overrides single-icon props when present) */
+  icons?: IconConfig[];
+}
+
+/**
+ * The ERD-specific profile keys. They are stored flat on a profile but applied
+ * into `shape.customProperties` rather than onto the shape directly, so they are
+ * stripped from {@link ShapeStyleUpdate} (the ERD facet folds them into
+ * `customProperties`).
+ */
+export type ErdProfileKey =
+  | 'rowSeparatorColor'
+  | 'rowBackgroundColor'
+  | 'rowAlternateColor'
+  | 'attributePaddingHorizontal'
+  | 'attributePaddingVertical';
+
+/**
+ * Concrete shape-field updates produced by applying a profile to a shape.
+ *
+ * Structurally a `Partial<Shape>`: the raw ERD keys are replaced by a single
+ * (already-merged) `customProperties` object, so the result can be handed
+ * straight to `updateShape(id, update)` with no special-casing at the call site.
+ */
+export type ShapeStyleUpdate = Omit<Partial<StyleProfileProperties>, ErdProfileKey> & {
+  customProperties?: Record<string, unknown>;
+};
+
+/**
+ * Fully-resolved extraction options (every flag concrete). The public
+ * `ExtractStyleOptions` is the partial form; the store resolves it before
+ * dispatching to facets.
+ */
+export interface ResolvedExtractOptions {
+  /** Include icon properties (iconId, iconSize, …). */
+  includeIconStyle: boolean;
+  /** Include label properties (labelFontSize, labelColor). */
+  includeLabelStyle: boolean;
+}
+
+/**
+ * One reusable style axis (universal fill/stroke, label, icon, ERD rows, …).
+ *
+ * A facet knows which shape *types* it applies to, how to read its fields off a
+ * shape into the flat profile bag ({@link extract}), and how to translate
+ * profile values into concrete shape-field updates ({@link apply}).
+ *
+ * `apply(props, shape)` is deliberately the same primitive a future "Dynamic
+ * Style Profiles" `styleProfileRef` would call to resolve/merge a referenced
+ * profile onto a shape — no separate code path needed.
+ */
+export interface StyleFacet {
+  /** Stable id for ordering/debugging. */
+  readonly id: string;
+  /** Human-readable property names this facet contributes (drives the UI hint). */
+  readonly names: readonly string[];
+  /** Whether this facet applies to the given shape type. */
+  appliesTo(type: string): boolean;
+  /** Pull this facet's concrete fields off a shape into the flat profile bag. */
+  extract(shape: BaseShape, opts: ResolvedExtractOptions): Partial<StyleProfileProperties>;
+  /**
+   * Translate profile values into concrete shape-field updates, merging with
+   * the existing shape where a field is a sub-object (ERD `customProperties`).
+   */
+  apply(props: StyleProfileProperties, shape: BaseShape): ShapeStyleUpdate;
+}

--- a/src/store/styleProfileStore.test.ts
+++ b/src/store/styleProfileStore.test.ts
@@ -14,6 +14,9 @@ import {
   extractStyleFromShape,
   getProfileUpdates,
   mergeProfileProperties,
+  seedProfiles,
+  migrateStyleProfiles,
+  useStyleProfileStore,
   type StyleProfile,
   type StyleProfileProperties,
 } from './styleProfileStore';
@@ -86,6 +89,69 @@ function makeProfile(name: string, properties: StyleProfileProperties): StylePro
     favorite: false,
   };
 }
+
+describe('default-profile hardening (JP-401)', () => {
+  it('seedProfiles seeds canonical built-ins, appends user profiles, applies favorites', () => {
+    const user = makeProfile('mine', { fill: '#111', stroke: '#222', strokeWidth: 1, opacity: 1 });
+    const seeded = seedProfiles([user], ['default-blue']);
+
+    expect(seeded.filter((p) => p.id.startsWith('default-')).length).toBe(5);
+    expect(seeded[seeded.length - 1]?.id).toBe(user.id);
+    expect(seeded.find((p) => p.id === 'default-blue')?.favorite).toBe(true);
+    expect(seeded.find((p) => p.id === 'default-green')?.favorite).toBe(false);
+  });
+
+  it('seedProfiles drops stray default- entries from user profiles (no duplicates)', () => {
+    const stray: StyleProfile = {
+      ...makeProfile('x', { fill: '#0', stroke: '#0', strokeWidth: 1, opacity: 1 }),
+      id: 'default-blue',
+    };
+    const seeded = seedProfiles([stray], []);
+    expect(seeded.filter((p) => p.id === 'default-blue').length).toBe(1);
+  });
+
+  it('migrateStyleProfiles v1 strips baked-in defaults and lifts favorited built-ins', () => {
+    const v1 = {
+      profiles: [
+        { id: 'default-blue', name: 'Default Blue', properties: { fill: '#x', stroke: '#y', strokeWidth: 2, opacity: 1 }, createdAt: 0, favorite: true },
+        { id: 'user-1', name: 'Mine', properties: { fill: '#a', stroke: '#b', strokeWidth: 1, opacity: 1 }, createdAt: 1, favorite: false },
+      ],
+    };
+    const out = migrateStyleProfiles(v1, 1);
+    expect(out.profiles.map((p) => p.id)).toEqual(['user-1']);
+    expect(out.favoriteDefaultIds).toEqual(['default-blue']);
+  });
+
+  it('migrateStyleProfiles is idempotent on v2 data', () => {
+    const v2 = {
+      profiles: [{ id: 'user-1', name: 'Mine', properties: { fill: null, stroke: null, strokeWidth: 1, opacity: 1 }, createdAt: 1, favorite: false }],
+      favoriteDefaultIds: ['default-green'],
+    };
+    expect(migrateStyleProfiles(v2, 2)).toEqual(v2);
+  });
+
+  it('updateProfile is a no-op on a built-in (immutable)', () => {
+    const before = useStyleProfileStore.getState().getProfile('default-blue');
+    useStyleProfileStore.getState().updateProfile('default-blue', {
+      name: 'HACKED',
+      properties: { fill: '#000', stroke: '#000', strokeWidth: 9, opacity: 0.1 },
+    });
+    const after = useStyleProfileStore.getState().getProfile('default-blue');
+    expect(after?.name).toBe(before?.name);
+    expect(after?.properties).toEqual(before?.properties);
+  });
+
+  it('toggleFavorite on a built-in tracks it in the favoriteDefaultIds overlay', () => {
+    const start = useStyleProfileStore.getState().favoriteDefaultIds.includes('default-subtle');
+    useStyleProfileStore.getState().toggleFavorite('default-subtle');
+    const s1 = useStyleProfileStore.getState();
+    expect(s1.favoriteDefaultIds.includes('default-subtle')).toBe(!start);
+    expect(s1.getProfile('default-subtle')?.favorite).toBe(!start);
+    // restore
+    useStyleProfileStore.getState().toggleFavorite('default-subtle');
+    expect(useStyleProfileStore.getState().favoriteDefaultIds.includes('default-subtle')).toBe(start);
+  });
+});
 
 describe('mergeProfileProperties — non-destructive master memory (JP-399)', () => {
   it('keeps a rectangle cornerRadius when later updating the profile from a file', () => {

--- a/src/store/styleProfileStore.test.ts
+++ b/src/store/styleProfileStore.test.ts
@@ -13,10 +13,11 @@ import { describe, it, expect } from 'vitest';
 import {
   extractStyleFromShape,
   getProfileUpdates,
+  mergeProfileProperties,
   type StyleProfile,
   type StyleProfileProperties,
 } from './styleProfileStore';
-import type { RectangleShape, LineShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
+import type { BaseShape, RectangleShape, LineShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
 
 function makeRectangle(overrides: Partial<RectangleShape> = {}): RectangleShape {
   return {
@@ -59,6 +60,23 @@ function makeLine(overrides: Partial<LineShape> = {}): LineShape {
   };
 }
 
+function makeFile(overrides: Record<string, unknown> = {}): BaseShape {
+  return {
+    id: 'file-1',
+    type: 'file',
+    x: 0,
+    y: 0,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: '#f8fafc',
+    stroke: '#cbd5e1',
+    strokeWidth: 1,
+    ...overrides,
+  } as unknown as BaseShape;
+}
+
 function makeProfile(name: string, properties: StyleProfileProperties): StyleProfile {
   return {
     id: `profile-${name}`,
@@ -68,6 +86,33 @@ function makeProfile(name: string, properties: StyleProfileProperties): StylePro
     favorite: false,
   };
 }
+
+describe('mergeProfileProperties — non-destructive master memory (JP-399)', () => {
+  it('keeps a rectangle cornerRadius when later updating the profile from a file', () => {
+    // Save a rectangle's style into a profile.
+    const rectProps = extractStyleFromShape(makeRectangle({ cornerRadius: 8, fill: '#ffffff' }));
+    expect(rectProps.cornerRadius).toBe(8);
+
+    // Later "Update with current" from a file shape, which has no cornerRadius.
+    const fileProps = extractStyleFromShape(makeFile({ fill: '#f8fafc' }));
+    expect(fileProps.cornerRadius).toBeUndefined();
+
+    const merged = mergeProfileProperties(rectProps, fileProps);
+
+    // The file's universal fill wins (the freshly-saved look)…
+    expect(merged.fill).toBe('#f8fafc');
+    // …but the rectangle's radius is preserved, not clobbered. This was the bug:
+    // a full replace deleted it.
+    expect(merged.cornerRadius).toBe(8);
+  });
+
+  it('unions fields across shapes so one profile can style many shape types', () => {
+    const a: StyleProfileProperties = { fill: '#111', stroke: '#222', strokeWidth: 2, opacity: 1, cornerRadius: 4 };
+    const b: StyleProfileProperties = { fill: '#333', stroke: '#444', strokeWidth: 3, opacity: 1, fontSize: 18 };
+    const merged = mergeProfileProperties(a, b);
+    expect(merged).toMatchObject({ fill: '#333', stroke: '#444', strokeWidth: 3, cornerRadius: 4, fontSize: 18 });
+  });
+});
 
 describe('extractStyleFromShape — icon coverage (JP-7)', () => {
   it('captures all 8 icon fields when includeIconStyle is true', () => {

--- a/src/store/styleProfileStore.test.ts
+++ b/src/store/styleProfileStore.test.ts
@@ -16,7 +16,7 @@ import {
   type StyleProfile,
   type StyleProfileProperties,
 } from './styleProfileStore';
-import type { RectangleShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
+import type { RectangleShape, LineShape, IconBadgeConfig, IconConfig } from '../shapes/Shape';
 
 function makeRectangle(overrides: Partial<RectangleShape> = {}): RectangleShape {
   return {
@@ -34,6 +34,27 @@ function makeRectangle(overrides: Partial<RectangleShape> = {}): RectangleShape 
     stroke: '#000000',
     strokeWidth: 2,
     cornerRadius: 0,
+    ...overrides,
+  };
+}
+
+function makeLine(overrides: Partial<LineShape> = {}): LineShape {
+  return {
+    id: 'line-1',
+    type: 'line',
+    x: 0,
+    y: 0,
+    x2: 50,
+    y2: 50,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+    fill: null,
+    stroke: '#000000',
+    strokeWidth: 2,
+    startArrow: false,
+    endArrow: true,
     ...overrides,
   };
 }
@@ -130,7 +151,7 @@ describe('getProfileUpdates — icon coverage (JP-7)', () => {
 
     const props = extractStyleFromShape(source, { includeIconStyle: true });
     const profile = makeProfile('roundtrip', props);
-    const updates = getProfileUpdates(profile, 'rectangle');
+    const updates = getProfileUpdates(profile, source);
 
     expect(updates.iconId).toBe('builtin:typescript');
     expect(updates.iconSize).toBe(32);
@@ -146,7 +167,7 @@ describe('getProfileUpdates — icon coverage (JP-7)', () => {
     // Profile saved with includeIconStyle: false — no icon props.
     const profileProps = extractStyleFromShape(makeRectangle(), { includeIconStyle: false });
     const profile = makeProfile('no-icons', profileProps);
-    const updates = getProfileUpdates(profile, 'rectangle');
+    const updates = getProfileUpdates(profile, makeRectangle());
 
     expect(updates.iconId).toBeUndefined();
     expect(updates.iconSize).toBeUndefined();
@@ -165,8 +186,8 @@ describe('getProfileUpdates — icon coverage (JP-7)', () => {
     );
     const profile = makeProfile('cross-shape', props);
 
-    // 'line' is not in SHAPE_CATEGORIES.withIcons.
-    const updates = getProfileUpdates(profile, 'line');
+    // A line does not support icons, so the icon facet does not apply.
+    const updates = getProfileUpdates(profile, makeLine());
 
     expect(updates.iconId).toBeUndefined();
     expect(updates.iconDisplayMode).toBeUndefined();

--- a/src/store/styleProfileStore.ts
+++ b/src/store/styleProfileStore.ts
@@ -297,3 +297,21 @@ export function getProfileUpdates(profile: StyleProfile, shape: BaseShape): Shap
 export function getApplicablePropertyNames(shapeType: string): string[] {
   return resolveStyleAdapter(shapeType).flatMap((facet) => [...facet.names]);
 }
+
+/**
+ * Non-destructively merge freshly-extracted style into a profile's existing
+ * properties — the "master memory" union.
+ *
+ * Keys absent from `incoming` are preserved from `existing`, so saving a shape
+ * that lacks a field (e.g. a file has no `cornerRadius`) never deletes another
+ * shape's saved value. This relies on `extractStyleFromShape` only emitting keys
+ * the shape actually has, which is what makes a plain union correct: across shape
+ * families there are no semantic collisions, and `getProfileUpdates` gates apply
+ * per shape, so a unioned profile hands each shape back only its own fields.
+ */
+export function mergeProfileProperties(
+  existing: StyleProfileProperties,
+  incoming: StyleProfileProperties
+): StyleProfileProperties {
+  return { ...existing, ...incoming };
+}

--- a/src/store/styleProfileStore.ts
+++ b/src/store/styleProfileStore.ts
@@ -1,86 +1,18 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { nanoid } from 'nanoid';
-import type { BaseShape, IconDisplayMode, IconBadgeConfig, IconConfig } from '../shapes/Shape';
+import type { BaseShape } from '../shapes/Shape';
+import { resolveStyleAdapter } from './styleProfile';
+import type {
+  StyleProfileProperties,
+  ShapeStyleUpdate,
+  ResolvedExtractOptions,
+} from './styleProfile';
 
-/**
- * Icon position options for shapes.
- */
-export type IconPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'center';
-
-/**
- * Style properties that can be saved in a profile.
- * These are the common style properties across all shape types.
- */
-export interface StyleProfileProperties {
-  // Universal properties
-  fill: string | null;
-  stroke: string | null;
-  strokeWidth: number;
-  opacity: number;
-
-  // Rectangle/Group properties
-  /** Optional - only applies to rectangles and groups */
-  cornerRadius?: number;
-
-  // Label properties
-  /** Optional - label font size for shapes with labels */
-  labelFontSize?: number;
-  /** Optional - label color for shapes with labels */
-  labelColor?: string;
-
-  // Text shape properties
-  /** Optional - font size for text shapes */
-  fontSize?: number;
-  /** Optional - font family for text shapes */
-  fontFamily?: string;
-
-  // Line/Connector properties
-  /** Optional - start arrow style */
-  startArrow?: string;
-  /** Optional - end arrow style */
-  endArrow?: string;
-  /** Optional - line style (solid, dashed) */
-  lineStyle?: string;
-
-  // Group-specific properties
-  /** Optional - background color for groups */
-  backgroundColor?: string;
-  /** Optional - border color for groups */
-  borderColor?: string;
-  /** Optional - border width for groups */
-  borderWidth?: number;
-
-  // ERD entity styling properties
-  /** Optional - row separator color */
-  rowSeparatorColor?: string;
-  /** Optional - row background color */
-  rowBackgroundColor?: string;
-  /** Optional - alternate row color for zebra striping */
-  rowAlternateColor?: string;
-  /** Optional - horizontal padding for attribute text */
-  attributePaddingHorizontal?: number;
-  /** Optional - vertical padding for attributes */
-  attributePaddingVertical?: number;
-
-  // Icon properties (Rectangle, Ellipse, LibraryShape)
-  /** Optional - icon ID reference */
-  iconId?: string;
-  /** Optional - icon size in pixels */
-  iconSize?: number;
-  /** Optional - icon padding from corner */
-  iconPadding?: number;
-  /** Optional - icon color override */
-  iconColor?: string;
-  /** Optional - icon position */
-  iconPosition?: IconPosition;
-  /** Optional - icon display mode ('inside' | 'badge' | 'icon-only') */
-  iconDisplayMode?: IconDisplayMode;
-  /** Optional - badge configuration when iconDisplayMode = 'badge' */
-  iconBadge?: IconBadgeConfig;
-  /** Optional - multi-icon configuration (overrides single-icon props when present) */
-  icons?: IconConfig[];
-}
+// The profile value types now live in `./styleProfile/types` (the dependency
+// root of the adapter layer). Re-export them here so existing import paths
+// (`./styleProfileStore`) keep working unchanged.
+export type { IconPosition, StyleProfileProperties } from './styleProfile';
 
 /**
  * A saved style profile.
@@ -306,20 +238,22 @@ const DEFAULT_EXTRACT_OPTIONS: ExtractStyleOptions = {
 
 /**
  * Extract style properties from a shape for creating a profile.
- * Extracts all applicable properties based on the shape type.
+ *
+ * Dispatches to the per-shape adapter (the facets that apply to `shape.type`):
+ * universal fill/stroke/strokeWidth/opacity are always present, and each facet
+ * layers on the type-specific fields it owns. See `./styleProfile`.
  *
  * @param shape - The shape to extract styles from
  * @param options - Options for what to include (default: include all)
  */
 export function extractStyleFromShape(shape: BaseShape, options?: ExtractStyleOptions): StyleProfileProperties {
-  const opts = { ...DEFAULT_EXTRACT_OPTIONS, ...options };
+  const opts: ResolvedExtractOptions = {
+    includeIconStyle: options?.includeIconStyle ?? DEFAULT_EXTRACT_OPTIONS.includeIconStyle ?? true,
+    includeLabelStyle: options?.includeLabelStyle ?? DEFAULT_EXTRACT_OPTIONS.includeLabelStyle ?? true,
+  };
 
-  // Subtype-specific fields aren't on BaseShape, so probe them via an
-  // index-signature view of the same object. Each access is guarded by a
-  // `typeof` runtime check, so the cast doesn't widen the effective type
-  // of any value that actually lands in `properties`.
-  const extra = shape as unknown as Record<string, unknown>;
-
+  // Seed the four universal (required) fields so the return type is satisfied
+  // even before facets run; the universal facet re-affirms the same values.
   const properties: StyleProfileProperties = {
     fill: shape.fill ?? null,
     stroke: shape.stroke ?? null,
@@ -327,309 +261,33 @@ export function extractStyleFromShape(shape: BaseShape, options?: ExtractStyleOp
     opacity: shape.opacity ?? 1,
   };
 
-  // Rectangle/Group properties
-  if (typeof extra['cornerRadius'] === 'number') {
-    properties.cornerRadius = extra['cornerRadius'];
-  }
-
-  // Label properties (conditionally included)
-  if (opts.includeLabelStyle) {
-    if (typeof extra['labelFontSize'] === 'number') {
-      properties.labelFontSize = extra['labelFontSize'];
-    }
-    if (typeof extra['labelColor'] === 'string') {
-      properties.labelColor = extra['labelColor'];
-    }
-  }
-
-  // Text shape properties
-  if (typeof extra['fontSize'] === 'number') {
-    properties.fontSize = extra['fontSize'];
-  }
-  if (typeof extra['fontFamily'] === 'string') {
-    properties.fontFamily = extra['fontFamily'];
-  }
-
-  // Line/Connector properties
-  if (typeof extra['startArrow'] === 'string') {
-    properties.startArrow = extra['startArrow'];
-  }
-  if (typeof extra['endArrow'] === 'string') {
-    properties.endArrow = extra['endArrow'];
-  }
-  if (typeof extra['lineStyle'] === 'string') {
-    properties.lineStyle = extra['lineStyle'];
-  }
-
-  // Group-specific properties
-  if (typeof extra['backgroundColor'] === 'string') {
-    properties.backgroundColor = extra['backgroundColor'];
-  }
-  if (typeof extra['borderColor'] === 'string') {
-    properties.borderColor = extra['borderColor'];
-  }
-  if (typeof extra['borderWidth'] === 'number') {
-    properties.borderWidth = extra['borderWidth'];
-  }
-
-  // ERD entity properties (from customProperties)
-  const customPropsRaw = extra['customProperties'];
-  if (customPropsRaw && typeof customPropsRaw === 'object') {
-    const customProps = customPropsRaw as Record<string, unknown>;
-    if (typeof customProps['rowSeparatorColor'] === 'string') {
-      properties.rowSeparatorColor = customProps['rowSeparatorColor'];
-    }
-    if (typeof customProps['rowBackgroundColor'] === 'string') {
-      properties.rowBackgroundColor = customProps['rowBackgroundColor'];
-    }
-    if (typeof customProps['rowAlternateColor'] === 'string') {
-      properties.rowAlternateColor = customProps['rowAlternateColor'];
-    }
-    if (typeof customProps['attributePaddingHorizontal'] === 'number') {
-      properties.attributePaddingHorizontal = customProps['attributePaddingHorizontal'];
-    }
-    if (typeof customProps['attributePaddingVertical'] === 'number') {
-      properties.attributePaddingVertical = customProps['attributePaddingVertical'];
-    }
-  }
-
-  // Icon properties (conditionally included)
-  if (opts.includeIconStyle) {
-    if (typeof extra['iconId'] === 'string') {
-      properties.iconId = extra['iconId'];
-    }
-    if (typeof extra['iconSize'] === 'number') {
-      properties.iconSize = extra['iconSize'];
-    }
-    if (typeof extra['iconPadding'] === 'number') {
-      properties.iconPadding = extra['iconPadding'];
-    }
-    if (typeof extra['iconColor'] === 'string') {
-      properties.iconColor = extra['iconColor'];
-    }
-    if (typeof extra['iconPosition'] === 'string') {
-      properties.iconPosition = extra['iconPosition'] as IconPosition;
-    }
-    if (typeof extra['iconDisplayMode'] === 'string') {
-      properties.iconDisplayMode = extra['iconDisplayMode'] as IconDisplayMode;
-    }
-    const iconBadge = extra['iconBadge'];
-    if (iconBadge && typeof iconBadge === 'object') {
-      // Shallow copy so future shape mutations don't bleed into the profile.
-      properties.iconBadge = { ...(iconBadge as IconBadgeConfig) };
-    }
-    const icons = extra['icons'];
-    if (Array.isArray(icons)) {
-      properties.icons = icons.map((icon) => ({ ...(icon as IconConfig) }));
-    }
+  for (const facet of resolveStyleAdapter(shape.type)) {
+    Object.assign(properties, facet.extract(shape, opts));
   }
 
   return properties;
 }
 
 /**
- * Shape type categories for determining applicable properties.
+ * Translate a profile into the concrete field updates to apply to a shape.
+ *
+ * Dispatches to the per-shape adapter. The result is a `Partial<Shape>`-shaped
+ * update (it includes an already-merged `customProperties` object for ERD
+ * entities), so callers hand it straight to `updateShape(id, updates)` with no
+ * shape-type special-casing.
+ *
+ * This is also the primitive a future "Dynamic Style Profiles" `styleProfileRef`
+ * would call to resolve/merge a referenced profile onto a shape.
+ *
+ * Note: the second parameter is the **shape** (not just its type) because the
+ * ERD facet needs the existing `customProperties` to merge rather than clobber.
  */
-const SHAPE_CATEGORIES = {
-  /** Shapes that support labels */
-  withLabels: new Set(['rectangle', 'ellipse', 'connector']),
-  /** Shapes that support corner radius */
-  withCornerRadius: new Set(['rectangle', 'group']),
-  /** Shapes that are text-based */
-  textBased: new Set(['text']),
-  /** Shapes that support arrows */
-  withArrows: new Set(['line', 'connector']),
-  /** Shapes that support line style */
-  withLineStyle: new Set(['connector']),
-  /** Group shapes with background/border */
-  groups: new Set(['group']),
-  /** ERD entity shapes with table styling */
-  erdEntities: new Set(['erd-entity', 'erd-weak-entity']),
-  /** Shapes that support icons */
-  withIcons: new Set(['rectangle', 'ellipse']),
-} as const;
-
-/**
- * Check if a shape type is an ERD entity shape.
- */
-function isERDEntityShape(shapeType: string): boolean {
-  return SHAPE_CATEGORIES.erdEntities.has(shapeType);
-}
-
-/**
- * Check if a shape type is a library shape (flowchart, ERD, UML, etc.)
- */
-function isLibraryShape(shapeType: string): boolean {
-  return shapeType.includes('-') || shapeType.startsWith('flowchart') ||
-         shapeType.startsWith('erd') || shapeType.startsWith('uml') ||
-         shapeType === 'diamond' || shapeType === 'terminator' ||
-         shapeType === 'document' || shapeType === 'data' ||
-         shapeType === 'predefined-process' || shapeType === 'manual-input' ||
-         shapeType === 'preparation' || shapeType === 'connector-circle' ||
-         shapeType === 'off-page-connector' || shapeType === 'actor' ||
-         shapeType === 'use-case' || shapeType === 'system-boundary';
-}
-
-/**
- * Get updates object to apply a profile to a shape.
- * Filters out properties that don't apply to the shape type.
- */
-export function getProfileUpdates(
-  profile: StyleProfile,
-  shapeType: string
-): Partial<StyleProfileProperties> {
-  const props = profile.properties;
-  const updates: Partial<StyleProfileProperties> = {};
-
-  // Universal properties - apply to all shapes
-  updates.fill = props.fill;
-  updates.stroke = props.stroke;
-  updates.strokeWidth = props.strokeWidth;
-  updates.opacity = props.opacity;
-
-  // Corner radius - rectangles and groups
-  if (SHAPE_CATEGORIES.withCornerRadius.has(shapeType) && props.cornerRadius !== undefined) {
-    updates.cornerRadius = props.cornerRadius;
+export function getProfileUpdates(profile: StyleProfile, shape: BaseShape): ShapeStyleUpdate {
+  const updates: ShapeStyleUpdate = {};
+  for (const facet of resolveStyleAdapter(shape.type)) {
+    Object.assign(updates, facet.apply(profile.properties, shape));
   }
-
-  // Label properties - rectangles, ellipses, connectors, and all library shapes
-  const supportsLabels = SHAPE_CATEGORIES.withLabels.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsLabels) {
-    if (props.labelFontSize !== undefined) {
-      updates.labelFontSize = props.labelFontSize;
-    }
-    if (props.labelColor !== undefined) {
-      updates.labelColor = props.labelColor;
-    }
-  }
-
-  // Text shape properties
-  if (SHAPE_CATEGORIES.textBased.has(shapeType)) {
-    if (props.fontSize !== undefined) {
-      updates.fontSize = props.fontSize;
-    }
-    if (props.fontFamily !== undefined) {
-      updates.fontFamily = props.fontFamily;
-    }
-    // For text shapes, fill is the text color (already applied above)
-  }
-
-  // Arrow properties - lines and connectors
-  if (SHAPE_CATEGORIES.withArrows.has(shapeType)) {
-    if (props.startArrow !== undefined) {
-      updates.startArrow = props.startArrow;
-    }
-    if (props.endArrow !== undefined) {
-      updates.endArrow = props.endArrow;
-    }
-  }
-
-  // Line style - connectors
-  if (SHAPE_CATEGORIES.withLineStyle.has(shapeType)) {
-    if (props.lineStyle !== undefined) {
-      updates.lineStyle = props.lineStyle;
-    }
-  }
-
-  // Group-specific properties
-  if (SHAPE_CATEGORIES.groups.has(shapeType)) {
-    if (props.backgroundColor !== undefined) {
-      updates.backgroundColor = props.backgroundColor;
-    }
-    if (props.borderColor !== undefined) {
-      updates.borderColor = props.borderColor;
-    }
-    if (props.borderWidth !== undefined) {
-      updates.borderWidth = props.borderWidth;
-    }
-  }
-
-  // ERD entity properties are applied via customProperties
-  // Note: These are included in the updates object but need special handling
-  // when applying to the shape (see getERDProfileCustomProperties)
-  if (isERDEntityShape(shapeType)) {
-    if (props.rowSeparatorColor !== undefined) {
-      updates.rowSeparatorColor = props.rowSeparatorColor;
-    }
-    if (props.rowBackgroundColor !== undefined) {
-      updates.rowBackgroundColor = props.rowBackgroundColor;
-    }
-    if (props.rowAlternateColor !== undefined) {
-      updates.rowAlternateColor = props.rowAlternateColor;
-    }
-    if (props.attributePaddingHorizontal !== undefined) {
-      updates.attributePaddingHorizontal = props.attributePaddingHorizontal;
-    }
-    if (props.attributePaddingVertical !== undefined) {
-      updates.attributePaddingVertical = props.attributePaddingVertical;
-    }
-  }
-
-  // Icon properties - rectangles, ellipses, and library shapes
-  const supportsIcons = SHAPE_CATEGORIES.withIcons.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsIcons) {
-    if (props.iconId !== undefined) {
-      updates.iconId = props.iconId;
-    }
-    if (props.iconSize !== undefined) {
-      updates.iconSize = props.iconSize;
-    }
-    if (props.iconPadding !== undefined) {
-      updates.iconPadding = props.iconPadding;
-    }
-    if (props.iconColor !== undefined) {
-      updates.iconColor = props.iconColor;
-    }
-    if (props.iconPosition !== undefined) {
-      updates.iconPosition = props.iconPosition;
-    }
-    if (props.iconDisplayMode !== undefined) {
-      updates.iconDisplayMode = props.iconDisplayMode;
-    }
-    if (props.iconBadge !== undefined) {
-      updates.iconBadge = props.iconBadge;
-    }
-    if (props.icons !== undefined) {
-      updates.icons = props.icons;
-    }
-  }
-
   return updates;
-}
-
-/**
- * Get ERD-specific customProperties updates from a profile.
- * These need to be merged with existing customProperties when applying.
- */
-export function getERDProfileCustomProperties(
-  profile: StyleProfile
-): Record<string, unknown> | null {
-  const props = profile.properties;
-  const customProps: Record<string, unknown> = {};
-  let hasProps = false;
-
-  if (props.rowSeparatorColor !== undefined) {
-    customProps['rowSeparatorColor'] = props.rowSeparatorColor;
-    hasProps = true;
-  }
-  if (props.rowBackgroundColor !== undefined) {
-    customProps['rowBackgroundColor'] = props.rowBackgroundColor;
-    hasProps = true;
-  }
-  if (props.rowAlternateColor !== undefined) {
-    customProps['rowAlternateColor'] = props.rowAlternateColor;
-    hasProps = true;
-  }
-  if (props.attributePaddingHorizontal !== undefined) {
-    customProps['attributePaddingHorizontal'] = props.attributePaddingHorizontal;
-    hasProps = true;
-  }
-  if (props.attributePaddingVertical !== undefined) {
-    customProps['attributePaddingVertical'] = props.attributePaddingVertical;
-    hasProps = true;
-  }
-
-  return hasProps ? customProps : null;
 }
 
 /**
@@ -637,41 +295,5 @@ export function getERDProfileCustomProperties(
  * Useful for UI to show what a profile will change.
  */
 export function getApplicablePropertyNames(shapeType: string): string[] {
-  const names: string[] = ['Fill', 'Stroke', 'Stroke Width', 'Opacity'];
-
-  if (SHAPE_CATEGORIES.withCornerRadius.has(shapeType)) {
-    names.push('Corner Radius');
-  }
-
-  const supportsLabels = SHAPE_CATEGORIES.withLabels.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsLabels) {
-    names.push('Label Font Size', 'Label Color');
-  }
-
-  if (SHAPE_CATEGORIES.textBased.has(shapeType)) {
-    names.push('Font Size', 'Font Family');
-  }
-
-  if (SHAPE_CATEGORIES.withArrows.has(shapeType)) {
-    names.push('Start Arrow', 'End Arrow');
-  }
-
-  if (SHAPE_CATEGORIES.withLineStyle.has(shapeType)) {
-    names.push('Line Style');
-  }
-
-  if (SHAPE_CATEGORIES.groups.has(shapeType)) {
-    names.push('Background Color', 'Border Color', 'Border Width');
-  }
-
-  if (isERDEntityShape(shapeType)) {
-    names.push('Row Colors', 'Padding', 'Separator Inset');
-  }
-
-  const supportsIcons = SHAPE_CATEGORIES.withIcons.has(shapeType) || isLibraryShape(shapeType);
-  if (supportsIcons) {
-    names.push('Icon', 'Icon Size', 'Icon Position');
-  }
-
-  return names;
+  return resolveStyleAdapter(shapeType).flatMap((facet) => [...facet.names]);
 }

--- a/src/store/styleProfileStore.ts
+++ b/src/store/styleProfileStore.ts
@@ -37,6 +37,18 @@ export interface StyleProfile {
  */
 interface StyleProfileState {
   profiles: StyleProfile[];
+  /**
+   * Ids of built-in default profiles the user has favorited. Built-ins are
+   * immutable and seeded from code (not persisted), so their one allowed
+   * mutation — the favorite flag — is tracked here as an overlay.
+   */
+  favoriteDefaultIds: string[];
+}
+
+/** Shape persisted to localStorage: user profiles only + the favorite overlay. */
+interface PersistedStyleProfiles {
+  profiles: StyleProfile[];
+  favoriteDefaultIds: string[];
 }
 
 /**
@@ -131,6 +143,46 @@ const DEFAULT_PROFILES: StyleProfile[] = [
   },
 ];
 
+/** Whether an id refers to a built-in default profile. */
+function isDefaultProfileId(id: string): boolean {
+  return id.startsWith('default-');
+}
+
+/**
+ * Build the runtime profile list: the canonical built-ins (seeded fresh from
+ * code so they can never drift or be clobbered) followed by the user's saved
+ * profiles. `favoriteDefaultIds` re-applies the user's favorite flags onto the
+ * built-ins — the one mutation allowed on a default.
+ */
+export function seedProfiles(userProfiles: StyleProfile[], favoriteDefaultIds: readonly string[]): StyleProfile[] {
+  const favSet = new Set(favoriteDefaultIds);
+  const defaults = DEFAULT_PROFILES.map((d) => ({ ...d, favorite: favSet.has(d.id) }));
+  const users = userProfiles.filter((p) => !isDefaultProfileId(p.id));
+  return [...defaults, ...users];
+}
+
+/**
+ * Migrate persisted style-profile state to the current persisted shape (user
+ * profiles + favorite overlay). v1 baked the built-ins into the array; strip
+ * them, lifting any favorited built-ins into the overlay. Idempotent — running
+ * it on an already-v2 blob is a no-op beyond defensive normalization.
+ */
+export function migrateStyleProfiles(persisted: unknown, version: number): PersistedStyleProfiles {
+  const prev = (persisted ?? {}) as Partial<PersistedStyleProfiles>;
+  const all = Array.isArray(prev.profiles) ? prev.profiles : [];
+  const userProfiles = all.filter((p) => !isDefaultProfileId(p.id));
+  if (version < 2) {
+    const favoriteDefaultIds = all
+      .filter((p) => isDefaultProfileId(p.id) && p.favorite)
+      .map((p) => p.id);
+    return { profiles: userProfiles, favoriteDefaultIds };
+  }
+  return {
+    profiles: userProfiles,
+    favoriteDefaultIds: Array.isArray(prev.favoriteDefaultIds) ? prev.favoriteDefaultIds : [],
+  };
+}
+
 /**
  * Style profile store for managing reusable style presets.
  * Persisted to localStorage.
@@ -138,7 +190,8 @@ const DEFAULT_PROFILES: StyleProfile[] = [
 export const useStyleProfileStore = create<StyleProfileState & StyleProfileActions>()(
   persist(
     (set, get) => ({
-      profiles: DEFAULT_PROFILES,
+      profiles: seedProfiles([], []),
+      favoriteDefaultIds: [],
 
       addProfile: (name: string, properties: StyleProfileProperties) => {
         const profile: StyleProfile = {
@@ -157,6 +210,10 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
       },
 
       updateProfile: (id: string, updates: Partial<Omit<StyleProfile, 'id' | 'createdAt'>>) => {
+        // Built-in defaults are immutable (seeded from code) — never let Update /
+        // merge / Reset rewrite them.
+        if (isDefaultProfileId(id)) return;
+
         set((state) => ({
           profiles: state.profiles.map((p) =>
             p.id === id ? { ...p, ...updates } : p
@@ -166,7 +223,7 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
 
       deleteProfile: (id: string) => {
         // Don't allow deleting default profiles
-        if (id.startsWith('default-')) return;
+        if (isDefaultProfileId(id)) return;
 
         set((state) => ({
           profiles: state.profiles.filter((p) => p.id !== id),
@@ -175,7 +232,7 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
 
       renameProfile: (id: string, name: string) => {
         // Don't allow renaming default profiles
-        if (id.startsWith('default-')) return;
+        if (isDefaultProfileId(id)) return;
 
         set((state) => ({
           profiles: state.profiles.map((p) =>
@@ -185,6 +242,24 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
       },
 
       toggleFavorite: (id: string) => {
+        if (isDefaultProfileId(id)) {
+          // Favorite is the only allowed mutation on a built-in; track it in the
+          // persisted overlay rather than mutating the (non-persisted) default.
+          set((state) => {
+            const isFav = state.favoriteDefaultIds.includes(id);
+            const favoriteDefaultIds = isFav
+              ? state.favoriteDefaultIds.filter((x) => x !== id)
+              : [...state.favoriteDefaultIds, id];
+            return {
+              favoriteDefaultIds,
+              profiles: state.profiles.map((p) =>
+                p.id === id ? { ...p, favorite: !isFav } : p
+              ),
+            };
+          });
+          return;
+        }
+
         set((state) => ({
           profiles: state.profiles.map((p) =>
             p.id === id ? { ...p, favorite: !p.favorite } : p
@@ -197,8 +272,8 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
       },
 
       clearProfiles: () => {
-        // Reset to default profiles only
-        set({ profiles: DEFAULT_PROFILES });
+        // Drop user profiles + the favorite overlay; reseed canonical built-ins.
+        set({ profiles: seedProfiles([], []), favoriteDefaultIds: [] });
       },
 
       getSortedProfiles: () => {
@@ -213,7 +288,25 @@ export const useStyleProfileStore = create<StyleProfileState & StyleProfileActio
     }),
     {
       name: 'docushark-style-profiles',
-      version: 1,
+      version: 2,
+      // Persist only user profiles + the default-favorite overlay; built-ins are
+      // seeded from code at runtime (see merge) so they never drift or get
+      // clobbered by a stale persisted copy.
+      partialize: (state): PersistedStyleProfiles => ({
+        profiles: state.profiles.filter((p) => !isDefaultProfileId(p.id)),
+        favoriteDefaultIds: state.favoriteDefaultIds,
+      }),
+      migrate: (persisted, version): PersistedStyleProfiles => migrateStyleProfiles(persisted, version),
+      merge: (persisted, current) => {
+        const prev = (persisted ?? {}) as Partial<PersistedStyleProfiles>;
+        const favoriteDefaultIds = Array.isArray(prev.favoriteDefaultIds) ? prev.favoriteDefaultIds : [];
+        const userProfiles = Array.isArray(prev.profiles) ? prev.profiles : [];
+        return {
+          ...current,
+          favoriteDefaultIds,
+          profiles: seedProfiles(userProfiles, favoriteDefaultIds),
+        };
+      },
     }
   )
 );

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -257,29 +257,40 @@ export function CanvasContainer({
   }, []);
 
   /**
-   * Subscribe to emphasis changes for focus animation.
+   * Subscribe to ephemeral render state (focus emphasis + live style preview).
+   * Both are pushed into the renderer and never touch the document.
    */
   useEffect(() => {
     const engine = engineRef.current;
     if (!engine) return;
 
     let lastEmphasis: string | null = null;
+    let lastPreview: Record<string, unknown> | null = null;
 
-    // Update renderer with emphasis state
-    const updateEmphasis = () => {
-      const { emphasizedShapeId } = useSessionStore.getState();
+    const updateEphemeral = () => {
+      const { emphasizedShapeId, stylePreviewOverrides } = useSessionStore.getState();
+      let dirty = false;
+
       if (emphasizedShapeId !== lastEmphasis) {
         lastEmphasis = emphasizedShapeId;
         engine.renderer.setEmphasis(emphasizedShapeId);
-        engine.requestRender();
+        dirty = true;
       }
+
+      if (stylePreviewOverrides !== lastPreview) {
+        lastPreview = stylePreviewOverrides;
+        engine.renderer.setStylePreviewOverrides(stylePreviewOverrides);
+        dirty = true;
+      }
+
+      if (dirty) engine.requestRender();
     };
 
     // Initial update
-    updateEmphasis();
+    updateEphemeral();
 
     // Subscribe to session store changes
-    const unsubscribe = useSessionStore.subscribe(updateEmphasis);
+    const unsubscribe = useSessionStore.subscribe(updateEphemeral);
 
     return () => {
       unsubscribe();

--- a/src/ui/CanvasToolbar.tsx
+++ b/src/ui/CanvasToolbar.tsx
@@ -113,24 +113,30 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
   const getUndoDescription = useHistoryStore((state) => state.getUndoDescription);
   const getRedoDescription = useHistoryStore((state) => state.getRedoDescription);
 
-  // Undo/redo are disabled in a collaboration session (JP-178): snapshot-based
-  // history would diverge from the authoritative relay Y.Doc. Subscribe so the
-  // buttons react when a session starts/stops.
+  // JP-402: undo/redo now work in a collab session too — backed by a per-user
+  // CRDT UndoManager (not snapshot history, which would diverge, JP-178). In collab
+  // availability comes from the reactive `canUndoCanvas`/`canRedoCanvas` mirror;
+  // subscribe so the buttons react to edits, undo/redo, and page switches.
   const collabActive = useCollaborationStore((state) => state.isActive);
+  const canUndoCanvas = useCollaborationStore((state) => state.canUndoCanvas);
+  const canRedoCanvas = useCollaborationStore((state) => state.canRedoCanvas);
 
   // Derive descriptions reactively (pageHistory triggers re-render)
   const _ph = pageHistory; const _ap = activeHistoryPage; // ensure subscription
   void _ph; void _ap;
   const undoDesc = getUndoDescription();
   const redoDesc = getRedoDescription();
-  const collabUndoNote = 'Undo/redo are unavailable in shared documents';
+  // In collab, undo/redo act on this user's own changes; descriptions come from the
+  // snapshot history, which is inactive there, so use a plain label.
+  const undoEnabled = collabActive ? canUndoCanvas : canUndo();
+  const redoEnabled = collabActive ? canRedoCanvas : canRedo();
   const undoTitle = collabActive
-    ? collabUndoNote
+    ? 'Undo your last change (Ctrl+Z)'
     : undoDesc
       ? `Undo: ${undoDesc} (Ctrl+Z)`
       : 'Undo (Ctrl+Z)';
   const redoTitle = collabActive
-    ? collabUndoNote
+    ? 'Redo your last change (Ctrl+Y)'
     : redoDesc
       ? `Redo: ${redoDesc} (Ctrl+Y)`
       : 'Redo (Ctrl+Y)';
@@ -209,7 +215,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
         <button
           className="toolbar-action-btn"
           onClick={undo}
-          disabled={collabActive || !canUndo()}
+          disabled={!undoEnabled}
           title={undoTitle}
           aria-label={undoTitle}
         >
@@ -218,7 +224,7 @@ export function CanvasToolbar({ onRebuildConnectors, getImportContext }: CanvasT
         <button
           className="toolbar-action-btn"
           onClick={redo}
-          disabled={collabActive || !canRedo()}
+          disabled={!redoEnabled}
           title={redoTitle}
           aria-label={redoTitle}
         >

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -1,6 +1,9 @@
 .style-profile-panel {
-  padding: 8px 0;
+  padding: var(--space-2) 0;
   border-top: 1px solid var(--border-color);
+  /* Establish a query context so the grid + controls reflow with panel width
+     (the panel is content-width-constrained, 180–640px, not viewport-based). */
+  container-type: inline-size;
 }
 
 .style-profile-header {
@@ -25,11 +28,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -50,16 +53,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
-  margin-left: 4px;
+  margin-left: var(--space-1);
 }
 
 .style-profile-add-btn:hover {
@@ -215,19 +218,32 @@
 
 /* Profile container - handles both grid and list modes */
 .style-profile-container {
-  padding: 0 8px;
+  padding: 0 var(--space-2);
 }
 
 .style-profile-container.grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: var(--space-2);
+}
+
+/* Fluid columns: tighter cells in a narrow panel, roomier when docked wide. */
+@container (max-width: 260px) {
+  .style-profile-container.grid {
+    grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+  }
+}
+
+@container (min-width: 440px) {
+  .style-profile-container.grid {
+    grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+  }
 }
 
 .style-profile-container.list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
 }
 
 /* Grid view items */
@@ -259,12 +275,13 @@
 }
 
 .style-profile-grid-preview {
-  width: 36px;
-  height: 36px;
-  border-radius: 4px;
+  width: 100%;
+  max-width: 48px;
+  aspect-ratio: 1;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .style-profile-grid-star {
@@ -276,7 +293,7 @@
 }
 
 .style-profile-grid-name {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
   max-width: 100%;
   text-align: center;
@@ -290,73 +307,43 @@
 }
 
 
-/* Grid confirmation overlay */
-.style-profile-grid-confirm {
+/* Grid ⋯ actions button (revealed on hover) */
+.style-profile-grid-menu {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  top: var(--space-1);
+  right: var(--space-1);
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  border-radius: 6px;
-  font-size: 10px;
-  font-weight: 500;
-}
-
-.style-profile-grid-confirm.delete {
-  background: rgba(229, 62, 62, 0.95);
-  color: white;
-}
-
-.style-profile-grid-confirm.overwrite {
-  background: rgba(74, 144, 217, 0.95);
-  color: white;
-}
-
-.style-profile-grid-confirm-actions {
-  display: flex;
-  gap: 4px;
-}
-
-.style-profile-grid-confirm-actions button {
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 500;
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  padding: 0;
   border: none;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: all 0.15s ease;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
 }
 
-.style-profile-grid-confirm.delete .style-profile-grid-confirm-actions button {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
+.style-profile-grid-item:hover .style-profile-grid-menu {
+  opacity: 0.85;
 }
 
-.style-profile-grid-confirm.delete .style-profile-grid-confirm-actions button:hover {
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.style-profile-grid-confirm.overwrite .style-profile-grid-confirm-actions button {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-}
-
-.style-profile-grid-confirm.overwrite .style-profile-grid-confirm-actions button:hover {
-  background: rgba(255, 255, 255, 0.3);
+.style-profile-grid-menu:hover {
+  opacity: 1;
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 /* List view items */
 .style-profile-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: 4px;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   transition: background 0.15s ease;
 }
 
@@ -370,17 +357,18 @@
 
 /* Color preview swatch */
 .style-profile-preview {
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
 /* Profile name */
 .style-profile-name {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -420,15 +408,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.15s ease;
+}
+
+.style-profile-action.menu:hover:not(:disabled) {
+  color: var(--text-primary);
 }
 
 .style-profile-action:hover:not(:disabled) {

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -1,310 +1,170 @@
-import { useState, useCallback, useEffect, useRef, useLayoutEffect } from 'react';
-import { useDocumentStore } from '../store/documentStore';
-import { getSelectedShapes } from '../store/sessionStore';
-import { useHistoryStore } from '../store/historyStore';
-import {
-  useStyleProfileStore,
-  StyleProfile,
-  extractStyleFromShape,
-  getProfileUpdates,
-  mergeProfileProperties,
-  ExtractStyleOptions,
-} from '../store/styleProfileStore';
+import { useState, useCallback, useEffect, useRef, useMemo, type CSSProperties } from 'react';
+import { Search, LayoutGrid, List, Plus, X } from 'lucide-react';
+import { getSelectedShapes, useSessionStore } from '../store/sessionStore';
+import { useStyleProfileStore, type StyleProfile } from '../store/styleProfileStore';
 import { useSettingsStore } from '../store/settingsStore';
+import { clampToViewport, MENU_SIZE_ESTIMATES } from './contextMenuUtils';
+import { useProfileActions } from './styleProfile/useProfileActions';
+import { ProfileCard, type MenuAnchor } from './styleProfile/ProfileCard';
 import './StyleProfilePanel.css';
 
 type ViewMode = 'grid' | 'list';
 
 interface ContextMenuState {
-  x: number;
-  y: number;
+  pos: { x: number; y: number };
   profileId: string;
 }
 
-/**
- * Panel for managing and applying style profiles.
- * Features compact grid/list views and profile management.
- */
-export function StyleProfilePanel() {
-  // Subscribe to profiles array directly so changes trigger re-renders
-  const storeProfiles = useStyleProfileStore((state) => state.profiles);
-  const addProfile = useStyleProfileStore((state) => state.addProfile);
-  const updateProfile = useStyleProfileStore((state) => state.updateProfile);
-  const deleteProfile = useStyleProfileStore((state) => state.deleteProfile);
-  const renameProfile = useStyleProfileStore((state) => state.renameProfile);
-  const toggleFavorite = useStyleProfileStore((state) => state.toggleFavorite);
+/** Preview swatch style for a profile (the universal dimensions). */
+function getPreviewStyle(profile: StyleProfile): CSSProperties {
+  return {
+    backgroundColor: profile.properties.fill || 'transparent',
+    borderColor: profile.properties.stroke || 'transparent',
+    borderWidth: Math.min(profile.properties.strokeWidth, 3),
+    borderStyle: 'solid',
+    opacity: profile.properties.opacity,
+    borderRadius: profile.properties.cornerRadius || 0,
+  };
+}
 
-  const updateShape = useDocumentStore((state) => state.updateShape);
-  const push = useHistoryStore((state) => state.push);
+export function StyleProfilePanel() {
+  const profilesRaw = useStyleProfileStore((state) => state.profiles);
+  const hideDefaultStyleProfiles = useSettingsStore((state) => state.hideDefaultStyleProfiles);
+
+  // Selection (reactive) → the shapes profiles act on.
+  const selectedIds = useSessionStore((state) => state.selectedIds);
+  const selectedShapes = useMemo(() => getSelectedShapes(), [selectedIds]);
+  const actions = useProfileActions(selectedShapes);
+  const { hasSelection, endPreview } = actions;
 
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [isCreating, setIsCreating] = useState(false);
   const [newProfileName, setNewProfileName] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [confirmOverwriteId, setConfirmOverwriteId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const [adjustedContextMenuPos, setAdjustedContextMenuPos] = useState<{ x: number; y: number } | null>(null);
-  const contextMenuRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const hideDefaultStyleProfiles = useSettingsStore((state) => state.hideDefaultStyleProfiles);
-  const saveIconStyleToProfile = useSettingsStore((state) => state.saveIconStyleToProfile);
-  const saveLabelStyleToProfile = useSettingsStore((state) => state.saveLabelStyleToProfile);
-
-  // Filter and sort profiles: optionally hide defaults, apply search, favorites first (alphabetically), then non-favorites (alphabetically)
-  const profiles = [...storeProfiles]
-    .filter((profile) => !hideDefaultStyleProfiles || !profile.id.startsWith('default-'))
-    .filter((profile) => !searchQuery || profile.name.toLowerCase().includes(searchQuery.toLowerCase()))
-    .sort((a, b) => {
-      if (a.favorite && !b.favorite) return -1;
-      if (!a.favorite && b.favorite) return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-  // Focus search input when search opens
-  useEffect(() => {
-    if (isSearching && searchInputRef.current) {
-      searchInputRef.current.focus();
-    }
-  }, [isSearching]);
-
-  const selectedShapes = getSelectedShapes();
-  const hasSelection = selectedShapes.length > 0;
-  const firstShape = selectedShapes[0];
-
-  // Apply a profile to selected shapes
-  const handleApplyProfile = useCallback(
-    (profile: StyleProfile) => {
-      if (selectedShapes.length === 0) return;
-
-      push('Apply style profile');
-
-      // The adapter translates the profile into concrete shape-field updates,
-      // including a pre-merged `customProperties` for ERD entities — so there is
-      // no shape-type special-casing to do here.
-      for (const shape of selectedShapes) {
-        updateShape(shape.id, getProfileUpdates(profile, shape));
-      }
-    },
-    [selectedShapes, push, updateShape]
+  // Sorted (favorites first) via the store's own comparator; filtered locally.
+  const sorted = useMemo(() => useStyleProfileStore.getState().getSortedProfiles(), [profilesRaw]);
+  const visible = useMemo(
+    () =>
+      sorted
+        .filter((p) => !hideDefaultStyleProfiles || !p.id.startsWith('default-'))
+        .filter((p) => !searchQuery || p.name.toLowerCase().includes(searchQuery.toLowerCase())),
+    [sorted, hideDefaultStyleProfiles, searchQuery]
   );
 
-  // Save current shape's style as a new profile
-  const handleSaveProfile = useCallback(() => {
-    if (!firstShape || !newProfileName.trim()) return;
+  useEffect(() => {
+    if (isSearching && searchInputRef.current) searchInputRef.current.focus();
+  }, [isSearching]);
 
-    const extractOptions: ExtractStyleOptions = {
-      includeIconStyle: saveIconStyleToProfile,
-      includeLabelStyle: saveLabelStyleToProfile,
+  // Clear any live preview when the selection changes or the panel unmounts.
+  useEffect(() => endPreview, [selectedIds, endPreview]);
+
+  const closeMenu = useCallback(() => setContextMenu(null), []);
+
+  const openMenu = useCallback((profileId: string, anchor: MenuAnchor) => {
+    const est = MENU_SIZE_ESTIMATES.medium;
+    const pos = clampToViewport(anchor.x, anchor.y, est.width, est.height);
+    setContextMenu({ pos, profileId });
+  }, []);
+
+  // Dismiss the context menu on outside click / Escape.
+  useEffect(() => {
+    if (!contextMenu) return;
+    const onDown = () => closeMenu();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu();
     };
-    const properties = extractStyleFromShape(firstShape, extractOptions);
-
-    addProfile(newProfileName.trim(), properties);
-    setNewProfileName('');
-    setIsCreating(false);
-  }, [firstShape, newProfileName, addProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
-
-  // Update an existing profile from the current shape's style.
-  //
-  // Merges (non-destructively unions) the extracted style into the profile's
-  // existing properties rather than replacing them — so a profile becomes a
-  // "master memory" across the shapes saved into it, and saving a shape that
-  // lacks a field (e.g. a file has no cornerRadius) never wipes another shape's
-  // saved value. Apply is gated per shape, so the unioned profile only ever
-  // hands each shape back its own fields.
-  const handleOverwriteProfile = useCallback((profileId: string) => {
-    if (!firstShape) return;
-
-    const extractOptions: ExtractStyleOptions = {
-      includeIconStyle: saveIconStyleToProfile,
-      includeLabelStyle: saveLabelStyleToProfile,
+    const t = setTimeout(() => {
+      document.addEventListener('click', onDown);
+      document.addEventListener('keydown', onKey);
+    }, 0);
+    return () => {
+      clearTimeout(t);
+      document.removeEventListener('click', onDown);
+      document.removeEventListener('keydown', onKey);
     };
-    const extracted = extractStyleFromShape(firstShape, extractOptions);
-    const existing = storeProfiles.find((p) => p.id === profileId);
-    const properties = existing
-      ? mergeProfileProperties(existing.properties, extracted)
-      : extracted;
+  }, [contextMenu, closeMenu]);
 
-    updateProfile(profileId, { properties });
-    setConfirmOverwriteId(null);
-  }, [firstShape, storeProfiles, updateProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
-
-  // Start editing a profile name
-  const handleStartEdit = useCallback((profile: StyleProfile) => {
-    if (profile.id.startsWith('default-')) return;
+  const startEditFromMenu = useCallback((profile: StyleProfile) => {
+    setViewMode('list');
     setEditingId(profile.id);
     setEditingName(profile.name);
   }, []);
 
-  // Save edited name
-  const handleSaveEdit = useCallback(() => {
-    if (editingId && editingName.trim()) {
-      renameProfile(editingId, editingName.trim());
-    }
+  const commitEdit = useCallback(() => {
+    if (editingId && editingName.trim()) actions.renameProfile(editingId, editingName.trim());
     setEditingId(null);
     setEditingName('');
-  }, [editingId, editingName, renameProfile]);
+  }, [editingId, editingName, actions]);
 
-  // Cancel editing
-  const handleCancelEdit = useCallback(() => {
+  const cancelEdit = useCallback(() => {
     setEditingId(null);
     setEditingName('');
   }, []);
 
-  // Request delete confirmation
-  const handleRequestDelete = useCallback((id: string) => {
-    setConfirmDeleteId(id);
-    setConfirmOverwriteId(null);
-  }, []);
+  const handleSaveNew = useCallback(() => {
+    actions.saveNewProfile(newProfileName);
+    setNewProfileName('');
+    setIsCreating(false);
+  }, [actions, newProfileName]);
 
-  // Confirm and delete a profile
-  const handleConfirmDelete = useCallback(() => {
-    if (confirmDeleteId) {
-      deleteProfile(confirmDeleteId);
-      setConfirmDeleteId(null);
-    }
-  }, [confirmDeleteId, deleteProfile]);
+  const applicableHint = actions.applicableNames.length ? `Applies: ${actions.applicableNames.join(', ')}` : '';
+  const titleFor = useCallback(
+    (profile: StyleProfile) => {
+      const parts = [profile.name];
+      if (!hasSelection) parts.push('(select a shape to apply)');
+      else if (applicableHint) parts.push(applicableHint);
+      parts.push('Right-click for options');
+      return parts.join('\n');
+    },
+    [hasSelection, applicableHint]
+  );
 
-  // Cancel delete
-  const handleCancelDelete = useCallback(() => {
-    setConfirmDeleteId(null);
-  }, []);
-
-  // Request overwrite confirmation
-  const handleRequestOverwrite = useCallback((id: string) => {
-    setConfirmOverwriteId(id);
-    setConfirmDeleteId(null);
-  }, []);
-
-  // Cancel overwrite
-  const handleCancelOverwrite = useCallback(() => {
-    setConfirmOverwriteId(null);
-  }, []);
-
-  // Toggle favorite status
-  const handleToggleFavorite = useCallback((id: string) => {
-    toggleFavorite(id);
-  }, [toggleFavorite]);
-
-  // Context menu handlers
-  const handleContextMenu = useCallback((e: React.MouseEvent, profileId: string) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setContextMenu({ x: e.clientX, y: e.clientY, profileId });
-  }, []);
-
-  const closeContextMenu = useCallback(() => {
-    setContextMenu(null);
-    setAdjustedContextMenuPos(null);
-  }, []);
-
-  // Adjust context menu position to stay within viewport
-  useLayoutEffect(() => {
-    if (!contextMenu || !contextMenuRef.current) {
-      setAdjustedContextMenuPos(null);
-      return;
-    }
-
-    const menu = contextMenuRef.current;
-    const rect = menu.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    const padding = 8;
-
-    let newX = contextMenu.x;
-    let newY = contextMenu.y;
-
-    // Check if menu overflows right edge
-    if (contextMenu.x + rect.width > viewportWidth - padding) {
-      newX = Math.max(padding, viewportWidth - rect.width - padding);
-    }
-
-    // Check if menu overflows bottom edge
-    if (contextMenu.y + rect.height > viewportHeight - padding) {
-      newY = Math.max(padding, viewportHeight - rect.height - padding);
-    }
-
-    setAdjustedContextMenuPos({ x: newX, y: newY });
-  }, [contextMenu]);
-
-  // Close context menu on click outside or escape
-  useEffect(() => {
-    if (!contextMenu) return;
-
-    const handleClick = () => closeContextMenu();
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeContextMenu();
-    };
-
-    const timeoutId = setTimeout(() => {
-      document.addEventListener('click', handleClick);
-      document.addEventListener('keydown', handleEscape);
-    }, 0);
-
-    return () => {
-      clearTimeout(timeoutId);
-      document.removeEventListener('click', handleClick);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [contextMenu, closeContextMenu]);
-
-  // Get preview style for a profile
-  const getPreviewStyle = (profile: StyleProfile): React.CSSProperties => {
-    return {
-      backgroundColor: profile.properties.fill || 'transparent',
-      borderColor: profile.properties.stroke || 'transparent',
-      borderWidth: Math.min(profile.properties.strokeWidth, 3),
-      borderStyle: 'solid',
-      opacity: profile.properties.opacity,
-      borderRadius: profile.properties.cornerRadius || 0,
-    };
-  };
+  const menuProfile = contextMenu ? sorted.find((p) => p.id === contextMenu.profileId) : undefined;
 
   return (
     <div className="style-profile-panel">
       <div className="style-profile-header">
         <span>Style Profiles</span>
         <div className="style-profile-header-actions">
-          {/* Search button */}
           <button
             className={`style-profile-view-btn ${isSearching || searchQuery ? 'active' : ''}`}
-            onClick={() => setIsSearching(!isSearching)}
+            onClick={() => setIsSearching((v) => !v)}
             title="Search profiles"
           >
-            <SearchIcon />
+            <Search size={15} />
           </button>
-          {/* View mode toggle */}
           <button
             className={`style-profile-view-btn ${viewMode === 'grid' ? 'active' : ''}`}
             onClick={() => setViewMode('grid')}
             title="Grid view"
           >
-            <GridIcon />
+            <LayoutGrid size={15} />
           </button>
           <button
             className={`style-profile-view-btn ${viewMode === 'list' ? 'active' : ''}`}
             onClick={() => setViewMode('list')}
             title="List view"
           >
-            <ListIcon />
+            <List size={15} />
           </button>
           {hasSelection && (
             <button
               className="style-profile-add-btn"
               onClick={() => setIsCreating(true)}
-              title="Save current style as profile"
+              title="Save current style as a new profile"
             >
-              <PlusIcon />
+              <Plus size={15} />
             </button>
           )}
         </div>
       </div>
 
-      {/* Search bar */}
       {isSearching && (
         <div className="style-profile-search">
           <input
@@ -322,18 +182,13 @@ export function StyleProfilePanel() {
             }}
           />
           {searchQuery && (
-            <button
-              className="style-profile-search-clear"
-              onClick={() => setSearchQuery('')}
-              title="Clear search"
-            >
-              <CloseIcon />
+            <button className="style-profile-search-clear" onClick={() => setSearchQuery('')} title="Clear search">
+              <X size={14} />
             </button>
           )}
         </div>
       )}
 
-      {/* Active filter indicator */}
       {searchQuery && !isSearching && (
         <div className="style-profile-filter-active">
           <span>Filtered: "{searchQuery}"</span>
@@ -345,13 +200,12 @@ export function StyleProfilePanel() {
             }}
             title="Clear filter"
           >
-            <CloseIcon />
+            <X size={13} />
           </button>
         </div>
       )}
 
-      {/* Create new profile form */}
-      {isCreating && firstShape && (
+      {isCreating && hasSelection && (
         <div className="style-profile-create">
           <input
             type="text"
@@ -361,16 +215,12 @@ export function StyleProfilePanel() {
             className="style-profile-input"
             autoFocus
             onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSaveProfile();
+              if (e.key === 'Enter') handleSaveNew();
               if (e.key === 'Escape') setIsCreating(false);
             }}
           />
           <div className="style-profile-create-actions">
-            <button
-              className="style-profile-btn save"
-              onClick={handleSaveProfile}
-              disabled={!newProfileName.trim()}
-            >
+            <button className="style-profile-btn save" onClick={handleSaveNew} disabled={!newProfileName.trim()}>
               Save
             </button>
             <button
@@ -386,355 +236,117 @@ export function StyleProfilePanel() {
         </div>
       )}
 
-      {/* Profile grid/list */}
       <div className={`style-profile-container ${viewMode}`}>
-        {profiles.map((profile) => {
-          const isDeleting = confirmDeleteId === profile.id;
-          const isOverwriting = confirmOverwriteId === profile.id;
-          const isDefault = profile.id.startsWith('default-');
-
-          if (viewMode === 'grid') {
-            return (
-              <div
-                key={profile.id}
-                className={`style-profile-grid-item ${!hasSelection ? 'disabled' : ''} ${profile.favorite ? 'favorite' : ''}`}
-                onClick={() => hasSelection && handleApplyProfile(profile)}
-                onContextMenu={(e) => handleContextMenu(e, profile.id)}
-                title={`${profile.name}${!hasSelection ? ' (select a shape to apply)' : ''}\nRight-click for options`}
-              >
-                <div
-                  className="style-profile-grid-preview"
-                  style={getPreviewStyle(profile)}
-                />
-                {profile.favorite && (
-                  <span className="style-profile-grid-star">★</span>
-                )}
-                <span className="style-profile-grid-name">{profile.name}</span>
-                {/* Confirmation overlays */}
-                {isDeleting && (
-                  <div className="style-profile-grid-confirm delete">
-                    <span>Delete?</span>
-                    <div className="style-profile-grid-confirm-actions">
-                      <button onClick={(e) => { e.stopPropagation(); handleConfirmDelete(); }}>Yes</button>
-                      <button onClick={(e) => { e.stopPropagation(); handleCancelDelete(); }}>No</button>
-                    </div>
-                  </div>
-                )}
-                {isOverwriting && (
-                  <div className="style-profile-grid-confirm overwrite">
-                    <span>Update?</span>
-                    <div className="style-profile-grid-confirm-actions">
-                      <button onClick={(e) => { e.stopPropagation(); handleOverwriteProfile(profile.id); }}>Yes</button>
-                      <button onClick={(e) => { e.stopPropagation(); handleCancelOverwrite(); }}>No</button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          }
-
-          // List view
-          return (
-            <div
-              key={profile.id}
-              className={`style-profile-item ${!hasSelection ? 'disabled' : ''}`}
-            >
-              {/* Color preview */}
-              <div
-                className="style-profile-preview"
-                style={getPreviewStyle(profile)}
-              />
-
-              {/* Favorite star */}
-              <button
-                className={`style-profile-action favorite ${profile.favorite ? 'active' : ''}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleToggleFavorite(profile.id);
-                }}
-                title={profile.favorite ? 'Remove from favorites' : 'Add to favorites'}
-              >
-                <StarIcon filled={profile.favorite} />
-              </button>
-
-              {/* Name (editable for custom profiles) */}
-              {editingId === profile.id ? (
-                <input
-                  type="text"
-                  value={editingName}
-                  onChange={(e) => setEditingName(e.target.value)}
-                  className="style-profile-edit-input"
-                  autoFocus
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSaveEdit();
-                    if (e.key === 'Escape') handleCancelEdit();
-                  }}
-                  onBlur={handleSaveEdit}
-                />
-              ) : (
-                <span
-                  className="style-profile-name"
-                  onDoubleClick={() => handleStartEdit(profile)}
-                  title={isDefault ? 'Built-in profile' : 'Double-click to rename'}
-                >
-                  {profile.name}
-                </span>
-              )}
-
-              {/* Actions */}
-              <div className="style-profile-actions">
-                <button
-                  className="style-profile-action apply"
-                  onClick={() => handleApplyProfile(profile)}
-                  disabled={!hasSelection}
-                  title="Apply to selected shapes"
-                >
-                  <ApplyIcon />
-                </button>
-                {!isDefault && hasSelection && !isDeleting && !isOverwriting && (
-                  <button
-                    className="style-profile-action overwrite"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleRequestOverwrite(profile.id);
-                    }}
-                    title="Update profile with this shape's style (merges; keeps other shapes' saved fields)"
-                  >
-                    <OverwriteIcon />
-                  </button>
-                )}
-                {!isDefault && (
-                  isDeleting ? (
-                    <>
-                      <button
-                        className="style-profile-action confirm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleConfirmDelete();
-                        }}
-                        title="Confirm delete"
-                      >
-                        <ApplyIcon />
-                      </button>
-                      <button
-                        className="style-profile-action cancel"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCancelDelete();
-                        }}
-                        title="Cancel"
-                      >
-                        <DeleteIcon />
-                      </button>
-                    </>
-                  ) : isOverwriting ? (
-                    <>
-                      <button
-                        className="style-profile-action confirm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleOverwriteProfile(profile.id);
-                        }}
-                        title="Confirm update"
-                      >
-                        <ApplyIcon />
-                      </button>
-                      <button
-                        className="style-profile-action cancel"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCancelOverwrite();
-                        }}
-                        title="Cancel"
-                      >
-                        <DeleteIcon />
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      className="style-profile-action delete"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRequestDelete(profile.id);
-                      }}
-                      title="Delete profile"
-                    >
-                      <DeleteIcon />
-                    </button>
-                  )
-                )}
-              </div>
-            </div>
-          );
-        })}
+        {visible.map((profile) => (
+          <ProfileCard
+            key={profile.id}
+            profile={profile}
+            viewMode={viewMode}
+            hasSelection={hasSelection}
+            isEditing={editingId === profile.id}
+            editingName={editingName}
+            previewStyle={getPreviewStyle(profile)}
+            titleText={titleFor(profile)}
+            onApply={() => actions.applyProfile(profile)}
+            onToggleFavorite={() => actions.toggleFavorite(profile.id)}
+            onOpenMenu={(anchor) => openMenu(profile.id, anchor)}
+            onStartEdit={() => {
+              setEditingId(profile.id);
+              setEditingName(profile.name);
+            }}
+            onEditNameChange={setEditingName}
+            onCommitEdit={commitEdit}
+            onCancelEdit={cancelEdit}
+            onPreviewEnter={() => actions.previewProfile(profile)}
+            onPreviewLeave={endPreview}
+          />
+        ))}
       </div>
 
-      {!hasSelection && (
-        <div className="style-profile-hint">
-          Select a shape to apply or save styles
-        </div>
-      )}
+      {!hasSelection && <div className="style-profile-hint">Select a shape to apply or save styles</div>}
 
-      {/* Context menu for grid items */}
-      {contextMenu && (() => {
-        const profile = profiles.find((p) => p.id === contextMenu.profileId);
-        if (!profile) return null;
-        const isDefault = profile.id.startsWith('default-');
-        const menuPos = adjustedContextMenuPos ?? { x: contextMenu.x, y: contextMenu.y };
-
-        return (
-          <div
-            ref={contextMenuRef}
-            className="style-profile-context-menu"
-            style={{ left: menuPos.x, top: menuPos.y }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            {hasSelection && (
-              <button
-                className="style-profile-context-menu-item"
-                onClick={() => {
-                  handleApplyProfile(profile);
-                  closeContextMenu();
-                }}
-              >
-                Apply Style
-              </button>
-            )}
+      {contextMenu && menuProfile && (
+        <div
+          className="style-profile-context-menu"
+          style={{ left: contextMenu.pos.x, top: contextMenu.pos.y }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {hasSelection && (
             <button
               className="style-profile-context-menu-item"
               onClick={() => {
-                handleToggleFavorite(profile.id);
-                closeContextMenu();
+                actions.applyProfile(menuProfile);
+                closeMenu();
               }}
             >
-              {profile.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+              Apply Style
             </button>
-            {!isDefault && (
-              <>
+          )}
+          <button
+            className="style-profile-context-menu-item"
+            onClick={() => {
+              actions.toggleFavorite(menuProfile.id);
+              closeMenu();
+            }}
+          >
+            {menuProfile.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+          </button>
+          <button
+            className="style-profile-context-menu-item"
+            onClick={() => {
+              actions.duplicateProfile(menuProfile);
+              closeMenu();
+            }}
+          >
+            Duplicate
+          </button>
+          {!menuProfile.id.startsWith('default-') && (
+            <>
+              <button
+                className="style-profile-context-menu-item"
+                onClick={() => {
+                  startEditFromMenu(menuProfile);
+                  closeMenu();
+                }}
+              >
+                Rename
+              </button>
+              {hasSelection && (
                 <button
                   className="style-profile-context-menu-item"
                   onClick={() => {
-                    handleStartEdit(profile);
-                    closeContextMenu();
+                    actions.updateProfileFromShape(menuProfile.id);
+                    closeMenu();
                   }}
                 >
-                  Rename
+                  Update with Current
                 </button>
-                {hasSelection && (
-                  <button
-                    className="style-profile-context-menu-item"
-                    onClick={() => {
-                      handleRequestOverwrite(profile.id);
-                      closeContextMenu();
-                    }}
-                  >
-                    Update with Current
-                  </button>
-                )}
-                <div className="style-profile-context-menu-separator" />
+              )}
+              {hasSelection && (
                 <button
-                  className="style-profile-context-menu-item danger"
+                  className="style-profile-context-menu-item"
                   onClick={() => {
-                    handleRequestDelete(profile.id);
-                    closeContextMenu();
+                    closeMenu();
+                    void actions.resetProfileFromShape(menuProfile);
                   }}
                 >
-                  Delete
+                  Reset to Shape
                 </button>
-              </>
-            )}
-          </div>
-        );
-      })()}
+              )}
+              <div className="style-profile-context-menu-separator" />
+              <button
+                className="style-profile-context-menu-item danger"
+                onClick={() => {
+                  closeMenu();
+                  void actions.deleteProfileById(menuProfile);
+                }}
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </div>
-  );
-}
-
-// SVG Icons
-
-function PlusIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M7 2v10M2 7h10" />
-    </svg>
-  );
-}
-
-function ApplyIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 7l4 4 6-8" />
-    </svg>
-  );
-}
-
-function DeleteIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M3 3l8 8M11 3l-8 8" />
-    </svg>
-  );
-}
-
-function StarIcon({ filled }: { filled: boolean }) {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 14 14"
-      fill={filled ? 'currentColor' : 'none'}
-      stroke="currentColor"
-      strokeWidth="1.5"
-    >
-      <path d="M7 1l1.8 3.6 4 .6-2.9 2.8.7 4-3.6-1.9-3.6 1.9.7-4-2.9-2.8 4-.6L7 1z" />
-    </svg>
-  );
-}
-
-function GridIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <rect x="1" y="1" width="5" height="5" rx="1" />
-      <rect x="8" y="1" width="5" height="5" rx="1" />
-      <rect x="1" y="8" width="5" height="5" rx="1" />
-      <rect x="8" y="8" width="5" height="5" rx="1" />
-    </svg>
-  );
-}
-
-function ListIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M4 3h9M4 7h9M4 11h9" />
-      <circle cx="1.5" cy="3" r="0.75" fill="currentColor" />
-      <circle cx="1.5" cy="7" r="0.75" fill="currentColor" />
-      <circle cx="1.5" cy="11" r="0.75" fill="currentColor" />
-    </svg>
-  );
-}
-
-function OverwriteIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 10v2h2l6-6-2-2-6 6z" />
-      <path d="M9 3l2 2" />
-    </svg>
-  );
-}
-
-function SearchIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <circle cx="6" cy="6" r="4" />
-      <path d="M9 9l3 3" />
-    </svg>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 2l8 8M10 2l-8 8" />
-    </svg>
   );
 }

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -7,6 +7,7 @@ import {
   StyleProfile,
   extractStyleFromShape,
   getProfileUpdates,
+  mergeProfileProperties,
   ExtractStyleOptions,
 } from '../store/styleProfileStore';
 import { useSettingsStore } from '../store/settingsStore';
@@ -107,7 +108,14 @@ export function StyleProfilePanel() {
     setIsCreating(false);
   }, [firstShape, newProfileName, addProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
 
-  // Overwrite a profile with current shape's style
+  // Update an existing profile from the current shape's style.
+  //
+  // Merges (non-destructively unions) the extracted style into the profile's
+  // existing properties rather than replacing them — so a profile becomes a
+  // "master memory" across the shapes saved into it, and saving a shape that
+  // lacks a field (e.g. a file has no cornerRadius) never wipes another shape's
+  // saved value. Apply is gated per shape, so the unioned profile only ever
+  // hands each shape back its own fields.
   const handleOverwriteProfile = useCallback((profileId: string) => {
     if (!firstShape) return;
 
@@ -115,11 +123,15 @@ export function StyleProfilePanel() {
       includeIconStyle: saveIconStyleToProfile,
       includeLabelStyle: saveLabelStyleToProfile,
     };
-    const properties = extractStyleFromShape(firstShape, extractOptions);
+    const extracted = extractStyleFromShape(firstShape, extractOptions);
+    const existing = storeProfiles.find((p) => p.id === profileId);
+    const properties = existing
+      ? mergeProfileProperties(existing.properties, extracted)
+      : extracted;
 
     updateProfile(profileId, { properties });
     setConfirmOverwriteId(null);
-  }, [firstShape, updateProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
+  }, [firstShape, storeProfiles, updateProfile, saveIconStyleToProfile, saveLabelStyleToProfile]);
 
   // Start editing a profile name
   const handleStartEdit = useCallback((profile: StyleProfile) => {
@@ -410,7 +422,7 @@ export function StyleProfilePanel() {
                 )}
                 {isOverwriting && (
                   <div className="style-profile-grid-confirm overwrite">
-                    <span>Overwrite?</span>
+                    <span>Update?</span>
                     <div className="style-profile-grid-confirm-actions">
                       <button onClick={(e) => { e.stopPropagation(); handleOverwriteProfile(profile.id); }}>Yes</button>
                       <button onClick={(e) => { e.stopPropagation(); handleCancelOverwrite(); }}>No</button>
@@ -486,7 +498,7 @@ export function StyleProfilePanel() {
                       e.stopPropagation();
                       handleRequestOverwrite(profile.id);
                     }}
-                    title="Overwrite with current style"
+                    title="Update profile with this shape's style (merges; keeps other shapes' saved fields)"
                   >
                     <OverwriteIcon />
                   </button>
@@ -523,7 +535,7 @@ export function StyleProfilePanel() {
                           e.stopPropagation();
                           handleOverwriteProfile(profile.id);
                         }}
-                        title="Confirm overwrite"
+                        title="Confirm update"
                       >
                         <ApplyIcon />
                       </button>
@@ -616,7 +628,7 @@ export function StyleProfilePanel() {
                       closeContextMenu();
                     }}
                   >
-                    Overwrite with Current
+                    Update with Current
                   </button>
                 )}
                 <div className="style-profile-context-menu-separator" />

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -7,7 +7,6 @@ import {
   StyleProfile,
   extractStyleFromShape,
   getProfileUpdates,
-  getERDProfileCustomProperties,
   ExtractStyleOptions,
 } from '../store/styleProfileStore';
 import { useSettingsStore } from '../store/settingsStore';
@@ -83,27 +82,11 @@ export function StyleProfilePanel() {
 
       push('Apply style profile');
 
+      // The adapter translates the profile into concrete shape-field updates,
+      // including a pre-merged `customProperties` for ERD entities — so there is
+      // no shape-type special-casing to do here.
       for (const shape of selectedShapes) {
-        const updates = getProfileUpdates(profile, shape.type);
-
-        // For ERD entity shapes, also apply customProperties
-        if (shape.type === 'erd-entity' || shape.type === 'erd-weak-entity') {
-          const erdProps = getERDProfileCustomProperties(profile);
-          if (erdProps) {
-            // Merge with existing customProperties
-            const existingCustomProps = (shape as unknown as { customProperties?: Record<string, unknown> }).customProperties || {};
-            updateShape(shape.id, {
-              ...updates,
-              customProperties: {
-                ...existingCustomProps,
-                ...erdProps,
-              },
-            } as Record<string, unknown>);
-            continue;
-          }
-        }
-
-        updateShape(shape.id, updates);
+        updateShape(shape.id, getProfileUpdates(profile, shape));
       }
     },
     [selectedShapes, push, updateShape]

--- a/src/ui/settings/GeneralSettings.tsx
+++ b/src/ui/settings/GeneralSettings.tsx
@@ -10,8 +10,10 @@
  * canvas toolbar's connector dropdown — there's no knob for it here anymore.)
  */
 
+import { useMemo } from 'react';
 import { useSettingsStore } from '../../store/settingsStore';
 import { useStyleProfileStore } from '../../store/styleProfileStore';
+import { RichSelect, type RichSelectItem } from '../components/RichSelect';
 import './GeneralSettings.css';
 
 export function GeneralSettings() {
@@ -29,10 +31,19 @@ export function GeneralSettings() {
 
   const profiles = useStyleProfileStore((state) => state.profiles);
 
-  const handleStyleProfileChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
+  const handleStyleProfileChange = (value: string) => {
     setDefaultStyleProfileId(value === '' ? null : value);
   };
+
+  const styleProfileItems = useMemo<RichSelectItem<string>[]>(
+    () => [
+      { value: '', label: 'None (Use Tool Defaults)' },
+      ...profiles
+        .filter((profile) => !hideDefaultStyleProfiles || !profile.id.startsWith('default-'))
+        .map((profile) => ({ value: profile.id, label: profile.name })),
+    ],
+    [profiles, hideDefaultStyleProfiles]
+  );
 
   return (
     <div className="general-settings">
@@ -43,24 +54,17 @@ export function GeneralSettings() {
         <h4 className="settings-group-title">Shapes</h4>
 
         <div className="settings-row">
-          <label className="settings-label" htmlFor="default-style-profile">
+          <label className="settings-label">
             Default Style Profile
           </label>
-          <select
-            id="default-style-profile"
-            className="settings-select"
+          <RichSelect
             value={defaultStyleProfileId ?? ''}
             onChange={handleStyleProfileChange}
-          >
-            <option value="">None (Use Tool Defaults)</option>
-            {profiles
-              .filter((profile) => !hideDefaultStyleProfiles || !profile.id.startsWith('default-'))
-              .map((profile) => (
-                <option key={profile.id} value={profile.id}>
-                  {profile.name}
-                </option>
-              ))}
-          </select>
+            items={styleProfileItems}
+            ariaLabel="Default Style Profile"
+            className="settings-select"
+            align="end"
+          />
           <span className="settings-hint">
             New shapes will be created with this style applied
           </span>

--- a/src/ui/styleProfile/ProfileCard.tsx
+++ b/src/ui/styleProfile/ProfileCard.tsx
@@ -1,0 +1,142 @@
+/**
+ * A single style-profile card, shared by the grid and list views (collapsing
+ * what used to be two near-duplicate renderings). Click applies; hover previews
+ * live on the canvas; the ⋯ button / right-click opens the actions menu.
+ */
+
+import type { CSSProperties, MouseEvent } from 'react';
+import { Star, MoreHorizontal } from 'lucide-react';
+import type { StyleProfile } from '../../store/styleProfileStore';
+
+export interface MenuAnchor {
+  x: number;
+  y: number;
+}
+
+interface ProfileCardProps {
+  profile: StyleProfile;
+  viewMode: 'grid' | 'list';
+  hasSelection: boolean;
+  isEditing: boolean;
+  editingName: string;
+  previewStyle: CSSProperties;
+  /** Tooltip describing what applying this profile affects on the selection. */
+  titleText: string;
+  onApply: () => void;
+  onToggleFavorite: () => void;
+  onOpenMenu: (anchor: MenuAnchor) => void;
+  onStartEdit: () => void;
+  onEditNameChange: (value: string) => void;
+  onCommitEdit: () => void;
+  onCancelEdit: () => void;
+  onPreviewEnter: () => void;
+  onPreviewLeave: () => void;
+}
+
+export function ProfileCard(props: ProfileCardProps) {
+  const {
+    profile, viewMode, hasSelection, isEditing, editingName, previewStyle, titleText,
+    onApply, onToggleFavorite, onOpenMenu, onStartEdit, onEditNameChange,
+    onCommitEdit, onCancelEdit, onPreviewEnter, onPreviewLeave,
+  } = props;
+
+  const handleContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onOpenMenu({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMenuButton = (e: MouseEvent) => {
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    onOpenMenu({ x: rect.left, y: rect.bottom });
+  };
+
+  const apply = () => {
+    if (hasSelection) onApply();
+  };
+
+  if (viewMode === 'grid') {
+    return (
+      <div
+        className={`style-profile-grid-item ${!hasSelection ? 'disabled' : ''} ${profile.favorite ? 'favorite' : ''}`}
+        onClick={apply}
+        onContextMenu={handleContextMenu}
+        onMouseEnter={() => hasSelection && onPreviewEnter()}
+        onMouseLeave={onPreviewLeave}
+        title={titleText}
+      >
+        <div className="style-profile-grid-preview" style={previewStyle} />
+        {profile.favorite && <span className="style-profile-grid-star">★</span>}
+        <span className="style-profile-grid-name">{profile.name}</span>
+        <button
+          className="style-profile-grid-menu"
+          onClick={handleMenuButton}
+          title="More options"
+          aria-label="More options"
+        >
+          <MoreHorizontal size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`style-profile-item ${!hasSelection ? 'disabled' : ''}`}
+      onContextMenu={handleContextMenu}
+      onMouseEnter={() => hasSelection && onPreviewEnter()}
+      onMouseLeave={onPreviewLeave}
+    >
+      <div
+        className="style-profile-preview"
+        style={previewStyle}
+        onClick={apply}
+        role="button"
+        title={hasSelection ? 'Apply to selection' : titleText}
+      />
+
+      <button
+        className={`style-profile-action favorite ${profile.favorite ? 'active' : ''}`}
+        onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}
+        title={profile.favorite ? 'Remove from favorites' : 'Add to favorites'}
+      >
+        <Star size={15} fill={profile.favorite ? 'currentColor' : 'none'} />
+      </button>
+
+      {isEditing ? (
+        <input
+          type="text"
+          value={editingName}
+          onChange={(e) => onEditNameChange(e.target.value)}
+          className="style-profile-edit-input"
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onCommitEdit();
+            if (e.key === 'Escape') onCancelEdit();
+          }}
+          onBlur={onCommitEdit}
+        />
+      ) : (
+        <span
+          className="style-profile-name"
+          onDoubleClick={onStartEdit}
+          title={titleText}
+        >
+          {profile.name}
+        </span>
+      )}
+
+      <div className="style-profile-actions">
+        <button
+          className="style-profile-action menu"
+          onClick={handleMenuButton}
+          title="More options"
+          aria-label="More options"
+        >
+          <MoreHorizontal size={15} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/styleProfile/useProfileActions.ts
+++ b/src/ui/styleProfile/useProfileActions.ts
@@ -1,0 +1,153 @@
+/**
+ * Actions for the Style Profile panel — apply, save/update/reset, duplicate,
+ * delete, rename, favorite, and the collab-safe live preview.
+ *
+ * Keeping these out of the panel component centralizes the profile↔shape logic
+ * (and the JP-399 Update=merge vs Reset=replace distinction) and keeps the panel
+ * focused on layout/state.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useDocumentStore } from '../../store/documentStore';
+import { useHistoryStore } from '../../store/historyStore';
+import { useSessionStore } from '../../store/sessionStore';
+import { useSettingsStore } from '../../store/settingsStore';
+import {
+  useStyleProfileStore,
+  extractStyleFromShape,
+  getProfileUpdates,
+  getApplicablePropertyNames,
+  mergeProfileProperties,
+  type StyleProfile,
+  type ExtractStyleOptions,
+} from '../../store/styleProfileStore';
+import { confirmDialog } from '../confirm/confirmStore';
+import type { Shape } from '../../shapes/Shape';
+
+export function useProfileActions(selectedShapes: Shape[]) {
+  const updateShape = useDocumentStore((s) => s.updateShape);
+  const push = useHistoryStore((s) => s.push);
+  const addProfile = useStyleProfileStore((s) => s.addProfile);
+  const updateProfile = useStyleProfileStore((s) => s.updateProfile);
+  const deleteProfile = useStyleProfileStore((s) => s.deleteProfile);
+  const renameProfile = useStyleProfileStore((s) => s.renameProfile);
+  const toggleFavorite = useStyleProfileStore((s) => s.toggleFavorite);
+  const getProfile = useStyleProfileStore((s) => s.getProfile);
+  const setStylePreview = useSessionStore((s) => s.setStylePreview);
+  const clearStylePreview = useSessionStore((s) => s.clearStylePreview);
+  const saveIconStyleToProfile = useSettingsStore((s) => s.saveIconStyleToProfile);
+  const saveLabelStyleToProfile = useSettingsStore((s) => s.saveLabelStyleToProfile);
+
+  const firstShape = selectedShapes[0];
+  const hasSelection = selectedShapes.length > 0;
+
+  const extractOptions = useMemo<ExtractStyleOptions>(
+    () => ({ includeIconStyle: saveIconStyleToProfile, includeLabelStyle: saveLabelStyleToProfile }),
+    [saveIconStyleToProfile, saveLabelStyleToProfile]
+  );
+
+  /** Style dimensions a profile can affect on the current selection (for the hint tooltip). */
+  const applicableNames = useMemo(
+    () => (firstShape ? getApplicablePropertyNames(firstShape.type) : []),
+    [firstShape]
+  );
+
+  const applyProfile = useCallback(
+    (profile: StyleProfile) => {
+      if (selectedShapes.length === 0) return;
+      clearStylePreview();
+      push('Apply style profile');
+      for (const shape of selectedShapes) {
+        updateShape(shape.id, getProfileUpdates(profile, shape));
+      }
+    },
+    [selectedShapes, push, updateShape, clearStylePreview]
+  );
+
+  /** Live, collab-safe preview: render-only overrides, never the document. */
+  const previewProfile = useCallback(
+    (profile: StyleProfile) => {
+      if (selectedShapes.length === 0) return;
+      const overrides: Record<string, Partial<Shape>> = {};
+      for (const shape of selectedShapes) {
+        overrides[shape.id] = getProfileUpdates(profile, shape);
+      }
+      setStylePreview(overrides);
+    },
+    [selectedShapes, setStylePreview]
+  );
+
+  const endPreview = useCallback(() => clearStylePreview(), [clearStylePreview]);
+
+  const saveNewProfile = useCallback(
+    (name: string) => {
+      if (!firstShape || !name.trim()) return;
+      addProfile(name.trim(), extractStyleFromShape(firstShape, extractOptions));
+    },
+    [firstShape, addProfile, extractOptions]
+  );
+
+  /** Update = non-destructive merge into the existing profile (master memory). */
+  const updateProfileFromShape = useCallback(
+    (profileId: string) => {
+      if (!firstShape) return;
+      const existing = getProfile(profileId);
+      const extracted = extractStyleFromShape(firstShape, extractOptions);
+      updateProfile(profileId, {
+        properties: existing ? mergeProfileProperties(existing.properties, extracted) : extracted,
+      });
+    },
+    [firstShape, getProfile, updateProfile, extractOptions]
+  );
+
+  /** Reset = replace the profile from this shape (counterpart to Update/merge). */
+  const resetProfileFromShape = useCallback(
+    async (profile: StyleProfile) => {
+      if (!firstShape) return;
+      const ok = await confirmDialog({
+        title: `Reset "${profile.name}"?`,
+        message: "Replace this profile entirely with the selected shape's current style.",
+        details: 'Unlike Update, this discards any styles previously saved into the profile from other shapes.',
+        confirmLabel: 'Reset',
+      });
+      if (!ok) return;
+      updateProfile(profile.id, { properties: extractStyleFromShape(firstShape, extractOptions) });
+    },
+    [firstShape, updateProfile, extractOptions]
+  );
+
+  const duplicateProfile = useCallback(
+    (profile: StyleProfile) => {
+      addProfile(`${profile.name} copy`, { ...profile.properties });
+    },
+    [addProfile]
+  );
+
+  const deleteProfileById = useCallback(
+    async (profile: StyleProfile) => {
+      const ok = await confirmDialog({
+        title: `Delete "${profile.name}"?`,
+        confirmLabel: 'Delete',
+        danger: true,
+      });
+      if (ok) deleteProfile(profile.id);
+    },
+    [deleteProfile]
+  );
+
+  return {
+    firstShape,
+    hasSelection,
+    applicableNames,
+    applyProfile,
+    previewProfile,
+    endPreview,
+    saveNewProfile,
+    updateProfileFromShape,
+    resetProfileFromShape,
+    duplicateProfile,
+    deleteProfileById,
+    renameProfile,
+    toggleFavorite,
+  };
+}


### PR DESCRIPTION
Promote `master` → `staging`. Deploys everything merged since the last staging sync (10 commits, 5 features):

- **JP-402** — per-user "best effort" canvas undo/redo in collaboration (#350)
- **JP-401** — Style Profile area TLC: refactor, responsive panel, live preview, default hardening (#349)
- **JP-399** — style profiles as non-corrupting master memory + swimlane adapter (#348)
- **JP-33** — per-shape style-profile adapters (#347)
- **JP-397** — harden JWKS cold-start (readiness gate + 503 + cold-JOIN hydrate) (#346)

All merged to `master` (typecheck + full test suite + build green per their PRs). Merging this triggers the staging deploy via the normal flow.

Assisted-by: Opus 4.8