### PR TITLE
JP-421: self-aligning context menus

### DIFF
--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -2,6 +2,9 @@
   position: fixed;
   z-index: 1000;
   min-width: 180px;
+  /* JP-421: never run off the bottom — size to the viewport and scroll. */
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
@@ -82,12 +85,17 @@
   opacity: 0.6;
 }
 
-/* Submenu content panel */
+/* Submenu content panel. JS positions it with `fixed` viewport coords
+   (placeFlyout) so it self-aligns and escapes the root menu's scroll clip;
+   the values below are the pre-measure fallback. */
 .context-menu-submenu-content {
   position: absolute;
   left: 100%;
   top: 0;
   min-width: 140px;
+  /* Never wider than the viewport on narrow/mobile screens. */
+  max-width: calc(100vw - 16px);
+  box-sizing: border-box;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);

--- a/src/ui/ContextMenu.tsx
+++ b/src/ui/ContextMenu.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useRef, useMemo, useLayoutEffect } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo, useLayoutEffect, type CSSProperties } from 'react';
+import { clampToViewport, placeFlyout } from './contextMenuUtils';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore } from '../store/historyStore';
@@ -27,15 +28,27 @@ interface SubmenuProps {
   label: string;
   items: SubmenuItem[];
   onClose: () => void;
+  /** Ref to the parent menu, so the submenu can measure its edges. */
+  parentMenuRef: React.RefObject<HTMLDivElement>;
+  /**
+   * Report the parent slide-left distance. `px` is the shift while open, or
+   * `null` when this submenu closes (the parent ignores a stale close from a
+   * submenu that is no longer the active one).
+   */
+  onShiftChange: (id: string, px: number | null) => void;
 }
 
 /**
- * Submenu component for nested menu options.
+ * Submenu component for nested menu options. Self-aligns against the viewport
+ * (JP-421): opens right, slides the parent left when tight, flips to the left
+ * when a wide submenu still won't fit, and clamps + scrolls vertically.
  */
