### PR TITLE
JP-416: Select Row / Column / All cells (table menu + toolbar)

### DIFF
--- a/src/tiptap/tableSelectCommands.test.ts
+++ b/src/tiptap/tableSelectCommands.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Table select commands (JP-416): Select Row / Column / All produce the right
+ * CellSelection. Headless `Editor` so the real schema + prosemirror-tables run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
+import { extensions } from '../ui/TiptapEditor';
+import { selectRow, selectColumn, selectAllCells } from './tableSelectCommands';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+function caretIn(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+function cellCount(sel: CellSelection): number {
+  let n = 0;
+  sel.forEachCell(() => { n += 1; });
+  return n;
+}
+
+// 3 cols × 2 rows.
+const TABLE =
+  '<table><tbody>' +
+  '<tr><td>R0a</td><td>R0b</td><td>R0c</td></tr>' +
+  '<tr><td>R1a</td><td>R1b</td><td>R1c</td></tr>' +
+  '</tbody></table>';
+
+describe('table select commands', () => {
+  it('Select Row selects the current row full-width', () => {
+    const ed = make(TABLE);
+    caretIn(ed, 'R0b');
+    expect(selectRow(ed)).toBe(true);
+    const sel = ed.state.selection as CellSelection;
+    expect(sel).toBeInstanceOf(CellSelection);
+    expect(sel.isRowSelection()).toBe(true);
+    expect(cellCount(sel)).toBe(3); // one row × 3 cols
+  });
+
+  it('Select Column selects the current column full-height', () => {
+    const ed = make(TABLE);
+    caretIn(ed, 'R0b'); // column 1
+    expect(selectColumn(ed)).toBe(true);
+    const sel = ed.state.selection as CellSelection;
+    expect(sel.isColSelection()).toBe(true);
+    expect(cellCount(sel)).toBe(2); // 2 rows × one col
+  });
+
+  it('Select All Cells selects the whole table', () => {
+    const ed = make(TABLE);
+    caretIn(ed, 'R0a');
+    expect(selectAllCells(ed)).toBe(true);
+    const sel = ed.state.selection as CellSelection;
+    expect(sel.isRowSelection()).toBe(true);
+    expect(sel.isColSelection()).toBe(true);
+    expect(cellCount(sel)).toBe(6); // 2 × 3
+  });
+
+  it('returns false outside a table', () => {
+    const ed = make('<p>nope</p>');
+    caretIn(ed, 'nope');
+    expect(selectRow(ed)).toBe(false);
+    expect(selectColumn(ed)).toBe(false);
+    expect(selectAllCells(ed)).toBe(false);
+  });
+});

--- a/src/tiptap/tableSelectCommands.ts
+++ b/src/tiptap/tableSelectCommands.ts
@@ -1,0 +1,60 @@
+/**
+ * Excel-like "select" commands for prose tables (JP-416): select the current
+ * row(s), column(s), or the whole table as a `CellSelection`. Surfaced in the
+ * right-click table menu + the toolbar so a range is easy to grab for a move /
+ * delete / format. Built on prosemirror-tables' `CellSelection` helpers.
+ *
+ * Each works off the current selection: a plain cursor selects its own
+ * row/column; an existing multi-cell selection selects every row/column it
+ * spans (so Select Row on a 3-row cell selection grabs all three full rows).
+ */
+
+import type { Editor } from '@tiptap/core';
+import type { EditorState } from '@tiptap/pm/state';
+import type { ResolvedPos } from '@tiptap/pm/model';
+import { CellSelection, cellAround, isInTable, selectedRect } from '@tiptap/pm/tables';
+
+/** The anchor/head cells of the current selection (a cursor's own cell, or a
+ *  CellSelection's two ends). Null when the selection isn't in a table cell. */
+function selectionCells(state: EditorState): { anchor: ResolvedPos; head: ResolvedPos } | null {
+  const sel = state.selection;
+  if (sel instanceof CellSelection) return { anchor: sel.$anchorCell, head: sel.$headCell };
+  const $cell = cellAround(sel.$anchor);
+  return $cell ? { anchor: $cell, head: $cell } : null;
+}
+
+export function selectRow(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const cells = selectionCells(state);
+  if (!cells) return false;
+  view.dispatch(state.tr.setSelection(CellSelection.rowSelection(cells.anchor, cells.head)));
+  view.focus();
+  return true;
+}
+
+export function selectColumn(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const cells = selectionCells(state);
+  if (!cells) return false;
+  view.dispatch(state.tr.setSelection(CellSelection.colSelection(cells.anchor, cells.head)));
+  view.focus();
+  return true;
+}
+
+export function selectAllCells(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const { map, tableStart } = selectedRect(state);
+  const firstOffset = map.map[0];
+  const lastOffset = map.map[map.width * map.height - 1];
+  if (firstOffset === undefined || lastOffset === undefined) return false;
+  const sel = new CellSelection(
+    state.doc.resolve(tableStart + firstOffset),
+    state.doc.resolve(tableStart + lastOffset),
+  );
+  view.dispatch(state.tr.setSelection(sel));
+  view.focus();
+  return true;
+}

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -611,6 +611,28 @@ export function DocumentEditorContextMenu({
         >
           <div
             className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.selectRow(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={Rows3} /></span>
+            <span className="doc-editor-context-menu-label">Select Row</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.selectColumn(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={Columns3} /></span>
+            <span className="doc-editor-context-menu-label">Select Column</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.selectAllCells(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={Table} /></span>
+            <span className="doc-editor-context-menu-label">Select All Cells</span>
+          </div>
+          <div className="doc-editor-context-menu-divider" />
+          <div
+            className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.addRowBefore(editor); onClose(); }}
           >
             <span className="doc-editor-context-menu-icon"><Icon icon={ArrowUpToLine} /></span>

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -505,6 +505,9 @@ export function DocumentEditorToolbar() {
                 title="Table Options"
               >
                 <div className="table-styles-menu">
+                  <button onClick={() => { editor && cmd.selectRow(editor); setShowTableStyles(false); }}>Select Row</button>
+                  <button onClick={() => { editor && cmd.selectColumn(editor); setShowTableStyles(false); }}>Select Column</button>
+                  <button onClick={() => { editor && cmd.selectAllCells(editor); setShowTableStyles(false); }}>Select All Cells</button>
                   <button onClick={() => { editor && cmd.toggleHeaderRow(editor); setShowTableStyles(false); }}>Toggle Header Row</button>
                   <button onClick={() => { editor && cmd.toggleHeaderColumn(editor); setShowTableStyles(false); }}>Toggle Header Column</button>
                   <button onClick={() => { editor && cmd.mergeCells(editor); setShowTableStyles(false); }}>Merge Cells</button>

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -17,6 +17,11 @@ import {
   moveRowUp as moveRowUpCmd,
   moveRowDown as moveRowDownCmd,
 } from '../tiptap/tableStructureCommands';
+import {
+  selectRow as selectRowCmd,
+  selectColumn as selectColumnCmd,
+  selectAllCells as selectAllCellsCmd,
+} from '../tiptap/tableSelectCommands';
 
 // Text formatting
 export const toggleBold = (editor: Editor) => editor.chain().focus().toggleBold().run();
@@ -83,6 +88,10 @@ export const moveColumnLeft = (editor: Editor) => moveColumnLeftCmd(editor);
 export const moveColumnRight = (editor: Editor) => moveColumnRightCmd(editor);
 export const moveRowUp = (editor: Editor) => moveRowUpCmd(editor);
 export const moveRowDown = (editor: Editor) => moveRowDownCmd(editor);
+// Select the current row(s) / column(s) / whole table as a CellSelection (JP-416).
+export const selectRow = (editor: Editor) => selectRowCmd(editor);
+export const selectColumn = (editor: Editor) => selectColumnCmd(editor);
+export const selectAllCells = (editor: Editor) => selectAllCellsCmd(editor);
 export const setCellBackground = (editor: Editor, color: string | null) =>
   editor.chain().focus().setCellAttribute('backgroundColor', color).run();
 // Text alignment for the selected cells (JP-416). With a column selected this


### PR DESCRIPTION
Replaces the closed #364 (the Ctrl/Cmd+Shift+click gesture) with discoverable, Excel-like **select options**, per your call. Branched off `master`.

## What

Three commands in the right-click table submenu **and** the toolbar's Table Options dropdown:

- **Select Row** — full-width selection of the current row(s).
- **Select Column** — full-height selection of the current column(s).
- **Select All Cells** — the whole table.

Each works off the current selection: a plain cursor selects its own row/column; an existing multi-cell selection selects every row/column it spans (so Select Row on a 3-row cell selection grabs all three full rows). The Excel equivalent of clicking a row/column header — then you can move/delete/format the band.

Built on prosemirror-tables' `CellSelection.rowSelection` / `colSelection`. Client-only — no doc-format/migration/relay changes.

(We considered Ctrl+Shift+Arrow keyboard extension; went with menu options as the clearer, lower-risk path. The closed #364 click-gesture is superseded by this.)

## Verification

- `bun run typecheck` clean; `bun run test --run` — 2800 tests pass.
- New `tableSelectCommands.test.ts`: Select Row → row selection of 3 cells (1×3); Select Column → col selection of 2 cells (2×1); Select All → 6 cells (full); all return false outside a table.
- **Live (please confirm):** right-click in a table → Select Row/Column/All; same from the toolbar Table Options.

This is the last piece of JP-416 (alongside the still-open #363). 

Assisted-by: Opus 4.8