### PR TITLE
JP-416 (S5): Word-like Tab navigation in tables

### DIFF
--- a/src/tiptap/TableKeymap.test.ts
+++ b/src/tiptap/TableKeymap.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TableKeymap (JP-416) — Tab navigation in tables. We test the extracted
+ * handlers directly (dispatching real key events through the keymap is brittle
+ * in jsdom). Headless `Editor` so the real table schema + commands run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import { handleTableTab, handleTableShiftTab } from './TableKeymap';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+function caretIn(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+const rows = (ed: Editor) => (ed.getHTML().match(/<tr/g) ?? []).length;
+
+const ROW = '<table><tbody><tr><td>A</td><td>B</td></tr></tbody></table>';
+
+describe('TableKeymap Tab handling', () => {
+  it('Tab in the last cell appends a new row', () => {
+    const ed = make(ROW);
+    caretIn(ed, 'B'); // last cell
+    expect(rows(ed)).toBe(1);
+    expect(handleTableTab(ed)).toBe(true);
+    expect(rows(ed)).toBe(2);
+  });
+
+  it('Tab in a non-last cell advances without adding a row', () => {
+    const ed = make(ROW);
+    caretIn(ed, 'A'); // first cell
+    expect(handleTableTab(ed)).toBe(true);
+    expect(rows(ed)).toBe(1);
+  });
+
+  it('Tab outside a table is not handled (returns false)', () => {
+    const ed = make('<p>OUTSIDE</p>');
+    caretIn(ed, 'OUTSIDE');
+    expect(handleTableTab(ed)).toBe(false);
+    expect(handleTableShiftTab(ed)).toBe(false);
+  });
+});

--- a/src/tiptap/TableKeymap.ts
+++ b/src/tiptap/TableKeymap.ts
@@ -1,0 +1,44 @@
+import { Extension } from '@tiptap/core';
+import type { Editor } from '@tiptap/core';
+
+/**
+ * TableKeymap (JP-416) — Word-like Tab navigation inside prose tables.
+ *
+ * Tab / Shift-Tab move to the next / previous cell, and Tab in the **last** cell
+ * appends a new row and lands in its first cell (so you can fill a table without
+ * reaching for the mouse). Outside a table the handlers return `false` so Tab
+ * keeps its default behavior (e.g. list indent / focus move).
+ */
+
+/**
+ * Tab handler, extracted so it's unit-testable without dispatching key events.
+ * Returns true if it handled the key (advanced a cell or grew the table).
+ */
+export function handleTableTab(editor: Editor): boolean {
+  if (!editor.isActive('table')) return false;
+  if (editor.commands.goToNextCell()) return true;
+  // At the last cell: add a row and step into it.
+  if (editor.can().addRowAfter()) {
+    return editor.chain().addRowAfter().goToNextCell().run();
+  }
+  return false;
+}
+
+/** Shift-Tab handler — previous cell, or pass through outside a table. */
+export function handleTableShiftTab(editor: Editor): boolean {
+  if (!editor.isActive('table')) return false;
+  return editor.commands.goToPreviousCell();
+}
+
+export const TableKeymap = Extension.create({
+  name: 'docusharkTableKeymap',
+
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => handleTableTab(this.editor),
+      'Shift-Tab': () => handleTableShiftTab(this.editor),
+    };
+  },
+});
+
+export default TableKeymap;

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -55,6 +55,7 @@ import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { CaretExtension } from '../tiptap/CaretExtension';
 import { TableSelection } from '../tiptap/TableSelectionExtension';
+import { TableKeymap } from '../tiptap/TableKeymap';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import { resolveBlobImagesIn } from './proseBlobImages';
 import { registerProseSchema } from '../collaboration/proseSchema';
@@ -122,6 +123,9 @@ export const sharedProseExtensions = [
       class: 'tiptap-table',
     },
   }),
+  // Word-like Tab navigation in tables (next/prev cell; Tab in the last cell
+  // appends a row). No nodes/marks, so the shared schema + collab are unaffected.
+  TableKeymap,
   TableRow,
   TableCell.extend({
     addAttributes() {


### PR DESCRIPTION
Fifth slice of the JP-416 tables makeover (extra). Branched off `master` (S1+S2); independent of the open slice PRs at the hunk level (new file + one line in the shared-extensions list).

## What & why

Streamlined keyboard editing in prose tables:

- **Tab** → next cell, **Shift-Tab** → previous cell.
- **Tab in the last cell** appends a new row and lands in its first cell, so you can fill a table without the mouse (Word-like).
- Outside a table the handlers return `false`, so Tab keeps its default behavior (list indent / focus move).

New `TableKeymap` extension added to `sharedProseExtensions` (so both the local and collaborative editors get it). The Tab/Shift-Tab logic is extracted into `handleTableTab` / `handleTableShiftTab` for unit testing.

Client-only — no doc-format/migration/relay changes.

## Verification

- `bun run typecheck` clean; `bun run test --run` — 224 files / 2786 tests pass.
- New `TableKeymap.test.ts`: Tab in the last cell adds a row; Tab in a non-last cell advances without adding a row; Tab outside a table is not handled.
- **Live (please confirm):** Tab through cells; Tab at the bottom-right cell adds a row.

Part of JP-416 (multi-slice). S1 (#355) + S2 (#356) merged; #357/#358/#359 open. Last slice S6 (`th scope`) edits the same `TableHeader.extend` block as S4 (#359), so I'll land it after #359 merges to avoid a conflict.

Assisted-by: Opus 4.8