### PR TITLE
docs-site: use "workspace" not "relay" + fix stale nav controls (JP-426)

### DIFF
--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -25,7 +25,7 @@ DocuShark runs right in your browser — open it, install it as a PWA, and you a
 
 ### Real-time Collaboration
 
-Work together in real time: connect a document to a relay and everyone sees each other's changes live. Sync uses CRDTs, so edits merge automatically and you'll never lose work to a conflict. See [Collaboration](/guide/collaboration) to get started.
+Work together in real time: connect a document to a workspace and everyone sees each other's changes live, with automatic conflict-free syncing — you'll never lose work to a conflict. Workspaces also give you cloud storage, sync across your devices, and integrations as they arrive. See [Collaboration](/guide/collaboration) to get started.
 
 ### Rich Shape Libraries
 

--- a/docs-site/guide/canvas-navigation.md
+++ b/docs-site/guide/canvas-navigation.md
@@ -7,19 +7,30 @@ description: Navigate DocuShark's infinite canvas — pan, zoom, fit-to-screen, 
 
 The canvas is your infinite drawing surface. Let's cover how to move around it efficiently.
 
-## Mouse Navigation
+## Trackpad & Mouse
 
-| Action | How |
-|--------|-----|
-| Pan | Middle-click + drag |
-| Zoom | Scroll wheel (zooms toward your cursor) |
-| Pan (alternative) | Hold Space + drag |
+There's no single "correct" way to move around the canvas — use whatever feels natural, and don't be afraid to mix it with the keyboard shortcuts below.
 
-Zooming always targets where your mouse cursor is, so you can quickly zoom into any area.
+- **Trackpad**: two-finger scroll pans in any direction; pinch to zoom.
+- **Mouse**: the scroll wheel pans vertically, Shift+scroll pans horizontally, and Ctrl (⌘ on Mac) + scroll zooms toward your cursor.
+- **Middle-click + drag** also pans, while the Select tool is active.
 
-## Keyboard Navigation (WASD)
+| Input | Result |
+|-------|--------|
+| Two-finger scroll (trackpad) | Pan |
+| Pinch (trackpad) | Zoom toward cursor |
+| Scroll wheel | Pan vertically |
+| Shift + scroll wheel | Pan horizontally |
+| Ctrl/⌘ + scroll wheel | Zoom toward cursor |
+| Middle-click + drag | Pan (Select tool) |
 
-Navigate the canvas like a game — hold multiple keys for diagonal movement:
+::: tip Trackpad pinch not zooming?
+On some Linux setups, a trackpad pinch isn't reported the way it is on macOS/Windows. `Q`/`E` (below) always work as a fallback.
+:::
+
+## Keyboard Navigation (WASD / QE)
+
+An additional option alongside the trackpad/mouse controls above — hold multiple keys for diagonal movement, and hold `Q`/`E` for a smooth zoom that speeds up the longer you hold it:
 
 | Key | Action |
 |-----|--------|
@@ -31,13 +42,6 @@ Navigate the canvas like a game — hold multiple keys for diagonal movement:
 | `E` | Zoom in |
 
 Arrow keys also pan the canvas when no shapes are selected.
-
-## Zoom Controls
-
-| Action | Shortcut |
-|--------|----------|
-| Zoom in | `E` or scroll up |
-| Zoom out | `Q` or scroll down |
 
 Click the zoom percentage in the status bar to reset to 100%, or the **Fit** button to frame all shapes in view.
 

--- a/docs-site/guide/collaboration.md
+++ b/docs-site/guide/collaboration.md
@@ -1,35 +1,21 @@
 ---
 title: Collaboration
-description: Real-time collaboration in DocuShark — connect to a relay and edit diagrams live with your team via CRDTs.
+description: Real-time collaboration in DocuShark — work together live in a shared workspace, with automatic conflict-free syncing.
 ---
 
 # Collaboration
 
-DocuShark supports real-time collaboration: when your document is connected to a
-**relay**, everyone editing it sees each other's changes live, with no manual
-saving or merging.
+DocuShark supports real-time collaboration: when your document lives in a **workspace**, everyone editing it sees each other's changes live, with no manual saving or merging.
 
-## How It Works
+## What a workspace gives you
 
-Collaboration is powered by a **relay** — a server that all collaborators connect
-to over a WebSocket:
+A workspace is where documents go to be shared — cloud storage, effortless real-time collaboration, sync across all your devices, and integrations as they arrive. Your **local documents stay local**; they never touch the network unless you move them into a workspace.
 
