### PR TITLE
JP-428: prose fidelity hardening + version capture-on-open

### DIFF
--- a/docs-site/guide/recovery-and-undo.md
+++ b/docs-site/guide/recovery-and-undo.md
@@ -22,8 +22,9 @@ Separately, DocuShark keeps an automatic **version history** for documents store
 To browse them, open **Version history**:
 
 1. Open the document and click the **history icon** in the toolbar — or use the **Version history** action on the document's card in Documents Home
-2. Versions are grouped by day, each showing when it was captured and its size
-3. Select a version to see a quick summary of what's inside — its pages with shape and word counts, and how that differs from the current document
+2. Opening the panel captures a fresh version of the document's current state, so the timeline always starts from *now*
+3. Versions are grouped by day, each showing when it was captured and its size
+4. Select a version to see a quick summary of what's inside — its pages with shape and word counts, and how that differs from the current document
 
 Each version offers two actions:
 

--- a/docs-site/public/openapi.yaml
+++ b/docs-site/public/openapi.yaml
@@ -244,6 +244,38 @@ paths:
         '404':
           description: Document not found in the caller's workspace.
 
+  /api/docs/{id}/recovery/capture:
+    parameters:
+      - $ref: '#/components/parameters/DocId'
+    post:
+      tags: [docs]
+      summary: Capture a recovery point now
+      description: |
+        Captures a recovery point immediately (JP-428) — backs the version
+        history UI's open-time refresh, so the timeline leads with current
+        state instead of the last periodic tick. A resident document is
+        flushed first so the point reflects "now"; state byte-identical to
+        the newest existing point dedupes to a no-op (`captured: false`).
+        Write-scoped like PUT /api/docs/{id}.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Capture result.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [captured]
+                properties:
+                  captured:
+                    type: boolean
+                    description: Whether a new recovery point was written.
+        '403':
+          description: Caller lacks write permission on the document.
+        '404':
+          description: Document not found in the caller's workspace.
+
   /api/docs/{id}/recovery/{pointId}:
     parameters:
       - $ref: '#/components/parameters/DocId'

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -244,6 +244,38 @@ paths:
         '404':
           description: Document not found in the caller's workspace.
 
+  /api/docs/{id}/recovery/capture:
+    parameters:
+      - $ref: '#/components/parameters/DocId'
+    post:
+      tags: [docs]
+      summary: Capture a recovery point now
+      description: |
+        Captures a recovery point immediately (JP-428) — backs the version
+        history UI's open-time refresh, so the timeline leads with current
+        state instead of the last periodic tick. A resident document is
+        flushed first so the point reflects "now"; state byte-identical to
+        the newest existing point dedupes to a no-op (`captured: false`).
+        Write-scoped like PUT /api/docs/{id}.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Capture result.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [captured]
+                properties:
+                  captured:
+                    type: boolean
+                    description: Whether a new recovery point was written.
+        '403':
+          description: Caller lacks write permission on the document.
+        '404':
+          description: Document not found in the caller's workspace.
+
   /api/docs/{id}/recovery/{pointId}:
     parameters:
       - $ref: '#/components/parameters/DocId'

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -271,6 +271,10 @@ pub fn routes() -> Router<Arc<ServerState>> {
         )
         .route("/api/docs/:id/recovery", get(list_recovery_handler))
         .route(
+            "/api/docs/:id/recovery/capture",
+            post(capture_recovery_handler),
+        )
+        .route(
             "/api/docs/:id/recovery/:pointId",
             get(recovery_point_content_handler),
         )
@@ -1011,6 +1015,62 @@ fn reconstruct_recovery_point(
             .into_response());
     }
     Ok((json, handle))
+}
+
+/// `POST /api/docs/:id/recovery/capture` — capture a recovery point NOW
+/// (JP-428). Backs the Version History panel's open-time refresh, so the
+/// timeline leads with current state instead of the last periodic tick.
+/// Write-scoped like `PUT /api/docs/:id`. A resident dirty doc is flushed
+/// first so the sidecar is current; byte-identical state dedupes to a no-op
+/// (`captured: false`).
+async fn capture_recovery_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    if state.doc_store().get_metadata(&ws, &doc_id).is_none() {
+        return (StatusCode::NOT_FOUND, ApiError::body("document not found")).into_response();
+    }
+    if let Err(e) = check_write_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        Some(&claims.sub),
+        Some(role_str(role)),
+    ) {
+        return permission_error_response(&e);
+    }
+    // Flush a resident doc's live state into the sidecar before copying it —
+    // otherwise the point captures the last persisted tick, not "now". The
+    // flush itself may capture (the periodic gate fires inside snapshot_doc),
+    // so `captured` is measured as "did a new point appear", not which
+    // mechanism wrote it.
+    let before = state
+        .doc_store()
+        .newest_recovery_point(&ws, &doc_id)
+        .map(|p| p.id);
+    if let Some(handle) = state.sync_registry().get(&ws, &doc_id) {
+        state.snapshot_doc(&ws, &doc_id, &handle);
+    }
+    state.capture_version_point(&ws, &doc_id, "on-demand");
+    let captured = state
+        .doc_store()
+        .newest_recovery_point(&ws, &doc_id)
+        .map(|p| p.id)
+        != before;
+    (StatusCode::OK, Json(serde_json::json!({ "captured": captured }))).into_response()
 }
 
 /// `GET /api/docs/:id/recovery/:pointId` — a recovery point's content as a

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1103,7 +1103,17 @@ async fn recovery_point_content_handler(
         return permission_error_response(&e);
     }
     match reconstruct_recovery_point(&state, &ws, &doc_id, &point_id) {
-        Ok((json, _handle)) => (StatusCode::OK, Json(json)).into_response(),
+        Ok((json, _handle)) => {
+            // Field-test breadcrumb: which point a "save to local" actually
+            // served, correlatable with the client's console log.
+            log::info!(
+                "recovery point read {}/{} point {}",
+                ws.as_str(),
+                doc_id.as_str(),
+                point_id
+            );
+            (StatusCode::OK, Json(json)).into_response()
+        }
         Err(resp) => resp,
     }
 }
@@ -1256,6 +1266,13 @@ async fn restore_recovery_handler(
     state.emit_doc_event(&ws, &doc_id, DocEventType::Deleted, Some(claims.sub.clone()));
     state.emit_doc_event(&ws, &new_doc_id, DocEventType::Created, Some(claims.sub.clone()));
 
+    log::info!(
+        "recovery point restored {}/{} point {} -> new doc {}",
+        ws.as_str(),
+        doc_id.as_str(),
+        point_id,
+        new_id
+    );
     (
         StatusCode::OK,
         Json(json!({ "newDocId": new_id, "serverVersion": 1 })),

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1272,19 +1272,36 @@ impl ServerState {
                 // JP-185: session boundary — the last participant left, so the
                 // just-flushed sidecar is a natural version. Dedupe makes this
                 // a no-op when the session changed nothing.
-                if self.binary_persistence
-                    && self.doc_store.push_recovery_point_if_changed(ws, doc_id)
-                {
-                    self.version_points.fetch_add(1, Ordering::Relaxed);
-                    log::info!(
-                        "session-end recovery point captured for {}/{}",
-                        ws.as_str(),
-                        doc_id.as_str()
-                    );
-                }
+                self.capture_version_point(ws, doc_id, "session-end");
             }
             self.sync_registry.evict(ws, doc_id);
         }
+    }
+
+    /// Capture a recovery point from the persisted sidecar unless it's
+    /// byte-identical to the newest existing point (JP-185 session-end /
+    /// JP-428 capture-on-demand). Gated on binary persistence — without a
+    /// sidecar there is nothing current to copy. Returns whether a point was
+    /// written; `trigger` labels the log line.
+    pub(crate) fn capture_version_point(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        trigger: &str,
+    ) -> bool {
+        if !self.binary_persistence {
+            return false;
+        }
+        if self.doc_store.push_recovery_point_if_changed(ws, doc_id) {
+            self.version_points.fetch_add(1, Ordering::Relaxed);
+            log::info!(
+                "{trigger} recovery point captured for {}/{}",
+                ws.as_str(),
+                doc_id.as_str()
+            );
+            return true;
+        }
+        false
     }
 
     /// Flatten one dirty Y.Doc back to its JSON snapshot (JP-36). The flatten

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -50,19 +50,18 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
     let metadata = doc.get_or_insert_map("metadata");
     let meta_any = metadata.to_json(&doc.transact());
 
-    // The union of page ids to flatten: every JSON page plus every live
-    // `shapes:<id>` surface in the Y.Doc (a freshly-added tab exists only in the
-    // Y.Doc until this flatten persists it). Read the Y.Doc root names under a
-    // short read txn; `shapeOrder:<id>` roots are skipped (distinct prefix).
+    // The pages to flatten are exactly the ones this Y.Doc CARRIES — the
+    // `shapes:<id>` roots (a freshly-added tab exists only in the Y.Doc until
+    // this flatten persists it). A JSON page with no root is a surface this
+    // doc's lineage never held — leave it untouched rather than zeroing it
+    // (JP-428): a live handle has a root for every hydrated JSON page
+    // (`json_to_ydoc` creates them), so this only bites where it should —
+    // recovery-point reconstruction (a page created after capture keeps its
+    // current content; "absence never erases") and a REST-added page on a
+    // resident doc (previously clobbered to `{}` by the next flatten).
+    // `shapeOrder:<id>` roots are skipped (distinct prefix).
     let mut page_ids: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
