### PR TITLE
JP-416 (S4): per-column cell text alignment

### DIFF
--- a/src/tiptap/tableAlign.test.ts
+++ b/src/tiptap/tableAlign.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-column alignment (JP-416): the table cell `align` attribute parses from
+ * and renders to a `text-align` style, and `setCellAlign` applies it to the
+ * focused cell. Headless `Editor` so the real schema + the TableCell/TableHeader
+ * `align` addAttributes run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import { setCellAlign } from '../ui/editorCommands';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+function caretInCell(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no cell text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+describe('table cell alignment', () => {
+  it('round-trips an align attribute through getHTML', () => {
+    const ed = make(
+      '<table><tbody><tr><td style="text-align: right">RIGHT</td><td>PLAIN</td></tr></tbody></table>',
+    );
+    expect(ed.getHTML()).toContain('text-align: right');
+  });
+
+  it('setCellAlign sets alignment on the focused cell, and null clears it', () => {
+    const ed = make('<table><tbody><tr><td>CELL</td></tr></tbody></table>');
+    caretInCell(ed, 'CELL');
+
+    setCellAlign(ed, 'center');
+    expect(ed.getHTML()).toContain('text-align: center');
+
+    setCellAlign(ed, null);
+    expect(ed.getHTML()).not.toContain('text-align');
+  });
+
+  it('preserves alignment alongside a cell background color', () => {
+    const ed = make(
+      '<table><tbody><tr><td style="text-align: center; background-color: rgb(255, 0, 0)">X</td></tr></tbody></table>',
+    );
+    const html = ed.getHTML();
+    expect(html).toContain('text-align: center');
+    expect(html).toContain('background-color: rgb(255, 0, 0)');
+  });
+});

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -55,6 +55,9 @@ import {
   Columns3,
   TableCellsMerge,
   TableCellsSplit,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
 } from 'lucide-react';
 import { useDocumentStore } from '../store/documentStore';
 import { isGroup, type GroupShape } from '../shapes/Shape';
@@ -707,6 +710,28 @@ export function DocumentEditorContextMenu({
           >
             <span className="doc-editor-context-menu-icon"><Icon icon={TableCellsSplit} /></span>
             <span className="doc-editor-context-menu-label">Split Cell</span>
+          </div>
+          <div className="doc-editor-context-menu-divider" />
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.setCellAlign(editor, 'left'); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={AlignLeft} /></span>
+            <span className="doc-editor-context-menu-label">Align Left</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.setCellAlign(editor, 'center'); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={AlignCenter} /></span>
+            <span className="doc-editor-context-menu-label">Align Center</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.setCellAlign(editor, 'right'); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={AlignRight} /></span>
+            <span className="doc-editor-context-menu-label">Align Right</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
           <div

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -532,6 +532,20 @@ export function DocumentEditorToolbar() {
             </div>
 
 
+            {/* Cell alignment - disabled when not in table */}
+            <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.setCellAlign(editor, 'left')} title="Align left" aria-label="Align cell left" disabled={!isInTable}>
+                <AlignLeft {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.setCellAlign(editor, 'center')} title="Align center" aria-label="Align cell center" disabled={!isInTable}>
+                <AlignCenter {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.setCellAlign(editor, 'right')} title="Align right" aria-label="Align cell right" disabled={!isInTable}>
+                <AlignRight {...ICON} />
+              </button>
+            </div>
+
+
             {/* Delete table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
               <button className="document-editor-toolbar-btn danger" onClick={() => editor && isInTable && cmd.deleteTable(editor)} title="Delete Table" disabled={!isInTable} aria-label="Delete table">

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -139,6 +139,21 @@ export const sharedProseExtensions = [
             };
           },
         },
+        // Per-column text alignment (JP-416). Stored on the cell, rendered as a
+        // `text-align` style (Tiptap merges it with backgroundColor's style), so
+        // it round-trips through getHTML.
+        align: {
+          default: null,
+          parseHTML: element => element.style.textAlign || null,
+          renderHTML: attributes => {
+            if (!attributes['align']) {
+              return {};
+            }
+            return {
+              style: `text-align: ${attributes['align']}`,
+            };
+          },
+        },
       };
     },
   }),
@@ -155,6 +170,21 @@ export const sharedProseExtensions = [
             }
             return {
               style: `background-color: ${attributes['backgroundColor']}`,
+            };
+          },
+        },
+        // Per-column text alignment (JP-416). Stored on the cell, rendered as a
+        // `text-align` style (Tiptap merges it with backgroundColor's style), so
+        // it round-trips through getHTML.
+        align: {
+          default: null,
+          parseHTML: element => element.style.textAlign || null,
+          renderHTML: attributes => {
+            if (!attributes['align']) {
+              return {};
+            }
+            return {
+              style: `text-align: ${attributes['align']}`,
             };
           },
         },

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -85,6 +85,10 @@ export const moveRowUp = (editor: Editor) => moveRowUpCmd(editor);
 export const moveRowDown = (editor: Editor) => moveRowDownCmd(editor);
 export const setCellBackground = (editor: Editor, color: string | null) =>
   editor.chain().focus().setCellAttribute('backgroundColor', color).run();
+// Text alignment for the selected cells (JP-416). With a column selected this
+// aligns the whole column; `null` clears back to the default (left).
+export const setCellAlign = (editor: Editor, align: 'left' | 'center' | 'right' | null) =>
+  editor.chain().focus().setCellAttribute('align', align).run();
 
 // Math
 export const setMathInline = (editor: Editor, latex: string) =>


### PR DESCRIPTION
Fourth slice of the JP-416 tables makeover (the first agreed extra). Branched off `master` (has S1+S2); doesn't touch the files in open PRs #357/#358.

## What & why

Per-column text alignment — a Word/Notion staple.

- New `align` attribute on `TableCell`/`TableHeader`, mirroring the existing `backgroundColor` pattern: it parses from / renders to a `text-align` style. Tiptap merges it with the background-color style, so a cell can carry both, and it round-trips through `getHTML`.
- New `setCellAlign(editor, 'left'|'center'|'right'|null)` command (`setCellAttribute('align', …)`), applied to the selected cells — selecting a column aligns the whole column; `null` clears back to default.
- Surfaced as **Align Left/Center/Right** in the Table toolbar tab and the right-click table submenu.

Client-only — no doc-format/migration/relay changes. (Markdown-alignment round-trip through the relay is a noted optional follow-up, not in this PR.)

## Verification

- `bun run typecheck` clean; `bun run test --run` — 224 files / 2786 tests pass.
- New `tableAlign.test.ts` (headless `Editor`): `align` round-trips through `getHTML`; `setCellAlign` sets/clears it on the focused cell; alignment + background color coexist.
- **Live (please confirm):** put the cursor in / select a column, hit Align Center/Right from the toolbar or right-click — the column's text aligns.

Part of JP-416 (multi-slice). S1 (#355) + S2 (#356) merged; #357 (spike removal) + #358 (rounded) open. Next: S5 — Tab/keyboard, S6 — `th scope` (both touch `TiptapEditor.tsx`, so I'll sequence them after this merges to avoid conflicts).

Assisted-by: Opus 4.8