### PR TITLE
docs-site: product-flow guide reorg + 6 new guides (JP-426 Phase B1)

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -12,7 +12,9 @@ const SITE_DESCRIPTION =
 const HOSTNAME = 'https://docs.docushark.app'
 
 // The Guides area spans two folders: /getting-started/ (the onboarding group)
-// and /guide/ (the using-DocuShark group). Both routes share one sidebar.
+// and /guide/ (the using-DocuShark group). Both routes share one sidebar,
+// ordered as a product-flow journey: install -> first document -> organize/
+// style -> software engineering diagrams -> collaborate -> import/reference.
 const guidesSidebar = [
   {
     text: 'Getting Started',
@@ -24,26 +26,52 @@ const guidesSidebar = [
     ],
   },
   {
-    text: 'Using DocuShark',
+    text: 'Your First Document',
     items: [
       { text: 'Canvas & Navigation', link: '/guide/canvas-navigation' },
-      { text: 'Layout Modes', link: '/guide/layout-modes' },
       { text: 'Drawing Tools', link: '/guide/drawing-tools' },
+      { text: 'Rich Text & Notes', link: '/guide/rich-text-editor' },
       { text: 'Connectors', link: '/guide/connectors' },
       { text: 'Shape Libraries', link: '/guide/shape-libraries' },
+    ],
+  },
+  {
+    text: 'Organize & Style',
+    items: [
       { text: 'Styling & Themes', link: '/guide/styling' },
+      { text: 'Layout Modes', link: '/guide/layout-modes' },
       { text: 'Multi-Page Documents', link: '/guide/multi-page-documents' },
-      { text: 'Rich Text & Notes', link: '/guide/rich-text-editor' },
-      { text: 'Citations & References', link: '/guide/citations' },
       { text: 'Document Fields', link: '/guide/document-fields' },
+      { text: 'Citations & References', link: '/guide/citations' },
       { text: 'Embedded Files', link: '/guide/embedded-files' },
       { text: 'Collections', link: '/guide/collections' },
-      { text: 'Export & Import', link: '/guide/export-import' },
-      { text: 'Whiteboard & Ideas', link: '/guide/whiteboard' },
+      { text: 'Recovery Points & Undo', link: '/guide/recovery-and-undo' },
+      { text: 'Offline & Sync', link: '/guide/offline-and-sync' },
+    ],
+  },
+  {
+    text: 'Software Engineering',
+    items: [
+      { text: 'UML & ERD Diagrams', link: '/guide/uml-and-erd' },
+      { text: 'Sequence Diagrams', link: '/guide/sequence-diagrams' },
+    ],
+  },
+  {
+    text: 'Go Further: Collaborate & Connect',
+    items: [
       { text: 'Collaboration', link: '/guide/collaboration' },
+      { text: 'Sharing & Workspace Access', link: '/guide/sharing-and-access' },
       { text: 'Connect an AI Agent', link: '/guide/connect-your-agent' },
-      { text: 'Keyboard Shortcuts', link: '/guide/keyboard-shortcuts' },
+      { text: 'Whiteboard & Ideas', link: '/guide/whiteboard' },
+    ],
+  },
+  {
+    text: 'Import, Export & Reference',
+    items: [
+      { text: 'Export & Import', link: '/guide/export-import' },
+      { text: 'Mobile Preview', link: '/guide/mobile-preview' },
       { text: 'Settings', link: '/guide/settings' },
+      { text: 'Keyboard Shortcuts', link: '/guide/keyboard-shortcuts' },
     ],
   },
 ]

