### PR TITLE
JP-416: new columns/rows inherit the reference column/row formatting

### DIFF
--- a/src/tiptap/TableKeymap.ts
+++ b/src/tiptap/TableKeymap.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@tiptap/core';
 import type { Editor } from '@tiptap/core';
+import { addRowAfterKeepHeader } from './tableStructureCommands';
 
 /**
  * TableKeymap (JP-416) — Word-like Tab navigation inside prose tables.
@@ -17,9 +18,13 @@ import type { Editor } from '@tiptap/core';
 export function handleTableTab(editor: Editor): boolean {
   if (!editor.isActive('table')) return false;
   if (editor.commands.goToNextCell()) return true;
-  // At the last cell: add a row and step into it.
+  // At the last cell: add a row and step into it. Use the inheriting wrapper
+  // (not the raw addRowAfter) so a Tab-created row keeps the header style and
+  // the reference row's formatting (JP-416) — the same as a toolbar/menu insert.
   if (editor.can().addRowAfter()) {
-    return editor.chain().addRowAfter().goToNextCell().run();
+    const added = addRowAfterKeepHeader(editor);
+    if (added) editor.commands.goToNextCell();
+    return added;
   }
   return false;
 }

--- a/src/tiptap/tableStructureCommands.test.ts
+++ b/src/tiptap/tableStructureCommands.test.ts
@@ -94,3 +94,46 @@ describe('table insert keeps header style', () => {
     expect((ed.getHTML().match(/<th/g) ?? []).length).toBe(0);
   });
 });
+
+describe('table insert inherits the reference formatting', () => {
+  // Reference column (col 0): green background + cell align right + a
+  // center-aligned paragraph. Col 1 is plain.
+  const FORMATTED =
+    '<table><tbody><tr>' +
+    '<td style="background-color: rgb(0, 128, 0); text-align: right"><p style="text-align: center">REF</p></td>' +
+    '<td><p>PLAIN</p></td>' +
+    '</tr></tbody></table>';
+
+  it('copies background, cell align, and paragraph text-align into a new column', () => {
+    const ed = make(FORMATTED);
+    caretInCell(ed, 'REF'); // reference column
+    const before = ed.getHTML();
+    expect((before.match(/background-color: rgb\(0, 128, 0\)/g) ?? []).length).toBe(1);
+
+    expect(addColumnAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    // The new column's cell inherited the reference column's formatting.
+    expect((html.match(/background-color: rgb\(0, 128, 0\)/g) ?? []).length).toBe(2);
+    expect((html.match(/text-align: right/g) ?? []).length).toBe(2); // cell align
+    expect((html.match(/text-align: center/g) ?? []).length).toBe(2); // paragraph
+  });
+
+  it('copies the reference row formatting into a new row', () => {
+    const ed = make(FORMATTED);
+    caretInCell(ed, 'REF');
+    expect(addRowAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    // The new row's first cell mirrors the reference row's first cell.
+    expect((html.match(/background-color: rgb\(0, 128, 0\)/g) ?? []).length).toBe(2);
+    expect((html.match(/text-align: center/g) ?? []).length).toBe(2);
+  });
+
+  it('leaves a plain table unformatted (no background/align copied)', () => {
+    const ed = make('<table><tbody><tr><td>x</td><td>y</td></tr></tbody></table>');
+    caretInCell(ed, 'x');
+    expect(addColumnAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    expect(html).not.toContain('background-color');
+    expect(html).not.toContain('text-align');
+  });
+});

--- a/src/tiptap/tableStructureCommands.test.ts
+++ b/src/tiptap/tableStructureCommands.test.ts
@@ -14,6 +14,8 @@ import {
   addColumnAfterKeepHeader,
   addRowAfterKeepHeader,
 } from './tableStructureCommands';
+import * as cmd from '../ui/editorCommands';
+import { handleTableTab } from './TableKeymap';
 
 let editor: Editor | null = null;
 
@@ -135,5 +137,25 @@ describe('table insert inherits the reference formatting', () => {
     const html = ed.getHTML();
     expect(html).not.toContain('background-color');
     expect(html).not.toContain('text-align');
+  });
+
+  // The live toolbar path: align via setCellAlign, then add a column/row.
+  it('inherits alignment set via the setCellAlign command (toolbar path)', () => {
+    const ed = make('<table><tbody><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></tbody></table>');
+    caretInCell(ed, 'A1');
+    cmd.setCellAlign(ed, 'right'); // align the cell like the toolbar button
+    caretInCell(ed, 'A1');
+    cmd.addColumnAfter(ed); // toolbar add → keep-header + inherit-format wrapper
+    // A1 is right-aligned; the new column's row-0 cell should inherit it.
+    expect((ed.getHTML().match(/text-align: right/g) ?? []).length).toBe(2);
+  });
+
+  // The Tab-to-add-row path (TableKeymap) must also inherit.
+  it('inherits formatting when a row is added by Tab in the last cell', () => {
+    const ed = make('<table><tbody><tr><td style="text-align: right">A1</td><td>B1</td></tr></tbody></table>');
+    caretInCell(ed, 'B1'); // last cell → Tab adds a row
+    expect(handleTableTab(ed)).toBe(true);
+    // The new row's first cell mirrors row 0's first cell (right-aligned).
+    expect((ed.getHTML().match(/text-align: right/g) ?? []).length).toBe(2);
   });
 });

--- a/src/tiptap/tableStructureCommands.ts
+++ b/src/tiptap/tableStructureCommands.ts
@@ -1,7 +1,10 @@
 /**
  * Table structure operations for JP-416 that aren't surfaced as Tiptap editor
- * commands: moving a column/row, and keeping header cells when a column/row is
- * inserted.
+ * commands: moving a column/row, and — when a column/row is inserted — keeping
+ * the header style AND inheriting the reference column/row's formatting (cell
+ * alignment, background, and block-level text formatting such as paragraph
+ * alignment) so a new column/row matches its neighbor instead of coming in
+ * blank.
  *
  * These build on prosemirror-tables' own primitives (`moveTableColumn`,
  * `moveTableRow`, `selectedRect`, `rowIsHeader`, `columnIsHeader`,
@@ -11,6 +14,8 @@
  */
 
 import type { Editor } from '@tiptap/core';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
