### PR TITLE
docs-site: generate shape/icon manifest from code (JP-426 Phase A)

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,49 +1,25 @@
-# Starlight Starter Kit: Basics
+# DocuShark Docs (VitePress)
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+Source for [docs.docushark.app](https://docs.docushark.app), built with [VitePress](https://vitepress.dev/).
 
-```
-bun create astro@latest -- --template starlight
-```
+## Commands
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+Run from `docs-site/`:
 
-## 🚀 Project Structure
+| Command | Action |
+|---|---|
+| `bun install` | Install dependencies |
+| `bun run dev` | Start the local dev server |
+| `bun run build` | Production build (online mode — fetches live data where applicable) |
+| `bun run build:offline` | Production build without network calls — use this to verify changes locally |
+| `bun run preview` | Preview a built site locally |
 
-Inside of your Astro + Starlight project, you'll see the following folders and files:
+## Structure
 
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   └── docs/
-│   └── content.config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
-```
+- `getting-started/` + `guide/` — the user-facing guides, sharing one sidebar (`guidesSidebar` in `.vitepress/config.mts`), ordered as a product-flow journey rather than an alphabetical feature list.
+- `developer/` — technical reference for contributors extending DocuShark (architecture, shape/tool authoring, the collaboration protocol).
+- `.vitepress/config.mts` — sidebar/nav structure, breadcrumb JSON-LD, and `llms.txt`/`llms-full.txt` generation. Any new top-level nav section needs a matching sidebar array, a `resolveBreadcrumb` branch, and a `buildEnd` section here.
+- `.vitepress/plugins/llms.ts` — generates `/llms.txt` + `/llms-full.txt` from the sidebar structures at build time.
+- `guide/shape-libraries.data.ts` — a VitePress build-time data loader that reads the shape/icon catalog directly from application source (`src/shapes/library/`, `scripts/gen-icon-catalog.ts`), so `shape-libraries.md` never drifts from what's actually in the app.
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
-
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
-
-Static assets, like favicons, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `bun install`             | Installs dependencies                            |
-| `bun dev`             | Starts local dev server at `localhost:4321`      |
-| `bun build`           | Build your production site to `./dist/`          |
-| `bun preview`         | Preview your build locally, before deploying     |
-| `bun astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `bun astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+See the repo root `AGENTS.md` (one directory up) for the DocuShark codebase's broader conventions.

--- a/docs-site/bun.lock
+++ b/docs-site/bun.lock
@@ -6,6 +6,7 @@
       "name": "docs-site",
       "dependencies": {
         "mermaid": "^11.4.1",
+        "simple-icons": "^16.9.0",
         "vitepress": "^1.6.3",
         "vitepress-plugin-mermaid": "^2.0.17",
         "vue": "^3.5.13",
@@ -560,6 +561,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
+    "simple-icons": ["simple-icons@16.24.1", "", {}, "sha512-AnDQPrZAVzYSym7cBVIrnbhLk9auWGgkl+9hKvkbTqGEfH6TU7WKgumEXYYaJuM1Ib87+cnzr881UZniCM7t+A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/docs-site/guide/shape-libraries.data.ts
+++ b/docs-site/guide/shape-libraries.data.ts
@@ -1,0 +1,117 @@
+import { fileURLToPath } from 'node:url';
+import { defineLoader } from 'vitepress';
+import { flowchartShapes } from '../../src/shapes/library/flowchartShapes';
+import { erdShapes } from '../../src/shapes/library/erdShapes';
+import { umlClassShapes } from '../../src/shapes/library/umlClassShapes';
+import { umlUseCaseShapes } from '../../src/shapes/library/umlUseCaseShapes';
+import { sequenceDiagramShapes } from '../../src/shapes/library/sequenceDiagramShapes';
+import { activityDiagramShapes } from '../../src/shapes/library/activityDiagramShapes';
+import { buildCatalog } from '../../scripts/gen-icon-catalog';
+import { ICON_CATEGORY_LABELS, type IconCategory } from '../../src/storage/IconTypes';
+
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+
+const LIBRARY_GROUPS: Array<{
+  category: string;
+  label: string;
+  description: string;
+  shapes: Array<{ metadata: { name: string; description?: string } }>;
+}> = [
+  {
+    category: 'flowchart',
+    label: 'Flowchart',
+    description: 'Standard flowchart symbols for process diagrams.',
+    shapes: flowchartShapes,
+  },
+  {
+    category: 'erd',
+    label: 'ERD (Entity-Relationship)',
+    description: "Database modeling shapes in Crow's Foot notation.",
+    shapes: erdShapes,
+  },
+  {
+    category: 'uml-class',
+    label: 'UML Class Diagrams',
+    description: 'Class, interface, and package shapes for software design.',
+    shapes: umlClassShapes,
+  },
+  {
+    category: 'uml-usecase',
+    label: 'UML Use Case Diagrams',
+    description: 'Actors, use cases, and system boundaries.',
+    shapes: umlUseCaseShapes,
+  },
+  {
+    category: 'uml-sequence',
+    label: 'UML Sequence Diagrams',
+    description: 'Lifelines, activations, and interaction fragments.',
+    shapes: sequenceDiagramShapes,
+  },
+  {
+    category: 'uml-activity',
+    label: 'UML Activity Diagrams',
+    description: 'Actions, decisions, and swimlanes for workflow modeling.',
+    shapes: activityDiagramShapes,
+  },
+];
+
+export interface ShapeManifestData {
+  libraryShapeCount: number;
+  libraryCategories: Array<{
+    category: string;
+    label: string;
+    description: string;
+    count: number;
+    shapes: Array<{ name: string; description: string }>;
+  }>;
+  iconCount: number;
+  iconCategories: Array<{ category: string; label: string; count: number }>;
+}
+
+export default defineLoader({
+  async load(): Promise<ShapeManifestData> {
+    const libraryCategories = LIBRARY_GROUPS.map((group) => ({
+      category: group.category,
+      label: group.label,
+      description: group.description,
+      count: group.shapes.length,
+      shapes: group.shapes.map((s) => ({
+        name: s.metadata.name,
+        description: s.metadata.description ?? '',
+      })),
+    }));
+
+    // gen-icon-catalog.ts's internal path resolution is intentionally anchored to
+    // process.cwd() (see its `rel()` helper) rather than import.meta.url, since
+    // vitest rewrites import.meta.url for that file's own drift test. A VitePress
+    // build's cwd is docs-site/, not the repo root where public/icons/ lives, so
+    // we relocate for the duration of this call and always restore afterward.
+    const previousCwd = process.cwd();
+    let catalog;
+    try {
+      process.chdir(REPO_ROOT);
+      catalog = await buildCatalog({ allowMissingManifests: true });
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const countsByCategory = new Map<string, number>();
+    for (const icon of catalog.icons) {
+      countsByCategory.set(icon.category, (countsByCategory.get(icon.category) ?? 0) + 1);
+    }
+    const iconCategories = [...countsByCategory.entries()]
+      .map(([category, count]) => ({
+        category,
+        label: ICON_CATEGORY_LABELS[category as IconCategory] ?? category,
+        count,
+      }))
+      .sort((a, b) => b.count - a.count);
+
+    return {
+      libraryShapeCount: libraryCategories.reduce((sum, c) => sum + c.count, 0),
+      libraryCategories,
+      iconCount: catalog.count,
+      iconCategories,
+    };
+  },
+});

--- a/docs-site/guide/shape-libraries.md
+++ b/docs-site/guide/shape-libraries.md
@@ -1,11 +1,15 @@
 ---
 title: Shape Libraries
-description: DocuShark's built-in shape libraries — flowchart, UML, ERD, AWS/Azure/GCP icons — plus custom libraries.
+description: DocuShark's built-in shape libraries — flowchart, UML, ERD, and cloud provider icons — generated from the app's own shape catalog.
 ---
+
+<script setup>
+import { data } from './shape-libraries.data.ts'
+</script>
 
 # Shape Libraries
 
-DocuShark comes with extensive shape libraries for creating any kind of diagram, plus a large collection of cloud provider icons for architecture diagrams.
+DocuShark comes with a full shape and icon library out of the box — everything below is generated straight from the app's shape catalog, so it never goes stale.
 
 ## Browsing Shape Libraries
 
@@ -16,9 +20,7 @@ Open the **Shape Picker** from the toolbar:
 3. Click a shape to select it as your current drawing tool
 4. Click on the canvas to place the shape
 
-## Built-in Libraries
-
-### Basic Shapes
+## Core Shapes
 
 The foundation shapes available in every document:
 
@@ -30,104 +32,49 @@ The foundation shapes available in every document:
 | **Text** | Text labels with full formatting |
 | **Connector** | Smart auto-routing connectors |
 | **Group** | Container for organizing shapes |
+| **File** | Embedded files with preview thumbnails |
 
-### Flowchart
+## Diagram Shape Libraries
 
-Standard flowchart symbols for process diagrams:
+DocuShark ships with {{ data.libraryShapeCount }} purpose-built shapes across flowchart, UML, and ERD notations.
 
-| Shape | Usage |
-|-------|-------|
-| **Decision** | Yes/No branch point (diamond) |
-| **Terminator** | Start/End points (rounded rectangle) |
-| **Data** | Input/Output (parallelogram) |
-| **Document** | Document reference (wavy bottom) |
-| **Predefined Process** | Subroutine call (double-sided) |
-| **Manual Input** | User input step (trapezoid) |
-| **Preparation** | Initialization step (hexagon) |
-| **Connector** | On-page connector (circle) |
-| **Off-Page Connector** | Off-page reference (pentagon arrow) |
+<table>
+  <thead>
+    <tr><th>Category</th><th>Shapes</th><th>What it's for</th></tr>
+  </thead>
+  <tbody>
+    <tr v-for="cat in data.libraryCategories" :key="cat.category">
+      <td>{{ cat.label }}</td>
+      <td>{{ cat.count }}</td>
+      <td>{{ cat.description }}</td>
+    </tr>
+  </tbody>
+</table>
 
-Use a standard **Rectangle** shape for generic process steps.
+<details v-for="cat in data.libraryCategories" :key="cat.category + '-detail'">
+  <summary>{{ cat.label }} — full shape list</summary>
+  <ul>
+    <li v-for="shape in cat.shapes" :key="shape.name">
+      <strong>{{ shape.name }}</strong><span v-if="shape.description"> — {{ shape.description }}</span>
+    </li>
+  </ul>
+</details>
 
-### UML
+## Cloud Provider & Technology Icons
 
-Unified Modeling Language shapes for software design:
+DocuShark includes {{ data.iconCount }} icons — official cloud provider service icons plus common dev-tooling logos, perfect for architecture diagrams.
 
-**Class Diagrams:**
-- **Class** — Three-compartment box with attributes and methods
-- **Interface** — Interface definition with stereotype
-- **Abstract Class** — Abstract class (italicized name)
-- **Enumeration** — Enum type
-- **Package** — Package container
-- **Note** — Dog-eared annotation note
-
-**Use Case Diagrams:**
-- **Actor** — Stick figure for users/systems
-- **Use Case** — Ellipse for functionality
-- **System Boundary** — Rectangle container with title
-
-**Sequence Diagrams:**
-- **Lifeline** — Actor/object with dashed vertical line (6 head type variants)
-- **Activation** — Execution bar on a lifeline (supports nesting)
-- **Fragment** — Interaction frame (loop, alt, opt, par, break, critical)
-- **Sequence Actor** — Stick figure variants (person, system, external)
-- **Destruction** — X marker for object destruction
-- **State Invariant**, **Time Constraint**, **Coregion**, **Continuation**
-
-**Activity Diagrams:**
-- **Action** — Rounded rectangle for activity nodes
-- **Initial/Final/Flow Final** — Standard UML activity node markers
-- **Fork/Join Bar** — Parallel flow synchronization
-- **Decision/Merge** — Diamond nodes for branching
-- **Send/Receive Signal** — Pentagon shapes for signal handling
-- **Swimlane** — Partitioned lanes for organizing activities by actor
-- **Object Node**, **Data Store**, **Central Buffer**, **Pins**, and more
-
-### ERD (Entity-Relationship)
-
-Database modeling shapes (Crow's Foot notation):
-
-| Shape | Description |
-|-------|-------------|
-| **Entity** | Database table (rectangle) |
-| **Weak Entity** | Dependent entity (double border) |
-| **Attribute** | Column/field (ellipse) |
-| **Key Attribute** | Primary key (underlined ellipse) |
-| **Relationship** | Association (diamond) |
-
-## Cloud Provider Icons
-
-DocuShark includes official service icons from major cloud providers, perfect for architecture diagrams:
-
-### AWS Icons
-
-Hundreds of AWS service and resource icons organized into sub-categories:
-
-- **Compute** — EC2, Lambda, ECS, EKS, Fargate, Batch, and more
-- **Storage** — S3, EBS, EFS, Glacier
-- **Databases** — RDS, DynamoDB, ElastiCache, Redshift
-- **Networking** — VPC, CloudFront, Route 53, API Gateway
-- **Security** — IAM, KMS, Cognito, WAF
-- **Analytics, Containers, AI/ML, DevTools**, and more
-
-### Azure Icons
-
-Official Azure service icons covering:
-
-- Compute, Networking, Databases, Identity, Storage, and many more categories
-
-### GCP Icons
-
-Google Cloud Platform icons for:
-
-- Compute Engine, Cloud Functions, BigQuery, Cloud Storage, Kubernetes Engine, and more
-
-### Other Technology Icons
-
-- **Kubernetes** — Pods, Services, Deployments, Ingress
-- **Docker** — Container icons
-- **Databases** — PostgreSQL, MySQL, MongoDB, Redis
-- **Languages & Frameworks** — Popular programming language and framework logos
+<table>
+  <thead>
+    <tr><th>Category</th><th>Icons</th></tr>
+  </thead>
+  <tbody>
+    <tr v-for="cat in data.iconCategories" :key="cat.category">
+      <td>{{ cat.label }}</td>
+      <td>{{ cat.count }}</td>
+    </tr>
+  </tbody>
+</table>
 
 ::: tip
 Cloud icons use brand colors from each provider. They maintain their visual identity in both light and dark themes.

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -12,7 +12,8 @@
     "vitepress": "^1.6.3",
     "vitepress-plugin-mermaid": "^2.0.17",
     "mermaid": "^11.4.1",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "simple-icons": "^16.9.0"
   },
   "devDependencies": {
     "@fontsource/jetbrains-mono": "^5.2.8",

--- a/docs-site/tsconfig.json
+++ b/docs-site/tsconfig.json
@@ -6,5 +6,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": [".vitepress/**/*.ts", ".vitepress/**/*.vue"]
+  "include": [".vitepress/**/*.ts", ".vitepress/**/*.vue", "**/*.data.ts"]
 }


### PR DESCRIPTION
## Summary
- `guide/shape-libraries.md` was hand-written and already stale (e.g. "and more" placeholders instead of real counts). Adds `guide/shape-libraries.data.ts`, a VitePress build-time data loader that reads the 53 library shapes directly from `src/shapes/library/` and reuses `scripts/gen-icon-catalog.ts`'s `buildCatalog()` for the 1300-icon catalog, so the page can't drift stale again.
- `gen-icon-catalog.ts` resolves `public/icons/` relative to `process.cwd()` by design (not `import.meta.url`, which vitest rewrites for its own drift test) — since a VitePress build's cwd is `docs-site/` rather than the repo root, the new loader temporarily relocates cwd for the duration of the call and restores it in a `finally`.
- Replaces the dead Astro Starlight starter `README.md` (leftover from before the site was rebuilt on VitePress) with real docs-site documentation.
- Confirmed via `git ls-files` that `public/icons/*-manifest.json` are actually committed, not gitignored as `gen-icon-catalog.ts`'s own comment claims — the loader still defends against the missing case anyway.

First of several PRs for JP-426 (docs-site restructure) — this phase is deliberately the smallest/most mechanical to validate the new `.data.ts` pattern before later phases (guide reorg, self-hosting section, API reference) build on it.

## Test plan
- [x] `bun run build:offline` succeeds in `docs-site/`
- [x] Rendered output confirms live counts: 53 library shapes across 6 categories (Flowchart 9, ERD 5, UML-class 6, UML-usecase 5, UML-sequence 9, UML-activity 19), 1300 icons across 12 categories (Azure 626, AWS 300, GCP 216, languages 39, devops 37, frameworks 28, databases 19, tech 10, shapes 7, symbols 7, arrows 6, general 5)
- [ ] Visual review of the rendered `/guide/shape-libraries` page (tables + collapsible per-category detail)

Assisted-by: Sonnet 5