### PR TITLE
fix(layout): Relaxed Properties pinning/sticking/vanishing (JP-410)

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -486,3 +486,44 @@ describe('uiPreferencesStore — appearance slice', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(1.1);
   });
 });
+
+describe('uiPreferencesStore — overrides preserve preset visibility (JP-410)', () => {
+  const resolvedRelaxedProps = () => {
+    const override = useUIPreferencesStore.getState().layout.modeOverrides.relaxed.properties;
+    return resolvePanelState('relaxed', 'properties', override);
+  };
+
+  it('Relaxed Properties starts hidden (preset visible:false)', () => {
+    expect(LAYOUT_PRESETS.relaxed.properties.visible).toBe(false);
+    expect(resolvedRelaxedProps().visible).toBe(false);
+  });
+
+  it('pinning Relaxed Properties keeps it hidden — pin must not fabricate visible:true', () => {
+    // Was the bug: the override defaulted visible:true, so pinning turned the
+    // selection-only Properties overlay into a permanently-docked panel.
+    useUIPreferencesStore.getState().togglePinFor('relaxed', 'properties');
+    const resolved = resolvedRelaxedProps();
+    expect(resolved.pinned).toBe(true);
+    expect(resolved.visible).toBe(false);
+  });
+
+  it('resizing Relaxed Properties keeps it hidden — "resize pins it" shared root cause', () => {
+    useUIPreferencesStore.getState().setPanelWidthFor('relaxed', 'properties', 300);
+    const resolved = resolvedRelaxedProps();
+    expect(resolved.width).toBe(300);
+    expect(resolved.visible).toBe(false);
+  });
+
+  it('an explicit visibility patch still works (fix does not over-suppress)', () => {
+    useUIPreferencesStore.getState().setPanelVisibleFor('relaxed', 'properties', true);
+    expect(resolvedRelaxedProps().visible).toBe(true);
+  });
+
+  it('pinning leaves an already-visible preset (Designer) visible', () => {
+    useUIPreferencesStore.getState().togglePinFor('designer', 'properties');
+    const override = useUIPreferencesStore.getState().layout.modeOverrides.designer.properties;
+    const resolved = resolvePanelState('designer', 'properties', override);
+    expect(resolved.pinned).toBe(true);
+    expect(resolved.visible).toBe(true);
+  });
+});

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -338,12 +338,18 @@ function mergePanelOverride(
 ): LayoutState['modeOverrides'] {
   const modeMap = current[mode];
   const existing = modeMap[panel];
+  // Unspecified keys inherit from the layout PRESET, not hard-coded defaults.
+  // A patch that only sets e.g. `pinned` or `width` must NOT fabricate
+  // `visible: true`, or it flips a preset-hidden panel (Relaxed Properties)
+  // into a permanently-docked one — the "pinning / resizing makes Properties
+  // stick visible in Relaxed" bugs.
+  const preset = LAYOUT_PRESETS[mode][panel];
   const merged: PanelState = {
-    dock: patch.dock ?? existing?.dock ?? 'right',
-    visible: patch.visible ?? existing?.visible ?? true,
-    order: patch.order ?? existing?.order ?? 0,
-    ...(patch.width !== undefined ? { width: patch.width } : existing?.width !== undefined ? { width: existing.width } : {}),
-    ...(patch.pinned !== undefined ? { pinned: patch.pinned } : existing?.pinned !== undefined ? { pinned: existing.pinned } : {}),
+    dock: patch.dock ?? existing?.dock ?? preset.dock,
+    visible: patch.visible ?? existing?.visible ?? preset.visible,
+    order: patch.order ?? existing?.order ?? preset.order,
+    ...(patch.width !== undefined ? { width: patch.width } : existing?.width !== undefined ? { width: existing.width } : preset.width !== undefined ? { width: preset.width } : {}),
+    ...(patch.pinned !== undefined ? { pinned: patch.pinned } : existing?.pinned !== undefined ? { pinned: existing.pinned } : preset.pinned !== undefined ? { pinned: preset.pinned } : {}),
   };
   return {
     ...current,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,7 @@ import { CanvasContainer } from './CanvasContainer';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
-import { isFlyoutLayout, resolveRegions } from './layout/modes';
+import { isFlyoutLayout, propertiesDockedVisible, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { MobilePreviewGate } from './mobile/MobilePreviewGate';
@@ -120,7 +120,10 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   const layersPanelState = useActivePanelState('layers');
   const layoutActions = useLayoutActions();
   const isDocumentVisible = documentPanelState.visible;
-  const isPropertiesVisible = propertiesPanelState.visible;
+  // Relaxed never docks Properties (selection-only overlay) even if a stale
+  // pinned/visible override persisted from before it was un-pinnable here —
+  // otherwise it shows docked over the prose, including in `write` focus.
+  const isPropertiesVisible = propertiesDockedVisible(activeMode, propertiesPanelState);
   const isLayersVisible = layersPanelState.visible;
   // Properties panel uses the fly-out wrapper in Designer/Technician unless the
   // user has pinned it for this layout. Power keeps it docked; Relaxed hides

--- a/src/ui/layout/FlyoutPanel.test.tsx
+++ b/src/ui/layout/FlyoutPanel.test.tsx
@@ -80,3 +80,29 @@ describe('FlyoutPanel — Relaxed railless overlay (JP-410)', () => {
     expect(container.querySelector('.flyout-panel-body')).toBeNull();
   });
 });
+
+describe('FlyoutPanel — focus-out behavior (JP-410)', () => {
+  it('railless overlay does not auto-collapse when focus leaves (edit then blur stays open)', () => {
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: false });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.blur(body, { relatedTarget: document.body });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).not.toBeNull();
+  });
+
+  it('rail fly-out collapses when focus leaves entirely (Designer/Technician unchanged)', () => {
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: true });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.blur(body, { relatedTarget: document.body });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).toBeNull();
+  });
+});

