### PR TITLE
JP-416 (S2): table structure — move row/column, header-on-insert, fuller toolbar

### DIFF
--- a/src/tiptap/tableStructureCommands.test.ts
+++ b/src/tiptap/tableStructureCommands.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Table structure ops (JP-416): moving a column/row and keeping header cells on
+ * insert. Headless `Editor` so the real schema + prosemirror-tables primitives
+ * run; assertions read `getHTML()` order / header-cell counts.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import {
+  moveColumnRight,
+  moveColumnLeft,
+  moveRowDown,
+  addColumnAfterKeepHeader,
+  addRowAfterKeepHeader,
+} from './tableStructureCommands';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+/** Put the cursor inside the cell whose text is `text`. */
+function caretInCell(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no cell text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+// Distinctive multi-char cell tokens so getHTML() ordering checks don't collide
+// with letters inside markup (e.g. the 'a'/'b' in `<table>`/`<tbody>`).
+const HEADER_TABLE =
+  '<table><tbody>' +
+  '<tr><th>COL1</th><th>COL2</th></tr>' +
+  '<tr><td>VAL1</td><td>VAL2</td></tr>' +
+  '</tbody></table>';
+
+describe('table move column/row', () => {
+  it('moves a column right (swaps order)', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'COL1'); // column 0
+    expect(moveColumnRight(ed)).toBe(true);
+    const html = ed.getHTML();
+    expect(html.indexOf('COL2')).toBeLessThan(html.indexOf('COL1'));
+    expect(html.indexOf('VAL2')).toBeLessThan(html.indexOf('VAL1'));
+  });
+
+  it('is a no-op past the left edge', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'COL1'); // column 0 — can't go further left
+    const before = ed.getHTML();
+    expect(moveColumnLeft(ed)).toBe(false);
+    expect(ed.getHTML()).toBe(before);
+  });
+
+  it('moves a row down (swaps rows)', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'VAL1'); // row 1
+    expect(moveRowDown(ed)).toBe(false); // already the last row
+    caretInCell(ed, 'COL1'); // row 0
+    expect(moveRowDown(ed)).toBe(true);
+    const html = ed.getHTML();
+    expect(html.indexOf('VAL1')).toBeLessThan(html.indexOf('COL1'));
+  });
+});
+
+describe('table insert keeps header style', () => {
+  it('promotes the new header-row cell to <th> on addColumnAfter', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'COL1'); // header row, column 0
+    expect(addColumnAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    // 2 header cells originally → 3 after the new column inherits the header.
+    expect((html.match(/<th/g) ?? []).length).toBe(3);
+  });
+
+  it('does not add header cells when there is no header row', () => {
+    const ed = make('<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody></table>');
+    caretInCell(ed, 'a');
+    expect(addRowAfterKeepHeader(ed)).toBe(true);
+    expect((ed.getHTML().match(/<th/g) ?? []).length).toBe(0);
+  });
+});

