### PR TITLE
JP-417: make heading links work in collab editor + preview

### DIFF
--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -140,8 +140,10 @@ export function CollaborativeProseEditor({
 
   // Shared editor chrome: right-click formatting menu, spellcheck popover,
   // custom-dictionary loader, inline-link handling, and blob:// image
-  // resolution. Heading-anchor nav is a local multi-page concern, omitted here.
-  const { onContextMenu, overlay } = useProseEditorChrome(editor, { headingAnchors: false });
+  // resolution. Heading-anchor nav is on (JP-417): collab docs are multi-page
+  // too (prose pages are CRDT shared types) and the panel drives the active
+  // page off the same richTextPagesStore the handler switches.
+  const { onContextMenu, overlay } = useProseEditorChrome(editor, { headingAnchors: true });
 
   // Expose the editor instance to the panel (autosave + toolbar).
   useEffect(() => {

--- a/src/ui/ProsePreview.tsx
+++ b/src/ui/ProsePreview.tsx
@@ -15,6 +15,7 @@
 import { useEditor, EditorContent } from '@tiptap/react';
 import { extensions } from './TiptapEditor';
 import { useResolveBlobImages } from './useProseBlobImages';
+import { useProseLinkClicks } from './useProseLinkClicks';
 import './TiptapEditor.css';
 
 export interface ProsePreviewProps {
@@ -38,6 +39,12 @@ export function ProsePreview({ html, className }: ProsePreviewProps) {
   // shown for a relay doc while its collab engine comes up, and without this its
   // images render broken until the editable surface mounts (JP-363).
   useResolveBlobImages(editor);
+
+  // Make inline links live in the read-only preview too (JP-417): heading
+  // anchors resolve to page-switch + scroll, http(s)/mailto open in a new tab.
+  // Without this they were dead in the transient preview + error-boundary
+  // fallback.
+  useProseLinkClicks(editor, { headingAnchors: true });
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`}>

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -24,6 +24,7 @@ import { SpellcheckService } from '../services/SpellcheckService';
 import { SpellcheckPopover } from './SpellcheckPopover';
 import { DocumentEditorContextMenu } from './DocumentEditorContextMenu';
 import { useResolveBlobImages } from './useProseBlobImages';
+import { useProseLinkClicks } from './useProseLinkClicks';
 
 interface ContextMenuState {
   isOpen: boolean;
@@ -121,55 +122,10 @@ export function useProseEditorChrome(
     rebuildSpellcheck(editor.view);
   }, [editor, spellcheckMode]);
 
-  // DOM-level click handler so inline link clicks reliably fire (handleClickOn
-  // doesn't trigger consistently for inline marks in all browsers). Opens
-  // http(s)/mailto in a new tab; with `headingAnchors`, also resolves
-  // `docushark://heading` cross-page nav.
-  useEffect(() => {
-    if (!editor) return;
-    const dom = editor.view.dom;
-    const onClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
-      if (!anchor || !dom.contains(anchor)) return;
-      const href = anchor.getAttribute('href') || '';
-
-      if (headingAnchors) {
-        const headingMatch = href.match(/^docushark:\/\/heading\/([^/]+)\/(\d+)$/);
-        if (headingMatch) {
-          event.preventDefault();
-          event.stopPropagation();
-          const pageId = headingMatch[1]!;
-          const headingIndex = parseInt(headingMatch[2]!, 10);
-          import('../store/richTextPagesStore').then(({ useRichTextPagesStore }) => {
-            const store = useRichTextPagesStore.getState();
-            if (store.activePageId !== pageId) store.setActivePage(pageId);
-            const scrollToHeading = (attempts = 0) => {
-              const headings = document.querySelectorAll(
-                '.tiptap-prose h1, .tiptap-prose h2, .tiptap-prose h3, .tiptap-prose h4, .tiptap-prose h5, .tiptap-prose h6',
-              );
-              const el = headings[headingIndex] as HTMLElement | undefined;
-              if (el) {
-                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-              } else if (attempts < 30) {
-                requestAnimationFrame(() => scrollToHeading(attempts + 1));
-              }
-            };
-            requestAnimationFrame(() => scrollToHeading());
-          });
-          return;
-        }
-      }
-
-      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
-        event.preventDefault();
-        event.stopPropagation();
-        window.open(href, '_blank', 'noopener,noreferrer');
-      }
-    };
-    dom.addEventListener('click', onClick);
-    return () => dom.removeEventListener('click', onClick);
-  }, [editor, headingAnchors]);
+  // Inline link click handling (open http(s)/mailto; resolve heading anchors
+  // when `headingAnchors`). Shared with `ProsePreview` so every prose surface
+  // behaves identically — see the hook.
+  useProseLinkClicks(editor, { headingAnchors });
 
   // Resolve blob:// images to object URLs (initial + on every update) —
   // collaborators on other devices embed images we must load. Shared with the

--- a/src/ui/useProseLinkClicks.test.tsx
+++ b/src/ui/useProseLinkClicks.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * useProseLinkClicks — inline link click handling shared by every prose surface.
+ *
+ * This is the automated repro for JP-417 ("Heading Links are Noops"): clicking a
+ * `docushark://heading/<pageId>/<index>` anchor must switch the active prose page
+ * via richTextPagesStore. Before the fix the handler was wired only into the
+ * local editor, so the same click was a noop in the collab editor and the
+ * read-only ProsePreview. We exercise it through ProsePreview (which now calls
+ * the hook with `headingAnchors: true`).
+ *
+ * jsdom doesn't implement Element.scrollIntoView; we stub it so the post-switch
+ * scroll (fired in a rAF) doesn't throw. The page-switch call is the assertion —
+ * it happens before the scroll.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { registerBlobDownloader, resetBlobCache } from '../storage/blobResolver';
+import { ProsePreview } from './ProsePreview';
+
+const { setActivePageMock } = vi.hoisted(() => ({ setActivePageMock: vi.fn() }));
+
+// The hook dynamically imports the page store; mock it with a stable spy.
+vi.mock('../store/richTextPagesStore', () => ({
+  useRichTextPagesStore: Object.assign(() => ({}), {
+    getState: () => ({ activePageId: 'other-page', setActivePage: setActivePageMock }),
+  }),
+}));
+
+describe('useProseLinkClicks heading-anchor nav (JP-417)', () => {
+  beforeEach(() => {
+    setActivePageMock.mockClear();
+    Element.prototype.scrollIntoView = vi.fn();
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  afterEach(() => {
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  it('switches the active page when a docushark://heading link is clicked', async () => {
+    const { container } = render(
+      <ProsePreview html={'<p><a href="docushark://heading/target-page/0">jump</a></p><h1>Target</h1>'} />,
+    );
+
+    const anchor = await waitFor(() => {
+      const a = container.querySelector('a[href^="docushark://heading/"]');
+      expect(a).not.toBeNull();
+      return a as HTMLAnchorElement;
+    });
+
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(setActivePageMock).toHaveBeenCalledWith('target-page');
+    });
+  });
+
+  it('does not switch pages for an external https link', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { container } = render(
+      <ProsePreview html={'<p><a href="https://example.com">out</a></p>'} />,
+    );
+
+    const anchor = await waitFor(() => {
+      const a = container.querySelector('a[href^="https://"]');
+      expect(a).not.toBeNull();
+      return a as HTMLAnchorElement;
+    });
+
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+    });
+    expect(setActivePageMock).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/src/ui/useProseLinkClicks.ts
+++ b/src/ui/useProseLinkClicks.ts
@@ -1,0 +1,84 @@
+/**
+ * useProseLinkClicks — DOM-level click handling for inline links in a Tiptap
+ * prose surface.
+ *
+ * A DOM `click` listener (rather than ProseMirror's `handleClickOn`) is used
+ * because `handleClickOn` doesn't fire consistently for inline marks across
+ * browsers. It:
+ *   - opens `http(s)` / `mailto` links in a new tab, and
+ *   - with `headingAnchors`, resolves `docushark://heading/<pageId>/<index>`
+ *     in-document anchors as cross-page heading navigation (switch the active
+ *     prose page, then scroll the heading into view).
+ *
+ * Shared by every prose surface so heading links behave identically: the local
+ * `TiptapEditor` and relay `CollaborativeProseEditor` (both via
+ * `useProseEditorChrome`) and the read-only `ProsePreview`. (Heading nav used to
+ * be wired only into the local editor — JP-417: heading links were noops in
+ * collab docs and the preview.)
+ */
+
+import { useEffect } from 'react';
+import type { Editor } from '@tiptap/core';
+
+export interface ProseLinkClickOptions {
+  /**
+   * Resolve in-document `docushark://heading/<pageId>/<index>` anchors as
+   * cross-page heading navigation. Both prose page lists and the active page are
+   * driven by `richTextPagesStore`, so this works for local and collab docs
+   * alike.
+   */
+  headingAnchors?: boolean;
+}
+
+export function useProseLinkClicks(
+  editor: Editor | null,
+  opts: ProseLinkClickOptions = {},
+): void {
+  const { headingAnchors = false } = opts;
+
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+    const onClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
+      if (!anchor || !dom.contains(anchor)) return;
+      const href = anchor.getAttribute('href') || '';
+
+      if (headingAnchors) {
+        const headingMatch = href.match(/^docushark:\/\/heading\/([^/]+)\/(\d+)$/);
+        if (headingMatch) {
+          event.preventDefault();
+          event.stopPropagation();
+          const pageId = headingMatch[1]!;
+          const headingIndex = parseInt(headingMatch[2]!, 10);
+          import('../store/richTextPagesStore').then(({ useRichTextPagesStore }) => {
+            const store = useRichTextPagesStore.getState();
+            if (store.activePageId !== pageId) store.setActivePage(pageId);
+            const scrollToHeading = (attempts = 0) => {
+              const headings = document.querySelectorAll(
+                '.tiptap-prose h1, .tiptap-prose h2, .tiptap-prose h3, .tiptap-prose h4, .tiptap-prose h5, .tiptap-prose h6',
+              );
+              const el = headings[headingIndex] as HTMLElement | undefined;
+              if (el) {
+                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              } else if (attempts < 30) {
+                requestAnimationFrame(() => scrollToHeading(attempts + 1));
+              }
+            };
+            requestAnimationFrame(() => scrollToHeading());
+          });
+          return;
+        }
+      }
+
+      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
+        event.preventDefault();
+        event.stopPropagation();
+        window.open(href, '_blank', 'noopener,noreferrer');
+      }
+    };
+    dom.addEventListener('click', onClick);
+    return () => dom.removeEventListener('click', onClick);
+  }, [editor, headingAnchors]);
+}


### PR DESCRIPTION
## Summary

Fixes **JP-417 — Heading Links are Noops**.

Heading links (`docushark://heading/<pageId>/<index>`, created via the Insert-Link dialog's **Heading** tab) were resolved by a DOM click handler that only ran with `headingAnchors: true`. That was enabled **only** in the local-only `TiptapEditor`. The collaborative editor passed `headingAnchors: false` and the read-only `ProsePreview` installed no link-click handler at all — yet the Insert-Link dialog is reachable from the toolbar in every editor. So in any Cloud/collab document (now the default surface), creating a heading link and clicking it did nothing.

The old disable rationale ("local multi-page concern") was stale: collab docs are multi-page too (prose pages are CRDT shared types since JP-339), and `DocumentEditorPanel` keys the collab editor off the same `richTextPagesStore.activePageId` the handler switches via `setActivePage`, so a handler-driven page switch correctly remounts the editor (the existing 30-frame rAF retry loop covers the async remount).

## Changes

- **New `src/ui/useProseLinkClicks.ts`** — the inline link-click effect, extracted verbatim from `useProseEditorChrome` (heading-anchor nav gated by `headingAnchors`; http(s)/mailto open in a new tab).
- **`useProseEditorChrome.tsx`** — delegates to the new hook (no behavior change for the local editor).
- **`CollaborativeProseEditor.tsx`** — `headingAnchors: false → true` + refreshed comment.
- **`ProsePreview.tsx`** — calls the hook with `headingAnchors: true`, so heading + external links also work in the transient preview / error-boundary fallback (they were previously dead there too — a strict improvement).
- **`useProseLinkClicks.test.tsx`** — regression test: clicking a `docushark://heading` anchor switches the active page; an external `https://` link opens in a new tab and does not switch pages.

## Verification

- `bun run typecheck` clean.
- `bun run test --run` — 221 files / 2777 tests pass, including the 2 new cases.
- Manual (recommended before merge): open a 2-page Cloud/relay doc, insert a cross-page heading link, click → switches page + scrolls to the heading; same-page link scrolls only; local editor + external links unchanged.

## Notes

OSS-side change (`docushark-app/`), purely technical — leak grep on touched files clean. Out of scope: index-based heading-lookup fragility (pre-existing) and a copy-link-to-heading / interactive TOC affordance.

Assisted-by: Opus 4.8