### PR TITLE
JP-427: RELAY_* env drift guard — README inventory + test

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -185,21 +185,52 @@ env and the relay runs with **no `relay.toml` at all**. Precedence is
 override the file but an explicit CLI flag still wins. Malformed values
 (a non-numeric port, an unknown mode) fail fast at startup.
 
+This table is the canonical inventory — a drift test
+(`tests/env_reference.rs`) fails the build when the code reads a
+`RELAY_*` name that has no row here.
+
 | Variable | Overrides |
 |---|---|
 | `RELAY_PORT` | `[server].port` |
 | `RELAY_NETWORK_MODE` | `[server].network_mode` (`localhost`/`lan`) |
 | `RELAY_DATA_DIR` | `[storage].path` |
+| `RELAY_STORAGE_BACKEND` | `[storage].backend` (`filesystem`/`s3`; a complete `RELAY_R2_*` credential set auto-selects `s3`) |
+| `RELAY_R2_ENDPOINT` | `[storage.s3].endpoint` |
+| `RELAY_R2_BUCKET` | `[storage.s3].bucket` |
+| `RELAY_R2_REGION` | `[storage.s3].region` (default `auto`) |
+| `RELAY_R2_ACCESS_KEY_ID` | `[storage.s3].access_key_id` |
+| `RELAY_R2_SECRET_ACCESS_KEY` | `[storage.s3].secret_access_key` |
+| `RELAY_R2_KEY_PREFIX` | `[storage.s3].key_prefix` |
+| `RELAY_R2_PUT_TTL_SECS` | `[storage.s3].put_ttl_secs` (presigned upload URL lifetime) |
+| `RELAY_R2_GET_TTL_SECS` | `[storage.s3].get_ttl_secs` (presigned download URL lifetime) |
 | `RELAY_JWT_ISSUER` | `[auth].issuer` |
 | `RELAY_JWT_JWKS_URL` | `[auth].jwks_url` |
 | `RELAY_JWT_AUDIENCE` | `[auth].audience` |
+| `RELAY_JWT_RESOURCE` | `[auth].resource` (RFC 8707 resource indicator advertised by MCP OAuth discovery) |
 | `RELAY_REVOCATION_BEARER` | `[auth].revocation_push_bearer` |
 | `RELAY_REVOCATION_POLLING_URL` | `[auth].revocation_polling_url` |
 | `RELAY_REVOCATION_POLLING_BEARER` | `[auth].revocation_polling_bearer` |
+| `RELAY_MCP_ENABLED` | `[mcp].enabled` |
+| `RELAY_MCP_PORT` | `[mcp].port` |
+| `RELAY_MCP_EXPOSE` | `[mcp].expose` (`local` = loopback-only, `public` = folded onto the main listener) |
 | `RELAY_TENANCY_MODE` | `[tenancy].mode` (`shared`/`dedicated`) |
 | `RELAY_TENANCY_WORKSPACE` | `[tenancy].workspace_id` |
-| `RELAY_REGION` | the `--region` value (used to enforce `wsp[].region`) |
+| `RELAY_STORAGE_QUOTA_BYTES` | `[tenancy.limits].storage_quota_bytes` (fallback cap when a token omits the limit claim; `0` = unlimited) |
+| `RELAY_MAX_EDITORS_PER_WORKSPACE` | `[tenancy.limits].max_editors_per_workspace` (fallback cap; `0` = unlimited) |
+| `RELAY_MAX_BLOB_BYTES` | `[tenancy.limits].max_blob_bytes` (per-blob size ceiling) |
+| `RELAY_MAX_CONCURRENT_BLOB_UPLOADS` | `[tenancy.limits].max_concurrent_blob_uploads` (bounds worst-case upload RAM: permits × max blob bytes) |
+| `RELAY_BLOB_GC_GRACE_SECS` | `[tenancy.limits].blob_gc_grace_secs` (orphaned-blob reclaim delay) |
+| `RELAY_BLOB_INGEST_ALLOWED_HOSTS` | `[tenancy.limits].blob_ingest_allowed_hosts` (comma-separated URL-ingest allowlist) |
+| `RELAY_SNAPSHOT_INTERVAL_SECS` | `[sync].snapshot_interval_secs` (Y.Doc → JSON flush cadence; `0` disables the timer) |
+| `RELAY_BINARY_PERSISTENCE` | `[sync].binary_persistence` (binary Y.Doc sidecar on snapshot; default on) |
+| `RELAY_POISON_GUARD` | `[sync].poison_guard` (hydrate sanity + N→0 backup; default on) |
+| `RELAY_DOC_CACHE_MAX_BYTES` | `[sync].doc_cache_max_bytes` (working-set cache cap driving LRU eviction; `0` disables) |
+| `RELAY_VERSION_INTERVAL_SECS` | `[sync].version_interval_secs` (minimum spacing between automatic recovery-point captures while a doc is edited; `0` disables periodic capture) |
+| `RELAY_VERSION_RING` | `[sync].version_ring` (recovery points retained per document) |
 | `RELAY_ENFORCE_PRIVATE_DOCS` | `[permissions].enforce_private_docs` (gate document reads on owner/share set; default off) |
+| `RELAY_REGION` | the `--region` value (used to enforce `wsp[].region`) |
+| `RELAY_TOMBSTONE_TTL_DAYS` | deleted-id tombstone retention window (no toml key; default 30) |
+| `RELAY_SHOW_MCP_TOKEN` | diagnostic only: print the static MCP token unredacted in CLI output (truthy values) |
 
 ## What's *not* here
 