-    if let Some(pages) = json.get("pages").and_then(Value::as_object) {
-        for id in pages.keys() {
-            if seen.insert(id.clone()) {
-                page_ids.push(id.clone());
-            }
-        }
-    }
     {
         let txn = doc.transact();
         for (name, _) in txn.root_refs() {
@@ -206,6 +205,40 @@ pub fn project_prose_into(pages: &[(String, String)], json: &mut Value) {
         for (id, _) in pages {
             if !order.iter().any(|v| v.as_str() == Some(id.as_str())) {
                 order.push(Value::String(id.clone()));
+            }
+        }
+    }
+}
+
+/// Clear `richTextPages` content for pages whose `prose:<id>` root EXISTS in
+/// the Y.Doc but is empty (JP-428). Pairs with [`project_prose_into`], which
+/// only overlays non-empty fragments: an existing-but-empty root means the
+/// content was deleted in this doc's CRDT lineage (a live page is never truly
+/// empty — the editor keeps a placeholder paragraph), so the JSON must not
+/// keep resurrecting the old text. Pages with NO root are untouched —
+/// absence never erases (a recovery point predating the page, or MCP-authored
+/// prose the Y.Doc never held).
+pub fn clear_prose_content_for(empty_ids: &[String], json: &mut Value) {
+    if empty_ids.is_empty() {
+        return;
+    }
+    let Some(pages_map) = json
+        .get_mut("richTextPages")
+        .and_then(|r| r.get_mut("pages"))
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    let now = now_ms();
+    for id in empty_ids {
+        if let Some(page) = pages_map.get_mut(id.as_str()).and_then(Value::as_object_mut) {
+            let had_content = page
+                .get("content")
+                .and_then(Value::as_str)
+                .is_some_and(|c| !c.trim().is_empty());
+            if had_content {
+                page.insert("content".to_string(), Value::String(String::new()));
+                page.insert("modifiedAt".to_string(), Value::from(now));
             }
         }
     }

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -369,7 +369,13 @@ fn block_has_substance(node: &super::prose_parse::PmNode) -> bool {
     // mistaken for the empty-page placeholder.
     if matches!(
         node.node_type.as_str(),
-        "image" | "horizontalRule" | "citationInline" | "bibliography" | "fieldRef"
+        "image"
+            | "horizontalRule"
+            | "citationInline"
+            | "bibliography"
+            | "fieldRef"
+            | "mathInline"
+            | "mathBlock"
     ) {
         return true;
     }

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -26,6 +26,8 @@ mod prose_parse;
 mod prose_schema;
 mod prose_validate;
 mod protocol;
+#[cfg(test)]
+mod roundtrip_tests;
 
 /// Apply an anchored, block-level prose edit to a page's HTML off the live path
 /// (the MCP cold path for a non-resident document). See [`prose_block`].
@@ -349,6 +351,29 @@ impl DocHandle {
         pages
     }
 
+    /// Page ids whose `prose:<id>` root exists but holds nothing (JP-428) —
+    /// the complement of [`Self::prose_pages`]. An existing-but-empty root
+    /// means the content was deleted in this doc's lineage; the flatten
+    /// clears the JSON copy so it stops resurrecting.
+    fn empty_prose_page_ids(&self) -> Vec<String> {
+        let names: Vec<String> = {
+            let txn = self.doc.transact();
+            txn.root_refs()
+                .map(|(name, _)| name)
+                .filter(|name| name.starts_with("prose:"))
+                .map(String::from)
+                .collect()
+        };
+        let mut ids = Vec::new();
+        for name in names {
+            let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+            if frag.len(&self.doc.transact()) == 0 {
+                ids.push(name.strip_prefix("prose:").unwrap_or(&name).to_string());
+            }
+        }
+        ids
+    }
+
     /// Encode the live `Y.Doc` as a binary sidecar blob tagged with
     /// `server_version` (JP-108). Captures the whole doc — every shared type,
     /// incl. prose — not just the active-page shapes the JSON flatten writes.
@@ -430,6 +455,9 @@ impl DocHandle {
         // shape-only flatten above never wrote). Read projection only — restore
         // stays binary-sidecar based.
         flatten::project_prose_into(&self.prose_pages(), json);
+        // JP-428: and clear pages whose root exists but was emptied in this
+        // lineage, so deleted prose stops resurrecting from the JSON copy.
+        flatten::clear_prose_content_for(&self.empty_prose_page_ids(), json);
         // JP-89: re-assert the reference library from the authoritative Y.Doc, so
         // a merged set (incl. live MCP/peer adds) is what persists.
         flatten::project_references_into(&self.doc, json);

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -220,6 +220,21 @@ fn image_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
                 _ => None,
             })
     };
+    // Sizing attrs are NUMBERS on a live-edited fragment (the editor's resize
+    // writes offsetWidth; gallery inserts `width: 220`; y-prosemirror stores
+    // attrs raw) but STRINGS on a seeded one (HTML attrs parse as strings) —
+    // accept both or the size is silently dropped on every flatten/read.
+    let dimension = |k: &str| {
+        el.get_attribute(txn, k).and_then(|o| match o {
+            Out::Any(Any::String(s)) => Some(s.to_string()),
+            Out::Any(Any::Number(n)) if n.is_finite() && n.fract() == 0.0 => {
+                Some(format!("{}", n as i64))
+            }
+            Out::Any(Any::Number(n)) if n.is_finite() => Some(n.to_string()),
+            Out::Any(Any::BigInt(i)) => Some(i.to_string()),
+            _ => None,
+        })
+    };
     let mut s = String::from("<img");
     if let Some(src) = attr("src") {
         let _ = write!(s, " src=\"{}\"", escape_attr(&src));
@@ -232,10 +247,10 @@ fn image_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
     }
     // Symmetric with the parser (`prose_parse` img): preserve sizing + float so
     // the image survives an MCP HTML round-trip instead of resetting to inline.
-    if let Some(width) = attr("width") {
+    if let Some(width) = dimension("width") {
         let _ = write!(s, " width=\"{}\"", escape_attr(&width));
     }
-    if let Some(height) = attr("height") {
+    if let Some(height) = dimension("height") {
         let _ = write!(s, " height=\"{}\"", escape_attr(&height));
     }
     // `float` (PM attr) → `data-float` (HTML), the reverse of the parser's

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -70,7 +70,7 @@ fn tokenize(html: &str) -> Vec<Token> {
                 }
                 break;
             }
-            let Some(close_rel) = html[i..].find('>') else {
+            let Some(close_rel) = find_tag_close(&html[i..]) else {
                 break; // malformed tail — stop
             };
             let inner = &html[i + 1..i + close_rel]; // between < and >
@@ -96,6 +96,31 @@ fn tokenize(html: &str) -> Vec<Token> {
         }
     }
     tokens
+}
+
+/// Offset of the `>` that closes the tag starting at `s[0] == '<'`, skipping
+/// `>` inside quoted attribute values. Browsers escape only `&` and `"` when
+/// serializing attributes — `<` and `>` stay raw (an image `alt="a > b"`, a
+/// bibliography's `data-bib-html` carrying markup) — so a quote-blind scan
+/// truncates the tag mid-attribute and corrupts everything after it.
+fn find_tag_close(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    let mut quote: Option<u8> = None;
+    for (i, &c) in b.iter().enumerate().skip(1) {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                b'"' | b'\'' => quote = Some(c),
+                b'>' => return Some(i),
+                _ => {}
+            },
+        }
+    }
+    None
 }
 
 /// Split a tag's inner text (`a href="x"`) into a lowercased name + attrs.

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -189,6 +189,34 @@ fn sanitize_node(
         return vec![strip_children_if_any(node, path, fixes)];
     }
 