--- a/docs-site/guide/mobile-preview.md
+++ b/docs-site/guide/mobile-preview.md
@@ -1,0 +1,27 @@
+---
+title: Mobile Preview
+description: DocuShark's experimental small-screen layout for phones and narrow touch devices — how to opt in, and how to switch back to the desktop layout.
+---
+
+# Mobile Preview
+
+DocuShark is built desktop-first, but it includes an early, experimental layout for phones and other narrow touch devices. It's genuinely useful for quick edits and reviewing documents on the go — just not yet a full replacement for the desktop experience.
+
+## Opting in
+
+The first time you open DocuShark on a touch device at a narrow screen width, you'll see a one-time prompt: **Mobile preview (experimental)**. Accepting switches you to the compact, touch-adapted layout; choosing **Not now** keeps the desktop layout and simply asks again next time.
+
+The prompt only appears on an actual touch device at a narrow viewport — resizing a desktop browser window doesn't trigger it.
+
+## Switching back
+
+If you've accepted mobile preview and want the desktop layout instead, go to **Settings → Appearance → Mobile preview** and turn it off. This is a durable setting — DocuShark will always use the desktop layout for you from then on, even on a phone, until you turn it back on.
+
+## What to expect
+
+Mobile preview is still early: expect some panels and workflows to feel tighter or less polished than on desktop. If something feels broken rather than just cramped, that's useful feedback — but it's not yet the primary way DocuShark is meant to be used.
+
+## See also
+
+- [Interface Tour](../getting-started/interface-tour) — the desktop layout this adapts from
+- [Layout Modes](./layout-modes) — desktop panel arrangement presets

--- a/docs-site/guide/offline-and-sync.md
+++ b/docs-site/guide/offline-and-sync.md
@@ -10,7 +10,7 @@ DocuShark is offline-first, but what "offline" means depends on where a document
 ## Three kinds of documents
 
 - **Local** — lives only on this device. Always available offline, since it was never anywhere else to begin with.
-- **Cloud (remote)** — lives on a relay. Available offline only for what's already been downloaded to this device — anything you haven't opened or viewed yet may not be cached locally.
+- **Cloud (remote)** — lives in a workspace. Available offline only for what's already been downloaded to this device — anything you haven't opened or viewed yet may not be cached locally.
 - **Cached** — a cloud document DocuShark has already pulled a local copy of, so it opens instantly and works offline even before you reconnect.
 
 ## Reading the sync badge
@@ -19,7 +19,7 @@ Every document shows a small status badge:
 
 | Badge | Meaning |
 |-------|---------|
