### PR TITLE
JP-416 (S3): rounded tables by default + Appearance opt-out

### DIFF
--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -94,6 +94,19 @@ describe('uiPreferencesStore — document browser grouping', () => {
   });
 });
 
+describe('uiPreferencesStore — rounded tables', () => {
+  it('defaults to on (opt-out)', () => {
+    expect(useUIPreferencesStore.getState().appearancePrefs.roundedTables).toBe(true);
+  });
+
+  it('setRoundedTables flips the preference', () => {
+    useUIPreferencesStore.getState().setRoundedTables(false);
+    expect(useUIPreferencesStore.getState().appearancePrefs.roundedTables).toBe(false);
+    useUIPreferencesStore.getState().setRoundedTables(true);
+    expect(useUIPreferencesStore.getState().appearancePrefs.roundedTables).toBe(true);
+  });
+});
+
 describe('uiPreferencesStore — spellcheck mode', () => {
   it('defaults to the custom (built-in) checker', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs.spellcheck).toBe('custom');
@@ -283,6 +296,7 @@ describe('uiPreferencesStore — migration', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -313,6 +327,7 @@ describe('uiPreferencesStore — migration', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
   });
 
@@ -340,6 +355,7 @@ describe('uiPreferencesStore — migration', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
   });
 
@@ -451,6 +467,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
   });
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -97,6 +97,8 @@ export interface AppearancePrefs {
   /** Which spellchecker runs in the prose editor (custom dictionary / system /
    *  off). Drives both the custom decorations and the native `spellcheck` attr. */
   spellcheck: SpellcheckMode;
+  /** Rounded corners on prose tables. Opt-out — on by default (JP-416). */
+  roundedTables: boolean;
 }
 
 /**
@@ -231,6 +233,8 @@ export interface UIPreferencesActions {
   setCaretStyle: (caretStyle: CaretStyle) => void;
   /** Toggle the smooth (gliding) caret. */
   setSmoothCaret: (smoothCaret: boolean) => void;
+  /** Toggle rounded corners on prose tables. */
+  setRoundedTables: (roundedTables: boolean) => void;
   /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
   setUiScale: (uiScale: number) => void;
   /** Set the prose editor background preset. */
@@ -297,6 +301,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   smoothCaret: true,
   caretColor: null,
   spellcheck: 'custom',
+  roundedTables: true,
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -595,6 +600,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ appearancePrefs: { ...get().appearancePrefs, smoothCaret } });
       },
 
+      setRoundedTables: (roundedTables) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, roundedTables } });
+      },
+
       setCaretColor: (caretColor) => {
         set({ appearancePrefs: { ...get().appearancePrefs, caretColor } });
       },
@@ -609,7 +618,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 12,
+      version: 13,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -760,6 +769,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // (never shown) so existing users get the hint once, like a new install.
         if (fromVersion < 12) {
           next['installAppHintSeen'] = next['installAppHintSeen'] ?? false;
+        }
+        // v12 → v13: appearance slice gained roundedTables (JP-416). Default on
+        // (opt-out) without clobbering existing appearance choices. (The `merge`
+        // below also backstops this.)
+        if (fromVersion < 13) {
+          next['appearancePrefs'] = {
+            ...initialAppearancePrefs,
+            ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
+          };
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -330,13 +330,22 @@
   margin: 1rem 0;
 }
 
+/* Rounded tables are the DEFAULT (JP-416 item 4, opt-out). Rounded corners need
+   `border-collapse: separate` — the table draws the outer border + radius (with
+   `overflow: hidden` clipping the corners) and cells draw only right+bottom
+   borders, trimmed on the last column/row, so there's no doubled/outer border.
+   `[data-rounded-tables="false"]` below reverts to collapsed square tables.
+
+   `width: 100%` + `table-layout: fixed` is the known-good geometry — columns get
+   real, equal widths so posAtCoords can tell laterally-adjacent cells apart (a
+   `max-content` width collapsed columns and broke lateral multi-cell selection).
+   The `.tableWrapper`'s `overflow-x: auto` still lets a resized-wider table
+   scroll. Fuller anti-cramping is JP-416 item 6 follow-up. */
 .tiptap-editor .ProseMirror table {
-  border-collapse: collapse;
-  /* `width: 100%` + `table-layout: fixed` is the known-good geometry — columns
-     get real, equal widths so posAtCoords can tell laterally-adjacent cells
-     apart (a `max-content` width here collapsed columns and broke lateral
-     multi-cell selection). The `.tableWrapper`'s `overflow-x: auto` still lets a
-     resized-wider table scroll. Fuller anti-cramping is JP-416 item 6 follow-up. */
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
   width: 100%;
   table-layout: fixed;
   overflow: hidden;
@@ -349,11 +358,33 @@
 
 .tiptap-editor .ProseMirror table th,
 .tiptap-editor .ProseMirror table td {
-  border: 1px solid var(--border-color);
+  border-right: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
   padding: 0.5rem 0.75rem;
   vertical-align: top;
   min-width: 50px;
   position: relative;
+}
+
+/* Trim the cell borders that would double the table's outer border. */
+.tiptap-editor .ProseMirror table th:last-child,
+.tiptap-editor .ProseMirror table td:last-child {
+  border-right: none;
+}
+.tiptap-editor .ProseMirror table tr:last-child th,
+.tiptap-editor .ProseMirror table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Squared opt-out: collapsed borders, no radius, full per-cell borders. */
+:root[data-rounded-tables="false"] .tiptap-editor .ProseMirror table {
+  border-collapse: collapse;
+  border: none;
+  border-radius: 0;
+}
+:root[data-rounded-tables="false"] .tiptap-editor .ProseMirror table th,
+:root[data-rounded-tables="false"] .tiptap-editor .ProseMirror table td {
+  border: 1px solid var(--border-color);
 }
 
 .tiptap-editor .ProseMirror table th {

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -75,6 +75,7 @@ describe('appearance snapshot seam (Abstraction B)', () => {
       density: 'spacious',
       uiScale: 1.15,
       proseBackground: 'glow',
+      roundedTables: true,
     });
   });
 
