### PR TITLE
docs-site: tone-fix keyboard-shortcuts.md and connectors.md (JP-426 Phase B2)

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -65,6 +65,7 @@ const developerSidebar = [
       { text: 'Creating Custom Tools', link: '/developer/creating-tools' },
       { text: 'Creating Prose Helpers', link: '/developer/creating-prose-helpers' },
       { text: 'Shape Properties', link: '/developer/shape-properties' },
+      { text: 'Keyboard Shortcuts Reference', link: '/developer/keyboard-shortcuts-reference' },
       { text: 'Plugin Development', link: '/developer/plugin-development' },
       { text: 'Collaboration Protocol', link: '/developer/collaboration-protocol' },
       { text: 'Utility Modules', link: '/developer/utilities' },

--- a/docs-site/developer/keyboard-shortcuts-reference.md
+++ b/docs-site/developer/keyboard-shortcuts-reference.md
@@ -28,11 +28,12 @@ The complete list. For the shortcuts most people actually use day to day — and
 | Pan down | `S` or `↓` (when nothing selected) |
 | Pan left | `A` or `←` (when nothing selected) |
 | Pan right | `D` or `→` (when nothing selected) |
-| Zoom in | `E` or scroll wheel up |
-| Zoom out | `Q` or scroll wheel down |
-| Pan (drag) | Middle-click + drag |
+| Zoom in | `E`, or Ctrl/⌘ + scroll up, or pinch out |
+| Zoom out | `Q`, or Ctrl/⌘ + scroll down, or pinch in |
+| Pan (scroll) | Scroll wheel (vertical), Shift+scroll (horizontal), or two-finger drag on a trackpad |
+| Pan (drag) | Middle-click + drag (Select tool) |
 
-Scroll wheel zooms toward the mouse cursor position. `Q`/`E` zoom toward the viewport center.
+`Q`/`E` zoom toward the viewport center; scroll/pinch zoom toward the cursor. See [Canvas & Navigation](../guide/canvas-navigation) for the full rundown, including the Linux trackpad-pinch caveat.
 
 ## Selection
 

--- a/docs-site/developer/keyboard-shortcuts-reference.md
+++ b/docs-site/developer/keyboard-shortcuts-reference.md
@@ -1,0 +1,89 @@
+---
+title: Keyboard Shortcuts Reference
+description: Complete keyboard shortcuts reference for DocuShark — tools, navigation, editing, and clipboard operations.
+---
+
+# Keyboard Shortcuts Reference
+
+The complete list. For the shortcuts most people actually use day to day — and the command palette, which makes this whole page optional — see the [Keyboard Shortcuts](../guide/keyboard-shortcuts) guide.
+
+## Tools
+
+| Action | Key |
+|--------|-----|
+| Select tool | `V` |
+| Rectangle | `R` |
+| Ellipse | `O` |
+| Line | `L` |
+| Connector | `C` |
+| Text | `T` |
+| Hand (pan) | `H` |
+| Command palette | `Ctrl + K` |
+
+## Canvas Navigation
+
+| Action | Method |
+|--------|--------|
+| Pan up | `W` or `↑` (when nothing selected) |
+| Pan down | `S` or `↓` (when nothing selected) |
+| Pan left | `A` or `←` (when nothing selected) |
+| Pan right | `D` or `→` (when nothing selected) |
+| Zoom in | `E` or scroll wheel up |
+| Zoom out | `Q` or scroll wheel down |
+| Pan (drag) | Middle-click + drag |
+
+Scroll wheel zooms toward the mouse cursor position. `Q`/`E` zoom toward the viewport center.
+
+## Selection
+
+| Action | Shortcut |
+|--------|----------|
+| Select all | `Ctrl+A` / `Cmd+A` |
+| Deselect all | `Escape` |
+| Add to selection | `Shift+Click` |
+
+## Editing
+
+| Action | Shortcut |
+|--------|----------|
+| Copy | `Ctrl+C` / `Cmd+C` |
+| Paste | `Ctrl+V` / `Cmd+V` |
+| Delete | `Delete` or `Backspace` |
+| Undo | `Ctrl+Z` / `Cmd+Z` |
+| Redo | `Ctrl+Shift+Z` or `Ctrl+Y` / `Cmd+Shift+Z` |
+
+## Movement (with shapes selected)
+
+| Action | Shortcut |
+|--------|----------|
+| Nudge by 10px | Arrow keys |
+| Nudge by 50px | `Shift+Arrow` |
+
+When shapes are selected, arrow keys nudge them. When nothing is selected, arrow keys pan the canvas (same as WASD).
+
+## Grouping
+
+| Action | Shortcut |
+|--------|----------|
+| Group | `Ctrl+G` / `Cmd+G` |
+| Ungroup | `Ctrl+Shift+G` / `Cmd+Shift+G` |
+
+## Shape Creation Modifiers
+
+Hold these keys while creating shapes:
+
+| Modifier | Effect |
+|----------|--------|
+| `Shift` | Constrain proportions (square, circle) |
+
+## Text Editing
+
+When editing text in the Document Editor:
+
+| Action | Shortcut |
+|--------|----------|
+| Bold | `Ctrl+B` / `Cmd+B` |
+| Italic | `Ctrl+I` / `Cmd+I` |
+| Underline | `Ctrl+U` / `Cmd+U` |
+| Inline code | `Ctrl+E` / `Cmd+E` |
+| Finish editing | `Escape` |

--- a/docs-site/developer/shape-properties.md
+++ b/docs-site/developer/shape-properties.md
@@ -95,11 +95,15 @@ Ellipses use only common properties. The shape is defined by its bounding box.
 | `startAnchor` | object | Start connection: `{ shapeId, port }` |
 | `endAnchor` | object | End connection: `{ shapeId, port }` |
 | `waypoints` | Point[] | Manual routing points |
-| `startArrow` | enum | Arrow at start |
-| `endArrow` | enum | Arrow at end |
+| `startArrow` | enum | Arrow at start: `none`, `arrow`, `triangle`, `circle`, `square`, `diamond` |
+| `endArrow` | enum | Arrow at end (same options) |
+| `arrowSize` | number | Arrowhead size multiplier |
 | `cornerRadius` | number | Corner rounding for orthogonal |
 | `label` | string | Connector label text |
 | `labelPosition` | number | Label position (0-1 along path) |
+| `flowType` | enum | `control` (solid, default), `object` (dashed) — activity diagram data vs. control flow |
+
+Sequence-diagram-specific connector semantics (sync/async markers, guard conditions, message numbering, self-messages) are covered in DocuShark's Software Engineering guides, not this reference.
 
 ### Connection Ports
 

--- a/docs-site/guide/connectors.md
+++ b/docs-site/guide/connectors.md
@@ -1,6 +1,6 @@
 ---
 title: Connectors
-description: Smart connectors that link shapes together — route styles, anchor points, and how they follow shape movement.
+description: Smart connectors that link shapes together — how to draw them, pick a routing style, and label them.
 ---
 
 # Connectors
@@ -18,88 +18,28 @@ The connector automatically routes itself between the two shapes.
 
 ## Connection Points
 
-Every shape has connection points where connectors can attach:
+Every shape has connection points where connectors can attach — top, right, bottom, left, and center. They become visible when you hover over a shape with the Connector tool active. (The four corners are resize handles, not connection points.) Some library shapes — UML classes, ERD entities — also expose extra anchors on their individual rows or compartments.
 
-| Port | Position |
-|------|----------|
-| `top` | Top center |
-| `right` | Right center |
-| `bottom` | Bottom center |
-| `left` | Left center |
-| `center` | Center of shape |
+## Picking a Routing Style
 
-Connection points become visible when you hover over a shape with the Connector tool active. (The four corners are resize handles, not connection points.) Some library shapes — UML classes, ERD entities — also expose extra anchors on their individual rows or compartments.
+Configure how a connector's path looks in the Property Panel:
 
-## Routing Styles
+- **Orthogonal** (the default) draws clean right-angle paths that route around shapes, and automatically adjusts when you move things — the safest choice for most diagrams, especially flowcharts and architecture diagrams.
+- **Straight** draws a direct line from start to end. Good for simple diagrams or when you want the shortest visual path.
+- **Curved** draws a smooth curve instead of hard angles — often reads better for organic or less rigidly structured relationships.
 
-Configure the connector's routing in the Property Panel:
-
-| Style | Description |
-|-------|-------------|
-| **Orthogonal** | Right-angle paths that route around shapes (default) |
-| **Straight** | Direct line from start to end |
-| **Curved** | Smooth curved path |
-
-Orthogonal connectors automatically adjust their path when you move shapes, keeping the diagram tidy.
-
-## Connector Properties
-
-| Property | What It Does |
-|----------|--------------|
-| **Start/End Arrow** | Choose arrowhead style: none, arrow, triangle, circle, square, diamond |
-| **Arrow Size** | Scale the arrowhead size |
-| **Label** | Add text to the connector |
-| **Label Position** | Where along the path the label appears (0 = start, 1 = end) |
-| **Corner Radius** | Rounding on orthogonal route corners |
-| **Stroke** | Color, width, and style (solid, dashed, dotted) |
+If a connector's path looks awkward after moving shapes around, switching routing style is usually the fastest fix.
 
 ## Labels and Annotations
 
-Click a connector's label area (or use the Property Panel) to add text. Labels float alongside the connector path and move with it.
+Click a connector's label area (or use the Property Panel) to add text. Labels float alongside the connector path and move with it — set where along the path it sits with the label position property.
 
-### Guard Conditions
-
-For activity and flowchart diagrams, connectors support **guard conditions** — text displayed in square brackets near the start of the connector:
-
-- Set the `guardCondition` property (e.g., `[yes]`, `[amount > 100]`)
-- Adjust `guardPosition` to control where along the path it appears
-
-### Message Numbering
-
-For sequence diagrams, use the `messageNumber` property to display numbered messages (e.g., `1:`, `2.1:`) near the connector start.
-
-## UML Sequence Markers
-
-Connectors support specialized markers for UML sequence diagrams:
-
-| Marker | Meaning |
-|--------|---------|
-| `sync` | Synchronous call (filled arrowhead) |
-| `async` | Asynchronous call (open arrowhead) |
-| `reply` | Return message (dashed line) |
-| `create` | Object creation |
-| `destroy` | Object destruction |
-| `lost` | Lost message |
-| `found` | Found message |
-
-Set these via the `startSequenceMarker` and `endSequenceMarker` properties.
-
-## Flow Types
-
-For activity diagrams, connectors have a **flow type**:
-
-| Type | Appearance | Use |
-|------|-----------|-----|
-| `control` | Solid line | Control flow (default) |
-| `object` | Dashed line | Object/data flow |
-
-## Self-Messages
-
-When a connector starts and ends on the same shape (common in sequence diagrams), it automatically routes as a loop to the right. Adjust the loop width with the `selfMessageWidth` property.
+UML sequence diagrams use connectors more specifically — synchronous/asynchronous markers, guard conditions, message numbering, and self-messages — covered in DocuShark's Software Engineering guides.
 
 ## Tips
 
 - **Move connected shapes freely** — connectors update their routes automatically
 - **Switch routing style** if a connector's path looks awkward — sometimes straight or curved works better
-- **Use orthogonal routing** for clean, professional diagrams
 - **Connectors snap** to the nearest connection point as you draw them
+
+For the full list of connector properties (arrowheads, corner radius, activity-diagram flow types, and more), see the [Shape Properties](../developer/shape-properties) reference.

--- a/docs-site/guide/keyboard-shortcuts.md
+++ b/docs-site/guide/keyboard-shortcuts.md
@@ -1,89 +1,29 @@
 ---
 title: Keyboard Shortcuts
-description: Complete keyboard shortcuts reference for DocuShark — tools, navigation, editing, and clipboard operations.
+description: The shortcuts people actually reach for in DocuShark, plus how to find the rest with the command palette.
 ---
 
 # Keyboard Shortcuts
 
-Master DocuShark with these keyboard shortcuts.
+Most things in DocuShark have a shortcut. If you ever forget one, you don't need to memorize a cheat sheet — press `Ctrl+K` (`Cmd+K` on Mac) to open the **command palette** and search for any action by name. It's the fastest way to discover a shortcut while you're using it.
 
-## Tools
+## The ones people learn first
 
-| Action | Key |
-|--------|-----|
+| Action | Shortcut |
+|--------|----------|
+| Command palette | `Ctrl+K` / `Cmd+K` |
 | Select tool | `V` |
-| Rectangle | `R` |
-| Ellipse | `O` |
-| Line | `L` |
-| Connector | `C` |
-| Text | `T` |
-| Hand (pan) | `H` |
-| Command Pallette | `Ctrl + K` |
-
-## Canvas Navigation
-
-| Action | Method |
-|--------|--------|
-| Pan up | `W` or `↑` (when nothing selected) |
-| Pan down | `S` or `↓` (when nothing selected) |
-| Pan left | `A` or `←` (when nothing selected) |
-| Pan right | `D` or `→` (when nothing selected) |
-| Zoom in | `E` or scroll wheel up |
-| Zoom out | `Q` or scroll wheel down |
-| Pan (drag) | Middle-click + drag |
-
-Scroll wheel zooms toward the mouse cursor position. `Q`/`E` zoom toward the viewport center.
-
-## Selection
-
-| Action | Shortcut |
-|--------|----------|
-| Select all | `Ctrl+A` / `Cmd+A` |
-| Deselect all | `Escape` |
-| Add to selection | `Shift+Click` |
-
-## Editing
-
-| Action | Shortcut |
-|--------|----------|
-| Copy | `Ctrl+C` / `Cmd+C` |
-| Paste | `Ctrl+V` / `Cmd+V` |
+| Connector tool | `C` |
+| Undo / Redo | `Ctrl+Z` / `Ctrl+Shift+Z` |
+| Copy / Paste | `Ctrl+C` / `Ctrl+V` |
 | Delete | `Delete` or `Backspace` |
-| Undo | `Ctrl+Z` / `Cmd+Z` |
-| Redo | `Ctrl+Shift+Z` or `Ctrl+Y` / `Cmd+Shift+Z` |
+| Select all | `Ctrl+A` |
+| Group / Ungroup | `Ctrl+G` / `Ctrl+Shift+G` |
+| Zoom in / out | Scroll wheel, or `E` / `Q` |
+| Pan | `W` `A` `S` `D`, or middle-click + drag |
 
-## Movement (with shapes selected)
+(Use `Cmd` in place of `Ctrl` on macOS.)
 
-| Action | Shortcut |
-|--------|----------|
-| Nudge by 10px | Arrow keys |
-| Nudge by 50px | `Shift+Arrow` |
+## Everything else
 
-When shapes are selected, arrow keys nudge them. When nothing is selected, arrow keys pan the canvas (same as WASD).
-
-## Grouping
-
-| Action | Shortcut |
-|--------|----------|
-| Group | `Ctrl+G` / `Cmd+G` |
-| Ungroup | `Ctrl+Shift+G` / `Cmd+Shift+G` |
-
-## Shape Creation Modifiers
-
-Hold these keys while creating shapes:
-
-| Modifier | Effect |
-|----------|--------|
-| `Shift` | Constrain proportions (square, circle) |
-
-## Text Editing
-
-When editing text in the Document Editor:
-
-| Action | Shortcut |
-|--------|----------|
-| Bold | `Ctrl+B` / `Cmd+B` |
-| Italic | `Ctrl+I` / `Cmd+I` |
-| Underline | `Ctrl+U` / `Cmd+U` |
-| Inline code | `Ctrl+E` / `Cmd+E` |
-| Finish editing | `Escape` |
+For every tool shortcut, navigation key, text-editing shortcut, and modifier key, see the [full keyboard shortcuts reference](../developer/keyboard-shortcuts-reference).

--- a/docs-site/guide/keyboard-shortcuts.md
+++ b/docs-site/guide/keyboard-shortcuts.md
@@ -19,8 +19,8 @@ Most things in DocuShark have a shortcut. If you ever forget one, you don't need
 | Delete | `Delete` or `Backspace` |
 | Select all | `Ctrl+A` |
 | Group / Ungroup | `Ctrl+G` / `Ctrl+Shift+G` |
-| Zoom in / out | Scroll wheel, or `E` / `Q` |
-| Pan | `W` `A` `S` `D`, or middle-click + drag |
+| Zoom in / out | Ctrl/⌘ + scroll, pinch, or `E` / `Q` |
+| Pan | Scroll, two-finger drag, `WASD`, or middle-click + drag |
 
 (Use `Cmd` in place of `Ctrl` on macOS.)
 


### PR DESCRIPTION
## Summary
- `keyboard-shortcuts.md` was 100% tables with no narrative. Now opens with the command palette (Ctrl/Cmd+K) as the real answer to "I forgot a shortcut," keeps a curated top-10 table, and links to a new `developer/keyboard-shortcuts-reference.md` (the full table, relocated verbatim) for everything else.
- `connectors.md` keeps its narrative (creating connectors, connection points, routing style tradeoffs, labels) and drops the raw property tables into `developer/shape-properties.md`'s existing Connector section rather than a near-duplicate page.
- Sequence-diagram-specific connector semantics (guard conditions, message numbering, self-messages, sync/async markers) aren't in either page here — they landed in a new Sequence Diagrams guide in Phase B1 (#375, a separate PR), since that's narrative content for a software-engineering audience, not a property dump. This PR deliberately avoids linking to that page directly so it builds standalone regardless of merge order — a plain-text mention instead of a broken link until both land.

Third of several PRs for JP-426 (docs-site restructure). Independent of Phase A (#374) and Phase B1 (#375) — can merge in any order relative to those.

## Test plan
- [x] `bun run build:offline` succeeds standalone (no dead links, even before Phase B1 merges)
- [ ] Visual review of both rewritten pages and the new reference page

Assisted-by: Sonnet 5