+    // Gallery: client content model is `image+`. Any other child makes the
+    // client's schema.node() throw during collab adoption — and y-prosemirror
+    // DELETES the throwing node from the live Y.Doc, so the gallery (and its
+    // images) silently vanish from the document and every later capture.
+    // Keep the valid images, move any other content out after the gallery,
+    // and unwrap entirely when no image survives.
+    if node.node_type == "gallery" {
+        return normalize_gallery(node, path, depth, fixes);
+    }
+
+    // Figure: strict `image figcaption` on the client — same crash/deletion
+    // class as gallery when malformed. No usable image → unwrap to content.
+    if node.node_type == "figure" {
+        return normalize_figure(node, path, depth, fixes);
+    }
+
+    // A figcaption outside a figure has no block group on the client —
+    // demote to a paragraph carrying its inline content.
+    if node.node_type == "figcaption" {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "figcaption".to_string(),
+            action: FixAction::Unwrapped,
+            reason: "figcaption is only valid inside a figure",
+        });
+        return unwrap_children(node, path, depth, fixes);
+    }
+
     // Tables: rebuild into a well-formed, rectangular shape.
     if node.node_type == "table" {
         return normalize_table(node, path, depth, fixes);
@@ -254,6 +282,149 @@ fn unwrap_children(node: PmNode, path: &str, depth: usize, fixes: &mut Vec<Prose
         blocks.insert(0, paragraph(inline));
     }
     blocks
+}
+
+/// Enforce the gallery content model (`image+`): sanitize children, keep the
+/// surviving images inside the gallery, emit any other block content AFTER it
+/// (demotion over elimination), and unwrap the gallery entirely when no image
+/// survives.
+fn normalize_gallery(
+    node: PmNode,
+    path: &str,
+    depth: usize,
+    fixes: &mut Vec<ProseFix>,
+) -> Vec<PmNode> {
+    let attrs = node.attrs;
+    let mut images: Vec<PmChild> = Vec::new();
+    let mut displaced: Vec<PmNode> = Vec::new();
+    let mut inline: Vec<PmChild> = Vec::new();
+    let mut had_foreign = false;
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                let child_path = format!("{path}/{}", n.node_type);
+                for sn in sanitize_node(n, &child_path, depth + 1, fixes) {
+                    if sn.node_type == "image" {
+                        images.push(PmChild::Node(sn));
+                    } else {
+                        had_foreign = true;
+                        displaced.push(sn);
+                    }
+                }
+            }
+            t @ PmChild::Text { .. } => {
+                if matches!(&t, PmChild::Text { text, .. } if !text.trim().is_empty()) {
+                    had_foreign = true;
+                    inline.push(t);
+                }
+            }
+        }
+    }
+    if !inline.is_empty() {
+        displaced.insert(0, paragraph(inline));
+    }
+    if images.is_empty() {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "gallery".to_string(),
+            action: FixAction::Unwrapped,
+            reason: "gallery has no usable image (client content model is image+)",
+        });
+        return displaced;
+    }
+    if had_foreign {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "gallery".to_string(),
+            action: FixAction::StrippedChildren,
+            reason: "gallery keeps image children only; other content moved after it",
+        });
+    }
+    let mut out = vec![PmNode { node_type: "gallery".to_string(), attrs, children: images }];
+    out.extend(displaced);
+    out
+}
+
+/// Enforce the figure content model (strict `image figcaption`): first usable
+/// image + first figcaption (synthesized empty when absent) stay in the
+/// figure; other content moves after it; no usable image → unwrap.
+fn normalize_figure(
+    node: PmNode,
+    path: &str,
+    depth: usize,
+    fixes: &mut Vec<ProseFix>,
+) -> Vec<PmNode> {
+    let attrs = node.attrs;
+    let mut image: Option<PmNode> = None;
+    let mut caption: Option<PmNode> = None;
+    let mut displaced: Vec<PmNode> = Vec::new();
+    let mut inline: Vec<PmChild> = Vec::new();
+    let mut had_foreign = false;
+    for child in node.children.into_iter() {
+        match child {
+            PmChild::Node(n) => {
+                if n.node_type == "figcaption" && caption.is_none() {
+                    // The caption's children are inline runs; keep as-is (the
+                    // standalone-figcaption demotion must not fire here).
+                    caption = Some(n);
+                    continue;
+                }
+                let child_path = format!("{path}/{}", n.node_type);
+                for sn in sanitize_node(n, &child_path, depth + 1, fixes) {
+                    if sn.node_type == "image" && image.is_none() {
+                        image = Some(sn);
+                    } else {
+                        had_foreign = true;
+                        displaced.push(sn);
+                    }
+                }
+            }
+            t @ PmChild::Text { .. } => {
+                if matches!(&t, PmChild::Text { text, .. } if !text.trim().is_empty()) {
+                    had_foreign = true;
+                    inline.push(t);
+                }
+            }
+        }
+    }
+    if !inline.is_empty() {
+        displaced.insert(0, paragraph(inline));
+    }
+    let Some(image) = image else {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "figure".to_string(),
+            action: FixAction::Unwrapped,
+            reason: "figure has no usable image (client content model is image+figcaption)",
+        });
+        // A caption without its figure degrades to a paragraph of its inline.
+        if let Some(cap) = caption {
+            let mut blocks = unwrap_children(cap, path, depth, fixes);
+            blocks.append(&mut displaced);
+            return blocks;
+        }
+        return displaced;
+    };
+    if had_foreign {
+        fixes.push(ProseFix {
+            path: path.to_string(),
+            node_type: "figure".to_string(),
+            action: FixAction::StrippedChildren,
+            reason: "figure keeps image+figcaption only; other content moved after it",
+        });
+    }
+    let figcaption = caption.unwrap_or(PmNode {
+        node_type: "figcaption".to_string(),
+        attrs: vec![],
+        children: vec![],
+    });
+    let mut out = vec![PmNode {
+        node_type: "figure".to_string(),
+        attrs,
+        children: vec![PmChild::Node(image), PmChild::Node(figcaption)],
+    }];
+    out.extend(displaced);
+    out
 }
 
 /// Rebuild a `table` into `table > tableRow+ > (tableCell|tableHeader)+`, with

