### PR TITLE
JP-335: create new pages offline in a synced doc

### DIFF
--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -280,7 +280,7 @@ export class RelayClient {
   }
 
   /**
-   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (the relay's
+   * JP-422: fetch a document's authoritative binary Y.Doc sidecar (the relay's
    * exact CRDT state — every shared type, with identity) as raw bytes. Seeding
    * these into the client's local Y.Doc lets a prefetched doc be opened + edited
    * offline and dedupe on reconnect (the bytes ARE the relay's lineage). Returns

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -293,6 +293,28 @@ export class YjsDocument {
     };
   }
 
+  /**
+   * Seed a SPECIFIC page's shape surface (`shapes:<pageId>`/`shapeOrder:<pageId>`)
+   * from a local snapshot, without touching the active-page binding (JP-335).
+   * Used by the reconnect handoff to push a pending-sync page's offline-drawn
+   * shapes. Safe by construction: per-item id-keyed `set`s are additive (never a
+   * `clear` — the seedClobber hazard), and the order array is written only when
+   * still empty (a page the relay has never seen), so this cannot wipe
+   * concurrent state.
+   */
+  seedPageShapes(pageId: string, shapes: Shape[], order: string[]): void {
+    const map = this.shapesMapFor(pageId);
+    const orderArr = this.shapeOrderArrFor(pageId);
+    this.withLocalUpdate(() => {
+      for (const shape of shapes) {
+        map.set(shape.id, JSON.parse(JSON.stringify(shape)) as Shape);
+      }
+      if (orderArr.length === 0 && order.length > 0) {
+        orderArr.push([...order]);
+      }
+    });
+  }
+
   // ============ Canvas undo/redo (JP-402) ============
 
   /** Undo this user's last tracked canvas edit on the active page. */

--- a/src/collaboration/collabRoom.ts
+++ b/src/collaboration/collabRoom.ts
@@ -4,7 +4,7 @@
  * Scoped per relay host + doc id (JP-108 / JP-117) so the same doc on a
  * different relay can't bleed. This is the SINGLE source of the key: both the
  * live collab session (collaborationStore) and the offline prefetch
- * (prefetchYdoc, JP-335) derive it here, so a prefetched seed and the live
+ * (prefetchYdoc, JP-422) derive it here, so a prefetched seed and the live
  * session bind the *same* room — a mismatch would silently strand the seed.
  *
  * `serverUrl` is the session's WebSocket URL (e.g. `wss://host/ws`); only its

