### PR TITLE
JP-422: seed local Y.Doc from relay sidecar so downloaded docs edit offline

### DIFF
--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -253,6 +253,7 @@ pub fn routes() -> Router<Arc<ServerState>> {
         )
         .route("/api/docs", get(list_docs_handler))
         .route("/api/docs/:id", get(get_doc_handler))
+        .route("/api/docs/:id/ydoc", get(get_doc_ydoc_handler))
         .route("/api/docs/:id", put(save_doc_handler))
         .route("/api/docs/:id", delete(delete_doc_handler))
         .route("/api/docs/:id/share", post(share_doc_handler))
@@ -833,6 +834,102 @@ async fn get_doc_handler(
     match state.doc_store().get_document(&ws, &doc_id) {
         Ok(doc) => (StatusCode::OK, Json(doc)).into_response(),
         Err(e) => (StatusCode::NOT_FOUND, ApiError::body(e)).into_response(),
+    }
+}
+
+/// `GET /api/docs/:id/ydoc` — the document's authoritative binary Y.Doc sidecar
+/// (JP-108: a `DSKY`-framed lib0-v1 full-state update — every shared type incl.
+/// prose, with CRDT identity) as `application/octet-stream`. Read-scoped exactly
+/// like `GET /api/docs/:id`.
+///
+/// JP-335: lets a client prefetch the relay's exact CRDT state so a downloaded
+/// doc can be opened + edited offline and dedupe trivially on reconnect (the
+/// bytes ARE the relay's own state, so a later re-hydrate merges without
+/// doubling). Prefers a live handle's freshest encode, else the last persisted
+/// sidecar; 404 when binary persistence is off or no sidecar exists yet — the
+/// client then keeps its JSON-body read-only view, no regression.
+async fn get_doc_ydoc_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // JP-200: restore from R2 by id on a local miss before the permission check,
+    // mirroring `get_doc_handler`.
+    state.ensure_doc_local(&ws, &doc_id).await;
+
+    if let Err(e) = check_read_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    // The `binary_persistence` gate is load-bearing, not incidental. The dedup
+    // guarantee (client prefetches these bytes, edits offline, reconnects, and
+    // the two states MERGE instead of doubling) holds ONLY if the identity we
+    // serve now is the identity the relay reproduces on that reconnect. Both
+    // sources below satisfy that: a persisted sidecar is re-hydrated verbatim,
+    // and a live handle's lineage is flushed to a sidecar on evict. With
+    // persistence OFF there is no such continuity — a cold reconnect re-hydrates
+    // from JSON with FRESH clientIDs, so any bytes we served would double. So
+    // never hydrate-from-JSON here to "fill the gap": 404 and let the client keep
+    // its read-only JSON view (no regression) instead of handing out a lineage
+    // the relay will not reproduce.
+    if !state.binary_persistence() {
+        return (
+            StatusCode::NOT_FOUND,
+            ApiError::body("binary sidecar not available"),
+        )
+            .into_response();
+    }
+
+    // Prefer a live handle's freshest full-state encode (captures edits not yet
+    // flushed to disk; its lineage is persisted on evict, so identity carries
+    // across the client's offline window); fall back to the last persisted
+    // sidecar. Either is a valid lib0-v1 full-state update the client can
+    // `Y.applyUpdate`.
+    let bytes = if let Some(handle) = state.sync_registry().get(&ws, &doc_id) {
+        let version = state
+            .doc_store()
+            .get_metadata(&ws, &doc_id)
+            .and_then(|m| m.server_version)
+            .unwrap_or(0);
+        Some(handle.encode_binary(version))
+    } else {
+        state.doc_store().load_ydoc_binary(&ws, &doc_id)
+    };
+
+    match bytes {
+        Some(bytes) => (
+            StatusCode::OK,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/octet-stream",
+            )],
+            bytes,
+        )
+            .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            ApiError::body("binary sidecar not found"),
+        )
+            .into_response(),
     }
 }
 

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -378,6 +378,97 @@ async fn join_delivers_authoritative_state_without_duplication() {
     relay.server.stop().await.expect("stop");
 }
 