--- a/relay/src/sync/roundtrip_tests.rs
+++ b/relay/src/sync/roundtrip_tests.rs
@@ -1,0 +1,320 @@
+//! JP-428 prose round-trip fidelity harness.
+//!
+//! Drives editor-shaped HTML through the exact production seed pipeline —
+//! `html_to_blocks → sanitize_blocks → seed_prose_deterministic` — then back
+//! out through `fragment_to_html`, asserting two invariants:
+//!
+//! 1. **Siblings always survive.** A node that fails to parse/validate may
+//!    degrade (unwrap to children, drop an unusable atom) but must NEVER take
+//!    content after it. The `<p>after</p>` trailer on every fixture is the
+//!    canary.
+//! 2. **Known nodes are fidelity-stable.** Galleries, images (including
+//!    numeric width/height as the live y-prosemirror binding stores them),
+//!    figures, bibliographies with browser-shaped attribute escaping, and
+//!    math atoms survive the trip they take on every JSON rebuild.
+//!
+//! These exist because the first JP-185 E2E lost a gallery and trailing prose
+//! from version content; the fixtures pin every defect found in that
+//! investigation (JP-428).
+
+use yrs::{Doc, Transact, XmlFragment};
+
+use super::{prose_html, prose_parse, prose_validate};
+
+/// The production seed pipeline (hydration's `json_prose_to_ydoc` body) for a
+/// single page, returning the re-serialized HTML.
+fn seed_round_trip(html: &str) -> String {
+    let (blocks, _fixes) = prose_validate::sanitize_blocks(prose_parse::html_to_blocks(html));
+    let doc = Doc::new();
+    super::seed_prose_deterministic(&doc, "p1", &blocks);
+    let frag = doc.get_or_insert_xml_fragment("prose:p1");
+    let txn = doc.transact();
+    prose_html::fragment_to_html(&frag, &txn)
+}
+
+/// Editor-shaped gallery markup (GalleryExtension.renderHTML): outer
+/// `div[data-gallery]` + inner `div.gallery-items` holding bare `<img>`s.
+fn gallery_html(imgs: &str) -> String {
+    format!(
+        "<div data-gallery=\"\" class=\"prose-gallery\" data-layout=\"grid\">\
+         <div class=\"gallery-items\">{imgs}</div></div>"
+    )
+}
+
+#[test]
+fn gallery_round_trips_with_trailing_content() {
+    let html = format!(
+        "<p>before</p>{}<p>after</p>",
+        gallery_html(
+            "<img src=\"blob://aaa\" alt=\"one\" width=\"220\">\
+             <img src=\"blob://bbb\" data-float=\"left\">"
+        )
+    );
+    let out = seed_round_trip(&html);
+    assert!(out.contains("<p>before</p>"), "leading sibling lost: {out}");
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(out.contains("data-gallery"), "gallery node lost: {out}");
+    assert!(
+        out.contains("src=\"blob://aaa\"") && out.contains("src=\"blob://bbb\""),
+        "gallery images lost: {out}"
+    );
+    assert!(out.contains("width=\"220\""), "image width lost: {out}");
+}
+
+#[test]
+fn gallery_with_unusable_images_degrades_without_taking_siblings() {
+    // Src-less images make the gallery unusable; it must degrade (drop/unwrap),
+    // never swallowing what follows.
+    let html = format!("{}<p>after</p>", gallery_html("<img alt=\"broken\">"));
+    let out = seed_round_trip(&html);
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(!out.contains("<img>"), "src-less img must not survive: {out}");
+}
+
+#[test]
+fn image_alt_with_raw_angle_brackets_survives() {
+    // Browsers do NOT escape `>` (or `<`) inside attribute values — only `&`
+    // and `"`. Editor getHTML → richTextPages carries this shape, and the
+    // rehydrate seed must not corrupt on it. (Images are block-level in the
+    // editor schema, so the fixture places it between paragraphs.)
+    let html = "<p>x</p><img src=\"blob://ccc\" alt=\"a > b\"><p>after</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("<p>x</p>"), "leading sibling lost: {out}");
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(out.contains("src=\"blob://ccc\""), "image lost: {out}");
+    assert!(out.contains("alt=\"a &gt; b\""), "alt mangled: {out}");
+}
+
+#[test]
+fn bibliography_with_browser_escaped_bib_html_survives() {
+    // Browser attribute serialization: `"` → `&quot;`, `&` → `&amp;`, but `<`
+    // and `>` stay RAW. This is exactly what a client REST save stores for a
+    // bibliography, and what the JSON-rebuild seed must parse.
+    let html = "<div data-bibliography=\"\" \
+                data-bib-html=\"<div class=&quot;csl-entry&quot;>Knuth, D.</div>\"></div>\
+                <p>after</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(out.contains("data-bibliography"), "bibliography lost: {out}");
+    assert!(out.contains("csl-entry"), "bibliography payload lost: {out}");
+}
+
+#[test]
+fn callout_wrapping_bibliography_keeps_structure() {
+    let html = "<div data-callout=\"\" data-variant=\"note\">\
+                <div data-bibliography=\"\" data-bib-html=\"<span>Ref</span>\"></div>\
+                <p>inside</p></div><p>after</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(out.contains("data-callout"), "callout lost: {out}");
+    assert!(out.contains("<p>inside</p>"), "callout content lost: {out}");
+}
+
+#[test]
+fn figure_round_trips_and_srcless_figure_degrades() {
+    let ok = seed_round_trip(
+        "<figure><img src=\"blob://ddd\"><figcaption>cap</figcaption></figure><p>after</p>",
+    );
+    assert!(ok.contains("<figure>"), "figure lost: {ok}");
+    assert!(ok.contains("cap"), "figcaption lost: {ok}");
+    assert!(ok.contains("<p>after</p>"), "trailing sibling lost: {ok}");
+
+    let degraded = seed_round_trip("<figure><img alt=\"x\"></figure><p>after</p>");
+    assert!(degraded.contains("<p>after</p>"), "trailing sibling lost: {degraded}");
+}
+
+#[test]
+fn citation_and_field_in_table_cell_round_trip() {
+    let html = "<table><tr><td><p>see <span data-citation data-ref-id=\"k97\" \
+                data-label=\"(Knuth, 1997)\">(Knuth, 1997)</span> and <span data-field \
+                data-name=\"Version\" data-label=\"1.0\">1.0</span></p></td></tr></table>\
+                <p>after</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(out.contains("data-citation"), "citation lost: {out}");
+    assert!(out.contains("data-field"), "field lost: {out}");
+}
+
+#[test]
+fn math_only_page_has_substance_and_seeds() {
+    // A page whose only content is math must seed on JSON rebuild — the
+    // substance gate treating math atoms as empty left math-only pages blank
+    // after every rehydrate.
+    let doc_json = serde_json::json!({
+        "richTextPages": {
+            "pageOrder": ["m1"],
+            "pages": {"m1": {"content":
+                "<div data-math-block data-latex=\"E = mc^2\"></div>"}}
+        }
+    });
+    let doc = Doc::new();
+    super::hydration::json_prose_to_ydoc(&doc_json, &doc);
+    let frag = doc.get_or_insert_xml_fragment("prose:m1");
+    let len = frag.len(&doc.transact());
+    assert!(len > 0, "math-only page failed to seed (fragment empty)");
+    let txn = doc.transact();
+    let out = prose_html::fragment_to_html(&frag, &txn);
+    assert!(out.contains("data-latex=\"E = mc^2\""), "math payload lost: {out}");
+}
+
+#[test]
+fn sanitize_drops_imageless_gallery_before_it_reaches_a_client() {
+    use super::prose_parse::{PmChild, PmNode};
+    // A gallery whose children hold no image would make the client's
+    // schema.node() throw — and y-prosemirror deletes the node from the live
+    // Y.Doc on that throw, poisoning every later capture. The write gate must
+    // degrade it instead.
+    let gallery = PmNode {
+        node_type: "gallery".to_string(),
+        attrs: vec![("layout".to_string(), "grid".to_string())],
+        children: vec![PmChild::Node(PmNode {
+            node_type: "paragraph".to_string(),
+            attrs: vec![],
+            children: vec![PmChild::Text { text: "stray".to_string(), marks: vec![] }],
+        })],
+    };
+    let after = PmNode {
+        node_type: "paragraph".to_string(),
+        attrs: vec![],
+        children: vec![PmChild::Text { text: "after".to_string(), marks: vec![] }],
+    };
+    let (out, _fixes) = prose_validate::sanitize_blocks(vec![gallery, after]);
+    let has_bad_gallery = out.iter().any(|n| {
+        n.node_type == "gallery"
+            && !n
+                .children
+                .iter()
+                .any(|c| matches!(c, PmChild::Node(inner) if inner.node_type == "image"))
+    });
+    assert!(!has_bad_gallery, "image-less gallery must not pass the gate: {out:?}");
+    assert!(
+        out.iter().any(|n| matches!(
+            n.children.first(),
+            Some(PmChild::Text { text, .. }) if text == "after"
+        )),
+        "sibling after the degraded gallery lost: {out:?}"
+    );
+}
+
+#[test]
+fn live_numeric_image_attrs_serialize() {
+    use yrs::{Any, Xml, XmlElementPrelim};
+    // The editor stores image width/height as NUMBERS (resize writes
+    // offsetWidth; gallery inserts width: 220) and y-prosemirror stores attrs
+    // raw — so the live fragment holds Any::Number, not strings. Serialization
+    // must not drop them (they vanish on every flatten/version otherwise).
+    let doc = Doc::new();
+    let frag = doc.get_or_insert_xml_fragment("prose:p1");
+    {
+        let mut txn = doc.transact_mut();
+        let img = frag.push_back(&mut txn, XmlElementPrelim::empty("image"));
+        img.insert_attribute(&mut txn, "src", "blob://eee");
+        img.insert_attribute(&mut txn, "width", Any::Number(220.0));
+        img.insert_attribute(&mut txn, "height", Any::BigInt(140));
+    }
+    let txn = doc.transact();
+    let out = prose_html::fragment_to_html(&frag, &txn);
+    assert!(out.contains("src=\"blob://eee\""), "src lost: {out}");
+    assert!(out.contains("width=\"220\""), "numeric width dropped: {out}");
+    assert!(out.contains("height=\"140\""), "numeric height dropped: {out}");
+}
+
+// ---- JP-428: recovery-point reconstruction semantics ----
+// "The version wins wherever the point's doc carries the corresponding root;
+// absence never erases."
+
+#[cfg(test)]
+mod reconstruction {
+    use super::super::DocHandle;
+    use serde_json::json;
+    use yrs::{Any, Doc, Map, Transact, XmlFragment, XmlTextPrelim};
+
+    /// A scaffold body with two canvas pages (both with shapes) and one prose
+    /// page with content — the CURRENT doc a recovery point flattens over.
+    fn scaffold() -> serde_json::Value {
+        json!({
+            "id": "d", "serverVersion": 3, "activePageId": "p1",
+            "pages": {
+                "p1": {"id": "p1", "shapes": {"s1": {"id": "s1"}}, "shapeOrder": ["s1"]},
+                "p2": {"id": "p2", "shapes": {"s2": {"id": "s2"}}, "shapeOrder": ["s2"]}
+            },
+            "richTextPages": {"pageOrder": ["r1"], "pages": {
+                "r1": {"id": "r1", "name": "Notes", "content": "<p>current text</p>"}
+            }}
+        })
+    }
+
+    #[test]
+    fn pages_absent_from_the_point_are_left_untouched() {
+        // The point's doc carries ONLY p1 (captured before p2 existed) and no
+        // prose roots. p2's shapes and r1's prose must survive reconstruction.
+        let point = Doc::new();
+        {
+            let shapes = point.get_or_insert_map("shapes:p1");
+            let mut txn = point.transact_mut();
+            shapes.insert(&mut txn, "s9", Any::String("from-version".into()));
+        }
+        let handle = DocHandle::from_decoded(point, Some("p1".to_string()));
+        let mut json = scaffold();
+        assert!(handle.flatten_into(&mut json));
+
+        assert!(
+            json["pages"]["p1"]["shapes"]["s9"].is_string(),
+            "point's page content must win: {json}"
+        );
+        assert!(
+            json["pages"]["p2"]["shapes"]["s2"].is_object(),
+            "page absent from the point must keep current shapes: {json}"
+        );
+        assert_eq!(
+            json["richTextPages"]["pages"]["r1"]["content"], "<p>current text</p>",
+            "prose absent from the point must keep current content"
+        );
+    }
+
+    #[test]
+    fn present_but_empty_root_restores_the_cleared_state() {
+        // The point carries p2's root EMPTY (cleared before capture) and an
+        // EMPTY prose root for r1 — a cleared surface restores cleared.
+        let point = Doc::new();
+        {
+            let shapes1 = point.get_or_insert_map("shapes:p1");
+            let _shapes2 = point.get_or_insert_map("shapes:p2");
+            let _prose = point.get_or_insert_xml_fragment("prose:r1");
+            let mut txn = point.transact_mut();
+            shapes1.insert(&mut txn, "s1", Any::String("kept".into()));
+        }
+        let handle = DocHandle::from_decoded(point, Some("p1".to_string()));
+        let mut json = scaffold();
+        assert!(handle.flatten_into(&mut json));
+
+        assert_eq!(
+            json["pages"]["p2"]["shapes"].as_object().map(|m| m.len()),
+            Some(0),
+            "present-but-empty shapes root restores the cleared page: {json}"
+        );
+        assert_eq!(
+            json["richTextPages"]["pages"]["r1"]["content"], "",
+            "present-but-empty prose root clears the JSON copy: {json}"
+        );
+    }
+
+    #[test]
+    fn non_empty_prose_root_overlays_the_version_content() {
+        let point = Doc::new();
+        {
+            let _shapes = point.get_or_insert_map("shapes:p1");
+            let prose = point.get_or_insert_xml_fragment("prose:r1");
+            let mut txn = point.transact_mut();
+            let p = prose.push_back(&mut txn, yrs::XmlElementPrelim::empty("paragraph"));
+            p.push_back(&mut txn, XmlTextPrelim::new("version text"));
+        }
+        let handle = DocHandle::from_decoded(point, Some("p1".to_string()));
+        let mut json = scaffold();
+        assert!(handle.flatten_into(&mut json));
+        assert_eq!(
+            json["richTextPages"]["pages"]["r1"]["content"], "<p>version text</p>",
+            "point's prose must win: {json}"
+        );
+    }
+}

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -35,6 +35,7 @@ use yrs::sync::SyncMessage;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
 use yrs::{
+    Xml,
     Any, Array, Doc, GetString, Map, ReadTxn, StateVector, Text, Transact, Update,
     XmlElementPrelim, XmlFragment, XmlOut, XmlTextPrelim,
 };
