### PR TITLE
JP-424: Collections durability — versioned PUT, atomic writes, reconcile prune

### DIFF
--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -307,7 +307,10 @@ paths:
         - bearerAuth: []
       responses:
         '200':
-          description: Collection definitions (id/name/colour/order), sorted by order.
+          description: |
+            Collection definitions (id/name/colour/order), sorted by order,
+            plus the registry version for the optimistic-concurrency
+            handshake on PUT.
           content:
             application/json:
               schema:
@@ -317,6 +320,10 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/CollectionDef'
+                  version:
+                    type: integer
+                    format: int64
+                    description: Registry version; bumps on every accepted PUT.
     put:
       tags: [docs]
       summary: Replace the workspace's collection definitions (wholesale)
@@ -324,6 +331,12 @@ paths:
         The editor owns the definition set and replaces it whole. Definitions
         are presentation metadata (name/colour/order), not membership — a
         document's membership is set via PUT /api/docs/{id}/collection.
+        Duplicate ids are healed keep-first; structural violations (empty or
+        oversized name/id/colour, more than 200 collections) are rejected
+        with 400. When `expectedVersion` is present the write is conditional
+        on the current registry version — a mismatch returns 409 with the
+        current state so the caller can rebase; omitted, the write is an
+        unconditional replace (legacy clients).
       security:
         - bearerAuth: []
       requestBody:
@@ -338,9 +351,32 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/CollectionDef'
+                expectedVersion:
+                  type: integer
+                  format: int64
+                  description: |
+                    The registry version this replace was computed against
+                    (from GET). Mismatch ⇒ 409, nothing written.
       responses:
         '200':
           description: Definitions replaced.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  newVersion:
+                    type: integer
+                    format: int64
+        '400':
+          description: Definition set failed validation.
+        '409':
+          description: |
+            `expectedVersion` no longer matches. Body carries
+            `errorCode: VERSION_CONFLICT`, `currentVersion`, and the current
+            `collections` set to rebase onto.
 
   /api/collections/{id}/documents:
     parameters:

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -24,7 +24,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::auth::{OidcClaims, WorkspaceRole};
-use crate::server::documents::{CollectionDef, SaveOutcome};
+use crate::server::documents::{
+    sanitize_collection_defs, CollectionDef, SaveOutcome, SetCollectionsOutcome,
+};
 use crate::server::protocol::ShareEntry;
 use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
@@ -335,11 +337,36 @@ struct CollectionMembershipRequest {
     collection_id: Option<String>,
 }
 
-/// Body of `PUT /api/collections` and response of `GET /api/collections`. The
-/// editor owns the definition set and replaces it wholesale.
-#[derive(Debug, Serialize, Deserialize)]
+/// Response of `GET /api/collections`: the definition set plus the registry
+/// version for the optimistic-concurrency handshake (JP-424). Pre-JP-424
+/// clients ignore the extra field.
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct CollectionsBody {
+struct CollectionsResponse {
+    collections: Vec<CollectionDef>,
+    version: u64,
+}
+
+/// Body of `PUT /api/collections`. The editor owns the definition set and
+/// replaces it wholesale. `expectedVersion` (JP-424) makes the write
+/// conditional on the current registry version — absent, the write is the
+/// legacy unconditional replace (pre-JP-424 clients).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetCollectionsRequest {
+    collections: Vec<CollectionDef>,
+    expected_version: Option<u64>,
+}
+
+/// 409 body for a conflicting `PUT /api/collections` (JP-424). Same
+/// `errorCode`/`currentVersion` keys as the doc-save [`VersionConflictBody`]
+/// so clients type it identically; `collections` carries the current set for
+/// consumers that want to rebase without another GET.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionsConflictBody {
+    error_code: &'static str,
+    current_version: u64,
     collections: Vec<CollectionDef>,
 }
 
@@ -1575,18 +1602,23 @@ async fn list_collections_handler(
         Err(resp) => return resp,
     };
     state.ensure_workspace_collections_local(&ws).await;
-    let collections = state.doc_store().list_collections(&ws);
-    (StatusCode::OK, Json(CollectionsBody { collections })).into_response()
+    let (collections, version) = state.doc_store().collections_snapshot(&ws);
+    (StatusCode::OK, Json(CollectionsResponse { collections, version })).into_response()
 }
 
 /// `PUT /api/collections` — replace the workspace's collection definitions
 /// wholesale (the editor owns the set). Definitions are presentation metadata,
 /// not membership, so a member-level session may update them; cross-workspace is