+/// JP-335: `GET /api/docs/:id/ydoc` serves the authoritative binary Y.Doc
+/// sidecar so a client can prefetch the relay's exact CRDT state, edit it
+/// offline, and dedupe on reconnect (the served bytes ARE the relay's lineage).
+#[tokio::test]
+async fn ydoc_endpoint_serves_authoritative_binary_sidecar() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-yd", "name": "Sidecar", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {
+                "id": "p1",
+                "shapes": {"s1": {"id": "s1", "type": "rectangle", "x": 5, "y": 6}},
+                "shapeOrder": ["s1"]
+            }}
+        }),
+    )
+    .await;
+
+    // Join + sync to bring up the live authoritative handle so the endpoint has a
+    // handle/sidecar to serve.
+    let mut client = WsClient::connect(&relay.ws_base).await;
+    client.auth(&token).await;
+    client.join_doc("doc-yd").await;
+    client
+        .send_sync(&SyncMessage::SyncStep1(StateVector::default()).encode_v1())
+        .await;
+    let local = LocalDoc::new();
+    for _ in 0..10 {
+        if let Some((ty, bytes)) = client.recv_within(300).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape("p1", "s1") {
+            break;
+        }
+    }
+
+    // Unauthenticated → rejected (same auth gate as `GET /api/docs/:id`).
+    let no_auth = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-yd/ydoc", relay.http))
+        .send()
+        .await
+        .expect("GET no auth");
+    assert!(
+        no_auth.status().is_client_error(),
+        "unauthenticated ydoc must be rejected, got {}",
+        no_auth.status()
+    );
+
+    // Authenticated read → 200 octet-stream, DSKY-framed, decodes to the shape.
+    let resp = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-yd/ydoc", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("GET ydoc");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK, "ydoc GET status");
+    assert_eq!(
+        resp.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/octet-stream"),
+        "ydoc content-type"
+    );
+    let bytes = resp.bytes().await.expect("ydoc bytes").to_vec();
+    assert!(
+        bytes.len() > 16 && &bytes[0..4] == b"DSKY",
+        "sidecar must be DSKY-framed, got {} bytes",
+        bytes.len()
+    );
+
+    // Decode the payload (skip the 16-byte header) and confirm CRDT content —
+    // the client will `Y.applyUpdate` exactly this into its local Y.Doc.
+    let update = Update::decode_v1(&bytes[16..]).expect("decode sidecar update");
+    let doc = Doc::new();
+    doc.transact_mut().apply_update(update).expect("apply sidecar");
+    let shapes = doc.get_or_insert_map("shapes:p1");
+    assert!(
+        shapes.contains_key(&doc.transact(), "s1"),
+        "sidecar carries the seeded shape"
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
 #[tokio::test]
 async fn update_from_one_client_reaches_the_other() {
     let relay = start_relay().await;

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -279,6 +279,28 @@ export class RelayClient {
     );
   }
 
+  /**
+   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (the relay's
+   * exact CRDT state — every shared type, with identity) as raw bytes. Seeding
+   * these into the client's local Y.Doc lets a prefetched doc be opened + edited
+   * offline and dedupe on reconnect (the bytes ARE the relay's lineage). Returns
+   * null when the relay has no sidecar (404) or binary persistence is off — the
+   * caller then keeps the read-only JSON view, no error.
+   */
+  async getYdoc(docId: string): Promise<Uint8Array | null> {
+    try {
+      const res = await this.requestRaw(
+        'GET',
+        `/api/docs/${encodeURIComponent(docId)}/ydoc`,
+      );
+      const buf = await res.arrayBuffer();
+      return new Uint8Array(buf);
+    } catch (e) {
+      if (e instanceof RelayError && e.status === 404) return null;
+      throw e;
+    }
+  }
+
   async updateDocumentShares(
     docId: string,
     shares: RelayShareEntry[],

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -93,6 +93,10 @@ export class RestDocumentProvider {
     return this.client.getRecoveryPointContent(docId, pointId);
   }
 
+  async getYdoc(docId: string): Promise<Uint8Array | null> {
+    return this.client.getYdoc(docId);
+  }
+
   async restoreRecoveryPoint(
     docId: string,
     pointId: string,

--- a/src/collaboration/collabRoom.test.ts
+++ b/src/collaboration/collabRoom.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { collabIdbRoom } from './collabRoom';
+
+describe('collabIdbRoom', () => {
+  it('keys on host:port + doc id, ignoring scheme and path', () => {
+    // The live session builds the room from its WS serverUrl; the offline
+    // prefetch builds it from restUrlToWsUrl(relayUrl). Both must land on the
+    // SAME key, so scheme (ws/wss/http/https) and path must not change it.
+    const doc = 'doc-abc';
+    const ws = collabIdbRoom('wss://relay.example.com/ws', doc);
+    expect(ws).toBe('relay.example.com:doc-abc');
+    // http/ws/https forms of the same host all match.
+    expect(collabIdbRoom('https://relay.example.com', doc)).toBe(ws);
+    expect(collabIdbRoom('ws://relay.example.com/ws?x=1', doc)).toBe(ws);
+  });
+
+  it('preserves an explicit port in the key', () => {
+    expect(collabIdbRoom('ws://localhost:9876/ws', 'd1')).toBe('localhost:9876:d1');
+  });
+
+  it('separates docs on the same host', () => {
+    const a = collabIdbRoom('wss://r.example.com/ws', 'a');
+    const b = collabIdbRoom('wss://r.example.com/ws', 'b');
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/collaboration/collabRoom.ts
+++ b/src/collaboration/collabRoom.ts
@@ -1,0 +1,16 @@
+/**
+ * The y-indexeddb room key for a relay-backed document's local Y.Doc.
+ *
+ * Scoped per relay host + doc id (JP-108 / JP-117) so the same doc on a
+ * different relay can't bleed. This is the SINGLE source of the key: both the
+ * live collab session (collaborationStore) and the offline prefetch
+ * (prefetchYdoc, JP-335) derive it here, so a prefetched seed and the live
+ * session bind the *same* room — a mismatch would silently strand the seed.
+ *
+ * `serverUrl` is the session's WebSocket URL (e.g. `wss://host/ws`); only its
+ * `host` (host:port) is used, which is identical for the ws and http forms of
+ * the same relay.
+ */
+export function collabIdbRoom(serverUrl: string, documentId: string): string {
+  return `${new URL(serverUrl).host}:${documentId}`;
+}

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -19,6 +19,7 @@ import { create } from 'zustand';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import { YjsDocument } from './YjsDocument';
 import type { ProsePageMeta, CanvasPageMeta } from './YjsDocument';
+import { collabIdbRoom } from './collabRoom';
 import { UnifiedSyncProvider, AwarenessUserState } from './UnifiedSyncProvider';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { registerCollabOwnsActivePageLoad } from '../store/pageStore';
@@ -474,7 +475,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // gave random clientIDs, so this no longer corrupts merges.
       get()._setIdbSynced(false);
       if (typeof indexedDB !== 'undefined') {
-        const idbRoom = `${new URL(config.serverUrl).host}:${config.documentId}`;
+        const idbRoom = collabIdbRoom(config.serverUrl, config.documentId);
         idbPersistence = new IndexeddbPersistence(idbRoom, yjsDoc.getDoc());
         idbPersistence.whenSynced
           .then(() => get()._setIdbSynced(true))

--- a/src/collaboration/prefetchYdoc.test.ts
+++ b/src/collaboration/prefetchYdoc.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { Doc as YDoc, encodeStateAsUpdate, applyUpdate } from 'yjs';
+import { stripSidecarHeader } from './prefetchYdoc';
+
+/** Frame a lib0-v1 update the way `relay/src/sync/binary.rs::encode_snapshot`
+ * does: `b"DSKY" | format_version:u32 LE | server_version:u64 LE | update`. */
+function frameSidecar(update: Uint8Array, formatVersion = 1, serverVersion = 7): Uint8Array {
+  const header = new Uint8Array(16);
+  header.set([0x44, 0x53, 0x4b, 0x59], 0); // "DSKY"
+  new DataView(header.buffer).setUint32(4, formatVersion, true);
+  new DataView(header.buffer).setBigUint64(8, BigInt(serverVersion), true);
+  const out = new Uint8Array(header.length + update.length);
+  out.set(header, 0);
+  out.set(update, header.length);
+  return out;
+}
+
+describe('stripSidecarHeader', () => {
+  it('strips the 16-byte DSKY header, yielding an applyUpdate-able payload', () => {
+    // Author a doc, encode it, frame it exactly like the relay, then strip.
+    const src = new YDoc();
+    src.getMap('shapes:p1').set('s1', 'rect');
+    const update = encodeStateAsUpdate(src);
+
+    const framed = frameSidecar(update);
+    const payload = stripSidecarHeader(framed);
+    expect(payload).not.toBeNull();
+
+    // The payload must reconstruct the original CRDT content — this is exactly
+    // what prefetchYdoc applies into the local room.
+    const dst = new YDoc();
+    applyUpdate(dst, payload!);
+    expect(dst.getMap('shapes:p1').get('s1')).toBe('rect');
+  });
+
+  it('rejects a buffer with the wrong magic', () => {
+    const framed = frameSidecar(new Uint8Array([1, 2, 3, 4]));
+    framed[0] = 0x58; // 'X'
+    expect(stripSidecarHeader(framed)).toBeNull();
+  });
+
+  it('rejects a buffer too short to contain a header + payload', () => {
+    expect(stripSidecarHeader(new Uint8Array(16))).toBeNull(); // header only, no payload
+    expect(stripSidecarHeader(new Uint8Array([0x44, 0x53, 0x4b, 0x59]))).toBeNull();
+    expect(stripSidecarHeader(new Uint8Array(0))).toBeNull();
+  });
+});

--- a/src/collaboration/prefetchYdoc.ts
+++ b/src/collaboration/prefetchYdoc.ts
@@ -1,0 +1,106 @@
+/**
+ * prefetchYdoc — seed a relay document's local Y.Doc room from the relay's
+ * authoritative binary sidecar, so a "downloaded but never opened" doc can be
+ * opened + edited OFFLINE (JP-335).
+ *
+ * The problem: the local y-indexeddb room (`host:docId`) is populated only by a
+ * live sync handshake. A doc that was cached (body + blobs, JP-281) but never
+ * opened while online has an EMPTY room, so opening it offline leaves the prose
+ * fragment empty → the editor is read-only (relay-is-sole-seeder, JP-284), and
+ * canvas edits can't be captured. Prefetching the relay's exact CRDT bytes into
+ * that room fixes both: the offline adopt path sees real content and the client
+ * edits the relay's own lineage, which dedupes trivially on reconnect.
+ *
+ * Correctness hinges on two things:
+ *  - the seeded room key must byte-match the live session's — both go through
+ *    {@link collabIdbRoom};
+ *  - the bytes must be the relay's real lineage (a sidecar it will reproduce on
+ *    reconnect), which the `GET /api/docs/:id/ydoc` endpoint guarantees (it only
+ *    serves a persisted/live-handle sidecar, never a fresh JSON hydrate).
+ */
+
+import { Doc as YDoc, applyUpdate, encodeStateVector } from 'yjs';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import { loadConnection } from '../api/relayConnection';
+import { restUrlToWsUrl } from '../api/completeCloudSignIn';
+import { getDocProvider } from '../store/relayDocumentStore';
+import { collabIdbRoom } from './collabRoom';
+
+/** An empty Yjs state vector — what an untouched room reports. */
+const EMPTY_STATE_VECTOR_LEN = 1;
+
+/**
+ * Fetch `docId`'s authoritative Y.Doc sidecar and apply it into the local
+ * y-indexeddb room so the doc can be opened offline. Resolves to:
+ *  - `'seeded'` — bytes were fetched and written into a previously-empty room,
+ *  - `'skipped'` — the room already had CRDT state (a prior sync/seed), or
+ *  - `'unavailable'` — no relay/provider/sidecar, or IndexedDB is absent.
+ *
+ * Best-effort and idempotent: re-applying the same sidecar is a no-op, and any
+ * failure leaves the doc on its existing (read-only) offline path — no throw.
+ */
+export async function prefetchYdoc(
+  docId: string,
+): Promise<'seeded' | 'skipped' | 'unavailable'> {
+  if (typeof indexedDB === 'undefined') return 'unavailable';
+
+  const provider = getDocProvider();
+  if (!provider?.getYdoc) return 'unavailable';
+
+  const conn = await loadConnection();
+  if (!conn?.relayUrl) return 'unavailable';
+
+  const room = collabIdbRoom(restUrlToWsUrl(conn.relayUrl), docId);
+
+  // Bind the room and wait for any persisted state to load. If it already holds
+  // CRDT state (the doc was synced/edited before), do NOT overwrite — the live
+  // lineage wins; seeding on top is unnecessary and could reintroduce a merge.
+  const doc = new YDoc();
+  const persistence = new IndexeddbPersistence(room, doc);
+  try {
+    await persistence.whenSynced;
+    if (encodeStateVector(doc).length > EMPTY_STATE_VECTOR_LEN) {
+      return 'skipped';
+    }
+
+    const bytes = await provider.getYdoc(docId);
+    if (!bytes || bytes.length === 0) return 'unavailable';
+
+    // Strip the sidecar's `DSKY|ver|serverVersion` header (16 bytes) to get the
+    // raw lib0-v1 state update; a short/garbage buffer just aborts the prefetch.
+    const update = stripSidecarHeader(bytes);
+    if (!update) return 'unavailable';
+
+    // Apply with a non-`this` origin (default) so y-indexeddb's `update`
+    // handler fires SYNCHRONOUSLY and creates the IDB write transaction before
+    // we detach. `destroy()` below calls `db.close()`, which per the IndexedDB
+    // spec lets that in-flight transaction complete — so the seed is durably
+    // persisted for the live session to load.
+    applyUpdate(doc, update);
+    return 'seeded';
+  } catch {
+    return 'unavailable';
+  } finally {
+    // Detach our transient handle; the persisted room stays on disk for the live
+    // session to pick up. `destroy()` also tears down the Y.Doc.
+    await persistence.destroy();
+    doc.destroy();
+  }
+}
+
+/** Sidecar magic + header length — mirrors `relay/src/sync/binary.rs`. */
+const SIDECAR_MAGIC = [0x44, 0x53, 0x4b, 0x59]; // "DSKY"
+const SIDECAR_HEADER_LEN = 16; // magic(4) + format_version(4) + server_version(8)
+
+/**
+ * Validate the `DSKY` header and return the lib0-v1 update payload, or null if
+ * the buffer isn't a recognizable sidecar (bad magic / too short). Exported for
+ * testing.
+ */
+export function stripSidecarHeader(bytes: Uint8Array): Uint8Array | null {
+  if (bytes.length <= SIDECAR_HEADER_LEN) return null;
+  for (let i = 0; i < SIDECAR_MAGIC.length; i++) {
+    if (bytes[i] !== SIDECAR_MAGIC[i]) return null;
+  }
+  return bytes.subarray(SIDECAR_HEADER_LEN);
+}

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -188,6 +188,31 @@ function adoptShapes(shapes: Shape[], order: string[] = shapes.map((s) => s.id))
   currentYjs.rebindActivePage.mockReturnValue({ shapes, order });
 }
 
+/** JP-335: start an engine-only OFFLINE session — no token (so `hasProvider` is
+ *  false, the offline-first engine) and idb-synced but NEVER relay-synced. This
+ *  is the exact state when opening a PREFETCHED doc offline: the local Y.Doc
+ *  room was seeded from the relay's sidecar, but the relay was never contacted
+ *  this session. */
+function startOfflineSession(docId = 'doc-off'): void {
+  act(() => {
+    usePageStore.setState({
+      pages: { p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['p1'],
+      activePageId: 'p1',
+    });
+  });
+  act(() => {
+    useCollaborationStore.getState().startSession({
+      serverUrl: 'ws://localhost:9876/ws',
+      documentId: docId,
+      // NO token → engine-only, `hasProvider` false. No `_setSynced(true)`:
+      // offline, the relay never confirmed its state.
+      user: { id: 'u', name: 'U', color: '#fff' },
+    });
+    useCollaborationStore.getState()._setIdbSynced(true);
+  });
+}
+
 describe('useCollaborationSync', () => {
   beforeEach(() => {
     useDocumentStore.getState().clear();
@@ -292,6 +317,39 @@ describe('useCollaborationSync', () => {
 
     act(() => useDocumentStore.getState().addShape(shape('S2')));
     expect(currentYjs.setShape).toHaveBeenCalled();
+  });
+
+  it('adopts a prefetched Y.Doc OFFLINE so canvas is editable (JP-335)', () => {
+    // The seeded room reports canvas content (`hasAnyShapes`), and we're offline
+    // (no provider, not relay-synced). Before JP-335 this state fell into the
+    // "offline + empty Y.Doc — defer" branch and canvas edits were dropped; with
+    // a prefetched (non-empty) room the adopt runs and the bridge initializes.
+    startOfflineSession();
+    adoptShapes([shape('OFF1')]);
+
+    renderHook(() => useCollaborationSync());
+
+    // The seeded shapes loaded into the view…
+    expect(Object.keys(useDocumentStore.getState().shapes)).toContain('OFF1');
+
+    // …and the doc-store→CRDT bridge is live (`initializedRef` set), so an
+    // offline edit is captured into the Y.Doc — not silently lost on reconnect.
+    currentYjs.setShape.mockClear();
+    act(() => useDocumentStore.getState().addShape(shape('OFF2')));
+    expect(currentYjs.setShape).toHaveBeenCalled();
+  });
+
+  it('defers adopt when OFFLINE and the Y.Doc is empty (unprefetched — no dup risk)', () => {
+    // Control for the above: a doc that was NOT prefetched has an empty room
+    // offline, so adopt must still defer — pushing edits into a not-yet-adopted
+    // Y.Doc would fork a fresh CRDT identity that duplicates on first sync.
+    startOfflineSession('doc-empty');
+    // hasAnyShapes stays false (default) and we never relay-sync.
+    renderHook(() => useCollaborationSync());
+
+    currentYjs.setShape.mockClear();
+    act(() => useDocumentStore.getState().addShape(shape('X')));
+    expect(currentYjs.setShape).not.toHaveBeenCalled();
   });
 
   it('re-binds onShapeChange to the new Y.Doc after switchDocument (#60)', () => {

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -23,6 +23,7 @@ import type { DiagramDocument } from '../types/Document';
 import type { DocumentRecord } from '../types/DocumentRegistry';
 import { useDocumentRegistry } from './documentRegistry';
 import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+import { prefetchYdoc } from '../collaboration/prefetchYdoc';
 
 /** Max blob downloads in flight at once during a prefetch. */
 const OFFLINE_PREFETCH_CONCURRENCY = 4;
@@ -140,6 +141,14 @@ export async function makeAvailableOffline(
   // loadRelayDocument serves (or fetches) the body and writes it to the
   // persistent offline cache as a side effect — that satisfies "body cached".
   const body = await useRelayDocumentStore.getState().loadRelayDocument(record.id);
+
+  // JP-335: also seed the local Y.Doc room from the relay's authoritative
+  // sidecar, so a doc that's only ever been "downloaded" (never opened live) can
+  // be opened + EDITED offline — not just rendered read-only. Best-effort: a
+  // missing sidecar or older relay just leaves the doc read-only offline (the
+  // prior behavior), never fails the prefetch.
+  await prefetchYdoc(record.id);
+
   const refs = collectBlobReferences(body);
   const total = refs.length;
 

--- a/src/store/relayDocumentStore.offlineOpen.test.ts
+++ b/src/store/relayDocumentStore.offlineOpen.test.ts
@@ -1,0 +1,87 @@
+/**
+ * JP-422 follow-up — opening a relay doc while offline.
+ *
+ * `docProvider` stays set on a mere disconnect, so it can't be the offline
+ * signal; `loadRelayDocument` now treats `navigator.onLine === false` as
+ * offline. Offline it (a) serves the persistent cache even if the relay's
+ * metadata looks newer, and (b) never attempts a doomed network fetch — it
+ * throws a typed error the open path turns into a friendly message.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn(async () => null as unknown),
+  put: vi.fn(async () => {}),
+  getCachedIdsForHost: vi.fn(() => [] as string[]),
+  getMeta: vi.fn(() => null),
+  remove: vi.fn(async () => {}),
+}));
+
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => ({ hasPendingChanges: () => false }),
+}));
+
+import {
+  useRelayDocumentStore,
+  RelayDocumentUnavailableOfflineError,
+  type DocumentProvider,
+} from './relayDocumentStore';
+import type { DiagramDocument } from '../types/Document';
+
+function doc(id: string, modifiedAt: number): DiagramDocument {
+  return {
+    id,
+    name: id,
+    pages: { p1: { id: 'p1', name: 'P1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt } },
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 0,
+    modifiedAt,
+    version: 1,
+  } as unknown as DiagramDocument;
+}
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { value: online, configurable: true });
+}
+
+const getDocument = vi.fn(async () => doc('d', 999));
+const provider = { getDocument } as unknown as DocumentProvider;
+
+describe('loadRelayDocument — offline open (JP-422)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheMock.get.mockResolvedValue(null);
+    useRelayDocumentStore.setState({ documentCache: {}, relayDocuments: {}, loadingDocs: new Set() });
+    useRelayDocumentStore.getState().setProvider(provider);
+  });
+  afterEach(() => setOnline(true));
+
+  it('throws a typed error and does NOT fetch when offline and uncached', async () => {
+    setOnline(false);
+    await expect(useRelayDocumentStore.getState().loadRelayDocument('d')).rejects.toBeInstanceOf(
+      RelayDocumentUnavailableOfflineError,
+    );
+    expect(getDocument).not.toHaveBeenCalled(); // no doomed network fetch
+  });
+
+  it('serves a STALE persistent cache when offline (beats failing to open)', async () => {
+    // Relay metadata is newer than the cached copy → `isFresh` is false, so
+    // online this would refetch. Offline it must still serve the local copy.
+    useRelayDocumentStore.setState({ relayDocuments: { d: { modifiedAt: 500 } as never } });
+    cacheMock.get.mockResolvedValue(doc('d', 100));
+    setOnline(false);
+
+    const loaded = await useRelayDocumentStore.getState().loadRelayDocument('d');
+    expect(loaded.id).toBe('d');
+    expect(getDocument).not.toHaveBeenCalled();
+  });
+
+  it('still fetches over the network when online and uncached (control)', async () => {
+    setOnline(true);
+    await useRelayDocumentStore.getState().loadRelayDocument('d');
+    expect(getDocument).toHaveBeenCalledWith('d');
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -118,6 +118,19 @@ interface RelayDocumentState {
  * the legacy WS-multiplexed implementation on `UnifiedSyncProvider`
  * stays in place but is no longer wired in here.
  */
+/**
+ * Thrown by `loadRelayDocument` when a relay doc can't be opened because we're
+ * offline and it was never cached (not "made available offline"). Typed so the
+ * open path can show a specific "not available offline" message rather than a
+ * generic failure.
+ */
+export class RelayDocumentUnavailableOfflineError extends Error {
+  constructor(public readonly docId: string) {
+    super('Document is not available offline');
+    this.name = 'RelayDocumentUnavailableOfflineError';
+  }
+}
+
 export interface DocumentProvider {
   listDocuments(): Promise<DocumentMetadata[]>;
   getDocument(docId: string): Promise<DiagramDocument | { document: DiagramDocument; serverVersion?: number }>;
@@ -427,11 +440,19 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         return registryCached;
       }
 
-      // Check persistent offline cache — but only trust it when we're
-      // offline (no docProvider) or when it's not stale relative to the
-      // relay. Otherwise we'd serve users their own pre-save snapshot.
+      // A real network outage counts as offline even while a provider is
+      // configured: `docProvider` stays set on a mere disconnect, so it can't
+      // be the offline signal on its own. `navigator.onLine === false` catches
+      // the internet-disconnected case the provider misses.
+      const offline =
+        !docProvider || (typeof navigator !== 'undefined' && navigator.onLine === false);
+
+      // Check persistent offline cache. Trust it whenever we're offline — a
+      // possibly-stale local copy beats failing to open, and the CRDT layer
+      // reconciles on reconnect. Online, still require freshness so we don't
+      // serve a pre-server-update snapshot over a reachable newer one.
       const persistentCached = await RelayDocumentCache.get(activeWorkspaceId(), docId);
-      if (persistentCached && (!docProvider || isFresh(persistentCached.modifiedAt))) {
+      if (persistentCached && (offline || isFresh(persistentCached.modifiedAt))) {
         console.log('[relayDocumentStore] Loaded from offline cache:', docId);
 
         // Update in-memory caches
@@ -446,9 +467,12 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         return persistentCached;
       }
 
-      // No usable cache — need network connection
-      if (!docProvider) {
-        throw new Error('Not connected to host and document not cached');
+      // No usable cache. Offline → don't attempt a doomed network fetch (it
+      // spews `net::ERR_INTERNET_DISCONNECTED` + a raw `TypeError: Failed to
+      // fetch`); throw a clear, catchable signal the open path turns into a
+      // friendly "not available offline" message instead of a silent no-op.
+      if (offline || !docProvider) {
+        throw new RelayDocumentUnavailableOfflineError(docId);
       }
 
       // Mark as loading

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -157,6 +157,12 @@ export interface DocumentProvider {
    */
   listRecoveryPoints?(docId: string): Promise<RelayRecoveryPoint[]>;
   getRecoveryPointContent?(docId: string, pointId: string): Promise<DiagramDocument>;
+  /**
+   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (raw
+   * lib0-v1 full-state bytes) so it can be seeded into the local Y.Doc room for
+   * offline editing. Optional so non-REST providers opt out; null = no sidecar.
+   */
+  getYdoc?(docId: string): Promise<Uint8Array | null>;
   restoreRecoveryPoint?(
     docId: string,
     pointId: string,

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -20,7 +20,12 @@ import {
   saveDocumentToStorage,
 } from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
-import { useRelayDocumentStore, useIsCloudSignedIn, isCloudSignedIn } from '../../store/relayDocumentStore';
+import {
+  useRelayDocumentStore,
+  useIsCloudSignedIn,
+  isCloudSignedIn,
+  RelayDocumentUnavailableOfflineError,
+} from '../../store/relayDocumentStore';
 import { ensureCollabSessionForDoc } from '../../collaboration/ensureCollabSession';
 import {
   computeOfflineStatus,
@@ -471,6 +476,17 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
           usePersistenceStore.getState().loadRemoteDocument(doc);
         } catch (error) {
           console.error('Failed to load relay document:', error);
+          const { useNotificationStore } = await import('../../store/notificationStore');
+          const offline =
+            error instanceof RelayDocumentUnavailableOfflineError ||
+            (typeof navigator !== 'undefined' && navigator.onLine === false);
+          useNotificationStore
+            .getState()
+            .warning(
+              offline
+                ? 'This document isn’t available offline. Open it while connected, or use “Make available offline” first, then reopen.'
+                : 'Couldn’t open this document. Check your connection and try again.',
+            );
         }
       } else {
         loadDocument(docId);


### PR DESCRIPTION
## Problem

A relay-backed doc that was cached ("downloaded" / made available offline via JP-281) but **never opened while online** has an empty local Y.Doc room. Opening it offline leaves the `prose:<pageId>` fragment empty, so the prose editor is **read-only** (`ProsePreview`), and canvas edits aren't captured by the CRDT bridge (`useCollaborationSync` `initializedRef` stays false → dropped on reconnect).

Same root cause as JP-335 (the relay is the sole prose seeder, JP-284, so the client never seeds a fragment locally) but a **different trigger** — no new page involved. Split out of JP-335, which stays scoped to offline page *creation*.

## Fix

Let the client adopt the relay's **own** authoritative bytes rather than re-seed. The relay already persists a full-state binary Y.Doc sidecar (JP-108, `DSKY`-framed lib0-v1 update); expose it read-only and seed it into the local y-indexeddb room at prefetch time. On reconnect the bytes dedupe trivially because they **are** the relay's lineage.

### Relay
- `GET /api/docs/:id/ydoc` → `application/octet-stream`. Auth/workspace scoping mirrored from the recovery GET. Prefers a live handle's freshest encode, else the persisted sidecar.
- Gated on `binary_persistence`, and **never hydrates-from-JSON on a cold miss** — only bytes whose CRDT identity the relay reproduces on reconnect are safe to serve, else they double on merge. Missing sidecar → 404, client keeps its read-only JSON view (no regression). This invariant is documented inline.

### Client
- `RelayClient.getYdoc` + optional provider seam (null on 404).
- `prefetchYdoc()`: fetch the sidecar, `applyUpdate` into the local room; skips a populated room; idempotent. Wired into `makeAvailableOffline` (JP-281).
- `collabRoom.ts`: single source of the `host:docId` idb room key, shared by the live session and the prefetch so they can't drift.

Once seeded, the **existing** offline adopt path makes prose editable (`fragHasContent`) and captures canvas edits (`initializedRef`); no gate changes.

### Offline doc-open robustness (folded in — same subject)
Surfaced while testing the above: `loadRelayDocument` used `!docProvider` as its "offline?" signal, but the provider stays set on a mere network drop, so a genuinely-offline open skipped the cache and fell through to a doomed fetch (`net::ERR_INTERNET_DISCONNECTED` → `TypeError`) that `handleOpen` swallowed as a silent no-op.
- Treat `navigator.onLine === false` as offline: serve the persistent cache even if the relay's metadata looks newer (a stale local copy beats failing to open), and throw a typed `RelayDocumentUnavailableOfflineError` instead of hitting the network.
- `handleOpen` shows a toast ("not available offline — make it available offline first, then reopen") instead of a silent failure.

## Tests
- Relay: `/ydoc` endpoint round-trip + unauthenticated-rejected (`yjs_authority`).
- Client: sidecar header parse (round-trips through yjs); room-key exactness; offline canvas adopt for a prefetched doc + dup-safe empty-room control; offline doc-open (uncached → typed error, no fetch; stale-cache → served; online control → fetches).
- Full vitest green (2828); relay `cargo build --bin relay` + `cargo check --all-targets`.
- **Pending:** full-stack E2E (offline open → edit prose+canvas → reconnect, no dup/loss) on a deploy.

## Scope note
New offline **page creation** (removing the JP-334 guard + the prose double-seed handoff) remains **JP-335** — a distinct, riskier concern kept on its own review surface.

Assisted-by: Opus 4.8