--- a/src/ui/layout/FlyoutPanel.test.tsx
+++ b/src/ui/layout/FlyoutPanel.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { FlyoutPanel } from './FlyoutPanel';
+import { useSessionStore } from '../../store/sessionStore';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+
+// Mirrors AUTO_COLLAPSE_DELAY_MS in FlyoutPanel.tsx.
+const AUTO_COLLAPSE_DELAY_MS = 500;
+
+function renderPanel(props: { showRail?: boolean } = {}) {
+  return render(
+    <FlyoutPanel
+      panelId="properties"
+      label="Properties"
+      icon={<span>P</span>}
+      expandOnSelection
+      side="right"
+      {...props}
+    >
+      <div data-testid="panel-body-content">body</div>
+    </FlyoutPanel>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useUIPreferencesStore.getState().reset();
+  useSessionStore.getState().clearSelection();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('FlyoutPanel — Relaxed railless overlay (JP-410)', () => {
+  it('railless overlay (showRail=false) hides the pin button', () => {
+    // Relaxed Properties is a selection-driven overlay with no docked target, so
+    // pinning was meaningless there — it only made Properties stick visible or
+    // dismissed the panel. The pin control is hidden in that mode.
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: false });
+    // expandOnSelection opened it on mount, so the body is present...
+    expect(container.querySelector('.flyout-panel-body')).not.toBeNull();
+    // ...but the pin button is not.
+    expect(screen.queryByRole('button', { name: /pin properties open/i })).toBeNull();
+  });
+
+  it('rail fly-out (showRail=true) still shows the pin button', () => {
+    useSessionStore.getState().select(['s1']);
+    renderPanel({ showRail: true });
+    expect(screen.queryByRole('button', { name: /pin properties open/i })).not.toBeNull();
+  });
+
+  it('railless overlay does not auto-collapse on mouse-leave (selection owns visibility)', () => {
+    // The focus/hover auto-collapse must not fight the selection-driven overlay,
+    // or editing one property (focus/pointer leaving the body) closes the panel
+    // before the next edit. The mouse-leave path shares the same showRail guard
+    // as the focus-out path.
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: false });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.mouseLeave(body, { buttons: 0 });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).not.toBeNull();
+  });
+
+  it('rail fly-out still auto-collapses on mouse-leave (Designer/Technician unchanged)', () => {
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: true });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.mouseLeave(body, { buttons: 0 });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).toBeNull();
+  });
+});