--- a/src/tiptap/tableStructureCommands.ts
+++ b/src/tiptap/tableStructureCommands.ts
@@ -1,0 +1,125 @@
+/**
+ * Table structure operations for JP-416 that aren't surfaced as Tiptap editor
+ * commands: moving a column/row, and keeping header cells when a column/row is
+ * inserted.
+ *
+ * These build on prosemirror-tables' own primitives (`moveTableColumn`,
+ * `moveTableRow`, `selectedRect`, `rowIsHeader`, `columnIsHeader`,
+ * `tableNodeTypes`) rather than hand-rolling table rebuilds, so colspan/rowspan
+ * and column-width handling stay correct. Each takes the Tiptap `Editor` and
+ * returns whether it changed anything (so the toolbar/menu can disable a no-op).
+ */
+
+import type { Editor } from '@tiptap/core';
+import {
+  isInTable,
+  selectedRect,
+  moveTableColumn,
+  moveTableRow,
+  rowIsHeader,
+  columnIsHeader,
+  tableNodeTypes,
+  type TableMap,
+} from '@tiptap/pm/tables';
+
+/**
+ * A clean (no rowspan/colspan) table has each cell appear exactly once in the
+ * map. A merged cell appears multiple times, shrinking the unique set. Move is
+ * disabled on merged tables to avoid corrupting spans (clean case first).
+ */
+export function tableHasMergedCells(map: TableMap): boolean {
+  return new Set(map.map).size !== map.map.length;
+}
+
+function moveCol(editor: Editor, dir: -1 | 1): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const rect = selectedRect(state);
+  if (tableHasMergedCells(rect.map)) return false;
+  const from = rect.left;
+  const to = from + dir;
+  if (to < 0 || to > rect.map.width - 1) return false;
+  const ok = moveTableColumn({ from, to })(state, view.dispatch);
+  if (ok) view.focus();
+  return ok;
+}
+
+function moveRowFn(editor: Editor, dir: -1 | 1): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const rect = selectedRect(state);
+  if (tableHasMergedCells(rect.map)) return false;
+  const from = rect.top;
+  const to = from + dir;
+  if (to < 0 || to > rect.map.height - 1) return false;
+  const ok = moveTableRow({ from, to })(state, view.dispatch);
+  if (ok) view.focus();
+  return ok;
+}
+
+export const moveColumnLeft = (editor: Editor) => moveCol(editor, -1);
+export const moveColumnRight = (editor: Editor) => moveCol(editor, 1);
+export const moveRowUp = (editor: Editor) => moveRowFn(editor, -1);
+export const moveRowDown = (editor: Editor) => moveRowFn(editor, 1);
+
+interface HeaderFlags {
+  headerRow: boolean;
+  headerColumn: boolean;
+}
+
+/** Whether the current table's first row / first column are header cells. */
+function captureHeaderFlags(editor: Editor): HeaderFlags {
+  const { state } = editor;
+  if (!isInTable(state)) return { headerRow: false, headerColumn: false };
+  const rect = selectedRect(state);
+  return {
+    headerRow: rowIsHeader(rect.map, rect.table, 0),
+    headerColumn: columnIsHeader(rect.map, rect.table, 0),
+  };
+}
+
+/**
+ * Force the header cells of the current table to match the captured flags: a
+ * cell becomes `tableHeader` iff it's in row 0 (when the table had a header row)
+ * or col 0 (header column). Only upgrades — never demotes — so it's idempotent
+ * and safe to run after every insert. Fixes "new column/row loses header style".
+ */
+function applyHeaderFlags(editor: Editor, flags: HeaderFlags): void {
+  if (!flags.headerRow && !flags.headerColumn) return;
+  const { state, view } = editor;
+  if (!isInTable(state)) return;
+  const rect = selectedRect(state);
+  const headerType = tableNodeTypes(state.schema)['header_cell'];
+  if (!headerType) return;
+
+  const { map, tableStart } = rect;
+  const tr = state.tr;
+  const seen = new Set<number>();
+  for (let row = 0; row < map.height; row++) {
+    for (let col = 0; col < map.width; col++) {
+      const shouldHeader = (row === 0 && flags.headerRow) || (col === 0 && flags.headerColumn);
+      if (!shouldHeader) continue;
+      const offset = map.map[row * map.width + col];
+      if (offset === undefined || seen.has(offset)) continue;
+      seen.add(offset);
+      const pos = tableStart + offset;
+      const node = state.doc.nodeAt(pos);
+      if (node && node.type !== headerType) {
+        tr.setNodeMarkup(pos, headerType, node.attrs);
+      }
+    }
+  }
+  if (tr.docChanged) view.dispatch(tr);
+}
+
+function insertKeepingHeader(editor: Editor, command: 'addColumnAfter' | 'addColumnBefore' | 'addRowAfter' | 'addRowBefore'): boolean {
+  const flags = captureHeaderFlags(editor);
+  const ok = editor.chain().focus()[command]().run();
+  if (ok) applyHeaderFlags(editor, flags);
+  return ok;
+}
+
+export const addColumnAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnAfter');
+export const addColumnBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnBefore');
+export const addRowAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowAfter');
+export const addRowBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowBefore');

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -47,6 +47,10 @@ import {
   ArrowDownToLine,
   ArrowLeftToLine,
   ArrowRightToLine,
+  ArrowUp,
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
   Rows3,
   Columns3,
   TableCellsMerge,
@@ -629,6 +633,35 @@ export function DocumentEditorContextMenu({
           >
             <span className="doc-editor-context-menu-icon"><Icon icon={ArrowRightToLine} /></span>
             <span className="doc-editor-context-menu-label">Insert Column Right</span>
+          </div>
+          <div className="doc-editor-context-menu-divider" />
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveColumnLeft(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowLeft} /></span>
+            <span className="doc-editor-context-menu-label">Move Column Left</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveColumnRight(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowRight} /></span>
+            <span className="doc-editor-context-menu-label">Move Column Right</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveRowUp(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowUp} /></span>
+            <span className="doc-editor-context-menu-label">Move Row Up</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveRowDown(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowDown} /></span>
+            <span className="doc-editor-context-menu-label">Move Row Down</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
           <div

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -15,6 +15,8 @@ import {
   Link, AlignLeft, AlignCenter, AlignRight, AlignJustify,
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
   BookMarked, Library, Info, Braces,
+  BetweenVerticalStart, BetweenVerticalEnd, BetweenHorizontalStart, BetweenHorizontalEnd,
+  ArrowLeft, ArrowRight, ArrowUp, ArrowDown,
 } from 'lucide-react';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
@@ -453,18 +455,40 @@ export function DocumentEditorToolbar() {
             </div>
 
 
-            {/* Structure - disabled when not in table */}
+            {/* Columns - disabled when not in table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addColumnAfter(editor)} title="Add Column" disabled={!isInTable}>
-                <span className="toolbar-icon">+⇥</span>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addColumnBefore(editor)} title="Insert column left" aria-label="Insert column left" disabled={!isInTable}>
+                <BetweenVerticalStart {...ICON} />
               </button>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addRowAfter(editor)} title="Add Row" disabled={!isInTable}>
-                <span className="toolbar-icon">+↓</span>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addColumnAfter(editor)} title="Insert column right" aria-label="Insert column right" disabled={!isInTable}>
+                <BetweenVerticalEnd {...ICON} />
               </button>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteColumn(editor)} title="Delete Column" disabled={!isInTable}>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveColumnLeft(editor)} title="Move column left" aria-label="Move column left" disabled={!isInTable}>
+                <ArrowLeft {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveColumnRight(editor)} title="Move column right" aria-label="Move column right" disabled={!isInTable}>
+                <ArrowRight {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteColumn(editor)} title="Delete column" aria-label="Delete column" disabled={!isInTable}>
                 <span className="toolbar-icon">-⇥</span>
               </button>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteRow(editor)} title="Delete Row" disabled={!isInTable}>
+            </div>
+
+            {/* Rows - disabled when not in table */}
+            <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addRowBefore(editor)} title="Insert row above" aria-label="Insert row above" disabled={!isInTable}>
+                <BetweenHorizontalStart {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addRowAfter(editor)} title="Insert row below" aria-label="Insert row below" disabled={!isInTable}>
+                <BetweenHorizontalEnd {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveRowUp(editor)} title="Move row up" aria-label="Move row up" disabled={!isInTable}>
+                <ArrowUp {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveRowDown(editor)} title="Move row down" aria-label="Move row down" disabled={!isInTable}>
+                <ArrowDown {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteRow(editor)} title="Delete row" aria-label="Delete row" disabled={!isInTable}>
                 <span className="toolbar-icon">-↓</span>
               </button>
             </div>
@@ -485,6 +509,7 @@ export function DocumentEditorToolbar() {
                   <button onClick={() => { editor && cmd.toggleHeaderColumn(editor); setShowTableStyles(false); }}>Toggle Header Column</button>
                   <button onClick={() => { editor && cmd.mergeCells(editor); setShowTableStyles(false); }}>Merge Cells</button>
                   <button onClick={() => { editor && cmd.splitCell(editor); setShowTableStyles(false); }}>Split Cell</button>
+                  <button onClick={() => { editor && cmd.mergeOrSplit(editor); setShowTableStyles(false); }}>Merge / Split (toggle)</button>
                 </div>
               </ToolbarDropdown>
               <ToolbarDropdown

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -7,6 +7,16 @@
 
 import type { Editor } from '@tiptap/core';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
+import {
+  addColumnAfterKeepHeader,
+  addColumnBeforeKeepHeader,
+  addRowAfterKeepHeader,
+  addRowBeforeKeepHeader,
+  moveColumnLeft as moveColumnLeftCmd,
+  moveColumnRight as moveColumnRightCmd,
+  moveRowUp as moveRowUpCmd,
+  moveRowDown as moveRowDownCmd,
+} from '../tiptap/tableStructureCommands';
 
 // Text formatting
 export const toggleBold = (editor: Editor) => editor.chain().focus().toggleBold().run();
@@ -52,10 +62,13 @@ export const unsetHighlight = (editor: Editor) =>
 // Tables
 export const insertTable = (editor: Editor) =>
   editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
-export const addColumnAfter = (editor: Editor) => editor.chain().focus().addColumnAfter().run();
-export const addColumnBefore = (editor: Editor) => editor.chain().focus().addColumnBefore().run();
-export const addRowAfter = (editor: Editor) => editor.chain().focus().addRowAfter().run();
-export const addRowBefore = (editor: Editor) => editor.chain().focus().addRowBefore().run();
+// Insert commands keep the table-header style on the new row/column (JP-416):
+// a fresh cell in the header row/column is promoted back to `tableHeader` so it
+// no longer needs a manual re-toggle.
+export const addColumnAfter = (editor: Editor) => addColumnAfterKeepHeader(editor);
+export const addColumnBefore = (editor: Editor) => addColumnBeforeKeepHeader(editor);
+export const addRowAfter = (editor: Editor) => addRowAfterKeepHeader(editor);
+export const addRowBefore = (editor: Editor) => addRowBeforeKeepHeader(editor);
 export const deleteColumn = (editor: Editor) => editor.chain().focus().deleteColumn().run();
 export const deleteRow = (editor: Editor) => editor.chain().focus().deleteRow().run();
 export const deleteTable = (editor: Editor) => editor.chain().focus().deleteTable().run();
@@ -63,6 +76,13 @@ export const toggleHeaderRow = (editor: Editor) => editor.chain().focus().toggle
 export const toggleHeaderColumn = (editor: Editor) => editor.chain().focus().toggleHeaderColumn().run();
 export const mergeCells = (editor: Editor) => editor.chain().focus().mergeCells().run();
 export const splitCell = (editor: Editor) => editor.chain().focus().splitCell().run();
+export const mergeOrSplit = (editor: Editor) => editor.chain().focus().mergeOrSplit().run();
+// Move the column/row containing the selection one step (JP-416). No-op at the
+// table edge or when the table has merged cells.
+export const moveColumnLeft = (editor: Editor) => moveColumnLeftCmd(editor);
+export const moveColumnRight = (editor: Editor) => moveColumnRightCmd(editor);
+export const moveRowUp = (editor: Editor) => moveRowUpCmd(editor);
+export const moveRowDown = (editor: Editor) => moveRowDownCmd(editor);
 export const setCellBackground = (editor: Editor, color: string | null) =>
   editor.chain().focus().setCellAttribute('backgroundColor', color).run();
 


### PR DESCRIPTION
Second slice of the JP-416 tables makeover — structural editing. Independent of S1 (PR #355): different files, branched off `master`. Client-only (no doc-format/migration/relay changes).

## What & why

- **Move column/row (item 1b — the user's "context actions" ask):** new `src/tiptap/tableStructureCommands.ts` builds on prosemirror-tables' own `moveTableColumn`/`moveTableRow` (so colspan/colwidth handling stays correct) rather than hand-rolling a table rebuild. `moveColumnLeft/Right`, `moveRowUp/Down` operate on the column/row under the selection; no-op at the table edge and **disabled when the table has merged cells** (clean rectangular case first). Wired into the toolbar Table tab and the right-click table submenu.
- **Header-on-insert (item 2):** stock `addColumn`/`addRow` create plain `tableCell`s, so a header row/column lost its styling on the new cell. The four insert commands now capture whether row 0 / col 0 are headers, insert, then promote the new header-row/column cell back to `tableHeader` — idempotent, upgrade-only. Fixes both the toolbar and the context menu (shared `editorCommands`).
- **Fuller toolbar (item 5):** the Table tab now has **Insert Column Left/Right** + **Insert Row Above/Below**, the four **Move** actions (lucide icons), and a **Merge/Split** toggle — parity with the context menu, which also gains the Move actions.

## Verification

- `bun run typecheck` clean; `bun run test --run` — 221 files / 2780 tests pass.
- New `tableStructureCommands.test.ts` (headless `Editor`): column moves right/swaps, no-op past the edge, row moves; `addColumnAfter` promotes the new header cell to `<th>` and stays plain when there's no header row.
- **Live (please confirm in-app):** move actions from toolbar + right-click; new column/row keeps header style without a re-toggle; insert-before variants; move disabled on a merged-cell table.

Part of JP-416 (multi-slice). S1 = PR #355. Next: S3 — rounded tables + Appearance opt-out.

Assisted-by: Opus 4.8