### PR TITLE
JP-416: cross-cell drag selects cells even when starting inside cell text

### DIFF
--- a/src/tiptap/TableCellSelect.test.ts
+++ b/src/tiptap/TableCellSelect.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TableCellSelect (JP-416) — a pointer selection spanning two cells of the same
+ * table becomes a CellSelection, regardless of where the drag started. We test
+ * the extracted rule with resolved positions from a real table doc (simulating
+ * the createSelectionBetween call).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
+import { extensions } from '../ui/TiptapEditor';
+import { cellSelectionBetween } from './TableCellSelect';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+/** Resolve a position inside the cell whose text is `text`. */
+function posIn(ed: Editor, text: string): number {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no text ${text}`);
+  return pos;
+}
+
+const TABLE = '<table><tbody><tr><td>AA</td><td>BB</td></tr><tr><td>CC</td><td>DD</td></tr></tbody></table>';
+
+describe('cellSelectionBetween', () => {
+  it('returns a CellSelection for two different cells in the same table', () => {
+    const ed = make(TABLE);
+    const $a = ed.state.doc.resolve(posIn(ed, 'AA'));
+    const $b = ed.state.doc.resolve(posIn(ed, 'DD'));
+    const sel = cellSelectionBetween($a, $b);
+    expect(sel).toBeInstanceOf(CellSelection);
+  });
+
+  it('returns null for anchor and head within the same cell', () => {
+    const ed = make(TABLE);
+    const $a = ed.state.doc.resolve(posIn(ed, 'AA'));
+    expect(cellSelectionBetween($a, $a)).toBeNull();
+  });
+
+  it('returns null when an endpoint is outside any table', () => {
+    const ed = make('<p>OUT</p>' + TABLE);
+    const $out = ed.state.doc.resolve(posIn(ed, 'OUT'));
+    const $cell = ed.state.doc.resolve(posIn(ed, 'AA'));
+    expect(cellSelectionBetween($out, $cell)).toBeNull();
+  });
+});

--- a/src/tiptap/TableCellSelect.ts
+++ b/src/tiptap/TableCellSelect.ts
@@ -1,0 +1,51 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { ResolvedPos } from '@tiptap/pm/model';
+import { cellAround, inSameTable, CellSelection } from '@tiptap/pm/tables';
+
+/**
+ * TableCellSelect (JP-416) — make a drag that crosses table cells reliably
+ * become a multi-cell `CellSelection`, even when the drag STARTS inside a cell's
+ * text.
+ *
+ * prosemirror-tables' own drag handler decides "the pointer moved to another
+ * cell" from `event.target`. When a drag begins on text, the browser runs a
+ * native text-selection drag that keeps `event.target` pinned to the start cell,
+ * so that cross-cell trigger never fires and the selection is clamped to the
+ * first cell (`normalizeSelection`). The `createSelectionBetween` prop instead
+ * works off the resolved anchor/head POSITIONS, so it's immune to the pinned
+ * target: if the two ends are in different cells of the same table, select the
+ * cells. (prosemirror-tables' own `createSelectionBetween` returns null unless
+ * its drag is active, so this composes — no conflict.)
+ */
+
+/** The cross-cell rule, extracted so it's unit-testable from resolved positions. */
+export function cellSelectionBetween(
+  $anchor: ResolvedPos,
+  $head: ResolvedPos,
+): CellSelection | null {
+  const anchorCell = cellAround($anchor);
+  const headCell = cellAround($head);
+  if (anchorCell && headCell && anchorCell.pos !== headCell.pos && inSameTable(anchorCell, headCell)) {
+    return new CellSelection(anchorCell, headCell);
+  }
+  return null;
+}
+
+export const TableCellSelect = Extension.create({
+  name: 'docusharkTableCellSelect',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('docusharkTableCellSelect'),
+        props: {
+          createSelectionBetween: (_view, $anchor, $head) =>
+            cellSelectionBetween($anchor, $head),
+        },
+      }),
+    ];
+  },
+});
+
+export default TableCellSelect;

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -56,6 +56,7 @@ import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { CaretExtension } from '../tiptap/CaretExtension';
 import { TableSelection } from '../tiptap/TableSelectionExtension';
 import { TableKeymap } from '../tiptap/TableKeymap';
+import { TableCellSelect } from '../tiptap/TableCellSelect';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import { resolveBlobImagesIn } from './proseBlobImages';
 import { registerProseSchema } from '../collaboration/proseSchema';
@@ -126,6 +127,9 @@ export const sharedProseExtensions = [
   // Word-like Tab navigation in tables (next/prev cell; Tab in the last cell
   // appends a row). No nodes/marks, so the shared schema + collab are unaffected.
   TableKeymap,
+  // Cross-cell drag → CellSelection even when the drag starts inside cell text
+  // (position-based, immune to the pinned-target quirk). No nodes/marks.
+  TableCellSelect,
   TableRow,
   TableCell.extend({
     addAttributes() {


### PR DESCRIPTION
Follow-up fix for the JP-416 selection work. Branched off `master` (all prior slices merged).

## The bug

Starting a drag-select from **inside a cell's text** never upgraded to a multi-cell `CellSelection` — it stayed a text selection clamped to the first cell.

Root cause: prosemirror-tables' drag handler decides "the pointer crossed into another cell" from `event.target`. When the drag begins on text, the browser runs a native text-selection drag that keeps `event.target` pinned to the start cell, so the cross-cell trigger never fires and `normalizeSelection` clamps the result to one cell.

## The fix

A `createSelectionBetween` editor prop that works off the resolved anchor/head **positions** (immune to the pinned target): when the two ends are in **different** cells of the same table, it returns a `CellSelection`. (prosemirror-tables' own `createSelectionBetween` returns null unless its drag is active, so this composes with no conflict.)

Crucially, this **only kicks in when the drag leaves the cell** — anchor and head in the *same* cell returns `null`, so selecting text within a cell (even across paragraphs) stays a normal text selection.

## Verification

- `bun run typecheck` clean; `bun run test --run` — 226 files / 2794 tests pass.
- New `TableCellSelect.test.ts`: two different cells → `CellSelection`; same cell → `null` (text selection preserved); an endpoint outside any table → `null`.
- **Live (please confirm):** drag from inside cell text into the next cell → the cells select (marquee shows); drag within one cell → normal text selection.

Part of JP-416. Next: S6 (`th scope`), then preserve-formatting-on-insert (the cherry).

Assisted-by: Opus 4.8