-/// already impossible (the set is keyed by the JWT's workspace).
+/// already impossible (the set is keyed by the JWT's workspace). JP-424: the
+/// write is validated (`sanitize_collection_defs` → 400) and, when the body
+/// carries `expectedVersion`, conditional on the registry version (→ 409 with
+/// the current state on mismatch). The registry is hydrated from R2 first so a
+/// cold machine neither spuriously conflicts against version 0 nor blind-writes
+/// over a mirrored set it never loaded.
 async fn set_collections_handler(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
-    Json(body): Json<CollectionsBody>,
+    Json(body): Json<SetCollectionsRequest>,
 ) -> impl IntoResponse {
     let claims = match require_auth(&state, &headers).await {
         Ok(c) => c,
@@ -1596,10 +1628,28 @@ async fn set_collections_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
-    if let Err(e) = state.doc_store().set_collections(&ws, body.collections) {
-        return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response();
+    state.ensure_workspace_collections_local(&ws).await;
+    let defs = match sanitize_collection_defs(body.collections) {
+        Ok(defs) => defs,
+        Err(e) => return (StatusCode::BAD_REQUEST, ApiError::body(e)).into_response(),
+    };
+    match state.doc_store().set_collections(&ws, defs, body.expected_version) {
+        Ok(SetCollectionsOutcome::Updated { version }) => (
+            StatusCode::OK,
+            Json(SaveAck { success: true, new_version: version }),
+        )
+            .into_response(),
+        Ok(SetCollectionsOutcome::VersionConflict { current_version, current }) => (
+            StatusCode::CONFLICT,
+            Json(CollectionsConflictBody {
+                error_code: "VERSION_CONFLICT",
+                current_version,
+                collections: current,
+            }),
+        )
+            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
     }
-    (StatusCode::OK, Json(WriteAck { success: true })).into_response()
 }
 
 // ============ Helpers ============

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -5,13 +5,52 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
 use super::blob_backend::DocObjectStore;
 use super::protocol::{DocId, WorkspaceId};
+
+/// Crash-safe file write (JP-424): write to a sibling temp file in the same
+/// directory (same filesystem — required for an atomic `rename`), fsync, then
+/// rename over the destination. A crash mid-write leaves only a stray temp
+/// file, never a torn destination — load paths that treat a malformed file as
+/// empty (e.g. the collections registry) can't be tripped by a partial write.
+/// The temp suffix is unique per process+call because writers of the *same*
+/// path (doc saves) are not serialized by any per-doc lock. Directory fsync is
+/// deliberately skipped: the worst post-crash case is "rename not yet durable"
+/// (file absent), the same exposure as a plain write, and the R2 mirror
+/// restore path covers it.
+fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let dir = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "file".to_string());
+    let tmp = dir.join(format!(
+        ".{}.tmp-{}-{}",
+        file_name,
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let result = (|| {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
 
 /// A document-mirror operation enqueued for the background R2 worker (JP-200).
 /// Writes stay synchronous against the local volume; the worker re-reads the
@@ -62,6 +101,96 @@ pub struct CollectionDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     pub order: i64,
+}
+
+/// In-memory per-workspace collections registry: the defs plus a monotonic
+/// version bumped on every accepted write (JP-424). The version backs the
+/// optimistic-concurrency check on `PUT /api/collections`, closing the
+/// lost-update window between two clients' read-modify-write cycles.
+#[derive(Debug, Clone, Default)]
+pub struct CollectionsRegistry {
+    pub version: u64,
+    pub defs: Vec<CollectionDef>,
+}
+
+/// On-disk shape of `collections.json` (JP-424): a version wrapper around the
+/// defs. Legacy files are a bare `[CollectionDef]` array — the loader accepts
+/// both (bare array ⇒ version 0) and the next accepted write rewrites the file
+/// in wrapper form.
+#[derive(Debug, Serialize, Deserialize)]
+struct CollectionsFile {
+    version: u64,
+    collections: Vec<CollectionDef>,
+}
+
+/// Parse `collections.json` content in either shape: the JP-424 version
+/// wrapper, or the legacy bare `[CollectionDef]` array (⇒ version 0). `None`
+/// when neither shape parses.
+fn parse_collections_file(data: &str) -> Option<CollectionsRegistry> {
+    if let Ok(file) = serde_json::from_str::<CollectionsFile>(data) {
+        return Some(CollectionsRegistry { version: file.version, defs: file.collections });
+    }
+    let defs = serde_json::from_str::<Vec<CollectionDef>>(data).ok()?;
+    Some(CollectionsRegistry { version: 0, defs })
+}
+
+/// Result of a collections-registry write attempt (JP-424) — mirrors the
+/// document-save `SaveOutcome` split so the handler can map a conflict to the
+/// same 409 wire shape.
+#[derive(Debug)]
+pub enum SetCollectionsOutcome {
+    /// The write landed; `version` is the new registry version.
+    Updated { version: u64 },
+    /// `expectedVersion` didn't match — nothing was written. Carries the
+    /// current state so the client can rebase without another GET.
+    VersionConflict { current_version: u64, current: Vec<CollectionDef> },
+}
+
+/// Registry caps enforced on `PUT /api/collections` (JP-424). Generous for
+/// interactive use; they exist to bound the sidecar file, not to police UX.
+pub const MAX_COLLECTIONS_PER_WORKSPACE: usize = 200;
+pub const MAX_COLLECTION_NAME_LEN: usize = 120;
+pub const MAX_COLLECTION_ID_LEN: usize = 64;
+pub const MAX_COLLECTION_COLOR_LEN: usize = 32;
+
+/// Validate + heal an incoming definition set (JP-424): duplicate ids are
+/// deduped keep-first (a heal for client bugs, not a user error); structural
+/// violations — empty/oversized fields or an oversized set — are rejected with
+/// a technical message the handler surfaces as a 400.
+pub fn sanitize_collection_defs(defs: Vec<CollectionDef>) -> Result<Vec<CollectionDef>, String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::with_capacity(defs.len());
+    for def in defs {
+        if !seen.insert(def.id.clone()) {
+            continue;
+        }
+        if def.id.is_empty() || def.id.len() > MAX_COLLECTION_ID_LEN {
+            return Err(format!(
+                "collection id must be 1..={} bytes",
+                MAX_COLLECTION_ID_LEN
+            ));
+        }
+        if def.name.trim().is_empty() || def.name.chars().count() > MAX_COLLECTION_NAME_LEN {
+            return Err(format!(
+                "collection name must be non-empty and at most {} characters",
+                MAX_COLLECTION_NAME_LEN
+            ));
+        }
+        if def.color.as_ref().is_some_and(|c| c.len() > MAX_COLLECTION_COLOR_LEN) {
+            return Err(format!(
+                "collection color exceeds {} bytes",
+                MAX_COLLECTION_COLOR_LEN
+            ));
+        }
+        out.push(def);
+    }
+    if out.len() > MAX_COLLECTIONS_PER_WORKSPACE {
+        return Err(format!(
+            "workspace exceeds {} collections",
+            MAX_COLLECTIONS_PER_WORKSPACE
+        ));
+    }
+    Ok(out)
 }
 
 /// Lightweight metadata for document listing
@@ -287,8 +416,11 @@ pub struct DocumentStore {
     /// Per-workspace collection **definitions** (name/colour/order), loaded from
     /// `workspaces/<ws>/collections.json`. Client-authoritative; the relay stores
     /// them so the web can render collection titles. Membership is not here (it's
-    /// `DocumentMetadata.collection_id`).
-    collections: RwLock<HashMap<WorkspaceId, Vec<CollectionDef>>>,
+    /// `DocumentMetadata.collection_id`). Key presence (even with empty defs)
+    /// means "loaded/probed" — [`ensure_workspace_collections_local`] keys its
+    /// cold-start R2 restore off that, so an emptied registry isn't re-fetched
+    /// (and resurrected) from a stale mirror (JP-424).
+    collections: RwLock<HashMap<WorkspaceId, CollectionsRegistry>>,
     /// JP-200 write-through R2 mirror sink. `Some` enqueues a [`MirrorOp`] after
     /// each successful local write for a background worker to upload; `None`
     /// (self-host / filesystem backend) keeps the store volume-only. The same
@@ -645,10 +777,10 @@ impl DocumentStore {
         let version = doc.get("serverVersion").and_then(|v| v.as_u64()).unwrap_or(0);
 
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.doc_path(ws, &doc_id), json_bytes)
+        write_atomic(&self.doc_path(ws, &doc_id), json_bytes)
             .map_err(|e| format!("restore: write json: {}", e))?;
         if let Some(bin) = ydoc_bytes {
-            std::fs::write(self.ydoc_path(ws, &doc_id), bin)
+            write_atomic(&self.ydoc_path(ws, &doc_id), bin)
                 .map_err(|e| format!("restore: write ydoc: {}", e))?;
         }
 
@@ -734,7 +866,7 @@ impl DocumentStore {
         match store.get_workspace_index(ws).await {
             Ok(Some(bytes)) => {
                 let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-                if std::fs::write(self.index_path(ws), &bytes).is_ok() {
+                if write_atomic(&self.index_path(ws), &bytes).is_ok() {
                     self.load_workspace_index(ws);
                     log::info!("restored index for workspace {} from R2", ws.as_str());
                 }
@@ -820,7 +952,7 @@ impl DocumentStore {
         bytes: &[u8],
     ) -> Result<(), String> {
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.ydoc_path(ws, doc_id), bytes)
+        write_atomic(&self.ydoc_path(ws, doc_id), bytes)
             .map_err(|e| format!("Write error: {}", e))?;
         // JP-231: refresh size/recency. No gen bump — json is the eviction gate;
         // restore is json-authoritative, a lagging ydoc is reconciled on hydrate.
@@ -1071,7 +1203,7 @@ impl DocumentStore {
             .map_err(|e| format!("Serialize error: {}", e))?;
         // Ensure the workspace dir exists before writing.
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.index_path(ws), json)
+        write_atomic(&self.index_path(ws), json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -1098,19 +1230,20 @@ impl DocumentStore {
     fn load_workspace_collections(&self, ws: &WorkspaceId) {
         let path = self.collections_path(ws);
         let Ok(data) = std::fs::read_to_string(&path) else { return };
-        let Ok(parsed) = serde_json::from_str::<Vec<CollectionDef>>(&data) else {
+        let Some(registry) = parse_collections_file(&data) else {
             log::warn!("collections for workspace {} are malformed — leaving empty", ws.as_str());
             return;
         };
         if let Ok(mut current) = self.collections.write() {
-            current.insert(ws.clone(), parsed);
+            current.insert(ws.clone(), registry);
         }
     }
 
-    /// Snapshot the in-memory definitions for a workspace and write them to disk.
-    /// A wholesale replace (the client PUTs the full set), so unlike the index
-    /// there's no per-entry merge race; the `index_write_lock` still serializes
-    /// concurrent file writes for this workspace's sidecars.
+    /// Snapshot the in-memory registry for a workspace and write it to disk in
+    /// the version-wrapper shape. A wholesale replace (the client PUTs the full
+    /// set), so unlike the index there's no per-entry merge race; the
+    /// `index_write_lock` still serializes concurrent file writes for this
+    /// workspace's sidecars.
     fn write_workspace_collections_file(&self, ws: &WorkspaceId) -> Result<(), String> {
         let _guard = self
             .index_write_lock
@@ -1120,10 +1253,11 @@ impl DocumentStore {
             let collections = self.collections.read().map_err(|e| e.to_string())?;
             collections.get(ws).cloned().unwrap_or_default()
         };
-        let json = serde_json::to_string_pretty(&snapshot)
+        let file = CollectionsFile { version: snapshot.version, collections: snapshot.defs };
+        let json = serde_json::to_string_pretty(&file)
             .map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws));
-        std::fs::write(self.collections_path(ws), json)
+        write_atomic(&self.collections_path(ws), json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -1136,26 +1270,71 @@ impl DocumentStore {
 
     /// List a workspace's collection definitions (sorted by `order`).
     pub fn list_collections(&self, ws: &WorkspaceId) -> Vec<CollectionDef> {
-        let mut defs = self
+        self.collections_snapshot(ws).0
+    }
+
+    /// A workspace's definitions (sorted by `order`) plus the registry version,
+    /// for the GET handler's optimistic-concurrency handshake (JP-424).
+    pub fn collections_snapshot(&self, ws: &WorkspaceId) -> (Vec<CollectionDef>, u64) {
+        let registry = self
             .collections
             .read()
             .ok()
             .and_then(|c| c.get(ws).cloned())
             .unwrap_or_default();
+        let mut defs = registry.defs;
         defs.sort_by_key(|c| c.order);
-        defs
+        (defs, registry.version)
+    }
+
+    /// Whether a workspace's registry has been loaded or probed (key presence —
+    /// an empty entry counts). Gates the cold-start R2 restore so an emptied
+    /// registry isn't re-fetched from a stale mirror (JP-424).
+    pub fn has_workspace_collections_loaded(&self, ws: &WorkspaceId) -> bool {
+        self.collections.read().ok().is_some_and(|c| c.contains_key(ws))
+    }
+
+    /// Ensure a workspace has an in-memory registry entry (default empty, v0).
+    /// Called once the cold-start restore attempt has run — hit or miss — so
+    /// repeated reads don't re-probe R2.
+    pub fn memoize_collections_probe(&self, ws: &WorkspaceId) {
+        if let Ok(mut current) = self.collections.write() {
+            current.entry(ws.clone()).or_default();
+        }
     }
 
     /// Replace a workspace's collection definitions wholesale (the editor owns
-    /// the set and PUTs it whole). Persists locally and mirrors to R2.
-    pub fn set_collections(&self, ws: &WorkspaceId, defs: Vec<CollectionDef>) -> Result<(), String> {
-        {
+    /// the set and PUTs it whole). When `expected` is `Some`, the write only
+    /// lands if it matches the current registry version (optimistic concurrency,
+    /// JP-424) — a mismatch returns the current state for the client to rebase
+    /// onto. `None` preserves the legacy blind write. Every accepted write bumps
+    /// the version, persists locally, and mirrors to R2.
+    pub fn set_collections(
+        &self,
+        ws: &WorkspaceId,
+        defs: Vec<CollectionDef>,
+        expected: Option<u64>,
+    ) -> Result<SetCollectionsOutcome, String> {
+        let version = {
             let mut current = self.collections.write().map_err(|e| e.to_string())?;
-            current.insert(ws.clone(), defs);
-        }
+            let entry = current.entry(ws.clone()).or_default();
+            if let Some(expected) = expected {
+                if expected != entry.version {
+                    let mut defs = entry.defs.clone();
+                    defs.sort_by_key(|c| c.order);
+                    return Ok(SetCollectionsOutcome::VersionConflict {
+                        current_version: entry.version,
+                        current: defs,
+                    });
+                }
+            }
+            entry.version += 1;
+            entry.defs = defs;
+            entry.version
+        };
         self.write_workspace_collections_file(ws)?;
         self.enqueue_mirror(MirrorOp::PutCollections { ws: ws.clone() });
-        Ok(())
+        Ok(SetCollectionsOutcome::Updated { version })
     }
 
     /// Restore a workspace's collection definitions from R2 on a cold machine
@@ -1168,7 +1347,7 @@ impl DocumentStore {
         match store.get_workspace_collections(ws).await {
             Ok(Some(bytes)) => {
                 let _ = std::fs::create_dir_all(self.workspace_root(ws));
-                if std::fs::write(self.collections_path(ws), &bytes).is_ok() {
+                if write_atomic(&self.collections_path(ws), &bytes).is_ok() {
                     self.load_workspace_collections(ws);
                     log::info!("restored collections for workspace {} from R2", ws.as_str());
                 }
@@ -1230,7 +1409,7 @@ impl DocumentStore {
         let json = serde_json::to_string_pretty(&snapshot)
             .map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws));
-        std::fs::write(self.deleted_ids_path(ws), json)
+        write_atomic(&self.deleted_ids_path(ws), json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -1327,7 +1506,7 @@ impl DocumentStore {
         match store.get_workspace_deleted_ids(ws).await {
             Ok(Some(bytes)) => {
                 let _ = std::fs::create_dir_all(self.workspace_root(ws));
-                if std::fs::write(self.deleted_ids_path(ws), &bytes).is_ok() {
+                if write_atomic(&self.deleted_ids_path(ws), &bytes).is_ok() {
                     self.load_workspace_deleted_ids(ws);
                     log::info!("restored tombstones for workspace {} from R2", ws.as_str());
                 }
@@ -1552,7 +1731,7 @@ impl DocumentStore {
         // Ensure the per-workspace docs dir exists (first-touch for a
         // new tenant on shared-mode Cloud).
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.doc_path(ws, &doc_id), doc_json)
+        write_atomic(&self.doc_path(ws, &doc_id), doc_json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
 
         {
@@ -1623,7 +1802,8 @@ impl DocumentStore {
 
         let doc_json = serde_json::to_string_pretty(&doc).map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.doc_path(ws, &doc_id), doc_json).map_err(|e| format!("Write error: {}", e))?;
+        write_atomic(&self.doc_path(ws, &doc_id), doc_json.as_bytes())
+            .map_err(|e| format!("Write error: {}", e))?;
 
         {
             let mut index = self.index.write().map_err(|e| e.to_string())?;
@@ -2105,24 +2285,164 @@ mod tests {
         {
             let store = DocumentStore::new(dir.path().to_path_buf());
             assert!(store.list_collections(&ws).is_empty());
-            store.set_collections(&ws, defs.clone()).unwrap();
+            let outcome = store.set_collections(&ws, defs.clone(), None).unwrap();
+            assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 1 }));
             // Sorted by order.
             let listed = store.list_collections(&ws);
             assert_eq!(listed.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(), ["a", "b"]);
             assert_eq!(listed[0].color.as_deref(), Some("#ef4444"));
         }
-        // A fresh store over the same dir preloads the persisted registry.
+        // A fresh store over the same dir preloads the persisted registry —
+        // including the version (the wrapper file shape round-trips).
         let reloaded = DocumentStore::new(dir.path().to_path_buf());
-        assert_eq!(reloaded.list_collections(&ws).len(), 2);
+        let (listed, version) = reloaded.collections_snapshot(&ws);
+        assert_eq!(listed.len(), 2);
+        assert_eq!(version, 1);
 
-        // Wholesale replace.
-        reloaded
-            .set_collections(&ws, vec![CollectionDef { id: "c".into(), name: "C".into(), color: None, order: 0 }])
+        // Wholesale replace bumps again.
+        let outcome = reloaded
+            .set_collections(
+                &ws,
+                vec![CollectionDef { id: "c".into(), name: "C".into(), color: None, order: 0 }],
+                None,
+            )
             .unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 2 }));
         assert_eq!(
             reloaded.list_collections(&ws).iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
             ["c"]
         );
+    }
+
+    #[test]
+    fn collections_legacy_bare_array_loads_as_v0_and_upgrades_on_write() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceId::single_tenant();
+        // Pre-JP-424 file: a bare CollectionDef array.
+        {
+            let store = DocumentStore::new(dir.path().to_path_buf());
+            let path = store.collections_path(&ws);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, br#"[{"id":"x","name":"X","order":0}]"#).unwrap();
+        }
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let (defs, version) = store.collections_snapshot(&ws);
+        assert_eq!(defs.len(), 1);
+        assert_eq!(version, 0, "legacy bare array reads as version 0");
+
+        // First accepted write (conditional on the legacy version) upgrades the
+        // file to the wrapper shape.
+        let outcome = store
+            .set_collections(
+                &ws,
+                vec![CollectionDef { id: "x".into(), name: "X2".into(), color: None, order: 0 }],
+                Some(0),
+            )
+            .unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 1 }));
+        let raw = std::fs::read_to_string(store.collections_path(&ws)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["version"], 1, "file rewritten in wrapper form");
+        assert_eq!(parsed["collections"][0]["name"], "X2");
+    }
+
+    #[test]
+    fn collections_expected_version_gates_the_write() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let def = |id: &str, order: i64| CollectionDef {
+            id: id.into(),
+            name: id.to_uppercase(),
+            color: None,
+            order,
+        };
+        store.set_collections(&ws, vec![def("a", 0)], None).unwrap(); // v1
+
+        // Stale expectation ⇒ conflict, nothing written.
+        let outcome = store.set_collections(&ws, vec![def("b", 0)], Some(0)).unwrap();
+        match outcome {
+            SetCollectionsOutcome::VersionConflict { current_version, current } => {
+                assert_eq!(current_version, 1);
+                assert_eq!(current.len(), 1);
+                assert_eq!(current[0].id, "a");
+            }
+            other => panic!("expected conflict, got {:?}", other),
+        }
+        assert_eq!(store.list_collections(&ws)[0].id, "a", "conflicting write must not land");
+
+        // Matching expectation ⇒ accepted.
+        let outcome = store.set_collections(&ws, vec![def("b", 0)], Some(1)).unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 2 }));
+
+        // Blind write (legacy client) still lands and bumps.
+        let outcome = store.set_collections(&ws, vec![def("c", 0)], None).unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 3 }));
+    }
+
+    #[test]
+    fn collections_presence_guard_and_probe_memoization() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        // Never touched: not loaded (the ensure path would probe R2 once).
+        assert!(!store.has_workspace_collections_loaded(&ws));
+        store.memoize_collections_probe(&ws);
+        assert!(store.has_workspace_collections_loaded(&ws));
+        assert!(store.list_collections(&ws).is_empty());
+        // A memoized empty entry is presence — an emptied registry must not be
+        // treated as "cold" again (stale-mirror resurrection guard).
+        assert_eq!(store.collections_snapshot(&ws).1, 0);
+    }
+
+    #[test]
+    fn sanitize_collection_defs_dedupes_and_rejects() {
+        let def = |id: &str, name: &str| CollectionDef {
+            id: id.into(),
+            name: name.into(),
+            color: None,
+            order: 0,
+        };
+        // Duplicate ids: keep-first heal, not an error.
+        let out =
+            sanitize_collection_defs(vec![def("a", "First"), def("a", "Second"), def("b", "B")])
+                .unwrap();
+        assert_eq!(out.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(), ["First", "B"]);
+
+        // Structural violations reject.
+        assert!(sanitize_collection_defs(vec![def("", "X")]).is_err());
+        assert!(sanitize_collection_defs(vec![def("a", "   ")]).is_err());
+        assert!(sanitize_collection_defs(vec![def("a", &"n".repeat(121))]).is_err());
+        assert!(sanitize_collection_defs(vec![def(&"i".repeat(65), "X")]).is_err());
+        let mut oversized_color = def("a", "X");
+        oversized_color.color = Some("c".repeat(33));
+        assert!(sanitize_collection_defs(vec![oversized_color]).is_err());
+        let too_many: Vec<_> =
+            (0..=MAX_COLLECTIONS_PER_WORKSPACE).map(|i| def(&format!("c{}", i), "N")).collect();
+        assert!(sanitize_collection_defs(too_many).is_err());
+
+        // At the cap is fine.
+        let at_cap: Vec<_> =
+            (0..MAX_COLLECTIONS_PER_WORKSPACE).map(|i| def(&format!("c{}", i), "N")).collect();
+        assert_eq!(sanitize_collection_defs(at_cap).unwrap().len(), MAX_COLLECTIONS_PER_WORKSPACE);
+    }
+
+    #[test]
+    fn write_atomic_lands_content_and_leaves_no_temp_residue() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("out.json");
+        write_atomic(&path, b"first").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"first");
+        // Overwrite via rename-over-existing.
+        write_atomic(&path, b"second").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
+        // No stray temp files.
+        let residue: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp-"))
+            .collect();
+        assert!(residue.is_empty(), "temp files must be renamed or removed");
     }
 
     #[test]
@@ -2234,8 +2554,12 @@ mod tests {
             ..Default::default()
         };
         store.restore_workspace_collections_from(&fake, &ws).await;
-        assert_eq!(store.list_collections(&ws).len(), 1);
-        assert_eq!(store.list_collections(&ws)[0].name, "X");
+        let (defs, version) = store.collections_snapshot(&ws);
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].name, "X");
+        // Legacy bare-array mirror object parses through the dual-format loader.
+        assert_eq!(version, 0);
+        assert!(store.has_workspace_collections_loaded(&ws));
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -945,10 +945,12 @@ impl ServerState {
     }
 
     /// Best-effort restore of a workspace's collection definitions from R2 before
-    /// serving the collections registry on a cold machine. Only reaches for R2
-    /// when the in-memory registry is empty, so a populated one is never clobbered.
+    /// serving the collections registry on a cold machine. Keyed on registry
+    /// **presence**, not emptiness (JP-424): a workspace that legitimately
+    /// emptied its registry must not have it resurrected from a stale mirror,
+    /// and a probe (hit or R2 miss) is memoized so repeat reads don't re-fetch.
     pub(crate) async fn ensure_workspace_collections_local(&self, ws: &WorkspaceId) {
-        if !self.doc_store.list_collections(ws).is_empty() {
+        if self.doc_store.has_workspace_collections_loaded(ws) {
             return;
         }
         if let Some(s3) = &self.s3 {
@@ -956,6 +958,7 @@ impl ServerState {
                 .restore_workspace_collections_from(s3.as_ref(), ws)
                 .await;
         }
+        self.doc_store.memoize_collections_probe(ws);
     }
 
     /// Try to register a new authenticated WS connection for the

--- a/relay/tests/collections_api.rs
+++ b/relay/tests/collections_api.rs
@@ -1,0 +1,200 @@
+//! Integration tests for the `/api/collections` registry surface (JP-424).
+//!
+//! Builds the relay in-process (same harness pattern as `smoke.rs`) and
+//! exercises the optimistic-concurrency handshake end to end: versioned GET,
+//! conditional PUT, the 409 conflict shape, and the sanitize gate.
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct RelayHarness {
+    base: String,
+    issuer: OidcTestIssuer,
+    server: Arc<WebSocketServer>,
+    _tmp: TempDir,
+}
+
+impl RelayHarness {
+    async fn start() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let issuer = OidcTestIssuer::new().await;
+
+        let server = Arc::new(WebSocketServer::new());
+        server.set_app_data_dir(tmp.path().to_path_buf()).await;
+        server.set_auth(issuer.auth_state()).await;
+        server
+            .set_config(ServerConfig {
+                port: 0,
+                network_mode: NetworkMode::Localhost,
+                max_connections: 0,
+            })
+            .await
+            .expect("set_config");
+
+        let bound = server.start(0).await.expect("start");
+        let http = bound
+            .strip_prefix("ws://")
+            .map(|rest| format!("http://{rest}"))
+            .unwrap_or(bound);
+
+        RelayHarness {
+            base: http,
+            issuer,
+            server,
+            _tmp: tmp,
+        }
+    }
+
+    fn token(&self, sub: &str) -> String {
+        self.issuer.mint(sub, "default", WorkspaceRole::Owner)
+    }
+
+    async fn stop(self) {
+        self.server.stop().await.expect("stop");
+    }
+}
+
+fn def(id: &str, name: &str, order: i64) -> serde_json::Value {
+    json!({ "id": id, "name": name, "order": order })
+}
+
+#[tokio::test]
+async fn collections_versioned_put_roundtrip_and_conflict() {
+    let harness = RelayHarness::start().await;
+    let client = reqwest::Client::new();
+    let bearer = format!("Bearer {}", harness.token("alice"));
+    let url = format!("{}/api/collections", harness.base);
+
+    // Cold GET: empty set, version 0.
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get empty");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["collections"].as_array().map(|a| a.len()), Some(0));
+    assert_eq!(body["version"], 0);
+
+    // Legacy blind PUT (no expectedVersion) lands and bumps to v1.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("a", "Alpha", 0)] }))
+        .send()
+        .await
+        .expect("blind put");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["newVersion"], 1);
+
+    // GET reflects the write and its version.
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get v1");
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["version"], 1);
+    assert_eq!(body["collections"][0]["id"], "a");
+
+    // Stale expectedVersion ⇒ 409 with the doc-save conflict keys plus the
+    // current set; the store is untouched.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("b", "Beta", 0)], "expectedVersion": 0 }))
+        .send()
+        .await
+        .expect("stale put");
+    assert_eq!(res.status().as_u16(), 409);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["errorCode"], "VERSION_CONFLICT");
+    assert_eq!(body["currentVersion"], 1);
+    assert_eq!(body["collections"][0]["id"], "a");
+
+    // Matching expectedVersion ⇒ accepted, v2.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("b", "Beta", 0)], "expectedVersion": 1 }))
+        .send()
+        .await
+        .expect("conditional put");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["newVersion"], 2);
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn collections_put_sanitizes_and_rejects() {
+    let harness = RelayHarness::start().await;
+    let client = reqwest::Client::new();
+    let bearer = format!("Bearer {}", harness.token("alice"));
+    let url = format!("{}/api/collections", harness.base);
+
+    // Duplicate ids are healed keep-first, not rejected.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("a", "First", 0), def("a", "Second", 1)] }))
+        .send()
+        .await
+        .expect("dupe put");
+    assert_eq!(res.status().as_u16(), 200);
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get after dupe");
+    let body: serde_json::Value = res.json().await.unwrap();
+    let listed = body["collections"].as_array().unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["name"], "First");
+
+    // Empty name ⇒ 400, nothing written (version unchanged).
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("b", "   ", 0)] }))
+        .send()
+        .await
+        .expect("bad name put");
+    assert_eq!(res.status().as_u16(), 400);
+
+    // Over the per-workspace cap ⇒ 400.
+    let too_many: Vec<serde_json::Value> =
+        (0..=200).map(|i| def(&format!("c{i}"), "N", i)).collect();
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": too_many }))
+        .send()
+        .await
+        .expect("over cap put");
+    assert_eq!(res.status().as_u16(), 400);
+
+    // Registry still at the healed single entry, version 1.
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("final get");
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["version"], 1);
+    assert_eq!(body["collections"].as_array().map(|a| a.len()), Some(1));
+
+    harness.stop().await;
+}

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -324,8 +324,12 @@ export class RelayClient {
 
   // ============ Collections (JP-159) ============
 
-  /** The connected workspace's collection definitions (`GET /api/collections`). */
-  async getCollections(): Promise<{ collections: RelayCollectionDef[] }> {
+  /**
+   * The connected workspace's collection definitions (`GET /api/collections`).
+   * `version` is the registry version for the optimistic-concurrency handshake
+   * (JP-424); absent when talking to a pre-JP-424 relay.
+   */
+  async getCollections(): Promise<{ collections: RelayCollectionDef[]; version?: number }> {
     return this.requestJson('GET', '/api/collections', { auth: true });
   }
 
@@ -333,12 +337,20 @@ export class RelayClient {
    * Replace the connected workspace's collection definitions wholesale
    * (`PUT /api/collections`). The relay scopes this to the token's workspace;
    * callers must pass that workspace's full set (read-modify-write), never a
-   * cross-workspace union of the client's global store.
+   * cross-workspace union of the client's global store. When `expectedVersion`
+   * is provided the write is conditional — a mismatch rejects with a typed
+   * `VersionConflictError` (JP-424); omitted, it's the legacy blind replace.
    */
-  async setCollections(collections: RelayCollectionDef[]): Promise<{ success: boolean }> {
+  async setCollections(
+    collections: RelayCollectionDef[],
+    expectedVersion?: number,
+  ): Promise<{ success: boolean }> {
     return this.requestJson('PUT', '/api/collections', {
       auth: true,
-      body: { collections },
+      body: {
+        collections,
+        ...(expectedVersion !== undefined ? { expectedVersion } : {}),
+      },
     });
   }
 

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -146,13 +146,15 @@ export class RestDocumentProvider {
 
   // ============ Collections (JP-159) ============
 
-  async getCollections(): Promise<RelayCollectionDef[]> {
-    const { collections } = await this.client.getCollections();
-    return collections;
+  async getCollections(): Promise<{ collections: RelayCollectionDef[]; version?: number }> {
+    return this.client.getCollections();
   }
 
-  async setCollections(collections: RelayCollectionDef[]): Promise<void> {
-    await this.client.setCollections(collections);
+  async setCollections(
+    collections: RelayCollectionDef[],
+    expectedVersion?: number,
+  ): Promise<void> {
+    await this.client.setCollections(collections, expectedVersion);
   }
 
   async setDocumentCollection(docId: string, collectionId: string | null): Promise<void> {

--- a/src/store/collectionStore.test.ts
+++ b/src/store/collectionStore.test.ts
@@ -141,6 +141,48 @@ describe('collectionStore scope (JP-366)', () => {
   });
 });
 
+describe('collectionStore hydrateFromRelay prune (JP-424)', () => {
+  beforeEach(reset);
+
+  function seedWorkspaceDefs() {
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [
+        { id: 'keep', name: 'Keep', order: 0, createdAt: 1 },
+        { id: 'gone', name: 'Gone', order: 1, createdAt: 1 },
+        { id: 'inflight', name: 'InFlight', order: 2, createdAt: 1 },
+      ],
+      memberships: { dKeep: 'keep', dGone: 'gone' },
+    });
+  }
+
+  it('without the directive, absent workspace defs are kept (upsert-only)', () => {
+    seedWorkspaceDefs();
+    useCollectionStore.getState().hydrateFromRelay({ definitions: [], memberships: {} });
+    expect(useCollectionStore.getState().collections['gone']).toBeDefined();
+  });
+
+  it('prunes workspace defs absent from the relay set, honouring keepIds, and drops their assignments', () => {
+    seedWorkspaceDefs();
+    const local = useCollectionStore.getState().createCollection('Personal', undefined, 'local');
+    useCollectionStore.getState().assignDocument('dLocal', local);
+
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'keep', name: 'Keep', order: 0, createdAt: 1 }],
+      memberships: {},
+      pruneWorkspaceDefs: { keepIds: ['inflight'] },
+    });
+
+    const st = useCollectionStore.getState();
+    expect(st.collections['keep']).toBeDefined(); // in the relay set
+    expect(st.collections['inflight']).toBeDefined(); // shielded by keepIds
+    expect(st.collections['gone']).toBeUndefined(); // pruned
+    expect(st.assignments['dGone']).toBeUndefined(); // its assignment dropped
+    expect(st.assignments['dKeep']).toBe('keep'); // untouched
+    expect(st.collections[local]).toBeDefined(); // local defs never pruned
+    expect(st.assignments['dLocal']).toBe(local);
+  });
+});
+
 describe('migrateCollections v1→v2 (JP-366)', () => {
   it('stamps scope=local on untagged v1 collections, preserving assignments', () => {
     const v1 = {

--- a/src/store/collectionStore.ts
+++ b/src/store/collectionStore.ts
@@ -78,10 +78,17 @@ export interface CollectionActions {
    * `null` clears. Local-doc assignments are never touched (the caller only
    * includes relay doc ids it intends to apply). The single atomic entry point
    * the sync layer uses; this store stays network-free.
+   *
+   * `pruneWorkspaceDefs` (JP-424): when present, workspace-scoped definitions
+   * absent from `definitions` are deleted (the relay no longer has them —
+   * deleted by another client) along with their assignments — except ids in
+   * `keepIds`, the caller's in-flight/unconfirmed creates. Local-scoped
+   * definitions are never pruned.
    */
   hydrateFromRelay: (input: {
     definitions: Collection[];
     memberships: Record<string, string | null>;
+    pruneWorkspaceDefs?: { keepIds: string[] };
   }) => void;
   /**
    * Drop every `workspace`-scoped collection and prune assignments that point at
@@ -232,7 +239,7 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
         return Object.values(collections).sort((a, b) => a.order - b.order);
       },
 
-      hydrateFromRelay: ({ definitions, memberships }) => {
+      hydrateFromRelay: ({ definitions, memberships, pruneWorkspaceDefs }) => {
         const { collections, assignments } = get();
         const nextCollections = { ...collections };
         for (const def of definitions) {
@@ -240,7 +247,26 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
           // can drop them and the scope guard treats them correctly.
           nextCollections[def.id] = { ...def, scope: 'workspace' };
         }
-        const nextAssignments = { ...assignments };
+
+        // Prune workspace defs the relay no longer has (deleted elsewhere),
+        // keeping unconfirmed in-flight creates. Same assignment-cleanup shape
+        // as deleteCollection/dropWorkspaceCollections.
+        const pruned = new Set<string>();
+        if (pruneWorkspaceDefs) {
+          const present = new Set(definitions.map((d) => d.id));
+          const keep = new Set(pruneWorkspaceDefs.keepIds);
+          for (const [id, col] of Object.entries(nextCollections)) {
+            if (isWorkspaceCollection(col) && !present.has(id) && !keep.has(id)) {
+              pruned.add(id);
+              delete nextCollections[id];
+            }
+          }
+        }
+
+        const nextAssignments: Record<string, string> = {};
+        for (const [docId, cid] of Object.entries(assignments)) {
+          if (!pruned.has(cid)) nextAssignments[docId] = cid;
+        }
         for (const [documentId, collectionId] of Object.entries(memberships)) {
           if (collectionId === null) {
             delete nextAssignments[documentId];

--- a/src/store/collectionSync.test.ts
+++ b/src/store/collectionSync.test.ts
@@ -38,10 +38,18 @@ const registryGetState = useDocumentRegistry.getState as unknown as Mock;
 const notifyGetState = useNotificationStore.getState as unknown as Mock;
 const warningSpy = vi.fn();
 
-function makeProvider(defs: RelayCollectionDef[]) {
+// `version: null` = a pre-JP-424 relay whose GET carries no version field.
+function makeProvider(defs: RelayCollectionDef[], version: number | null = 1) {
   return {
-    getCollections: vi.fn(async (): Promise<RelayCollectionDef[]> => defs.map((d) => ({ ...d }))),
-    setCollections: vi.fn(async (_defs: RelayCollectionDef[]): Promise<void> => {}),
+    getCollections: vi.fn(
+      async (): Promise<{ collections: RelayCollectionDef[]; version?: number }> => ({
+        collections: defs.map((d) => ({ ...d })),
+        ...(version !== null ? { version } : {}),
+      }),
+    ),
+    setCollections: vi.fn(
+      async (_defs: RelayCollectionDef[], _expectedVersion?: number): Promise<void> => {},
+    ),
     setDocumentCollection: vi.fn(async (_docId: string, _collectionId: string | null): Promise<void> => {}),
   };
 }
@@ -123,11 +131,11 @@ describe('collectionSync reconcileFromRelay (JP-159)', () => {
   it('hydrates relay defs + memberships, leaves local-doc assignments untouched', async () => {
     const provider = makeProvider([{ id: 'A', name: 'Alpha', order: 0, color: '#fff' }]);
     getDocProviderMock.mockReturnValue(provider);
-    // Seed a local-only collection + assignment that reconcile must NOT touch.
-    useCollectionStore.getState().hydrateFromRelay({
-      definitions: [{ id: 'localCol', name: 'Local', order: 9, createdAt: 1 }],
-      memberships: { localDoc: 'localCol' },
-    });
+    // Seed a genuinely local-scoped collection + assignment that reconcile
+    // must NOT touch (JP-424: workspace-scoped defs absent from the relay are
+    // pruned, so the seam matters).
+    const localCol = useCollectionStore.getState().createCollection('Local', undefined, 'local');
+    useCollectionStore.getState().assignDocument('localDoc', localCol);
 
     await reconcileFromRelay([meta('d1', 'A'), meta('d2')]);
 
@@ -136,8 +144,39 @@ describe('collectionSync reconcileFromRelay (JP-159)', () => {
     expect(typeof st.collections['A']?.createdAt).toBe('number');
     expect(st.assignments['d1']).toBe('A'); // relay membership applied
     expect(st.assignments['d2']).toBeUndefined(); // relay-absent → cleared
-    expect(st.assignments['localDoc']).toBe('localCol'); // local doc untouched
-    expect(st.collections['localCol']).toBeDefined(); // local def preserved
+    expect(st.assignments['localDoc']).toBe(localCol); // local doc untouched
+    expect(st.collections[localCol]).toBeDefined(); // local def preserved
+  });
+
+  it('prunes workspace defs the relay no longer has, plus their assignments (JP-424)', async () => {
+    // Seed a workspace def that another client has since deleted on the relay.
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'gone', name: 'Gone', order: 0, createdAt: 1 }],
+      memberships: { d9: 'gone' },
+    });
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+
+    await reconcileFromRelay([]);
+
+    const st = useCollectionStore.getState();
+    expect(st.collections['gone']).toBeUndefined(); // ghost def pruned
+    expect(st.assignments['d9']).toBeUndefined(); // its assignment dropped
+    expect(st.collections['A']).toBeDefined(); // relay set hydrated
+  });
+
+  it('keeps an unconfirmed created def across a prune when its push failed (JP-424)', async () => {
+    const provider = makeProvider([]);
+    provider.setCollections.mockRejectedValue(new Error('relay down'));
+    getDocProviderMock.mockReturnValue(provider);
+
+    const newId = syncedActions.createCollection('Fresh');
+    await flush();
+    expect(useCollectionStore.getState().collections[newId]).toBeDefined();
+
+    // Reconcile sees a relay set without the new id — it must survive.
+    await reconcileFromRelay([]);
+    expect(useCollectionStore.getState().collections[newId]).toBeDefined();
   });
 
   it('does NOT clear a relay doc with a pending queued save (clear-guard)', async () => {
@@ -233,7 +272,7 @@ describe('collectionSync scope (JP-366)', () => {
     expect(warningSpy).not.toHaveBeenCalled();
   });
 
-  it('resetWorkspaceSync forgets the known workspace set so the membership gate reopens', async () => {
+  it('resetWorkspaceSync forgets the known workspace set so the membership gate reopens (JP-366)', async () => {
     const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
     getDocProviderMock.mockReturnValue(provider);
     await reconcileFromRelay([]); // known = {A}
@@ -246,5 +285,86 @@ describe('collectionSync scope (JP-366)', () => {
 
     syncedActions.assignDocuments(['d'], 'B'); // gate empty now → push allowed
     await vi.waitFor(() => expect(provider.setDocumentCollection).toHaveBeenCalledWith('d', 'B'));
+  });
+});
+
+describe('collectionSync versioned definitions (JP-424)', () => {
+  it('sends the fetched registry version as expectedVersion on PUT', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }], 7);
+    getDocProviderMock.mockReturnValue(provider);
+
+    syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+
+    const [, expectedVersion] = provider.setCollections.mock.calls[0]!;
+    expect(expectedVersion).toBe(7);
+  });
+
+  it('a version-less GET (pre-JP-424 relay) degrades to the legacy blind write', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }], null);
+    getDocProviderMock.mockReturnValue(provider);
+
+    syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+
+    const [, expectedVersion] = provider.setCollections.mock.calls[0]!;
+    expect(expectedVersion).toBeUndefined();
+  });
+
+  it('rebases exactly once on a version conflict: fresh GET, re-applied transform', async () => {
+    const { VersionConflictError } = await import('../api/relayClient');
+    const provider = makeProvider([]);
+    // First GET: v1, set {A}. Second GET (after conflict): v2, set {A, B} —
+    // another client added B between our GET and PUT.
+    provider.getCollections
+      .mockResolvedValueOnce({ collections: [{ id: 'A', name: 'A', order: 0 }], version: 1 })
+      .mockResolvedValueOnce({
+        collections: [
+          { id: 'A', name: 'A', order: 0 },
+          { id: 'B', name: 'B', order: 1 },
+        ],
+        version: 2,
+      });
+    provider.setCollections
+      .mockRejectedValueOnce(new VersionConflictError('/api/collections', 2))
+      .mockResolvedValueOnce(undefined);
+    getDocProviderMock.mockReturnValue(provider);
+
+    const newId = syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalledTimes(2));
+
+    const [retryDefs, retryVersion] = provider.setCollections.mock.calls[1]! as [
+      RelayCollectionDef[],
+      number | undefined,
+    ];
+    const ids = retryDefs.map((d) => d.id);
+    expect(ids).toContain('B'); // rebase picked up the other client's write
+    expect(ids).toContain(newId); // and re-applied our transform
+    expect(retryVersion).toBe(2); // conditional on the fresh version
+  });
+
+  it('a second consecutive conflict is swallowed (best-effort, heals on reconcile)', async () => {
+    const { VersionConflictError } = await import('../api/relayClient');
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    provider.setCollections.mockRejectedValue(new VersionConflictError('/api/collections', 9));
+    getDocProviderMock.mockReturnValue(provider);
+
+    expect(() => syncedActions.createCollection('Created')).not.toThrow();
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalledTimes(2));
+    await flush(); // no third attempt, no unhandled rejection
+    expect(provider.setCollections).toHaveBeenCalledTimes(2);
+  });
+
+  it('a successful push confirms the created id (later prune may drop it if relay-deleted)', async () => {
+    const provider = makeProvider([]);
+    getDocProviderMock.mockReturnValue(provider);
+
+    const newId = syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+
+    // Push confirmed → the id is no longer shielded: a reconcile whose relay
+    // set lacks it (deleted by another client) now prunes it.
+    await reconcileFromRelay([]);
+    expect(useCollectionStore.getState().collections[newId]).toBeUndefined();
   });
 });

--- a/src/store/collectionSync.ts
+++ b/src/store/collectionSync.ts
@@ -18,7 +18,7 @@
  * which carries `collectionId` in its body (persistenceStore stamp).
  */
 
-import type { RelayCollectionDef } from '../api/relayClient';
+import { VersionConflictError, type RelayCollectionDef } from '../api/relayClient';
 import type { DocumentMetadata } from '../types/Document';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import {
@@ -36,11 +36,18 @@ import { useDocumentRegistry } from './documentRegistry';
  *  (which would leave a dangling `collectionId`). */
 let knownCollectionIds = new Set<string>();
 
+/** Workspace collection ids created locally whose relay push hasn't succeeded
+ *  yet (JP-424). Reconcile's prune must skip them — pruning "absent from the
+ *  relay" would otherwise erase a brand-new collection whose create push is
+ *  still in flight or failed (it re-lands on the user's next mutation). */
+let unconfirmedWorkspaceDefIds = new Set<string>();
+
 /** Forget the connected workspace's collection set. Called when leaving a
  *  workspace (full sign-out / Remove Workspace) so a stale set can't gate the
  *  next workspace's membership pushes. */
 export function resetWorkspaceSync(): void {
   knownCollectionIds = new Set();
+  unconfirmedWorkspaceDefIds = new Set();
 }
 
 /** Serialize relay-definition read-modify-writes so concurrent mutations can't
@@ -61,23 +68,52 @@ function toDef(col: Collection): RelayCollectionDef {
   };
 }
 
+/** One GET → transform → conditional PUT cycle (JP-424). Sends the fetched
+ *  registry version as `expectedVersion` (absent against a pre-JP-424 relay ⇒
+ *  legacy blind write) and, on success, confirms any pending created ids. */
+async function pushDefsOnce(
+  getCollections: () => Promise<{ collections: RelayCollectionDef[]; version?: number }>,
+  setCollections: (defs: RelayCollectionDef[], expectedVersion?: number) => Promise<void>,
+  transform: (defs: RelayCollectionDef[]) => RelayCollectionDef[],
+): Promise<void> {
+  const { collections: current, version } = await getCollections();
+  const next = transform(current);
+  knownCollectionIds = new Set(next.map((d) => d.id));
+  await setCollections(next, version);
+  for (const def of next) unconfirmedWorkspaceDefIds.delete(def.id);
+}
+
 /**
  * Read the connected workspace's definition set, apply `transform`, write it
  * back. Best-effort + serialized + auth-gated. Refreshes `knownCollectionIds`.
+ * A version conflict (another client wrote between our GET and PUT) is rebased
+ * exactly once — fresh GET, re-applied transform; a second conflict stays
+ * best-effort (the next reconcile heals).
  */
 function mutateRelayDefs(
   transform: (defs: RelayCollectionDef[]) => RelayCollectionDef[],
 ): Promise<void> {
   return serialize(async () => {
     const provider = getDocProvider();
-    if (!provider?.getCollections || !provider.setCollections) return;
+    const getCollections = provider?.getCollections?.bind(provider);
+    const setCollections = provider?.setCollections?.bind(provider);
+    if (!getCollections || !setCollections) return;
     if (!isCloudSignedIn()) return;
     try {
-      const current = await provider.getCollections();
-      const next = transform(current);
-      knownCollectionIds = new Set(next.map((d) => d.id));
-      await provider.setCollections(next);
+      await pushDefsOnce(getCollections, setCollections, transform);
     } catch (e) {
+      if (e instanceof VersionConflictError) {
+        try {
+          await pushDefsOnce(getCollections, setCollections, transform);
+          return;
+        } catch (retryError) {
+          console.warn(
+            '[collectionSync] definitions push failed after rebase (best-effort):',
+            retryError,
+          );
+          return;
+        }
+      }
       console.warn('[collectionSync] definitions push failed (best-effort):', e);
     }
   });
@@ -120,6 +156,9 @@ export const syncedActions = {
     if (id && resolvedScope === 'workspace') {
       const col = useCollectionStore.getState().collections[id];
       if (col) {
+        // Track the create until its push is confirmed so a reconcile that
+        // races (or follows a failed push) can't prune it (JP-424).
+        unconfirmedWorkspaceDefIds.add(col.id);
         void mutateRelayDefs((defs) =>
           defs.some((d) => d.id === col.id) ? defs : [...defs, toDef(col)],
         );
@@ -232,46 +271,60 @@ function reprojectDefinition(id: string): Promise<void> {
  * Pull the connected workspace's collections + relay-doc memberships and
  * reconcile them into the store. Called from `fetchDocumentList`. Best-effort:
  * a failure here must not fail the doc-list fetch.
+ *
+ * Runs through the `serialize()` chain (JP-424): an in-flight definition push
+ * occupies the chain ahead of us, so by the time our GET runs that push has
+ * landed and its ids are in the fetched set — a snapshot-then-prune race can't
+ * drop a collection that was being created. Ids whose push *failed* are kept
+ * via `unconfirmedWorkspaceDefIds`.
  */
 export async function reconcileFromRelay(relayDocs: DocumentMetadata[]): Promise<void> {
-  const provider = getDocProvider();
-  if (!provider?.getCollections) return;
+  return serialize(async () => {
+    const provider = getDocProvider();
+    if (!provider?.getCollections) return;
 
-  let relaySet: RelayCollectionDef[];
-  try {
-    relaySet = await provider.getCollections();
-  } catch (e) {
-    console.warn('[collectionSync] reconcile getCollections failed (best-effort):', e);
-    return;
-  }
-  knownCollectionIds = new Set(relaySet.map((d) => d.id));
-
-  const store = useCollectionStore.getState();
-  const definitions: Collection[] = relaySet.map((d) => {
-    const existing = store.collections[d.id];
-    return {
-      id: d.id,
-      name: d.name,
-      order: d.order,
-      createdAt: existing?.createdAt ?? Date.now(),
-      ...(d.color !== undefined ? { color: d.color } : {}),
-    };
-  });
-
-  // Membership: relay is authoritative for relay docs. Clear an absent
-  // membership only when there's no pending queued save for that doc — an
-  // offline assign that reconnects before its content-save replays would
-  // otherwise be reverted by a stale reconcile.
-  const sync = getSyncStateManager();
-  const memberships: Record<string, string | null> = {};
-  for (const doc of relayDocs) {
-    const cid = doc.collectionId;
-    if (typeof cid === 'string') {
-      memberships[doc.id] = cid;
-    } else if (!sync.hasPendingChanges(doc.id)) {
-      memberships[doc.id] = null;
+    let relaySet: RelayCollectionDef[];
+    try {
+      ({ collections: relaySet } = await provider.getCollections());
+    } catch (e) {
+      console.warn('[collectionSync] reconcile getCollections failed (best-effort):', e);
+      return;
     }
-  }
+    knownCollectionIds = new Set(relaySet.map((d) => d.id));
 
-  store.hydrateFromRelay({ definitions, memberships });
+    const store = useCollectionStore.getState();
+    const definitions: Collection[] = relaySet.map((d) => {
+      const existing = store.collections[d.id];
+      return {
+        id: d.id,
+        name: d.name,
+        order: d.order,
+        createdAt: existing?.createdAt ?? Date.now(),
+        ...(d.color !== undefined ? { color: d.color } : {}),
+      };
+    });
+
+    // Membership: relay is authoritative for relay docs. Clear an absent
+    // membership only when there's no pending queued save for that doc — an
+    // offline assign that reconnects before its content-save replays would
+    // otherwise be reverted by a stale reconcile.
+    const sync = getSyncStateManager();
+    const memberships: Record<string, string | null> = {};
+    for (const doc of relayDocs) {
+      const cid = doc.collectionId;
+      if (typeof cid === 'string') {
+        memberships[doc.id] = cid;
+      } else if (!sync.hasPendingChanges(doc.id)) {
+        memberships[doc.id] = null;
+      }
+    }
+
+    store.hydrateFromRelay({
+      definitions,
+      memberships,
+      // Workspace defs absent from the relay were deleted by another client —
+      // drop them (and their assignments) instead of ghosting forever.
+      pruneWorkspaceDefs: { keepIds: [...unconfirmedWorkspaceDefIds] },
+    });
+  });
 }

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -184,10 +184,13 @@ export interface DocumentProvider {
   ): Promise<{ newDocId: string; serverVersion: number }>;
   /**
    * Collection sync (JP-159). Optional so non-REST providers opt out. The relay
-   * scopes all three to the connected workspace from the bearer token.
+   * scopes all three to the connected workspace from the bearer token. The
+   * registry `version` + `expectedVersion` pair is the JP-424 optimistic-
+   * concurrency handshake; `version` is absent on pre-JP-424 relays and an
+   * omitted `expectedVersion` degrades to the legacy blind replace.
    */
-  getCollections?(): Promise<RelayCollectionDef[]>;
-  setCollections?(collections: RelayCollectionDef[]): Promise<void>;
+  getCollections?(): Promise<{ collections: RelayCollectionDef[]; version?: number }>;
+  setCollections?(collections: RelayCollectionDef[], expectedVersion?: number): Promise<void>;
   setDocumentCollection?(docId: string, collectionId: string | null): Promise<void>;
 }
 


### PR DESCRIPTION
Closes JP-424. Hardens the collections feature after a durability review: the client layer was solid (scope choke point, pending-save guard, tested migration), but the relay had real gaps and the client ghosted cross-device deletes.

## Findings fixed

1. **Lost updates on `PUT /api/collections`** — wholesale blind replace meant two devices doing GET→mutate→PUT silently erased each other's collections.
2. **Non-atomic file writes** — every persistence site (doc JSON, ydoc, all three workspace sidecars, the R2-restore writers) used direct `std::fs::write`; a crash mid-write left a torn file, and filesystem-only self-host deployments have no R2 self-heal.
3. **Stale-mirror resurrection** — the cold-start restore guard keyed on registry *emptiness*, so a workspace that deleted all its collections re-probed R2 on every GET and could resurrect them from a stale mirror.
4. **No PUT validation** — no id dedupe, no caps.
5. **Ghost collections client-side** — `hydrateFromRelay` was upsert-only; a collection deleted on device B never disappeared on device A.

## Changes

**Relay**
- `write_atomic` (sibling temp file + fsync + rename) used by all 11 write sites. Directory fsync deliberately skipped (documented trade-off; R2 mirror restore covers the file-absent case).
- `collections.json` becomes `{version, collections}` with a dual-format loader (legacy bare array ⇒ version 0; first write upgrades in place — R2-mirrored legacy objects also parse). `GET` returns the version; `PUT` takes optional `expectedVersion` → `409 {errorCode: VERSION_CONFLICT, currentVersion, collections}` on mismatch, reusing the doc-save conflict keys so the editor's typed error mapping applies unchanged. Omitted `expectedVersion` = legacy blind write, so old clients are unaffected; new clients against an old relay degrade the same way.
- `PUT` hydrates from R2 before mutating (a cold machine neither spuriously conflicts against v0 nor blind-writes over the mirror), dedupes duplicate ids keep-first, and 400s structural violations (empty/oversized name/id/colour, >200 collections).
- Cold-start restore guard keys on registry **presence** with a memoized probe.

**Client**
- `mutateRelayDefs` sends the fetched version as `expectedVersion` and rebases exactly once on `VersionConflictError` (fresh GET, re-applied transform); still best-effort.
- `reconcileFromRelay` now runs through the `serialize()` chain (ordering it after in-flight definition pushes) and prunes workspace-scoped defs absent from the relay set, plus their assignments. In-flight/failed creates are shielded via an unconfirmed-ids set until their push succeeds. Local-scoped collections are never pruned.

**Not changed:** membership endpoint semantics and its pending-save reconcile guard, mirror worker/shutdown flush, `PROTOCOL_VERSION` (REST-only change), `CollectionDef` wire fields, collectionStore's persisted localStorage shape.

**Cross-repo check:** docushark-web consumes collections only via the relay REST proxy and unwraps `{collections}` — tolerant of the added field. It never parses the R2 bytes, so no web-side change or deploy sequencing is needed.

## Verification

- `cargo check --all-targets` clean; `cargo test` all green (565 lib + integration suites), including new coverage: dual-format load + in-place upgrade, conflict matrix, sanitize matrix, `write_atomic` residue check, probe memoization, and a new `relay/tests/collections_api.rs` end-to-end suite (versioned round-trip, 409 shape, dedupe/caps).
- `bun run typecheck` clean; `bun run test --run` all green (2,881 tests), including new suites: 409-rebase re-applies the transform to the fresh set, double-conflict swallow, reconcile prune + assignment cleanup, keepIds shielding, and legacy version-less relay behavior.
- Two-device conflict/prune behavior on staging is the remaining human E2E.

Assisted-by: Fable 5