### PR TITLE
JP-428: restored-copy prose images — pin blobs on save-to-local + heal on blob load

### DIFF
--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -18,6 +18,7 @@ import { MobileProseToolbar } from './mobile/MobileProseToolbar';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { useKeyboardInset } from './mobile/useKeyboardInset';
 import { TiptapEditor } from './TiptapEditor';
+import { resolveBlobImagesIn } from './proseBlobImages';
 import { TiptapEditorProvider } from './TiptapEditorContext';
 import { RichTextTabBar } from './RichTextTabBar';
 import { useRichTextPagesStore, initializeRichTextPages } from '../store/richTextPagesStore';
@@ -351,6 +352,16 @@ export function DocumentEditorPanel({
           content: editorRef.current.getJSON(),
           version: RICH_TEXT_VERSION,
         });
+        // Resolve blob:// images NOW: `commands.setContent` emits NO `update`
+        // event (Tiptap's emitUpdate defaults to false), so the on-update
+        // resolver in useResolveBlobImages never fires for panel-driven loads —
+        // without this, images in a freshly-loaded page render as raw blob://
+        // srcs the browser refuses ("Not allowed to load local resource",
+        // JP-428). Immediate pass + next-frame pass, mirroring the hook (the
+        // second pass covers node views that re-render after the first).
+        const editorDom = editorRef.current.view.dom;
+        void resolveBlobImagesIn(editorDom);
+        requestAnimationFrame(() => void resolveBlobImagesIn(editorDom));
         // Restore scroll position after layout settles (retries + aborts on
         // user scroll — see restoreScrollTop).
         const savedScroll = useSessionStore.getState().getEditorScroll(targetPageId) ?? 0;

--- a/src/ui/TiptapEditor.parse.test.ts
+++ b/src/ui/TiptapEditor.parse.test.ts
@@ -15,6 +15,26 @@ const SERVED_HTML =
   '</div></div>' +
   '<h1>Heading After Gallery</h1><p>Welcome, again.</p>';
 
