### PR TITLE
JP-404: expose active-doc + memory-pressure metrics for surge visibility

### DIFF
--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -2252,7 +2252,7 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
         }
     }
 
-    let body = format!(
+    let mut body = format!(
         "# HELP relay_build_info Relay build identity (always 1; read the labels).\n\
          # TYPE relay_build_info gauge\n\
          relay_build_info{{version=\"{version}\",commit=\"{commit}\"}} 1\n\
@@ -2289,10 +2289,41 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
         jwks_failures = jwks.refresh_failures_total,
         jwks_keys = jwks.key_count,
     );
+
+    // Surge-visibility signals (JP-404). Resident hydrated Y.Docs are the
+    // pod's dominant memory driver, so scrapers need the count alongside the
+    // process RSS to see memory pressure building before the kernel does.
+    let active_docs = state.sync_registry().len();
+    body.push_str(&format!(
+        "# HELP relay_active_docs_total Documents currently resident in memory (hydrated Y.Docs).\n\
+         # TYPE relay_active_docs_total gauge\n\
+         relay_active_docs_total {active_docs}\n"
+    ));
+    // RSS comes from procfs, so the series only exists on Linux; consumers
+    // must tolerate its absence rather than read it as 0.
+    #[cfg(target_os = "linux")]
+    if let Some(rss_bytes) = process_rss_bytes() {
+        body.push_str(&format!(
+            "# HELP relay_process_rss_bytes Resident set size of the relay process.\n\
+             # TYPE relay_process_rss_bytes gauge\n\
+             relay_process_rss_bytes {rss_bytes}\n"
+        ));
+    }
+
     (
         [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
         body,
     )
+}
+
+/// Resident-set size of this process in bytes, parsed from the `VmRSS:` line
+/// of `/proc/self/status` (reported by the kernel in kB).
+#[cfg(target_os = "linux")]
+fn process_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let line = status.lines().find(|l| l.starts_with("VmRSS:"))?;
+    let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+    Some(kb * 1024)
 }
 
 // ============ Blob HTTP Endpoints ============

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1273,8 +1273,9 @@ impl DocRegistry {
             .collect()
     }
 
-    /// Number of resident docs (diagnostics / tests).
-    #[allow(dead_code)]
+    /// Number of resident docs. Exposed as `relay_active_docs_total` on
+    /// `/metrics` (JP-404) — resident Y.Docs are the pod's main memory
+    /// driver, so surge visibility keys off this count.
     pub fn len(&self) -> usize {
         self.docs.read().unwrap().len()
     }

--- a/relay/tests/panic_isolation.rs
+++ b/relay/tests/panic_isolation.rs
@@ -84,6 +84,7 @@ async fn metrics_endpoint_exposes_panic_counter_in_prometheus_format() {
         "relay_active_editors_total",
         "relay_active_viewers_total",
         "relay_rate_limit_rejections_total",
+        "relay_active_docs_total",
     ] {
         assert!(
             body.contains(&format!("# TYPE {series}")),
@@ -98,6 +99,23 @@ async fn metrics_endpoint_exposes_panic_counter_in_prometheus_format() {
             !body.contains(&format!("{series}{{")),
             "{series} must not carry per-workspace labels in {body:?}"
         );
+    }
+
+    // RSS is procfs-backed, so the series is Linux-only (JP-404). Where it
+    // exists it must be a positive gauge — a running process has nonzero RSS.
+    #[cfg(target_os = "linux")]
+    {
+        assert!(
+            body.contains("# TYPE relay_process_rss_bytes gauge"),
+            "missing TYPE comment for relay_process_rss_bytes in {body:?}"
+        );
+        let rss = body
+            .lines()
+            .find(|l| l.starts_with("relay_process_rss_bytes "))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|v| v.parse::<u64>().ok())
+            .expect("relay_process_rss_bytes series present and numeric");
+        assert!(rss > 0, "expected nonzero RSS, got {rss}");
     }
 
     server.stop().await.expect("stop");


### PR DESCRIPTION
Adds the two surge-visibility gauges to `/metrics` (JP-404):

- `relay_active_docs_total` — documents currently resident in memory (hydrated Y.Docs, from `DocRegistry::len()`). Resident docs are the pod's dominant memory driver; without this count a memory-pressure scrape is blind to exactly the variable that grows under load.
- `relay_process_rss_bytes` — resident set size parsed from `/proc/self/status` (`VmRSS`). Linux-only: the series is omitted on other platforms, and consumers must treat absence as "no signal", not 0.

Both are pod-level aggregates with no per-workspace labels (cardinality stays bounded, matching the existing metering series).

## Verification

- `cargo check --all-targets` clean
- Full `cargo test` green (565 lib + all integration suites)
- `tests/panic_isolation.rs` at-rest smoke test extended: asserts `relay_active_docs_total 0` on a fresh relay and a present, nonzero `relay_process_rss_bytes` on Linux

Assisted-by: Fable 5