+import type { NodeType } from '@tiptap/pm/model';
 import {
   isInTable,
   selectedRect,
@@ -20,12 +25,14 @@ import {
   columnIsHeader,
   tableNodeTypes,
   type TableMap,
+  type TableRect,
 } from '@tiptap/pm/tables';
 
 /**
  * A clean (no rowspan/colspan) table has each cell appear exactly once in the
- * map. A merged cell appears multiple times, shrinking the unique set. Move is
- * disabled on merged tables to avoid corrupting spans (clean case first).
+ * map. A merged cell appears multiple times, shrinking the unique set. Move +
+ * formatting inheritance are disabled on merged tables to avoid corrupting spans
+ * / mis-indexing (clean case first).
  */
 export function tableHasMergedCells(map: TableMap): boolean {
   return new Set(map.map).size !== map.map.length;
@@ -67,15 +74,69 @@ interface HeaderFlags {
   headerColumn: boolean;
 }
 
-/** Whether the current table's first row / first column are header cells. */
-function captureHeaderFlags(editor: Editor): HeaderFlags {
-  const { state } = editor;
-  if (!isInTable(state)) return { headerRow: false, headerColumn: false };
-  const rect = selectedRect(state);
+/**
+ * The inheritable formatting of a cell: its own attrs (alignment + background)
+ * plus its first block's type+attrs, which carry text formatting like paragraph
+ * `textAlign` (JP-416). Inline marks (bold/color) aren't captured — a new cell
+ * is empty, so there's no text to carry them on.
+ */
+interface CellFormat {
+  align: unknown;
+  backgroundColor: unknown;
+  blockType: NodeType | null;
+  blockAttrs: Record<string, unknown> | null;
+}
+
+function cellFormatAt(state: EditorState, rect: TableRect, row: number, col: number): CellFormat {
+  const offset = rect.map.map[row * rect.map.width + col];
+  const node = offset === undefined ? null : state.doc.nodeAt(rect.tableStart + offset);
+  const firstBlock = node?.firstChild ?? null;
   return {
-    headerRow: rowIsHeader(rect.map, rect.table, 0),
-    headerColumn: columnIsHeader(rect.map, rect.table, 0),
+    align: node?.attrs['align'] ?? null,
+    backgroundColor: node?.attrs['backgroundColor'] ?? null,
+    blockType: firstBlock?.type ?? null,
+    blockAttrs: firstBlock ? { ...firstBlock.attrs } : null,
   };
+}
+
+/** Copy `fmt` onto the cell at (row, col) of the current rect (keeping its type). */
+function applyCellFormat(
+  tr: Transaction,
+  state: EditorState,
+  rect: TableRect,
+  row: number,
+  col: number,
+  fmt: CellFormat | undefined,
+): void {
+  if (!fmt) return;
+  const offset = rect.map.map[row * rect.map.width + col];
+  if (offset === undefined) return;
+  const pos = rect.tableStart + offset;
+  const node = state.doc.nodeAt(pos);
+  if (!node) return;
+
+  // Cell-level attrs: alignment + background.
+  if (fmt.align != null || fmt.backgroundColor != null) {
+    tr.setNodeMarkup(pos, undefined, {
+      ...node.attrs,
+      align: fmt.align,
+      backgroundColor: fmt.backgroundColor,
+    });
+  }
+
+  // First-block text formatting (paragraph `textAlign`, etc.). Only when the new
+  // cell's first block is the same node type, so we never restructure the cell —
+  // and only when the attrs actually differ, to avoid a no-op transaction.
+  const inner = node.firstChild;
+  if (
+    fmt.blockType &&
+    fmt.blockAttrs &&
+    inner &&
+    inner.type === fmt.blockType &&
+    JSON.stringify(inner.attrs) !== JSON.stringify(fmt.blockAttrs)
+  ) {
+    tr.setNodeMarkup(pos + 1, undefined, fmt.blockAttrs);
+  }
 }
 
 /**
@@ -112,14 +173,72 @@ function applyHeaderFlags(editor: Editor, flags: HeaderFlags): void {
   if (tr.docChanged) view.dispatch(tr);
 }
 
-function insertKeepingHeader(editor: Editor, command: 'addColumnAfter' | 'addColumnBefore' | 'addRowAfter' | 'addRowBefore'): boolean {
-  const flags = captureHeaderFlags(editor);
+function insertColumn(editor: Editor, dir: 'after' | 'before'): boolean {
+  const command = dir === 'after' ? 'addColumnAfter' : 'addColumnBefore';
+  const { state } = editor;
+  if (!isInTable(state)) return editor.chain().focus()[command]().run();
+
+  const before = selectedRect(state);
+  const flags: HeaderFlags = {
+    headerRow: rowIsHeader(before.map, before.table, 0),
+    headerColumn: columnIsHeader(before.map, before.table, 0),
+  };
+  const refCol = before.left;
+  // Reference column's per-row formatting (skip on merged tables — the map index
+  // isn't 1:1 there).
+  const colFmt = tableHasMergedCells(before.map)
+    ? null
+    : Array.from({ length: before.map.height }, (_, r) => cellFormatAt(state, before, r, refCol));
+
   const ok = editor.chain().focus()[command]().run();
-  if (ok) applyHeaderFlags(editor, flags);
-  return ok;
+  if (!ok) return false;
+
+  // Copy the reference column's formatting into the freshly inserted column.
+  if (colFmt) {
+    const after = selectedRect(editor.state);
+    const newCol = dir === 'after' ? refCol + 1 : refCol;
+    const tr = editor.state.tr;
+    for (let r = 0; r < after.map.height; r++) {
+      applyCellFormat(tr, editor.state, after, r, newCol, colFmt[r]);
+    }
+    if (tr.docChanged) editor.view.dispatch(tr);
+  }
+  applyHeaderFlags(editor, flags);
+  return true;
 }
 
-export const addColumnAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnAfter');
-export const addColumnBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnBefore');
-export const addRowAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowAfter');
-export const addRowBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowBefore');
+function insertRow(editor: Editor, dir: 'after' | 'before'): boolean {
+  const command = dir === 'after' ? 'addRowAfter' : 'addRowBefore';
+  const { state } = editor;
+  if (!isInTable(state)) return editor.chain().focus()[command]().run();
+
+  const before = selectedRect(state);
+  const flags: HeaderFlags = {
+    headerRow: rowIsHeader(before.map, before.table, 0),
+    headerColumn: columnIsHeader(before.map, before.table, 0),
+  };
+  const refRow = before.top;
+  const rowFmt = tableHasMergedCells(before.map)
+    ? null
+    : Array.from({ length: before.map.width }, (_, c) => cellFormatAt(state, before, refRow, c));
+
+  const ok = editor.chain().focus()[command]().run();
+  if (!ok) return false;
+
+  if (rowFmt) {
+    const after = selectedRect(editor.state);
+    const newRow = dir === 'after' ? refRow + 1 : refRow;
+    const tr = editor.state.tr;
+    for (let c = 0; c < after.map.width; c++) {
+      applyCellFormat(tr, editor.state, after, newRow, c, rowFmt[c]);
+    }
+    if (tr.docChanged) editor.view.dispatch(tr);
+  }
+  applyHeaderFlags(editor, flags);
+  return true;
+}
+
+export const addColumnAfterKeepHeader = (editor: Editor) => insertColumn(editor, 'after');
+export const addColumnBeforeKeepHeader = (editor: Editor) => insertColumn(editor, 'before');
+export const addRowAfterKeepHeader = (editor: Editor) => insertRow(editor, 'after');
+export const addRowBeforeKeepHeader = (editor: Editor) => insertRow(editor, 'before');


### PR DESCRIPTION
The "cherry on top" of the JP-416 tables makeover. Branched off `master` (all prior slices merged).

## What & why

When you add a column/row, the new cells now **match their neighbor** instead of coming in blank. Extends S2's header-type inheritance to also copy, from the reference column/row:

- the cell **alignment** (`align`) and **background** (`backgroundColor`),
- **block-level text formatting** — the reference cell's first-block attributes, e.g. a paragraph's `textAlign`.

Details:
- Block formatting is copied only when the new cell's first block is the **same node type** (the common paragraph case), so a cell is never restructured.
- **Inline marks** (bold/italic/color) aren't carried — a freshly inserted cell is empty, so there's no text to put them on (ProseMirror drops empty marked text). Block-level formatting and the cell attrs are what survive.
- A **plain** table stays untouched (nothing is copied when the reference has no formatting — no transaction churn).
- Skipped on **merged-cell** tables (the map index isn't 1:1), like the move commands.

Built on prosemirror-tables' `selectedRect` / `TableMap`; no hand-rolled rebuilds. Client-only — no doc-format/migration/relay changes.

## Verification

- `bun run typecheck` clean; `bun run test --run` — 225 files / 2794 tests pass.
- Extended `tableStructureCommands.test.ts`: a new column inherits the reference column's background + cell-align + paragraph text-align; a new row inherits the reference row's; a plain table copies nothing; (existing move + header-inheritance tests still pass).
- **Live (please confirm):** format a column (background / align / center its text), add a column or row next to it — the new cells match.

This wraps up the JP-416 work (the 6 sliced items + the cross-cell-from-text selection fix + this formatting-inheritance cherry).

Assisted-by: Opus 4.8