### PR TITLE
JP-416 (S6): header cells expose a scope for accessibility

### DIFF
--- a/src/tiptap/tableHeaderScope.test.ts
+++ b/src/tiptap/tableHeaderScope.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Accessibility (JP-416): header cells render a `scope` so screen readers and
+ * exported HTML/PDF treat them as headers. Defaults to `col` and round-trips.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+describe('table header scope', () => {
+  it('emits scope="col" on header cells by default', () => {
+    const ed = make(
+      '<table><tbody><tr><th>H1</th><th>H2</th></tr><tr><td>a</td><td>b</td></tr></tbody></table>',
+    );
+    const html = ed.getHTML();
+    expect((html.match(/<th[^>]*scope="col"/g) ?? []).length).toBe(2);
+    // Body cells stay plain <td> without a scope.
+    expect(html).not.toMatch(/<td[^>]*scope=/);
+  });
+
+  it('round-trips an explicit scope="row"', () => {
+    const ed = make(
+      '<table><tbody><tr><th scope="row">R</th><td>x</td></tr></tbody></table>',
+    );
+    expect(ed.getHTML()).toContain('scope="row"');
+  });
+});

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -192,6 +192,14 @@ export const sharedProseExtensions = [
             };
           },
         },
+        // Header cells expose a `scope` for screen readers + clean PDF/HTML
+        // export (JP-416). Defaults to `col` (the header-row case insertTable
+        // creates); round-trips via the attribute so it survives save/load.
+        scope: {
+          default: 'col',
+          parseHTML: element => element.getAttribute('scope') || 'col',
+          renderHTML: attributes => ({ scope: attributes['scope'] || 'col' }),
+        },
       };
     },
   }),


### PR DESCRIPTION
Sixth/last planned slice of the JP-416 tables makeover (extra). Branched off `master`; touches a different region of `TiptapEditor.tsx` than the open #361.

## What & why

Header cells (`<th>`) now carry a `scope` attribute (default `"col"`), so screen readers and exported HTML/PDF correctly treat them as headers instead of plain cells.

- Implemented as a `scope` attribute on `TableHeader` (default `"col"`), rendered onto the `<th>` and parsed back, so it round-trips through `getHTML` and survives save/load. An explicit `scope="row"` is preserved.
- `"col"` is the right default for the header-row tables `insertTable` creates (and the common case). Deriving `col` vs `row` from the cell's position is a possible future refinement (renderHTML has no position context); the current default is a clear, serializable improvement over no scope.

Client-only — additive node attribute with a default, so existing prose parses fine (no migration). The relay markdown path doesn't round-trip cell attributes (a known pre-existing gap, same as `backgroundColor`); client + collab persistence keep it.

## Verification

- `bun run typecheck` clean; `bun run test --run` — 226 files / 2793 tests pass.
- New `tableHeaderScope.test.ts`: header cells emit `scope="col"`, body `<td>` stay scope-less, explicit `scope="row"` round-trips.
- **Live (optional):** inspect a table's header cells — `<th scope="col">`.

Completes the JP-416 slice plan. Remaining: the preserve-formatting-on-insert "cherry" (next).

Assisted-by: Opus 4.8