-1. Each collaborator's editor connects to the relay.
-2. The relay holds the **authoritative copy** of the document and streams changes
-   to everyone in real time.
-3. Edits merge automatically using **CRDTs** (Conflict-free Replicated Data
-   Types, via [Yjs](https://yjs.dev)).
-
-::: tip
-CRDT-based sync means you'll never lose work to a conflict. If two people edit the
-same shape at the same time, the changes merge deterministically — no "their
-version vs. yours" prompt.
+::: info Free workspaces
+Free workspaces don't include every advanced collaboration feature — some are limited by the network and data demands of real-time sync at scale.
 :::
 
-Your **local documents stay local** — they never touch the network. A document
-only collaborates once it lives on a relay.
-
-## Connecting to a Relay
+## Connecting to a Workspace
 
 Open the **Documents** screen (press `Cmd/Ctrl+Shift+O`, or use the Documents button). The simplest way to connect is:
 
@@ -39,18 +25,9 @@ Open the **Documents** screen (press `Cmd/Ctrl+Shift+O`, or use the Documents bu
 3. The app finishes connecting automatically. You'll see your signed-in identity
    and a **Disconnect** button.
 
-Once signed in, opening a relay-hosted document joins its live session. The status
+Once signed in, opening a workspace document joins its live session. The status
 bar shows whether you're connected and whether the current document is actively
 syncing.
-
-::: tip Advanced: your own relay
-DocuShark's relay is open source. If you want to run your own (for a fully
-self-managed setup), point the **DocuShark Cloud URL** field at it instead — the
-default for a local relay is `http://localhost:9876`. Running a relay is an operator task with
-its own setup; see the relay's
-[README](https://github.com/JPE-Net-Technologies/docushark/blob/master/relay/README.md)
-in the repository. For most people, signing in is the quickest path.
-:::
 
 ## Collaboration Features
 
@@ -79,11 +56,7 @@ The toolbar shows who's connected:
 
 ### Real-time Sync
 
-All document changes sync live:
-
-- Shape creation, modification, deletion
-- Property changes (colors, text, etc.)
-- Prose edits, pages, and structure
+All document changes sync live — shape creation, modification, and deletion; property changes; prose edits, pages, and structure. If two people edit the same thing at the same time, DocuShark merges the changes automatically — there's no "their version vs. yours" prompt to resolve.
 
 ## Offline Support
 
@@ -96,9 +69,9 @@ drops.
 2. **Changes queued** — your edits are stored locally in an offline queue
 3. **Reconnection** — queued changes sync automatically when the connection
    returns
-4. **Conflict resolution** — CRDTs merge everything without conflicts
+4. **Conflict resolution** — everything merges automatically, with nothing to resolve by hand
 
-The offline queue is persisted to **IndexedDB**, so pending changes survive an app
+The offline queue is persisted locally, so pending changes survive an app
 restart and replay once you're back online.
 
 ### Connection Indicators
@@ -114,36 +87,29 @@ The status bar shows the current connection state:
 If automatic reconnection doesn't recover:
 
 1. Check your network connection
-2. Confirm you're still signed in (**Settings → Relay**)
+2. Confirm you're still signed in
 3. Use the reconnect action in the status bar
 
 ## A Note on Authentication
 
 You never give DocuShark a password to collaborate. Signing in obtains a
-short-lived access token from the identity provider (DocuShark Cloud by default),
-and the relay simply **validates** that token — it never stores passwords or mints
-its own credentials. Sessions, multi-factor auth, and account management all live
+short-lived access token from your identity provider (DocuShark Cloud by
+default) — DocuShark itself never stores passwords or mints its own
+credentials. Sessions, multi-factor auth, and account management all live
 with the identity provider.
-
-::: info Private document networks
-Dedicated, privately-hosted relays for a team or organization — set up for you
-rather than self-run — are planned for the future. Today, sign in to collaborate,
-or run your own relay if you need full control now.
-:::
 
 ## Troubleshooting
 
 ### Can't Connect
 
 - Confirm you completed the browser sign-in step (the code must be authorized)
-- Check that the **Relay URL** in Settings is reachable from your network
-- If you're on a custom/self-hosted relay, verify it's running and that its auth
-  (OIDC issuer) is configured
+- Check your network connection
+- If you're on a self-managed setup, verify it's reachable
 
 ### Changes Not Syncing
 
 - Check the connection status in the status bar
-- Confirm the document is a relay-hosted document (local documents don't sync)
+- Confirm the document is actually in a workspace (local documents don't sync)
 - Look for error notifications
 - Try disconnecting and signing back in
 
@@ -152,3 +118,12 @@ or run your own relay if you need full control now.
 - Large documents take longer to sync on first join
 - Check your network bandwidth
 - Subsequent edits sync incrementally and stay fast
+
+## Under the hood
+
+DocuShark's real-time sync is built on [Yjs](https://yjs.dev), an open-source
+CRDT (Conflict-free Replicated Data Type) library — the reason edits merge
+automatically instead of prompting you to resolve a conflict. DocuShark's
+sync engine is open source too; see the
+[DocuShark repository](https://github.com/JPE-Net-Technologies/docushark) if
+you're curious how it fits together.

--- a/docs-site/guide/connect-your-agent.md
+++ b/docs-site/guide/connect-your-agent.md
@@ -27,7 +27,7 @@ into your agent:
 
 ::: tip Which location is mine?
 It's the region you chose when you created your DocuShark Cloud workspace. Not sure? Toronto
-(`yyz`) is the default. Running your own relay instead? See [Self-hosting](#self-hosting) below.
+(`yyz`) is the default.
 :::
 
 ## 3. Connect your agent
@@ -40,10 +40,10 @@ Add your **MCP endpoint** to your client as a remote / custom MCP server. The fi
 agent connects, DocuShark walks you through signing in to your workspace — there's no token to
 copy or paste. This is also the **only** option for **claude.ai on the web**.
 
-### Option B — Use a token (advanced / self-host)
+### Option B — Use a token (advanced)
 
-Some setups authenticate with a token instead of signing in (handy for a self-hosted relay or
-a headless script). Send it as a header:
+Some setups authenticate with a token instead of signing in (handy for a headless script). Send
+it as a header:
 
 ```
 Authorization: Bearer <your-token>
@@ -88,12 +88,6 @@ description, notes → a structured document, and more. On Claude they load auto
 other clients you paste a recipe into your system prompt. See
 [AI Agents (MCP) & Recipes](/developer/mcp-agent-recipes) for the recipe list and the full
 tool reference.
-
-## Self-hosting
-
-Running your own relay? Use its address instead of a Cloud region — for example
-`http://localhost:9877/mcp` for a local relay, or `https://your-host/mcp` for a public one.
-Everything else in this guide is the same.
 
 ::: tip Good to know
 Your agent writes to your **workspace** (Cloud) documents. Local, on-device documents are

--- a/docs-site/guide/settings.md
+++ b/docs-site/guide/settings.md
@@ -67,16 +67,9 @@ View and manage stored data:
 - **Garbage collection**: Clean up orphaned blobs (icons are protected by default)
 - Storage usage statistics
 
-## Relay (Collaboration)
+## Workspace (Collaboration)
 
-The **Relay** tab is where you connect to a relay for real-time collaboration:
-
-| Setting | Description |
-|---------|-------------|
-| Sign in with DocuShark Cloud | Connect using a browser sign-in — the simplest path |
-| Relay URL | The relay to connect to (point this at your own relay if you self-host) |
-| Signed-in identity | Who you're connected as, once signed in |
-| Disconnect | End the session and clear your stored token |
+Connecting to a workspace happens from **Documents Home**, not this Settings window — look for the Cloud panel. From there you can sign in with DocuShark Cloud, see your signed-in identity, and disconnect.
 
 For how collaboration works and how to connect, see
 **[Collaboration](./collaboration)**.


### PR DESCRIPTION
## Summary
Two independent fixes to the customer-facing guide tier, both surfaced during review of the JP-426 restructure:

**1. Terminology: "workspace," never "relay."** "Relay" is the internal sync-server component name in code — customers should only ever see "workspace," the actual product concept. Sweeps `collaboration.md`, `connect-your-agent.md`, `settings.md`, `introduction.md`. `collaboration.md`'s "How It Works" section previously walked through WebSocket connections, the authoritative-copy model, and CRDT internals — replaced with workspace value-prop framing (cloud storage, sync across devices, integrations as they arrive) plus a single "Under the hood" note at the very bottom crediting Yjs (open-source CRDT library) and linking the repo. Also removes the self-hosting aside from `connect-your-agent.md` — that content is being consolidated into a dedicated Self-Hosting (Future) section in an upcoming PR rather than scattered across customer guides.

Along the way: `settings.md`'s "Relay (Collaboration)" section described a Settings tab that doesn't exist anymore — Cloud/workspace connection moved to Documents Home per JP-218, and the Settings modal today only has General/Appearance/Style Profiles/Backup & Restore/About. Fixed that section specifically; **flagging that `settings.md`'s Documents/Shape Libraries/Storage/Canvas/PDF Export sections look similarly stale and likely need their own accuracy pass** — not verified/touched in this PR.

**2. Fixed stale pan/zoom controls in `canvas-navigation.md`.** Ground-truthed against `Engine.ts`'s actual wheel-event handling: a plain scroll wheel **pans** (not zooms — zoom needs Ctrl/Cmd held, or pinch on a trackpad), Shift+scroll pans horizontally, and "Hold Space + drag" never shipped (a stale doc comment in `PanTool.ts`, never wired into `ToolManager`). Also notes the Linux trackpad-pinch gap (Q/E as the guaranteed fallback) and that middle-click-drag pan is scoped to the Select tool. The same stale scroll-wheel-zooms claim is also fixed in the keyboard-shortcuts pages from #376 (pushed there directly).

Independent of the other three open JP-426 PRs (#374, #375, #376) — different files or non-conflicting edits to shared ones (cherry-picked the terminology fix onto #375's own new pages directly).

## Test plan
- [x] `bun run build:offline` succeeds
- [x] Repo-wide grep confirms no remaining "relay" in customer guide prose (one literal infra hostname in a JSON example remains, which is a real technical value users paste verbatim, not a conceptual mention)
- [ ] Visual review, especially of the rewritten collaboration.md framing

Assisted-by: Sonnet 5