@@ -105,6 +106,7 @@ describe('appearance snapshot seam (Abstraction B)', () => {
       density: 'normal',
       uiScale: 1,
       proseBackground: 'default',
+      roundedTables: true,
     });
   });
 });

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -22,6 +22,7 @@ export interface AppearanceConfig {
   density: Density;
   uiScale: number;
   proseBackground: ProseBackground;
+  roundedTables: boolean;
 }
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
@@ -31,13 +32,22 @@ export const DEFAULT_APPEARANCE: AppearanceConfig = {
   density: 'normal',
   uiScale: 1,
   proseBackground: 'default',
+  roundedTables: true,
 };
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { themeInputs, motion, density, uiScale, proseBackground } =
+  const { themeInputs, motion, density, uiScale, proseBackground, roundedTables } =
     useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale, proseBackground };
+  return {
+    theme: useThemeStore.getState().preference,
+    themeInputs,
+    motion,
+    density,
+    uiScale,
+    proseBackground,
+    roundedTables,
+  };
 }
 
 /** Apply a (partial) appearance config across both stores. */
@@ -52,6 +62,7 @@ export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
   if (cfg.density !== undefined) ui.setDensity(cfg.density);
   if (cfg.uiScale !== undefined) ui.setUiScale(cfg.uiScale);
   if (cfg.proseBackground !== undefined) ui.setProseBackground(cfg.proseBackground);
+  if (cfg.roundedTables !== undefined) ui.setRoundedTables(cfg.roundedTables);
 }
 
 /**

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -54,6 +54,9 @@ function applyNonColor(prefs: AppearancePrefs): void {
     } else {
       root.style.removeProperty('--prose-bg');
     }
+    // Rounded prose tables (opt-out). The table CSS keys off this attribute;
+    // only the "false" (squared) case needs an override (JP-416).
+    root.dataset['roundedTables'] = String(prefs.roundedTables);
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -16,6 +16,8 @@ describe('AppearanceSettings', () => {
     // Prose background presets render.
     expect(screen.getByText('Prose background')).toBeTruthy();
     expect(screen.getByText('Glow')).toBeTruthy();
+    // Rounded-tables opt-out (JP-416).
+    expect(screen.getByText('Rounded tables')).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -103,6 +103,8 @@ export function AppearanceSettings() {
   const setCaretColor = useUIPreferencesStore((s) => s.setCaretColor);
   const spellcheck = useUIPreferencesStore((s) => s.appearancePrefs.spellcheck);
   const setSpellcheckMode = useUIPreferencesStore((s) => s.setSpellcheckMode);
+  const roundedTables = useUIPreferencesStore((s) => s.appearancePrefs.roundedTables);
+  const setRoundedTables = useUIPreferencesStore((s) => s.setRoundedTables);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -287,6 +289,23 @@ export function AppearanceSettings() {
             <strong>Custom</strong> uses DocuShark's dictionary and “Add to dictionary”.
             <strong> System</strong> uses your browser/OS spellchecker.
             <strong> Off</strong> disables spellchecking. Only one runs at a time.
+          </span>
+        </div>
+      </div>
+
+      {/* Tables */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Tables</h4>
+        <div className="settings-row">
+          <span className="settings-label">Rounded tables</span>
+          <Switch
+            ariaLabel="Rounded tables"
+            checked={roundedTables}
+            onCheckedChange={setRoundedTables}
+          />
+          <span className="settings-hint">
+            Round the corners of tables in the writing editor. Turn off for square,
+            grid-style tables.
           </span>
         </div>
       </div>


### PR DESCRIPTION
Third slice of the JP-416 tables makeover. Branched off `master` (has S1+S2). Independent of the open #357 (spike removal) — different files.

## What & why (item 4)

Prose tables are now **rounded by default**, with an Appearance **opt-out** (the issue says "opt-out rounded tables"). Implemented exactly like the `smoothCaret` opt-out pref:

- `roundedTables: boolean` added to `AppearancePrefs` (default `true`), with a `setRoundedTables` setter, a `v12 → v13` migration, and the `merge` backstop so older persisted state hydrates cleanly.
- Added to the appearance-snapshot seam (`appearanceConfig.ts`) so it rides the Workspaces/export-import path, alongside `proseBackground`.
- Applied as a `data-rounded-tables` root attribute in `applyAppearance.ts` (before first paint, no flash).
- New **Tables → Rounded tables** switch in Settings → Appearance.
- CSS: rounded default uses `border-collapse: separate` + `border-radius` with `overflow: hidden` clipping corners; cells draw only right/bottom borders, trimmed on the last column/row so the outer border isn't doubled. `:root[data-rounded-tables="false"]` reverts to collapsed square borders.

## Verification

- `bun run typecheck` clean; `bun run test --run` — 223 files / 2785 tests pass.
- Store test: `roundedTables` defaults on + the setter flips it. Appearance-snapshot tests updated for the new field. Settings test asserts the toggle renders.
- **Live (please confirm):** tables render rounded by default; the Appearance toggle squares them with no reload; composes with the lateral-scroll wrapper.

Part of JP-416 (multi-slice). S1 (#355) + S2 (#356) merged; spike removal in #357. Next: S4 — per-column alignment.

Assisted-by: Opus 4.8