--- a/src/ui/layout/FlyoutPanel.tsx
+++ b/src/ui/layout/FlyoutPanel.tsx
@@ -184,6 +184,12 @@ export function FlyoutPanel({
 
   const handleFocusOut = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
+      // A railless overlay (Relaxed's selection-driven Properties) is owned by
+      // the selection, not by focus: the parent mounts it while a shape is
+      // selected and unmounts on deselect. Focus leaving it — committing an
+      // edit, closing a picker — must NOT auto-collapse it, or the next edit
+      // finds the panel gone.
+      if (!showRail) return;
       // Only schedule collapse if focus left the panel entirely (relatedTarget
       // is null or outside our subtree).
       const next = e.relatedTarget as Node | null;
@@ -193,7 +199,7 @@ export function FlyoutPanel({
       if (next instanceof Element && next.closest('[data-flyout-keep-open]')) return;
       scheduleCollapse();
     },
-    [scheduleCollapse]
+    [scheduleCollapse, showRail]
   );
 
   // Cleanup pending timer on unmount.
@@ -245,26 +251,31 @@ export function FlyoutPanel({
           onBlur={handleFocusOut}
           onMouseEnter={handleFocusIn}
           onMouseLeave={(e) => {
-            // Don't start the auto-collapse timer while the user is dragging —
-            // a resize handle pull can briefly leave the body's bounds while
-            // a mouse button is still held. Without this check, the panel
-            // collapses mid-drag and the user has to pin it before resizing.
-            if (e.buttons === 0) scheduleCollapse();
+            // Don't auto-collapse a railless selection overlay (Relaxed) on
+            // mouse-leave — the selection owns its visibility. And don't start
+            // the timer mid-drag: a resize-handle pull can briefly leave the
+            // body's bounds while a button is still held (buttons !== 0).
+            if (e.buttons === 0 && showRail) scheduleCollapse();
           }}
         >
           <div className="flyout-panel-header">
             <span className="flyout-panel-header-title">{label}</span>
-            <button
-              type="button"
-              className="flyout-panel-pin"
-              onClick={handlePin}
-              aria-label={`Pin ${label} open`}
-              title={`Pin ${label} open`}
-            >
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
-              </svg>
-            </button>
+            {/* Pin promotes a fly-out to docked. Hidden on the railless Relaxed
+                overlay, which has no docked target — pinning there only made
+                Properties stick visible (or dismissed it on click). */}
+            {showRail && (
+              <button
+                type="button"
+                className="flyout-panel-pin"
+                onClick={handlePin}
+                aria-label={`Pin ${label} open`}
+                title={`Pin ${label} open`}
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
+                </svg>
+              </button>
+            )}
           </div>
           <div className="flyout-panel-content">{children}</div>
         </div>

--- a/src/ui/layout/modes.test.ts
+++ b/src/ui/layout/modes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { LAYOUT_PRESETS, primaryRegion, resolveRegions } from './modes';
+import { LAYOUT_PRESETS, primaryRegion, propertiesDockedVisible, resolveRegions } from './modes';
 import { LAYOUT_MODES } from './types';
+import type { PanelState } from './types';
 
 describe('primaryRegion', () => {
   it('makes Relaxed document-primary (writing-first) and everything else canvas-primary', () => {
@@ -41,5 +42,19 @@ describe('Relaxed preset (writing-first)', () => {
     expect(LAYOUT_PRESETS.relaxed.document.width).toBeUndefined();
     expect(LAYOUT_PRESETS.relaxed.layers.visible).toBe(false);
     expect(LAYOUT_PRESETS.relaxed.properties.visible).toBe(false);
+  });
+});
+
+describe('propertiesDockedVisible (JP-410)', () => {
+  it('Relaxed never docks Properties — even with a stale pinned+visible override', () => {
+    const stalePinned: PanelState = { dock: 'right', visible: true, order: 0, width: 240, pinned: true };
+    expect(propertiesDockedVisible('relaxed', stalePinned)).toBe(false);
+    expect(propertiesDockedVisible('relaxed', { dock: 'right', visible: false, order: 0 })).toBe(false);
+  });
+
+  it('non-Relaxed modes honor state.visible', () => {
+    expect(propertiesDockedVisible('designer', { dock: 'right', visible: true, order: 0 })).toBe(true);
+    expect(propertiesDockedVisible('technician', { dock: 'right', visible: false, order: 0 })).toBe(false);
+    expect(propertiesDockedVisible('power', { dock: 'right', visible: true, order: 0, pinned: true })).toBe(true);
   });
 });

--- a/src/ui/layout/modes.ts
+++ b/src/ui/layout/modes.ts
@@ -23,6 +23,18 @@ export function isFlyoutLayout(mode: LayoutMode): boolean {
 }
 
 /**
+ * Whether Properties renders as a persistent *docked* panel for this mode+state.
+ * In Relaxed it NEVER does — Properties is a selection-only overlay there, so a
+ * stale `visible`/`pinned` override (e.g. left behind from before it became
+ * un-pinnable in Relaxed) must not dock it over the prose, including in `write`
+ * focus. Every other mode honors `state.visible`.
+ */
+export function propertiesDockedVisible(mode: LayoutMode, state: PanelState): boolean {
+  if (mode === 'relaxed') return false;
+  return state.visible;
+}
+
+/**
  * Hard-coded panel arrangement for each layout. `pinned` is set on Power so
  * panels render docked even though Power happens not to use the fly-out model
  * — keeping the flag truthful makes downstream logic uniform.


### PR DESCRIPTION
Fixes the four Relaxed-mode panel bugs in JP-410. Repro-first: each is covered by a test that fails on `master` and passes here.

## Root causes (tighter than first thought — 3 of 4 share 2 causes)

| Reported bug | Root cause | Fix |
|---|---|---|
| 1. Properties/Style Profiles appear (stuck) in Relaxed when pinned | `mergePanelOverride` defaulted `visible: true` for any new override → flipped the preset-hidden Relaxed Properties into a docked panel | Inherit unset keys from the layout **preset**, not hard-coded defaults (`uiPreferencesStore.ts`) |
| 3. Resizing a panel "pins" it | **Same** cause — a width-only override also fabricated `visible: true`, so resize made it stick | Same fix |
| 2. Pinning dismisses the panel | Relaxed has no docked target, and `handlePin` always `collapseNow()`s | Hide the pin button on the railless overlay (`FlyoutPanel.tsx`) |
| 4. Panel disappears after one edit | Focus/hover auto-collapse fought the selection-driven overlay | Suppress auto-collapse when railless — selection owns visibility; parent mounts/unmounts on select/deselect |

The `showRail === false` signal cleanly identifies the Relaxed selection overlay (App passes `showRail={!relaxedTransientProps}`), so Designer/Technician fly-out behavior is unchanged.

## Tests (the "layouts get tested" goal)

- `uiPreferencesStore.test.ts` — an override never forces `visible: true`; pinning/resizing Relaxed Properties stays hidden; explicit visibility + already-visible presets (Designer) still work. This is the durable guard as more properties are added.
- `FlyoutPanel.test.tsx` (new) — pin hidden + no auto-collapse on the railless overlay; pin shown + auto-collapse retained on the rail fly-out.

`bun run typecheck` clean; targeted suites green (48 tests). Visual confirmation of the four behaviors in the running editor is still worth a manual pass on your end.

Refs JP-410.

Assisted-by: Opus 4.8