### PR TITLE
Drop collection enrollment when a document is trashed (JP-418)

### DIFF
--- a/src/store/trashStore.collection.test.ts
+++ b/src/store/trashStore.collection.test.ts
@@ -1,0 +1,78 @@
+/**
+ * JP-418 — trashing a document drops its collection enrollment.
+ *
+ * A collection counts members from `collectionStore.assignments`. Before this
+ * fix a trashed doc kept its assignment, so the collection's sidebar count kept
+ * including a doc that no longer exists in the active set. `trashLocal` and
+ * `trashStranded` (the single funnel for all three trash paths) now clear the
+ * assignment. Restore brings the doc back Unassigned.
+ *
+ * We use the REAL `collectionStore` (a plain zustand store) and mock only the
+ * storage layer so no IndexedDB is touched.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../storage/TrashStorage', () => ({
+  moveToTrash: vi.fn(),
+  getTrashItems: vi.fn(() => []),
+  getTrashedBlobReferences: vi.fn(() => new Set<string>()),
+  recoverFromTrash: vi.fn(),
+  permanentlyDeleteFromTrash: vi.fn(),
+  emptyTrash: vi.fn(() => 0),
+  cleanupExpiredTrash: vi.fn(() => 0),
+}));
+vi.mock('../storage/AssetBundler', () => ({
+  collectBlobReferences: vi.fn(() => []),
+}));
+vi.mock('../storage/BlobStorage', () => ({
+  blobStorage: { listAllBlobs: vi.fn(async () => []) },
+}));
+vi.mock('../storage/BlobGarbageCollector', () => ({
+  BlobGarbageCollector: class {
+    collectGarbageIncremental = vi.fn(async () => {});
+  },
+}));
+vi.mock('./persistenceStore', () => ({
+  usePersistenceStore: { getState: () => ({ getDocumentList: () => [], adoptDocument: vi.fn() }) },
+  loadDocumentFromStorage: vi.fn(() => null),
+}));
+
+import { useTrashStore } from './trashStore';
+import { useCollectionStore } from './collectionStore';
+import type { DiagramDocument } from '../types/Document';
+
+const DOC_ID = 'doc-1';
+const makeDoc = (): DiagramDocument =>
+  ({ id: DOC_ID, name: 'My Doc', pages: {}, pageOrder: [] }) as unknown as DiagramDocument;
+
+function seedAssignedDoc(): string {
+  useCollectionStore.getState().reset();
+  const cid = useCollectionStore.getState().createCollection('Research', undefined, 'local');
+  useCollectionStore.getState().assignDocument(DOC_ID, cid);
+  // Sanity: the doc counts as a member before trashing.
+  expect(useCollectionStore.getState().assignments[DOC_ID]).toBe(cid);
+  return cid;
+}
+
+describe('trashStore drops collection enrollment (JP-418)', () => {
+  beforeEach(() => {
+    useCollectionStore.getState().reset();
+  });
+
+  it('trashLocal clears the doc assignment', () => {
+    const cid = seedAssignedDoc();
+    useTrashStore.getState().trashLocal(makeDoc());
+    expect(useCollectionStore.getState().assignments[DOC_ID]).toBeUndefined();
+    // The collection's member count (derived from assignments) drops to 0.
+    const count = Object.values(useCollectionStore.getState().assignments).filter((c) => c === cid).length;
+    expect(count).toBe(0);
+  });
+
+  it('trashStranded clears the doc assignment', () => {
+    const cid = seedAssignedDoc();
+    useTrashStore.getState().trashStranded(makeDoc(), { relayId: 'relay-1' });
+    expect(useCollectionStore.getState().assignments[DOC_ID]).toBeUndefined();
+    const count = Object.values(useCollectionStore.getState().assignments).filter((c) => c === cid).length;
+    expect(count).toBe(0);
+  });
+});

--- a/src/store/trashStore.ts
+++ b/src/store/trashStore.ts
@@ -41,6 +41,7 @@ import {
   type TrashOrigin,
 } from '../storage/TrashStorage';
 import { usePersistenceStore, loadDocumentFromStorage } from './persistenceStore';
+import { useCollectionStore } from './collectionStore';
 
 /** Reused so the incremental ref cache survives across reclaim passes. */
 const gc = new BlobGarbageCollector(blobStorage);
@@ -130,6 +131,10 @@ export const useTrashStore = create<TrashState & TrashActions>((set, get) => ({
       blobReferences: collectBlobReferences(doc),
     });
     get().refresh();
+    // Trashing removes the doc from the active set, so drop its collection
+    // enrollment too — otherwise the collection keeps counting it as a member
+    // (JP-418). Restore brings it back Unassigned.
+    useCollectionStore.getState().assignDocument(doc.id, null);
   },
 
   trashStranded: (doc, origin) => {
@@ -139,6 +144,8 @@ export const useTrashStore = create<TrashState & TrashActions>((set, get) => ({
       blobReferences: collectBlobReferences(doc),
     });
     get().refresh();
+    // See trashLocal: drop collection enrollment for the stranded doc (JP-418).
+    useCollectionStore.getState().assignDocument(doc.id, null);
   },
 
   restore: async (id) => {

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -523,6 +523,10 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       } else {
         permanentlyDeleteDocument(docId);
       }
+      // The doc is gone from the active set — drop its collection enrollment so
+      // the collection stops counting it as a member (JP-418). Network-free;
+      // the relay copy is already deleted above.
+      useCollectionStore.getState().assignDocument(docId, null);
     },
     [entries, deleteFromHost, permanentlyDeleteDocument]
   );


### PR DESCRIPTION
## Summary

Fixes **JP-418** — a document kept its Collection enrollment after being moved to Trash, so the collection's sidebar count badge kept counting a doc that no longer exists in the active set.

Collection membership lives in `collectionStore.assignments` (`docId → collectionId`). Nothing cleared an assignment when its document left the active set; the visible symptom was `collectionCounts` in `DocumentsHome.tsx`, which tallies raw `assignments` values with no existence check. (The document *list* is registry-derived and already dropped trashed docs — only the count lingered.)

## Change

Clear the assignment (`assignDocument(id, null)`, network-free + persisted) at the two removal chokes:

- **`trashStore.trashLocal` / `trashStranded`** — the single funnel for all three trash paths: local soft-delete (`persistenceStore.deleteDocument`), user-trashed relay doc (`trashRelayDocument`), and relay-deleted-out-from-under-us (`strandOrDemoteDeletedDoc`).
- **`useDocumentBrowserModel.handlePermanentDelete`** — the sole permanent-delete entry, covering both the relay and local branches. `deleteFromHost` is deliberately *not* used as a choke since promote/transfer reuse it and must not touch local enrollment.

Restore brings a doc back **Unassigned** (matches the issue intent). Assignments are UI-org metadata, not document JSON — no schema change or migration.

## Testing

- New unit test `src/store/trashStore.collection.test.ts` — asserts `trashLocal`/`trashStranded` clear the assignment and the derived member count drops to 0 (real `collectionStore`, mocked storage layer).
- `bun run typecheck` clean; adjacent `relayDocumentStore.strand` + `TrashStorage` suites pass.
- Manual E2E (staging): assign a doc to a collection (badge = 1) → Trash → badge = 0 and doc not listed under the collection filter; repeat with "Delete permanently"; Restore returns the doc Unassigned.

Assisted-by: Opus 4.8