@@ -2006,6 +2007,120 @@ async fn automatic_version_capture_on_edit_and_session_end() {
         wait_for_points(2).await,
         "a changed session should add a session-end recovery point, got {}",
         count_points().await
+    );
+
+    relay.server.stop().await.expect("stop");
+}
+
+/// JP-428: the user-reported fidelity scenario end-to-end — prose = text +
+/// gallery (numeric attrs, as the live editor stores them) + text, captured
+/// on demand, read back through the recovery content endpoint. The version
+/// must carry ALL of it: the gallery with its images and sizing, and the
+/// content after it. Also proves the capture endpoint's dedupe (`captured:
+/// false` on an unchanged doc).
+#[tokio::test]
+async fn on_demand_capture_preserves_gallery_and_trailing_prose() {
+    let relay = start_relay().await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-fid", "name": "Fidelity", "pageOrder": ["p1"],
+            "activePageId": "p1", "createdAt": 1, "modifiedAt": 2,
+            "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {"pageOrder": ["r1"], "pages": {
+                "r1": {"id": "r1", "name": "Notes", "content": ""}
+            }}
+        }),
+    )
+    .await;
+
+    // Live session: build prose exactly as the editor's y-prosemirror binding
+    // does — paragraph, gallery with an image carrying NUMERIC width, then a
+    // trailing paragraph typed after the gallery.
+    let mut c = WsClient::connect(&relay.ws_base).await;
+    c.auth(&token).await;
+    c.join_doc("doc-fid").await;
+    let local = LocalDoc::new();
+    let update = {
+        let before = local.doc.transact().state_vector();
+        let frag = local.doc.get_or_insert_xml_fragment("prose:r1");
+        {
+            let mut txn = local.doc.transact_mut();
+            let p1 = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+            p1.push_back(&mut txn, XmlTextPrelim::new("text before"));
+            let gallery = frag.push_back(&mut txn, XmlElementPrelim::empty("gallery"));
+            gallery.insert_attribute(&mut txn, "layout", "grid");
+            let img = gallery.push_back(&mut txn, XmlElementPrelim::empty("image"));
+            img.insert_attribute(&mut txn, "src", "blob://abc123");
+            img.insert_attribute(&mut txn, "width", Any::Number(220.0));
+            let p2 = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+            p2.push_back(&mut txn, XmlTextPrelim::new("newly added text after"));
+        }
+        let u = local.doc.transact().encode_state_as_update_v1(&before);
+        yrs::sync::SyncMessage::Update(u).encode_v1()
+    };
+    c.send_sync(&update).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Capture NOW (what the Version History panel does on open).
+    let client = reqwest::Client::new();
+    let cap: Value = client
+        .post(format!("{}/api/docs/doc-fid/recovery/capture", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("capture")
+        .json()
+        .await
+        .expect("capture json");
+    assert_eq!(cap["captured"], json!(true), "first capture writes a point: {cap}");
+
+    // Unchanged doc → dedupe.
+    let cap2: Value = client
+        .post(format!("{}/api/docs/doc-fid/recovery/capture", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("capture 2")
+        .json()
+        .await
+        .expect("capture 2 json");
+    assert_eq!(cap2["captured"], json!(false), "unchanged doc dedupes: {cap2}");
+
+    // Read the newest point's content — full prose fidelity.
+    let points: Value = client
+        .get(format!("{}/api/docs/doc-fid/recovery", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("list")
+        .json()
+        .await
+        .expect("list json");
+    let point_id = points["recoveryPoints"][0]["id"].as_str().expect("point id");
+    let content: Value = client
+        .get(format!("{}/api/docs/doc-fid/recovery/{point_id}", relay.http))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("content")
+        .json()
+        .await
+        .expect("content json");
+    let prose = content["richTextPages"]["pages"]["r1"]["content"]
+        .as_str()
+        .expect("prose content");
+    assert!(prose.contains("text before"), "leading text lost: {prose}");
+    assert!(prose.contains("data-gallery"), "gallery lost: {prose}");
+    assert!(prose.contains("src=\"blob://abc123\""), "gallery image lost: {prose}");
+    assert!(prose.contains("width=\"220\""), "numeric image width lost: {prose}");
+    assert!(
+        prose.contains("newly added text after"),
+        "content after the gallery lost: {prose}"
     );
 
     relay.server.stop().await.expect("stop");

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -242,6 +242,19 @@ export class RelayClient {
     return this.requestJson('DELETE', `/api/docs/${encodeURIComponent(docId)}`, { auth: true });
   }
 
+  /**
+   * Capture a recovery point NOW (JP-428) — the Version History panel calls
+   * this on open so the timeline leads with current state. The relay flushes
+   * a resident doc first and dedupes byte-identical state (`captured: false`).
+   */
+  async captureRecoveryPoint(docId: string): Promise<{ captured: boolean }> {
+    return this.requestJson(
+      'POST',
+      `/api/docs/${encodeURIComponent(docId)}/recovery/capture`,
+      { auth: true },
+    );
+  }
+
   /** List a document's recovery points (JP-183), newest first. */
   async listRecoveryPoints(docId: string): Promise<RelayRecoveryPoint[]> {
     const { recoveryPoints } = await this.requestJson<{ recoveryPoints: RelayRecoveryPoint[] }>(

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -89,6 +89,10 @@ export class RestDocumentProvider {
     return this.client.listRecoveryPoints(docId);
   }
 
+  async captureRecoveryPoint(docId: string): Promise<{ captured: boolean }> {
+    return this.client.captureRecoveryPoint(docId);
+  }
+
   async getRecoveryPointContent(docId: string, pointId: string): Promise<DiagramDocument> {
     return this.client.getRecoveryPointContent(docId, pointId);
   }

--- a/src/store/persistenceStore.legacyProse.test.ts
+++ b/src/store/persistenceStore.legacyProse.test.ts
@@ -1,0 +1,82 @@
+/**
+ * JP-428 field repro: relay-derived documents carry a FOSSILIZED legacy
+ * `richTextContent` (single-page Tiptap JSON frozen at the doc's first REST
+ * save — the relay only maintains `richTextPages`). Loading such a doc must
+ * not seed the live rich-text store from the fossil: when the multi-page
+ * format is present, the pages store owns prose.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePersistenceStore, saveDocumentToStorage } from './persistenceStore';
+import { useRichTextStore } from './richTextStore';
+import { useRichTextPagesStore } from './richTextPagesStore';
+import { DOCUMENT_VERSION } from '../types/Document';
+import type { DiagramDocument } from '../types/Document';
+
+const FULL_PROSE =
+  '<p>Hello</p><h1>My Gallery</h1><p>Welcome.</p>' +
+  '<div data-gallery data-layout="grid"><div class="gallery-items">' +
+  '<img src="blob://abc" alt="a" width="220"></div></div>' +
+  '<h1>Heading After Gallery</h1><p>Welcome, again.</p>';
+
+/** A local copy of a relay doc: stale legacy prose + current multi-page prose. */
+function fossilDoc(): DiagramDocument {
+  return {
+    id: 'doc-fossil-repro',
+    name: 'Fossil Repro',
+    pages: {
+      p1: { id: 'p1', name: 'Page 1', shapes: {}, shapeOrder: [], createdAt: 1, modifiedAt: 2 },
+    },
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 1,
+    modifiedAt: 2,
+    version: DOCUMENT_VERSION,
+    // The fossil: first-save-era prose, long since superseded.
+    richTextContent: {
+      content: {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+      },
+      version: 1,
+    },
+    richTextPages: {
+      pageOrder: ['rt-1'],
+      pages: {
+        'rt-1': { id: 'rt-1', name: 'Notes', content: FULL_PROSE, order: 0, createdAt: 1, modifiedAt: 2 },
+      },
+      activePageId: 'rt-1',
+    },
+  } as DiagramDocument;
+}
+
+describe('loading a doc with a fossilized legacy richTextContent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not seed the live rich-text store from the fossil when richTextPages exists', () => {
+    const doc = fossilDoc();
+    saveDocumentToStorage(doc);
+    const ok = usePersistenceStore.getState().loadDocument(doc.id);
+    expect(ok).toBe(true);
+
+    // Pages store (the prose owner) carries the real content.
+    const page = useRichTextPagesStore.getState().pages['rt-1'];
+    expect(page?.content).toContain('Heading After Gallery');
+
+    // The live store must NOT hold the fossil — the editor mounts from it,
+    // and the fossil is what made restored copies open as "Hello"-only.
+    const live = useRichTextStore.getState().getContent();
+    expect(JSON.stringify(live.content)).not.toContain('Hello');
+  });
+
+  it('still loads legacy-only documents through richTextContent', () => {
+    const doc = fossilDoc();
+    delete doc.richTextPages;
+    saveDocumentToStorage(doc);
+    const ok = usePersistenceStore.getState().loadDocument(doc.id);
+    expect(ok).toBe(true);
+    const live = useRichTextStore.getState().getContent();
+    expect(JSON.stringify(live.content)).toContain('Hello');
+  });
+});

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -701,8 +701,14 @@ function loadDocumentToPageStore(input: DiagramDocument): void {
     };
     usePageStore.getState().loadSnapshot(snapshot);
 
-    // Load rich text content (or reset if not present for backwards compatibility)
-    useRichTextStore.getState().loadContent(doc.richTextContent);
+    // Load rich text content. When the multi-page format is present, the pages
+    // store owns prose and the legacy single-page field must be IGNORED: on
+    // relay-derived documents it is a fossil frozen at the doc's first REST
+    // save (the relay only maintains richTextPages), and seeding the live
+    // store from it makes the editor open on first-save-era prose (JP-428).
+    // Legacy-only documents (pre-multi-page) still load through it.
+    const hasProsePages = (doc.richTextPages?.pageOrder.length ?? 0) > 0;
+    useRichTextStore.getState().loadContent(hasProsePages ? undefined : doc.richTextContent);
 
     // Load rich text pages (or initialize with default if not present)
     if (doc.richTextPages) {

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -171,6 +171,8 @@ export interface DocumentProvider {
    * download-to-local), or restore one (→ a new doc id; tombstones the source).
    */
   listRecoveryPoints?(docId: string): Promise<RelayRecoveryPoint[]>;
+  /** Capture a recovery point now (JP-428) — best-effort freshness for the panel. */
+  captureRecoveryPoint?(docId: string): Promise<{ captured: boolean }>;
   getRecoveryPointContent?(docId: string, pointId: string): Promise<DiagramDocument>;
   /**
    * JP-422: fetch a document's authoritative binary Y.Doc sidecar (raw

--- a/src/tiptap/GalleryExtension.test.ts
+++ b/src/tiptap/GalleryExtension.test.ts
@@ -137,3 +137,35 @@ describe('removeSelectedImage (gallery)', () => {
     element.remove();
   });
 });
+
+describe('gallery resilience (JP-428)', () => {
+  it('a gallery containing a src-less image renders without throwing', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({
+      element,
+      extensions,
+      content: {
+        type: 'doc',
+        content: [
+          {
+            type: 'gallery',
+            attrs: { layout: 'grid' },
+            content: [
+              { type: 'image', attrs: { src: 'blob://ok' } },
+              { type: 'image', attrs: { src: null } },
+            ],
+          },
+          { type: 'paragraph', content: [{ type: 'text', text: 'after' }] },
+        ],
+      },
+    });
+
+    expect(element.querySelectorAll('img').length).toBe(2);
+    expect(element.querySelector('img.tiptap-image--missing')).toBeTruthy();
+    expect(element.textContent).toContain('after');
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/ResizableImageExtension.css
+++ b/src/tiptap/ResizableImageExtension.css
@@ -75,3 +75,13 @@ img.tiptap-image[data-float='right'] {
   padding-left: 0.45rem;
   border-left: 1px solid var(--border-color);
 }
+
+/* Src-less image (a node reconstructed from JSON with a lost src, JP-428):
+   a visible, labeled placeholder instead of a broken-image request. */
+.tiptap-image--missing {
+  min-width: 120px;
+  min-height: 64px;
+  border: 1px dashed var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.04));
+}

--- a/src/tiptap/ResizableImageExtension.test.ts
+++ b/src/tiptap/ResizableImageExtension.test.ts
@@ -114,3 +114,57 @@ describe('image float', () => {
     element.remove();
   });
 });
+
+describe('src-less image nodes (JP-428)', () => {
+  // A node reconstructed from JSON (collab seeding, a restored version) can
+  // carry a null/empty src — ProseMirror attrs default permissively even
+  // though parseHTML only matches img[src]. The nodeView must render a
+  // labeled placeholder, never coerce null into the literal string "null".
+  function makeJsonEditor(content: object): { editor: Editor; element: HTMLElement } {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({ element, extensions, content });
+    return { editor, element };
+  }
+
+  it('renders a labeled placeholder instead of src="null"', () => {
+    const { editor, element } = makeJsonEditor({
+      type: 'doc',
+      content: [
+        { type: 'image', attrs: { src: null } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'after' }] },
+      ],
+    });
+
+    const img = element.querySelector('img.tiptap-image');
+    expect(img, 'image nodeView rendered').toBeTruthy();
+    expect(img?.getAttribute('src')).toBeNull();
+    expect(img?.classList.contains('tiptap-image--missing')).toBe(true);
+    expect(img?.getAttribute('alt')).toBe('Image unavailable');
+    // The document around it is intact.
+    expect(element.textContent).toContain('after');
+
+    editor.destroy();
+    element.remove();
+  });
+
+  it('a later src update clears the placeholder state', () => {
+    const { editor, element } = makeJsonEditor({
+      type: 'doc',
+      content: [{ type: 'image', attrs: { src: null } }],
+    });
+    editor.commands.command(({ state, dispatch }) => {
+      const node = state.doc.nodeAt(0);
+      if (!node || node.type.name !== 'image' || !dispatch) return false;
+      dispatch(state.tr.setNodeMarkup(0, undefined, { ...node.attrs, src: 'blob://fixed' }));
+      return true;
+    });
+
+    const img = element.querySelector('img.tiptap-image');
+    expect(img?.getAttribute('src')).toBe('blob://fixed');
+    expect(img?.classList.contains('tiptap-image--missing')).toBe(false);
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/tiptap/ResizableImageExtension.ts
+++ b/src/tiptap/ResizableImageExtension.ts
@@ -110,7 +110,23 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
       container.classList.add('resizable-image-container');
 
       const img = document.createElement('img');
-      img.src = node.attrs['src'] as string;
+      // A node reconstructed from JSON (collab seeding, a restored version)
+      // can carry a null/empty src — ProseMirror attrs default permissively.
+      // Assigning that directly coerces to the literal string "null"/"undefined"
+      // (a broken request + a broken image). Render a labeled placeholder
+      // instead; never write a bogus src (JP-428).
+      const applySrc = (src: unknown) => {
+        if (typeof src === 'string' && src !== '') {
+          img.src = src;
+          img.classList.remove('tiptap-image--missing');
+          if (img.alt === 'Image unavailable') img.alt = '';
+        } else {
+          img.removeAttribute('src');
+          img.classList.add('tiptap-image--missing');
+          if (!img.alt) img.alt = 'Image unavailable';
+        }
+      };
+      applySrc(node.attrs['src']);
       if (node.attrs['alt']) img.alt = node.attrs['alt'] as string;
       if (node.attrs['title']) img.title = node.attrs['title'] as string;
       if (node.attrs['width']) img.style.width = `${node.attrs['width']}px`;
@@ -352,7 +368,7 @@ export const ResizableImage = Node.create<ResizableImageOptions>({
         update: (updatedNode) => {
           if (updatedNode.type.name !== 'image') return false;
 
-          img.src = updatedNode.attrs['src'] as string;
+          applySrc(updatedNode.attrs['src']);
           if (updatedNode.attrs['alt']) img.alt = updatedNode.attrs['alt'] as string;
           if (updatedNode.attrs['title'])
             img.title = updatedNode.attrs['title'] as string;

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -187,6 +187,11 @@ export function DocumentEditorPanel({
   const useCollabEditor = isRelayDoc && proseEditable && !!collabYdoc && !!proseField;
 
   const lastActivePageRef = useRef<string | null>(null);
+  // Which document lastActivePageRef belongs to. Page ids survive copies and
+  // restores (a "vcs testing (Restored …)" copy keeps rt-page-1), so a doc
+  // switch can land on an UNCHANGED activePageId — the page-switch effect must
+  // detect the document boundary itself, not infer it from the page id (JP-428).
+  const lastDocIdRef = useRef<string | null>(null);
   // The prose page id the currently-mounted `editor` is bound to (null when the
   // active page is read-only `ProsePreview`, which mounts no editor). Lets the
   // page-switch save below verify the editor actually belongs to the page being
@@ -273,6 +278,17 @@ export function DocumentEditorPanel({
   useEffect(() => {
     if (!editor || !activePageId) return;
 
+    // Document boundary: the pages store now belongs to the NEW doc, while the
+    // editor still shows the previous doc's page. Two consequences (JP-428):
+    // the leaving-page persist below must NOT run (it would write the old
+    // doc's prose into the new doc's same-id page slot), and the active page
+    // must load even when its id is unchanged — otherwise a copy that keeps
+    // its source's page ids opens blank (or on whatever the editor last held).
+    if (lastDocIdRef.current !== currentDocId) {
+      lastDocIdRef.current = currentDocId;
+      lastActivePageRef.current = null;
+    }
+
     // Same page — nothing to do
     if (lastActivePageRef.current === activePageId) return;
 
@@ -352,7 +368,7 @@ export function DocumentEditorPanel({
     }, 0);
     // `pages` is intentionally excluded from deps — it is read imperatively
     // inside the timeout to avoid stale closures and spurious re-runs.
-  }, [activePageId, updatePageContent, editor, clearTiptapHistory, isRelayDoc]);
+  }, [activePageId, updatePageContent, editor, clearTiptapHistory, isRelayDoc, currentDocId]);
 
   // Relay docs: the collab editor is keyed per page (`docId:pageId:sessionEpoch`)
   // so a page-switch remounts it and scroll resets to 0. The page-switch effect

--- a/src/ui/TiptapEditor.parse.test.ts
+++ b/src/ui/TiptapEditor.parse.test.ts
@@ -1,0 +1,35 @@
+/**
+ * JP-428 field repro: parse the exact relay-served version-history HTML with
+ * the REAL local-editor extension list (not a minimal subset) and assert
+ * nothing after the first paragraph is dropped.
+ */
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from './TiptapEditor';
+
+const SERVED_HTML =
+  '<p>Hello</p><h1>My Gallery</h1><p>Welcome.</p>' +
+  '<div data-gallery data-layout="grid"><div class="gallery-items">' +
+  '<img src="blob://680e63319c0de1f2b3a2b58596db2d85fb88cbb2e5375bb042cd9233a430a78c" alt="JNT-Logo-v1.png" width="220">' +
+  '<img src="blob://4b9214df4f73b5e4c6d54ccf715bf18b9ccbb7aed6b3f4b875071c1bf0f95c7c" alt="Blackcache-Origin.png" width="220">' +
+  '</div></div>' +
+  '<h1>Heading After Gallery</h1><p>Welcome, again.</p>';
+
+describe('local editor parse of relay-served prose', () => {
+  it('keeps the gallery and all content after it (setContent path)', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({ element, extensions, content: '<p></p>' });
+    editor.commands.setContent(SERVED_HTML);
+
+    const html = editor.getHTML();
+    expect(html).toContain('My Gallery');
+    expect(html).toContain('data-gallery');
+    expect(html).toContain('blob://680e63319');
+    expect(html).toContain('Heading After Gallery');
+    expect(html).toContain('Welcome, again.');
+
+    editor.destroy();
+    element.remove();
+  });
+});

--- a/src/ui/VersionHistoryPanel.css
+++ b/src/ui/VersionHistoryPanel.css
@@ -153,6 +153,19 @@
   color: var(--text-secondary);
 }
 
+.version-history__latest {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--navy-700);
+  color: white;
+  vertical-align: middle;
+}
+
 .version-history__summary {
   padding: 0 12px 12px;
 }

--- a/src/ui/VersionHistoryPanel.test.ts
+++ b/src/ui/VersionHistoryPanel.test.ts
@@ -41,11 +41,14 @@ describe('buildLocalCopyFromVersion', () => {
     expect(copy.version).toBe(DOCUMENT_VERSION);
   });
 
-  it('mints a fresh id, names the copy, and strips relay ownership', () => {
+  it('mints a fresh id, names the copy with the version time, and strips relay ownership', () => {
     const createdAt = 1_700_000_000_000;
     const copy = buildLocalCopyFromVersion(versionContent(), 'Cloud Doc', createdAt);
     expect(copy.id).not.toBe('doc-cloud');
     expect(copy.name).toContain('Cloud Doc (Restored ');
+    // Same-day copies must stay distinguishable, so the name carries the full
+    // timestamp (date AND time), not just the date.
+    expect(copy.name).toContain(new Date(createdAt).toLocaleString());
     expect(copy.isRelayDocument).toBe(false);
     expect('ownerId' in copy).toBe(false);
     expect('ownerName' in copy).toBe(false);

--- a/src/ui/VersionHistoryPanel.test.ts
+++ b/src/ui/VersionHistoryPanel.test.ts
@@ -55,6 +55,41 @@ describe('buildLocalCopyFromVersion', () => {
     expect('serverVersion' in copy).toBe(false);
   });
 
+  it('drops a fossilized legacy richTextContent when richTextPages exists', () => {
+    const copy = buildLocalCopyFromVersion(
+      versionContent({
+        // Frozen at the relay doc's first REST save — never updated again
+        // (the relay only maintains richTextPages). Carrying it into the
+        // local copy makes the copy open as the first-save prose.
+        richTextContent: {
+          content: {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }],
+          },
+          version: 1,
+        },
+        richTextPages: {
+          pageOrder: ['r1'],
+          pages: {
+            r1: {
+              id: 'r1',
+              name: 'Notes',
+              content: '<p>Hello</p><h1>After</h1>',
+              order: 0,
+              createdAt: 1,
+              modifiedAt: 2,
+            },
+          },
+          activePageId: 'r1',
+        },
+      }),
+      'Cloud Doc',
+      1,
+    );
+    expect('richTextContent' in copy).toBe(false);
+    expect(copy.richTextPages?.pages['r1']?.content).toContain('<h1>After</h1>');
+  });
+
   it('preserves prose content untouched', () => {
     const copy = buildLocalCopyFromVersion(
       versionContent({

--- a/src/ui/VersionHistoryPanel.test.ts
+++ b/src/ui/VersionHistoryPanel.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the Version History panel's pure save-to-local helper
+ * (JP-428): version content skips the normal document-open path, so the copy
+ * builder must run the JP-347 migration funnel and strip relay ownership.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildLocalCopyFromVersion } from './VersionHistoryPanel';
+import { DOCUMENT_VERSION } from '../types/Document';
+import type { DiagramDocument } from '../types/Document';
+
+function versionContent(overrides: Partial<DiagramDocument> = {}): DiagramDocument {
+  return {
+    id: 'doc-cloud',
+    name: 'Cloud Doc',
+    pages: {
+      p1: {
+        id: 'p1',
+        name: 'Page 1',
+        shapes: {},
+        shapeOrder: [],
+        createdAt: 1,
+        modifiedAt: 2,
+      },
+    },
+    pageOrder: ['p1'],
+    activePageId: 'p1',
+    createdAt: 1,
+    modifiedAt: 2,
+    version: 1, // an older-format recovery point
+    ownerId: 'alice',
+    ownerName: 'Alice',
+    serverVersion: 7,
+    isRelayDocument: true,
+    ...overrides,
+  } as DiagramDocument;
+}
+
+describe('buildLocalCopyFromVersion', () => {
+  it('runs the migration funnel (old version → current format)', () => {
+    const copy = buildLocalCopyFromVersion(versionContent(), 'Cloud Doc', 1_700_000_000_000);
+    expect(copy.version).toBe(DOCUMENT_VERSION);
+  });
+
+  it('mints a fresh id, names the copy, and strips relay ownership', () => {
+    const createdAt = 1_700_000_000_000;
+    const copy = buildLocalCopyFromVersion(versionContent(), 'Cloud Doc', createdAt);
+    expect(copy.id).not.toBe('doc-cloud');
+    expect(copy.name).toContain('Cloud Doc (Restored ');
+    expect(copy.isRelayDocument).toBe(false);
+    expect('ownerId' in copy).toBe(false);
+    expect('ownerName' in copy).toBe(false);
+    expect('serverVersion' in copy).toBe(false);
+  });
+
+  it('preserves prose content untouched', () => {
+    const copy = buildLocalCopyFromVersion(
+      versionContent({
+        richTextPages: {
+          pageOrder: ['r1'],
+          pages: {
+            r1: {
+              id: 'r1',
+              name: 'Notes',
+              content: '<p>text</p><div data-gallery data-layout="grid"><div class="gallery-items"><img src="blob://a"></div></div><p>after</p>',
+              order: 0,
+              createdAt: 1,
+              modifiedAt: 2,
+            },
+          },
+          activePageId: 'r1',
+        },
+      }),
+      'Cloud Doc',
+      1,
+    );
+    const content = copy.richTextPages?.pages['r1']?.content ?? '';
+    expect(content).toContain('data-gallery');
+    expect(content).toContain('<p>after</p>');
+  });
+});

--- a/src/ui/VersionHistoryPanel.tsx
+++ b/src/ui/VersionHistoryPanel.tsx
@@ -27,6 +27,7 @@ import { saveDocumentToStorage } from '../store/persistenceStore';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { getDocumentMetadata } from '../types/Document';
 import type { DiagramDocument } from '../types/Document';
+import { migrateDocument } from '../migrations/documentMigrations';
 import { confirmDialog } from './confirm/confirmStore';
 import {
   summarizeDocument,
@@ -46,6 +47,30 @@ interface VersionHistoryPanelProps {
   onClose: () => void;
   /** Called after a successful restore with the new document id. */
   onRestored?: (newDocId: string) => void;
+}
+
+/**
+ * Build the local-document copy of a version's content (JP-428): runs the
+ * JP-347 migration funnel (version content skips the normal open path), mints
+ * a fresh id, and strips relay-ownership fields. Pure — exported for tests.
+ */
+export function buildLocalCopyFromVersion(
+  content: DiagramDocument,
+  docName: string,
+  createdAt: number,
+): DiagramDocument {
+  const copy = {
+    ...migrateDocument(content),
+    id: crypto.randomUUID(),
+    name: `${docName} (Restored ${new Date(createdAt).toLocaleDateString()})`,
+    isRelayDocument: false,
+  };
+  delete copy.ownerId;
+  delete copy.ownerName;
+  delete copy.sharedWith;
+  delete copy.collectionId;
+  delete copy.serverVersion;
+  return copy;
 }
 
 function formatTimestamp(ms: number): string {
@@ -103,8 +128,14 @@ export function VersionHistoryPanel({
       return;
     }
     setError(null);
-    provider
-      .listRecoveryPoints(docId)
+    // Capture-on-open (JP-428): ask the relay for a fresh point first so the
+    // timeline leads with current state instead of the last periodic tick.
+    // Best-effort — an old relay (404) or transient failure still lists.
+    const fresh = provider.captureRecoveryPoint
+      ? provider.captureRecoveryPoint(docId).catch(() => undefined)
+      : Promise.resolve(undefined);
+    fresh
+      .then(() => provider.listRecoveryPoints!(docId))
       .then((p) => setPoints(p))
       .catch((e) => {
         setError(e instanceof Error ? e.message : 'Failed to load version history.');
@@ -198,17 +229,7 @@ export function VersionHistoryPanel({
       setBusyId(point.id);
       try {
         const content = await provider.getRecoveryPointContent(docId, point.id);
-        const copy = {
-          ...content,
-          id: crypto.randomUUID(),
-          name: `${docName} (Restored ${new Date(point.createdAt).toLocaleDateString()})`,
-          isRelayDocument: false,
-        };
-        delete copy.ownerId;
-        delete copy.ownerName;
-        delete copy.sharedWith;
-        delete copy.collectionId;
-        delete copy.serverVersion;
+        const copy = buildLocalCopyFromVersion(content, docName, point.createdAt);
         saveDocumentToStorage(copy);
         useDocumentRegistry.getState().registerLocal(getDocumentMetadata(copy));
         useNotificationStore.getState().success('Saved a local copy of this version.');

--- a/src/ui/VersionHistoryPanel.tsx
+++ b/src/ui/VersionHistoryPanel.tsx
@@ -62,7 +62,7 @@ export function buildLocalCopyFromVersion(
   const copy = {
     ...migrateDocument(content),
     id: crypto.randomUUID(),
-    name: `${docName} (Restored ${new Date(createdAt).toLocaleDateString()})`,
+    name: `${docName} (Restored ${formatTimestamp(createdAt)})`,
     isRelayDocument: false,
   };
   delete copy.ownerId;
@@ -229,10 +229,18 @@ export function VersionHistoryPanel({
       setBusyId(point.id);
       try {
         const content = await provider.getRecoveryPointContent(docId, point.id);
+        // Field-test breadcrumb: which point was served and how much prose it
+        // carried, so "the copy looks old" reports are correlatable with the
+        // relay's recovery-read log line.
+        console.info(
+          `[version-history] save-to-local doc=${docId} point=${point.id} words=${summarizeDocument(content).totalWords}`,
+        );
         const copy = buildLocalCopyFromVersion(content, docName, point.createdAt);
         saveDocumentToStorage(copy);
         useDocumentRegistry.getState().registerLocal(getDocumentMetadata(copy));
-        useNotificationStore.getState().success('Saved a local copy of this version.');
+        useNotificationStore
+          .getState()
+          .success(`Saved a local copy of the ${formatTimeOfDay(point.createdAt)} version.`);
       } catch (e) {
         useNotificationStore
           .getState()
@@ -377,6 +385,9 @@ export function VersionHistoryPanel({
                         >
                           <span className="version-history__time">
                             {formatTimeOfDay(point.createdAt)}
+                            {point.id === points[0]?.id && (
+                              <span className="version-history__latest">Latest</span>
+                            )}
                           </span>
                           <span className="version-history__sub">
                             v{point.serverVersion} · {formatSize(point.sizeBytes)}

--- a/src/ui/VersionHistoryPanel.tsx
+++ b/src/ui/VersionHistoryPanel.tsx
@@ -70,6 +70,12 @@ export function buildLocalCopyFromVersion(
   delete copy.sharedWith;
   delete copy.collectionId;
   delete copy.serverVersion;
+  // Relay docs carry a fossilized legacy richTextContent (frozen at the doc's
+  // first REST save — the relay only maintains richTextPages). Never let it
+  // shadow the version's real prose in the copy (JP-428).
+  if ((copy.richTextPages?.pageOrder.length ?? 0) > 0) {
+    delete copy.richTextContent;
+  }
   return copy;
 }
 


### PR DESCRIPTION
Fixes the first JP-185 version-history E2E failures ("Save to local" of a version lost a gallery **and all content after it**; versions looked too old / missed new text) and hardens the gallery/prose-image pipeline per review. Repro-first: `relay/src/sync/roundtrip_tests.rs` drives editor-shaped fixtures through the exact production seed pipeline (`html_to_blocks → sanitize_blocks → seed_prose_deterministic → fragment_to_html`) and went **red on four independent defects**; a new `yjs_authority` integration test reproduces the exact reported scenario (live session, text + gallery with numeric attrs + text → capture → GET version content → full fidelity).

## Primary cause of the report: staleness → capture-on-open
Captures were periodic + session-end only, so the newest point could predate recent edits — prose ending exactly where the gallery went in explains both symptoms at once. Fix: **`POST /api/docs/:id/recovery/capture`** (write-scoped; flushes a resident doc, byte-identical state dedupes) and the Version History panel calls it best-effort on open, so the timeline always leads with *now*. `captured` reports "did a new point appear" across the flush+capture (the flush itself can capture via the periodic gate). OpenAPI + the drift-guarded docs-site spec copy updated.

## Four pipeline defects (each pinned by a red-first test)
1. **Tokenizer quote-blindness** — `tokenize` took the first `>` after `<` with no quote state; browsers don't escape `>` in attribute values, so every bibliography (`data-bib-html`) and any `alt`/`title` with `>` corrupted the fragment rebuilt from `richTextPages` on rehydrate. Now quote-aware.
2. **Numeric image attrs dropped** — the editor stores `width`/`height` as numbers (resize writes offsetWidth; galleries insert `width: 220`) and y-prosemirror stores attrs raw, but `image_html` accepted only strings → sizing silently lost on every flatten/MCP read/version read.
3. **Schema-throw node deletion** — `sanitize_blocks` had no gallery/figure content rules; an image-less gallery reaching the client makes `schema.node()` throw and **y-prosemirror deletes the node from the live Y.Doc**, poisoning all later captures. The gate now enforces gallery = `image+` (else unwrap, content preserved after it), figure = `image figcaption` (else unwrap), standalone figcaption demotes.
4. **Math-only pages never seeded** on JSON rebuild — `block_has_substance` now counts `mathInline`/`mathBlock`.

## Version reconstruction semantics
*"The version wins wherever the point's doc carries the corresponding root; absence never erases."* `flatten_into` now writes only root-present pages — a page created **after** a capture keeps its current shapes instead of being zeroed to `{}` (this also stops live flatten clobbering REST-added pages on resident docs) — and an existing-but-empty `prose:` root clears the JSON copy so deleted prose stops resurrecting. Live snapshot output is byte-identical (hydration creates a root per JSON page); pinned by reconstruction regression tests.

## Editor guards
- `ResizableImage` nodeView renders a labeled placeholder for null/empty `src` instead of coercing to `src="null"` (+ gallery-with-broken-image resilience test).
- Save-to-local runs the JP-347 `migrateDocument` funnel via the extracted, unit-tested `buildLocalCopyFromVersion`.

## Verification
- Relay: `cargo check --all-targets` clean; **650 tests green** (571→584 lib incl. the new harness + reconstruction tests, all integration suites incl. the new end-to-end fidelity test and JP-338 doubled-prose tests).
- Editor: `bun run typecheck`, **2894 tests green**, production build green.
- Suggested manual E2E (local stack, `task up`): type text → insert a gallery → type more text → open Version history → newest entry is *current* and its summary/save-to-local carries the gallery **and** the text after it; restore lands intact.

## Follow-up: clarity + diagnosability (post re-test forensics)

A second field test reported "the latest version restored just 'Hello'". Forensics on the real relay data (decoding every ring point + running the reconstruction code over the actual files) proved the capture ring and reconstruction fully correct — every point past the first carries the complete prose (gallery, numeric attrs, trailing headings). The report could not be correlated, however: recovery reads logged nothing, and same-day local copies shared an identical "(Restored <date>)" name.

- Local copies are named with the full timestamp (date + time), keeping same-day saves distinguishable.
- "Latest" badge on the newest version row; the save-to-local toast names the version time.
- Relay logs recovery point reads/restores (ws/doc/pointId); the panel logs the served pointId + word count — the next field report pinpoints exactly which point was served.

## Root cause found: fossilized legacy `richTextContent` (second re-test)

The new pointId logging pinned the second failure: the client fetched the **newest** point, the relay served the **full** prose (verified by decoding the served ring file and re-running reconstruction over it), and the local copy still opened as first-save-era prose. Cause: relay docs carry the legacy single-page `richTextContent` frozen at the doc's **first REST save** (the relay's flatten only maintains `richTextPages`). The copy inherited the fossil and the document load path seeded the live rich-text store from it, shadowing the restored prose.

- `loadDocumentToPageStore`: when `richTextPages` has pages, the pages store owns prose — the legacy field is ignored (legacy-only docs still load through it). Fixes the whole class, not just version copies.
- `buildLocalCopyFromVersion` drops the fossil from version copies.
- Red-first repro tests: fossil-shadowing load, fossil strip, and a full-extension-list Tiptap parse of the exact relay-served HTML.
- **Companion fix (third field test, blank page):** the panel's page-switch effect inferred document changes from `activePageId`, but page ids survive copies/restores — opening a same-id copy hit the same-page early return and nothing loaded the page (the fossil used to mask this; its removal exposed it as a blank). The effect now tracks the owning document: on a doc boundary it skips the leaving-page persist (cross-doc slot collision) and force-loads the active page.

Closes the JP-185 field-test findings; JP-428 in Linear.

Assisted-by: Fable 5