--- a/src/collaboration/prefetchYdoc.ts
+++ b/src/collaboration/prefetchYdoc.ts
@@ -1,7 +1,7 @@
 /**
  * prefetchYdoc — seed a relay document's local Y.Doc room from the relay's
  * authoritative binary sidecar, so a "downloaded but never opened" doc can be
- * opened + edited OFFLINE (JP-335).
+ * opened + edited OFFLINE (JP-422).
  *
  * The problem: the local y-indexeddb room (`host:docId`) is populated only by a
  * live sync handshake. A doc that was cached (body + blobs, JP-281) but never

--- a/src/collaboration/proseReseedDuplication.test.ts
+++ b/src/collaboration/proseReseedDuplication.test.ts
@@ -53,4 +53,30 @@ describe('JP-282: independent prose seedings merge to duplicates', () => {
     expect(client.getXmlFragment('prose:p1').length).toBe(1);
     expect(relay.getXmlFragment('prose:p1').length).toBe(1);
   });
+
+  it('does NOT double for a page CREATED offline when the relay never seeds it (JP-335)', () => {
+    // Offline new-page creation: the client authors `prose:<newId>` (its live
+    // random-clientID lineage) while the relay never learns the page — the
+    // collab body-save suppression + the pending-page body-withhold keep its
+    // HTML out of the relay's stored JSON, so json_prose_to_ydoc has nothing to
+    // seed. On reconnect the client's fragment is the SOLE lineage.
+    const client = new Y.Doc();
+    seedParagraph(client, 'prose:new-offline', 'typed while offline');
+
+    const relay = new Y.Doc(); // hydrated from a body with content: '' for this page
+
+    Y.applyUpdate(relay, Y.encodeStateAsUpdate(client));
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(relay));
+
+    expect(client.getXmlFragment('prose:new-offline').length).toBe(1);
+    expect(relay.getXmlFragment('prose:new-offline').length).toBe(1);
+
+    // Control — the hazard the withhold exists to prevent: if the page's HTML
+    // HAD reached the relay body, the relay would mint its own lineage and the
+    // merge doubles (the first test's mechanism, restated for the new-page case).
+    const leakyRelay = new Y.Doc();
+    seedParagraph(leakyRelay, 'prose:new-offline', 'typed while offline');
+    Y.applyUpdate(leakyRelay, Y.encodeStateAsUpdate(client));
+    expect(leakyRelay.getXmlFragment('prose:new-offline').length).toBe(2);
+  });
 });

--- a/src/collaboration/sharedDocOffline.test.ts
+++ b/src/collaboration/sharedDocOffline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeSharedDocOffline } from './offlinePageGuard';
+import { computeSharedDocOffline } from './sharedDocOffline';
 
 // A relay doc identified by an active collab session, currently online.
 const onlineRelay = {

--- a/src/collaboration/sharedDocOffline.ts
+++ b/src/collaboration/sharedDocOffline.ts
@@ -5,14 +5,16 @@ import { useDocumentRegistry } from '../store/documentRegistry';
 import { useCollaborationStore } from './collaborationStore';
 
 /**
- * JP-334: while a relay-backed (shared) doc is offline, creating a new page —
- * prose OR canvas — is blocked. Prose: a never-synced empty fragment is
- * read-only by design (relay is the sole seeder, JP-284) and editing it would
- * risk dual-lineage duplication. Canvas: a new page's shapes never reach the
- * relay's active-page-only flatten → lost on reconnect. Either way the page
- * can't be created safely until reconnect. Enabling it is JP-335.
+ * "Is this shared (relay-backed) doc currently offline?" — the predicate behind
+ * the StatusBar's ambient offline chip (JP-237) and the pending-sync marking of
+ * pages created offline (JP-335, `pendingSyncPages`).
  *
- * Local-only docs are never blocked (no relay involved).
+ * History: this was `offlinePageGuard.ts` (JP-334), which BLOCKED new-page
+ * creation while a shared doc was offline. JP-335 lifted the block — offline
+ * page creation is now allowed; a created page is marked pending-sync and
+ * handed to the relay on reconnect (see `useCollaborationSync`'s handoff).
+ *
+ * Local-only docs are never "shared offline" (no relay involved).
  */
 
 /** Pure decision: relay-backed AND the live connection isn't fully up. */

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -22,6 +22,10 @@ function makeMockYjs() {
     // JP-340 per-page binding surface.
     hasAnyShapes: vi.fn(() => false),
     rebindActivePage: vi.fn(() => ({ shapes: [] as Shape[], order: [] as string[] })),
+    // JP-335 pending-page handoff surface.
+    seedPageShapes: vi.fn(),
+    // JP-338 self-heal (runs over the prose page list after adopt).
+    healDoubledProse: vi.fn(),
     getShapesForPage: vi.fn(() => [] as Shape[]),
     getShapeOrderForPage: vi.fn(() => [] as string[]),
     getName: vi.fn(() => undefined),
@@ -141,6 +145,8 @@ vi.mock('../store/persistenceStore', () => ({ applyRemoteDocumentName: vi.fn() }
 import { useCollaborationStore } from './collaborationStore';
 import { useDocumentStore } from '../store/documentStore';
 import { usePageStore } from '../store/pageStore';
+import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { usePendingSyncPages, isPagePendingSync } from '../store/pendingSyncPages';
 import { useCollaborationSync } from './useCollaborationSync';
 import { withAutoSaveSuppressed } from '../store/autoSaveGuard';
 
@@ -216,6 +222,8 @@ function startOfflineSession(docId = 'doc-off'): void {
 describe('useCollaborationSync', () => {
   beforeEach(() => {
     useDocumentStore.getState().clear();
+    usePendingSyncPages.setState({ pending: {} });
+    useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
     useCollaborationStore.setState({
       isActive: false,
       isSynced: false,
@@ -350,6 +358,81 @@ describe('useCollaborationSync', () => {
     currentYjs.setShape.mockClear();
     act(() => useDocumentStore.getState().addShape(shape('X')));
     expect(currentYjs.setShape).not.toHaveBeenCalled();
+  });
+
+  it('hands off pending-sync pages on a synced session (JP-335)', () => {
+    // A prose page + a (non-active) canvas page were created offline and marked
+    // pending. On a live synced session the handoff must (re)emit their metas
+    // into the CRDT, push the canvas page's committed shapes, and clear markers.
+    act(() => {
+      useRichTextPagesStore.setState({
+        pages: {
+          'rt-off': { id: 'rt-off', name: 'Offline notes', content: '<p>x</p>', order: 0, createdAt: 1, modifiedAt: 2 },
+        },
+        pageOrder: ['rt-off'],
+        activePageId: 'rt-off',
+      });
+      usePendingSyncPages.getState().markPending('rt-off', 'doc-1');
+      usePendingSyncPages.getState().markPending('cv-off', 'doc-1');
+    });
+    startSyncedSession('doc-1');
+    // Add the pending canvas page (non-active; 'p1' stays active) with a shape.
+    act(() => {
+      usePageStore.setState((prev) => ({
+        pages: {
+          ...prev.pages,
+          'cv-off': {
+            id: 'cv-off', name: 'Offline canvas', createdAt: 1, modifiedAt: 2,
+            shapes: { S9: shape('S9') }, shapeOrder: ['S9'],
+          },
+        },
+        pageOrder: [...prev.pageOrder, 'cv-off'],
+      }));
+    });
+
+    renderHook(() => useCollaborationSync());
+
+    // Prose meta reached the CRDT page list.
+    expect(currentYjs.setProsePage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rt-off', name: 'Offline notes' }),
+    );
+    // Canvas meta + the committed shapes reached the page's own surface.
+    expect(currentYjs.setCanvasPage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cv-off', name: 'Offline canvas' }),
+    );
+    expect(currentYjs.seedPageShapes).toHaveBeenCalledWith(
+      'cv-off',
+      [expect.objectContaining({ id: 'S9' })],
+      ['S9'],
+    );
+    // Markers cleared — the pages are ordinary synced pages from here on.
+    expect(isPagePendingSync('rt-off')).toBe(false);
+    expect(isPagePendingSync('cv-off')).toBe(false);
+  });
+
+  it('does NOT hand off while offline (no provider) — markers persist', () => {
+    act(() => {
+      usePendingSyncPages.getState().markPending('rt-off', 'doc-off');
+    });
+    // Engine-only offline session (no token → no provider, never synced).
+    act(() => {
+      usePageStore.setState({
+        pages: { p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt: 0 } },
+        pageOrder: ['p1'],
+        activePageId: 'p1',
+      });
+      useCollaborationStore.getState().startSession({
+        serverUrl: 'ws://localhost:9876/ws',
+        documentId: 'doc-off',
+        user: { id: 'u', name: 'U', color: '#fff' },
+      });
+      useCollaborationStore.getState()._setIdbSynced(true);
+    });
+
+    renderHook(() => useCollaborationSync());
+
+    expect(currentYjs.setProsePage).not.toHaveBeenCalled();
+    expect(isPagePendingSync('rt-off')).toBe(true);
   });
 
   it('re-binds onShapeChange to the new Y.Doc after switchDocument (#60)', () => {

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -24,6 +24,8 @@ import { usePageStore } from '../store/pageStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
+import { useConnectionStore } from '../store/connectionStore';
+import { usePendingSyncPages, pendingPagesForDoc } from '../store/pendingSyncPages';
 import { useCollaborationStore } from './collaborationStore';
 import type { YjsDocument, ProsePageMeta, CanvasPageMeta } from './YjsDocument';
 
@@ -621,6 +623,86 @@ export function useCollaborationSync(): void {
 
     return unsubscribe;
   }, [isActive, syncCanvasPage, syncDeleteCanvasPage, syncCanvasPageOrder]);
+
+  // JP-335: reconnect handoff for pages created offline (pending-sync). Once the
+  // session has a live, synced, authenticated relay exchange, every pending
+  // page's meta (+ canvas shapes) is (re)emitted into the CRDT and its marker
+  // clears. On the common path (room seeded/adopted, `initializedRef` true) the
+  // page-list subscriptions above already put the meta in the Y.Doc and the
+  // bridge captured shapes as they were drawn — the re-emit is an idempotent
+  // no-op and this effect just clears markers. On the un-adopted edge (empty
+  // room offline, subscriptions gated) it's the correctness path: without it the
+  // fragment would sync while the meta never does (an orphaned, list-invisible
+  // page). The prose FRAGMENT itself needs no push — the editor wrote it into
+  // the shared Y.Doc directly (y-prosemirror) and the sync exchange carried it.
+  // `connAuthenticated` is a dep so the handoff re-fires after every reconnect
+  // (`isSynced` does not reset on a transient drop).
+  const connAuthenticated = useConnectionStore((s) => s.status === 'authenticated');
+  useEffect(() => {
+    if (!isActive || !isSynced || !hasProvider || !connAuthenticated) return;
+    const docId = useCollaborationStore.getState().config?.documentId;
+    if (!docId) return;
+    const pendingIds = pendingPagesForDoc(docId);
+    if (pendingIds.length === 0) return;
+    const yjsDoc = getYjsDocument();
+    if (!yjsDoc) return;
+
+    const proseState = useRichTextPagesStore.getState();
+    const pageState = usePageStore.getState();
+    for (const pageId of pendingIds) {
+      const prose = proseState.pages[pageId];
+      if (prose) {
+        const meta: ProsePageMeta = {
+          id: pageId,
+          name: prose.name,
+          order: Math.max(0, proseState.pageOrder.indexOf(pageId)),
+          createdAt: prose.createdAt,
+          modifiedAt: prose.modifiedAt,
+        };
+        if (prose.color !== undefined) meta.color = prose.color;
+        syncProsePage(meta);
+      }
+
+      const canvas = pageState.pages[pageId];
+      if (canvas) {
+        const canvasMeta: CanvasPageMeta = {
+          id: pageId,
+          name: canvas.name,
+          createdAt: canvas.createdAt,
+          modifiedAt: canvas.modifiedAt,
+        };
+        syncCanvasPage(canvasMeta);
+        // Push the page's offline-drawn shapes from the committed pageStore
+        // snapshot (NOT documentStore — the adopt effect may have just cleared
+        // the view). Additive by shape id, so a no-op where the bridge already
+        // captured them live.
+        yjsDoc.seedPageShapes(pageId, Object.values(canvas.shapes), canvas.shapeOrder);
+        // If the pending page is the active one and the adopt effect just
+        // loaded its (previously empty) Y.Doc snapshot into the view, reload it
+        // now that the seed landed.
+        if (pageState.activePageId === pageId) {
+          const snapshot = yjsDoc.rebindActivePage(pageId);
+          runWithProvenance('remote-apply', () => {
+            const store = useDocumentStore.getState();
+            store.clear();
+            if (snapshot.shapes.length > 0) store.addShapes(snapshot.shapes);
+            if (snapshot.order.length > 0) store.reorderShapes(snapshot.order);
+          });
+        }
+      }
+
+      usePendingSyncPages.getState().clearPending(pageId);
+    }
+  }, [
+    isActive,
+    isSynced,
+    hasProvider,
+    connAuthenticated,
+    sessionEpoch,
+    getYjsDocument,
+    syncProsePage,
+    syncCanvasPage,
+  ]);
 }
 
 /**

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -142,7 +142,7 @@ export async function makeAvailableOffline(
   // persistent offline cache as a side effect — that satisfies "body cached".
   const body = await useRelayDocumentStore.getState().loadRelayDocument(record.id);
 
-  // JP-335: also seed the local Y.Doc room from the relay's authoritative
+  // JP-422: also seed the local Y.Doc room from the relay's authoritative
   // sidecar, so a doc that's only ever been "downloaded" (never opened live) can
   // be opened + EDITED offline — not just rendered read-only. Best-effort: a
   // missing sidecar or older relay just leaves the doc read-only offline (the

--- a/src/store/pageStore.ts
+++ b/src/store/pageStore.ts
@@ -9,6 +9,7 @@ import { immer } from 'zustand/middleware/immer';
 import { nanoid } from 'nanoid';
 import { Page, createPage } from '../types/Document';
 import { CANVAS_PAGE_BASE, nextDefaultPageName } from './pageNaming';
+import { isPagePendingSync } from './pendingSyncPages';
 import type { CanvasPageList } from '../collaboration/YjsDocument';
 import { useDocumentStore } from './documentStore';
 import { useSessionStore } from './sessionStore';
@@ -444,14 +445,24 @@ export const usePageStore = create<PageState & PageActions>()(
           }
         }
 
-        // Drop pages the merged set no longer contains (a remote delete).
+        // Drop pages the merged set no longer contains (a remote delete) —
+        // EXCEPT pending-sync pages (JP-335): a page created offline hasn't
+        // reached the relay's list yet, so its absence there is not a delete.
+        // Keep it (and keep it visible in the order); the reconnect handoff
+        // uploads its meta + shapes.
+        const spared = new Set<string>();
         for (const id of Object.keys(draft.pages)) {
           if (!incoming.has(id)) {
+            if (isPagePendingSync(id)) {
+              spared.add(id);
+              continue;
+            }
             delete draft.pages[id];
           }
         }
 
-        draft.pageOrder = [...list.pageOrder];
+        const sparedOrdered = draft.pageOrder.filter((id) => spared.has(id));
+        draft.pageOrder = [...list.pageOrder, ...sparedOrdered];
 
         // Repoint the (client-local) active page if it was pruned. The deleted-
         // active-page case is also covered by the relay's resident-page evict +

--- a/src/store/pendingPagesPrune.test.ts
+++ b/src/store/pendingPagesPrune.test.ts
@@ -1,0 +1,93 @@
+/**
+ * JP-335 — the reconnect page-list prune must SPARE pending-sync pages.
+ *
+ * `applyRemoteProsePageList` / `applyRemoteCanvasPageList` drop local pages
+ * absent from the adopted (relay) list — correct for remote deletes, but a page
+ * created offline is absent because the relay hasn't LEARNED it yet. Pruning it
+ * before the handoff uploads it would destroy the user's offline work.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRichTextPagesStore } from './richTextPagesStore';
+import { usePageStore } from './pageStore';
+import { usePendingSyncPages } from './pendingSyncPages';
+import { createPage } from '../types/Document';
+
+describe('applyRemoteProsePageList — pending-sync spare (JP-335)', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+    useRichTextPagesStore.setState({
+      pages: {
+        synced: { id: 'synced', name: 'Synced', content: '<p>a</p>', order: 0, createdAt: 0, modifiedAt: 0 },
+        stale: { id: 'stale', name: 'Stale', content: '<p>b</p>', order: 1, createdAt: 0, modifiedAt: 0 },
+        offline: { id: 'offline', name: 'Offline', content: '<p>c</p>', order: 2, createdAt: 0, modifiedAt: 0 },
+      },
+      pageOrder: ['synced', 'stale', 'offline'],
+      activePageId: 'offline',
+    });
+  });
+
+  it('spares a pending page from the prune and keeps it in the order', () => {
+    usePendingSyncPages.getState().markPending('offline', 'doc-1');
+
+    // Relay's list knows only 'synced' — 'stale' is a genuine remote delete,
+    // 'offline' is the pending page the relay hasn't learned yet.
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: { synced: { id: 'synced', name: 'Synced', order: 0, createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+
+    const state = useRichTextPagesStore.getState();
+    expect(state.pages['offline']).toBeDefined();
+    expect(state.pages['offline']?.content).toBe('<p>c</p>');
+    expect(state.pageOrder).toEqual(['synced', 'offline']);
+    // The genuine remote delete still lands.
+    expect(state.pages['stale']).toBeUndefined();
+    // The active page (the spared one) is not repointed away.
+    expect(state.activePageId).toBe('offline');
+  });
+
+  it('prunes the same page normally once its marker is cleared', () => {
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: { synced: { id: 'synced', name: 'Synced', order: 0, createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+    const state = useRichTextPagesStore.getState();
+    expect(state.pages['offline']).toBeUndefined();
+    expect(state.pageOrder).toEqual(['synced']);
+  });
+});
+
+describe('applyRemoteCanvasPageList — pending-sync spare (JP-335)', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+    const synced = createPage('Synced', 'synced');
+    const offline = createPage('Offline', 'offline');
+    usePageStore.setState({
+      pages: { synced, offline },
+      pageOrder: ['synced', 'offline'],
+      activePageId: 'synced',
+    });
+  });
+
+  it('spares a pending canvas page (shapes intact) and keeps it in the order', () => {
+    usePendingSyncPages.getState().markPending('offline', 'doc-1');
+
+    usePageStore.getState().applyRemoteCanvasPageList({
+      pages: { synced: { id: 'synced', name: 'Synced', createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+
+    const state = usePageStore.getState();
+    expect(state.pages['offline']).toBeDefined();
+    expect(state.pageOrder).toEqual(['synced', 'offline']);
+  });
+
+  it('prunes normally without a marker', () => {
+    usePageStore.getState().applyRemoteCanvasPageList({
+      pages: { synced: { id: 'synced', name: 'Synced', createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+    expect(usePageStore.getState().pages['offline']).toBeUndefined();
+  });
+});

--- a/src/store/pendingSyncPages.test.ts
+++ b/src/store/pendingSyncPages.test.ts
@@ -1,0 +1,101 @@
+/**
+ * JP-335 — pending-sync page markers + the REST body-withhold.
+ *
+ * The withhold is the double-safety keystone: a pending page's HTML must never
+ * reach the relay's stored JSON (its sole-seeder hydration would mint a
+ * deterministic prose lineage that merge-doubles against the client's live
+ * fragment — the JP-282 class).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  usePendingSyncPages,
+  isPagePendingSync,
+  pendingPagesForDoc,
+  withholdPendingProseFromBody,
+} from './pendingSyncPages';
+import type { DiagramDocument } from '../types/Document';
+
+function docWithProse(pages: Record<string, string>): DiagramDocument {
+  return {
+    id: 'doc-1',
+    name: 'Doc',
+    pages: {},
+    pageOrder: [],
+    activePageId: null,
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 2,
+    richTextPages: {
+      pages: Object.fromEntries(
+        Object.entries(pages).map(([id, content]) => [
+          id,
+          { id, name: id, content, order: 0, createdAt: 0, modifiedAt: 0 },
+        ]),
+      ),
+      pageOrder: Object.keys(pages),
+      activePageId: Object.keys(pages)[0] ?? null,
+    },
+  } as unknown as DiagramDocument;
+}
+
+describe('pendingSyncPages store', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+  });
+
+  it('marks, queries, and clears per page', () => {
+    usePendingSyncPages.getState().markPending('p1', 'doc-1');
+    usePendingSyncPages.getState().markPending('p2', 'doc-2');
+
+    expect(isPagePendingSync('p1')).toBe(true);
+    expect(isPagePendingSync('nope')).toBe(false);
+    expect(pendingPagesForDoc('doc-1')).toEqual(['p1']);
+
+    usePendingSyncPages.getState().clearPending('p1');
+    expect(isPagePendingSync('p1')).toBe(false);
+    expect(pendingPagesForDoc('doc-1')).toEqual([]);
+  });
+
+  it('clearDoc drops only that doc’s markers', () => {
+    usePendingSyncPages.getState().markPending('p1', 'doc-1');
+    usePendingSyncPages.getState().markPending('p2', 'doc-2');
+    usePendingSyncPages.getState().clearDoc('doc-1');
+    expect(isPagePendingSync('p1')).toBe(false);
+    expect(isPagePendingSync('p2')).toBe(true);
+  });
+});
+
+describe('withholdPendingProseFromBody', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+  });
+
+  it('blanks a pending page’s content but keeps its meta/tab', () => {
+    usePendingSyncPages.getState().markPending('new-page', 'doc-1');
+    const doc = docWithProse({ 'new-page': '<p>offline words</p>', stable: '<p>synced</p>' });
+
+    const out = withholdPendingProseFromBody(doc);
+
+    expect(out.richTextPages?.pages['new-page']?.content).toBe('');
+    // Meta survives — the tab must not vanish from the body.
+    expect(out.richTextPages?.pages['new-page']?.name).toBe('new-page');
+    expect(out.richTextPages?.pageOrder).toContain('new-page');
+    // Non-pending pages are untouched.
+    expect(out.richTextPages?.pages['stable']?.content).toBe('<p>synced</p>');
+    // Input is not mutated.
+    expect(doc.richTextPages?.pages['new-page']?.content).toBe('<p>offline words</p>');
+  });
+
+  it('returns the input unchanged when nothing is pending', () => {
+    const doc = docWithProse({ a: '<p>x</p>' });
+    expect(withholdPendingProseFromBody(doc)).toBe(doc);
+  });
+
+  it('content flows again once the marker clears', () => {
+    usePendingSyncPages.getState().markPending('new-page', 'doc-1');
+    const doc = docWithProse({ 'new-page': '<p>offline words</p>' });
+    usePendingSyncPages.getState().clearPending('new-page');
+    expect(withholdPendingProseFromBody(doc)).toBe(doc);
+  });
+});

--- a/src/store/pendingSyncPages.ts
+++ b/src/store/pendingSyncPages.ts
@@ -1,0 +1,110 @@
+/**
+ * Pending-sync pages (JP-335) — pages created locally while their relay-backed
+ * doc was OFFLINE, not yet handed to the relay. Transient sync bookkeeping,
+ * deliberately NOT a document-format field: it must never leak into the body
+ * the relay stores, and it needs no migration chain (mirrors the
+ * shapePickerStore isolation rationale). Persisted so an offline reload keeps
+ * protecting the page.
+ *
+ * What the marker drives:
+ *  - **Editability** (DocumentEditorPanel): an empty never-synced prose
+ *    fragment is normally read-only (relay is the sole seeder, JP-284). A
+ *    pending page is editable — its id is fresh, so its `prose:<id>` fragment
+ *    exists nowhere else and cannot double on a later merge.
+ *  - **Prune-spare** (applyRemote*PageList): reconnect page-list adoption must
+ *    not delete a page the relay hasn't learned about yet.
+ *  - **Body-withhold** (persistenceStore): REST bodies serialize a pending
+ *    page's content as '' so a queued replay can never make the relay's
+ *    JSON-hydration seeder mint a competing prose lineage (the JP-282 double).
+ *
+ * Cleared by the reconnect handoff (useCollaborationSync) once a live synced
+ * exchange has carried the page's meta + content to the relay.
+ *
+ * Keyed by pageId alone: page ids are nanoids, globally unique across docs, so
+ * consumers (store-level prune, body serialization) don't need doc context.
+ * The docId value exists for doc-scoped enumeration by the handoff.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { DiagramDocument } from '../types/Document';
+
+export interface PendingSyncPagesState {
+  /** pageId → docId it was created in. */
+  pending: Record<string, string>;
+  /** Mark a page as created-offline, awaiting relay handoff. */
+  markPending: (pageId: string, docId: string) => void;
+  /** Clear one page's marker (handoff complete, or page deleted locally). */
+  clearPending: (pageId: string) => void;
+  /** Clear every marker for a doc (doc deleted / transferred). */
+  clearDoc: (docId: string) => void;
+}
+
+export const usePendingSyncPages = create<PendingSyncPagesState>()(
+  persist(
+    (set) => ({
+      pending: {},
+      markPending: (pageId, docId) =>
+        set((state) => ({ pending: { ...state.pending, [pageId]: docId } })),
+      clearPending: (pageId) =>
+        set((state) => {
+          if (!(pageId in state.pending)) return state;
+          const next = { ...state.pending };
+          delete next[pageId];
+          return { pending: next };
+        }),
+      clearDoc: (docId) =>
+        set((state) => ({
+          pending: Object.fromEntries(
+            Object.entries(state.pending).filter(([, d]) => d !== docId),
+          ),
+        })),
+    }),
+    {
+      name: 'docushark-pending-sync-pages',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ pending: state.pending }),
+    },
+  ),
+);
+
+/** Non-reactive: is this page awaiting relay handoff? */
+export function isPagePendingSync(pageId: string): boolean {
+  return pageId in usePendingSyncPages.getState().pending;
+}
+
+/** Non-reactive: all pending page ids belonging to `docId`. */
+export function pendingPagesForDoc(docId: string): string[] {
+  return Object.entries(usePendingSyncPages.getState().pending)
+    .filter(([, d]) => d === docId)
+    .map(([pageId]) => pageId);
+}
+
+/**
+ * The body-withhold (JP-335): return `doc` with every pending-sync prose page's
+ * `content` blanked, for REST-bound bodies (queue replay or live push). If a
+ * pending page's HTML landed in the relay's stored JSON, the sole-seeder
+ * hydration (`json_prose_to_ydoc`) would mint a deterministic prose lineage
+ * that merge-DOUBLES against the client's live fragment (the JP-282 class);
+ * empty content is skipped by that seeder, closing the hole. The page's meta
+ * stays in the body (tab survives); canvas shapes need no withholding (id-keyed
+ * map — merges by key, no dup). Returns the input unchanged when nothing is
+ * pending. Local caches must keep the FULL body — apply this only at the REST
+ * boundary.
+ */
+export function withholdPendingProseFromBody(doc: DiagramDocument): DiagramDocument {
+  const rtp = doc.richTextPages;
+  if (!rtp) return doc;
+  const { pending } = usePendingSyncPages.getState();
+  const withheld = Object.keys(rtp.pages).filter((id) => {
+    const page = rtp.pages[id];
+    return id in pending && page !== undefined && page.content !== '';
+  });
+  if (withheld.length === 0) return doc;
+  const pages = { ...rtp.pages };
+  for (const id of withheld) {
+    const page = pages[id];
+    if (page) pages[id] = { ...page, content: '' };
+  }
+  return { ...doc, richTextPages: { ...rtp, pages } };
+}

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -22,6 +22,7 @@ import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
+import { withholdPendingProseFromBody } from './pendingSyncPages';
 import { useReferenceStore } from './referenceStore';
 import { useFieldStore } from './fieldStore';
 import { useUserStore } from './userStore';
@@ -188,11 +189,18 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     return;
   }
 
+  // JP-335: pages created offline in a shared doc (pending-sync) must reach the
+  // relay over CRDT only — blank their HTML in any REST-bound body (queued
+  // replay or live push). The local cache put keeps the FULL body so the doc
+  // still opens offline with its content; the relay's own flatten writes the
+  // real HTML from its fragment once the CRDT handoff completes.
+  const restDoc = withholdPendingProseFromBody(doc);
+
   const queueForReplay = (reason: string): void => {
     void RelayDocumentCache.put(doc, homeRelayId, activeWorkspaceId()).catch((e) =>
       console.error('[persistenceStore] Failed to cache relay edit:', e),
     );
-    getSyncStateManager().queueSave(doc, homeRelayId);
+    getSyncStateManager().queueSave(restDoc, homeRelayId);
     console.warn(
       `[persistenceStore] ${reason} — cached + queued relay save under ${homeRelayId} for replay (${context})`,
     );
@@ -212,7 +220,7 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     return;
   }
 
-  relayStore.saveToHost(doc).catch((err) => {
+  relayStore.saveToHost(restDoc).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     const status = (err as { status?: unknown }).status;
 

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -171,7 +171,7 @@ export interface DocumentProvider {
   listRecoveryPoints?(docId: string): Promise<RelayRecoveryPoint[]>;
   getRecoveryPointContent?(docId: string, pointId: string): Promise<DiagramDocument>;
   /**
-   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (raw
+   * JP-422: fetch a document's authoritative binary Y.Doc sidecar (raw
    * lib0-v1 full-state bytes) so it can be seeded into the local Y.Doc room for
    * offline editing. Optional so non-REST providers opt out; null = no sidecar.
    */

--- a/src/store/richTextPagesStore.ts
+++ b/src/store/richTextPagesStore.ts
@@ -15,6 +15,7 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { PROSE_PAGE_BASE, nextDefaultPageName } from './pageNaming';
+import { isPagePendingSync } from './pendingSyncPages';
 import type { ProsePageList } from '../collaboration/YjsDocument';
 
 /**
@@ -297,14 +298,24 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
           draft.pages[id] = page;
         });
 
-        // Drop pages the merged set no longer contains (a remote delete).
+        // Drop pages the merged set no longer contains (a remote delete) —
+        // EXCEPT pending-sync pages (JP-335): a page created offline hasn't
+        // reached the relay's list yet, so its absence there is not a delete.
+        // Keep it (and keep it visible in the order); the reconnect handoff
+        // uploads its meta + content.
+        const spared = new Set<string>();
         for (const id of Object.keys(draft.pages)) {
           if (!incoming.has(id)) {
+            if (isPagePendingSync(id)) {
+              spared.add(id);
+              continue;
+            }
             delete draft.pages[id];
           }
         }
 
-        draft.pageOrder = [...list.pageOrder];
+        const sparedOrdered = draft.pageOrder.filter((id) => spared.has(id));
+        draft.pageOrder = [...list.pageOrder, ...sparedOrdered];
 
         // Repoint the (client-local) active page if it was pruned.
         if (!draft.activePageId || !draft.pages[draft.activePageId]) {

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -21,6 +21,7 @@ import { TiptapEditor } from './TiptapEditor';
 import { TiptapEditorProvider } from './TiptapEditorContext';
 import { RichTextTabBar } from './RichTextTabBar';
 import { useRichTextPagesStore, initializeRichTextPages } from '../store/richTextPagesStore';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
 import { useRichTextStore } from '../store/richTextStore';
 import { useSessionStore } from '../store/sessionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
@@ -159,13 +160,22 @@ export function DocumentEditorPanel({
   // doc with prose reads non-empty here even offline.
   const fragHasContent =
     !!collabYdoc && !!proseField && collabYdoc.getXmlFragment(proseField).length > 0;
+  // A page created offline in this shared doc, awaiting relay handoff (JP-335).
+  // Its `prose:<id>` fragment is empty and never-synced, but editing it is safe:
+  // the page id is fresh, so the fragment exists nowhere else — no competing
+  // lineage to merge-double with (and the body-withhold keeps the relay's JSON
+  // seeder from ever minting one).
+  const activePagePending = usePendingSyncPages((s) =>
+    activePageId ? activePageId in s.pending : false,
+  );
   // Editable when the engine is live AND the fragment is established. NOT gated on
   // the live connection — prose stays editable offline (offline-first). The relay
   // is the sole seeder (JP-284), so `collabSynced` adds the first-online-open case
   // (relay confirmed its state → adopt + edit an empty fragment). A never-synced
-  // empty fragment stays read-only (ProsePreview) — there's nothing to adopt yet.
+  // empty fragment stays read-only (ProsePreview) — there's nothing to adopt yet —
+  // UNLESS it's a pending-sync page created offline (JP-335, above).
   const proseEditable =
-    engineReady && (fragHasContent || collabSynced);
+    engineReady && (fragHasContent || collabSynced || activePagePending);
   // Mount the live collab editor whenever the engine + fragment are ready. We do
   // NOT pre-screen the fragment's schema validity: y-prosemirror builds the doc
   // the same way the editor does, so any "fits-to-schema" build a screen could do

--- a/src/ui/InlinePageTabs.tsx
+++ b/src/ui/InlinePageTabs.tsx
@@ -12,8 +12,9 @@ import { PageTabStrip, type PageTabStripItem } from './components/PageTabStrip';
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
-import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
-import { useNotificationStore } from '../store/notificationStore';
+import { sharedDocOffline } from '../collaboration/sharedDocOffline';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
+import { usePersistenceStore } from '../store/persistenceStore';
 
 /**
  * Context menu state for page tabs.
@@ -62,19 +63,16 @@ export function InlinePageTabs() {
     [setActivePage, editingPageId]
   );
 
-  const sharedOffline = useSharedDocOffline();
-
-  // Blocked while a shared doc is offline (JP-334): the relay is active-page-only,
-  // so a new offline page's shapes never reach its flatten and are lost on
-  // reconnect. Enabling offline creation is JP-335.
+  // Allowed offline (JP-335): a canvas page created while the shared doc is
+  // offline is marked pending-sync — spared from the reconnect page-list prune
+  // and handed to the relay (meta + shapes) by the reconnect handoff
+  // (useCollaborationSync).
   const handleAddPage = useCallback(() => {
-    if (sharedDocOffline()) {
-      useNotificationStore
-        .getState()
-        .warning('This shared document is offline — reconnect to add pages.');
-      return;
-    }
     const newPageId = createPage();
+    if (sharedDocOffline()) {
+      const docId = usePersistenceStore.getState().currentDocumentId;
+      if (docId) usePendingSyncPages.getState().markPending(newPageId, docId);
+    }
     setActivePage(newPageId);
     useHistoryStore.getState().setActivePage(newPageId);
   }, [createPage, setActivePage]);
@@ -202,8 +200,6 @@ export function InlinePageTabs() {
           );
         }}
         onAdd={handleAddPage}
-        addDisabled={sharedOffline}
-        addTitle={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add page'}
       />
 
       {/* Context Menu */}

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -16,8 +16,9 @@ import { Icon } from './icons';
 import { createPortal } from 'react-dom';
 import { PageTabStrip, type PageTabStripItem } from './components/PageTabStrip';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
-import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
-import { useNotificationStore } from '../store/notificationStore';
+import { sharedDocOffline } from '../collaboration/sharedDocOffline';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
+import { usePersistenceStore } from '../store/persistenceStore';
 import './RichTextTabBar.css';
 
 interface RichTextTabBarProps {
@@ -150,19 +151,17 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
     });
   }, []);
 
-  const sharedOffline = useSharedDocOffline();
-
-  // Handle add new page. Blocked while a shared doc is offline (JP-334): a new
-  // prose page can't be seeded offline without risking dual-lineage duplication
-  // (the relay is the sole seeder, JP-284). Enabling offline creation is JP-335.
+  // Handle add new page. Allowed offline (JP-335): a page created while the
+  // shared doc is offline is marked pending-sync — editable immediately (its
+  // fresh id means its fragment can't collide with anything), spared from the
+  // reconnect page-list prune, and handed to the relay by the reconnect handoff
+  // (useCollaborationSync).
   const handleAddPage = useCallback(() => {
-    if (sharedDocOffline()) {
-      useNotificationStore
-        .getState()
-        .warning('This shared document is offline — reconnect to add pages.');
-      return;
-    }
     const newId = createPage();
+    if (sharedDocOffline()) {
+      const docId = usePersistenceStore.getState().currentDocumentId;
+      if (docId) usePendingSyncPages.getState().markPending(newId, docId);
+    }
     setActivePage(newId);
   }, [createPage, setActivePage]);
 
@@ -282,8 +281,6 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
           );
         }}
         onAdd={handleAddPage}
-        addDisabled={sharedOffline}
-        addTitle={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add new page'}
       />
 
       {/* Context menu */}

--- a/src/ui/StatusBar.connchip.test.tsx
+++ b/src/ui/StatusBar.connchip.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 
 let offline = false;
-vi.mock('../collaboration/offlinePageGuard', () => ({
+vi.mock('../collaboration/sharedDocOffline', () => ({
   useSharedDocOffline: () => offline,
 }));
 

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -12,7 +12,7 @@ import { WifiOff, RefreshCw } from 'lucide-react';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useConnectionStore } from '../store/connectionStore';
-import { useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useSharedDocOffline } from '../collaboration/sharedDocOffline';
 import { calculateCombinedBounds } from '../shapes/utils/bounds';
 import { Icon } from './icons';
 import './StatusBar.css';


### PR DESCRIPTION
## Problem

Creating a new page while a relay-backed (shared) doc is offline was blocked by the JP-334 guard: a never-synced empty `prose:<id>` fragment is read-only by design (relay is the sole seeder, JP-284), and seeding it was assumed to risk the JP-282 dual-lineage duplication.

## Why it's safe now (the design)

A brand-new page's id is fresh — its fragment exists nowhere else, so the client's offline-typed lineage merges cleanly as the **sole** lineage on reconnect. The only way to double is if the relay *independently* seeds the same page from stored JSON (`json_prose_to_ydoc`). Two mechanisms guarantee it never can:

1. **Existing:** the collab body-save suppression (`isCollabContentDoc`, JP-108) — while the doc is open in a session, no REST body reaches the relay at all.
2. **New (the keystone):** a **body-withhold** — every REST-bound body (queued replay or live push) serializes a pending page's `content` as `''` (the relay's seeder skips empty content). This closes the save-time gap where a queued save could fire after the session moved on.

CRDT-native throughout: no local-HTML editor fork, no cross-impl seeder, **no relay changes**.

## Changes

- **`pendingSyncPages` store (new):** ephemeral persisted marker (`pageId → docId`) for pages created while the shared doc is offline. Deliberately not a doc-format field — sync bookkeeping must not leak into the stored body (and needs no migration).
- **Guard removed:** `RichTextTabBar` / `InlinePageTabs` create + mark instead of block; `PageTabStrip` dimming dropped. `offlinePageGuard.ts` → `sharedDocOffline.ts` (the predicate survives for the StatusBar offline chip + marking).
- **Editability:** `proseEditable` admits a pending page, mounting `CollaborativeProseEditor` on the empty fragment (offline typing goes straight into the local Y.Doc / y-indexeddb).
- **Prune-spare:** `applyRemoteProsePageList` / `applyRemoteCanvasPageList` keep pending pages absent from the adopted relay list — absence isn't a delete for a page the relay hasn't learned yet. Genuine remote deletes still land.
- **Reconnect handoff** (`useCollaborationSync`): on a live synced+authenticated exchange, re-emit pending pages' metas into the CRDT page lists (covers the un-adopted edge where the gated subscriptions never saw the creation — prevents an orphaned, list-invisible page), push a pending canvas page's committed shapes via the new `YjsDocument.seedPageShapes` (additive per-id sets; order only-when-empty; never a `clear` — the seedClobber hazard), then clear markers. Re-fires per reconnect via a connection-status dep (`isSynced` doesn't reset on transient drops).

## Tests

- Marker store + body-withhold round-trip (blank while pending, flows after clear, meta/tab preserved).
- Prune-spare in both stores, with genuine-delete controls.
- Handoff: emit metas + seed shapes + clear markers on a synced session; no handoff while offline (markers persist).
- JP-335 single-lineage repro + a leaky-relay control appended to `proseReseedDuplication.test.ts` (documents exactly what the withhold prevents).
- Full vitest **2840 green**; typecheck clean; `proseWriteBoundary` / `seedClobber` untouched and green. Relay unchanged (no cargo surface).

## Remaining

Full-stack E2E on a deploy: offline → create prose + canvas page → type/draw → reconnect → both survive with content, no dup/loss, second client sees them. The un-adopted edge (cached body but empty local room — pre-JP-422 caches or sidecar-404) stays read-only for prose as before; page existence is still protected there.

Assisted-by: Fable 5