+describe('panel-driven content loads (JP-428)', () => {
+  // The canary behind the restored-copy broken-images bug: the panel's
+  // page-load path uses commands.setContent, which emits NO `update` event —
+  // so useResolveBlobImages' on-update listener never fires for it, and the
+  // panel must call resolveBlobImagesIn explicitly after loading content.
+  // If Tiptap ever changes this default, this test tells us the explicit
+  // resolve became redundant (not that it breaks anything).
+  it('commands.setContent emits no update event', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    const editor = new Editor({ element, extensions, content: '<p></p>' });
+    let updates = 0;
+    editor.on('update', () => updates++);
+    editor.commands.setContent(SERVED_HTML);
+    expect(updates).toBe(0);
+    editor.destroy();
+    element.remove();
+  });
+});
+
 describe('local editor parse of relay-served prose', () => {
   it('keeps the gallery and all content after it (setContent path)', () => {
     const element = document.createElement('div');

--- a/src/ui/VersionHistoryPanel.tsx
+++ b/src/ui/VersionHistoryPanel.tsx
@@ -24,6 +24,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { getDocProvider, useRelayDocumentStore } from '../store/relayDocumentStore';
 import { useNotificationStore } from '../store/notificationStore';
 import { saveDocumentToStorage } from '../store/persistenceStore';
+import { collectBlobReferences } from '../storage/AssetBundler';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { getDocumentMetadata } from '../types/Document';
 import type { DiagramDocument } from '../types/Document';
@@ -244,6 +245,14 @@ export function VersionHistoryPanel({
         const copy = buildLocalCopyFromVersion(content, docName, point.createdAt);
         saveDocumentToStorage(copy);
         useDocumentRegistry.getState().registerLocal(getDocumentMetadata(copy));
+        // Pin the copy's blob bytes into local storage while the relay is at
+        // hand (JP-428): a local doc can't re-fetch after sign-out, and its
+        // images shouldn't depend on a live download when it's first opened.
+        const blobHashes = collectBlobReferences(copy);
+        if (blobHashes.length > 0 && provider.downloadBlobs) {
+          console.info(`[version-history] pinning ${blobHashes.length} blob(s) for local copy`);
+          void provider.downloadBlobs(blobHashes).catch(() => undefined);
+        }
         useNotificationStore
           .getState()
           .success(`Saved a local copy of the ${formatTimeOfDay(point.createdAt)} version.`);

--- a/src/ui/proseBlobImages.test.ts
+++ b/src/ui/proseBlobImages.test.ts
@@ -84,6 +84,62 @@ describe('resolveBlobImagesIn', () => {
     expect(img.style.padding).toBe('');
   });
 
+  // JP-428: heal-only passes back the blob-load subscription in
+  // useResolveBlobImages. They must never start downloads (a failed resolve
+  // notifies, which would re-trigger the pass and loop on a missing blob) —
+  // but must still swap + clean up once the hash is known available.
+  describe('heal-only pass (onlyKnownAvailable)', () => {
+    it('skips an image whose hash is unknown or known-missing (no resolve attempt)', async () => {
+      loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob').mockResolvedValue(null);
+      const { dom, img } = subtreeWithBlobImage();
+
+      // Unknown availability — heal pass must not touch it.
+      await resolveBlobImagesIn(dom, { onlyKnownAvailable: true });
+      expect(loadBlobSpy).not.toHaveBeenCalled();
+      expect(img.hasAttribute('data-blob-missing')).toBe(false);
+
+      // Full pass marks it missing; a heal pass afterwards still skips it.
+      await resolveBlobImagesIn(dom);
+      expect(img.hasAttribute('data-blob-missing')).toBe(true);
+      loadBlobSpy.mockClear();
+      await resolveBlobImagesIn(dom, { onlyKnownAvailable: true });
+      expect(loadBlobSpy).not.toHaveBeenCalled();
+      expect(img.hasAttribute('data-blob-missing')).toBe(true);
+    });
+
+    it('heals a placeholder once the hash is known available', async () => {
+      loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob').mockResolvedValueOnce(null);
+      const { dom, img } = subtreeWithBlobImage();
+      await resolveBlobImagesIn(dom);
+      expect(img.hasAttribute('data-blob-missing')).toBe(true);
+
+      // Another surface resolves the hash (e.g. the save-to-local pin download
+      // landed) — availability flips, and the heal pass swaps + cleans up.
+      loadBlobSpy.mockResolvedValue(pngBlob());
+      const { dom: other } = subtreeWithBlobImage();
+      await resolveBlobImagesIn(other);
+
+      await resolveBlobImagesIn(dom, { onlyKnownAvailable: true });
+      expect(img.getAttribute('src')).toBe('blob:mock-0');
+      expect(img.hasAttribute('data-blob-missing')).toBe(false);
+      expect(img.getAttribute('alt')).toBeNull();
+    });
+
+    it('full pass still retries the download for a marked-missing image (JP-363 guard)', async () => {
+      loadBlobSpy = vi
+        .spyOn(blobStorage, 'loadBlob')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(pngBlob());
+      const { dom, img } = subtreeWithBlobImage();
+      await resolveBlobImagesIn(dom);
+      expect(img.hasAttribute('data-blob-missing')).toBe(true);
+
+      await resolveBlobImagesIn(dom); // full pass — retry allowed
+      expect(img.getAttribute('src')).toBe('blob:mock-0');
+      expect(img.hasAttribute('data-blob-missing')).toBe(false);
+    });
+  });
+
   it('leaves directly-loadable srcs untouched (only blob:// is rewritten)', async () => {
     loadBlobSpy = vi.spyOn(blobStorage, 'loadBlob');
     const dom = document.createElement('div');

--- a/src/ui/proseBlobImages.ts
+++ b/src/ui/proseBlobImages.ts
@@ -12,14 +12,34 @@
  * are returned unchanged; a true miss shows an inline placeholder.
  */
 
-import { resolveBlobUrl } from '../storage/blobResolver';
+import { resolveBlobUrl, blobHashFromRef, isBlobMissing } from '../storage/blobResolver';
 
-export async function resolveBlobImagesIn(dom: HTMLElement): Promise<void> {
+export interface ResolveImagesOptions {
+  /**
+   * Heal-only pass: touch only images whose hash the resolver already knows is
+   * available (cache/IndexedDB swap, no download attempts). Used by the
+   * blob-load subscription — a full pass there would retry the download of a
+   * permanently missing blob on every notification and loop (each failed
+   * resolve itself notifies). Editor-update passes stay full-fat so the JP-363
+   * mode-flip self-heal keeps retrying downloads.
+   */
+  onlyKnownAvailable?: boolean;
+}
+
+export async function resolveBlobImagesIn(
+  dom: HTMLElement,
+  { onlyKnownAvailable = false }: ResolveImagesOptions = {},
+): Promise<void> {
   const images = dom.querySelectorAll('img[src^="blob://"]');
   for (const el of Array.from(images)) {
     const img = el as HTMLImageElement;
     const blobUrl = img.getAttribute('src');
     if (!blobUrl) continue;
+
+    if (onlyKnownAvailable) {
+      const hash = blobHashFromRef(blobUrl);
+      if (hash === null || isBlobMissing(hash) !== false) continue;
+    }
 
     const objectUrl = await resolveBlobUrl(blobUrl);
     if (objectUrl && objectUrl !== blobUrl) {
@@ -36,6 +56,11 @@ export async function resolveBlobImagesIn(dom: HTMLElement): Promise<void> {
     } else if (!objectUrl) {
       // Show a placeholder for a blob we genuinely can't resolve. Marked so a
       // later successful resolve (the self-heal path) can clear it.
+      if (!img.hasAttribute('data-blob-missing')) {
+        // Field-test breadcrumb (JP-428): a persistent placeholder means the
+        // local store missed AND the relay download failed — say which hash.
+        console.warn(`[prose-images] unresolved blob image ${blobUrl}`);
+      }
       img.setAttribute('data-blob-missing', '');
       img.setAttribute('alt', '(Image not found)');
       img.style.border = '2px dashed var(--border-color)';

--- a/src/ui/useProseBlobImages.ts
+++ b/src/ui/useProseBlobImages.ts
@@ -24,6 +24,7 @@
 
 import { useEffect } from 'react';
 import type { Editor } from '@tiptap/core';
+import { onBlobLoad } from '../storage/blobResolver';
 import { resolveBlobImagesIn } from './proseBlobImages';
 
 export function useResolveBlobImages(editor: Editor | null): void {
@@ -37,9 +38,19 @@ export function useResolveBlobImages(editor: Editor | null): void {
     };
     convert();
     editor.on('update', convert);
+    // Heal placeholders when a blob lands OUTSIDE an editor update — a relay
+    // doc gets constant collab updates and self-heals, but a LOCAL doc has no
+    // updates until the user types, so a resolve that failed at open (e.g. a
+    // download still in flight or a transient miss) stayed broken forever
+    // (JP-428). Heal-only mode: a full pass here would retry the download of
+    // a permanently missing blob on every notification and loop.
+    const offBlobLoad = onBlobLoad(() => {
+      void resolveBlobImagesIn(editor.view.dom, { onlyKnownAvailable: true });
+    });
     return () => {
       cancelAnimationFrame(raf);
       editor.off('update', convert);
+      offBlobLoad();
     };
   }, [editor]);
 }


### PR DESCRIPTION
## Problem

Field report after the JP-428 version-history fixes (PR #383, merged): prose images in a version copy **saved to local** render as broken ("404"-looking failed requests), while the same images render fine in the source relay document.

## Diagnosis

Relay side verified healthy on the real local-stack data: both image blobs exist on disk, `blob_acl.json` lists them for the workspace, `blob_refs.json` ties them to the source doc, and the caller is workspace owner (exempt from the JP-370 read gate) — the relay cannot 404 these. The visible failures are raw **un-swapped `blob://<hash>` img srcs**: client-side resolution missed once at open (e.g. a transient download failure) and stuck.

The local-vs-relay asymmetry: `useResolveBlobImages` re-runs only on editor `update` events. A relay doc gets constant collab updates and self-heals; a **local doc gets none** until the user types, so one transient miss leaves "(Image not found)" placeholders indefinitely. Structurally, nothing pinned a version copy's blob bytes locally at save time — the copy's first open depended on a live relay round-trip it shouldn't need (and can never make after sign-out).

## Changes

- **Save to local pins blobs**: `handleSaveLocal` collects the copy's blob references and best-effort downloads them into local IndexedDB while the relay is at hand (`collectBlobReferences` + `provider.downloadBlobs`).
- **Heal on blob load**: `useResolveBlobImages` also subscribes to the resolver's blob-load notifications with a **heal-only** pass (touches only known-available hashes). Placeholders clear the moment bytes land; full editor-update passes keep retrying downloads (preserves the JP-363 mode-flip self-heal), and heal-only mode can't retry-loop on a permanently missing blob.
- **Diagnosability**: first transition to placeholder logs `[prose-images] unresolved blob image <ref>`; the save-to-local breadcrumb reports how many blobs were pinned.

## Root cause (second field round): setContent emits no update event

Field re-test showed `Not allowed to load local resource: blob://<hash>` — srcs never swapped at all, while the pin breadcrumb confirmed the bytes landed locally. Probe-verified root cause: `commands.setContent` emits **no `update` event** (Tiptap default), so the on-update resolver never fires for the panel's page-load path — the path every local doc open and page switch uses since the JP-428 document-boundary fix. `DocumentEditorPanel` now resolves blob images explicitly after its `setContent` (immediate + next-frame pass); a canary test pins the no-update-event behavior. TiptapEditor's own content-watcher already resolved after its setContent; no other `setContent` callers exist.

## Verification

- `bun run typecheck`, **2901 tests green** (3 new heal-pass tests in `proseBlobImages.test.ts`), production build green, leak-grep clean.
- Manual E2E: relay doc with gallery images → Version history → Save to local → open the copy: images render; reopen with the relay stopped: still render (bytes pinned). Any future placeholder names its hash in the console.

Assisted-by: Fable 5