-| **Synced** | Up to date with the relay |
+| **Synced** | Up to date with your workspace |
 | **Syncing** | Changes are actively going up or down right now |
 | **Pending** | You have local changes waiting to sync (e.g. you're offline right now) |
 | **Error** | The last sync attempt failed |
@@ -41,5 +41,5 @@ A document can end up **partially** available if some blobs fail to download (a 
 
 ## See also
 
-- [Collaboration](./collaboration) — how documents get onto a relay in the first place
+- [Collaboration](./collaboration) — how documents get into a workspace in the first place
 - [Recovery Points & Undo](./recovery-and-undo) — DocuShark's safety nets for cloud documents

--- a/docs-site/guide/offline-and-sync.md
+++ b/docs-site/guide/offline-and-sync.md
@@ -1,0 +1,45 @@
+---
+title: Offline & Sync
+description: What "offline" means for each kind of DocuShark document, how to make a cloud document available offline on purpose, and reading the sync status badge.
+---
+
+# Offline & Sync
+
+DocuShark is offline-first, but what "offline" means depends on where a document lives.
+
+## Three kinds of documents
+
+- **Local** — lives only on this device. Always available offline, since it was never anywhere else to begin with.
+- **Cloud (remote)** — lives on a relay. Available offline only for what's already been downloaded to this device — anything you haven't opened or viewed yet may not be cached locally.
+- **Cached** — a cloud document DocuShark has already pulled a local copy of, so it opens instantly and works offline even before you reconnect.
+
+## Reading the sync badge
+
+Every document shows a small status badge:
+
+| Badge | Meaning |
+|-------|---------|
+| **Synced** | Up to date with the relay |
+| **Syncing** | Changes are actively going up or down right now |
+| **Pending** | You have local changes waiting to sync (e.g. you're offline right now) |
+| **Error** | The last sync attempt failed |
+| **Local** | A personal document — nothing to sync, by design |
+| **Idle** | Signed in, document just isn't open right now — it'll sync instantly when you reopen it |
+| **Offline** | Cached and usable, but not currently reachable — changes will sync once you're back online |
+
+## Making a document available offline
+
+Blobs (images, embedded files) inside a cloud document are normally fetched on demand — only what you've actually viewed gets cached locally. If you know you're about to lose your connection (a flight, a site visit, spotty wifi), tell DocuShark to grab everything up front instead:
+
+1. Find the document in Documents Home
+2. Choose **Make available offline**
+3. DocuShark downloads the document body and every file/image it references, showing progress as it goes
+
+Once complete, the document is fully usable offline — including editing, not just viewing — because DocuShark also seeds the local collaborative session data it needs to let you keep working and sync up later.
+
+A document can end up **partially** available if some blobs fail to download (a flaky connection, for instance) — it's still usable, just not guaranteed complete until you retry.
+
+## See also
+
+- [Collaboration](./collaboration) — how documents get onto a relay in the first place
+- [Recovery Points & Undo](./recovery-and-undo) — DocuShark's safety nets for cloud documents

--- a/docs-site/guide/recovery-and-undo.md
+++ b/docs-site/guide/recovery-and-undo.md
@@ -1,0 +1,40 @@
+---
+title: Recovery Points & Undo
+description: How DocuShark protects your work — automatic recovery points for cloud documents, and undo/redo during a live collaboration session.
+---
+
+# Recovery Points & Undo
+
+DocuShark has two separate safety nets, and it's worth knowing what each one actually covers — neither is a full, browse-any-past-version history yet.
+
+## Undo during collaboration
+
+Normal undo/redo (Ctrl/Cmd+Z) works everywhere, including live collaboration — but in a collab session it only undoes **your own recent edits**, not the whole document's history. This is deliberate: once other people are editing alongside you, "undo" can only mean "undo what I just did," not "rewind the shared document," since rewinding would also erase everyone else's work.
+
+- Undo/redo stacks are **per document page** and **session-scoped** — they reset when you reload
+- Each distinct action (not every mouse movement) becomes its own undo step
+- This does not go back indefinitely — it covers your recent working session, not the document's full lifetime
+
+## Recovery points for cloud documents
+
+Separately, DocuShark automatically captures **recovery points** for documents stored on a relay — snapshots taken when a document is at risk of losing content (not on a fixed schedule, and not something you trigger manually today).
+
+To see them, open a cloud document's **Backups** panel:
+
+1. Open the document
+2. Find the **Backups** option (from the document menu or Documents Home)
+3. Browse the list of recovery points, newest first, each showing when it was captured and its size
+
+Each recovery point offers two actions:
+
+- **Restore** — brings the document back to that point in time, as a **new document**. Anyone currently viewing the original is returned to the browser, and their working copy is moved to Trash rather than lost outright. This is a meaningful action, so DocuShark asks you to confirm first.
+- **Save to local** — downloads that point's content as a new local (non-cloud) document, without touching the original at all. Use this when you just want a copy, not a rollback.
+
+## What this doesn't do yet
+
+There's no browsable, complete version history — you can't scrub through every edit ever made to a document, and recovery points are captured automatically rather than on demand ("save a version now"). If you need a guaranteed checkpoint before a risky edit, **Save to local** is the closest thing to a manual save point today.
+
+## See also
+
+- [Collections](./collections) — organizing documents, including where Trash fits in
+- [Collaboration](./collaboration) — how live editing works alongside undo

--- a/docs-site/guide/recovery-and-undo.md
+++ b/docs-site/guide/recovery-and-undo.md
@@ -17,7 +17,7 @@ Normal undo/redo (Ctrl/Cmd+Z) works everywhere, including live collaboration —
 
 ## Recovery points for cloud documents
 
-Separately, DocuShark automatically captures **recovery points** for documents stored on a relay — snapshots taken when a document is at risk of losing content (not on a fixed schedule, and not something you trigger manually today).
+Separately, DocuShark automatically captures **recovery points** for documents stored in a workspace — snapshots taken when a document is at risk of losing content (not on a fixed schedule, and not something you trigger manually today).
 
 To see them, open a cloud document's **Backups** panel:
 

--- a/docs-site/guide/sequence-diagrams.md
+++ b/docs-site/guide/sequence-diagrams.md
@@ -1,0 +1,44 @@
+---
+title: Sequence Diagrams
+description: Model interaction over time between actors, objects, and systems — lifelines, activations, guard conditions, and message numbering.
+---
+
+# Sequence Diagrams
+
+A sequence diagram answers a question class and use case diagrams can't: *in what order do these things talk to each other?* It reads top-to-bottom as a timeline of messages between participants.
+
+## The building blocks
+
+1. Open the Shape Picker and switch to **UML Sequence Diagrams**
+2. Place a **Lifeline** for each participant — an actor, object, or system. Lifelines come in variants (person, system, external) so you can tell participants apart at a glance
+3. Connect two lifelines with a connector to represent a message; drag downward as the interaction progresses — time flows down the page
+4. Add an **Activation** bar on a lifeline to show it's actively doing work in response to a message; activations can nest when a call triggers another call before returning
+5. Use a **Fragment** frame to wrap a group of messages under a condition — loop, alt (if/else), opt (optional), par (parallel), break, or critical
+6. Mark the end of a participant's life with a **Destruction** marker (an X)
+
+Smaller supporting shapes — **State Invariant**, **Time Constraint**, **Coregion**, and **Continuation** — cover more specialized timing and state-assertion notation when a diagram needs it.
+
+## Giving messages meaning
+
+Connectors between lifelines carry sequence-specific semantics, set in the Property Panel once a connector is selected:
+
+- **Synchronous vs. asynchronous** — a synchronous call blocks until it returns (filled arrowhead); an asynchronous one doesn't (open arrowhead). Set this via the connector's start/end sequence marker.
+- **Reply** — a dashed return message, distinct from an outbound call.
+- **Create / destroy** — a message that instantiates or tears down a participant.
+- **Lost / found** — a message whose sender or receiver isn't shown on the diagram.
+
+**Guard conditions** — the bracketed text you often see next to a message, like `[amount > 100]` — describe the condition under which a message is sent. Set it from the connector's properties; DocuShark positions it near the start of the arrow automatically.
+
+**Message numbering** — for diagrams where the order matters more than the vertical position (or you're cross-referencing a written spec), turn on message numbers to label each connector `1:`, `2:`, `2.1:`, and so on.
+
+**Self-messages** — when a participant calls itself, the connector automatically loops out and back rather than trying to connect a lifeline to itself in a straight line.
+
+## A typical flow
+
+A request/response between two services usually looks like: lifeline for the caller, lifeline for the callee, a synchronous message down, an activation bar on the callee while it works, a reply message back, activation ends. Wrap the whole thing in an `alt` fragment once you need to show the error path too.
+
+## See also
+
+- [UML & ERD Diagrams](./uml-and-erd) — for structural diagrams that don't involve a timeline
+- [Connectors](./connectors) — general routing and arrow styling
+- [Shape Libraries](./shape-libraries) — the full generated shape catalog

--- a/docs-site/guide/sharing-and-access.md
+++ b/docs-site/guide/sharing-and-access.md
@@ -1,0 +1,36 @@
+---
+title: Sharing & Workspace Access
+description: Share a cloud document with specific workspace members, transfer ownership, and manage who belongs to your workspace.
+---
+
+# Sharing & Workspace Access
+
+Once a document lives on a relay (see [Collaboration](./collaboration)), you control exactly who can see and edit it — both at the document level and at the workspace level.
+
+## Sharing a document
+
+Only a document's **owner** can manage its access. Open **Manage Access** from the document menu:
+
+1. Pick a member from your workspace roster and choose their permission — **Viewer** (read-only) or **Editor** (can make changes)
+2. Click **Add** — they now appear in the current shares list
+3. Change or revoke anyone's access at any time from the same list; **Revoke All** clears every share in one step
+4. Save your changes
+
+You can only share with people already in your workspace — invite them first (see below) if they're not listed yet. If someone's access was granted and they've since left the workspace, they're flagged as a **former member** so you can clean up the stale grant.
+
+### Transferring ownership
+
+From the same dialog, you can hand a document off to someone else entirely: pick **Transfer ownership** next to a current editor. This is permanent — you become an editor on the document rather than the owner, and DocuShark asks you to confirm before it happens.
+
+## Workspace members and invites
+
+Anyone in a workspace can see its member roster from the Cloud panel. If you're the workspace **owner**, you can also:
+
+- **Create an invite link** — choose a role (**Member**, who can edit shared documents, or **Viewer**, read-only) and generate a shareable link. Anyone with the link can join until it expires or you revoke it.
+- **Copy or revoke** any pending invite
+- **Remove a member** — they lose access to the workspace and everything shared with them, though anything already downloaded to their device stays put. You can always re-invite them later.
+
+## See also
+
+- [Collaboration](./collaboration) — live editing, presence, and connecting to a relay
+- [Offline & Sync](./offline-and-sync) — what happens to shared documents when you're not connected

--- a/docs-site/guide/sharing-and-access.md
+++ b/docs-site/guide/sharing-and-access.md
@@ -5,7 +5,7 @@ description: Share a cloud document with specific workspace members, transfer ow
 
 # Sharing & Workspace Access
 
-Once a document lives on a relay (see [Collaboration](./collaboration)), you control exactly who can see and edit it — both at the document level and at the workspace level.
+Once a document lives in a workspace (see [Collaboration](./collaboration)), you control exactly who can see and edit it — both at the document level and at the workspace level.
 
 ## Sharing a document
 
@@ -32,5 +32,5 @@ Anyone in a workspace can see its member roster from the Cloud panel. If you're 
 
 ## See also
 
-- [Collaboration](./collaboration) — live editing, presence, and connecting to a relay
+- [Collaboration](./collaboration) — live editing, presence, and connecting to a workspace
 - [Offline & Sync](./offline-and-sync) — what happens to shared documents when you're not connected

--- a/docs-site/guide/styling.md
+++ b/docs-site/guide/styling.md
@@ -27,21 +27,23 @@ Every shape has styling properties you can adjust in the Property Panel:
 
 Select a shape and tweak these in the Property Panel on the right side of the screen.
 
-## Style Profiles
+## Style Profiles — your branding kit
 
-Style profiles let you save a combination of styling properties and apply them to any shape with one click.
+Think of a style profile less as a "saved preset" and more as a **branding kit**: it remembers how a shape type should look — fill, stroke, font, shadow, icon treatment — so a whole document (or every document you make) can share one consistent visual identity instead of you restyling shapes by hand every time.
 
 ### Saving a Style Profile
 
 1. Style a shape exactly how you want it (fill, stroke, font, shadow, etc.)
 2. Right-click the shape → **Save Style**
-3. Give your profile a name
+3. Give your profile a name — something like your team or product name works well, since this is the kit you'll reuse everywhere
 
 ### Applying a Style Profile
 
 1. Select one or more shapes
 2. Open the **Style** dropdown in the Property Panel
 3. Choose a saved profile — all the styling applies instantly
+
+Because a profile can remember per-shape-type styling, applying the same kit across a mixed selection (rectangles, connectors, text) gives you one cohesive look in a single click, instead of restyling each shape type separately.
 
 ### Managing Profiles
 

--- a/docs-site/guide/uml-and-erd.md
+++ b/docs-site/guide/uml-and-erd.md
@@ -1,0 +1,66 @@
+---
+title: UML & ERD Diagrams
+description: Model your system's structure — classes, use cases, activities, and database schemas — with DocuShark's UML and ERD shape libraries.
+---
+
+# UML & ERD Diagrams
+
+If you're documenting a system rather than a process, DocuShark's structural diagram libraries cover the notations software engineers actually use: UML class diagrams, use case diagrams, activity diagrams, and Entity-Relationship diagrams for database schemas. Each one exists to answer a different question about your system.
+
+## Class Diagrams — "what are the pieces, and how do they relate?"
+
+Use a class diagram to document the shape of your codebase or API surface: classes, interfaces, and the relationships between them.
+
+1. Open the Shape Picker and switch to the **UML Class Diagrams** category
+2. Place a **Class** shape — it's a three-compartment box (name, attributes, methods) you can edit directly on the canvas
+3. Add **Interface** shapes for contracts, **Abstract Class** for base types, and **Enumeration** for fixed value sets
+4. Group related classes visually with a **Package** container
+5. Connect classes with connectors — set the arrowhead to reflect the relationship (inheritance, composition, association)
+6. Drop a **Note** shape anywhere you need a design rationale that doesn't belong on a class itself
+
+Class diagrams work well as living documentation next to a [prose page](./rich-text-editor) describing the "why" behind the structure the diagram shows.
+
+## Use Case Diagrams — "who does what with the system?"
+
+Use case diagrams capture the system from the outside: actors and the goals they accomplish.
+
+1. Place an **Actor** shape (the stick figure) for each user or external system
+2. Place a **Use Case** shape (an ellipse) for each goal or capability
+3. Connect actors to the use cases they participate in
+4. Wrap related use cases in a **System Boundary** to show what's in scope
+5. Use **Include** and **Extend** relations between use cases when one goal always (include) or sometimes (extend) triggers another
+
+These are the fastest diagrams to sketch in a stakeholder meeting — start rough, refine the boundary once the scope is agreed.
+
+## Activity Diagrams — "what's the workflow?"
+
+Activity diagrams model a process as a flow of actions, decisions, and parallel branches — closer to a flowchart than a class diagram, but with UML's richer vocabulary for concurrency and lifecycle.
+
+- **Action** nodes for individual steps, bounded by **Initial** and **Final** markers
+- **Decision** and **Merge** diamonds for branching logic
+- **Fork/Join** bars where work genuinely happens in parallel, not just branches
+- **Swimlanes** to show which actor or system owns each step
+- **Send/Receive Signal** shapes for asynchronous, event-driven steps
+- Supporting nodes for more advanced modeling: object nodes, data stores, buffers, pins, and expansion regions
+
+Start with just Action, Decision, and Swimlane — the rest are there when a workflow genuinely needs them, not a checklist to fill out.
+
+## ERD — "what does the database look like?"
+
+Entity-Relationship diagrams use Crow's Foot notation to document schemas.
+
+1. Place an **Entity** shape per table; a **Weak Entity** (double border) for tables that only exist through another table
+2. Add **Attribute** shapes for columns, and use **Key Attribute** (underlined) for primary keys
+3. Connect entities with a **Relationship** diamond, or connect them directly and set the connector's cardinality in the Property Panel (one-to-many, many-to-many, and so on)
+
+ERDs are usually the fastest of these four to keep in sync with reality — regenerate one whenever the schema changes rather than letting it drift.
+
+## Bringing in an existing diagram
+
+Already have a UML or ERD diagram in Mermaid or draw.io? See [Export & Import](./export-import) — DocuShark can bring it in and lay it out automatically.
+
+## See also
+
+- [Shape Libraries](./shape-libraries) — the full generated catalog of every shape in these libraries
+- [Sequence Diagrams](./sequence-diagrams) — for modeling interaction over time, which these four notations don't cover
+- [Connectors](./connectors) — routing, arrowheads, and cardinality


### PR DESCRIPTION
## Summary
- Restructures the `guide/`+`getting-started/` sidebar from a flat two-group list into six narrative-ordered groups that match how someone actually progresses through the app: Getting Started, Your First Document, Organize & Style, Software Engineering, Go Further: Collaborate & Connect, Import/Export & Reference.
- Adds 4 guides for real features that had no documentation home: **Recovery Points & Undo** (deliberately scoped — not a full version history, the page says so), **Sharing & Workspace Access**, **Offline & Sync**, **Mobile Preview**.
- Adds a new **Software Engineering** group (**UML & ERD Diagrams**, **Sequence Diagrams**) — this notation was previously thin (a stale bullet list in shape-libraries.md) or stranded as property tables in connectors.md with no narrative home.
- Reframes Style Profiles in `styling.md` as a "branding kit" — a profile remembers per-shape-type styling and applies as a cohesive kit, not just a saved preset.

Second of several PRs for JP-426 (docs-site restructure). Independent of Phase A (#374) — different files, can merge in either order.

## Test plan
- [x] `bun run build:offline` succeeds — no dead links across the 6 new pages' cross-links
- [x] `llms.txt` reflects the new 6-group structure (verified section headers)
- [ ] Visual review of the new sidebar grouping and the 6 new pages

Assisted-by: Sonnet 5