-function Submenu({ label, items, onClose }: SubmenuProps) {
+function Submenu({ label, items, onClose, parentMenuRef, onShiftChange }: SubmenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentStyle, setContentStyle] = useState<CSSProperties | undefined>(undefined);
 
   const handleMouseEnter = useCallback(() => {
     if (timeoutRef.current) {
@@ -58,6 +71,40 @@ function Submenu({ label, items, onClose }: SubmenuProps) {
     }
   }, [onClose]);
 
+  // Position the submenu once it has rendered (so we can measure it).
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setContentStyle(undefined);
+      onShiftChange(label, null);
+      return;
+    }
+    const content = contentRef.current;
+    const item = containerRef.current;
+    const parent = parentMenuRef.current;
+    if (!content || !item || !parent) return;
+
+    const itemRect = item.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+    const placement = placeFlyout(
+      itemRect,
+      { left: parentRect.left, right: parentRect.right },
+      { width: content.offsetWidth, height: content.scrollHeight },
+    );
+
+    // Position the panel with viewport coords (`fixed`) so it escapes the root
+    // menu's own scroll-overflow clipping. placement.x already accounts for the
+    // parent shift, so the submenu lands beside the shifted parent.
+    setContentStyle({
+      position: 'fixed',
+      left: placement.x,
+      top: placement.y,
+      margin: 0,
+      maxHeight: placement.maxHeight,
+      overflowY: 'auto',
+    });
+    onShiftChange(label, placement.parentShift);
+  }, [isOpen, parentMenuRef, onShiftChange, items.length, label]);
+
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -78,7 +125,7 @@ function Submenu({ label, items, onClose }: SubmenuProps) {
         <span className="context-menu-arrow">▶</span>
       </div>
       {isOpen && (
-        <div className="context-menu-submenu-content">
+        <div ref={contentRef} className="context-menu-submenu-content" style={contentStyle}>
           {items.map((item, index) => (
             <button
               key={index}
@@ -104,6 +151,22 @@ function Submenu({ label, items, onClose }: SubmenuProps) {
 export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [adjustedPosition, setAdjustedPosition] = useState({ x, y });
+  // How far the menu slides left so the open submenu has room on the right.
+  // Owner-tracked so a delayed close from a previous submenu can't clobber the
+  // shift the newly-hovered submenu just set.
+  const [submenuShift, setSubmenuShift] = useState(0);
+  const shiftOwnerRef = useRef<string | null>(null);
+  const handleShiftChange = useCallback((id: string, px: number | null) => {
+    if (px === null) {
+      if (shiftOwnerRef.current === id) {
+        shiftOwnerRef.current = null;
+        setSubmenuShift(0);
+      }
+      return;
+    }
+    shiftOwnerRef.current = id;
+    setSubmenuShift(px);
+  }, []);
   const selectedIds = useSessionStore((state) => state.selectedIds);
   const shapes = useDocumentStore((state) => state.shapes);
   const updateShape = useDocumentStore((state) => state.updateShape);
@@ -185,39 +248,12 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
     });
   }, [shapes, selectedArray]);
 
-  // Adjust position to keep menu within viewport
+  // Adjust position to keep the menu within the viewport (single source of
+  // truth — shared with the prose menu + whiteboard via clampToViewport).
   useLayoutEffect(() => {
     if (!menuRef.current) return;
-
-    const menu = menuRef.current;
-    const rect = menu.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    const padding = 8;
-
-    let newX = x;
-    let newY = y;
-
-    // Check if menu overflows right edge
-    if (x + rect.width > viewportWidth - padding) {
-      newX = Math.max(padding, viewportWidth - rect.width - padding);
-    }
-
-    // Check if menu overflows bottom edge
-    if (y + rect.height > viewportHeight - padding) {
-      newY = Math.max(padding, viewportHeight - rect.height - padding);
-    }
-
-    // Check left edge
-    if (newX < padding) {
-      newX = padding;
-    }
-
-    // Check top edge
-    if (newY < padding) {
-      newY = padding;
-    }
-
+    const rect = menuRef.current.getBoundingClientRect();
+    const { x: newX, y: newY } = clampToViewport(x, y, rect.width, rect.height);
     if (newX !== adjustedPosition.x || newY !== adjustedPosition.y) {
       setAdjustedPosition({ x: newX, y: newY });
     }
@@ -453,7 +489,7 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
     <div
       ref={menuRef}
       className="context-menu"
-      style={{ left: adjustedPosition.x, top: adjustedPosition.y }}
+      style={{ left: adjustedPosition.x - submenuShift, top: adjustedPosition.y }}
       onClick={(e) => e.stopPropagation()}
     >
       {canGroup && (
@@ -472,7 +508,7 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
 
       {/* Add to Group submenu - show when groups exist and shapes are selected */}
       {hasSelection && availableGroups.length > 0 && (
-        <Submenu label="Add to Group" items={addToGroupItems} onClose={onClose} />
+        <Submenu label="Add to Group" items={addToGroupItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />
       )}
 
       {/* Remove from Group - show when selected shapes are in a group */}
@@ -492,7 +528,7 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
             <span className="context-menu-label">Select connected</span>
             <span className="context-menu-shortcut">Ctrl+Shift+A</span>
           </button>
-          {canGroup && <Submenu label="Auto-layout" items={autoLayoutItems} onClose={onClose} />}
+          {canGroup && <Submenu label="Auto-layout" items={autoLayoutItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />}
 
           <div className="context-menu-separator" />
 
@@ -507,11 +543,11 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
 
           {/* Connector Routing submenu */}
           {hasConnector && (
-            <Submenu label="Routing" items={routingItems} onClose={onClose} />
+            <Submenu label="Routing" items={routingItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />
           )}
 
           {/* Lock submenu */}
-          <Submenu label="Lock" items={lockItems} onClose={onClose} />
+          <Submenu label="Lock" items={lockItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />
 
           <div className="context-menu-separator" />
 

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -6,6 +6,10 @@
   position: fixed;
   z-index: 10000;
   min-width: 200px;
+  /* JP-421: fit the viewport and scroll rather than running off the bottom.
+     Submenus are portaled siblings, so this scroll container never clips them. */
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -92,7 +96,9 @@
   position: fixed;
   z-index: 10001;
   min-width: 200px;
-  max-width: 280px;
+  /* Cap at 280px but never wider than the viewport on narrow/mobile screens. */
+  max-width: min(280px, calc(100vw - 16px));
+  box-sizing: border-box;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -10,8 +10,9 @@
  * - Inserting embedded groups from the canvas
  */
 
-import { useEffect, useCallback, useState, useRef, useMemo } from 'react';
+import { useEffect, useCallback, useState, useRef, useMemo, useLayoutEffect, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
+import { clampToViewport, placeFlyout } from './contextMenuUtils';
 import type { Editor } from '@tiptap/core';
 import { NodeSelection } from '@tiptap/pm/state';
 import {
@@ -121,7 +122,12 @@ export function DocumentEditorContextMenu({
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [activeSubmenu, setActiveSubmenu] = useState<'format' | 'heading' | 'list' | 'table' | 'group' | null>(null);
-  const [submenuPosition, setSubmenuPosition] = useState({ x: 0, y: 0 });
+  // JP-421: self-aligning submenu placement (viewport coords + height cap), and
+  // how far the root menu slides left to make room for the open submenu.
+  const [submenuPlacement, setSubmenuPlacement] = useState({ x: 0, y: 0, maxHeight: 0 });
+  const [parentShift, setParentShift] = useState(0);
+  const submenuAnchorRef = useRef<DOMRect | null>(null);
+  const [rootPos, setRootPos] = useState({ x, y });
   const [searchQuery, setSearchQuery] = useState('');
 
   // Get groups from document store
@@ -214,10 +220,40 @@ export function DocumentEditorContextMenu({
     }
   }, [activeSubmenu]);
 
-  // Adjust position to stay within viewport
-  const adjustedPosition = {
-    x: Math.min(x, window.innerWidth - 220),
-    y: Math.min(y, window.innerHeight - 400),
+  // Clamp the root menu to the viewport using its measured size (shared helper).
+  useLayoutEffect(() => {
+    if (!menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const clamped = clampToViewport(x, y, rect.width, rect.height);
+    setRootPos((prev) => (prev.x === clamped.x && prev.y === clamped.y ? prev : clamped));
+  }, [x, y]);
+
+  // Position the submenu once it has mounted, so we can measure it and
+  // self-align against the viewport (flip / shift parent / clamp + scroll).
+  useLayoutEffect(() => {
+    if (!activeSubmenu) {
+      setParentShift(0);
+      return;
+    }
+    const submenu = submenuRef.current;
+    const root = menuRef.current;
+    const anchor = submenuAnchorRef.current;
+    if (!submenu || !root || !anchor) return;
+    const rootRect = root.getBoundingClientRect();
+    const placement = placeFlyout(
+      anchor,
+      { left: rootRect.left, right: rootRect.right },
+      { width: submenu.offsetWidth, height: submenu.scrollHeight },
+    );
+    setSubmenuPlacement({ x: placement.x, y: placement.y, maxHeight: placement.maxHeight });
+    setParentShift(placement.parentShift);
+  }, [activeSubmenu]);
+
+  const submenuStyle: CSSProperties = {
+    left: submenuPlacement.x,
+    top: submenuPlacement.y,
+    maxHeight: submenuPlacement.maxHeight || undefined,
+    overflowY: 'auto',
   };
 
   // Handle inserting an embedded group
@@ -263,7 +299,8 @@ export function DocumentEditorContextMenu({
     [editor, onClose]
   );
 
-  // Generic submenu hover handler
+  // Generic submenu hover handler. Capture the anchor rect; the actual position
+  // is computed in a layout effect once the submenu has mounted and measured.
   const handleSubmenuEnter = useCallback(
     (submenu: typeof activeSubmenu, e: React.MouseEvent<HTMLDivElement>) => {
       if (hoverTimeoutRef.current) {
@@ -271,11 +308,7 @@ export function DocumentEditorContextMenu({
         hoverTimeoutRef.current = null;
       }
 
-      const rect = e.currentTarget.getBoundingClientRect();
-      setSubmenuPosition({
-        x: rect.right + 4,
-        y: rect.top - 8,
-      });
+      submenuAnchorRef.current = e.currentTarget.getBoundingClientRect();
       setActiveSubmenu(submenu);
     },
     []
@@ -308,8 +341,8 @@ export function DocumentEditorContextMenu({
         ref={menuRef}
         className="doc-editor-context-menu"
         style={{
-          left: adjustedPosition.x,
-          top: adjustedPosition.y,
+          left: rootPos.x - parentShift,
+          top: rootPos.y,
         }}
       >
         {/* Image actions (when an image node is selected) */}
@@ -469,7 +502,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -542,7 +575,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -572,7 +605,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -605,7 +638,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -749,7 +782,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >

--- a/src/ui/contextMenuUtils.test.ts
+++ b/src/ui/contextMenuUtils.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { clampToViewport, placeFlyout } from './contextMenuUtils';
+
+describe('clampToViewport', () => {
+  it('keeps an in-bounds menu where it is', () => {
+    expect(clampToViewport(100, 100, 180, 200)).toEqual({ x: 100, y: 100 });
+  });
+
+  it('pulls a menu in from the right and bottom edges', () => {
+    // jsdom default viewport is 1024x768.
+    const { x, y } = clampToViewport(2000, 2000, 180, 200);
+    expect(x).toBe(1024 - 180 - 8);
+    expect(y).toBe(768 - 200 - 8);
+  });
+});
+
+describe('placeFlyout', () => {
+  const VW = 1000;
+  const VH = 800;
+  const vp = { viewportWidth: VW, viewportHeight: VH, padding: 8, gap: 4 };
+
+  // A parent menu sitting comfortably mid-screen.
+  const parent = { left: 200, right: 380 };
+  const anchor = { top: 250, bottom: 280, left: 200, right: 380 };
+
+  describe('horizontal (hybrid)', () => {
+    it('opens to the right when there is room', () => {
+      const p = placeFlyout(anchor, parent, { width: 160, height: 200 }, vp);
+      expect(p.side).toBe('right');
+      expect(p.parentShift).toBe(0);
+      expect(p.x).toBe(parent.right + 4); // 384
+    });
+
+    it('shifts the parent left when the right is tight but the parent can move', () => {
+      const tightParent = { left: 700, right: 880 };
+      const p = placeFlyout(
+        { ...anchor, left: 700, right: 880 },
+        tightParent,
+        { width: 160, height: 200 },
+        vp,
+      );
+      // rightX=884, +160=1044, limit=992 → overflow 52; parent can move 692.
+      expect(p.side).toBe('right');
+      expect(p.parentShift).toBe(52);
+      expect(p.x).toBe(884 - 52); // submenu rides the shifted parent
+    });
+
+    it('flips to the left when a wide submenu cannot fit right even after shifting', () => {
+      const rightParent = { left: 800, right: 1000 };
+      const p = placeFlyout(
+        { ...anchor, left: 800, right: 1000 },
+        rightParent,
+        { width: 782, height: 200 },
+        vp,
+      );
+      // rightX=1004, +782 overflows by 794; max parent shift is 792 → can't.
+      // leftX = 800 - 4 - 782 = 14 >= 8 → clean flip to the left.
+      expect(p.side).toBe('left');
+      expect(p.parentShift).toBe(0);
+      expect(p.x).toBe(14);
+    });
+
+    it('clamps into the viewport when neither side fits (very narrow)', () => {
+      const narrowVp = { viewportWidth: 360, viewportHeight: 640, padding: 8, gap: 4 };
+      const p = placeFlyout(
+        { top: 100, bottom: 130, left: 40, right: 320 },
+        { left: 40, right: 320 },
+        { width: 280, height: 200 },
+        narrowVp,
+      );
+      expect(p.x).toBeGreaterThanOrEqual(8);
+      expect(p.x + 280).toBeLessThanOrEqual(360); // never spills off either edge
+    });
+  });
+
+  describe('vertical (align + clamp + scroll)', () => {
+    it('aligns to the anchor top when it fits', () => {
+      const p = placeFlyout(anchor, parent, { width: 160, height: 200 }, vp);
+      expect(p.y).toBe(250);
+      expect(p.maxHeight).toBe(200);
+    });
+
+    it('shifts up so the bottom stays on-screen', () => {
+      const lowAnchor = { top: 700, bottom: 730, left: 200, right: 380 };
+      const p = placeFlyout(lowAnchor, parent, { width: 160, height: 300 }, vp);
+      expect(p.y).toBe(VH - 8 - 300); // 492 — pulled up so it fits
+      expect(p.maxHeight).toBe(300); // still no scroll
+    });
+
+    it('caps height and enables scroll when taller than the viewport', () => {
+      const p = placeFlyout(anchor, parent, { width: 160, height: 2000 }, vp);
+      expect(p.maxHeight).toBe(VH - 2 * 8); // 784
+      expect(p.y).toBe(8); // pinned to the top padding
+    });
+
+    it('never lets y go above the top padding', () => {
+      const highAnchor = { top: 2, bottom: 30, left: 200, right: 380 };
+      const p = placeFlyout(highAnchor, parent, { width: 160, height: 200 }, vp);
+      expect(p.y).toBe(8);
+    });
+  });
+});

--- a/src/ui/contextMenuUtils.ts
+++ b/src/ui/contextMenuUtils.ts
@@ -59,3 +59,117 @@ export const MENU_SIZE_ESTIMATES = {
   /** Large menu (7+ items) */
   large: { width: 200, height: 280 },
 } as const;
+
+/** Which side of the parent menu a submenu (flyout) opened on. */
+export type FlyoutSide = 'right' | 'left';
+
+export interface FlyoutPlacement {
+  /** Viewport x (left) for the submenu panel. */
+  x: number;
+  /** Viewport y (top) for the submenu panel. */
+  y: number;
+  /** Height cap for the panel — enables scroll when content is taller. */
+  maxHeight: number;
+  /** Which side the submenu opened on. */
+  side: FlyoutSide;
+  /** Pixels the parent menu must slide LEFT to free room on the right (>=0). */
+  parentShift: number;
+}
+
+export interface FlyoutOptions {
+  /** Padding kept from viewport edges (default 8). */
+  padding?: number;
+  /** Gap between the parent menu and the submenu (default 4). */
+  gap?: number;
+  /** Override viewport width (defaults to window.innerWidth). */
+  viewportWidth?: number;
+  /** Override viewport height (defaults to window.innerHeight). */
+  viewportHeight?: number;
+}
+
+interface AnchorRect {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+/**
+ * Place a submenu (flyout) next to its parent menu without overflowing the
+ * viewport. Pure + viewport-driven so it behaves correctly on narrow/mobile
+ * widths with no separate code path.
+ *
+ * Horizontal strategy is "hybrid":
+ *   1. Open to the right of the parent if it fits.
+ *   2. Otherwise slide the parent left (parentShift) to free room on the right,
+ *      as long as the parent stays on-screen.
+ *   3. Otherwise flip the submenu to the left of the parent.
+ *   4. Otherwise (neither side fits — very narrow) clamp into the viewport;
+ *      the caller also caps width in CSS so it can't exceed the viewport.
+ *
+ * Vertical strategy aligns the panel to the anchor item, clamps it inside the
+ * viewport, and caps its height (scroll) when it is taller than the viewport.
+ *
+ * @param anchor  Rect of the hovered parent item (viewport coords).
+ * @param parent  Left/right edges of the parent menu (viewport coords).
+ * @param submenu Measured width/height of the submenu panel.
+ */
+export function placeFlyout(
+  anchor: AnchorRect,
+  parent: { left: number; right: number },
+  submenu: { width: number; height: number },
+  opts: FlyoutOptions = {},
+): FlyoutPlacement {
+  const padding = opts.padding ?? 8;
+  const gap = opts.gap ?? 4;
+  const vw = opts.viewportWidth ?? window.innerWidth;
+  const vh = opts.viewportHeight ?? window.innerHeight;
+
+  const { width, height } = submenu;
+  const rightLimit = vw - padding;
+
+  // --- Horizontal (hybrid) ---
+  let side: FlyoutSide;
+  let x: number;
+  let parentShift = 0;
+
+  const rightX = parent.right + gap;
+  if (rightX + width <= rightLimit) {
+    // 1. Fits to the right as-is.
+    side = 'right';
+    x = rightX;
+  } else {
+    const overflow = rightX + width - rightLimit;
+    const maxShift = parent.left - padding; // how far parent can slide left
+    if (overflow <= maxShift) {
+      // 2. Slide the parent left to free room on the right.
+      side = 'right';
+      parentShift = overflow;
+      x = rightX - parentShift;
+    } else {
+      const leftX = parent.left - gap - width;
+      if (leftX >= padding) {
+        // 3. Flip to the left.
+        side = 'left';
+        x = leftX;
+      } else {
+        // 4. Neither side fits — pick the roomier side and clamp.
+        const roomRight = vw - parent.right;
+        const roomLeft = parent.left;
+        side = roomRight >= roomLeft ? 'right' : 'left';
+        const lowerBound = padding;
+        const upperBound = Math.max(padding, rightLimit - width);
+        const desired = side === 'right' ? rightX : leftX;
+        x = Math.min(Math.max(desired, lowerBound), upperBound);
+      }
+    }
+  }
+
+  // --- Vertical (align + clamp + scroll) ---
+  const cap = vh - 2 * padding;
+  const maxHeight = Math.min(height, cap);
+  const yUpper = Math.max(padding, vh - padding - maxHeight);
+  const y = Math.min(Math.max(anchor.top, padding), yUpper);
+
+  return { x, y, maxHeight, side, parentShift };
+}


### PR DESCRIPTION
## What

Both right-click menus overflowed the viewport — badly on submenus, which always opened to the right with zero collision handling and no scroll. This makes them self-align so they never overflow, including on narrow/mobile widths (JP-421).

## Approach

New shared `placeFlyout` helper in `contextMenuUtils.ts` implementing **hybrid** submenu placement:

1. Open to the right if it fits.
2. Otherwise **slide the parent menu left** to free room on the right (as worded in the issue).
3. Otherwise **flip the submenu to the left** when a wide submenu still won't fit.
4. Otherwise clamp into the viewport (+ a CSS width cap) on very narrow screens.

Vertically it aligns to the anchor item, clamps inside the viewport, and **caps height → scroll** when taller than the screen. It's pure and viewport-driven, so narrow/mobile is handled by math, not a separate code path.

## Changes

- **`contextMenuUtils.ts`** — add `placeFlyout` (+ keep `clampToViewport`, now the single root-clamp path for both menus).
- **Canvas `ContextMenu.tsx`** — `Submenu` measures + places via `placeFlyout`; the panel uses `fixed` viewport coords so it escapes the root's new scroll container; parent slides left via an **owner-tracked** shift (a delayed close from a previous submenu can't clobber the active one). Inline root clamp consolidated onto `clampToViewport`.
- **Prose `DocumentEditorContextMenu.tsx`** — submenu measured + placed after mount; the magic-number root clamp (`innerWidth-220` / `innerHeight-400`) replaced with a measured `clampToViewport`; parent shift mirrors the canvas.
- **CSS** — root menus get `max-height: calc(100vh - 16px); overflow-y: auto`; submenus get a viewport-aware `max-width` so they can't spill horizontally.

## Testing

- `contextMenuUtils.test.ts` covers open-right, shift-parent-left, flip-left, narrow neither-fits clamp, vertical shift-up, and too-tall → scroll.
- `bun run typecheck` clean; full suite (2811 tests) green.
- Manual viewport pass pending (right-click near each edge, tall "Add to Group"/Table submenus, ~360px width) — viewport-dependent, so it's the E2E confirmation before Done.

Assisted-by: Opus 4.8