### PR TITLE
Deploy to staging: relay image rebuild (JP-404 surge metrics + JP-424 collections durability + JP-335 sidecar) + JP-416 tables + JP-423 sync hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # DocuShark
 
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
-[![Deploy Documentation](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/docs.yml/badge.svg)](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/docs.yml)
-[![Build Release Artifacts](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/release.yml/badge.svg)](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/release.yml)
 
 **The open-source engine behind DocuShark — a page-based document editor where prose, diagrams, data, and files live on the same page, with a built-in MCP server so AI agents can read and write your documents directly.**
 
@@ -18,7 +16,7 @@ or hand the whole document to an AI agent over MCP.
 **[Open DocuShark free in your browser → app.docushark.app](https://app.docushark.app)**
 No account required — documents you create in local mode never leave your device.
 
-**[Read the docs → dev.docushark.app](https://dev.docushark.app/)**
+**[Read the docs → docs.docushark.app](https://docs.docushark.app/)**
 
 > A desktop build (Tauri, offline-first) is in beta; the browser app is the
 > recommended way to start today.
@@ -39,7 +37,7 @@ No account required — documents you create in local mode never leave your devi
 - **MCP-native** — the relay ships a Model Context Protocol server, so agents
   (Claude Code/Desktop, Cursor, Zed, …) can create documents, write prose, and
   build diagrams programmatically. See
-  [`relay/docs/mcp/README.md`](relay/docs/mcp/README.md).
+  [our OSS architecture here](https://docs.docushark.app/developer/architecture.html).
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,42 @@
 [![Deploy Documentation](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/docs.yml/badge.svg)](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/docs.yml)
 [![Build Release Artifacts](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/release.yml/badge.svg)](https://github.com/JPE-Net-Technologies/docushark/actions/workflows/release.yml)
 
-The open-source DocuShark engine: a high-performance technical diagramming
-and docs editor. Runs as a Tauri desktop app or in the browser, talks to a
-self-hostable Rust relay for real-time collaboration.
+**The open-source engine behind DocuShark — a page-based document editor where prose, diagrams, data, and files live on the same page, with a built-in MCP server so AI agents can read and write your documents directly.**
 
-**[Download the latest release →](https://github.com/JPE-Net-Technologies/docushark/releases)**
-&nbsp;·&nbsp; **[Documentation →](https://dev.docushark.app/)**
+Write in rich text, drop in a flowchart or an architecture diagram, attach
+files, define reusable data fields and citations — then collaborate on it live,
+or hand the whole document to an AI agent over MCP.
+
+<!-- TODO(JP-412): hero screenshot / short GIF of the editor goes here.
+     Add the asset under docs/ or .github/ and reference it above the fold. -->
+
+## Try it
+
+**[Open DocuShark free in your browser → app.docushark.app](https://app.docushark.app)**
+No account required — documents you create in local mode never leave your device.
+
+**[Read the docs → dev.docushark.app](https://dev.docushark.app/)**
+
+> A desktop build (Tauri, offline-first) is in beta; the browser app is the
+> recommended way to start today.
+
+## What's inside
+
+- **Prose and canvas in one document** — a rich-text editor (Tiptap /
+  ProseMirror) alongside a high-performance Canvas 2D diagramming engine
+  (targeting 10,000+ shapes at 60fps). Page-based, not two tools bolted
+  together.
+- **Diagramming** — flowchart, UML, and custom shape libraries, with
+  auto-layout and smart connector routing. Import from **Mermaid, draw.io,
+  and Excalidraw**.
+- **Structured documents** — reusable document fields, citations, and
+  file/blob attachments as first-class content.
+- **Real-time collaboration** — CRDT sync (Yjs) over a self-hostable Rust
+  relay that holds the authoritative document; offline-first by design.
+- **MCP-native** — the relay ships a Model Context Protocol server, so agents
+  (Claude Code/Desktop, Cursor, Zed, …) can create documents, write prose, and
+  build diagrams programmatically. See
+  [`relay/docs/mcp/README.md`](relay/docs/mcp/README.md).
 
 ## Quick start
 
@@ -41,9 +71,8 @@ deploy + ops.
 [GNU Affero General Public License v3.0 or later](LICENSE).
 
 DocuShark is open-core. This repository (engine, desktop, relay, docs) is
-AGPL-3.0; the managed **DocuShark Cloud** control plane (marketing,
-billing, account portal, relay provisioning, premium integrations) is a
-separate proprietary codebase.
+AGPL-3.0; the managed **DocuShark Cloud** service (hosted relay + account
+portal) is a separate proprietary codebase.
 
 If you run a modified version as a network service, AGPL-3.0 requires you
 to release your modifications. Self-hosting for your own use is

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -307,7 +307,10 @@ paths:
         - bearerAuth: []
       responses:
         '200':
-          description: Collection definitions (id/name/colour/order), sorted by order.
+          description: |
+            Collection definitions (id/name/colour/order), sorted by order,
+            plus the registry version for the optimistic-concurrency
+            handshake on PUT.
           content:
             application/json:
               schema:
@@ -317,6 +320,10 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/CollectionDef'
+                  version:
+                    type: integer
+                    format: int64
+                    description: Registry version; bumps on every accepted PUT.
     put:
       tags: [docs]
       summary: Replace the workspace's collection definitions (wholesale)
@@ -324,6 +331,12 @@ paths:
         The editor owns the definition set and replaces it whole. Definitions
         are presentation metadata (name/colour/order), not membership — a
         document's membership is set via PUT /api/docs/{id}/collection.
+        Duplicate ids are healed keep-first; structural violations (empty or
+        oversized name/id/colour, more than 200 collections) are rejected
+        with 400. When `expectedVersion` is present the write is conditional
+        on the current registry version — a mismatch returns 409 with the
+        current state so the caller can rebase; omitted, the write is an
+        unconditional replace (legacy clients).
       security:
         - bearerAuth: []
       requestBody:
@@ -338,9 +351,32 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/CollectionDef'
+                expectedVersion:
+                  type: integer
+                  format: int64
+                  description: |
+                    The registry version this replace was computed against
+                    (from GET). Mismatch ⇒ 409, nothing written.
       responses:
         '200':
           description: Definitions replaced.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  newVersion:
+                    type: integer
+                    format: int64
+        '400':
+          description: Definition set failed validation.
+        '409':
+          description: |
+            `expectedVersion` no longer matches. Body carries
+            `errorCode: VERSION_CONFLICT`, `currentVersion`, and the current
+            `collections` set to rebase onto.
 
   /api/collections/{id}/documents:
     parameters:

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -253,6 +253,7 @@ pub fn routes() -> Router<Arc<ServerState>> {
         )
         .route("/api/docs", get(list_docs_handler))
         .route("/api/docs/:id", get(get_doc_handler))
+        .route("/api/docs/:id/ydoc", get(get_doc_ydoc_handler))
         .route("/api/docs/:id", put(save_doc_handler))
         .route("/api/docs/:id", delete(delete_doc_handler))
         .route("/api/docs/:id/share", post(share_doc_handler))
@@ -833,6 +834,102 @@ async fn get_doc_handler(
     match state.doc_store().get_document(&ws, &doc_id) {
         Ok(doc) => (StatusCode::OK, Json(doc)).into_response(),
         Err(e) => (StatusCode::NOT_FOUND, ApiError::body(e)).into_response(),
+    }
+}
+
+/// `GET /api/docs/:id/ydoc` — the document's authoritative binary Y.Doc sidecar
+/// (JP-108: a `DSKY`-framed lib0-v1 full-state update — every shared type incl.
+/// prose, with CRDT identity) as `application/octet-stream`. Read-scoped exactly
+/// like `GET /api/docs/:id`.
+///
+/// JP-335: lets a client prefetch the relay's exact CRDT state so a downloaded
+/// doc can be opened + edited offline and dedupe trivially on reconnect (the
+/// bytes ARE the relay's own state, so a later re-hydrate merges without
+/// doubling). Prefers a live handle's freshest encode, else the last persisted
+/// sidecar; 404 when binary persistence is off or no sidecar exists yet — the
+/// client then keeps its JSON-body read-only view, no regression.
+async fn get_doc_ydoc_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // JP-200: restore from R2 by id on a local miss before the permission check,
+    // mirroring `get_doc_handler`.
+    state.ensure_doc_local(&ws, &doc_id).await;
+
+    if let Err(e) = check_read_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    // The `binary_persistence` gate is load-bearing, not incidental. The dedup
+    // guarantee (client prefetches these bytes, edits offline, reconnects, and
+    // the two states MERGE instead of doubling) holds ONLY if the identity we
+    // serve now is the identity the relay reproduces on that reconnect. Both
+    // sources below satisfy that: a persisted sidecar is re-hydrated verbatim,
+    // and a live handle's lineage is flushed to a sidecar on evict. With
+    // persistence OFF there is no such continuity — a cold reconnect re-hydrates
+    // from JSON with FRESH clientIDs, so any bytes we served would double. So
+    // never hydrate-from-JSON here to "fill the gap": 404 and let the client keep
+    // its read-only JSON view (no regression) instead of handing out a lineage
+    // the relay will not reproduce.
+    if !state.binary_persistence() {
+        return (
+            StatusCode::NOT_FOUND,
+            ApiError::body("binary sidecar not available"),
+        )
+            .into_response();
+    }
+
+    // Prefer a live handle's freshest full-state encode (captures edits not yet
+    // flushed to disk; its lineage is persisted on evict, so identity carries
+    // across the client's offline window); fall back to the last persisted
+    // sidecar. Either is a valid lib0-v1 full-state update the client can
+    // `Y.applyUpdate`.
+    let bytes = if let Some(handle) = state.sync_registry().get(&ws, &doc_id) {
+        let version = state
+            .doc_store()
+            .get_metadata(&ws, &doc_id)
+            .and_then(|m| m.server_version)
+            .unwrap_or(0);
+        Some(handle.encode_binary(version))
+    } else {
+        state.doc_store().load_ydoc_binary(&ws, &doc_id)
+    };
+
+    match bytes {
+        Some(bytes) => (
+            StatusCode::OK,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/octet-stream",
+            )],
+            bytes,
+        )
+            .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            ApiError::body("binary sidecar not found"),
+        )
+            .into_response(),
     }
 }
 

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -24,7 +24,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::auth::{OidcClaims, WorkspaceRole};
-use crate::server::documents::{CollectionDef, SaveOutcome};
+use crate::server::documents::{
+    sanitize_collection_defs, CollectionDef, SaveOutcome, SetCollectionsOutcome,
+};
 use crate::server::protocol::ShareEntry;
 use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
@@ -335,11 +337,36 @@ struct CollectionMembershipRequest {
     collection_id: Option<String>,
 }
 
-/// Body of `PUT /api/collections` and response of `GET /api/collections`. The
-/// editor owns the definition set and replaces it wholesale.
-#[derive(Debug, Serialize, Deserialize)]
+/// Response of `GET /api/collections`: the definition set plus the registry
+/// version for the optimistic-concurrency handshake (JP-424). Pre-JP-424
+/// clients ignore the extra field.
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct CollectionsBody {
+struct CollectionsResponse {
+    collections: Vec<CollectionDef>,
+    version: u64,
+}
+
+/// Body of `PUT /api/collections`. The editor owns the definition set and
+/// replaces it wholesale. `expectedVersion` (JP-424) makes the write
+/// conditional on the current registry version — absent, the write is the
+/// legacy unconditional replace (pre-JP-424 clients).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetCollectionsRequest {
+    collections: Vec<CollectionDef>,
+    expected_version: Option<u64>,
+}
+
+/// 409 body for a conflicting `PUT /api/collections` (JP-424). Same
+/// `errorCode`/`currentVersion` keys as the doc-save [`VersionConflictBody`]
+/// so clients type it identically; `collections` carries the current set for
+/// consumers that want to rebase without another GET.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionsConflictBody {
+    error_code: &'static str,
+    current_version: u64,
     collections: Vec<CollectionDef>,
 }
 
@@ -1575,18 +1602,23 @@ async fn list_collections_handler(
         Err(resp) => return resp,
     };
     state.ensure_workspace_collections_local(&ws).await;
-    let collections = state.doc_store().list_collections(&ws);
-    (StatusCode::OK, Json(CollectionsBody { collections })).into_response()
+    let (collections, version) = state.doc_store().collections_snapshot(&ws);
+    (StatusCode::OK, Json(CollectionsResponse { collections, version })).into_response()
 }
 
 /// `PUT /api/collections` — replace the workspace's collection definitions
 /// wholesale (the editor owns the set). Definitions are presentation metadata,
 /// not membership, so a member-level session may update them; cross-workspace is
-/// already impossible (the set is keyed by the JWT's workspace).
+/// already impossible (the set is keyed by the JWT's workspace). JP-424: the
+/// write is validated (`sanitize_collection_defs` → 400) and, when the body
+/// carries `expectedVersion`, conditional on the registry version (→ 409 with
+/// the current state on mismatch). The registry is hydrated from R2 first so a
+/// cold machine neither spuriously conflicts against version 0 nor blind-writes
+/// over a mirrored set it never loaded.
 async fn set_collections_handler(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
-    Json(body): Json<CollectionsBody>,
+    Json(body): Json<SetCollectionsRequest>,
 ) -> impl IntoResponse {
     let claims = match require_auth(&state, &headers).await {
         Ok(c) => c,
@@ -1596,10 +1628,28 @@ async fn set_collections_handler(
         Ok(ws) => ws,
         Err(resp) => return resp,
     };
-    if let Err(e) = state.doc_store().set_collections(&ws, body.collections) {
-        return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response();
+    state.ensure_workspace_collections_local(&ws).await;
+    let defs = match sanitize_collection_defs(body.collections) {
+        Ok(defs) => defs,
+        Err(e) => return (StatusCode::BAD_REQUEST, ApiError::body(e)).into_response(),
+    };
+    match state.doc_store().set_collections(&ws, defs, body.expected_version) {
+        Ok(SetCollectionsOutcome::Updated { version }) => (
+            StatusCode::OK,
+            Json(SaveAck { success: true, new_version: version }),
+        )
+            .into_response(),
+        Ok(SetCollectionsOutcome::VersionConflict { current_version, current }) => (
+            StatusCode::CONFLICT,
+            Json(CollectionsConflictBody {
+                error_code: "VERSION_CONFLICT",
+                current_version,
+                collections: current,
+            }),
+        )
+            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
     }
-    (StatusCode::OK, Json(WriteAck { success: true })).into_response()
 }
 
 // ============ Helpers ============

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -5,13 +5,52 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
 use super::blob_backend::DocObjectStore;
 use super::protocol::{DocId, WorkspaceId};
+
+/// Crash-safe file write (JP-424): write to a sibling temp file in the same
+/// directory (same filesystem — required for an atomic `rename`), fsync, then
+/// rename over the destination. A crash mid-write leaves only a stray temp
+/// file, never a torn destination — load paths that treat a malformed file as
+/// empty (e.g. the collections registry) can't be tripped by a partial write.
+/// The temp suffix is unique per process+call because writers of the *same*
+/// path (doc saves) are not serialized by any per-doc lock. Directory fsync is
+/// deliberately skipped: the worst post-crash case is "rename not yet durable"
+/// (file absent), the same exposure as a plain write, and the R2 mirror
+/// restore path covers it.
+fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let dir = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "file".to_string());
+    let tmp = dir.join(format!(
+        ".{}.tmp-{}-{}",
+        file_name,
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let result = (|| {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
 
 /// A document-mirror operation enqueued for the background R2 worker (JP-200).
 /// Writes stay synchronous against the local volume; the worker re-reads the
@@ -62,6 +101,96 @@ pub struct CollectionDef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     pub order: i64,
+}
+
+/// In-memory per-workspace collections registry: the defs plus a monotonic
+/// version bumped on every accepted write (JP-424). The version backs the
+/// optimistic-concurrency check on `PUT /api/collections`, closing the
+/// lost-update window between two clients' read-modify-write cycles.
+#[derive(Debug, Clone, Default)]
+pub struct CollectionsRegistry {
+    pub version: u64,
+    pub defs: Vec<CollectionDef>,
+}
+
+/// On-disk shape of `collections.json` (JP-424): a version wrapper around the
+/// defs. Legacy files are a bare `[CollectionDef]` array — the loader accepts
+/// both (bare array ⇒ version 0) and the next accepted write rewrites the file
+/// in wrapper form.
+#[derive(Debug, Serialize, Deserialize)]
+struct CollectionsFile {
+    version: u64,
+    collections: Vec<CollectionDef>,
+}
+
+/// Parse `collections.json` content in either shape: the JP-424 version
+/// wrapper, or the legacy bare `[CollectionDef]` array (⇒ version 0). `None`
+/// when neither shape parses.
+fn parse_collections_file(data: &str) -> Option<CollectionsRegistry> {
+    if let Ok(file) = serde_json::from_str::<CollectionsFile>(data) {
+        return Some(CollectionsRegistry { version: file.version, defs: file.collections });
+    }
+    let defs = serde_json::from_str::<Vec<CollectionDef>>(data).ok()?;
+    Some(CollectionsRegistry { version: 0, defs })
+}
+
+/// Result of a collections-registry write attempt (JP-424) — mirrors the
+/// document-save `SaveOutcome` split so the handler can map a conflict to the
+/// same 409 wire shape.
+#[derive(Debug)]
+pub enum SetCollectionsOutcome {
+    /// The write landed; `version` is the new registry version.
+    Updated { version: u64 },
+    /// `expectedVersion` didn't match — nothing was written. Carries the
+    /// current state so the client can rebase without another GET.
+    VersionConflict { current_version: u64, current: Vec<CollectionDef> },
+}
+
+/// Registry caps enforced on `PUT /api/collections` (JP-424). Generous for
+/// interactive use; they exist to bound the sidecar file, not to police UX.
+pub const MAX_COLLECTIONS_PER_WORKSPACE: usize = 200;
+pub const MAX_COLLECTION_NAME_LEN: usize = 120;
+pub const MAX_COLLECTION_ID_LEN: usize = 64;
+pub const MAX_COLLECTION_COLOR_LEN: usize = 32;
+
+/// Validate + heal an incoming definition set (JP-424): duplicate ids are
+/// deduped keep-first (a heal for client bugs, not a user error); structural
+/// violations — empty/oversized fields or an oversized set — are rejected with
+/// a technical message the handler surfaces as a 400.
+pub fn sanitize_collection_defs(defs: Vec<CollectionDef>) -> Result<Vec<CollectionDef>, String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::with_capacity(defs.len());
+    for def in defs {
+        if !seen.insert(def.id.clone()) {
+            continue;
+        }
+        if def.id.is_empty() || def.id.len() > MAX_COLLECTION_ID_LEN {
+            return Err(format!(
+                "collection id must be 1..={} bytes",
+                MAX_COLLECTION_ID_LEN
+            ));
+        }
+        if def.name.trim().is_empty() || def.name.chars().count() > MAX_COLLECTION_NAME_LEN {
+            return Err(format!(
+                "collection name must be non-empty and at most {} characters",
+                MAX_COLLECTION_NAME_LEN
+            ));
+        }
+        if def.color.as_ref().is_some_and(|c| c.len() > MAX_COLLECTION_COLOR_LEN) {
+            return Err(format!(
+                "collection color exceeds {} bytes",
+                MAX_COLLECTION_COLOR_LEN
+            ));
+        }
+        out.push(def);
+    }
+    if out.len() > MAX_COLLECTIONS_PER_WORKSPACE {
+        return Err(format!(
+            "workspace exceeds {} collections",
+            MAX_COLLECTIONS_PER_WORKSPACE
+        ));
+    }
+    Ok(out)
 }
 
 /// Lightweight metadata for document listing
@@ -287,8 +416,11 @@ pub struct DocumentStore {
     /// Per-workspace collection **definitions** (name/colour/order), loaded from
     /// `workspaces/<ws>/collections.json`. Client-authoritative; the relay stores
     /// them so the web can render collection titles. Membership is not here (it's
-    /// `DocumentMetadata.collection_id`).
-    collections: RwLock<HashMap<WorkspaceId, Vec<CollectionDef>>>,
+    /// `DocumentMetadata.collection_id`). Key presence (even with empty defs)
+    /// means "loaded/probed" — [`ensure_workspace_collections_local`] keys its
+    /// cold-start R2 restore off that, so an emptied registry isn't re-fetched
+    /// (and resurrected) from a stale mirror (JP-424).
+    collections: RwLock<HashMap<WorkspaceId, CollectionsRegistry>>,
     /// JP-200 write-through R2 mirror sink. `Some` enqueues a [`MirrorOp`] after
     /// each successful local write for a background worker to upload; `None`
     /// (self-host / filesystem backend) keeps the store volume-only. The same
@@ -645,10 +777,10 @@ impl DocumentStore {
         let version = doc.get("serverVersion").and_then(|v| v.as_u64()).unwrap_or(0);
 
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.doc_path(ws, &doc_id), json_bytes)
+        write_atomic(&self.doc_path(ws, &doc_id), json_bytes)
             .map_err(|e| format!("restore: write json: {}", e))?;
         if let Some(bin) = ydoc_bytes {
-            std::fs::write(self.ydoc_path(ws, &doc_id), bin)
+            write_atomic(&self.ydoc_path(ws, &doc_id), bin)
                 .map_err(|e| format!("restore: write ydoc: {}", e))?;
         }
 
@@ -734,7 +866,7 @@ impl DocumentStore {
         match store.get_workspace_index(ws).await {
             Ok(Some(bytes)) => {
                 let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-                if std::fs::write(self.index_path(ws), &bytes).is_ok() {
+                if write_atomic(&self.index_path(ws), &bytes).is_ok() {
                     self.load_workspace_index(ws);
                     log::info!("restored index for workspace {} from R2", ws.as_str());
                 }
@@ -820,7 +952,7 @@ impl DocumentStore {
         bytes: &[u8],
     ) -> Result<(), String> {
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.ydoc_path(ws, doc_id), bytes)
+        write_atomic(&self.ydoc_path(ws, doc_id), bytes)
             .map_err(|e| format!("Write error: {}", e))?;
         // JP-231: refresh size/recency. No gen bump — json is the eviction gate;
         // restore is json-authoritative, a lagging ydoc is reconciled on hydrate.
@@ -1071,7 +1203,7 @@ impl DocumentStore {
             .map_err(|e| format!("Serialize error: {}", e))?;
         // Ensure the workspace dir exists before writing.
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.index_path(ws), json)
+        write_atomic(&self.index_path(ws), json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -1098,19 +1230,20 @@ impl DocumentStore {
     fn load_workspace_collections(&self, ws: &WorkspaceId) {
         let path = self.collections_path(ws);
         let Ok(data) = std::fs::read_to_string(&path) else { return };
-        let Ok(parsed) = serde_json::from_str::<Vec<CollectionDef>>(&data) else {
+        let Some(registry) = parse_collections_file(&data) else {
             log::warn!("collections for workspace {} are malformed — leaving empty", ws.as_str());
             return;
         };
         if let Ok(mut current) = self.collections.write() {
-            current.insert(ws.clone(), parsed);
+            current.insert(ws.clone(), registry);
         }
     }
 
-    /// Snapshot the in-memory definitions for a workspace and write them to disk.
-    /// A wholesale replace (the client PUTs the full set), so unlike the index
-    /// there's no per-entry merge race; the `index_write_lock` still serializes
-    /// concurrent file writes for this workspace's sidecars.
+    /// Snapshot the in-memory registry for a workspace and write it to disk in
+    /// the version-wrapper shape. A wholesale replace (the client PUTs the full
+    /// set), so unlike the index there's no per-entry merge race; the
+    /// `index_write_lock` still serializes concurrent file writes for this
+    /// workspace's sidecars.
     fn write_workspace_collections_file(&self, ws: &WorkspaceId) -> Result<(), String> {
         let _guard = self
             .index_write_lock
@@ -1120,10 +1253,11 @@ impl DocumentStore {
             let collections = self.collections.read().map_err(|e| e.to_string())?;
             collections.get(ws).cloned().unwrap_or_default()
         };
-        let json = serde_json::to_string_pretty(&snapshot)
+        let file = CollectionsFile { version: snapshot.version, collections: snapshot.defs };
+        let json = serde_json::to_string_pretty(&file)
             .map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws));
-        std::fs::write(self.collections_path(ws), json)
+        write_atomic(&self.collections_path(ws), json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -1136,26 +1270,71 @@ impl DocumentStore {
 
     /// List a workspace's collection definitions (sorted by `order`).
     pub fn list_collections(&self, ws: &WorkspaceId) -> Vec<CollectionDef> {
-        let mut defs = self
+        self.collections_snapshot(ws).0
+    }
+
+    /// A workspace's definitions (sorted by `order`) plus the registry version,
+    /// for the GET handler's optimistic-concurrency handshake (JP-424).
+    pub fn collections_snapshot(&self, ws: &WorkspaceId) -> (Vec<CollectionDef>, u64) {
+        let registry = self
             .collections
             .read()
             .ok()
             .and_then(|c| c.get(ws).cloned())
             .unwrap_or_default();
+        let mut defs = registry.defs;
         defs.sort_by_key(|c| c.order);
-        defs
+        (defs, registry.version)
+    }
+
+    /// Whether a workspace's registry has been loaded or probed (key presence —
+    /// an empty entry counts). Gates the cold-start R2 restore so an emptied
+    /// registry isn't re-fetched from a stale mirror (JP-424).
+    pub fn has_workspace_collections_loaded(&self, ws: &WorkspaceId) -> bool {
+        self.collections.read().ok().is_some_and(|c| c.contains_key(ws))
+    }
+
+    /// Ensure a workspace has an in-memory registry entry (default empty, v0).
+    /// Called once the cold-start restore attempt has run — hit or miss — so
+    /// repeated reads don't re-probe R2.
+    pub fn memoize_collections_probe(&self, ws: &WorkspaceId) {
+        if let Ok(mut current) = self.collections.write() {
+            current.entry(ws.clone()).or_default();
+        }
     }
 
     /// Replace a workspace's collection definitions wholesale (the editor owns
-    /// the set and PUTs it whole). Persists locally and mirrors to R2.
-    pub fn set_collections(&self, ws: &WorkspaceId, defs: Vec<CollectionDef>) -> Result<(), String> {
-        {
+    /// the set and PUTs it whole). When `expected` is `Some`, the write only
+    /// lands if it matches the current registry version (optimistic concurrency,
+    /// JP-424) — a mismatch returns the current state for the client to rebase
+    /// onto. `None` preserves the legacy blind write. Every accepted write bumps
+    /// the version, persists locally, and mirrors to R2.
+    pub fn set_collections(
+        &self,
+        ws: &WorkspaceId,
+        defs: Vec<CollectionDef>,
+        expected: Option<u64>,
+    ) -> Result<SetCollectionsOutcome, String> {
+        let version = {
             let mut current = self.collections.write().map_err(|e| e.to_string())?;
-            current.insert(ws.clone(), defs);
-        }
+            let entry = current.entry(ws.clone()).or_default();
+            if let Some(expected) = expected {
+                if expected != entry.version {
+                    let mut defs = entry.defs.clone();
+                    defs.sort_by_key(|c| c.order);
+                    return Ok(SetCollectionsOutcome::VersionConflict {
+                        current_version: entry.version,
+                        current: defs,
+                    });
+                }
+            }
+            entry.version += 1;
+            entry.defs = defs;
+            entry.version
+        };
         self.write_workspace_collections_file(ws)?;
         self.enqueue_mirror(MirrorOp::PutCollections { ws: ws.clone() });
-        Ok(())
+        Ok(SetCollectionsOutcome::Updated { version })
     }
 
     /// Restore a workspace's collection definitions from R2 on a cold machine
@@ -1168,7 +1347,7 @@ impl DocumentStore {
         match store.get_workspace_collections(ws).await {
             Ok(Some(bytes)) => {
                 let _ = std::fs::create_dir_all(self.workspace_root(ws));
-                if std::fs::write(self.collections_path(ws), &bytes).is_ok() {
+                if write_atomic(&self.collections_path(ws), &bytes).is_ok() {
                     self.load_workspace_collections(ws);
                     log::info!("restored collections for workspace {} from R2", ws.as_str());
                 }
@@ -1230,7 +1409,7 @@ impl DocumentStore {
         let json = serde_json::to_string_pretty(&snapshot)
             .map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws));
-        std::fs::write(self.deleted_ids_path(ws), json)
+        write_atomic(&self.deleted_ids_path(ws), json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
         Ok(())
     }
@@ -1327,7 +1506,7 @@ impl DocumentStore {
         match store.get_workspace_deleted_ids(ws).await {
             Ok(Some(bytes)) => {
                 let _ = std::fs::create_dir_all(self.workspace_root(ws));
-                if std::fs::write(self.deleted_ids_path(ws), &bytes).is_ok() {
+                if write_atomic(&self.deleted_ids_path(ws), &bytes).is_ok() {
                     self.load_workspace_deleted_ids(ws);
                     log::info!("restored tombstones for workspace {} from R2", ws.as_str());
                 }
@@ -1552,7 +1731,7 @@ impl DocumentStore {
         // Ensure the per-workspace docs dir exists (first-touch for a
         // new tenant on shared-mode Cloud).
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.doc_path(ws, &doc_id), doc_json)
+        write_atomic(&self.doc_path(ws, &doc_id), doc_json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
 
         {
@@ -1623,7 +1802,8 @@ impl DocumentStore {
 
         let doc_json = serde_json::to_string_pretty(&doc).map_err(|e| format!("Serialize error: {}", e))?;
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
-        std::fs::write(self.doc_path(ws, &doc_id), doc_json).map_err(|e| format!("Write error: {}", e))?;
+        write_atomic(&self.doc_path(ws, &doc_id), doc_json.as_bytes())
+            .map_err(|e| format!("Write error: {}", e))?;
 
         {
             let mut index = self.index.write().map_err(|e| e.to_string())?;
@@ -2105,24 +2285,164 @@ mod tests {
         {
             let store = DocumentStore::new(dir.path().to_path_buf());
             assert!(store.list_collections(&ws).is_empty());
-            store.set_collections(&ws, defs.clone()).unwrap();
+            let outcome = store.set_collections(&ws, defs.clone(), None).unwrap();
+            assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 1 }));
             // Sorted by order.
             let listed = store.list_collections(&ws);
             assert_eq!(listed.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(), ["a", "b"]);
             assert_eq!(listed[0].color.as_deref(), Some("#ef4444"));
         }
-        // A fresh store over the same dir preloads the persisted registry.
+        // A fresh store over the same dir preloads the persisted registry —
+        // including the version (the wrapper file shape round-trips).
         let reloaded = DocumentStore::new(dir.path().to_path_buf());
-        assert_eq!(reloaded.list_collections(&ws).len(), 2);
+        let (listed, version) = reloaded.collections_snapshot(&ws);
+        assert_eq!(listed.len(), 2);
+        assert_eq!(version, 1);
 
-        // Wholesale replace.
-        reloaded
-            .set_collections(&ws, vec![CollectionDef { id: "c".into(), name: "C".into(), color: None, order: 0 }])
+        // Wholesale replace bumps again.
+        let outcome = reloaded
+            .set_collections(
+                &ws,
+                vec![CollectionDef { id: "c".into(), name: "C".into(), color: None, order: 0 }],
+                None,
+            )
             .unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 2 }));
         assert_eq!(
             reloaded.list_collections(&ws).iter().map(|c| c.id.clone()).collect::<Vec<_>>(),
             ["c"]
         );
+    }
+
+    #[test]
+    fn collections_legacy_bare_array_loads_as_v0_and_upgrades_on_write() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceId::single_tenant();
+        // Pre-JP-424 file: a bare CollectionDef array.
+        {
+            let store = DocumentStore::new(dir.path().to_path_buf());
+            let path = store.collections_path(&ws);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, br#"[{"id":"x","name":"X","order":0}]"#).unwrap();
+        }
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let (defs, version) = store.collections_snapshot(&ws);
+        assert_eq!(defs.len(), 1);
+        assert_eq!(version, 0, "legacy bare array reads as version 0");
+
+        // First accepted write (conditional on the legacy version) upgrades the
+        // file to the wrapper shape.
+        let outcome = store
+            .set_collections(
+                &ws,
+                vec![CollectionDef { id: "x".into(), name: "X2".into(), color: None, order: 0 }],
+                Some(0),
+            )
+            .unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 1 }));
+        let raw = std::fs::read_to_string(store.collections_path(&ws)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["version"], 1, "file rewritten in wrapper form");
+        assert_eq!(parsed["collections"][0]["name"], "X2");
+    }
+
+    #[test]
+    fn collections_expected_version_gates_the_write() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let def = |id: &str, order: i64| CollectionDef {
+            id: id.into(),
+            name: id.to_uppercase(),
+            color: None,
+            order,
+        };
+        store.set_collections(&ws, vec![def("a", 0)], None).unwrap(); // v1
+
+        // Stale expectation ⇒ conflict, nothing written.
+        let outcome = store.set_collections(&ws, vec![def("b", 0)], Some(0)).unwrap();
+        match outcome {
+            SetCollectionsOutcome::VersionConflict { current_version, current } => {
+                assert_eq!(current_version, 1);
+                assert_eq!(current.len(), 1);
+                assert_eq!(current[0].id, "a");
+            }
+            other => panic!("expected conflict, got {:?}", other),
+        }
+        assert_eq!(store.list_collections(&ws)[0].id, "a", "conflicting write must not land");
+
+        // Matching expectation ⇒ accepted.
+        let outcome = store.set_collections(&ws, vec![def("b", 0)], Some(1)).unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 2 }));
+
+        // Blind write (legacy client) still lands and bumps.
+        let outcome = store.set_collections(&ws, vec![def("c", 0)], None).unwrap();
+        assert!(matches!(outcome, SetCollectionsOutcome::Updated { version: 3 }));
+    }
+
+    #[test]
+    fn collections_presence_guard_and_probe_memoization() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        // Never touched: not loaded (the ensure path would probe R2 once).
+        assert!(!store.has_workspace_collections_loaded(&ws));
+        store.memoize_collections_probe(&ws);
+        assert!(store.has_workspace_collections_loaded(&ws));
+        assert!(store.list_collections(&ws).is_empty());
+        // A memoized empty entry is presence — an emptied registry must not be
+        // treated as "cold" again (stale-mirror resurrection guard).
+        assert_eq!(store.collections_snapshot(&ws).1, 0);
+    }
+
+    #[test]
+    fn sanitize_collection_defs_dedupes_and_rejects() {
+        let def = |id: &str, name: &str| CollectionDef {
+            id: id.into(),
+            name: name.into(),
+            color: None,
+            order: 0,
+        };
+        // Duplicate ids: keep-first heal, not an error.
+        let out =
+            sanitize_collection_defs(vec![def("a", "First"), def("a", "Second"), def("b", "B")])
+                .unwrap();
+        assert_eq!(out.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(), ["First", "B"]);
+
+        // Structural violations reject.
+        assert!(sanitize_collection_defs(vec![def("", "X")]).is_err());
+        assert!(sanitize_collection_defs(vec![def("a", "   ")]).is_err());
+        assert!(sanitize_collection_defs(vec![def("a", &"n".repeat(121))]).is_err());
+        assert!(sanitize_collection_defs(vec![def(&"i".repeat(65), "X")]).is_err());
+        let mut oversized_color = def("a", "X");
+        oversized_color.color = Some("c".repeat(33));
+        assert!(sanitize_collection_defs(vec![oversized_color]).is_err());
+        let too_many: Vec<_> =
+            (0..=MAX_COLLECTIONS_PER_WORKSPACE).map(|i| def(&format!("c{}", i), "N")).collect();
+        assert!(sanitize_collection_defs(too_many).is_err());
+
+        // At the cap is fine.
+        let at_cap: Vec<_> =
+            (0..MAX_COLLECTIONS_PER_WORKSPACE).map(|i| def(&format!("c{}", i), "N")).collect();
+        assert_eq!(sanitize_collection_defs(at_cap).unwrap().len(), MAX_COLLECTIONS_PER_WORKSPACE);
+    }
+
+    #[test]
+    fn write_atomic_lands_content_and_leaves_no_temp_residue() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("out.json");
+        write_atomic(&path, b"first").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"first");
+        // Overwrite via rename-over-existing.
+        write_atomic(&path, b"second").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
+        // No stray temp files.
+        let residue: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp-"))
+            .collect();
+        assert!(residue.is_empty(), "temp files must be renamed or removed");
     }
 
     #[test]
@@ -2234,8 +2554,12 @@ mod tests {
             ..Default::default()
         };
         store.restore_workspace_collections_from(&fake, &ws).await;
-        assert_eq!(store.list_collections(&ws).len(), 1);
-        assert_eq!(store.list_collections(&ws)[0].name, "X");
+        let (defs, version) = store.collections_snapshot(&ws);
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].name, "X");
+        // Legacy bare-array mirror object parses through the dual-format loader.
+        assert_eq!(version, 0);
+        assert!(store.has_workspace_collections_loaded(&ws));
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -2252,7 +2252,7 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
         }
     }
 
-    let body = format!(
+    let mut body = format!(
         "# HELP relay_build_info Relay build identity (always 1; read the labels).\n\
          # TYPE relay_build_info gauge\n\
          relay_build_info{{version=\"{version}\",commit=\"{commit}\"}} 1\n\
@@ -2289,10 +2289,41 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
         jwks_failures = jwks.refresh_failures_total,
         jwks_keys = jwks.key_count,
     );
+
+    // Surge-visibility signals (JP-404). Resident hydrated Y.Docs are the
+    // pod's dominant memory driver, so scrapers need the count alongside the
+    // process RSS to see memory pressure building before the kernel does.
+    let active_docs = state.sync_registry().len();
+    body.push_str(&format!(
+        "# HELP relay_active_docs_total Documents currently resident in memory (hydrated Y.Docs).\n\
+         # TYPE relay_active_docs_total gauge\n\
+         relay_active_docs_total {active_docs}\n"
+    ));
+    // RSS comes from procfs, so the series only exists on Linux; consumers
+    // must tolerate its absence rather than read it as 0.
+    #[cfg(target_os = "linux")]
+    if let Some(rss_bytes) = process_rss_bytes() {
+        body.push_str(&format!(
+            "# HELP relay_process_rss_bytes Resident set size of the relay process.\n\
+             # TYPE relay_process_rss_bytes gauge\n\
+             relay_process_rss_bytes {rss_bytes}\n"
+        ));
+    }
+
     (
         [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
         body,
     )
+}
+
+/// Resident-set size of this process in bytes, parsed from the `VmRSS:` line
+/// of `/proc/self/status` (reported by the kernel in kB).
+#[cfg(target_os = "linux")]
+fn process_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let line = status.lines().find(|l| l.starts_with("VmRSS:"))?;
+    let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+    Some(kb * 1024)
 }
 
 // ============ Blob HTTP Endpoints ============

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -945,10 +945,12 @@ impl ServerState {
     }
 
     /// Best-effort restore of a workspace's collection definitions from R2 before
-    /// serving the collections registry on a cold machine. Only reaches for R2
-    /// when the in-memory registry is empty, so a populated one is never clobbered.
+    /// serving the collections registry on a cold machine. Keyed on registry
+    /// **presence**, not emptiness (JP-424): a workspace that legitimately
+    /// emptied its registry must not have it resurrected from a stale mirror,
+    /// and a probe (hit or R2 miss) is memoized so repeat reads don't re-fetch.
     pub(crate) async fn ensure_workspace_collections_local(&self, ws: &WorkspaceId) {
-        if !self.doc_store.list_collections(ws).is_empty() {
+        if self.doc_store.has_workspace_collections_loaded(ws) {
             return;
         }
         if let Some(s3) = &self.s3 {
@@ -956,6 +958,7 @@ impl ServerState {
                 .restore_workspace_collections_from(s3.as_ref(), ws)
                 .await;
         }
+        self.doc_store.memoize_collections_probe(ws);
     }
 
     /// Try to register a new authenticated WS connection for the

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1273,8 +1273,9 @@ impl DocRegistry {
             .collect()
     }
 
-    /// Number of resident docs (diagnostics / tests).
-    #[allow(dead_code)]
+    /// Number of resident docs. Exposed as `relay_active_docs_total` on
+    /// `/metrics` (JP-404) — resident Y.Docs are the pod's main memory
+    /// driver, so surge visibility keys off this count.
     pub fn len(&self) -> usize {
         self.docs.read().unwrap().len()
     }

--- a/relay/tests/collections_api.rs
+++ b/relay/tests/collections_api.rs
@@ -1,0 +1,200 @@
+//! Integration tests for the `/api/collections` registry surface (JP-424).
+//!
+//! Builds the relay in-process (same harness pattern as `smoke.rs`) and
+//! exercises the optimistic-concurrency handshake end to end: versioned GET,
+//! conditional PUT, the 409 conflict shape, and the sanitize gate.
+
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct RelayHarness {
+    base: String,
+    issuer: OidcTestIssuer,
+    server: Arc<WebSocketServer>,
+    _tmp: TempDir,
+}
+
+impl RelayHarness {
+    async fn start() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let issuer = OidcTestIssuer::new().await;
+
+        let server = Arc::new(WebSocketServer::new());
+        server.set_app_data_dir(tmp.path().to_path_buf()).await;
+        server.set_auth(issuer.auth_state()).await;
+        server
+            .set_config(ServerConfig {
+                port: 0,
+                network_mode: NetworkMode::Localhost,
+                max_connections: 0,
+            })
+            .await
+            .expect("set_config");
+
+        let bound = server.start(0).await.expect("start");
+        let http = bound
+            .strip_prefix("ws://")
+            .map(|rest| format!("http://{rest}"))
+            .unwrap_or(bound);
+
+        RelayHarness {
+            base: http,
+            issuer,
+            server,
+            _tmp: tmp,
+        }
+    }
+
+    fn token(&self, sub: &str) -> String {
+        self.issuer.mint(sub, "default", WorkspaceRole::Owner)
+    }
+
+    async fn stop(self) {
+        self.server.stop().await.expect("stop");
+    }
+}
+
+fn def(id: &str, name: &str, order: i64) -> serde_json::Value {
+    json!({ "id": id, "name": name, "order": order })
+}
+
+#[tokio::test]
+async fn collections_versioned_put_roundtrip_and_conflict() {
+    let harness = RelayHarness::start().await;
+    let client = reqwest::Client::new();
+    let bearer = format!("Bearer {}", harness.token("alice"));
+    let url = format!("{}/api/collections", harness.base);
+
+    // Cold GET: empty set, version 0.
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get empty");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["collections"].as_array().map(|a| a.len()), Some(0));
+    assert_eq!(body["version"], 0);
+
+    // Legacy blind PUT (no expectedVersion) lands and bumps to v1.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("a", "Alpha", 0)] }))
+        .send()
+        .await
+        .expect("blind put");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["newVersion"], 1);
+
+    // GET reflects the write and its version.
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get v1");
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["version"], 1);
+    assert_eq!(body["collections"][0]["id"], "a");
+
+    // Stale expectedVersion ⇒ 409 with the doc-save conflict keys plus the
+    // current set; the store is untouched.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("b", "Beta", 0)], "expectedVersion": 0 }))
+        .send()
+        .await
+        .expect("stale put");
+    assert_eq!(res.status().as_u16(), 409);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["errorCode"], "VERSION_CONFLICT");
+    assert_eq!(body["currentVersion"], 1);
+    assert_eq!(body["collections"][0]["id"], "a");
+
+    // Matching expectedVersion ⇒ accepted, v2.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("b", "Beta", 0)], "expectedVersion": 1 }))
+        .send()
+        .await
+        .expect("conditional put");
+    assert_eq!(res.status().as_u16(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["newVersion"], 2);
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn collections_put_sanitizes_and_rejects() {
+    let harness = RelayHarness::start().await;
+    let client = reqwest::Client::new();
+    let bearer = format!("Bearer {}", harness.token("alice"));
+    let url = format!("{}/api/collections", harness.base);
+
+    // Duplicate ids are healed keep-first, not rejected.
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("a", "First", 0), def("a", "Second", 1)] }))
+        .send()
+        .await
+        .expect("dupe put");
+    assert_eq!(res.status().as_u16(), 200);
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("get after dupe");
+    let body: serde_json::Value = res.json().await.unwrap();
+    let listed = body["collections"].as_array().unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["name"], "First");
+
+    // Empty name ⇒ 400, nothing written (version unchanged).
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": [def("b", "   ", 0)] }))
+        .send()
+        .await
+        .expect("bad name put");
+    assert_eq!(res.status().as_u16(), 400);
+
+    // Over the per-workspace cap ⇒ 400.
+    let too_many: Vec<serde_json::Value> =
+        (0..=200).map(|i| def(&format!("c{i}"), "N", i)).collect();
+    let res = client
+        .put(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .json(&json!({ "collections": too_many }))
+        .send()
+        .await
+        .expect("over cap put");
+    assert_eq!(res.status().as_u16(), 400);
+
+    // Registry still at the healed single entry, version 1.
+    let res = client
+        .get(&url)
+        .header(reqwest::header::AUTHORIZATION, &bearer)
+        .send()
+        .await
+        .expect("final get");
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["version"], 1);
+    assert_eq!(body["collections"].as_array().map(|a| a.len()), Some(1));
+
+    harness.stop().await;
+}

--- a/relay/tests/panic_isolation.rs
+++ b/relay/tests/panic_isolation.rs
@@ -84,6 +84,7 @@ async fn metrics_endpoint_exposes_panic_counter_in_prometheus_format() {
         "relay_active_editors_total",
         "relay_active_viewers_total",
         "relay_rate_limit_rejections_total",
+        "relay_active_docs_total",
     ] {
         assert!(
             body.contains(&format!("# TYPE {series}")),
@@ -98,6 +99,23 @@ async fn metrics_endpoint_exposes_panic_counter_in_prometheus_format() {
             !body.contains(&format!("{series}{{")),
             "{series} must not carry per-workspace labels in {body:?}"
         );
+    }
+
+    // RSS is procfs-backed, so the series is Linux-only (JP-404). Where it
+    // exists it must be a positive gauge — a running process has nonzero RSS.
+    #[cfg(target_os = "linux")]
+    {
+        assert!(
+            body.contains("# TYPE relay_process_rss_bytes gauge"),
+            "missing TYPE comment for relay_process_rss_bytes in {body:?}"
+        );
+        let rss = body
+            .lines()
+            .find(|l| l.starts_with("relay_process_rss_bytes "))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|v| v.parse::<u64>().ok())
+            .expect("relay_process_rss_bytes series present and numeric");
+        assert!(rss > 0, "expected nonzero RSS, got {rss}");
     }
 
     server.stop().await.expect("stop");

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -378,6 +378,97 @@ async fn join_delivers_authoritative_state_without_duplication() {
     relay.server.stop().await.expect("stop");
 }
 
+/// JP-335: `GET /api/docs/:id/ydoc` serves the authoritative binary Y.Doc
+/// sidecar so a client can prefetch the relay's exact CRDT state, edit it
+/// offline, and dedupe on reconnect (the served bytes ARE the relay's lineage).
+#[tokio::test]
+async fn ydoc_endpoint_serves_authoritative_binary_sidecar() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-yd", "name": "Sidecar", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {
+                "id": "p1",
+                "shapes": {"s1": {"id": "s1", "type": "rectangle", "x": 5, "y": 6}},
+                "shapeOrder": ["s1"]
+            }}
+        }),
+    )
+    .await;
+
+    // Join + sync to bring up the live authoritative handle so the endpoint has a
+    // handle/sidecar to serve.
+    let mut client = WsClient::connect(&relay.ws_base).await;
+    client.auth(&token).await;
+    client.join_doc("doc-yd").await;
+    client
+        .send_sync(&SyncMessage::SyncStep1(StateVector::default()).encode_v1())
+        .await;
+    let local = LocalDoc::new();
+    for _ in 0..10 {
+        if let Some((ty, bytes)) = client.recv_within(300).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.has_shape("p1", "s1") {
+            break;
+        }
+    }
+
+    // Unauthenticated → rejected (same auth gate as `GET /api/docs/:id`).
+    let no_auth = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-yd/ydoc", relay.http))
+        .send()
+        .await
+        .expect("GET no auth");
+    assert!(
+        no_auth.status().is_client_error(),
+        "unauthenticated ydoc must be rejected, got {}",
+        no_auth.status()
+    );
+
+    // Authenticated read → 200 octet-stream, DSKY-framed, decodes to the shape.
+    let resp = reqwest::Client::new()
+        .get(format!("{}/api/docs/doc-yd/ydoc", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("GET ydoc");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK, "ydoc GET status");
+    assert_eq!(
+        resp.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/octet-stream"),
+        "ydoc content-type"
+    );
+    let bytes = resp.bytes().await.expect("ydoc bytes").to_vec();
+    assert!(
+        bytes.len() > 16 && &bytes[0..4] == b"DSKY",
+        "sidecar must be DSKY-framed, got {} bytes",
+        bytes.len()
+    );
+
+    // Decode the payload (skip the 16-byte header) and confirm CRDT content —
+    // the client will `Y.applyUpdate` exactly this into its local Y.Doc.
+    let update = Update::decode_v1(&bytes[16..]).expect("decode sidecar update");
+    let doc = Doc::new();
+    doc.transact_mut().apply_update(update).expect("apply sidecar");
+    let shapes = doc.get_or_insert_map("shapes:p1");
+    assert!(
+        shapes.contains_key(&doc.transact(), "s1"),
+        "sidecar carries the seeded shape"
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
 #[tokio::test]
 async fn update_from_one_client_reaches_the_other() {
     let relay = start_relay().await;

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -280,7 +280,7 @@ export class RelayClient {
   }
 
   /**
-   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (the relay's
+   * JP-422: fetch a document's authoritative binary Y.Doc sidecar (the relay's
    * exact CRDT state — every shared type, with identity) as raw bytes. Seeding
    * these into the client's local Y.Doc lets a prefetched doc be opened + edited
    * offline and dedupe on reconnect (the bytes ARE the relay's lineage). Returns

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -279,6 +279,28 @@ export class RelayClient {
     );
   }
 
+  /**
+   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (the relay's
+   * exact CRDT state — every shared type, with identity) as raw bytes. Seeding
+   * these into the client's local Y.Doc lets a prefetched doc be opened + edited
+   * offline and dedupe on reconnect (the bytes ARE the relay's lineage). Returns
+   * null when the relay has no sidecar (404) or binary persistence is off — the
+   * caller then keeps the read-only JSON view, no error.
+   */
+  async getYdoc(docId: string): Promise<Uint8Array | null> {
+    try {
+      const res = await this.requestRaw(
+        'GET',
+        `/api/docs/${encodeURIComponent(docId)}/ydoc`,
+      );
+      const buf = await res.arrayBuffer();
+      return new Uint8Array(buf);
+    } catch (e) {
+      if (e instanceof RelayError && e.status === 404) return null;
+      throw e;
+    }
+  }
+
   async updateDocumentShares(
     docId: string,
     shares: RelayShareEntry[],

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -324,8 +324,12 @@ export class RelayClient {
 
   // ============ Collections (JP-159) ============
 
-  /** The connected workspace's collection definitions (`GET /api/collections`). */
-  async getCollections(): Promise<{ collections: RelayCollectionDef[] }> {
+  /**
+   * The connected workspace's collection definitions (`GET /api/collections`).
+   * `version` is the registry version for the optimistic-concurrency handshake
+   * (JP-424); absent when talking to a pre-JP-424 relay.
+   */
+  async getCollections(): Promise<{ collections: RelayCollectionDef[]; version?: number }> {
     return this.requestJson('GET', '/api/collections', { auth: true });
   }
 
@@ -333,12 +337,20 @@ export class RelayClient {
    * Replace the connected workspace's collection definitions wholesale
    * (`PUT /api/collections`). The relay scopes this to the token's workspace;
    * callers must pass that workspace's full set (read-modify-write), never a
-   * cross-workspace union of the client's global store.
+   * cross-workspace union of the client's global store. When `expectedVersion`
+   * is provided the write is conditional — a mismatch rejects with a typed
+   * `VersionConflictError` (JP-424); omitted, it's the legacy blind replace.
    */
-  async setCollections(collections: RelayCollectionDef[]): Promise<{ success: boolean }> {
+  async setCollections(
+    collections: RelayCollectionDef[],
+    expectedVersion?: number,
+  ): Promise<{ success: boolean }> {
     return this.requestJson('PUT', '/api/collections', {
       auth: true,
-      body: { collections },
+      body: {
+        collections,
+        ...(expectedVersion !== undefined ? { expectedVersion } : {}),
+      },
     });
   }
 

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -93,6 +93,10 @@ export class RestDocumentProvider {
     return this.client.getRecoveryPointContent(docId, pointId);
   }
 
+  async getYdoc(docId: string): Promise<Uint8Array | null> {
+    return this.client.getYdoc(docId);
+  }
+
   async restoreRecoveryPoint(
     docId: string,
     pointId: string,

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -146,13 +146,15 @@ export class RestDocumentProvider {
 
   // ============ Collections (JP-159) ============
 
-  async getCollections(): Promise<RelayCollectionDef[]> {
-    const { collections } = await this.client.getCollections();
-    return collections;
+  async getCollections(): Promise<{ collections: RelayCollectionDef[]; version?: number }> {
+    return this.client.getCollections();
   }
 
-  async setCollections(collections: RelayCollectionDef[]): Promise<void> {
-    await this.client.setCollections(collections);
+  async setCollections(
+    collections: RelayCollectionDef[],
+    expectedVersion?: number,
+  ): Promise<void> {
+    await this.client.setCollections(collections, expectedVersion);
   }
 
   async setDocumentCollection(docId: string, collectionId: string | null): Promise<void> {

--- a/src/collaboration/SyncStateManager.serializeSeam.test.ts
+++ b/src/collaboration/SyncStateManager.serializeSeam.test.ts
@@ -1,0 +1,96 @@
+/**
+ * JP-423 — the `queueSave` seam applies `serializeDocForRest`.
+ *
+ * A queued body IS a REST body (it replays as one), so the withhold applies at
+ * enqueue time — reflecting the pending markers as they were when the edit
+ * happened, not whenever the replay later fires.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../store/documentRegistry', () => ({
+  useDocumentRegistry: {
+    getState: vi.fn(() => ({
+      hasDocument: vi.fn(() => false),
+      isRemoteDocument: vi.fn(() => false),
+      setSyncState: vi.fn(),
+      incrementPendingChanges: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('../store/connectionStore', () => ({
+  useConnectionStore: {
+    getState: vi.fn(() => ({ status: 'disconnected', host: null })),
+    subscribe: vi.fn(() => vi.fn()),
+  },
+}));
+
+vi.mock('../storage/SyncQueueStorage', () => ({
+  getSyncQueueStorage: vi.fn(() => ({
+    loadAll: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    saveAll: vi.fn().mockResolvedValue({ success: true }),
+    clearAll: vi.fn().mockResolvedValue({ success: true }),
+  })),
+}));
+
+import { SyncStateManager } from './SyncStateManager';
+import { resetOfflineQueue } from './OfflineQueue';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
+import type { DiagramDocument } from '../types/Document';
+
+function makeDoc(): DiagramDocument {
+  return {
+    id: 'doc-1',
+    name: 'Doc',
+    pages: {},
+    pageOrder: [],
+    activePageId: '',
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 1,
+    richTextPages: {
+      pages: {
+        'rt-pending': {
+          id: 'rt-pending',
+          name: 'Pending',
+          content: '<p>offline-created</p>',
+          createdAt: 0,
+          modifiedAt: 0,
+        },
+      },
+      pageOrder: ['rt-pending'],
+      activePageId: 'rt-pending',
+    },
+  } as unknown as DiagramDocument;
+}
+
+describe('queueSave seam (JP-423)', () => {
+  beforeEach(() => {
+    resetOfflineQueue();
+    usePendingSyncPages.setState({ pending: {} });
+  });
+
+  it('enqueues the withheld body when a page is pending', () => {
+    usePendingSyncPages.getState().markPending('rt-pending', 'doc-1');
+    const manager = new SyncStateManager({ autoProcessOnReconnect: false });
+
+    const op = manager.queueSave(makeDoc(), 'relay-1');
+
+    expect(op.type).toBe('save');
+    if (op.type === 'save') {
+      expect(op.document.richTextPages?.pages['rt-pending']?.content).toBe('');
+    }
+  });
+
+  it('enqueues the body unchanged when nothing is pending', () => {
+    const manager = new SyncStateManager({ autoProcessOnReconnect: false });
+
+    const op = manager.queueSave(makeDoc(), 'relay-1');
+
+    if (op.type === 'save') {
+      expect(op.document.richTextPages?.pages['rt-pending']?.content).toBe(
+        '<p>offline-created</p>',
+      );
+    }
+  });
+});

--- a/src/collaboration/SyncStateManager.ts
+++ b/src/collaboration/SyncStateManager.ts
@@ -24,6 +24,7 @@ import {
 } from '../storage/SyncQueueStorage';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { useConnectionStore, type ConnectionStatus } from '../store/connectionStore';
+import { serializeDocForRest } from '../store/serializeDocForRest';
 import type { DiagramDocument } from '../types/Document';
 
 /**
@@ -210,7 +211,10 @@ export class SyncStateManager {
    * Updates document registry sync state.
    */
   queueSave(document: DiagramDocument, relayId: string): QueuedOperation {
-    const operation = this.queue.enqueueSave(document, relayId);
+    // The queued body IS a REST body (it replays as one) — serialize it at
+    // enqueue time so the withhold reflects the markers as they were when the
+    // edit happened, not whenever the replay fires (JP-423).
+    const operation = this.queue.enqueueSave(serializeDocForRest(document), relayId);
 
     // Update registry sync state
     const registry = useDocumentRegistry.getState();

--- a/src/collaboration/YjsDocument.proseInvariant.test.ts
+++ b/src/collaboration/YjsDocument.proseInvariant.test.ts
@@ -1,0 +1,98 @@
+/**
+ * JP-423 — orphaned-prose-fragment DETECTION (`listOrphanedProseFragmentIds`).
+ *
+ * The fragment↔page-list asymmetry: `prose:<id>` fragments sync
+ * unconditionally, `prosePages` meta is a separate write. Detection must
+ * report content-bearing roots with no meta — and NOTHING else: merely
+ * accessed (empty) roots don't count, and a deleted page's undeletable root
+ * IS reported (presence alone can't distinguish it — the policy layer
+ * corroborates before repairing).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getSchema, type JSONContent } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import * as Y from 'yjs';
+import { YjsDocument, type ProsePageMeta } from './YjsDocument';
+import { registerProseSchema, __resetProseSchemaForTests } from './proseSchema';
+
+const schema = getSchema([StarterKit.configure({ history: false })]);
+
+function paras(...texts: string[]): JSONContent {
+  return {
+    type: 'doc',
+    content: texts.map((text) => ({
+      type: 'paragraph',
+      content: text ? [{ type: 'text', text }] : [],
+    })),
+  };
+}
+
+function meta(id: string, name: string): ProsePageMeta {
+  return { id, name, order: 0, createdAt: 1, modifiedAt: 2 };
+}
+
+function crossSync(a: YjsDocument, b: YjsDocument): void {
+  Y.applyUpdate(b.getDoc(), Y.encodeStateAsUpdate(a.getDoc()));
+  Y.applyUpdate(a.getDoc(), Y.encodeStateAsUpdate(b.getDoc()));
+}
+
+describe('YjsDocument.listOrphanedProseFragmentIds (JP-423)', () => {
+  beforeEach(() => registerProseSchema(schema));
+  afterEach(() => __resetProseSchemaForTests());
+
+  it('fragment + meta → not orphaned', () => {
+    const doc = new YjsDocument();
+    doc.setProse('rt-1', paras('content'));
+    doc.setProsePage(meta('rt-1', 'Page'));
+
+    expect(doc.listOrphanedProseFragmentIds()).toEqual([]);
+  });
+
+  it('content-bearing fragment with no meta → reported', () => {
+    const doc = new YjsDocument();
+    doc.setProse('rt-orphan', paras('content that no list shows'));
+
+    expect(doc.listOrphanedProseFragmentIds()).toEqual(['rt-orphan']);
+  });
+
+  it('a merely-accessed empty root is NOT reported', () => {
+    const doc = new YjsDocument();
+    // Accessing a root creates it in doc.share even with zero content.
+    doc.getDoc().getXmlFragment('prose:rt-empty');
+
+    expect(doc.listOrphanedProseFragmentIds()).toEqual([]);
+  });
+
+  it('a fragment synced from a peer without its meta → reported on the receiver', () => {
+    const writer = new YjsDocument();
+    const receiver = new YjsDocument();
+    crossSync(writer, receiver);
+
+    // The writer wrote content but "forgot" the meta write (the orphan class
+    // an integration manufactures on its first mirror write).
+    writer.setProse('rt-m', paras('mirrored content'));
+    crossSync(writer, receiver);
+
+    expect(receiver.listOrphanedProseFragmentIds()).toEqual(['rt-m']);
+
+    // Once the meta lands, the orphan disappears everywhere.
+    writer.setProsePage(meta('rt-m', 'Mirror'));
+    crossSync(writer, receiver);
+    expect(receiver.listOrphanedProseFragmentIds()).toEqual([]);
+    expect(writer.listOrphanedProseFragmentIds()).toEqual([]);
+  });
+
+  it('deleteProsePage leaves a content-bearing root that IS reported (undeletable roots)', () => {
+    const doc = new YjsDocument();
+    doc.setProse('rt-del', paras('kept by Yjs forever'));
+    doc.setProsePage(meta('rt-del', 'Doomed'));
+    expect(doc.listOrphanedProseFragmentIds()).toEqual([]);
+
+    doc.deleteProsePage('rt-del');
+
+    // Pins the sharp edge: meta+order are gone, the root cannot be — so a
+    // deleted page is indistinguishable from an orphan by presence alone.
+    // Policy (healOrphanedProseFragments) must corroborate before repairing.
+    expect(doc.listOrphanedProseFragmentIds()).toEqual(['rt-del']);
+  });
+});

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -293,6 +293,28 @@ export class YjsDocument {
     };
   }
 
+  /**
+   * Seed a SPECIFIC page's shape surface (`shapes:<pageId>`/`shapeOrder:<pageId>`)
+   * from a local snapshot, without touching the active-page binding (JP-335).
+   * Used by the reconnect handoff to push a pending-sync page's offline-drawn
+   * shapes. Safe by construction: per-item id-keyed `set`s are additive (never a
+   * `clear` — the seedClobber hazard), and the order array is written only when
+   * still empty (a page the relay has never seen), so this cannot wipe
+   * concurrent state.
+   */
+  seedPageShapes(pageId: string, shapes: Shape[], order: string[]): void {
+    const map = this.shapesMapFor(pageId);
+    const orderArr = this.shapeOrderArrFor(pageId);
+    this.withLocalUpdate(() => {
+      for (const shape of shapes) {
+        map.set(shape.id, JSON.parse(JSON.stringify(shape)) as Shape);
+      }
+      if (orderArr.length === 0 && order.length > 0) {
+        orderArr.push([...order]);
+      }
+    });
+  }
+
   // ============ Canvas undo/redo (JP-402) ============
 
   /** Undo this user's last tracked canvas edit on the active page. */

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -729,6 +729,33 @@ export class YjsDocument {
     return { pages, pageOrder };
   }
 
+  /**
+   * Page ids whose `prose:<id>` root carries content but which have NO
+   * `prosePages` entry — the fragment↔page-list asymmetry (JP-423): fragments
+   * sync unconditionally (y-prosemirror writes the shared Y.Doc) while list
+   * meta is a separate write, so a writer that forgets the meta manufactures
+   * a list-invisible page.
+   *
+   * Detection only — callers decide the policy. Two facts make presence alone
+   * insufficient for repair: `doc.share` holds every root ever ACCESSED
+   * locally (hence the content check), and a deleted page's root is
+   * undeletable in Yjs (`deleteProsePage` removes only meta + order), so a
+   * lingering non-empty root may be a legitimate deletion. Corroborate before
+   * repairing.
+   */
+  listOrphanedProseFragmentIds(): string[] {
+    const orphans: string[] = [];
+    for (const [name] of this.doc.share) {
+      if (!name.startsWith('prose:')) continue;
+      const id = name.slice('prose:'.length);
+      if (this.prosePages.has(id)) continue;
+      if (this.doc.getXmlFragment(name).length > 0) {
+        orphans.push(id);
+      }
+    }
+    return orphans;
+  }
+
   // ============ Canvas page-list (JP-339) — local to remote ============
 
   /**

--- a/src/collaboration/collabRoom.test.ts
+++ b/src/collaboration/collabRoom.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { collabIdbRoom } from './collabRoom';
+
+describe('collabIdbRoom', () => {
+  it('keys on host:port + doc id, ignoring scheme and path', () => {
+    // The live session builds the room from its WS serverUrl; the offline
+    // prefetch builds it from restUrlToWsUrl(relayUrl). Both must land on the
+    // SAME key, so scheme (ws/wss/http/https) and path must not change it.
+    const doc = 'doc-abc';
+    const ws = collabIdbRoom('wss://relay.example.com/ws', doc);
+    expect(ws).toBe('relay.example.com:doc-abc');
+    // http/ws/https forms of the same host all match.
+    expect(collabIdbRoom('https://relay.example.com', doc)).toBe(ws);
+    expect(collabIdbRoom('ws://relay.example.com/ws?x=1', doc)).toBe(ws);
+  });
+
+  it('preserves an explicit port in the key', () => {
+    expect(collabIdbRoom('ws://localhost:9876/ws', 'd1')).toBe('localhost:9876:d1');
+  });
+
+  it('separates docs on the same host', () => {
+    const a = collabIdbRoom('wss://r.example.com/ws', 'a');
+    const b = collabIdbRoom('wss://r.example.com/ws', 'b');
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/collaboration/collabRoom.ts
+++ b/src/collaboration/collabRoom.ts
@@ -1,0 +1,16 @@
+/**
+ * The y-indexeddb room key for a relay-backed document's local Y.Doc.
+ *
+ * Scoped per relay host + doc id (JP-108 / JP-117) so the same doc on a
+ * different relay can't bleed. This is the SINGLE source of the key: both the
+ * live collab session (collaborationStore) and the offline prefetch
+ * (prefetchYdoc, JP-335) derive it here, so a prefetched seed and the live
+ * session bind the *same* room — a mismatch would silently strand the seed.
+ *
+ * `serverUrl` is the session's WebSocket URL (e.g. `wss://host/ws`); only its
+ * `host` (host:port) is used, which is identical for the ws and http forms of
+ * the same relay.
+ */
+export function collabIdbRoom(serverUrl: string, documentId: string): string {
+  return `${new URL(serverUrl).host}:${documentId}`;
+}

--- a/src/collaboration/collabRoom.ts
+++ b/src/collaboration/collabRoom.ts
@@ -4,7 +4,7 @@
  * Scoped per relay host + doc id (JP-108 / JP-117) so the same doc on a
  * different relay can't bleed. This is the SINGLE source of the key: both the
  * live collab session (collaborationStore) and the offline prefetch
- * (prefetchYdoc, JP-335) derive it here, so a prefetched seed and the live
+ * (prefetchYdoc, JP-422) derive it here, so a prefetched seed and the live
  * session bind the *same* room — a mismatch would silently strand the seed.
  *
  * `serverUrl` is the session's WebSocket URL (e.g. `wss://host/ws`); only its

--- a/src/collaboration/collaborationStore.test.ts
+++ b/src/collaboration/collaborationStore.test.ts
@@ -436,6 +436,32 @@ describe('collaborationStore', () => {
       expect(useCollaborationStore.getState().isSynced).toBe(true);
     });
 
+    it('_markSyncedHandshake bumps syncEpoch once per completed handshake (JP-423)', () => {
+      useCollaborationStore.setState({ syncEpoch: 0 });
+
+      useCollaborationStore.getState()._markSyncedHandshake();
+      expect(useCollaborationStore.getState().isSynced).toBe(true);
+      expect(useCollaborationStore.getState().syncEpoch).toBe(1);
+
+      // A reconnect that completes sync step 2 bumps again; isSynced stays.
+      useCollaborationStore.getState()._markSyncedHandshake();
+      expect(useCollaborationStore.getState().isSynced).toBe(true);
+      expect(useCollaborationStore.getState().syncEpoch).toBe(2);
+    });
+
+    it('syncEpoch survives session teardown while isSynced resets (JP-423)', () => {
+      useCollaborationStore.setState({ syncEpoch: 0 });
+      useCollaborationStore.getState().startSession(createTestConfig());
+      useCollaborationStore.getState()._markSyncedHandshake();
+
+      useCollaborationStore.getState().stopSession();
+
+      expect(useCollaborationStore.getState().isSynced).toBe(false);
+      // Monotonic across sessions: effect deps can never alias a new session's
+      // first handshake with an old one.
+      expect(useCollaborationStore.getState().syncEpoch).toBe(1);
+    });
+
     it('sets error', () => {
       useCollaborationStore.getState()._setError('Test error');
       expect(useCollaborationStore.getState().error).toBe('Test error');

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -19,6 +19,7 @@ import { create } from 'zustand';
 import { IndexeddbPersistence } from 'y-indexeddb';
 import { YjsDocument } from './YjsDocument';
 import type { ProsePageMeta, CanvasPageMeta } from './YjsDocument';
+import { collabIdbRoom } from './collabRoom';
 import { UnifiedSyncProvider, AwarenessUserState } from './UnifiedSyncProvider';
 import { useRelayDocumentStore } from '../store/relayDocumentStore';
 import { registerCollabOwnsActivePageLoad } from '../store/pageStore';
@@ -474,7 +475,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       // gave random clientIDs, so this no longer corrupts merges.
       get()._setIdbSynced(false);
       if (typeof indexedDB !== 'undefined') {
-        const idbRoom = `${new URL(config.serverUrl).host}:${config.documentId}`;
+        const idbRoom = collabIdbRoom(config.serverUrl, config.documentId);
         idbPersistence = new IndexeddbPersistence(idbRoom, yjsDoc.getDoc());
         idbPersistence.whenSynced
           .then(() => get()._setIdbSynced(true))

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -100,8 +100,25 @@ interface CollaborationState {
   isActive: boolean;
   /** Current connection status */
   connectionStatus: ConnectionStatus;
-  /** Whether the document is synced with server */
+  /**
+   * Whether the document is synced with server. Session-level: set on the
+   * first completed handshake and NOT reset on a transient connection drop
+   * (only session teardown clears it) — it answers "has the relay confirmed
+   * authoritative state at least once this session?". Consumers that mean
+   * "did an exchange complete on the CURRENT connection?" must key off
+   * `syncEpoch` instead (JP-423).
+   */
   isSynced: boolean;
+  /**
+   * Count of completed sync handshakes (provider sync step 2) across this
+   * store's lifetime (JP-423). Bumps exactly once per connection that reaches
+   * a full exchange — the provider's internal synced flag resets on every
+   * drop — so effects can depend on it to re-run per completed handshake
+   * without proxying through auth-status flickers. Monotonic and deliberately
+   * NOT reset on session teardown, so effect deps can never alias across
+   * sessions; pair with `sessionEpoch` when session identity matters.
+   */
+  syncEpoch: number;
   /**
    * Whether the local `y-indexeddb` persistence has finished loading the
    * Y.Doc from IndexedDB (JP-108 step 3). The CRDT→view adopt must wait for
@@ -243,6 +260,8 @@ interface CollaborationActions {
   _setConnectionStatus: (status: ConnectionStatus) => void;
   /** Set synced state (internal) */
   _setSynced: (synced: boolean) => void;
+  /** Record a completed sync handshake: isSynced=true + syncEpoch++ (internal) */
+  _markSyncedHandshake: () => void;
   /** Set IndexedDB-loaded state (internal) */
   _setIdbSynced: (synced: boolean) => void;
   /** Set error (internal) */
@@ -396,6 +415,7 @@ function teardownSession(
   set({
     isActive: false,
     connectionStatus: 'disconnected',
+    // syncEpoch deliberately survives teardown (monotonic — see its doc).
     isSynced: false,
     isIdbSynced: false,
     error: null,
@@ -415,6 +435,7 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
     isActive: false,
     connectionStatus: 'disconnected',
     isSynced: false,
+    syncEpoch: 0,
     isIdbSynced: false,
     error: null,
     remoteUsers: [],
@@ -533,7 +554,10 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
           }
         },
         onSynced: () => {
-          get()._setSynced(true);
+          // Fires once per connection that completes sync step 2 (the
+          // provider's internal flag resets on drop), so this is exactly one
+          // epoch bump per completed handshake (JP-423).
+          get()._markSyncedHandshake();
         },
         onAuthenticated: (success, user) => {
           useRelayDocumentStore.getState().setAuthenticated(success);
@@ -909,6 +933,10 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
       set({ isSynced: synced });
     },
 
+    _markSyncedHandshake: () => {
+      set((state) => ({ isSynced: true, syncEpoch: state.syncEpoch + 1 }));
+    },
+
     _setIdbSynced: (synced: boolean) => {
       set({ isIdbSynced: synced });
     },
@@ -945,7 +973,12 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
 //     indicator, reconnect gating) → `isRelayAuthenticated` / `useIsRelayAuthenticated`.
 //   - "this doc is synced and safe to treat as a live collaborator" → these.
 
-/** Imperative: token accepted on a live WS AND the active doc has CRDT-synced. */
+/**
+ * Imperative: token accepted on a live WS AND the active doc has CRDT-synced.
+ * `isSynced` here is the session-level flag on purpose: "live" = authed NOW
+ * (via `isRelayAuthenticated`) + synced at least once this session. Per-
+ * connection freshness is `syncEpoch`'s job (JP-423), not this predicate's.
+ */
 export function isRelaySessionLive(): boolean {
   const collab = useCollaborationStore.getState();
   return isRelayAuthenticated() && collab.isActive && collab.isSynced;

--- a/src/collaboration/prefetchYdoc.test.ts
+++ b/src/collaboration/prefetchYdoc.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { Doc as YDoc, encodeStateAsUpdate, applyUpdate } from 'yjs';
+import { stripSidecarHeader } from './prefetchYdoc';
+
+/** Frame a lib0-v1 update the way `relay/src/sync/binary.rs::encode_snapshot`
+ * does: `b"DSKY" | format_version:u32 LE | server_version:u64 LE | update`. */
+function frameSidecar(update: Uint8Array, formatVersion = 1, serverVersion = 7): Uint8Array {
+  const header = new Uint8Array(16);
+  header.set([0x44, 0x53, 0x4b, 0x59], 0); // "DSKY"
+  new DataView(header.buffer).setUint32(4, formatVersion, true);
+  new DataView(header.buffer).setBigUint64(8, BigInt(serverVersion), true);
+  const out = new Uint8Array(header.length + update.length);
+  out.set(header, 0);
+  out.set(update, header.length);
+  return out;
+}
+
+describe('stripSidecarHeader', () => {
+  it('strips the 16-byte DSKY header, yielding an applyUpdate-able payload', () => {
+    // Author a doc, encode it, frame it exactly like the relay, then strip.
+    const src = new YDoc();
+    src.getMap('shapes:p1').set('s1', 'rect');
+    const update = encodeStateAsUpdate(src);
+
+    const framed = frameSidecar(update);
+    const payload = stripSidecarHeader(framed);
+    expect(payload).not.toBeNull();
+
+    // The payload must reconstruct the original CRDT content — this is exactly
+    // what prefetchYdoc applies into the local room.
+    const dst = new YDoc();
+    applyUpdate(dst, payload!);
+    expect(dst.getMap('shapes:p1').get('s1')).toBe('rect');
+  });
+
+  it('rejects a buffer with the wrong magic', () => {
+    const framed = frameSidecar(new Uint8Array([1, 2, 3, 4]));
+    framed[0] = 0x58; // 'X'
+    expect(stripSidecarHeader(framed)).toBeNull();
+  });
+
+  it('rejects a buffer too short to contain a header + payload', () => {
+    expect(stripSidecarHeader(new Uint8Array(16))).toBeNull(); // header only, no payload
+    expect(stripSidecarHeader(new Uint8Array([0x44, 0x53, 0x4b, 0x59]))).toBeNull();
+    expect(stripSidecarHeader(new Uint8Array(0))).toBeNull();
+  });
+});

--- a/src/collaboration/prefetchYdoc.ts
+++ b/src/collaboration/prefetchYdoc.ts
@@ -1,0 +1,106 @@
+/**
+ * prefetchYdoc — seed a relay document's local Y.Doc room from the relay's
+ * authoritative binary sidecar, so a "downloaded but never opened" doc can be
+ * opened + edited OFFLINE (JP-335).
+ *
+ * The problem: the local y-indexeddb room (`host:docId`) is populated only by a
+ * live sync handshake. A doc that was cached (body + blobs, JP-281) but never
+ * opened while online has an EMPTY room, so opening it offline leaves the prose
+ * fragment empty → the editor is read-only (relay-is-sole-seeder, JP-284), and
+ * canvas edits can't be captured. Prefetching the relay's exact CRDT bytes into
+ * that room fixes both: the offline adopt path sees real content and the client
+ * edits the relay's own lineage, which dedupes trivially on reconnect.
+ *
+ * Correctness hinges on two things:
+ *  - the seeded room key must byte-match the live session's — both go through
+ *    {@link collabIdbRoom};
+ *  - the bytes must be the relay's real lineage (a sidecar it will reproduce on
+ *    reconnect), which the `GET /api/docs/:id/ydoc` endpoint guarantees (it only
+ *    serves a persisted/live-handle sidecar, never a fresh JSON hydrate).
+ */
+
+import { Doc as YDoc, applyUpdate, encodeStateVector } from 'yjs';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import { loadConnection } from '../api/relayConnection';
+import { restUrlToWsUrl } from '../api/completeCloudSignIn';
+import { getDocProvider } from '../store/relayDocumentStore';
+import { collabIdbRoom } from './collabRoom';
+
+/** An empty Yjs state vector — what an untouched room reports. */
+const EMPTY_STATE_VECTOR_LEN = 1;
+
+/**
+ * Fetch `docId`'s authoritative Y.Doc sidecar and apply it into the local
+ * y-indexeddb room so the doc can be opened offline. Resolves to:
+ *  - `'seeded'` — bytes were fetched and written into a previously-empty room,
+ *  - `'skipped'` — the room already had CRDT state (a prior sync/seed), or
+ *  - `'unavailable'` — no relay/provider/sidecar, or IndexedDB is absent.
+ *
+ * Best-effort and idempotent: re-applying the same sidecar is a no-op, and any
+ * failure leaves the doc on its existing (read-only) offline path — no throw.
+ */
+export async function prefetchYdoc(
+  docId: string,
+): Promise<'seeded' | 'skipped' | 'unavailable'> {
+  if (typeof indexedDB === 'undefined') return 'unavailable';
+
+  const provider = getDocProvider();
+  if (!provider?.getYdoc) return 'unavailable';
+
+  const conn = await loadConnection();
+  if (!conn?.relayUrl) return 'unavailable';
+
+  const room = collabIdbRoom(restUrlToWsUrl(conn.relayUrl), docId);
+
+  // Bind the room and wait for any persisted state to load. If it already holds
+  // CRDT state (the doc was synced/edited before), do NOT overwrite — the live
+  // lineage wins; seeding on top is unnecessary and could reintroduce a merge.
+  const doc = new YDoc();
+  const persistence = new IndexeddbPersistence(room, doc);
+  try {
+    await persistence.whenSynced;
+    if (encodeStateVector(doc).length > EMPTY_STATE_VECTOR_LEN) {
+      return 'skipped';
+    }
+
+    const bytes = await provider.getYdoc(docId);
+    if (!bytes || bytes.length === 0) return 'unavailable';
+
+    // Strip the sidecar's `DSKY|ver|serverVersion` header (16 bytes) to get the
+    // raw lib0-v1 state update; a short/garbage buffer just aborts the prefetch.
+    const update = stripSidecarHeader(bytes);
+    if (!update) return 'unavailable';
+
+    // Apply with a non-`this` origin (default) so y-indexeddb's `update`
+    // handler fires SYNCHRONOUSLY and creates the IDB write transaction before
+    // we detach. `destroy()` below calls `db.close()`, which per the IndexedDB
+    // spec lets that in-flight transaction complete — so the seed is durably
+    // persisted for the live session to load.
+    applyUpdate(doc, update);
+    return 'seeded';
+  } catch {
+    return 'unavailable';
+  } finally {
+    // Detach our transient handle; the persisted room stays on disk for the live
+    // session to pick up. `destroy()` also tears down the Y.Doc.
+    await persistence.destroy();
+    doc.destroy();
+  }
+}
+
+/** Sidecar magic + header length — mirrors `relay/src/sync/binary.rs`. */
+const SIDECAR_MAGIC = [0x44, 0x53, 0x4b, 0x59]; // "DSKY"
+const SIDECAR_HEADER_LEN = 16; // magic(4) + format_version(4) + server_version(8)
+
+/**
+ * Validate the `DSKY` header and return the lib0-v1 update payload, or null if
+ * the buffer isn't a recognizable sidecar (bad magic / too short). Exported for
+ * testing.
+ */
+export function stripSidecarHeader(bytes: Uint8Array): Uint8Array | null {
+  if (bytes.length <= SIDECAR_HEADER_LEN) return null;
+  for (let i = 0; i < SIDECAR_MAGIC.length; i++) {
+    if (bytes[i] !== SIDECAR_MAGIC[i]) return null;
+  }
+  return bytes.subarray(SIDECAR_HEADER_LEN);
+}

--- a/src/collaboration/prefetchYdoc.ts
+++ b/src/collaboration/prefetchYdoc.ts
@@ -1,7 +1,7 @@
 /**
  * prefetchYdoc — seed a relay document's local Y.Doc room from the relay's
  * authoritative binary sidecar, so a "downloaded but never opened" doc can be
- * opened + edited OFFLINE (JP-335).
+ * opened + edited OFFLINE (JP-422).
  *
  * The problem: the local y-indexeddb room (`host:docId`) is populated only by a
  * live sync handshake. A doc that was cached (body + blobs, JP-281) but never

--- a/src/collaboration/proseInvariant.test.ts
+++ b/src/collaboration/proseInvariant.test.ts
@@ -1,0 +1,146 @@
+/**
+ * JP-423 — orphaned-prose-fragment POLICY (`healOrphanedProseFragments`).
+ *
+ * Log always; repair only when the local `richTextPagesStore` corroborates;
+ * repair is additive-only (`setProsePage` — never a fragment or meta delete).
+ * The named cases: a deleted page is never resurrected, an in-flight external
+ * write is never fought, a corroborated orphan is repaired idempotently.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getSchema, type JSONContent } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { YjsDocument } from './YjsDocument';
+import { registerProseSchema, __resetProseSchemaForTests } from './proseSchema';
+import { healOrphanedProseFragments, synthesizeProsePageMeta } from './proseInvariant';
+import { useRichTextPagesStore, type RichTextPage } from '../store/richTextPagesStore';
+
+const schema = getSchema([StarterKit.configure({ history: false })]);
+
+function paras(...texts: string[]): JSONContent {
+  return {
+    type: 'doc',
+    content: texts.map((text) => ({
+      type: 'paragraph',
+      content: text ? [{ type: 'text', text }] : [],
+    })),
+  };
+}
+
+function storePage(id: string, name: string, color?: string): RichTextPage {
+  const page: RichTextPage = {
+    id,
+    name,
+    content: '<p>x</p>',
+    order: 0,
+    createdAt: 11,
+    modifiedAt: 22,
+  };
+  if (color !== undefined) page.color = color;
+  return page;
+}
+
+describe('healOrphanedProseFragments (JP-423)', () => {
+  beforeEach(() => {
+    registerProseSchema(schema);
+    useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    __resetProseSchemaForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('does not resurrect a deleted page', () => {
+    const doc = new YjsDocument();
+    doc.setProse('rt-del', paras('content'));
+    doc.setProsePage({ id: 'rt-del', name: 'Doomed', order: 0, createdAt: 1, modifiedAt: 2 });
+    doc.deleteProsePage('rt-del');
+    // Adoption already pruned the local store (no entry) — no corroboration.
+
+    const result = healOrphanedProseFragments(doc, 'doc-1');
+
+    expect(result.logged).toEqual(['rt-del']);
+    expect(result.repaired).toEqual([]);
+    expect(doc.getProsePageList().pages['rt-del']).toBeUndefined();
+    // The fragment itself is untouched (additive-only policy).
+    expect(doc.getDoc().getXmlFragment('prose:rt-del').length).toBeGreaterThan(0);
+  });
+
+  it('leaves an uncorroborated orphan alone (in-flight external write window)', () => {
+    // An integration wrote the fragment; its meta write hasn't landed yet.
+    // This client has never seen the page — log-only, nothing to fight.
+    const doc = new YjsDocument();
+    doc.setProse('rt-mirror', paras('externally mirrored'));
+
+    const result = healOrphanedProseFragments(doc, 'doc-1');
+
+    expect(result.logged).toEqual(['rt-mirror']);
+    expect(result.repaired).toEqual([]);
+    expect(doc.getProsePageList().pages['rt-mirror']).toBeUndefined();
+  });
+
+  it('repairs a corroborated orphan from the local page, idempotently', () => {
+    const doc = new YjsDocument();
+    doc.setProse('rt-lost', paras('content whose meta write was lost'));
+    useRichTextPagesStore.setState({
+      pages: { 'rt-lost': storePage('rt-lost', 'Lost notes', '#aabbcc') },
+      pageOrder: ['rt-lost'],
+      activePageId: 'rt-lost',
+    });
+
+    const first = healOrphanedProseFragments(doc, 'doc-1');
+    expect(first.repaired).toEqual(['rt-lost']);
+    const repaired = doc.getProsePageList().pages['rt-lost'];
+    expect(repaired).toMatchObject({
+      id: 'rt-lost',
+      name: 'Lost notes',
+      color: '#aabbcc',
+      order: 0,
+      createdAt: 11,
+      modifiedAt: 22,
+    });
+
+    // Second run: the meta exists now — nothing to log or repair.
+    const second = healOrphanedProseFragments(doc, 'doc-1');
+    expect(second).toEqual({ logged: [], repaired: [] });
+  });
+
+  it('handles a mixed batch: repairs the corroborated, logs the rest', () => {
+    const doc = new YjsDocument();
+    doc.setProse('rt-known', paras('known'));
+    doc.setProse('rt-foreign', paras('foreign'));
+    useRichTextPagesStore.setState({
+      pages: { 'rt-known': storePage('rt-known', 'Known') },
+      pageOrder: ['rt-known'],
+      activePageId: 'rt-known',
+    });
+
+    const result = healOrphanedProseFragments(doc, 'doc-1');
+
+    expect(result.logged.sort()).toEqual(['rt-foreign', 'rt-known']);
+    expect(result.repaired).toEqual(['rt-known']);
+    expect(doc.getProsePageList().pages['rt-foreign']).toBeUndefined();
+  });
+});
+
+describe('synthesizeProsePageMeta (JP-423)', () => {
+  it('builds the meta from the page, clamping a not-found order to 0', () => {
+    expect(synthesizeProsePageMeta(storePage('rt-1', 'Notes'), -1)).toEqual({
+      id: 'rt-1',
+      name: 'Notes',
+      order: 0,
+      createdAt: 11,
+      modifiedAt: 22,
+    });
+  });
+
+  it('round-trips optional color without materializing undefined', () => {
+    const withColor = synthesizeProsePageMeta(storePage('rt-1', 'Notes', '#123456'), 2);
+    expect(withColor.color).toBe('#123456');
+    expect(withColor.order).toBe(2);
+
+    const withoutColor = synthesizeProsePageMeta(storePage('rt-2', 'Plain'), 1);
+    // exactOptionalPropertyTypes: the key must be absent, not undefined.
+    expect('color' in withoutColor).toBe(false);
+  });
+});

--- a/src/collaboration/proseInvariant.ts
+++ b/src/collaboration/proseInvariant.ts
@@ -1,0 +1,84 @@
+/**
+ * Fragment↔page-list invariant (JP-423).
+ *
+ * Prose content and prose page-list metadata live in DIFFERENT Y.Doc
+ * surfaces with different write paths: the `prose:<id>` fragment syncs
+ * unconditionally (y-prosemirror writes the shared doc), the `prosePages`
+ * meta is a separate, forgettable write. When they diverge the page's
+ * content exists but no list shows it — an orphaned fragment.
+ *
+ * Policy (deliberately conservative):
+ *  - LOG every orphan, always — the observability floor.
+ *  - REPAIR (synthesize the missing meta) only when corroborated by the
+ *    local `richTextPagesStore` — i.e. THIS client believes the page exists.
+ *    Adoption reconciles the store from the authoritative CRDT list before
+ *    this runs, pruning legitimately deleted pages (pending-sync pages are
+ *    prune-spared), so:
+ *      - a deleted page's lingering root (Yjs roots are undeletable) has no
+ *        store entry → log-only, never resurrected;
+ *      - a writer mid-flight between fragment and meta (an integration
+ *        writing non-atomically) has no store entry on OTHER clients →
+ *        log-only, nothing fights the in-flight write.
+ *  - Repair is ADDITIVE-only: the single op is `setProsePage`; fragments and
+ *    metas are never deleted here. A wrong repair can at worst re-list a
+ *    tab; it can never destroy content.
+ */
+
+import type { YjsDocument, ProsePageMeta } from './YjsDocument';
+import { useRichTextPagesStore, type RichTextPage } from '../store/richTextPagesStore';
+
+/**
+ * The single construction point for a ProsePageMeta synthesized from local
+ * page state (the reconnect handoff and the orphan repair both build through
+ * here) — a future meta field lands in one place, not N call sites.
+ */
+export function synthesizeProsePageMeta(page: RichTextPage, order: number): ProsePageMeta {
+  const meta: ProsePageMeta = {
+    id: page.id,
+    name: page.name,
+    order: Math.max(0, order),
+    createdAt: page.createdAt,
+    modifiedAt: page.modifiedAt,
+  };
+  if (page.color !== undefined) meta.color = page.color;
+  return meta;
+}
+
+export interface OrphanHealResult {
+  /** Every orphaned fragment id found (logged). */
+  logged: string[];
+  /** The subset repaired by synthesizing a `prosePages` meta. */
+  repaired: string[];
+}
+
+/**
+ * Detect orphaned prose fragments and repair the corroborated ones. Runs at
+ * adopt time, AFTER the page-list adoption reconciled `richTextPagesStore`
+ * with the CRDT list. The `setProsePage` repair is a local→remote CRDT write —
+ * call OUTSIDE any remote-apply window, like the reconnect handoff.
+ */
+export function healOrphanedProseFragments(yjsDoc: YjsDocument, docId: string): OrphanHealResult {
+  const result: OrphanHealResult = { logged: [], repaired: [] };
+  const orphans = yjsDoc.listOrphanedProseFragmentIds();
+  if (orphans.length === 0) return result;
+
+  const proseState = useRichTextPagesStore.getState();
+  for (const pageId of orphans) {
+    result.logged.push(pageId);
+    const page = proseState.pages[pageId];
+    if (page) {
+      console.warn(
+        `[proseInvariant] Orphaned prose fragment ${pageId} in ${docId} — ` +
+          'content with no page-list meta; repairing from the local page (JP-423).',
+      );
+      yjsDoc.setProsePage(synthesizeProsePageMeta(page, proseState.pageOrder.indexOf(pageId)));
+      result.repaired.push(pageId);
+    } else {
+      console.warn(
+        `[proseInvariant] Orphaned prose fragment ${pageId} in ${docId} — ` +
+          'no local corroboration (deleted page or an in-flight external write); left as-is (JP-423).',
+      );
+    }
+  }
+  return result;
+}

--- a/src/collaboration/proseReseedDuplication.test.ts
+++ b/src/collaboration/proseReseedDuplication.test.ts
@@ -53,4 +53,30 @@ describe('JP-282: independent prose seedings merge to duplicates', () => {
     expect(client.getXmlFragment('prose:p1').length).toBe(1);
     expect(relay.getXmlFragment('prose:p1').length).toBe(1);
   });
+
+  it('does NOT double for a page CREATED offline when the relay never seeds it (JP-335)', () => {
+    // Offline new-page creation: the client authors `prose:<newId>` (its live
+    // random-clientID lineage) while the relay never learns the page — the
+    // collab body-save suppression + the pending-page body-withhold keep its
+    // HTML out of the relay's stored JSON, so json_prose_to_ydoc has nothing to
+    // seed. On reconnect the client's fragment is the SOLE lineage.
+    const client = new Y.Doc();
+    seedParagraph(client, 'prose:new-offline', 'typed while offline');
+
+    const relay = new Y.Doc(); // hydrated from a body with content: '' for this page
+
+    Y.applyUpdate(relay, Y.encodeStateAsUpdate(client));
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(relay));
+
+    expect(client.getXmlFragment('prose:new-offline').length).toBe(1);
+    expect(relay.getXmlFragment('prose:new-offline').length).toBe(1);
+
+    // Control — the hazard the withhold exists to prevent: if the page's HTML
+    // HAD reached the relay body, the relay would mint its own lineage and the
+    // merge doubles (the first test's mechanism, restated for the new-page case).
+    const leakyRelay = new Y.Doc();
+    seedParagraph(leakyRelay, 'prose:new-offline', 'typed while offline');
+    Y.applyUpdate(leakyRelay, Y.encodeStateAsUpdate(client));
+    expect(leakyRelay.getXmlFragment('prose:new-offline').length).toBe(2);
+  });
 });

--- a/src/collaboration/sharedDocOffline.test.ts
+++ b/src/collaboration/sharedDocOffline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeSharedDocOffline } from './offlinePageGuard';
+import { computeSharedDocOffline } from './sharedDocOffline';
 
 // A relay doc identified by an active collab session, currently online.
 const onlineRelay = {

--- a/src/collaboration/sharedDocOffline.ts
+++ b/src/collaboration/sharedDocOffline.ts
@@ -5,14 +5,16 @@ import { useDocumentRegistry } from '../store/documentRegistry';
 import { useCollaborationStore } from './collaborationStore';
 
 /**
- * JP-334: while a relay-backed (shared) doc is offline, creating a new page —
- * prose OR canvas — is blocked. Prose: a never-synced empty fragment is
- * read-only by design (relay is the sole seeder, JP-284) and editing it would
- * risk dual-lineage duplication. Canvas: a new page's shapes never reach the
- * relay's active-page-only flatten → lost on reconnect. Either way the page
- * can't be created safely until reconnect. Enabling it is JP-335.
+ * "Is this shared (relay-backed) doc currently offline?" — the predicate behind
+ * the StatusBar's ambient offline chip (JP-237) and the pending-sync marking of
+ * pages created offline (JP-335, `pendingSyncPages`).
  *
- * Local-only docs are never blocked (no relay involved).
+ * History: this was `offlinePageGuard.ts` (JP-334), which BLOCKED new-page
+ * creation while a shared doc was offline. JP-335 lifted the block — offline
+ * page creation is now allowed; a created page is marked pending-sync and
+ * handed to the relay on reconnect (see `useCollaborationSync`'s handoff).
+ *
+ * Local-only docs are never "shared offline" (no relay involved).
  */
 
 /** Pure decision: relay-backed AND the live connection isn't fully up. */

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -22,6 +22,10 @@ function makeMockYjs() {
     // JP-340 per-page binding surface.
     hasAnyShapes: vi.fn(() => false),
     rebindActivePage: vi.fn(() => ({ shapes: [] as Shape[], order: [] as string[] })),
+    // JP-335 pending-page handoff surface.
+    seedPageShapes: vi.fn(),
+    // JP-338 self-heal (runs over the prose page list after adopt).
+    healDoubledProse: vi.fn(),
     getShapesForPage: vi.fn(() => [] as Shape[]),
     getShapeOrderForPage: vi.fn(() => [] as string[]),
     getName: vi.fn(() => undefined),
@@ -141,6 +145,8 @@ vi.mock('../store/persistenceStore', () => ({ applyRemoteDocumentName: vi.fn() }
 import { useCollaborationStore } from './collaborationStore';
 import { useDocumentStore } from '../store/documentStore';
 import { usePageStore } from '../store/pageStore';
+import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { usePendingSyncPages, isPagePendingSync } from '../store/pendingSyncPages';
 import { useCollaborationSync } from './useCollaborationSync';
 import { withAutoSaveSuppressed } from '../store/autoSaveGuard';
 
@@ -216,6 +222,8 @@ function startOfflineSession(docId = 'doc-off'): void {
 describe('useCollaborationSync', () => {
   beforeEach(() => {
     useDocumentStore.getState().clear();
+    usePendingSyncPages.setState({ pending: {} });
+    useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
     useCollaborationStore.setState({
       isActive: false,
       isSynced: false,
@@ -350,6 +358,81 @@ describe('useCollaborationSync', () => {
     currentYjs.setShape.mockClear();
     act(() => useDocumentStore.getState().addShape(shape('X')));
     expect(currentYjs.setShape).not.toHaveBeenCalled();
+  });
+
+  it('hands off pending-sync pages on a synced session (JP-335)', () => {
+    // A prose page + a (non-active) canvas page were created offline and marked
+    // pending. On a live synced session the handoff must (re)emit their metas
+    // into the CRDT, push the canvas page's committed shapes, and clear markers.
+    act(() => {
+      useRichTextPagesStore.setState({
+        pages: {
+          'rt-off': { id: 'rt-off', name: 'Offline notes', content: '<p>x</p>', order: 0, createdAt: 1, modifiedAt: 2 },
+        },
+        pageOrder: ['rt-off'],
+        activePageId: 'rt-off',
+      });
+      usePendingSyncPages.getState().markPending('rt-off', 'doc-1');
+      usePendingSyncPages.getState().markPending('cv-off', 'doc-1');
+    });
+    startSyncedSession('doc-1');
+    // Add the pending canvas page (non-active; 'p1' stays active) with a shape.
+    act(() => {
+      usePageStore.setState((prev) => ({
+        pages: {
+          ...prev.pages,
+          'cv-off': {
+            id: 'cv-off', name: 'Offline canvas', createdAt: 1, modifiedAt: 2,
+            shapes: { S9: shape('S9') }, shapeOrder: ['S9'],
+          },
+        },
+        pageOrder: [...prev.pageOrder, 'cv-off'],
+      }));
+    });
+
+    renderHook(() => useCollaborationSync());
+
+    // Prose meta reached the CRDT page list.
+    expect(currentYjs.setProsePage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rt-off', name: 'Offline notes' }),
+    );
+    // Canvas meta + the committed shapes reached the page's own surface.
+    expect(currentYjs.setCanvasPage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cv-off', name: 'Offline canvas' }),
+    );
+    expect(currentYjs.seedPageShapes).toHaveBeenCalledWith(
+      'cv-off',
+      [expect.objectContaining({ id: 'S9' })],
+      ['S9'],
+    );
+    // Markers cleared — the pages are ordinary synced pages from here on.
+    expect(isPagePendingSync('rt-off')).toBe(false);
+    expect(isPagePendingSync('cv-off')).toBe(false);
+  });
+
+  it('does NOT hand off while offline (no provider) — markers persist', () => {
+    act(() => {
+      usePendingSyncPages.getState().markPending('rt-off', 'doc-off');
+    });
+    // Engine-only offline session (no token → no provider, never synced).
+    act(() => {
+      usePageStore.setState({
+        pages: { p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt: 0 } },
+        pageOrder: ['p1'],
+        activePageId: 'p1',
+      });
+      useCollaborationStore.getState().startSession({
+        serverUrl: 'ws://localhost:9876/ws',
+        documentId: 'doc-off',
+        user: { id: 'u', name: 'U', color: '#fff' },
+      });
+      useCollaborationStore.getState()._setIdbSynced(true);
+    });
+
+    renderHook(() => useCollaborationSync());
+
+    expect(currentYjs.setProsePage).not.toHaveBeenCalled();
+    expect(isPagePendingSync('rt-off')).toBe(true);
   });
 
   it('re-binds onShapeChange to the new Y.Doc after switchDocument (#60)', () => {

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -188,6 +188,31 @@ function adoptShapes(shapes: Shape[], order: string[] = shapes.map((s) => s.id))
   currentYjs.rebindActivePage.mockReturnValue({ shapes, order });
 }
 
+/** JP-335: start an engine-only OFFLINE session — no token (so `hasProvider` is
+ *  false, the offline-first engine) and idb-synced but NEVER relay-synced. This
+ *  is the exact state when opening a PREFETCHED doc offline: the local Y.Doc
+ *  room was seeded from the relay's sidecar, but the relay was never contacted
+ *  this session. */
+function startOfflineSession(docId = 'doc-off'): void {
+  act(() => {
+    usePageStore.setState({
+      pages: { p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['p1'],
+      activePageId: 'p1',
+    });
+  });
+  act(() => {
+    useCollaborationStore.getState().startSession({
+      serverUrl: 'ws://localhost:9876/ws',
+      documentId: docId,
+      // NO token → engine-only, `hasProvider` false. No `_setSynced(true)`:
+      // offline, the relay never confirmed its state.
+      user: { id: 'u', name: 'U', color: '#fff' },
+    });
+    useCollaborationStore.getState()._setIdbSynced(true);
+  });
+}
+
 describe('useCollaborationSync', () => {
   beforeEach(() => {
     useDocumentStore.getState().clear();
@@ -292,6 +317,39 @@ describe('useCollaborationSync', () => {
 
     act(() => useDocumentStore.getState().addShape(shape('S2')));
     expect(currentYjs.setShape).toHaveBeenCalled();
+  });
+
+  it('adopts a prefetched Y.Doc OFFLINE so canvas is editable (JP-335)', () => {
+    // The seeded room reports canvas content (`hasAnyShapes`), and we're offline
+    // (no provider, not relay-synced). Before JP-335 this state fell into the
+    // "offline + empty Y.Doc — defer" branch and canvas edits were dropped; with
+    // a prefetched (non-empty) room the adopt runs and the bridge initializes.
+    startOfflineSession();
+    adoptShapes([shape('OFF1')]);
+
+    renderHook(() => useCollaborationSync());
+
+    // The seeded shapes loaded into the view…
+    expect(Object.keys(useDocumentStore.getState().shapes)).toContain('OFF1');
+
+    // …and the doc-store→CRDT bridge is live (`initializedRef` set), so an
+    // offline edit is captured into the Y.Doc — not silently lost on reconnect.
+    currentYjs.setShape.mockClear();
+    act(() => useDocumentStore.getState().addShape(shape('OFF2')));
+    expect(currentYjs.setShape).toHaveBeenCalled();
+  });
+
+  it('defers adopt when OFFLINE and the Y.Doc is empty (unprefetched — no dup risk)', () => {
+    // Control for the above: a doc that was NOT prefetched has an empty room
+    // offline, so adopt must still defer — pushing edits into a not-yet-adopted
+    // Y.Doc would fork a fresh CRDT identity that duplicates on first sync.
+    startOfflineSession('doc-empty');
+    // hasAnyShapes stays false (default) and we never relay-sync.
+    renderHook(() => useCollaborationSync());
+
+    currentYjs.setShape.mockClear();
+    act(() => useDocumentStore.getState().addShape(shape('X')));
+    expect(currentYjs.setShape).not.toHaveBeenCalled();
   });
 
   it('re-binds onShapeChange to the new Y.Doc after switchDocument (#60)', () => {

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -26,6 +26,8 @@ function makeMockYjs() {
     seedPageShapes: vi.fn(),
     // JP-338 self-heal (runs over the prose page list after adopt).
     healDoubledProse: vi.fn(),
+    // JP-423 fragment↔page-list invariant (runs after adopt).
+    listOrphanedProseFragmentIds: vi.fn(() => [] as string[]),
     getShapesForPage: vi.fn(() => [] as Shape[]),
     getShapeOrderForPage: vi.fn(() => [] as string[]),
     getName: vi.fn(() => undefined),

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -147,6 +147,7 @@ import { useDocumentStore } from '../store/documentStore';
 import { usePageStore } from '../store/pageStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { usePendingSyncPages, isPagePendingSync } from '../store/pendingSyncPages';
+import { useConnectionStore } from '../store/connectionStore';
 import { useCollaborationSync } from './useCollaborationSync';
 import { withAutoSaveSuppressed } from '../store/autoSaveGuard';
 
@@ -182,7 +183,9 @@ function startSyncedSession(docId = 'doc-1'): void {
       token: 'test-token',
       user: { id: 'u', name: 'U', color: '#fff' },
     });
-    useCollaborationStore.getState()._setSynced(true);
+    // A COMPLETED handshake (isSynced + syncEpoch bump), as onSynced records it
+    // — the JP-335 handoff keys off the epoch, not the session-level flag.
+    useCollaborationStore.getState()._markSyncedHandshake();
     useCollaborationStore.getState()._setIdbSynced(true);
   });
 }
@@ -227,6 +230,8 @@ describe('useCollaborationSync', () => {
     useCollaborationStore.setState({
       isActive: false,
       isSynced: false,
+      // Monotonic in production; reset here so each test's epoch is deterministic.
+      syncEpoch: 0,
       isIdbSynced: false,
       config: null,
     });
@@ -433,6 +438,95 @@ describe('useCollaborationSync', () => {
 
     expect(currentYjs.setProsePage).not.toHaveBeenCalled();
     expect(isPagePendingSync('rt-off')).toBe(true);
+  });
+
+  it('does NOT hand off before the first completed handshake, even authenticated (JP-423)', () => {
+    // The auth-flicker case the old connection-status dep mis-fired on: the
+    // socket authenticated but sync step 2 hasn't merged relay state yet
+    // (isSynced true from the session's earlier life, epoch still 0 here).
+    act(() => {
+      useRichTextPagesStore.setState({
+        pages: {
+          'rt-off': { id: 'rt-off', name: 'Offline notes', content: '<p>x</p>', order: 0, createdAt: 1, modifiedAt: 2 },
+        },
+        pageOrder: ['rt-off'],
+        activePageId: 'rt-off',
+      });
+      usePendingSyncPages.getState().markPending('rt-off', 'doc-1');
+      usePageStore.setState({
+        pages: { p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt: 0 } },
+        pageOrder: ['p1'],
+        activePageId: 'p1',
+      });
+      useCollaborationStore.getState().startSession({
+        serverUrl: 'ws://localhost:9876/ws',
+        documentId: 'doc-1',
+        token: 'test-token',
+        user: { id: 'u', name: 'U', color: '#fff' },
+      });
+      useCollaborationStore.getState()._setSynced(true);
+      useCollaborationStore.getState()._setIdbSynced(true);
+    });
+
+    renderHook(() => useCollaborationSync());
+
+    expect(currentYjs.setProsePage).not.toHaveBeenCalled();
+    expect(isPagePendingSync('rt-off')).toBe(true);
+  });
+
+  it('does NOT hand off while disconnected at epoch ≥ 1 — markers keep the withhold (JP-423)', () => {
+    // A remount after a drop: a handshake completed earlier this session
+    // (epoch 1) but the connection is down NOW. Clearing markers here would
+    // end the REST body-withhold before the CRDT carried the page (JP-282).
+    const connState = useConnectionStore.getState() as { status: string };
+    startSyncedSession('doc-1');
+    act(() => {
+      useRichTextPagesStore.setState({
+        pages: {
+          'rt-late': { id: 'rt-late', name: 'Made offline', content: '<p>y</p>', order: 0, createdAt: 1, modifiedAt: 2 },
+        },
+        pageOrder: ['rt-late'],
+        activePageId: 'rt-late',
+      });
+      usePendingSyncPages.getState().markPending('rt-late', 'doc-1');
+    });
+    connState.status = 'disconnected';
+    try {
+      renderHook(() => useCollaborationSync());
+
+      expect(currentYjs.setProsePage).not.toHaveBeenCalled();
+      expect(isPagePendingSync('rt-late')).toBe(true);
+    } finally {
+      connState.status = 'authenticated';
+    }
+  });
+
+  it('re-runs the handoff on the NEXT completed handshake, not on rerenders (JP-423)', () => {
+    startSyncedSession('doc-1');
+    const view = renderHook(() => useCollaborationSync());
+
+    // A page goes pending after the first handshake's handoff already ran.
+    act(() => {
+      useRichTextPagesStore.setState({
+        pages: {
+          'rt-late': { id: 'rt-late', name: 'Made offline', content: '<p>y</p>', order: 0, createdAt: 1, modifiedAt: 2 },
+        },
+        pageOrder: ['rt-late'],
+        activePageId: 'rt-late',
+      });
+      usePendingSyncPages.getState().markPending('rt-late', 'doc-1');
+    });
+
+    // No dep changed (auth churn alone no longer re-fires the effect).
+    view.rerender();
+    expect(isPagePendingSync('rt-late')).toBe(true);
+
+    // The reconnect's completed handshake bumps the epoch → handoff runs.
+    act(() => useCollaborationStore.getState()._markSyncedHandshake());
+    expect(currentYjs.setProsePage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'rt-late', name: 'Made offline' }),
+    );
+    expect(isPagePendingSync('rt-late')).toBe(false);
   });
 
   it('re-binds onShapeChange to the new Y.Doc after switchDocument (#60)', () => {

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -24,6 +24,8 @@ import { usePageStore } from '../store/pageStore';
 import { applyRemoteDocumentName } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
+import { useConnectionStore } from '../store/connectionStore';
+import { usePendingSyncPages, pendingPagesForDoc } from '../store/pendingSyncPages';
 import { useCollaborationStore } from './collaborationStore';
 import type { YjsDocument, ProsePageMeta, CanvasPageMeta } from './YjsDocument';
 
@@ -621,6 +623,86 @@ export function useCollaborationSync(): void {
 
     return unsubscribe;
   }, [isActive, syncCanvasPage, syncDeleteCanvasPage, syncCanvasPageOrder]);
+
+  // JP-335: reconnect handoff for pages created offline (pending-sync). Once the
+  // session has a live, synced, authenticated relay exchange, every pending
+  // page's meta (+ canvas shapes) is (re)emitted into the CRDT and its marker
+  // clears. On the common path (room seeded/adopted, `initializedRef` true) the
+  // page-list subscriptions above already put the meta in the Y.Doc and the
+  // bridge captured shapes as they were drawn — the re-emit is an idempotent
+  // no-op and this effect just clears markers. On the un-adopted edge (empty
+  // room offline, subscriptions gated) it's the correctness path: without it the
+  // fragment would sync while the meta never does (an orphaned, list-invisible
+  // page). The prose FRAGMENT itself needs no push — the editor wrote it into
+  // the shared Y.Doc directly (y-prosemirror) and the sync exchange carried it.
+  // `connAuthenticated` is a dep so the handoff re-fires after every reconnect
+  // (`isSynced` does not reset on a transient drop).
+  const connAuthenticated = useConnectionStore((s) => s.status === 'authenticated');
+  useEffect(() => {
+    if (!isActive || !isSynced || !hasProvider || !connAuthenticated) return;
+    const docId = useCollaborationStore.getState().config?.documentId;
+    if (!docId) return;
+    const pendingIds = pendingPagesForDoc(docId);
+    if (pendingIds.length === 0) return;
+    const yjsDoc = getYjsDocument();
+    if (!yjsDoc) return;
+
+    const proseState = useRichTextPagesStore.getState();
+    const pageState = usePageStore.getState();
+    for (const pageId of pendingIds) {
+      const prose = proseState.pages[pageId];
+      if (prose) {
+        const meta: ProsePageMeta = {
+          id: pageId,
+          name: prose.name,
+          order: Math.max(0, proseState.pageOrder.indexOf(pageId)),
+          createdAt: prose.createdAt,
+          modifiedAt: prose.modifiedAt,
+        };
+        if (prose.color !== undefined) meta.color = prose.color;
+        syncProsePage(meta);
+      }
+
+      const canvas = pageState.pages[pageId];
+      if (canvas) {
+        const canvasMeta: CanvasPageMeta = {
+          id: pageId,
+          name: canvas.name,
+          createdAt: canvas.createdAt,
+          modifiedAt: canvas.modifiedAt,
+        };
+        syncCanvasPage(canvasMeta);
+        // Push the page's offline-drawn shapes from the committed pageStore
+        // snapshot (NOT documentStore — the adopt effect may have just cleared
+        // the view). Additive by shape id, so a no-op where the bridge already
+        // captured them live.
+        yjsDoc.seedPageShapes(pageId, Object.values(canvas.shapes), canvas.shapeOrder);
+        // If the pending page is the active one and the adopt effect just
+        // loaded its (previously empty) Y.Doc snapshot into the view, reload it
+        // now that the seed landed.
+        if (pageState.activePageId === pageId) {
+          const snapshot = yjsDoc.rebindActivePage(pageId);
+          runWithProvenance('remote-apply', () => {
+            const store = useDocumentStore.getState();
+            store.clear();
+            if (snapshot.shapes.length > 0) store.addShapes(snapshot.shapes);
+            if (snapshot.order.length > 0) store.reorderShapes(snapshot.order);
+          });
+        }
+      }
+
+      usePendingSyncPages.getState().clearPending(pageId);
+    }
+  }, [
+    isActive,
+    isSynced,
+    hasProvider,
+    connAuthenticated,
+    sessionEpoch,
+    getYjsDocument,
+    syncProsePage,
+    syncCanvasPage,
+  ]);
 }
 
 /**

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -635,11 +635,20 @@ export function useCollaborationSync(): void {
   // fragment would sync while the meta never does (an orphaned, list-invisible
   // page). The prose FRAGMENT itself needs no push — the editor wrote it into
   // the shared Y.Doc directly (y-prosemirror) and the sync exchange carried it.
-  // `connAuthenticated` is a dep so the handoff re-fires after every reconnect
-  // (`isSynced` does not reset on a transient drop).
-  const connAuthenticated = useConnectionStore((s) => s.status === 'authenticated');
+  //
+  // `syncEpoch` is the re-fire dep (JP-423): it bumps once per COMPLETED
+  // handshake, so the handoff re-runs after every reconnect but never fires on
+  // an auth flicker before the new connection's sync step 2 merged relay
+  // state (its predecessor dep, connection-status === authenticated, could).
+  // The non-reactive live check below still guards the other direction: an
+  // effect re-run while disconnected (e.g. a remount at epoch ≥ 1) must not
+  // re-emit + clear markers — a cleared marker ends the REST body-withhold,
+  // and a queued replay carrying the page's HTML before the CRDT handoff
+  // lands would re-open the JP-282 double.
+  const syncEpoch = useCollaborationStore((s) => s.syncEpoch);
   useEffect(() => {
-    if (!isActive || !isSynced || !hasProvider || !connAuthenticated) return;
+    if (!isActive || !hasProvider || syncEpoch === 0) return;
+    if (useConnectionStore.getState().status !== 'authenticated') return;
     const docId = useCollaborationStore.getState().config?.documentId;
     if (!docId) return;
     const pendingIds = pendingPagesForDoc(docId);
@@ -695,9 +704,8 @@ export function useCollaborationSync(): void {
     }
   }, [
     isActive,
-    isSynced,
     hasProvider,
-    connAuthenticated,
+    syncEpoch,
     sessionEpoch,
     getYjsDocument,
     syncProsePage,

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -27,7 +27,8 @@ import { getProvenance, runWithProvenance } from '../store/writeProvenance';
 import { useConnectionStore } from '../store/connectionStore';
 import { usePendingSyncPages, pendingPagesForDoc } from '../store/pendingSyncPages';
 import { useCollaborationStore } from './collaborationStore';
-import type { YjsDocument, ProsePageMeta, CanvasPageMeta } from './YjsDocument';
+import { healOrphanedProseFragments, synthesizeProsePageMeta } from './proseInvariant';
+import type { YjsDocument, CanvasPageMeta } from './YjsDocument';
 
 /**
  * Adopt the relay's authoritative prose page LIST into `richTextPagesStore`
@@ -316,6 +317,15 @@ export function useCollaborationSync(): void {
       for (const pageId of useRichTextPagesStore.getState().pageOrder) {
         yjsDoc.healDoubledProse(pageId);
       }
+      // JP-423 fragment↔page-list invariant: log any `prose:*` root with
+      // content but no `prosePages` meta; repair the ones the local store
+      // corroborates (adoptProsePageList just reconciled it). A local→remote
+      // CRDT write, so OUTSIDE the remote-apply window above — like the
+      // pending-page handoff.
+      const adoptedDocId = useCollaborationStore.getState().config?.documentId;
+      if (adoptedDocId) {
+        healOrphanedProseFragments(yjsDoc, adoptedDocId);
+      }
     }
   }, [isActive, isSynced, isIdbSynced, hasProvider, getYjsDocument, sessionEpoch]);
 
@@ -546,15 +556,7 @@ export function useCollaborationSync(): void {
         const metaChanged =
           !prev || prev.name !== cur.name || prev.color !== cur.color || prev.order !== cur.order;
         if (metaChanged) {
-          const meta: ProsePageMeta = {
-            id,
-            name: cur.name,
-            order: index,
-            createdAt: cur.createdAt,
-            modifiedAt: cur.modifiedAt,
-          };
-          if (cur.color !== undefined) meta.color = cur.color;
-          syncProsePage(meta);
+          syncProsePage(synthesizeProsePageMeta(cur, index));
         }
       });
 
@@ -661,15 +663,7 @@ export function useCollaborationSync(): void {
     for (const pageId of pendingIds) {
       const prose = proseState.pages[pageId];
       if (prose) {
-        const meta: ProsePageMeta = {
-          id: pageId,
-          name: prose.name,
-          order: Math.max(0, proseState.pageOrder.indexOf(pageId)),
-          createdAt: prose.createdAt,
-          modifiedAt: prose.modifiedAt,
-        };
-        if (prose.color !== undefined) meta.color = prose.color;
-        syncProsePage(meta);
+        syncProsePage(synthesizeProsePageMeta(prose, proseState.pageOrder.indexOf(pageId)));
       }
 
       const canvas = pageState.pages[pageId];

--- a/src/store/collectionStore.test.ts
+++ b/src/store/collectionStore.test.ts
@@ -141,6 +141,48 @@ describe('collectionStore scope (JP-366)', () => {
   });
 });
 
+describe('collectionStore hydrateFromRelay prune (JP-424)', () => {
+  beforeEach(reset);
+
+  function seedWorkspaceDefs() {
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [
+        { id: 'keep', name: 'Keep', order: 0, createdAt: 1 },
+        { id: 'gone', name: 'Gone', order: 1, createdAt: 1 },
+        { id: 'inflight', name: 'InFlight', order: 2, createdAt: 1 },
+      ],
+      memberships: { dKeep: 'keep', dGone: 'gone' },
+    });
+  }
+
+  it('without the directive, absent workspace defs are kept (upsert-only)', () => {
+    seedWorkspaceDefs();
+    useCollectionStore.getState().hydrateFromRelay({ definitions: [], memberships: {} });
+    expect(useCollectionStore.getState().collections['gone']).toBeDefined();
+  });
+
+  it('prunes workspace defs absent from the relay set, honouring keepIds, and drops their assignments', () => {
+    seedWorkspaceDefs();
+    const local = useCollectionStore.getState().createCollection('Personal', undefined, 'local');
+    useCollectionStore.getState().assignDocument('dLocal', local);
+
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'keep', name: 'Keep', order: 0, createdAt: 1 }],
+      memberships: {},
+      pruneWorkspaceDefs: { keepIds: ['inflight'] },
+    });
+
+    const st = useCollectionStore.getState();
+    expect(st.collections['keep']).toBeDefined(); // in the relay set
+    expect(st.collections['inflight']).toBeDefined(); // shielded by keepIds
+    expect(st.collections['gone']).toBeUndefined(); // pruned
+    expect(st.assignments['dGone']).toBeUndefined(); // its assignment dropped
+    expect(st.assignments['dKeep']).toBe('keep'); // untouched
+    expect(st.collections[local]).toBeDefined(); // local defs never pruned
+    expect(st.assignments['dLocal']).toBe(local);
+  });
+});
+
 describe('migrateCollections v1→v2 (JP-366)', () => {
   it('stamps scope=local on untagged v1 collections, preserving assignments', () => {
     const v1 = {

--- a/src/store/collectionStore.ts
+++ b/src/store/collectionStore.ts
@@ -78,10 +78,17 @@ export interface CollectionActions {
    * `null` clears. Local-doc assignments are never touched (the caller only
    * includes relay doc ids it intends to apply). The single atomic entry point
    * the sync layer uses; this store stays network-free.
+   *
+   * `pruneWorkspaceDefs` (JP-424): when present, workspace-scoped definitions
+   * absent from `definitions` are deleted (the relay no longer has them —
+   * deleted by another client) along with their assignments — except ids in
+   * `keepIds`, the caller's in-flight/unconfirmed creates. Local-scoped
+   * definitions are never pruned.
    */
   hydrateFromRelay: (input: {
     definitions: Collection[];
     memberships: Record<string, string | null>;
+    pruneWorkspaceDefs?: { keepIds: string[] };
   }) => void;
   /**
    * Drop every `workspace`-scoped collection and prune assignments that point at
@@ -232,7 +239,7 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
         return Object.values(collections).sort((a, b) => a.order - b.order);
       },
 
-      hydrateFromRelay: ({ definitions, memberships }) => {
+      hydrateFromRelay: ({ definitions, memberships, pruneWorkspaceDefs }) => {
         const { collections, assignments } = get();
         const nextCollections = { ...collections };
         for (const def of definitions) {
@@ -240,7 +247,26 @@ export const useCollectionStore = create<CollectionState & CollectionActions>()(
           // can drop them and the scope guard treats them correctly.
           nextCollections[def.id] = { ...def, scope: 'workspace' };
         }
-        const nextAssignments = { ...assignments };
+
+        // Prune workspace defs the relay no longer has (deleted elsewhere),
+        // keeping unconfirmed in-flight creates. Same assignment-cleanup shape
+        // as deleteCollection/dropWorkspaceCollections.
+        const pruned = new Set<string>();
+        if (pruneWorkspaceDefs) {
+          const present = new Set(definitions.map((d) => d.id));
+          const keep = new Set(pruneWorkspaceDefs.keepIds);
+          for (const [id, col] of Object.entries(nextCollections)) {
+            if (isWorkspaceCollection(col) && !present.has(id) && !keep.has(id)) {
+              pruned.add(id);
+              delete nextCollections[id];
+            }
+          }
+        }
+
+        const nextAssignments: Record<string, string> = {};
+        for (const [docId, cid] of Object.entries(assignments)) {
+          if (!pruned.has(cid)) nextAssignments[docId] = cid;
+        }
         for (const [documentId, collectionId] of Object.entries(memberships)) {
           if (collectionId === null) {
             delete nextAssignments[documentId];

--- a/src/store/collectionSync.test.ts
+++ b/src/store/collectionSync.test.ts
@@ -38,10 +38,18 @@ const registryGetState = useDocumentRegistry.getState as unknown as Mock;
 const notifyGetState = useNotificationStore.getState as unknown as Mock;
 const warningSpy = vi.fn();
 
-function makeProvider(defs: RelayCollectionDef[]) {
+// `version: null` = a pre-JP-424 relay whose GET carries no version field.
+function makeProvider(defs: RelayCollectionDef[], version: number | null = 1) {
   return {
-    getCollections: vi.fn(async (): Promise<RelayCollectionDef[]> => defs.map((d) => ({ ...d }))),
-    setCollections: vi.fn(async (_defs: RelayCollectionDef[]): Promise<void> => {}),
+    getCollections: vi.fn(
+      async (): Promise<{ collections: RelayCollectionDef[]; version?: number }> => ({
+        collections: defs.map((d) => ({ ...d })),
+        ...(version !== null ? { version } : {}),
+      }),
+    ),
+    setCollections: vi.fn(
+      async (_defs: RelayCollectionDef[], _expectedVersion?: number): Promise<void> => {},
+    ),
     setDocumentCollection: vi.fn(async (_docId: string, _collectionId: string | null): Promise<void> => {}),
   };
 }
@@ -123,11 +131,11 @@ describe('collectionSync reconcileFromRelay (JP-159)', () => {
   it('hydrates relay defs + memberships, leaves local-doc assignments untouched', async () => {
     const provider = makeProvider([{ id: 'A', name: 'Alpha', order: 0, color: '#fff' }]);
     getDocProviderMock.mockReturnValue(provider);
-    // Seed a local-only collection + assignment that reconcile must NOT touch.
-    useCollectionStore.getState().hydrateFromRelay({
-      definitions: [{ id: 'localCol', name: 'Local', order: 9, createdAt: 1 }],
-      memberships: { localDoc: 'localCol' },
-    });
+    // Seed a genuinely local-scoped collection + assignment that reconcile
+    // must NOT touch (JP-424: workspace-scoped defs absent from the relay are
+    // pruned, so the seam matters).
+    const localCol = useCollectionStore.getState().createCollection('Local', undefined, 'local');
+    useCollectionStore.getState().assignDocument('localDoc', localCol);
 
     await reconcileFromRelay([meta('d1', 'A'), meta('d2')]);
 
@@ -136,8 +144,39 @@ describe('collectionSync reconcileFromRelay (JP-159)', () => {
     expect(typeof st.collections['A']?.createdAt).toBe('number');
     expect(st.assignments['d1']).toBe('A'); // relay membership applied
     expect(st.assignments['d2']).toBeUndefined(); // relay-absent → cleared
-    expect(st.assignments['localDoc']).toBe('localCol'); // local doc untouched
-    expect(st.collections['localCol']).toBeDefined(); // local def preserved
+    expect(st.assignments['localDoc']).toBe(localCol); // local doc untouched
+    expect(st.collections[localCol]).toBeDefined(); // local def preserved
+  });
+
+  it('prunes workspace defs the relay no longer has, plus their assignments (JP-424)', async () => {
+    // Seed a workspace def that another client has since deleted on the relay.
+    useCollectionStore.getState().hydrateFromRelay({
+      definitions: [{ id: 'gone', name: 'Gone', order: 0, createdAt: 1 }],
+      memberships: { d9: 'gone' },
+    });
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    getDocProviderMock.mockReturnValue(provider);
+
+    await reconcileFromRelay([]);
+
+    const st = useCollectionStore.getState();
+    expect(st.collections['gone']).toBeUndefined(); // ghost def pruned
+    expect(st.assignments['d9']).toBeUndefined(); // its assignment dropped
+    expect(st.collections['A']).toBeDefined(); // relay set hydrated
+  });
+
+  it('keeps an unconfirmed created def across a prune when its push failed (JP-424)', async () => {
+    const provider = makeProvider([]);
+    provider.setCollections.mockRejectedValue(new Error('relay down'));
+    getDocProviderMock.mockReturnValue(provider);
+
+    const newId = syncedActions.createCollection('Fresh');
+    await flush();
+    expect(useCollectionStore.getState().collections[newId]).toBeDefined();
+
+    // Reconcile sees a relay set without the new id — it must survive.
+    await reconcileFromRelay([]);
+    expect(useCollectionStore.getState().collections[newId]).toBeDefined();
   });
 
   it('does NOT clear a relay doc with a pending queued save (clear-guard)', async () => {
@@ -233,7 +272,7 @@ describe('collectionSync scope (JP-366)', () => {
     expect(warningSpy).not.toHaveBeenCalled();
   });
 
-  it('resetWorkspaceSync forgets the known workspace set so the membership gate reopens', async () => {
+  it('resetWorkspaceSync forgets the known workspace set so the membership gate reopens (JP-366)', async () => {
     const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
     getDocProviderMock.mockReturnValue(provider);
     await reconcileFromRelay([]); // known = {A}
@@ -246,5 +285,86 @@ describe('collectionSync scope (JP-366)', () => {
 
     syncedActions.assignDocuments(['d'], 'B'); // gate empty now → push allowed
     await vi.waitFor(() => expect(provider.setDocumentCollection).toHaveBeenCalledWith('d', 'B'));
+  });
+});
+
+describe('collectionSync versioned definitions (JP-424)', () => {
+  it('sends the fetched registry version as expectedVersion on PUT', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }], 7);
+    getDocProviderMock.mockReturnValue(provider);
+
+    syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+
+    const [, expectedVersion] = provider.setCollections.mock.calls[0]!;
+    expect(expectedVersion).toBe(7);
+  });
+
+  it('a version-less GET (pre-JP-424 relay) degrades to the legacy blind write', async () => {
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }], null);
+    getDocProviderMock.mockReturnValue(provider);
+
+    syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+
+    const [, expectedVersion] = provider.setCollections.mock.calls[0]!;
+    expect(expectedVersion).toBeUndefined();
+  });
+
+  it('rebases exactly once on a version conflict: fresh GET, re-applied transform', async () => {
+    const { VersionConflictError } = await import('../api/relayClient');
+    const provider = makeProvider([]);
+    // First GET: v1, set {A}. Second GET (after conflict): v2, set {A, B} —
+    // another client added B between our GET and PUT.
+    provider.getCollections
+      .mockResolvedValueOnce({ collections: [{ id: 'A', name: 'A', order: 0 }], version: 1 })
+      .mockResolvedValueOnce({
+        collections: [
+          { id: 'A', name: 'A', order: 0 },
+          { id: 'B', name: 'B', order: 1 },
+        ],
+        version: 2,
+      });
+    provider.setCollections
+      .mockRejectedValueOnce(new VersionConflictError('/api/collections', 2))
+      .mockResolvedValueOnce(undefined);
+    getDocProviderMock.mockReturnValue(provider);
+
+    const newId = syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalledTimes(2));
+
+    const [retryDefs, retryVersion] = provider.setCollections.mock.calls[1]! as [
+      RelayCollectionDef[],
+      number | undefined,
+    ];
+    const ids = retryDefs.map((d) => d.id);
+    expect(ids).toContain('B'); // rebase picked up the other client's write
+    expect(ids).toContain(newId); // and re-applied our transform
+    expect(retryVersion).toBe(2); // conditional on the fresh version
+  });
+
+  it('a second consecutive conflict is swallowed (best-effort, heals on reconcile)', async () => {
+    const { VersionConflictError } = await import('../api/relayClient');
+    const provider = makeProvider([{ id: 'A', name: 'A', order: 0 }]);
+    provider.setCollections.mockRejectedValue(new VersionConflictError('/api/collections', 9));
+    getDocProviderMock.mockReturnValue(provider);
+
+    expect(() => syncedActions.createCollection('Created')).not.toThrow();
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalledTimes(2));
+    await flush(); // no third attempt, no unhandled rejection
+    expect(provider.setCollections).toHaveBeenCalledTimes(2);
+  });
+
+  it('a successful push confirms the created id (later prune may drop it if relay-deleted)', async () => {
+    const provider = makeProvider([]);
+    getDocProviderMock.mockReturnValue(provider);
+
+    const newId = syncedActions.createCollection('Created');
+    await vi.waitFor(() => expect(provider.setCollections).toHaveBeenCalled());
+
+    // Push confirmed → the id is no longer shielded: a reconcile whose relay
+    // set lacks it (deleted by another client) now prunes it.
+    await reconcileFromRelay([]);
+    expect(useCollectionStore.getState().collections[newId]).toBeUndefined();
   });
 });

--- a/src/store/collectionSync.ts
+++ b/src/store/collectionSync.ts
@@ -18,7 +18,7 @@
  * which carries `collectionId` in its body (persistenceStore stamp).
  */
 
-import type { RelayCollectionDef } from '../api/relayClient';
+import { VersionConflictError, type RelayCollectionDef } from '../api/relayClient';
 import type { DocumentMetadata } from '../types/Document';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import {
@@ -36,11 +36,18 @@ import { useDocumentRegistry } from './documentRegistry';
  *  (which would leave a dangling `collectionId`). */
 let knownCollectionIds = new Set<string>();
 
+/** Workspace collection ids created locally whose relay push hasn't succeeded
+ *  yet (JP-424). Reconcile's prune must skip them — pruning "absent from the
+ *  relay" would otherwise erase a brand-new collection whose create push is
+ *  still in flight or failed (it re-lands on the user's next mutation). */
+let unconfirmedWorkspaceDefIds = new Set<string>();
+
 /** Forget the connected workspace's collection set. Called when leaving a
  *  workspace (full sign-out / Remove Workspace) so a stale set can't gate the
  *  next workspace's membership pushes. */
 export function resetWorkspaceSync(): void {
   knownCollectionIds = new Set();
+  unconfirmedWorkspaceDefIds = new Set();
 }
 
 /** Serialize relay-definition read-modify-writes so concurrent mutations can't
@@ -61,23 +68,52 @@ function toDef(col: Collection): RelayCollectionDef {
   };
 }
 
+/** One GET → transform → conditional PUT cycle (JP-424). Sends the fetched
+ *  registry version as `expectedVersion` (absent against a pre-JP-424 relay ⇒
+ *  legacy blind write) and, on success, confirms any pending created ids. */
+async function pushDefsOnce(
+  getCollections: () => Promise<{ collections: RelayCollectionDef[]; version?: number }>,
+  setCollections: (defs: RelayCollectionDef[], expectedVersion?: number) => Promise<void>,
+  transform: (defs: RelayCollectionDef[]) => RelayCollectionDef[],
+): Promise<void> {
+  const { collections: current, version } = await getCollections();
+  const next = transform(current);
+  knownCollectionIds = new Set(next.map((d) => d.id));
+  await setCollections(next, version);
+  for (const def of next) unconfirmedWorkspaceDefIds.delete(def.id);
+}
+
 /**
  * Read the connected workspace's definition set, apply `transform`, write it
  * back. Best-effort + serialized + auth-gated. Refreshes `knownCollectionIds`.
+ * A version conflict (another client wrote between our GET and PUT) is rebased
+ * exactly once — fresh GET, re-applied transform; a second conflict stays
+ * best-effort (the next reconcile heals).
  */
 function mutateRelayDefs(
   transform: (defs: RelayCollectionDef[]) => RelayCollectionDef[],
 ): Promise<void> {
   return serialize(async () => {
     const provider = getDocProvider();
-    if (!provider?.getCollections || !provider.setCollections) return;
+    const getCollections = provider?.getCollections?.bind(provider);
+    const setCollections = provider?.setCollections?.bind(provider);
+    if (!getCollections || !setCollections) return;
     if (!isCloudSignedIn()) return;
     try {
-      const current = await provider.getCollections();
-      const next = transform(current);
-      knownCollectionIds = new Set(next.map((d) => d.id));
-      await provider.setCollections(next);
+      await pushDefsOnce(getCollections, setCollections, transform);
     } catch (e) {
+      if (e instanceof VersionConflictError) {
+        try {
+          await pushDefsOnce(getCollections, setCollections, transform);
+          return;
+        } catch (retryError) {
+          console.warn(
+            '[collectionSync] definitions push failed after rebase (best-effort):',
+            retryError,
+          );
+          return;
+        }
+      }
       console.warn('[collectionSync] definitions push failed (best-effort):', e);
     }
   });
@@ -120,6 +156,9 @@ export const syncedActions = {
     if (id && resolvedScope === 'workspace') {
       const col = useCollectionStore.getState().collections[id];
       if (col) {
+        // Track the create until its push is confirmed so a reconcile that
+        // races (or follows a failed push) can't prune it (JP-424).
+        unconfirmedWorkspaceDefIds.add(col.id);
         void mutateRelayDefs((defs) =>
           defs.some((d) => d.id === col.id) ? defs : [...defs, toDef(col)],
         );
@@ -232,46 +271,60 @@ function reprojectDefinition(id: string): Promise<void> {
  * Pull the connected workspace's collections + relay-doc memberships and
  * reconcile them into the store. Called from `fetchDocumentList`. Best-effort:
  * a failure here must not fail the doc-list fetch.
+ *
+ * Runs through the `serialize()` chain (JP-424): an in-flight definition push
+ * occupies the chain ahead of us, so by the time our GET runs that push has
+ * landed and its ids are in the fetched set — a snapshot-then-prune race can't
+ * drop a collection that was being created. Ids whose push *failed* are kept
+ * via `unconfirmedWorkspaceDefIds`.
  */
 export async function reconcileFromRelay(relayDocs: DocumentMetadata[]): Promise<void> {
-  const provider = getDocProvider();
-  if (!provider?.getCollections) return;
+  return serialize(async () => {
+    const provider = getDocProvider();
+    if (!provider?.getCollections) return;
 
-  let relaySet: RelayCollectionDef[];
-  try {
-    relaySet = await provider.getCollections();
-  } catch (e) {
-    console.warn('[collectionSync] reconcile getCollections failed (best-effort):', e);
-    return;
-  }
-  knownCollectionIds = new Set(relaySet.map((d) => d.id));
-
-  const store = useCollectionStore.getState();
-  const definitions: Collection[] = relaySet.map((d) => {
-    const existing = store.collections[d.id];
-    return {
-      id: d.id,
-      name: d.name,
-      order: d.order,
-      createdAt: existing?.createdAt ?? Date.now(),
-      ...(d.color !== undefined ? { color: d.color } : {}),
-    };
-  });
-
-  // Membership: relay is authoritative for relay docs. Clear an absent
-  // membership only when there's no pending queued save for that doc — an
-  // offline assign that reconnects before its content-save replays would
-  // otherwise be reverted by a stale reconcile.
-  const sync = getSyncStateManager();
-  const memberships: Record<string, string | null> = {};
-  for (const doc of relayDocs) {
-    const cid = doc.collectionId;
-    if (typeof cid === 'string') {
-      memberships[doc.id] = cid;
-    } else if (!sync.hasPendingChanges(doc.id)) {
-      memberships[doc.id] = null;
+    let relaySet: RelayCollectionDef[];
+    try {
+      ({ collections: relaySet } = await provider.getCollections());
+    } catch (e) {
+      console.warn('[collectionSync] reconcile getCollections failed (best-effort):', e);
+      return;
     }
-  }
+    knownCollectionIds = new Set(relaySet.map((d) => d.id));
 
-  store.hydrateFromRelay({ definitions, memberships });
+    const store = useCollectionStore.getState();
+    const definitions: Collection[] = relaySet.map((d) => {
+      const existing = store.collections[d.id];
+      return {
+        id: d.id,
+        name: d.name,
+        order: d.order,
+        createdAt: existing?.createdAt ?? Date.now(),
+        ...(d.color !== undefined ? { color: d.color } : {}),
+      };
+    });
+
+    // Membership: relay is authoritative for relay docs. Clear an absent
+    // membership only when there's no pending queued save for that doc — an
+    // offline assign that reconnects before its content-save replays would
+    // otherwise be reverted by a stale reconcile.
+    const sync = getSyncStateManager();
+    const memberships: Record<string, string | null> = {};
+    for (const doc of relayDocs) {
+      const cid = doc.collectionId;
+      if (typeof cid === 'string') {
+        memberships[doc.id] = cid;
+      } else if (!sync.hasPendingChanges(doc.id)) {
+        memberships[doc.id] = null;
+      }
+    }
+
+    store.hydrateFromRelay({
+      definitions,
+      memberships,
+      // Workspace defs absent from the relay were deleted by another client —
+      // drop them (and their assignments) instead of ghosting forever.
+      pruneWorkspaceDefs: { keepIds: [...unconfirmedWorkspaceDefIds] },
+    });
+  });
 }

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -23,6 +23,7 @@ import type { DiagramDocument } from '../types/Document';
 import type { DocumentRecord } from '../types/DocumentRegistry';
 import { useDocumentRegistry } from './documentRegistry';
 import { getDocProvider, useRelayDocumentStore } from './relayDocumentStore';
+import { prefetchYdoc } from '../collaboration/prefetchYdoc';
 
 /** Max blob downloads in flight at once during a prefetch. */
 const OFFLINE_PREFETCH_CONCURRENCY = 4;
@@ -140,6 +141,14 @@ export async function makeAvailableOffline(
   // loadRelayDocument serves (or fetches) the body and writes it to the
   // persistent offline cache as a side effect — that satisfies "body cached".
   const body = await useRelayDocumentStore.getState().loadRelayDocument(record.id);
+
+  // JP-335: also seed the local Y.Doc room from the relay's authoritative
+  // sidecar, so a doc that's only ever been "downloaded" (never opened live) can
+  // be opened + EDITED offline — not just rendered read-only. Best-effort: a
+  // missing sidecar or older relay just leaves the doc read-only offline (the
+  // prior behavior), never fails the prefetch.
+  await prefetchYdoc(record.id);
+
   const refs = collectBlobReferences(body);
   const total = refs.length;
 

--- a/src/store/offlineAvailability.ts
+++ b/src/store/offlineAvailability.ts
@@ -142,7 +142,7 @@ export async function makeAvailableOffline(
   // persistent offline cache as a side effect — that satisfies "body cached".
   const body = await useRelayDocumentStore.getState().loadRelayDocument(record.id);
 
-  // JP-335: also seed the local Y.Doc room from the relay's authoritative
+  // JP-422: also seed the local Y.Doc room from the relay's authoritative
   // sidecar, so a doc that's only ever been "downloaded" (never opened live) can
   // be opened + EDITED offline — not just rendered read-only. Best-effort: a
   // missing sidecar or older relay just leaves the doc read-only offline (the

--- a/src/store/pageStore.ts
+++ b/src/store/pageStore.ts
@@ -9,6 +9,7 @@ import { immer } from 'zustand/middleware/immer';
 import { nanoid } from 'nanoid';
 import { Page, createPage } from '../types/Document';
 import { CANVAS_PAGE_BASE, nextDefaultPageName } from './pageNaming';
+import { isPagePendingSync } from './pendingSyncPages';
 import type { CanvasPageList } from '../collaboration/YjsDocument';
 import { useDocumentStore } from './documentStore';
 import { useSessionStore } from './sessionStore';
@@ -444,14 +445,24 @@ export const usePageStore = create<PageState & PageActions>()(
           }
         }
 
-        // Drop pages the merged set no longer contains (a remote delete).
+        // Drop pages the merged set no longer contains (a remote delete) —
+        // EXCEPT pending-sync pages (JP-335): a page created offline hasn't
+        // reached the relay's list yet, so its absence there is not a delete.
+        // Keep it (and keep it visible in the order); the reconnect handoff
+        // uploads its meta + shapes.
+        const spared = new Set<string>();
         for (const id of Object.keys(draft.pages)) {
           if (!incoming.has(id)) {
+            if (isPagePendingSync(id)) {
+              spared.add(id);
+              continue;
+            }
             delete draft.pages[id];
           }
         }
 
-        draft.pageOrder = [...list.pageOrder];
+        const sparedOrdered = draft.pageOrder.filter((id) => spared.has(id));
+        draft.pageOrder = [...list.pageOrder, ...sparedOrdered];
 
         // Repoint the (client-local) active page if it was pruned. The deleted-
         // active-page case is also covered by the relay's resident-page evict +

--- a/src/store/pendingPagesPrune.test.ts
+++ b/src/store/pendingPagesPrune.test.ts
@@ -1,0 +1,93 @@
+/**
+ * JP-335 — the reconnect page-list prune must SPARE pending-sync pages.
+ *
+ * `applyRemoteProsePageList` / `applyRemoteCanvasPageList` drop local pages
+ * absent from the adopted (relay) list — correct for remote deletes, but a page
+ * created offline is absent because the relay hasn't LEARNED it yet. Pruning it
+ * before the handoff uploads it would destroy the user's offline work.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRichTextPagesStore } from './richTextPagesStore';
+import { usePageStore } from './pageStore';
+import { usePendingSyncPages } from './pendingSyncPages';
+import { createPage } from '../types/Document';
+
+describe('applyRemoteProsePageList — pending-sync spare (JP-335)', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+    useRichTextPagesStore.setState({
+      pages: {
+        synced: { id: 'synced', name: 'Synced', content: '<p>a</p>', order: 0, createdAt: 0, modifiedAt: 0 },
+        stale: { id: 'stale', name: 'Stale', content: '<p>b</p>', order: 1, createdAt: 0, modifiedAt: 0 },
+        offline: { id: 'offline', name: 'Offline', content: '<p>c</p>', order: 2, createdAt: 0, modifiedAt: 0 },
+      },
+      pageOrder: ['synced', 'stale', 'offline'],
+      activePageId: 'offline',
+    });
+  });
+
+  it('spares a pending page from the prune and keeps it in the order', () => {
+    usePendingSyncPages.getState().markPending('offline', 'doc-1');
+
+    // Relay's list knows only 'synced' — 'stale' is a genuine remote delete,
+    // 'offline' is the pending page the relay hasn't learned yet.
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: { synced: { id: 'synced', name: 'Synced', order: 0, createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+
+    const state = useRichTextPagesStore.getState();
+    expect(state.pages['offline']).toBeDefined();
+    expect(state.pages['offline']?.content).toBe('<p>c</p>');
+    expect(state.pageOrder).toEqual(['synced', 'offline']);
+    // The genuine remote delete still lands.
+    expect(state.pages['stale']).toBeUndefined();
+    // The active page (the spared one) is not repointed away.
+    expect(state.activePageId).toBe('offline');
+  });
+
+  it('prunes the same page normally once its marker is cleared', () => {
+    useRichTextPagesStore.getState().applyRemoteProsePageList({
+      pages: { synced: { id: 'synced', name: 'Synced', order: 0, createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+    const state = useRichTextPagesStore.getState();
+    expect(state.pages['offline']).toBeUndefined();
+    expect(state.pageOrder).toEqual(['synced']);
+  });
+});
+
+describe('applyRemoteCanvasPageList — pending-sync spare (JP-335)', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+    const synced = createPage('Synced', 'synced');
+    const offline = createPage('Offline', 'offline');
+    usePageStore.setState({
+      pages: { synced, offline },
+      pageOrder: ['synced', 'offline'],
+      activePageId: 'synced',
+    });
+  });
+
+  it('spares a pending canvas page (shapes intact) and keeps it in the order', () => {
+    usePendingSyncPages.getState().markPending('offline', 'doc-1');
+
+    usePageStore.getState().applyRemoteCanvasPageList({
+      pages: { synced: { id: 'synced', name: 'Synced', createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+
+    const state = usePageStore.getState();
+    expect(state.pages['offline']).toBeDefined();
+    expect(state.pageOrder).toEqual(['synced', 'offline']);
+  });
+
+  it('prunes normally without a marker', () => {
+    usePageStore.getState().applyRemoteCanvasPageList({
+      pages: { synced: { id: 'synced', name: 'Synced', createdAt: 0, modifiedAt: 0 } },
+      pageOrder: ['synced'],
+    });
+    expect(usePageStore.getState().pages['offline']).toBeUndefined();
+  });
+});

--- a/src/store/pendingSyncPages.clearDoc.test.ts
+++ b/src/store/pendingSyncPages.clearDoc.test.ts
@@ -1,0 +1,137 @@
+/**
+ * JP-423 — pending-sync marker lifecycle at doc-level transitions.
+ *
+ * Markers protect offline-created pages until the relay handoff completes
+ * (JP-335). When the doc itself goes away for good — hard delete, relay
+ * delete, transfer to personal — its markers must clear so they don't sit in
+ * localStorage forever. Soft delete (trash) deliberately KEEPS them: a
+ * restored doc may still owe the relay its pages.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn(async () => null as unknown),
+  put: vi.fn(async () => {}),
+  getCachedIdsForHost: vi.fn(() => [] as string[]),
+  getMeta: vi.fn(() => null),
+  remove: vi.fn(async () => {}),
+}));
+
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => ({ hasPendingChanges: () => false }),
+}));
+
+import { usePersistenceStore, saveDocumentToStorage } from './persistenceStore';
+import { useRelayDocumentStore, type DocumentProvider } from './relayDocumentStore';
+import { usePendingSyncPages } from './pendingSyncPages';
+import { emptyTrash, isInTrash } from '../storage/TrashStorage';
+import { blobStorage } from '../storage/BlobStorage';
+import { getDocumentMetadata, type DiagramDocument } from '../types/Document';
+
+function makeDoc(id: string, relay = false): DiagramDocument {
+  const doc: DiagramDocument = {
+    id,
+    name: id,
+    pages: {},
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 1,
+    blobReferences: [],
+  };
+  if (relay) {
+    doc.isRelayDocument = true;
+    doc.ownerId = 'u1';
+  }
+  return doc;
+}
+
+function seedMarkers(): void {
+  usePendingSyncPages.setState({ pending: {} });
+  const mark = usePendingSyncPages.getState().markPending;
+  mark('page-a1', 'doc-a');
+  mark('page-a2', 'doc-a');
+  mark('page-b1', 'doc-b');
+}
+
+function pendingIds(): string[] {
+  return Object.keys(usePendingSyncPages.getState().pending).sort();
+}
+
+describe('pendingSyncPages.clearDoc wiring (JP-423)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    emptyTrash();
+    vi.restoreAllMocks();
+    vi.spyOn(blobStorage, 'decrementUsageCount').mockResolvedValue(undefined);
+    usePersistenceStore.setState({ currentDocumentId: 'other', documents: {} });
+    useRelayDocumentStore.getState().setProvider(null);
+    seedMarkers();
+  });
+
+  it('permanentlyDeleteDocument clears only the deleted doc\'s markers', () => {
+    const doc = makeDoc('doc-a');
+    saveDocumentToStorage(doc);
+    usePersistenceStore.setState((s) => ({
+      documents: { ...s.documents, 'doc-a': getDocumentMetadata(doc) },
+    }));
+
+    usePersistenceStore.getState().permanentlyDeleteDocument('doc-a');
+
+    expect(pendingIds()).toEqual(['page-b1']);
+  });
+
+  it('soft delete (trash) keeps markers — the doc is restorable', () => {
+    const doc = makeDoc('doc-a');
+    saveDocumentToStorage(doc);
+    usePersistenceStore.setState((s) => ({
+      documents: { ...s.documents, 'doc-a': getDocumentMetadata(doc) },
+    }));
+
+    usePersistenceStore.getState().deleteDocument('doc-a');
+
+    expect(isInTrash('doc-a')).toBe(true);
+    expect(pendingIds()).toEqual(['page-a1', 'page-a2', 'page-b1']);
+  });
+
+  it('transferToPersonal clears the doc\'s markers', () => {
+    const doc = makeDoc('doc-a', true);
+    saveDocumentToStorage(doc);
+    usePersistenceStore.setState((s) => ({
+      documents: { ...s.documents, 'doc-a': getDocumentMetadata(doc) },
+    }));
+
+    const ok = usePersistenceStore.getState().transferToPersonal('doc-a');
+
+    expect(ok).toBe(true);
+    expect(pendingIds()).toEqual(['page-b1']);
+  });
+
+  it('deleteFromHost clears markers on a successful relay delete', async () => {
+    const provider = {
+      deleteDocument: vi.fn(async () => {}),
+    } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await useRelayDocumentStore.getState().deleteFromHost('doc-a');
+
+    expect(pendingIds()).toEqual(['page-b1']);
+  });
+
+  it('deleteFromHost keeps markers when the relay delete fails', async () => {
+    const provider = {
+      deleteDocument: vi.fn(async () => {
+        throw new Error('relay unreachable');
+      }),
+    } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await expect(useRelayDocumentStore.getState().deleteFromHost('doc-a')).rejects.toThrow(
+      'relay unreachable',
+    );
+
+    expect(pendingIds()).toEqual(['page-a1', 'page-a2', 'page-b1']);
+  });
+});

--- a/src/store/pendingSyncPages.test.ts
+++ b/src/store/pendingSyncPages.test.ts
@@ -1,0 +1,101 @@
+/**
+ * JP-335 — pending-sync page markers + the REST body-withhold.
+ *
+ * The withhold is the double-safety keystone: a pending page's HTML must never
+ * reach the relay's stored JSON (its sole-seeder hydration would mint a
+ * deterministic prose lineage that merge-doubles against the client's live
+ * fragment — the JP-282 class).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  usePendingSyncPages,
+  isPagePendingSync,
+  pendingPagesForDoc,
+  withholdPendingProseFromBody,
+} from './pendingSyncPages';
+import type { DiagramDocument } from '../types/Document';
+
+function docWithProse(pages: Record<string, string>): DiagramDocument {
+  return {
+    id: 'doc-1',
+    name: 'Doc',
+    pages: {},
+    pageOrder: [],
+    activePageId: null,
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 2,
+    richTextPages: {
+      pages: Object.fromEntries(
+        Object.entries(pages).map(([id, content]) => [
+          id,
+          { id, name: id, content, order: 0, createdAt: 0, modifiedAt: 0 },
+        ]),
+      ),
+      pageOrder: Object.keys(pages),
+      activePageId: Object.keys(pages)[0] ?? null,
+    },
+  } as unknown as DiagramDocument;
+}
+
+describe('pendingSyncPages store', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+  });
+
+  it('marks, queries, and clears per page', () => {
+    usePendingSyncPages.getState().markPending('p1', 'doc-1');
+    usePendingSyncPages.getState().markPending('p2', 'doc-2');
+
+    expect(isPagePendingSync('p1')).toBe(true);
+    expect(isPagePendingSync('nope')).toBe(false);
+    expect(pendingPagesForDoc('doc-1')).toEqual(['p1']);
+
+    usePendingSyncPages.getState().clearPending('p1');
+    expect(isPagePendingSync('p1')).toBe(false);
+    expect(pendingPagesForDoc('doc-1')).toEqual([]);
+  });
+
+  it('clearDoc drops only that doc’s markers', () => {
+    usePendingSyncPages.getState().markPending('p1', 'doc-1');
+    usePendingSyncPages.getState().markPending('p2', 'doc-2');
+    usePendingSyncPages.getState().clearDoc('doc-1');
+    expect(isPagePendingSync('p1')).toBe(false);
+    expect(isPagePendingSync('p2')).toBe(true);
+  });
+});
+
+describe('withholdPendingProseFromBody', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+  });
+
+  it('blanks a pending page’s content but keeps its meta/tab', () => {
+    usePendingSyncPages.getState().markPending('new-page', 'doc-1');
+    const doc = docWithProse({ 'new-page': '<p>offline words</p>', stable: '<p>synced</p>' });
+
+    const out = withholdPendingProseFromBody(doc);
+
+    expect(out.richTextPages?.pages['new-page']?.content).toBe('');
+    // Meta survives — the tab must not vanish from the body.
+    expect(out.richTextPages?.pages['new-page']?.name).toBe('new-page');
+    expect(out.richTextPages?.pageOrder).toContain('new-page');
+    // Non-pending pages are untouched.
+    expect(out.richTextPages?.pages['stable']?.content).toBe('<p>synced</p>');
+    // Input is not mutated.
+    expect(doc.richTextPages?.pages['new-page']?.content).toBe('<p>offline words</p>');
+  });
+
+  it('returns the input unchanged when nothing is pending', () => {
+    const doc = docWithProse({ a: '<p>x</p>' });
+    expect(withholdPendingProseFromBody(doc)).toBe(doc);
+  });
+
+  it('content flows again once the marker clears', () => {
+    usePendingSyncPages.getState().markPending('new-page', 'doc-1');
+    const doc = docWithProse({ 'new-page': '<p>offline words</p>' });
+    usePendingSyncPages.getState().clearPending('new-page');
+    expect(withholdPendingProseFromBody(doc)).toBe(doc);
+  });
+});

--- a/src/store/pendingSyncPages.ts
+++ b/src/store/pendingSyncPages.ts
@@ -1,0 +1,110 @@
+/**
+ * Pending-sync pages (JP-335) — pages created locally while their relay-backed
+ * doc was OFFLINE, not yet handed to the relay. Transient sync bookkeeping,
+ * deliberately NOT a document-format field: it must never leak into the body
+ * the relay stores, and it needs no migration chain (mirrors the
+ * shapePickerStore isolation rationale). Persisted so an offline reload keeps
+ * protecting the page.
+ *
+ * What the marker drives:
+ *  - **Editability** (DocumentEditorPanel): an empty never-synced prose
+ *    fragment is normally read-only (relay is the sole seeder, JP-284). A
+ *    pending page is editable — its id is fresh, so its `prose:<id>` fragment
+ *    exists nowhere else and cannot double on a later merge.
+ *  - **Prune-spare** (applyRemote*PageList): reconnect page-list adoption must
+ *    not delete a page the relay hasn't learned about yet.
+ *  - **Body-withhold** (persistenceStore): REST bodies serialize a pending
+ *    page's content as '' so a queued replay can never make the relay's
+ *    JSON-hydration seeder mint a competing prose lineage (the JP-282 double).
+ *
+ * Cleared by the reconnect handoff (useCollaborationSync) once a live synced
+ * exchange has carried the page's meta + content to the relay.
+ *
+ * Keyed by pageId alone: page ids are nanoids, globally unique across docs, so
+ * consumers (store-level prune, body serialization) don't need doc context.
+ * The docId value exists for doc-scoped enumeration by the handoff.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { DiagramDocument } from '../types/Document';
+
+export interface PendingSyncPagesState {
+  /** pageId → docId it was created in. */
+  pending: Record<string, string>;
+  /** Mark a page as created-offline, awaiting relay handoff. */
+  markPending: (pageId: string, docId: string) => void;
+  /** Clear one page's marker (handoff complete, or page deleted locally). */
+  clearPending: (pageId: string) => void;
+  /** Clear every marker for a doc (doc deleted / transferred). */
+  clearDoc: (docId: string) => void;
+}
+
+export const usePendingSyncPages = create<PendingSyncPagesState>()(
+  persist(
+    (set) => ({
+      pending: {},
+      markPending: (pageId, docId) =>
+        set((state) => ({ pending: { ...state.pending, [pageId]: docId } })),
+      clearPending: (pageId) =>
+        set((state) => {
+          if (!(pageId in state.pending)) return state;
+          const next = { ...state.pending };
+          delete next[pageId];
+          return { pending: next };
+        }),
+      clearDoc: (docId) =>
+        set((state) => ({
+          pending: Object.fromEntries(
+            Object.entries(state.pending).filter(([, d]) => d !== docId),
+          ),
+        })),
+    }),
+    {
+      name: 'docushark-pending-sync-pages',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ pending: state.pending }),
+    },
+  ),
+);
+
+/** Non-reactive: is this page awaiting relay handoff? */
+export function isPagePendingSync(pageId: string): boolean {
+  return pageId in usePendingSyncPages.getState().pending;
+}
+
+/** Non-reactive: all pending page ids belonging to `docId`. */
+export function pendingPagesForDoc(docId: string): string[] {
+  return Object.entries(usePendingSyncPages.getState().pending)
+    .filter(([, d]) => d === docId)
+    .map(([pageId]) => pageId);
+}
+
+/**
+ * The body-withhold (JP-335): return `doc` with every pending-sync prose page's
+ * `content` blanked, for REST-bound bodies (queue replay or live push). If a
+ * pending page's HTML landed in the relay's stored JSON, the sole-seeder
+ * hydration (`json_prose_to_ydoc`) would mint a deterministic prose lineage
+ * that merge-DOUBLES against the client's live fragment (the JP-282 class);
+ * empty content is skipped by that seeder, closing the hole. The page's meta
+ * stays in the body (tab survives); canvas shapes need no withholding (id-keyed
+ * map — merges by key, no dup). Returns the input unchanged when nothing is
+ * pending. Local caches must keep the FULL body — apply this only at the REST
+ * boundary.
+ */
+export function withholdPendingProseFromBody(doc: DiagramDocument): DiagramDocument {
+  const rtp = doc.richTextPages;
+  if (!rtp) return doc;
+  const { pending } = usePendingSyncPages.getState();
+  const withheld = Object.keys(rtp.pages).filter((id) => {
+    const page = rtp.pages[id];
+    return id in pending && page !== undefined && page.content !== '';
+  });
+  if (withheld.length === 0) return doc;
+  const pages = { ...rtp.pages };
+  for (const id of withheld) {
+    const page = pages[id];
+    if (page) pages[id] = { ...page, content: '' };
+  }
+  return { ...doc, richTextPages: { ...rtp, pages } };
+}

--- a/src/store/pendingSyncPages.ts
+++ b/src/store/pendingSyncPages.ts
@@ -13,9 +13,11 @@
  *    exists nowhere else and cannot double on a later merge.
  *  - **Prune-spare** (applyRemote*PageList): reconnect page-list adoption must
  *    not delete a page the relay hasn't learned about yet.
- *  - **Body-withhold** (persistenceStore): REST bodies serialize a pending
- *    page's content as '' so a queued replay can never make the relay's
- *    JSON-hydration seeder mint a competing prose lineage (the JP-282 double).
+ *  - **Body-withhold** (via `serializeDocForRest`, applied at the REST seams —
+ *    the `saveToHost` wire call and `queueSave`, JP-423): REST bodies serialize
+ *    a pending page's content as '' so a queued replay can never make the
+ *    relay's JSON-hydration seeder mint a competing prose lineage (the JP-282
+ *    double).
  *
  * Cleared by the reconnect handoff (useCollaborationSync) once a live synced
  * exchange has carried the page's meta + content to the relay.

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -22,6 +22,7 @@ import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
+import { withholdPendingProseFromBody } from './pendingSyncPages';
 import { useReferenceStore } from './referenceStore';
 import { useFieldStore } from './fieldStore';
 import { useUserStore } from './userStore';
@@ -188,11 +189,18 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     return;
   }
 
+  // JP-335: pages created offline in a shared doc (pending-sync) must reach the
+  // relay over CRDT only — blank their HTML in any REST-bound body (queued
+  // replay or live push). The local cache put keeps the FULL body so the doc
+  // still opens offline with its content; the relay's own flatten writes the
+  // real HTML from its fragment once the CRDT handoff completes.
+  const restDoc = withholdPendingProseFromBody(doc);
+
   const queueForReplay = (reason: string): void => {
     void RelayDocumentCache.put(doc, homeRelayId, activeWorkspaceId()).catch((e) =>
       console.error('[persistenceStore] Failed to cache relay edit:', e),
     );
-    getSyncStateManager().queueSave(doc, homeRelayId);
+    getSyncStateManager().queueSave(restDoc, homeRelayId);
     console.warn(
       `[persistenceStore] ${reason} — cached + queued relay save under ${homeRelayId} for replay (${context})`,
     );
@@ -212,7 +220,7 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     return;
   }
 
-  relayStore.saveToHost(doc).catch((err) => {
+  relayStore.saveToHost(restDoc).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     const status = (err as { status?: unknown }).status;
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -22,7 +22,7 @@ import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
-import { usePendingSyncPages, withholdPendingProseFromBody } from './pendingSyncPages';
+import { usePendingSyncPages } from './pendingSyncPages';
 import { useReferenceStore } from './referenceStore';
 import { useFieldStore } from './fieldStore';
 import { useUserStore } from './userStore';
@@ -190,17 +190,18 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
   }
 
   // JP-335: pages created offline in a shared doc (pending-sync) must reach the
-  // relay over CRDT only — blank their HTML in any REST-bound body (queued
-  // replay or live push). The local cache put keeps the FULL body so the doc
-  // still opens offline with its content; the relay's own flatten writes the
-  // real HTML from its fragment once the CRDT handoff completes.
-  const restDoc = withholdPendingProseFromBody(doc);
-
+  // relay over CRDT only — their HTML is blanked in any REST-bound body by
+  // `serializeDocForRest`, applied inside the seams themselves (the wire call
+  // in `relayDocumentStore.saveToHost` and `SyncStateManager.queueSave`,
+  // JP-423) — so this path hands over the FULL doc. The local cache put also
+  // keeps the FULL body so the doc still opens offline with its content; the
+  // relay's own flatten writes the real HTML from its fragment once the CRDT
+  // handoff completes.
   const queueForReplay = (reason: string): void => {
     void RelayDocumentCache.put(doc, homeRelayId, activeWorkspaceId()).catch((e) =>
       console.error('[persistenceStore] Failed to cache relay edit:', e),
     );
-    getSyncStateManager().queueSave(restDoc, homeRelayId);
+    getSyncStateManager().queueSave(doc, homeRelayId);
     console.warn(
       `[persistenceStore] ${reason} — cached + queued relay save under ${homeRelayId} for replay (${context})`,
     );
@@ -220,7 +221,7 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     return;
   }
 
-  relayStore.saveToHost(restDoc).catch((err) => {
+  relayStore.saveToHost(doc).catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     const status = (err as { status?: unknown }).status;
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -22,7 +22,7 @@ import { useNotificationStore } from './notificationStore';
 import type { Page } from '../types/Document';
 import { useRichTextStore } from './richTextStore';
 import { useRichTextPagesStore } from './richTextPagesStore';
-import { withholdPendingProseFromBody } from './pendingSyncPages';
+import { usePendingSyncPages, withholdPendingProseFromBody } from './pendingSyncPages';
 import { useReferenceStore } from './referenceStore';
 import { useFieldStore } from './fieldStore';
 import { useUserStore } from './userStore';
@@ -1091,6 +1091,11 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         // Remove from document registry
         useDocumentRegistry.getState().removeDocument(id);
 
+        // The doc is gone for good — drop any pending-sync markers so they
+        // don't linger in localStorage (JP-423). Soft-delete (trash) keeps
+        // them: a restored doc may still owe the relay its pages.
+        usePendingSyncPages.getState().clearDoc(id);
+
         // If we deleted the current document, create a new one
         if (state.currentDocumentId === id) {
           get().newDocument();
@@ -1420,6 +1425,10 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         delete doc.lastModifiedBy;
         delete doc.lastModifiedByName;
         doc.modifiedAt = Date.now();
+
+        // Local-only now: pending-sync markers are relay-handoff bookkeeping
+        // with no remaining consumer for this doc (JP-423).
+        usePendingSyncPages.getState().clearDoc(docId);
 
         // Save back to localStorage
         saveDocumentToStorage(doc);

--- a/src/store/relayDocumentStore.offlineOpen.test.ts
+++ b/src/store/relayDocumentStore.offlineOpen.test.ts
@@ -1,0 +1,87 @@
+/**
+ * JP-422 follow-up — opening a relay doc while offline.
+ *
+ * `docProvider` stays set on a mere disconnect, so it can't be the offline
+ * signal; `loadRelayDocument` now treats `navigator.onLine === false` as
+ * offline. Offline it (a) serves the persistent cache even if the relay's
+ * metadata looks newer, and (b) never attempts a doomed network fetch — it
+ * throws a typed error the open path turns into a friendly message.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn(async () => null as unknown),
+  put: vi.fn(async () => {}),
+  getCachedIdsForHost: vi.fn(() => [] as string[]),
+  getMeta: vi.fn(() => null),
+  remove: vi.fn(async () => {}),
+}));
+
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => ({ hasPendingChanges: () => false }),
+}));
+
+import {
+  useRelayDocumentStore,
+  RelayDocumentUnavailableOfflineError,
+  type DocumentProvider,
+} from './relayDocumentStore';
+import type { DiagramDocument } from '../types/Document';
+
+function doc(id: string, modifiedAt: number): DiagramDocument {
+  return {
+    id,
+    name: id,
+    pages: { p1: { id: 'p1', name: 'P1', shapes: {}, shapeOrder: [], createdAt: 0, modifiedAt } },
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 0,
+    modifiedAt,
+    version: 1,
+  } as unknown as DiagramDocument;
+}
+
+function setOnline(online: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { value: online, configurable: true });
+}
+
+const getDocument = vi.fn(async () => doc('d', 999));
+const provider = { getDocument } as unknown as DocumentProvider;
+
+describe('loadRelayDocument — offline open (JP-422)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheMock.get.mockResolvedValue(null);
+    useRelayDocumentStore.setState({ documentCache: {}, relayDocuments: {}, loadingDocs: new Set() });
+    useRelayDocumentStore.getState().setProvider(provider);
+  });
+  afterEach(() => setOnline(true));
+
+  it('throws a typed error and does NOT fetch when offline and uncached', async () => {
+    setOnline(false);
+    await expect(useRelayDocumentStore.getState().loadRelayDocument('d')).rejects.toBeInstanceOf(
+      RelayDocumentUnavailableOfflineError,
+    );
+    expect(getDocument).not.toHaveBeenCalled(); // no doomed network fetch
+  });
+
+  it('serves a STALE persistent cache when offline (beats failing to open)', async () => {
+    // Relay metadata is newer than the cached copy → `isFresh` is false, so
+    // online this would refetch. Offline it must still serve the local copy.
+    useRelayDocumentStore.setState({ relayDocuments: { d: { modifiedAt: 500 } as never } });
+    cacheMock.get.mockResolvedValue(doc('d', 100));
+    setOnline(false);
+
+    const loaded = await useRelayDocumentStore.getState().loadRelayDocument('d');
+    expect(loaded.id).toBe('d');
+    expect(getDocument).not.toHaveBeenCalled();
+  });
+
+  it('still fetches over the network when online and uncached (control)', async () => {
+    setOnline(true);
+    await useRelayDocumentStore.getState().loadRelayDocument('d');
+    expect(getDocument).toHaveBeenCalledWith('d');
+  });
+});

--- a/src/store/relayDocumentStore.serializeSeam.test.ts
+++ b/src/store/relayDocumentStore.serializeSeam.test.ts
@@ -1,0 +1,102 @@
+/**
+ * JP-423 — the `saveToHost` wire seam applies `serializeDocForRest`.
+ *
+ * The withhold happens at the wire ONLY: the provider receives the blanked
+ * body while the store's caches keep the FULL body (a pending page must still
+ * open offline with its content).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn(async () => null as unknown),
+  put: vi.fn(async (..._args: unknown[]) => {}),
+  getCachedIdsForHost: vi.fn(() => [] as string[]),
+  getMeta: vi.fn(() => null),
+  remove: vi.fn(async () => {}),
+}));
+
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => ({ hasPendingChanges: () => false }),
+}));
+
+import { useRelayDocumentStore, type DocumentProvider } from './relayDocumentStore';
+import { usePendingSyncPages } from './pendingSyncPages';
+import type { DiagramDocument } from '../types/Document';
+
+function makeDoc(): DiagramDocument {
+  return {
+    id: 'doc-1',
+    name: 'Doc',
+    pages: {},
+    pageOrder: [],
+    activePageId: '',
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 1,
+    blobReferences: [],
+    richTextPages: {
+      pages: {
+        'rt-pending': {
+          id: 'rt-pending',
+          name: 'Pending',
+          content: '<p>offline-created</p>',
+          createdAt: 0,
+          modifiedAt: 0,
+        },
+        'rt-normal': {
+          id: 'rt-normal',
+          name: 'Normal',
+          content: '<p>synced</p>',
+          createdAt: 0,
+          modifiedAt: 0,
+        },
+      },
+      pageOrder: ['rt-pending', 'rt-normal'],
+      activePageId: 'rt-pending',
+    },
+  } as unknown as DiagramDocument;
+}
+
+describe('saveToHost wire seam (JP-423)', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+    useRelayDocumentStore.getState().setProvider(null);
+    cacheMock.put.mockClear();
+  });
+
+  it('sends the withheld body over the wire but caches the full body', async () => {
+    usePendingSyncPages.getState().markPending('rt-pending', 'doc-1');
+    const saveDocument = vi.fn(async (_doc: DiagramDocument) => ({ newVersion: 2 }));
+    useRelayDocumentStore
+      .getState()
+      .setProvider({ saveDocument } as unknown as DocumentProvider);
+
+    const doc = makeDoc();
+    await useRelayDocumentStore.getState().saveToHost(doc);
+
+    // Wire body: pending page blanked, others intact.
+    const sent = saveDocument.mock.calls[0]![0];
+    expect(sent.richTextPages?.pages['rt-pending']?.content).toBe('');
+    expect(sent.richTextPages?.pages['rt-normal']?.content).toBe('<p>synced</p>');
+
+    // Input untouched; caches keep the FULL body.
+    expect(doc.richTextPages?.pages['rt-pending']?.content).toBe('<p>offline-created</p>');
+    const inMemory = useRelayDocumentStore.getState().documentCache['doc-1'];
+    expect(inMemory?.richTextPages?.pages['rt-pending']?.content).toBe('<p>offline-created</p>');
+    const persisted = cacheMock.put.mock.calls[0]![0] as unknown as DiagramDocument;
+    expect(persisted.richTextPages?.pages['rt-pending']?.content).toBe('<p>offline-created</p>');
+  });
+
+  it('sends the body unchanged when nothing is pending', async () => {
+    const saveDocument = vi.fn(async (_doc: DiagramDocument) => ({ newVersion: 2 }));
+    useRelayDocumentStore
+      .getState()
+      .setProvider({ saveDocument } as unknown as DocumentProvider);
+
+    await useRelayDocumentStore.getState().saveToHost(makeDoc());
+
+    const sent = saveDocument.mock.calls[0]![0];
+    expect(sent.richTextPages?.pages['rt-pending']?.content).toBe('<p>offline-created</p>');
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -118,6 +118,19 @@ interface RelayDocumentState {
  * the legacy WS-multiplexed implementation on `UnifiedSyncProvider`
  * stays in place but is no longer wired in here.
  */
+/**
+ * Thrown by `loadRelayDocument` when a relay doc can't be opened because we're
+ * offline and it was never cached (not "made available offline"). Typed so the
+ * open path can show a specific "not available offline" message rather than a
+ * generic failure.
+ */
+export class RelayDocumentUnavailableOfflineError extends Error {
+  constructor(public readonly docId: string) {
+    super('Document is not available offline');
+    this.name = 'RelayDocumentUnavailableOfflineError';
+  }
+}
+
 export interface DocumentProvider {
   listDocuments(): Promise<DocumentMetadata[]>;
   getDocument(docId: string): Promise<DiagramDocument | { document: DiagramDocument; serverVersion?: number }>;
@@ -427,11 +440,19 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         return registryCached;
       }
 
-      // Check persistent offline cache — but only trust it when we're
-      // offline (no docProvider) or when it's not stale relative to the
-      // relay. Otherwise we'd serve users their own pre-save snapshot.
+      // A real network outage counts as offline even while a provider is
+      // configured: `docProvider` stays set on a mere disconnect, so it can't
+      // be the offline signal on its own. `navigator.onLine === false` catches
+      // the internet-disconnected case the provider misses.
+      const offline =
+        !docProvider || (typeof navigator !== 'undefined' && navigator.onLine === false);
+
+      // Check persistent offline cache. Trust it whenever we're offline — a
+      // possibly-stale local copy beats failing to open, and the CRDT layer
+      // reconciles on reconnect. Online, still require freshness so we don't
+      // serve a pre-server-update snapshot over a reachable newer one.
       const persistentCached = await RelayDocumentCache.get(activeWorkspaceId(), docId);
-      if (persistentCached && (!docProvider || isFresh(persistentCached.modifiedAt))) {
+      if (persistentCached && (offline || isFresh(persistentCached.modifiedAt))) {
         console.log('[relayDocumentStore] Loaded from offline cache:', docId);
 
         // Update in-memory caches
@@ -446,9 +467,12 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
         return persistentCached;
       }
 
-      // No usable cache — need network connection
-      if (!docProvider) {
-        throw new Error('Not connected to host and document not cached');
+      // No usable cache. Offline → don't attempt a doomed network fetch (it
+      // spews `net::ERR_INTERNET_DISCONNECTED` + a raw `TypeError: Failed to
+      // fetch`); throw a clear, catchable signal the open path turns into a
+      // friendly "not available offline" message instead of a silent no-op.
+      if (offline || !docProvider) {
+        throw new RelayDocumentUnavailableOfflineError(docId);
       }
 
       // Mark as loading

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -171,7 +171,7 @@ export interface DocumentProvider {
   listRecoveryPoints?(docId: string): Promise<RelayRecoveryPoint[]>;
   getRecoveryPointContent?(docId: string, pointId: string): Promise<DiagramDocument>;
   /**
-   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (raw
+   * JP-422: fetch a document's authoritative binary Y.Doc sidecar (raw
    * lib0-v1 full-state bytes) so it can be seeded into the local Y.Doc room for
    * offline editing. Optional so non-REST providers opt out; null = no sidecar.
    */

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -157,6 +157,12 @@ export interface DocumentProvider {
    */
   listRecoveryPoints?(docId: string): Promise<RelayRecoveryPoint[]>;
   getRecoveryPointContent?(docId: string, pointId: string): Promise<DiagramDocument>;
+  /**
+   * JP-335: fetch a document's authoritative binary Y.Doc sidecar (raw
+   * lib0-v1 full-state bytes) so it can be seeded into the local Y.Doc room for
+   * offline editing. Optional so non-REST providers opt out; null = no sidecar.
+   */
+  getYdoc?(docId: string): Promise<Uint8Array | null>;
   restoreRecoveryPoint?(
     docId: string,
     pointId: string,

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -184,10 +184,13 @@ export interface DocumentProvider {
   ): Promise<{ newDocId: string; serverVersion: number }>;
   /**
    * Collection sync (JP-159). Optional so non-REST providers opt out. The relay
-   * scopes all three to the connected workspace from the bearer token.
+   * scopes all three to the connected workspace from the bearer token. The
+   * registry `version` + `expectedVersion` pair is the JP-424 optimistic-
+   * concurrency handshake; `version` is absent on pre-JP-424 relays and an
+   * omitted `expectedVersion` degrades to the legacy blind replace.
    */
-  getCollections?(): Promise<RelayCollectionDef[]>;
-  setCollections?(collections: RelayCollectionDef[]): Promise<void>;
+  getCollections?(): Promise<{ collections: RelayCollectionDef[]; version?: number }>;
+  setCollections?(collections: RelayCollectionDef[], expectedVersion?: number): Promise<void>;
   setDocumentCollection?(docId: string, collectionId: string | null): Promise<void>;
 }
 

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -32,6 +32,7 @@ import { registerBlobDownloader } from '../storage/blobResolver';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { isCollabContentDoc, useCollaborationStore } from '../collaboration/collaborationStore';
 import { usePersistenceStore } from './persistenceStore';
+import { usePendingSyncPages } from './pendingSyncPages';
 import { useNotificationStore } from './notificationStore';
 import { useTrashStore } from './trashStore';
 import type { TrashOrigin } from '../storage/TrashStorage';
@@ -718,7 +719,12 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
 
         // Remove from registry
         useDocumentRegistry.getState().removeDocument(docId);
-        
+
+        // Delete succeeded on the relay — drop any pending-sync markers for
+        // the doc (JP-423). Only on success: a failed delete keeps the doc,
+        // so its markers must keep protecting queued saves.
+        usePendingSyncPages.getState().clearDoc(docId);
+
         // Remove from persistent offline cache
         await RelayDocumentCache.remove(activeWorkspaceId(), docId);
       } catch (e) {

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -33,6 +33,7 @@ import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import { isCollabContentDoc, useCollaborationStore } from '../collaboration/collaborationStore';
 import { usePersistenceStore } from './persistenceStore';
 import { usePendingSyncPages } from './pendingSyncPages';
+import { serializeDocForRest } from './serializeDocForRest';
 import { useNotificationStore } from './notificationStore';
 import { useTrashStore } from './trashStore';
 import type { TrashOrigin } from '../storage/TrashStorage';
@@ -626,8 +627,14 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           console.log(`[relayDocumentStore] Bundled ${bundleResult.assetCount} assets (${bundleResult.totalSize} bytes)`);
         }
 
-        // Save with optional version check (+ JP-375 tombstone override)
-        const saveResult = await docProvider.saveDocument(docToSave, expectedVersion, opts);
+        // Save with optional version check (+ JP-375 tombstone override).
+        // serializeDocForRest applies at the wire ONLY (JP-423): the cache /
+        // registry puts below must keep the full body.
+        const saveResult = await docProvider.saveDocument(
+          serializeDocForRest(docToSave),
+          expectedVersion,
+          opts,
+        );
         const newVersion = saveResult && typeof saveResult === 'object' && 'newVersion' in saveResult
           ? saveResult.newVersion
           : undefined;

--- a/src/store/restWriteBoundary.test.ts
+++ b/src/store/restWriteBoundary.test.ts
@@ -1,0 +1,88 @@
+/**
+ * REST-bound document-body write boundary (JP-423).
+ *
+ * Every document body that leaves for the relay over REST — a live save or a
+ * queued replay — must pass through `serializeDocForRest` (the withhold of
+ * pending-sync prose + future sanitization). That function is applied inside
+ * the two deep seams (`relayDocumentStore.saveToHost` at the wire,
+ * `SyncStateManager.queueSave` at enqueue), so the invariant holds for every
+ * caller OF those seams — what's left to police is the caller set itself:
+ * a new module pushing bodies at the relay is a new integration surface and
+ * must be a deliberate, reviewed decision.
+ *
+ * If this fails: do NOT add your file to the allowlist to make it pass. Route
+ * the save through `persistenceStore.pushRelaySaveOrQueue` (or the seams'
+ * existing callers). A path that genuinely cannot must still send
+ * `serializeDocForRest(doc)` and be allowlisted here with a WHY.
+ *
+ * Detection modeled on `proseWriteBoundary.test.ts`: the dot-call forms
+ * `.saveToHost(` / `.queueSave(` / `.enqueueSave(` — interface/method
+ * declarations don't match, `getState().`/`this.deps.`/variable-held forms do.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = resolve(__dirname, '..');
+
+/** Recursively collect non-test `.ts`/`.tsx` files under `dir`. */
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** REST-push vectors: live wire save, queue-for-replay, raw queue append. */
+const REST_WRITE_RE = /\.(?:saveToHost|queueSave|enqueueSave)\s*\(/g;
+
+/**
+ * Modules permitted to push document bodies at the REST seams, each with WHY.
+ * Keep it small — every entry is a surface `serializeDocForRest` must cover.
+ */
+const ALLOWLIST = new Set<string>([
+  'store/persistenceStore.ts', // pushRelaySaveOrQueue + versioned direct saves + reattach/on-connect queueing
+  'collaboration/SyncStateManager.ts', // defines queueSave (applies serializeDocForRest), wraps enqueueSave
+  'collaboration/OfflineQueue.ts', // defines the queue; only doc-comment usage examples match
+  'ui/App.tsx', // wires the transfer-service + conflict-resolution deps to relayDocumentStore.saveToHost
+  'services/DocumentTransferService.ts', // pushes via its injected saveToHost dep (wired in App.tsx)
+]);
+
+describe('REST-bound body write boundary (JP-423)', () => {
+  const files = listSourceFiles(SRC_ROOT);
+
+  it('smoke: found a representative number of source files', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('only allowlisted modules push document bodies at the REST seams', () => {
+    const offenders: Array<{ file: string; match: string }> = [];
+    for (const file of files) {
+      const rel = relative(SRC_ROOT, file).split(sep).join('/');
+      if (ALLOWLIST.has(rel)) continue;
+      const source = readFileSync(file, 'utf-8');
+      for (const m of source.matchAll(REST_WRITE_RE)) {
+        offenders.push({ file: rel, match: m[0] });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('smoke: the allowlisted writers actually match (regex works)', () => {
+    const writers = [...ALLOWLIST].filter((rel) => {
+      const source = readFileSync(resolve(SRC_ROOT, rel), 'utf-8');
+      REST_WRITE_RE.lastIndex = 0;
+      return REST_WRITE_RE.test(source);
+    });
+    // Near-empty means the detection regex silently stopped working.
+    expect(writers.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/store/richTextPagesStore.ts
+++ b/src/store/richTextPagesStore.ts
@@ -15,6 +15,7 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { PROSE_PAGE_BASE, nextDefaultPageName } from './pageNaming';
+import { isPagePendingSync } from './pendingSyncPages';
 import type { ProsePageList } from '../collaboration/YjsDocument';
 
 /**
@@ -297,14 +298,24 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
           draft.pages[id] = page;
         });
 
-        // Drop pages the merged set no longer contains (a remote delete).
+        // Drop pages the merged set no longer contains (a remote delete) —
+        // EXCEPT pending-sync pages (JP-335): a page created offline hasn't
+        // reached the relay's list yet, so its absence there is not a delete.
+        // Keep it (and keep it visible in the order); the reconnect handoff
+        // uploads its meta + content.
+        const spared = new Set<string>();
         for (const id of Object.keys(draft.pages)) {
           if (!incoming.has(id)) {
+            if (isPagePendingSync(id)) {
+              spared.add(id);
+              continue;
+            }
             delete draft.pages[id];
           }
         }
 
-        draft.pageOrder = [...list.pageOrder];
+        const sparedOrdered = draft.pageOrder.filter((id) => spared.has(id));
+        draft.pageOrder = [...list.pageOrder, ...sparedOrdered];
 
         // Repoint the (client-local) active page if it was pruned.
         if (!draft.activePageId || !draft.pages[draft.activePageId]) {

--- a/src/store/serializeDocForRest.test.ts
+++ b/src/store/serializeDocForRest.test.ts
@@ -1,0 +1,71 @@
+/**
+ * JP-423 — `serializeDocForRest` contract.
+ *
+ * The one blessed REST-body transform: blanks pending-sync pages' prose
+ * (JP-335 withhold) and is where future sanitization composes. The contract
+ * the seams rely on: idempotent, non-mutating, identity when nothing pends.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { serializeDocForRest } from './serializeDocForRest';
+import { usePendingSyncPages } from './pendingSyncPages';
+import type { DiagramDocument } from '../types/Document';
+
+function makeDoc(): DiagramDocument {
+  return {
+    id: 'doc-1',
+    name: 'Doc',
+    pages: {},
+    pageOrder: [],
+    activePageId: '',
+    createdAt: 0,
+    modifiedAt: 0,
+    version: 1,
+    blobReferences: [],
+    richTextPages: {
+      pages: {
+        'rt-a': { id: 'rt-a', name: 'A', content: '<p>alpha</p>', createdAt: 0, modifiedAt: 0 },
+        'rt-b': { id: 'rt-b', name: 'B', content: '<p>beta</p>', createdAt: 0, modifiedAt: 0 },
+      },
+      pageOrder: ['rt-a', 'rt-b'],
+      activePageId: 'rt-a',
+    },
+  } as unknown as DiagramDocument;
+}
+
+describe('serializeDocForRest (JP-423)', () => {
+  beforeEach(() => {
+    usePendingSyncPages.setState({ pending: {} });
+  });
+
+  it('blanks a pending page\'s prose and leaves others untouched', () => {
+    usePendingSyncPages.getState().markPending('rt-a', 'doc-1');
+
+    const out = serializeDocForRest(makeDoc());
+
+    expect(out.richTextPages?.pages['rt-a']?.content).toBe('');
+    expect(out.richTextPages?.pages['rt-b']?.content).toBe('<p>beta</p>');
+  });
+
+  it('returns the input by reference when nothing is pending', () => {
+    const doc = makeDoc();
+    expect(serializeDocForRest(doc)).toBe(doc);
+  });
+
+  it('is idempotent', () => {
+    usePendingSyncPages.getState().markPending('rt-a', 'doc-1');
+
+    const once = serializeDocForRest(makeDoc());
+    const twice = serializeDocForRest(once);
+
+    expect(twice).toEqual(once);
+  });
+
+  it('does not mutate the input document', () => {
+    usePendingSyncPages.getState().markPending('rt-a', 'doc-1');
+    const doc = makeDoc();
+
+    serializeDocForRest(doc);
+
+    expect(doc.richTextPages?.pages['rt-a']?.content).toBe('<p>alpha</p>');
+  });
+});

--- a/src/store/serializeDocForRest.ts
+++ b/src/store/serializeDocForRest.ts
@@ -1,0 +1,36 @@
+/**
+ * The single REST-body choke point (JP-423).
+ *
+ * Every document body bound for the relay over REST — a live save or a queued
+ * replay — MUST pass through this function. It is applied inside the two deep
+ * seams, so all existing paths are covered without their callers knowing:
+ *
+ *  - `relayDocumentStore.saveToHost` — at the wire, immediately before
+ *    `docProvider.saveDocument(...)`.
+ *  - `SyncStateManager.queueSave` — before the body is enqueued for replay.
+ *
+ * A new REST path (e.g. an integration flow pushing bodies from a non-editor
+ * context) should route through those seams; one that cannot must call this
+ * function itself, LAST, immediately before the wire. The
+ * `restWriteBoundary.test.ts` allowlist polices who may call the seams.
+ *
+ * Contract:
+ *  - Idempotent — applying twice equals applying once.
+ *  - Non-mutating — returns the input unchanged (by reference) when there is
+ *    nothing to do, a modified copy otherwise.
+ *  - REST-boundary only — local caches and stores must keep the FULL body;
+ *    never feed the return value back into a cache put.
+ *
+ * Current steps: blank pending-sync pages' prose so a replay can never make
+ * the relay's JSON-hydration seeder mint a competing prose lineage (JP-335,
+ * the JP-282 double). Future sanitization steps compose here; they must
+ * copy-and-override rather than rebuild objects from known fields, so new
+ * page/meta fields survive by default.
+ */
+
+import type { DiagramDocument } from '../types/Document';
+import { withholdPendingProseFromBody } from './pendingSyncPages';
+
+export function serializeDocForRest(doc: DiagramDocument): DiagramDocument {
+  return withholdPendingProseFromBody(doc);
+}

--- a/src/store/trashStore.collection.test.ts
+++ b/src/store/trashStore.collection.test.ts
@@ -1,0 +1,78 @@
+/**
+ * JP-418 — trashing a document drops its collection enrollment.
+ *
+ * A collection counts members from `collectionStore.assignments`. Before this
+ * fix a trashed doc kept its assignment, so the collection's sidebar count kept
+ * including a doc that no longer exists in the active set. `trashLocal` and
+ * `trashStranded` (the single funnel for all three trash paths) now clear the
+ * assignment. Restore brings the doc back Unassigned.
+ *
+ * We use the REAL `collectionStore` (a plain zustand store) and mock only the
+ * storage layer so no IndexedDB is touched.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../storage/TrashStorage', () => ({
+  moveToTrash: vi.fn(),
+  getTrashItems: vi.fn(() => []),
+  getTrashedBlobReferences: vi.fn(() => new Set<string>()),
+  recoverFromTrash: vi.fn(),
+  permanentlyDeleteFromTrash: vi.fn(),
+  emptyTrash: vi.fn(() => 0),
+  cleanupExpiredTrash: vi.fn(() => 0),
+}));
+vi.mock('../storage/AssetBundler', () => ({
+  collectBlobReferences: vi.fn(() => []),
+}));
+vi.mock('../storage/BlobStorage', () => ({
+  blobStorage: { listAllBlobs: vi.fn(async () => []) },
+}));
+vi.mock('../storage/BlobGarbageCollector', () => ({
+  BlobGarbageCollector: class {
+    collectGarbageIncremental = vi.fn(async () => {});
+  },
+}));
+vi.mock('./persistenceStore', () => ({
+  usePersistenceStore: { getState: () => ({ getDocumentList: () => [], adoptDocument: vi.fn() }) },
+  loadDocumentFromStorage: vi.fn(() => null),
+}));
+
+import { useTrashStore } from './trashStore';
+import { useCollectionStore } from './collectionStore';
+import type { DiagramDocument } from '../types/Document';
+
+const DOC_ID = 'doc-1';
+const makeDoc = (): DiagramDocument =>
+  ({ id: DOC_ID, name: 'My Doc', pages: {}, pageOrder: [] }) as unknown as DiagramDocument;
+
+function seedAssignedDoc(): string {
+  useCollectionStore.getState().reset();
+  const cid = useCollectionStore.getState().createCollection('Research', undefined, 'local');
+  useCollectionStore.getState().assignDocument(DOC_ID, cid);
+  // Sanity: the doc counts as a member before trashing.
+  expect(useCollectionStore.getState().assignments[DOC_ID]).toBe(cid);
+  return cid;
+}
+
+describe('trashStore drops collection enrollment (JP-418)', () => {
+  beforeEach(() => {
+    useCollectionStore.getState().reset();
+  });
+
+  it('trashLocal clears the doc assignment', () => {
+    const cid = seedAssignedDoc();
+    useTrashStore.getState().trashLocal(makeDoc());
+    expect(useCollectionStore.getState().assignments[DOC_ID]).toBeUndefined();
+    // The collection's member count (derived from assignments) drops to 0.
+    const count = Object.values(useCollectionStore.getState().assignments).filter((c) => c === cid).length;
+    expect(count).toBe(0);
+  });
+
+  it('trashStranded clears the doc assignment', () => {
+    const cid = seedAssignedDoc();
+    useTrashStore.getState().trashStranded(makeDoc(), { relayId: 'relay-1' });
+    expect(useCollectionStore.getState().assignments[DOC_ID]).toBeUndefined();
+    const count = Object.values(useCollectionStore.getState().assignments).filter((c) => c === cid).length;
+    expect(count).toBe(0);
+  });
+});

--- a/src/store/trashStore.ts
+++ b/src/store/trashStore.ts
@@ -41,6 +41,7 @@ import {
   type TrashOrigin,
 } from '../storage/TrashStorage';
 import { usePersistenceStore, loadDocumentFromStorage } from './persistenceStore';
+import { useCollectionStore } from './collectionStore';
 
 /** Reused so the incremental ref cache survives across reclaim passes. */
 const gc = new BlobGarbageCollector(blobStorage);
@@ -130,6 +131,10 @@ export const useTrashStore = create<TrashState & TrashActions>((set, get) => ({
       blobReferences: collectBlobReferences(doc),
     });
     get().refresh();
+    // Trashing removes the doc from the active set, so drop its collection
+    // enrollment too — otherwise the collection keeps counting it as a member
+    // (JP-418). Restore brings it back Unassigned.
+    useCollectionStore.getState().assignDocument(doc.id, null);
   },
 
   trashStranded: (doc, origin) => {
@@ -139,6 +144,8 @@ export const useTrashStore = create<TrashState & TrashActions>((set, get) => ({
       blobReferences: collectBlobReferences(doc),
     });
     get().refresh();
+    // See trashLocal: drop collection enrollment for the stranded doc (JP-418).
+    useCollectionStore.getState().assignDocument(doc.id, null);
   },
 
   restore: async (id) => {

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -486,3 +486,44 @@ describe('uiPreferencesStore — appearance slice', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs.uiScale).toBe(1.1);
   });
 });
+
+describe('uiPreferencesStore — overrides preserve preset visibility (JP-410)', () => {
+  const resolvedRelaxedProps = () => {
+    const override = useUIPreferencesStore.getState().layout.modeOverrides.relaxed.properties;
+    return resolvePanelState('relaxed', 'properties', override);
+  };
+
+  it('Relaxed Properties starts hidden (preset visible:false)', () => {
+    expect(LAYOUT_PRESETS.relaxed.properties.visible).toBe(false);
+    expect(resolvedRelaxedProps().visible).toBe(false);
+  });
+
+  it('pinning Relaxed Properties keeps it hidden — pin must not fabricate visible:true', () => {
+    // Was the bug: the override defaulted visible:true, so pinning turned the
+    // selection-only Properties overlay into a permanently-docked panel.
+    useUIPreferencesStore.getState().togglePinFor('relaxed', 'properties');
+    const resolved = resolvedRelaxedProps();
+    expect(resolved.pinned).toBe(true);
+    expect(resolved.visible).toBe(false);
+  });
+
+  it('resizing Relaxed Properties keeps it hidden — "resize pins it" shared root cause', () => {
+    useUIPreferencesStore.getState().setPanelWidthFor('relaxed', 'properties', 300);
+    const resolved = resolvedRelaxedProps();
+    expect(resolved.width).toBe(300);
+    expect(resolved.visible).toBe(false);
+  });
+
+  it('an explicit visibility patch still works (fix does not over-suppress)', () => {
+    useUIPreferencesStore.getState().setPanelVisibleFor('relaxed', 'properties', true);
+    expect(resolvedRelaxedProps().visible).toBe(true);
+  });
+
+  it('pinning leaves an already-visible preset (Designer) visible', () => {
+    useUIPreferencesStore.getState().togglePinFor('designer', 'properties');
+    const override = useUIPreferencesStore.getState().layout.modeOverrides.designer.properties;
+    const resolved = resolvePanelState('designer', 'properties', override);
+    expect(resolved.pinned).toBe(true);
+    expect(resolved.visible).toBe(true);
+  });
+});

--- a/src/store/uiPreferencesStore.test.ts
+++ b/src/store/uiPreferencesStore.test.ts
@@ -94,6 +94,19 @@ describe('uiPreferencesStore — document browser grouping', () => {
   });
 });
 
+describe('uiPreferencesStore — rounded tables', () => {
+  it('defaults to on (opt-out)', () => {
+    expect(useUIPreferencesStore.getState().appearancePrefs.roundedTables).toBe(true);
+  });
+
+  it('setRoundedTables flips the preference', () => {
+    useUIPreferencesStore.getState().setRoundedTables(false);
+    expect(useUIPreferencesStore.getState().appearancePrefs.roundedTables).toBe(false);
+    useUIPreferencesStore.getState().setRoundedTables(true);
+    expect(useUIPreferencesStore.getState().appearancePrefs.roundedTables).toBe(true);
+  });
+});
+
 describe('uiPreferencesStore — spellcheck mode', () => {
   it('defaults to the custom (built-in) checker', () => {
     expect(useUIPreferencesStore.getState().appearancePrefs.spellcheck).toBe('custom');
@@ -283,6 +296,7 @@ describe('uiPreferencesStore — migration', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
     // Layout from the older payload is untouched.
     expect(state.layout.defaultMode).toBe('power');
@@ -313,6 +327,7 @@ describe('uiPreferencesStore — migration', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
   });
 
@@ -340,6 +355,7 @@ describe('uiPreferencesStore — migration', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
   });
 
@@ -451,6 +467,7 @@ describe('uiPreferencesStore — appearance slice', () => {
       smoothCaret: true,
       caretColor: null,
       spellcheck: 'custom',
+      roundedTables: true,
     });
   });
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -338,12 +338,18 @@ function mergePanelOverride(
 ): LayoutState['modeOverrides'] {
   const modeMap = current[mode];
   const existing = modeMap[panel];
+  // Unspecified keys inherit from the layout PRESET, not hard-coded defaults.
+  // A patch that only sets e.g. `pinned` or `width` must NOT fabricate
+  // `visible: true`, or it flips a preset-hidden panel (Relaxed Properties)
+  // into a permanently-docked one — the "pinning / resizing makes Properties
+  // stick visible in Relaxed" bugs.
+  const preset = LAYOUT_PRESETS[mode][panel];
   const merged: PanelState = {
-    dock: patch.dock ?? existing?.dock ?? 'right',
-    visible: patch.visible ?? existing?.visible ?? true,
-    order: patch.order ?? existing?.order ?? 0,
-    ...(patch.width !== undefined ? { width: patch.width } : existing?.width !== undefined ? { width: existing.width } : {}),
-    ...(patch.pinned !== undefined ? { pinned: patch.pinned } : existing?.pinned !== undefined ? { pinned: existing.pinned } : {}),
+    dock: patch.dock ?? existing?.dock ?? preset.dock,
+    visible: patch.visible ?? existing?.visible ?? preset.visible,
+    order: patch.order ?? existing?.order ?? preset.order,
+    ...(patch.width !== undefined ? { width: patch.width } : existing?.width !== undefined ? { width: existing.width } : preset.width !== undefined ? { width: preset.width } : {}),
+    ...(patch.pinned !== undefined ? { pinned: patch.pinned } : existing?.pinned !== undefined ? { pinned: existing.pinned } : preset.pinned !== undefined ? { pinned: preset.pinned } : {}),
   };
   return {
     ...current,

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -97,6 +97,8 @@ export interface AppearancePrefs {
   /** Which spellchecker runs in the prose editor (custom dictionary / system /
    *  off). Drives both the custom decorations and the native `spellcheck` attr. */
   spellcheck: SpellcheckMode;
+  /** Rounded corners on prose tables. Opt-out — on by default (JP-416). */
+  roundedTables: boolean;
 }
 
 /**
@@ -231,6 +233,8 @@ export interface UIPreferencesActions {
   setCaretStyle: (caretStyle: CaretStyle) => void;
   /** Toggle the smooth (gliding) caret. */
   setSmoothCaret: (smoothCaret: boolean) => void;
+  /** Toggle rounded corners on prose tables. */
+  setRoundedTables: (roundedTables: boolean) => void;
   /** Set the interface size multiplier (clamped to [0.9, 1.25]). */
   setUiScale: (uiScale: number) => void;
   /** Set the prose editor background preset. */
@@ -297,6 +301,7 @@ const initialAppearancePrefs: AppearancePrefs = {
   smoothCaret: true,
   caretColor: null,
   spellcheck: 'custom',
+  roundedTables: true,
 };
 
 /** Clamp a UI-scale value into the supported range. */
@@ -595,6 +600,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         set({ appearancePrefs: { ...get().appearancePrefs, smoothCaret } });
       },
 
+      setRoundedTables: (roundedTables) => {
+        set({ appearancePrefs: { ...get().appearancePrefs, roundedTables } });
+      },
+
       setCaretColor: (caretColor) => {
         set({ appearancePrefs: { ...get().appearancePrefs, caretColor } });
       },
@@ -609,7 +618,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
     }),
     {
       name: 'docushark-ui-preferences',
-      version: 12,
+      version: 13,
       partialize: (state) => ({
         expandedSections: state.expandedSections,
         rotationUnit: state.rotationUnit,
@@ -760,6 +769,15 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // (never shown) so existing users get the hint once, like a new install.
         if (fromVersion < 12) {
           next['installAppHintSeen'] = next['installAppHintSeen'] ?? false;
+        }
+        // v12 → v13: appearance slice gained roundedTables (JP-416). Default on
+        // (opt-out) without clobbering existing appearance choices. (The `merge`
+        // below also backstops this.)
+        if (fromVersion < 13) {
+          next['appearancePrefs'] = {
+            ...initialAppearancePrefs,
+            ...((next['appearancePrefs'] as Partial<AppearancePrefs> | undefined) ?? {}),
+          };
         }
         return next as unknown as UIPreferencesState;
       },

--- a/src/tiptap/TableCellSelect.test.ts
+++ b/src/tiptap/TableCellSelect.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TableCellSelect (JP-416) — a pointer selection spanning two cells of the same
+ * table becomes a CellSelection, regardless of where the drag started. We test
+ * the extracted rule with resolved positions from a real table doc (simulating
+ * the createSelectionBetween call).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
+import { extensions } from '../ui/TiptapEditor';
+import { cellSelectionBetween } from './TableCellSelect';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+/** Resolve a position inside the cell whose text is `text`. */
+function posIn(ed: Editor, text: string): number {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no text ${text}`);
+  return pos;
+}
+
+const TABLE = '<table><tbody><tr><td>AA</td><td>BB</td></tr><tr><td>CC</td><td>DD</td></tr></tbody></table>';
+
+describe('cellSelectionBetween', () => {
+  it('returns a CellSelection for two different cells in the same table', () => {
+    const ed = make(TABLE);
+    const $a = ed.state.doc.resolve(posIn(ed, 'AA'));
+    const $b = ed.state.doc.resolve(posIn(ed, 'DD'));
+    const sel = cellSelectionBetween($a, $b);
+    expect(sel).toBeInstanceOf(CellSelection);
+  });
+
+  it('returns null for anchor and head within the same cell', () => {
+    const ed = make(TABLE);
+    const $a = ed.state.doc.resolve(posIn(ed, 'AA'));
+    expect(cellSelectionBetween($a, $a)).toBeNull();
+  });
+
+  it('returns null when an endpoint is outside any table', () => {
+    const ed = make('<p>OUT</p>' + TABLE);
+    const $out = ed.state.doc.resolve(posIn(ed, 'OUT'));
+    const $cell = ed.state.doc.resolve(posIn(ed, 'AA'));
+    expect(cellSelectionBetween($out, $cell)).toBeNull();
+  });
+});

--- a/src/tiptap/TableCellSelect.ts
+++ b/src/tiptap/TableCellSelect.ts
@@ -1,0 +1,51 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { ResolvedPos } from '@tiptap/pm/model';
+import { cellAround, inSameTable, CellSelection } from '@tiptap/pm/tables';
+
+/**
+ * TableCellSelect (JP-416) — make a drag that crosses table cells reliably
+ * become a multi-cell `CellSelection`, even when the drag STARTS inside a cell's
+ * text.
+ *
+ * prosemirror-tables' own drag handler decides "the pointer moved to another
+ * cell" from `event.target`. When a drag begins on text, the browser runs a
+ * native text-selection drag that keeps `event.target` pinned to the start cell,
+ * so that cross-cell trigger never fires and the selection is clamped to the
+ * first cell (`normalizeSelection`). The `createSelectionBetween` prop instead
+ * works off the resolved anchor/head POSITIONS, so it's immune to the pinned
+ * target: if the two ends are in different cells of the same table, select the
+ * cells. (prosemirror-tables' own `createSelectionBetween` returns null unless
+ * its drag is active, so this composes — no conflict.)
+ */
+
+/** The cross-cell rule, extracted so it's unit-testable from resolved positions. */
+export function cellSelectionBetween(
+  $anchor: ResolvedPos,
+  $head: ResolvedPos,
+): CellSelection | null {
+  const anchorCell = cellAround($anchor);
+  const headCell = cellAround($head);
+  if (anchorCell && headCell && anchorCell.pos !== headCell.pos && inSameTable(anchorCell, headCell)) {
+    return new CellSelection(anchorCell, headCell);
+  }
+  return null;
+}
+
+export const TableCellSelect = Extension.create({
+  name: 'docusharkTableCellSelect',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('docusharkTableCellSelect'),
+        props: {
+          createSelectionBetween: (_view, $anchor, $head) =>
+            cellSelectionBetween($anchor, $head),
+        },
+      }),
+    ];
+  },
+});
+
+export default TableCellSelect;

--- a/src/tiptap/TableKeymap.test.ts
+++ b/src/tiptap/TableKeymap.test.ts
@@ -1,0 +1,62 @@
+/**
+ * TableKeymap (JP-416) — Tab navigation in tables. We test the extracted
+ * handlers directly (dispatching real key events through the keymap is brittle
+ * in jsdom). Headless `Editor` so the real table schema + commands run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import { handleTableTab, handleTableShiftTab } from './TableKeymap';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+function caretIn(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+const rows = (ed: Editor) => (ed.getHTML().match(/<tr/g) ?? []).length;
+
+const ROW = '<table><tbody><tr><td>A</td><td>B</td></tr></tbody></table>';
+
+describe('TableKeymap Tab handling', () => {
+  it('Tab in the last cell appends a new row', () => {
+    const ed = make(ROW);
+    caretIn(ed, 'B'); // last cell
+    expect(rows(ed)).toBe(1);
+    expect(handleTableTab(ed)).toBe(true);
+    expect(rows(ed)).toBe(2);
+  });
+
+  it('Tab in a non-last cell advances without adding a row', () => {
+    const ed = make(ROW);
+    caretIn(ed, 'A'); // first cell
+    expect(handleTableTab(ed)).toBe(true);
+    expect(rows(ed)).toBe(1);
+  });
+
+  it('Tab outside a table is not handled (returns false)', () => {
+    const ed = make('<p>OUTSIDE</p>');
+    caretIn(ed, 'OUTSIDE');
+    expect(handleTableTab(ed)).toBe(false);
+    expect(handleTableShiftTab(ed)).toBe(false);
+  });
+});

--- a/src/tiptap/TableKeymap.ts
+++ b/src/tiptap/TableKeymap.ts
@@ -1,0 +1,44 @@
+import { Extension } from '@tiptap/core';
+import type { Editor } from '@tiptap/core';
+
+/**
+ * TableKeymap (JP-416) — Word-like Tab navigation inside prose tables.
+ *
+ * Tab / Shift-Tab move to the next / previous cell, and Tab in the **last** cell
+ * appends a new row and lands in its first cell (so you can fill a table without
+ * reaching for the mouse). Outside a table the handlers return `false` so Tab
+ * keeps its default behavior (e.g. list indent / focus move).
+ */
+
+/**
+ * Tab handler, extracted so it's unit-testable without dispatching key events.
+ * Returns true if it handled the key (advanced a cell or grew the table).
+ */
+export function handleTableTab(editor: Editor): boolean {
+  if (!editor.isActive('table')) return false;
+  if (editor.commands.goToNextCell()) return true;
+  // At the last cell: add a row and step into it.
+  if (editor.can().addRowAfter()) {
+    return editor.chain().addRowAfter().goToNextCell().run();
+  }
+  return false;
+}
+
+/** Shift-Tab handler — previous cell, or pass through outside a table. */
+export function handleTableShiftTab(editor: Editor): boolean {
+  if (!editor.isActive('table')) return false;
+  return editor.commands.goToPreviousCell();
+}
+
+export const TableKeymap = Extension.create({
+  name: 'docusharkTableKeymap',
+
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => handleTableTab(this.editor),
+      'Shift-Tab': () => handleTableShiftTab(this.editor),
+    };
+  },
+});
+
+export default TableKeymap;

--- a/src/tiptap/TableKeymap.ts
+++ b/src/tiptap/TableKeymap.ts
@@ -1,5 +1,6 @@
 import { Extension } from '@tiptap/core';
 import type { Editor } from '@tiptap/core';
+import { addRowAfterKeepHeader } from './tableStructureCommands';
 
 /**
  * TableKeymap (JP-416) — Word-like Tab navigation inside prose tables.
@@ -17,9 +18,13 @@ import type { Editor } from '@tiptap/core';
 export function handleTableTab(editor: Editor): boolean {
   if (!editor.isActive('table')) return false;
   if (editor.commands.goToNextCell()) return true;
-  // At the last cell: add a row and step into it.
+  // At the last cell: add a row and step into it. Use the inheriting wrapper
+  // (not the raw addRowAfter) so a Tab-created row keeps the header style and
+  // the reference row's formatting (JP-416) — the same as a toolbar/menu insert.
   if (editor.can().addRowAfter()) {
-    return editor.chain().addRowAfter().goToNextCell().run();
+    const added = addRowAfterKeepHeader(editor);
+    if (added) editor.commands.goToNextCell();
+    return added;
   }
   return false;
 }

--- a/src/tiptap/TableSelectionExtension.test.ts
+++ b/src/tiptap/TableSelectionExtension.test.ts
@@ -1,10 +1,12 @@
 /**
  * TableSelection (JP-416) — the stroke-marquee overlay for a multi-cell
- * selection. This verifies the plugin wiring: a `.table-selection-marquee`
- * element is created inside the table wrapper exactly when the selection is a
- * `CellSelection`, and removed when it collapses. (Pixel positioning is
- * jsdom-untestable — `getBoundingClientRect` returns zeros — so we assert
- * presence/absence, not geometry.)
+ * selection. Verifies the plugin wiring: the `.table-selection-marquee` overlay
+ * shows when the selection is a `CellSelection` and hides when it collapses, and
+ * — critically — that it lives OUTSIDE the contenteditable. Appending it inside
+ * the table wrapper tripped ProseMirror's DOM observer (TableView.ignoreMutation
+ * only ignores `attributes`, not `childList`) and crashed the editor; this test
+ * guards against that regression. (Pixel geometry is jsdom-untestable —
+ * getBoundingClientRect returns zeros — so we assert visibility + placement.)
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -28,9 +30,12 @@ function cellPositions(ed: Editor): number[] {
 }
 
 describe('TableSelection marquee', () => {
-  it('adds a marquee on a CellSelection and removes it when collapsed', () => {
+  it('shows on a CellSelection, hides when collapsed, and stays outside the contenteditable', () => {
+    const host = document.createElement('div');
+    host.className = 'tiptap-editor';
+    document.body.appendChild(host);
     const element = document.createElement('div');
-    document.body.appendChild(element);
+    host.appendChild(element);
     editor = new Editor({
       element,
       extensions,
@@ -45,13 +50,15 @@ describe('TableSelection marquee', () => {
     editor.commands.setCellSelection({ anchorCell: cells[0]!, headCell: cells[1]! });
     expect(editor.state.selection).toBeInstanceOf(CellSelection);
 
-    const wrapper = editor.view.dom.querySelector('.tableWrapper');
-    expect(wrapper).not.toBeNull();
-    expect(wrapper!.querySelector('.table-selection-marquee')).not.toBeNull();
+    const marquee = host.querySelector('.table-selection-marquee') as HTMLElement | null;
+    expect(marquee).not.toBeNull();
+    expect(marquee!.style.display).toBe('block');
+    // The crash regression guard: never inside the editable content DOM.
+    expect(editor.view.dom.contains(marquee)).toBe(false);
 
-    // Collapse to a plain caret → marquee gone.
+    // Collapse to a plain caret → marquee hidden (element stays, just display:none).
     editor.commands.setTextSelection(cells[0]! + 1);
     expect(editor.state.selection).not.toBeInstanceOf(CellSelection);
-    expect(wrapper!.querySelector('.table-selection-marquee')).toBeNull();
+    expect(marquee!.style.display).toBe('none');
   });
 });

--- a/src/tiptap/TableSelectionExtension.test.ts
+++ b/src/tiptap/TableSelectionExtension.test.ts
@@ -1,0 +1,57 @@
+/**
+ * TableSelection (JP-416) — the stroke-marquee overlay for a multi-cell
+ * selection. This verifies the plugin wiring: a `.table-selection-marquee`
+ * element is created inside the table wrapper exactly when the selection is a
+ * `CellSelection`, and removed when it collapses. (Pixel positioning is
+ * jsdom-untestable — `getBoundingClientRect` returns zeros — so we assert
+ * presence/absence, not geometry.)
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
+import { extensions } from '../ui/TiptapEditor';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function cellPositions(ed: Editor): number[] {
+  const out: number[] = [];
+  ed.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') out.push(pos);
+  });
+  return out;
+}
+
+describe('TableSelection marquee', () => {
+  it('adds a marquee on a CellSelection and removes it when collapsed', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    editor = new Editor({
+      element,
+      extensions,
+      content:
+        '<table><tbody><tr><th>a</th><th>b</th></tr><tr><td>c</td><td>d</td></tr></tbody></table>',
+    });
+
+    const cells = cellPositions(editor);
+    expect(cells.length).toBe(4);
+
+    // Select the two header cells → a CellSelection spanning the top row.
+    editor.commands.setCellSelection({ anchorCell: cells[0]!, headCell: cells[1]! });
+    expect(editor.state.selection).toBeInstanceOf(CellSelection);
+
+    const wrapper = editor.view.dom.querySelector('.tableWrapper');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.querySelector('.table-selection-marquee')).not.toBeNull();
+
+    // Collapse to a plain caret → marquee gone.
+    editor.commands.setTextSelection(cells[0]! + 1);
+    expect(editor.state.selection).not.toBeInstanceOf(CellSelection);
+    expect(wrapper!.querySelector('.table-selection-marquee')).toBeNull();
+  });
+});

--- a/src/tiptap/TableSelectionExtension.ts
+++ b/src/tiptap/TableSelectionExtension.ts
@@ -27,30 +27,6 @@ import type { EditorView } from '@tiptap/pm/view';
 
 const TABLE_SELECTION_PLUGIN_KEY = new PluginKey('docusharkTableSelection');
 
-/**
- * Gated drag diagnostic (JP-416): set `localStorage.dsTableDebug = '1'` and
- * reload, then drag across cells — the console shows whether each mousemove sees
- * a different cell and what selection forms, so we can pin why a cross-cell drag
- * stays a TextSelection (prosemirror-tables clamps cross-cell text to one cell;
- * only `handleMouseDown`'s drag detection upgrades to a CellSelection). Inert
- * unless the flag is set.
- */
-function tableDebugOn(): boolean {
-  try {
-    return typeof localStorage !== 'undefined' && localStorage.getItem('dsTableDebug') === '1';
-  } catch {
-    return false;
-  }
-}
-
-function cellOf(node: EventTarget | null): HTMLElement | null {
-  let el = node as HTMLElement | null;
-  for (; el; el = el.parentElement) {
-    if (el.nodeName === 'TD' || el.nodeName === 'TH') return el;
-  }
-  return null;
-}
-
 class TableSelectionView {
   private marquee: HTMLDivElement;
   private host: HTMLElement;
@@ -84,38 +60,7 @@ class TableSelectionView {
     window.addEventListener('scroll', this.onScroll, { capture: true, passive: true });
     window.addEventListener('resize', this.onResize);
 
-    this.attachDebug(view);
     this.render(view);
-  }
-
-  /** Drag diagnostic — only active behind the `dsTableDebug` flag. */
-  private attachDebug(view: EditorView): void {
-    view.dom.addEventListener('mousedown', (e) => {
-      if (!tableDebugOn() || (e as MouseEvent).button !== 0) return;
-      const startCell = cellOf(e.target);
-      // eslint-disable-next-line no-console
-      console.log('[dsTable] mousedown', { target: (e.target as HTMLElement)?.nodeName, inCell: !!startCell });
-      const move = (me: MouseEvent) => {
-        const c = cellOf(me.target);
-        const pc = view.posAtCoords({ left: me.clientX, top: me.clientY });
-        // eslint-disable-next-line no-console
-        console.log('[dsTable] move', {
-          target: (me.target as HTMLElement)?.nodeName,
-          inCell: !!c,
-          differentCell: !!c && c !== startCell,
-          posAtCoords: pc?.pos ?? null,
-          selection: view.state.selection.constructor.name,
-        });
-      };
-      const up = () => {
-        document.removeEventListener('mousemove', move);
-        document.removeEventListener('mouseup', up);
-        // eslint-disable-next-line no-console
-        console.log('[dsTable] mouseup → selection', view.state.selection.constructor.name);
-      };
-      document.addEventListener('mousemove', move);
-      document.addEventListener('mouseup', up);
-    });
   }
 
   update(view: EditorView): void {

--- a/src/tiptap/TableSelectionExtension.ts
+++ b/src/tiptap/TableSelectionExtension.ts
@@ -11,23 +11,55 @@ import type { EditorView } from '@tiptap/pm/view';
  * Tiptap/prosemirror-tables marks each selected cell with a `.selectedCell`
  * class; the app styles that with a faint tint (see TiptapEditor.css). On top of
  * that, when the current selection is a `CellSelection`, this plugin positions
- * one `pointer-events:none` overlay div sized to the union rectangle of the
- * selected cells, giving a crisp 2px outline around the whole block.
+ * one `pointer-events:none` overlay sized to the union rectangle of the selected
+ * cells — a crisp outline around the whole block.
  *
- * The overlay lives inside the table's `.tableWrapper` (which is
- * `position: relative` and the horizontal-scroll container), so it scrolls with
- * the table content for free — no scroll listener needed. It is never inside the
- * contenteditable's content DOM, so it can't pollute the document or selection.
- * Inert outside a CellSelection (so read-only `ProsePreview`, where no
- * CellSelection forms, never shows it).
+ * The overlay lives in the editor's scroll container (`.tiptap-editor`), **never
+ * inside the contenteditable** — exactly like `CaretExtension`. An earlier
+ * version appended it inside the table's `.tableWrapper`; that's a `childList`
+ * mutation the Tiptap `TableView.ignoreMutation` does NOT ignore (it only
+ * ignores `attributes` on the table/colgroup), so ProseMirror's DOM observer
+ * tried to reconcile the foreign node and desynced — breaking selection and
+ * crashing the editor. Being an absolute child of the scroll container, the
+ * marquee is positioned from viewport coords and tracks scroll via a listener,
+ * so it can't pollute the document or selection.
  */
 
 const TABLE_SELECTION_PLUGIN_KEY = new PluginKey('docusharkTableSelection');
 
 class TableSelectionView {
-  private marquee: HTMLDivElement | null = null;
+  private marquee: HTMLDivElement;
+  private host: HTMLElement;
+  private onScroll: () => void;
+  private onResize: () => void;
+  private rafId = 0;
 
   constructor(view: EditorView) {
+    this.marquee = document.createElement('div');
+    this.marquee.className = 'table-selection-marquee';
+    this.marquee.setAttribute('aria-hidden', 'true');
+    this.marquee.style.display = 'none';
+
+    this.host =
+      (view.dom.closest('.tiptap-editor') as HTMLElement | null) ??
+      view.dom.parentElement ??
+      view.dom;
+    this.host.appendChild(this.marquee);
+
+    // Reposition on scroll (capture phase: inner scrollers — the editor's own
+    // vertical scroll and a table wrapper's horizontal scroll — don't bubble)
+    // and on resize, rAF-throttled.
+    this.onScroll = () => {
+      if (this.rafId) return;
+      this.rafId = requestAnimationFrame(() => {
+        this.rafId = 0;
+        this.render(view);
+      });
+    };
+    this.onResize = () => this.render(view);
+    window.addEventListener('scroll', this.onScroll, { capture: true, passive: true });
+    window.addEventListener('resize', this.onResize);
+
     this.render(view);
   }
 
@@ -36,70 +68,54 @@ class TableSelectionView {
   }
 
   private render(view: EditorView): void {
-    const sel = view.state.selection;
-    if (!(sel instanceof CellSelection)) {
-      this.hide();
-      return;
-    }
+    // A marquee glitch must never crash the editor — fail closed (hidden).
+    try {
+      const sel = view.state.selection;
+      if (!(sel instanceof CellSelection)) {
+        this.marquee.style.display = 'none';
+        return;
+      }
 
-    const anchorDOM = view.nodeDOM(sel.$anchorCell.pos) as HTMLElement | null;
-    const wrapper = anchorDOM?.closest('.tableWrapper') as HTMLElement | null;
-    if (!wrapper) {
-      this.hide();
-      return;
-    }
+      // Union the viewport rects of every selected cell.
+      let top = Infinity;
+      let left = Infinity;
+      let right = -Infinity;
+      let bottom = -Infinity;
+      sel.forEachCell((_node, pos) => {
+        const dom = view.nodeDOM(pos) as HTMLElement | null;
+        if (!dom || typeof dom.getBoundingClientRect !== 'function') return;
+        const r = dom.getBoundingClientRect();
+        top = Math.min(top, r.top);
+        left = Math.min(left, r.left);
+        right = Math.max(right, r.right);
+        bottom = Math.max(bottom, r.bottom);
+      });
+      if (!Number.isFinite(top)) {
+        this.marquee.style.display = 'none';
+        return;
+      }
 
-    // Union the viewport rects of every selected cell.
-    let top = Infinity;
-    let left = Infinity;
-    let right = -Infinity;
-    let bottom = -Infinity;
-    sel.forEachCell((_node, pos) => {
-      const dom = view.nodeDOM(pos) as HTMLElement | null;
-      if (!dom) return;
-      const r = dom.getBoundingClientRect();
-      top = Math.min(top, r.top);
-      left = Math.min(left, r.left);
-      right = Math.max(right, r.right);
-      bottom = Math.max(bottom, r.bottom);
-    });
-    if (!Number.isFinite(top)) {
-      this.hide();
-      return;
-    }
-
-    // Convert to the wrapper's scrolled-content coordinates. Because the marquee
-    // is a child of the wrapper, these stay correct as the wrapper scrolls.
-    const wr = wrapper.getBoundingClientRect();
-    const m = this.ensure(wrapper);
-    m.style.top = `${top - wr.top + wrapper.scrollTop}px`;
-    m.style.left = `${left - wr.left + wrapper.scrollLeft}px`;
-    m.style.width = `${right - left}px`;
-    m.style.height = `${bottom - top}px`;
-    m.style.display = 'block';
-  }
-
-  /** Ensure the marquee element exists and is parented to `wrapper`. */
-  private ensure(wrapper: HTMLElement): HTMLDivElement {
-    if (this.marquee && this.marquee.parentElement === wrapper) return this.marquee;
-    this.hide();
-    const m = document.createElement('div');
-    m.className = 'table-selection-marquee';
-    m.setAttribute('aria-hidden', 'true');
-    wrapper.appendChild(m);
-    this.marquee = m;
-    return m;
-  }
-
-  private hide(): void {
-    if (this.marquee) {
-      this.marquee.remove();
-      this.marquee = null;
+      // Position against the marquee's actual offset parent (resolved only once
+      // it's displayed), converting viewport coords to the scroller's content
+      // coords so it stays glued as the editor / table wrapper scrolls.
+      this.marquee.style.display = 'block';
+      const offsetParent = (this.marquee.offsetParent as HTMLElement | null) ?? this.host;
+      const op = offsetParent.getBoundingClientRect();
+      const x = left - op.left + offsetParent.scrollLeft;
+      const y = top - op.top + offsetParent.scrollTop;
+      this.marquee.style.transform = `translate(${x}px, ${y}px)`;
+      this.marquee.style.width = `${Math.max(0, right - left)}px`;
+      this.marquee.style.height = `${Math.max(0, bottom - top)}px`;
+    } catch {
+      this.marquee.style.display = 'none';
     }
   }
 
   destroy(): void {
-    this.hide();
+    window.removeEventListener('scroll', this.onScroll, true);
+    window.removeEventListener('resize', this.onResize);
+    if (this.rafId) cancelAnimationFrame(this.rafId);
+    this.marquee.remove();
   }
 }
 

--- a/src/tiptap/TableSelectionExtension.ts
+++ b/src/tiptap/TableSelectionExtension.ts
@@ -27,6 +27,30 @@ import type { EditorView } from '@tiptap/pm/view';
 
 const TABLE_SELECTION_PLUGIN_KEY = new PluginKey('docusharkTableSelection');
 
+/**
+ * Gated drag diagnostic (JP-416): set `localStorage.dsTableDebug = '1'` and
+ * reload, then drag across cells — the console shows whether each mousemove sees
+ * a different cell and what selection forms, so we can pin why a cross-cell drag
+ * stays a TextSelection (prosemirror-tables clamps cross-cell text to one cell;
+ * only `handleMouseDown`'s drag detection upgrades to a CellSelection). Inert
+ * unless the flag is set.
+ */
+function tableDebugOn(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem('dsTableDebug') === '1';
+  } catch {
+    return false;
+  }
+}
+
+function cellOf(node: EventTarget | null): HTMLElement | null {
+  let el = node as HTMLElement | null;
+  for (; el; el = el.parentElement) {
+    if (el.nodeName === 'TD' || el.nodeName === 'TH') return el;
+  }
+  return null;
+}
+
 class TableSelectionView {
   private marquee: HTMLDivElement;
   private host: HTMLElement;
@@ -60,7 +84,38 @@ class TableSelectionView {
     window.addEventListener('scroll', this.onScroll, { capture: true, passive: true });
     window.addEventListener('resize', this.onResize);
 
+    this.attachDebug(view);
     this.render(view);
+  }
+
+  /** Drag diagnostic — only active behind the `dsTableDebug` flag. */
+  private attachDebug(view: EditorView): void {
+    view.dom.addEventListener('mousedown', (e) => {
+      if (!tableDebugOn() || (e as MouseEvent).button !== 0) return;
+      const startCell = cellOf(e.target);
+      // eslint-disable-next-line no-console
+      console.log('[dsTable] mousedown', { target: (e.target as HTMLElement)?.nodeName, inCell: !!startCell });
+      const move = (me: MouseEvent) => {
+        const c = cellOf(me.target);
+        const pc = view.posAtCoords({ left: me.clientX, top: me.clientY });
+        // eslint-disable-next-line no-console
+        console.log('[dsTable] move', {
+          target: (me.target as HTMLElement)?.nodeName,
+          inCell: !!c,
+          differentCell: !!c && c !== startCell,
+          posAtCoords: pc?.pos ?? null,
+          selection: view.state.selection.constructor.name,
+        });
+      };
+      const up = () => {
+        document.removeEventListener('mousemove', move);
+        document.removeEventListener('mouseup', up);
+        // eslint-disable-next-line no-console
+        console.log('[dsTable] mouseup → selection', view.state.selection.constructor.name);
+      };
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', up);
+    });
   }
 
   update(view: EditorView): void {

--- a/src/tiptap/TableSelectionExtension.ts
+++ b/src/tiptap/TableSelectionExtension.ts
@@ -1,0 +1,119 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { CellSelection } from '@tiptap/pm/tables';
+import type { EditorView } from '@tiptap/pm/view';
+
+/**
+ * TableSelection (JP-416) — draws a single stroked **marquee** around the active
+ * multi-cell selection instead of the flat per-cell fill, which reads as
+ * unrefined.
+ *
+ * Tiptap/prosemirror-tables marks each selected cell with a `.selectedCell`
+ * class; the app styles that with a faint tint (see TiptapEditor.css). On top of
+ * that, when the current selection is a `CellSelection`, this plugin positions
+ * one `pointer-events:none` overlay div sized to the union rectangle of the
+ * selected cells, giving a crisp 2px outline around the whole block.
+ *
+ * The overlay lives inside the table's `.tableWrapper` (which is
+ * `position: relative` and the horizontal-scroll container), so it scrolls with
+ * the table content for free — no scroll listener needed. It is never inside the
+ * contenteditable's content DOM, so it can't pollute the document or selection.
+ * Inert outside a CellSelection (so read-only `ProsePreview`, where no
+ * CellSelection forms, never shows it).
+ */
+
+const TABLE_SELECTION_PLUGIN_KEY = new PluginKey('docusharkTableSelection');
+
+class TableSelectionView {
+  private marquee: HTMLDivElement | null = null;
+
+  constructor(view: EditorView) {
+    this.render(view);
+  }
+
+  update(view: EditorView): void {
+    this.render(view);
+  }
+
+  private render(view: EditorView): void {
+    const sel = view.state.selection;
+    if (!(sel instanceof CellSelection)) {
+      this.hide();
+      return;
+    }
+
+    const anchorDOM = view.nodeDOM(sel.$anchorCell.pos) as HTMLElement | null;
+    const wrapper = anchorDOM?.closest('.tableWrapper') as HTMLElement | null;
+    if (!wrapper) {
+      this.hide();
+      return;
+    }
+
+    // Union the viewport rects of every selected cell.
+    let top = Infinity;
+    let left = Infinity;
+    let right = -Infinity;
+    let bottom = -Infinity;
+    sel.forEachCell((_node, pos) => {
+      const dom = view.nodeDOM(pos) as HTMLElement | null;
+      if (!dom) return;
+      const r = dom.getBoundingClientRect();
+      top = Math.min(top, r.top);
+      left = Math.min(left, r.left);
+      right = Math.max(right, r.right);
+      bottom = Math.max(bottom, r.bottom);
+    });
+    if (!Number.isFinite(top)) {
+      this.hide();
+      return;
+    }
+
+    // Convert to the wrapper's scrolled-content coordinates. Because the marquee
+    // is a child of the wrapper, these stay correct as the wrapper scrolls.
+    const wr = wrapper.getBoundingClientRect();
+    const m = this.ensure(wrapper);
+    m.style.top = `${top - wr.top + wrapper.scrollTop}px`;
+    m.style.left = `${left - wr.left + wrapper.scrollLeft}px`;
+    m.style.width = `${right - left}px`;
+    m.style.height = `${bottom - top}px`;
+    m.style.display = 'block';
+  }
+
+  /** Ensure the marquee element exists and is parented to `wrapper`. */
+  private ensure(wrapper: HTMLElement): HTMLDivElement {
+    if (this.marquee && this.marquee.parentElement === wrapper) return this.marquee;
+    this.hide();
+    const m = document.createElement('div');
+    m.className = 'table-selection-marquee';
+    m.setAttribute('aria-hidden', 'true');
+    wrapper.appendChild(m);
+    this.marquee = m;
+    return m;
+  }
+
+  private hide(): void {
+    if (this.marquee) {
+      this.marquee.remove();
+      this.marquee = null;
+    }
+  }
+
+  destroy(): void {
+    this.hide();
+  }
+}
+
+export const TableSelection = Extension.create({
+  name: 'docusharkTableSelection',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: TABLE_SELECTION_PLUGIN_KEY,
+        view: (view) => new TableSelectionView(view),
+      }),
+    ];
+  },
+});
+
+export default TableSelection;

--- a/src/tiptap/tableAlign.test.ts
+++ b/src/tiptap/tableAlign.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-column alignment (JP-416): the table cell `align` attribute parses from
+ * and renders to a `text-align` style, and `setCellAlign` applies it to the
+ * focused cell. Headless `Editor` so the real schema + the TableCell/TableHeader
+ * `align` addAttributes run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import { setCellAlign } from '../ui/editorCommands';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+function caretInCell(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no cell text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+describe('table cell alignment', () => {
+  it('round-trips an align attribute through getHTML', () => {
+    const ed = make(
+      '<table><tbody><tr><td style="text-align: right">RIGHT</td><td>PLAIN</td></tr></tbody></table>',
+    );
+    expect(ed.getHTML()).toContain('text-align: right');
+  });
+
+  it('setCellAlign sets alignment on the focused cell, and null clears it', () => {
+    const ed = make('<table><tbody><tr><td>CELL</td></tr></tbody></table>');
+    caretInCell(ed, 'CELL');
+
+    setCellAlign(ed, 'center');
+    expect(ed.getHTML()).toContain('text-align: center');
+
+    setCellAlign(ed, null);
+    expect(ed.getHTML()).not.toContain('text-align');
+  });
+
+  it('preserves alignment alongside a cell background color', () => {
+    const ed = make(
+      '<table><tbody><tr><td style="text-align: center; background-color: rgb(255, 0, 0)">X</td></tr></tbody></table>',
+    );
+    const html = ed.getHTML();
+    expect(html).toContain('text-align: center');
+    expect(html).toContain('background-color: rgb(255, 0, 0)');
+  });
+});

--- a/src/tiptap/tableHeaderScope.test.ts
+++ b/src/tiptap/tableHeaderScope.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Accessibility (JP-416): header cells render a `scope` so screen readers and
+ * exported HTML/PDF treat them as headers. Defaults to `col` and round-trips.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+describe('table header scope', () => {
+  it('emits scope="col" on header cells by default', () => {
+    const ed = make(
+      '<table><tbody><tr><th>H1</th><th>H2</th></tr><tr><td>a</td><td>b</td></tr></tbody></table>',
+    );
+    const html = ed.getHTML();
+    expect((html.match(/<th[^>]*scope="col"/g) ?? []).length).toBe(2);
+    // Body cells stay plain <td> without a scope.
+    expect(html).not.toMatch(/<td[^>]*scope=/);
+  });
+
+  it('round-trips an explicit scope="row"', () => {
+    const ed = make(
+      '<table><tbody><tr><th scope="row">R</th><td>x</td></tr></tbody></table>',
+    );
+    expect(ed.getHTML()).toContain('scope="row"');
+  });
+});

--- a/src/tiptap/tableSelectCommands.test.ts
+++ b/src/tiptap/tableSelectCommands.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Table select commands (JP-416): Select Row / Column / All produce the right
+ * CellSelection. Headless `Editor` so the real schema + prosemirror-tables run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
+import { extensions } from '../ui/TiptapEditor';
+import { selectRow, selectColumn, selectAllCells } from './tableSelectCommands';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+function caretIn(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+function cellCount(sel: CellSelection): number {
+  let n = 0;
+  sel.forEachCell(() => { n += 1; });
+  return n;
+}
+
+// 3 cols × 2 rows.
+const TABLE =
+  '<table><tbody>' +
+  '<tr><td>R0a</td><td>R0b</td><td>R0c</td></tr>' +
+  '<tr><td>R1a</td><td>R1b</td><td>R1c</td></tr>' +
+  '</tbody></table>';
+
+describe('table select commands', () => {
+  it('Select Row selects the current row full-width', () => {
+    const ed = make(TABLE);
+    caretIn(ed, 'R0b');
+    expect(selectRow(ed)).toBe(true);
+    const sel = ed.state.selection as CellSelection;
+    expect(sel).toBeInstanceOf(CellSelection);
+    expect(sel.isRowSelection()).toBe(true);
+    expect(cellCount(sel)).toBe(3); // one row × 3 cols
+  });
+
+  it('Select Column selects the current column full-height', () => {
+    const ed = make(TABLE);
+    caretIn(ed, 'R0b'); // column 1
+    expect(selectColumn(ed)).toBe(true);
+    const sel = ed.state.selection as CellSelection;
+    expect(sel.isColSelection()).toBe(true);
+    expect(cellCount(sel)).toBe(2); // 2 rows × one col
+  });
+
+  it('Select All Cells selects the whole table', () => {
+    const ed = make(TABLE);
+    caretIn(ed, 'R0a');
+    expect(selectAllCells(ed)).toBe(true);
+    const sel = ed.state.selection as CellSelection;
+    expect(sel.isRowSelection()).toBe(true);
+    expect(sel.isColSelection()).toBe(true);
+    expect(cellCount(sel)).toBe(6); // 2 × 3
+  });
+
+  it('returns false outside a table', () => {
+    const ed = make('<p>nope</p>');
+    caretIn(ed, 'nope');
+    expect(selectRow(ed)).toBe(false);
+    expect(selectColumn(ed)).toBe(false);
+    expect(selectAllCells(ed)).toBe(false);
+  });
+});

--- a/src/tiptap/tableSelectCommands.ts
+++ b/src/tiptap/tableSelectCommands.ts
@@ -1,0 +1,60 @@
+/**
+ * Excel-like "select" commands for prose tables (JP-416): select the current
+ * row(s), column(s), or the whole table as a `CellSelection`. Surfaced in the
+ * right-click table menu + the toolbar so a range is easy to grab for a move /
+ * delete / format. Built on prosemirror-tables' `CellSelection` helpers.
+ *
+ * Each works off the current selection: a plain cursor selects its own
+ * row/column; an existing multi-cell selection selects every row/column it
+ * spans (so Select Row on a 3-row cell selection grabs all three full rows).
+ */
+
+import type { Editor } from '@tiptap/core';
+import type { EditorState } from '@tiptap/pm/state';
+import type { ResolvedPos } from '@tiptap/pm/model';
+import { CellSelection, cellAround, isInTable, selectedRect } from '@tiptap/pm/tables';
+
+/** The anchor/head cells of the current selection (a cursor's own cell, or a
+ *  CellSelection's two ends). Null when the selection isn't in a table cell. */
+function selectionCells(state: EditorState): { anchor: ResolvedPos; head: ResolvedPos } | null {
+  const sel = state.selection;
+  if (sel instanceof CellSelection) return { anchor: sel.$anchorCell, head: sel.$headCell };
+  const $cell = cellAround(sel.$anchor);
+  return $cell ? { anchor: $cell, head: $cell } : null;
+}
+
+export function selectRow(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const cells = selectionCells(state);
+  if (!cells) return false;
+  view.dispatch(state.tr.setSelection(CellSelection.rowSelection(cells.anchor, cells.head)));
+  view.focus();
+  return true;
+}
+
+export function selectColumn(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const cells = selectionCells(state);
+  if (!cells) return false;
+  view.dispatch(state.tr.setSelection(CellSelection.colSelection(cells.anchor, cells.head)));
+  view.focus();
+  return true;
+}
+
+export function selectAllCells(editor: Editor): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const { map, tableStart } = selectedRect(state);
+  const firstOffset = map.map[0];
+  const lastOffset = map.map[map.width * map.height - 1];
+  if (firstOffset === undefined || lastOffset === undefined) return false;
+  const sel = new CellSelection(
+    state.doc.resolve(tableStart + firstOffset),
+    state.doc.resolve(tableStart + lastOffset),
+  );
+  view.dispatch(state.tr.setSelection(sel));
+  view.focus();
+  return true;
+}

--- a/src/tiptap/tableStructureCommands.test.ts
+++ b/src/tiptap/tableStructureCommands.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Table structure ops (JP-416): moving a column/row and keeping header cells on
+ * insert. Headless `Editor` so the real schema + prosemirror-tables primitives
+ * run; assertions read `getHTML()` order / header-cell counts.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import {
+  moveColumnRight,
+  moveColumnLeft,
+  moveRowDown,
+  addColumnAfterKeepHeader,
+  addRowAfterKeepHeader,
+} from './tableStructureCommands';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function make(content: string): Editor {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const ed = new Editor({ element, extensions, content });
+  editor = ed;
+  return ed;
+}
+
+/** Put the cursor inside the cell whose text is `text`. */
+function caretInCell(ed: Editor, text: string): void {
+  let pos = -1;
+  ed.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text) pos = p;
+  });
+  if (pos < 0) throw new Error(`no cell text ${text}`);
+  ed.commands.setTextSelection(pos);
+}
+
+// Distinctive multi-char cell tokens so getHTML() ordering checks don't collide
+// with letters inside markup (e.g. the 'a'/'b' in `<table>`/`<tbody>`).
+const HEADER_TABLE =
+  '<table><tbody>' +
+  '<tr><th>COL1</th><th>COL2</th></tr>' +
+  '<tr><td>VAL1</td><td>VAL2</td></tr>' +
+  '</tbody></table>';
+
+describe('table move column/row', () => {
+  it('moves a column right (swaps order)', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'COL1'); // column 0
+    expect(moveColumnRight(ed)).toBe(true);
+    const html = ed.getHTML();
+    expect(html.indexOf('COL2')).toBeLessThan(html.indexOf('COL1'));
+    expect(html.indexOf('VAL2')).toBeLessThan(html.indexOf('VAL1'));
+  });
+
+  it('is a no-op past the left edge', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'COL1'); // column 0 — can't go further left
+    const before = ed.getHTML();
+    expect(moveColumnLeft(ed)).toBe(false);
+    expect(ed.getHTML()).toBe(before);
+  });
+
+  it('moves a row down (swaps rows)', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'VAL1'); // row 1
+    expect(moveRowDown(ed)).toBe(false); // already the last row
+    caretInCell(ed, 'COL1'); // row 0
+    expect(moveRowDown(ed)).toBe(true);
+    const html = ed.getHTML();
+    expect(html.indexOf('VAL1')).toBeLessThan(html.indexOf('COL1'));
+  });
+});
+
+describe('table insert keeps header style', () => {
+  it('promotes the new header-row cell to <th> on addColumnAfter', () => {
+    const ed = make(HEADER_TABLE);
+    caretInCell(ed, 'COL1'); // header row, column 0
+    expect(addColumnAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    // 2 header cells originally → 3 after the new column inherits the header.
+    expect((html.match(/<th/g) ?? []).length).toBe(3);
+  });
+
+  it('does not add header cells when there is no header row', () => {
+    const ed = make('<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody></table>');
+    caretInCell(ed, 'a');
+    expect(addRowAfterKeepHeader(ed)).toBe(true);
+    expect((ed.getHTML().match(/<th/g) ?? []).length).toBe(0);
+  });
+});

--- a/src/tiptap/tableStructureCommands.test.ts
+++ b/src/tiptap/tableStructureCommands.test.ts
@@ -94,3 +94,46 @@ describe('table insert keeps header style', () => {
     expect((ed.getHTML().match(/<th/g) ?? []).length).toBe(0);
   });
 });
+
+describe('table insert inherits the reference formatting', () => {
+  // Reference column (col 0): green background + cell align right + a
+  // center-aligned paragraph. Col 1 is plain.
+  const FORMATTED =
+    '<table><tbody><tr>' +
+    '<td style="background-color: rgb(0, 128, 0); text-align: right"><p style="text-align: center">REF</p></td>' +
+    '<td><p>PLAIN</p></td>' +
+    '</tr></tbody></table>';
+
+  it('copies background, cell align, and paragraph text-align into a new column', () => {
+    const ed = make(FORMATTED);
+    caretInCell(ed, 'REF'); // reference column
+    const before = ed.getHTML();
+    expect((before.match(/background-color: rgb\(0, 128, 0\)/g) ?? []).length).toBe(1);
+
+    expect(addColumnAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    // The new column's cell inherited the reference column's formatting.
+    expect((html.match(/background-color: rgb\(0, 128, 0\)/g) ?? []).length).toBe(2);
+    expect((html.match(/text-align: right/g) ?? []).length).toBe(2); // cell align
+    expect((html.match(/text-align: center/g) ?? []).length).toBe(2); // paragraph
+  });
+
+  it('copies the reference row formatting into a new row', () => {
+    const ed = make(FORMATTED);
+    caretInCell(ed, 'REF');
+    expect(addRowAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    // The new row's first cell mirrors the reference row's first cell.
+    expect((html.match(/background-color: rgb\(0, 128, 0\)/g) ?? []).length).toBe(2);
+    expect((html.match(/text-align: center/g) ?? []).length).toBe(2);
+  });
+
+  it('leaves a plain table unformatted (no background/align copied)', () => {
+    const ed = make('<table><tbody><tr><td>x</td><td>y</td></tr></tbody></table>');
+    caretInCell(ed, 'x');
+    expect(addColumnAfterKeepHeader(ed)).toBe(true);
+    const html = ed.getHTML();
+    expect(html).not.toContain('background-color');
+    expect(html).not.toContain('text-align');
+  });
+});

--- a/src/tiptap/tableStructureCommands.test.ts
+++ b/src/tiptap/tableStructureCommands.test.ts
@@ -14,6 +14,8 @@ import {
   addColumnAfterKeepHeader,
   addRowAfterKeepHeader,
 } from './tableStructureCommands';
+import * as cmd from '../ui/editorCommands';
+import { handleTableTab } from './TableKeymap';
 
 let editor: Editor | null = null;
 
@@ -135,5 +137,25 @@ describe('table insert inherits the reference formatting', () => {
     const html = ed.getHTML();
     expect(html).not.toContain('background-color');
     expect(html).not.toContain('text-align');
+  });
+
+  // The live toolbar path: align via setCellAlign, then add a column/row.
+  it('inherits alignment set via the setCellAlign command (toolbar path)', () => {
+    const ed = make('<table><tbody><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></tbody></table>');
+    caretInCell(ed, 'A1');
+    cmd.setCellAlign(ed, 'right'); // align the cell like the toolbar button
+    caretInCell(ed, 'A1');
+    cmd.addColumnAfter(ed); // toolbar add → keep-header + inherit-format wrapper
+    // A1 is right-aligned; the new column's row-0 cell should inherit it.
+    expect((ed.getHTML().match(/text-align: right/g) ?? []).length).toBe(2);
+  });
+
+  // The Tab-to-add-row path (TableKeymap) must also inherit.
+  it('inherits formatting when a row is added by Tab in the last cell', () => {
+    const ed = make('<table><tbody><tr><td style="text-align: right">A1</td><td>B1</td></tr></tbody></table>');
+    caretInCell(ed, 'B1'); // last cell → Tab adds a row
+    expect(handleTableTab(ed)).toBe(true);
+    // The new row's first cell mirrors row 0's first cell (right-aligned).
+    expect((ed.getHTML().match(/text-align: right/g) ?? []).length).toBe(2);
   });
 });

--- a/src/tiptap/tableStructureCommands.ts
+++ b/src/tiptap/tableStructureCommands.ts
@@ -1,0 +1,125 @@
+/**
+ * Table structure operations for JP-416 that aren't surfaced as Tiptap editor
+ * commands: moving a column/row, and keeping header cells when a column/row is
+ * inserted.
+ *
+ * These build on prosemirror-tables' own primitives (`moveTableColumn`,
+ * `moveTableRow`, `selectedRect`, `rowIsHeader`, `columnIsHeader`,
+ * `tableNodeTypes`) rather than hand-rolling table rebuilds, so colspan/rowspan
+ * and column-width handling stay correct. Each takes the Tiptap `Editor` and
+ * returns whether it changed anything (so the toolbar/menu can disable a no-op).
+ */
+
+import type { Editor } from '@tiptap/core';
+import {
+  isInTable,
+  selectedRect,
+  moveTableColumn,
+  moveTableRow,
+  rowIsHeader,
+  columnIsHeader,
+  tableNodeTypes,
+  type TableMap,
+} from '@tiptap/pm/tables';
+
+/**
+ * A clean (no rowspan/colspan) table has each cell appear exactly once in the
+ * map. A merged cell appears multiple times, shrinking the unique set. Move is
+ * disabled on merged tables to avoid corrupting spans (clean case first).
+ */
+export function tableHasMergedCells(map: TableMap): boolean {
+  return new Set(map.map).size !== map.map.length;
+}
+
+function moveCol(editor: Editor, dir: -1 | 1): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const rect = selectedRect(state);
+  if (tableHasMergedCells(rect.map)) return false;
+  const from = rect.left;
+  const to = from + dir;
+  if (to < 0 || to > rect.map.width - 1) return false;
+  const ok = moveTableColumn({ from, to })(state, view.dispatch);
+  if (ok) view.focus();
+  return ok;
+}
+
+function moveRowFn(editor: Editor, dir: -1 | 1): boolean {
+  const { state, view } = editor;
+  if (!isInTable(state)) return false;
+  const rect = selectedRect(state);
+  if (tableHasMergedCells(rect.map)) return false;
+  const from = rect.top;
+  const to = from + dir;
+  if (to < 0 || to > rect.map.height - 1) return false;
+  const ok = moveTableRow({ from, to })(state, view.dispatch);
+  if (ok) view.focus();
+  return ok;
+}
+
+export const moveColumnLeft = (editor: Editor) => moveCol(editor, -1);
+export const moveColumnRight = (editor: Editor) => moveCol(editor, 1);
+export const moveRowUp = (editor: Editor) => moveRowFn(editor, -1);
+export const moveRowDown = (editor: Editor) => moveRowFn(editor, 1);
+
+interface HeaderFlags {
+  headerRow: boolean;
+  headerColumn: boolean;
+}
+
+/** Whether the current table's first row / first column are header cells. */
+function captureHeaderFlags(editor: Editor): HeaderFlags {
+  const { state } = editor;
+  if (!isInTable(state)) return { headerRow: false, headerColumn: false };
+  const rect = selectedRect(state);
+  return {
+    headerRow: rowIsHeader(rect.map, rect.table, 0),
+    headerColumn: columnIsHeader(rect.map, rect.table, 0),
+  };
+}
+
+/**
+ * Force the header cells of the current table to match the captured flags: a
+ * cell becomes `tableHeader` iff it's in row 0 (when the table had a header row)
+ * or col 0 (header column). Only upgrades — never demotes — so it's idempotent
+ * and safe to run after every insert. Fixes "new column/row loses header style".
+ */
+function applyHeaderFlags(editor: Editor, flags: HeaderFlags): void {
+  if (!flags.headerRow && !flags.headerColumn) return;
+  const { state, view } = editor;
+  if (!isInTable(state)) return;
+  const rect = selectedRect(state);
+  const headerType = tableNodeTypes(state.schema)['header_cell'];
+  if (!headerType) return;
+
+  const { map, tableStart } = rect;
+  const tr = state.tr;
+  const seen = new Set<number>();
+  for (let row = 0; row < map.height; row++) {
+    for (let col = 0; col < map.width; col++) {
+      const shouldHeader = (row === 0 && flags.headerRow) || (col === 0 && flags.headerColumn);
+      if (!shouldHeader) continue;
+      const offset = map.map[row * map.width + col];
+      if (offset === undefined || seen.has(offset)) continue;
+      seen.add(offset);
+      const pos = tableStart + offset;
+      const node = state.doc.nodeAt(pos);
+      if (node && node.type !== headerType) {
+        tr.setNodeMarkup(pos, headerType, node.attrs);
+      }
+    }
+  }
+  if (tr.docChanged) view.dispatch(tr);
+}
+
+function insertKeepingHeader(editor: Editor, command: 'addColumnAfter' | 'addColumnBefore' | 'addRowAfter' | 'addRowBefore'): boolean {
+  const flags = captureHeaderFlags(editor);
+  const ok = editor.chain().focus()[command]().run();
+  if (ok) applyHeaderFlags(editor, flags);
+  return ok;
+}
+
+export const addColumnAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnAfter');
+export const addColumnBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnBefore');
+export const addRowAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowAfter');
+export const addRowBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowBefore');

--- a/src/tiptap/tableStructureCommands.ts
+++ b/src/tiptap/tableStructureCommands.ts
@@ -1,7 +1,10 @@
 /**
  * Table structure operations for JP-416 that aren't surfaced as Tiptap editor
- * commands: moving a column/row, and keeping header cells when a column/row is
- * inserted.
+ * commands: moving a column/row, and — when a column/row is inserted — keeping
+ * the header style AND inheriting the reference column/row's formatting (cell
+ * alignment, background, and block-level text formatting such as paragraph
+ * alignment) so a new column/row matches its neighbor instead of coming in
+ * blank.
  *
  * These build on prosemirror-tables' own primitives (`moveTableColumn`,
  * `moveTableRow`, `selectedRect`, `rowIsHeader`, `columnIsHeader`,
@@ -11,6 +14,8 @@
  */
 
 import type { Editor } from '@tiptap/core';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
+import type { NodeType } from '@tiptap/pm/model';
 import {
   isInTable,
   selectedRect,
@@ -20,12 +25,14 @@ import {
   columnIsHeader,
   tableNodeTypes,
   type TableMap,
+  type TableRect,
 } from '@tiptap/pm/tables';
 
 /**
  * A clean (no rowspan/colspan) table has each cell appear exactly once in the
- * map. A merged cell appears multiple times, shrinking the unique set. Move is
- * disabled on merged tables to avoid corrupting spans (clean case first).
+ * map. A merged cell appears multiple times, shrinking the unique set. Move +
+ * formatting inheritance are disabled on merged tables to avoid corrupting spans
+ * / mis-indexing (clean case first).
  */
 export function tableHasMergedCells(map: TableMap): boolean {
   return new Set(map.map).size !== map.map.length;
@@ -67,15 +74,69 @@ interface HeaderFlags {
   headerColumn: boolean;
 }
 
-/** Whether the current table's first row / first column are header cells. */
-function captureHeaderFlags(editor: Editor): HeaderFlags {
-  const { state } = editor;
-  if (!isInTable(state)) return { headerRow: false, headerColumn: false };
-  const rect = selectedRect(state);
+/**
+ * The inheritable formatting of a cell: its own attrs (alignment + background)
+ * plus its first block's type+attrs, which carry text formatting like paragraph
+ * `textAlign` (JP-416). Inline marks (bold/color) aren't captured — a new cell
+ * is empty, so there's no text to carry them on.
+ */
+interface CellFormat {
+  align: unknown;
+  backgroundColor: unknown;
+  blockType: NodeType | null;
+  blockAttrs: Record<string, unknown> | null;
+}
+
+function cellFormatAt(state: EditorState, rect: TableRect, row: number, col: number): CellFormat {
+  const offset = rect.map.map[row * rect.map.width + col];
+  const node = offset === undefined ? null : state.doc.nodeAt(rect.tableStart + offset);
+  const firstBlock = node?.firstChild ?? null;
   return {
-    headerRow: rowIsHeader(rect.map, rect.table, 0),
-    headerColumn: columnIsHeader(rect.map, rect.table, 0),
+    align: node?.attrs['align'] ?? null,
+    backgroundColor: node?.attrs['backgroundColor'] ?? null,
+    blockType: firstBlock?.type ?? null,
+    blockAttrs: firstBlock ? { ...firstBlock.attrs } : null,
   };
+}
+
+/** Copy `fmt` onto the cell at (row, col) of the current rect (keeping its type). */
+function applyCellFormat(
+  tr: Transaction,
+  state: EditorState,
+  rect: TableRect,
+  row: number,
+  col: number,
+  fmt: CellFormat | undefined,
+): void {
+  if (!fmt) return;
+  const offset = rect.map.map[row * rect.map.width + col];
+  if (offset === undefined) return;
+  const pos = rect.tableStart + offset;
+  const node = state.doc.nodeAt(pos);
+  if (!node) return;
+
+  // Cell-level attrs: alignment + background.
+  if (fmt.align != null || fmt.backgroundColor != null) {
+    tr.setNodeMarkup(pos, undefined, {
+      ...node.attrs,
+      align: fmt.align,
+      backgroundColor: fmt.backgroundColor,
+    });
+  }
+
+  // First-block text formatting (paragraph `textAlign`, etc.). Only when the new
+  // cell's first block is the same node type, so we never restructure the cell —
+  // and only when the attrs actually differ, to avoid a no-op transaction.
+  const inner = node.firstChild;
+  if (
+    fmt.blockType &&
+    fmt.blockAttrs &&
+    inner &&
+    inner.type === fmt.blockType &&
+    JSON.stringify(inner.attrs) !== JSON.stringify(fmt.blockAttrs)
+  ) {
+    tr.setNodeMarkup(pos + 1, undefined, fmt.blockAttrs);
+  }
 }
 
 /**
@@ -112,14 +173,72 @@ function applyHeaderFlags(editor: Editor, flags: HeaderFlags): void {
   if (tr.docChanged) view.dispatch(tr);
 }
 
-function insertKeepingHeader(editor: Editor, command: 'addColumnAfter' | 'addColumnBefore' | 'addRowAfter' | 'addRowBefore'): boolean {
-  const flags = captureHeaderFlags(editor);
+function insertColumn(editor: Editor, dir: 'after' | 'before'): boolean {
+  const command = dir === 'after' ? 'addColumnAfter' : 'addColumnBefore';
+  const { state } = editor;
+  if (!isInTable(state)) return editor.chain().focus()[command]().run();
+
+  const before = selectedRect(state);
+  const flags: HeaderFlags = {
+    headerRow: rowIsHeader(before.map, before.table, 0),
+    headerColumn: columnIsHeader(before.map, before.table, 0),
+  };
+  const refCol = before.left;
+  // Reference column's per-row formatting (skip on merged tables — the map index
+  // isn't 1:1 there).
+  const colFmt = tableHasMergedCells(before.map)
+    ? null
+    : Array.from({ length: before.map.height }, (_, r) => cellFormatAt(state, before, r, refCol));
+
   const ok = editor.chain().focus()[command]().run();
-  if (ok) applyHeaderFlags(editor, flags);
-  return ok;
+  if (!ok) return false;
+
+  // Copy the reference column's formatting into the freshly inserted column.
+  if (colFmt) {
+    const after = selectedRect(editor.state);
+    const newCol = dir === 'after' ? refCol + 1 : refCol;
+    const tr = editor.state.tr;
+    for (let r = 0; r < after.map.height; r++) {
+      applyCellFormat(tr, editor.state, after, r, newCol, colFmt[r]);
+    }
+    if (tr.docChanged) editor.view.dispatch(tr);
+  }
+  applyHeaderFlags(editor, flags);
+  return true;
 }
 
-export const addColumnAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnAfter');
-export const addColumnBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addColumnBefore');
-export const addRowAfterKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowAfter');
-export const addRowBeforeKeepHeader = (editor: Editor) => insertKeepingHeader(editor, 'addRowBefore');
+function insertRow(editor: Editor, dir: 'after' | 'before'): boolean {
+  const command = dir === 'after' ? 'addRowAfter' : 'addRowBefore';
+  const { state } = editor;
+  if (!isInTable(state)) return editor.chain().focus()[command]().run();
+
+  const before = selectedRect(state);
+  const flags: HeaderFlags = {
+    headerRow: rowIsHeader(before.map, before.table, 0),
+    headerColumn: columnIsHeader(before.map, before.table, 0),
+  };
+  const refRow = before.top;
+  const rowFmt = tableHasMergedCells(before.map)
+    ? null
+    : Array.from({ length: before.map.width }, (_, c) => cellFormatAt(state, before, refRow, c));
+
+  const ok = editor.chain().focus()[command]().run();
+  if (!ok) return false;
+
+  if (rowFmt) {
+    const after = selectedRect(editor.state);
+    const newRow = dir === 'after' ? refRow + 1 : refRow;
+    const tr = editor.state.tr;
+    for (let c = 0; c < after.map.width; c++) {
+      applyCellFormat(tr, editor.state, after, newRow, c, rowFmt[c]);
+    }
+    if (tr.docChanged) editor.view.dispatch(tr);
+  }
+  applyHeaderFlags(editor, flags);
+  return true;
+}
+
+export const addColumnAfterKeepHeader = (editor: Editor) => insertColumn(editor, 'after');
+export const addColumnBeforeKeepHeader = (editor: Editor) => insertColumn(editor, 'before');
+export const addRowAfterKeepHeader = (editor: Editor) => insertRow(editor, 'after');
+export const addRowBeforeKeepHeader = (editor: Editor) => insertRow(editor, 'before');

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,7 @@ import { CanvasContainer } from './CanvasContainer';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
-import { isFlyoutLayout, resolveRegions } from './layout/modes';
+import { isFlyoutLayout, propertiesDockedVisible, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { MobilePreviewGate } from './mobile/MobilePreviewGate';
@@ -120,7 +120,10 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   const layersPanelState = useActivePanelState('layers');
   const layoutActions = useLayoutActions();
   const isDocumentVisible = documentPanelState.visible;
-  const isPropertiesVisible = propertiesPanelState.visible;
+  // Relaxed never docks Properties (selection-only overlay) even if a stale
+  // pinned/visible override persisted from before it was un-pinnable here —
+  // otherwise it shows docked over the prose, including in `write` focus.
+  const isPropertiesVisible = propertiesDockedVisible(activeMode, propertiesPanelState);
   const isLayersVisible = layersPanelState.visible;
   // Properties panel uses the fly-out wrapper in Designer/Technician unless the
   // user has pinned it for this layout. Power keeps it docked; Relaxed hides

--- a/src/ui/CollaborativeProseEditor.tsx
+++ b/src/ui/CollaborativeProseEditor.tsx
@@ -140,8 +140,10 @@ export function CollaborativeProseEditor({
 
   // Shared editor chrome: right-click formatting menu, spellcheck popover,
   // custom-dictionary loader, inline-link handling, and blob:// image
-  // resolution. Heading-anchor nav is a local multi-page concern, omitted here.
-  const { onContextMenu, overlay } = useProseEditorChrome(editor, { headingAnchors: false });
+  // resolution. Heading-anchor nav is on (JP-417): collab docs are multi-page
+  // too (prose pages are CRDT shared types) and the panel drives the active
+  // page off the same richTextPagesStore the handler switches.
+  const { onContextMenu, overlay } = useProseEditorChrome(editor, { headingAnchors: true });
 
   // Expose the editor instance to the panel (autosave + toolbar).
   useEffect(() => {

--- a/src/ui/ContextMenu.css
+++ b/src/ui/ContextMenu.css
@@ -2,6 +2,9 @@
   position: fixed;
   z-index: 1000;
   min-width: 180px;
+  /* JP-421: never run off the bottom — size to the viewport and scroll. */
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
@@ -82,12 +85,17 @@
   opacity: 0.6;
 }
 
-/* Submenu content panel */
+/* Submenu content panel. JS positions it with `fixed` viewport coords
+   (placeFlyout) so it self-aligns and escapes the root menu's scroll clip;
+   the values below are the pre-measure fallback. */
 .context-menu-submenu-content {
   position: absolute;
   left: 100%;
   top: 0;
   min-width: 140px;
+  /* Never wider than the viewport on narrow/mobile screens. */
+  max-width: calc(100vw - 16px);
+  box-sizing: border-box;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);

--- a/src/ui/ContextMenu.tsx
+++ b/src/ui/ContextMenu.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useRef, useMemo, useLayoutEffect } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo, useLayoutEffect, type CSSProperties } from 'react';
+import { clampToViewport, placeFlyout } from './contextMenuUtils';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useHistoryStore } from '../store/historyStore';
@@ -27,15 +28,27 @@ interface SubmenuProps {
   label: string;
   items: SubmenuItem[];
   onClose: () => void;
+  /** Ref to the parent menu, so the submenu can measure its edges. */
+  parentMenuRef: React.RefObject<HTMLDivElement>;
+  /**
+   * Report the parent slide-left distance. `px` is the shift while open, or
+   * `null` when this submenu closes (the parent ignores a stale close from a
+   * submenu that is no longer the active one).
+   */
+  onShiftChange: (id: string, px: number | null) => void;
 }
 
 /**
- * Submenu component for nested menu options.
+ * Submenu component for nested menu options. Self-aligns against the viewport
+ * (JP-421): opens right, slides the parent left when tight, flips to the left
+ * when a wide submenu still won't fit, and clamps + scrolls vertically.
  */
-function Submenu({ label, items, onClose }: SubmenuProps) {
+function Submenu({ label, items, onClose, parentMenuRef, onShiftChange }: SubmenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentStyle, setContentStyle] = useState<CSSProperties | undefined>(undefined);
 
   const handleMouseEnter = useCallback(() => {
     if (timeoutRef.current) {
@@ -58,6 +71,40 @@ function Submenu({ label, items, onClose }: SubmenuProps) {
     }
   }, [onClose]);
 
+  // Position the submenu once it has rendered (so we can measure it).
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setContentStyle(undefined);
+      onShiftChange(label, null);
+      return;
+    }
+    const content = contentRef.current;
+    const item = containerRef.current;
+    const parent = parentMenuRef.current;
+    if (!content || !item || !parent) return;
+
+    const itemRect = item.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+    const placement = placeFlyout(
+      itemRect,
+      { left: parentRect.left, right: parentRect.right },
+      { width: content.offsetWidth, height: content.scrollHeight },
+    );
+
+    // Position the panel with viewport coords (`fixed`) so it escapes the root
+    // menu's own scroll-overflow clipping. placement.x already accounts for the
+    // parent shift, so the submenu lands beside the shifted parent.
+    setContentStyle({
+      position: 'fixed',
+      left: placement.x,
+      top: placement.y,
+      margin: 0,
+      maxHeight: placement.maxHeight,
+      overflowY: 'auto',
+    });
+    onShiftChange(label, placement.parentShift);
+  }, [isOpen, parentMenuRef, onShiftChange, items.length, label]);
+
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
@@ -78,7 +125,7 @@ function Submenu({ label, items, onClose }: SubmenuProps) {
         <span className="context-menu-arrow">▶</span>
       </div>
       {isOpen && (
-        <div className="context-menu-submenu-content">
+        <div ref={contentRef} className="context-menu-submenu-content" style={contentStyle}>
           {items.map((item, index) => (
             <button
               key={index}
@@ -104,6 +151,22 @@ function Submenu({ label, items, onClose }: SubmenuProps) {
 export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [adjustedPosition, setAdjustedPosition] = useState({ x, y });
+  // How far the menu slides left so the open submenu has room on the right.
+  // Owner-tracked so a delayed close from a previous submenu can't clobber the
+  // shift the newly-hovered submenu just set.
+  const [submenuShift, setSubmenuShift] = useState(0);
+  const shiftOwnerRef = useRef<string | null>(null);
+  const handleShiftChange = useCallback((id: string, px: number | null) => {
+    if (px === null) {
+      if (shiftOwnerRef.current === id) {
+        shiftOwnerRef.current = null;
+        setSubmenuShift(0);
+      }
+      return;
+    }
+    shiftOwnerRef.current = id;
+    setSubmenuShift(px);
+  }, []);
   const selectedIds = useSessionStore((state) => state.selectedIds);
   const shapes = useDocumentStore((state) => state.shapes);
   const updateShape = useDocumentStore((state) => state.updateShape);
@@ -185,39 +248,12 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
     });
   }, [shapes, selectedArray]);
 
-  // Adjust position to keep menu within viewport
+  // Adjust position to keep the menu within the viewport (single source of
+  // truth — shared with the prose menu + whiteboard via clampToViewport).
   useLayoutEffect(() => {
     if (!menuRef.current) return;
-
-    const menu = menuRef.current;
-    const rect = menu.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    const padding = 8;
-
-    let newX = x;
-    let newY = y;
-
-    // Check if menu overflows right edge
-    if (x + rect.width > viewportWidth - padding) {
-      newX = Math.max(padding, viewportWidth - rect.width - padding);
-    }
-
-    // Check if menu overflows bottom edge
-    if (y + rect.height > viewportHeight - padding) {
-      newY = Math.max(padding, viewportHeight - rect.height - padding);
-    }
-
-    // Check left edge
-    if (newX < padding) {
-      newX = padding;
-    }
-
-    // Check top edge
-    if (newY < padding) {
-      newY = padding;
-    }
-
+    const rect = menuRef.current.getBoundingClientRect();
+    const { x: newX, y: newY } = clampToViewport(x, y, rect.width, rect.height);
     if (newX !== adjustedPosition.x || newY !== adjustedPosition.y) {
       setAdjustedPosition({ x: newX, y: newY });
     }
@@ -453,7 +489,7 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
     <div
       ref={menuRef}
       className="context-menu"
-      style={{ left: adjustedPosition.x, top: adjustedPosition.y }}
+      style={{ left: adjustedPosition.x - submenuShift, top: adjustedPosition.y }}
       onClick={(e) => e.stopPropagation()}
     >
       {canGroup && (
@@ -472,7 +508,7 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
 
       {/* Add to Group submenu - show when groups exist and shapes are selected */}
       {hasSelection && availableGroups.length > 0 && (
-        <Submenu label="Add to Group" items={addToGroupItems} onClose={onClose} />
+        <Submenu label="Add to Group" items={addToGroupItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />
       )}
 
       {/* Remove from Group - show when selected shapes are in a group */}
@@ -492,7 +528,7 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
             <span className="context-menu-label">Select connected</span>
             <span className="context-menu-shortcut">Ctrl+Shift+A</span>
           </button>
-          {canGroup && <Submenu label="Auto-layout" items={autoLayoutItems} onClose={onClose} />}
+          {canGroup && <Submenu label="Auto-layout" items={autoLayoutItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />}
 
           <div className="context-menu-separator" />
 
@@ -507,11 +543,11 @@ export function ContextMenu({ x, y, onClose, onExport, onSaveToLibrary }: Contex
 
           {/* Connector Routing submenu */}
           {hasConnector && (
-            <Submenu label="Routing" items={routingItems} onClose={onClose} />
+            <Submenu label="Routing" items={routingItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />
           )}
 
           {/* Lock submenu */}
-          <Submenu label="Lock" items={lockItems} onClose={onClose} />
+          <Submenu label="Lock" items={lockItems} onClose={onClose} parentMenuRef={menuRef} onShiftChange={handleShiftChange} />
 
           <div className="context-menu-separator" />
 

--- a/src/ui/DocumentEditorContextMenu.css
+++ b/src/ui/DocumentEditorContextMenu.css
@@ -6,6 +6,10 @@
   position: fixed;
   z-index: 10000;
   min-width: 200px;
+  /* JP-421: fit the viewport and scroll rather than running off the bottom.
+     Submenus are portaled siblings, so this scroll container never clips them. */
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -92,7 +96,9 @@
   position: fixed;
   z-index: 10001;
   min-width: 200px;
-  max-width: 280px;
+  /* Cap at 280px but never wider than the viewport on narrow/mobile screens. */
+  max-width: min(280px, calc(100vw - 16px));
+  box-sizing: border-box;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -47,6 +47,10 @@ import {
   ArrowDownToLine,
   ArrowLeftToLine,
   ArrowRightToLine,
+  ArrowUp,
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
   Rows3,
   Columns3,
   TableCellsMerge,
@@ -629,6 +633,35 @@ export function DocumentEditorContextMenu({
           >
             <span className="doc-editor-context-menu-icon"><Icon icon={ArrowRightToLine} /></span>
             <span className="doc-editor-context-menu-label">Insert Column Right</span>
+          </div>
+          <div className="doc-editor-context-menu-divider" />
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveColumnLeft(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowLeft} /></span>
+            <span className="doc-editor-context-menu-label">Move Column Left</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveColumnRight(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowRight} /></span>
+            <span className="doc-editor-context-menu-label">Move Column Right</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveRowUp(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowUp} /></span>
+            <span className="doc-editor-context-menu-label">Move Row Up</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.moveRowDown(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={ArrowDown} /></span>
+            <span className="doc-editor-context-menu-label">Move Row Down</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
           <div

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -611,6 +611,28 @@ export function DocumentEditorContextMenu({
         >
           <div
             className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.selectRow(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={Rows3} /></span>
+            <span className="doc-editor-context-menu-label">Select Row</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.selectColumn(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={Columns3} /></span>
+            <span className="doc-editor-context-menu-label">Select Column</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.selectAllCells(editor); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={Table} /></span>
+            <span className="doc-editor-context-menu-label">Select All Cells</span>
+          </div>
+          <div className="doc-editor-context-menu-divider" />
+          <div
+            className="doc-editor-context-menu-item"
             onClick={() => { if (editor) cmd.addRowBefore(editor); onClose(); }}
           >
             <span className="doc-editor-context-menu-icon"><Icon icon={ArrowUpToLine} /></span>

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -55,6 +55,9 @@ import {
   Columns3,
   TableCellsMerge,
   TableCellsSplit,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
 } from 'lucide-react';
 import { useDocumentStore } from '../store/documentStore';
 import { isGroup, type GroupShape } from '../shapes/Shape';
@@ -707,6 +710,28 @@ export function DocumentEditorContextMenu({
           >
             <span className="doc-editor-context-menu-icon"><Icon icon={TableCellsSplit} /></span>
             <span className="doc-editor-context-menu-label">Split Cell</span>
+          </div>
+          <div className="doc-editor-context-menu-divider" />
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.setCellAlign(editor, 'left'); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={AlignLeft} /></span>
+            <span className="doc-editor-context-menu-label">Align Left</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.setCellAlign(editor, 'center'); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={AlignCenter} /></span>
+            <span className="doc-editor-context-menu-label">Align Center</span>
+          </div>
+          <div
+            className="doc-editor-context-menu-item"
+            onClick={() => { if (editor) cmd.setCellAlign(editor, 'right'); onClose(); }}
+          >
+            <span className="doc-editor-context-menu-icon"><Icon icon={AlignRight} /></span>
+            <span className="doc-editor-context-menu-label">Align Right</span>
           </div>
           <div className="doc-editor-context-menu-divider" />
           <div

--- a/src/ui/DocumentEditorContextMenu.tsx
+++ b/src/ui/DocumentEditorContextMenu.tsx
@@ -10,8 +10,9 @@
  * - Inserting embedded groups from the canvas
  */
 
-import { useEffect, useCallback, useState, useRef, useMemo } from 'react';
+import { useEffect, useCallback, useState, useRef, useMemo, useLayoutEffect, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
+import { clampToViewport, placeFlyout } from './contextMenuUtils';
 import type { Editor } from '@tiptap/core';
 import { NodeSelection } from '@tiptap/pm/state';
 import {
@@ -121,7 +122,12 @@ export function DocumentEditorContextMenu({
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [activeSubmenu, setActiveSubmenu] = useState<'format' | 'heading' | 'list' | 'table' | 'group' | null>(null);
-  const [submenuPosition, setSubmenuPosition] = useState({ x: 0, y: 0 });
+  // JP-421: self-aligning submenu placement (viewport coords + height cap), and
+  // how far the root menu slides left to make room for the open submenu.
+  const [submenuPlacement, setSubmenuPlacement] = useState({ x: 0, y: 0, maxHeight: 0 });
+  const [parentShift, setParentShift] = useState(0);
+  const submenuAnchorRef = useRef<DOMRect | null>(null);
+  const [rootPos, setRootPos] = useState({ x, y });
   const [searchQuery, setSearchQuery] = useState('');
 
   // Get groups from document store
@@ -214,10 +220,40 @@ export function DocumentEditorContextMenu({
     }
   }, [activeSubmenu]);
 
-  // Adjust position to stay within viewport
-  const adjustedPosition = {
-    x: Math.min(x, window.innerWidth - 220),
-    y: Math.min(y, window.innerHeight - 400),
+  // Clamp the root menu to the viewport using its measured size (shared helper).
+  useLayoutEffect(() => {
+    if (!menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const clamped = clampToViewport(x, y, rect.width, rect.height);
+    setRootPos((prev) => (prev.x === clamped.x && prev.y === clamped.y ? prev : clamped));
+  }, [x, y]);
+
+  // Position the submenu once it has mounted, so we can measure it and
+  // self-align against the viewport (flip / shift parent / clamp + scroll).
+  useLayoutEffect(() => {
+    if (!activeSubmenu) {
+      setParentShift(0);
+      return;
+    }
+    const submenu = submenuRef.current;
+    const root = menuRef.current;
+    const anchor = submenuAnchorRef.current;
+    if (!submenu || !root || !anchor) return;
+    const rootRect = root.getBoundingClientRect();
+    const placement = placeFlyout(
+      anchor,
+      { left: rootRect.left, right: rootRect.right },
+      { width: submenu.offsetWidth, height: submenu.scrollHeight },
+    );
+    setSubmenuPlacement({ x: placement.x, y: placement.y, maxHeight: placement.maxHeight });
+    setParentShift(placement.parentShift);
+  }, [activeSubmenu]);
+
+  const submenuStyle: CSSProperties = {
+    left: submenuPlacement.x,
+    top: submenuPlacement.y,
+    maxHeight: submenuPlacement.maxHeight || undefined,
+    overflowY: 'auto',
   };
 
   // Handle inserting an embedded group
@@ -263,7 +299,8 @@ export function DocumentEditorContextMenu({
     [editor, onClose]
   );
 
-  // Generic submenu hover handler
+  // Generic submenu hover handler. Capture the anchor rect; the actual position
+  // is computed in a layout effect once the submenu has mounted and measured.
   const handleSubmenuEnter = useCallback(
     (submenu: typeof activeSubmenu, e: React.MouseEvent<HTMLDivElement>) => {
       if (hoverTimeoutRef.current) {
@@ -271,11 +308,7 @@ export function DocumentEditorContextMenu({
         hoverTimeoutRef.current = null;
       }
 
-      const rect = e.currentTarget.getBoundingClientRect();
-      setSubmenuPosition({
-        x: rect.right + 4,
-        y: rect.top - 8,
-      });
+      submenuAnchorRef.current = e.currentTarget.getBoundingClientRect();
       setActiveSubmenu(submenu);
     },
     []
@@ -308,8 +341,8 @@ export function DocumentEditorContextMenu({
         ref={menuRef}
         className="doc-editor-context-menu"
         style={{
-          left: adjustedPosition.x,
-          top: adjustedPosition.y,
+          left: rootPos.x - parentShift,
+          top: rootPos.y,
         }}
       >
         {/* Image actions (when an image node is selected) */}
@@ -469,7 +502,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -542,7 +575,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -572,7 +605,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -605,7 +638,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >
@@ -749,7 +782,7 @@ export function DocumentEditorContextMenu({
         <div
           ref={submenuRef}
           className="doc-editor-context-submenu"
-          style={{ left: submenuPosition.x, top: submenuPosition.y }}
+          style={submenuStyle}
           onMouseEnter={handleSubmenuHover}
           onMouseLeave={handleSubmenuLeave}
         >

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -21,6 +21,7 @@ import { TiptapEditor } from './TiptapEditor';
 import { TiptapEditorProvider } from './TiptapEditorContext';
 import { RichTextTabBar } from './RichTextTabBar';
 import { useRichTextPagesStore, initializeRichTextPages } from '../store/richTextPagesStore';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
 import { useRichTextStore } from '../store/richTextStore';
 import { useSessionStore } from '../store/sessionStore';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
@@ -159,13 +160,22 @@ export function DocumentEditorPanel({
   // doc with prose reads non-empty here even offline.
   const fragHasContent =
     !!collabYdoc && !!proseField && collabYdoc.getXmlFragment(proseField).length > 0;
+  // A page created offline in this shared doc, awaiting relay handoff (JP-335).
+  // Its `prose:<id>` fragment is empty and never-synced, but editing it is safe:
+  // the page id is fresh, so the fragment exists nowhere else — no competing
+  // lineage to merge-double with (and the body-withhold keeps the relay's JSON
+  // seeder from ever minting one).
+  const activePagePending = usePendingSyncPages((s) =>
+    activePageId ? activePageId in s.pending : false,
+  );
   // Editable when the engine is live AND the fragment is established. NOT gated on
   // the live connection — prose stays editable offline (offline-first). The relay
   // is the sole seeder (JP-284), so `collabSynced` adds the first-online-open case
   // (relay confirmed its state → adopt + edit an empty fragment). A never-synced
-  // empty fragment stays read-only (ProsePreview) — there's nothing to adopt yet.
+  // empty fragment stays read-only (ProsePreview) — there's nothing to adopt yet —
+  // UNLESS it's a pending-sync page created offline (JP-335, above).
   const proseEditable =
-    engineReady && (fragHasContent || collabSynced);
+    engineReady && (fragHasContent || collabSynced || activePagePending);
   // Mount the live collab editor whenever the engine + fragment are ready. We do
   // NOT pre-screen the fragment's schema validity: y-prosemirror builds the doc
   // the same way the editor does, so any "fits-to-schema" build a screen could do

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -505,6 +505,9 @@ export function DocumentEditorToolbar() {
                 title="Table Options"
               >
                 <div className="table-styles-menu">
+                  <button onClick={() => { editor && cmd.selectRow(editor); setShowTableStyles(false); }}>Select Row</button>
+                  <button onClick={() => { editor && cmd.selectColumn(editor); setShowTableStyles(false); }}>Select Column</button>
+                  <button onClick={() => { editor && cmd.selectAllCells(editor); setShowTableStyles(false); }}>Select All Cells</button>
                   <button onClick={() => { editor && cmd.toggleHeaderRow(editor); setShowTableStyles(false); }}>Toggle Header Row</button>
                   <button onClick={() => { editor && cmd.toggleHeaderColumn(editor); setShowTableStyles(false); }}>Toggle Header Column</button>
                   <button onClick={() => { editor && cmd.mergeCells(editor); setShowTableStyles(false); }}>Merge Cells</button>

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -532,6 +532,20 @@ export function DocumentEditorToolbar() {
             </div>
 
 
+            {/* Cell alignment - disabled when not in table */}
+            <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.setCellAlign(editor, 'left')} title="Align left" aria-label="Align cell left" disabled={!isInTable}>
+                <AlignLeft {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.setCellAlign(editor, 'center')} title="Align center" aria-label="Align cell center" disabled={!isInTable}>
+                <AlignCenter {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.setCellAlign(editor, 'right')} title="Align right" aria-label="Align cell right" disabled={!isInTable}>
+                <AlignRight {...ICON} />
+              </button>
+            </div>
+
+
             {/* Delete table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
               <button className="document-editor-toolbar-btn danger" onClick={() => editor && isInTable && cmd.deleteTable(editor)} title="Delete Table" disabled={!isInTable} aria-label="Delete table">

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -15,6 +15,8 @@ import {
   Link, AlignLeft, AlignCenter, AlignRight, AlignJustify,
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
   BookMarked, Library, Info, Braces,
+  BetweenVerticalStart, BetweenVerticalEnd, BetweenHorizontalStart, BetweenHorizontalEnd,
+  ArrowLeft, ArrowRight, ArrowUp, ArrowDown,
 } from 'lucide-react';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
@@ -453,18 +455,40 @@ export function DocumentEditorToolbar() {
             </div>
 
 
-            {/* Structure - disabled when not in table */}
+            {/* Columns - disabled when not in table */}
             <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addColumnAfter(editor)} title="Add Column" disabled={!isInTable}>
-                <span className="toolbar-icon">+⇥</span>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addColumnBefore(editor)} title="Insert column left" aria-label="Insert column left" disabled={!isInTable}>
+                <BetweenVerticalStart {...ICON} />
               </button>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addRowAfter(editor)} title="Add Row" disabled={!isInTable}>
-                <span className="toolbar-icon">+↓</span>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addColumnAfter(editor)} title="Insert column right" aria-label="Insert column right" disabled={!isInTable}>
+                <BetweenVerticalEnd {...ICON} />
               </button>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteColumn(editor)} title="Delete Column" disabled={!isInTable}>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveColumnLeft(editor)} title="Move column left" aria-label="Move column left" disabled={!isInTable}>
+                <ArrowLeft {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveColumnRight(editor)} title="Move column right" aria-label="Move column right" disabled={!isInTable}>
+                <ArrowRight {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteColumn(editor)} title="Delete column" aria-label="Delete column" disabled={!isInTable}>
                 <span className="toolbar-icon">-⇥</span>
               </button>
-              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteRow(editor)} title="Delete Row" disabled={!isInTable}>
+            </div>
+
+            {/* Rows - disabled when not in table */}
+            <div className={`document-editor-toolbar-group ${!isInTable ? 'disabled-group' : ''}`}>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addRowBefore(editor)} title="Insert row above" aria-label="Insert row above" disabled={!isInTable}>
+                <BetweenHorizontalStart {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.addRowAfter(editor)} title="Insert row below" aria-label="Insert row below" disabled={!isInTable}>
+                <BetweenHorizontalEnd {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveRowUp(editor)} title="Move row up" aria-label="Move row up" disabled={!isInTable}>
+                <ArrowUp {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.moveRowDown(editor)} title="Move row down" aria-label="Move row down" disabled={!isInTable}>
+                <ArrowDown {...ICON} />
+              </button>
+              <button className="document-editor-toolbar-btn" onClick={() => editor && isInTable && cmd.deleteRow(editor)} title="Delete row" aria-label="Delete row" disabled={!isInTable}>
                 <span className="toolbar-icon">-↓</span>
               </button>
             </div>
@@ -485,6 +509,7 @@ export function DocumentEditorToolbar() {
                   <button onClick={() => { editor && cmd.toggleHeaderColumn(editor); setShowTableStyles(false); }}>Toggle Header Column</button>
                   <button onClick={() => { editor && cmd.mergeCells(editor); setShowTableStyles(false); }}>Merge Cells</button>
                   <button onClick={() => { editor && cmd.splitCell(editor); setShowTableStyles(false); }}>Split Cell</button>
+                  <button onClick={() => { editor && cmd.mergeOrSplit(editor); setShowTableStyles(false); }}>Merge / Split (toggle)</button>
                 </div>
               </ToolbarDropdown>
               <ToolbarDropdown

--- a/src/ui/InlinePageTabs.tsx
+++ b/src/ui/InlinePageTabs.tsx
@@ -12,8 +12,9 @@ import { PageTabStrip, type PageTabStripItem } from './components/PageTabStrip';
 import { usePageStore } from '../store/pageStore';
 import { useHistoryStore } from '../store/historyStore';
 import { clampToViewport } from './contextMenuUtils';
-import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
-import { useNotificationStore } from '../store/notificationStore';
+import { sharedDocOffline } from '../collaboration/sharedDocOffline';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
+import { usePersistenceStore } from '../store/persistenceStore';
 
 /**
  * Context menu state for page tabs.
@@ -62,19 +63,16 @@ export function InlinePageTabs() {
     [setActivePage, editingPageId]
   );
 
-  const sharedOffline = useSharedDocOffline();
-
-  // Blocked while a shared doc is offline (JP-334): the relay is active-page-only,
-  // so a new offline page's shapes never reach its flatten and are lost on
-  // reconnect. Enabling offline creation is JP-335.
+  // Allowed offline (JP-335): a canvas page created while the shared doc is
+  // offline is marked pending-sync — spared from the reconnect page-list prune
+  // and handed to the relay (meta + shapes) by the reconnect handoff
+  // (useCollaborationSync).
   const handleAddPage = useCallback(() => {
-    if (sharedDocOffline()) {
-      useNotificationStore
-        .getState()
-        .warning('This shared document is offline — reconnect to add pages.');
-      return;
-    }
     const newPageId = createPage();
+    if (sharedDocOffline()) {
+      const docId = usePersistenceStore.getState().currentDocumentId;
+      if (docId) usePendingSyncPages.getState().markPending(newPageId, docId);
+    }
     setActivePage(newPageId);
     useHistoryStore.getState().setActivePage(newPageId);
   }, [createPage, setActivePage]);
@@ -202,8 +200,6 @@ export function InlinePageTabs() {
           );
         }}
         onAdd={handleAddPage}
-        addDisabled={sharedOffline}
-        addTitle={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add page'}
       />
 
       {/* Context Menu */}

--- a/src/ui/ProsePreview.tsx
+++ b/src/ui/ProsePreview.tsx
@@ -15,6 +15,7 @@
 import { useEditor, EditorContent } from '@tiptap/react';
 import { extensions } from './TiptapEditor';
 import { useResolveBlobImages } from './useProseBlobImages';
+import { useProseLinkClicks } from './useProseLinkClicks';
 import './TiptapEditor.css';
 
 export interface ProsePreviewProps {
@@ -38,6 +39,12 @@ export function ProsePreview({ html, className }: ProsePreviewProps) {
   // shown for a relay doc while its collab engine comes up, and without this its
   // images render broken until the editable surface mounts (JP-363).
   useResolveBlobImages(editor);
+
+  // Make inline links live in the read-only preview too (JP-417): heading
+  // anchors resolve to page-switch + scroll, http(s)/mailto open in a new tab.
+  // Without this they were dead in the transient preview + error-boundary
+  // fallback.
+  useProseLinkClicks(editor, { headingAnchors: true });
 
   return (
     <div className={`tiptap-editor ${className ?? ''}`}>

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -16,8 +16,9 @@ import { Icon } from './icons';
 import { createPortal } from 'react-dom';
 import { PageTabStrip, type PageTabStripItem } from './components/PageTabStrip';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
-import { sharedDocOffline, useSharedDocOffline } from '../collaboration/offlinePageGuard';
-import { useNotificationStore } from '../store/notificationStore';
+import { sharedDocOffline } from '../collaboration/sharedDocOffline';
+import { usePendingSyncPages } from '../store/pendingSyncPages';
+import { usePersistenceStore } from '../store/persistenceStore';
 import './RichTextTabBar.css';
 
 interface RichTextTabBarProps {
@@ -150,19 +151,17 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
     });
   }, []);
 
-  const sharedOffline = useSharedDocOffline();
-
-  // Handle add new page. Blocked while a shared doc is offline (JP-334): a new
-  // prose page can't be seeded offline without risking dual-lineage duplication
-  // (the relay is the sole seeder, JP-284). Enabling offline creation is JP-335.
+  // Handle add new page. Allowed offline (JP-335): a page created while the
+  // shared doc is offline is marked pending-sync — editable immediately (its
+  // fresh id means its fragment can't collide with anything), spared from the
+  // reconnect page-list prune, and handed to the relay by the reconnect handoff
+  // (useCollaborationSync).
   const handleAddPage = useCallback(() => {
-    if (sharedDocOffline()) {
-      useNotificationStore
-        .getState()
-        .warning('This shared document is offline — reconnect to add pages.');
-      return;
-    }
     const newId = createPage();
+    if (sharedDocOffline()) {
+      const docId = usePersistenceStore.getState().currentDocumentId;
+      if (docId) usePendingSyncPages.getState().markPending(newId, docId);
+    }
     setActivePage(newId);
   }, [createPage, setActivePage]);
 
@@ -282,8 +281,6 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
           );
         }}
         onAdd={handleAddPage}
-        addDisabled={sharedOffline}
-        addTitle={sharedOffline ? 'Reconnect to add pages to a shared document' : 'Add new page'}
       />
 
       {/* Context menu */}

--- a/src/ui/StatusBar.connchip.test.tsx
+++ b/src/ui/StatusBar.connchip.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 
 let offline = false;
-vi.mock('../collaboration/offlinePageGuard', () => ({
+vi.mock('../collaboration/sharedDocOffline', () => ({
   useSharedDocOffline: () => offline,
 }));
 

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -12,7 +12,7 @@ import { WifiOff, RefreshCw } from 'lucide-react';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useConnectionStore } from '../store/connectionStore';
-import { useSharedDocOffline } from '../collaboration/offlinePageGuard';
+import { useSharedDocOffline } from '../collaboration/sharedDocOffline';
 import { calculateCombinedBounds } from '../shapes/utils/bounds';
 import { Icon } from './icons';
 import './StatusBar.css';

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -375,10 +375,14 @@
   pointer-events: none;
 }
 
-/* Single stroked marquee around the active CellSelection, positioned by
-   TableSelectionExtension inside `.tableWrapper`. */
-.tiptap-editor .ProseMirror .tableWrapper > .table-selection-marquee {
+/* Single stroked marquee around the active CellSelection. Lives in the editor
+   scroll container (`.tiptap-editor`), NOT inside the contenteditable — see
+   TableSelectionExtension — and is positioned via `transform: translate(...)`
+   from the top-left origin. */
+.tiptap-editor .table-selection-marquee {
   position: absolute;
+  top: 0;
+  left: 0;
   display: none;
   z-index: 11;
   pointer-events: none;

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -319,12 +319,30 @@
 /* ============================================
    Tables
    ============================================ */
+/* Tiptap wraps each table in `.tableWrapper`. It's the horizontal-scroll
+   container (JP-416 item 6: wide tables scroll instead of cramping) and the
+   positioning context for the selection marquee. `renderWrapper: true` makes it
+   exist in the read-only preview too. */
+.tiptap-editor .ProseMirror .tableWrapper {
+  position: relative;
+  overflow-x: auto;
+  max-width: 100%;
+  margin: 1rem 0;
+}
+
 .tiptap-editor .ProseMirror table {
   border-collapse: collapse;
-  width: 100%;
-  margin: 1rem 0;
+  /* Fill the column by default, but allow a wide (resized / many-column) table
+     to exceed it so the wrapper scrolls rather than crushing cells. */
+  min-width: 100%;
+  width: max-content;
   table-layout: fixed;
   overflow: hidden;
+}
+
+/* The wrapper owns the vertical margin now. */
+.tiptap-editor .ProseMirror .tableWrapper > table {
+  margin: 0;
 }
 
 .tiptap-editor .ProseMirror table th,
@@ -346,12 +364,27 @@
   background-color: var(--bg-primary);
 }
 
+/* Selected cells get a faint tint only; the crisp outline is the single
+   stroke-marquee overlay (TableSelectionExtension), not a heavy per-cell fill
+   (JP-416 item 1). */
 .tiptap-editor .ProseMirror table .selectedCell::after {
   content: '';
   position: absolute;
   inset: 0;
-  background-color: var(--color-primary-light);
+  background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
   pointer-events: none;
+}
+
+/* Single stroked marquee around the active CellSelection, positioned by
+   TableSelectionExtension inside `.tableWrapper`. */
+.tiptap-editor .ProseMirror .tableWrapper > .table-selection-marquee {
+  position: absolute;
+  display: none;
+  z-index: 11;
+  pointer-events: none;
+  border: 2px solid var(--color-primary);
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary) 25%, transparent);
 }
 
 /* Table resize handle */

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -332,10 +332,12 @@
 
 .tiptap-editor .ProseMirror table {
   border-collapse: collapse;
-  /* Fill the column by default, but allow a wide (resized / many-column) table
-     to exceed it so the wrapper scrolls rather than crushing cells. */
-  min-width: 100%;
-  width: max-content;
+  /* `width: 100%` + `table-layout: fixed` is the known-good geometry — columns
+     get real, equal widths so posAtCoords can tell laterally-adjacent cells
+     apart (a `max-content` width here collapsed columns and broke lateral
+     multi-cell selection). The `.tableWrapper`'s `overflow-x: auto` still lets a
+     resized-wider table scroll. Fuller anti-cramping is JP-416 item 6 follow-up. */
+  width: 100%;
   table-layout: fixed;
   overflow: hidden;
 }

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -364,19 +364,17 @@
   background-color: var(--bg-primary);
 }
 
-/* Selected cells get a faint tint only; the crisp outline is the single
-   stroke-marquee overlay (TableSelectionExtension), not a heavy per-cell fill
-   (JP-416 item 1). */
+/* No per-cell fill: the single stroke-marquee overlay is the only selection
+   indicator, so there's no doubled shading (per-cell tint + native text
+   highlight) layered on the selected block (JP-416 item 1). The empty rule keeps
+   the prosemirror `.selectedCell` hook documented and overridable. */
 .tiptap-editor .ProseMirror table .selectedCell::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
-  pointer-events: none;
+  content: none;
 }
 
-/* Single stroked marquee around the active CellSelection. Lives in the editor
-   scroll container (`.tiptap-editor`), NOT inside the contenteditable — see
+/* Single stroked marquee around the active CellSelection — a light wash + thin
+   stroke, not a heavy fill. Lives in the editor scroll container
+   (`.tiptap-editor`), NOT inside the contenteditable — see
    TableSelectionExtension — and is positioned via `transform: translate(...)`
    from the top-left origin. */
 .tiptap-editor .table-selection-marquee {
@@ -386,9 +384,9 @@
   display: none;
   z-index: 11;
   pointer-events: none;
-  border: 2px solid var(--color-primary);
+  border: 1.5px solid color-mix(in srgb, var(--color-primary) 70%, transparent);
   border-radius: 3px;
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary) 25%, transparent);
+  background-color: color-mix(in srgb, var(--color-primary) 8%, transparent);
 }
 
 /* Table resize handle */

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -330,13 +330,22 @@
   margin: 1rem 0;
 }
 
+/* Rounded tables are the DEFAULT (JP-416 item 4, opt-out). Rounded corners need
+   `border-collapse: separate` — the table draws the outer border + radius (with
+   `overflow: hidden` clipping the corners) and cells draw only right+bottom
+   borders, trimmed on the last column/row, so there's no doubled/outer border.
+   `[data-rounded-tables="false"]` below reverts to collapsed square tables.
+
+   `width: 100%` + `table-layout: fixed` is the known-good geometry — columns get
+   real, equal widths so posAtCoords can tell laterally-adjacent cells apart (a
+   `max-content` width collapsed columns and broke lateral multi-cell selection).
+   The `.tableWrapper`'s `overflow-x: auto` still lets a resized-wider table
+   scroll. Fuller anti-cramping is JP-416 item 6 follow-up. */
 .tiptap-editor .ProseMirror table {
-  border-collapse: collapse;
-  /* `width: 100%` + `table-layout: fixed` is the known-good geometry — columns
-     get real, equal widths so posAtCoords can tell laterally-adjacent cells
-     apart (a `max-content` width here collapsed columns and broke lateral
-     multi-cell selection). The `.tableWrapper`'s `overflow-x: auto` still lets a
-     resized-wider table scroll. Fuller anti-cramping is JP-416 item 6 follow-up. */
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
   width: 100%;
   table-layout: fixed;
   overflow: hidden;
@@ -349,11 +358,33 @@
 
 .tiptap-editor .ProseMirror table th,
 .tiptap-editor .ProseMirror table td {
-  border: 1px solid var(--border-color);
+  border-right: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
   padding: 0.5rem 0.75rem;
   vertical-align: top;
   min-width: 50px;
   position: relative;
+}
+
+/* Trim the cell borders that would double the table's outer border. */
+.tiptap-editor .ProseMirror table th:last-child,
+.tiptap-editor .ProseMirror table td:last-child {
+  border-right: none;
+}
+.tiptap-editor .ProseMirror table tr:last-child th,
+.tiptap-editor .ProseMirror table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Squared opt-out: collapsed borders, no radius, full per-cell borders. */
+:root[data-rounded-tables="false"] .tiptap-editor .ProseMirror table {
+  border-collapse: collapse;
+  border: none;
+  border-radius: 0;
+}
+:root[data-rounded-tables="false"] .tiptap-editor .ProseMirror table th,
+:root[data-rounded-tables="false"] .tiptap-editor .ProseMirror table td {
+  border: 1px solid var(--border-color);
 }
 
 .tiptap-editor .ProseMirror table th {

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -55,6 +55,7 @@ import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { CaretExtension } from '../tiptap/CaretExtension';
 import { TableSelection } from '../tiptap/TableSelectionExtension';
+import { TableKeymap } from '../tiptap/TableKeymap';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import { resolveBlobImagesIn } from './proseBlobImages';
 import { registerProseSchema } from '../collaboration/proseSchema';
@@ -122,6 +123,9 @@ export const sharedProseExtensions = [
       class: 'tiptap-table',
     },
   }),
+  // Word-like Tab navigation in tables (next/prev cell; Tab in the last cell
+  // appends a row). No nodes/marks, so the shared schema + collab are unaffected.
+  TableKeymap,
   TableRow,
   TableCell.extend({
     addAttributes() {

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -56,6 +56,7 @@ import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { CaretExtension } from '../tiptap/CaretExtension';
 import { TableSelection } from '../tiptap/TableSelectionExtension';
 import { TableKeymap } from '../tiptap/TableKeymap';
+import { TableCellSelect } from '../tiptap/TableCellSelect';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import { resolveBlobImagesIn } from './proseBlobImages';
 import { registerProseSchema } from '../collaboration/proseSchema';
@@ -126,6 +127,9 @@ export const sharedProseExtensions = [
   // Word-like Tab navigation in tables (next/prev cell; Tab in the last cell
   // appends a row). No nodes/marks, so the shared schema + collab are unaffected.
   TableKeymap,
+  // Cross-cell drag → CellSelection even when the drag starts inside cell text
+  // (position-based, immune to the pinned-target quirk). No nodes/marks.
+  TableCellSelect,
   TableRow,
   TableCell.extend({
     addAttributes() {

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -54,6 +54,7 @@ import { isProjectionTransaction } from '../tiptap/proseProjection';
 import { CodeBlockKeymap } from '../tiptap/CodeBlockKeymap';
 import { SpellcheckExtension } from '../tiptap/SpellcheckExtension';
 import { CaretExtension } from '../tiptap/CaretExtension';
+import { TableSelection } from '../tiptap/TableSelectionExtension';
 import { useProseEditorChrome } from './useProseEditorChrome';
 import { resolveBlobImagesIn } from './proseBlobImages';
 import { registerProseSchema } from '../collaboration/proseSchema';
@@ -109,6 +110,14 @@ export const sharedProseExtensions = [
   // Tables
   Table.configure({
     resizable: true,
+    // Narrow the column-resize hot-zone (default 5px each side of a boundary).
+    // That band hijacks a drag that should start a cell selection into a column
+    // resize — the root cause of "click in the middle / multi-cell selection
+    // near-impossible" (JP-416 item 1). Keep it grabbable, just precise.
+    handleWidth: 4,
+    // Render the `.tableWrapper` in non-editable mode too, so the read-only
+    // `ProsePreview` also gets the lateral-scroll container + marquee anchor.
+    renderWrapper: true,
     HTMLAttributes: {
       class: 'tiptap-table',
     },
@@ -200,6 +209,11 @@ export const sharedProseExtensions = [
   // Image gallery (grid/row) holding multiple images; inserted via multi-upload.
   Gallery,
   EmbeddedGroup,
+  // Stroke-marquee overlay for the active multi-cell (CellSelection) — a single
+  // crisp outline around the selected rectangle instead of the flat per-cell
+  // fill (JP-416 item 1). No nodes/marks, so the shared schema + collab are
+  // unaffected; inert outside a CellSelection.
+  TableSelection,
 ];
 
 /**

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -139,6 +139,21 @@ export const sharedProseExtensions = [
             };
           },
         },
+        // Per-column text alignment (JP-416). Stored on the cell, rendered as a
+        // `text-align` style (Tiptap merges it with backgroundColor's style), so
+        // it round-trips through getHTML.
+        align: {
+          default: null,
+          parseHTML: element => element.style.textAlign || null,
+          renderHTML: attributes => {
+            if (!attributes['align']) {
+              return {};
+            }
+            return {
+              style: `text-align: ${attributes['align']}`,
+            };
+          },
+        },
       };
     },
   }),
@@ -155,6 +170,21 @@ export const sharedProseExtensions = [
             }
             return {
               style: `background-color: ${attributes['backgroundColor']}`,
+            };
+          },
+        },
+        // Per-column text alignment (JP-416). Stored on the cell, rendered as a
+        // `text-align` style (Tiptap merges it with backgroundColor's style), so
+        // it round-trips through getHTML.
+        align: {
+          default: null,
+          parseHTML: element => element.style.textAlign || null,
+          renderHTML: attributes => {
+            if (!attributes['align']) {
+              return {};
+            }
+            return {
+              style: `text-align: ${attributes['align']}`,
             };
           },
         },

--- a/src/ui/TiptapEditor.tsx
+++ b/src/ui/TiptapEditor.tsx
@@ -192,6 +192,14 @@ export const sharedProseExtensions = [
             };
           },
         },
+        // Header cells expose a `scope` for screen readers + clean PDF/HTML
+        // export (JP-416). Defaults to `col` (the header-row case insertTable
+        // creates); round-trips via the attribute so it survives save/load.
+        scope: {
+          default: 'col',
+          parseHTML: element => element.getAttribute('scope') || 'col',
+          renderHTML: attributes => ({ scope: attributes['scope'] || 'col' }),
+        },
       };
     },
   }),

--- a/src/ui/appearance/appearance.test.ts
+++ b/src/ui/appearance/appearance.test.ts
@@ -75,6 +75,7 @@ describe('appearance snapshot seam (Abstraction B)', () => {
       density: 'spacious',
       uiScale: 1.15,
       proseBackground: 'glow',
+      roundedTables: true,
     });
   });
 
@@ -105,6 +106,7 @@ describe('appearance snapshot seam (Abstraction B)', () => {
       density: 'normal',
       uiScale: 1,
       proseBackground: 'default',
+      roundedTables: true,
     });
   });
 });

--- a/src/ui/appearance/appearanceConfig.ts
+++ b/src/ui/appearance/appearanceConfig.ts
@@ -22,6 +22,7 @@ export interface AppearanceConfig {
   density: Density;
   uiScale: number;
   proseBackground: ProseBackground;
+  roundedTables: boolean;
 }
 
 export const DEFAULT_APPEARANCE: AppearanceConfig = {
@@ -31,13 +32,22 @@ export const DEFAULT_APPEARANCE: AppearanceConfig = {
   density: 'normal',
   uiScale: 1,
   proseBackground: 'default',
+  roundedTables: true,
 };
 
 /** Capture the current appearance as a portable config object. */
 export function getAppearanceSnapshot(): AppearanceConfig {
-  const { themeInputs, motion, density, uiScale, proseBackground } =
+  const { themeInputs, motion, density, uiScale, proseBackground, roundedTables } =
     useUIPreferencesStore.getState().appearancePrefs;
-  return { theme: useThemeStore.getState().preference, themeInputs, motion, density, uiScale, proseBackground };
+  return {
+    theme: useThemeStore.getState().preference,
+    themeInputs,
+    motion,
+    density,
+    uiScale,
+    proseBackground,
+    roundedTables,
+  };
 }
 
 /** Apply a (partial) appearance config across both stores. */
@@ -52,6 +62,7 @@ export function applyAppearanceSnapshot(cfg: Partial<AppearanceConfig>): void {
   if (cfg.density !== undefined) ui.setDensity(cfg.density);
   if (cfg.uiScale !== undefined) ui.setUiScale(cfg.uiScale);
   if (cfg.proseBackground !== undefined) ui.setProseBackground(cfg.proseBackground);
+  if (cfg.roundedTables !== undefined) ui.setRoundedTables(cfg.roundedTables);
 }
 
 /**

--- a/src/ui/appearance/applyAppearance.ts
+++ b/src/ui/appearance/applyAppearance.ts
@@ -54,6 +54,9 @@ function applyNonColor(prefs: AppearancePrefs): void {
     } else {
       root.style.removeProperty('--prose-bg');
     }
+    // Rounded prose tables (opt-out). The table CSS keys off this attribute;
+    // only the "false" (squared) case needs an override (JP-416).
+    root.dataset['roundedTables'] = String(prefs.roundedTables);
   }
   setMotionPreference(prefs.motion);
 }

--- a/src/ui/contextMenuUtils.test.ts
+++ b/src/ui/contextMenuUtils.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { clampToViewport, placeFlyout } from './contextMenuUtils';
+
+describe('clampToViewport', () => {
+  it('keeps an in-bounds menu where it is', () => {
+    expect(clampToViewport(100, 100, 180, 200)).toEqual({ x: 100, y: 100 });
+  });
+
+  it('pulls a menu in from the right and bottom edges', () => {
+    // jsdom default viewport is 1024x768.
+    const { x, y } = clampToViewport(2000, 2000, 180, 200);
+    expect(x).toBe(1024 - 180 - 8);
+    expect(y).toBe(768 - 200 - 8);
+  });
+});
+
+describe('placeFlyout', () => {
+  const VW = 1000;
+  const VH = 800;
+  const vp = { viewportWidth: VW, viewportHeight: VH, padding: 8, gap: 4 };
+
+  // A parent menu sitting comfortably mid-screen.
+  const parent = { left: 200, right: 380 };
+  const anchor = { top: 250, bottom: 280, left: 200, right: 380 };
+
+  describe('horizontal (hybrid)', () => {
+    it('opens to the right when there is room', () => {
+      const p = placeFlyout(anchor, parent, { width: 160, height: 200 }, vp);
+      expect(p.side).toBe('right');
+      expect(p.parentShift).toBe(0);
+      expect(p.x).toBe(parent.right + 4); // 384
+    });
+
+    it('shifts the parent left when the right is tight but the parent can move', () => {
+      const tightParent = { left: 700, right: 880 };
+      const p = placeFlyout(
+        { ...anchor, left: 700, right: 880 },
+        tightParent,
+        { width: 160, height: 200 },
+        vp,
+      );
+      // rightX=884, +160=1044, limit=992 → overflow 52; parent can move 692.
+      expect(p.side).toBe('right');
+      expect(p.parentShift).toBe(52);
+      expect(p.x).toBe(884 - 52); // submenu rides the shifted parent
+    });
+
+    it('flips to the left when a wide submenu cannot fit right even after shifting', () => {
+      const rightParent = { left: 800, right: 1000 };
+      const p = placeFlyout(
+        { ...anchor, left: 800, right: 1000 },
+        rightParent,
+        { width: 782, height: 200 },
+        vp,
+      );
+      // rightX=1004, +782 overflows by 794; max parent shift is 792 → can't.
+      // leftX = 800 - 4 - 782 = 14 >= 8 → clean flip to the left.
+      expect(p.side).toBe('left');
+      expect(p.parentShift).toBe(0);
+      expect(p.x).toBe(14);
+    });
+
+    it('clamps into the viewport when neither side fits (very narrow)', () => {
+      const narrowVp = { viewportWidth: 360, viewportHeight: 640, padding: 8, gap: 4 };
+      const p = placeFlyout(
+        { top: 100, bottom: 130, left: 40, right: 320 },
+        { left: 40, right: 320 },
+        { width: 280, height: 200 },
+        narrowVp,
+      );
+      expect(p.x).toBeGreaterThanOrEqual(8);
+      expect(p.x + 280).toBeLessThanOrEqual(360); // never spills off either edge
+    });
+  });
+
+  describe('vertical (align + clamp + scroll)', () => {
+    it('aligns to the anchor top when it fits', () => {
+      const p = placeFlyout(anchor, parent, { width: 160, height: 200 }, vp);
+      expect(p.y).toBe(250);
+      expect(p.maxHeight).toBe(200);
+    });
+
+    it('shifts up so the bottom stays on-screen', () => {
+      const lowAnchor = { top: 700, bottom: 730, left: 200, right: 380 };
+      const p = placeFlyout(lowAnchor, parent, { width: 160, height: 300 }, vp);
+      expect(p.y).toBe(VH - 8 - 300); // 492 — pulled up so it fits
+      expect(p.maxHeight).toBe(300); // still no scroll
+    });
+
+    it('caps height and enables scroll when taller than the viewport', () => {
+      const p = placeFlyout(anchor, parent, { width: 160, height: 2000 }, vp);
+      expect(p.maxHeight).toBe(VH - 2 * 8); // 784
+      expect(p.y).toBe(8); // pinned to the top padding
+    });
+
+    it('never lets y go above the top padding', () => {
+      const highAnchor = { top: 2, bottom: 30, left: 200, right: 380 };
+      const p = placeFlyout(highAnchor, parent, { width: 160, height: 200 }, vp);
+      expect(p.y).toBe(8);
+    });
+  });
+});

--- a/src/ui/contextMenuUtils.ts
+++ b/src/ui/contextMenuUtils.ts
@@ -59,3 +59,117 @@ export const MENU_SIZE_ESTIMATES = {
   /** Large menu (7+ items) */
   large: { width: 200, height: 280 },
 } as const;
+
+/** Which side of the parent menu a submenu (flyout) opened on. */
+export type FlyoutSide = 'right' | 'left';
+
+export interface FlyoutPlacement {
+  /** Viewport x (left) for the submenu panel. */
+  x: number;
+  /** Viewport y (top) for the submenu panel. */
+  y: number;
+  /** Height cap for the panel — enables scroll when content is taller. */
+  maxHeight: number;
+  /** Which side the submenu opened on. */
+  side: FlyoutSide;
+  /** Pixels the parent menu must slide LEFT to free room on the right (>=0). */
+  parentShift: number;
+}
+
+export interface FlyoutOptions {
+  /** Padding kept from viewport edges (default 8). */
+  padding?: number;
+  /** Gap between the parent menu and the submenu (default 4). */
+  gap?: number;
+  /** Override viewport width (defaults to window.innerWidth). */
+  viewportWidth?: number;
+  /** Override viewport height (defaults to window.innerHeight). */
+  viewportHeight?: number;
+}
+
+interface AnchorRect {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+/**
+ * Place a submenu (flyout) next to its parent menu without overflowing the
+ * viewport. Pure + viewport-driven so it behaves correctly on narrow/mobile
+ * widths with no separate code path.
+ *
+ * Horizontal strategy is "hybrid":
+ *   1. Open to the right of the parent if it fits.
+ *   2. Otherwise slide the parent left (parentShift) to free room on the right,
+ *      as long as the parent stays on-screen.
+ *   3. Otherwise flip the submenu to the left of the parent.
+ *   4. Otherwise (neither side fits — very narrow) clamp into the viewport;
+ *      the caller also caps width in CSS so it can't exceed the viewport.
+ *
+ * Vertical strategy aligns the panel to the anchor item, clamps it inside the
+ * viewport, and caps its height (scroll) when it is taller than the viewport.
+ *
+ * @param anchor  Rect of the hovered parent item (viewport coords).
+ * @param parent  Left/right edges of the parent menu (viewport coords).
+ * @param submenu Measured width/height of the submenu panel.
+ */
+export function placeFlyout(
+  anchor: AnchorRect,
+  parent: { left: number; right: number },
+  submenu: { width: number; height: number },
+  opts: FlyoutOptions = {},
+): FlyoutPlacement {
+  const padding = opts.padding ?? 8;
+  const gap = opts.gap ?? 4;
+  const vw = opts.viewportWidth ?? window.innerWidth;
+  const vh = opts.viewportHeight ?? window.innerHeight;
+
+  const { width, height } = submenu;
+  const rightLimit = vw - padding;
+
+  // --- Horizontal (hybrid) ---
+  let side: FlyoutSide;
+  let x: number;
+  let parentShift = 0;
+
+  const rightX = parent.right + gap;
+  if (rightX + width <= rightLimit) {
+    // 1. Fits to the right as-is.
+    side = 'right';
+    x = rightX;
+  } else {
+    const overflow = rightX + width - rightLimit;
+    const maxShift = parent.left - padding; // how far parent can slide left
+    if (overflow <= maxShift) {
+      // 2. Slide the parent left to free room on the right.
+      side = 'right';
+      parentShift = overflow;
+      x = rightX - parentShift;
+    } else {
+      const leftX = parent.left - gap - width;
+      if (leftX >= padding) {
+        // 3. Flip to the left.
+        side = 'left';
+        x = leftX;
+      } else {
+        // 4. Neither side fits — pick the roomier side and clamp.
+        const roomRight = vw - parent.right;
+        const roomLeft = parent.left;
+        side = roomRight >= roomLeft ? 'right' : 'left';
+        const lowerBound = padding;
+        const upperBound = Math.max(padding, rightLimit - width);
+        const desired = side === 'right' ? rightX : leftX;
+        x = Math.min(Math.max(desired, lowerBound), upperBound);
+      }
+    }
+  }
+
+  // --- Vertical (align + clamp + scroll) ---
+  const cap = vh - 2 * padding;
+  const maxHeight = Math.min(height, cap);
+  const yUpper = Math.max(padding, vh - padding - maxHeight);
+  const y = Math.min(Math.max(anchor.top, padding), yUpper);
+
+  return { x, y, maxHeight, side, parentShift };
+}

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -85,6 +85,10 @@ export const moveRowUp = (editor: Editor) => moveRowUpCmd(editor);
 export const moveRowDown = (editor: Editor) => moveRowDownCmd(editor);
 export const setCellBackground = (editor: Editor, color: string | null) =>
   editor.chain().focus().setCellAttribute('backgroundColor', color).run();
+// Text alignment for the selected cells (JP-416). With a column selected this
+// aligns the whole column; `null` clears back to the default (left).
+export const setCellAlign = (editor: Editor, align: 'left' | 'center' | 'right' | null) =>
+  editor.chain().focus().setCellAttribute('align', align).run();
 
 // Math
 export const setMathInline = (editor: Editor, latex: string) =>

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -17,6 +17,11 @@ import {
   moveRowUp as moveRowUpCmd,
   moveRowDown as moveRowDownCmd,
 } from '../tiptap/tableStructureCommands';
+import {
+  selectRow as selectRowCmd,
+  selectColumn as selectColumnCmd,
+  selectAllCells as selectAllCellsCmd,
+} from '../tiptap/tableSelectCommands';
 
 // Text formatting
 export const toggleBold = (editor: Editor) => editor.chain().focus().toggleBold().run();
@@ -83,6 +88,10 @@ export const moveColumnLeft = (editor: Editor) => moveColumnLeftCmd(editor);
 export const moveColumnRight = (editor: Editor) => moveColumnRightCmd(editor);
 export const moveRowUp = (editor: Editor) => moveRowUpCmd(editor);
 export const moveRowDown = (editor: Editor) => moveRowDownCmd(editor);
+// Select the current row(s) / column(s) / whole table as a CellSelection (JP-416).
+export const selectRow = (editor: Editor) => selectRowCmd(editor);
+export const selectColumn = (editor: Editor) => selectColumnCmd(editor);
+export const selectAllCells = (editor: Editor) => selectAllCellsCmd(editor);
 export const setCellBackground = (editor: Editor, color: string | null) =>
   editor.chain().focus().setCellAttribute('backgroundColor', color).run();
 // Text alignment for the selected cells (JP-416). With a column selected this

--- a/src/ui/editorCommands.ts
+++ b/src/ui/editorCommands.ts
@@ -7,6 +7,16 @@
 
 import type { Editor } from '@tiptap/core';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
+import {
+  addColumnAfterKeepHeader,
+  addColumnBeforeKeepHeader,
+  addRowAfterKeepHeader,
+  addRowBeforeKeepHeader,
+  moveColumnLeft as moveColumnLeftCmd,
+  moveColumnRight as moveColumnRightCmd,
+  moveRowUp as moveRowUpCmd,
+  moveRowDown as moveRowDownCmd,
+} from '../tiptap/tableStructureCommands';
 
 // Text formatting
 export const toggleBold = (editor: Editor) => editor.chain().focus().toggleBold().run();
@@ -52,10 +62,13 @@ export const unsetHighlight = (editor: Editor) =>
 // Tables
 export const insertTable = (editor: Editor) =>
   editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
-export const addColumnAfter = (editor: Editor) => editor.chain().focus().addColumnAfter().run();
-export const addColumnBefore = (editor: Editor) => editor.chain().focus().addColumnBefore().run();
-export const addRowAfter = (editor: Editor) => editor.chain().focus().addRowAfter().run();
-export const addRowBefore = (editor: Editor) => editor.chain().focus().addRowBefore().run();
+// Insert commands keep the table-header style on the new row/column (JP-416):
+// a fresh cell in the header row/column is promoted back to `tableHeader` so it
+// no longer needs a manual re-toggle.
+export const addColumnAfter = (editor: Editor) => addColumnAfterKeepHeader(editor);
+export const addColumnBefore = (editor: Editor) => addColumnBeforeKeepHeader(editor);
+export const addRowAfter = (editor: Editor) => addRowAfterKeepHeader(editor);
+export const addRowBefore = (editor: Editor) => addRowBeforeKeepHeader(editor);
 export const deleteColumn = (editor: Editor) => editor.chain().focus().deleteColumn().run();
 export const deleteRow = (editor: Editor) => editor.chain().focus().deleteRow().run();
 export const deleteTable = (editor: Editor) => editor.chain().focus().deleteTable().run();
@@ -63,6 +76,13 @@ export const toggleHeaderRow = (editor: Editor) => editor.chain().focus().toggle
 export const toggleHeaderColumn = (editor: Editor) => editor.chain().focus().toggleHeaderColumn().run();
 export const mergeCells = (editor: Editor) => editor.chain().focus().mergeCells().run();
 export const splitCell = (editor: Editor) => editor.chain().focus().splitCell().run();
+export const mergeOrSplit = (editor: Editor) => editor.chain().focus().mergeOrSplit().run();
+// Move the column/row containing the selection one step (JP-416). No-op at the
+// table edge or when the table has merged cells.
+export const moveColumnLeft = (editor: Editor) => moveColumnLeftCmd(editor);
+export const moveColumnRight = (editor: Editor) => moveColumnRightCmd(editor);
+export const moveRowUp = (editor: Editor) => moveRowUpCmd(editor);
+export const moveRowDown = (editor: Editor) => moveRowDownCmd(editor);
 export const setCellBackground = (editor: Editor, color: string | null) =>
   editor.chain().focus().setCellAttribute('backgroundColor', color).run();
 

--- a/src/ui/layout/FlyoutPanel.test.tsx
+++ b/src/ui/layout/FlyoutPanel.test.tsx
@@ -80,3 +80,29 @@ describe('FlyoutPanel — Relaxed railless overlay (JP-410)', () => {
     expect(container.querySelector('.flyout-panel-body')).toBeNull();
   });
 });
+
+describe('FlyoutPanel — focus-out behavior (JP-410)', () => {
+  it('railless overlay does not auto-collapse when focus leaves (edit then blur stays open)', () => {
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: false });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.blur(body, { relatedTarget: document.body });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).not.toBeNull();
+  });
+
+  it('rail fly-out collapses when focus leaves entirely (Designer/Technician unchanged)', () => {
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: true });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.blur(body, { relatedTarget: document.body });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).toBeNull();
+  });
+});

--- a/src/ui/layout/FlyoutPanel.test.tsx
+++ b/src/ui/layout/FlyoutPanel.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { FlyoutPanel } from './FlyoutPanel';
+import { useSessionStore } from '../../store/sessionStore';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+
+// Mirrors AUTO_COLLAPSE_DELAY_MS in FlyoutPanel.tsx.
+const AUTO_COLLAPSE_DELAY_MS = 500;
+
+function renderPanel(props: { showRail?: boolean } = {}) {
+  return render(
+    <FlyoutPanel
+      panelId="properties"
+      label="Properties"
+      icon={<span>P</span>}
+      expandOnSelection
+      side="right"
+      {...props}
+    >
+      <div data-testid="panel-body-content">body</div>
+    </FlyoutPanel>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useUIPreferencesStore.getState().reset();
+  useSessionStore.getState().clearSelection();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('FlyoutPanel — Relaxed railless overlay (JP-410)', () => {
+  it('railless overlay (showRail=false) hides the pin button', () => {
+    // Relaxed Properties is a selection-driven overlay with no docked target, so
+    // pinning was meaningless there — it only made Properties stick visible or
+    // dismissed the panel. The pin control is hidden in that mode.
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: false });
+    // expandOnSelection opened it on mount, so the body is present...
+    expect(container.querySelector('.flyout-panel-body')).not.toBeNull();
+    // ...but the pin button is not.
+    expect(screen.queryByRole('button', { name: /pin properties open/i })).toBeNull();
+  });
+
+  it('rail fly-out (showRail=true) still shows the pin button', () => {
+    useSessionStore.getState().select(['s1']);
+    renderPanel({ showRail: true });
+    expect(screen.queryByRole('button', { name: /pin properties open/i })).not.toBeNull();
+  });
+
+  it('railless overlay does not auto-collapse on mouse-leave (selection owns visibility)', () => {
+    // The focus/hover auto-collapse must not fight the selection-driven overlay,
+    // or editing one property (focus/pointer leaving the body) closes the panel
+    // before the next edit. The mouse-leave path shares the same showRail guard
+    // as the focus-out path.
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: false });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.mouseLeave(body, { buttons: 0 });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).not.toBeNull();
+  });
+
+  it('rail fly-out still auto-collapses on mouse-leave (Designer/Technician unchanged)', () => {
+    useSessionStore.getState().select(['s1']);
+    const { container } = renderPanel({ showRail: true });
+    const body = container.querySelector('.flyout-panel-body')!;
+    vi.useFakeTimers();
+    fireEvent.mouseLeave(body, { buttons: 0 });
+    act(() => {
+      vi.advanceTimersByTime(AUTO_COLLAPSE_DELAY_MS + 100);
+    });
+    expect(container.querySelector('.flyout-panel-body')).toBeNull();
+  });
+});

--- a/src/ui/layout/FlyoutPanel.tsx
+++ b/src/ui/layout/FlyoutPanel.tsx
@@ -184,6 +184,12 @@ export function FlyoutPanel({
 
   const handleFocusOut = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
+      // A railless overlay (Relaxed's selection-driven Properties) is owned by
+      // the selection, not by focus: the parent mounts it while a shape is
+      // selected and unmounts on deselect. Focus leaving it — committing an
+      // edit, closing a picker — must NOT auto-collapse it, or the next edit
+      // finds the panel gone.
+      if (!showRail) return;
       // Only schedule collapse if focus left the panel entirely (relatedTarget
       // is null or outside our subtree).
       const next = e.relatedTarget as Node | null;
@@ -193,7 +199,7 @@ export function FlyoutPanel({
       if (next instanceof Element && next.closest('[data-flyout-keep-open]')) return;
       scheduleCollapse();
     },
-    [scheduleCollapse]
+    [scheduleCollapse, showRail]
   );
 
   // Cleanup pending timer on unmount.
@@ -245,26 +251,31 @@ export function FlyoutPanel({
           onBlur={handleFocusOut}
           onMouseEnter={handleFocusIn}
           onMouseLeave={(e) => {
-            // Don't start the auto-collapse timer while the user is dragging —
-            // a resize handle pull can briefly leave the body's bounds while
-            // a mouse button is still held. Without this check, the panel
-            // collapses mid-drag and the user has to pin it before resizing.
-            if (e.buttons === 0) scheduleCollapse();
+            // Don't auto-collapse a railless selection overlay (Relaxed) on
+            // mouse-leave — the selection owns its visibility. And don't start
+            // the timer mid-drag: a resize-handle pull can briefly leave the
+            // body's bounds while a button is still held (buttons !== 0).
+            if (e.buttons === 0 && showRail) scheduleCollapse();
           }}
         >
           <div className="flyout-panel-header">
             <span className="flyout-panel-header-title">{label}</span>
-            <button
-              type="button"
-              className="flyout-panel-pin"
-              onClick={handlePin}
-              aria-label={`Pin ${label} open`}
-              title={`Pin ${label} open`}
-            >
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
-              </svg>
-            </button>
+            {/* Pin promotes a fly-out to docked. Hidden on the railless Relaxed
+                overlay, which has no docked target — pinning there only made
+                Properties stick visible (or dismissed it on click). */}
+            {showRail && (
+              <button
+                type="button"
+                className="flyout-panel-pin"
+                onClick={handlePin}
+                aria-label={`Pin ${label} open`}
+                title={`Pin ${label} open`}
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z" />
+                </svg>
+              </button>
+            )}
           </div>
           <div className="flyout-panel-content">{children}</div>
         </div>

--- a/src/ui/layout/modes.test.ts
+++ b/src/ui/layout/modes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { LAYOUT_PRESETS, primaryRegion, resolveRegions } from './modes';
+import { LAYOUT_PRESETS, primaryRegion, propertiesDockedVisible, resolveRegions } from './modes';
 import { LAYOUT_MODES } from './types';
+import type { PanelState } from './types';
 
 describe('primaryRegion', () => {
   it('makes Relaxed document-primary (writing-first) and everything else canvas-primary', () => {
@@ -41,5 +42,19 @@ describe('Relaxed preset (writing-first)', () => {
     expect(LAYOUT_PRESETS.relaxed.document.width).toBeUndefined();
     expect(LAYOUT_PRESETS.relaxed.layers.visible).toBe(false);
     expect(LAYOUT_PRESETS.relaxed.properties.visible).toBe(false);
+  });
+});
+
+describe('propertiesDockedVisible (JP-410)', () => {
+  it('Relaxed never docks Properties — even with a stale pinned+visible override', () => {
+    const stalePinned: PanelState = { dock: 'right', visible: true, order: 0, width: 240, pinned: true };
+    expect(propertiesDockedVisible('relaxed', stalePinned)).toBe(false);
+    expect(propertiesDockedVisible('relaxed', { dock: 'right', visible: false, order: 0 })).toBe(false);
+  });
+
+  it('non-Relaxed modes honor state.visible', () => {
+    expect(propertiesDockedVisible('designer', { dock: 'right', visible: true, order: 0 })).toBe(true);
+    expect(propertiesDockedVisible('technician', { dock: 'right', visible: false, order: 0 })).toBe(false);
+    expect(propertiesDockedVisible('power', { dock: 'right', visible: true, order: 0, pinned: true })).toBe(true);
   });
 });

--- a/src/ui/layout/modes.ts
+++ b/src/ui/layout/modes.ts
@@ -23,6 +23,18 @@ export function isFlyoutLayout(mode: LayoutMode): boolean {
 }
 
 /**
+ * Whether Properties renders as a persistent *docked* panel for this mode+state.
+ * In Relaxed it NEVER does — Properties is a selection-only overlay there, so a
+ * stale `visible`/`pinned` override (e.g. left behind from before it became
+ * un-pinnable in Relaxed) must not dock it over the prose, including in `write`
+ * focus. Every other mode honors `state.visible`.
+ */
+export function propertiesDockedVisible(mode: LayoutMode, state: PanelState): boolean {
+  if (mode === 'relaxed') return false;
+  return state.visible;
+}
+
+/**
  * Hard-coded panel arrangement for each layout. `pinned` is set on Power so
  * panels render docked even though Power happens not to use the fly-out model
  * — keeping the flag truthful makes downstream logic uniform.

--- a/src/ui/settings/AppearanceSettings.test.tsx
+++ b/src/ui/settings/AppearanceSettings.test.tsx
@@ -16,6 +16,8 @@ describe('AppearanceSettings', () => {
     // Prose background presets render.
     expect(screen.getByText('Prose background')).toBeTruthy();
     expect(screen.getByText('Glow')).toBeTruthy();
+    // Rounded-tables opt-out (JP-416).
+    expect(screen.getByText('Rounded tables')).toBeTruthy();
   });
 
   // JP-107 regression: the DocuShark title-bar control is desktop-only. In the

--- a/src/ui/settings/AppearanceSettings.tsx
+++ b/src/ui/settings/AppearanceSettings.tsx
@@ -103,6 +103,8 @@ export function AppearanceSettings() {
   const setCaretColor = useUIPreferencesStore((s) => s.setCaretColor);
   const spellcheck = useUIPreferencesStore((s) => s.appearancePrefs.spellcheck);
   const setSpellcheckMode = useUIPreferencesStore((s) => s.setSpellcheckMode);
+  const roundedTables = useUIPreferencesStore((s) => s.appearancePrefs.roundedTables);
+  const setRoundedTables = useUIPreferencesStore((s) => s.setRoundedTables);
   const gridOpacity = useSettingsStore((s) => s.gridOpacity);
   const setGridOpacity = useSettingsStore((s) => s.setGridOpacity);
 
@@ -287,6 +289,23 @@ export function AppearanceSettings() {
             <strong>Custom</strong> uses DocuShark's dictionary and “Add to dictionary”.
             <strong> System</strong> uses your browser/OS spellchecker.
             <strong> Off</strong> disables spellchecking. Only one runs at a time.
+          </span>
+        </div>
+      </div>
+
+      {/* Tables */}
+      <div className="settings-group">
+        <h4 className="settings-group-title">Tables</h4>
+        <div className="settings-row">
+          <span className="settings-label">Rounded tables</span>
+          <Switch
+            ariaLabel="Rounded tables"
+            checked={roundedTables}
+            onCheckedChange={setRoundedTables}
+          />
+          <span className="settings-hint">
+            Round the corners of tables in the writing editor. Turn off for square,
+            grid-style tables.
           </span>
         </div>
       </div>

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -20,7 +20,12 @@ import {
   saveDocumentToStorage,
 } from '../../store/persistenceStore';
 import { useConnectionStore, useIsRelayAuthenticated } from '../../store/connectionStore';
-import { useRelayDocumentStore, useIsCloudSignedIn, isCloudSignedIn } from '../../store/relayDocumentStore';
+import {
+  useRelayDocumentStore,
+  useIsCloudSignedIn,
+  isCloudSignedIn,
+  RelayDocumentUnavailableOfflineError,
+} from '../../store/relayDocumentStore';
 import { ensureCollabSessionForDoc } from '../../collaboration/ensureCollabSession';
 import {
   computeOfflineStatus,
@@ -471,6 +476,17 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
           usePersistenceStore.getState().loadRemoteDocument(doc);
         } catch (error) {
           console.error('Failed to load relay document:', error);
+          const { useNotificationStore } = await import('../../store/notificationStore');
+          const offline =
+            error instanceof RelayDocumentUnavailableOfflineError ||
+            (typeof navigator !== 'undefined' && navigator.onLine === false);
+          useNotificationStore
+            .getState()
+            .warning(
+              offline
+                ? 'This document isn’t available offline. Open it while connected, or use “Make available offline” first, then reopen.'
+                : 'Couldn’t open this document. Check your connection and try again.',
+            );
         }
       } else {
         loadDocument(docId);

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -523,6 +523,10 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       } else {
         permanentlyDeleteDocument(docId);
       }
+      // The doc is gone from the active set — drop its collection enrollment so
+      // the collection stops counting it as a member (JP-418). Network-free;
+      // the relay copy is already deleted above.
+      useCollectionStore.getState().assignDocument(docId, null);
     },
     [entries, deleteFromHost, permanentlyDeleteDocument]
   );

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -17,6 +17,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { Editor } from '@tiptap/core';
+import { CellSelection } from '@tiptap/pm/tables';
 import { useRichTextStore } from '../store/richTextStore';
 import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { rebuildSpellcheck } from '../tiptap/SpellcheckExtension';
@@ -170,6 +171,25 @@ export function useProseEditorChrome(
     dom.addEventListener('click', onClick);
     return () => dom.removeEventListener('click', onClick);
   }, [editor, headingAnchors]);
+
+  // Right-click must not collapse a multi-cell selection (JP-416 item 3). The
+  // right-button `mousedown` reaches ProseMirror's table handler, which moves the
+  // selection to the clicked cell *before* `onContextMenu` fires — so the menu's
+  // Merge/background/move actions would act on one cell instead of the selected
+  // block. When the current selection is a CellSelection, swallow the right-button
+  // mousedown so PM leaves it intact; the contextmenu event still fires.
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+    const onMouseDown = (event: MouseEvent) => {
+      if (event.button !== 2) return;
+      if (editor.state.selection instanceof CellSelection) {
+        event.preventDefault();
+      }
+    };
+    dom.addEventListener('mousedown', onMouseDown);
+    return () => dom.removeEventListener('mousedown', onMouseDown);
+  }, [editor]);
 
   // Resolve blob:// images to object URLs (initial + on every update) —
   // collaborators on other devices embed images we must load. Shared with the

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -24,6 +24,7 @@ import { SpellcheckService } from '../services/SpellcheckService';
 import { SpellcheckPopover } from './SpellcheckPopover';
 import { DocumentEditorContextMenu } from './DocumentEditorContextMenu';
 import { useResolveBlobImages } from './useProseBlobImages';
+import { useProseLinkClicks } from './useProseLinkClicks';
 
 interface ContextMenuState {
   isOpen: boolean;
@@ -121,55 +122,10 @@ export function useProseEditorChrome(
     rebuildSpellcheck(editor.view);
   }, [editor, spellcheckMode]);
 
-  // DOM-level click handler so inline link clicks reliably fire (handleClickOn
-  // doesn't trigger consistently for inline marks in all browsers). Opens
-  // http(s)/mailto in a new tab; with `headingAnchors`, also resolves
-  // `docushark://heading` cross-page nav.
-  useEffect(() => {
-    if (!editor) return;
-    const dom = editor.view.dom;
-    const onClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
-      if (!anchor || !dom.contains(anchor)) return;
-      const href = anchor.getAttribute('href') || '';
-
-      if (headingAnchors) {
-        const headingMatch = href.match(/^docushark:\/\/heading\/([^/]+)\/(\d+)$/);
-        if (headingMatch) {
-          event.preventDefault();
-          event.stopPropagation();
-          const pageId = headingMatch[1]!;
-          const headingIndex = parseInt(headingMatch[2]!, 10);
-          import('../store/richTextPagesStore').then(({ useRichTextPagesStore }) => {
-            const store = useRichTextPagesStore.getState();
-            if (store.activePageId !== pageId) store.setActivePage(pageId);
-            const scrollToHeading = (attempts = 0) => {
-              const headings = document.querySelectorAll(
-                '.tiptap-prose h1, .tiptap-prose h2, .tiptap-prose h3, .tiptap-prose h4, .tiptap-prose h5, .tiptap-prose h6',
-              );
-              const el = headings[headingIndex] as HTMLElement | undefined;
-              if (el) {
-                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-              } else if (attempts < 30) {
-                requestAnimationFrame(() => scrollToHeading(attempts + 1));
-              }
-            };
-            requestAnimationFrame(() => scrollToHeading());
-          });
-          return;
-        }
-      }
-
-      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
-        event.preventDefault();
-        event.stopPropagation();
-        window.open(href, '_blank', 'noopener,noreferrer');
-      }
-    };
-    dom.addEventListener('click', onClick);
-    return () => dom.removeEventListener('click', onClick);
-  }, [editor, headingAnchors]);
+  // Inline link click handling (open http(s)/mailto; resolve heading anchors
+  // when `headingAnchors`). Shared with `ProsePreview` so every prose surface
+  // behaves identically — see the hook.
+  useProseLinkClicks(editor, { headingAnchors });
 
   // Resolve blob:// images to object URLs (initial + on every update) —
   // collaborators on other devices embed images we must load. Shared with the

--- a/src/ui/useProseLinkClicks.test.tsx
+++ b/src/ui/useProseLinkClicks.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * useProseLinkClicks — inline link click handling shared by every prose surface.
+ *
+ * This is the automated repro for JP-417 ("Heading Links are Noops"): clicking a
+ * `docushark://heading/<pageId>/<index>` anchor must switch the active prose page
+ * via richTextPagesStore. Before the fix the handler was wired only into the
+ * local editor, so the same click was a noop in the collab editor and the
+ * read-only ProsePreview. We exercise it through ProsePreview (which now calls
+ * the hook with `headingAnchors: true`).
+ *
+ * jsdom doesn't implement Element.scrollIntoView; we stub it so the post-switch
+ * scroll (fired in a rAF) doesn't throw. The page-switch call is the assertion —
+ * it happens before the scroll.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { registerBlobDownloader, resetBlobCache } from '../storage/blobResolver';
+import { ProsePreview } from './ProsePreview';
+
+const { setActivePageMock } = vi.hoisted(() => ({ setActivePageMock: vi.fn() }));
+
+// The hook dynamically imports the page store; mock it with a stable spy.
+vi.mock('../store/richTextPagesStore', () => ({
+  useRichTextPagesStore: Object.assign(() => ({}), {
+    getState: () => ({ activePageId: 'other-page', setActivePage: setActivePageMock }),
+  }),
+}));
+
+describe('useProseLinkClicks heading-anchor nav (JP-417)', () => {
+  beforeEach(() => {
+    setActivePageMock.mockClear();
+    Element.prototype.scrollIntoView = vi.fn();
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  afterEach(() => {
+    registerBlobDownloader(null);
+    resetBlobCache();
+  });
+
+  it('switches the active page when a docushark://heading link is clicked', async () => {
+    const { container } = render(
+      <ProsePreview html={'<p><a href="docushark://heading/target-page/0">jump</a></p><h1>Target</h1>'} />,
+    );
+
+    const anchor = await waitFor(() => {
+      const a = container.querySelector('a[href^="docushark://heading/"]');
+      expect(a).not.toBeNull();
+      return a as HTMLAnchorElement;
+    });
+
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(setActivePageMock).toHaveBeenCalledWith('target-page');
+    });
+  });
+
+  it('does not switch pages for an external https link', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { container } = render(
+      <ProsePreview html={'<p><a href="https://example.com">out</a></p>'} />,
+    );
+
+    const anchor = await waitFor(() => {
+      const a = container.querySelector('a[href^="https://"]');
+      expect(a).not.toBeNull();
+      return a as HTMLAnchorElement;
+    });
+
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+    });
+    expect(setActivePageMock).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/src/ui/useProseLinkClicks.ts
+++ b/src/ui/useProseLinkClicks.ts
@@ -1,0 +1,84 @@
+/**
+ * useProseLinkClicks — DOM-level click handling for inline links in a Tiptap
+ * prose surface.
+ *
+ * A DOM `click` listener (rather than ProseMirror's `handleClickOn`) is used
+ * because `handleClickOn` doesn't fire consistently for inline marks across
+ * browsers. It:
+ *   - opens `http(s)` / `mailto` links in a new tab, and
+ *   - with `headingAnchors`, resolves `docushark://heading/<pageId>/<index>`
+ *     in-document anchors as cross-page heading navigation (switch the active
+ *     prose page, then scroll the heading into view).
+ *
+ * Shared by every prose surface so heading links behave identically: the local
+ * `TiptapEditor` and relay `CollaborativeProseEditor` (both via
+ * `useProseEditorChrome`) and the read-only `ProsePreview`. (Heading nav used to
+ * be wired only into the local editor — JP-417: heading links were noops in
+ * collab docs and the preview.)
+ */
+
+import { useEffect } from 'react';
+import type { Editor } from '@tiptap/core';
+
+export interface ProseLinkClickOptions {
+  /**
+   * Resolve in-document `docushark://heading/<pageId>/<index>` anchors as
+   * cross-page heading navigation. Both prose page lists and the active page are
+   * driven by `richTextPagesStore`, so this works for local and collab docs
+   * alike.
+   */
+  headingAnchors?: boolean;
+}
+
+export function useProseLinkClicks(
+  editor: Editor | null,
+  opts: ProseLinkClickOptions = {},
+): void {
+  const { headingAnchors = false } = opts;
+
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+    const onClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
+      if (!anchor || !dom.contains(anchor)) return;
+      const href = anchor.getAttribute('href') || '';
+
+      if (headingAnchors) {
+        const headingMatch = href.match(/^docushark:\/\/heading\/([^/]+)\/(\d+)$/);
+        if (headingMatch) {
+          event.preventDefault();
+          event.stopPropagation();
+          const pageId = headingMatch[1]!;
+          const headingIndex = parseInt(headingMatch[2]!, 10);
+          import('../store/richTextPagesStore').then(({ useRichTextPagesStore }) => {
+            const store = useRichTextPagesStore.getState();
+            if (store.activePageId !== pageId) store.setActivePage(pageId);
+            const scrollToHeading = (attempts = 0) => {
+              const headings = document.querySelectorAll(
+                '.tiptap-prose h1, .tiptap-prose h2, .tiptap-prose h3, .tiptap-prose h4, .tiptap-prose h5, .tiptap-prose h6',
+              );
+              const el = headings[headingIndex] as HTMLElement | undefined;
+              if (el) {
+                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              } else if (attempts < 30) {
+                requestAnimationFrame(() => scrollToHeading(attempts + 1));
+              }
+            };
+            requestAnimationFrame(() => scrollToHeading());
+          });
+          return;
+        }
+      }
+
+      if (/^https?:\/\//i.test(href) || /^mailto:/i.test(href)) {
+        event.preventDefault();
+        event.stopPropagation();
+        window.open(href, '_blank', 'noopener,noreferrer');
+      }
+    };
+    dom.addEventListener('click', onClick);
+    return () => dom.removeEventListener('click', onClick);
+  }, [editor, headingAnchors]);
+}


### PR DESCRIPTION
Promote `master` → `staging`. 50 commits since PR #351. Primary motivation is a new relay image build — 3 commits touch `relay/` source. No `PROTOCOL_VERSION` bump and no Cargo version change (`1.0.0-beta.1` already on staging from #351); the image rebuild is source-change-driven only.

**Relay image (3 commits):**
- **JP-404** (#372) — expose `relay_active_docs_total` (DocRegistry::len) + `relay_process_rss_bytes` (VmRSS, Linux-only) on `/metrics` for surge visibility
- **JP-424** (#371) — collections durability: versioned PUT with 409 on conflict, atomic sidecar writes (`write_atomic`), reconcile-prune of relay-deleted workspace defs
- **JP-335 Slices 1-2** (#369) — new relay endpoint serving the Y.Doc sidecar for offline-edit prefetch

**Sync / collab hardening (4 commits, app-side):**
- **JP-423** (#370) — `syncEpoch` per-handshake counter, `serializeDocForRest` choke point at REST seams, fragment-to-page-list invariant + conservative self-heal, `pendingSyncPages.clearDoc` wired into doc lifecycle
- **JP-335** — create new pages offline in a synced doc (consumes the new sidecar endpoint)

**Editor (43 commits):**
- **JP-416** — table editing (S1-S6 + follow-ups): selection hot-zone/marquee, row/column move, header-on-insert, rounded-by-default, per-column alignment, Tab navigation, cell drag-select, scope/accessibility, format inheritance, Select Row/Column/All
- **JP-410** — Relaxed layout: Properties pinning/sticking/vanishing fixes, no-dock-on-focus-out
- **JP-417** — heading links work in collab editor + preview
- **JP-421** — self-aligning context menus
- **JP-418** — drop collection enrollment when a document is trashed
- **JP-422** — open cached docs offline + graceful message when uncached
- README PWA-first landing + feature overview

All merged to `master` with typecheck + full test suite green per their PRs. Merging this triggers the staging relay rebuild + deploy via the normal flow.