--- a/relay/tests/env_reference.rs
+++ b/relay/tests/env_reference.rs
@@ -1,0 +1,105 @@
+//! Drift guard (JP-427): every `RELAY_*` environment variable the relay reads
+//! at runtime must be documented in the README's environment-variable table.
+//!
+//! The relay silently ignores unknown env names, so an operator's typo no-ops
+//! and an undocumented knob never reaches ops runbooks. This test extracts the
+//! `"RELAY_…"` string literals from the source (the single place env names can
+//! exist) and fails when one is missing from `relay/README.md`.
+//!
+//! Directionality: code → README is a hard failure (undocumented knob).
+//! README → code is a warning only, so documentation can land ahead of (or
+//! compose across) in-flight feature branches without breaking master.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Extract `RELAY_[A-Z0-9_]+` tokens from `text`. When `quoted_only` is set,
+/// only tokens wrapped in double quotes count (string literals in Rust source,
+/// not prose or comments); otherwise any token counts (README backtick usage).
+fn extract_env_names(text: &str, quoted_only: bool) -> BTreeSet<String> {
+    let bytes = text.as_bytes();
+    let mut out = BTreeSet::new();
+    let mut i = 0;
+    while let Some(pos) = text[i..].find("RELAY_") {
+        let start = i + pos;
+        let mut end = start + "RELAY_".len();
+        while end < bytes.len() && (bytes[end].is_ascii_uppercase() || bytes[end].is_ascii_digit() || bytes[end] == b'_') {
+            end += 1;
+        }
+        let name = &text[start..end];
+        // A bare "RELAY_" prefix (e.g. the README's `RELAY_*` wildcard) or a
+        // trailing underscore isn't a variable name.
+        let is_name = name.len() > "RELAY_".len() && !name.ends_with('_');
+        let quoted = start > 0
+            && bytes[start - 1] == b'"'
+            && end < bytes.len()
+            && bytes[end] == b'"';
+        if is_name && (!quoted_only || quoted) {
+            out.insert(name.to_string());
+        }
+        i = end;
+    }
+    out
+}
+
+/// Recursively collect quoted `RELAY_*` literals from every `.rs` file under `dir`.
+fn collect_from_sources(dir: &Path, out: &mut BTreeSet<String>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}"));
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_from_sources(&path, out);
+        } else if path.extension().is_some_and(|x| x == "rs") {
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+            out.extend(extract_env_names(&text, true));
+        }
+    }
+}
+
+#[test]
+fn every_relay_env_var_is_documented_in_the_readme() {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut code_names = BTreeSet::new();
+    collect_from_sources(&manifest.join("src"), &mut code_names);
+    // Test-only env gates (e.g. the env-gated live S3 tests) are not operator
+    // surface — exclude by prefix. RELAY_GIT_SHA / RELAY_BUILD_TIME are
+    // compile-time stamps injected by build.rs (`cargo:rustc-env`), not
+    // runtime configuration an operator can set.
+    code_names.retain(|n| !n.starts_with("RELAY_TEST_"));
+    code_names.remove("RELAY_GIT_SHA");
+    code_names.remove("RELAY_BUILD_TIME");
+
+    let readme = std::fs::read_to_string(manifest.join("README.md")).expect("read README.md");
+    let doc_names = extract_env_names(&readme, false);
+
+    let undocumented: Vec<&String> = code_names.difference(&doc_names).collect();
+    assert!(
+        undocumented.is_empty(),
+        "RELAY_* env vars read by the relay but missing from README.md's \
+         'Environment variables' table: {undocumented:?}\n\
+         Add a row per variable (name → toml key / effect) to relay/README.md."
+    );
+
+    // Reverse direction: a documented name the code no longer reads is doc
+    // rot, but only a warning — docs may land ahead of an in-flight branch.
+    let unknown: Vec<&String> = doc_names.difference(&code_names).collect();
+    if !unknown.is_empty() {
+        eprintln!(
+            "warning: README.md documents RELAY_* names the code does not read \
+             (stale doc rows or pending features): {unknown:?}"
+        );
+    }
+}
+
+#[test]
+fn extractor_understands_quoting_and_wildcards() {
+    let src = r#"get("RELAY_PORT") // mentions RELAY_IN_COMMENT and RELAY_*"#;
+    let quoted = extract_env_names(src, false);
+    assert!(quoted.contains("RELAY_PORT") && quoted.contains("RELAY_IN_COMMENT"));
+    let strict = extract_env_names(src, true);
+    assert!(strict.contains("RELAY_PORT"));
+    assert!(!strict.contains("RELAY_IN_COMMENT"), "comments must not count as code reads");
+    assert!(!strict.iter().any(|n| n == "RELAY_"), "wildcard prefix is not a name");
+}


### PR DESCRIPTION
The relay silently ignores unknown env names, so consumer typos no-op and new knobs never reach the ops docs. This makes `relay/README.md`'s environment-variable table the drift-tested canonical inventory:

- **`relay/tests/env_reference.rs`** — extracts every quoted `RELAY_*` literal under `relay/src` (hand-rolled scan, no new deps) and fails when one has no README row. Code→doc is a hard failure; doc→code (a documented name the code no longer reads) is a warning only, so documentation can land ahead of in-flight feature branches without breaking master. `RELAY_TEST_*` gates and the build.rs compile-time stamps (`RELAY_GIT_SHA` / `RELAY_BUILD_TIME`) are excluded.
- **README table completed** — was 13 rows, code reads 41 runtime knobs. The first red run listed all 29 missing, including JP-185's day-old `RELAY_VERSION_INTERVAL_SECS` / `RELAY_VERSION_RING` — exactly the drift class this exists to catch.

Companion `task env:audit` on the consumer side lands in docushark-web.

Verification: `cargo test --test env_reference` red before the table fix (29 names listed), green after; full `cargo check --all-targets` clean.

Assisted-by: Fable 5