### PR TITLE
JP-385 Document organization: browser facelift + tags + search

### DIFF
--- a/docs-site/.vitepress/config.mts
+++ b/docs-site/.vitepress/config.mts
@@ -44,7 +44,7 @@ const guidesSidebar = [
       { text: 'Document Fields', link: '/guide/document-fields' },
       { text: 'Citations & References', link: '/guide/citations' },
       { text: 'Embedded Files', link: '/guide/embedded-files' },
-      { text: 'Collections', link: '/guide/collections' },
+      { text: 'Collections & Tags', link: '/guide/collections' },
       { text: 'Version History & Undo', link: '/guide/recovery-and-undo' },
       { text: 'Offline & Sync', link: '/guide/offline-and-sync' },
     ],

--- a/docs-site/guide/collections.md
+++ b/docs-site/guide/collections.md
@@ -37,9 +37,10 @@ Open the **document browser** and switch the **Group by** control to
 
 ### Adding a document to a collection
 
-Use a document card's **Move to collection** menu to drop it into a collection
-(or pull it back out to Unassigned). You can move several documents at once when
-you have multiple selected.
+Open a document card's **⋯ (More actions)** menu and pick **Move to
+collection** to drop it into a collection (or pull it back out to Unassigned).
+You can move several documents at once when you have multiple selected — the
+selection bar's **Add to collection** menu applies to everything selected.
 
 <!-- SCREENSHOT: a document card's "Move to collection" submenu listing available collections -->
 

--- a/docs-site/guide/collections.md
+++ b/docs-site/guide/collections.md
@@ -1,9 +1,17 @@
 ---
-title: Collections
-description: Group related DocuShark documents into named, color-coded collections to organize your whole library.
+title: Collections & Tags
+description: Organize your DocuShark library with named, color-coded collections and free-form searchable tags.
 ---
 
-# Collections
+# Collections & Tags
+
+DocuShark gives you two ways to organize a growing library, and they answer
+different questions:
+
+- **Collections** answer *"where does this document live?"* — each document
+  sits in at most one collection, like a folder.
+- **Tags** answer *"what is this document about?"* — a document can carry many
+  tags, and search can target them directly.
 
 Collections are **containers for your documents** — think of them as
 "workspaces inside your workspace." As your library grows, collections let you
@@ -57,6 +65,36 @@ A document and its collection must share scope — a local document can only joi
 a local collection, and a workspace document can only join a workspace
 collection. This keeps personal organisation separate from a shared workspace's,
 and means signing out of a workspace never disturbs your local collections.
+
+## Tags
+
+Tags are free-form labels that live **on the document itself**. Where a
+collection is a place, tags are properties — a document can have up to 20, and
+each tag gets a consistent colour everywhere it appears.
+
+- **Add tags** from a document card's **⋯ (More actions) › Edit tags…** —
+  type and press Enter, or pick from tags you've used before. With several
+  documents selected, the selection bar's **Add tags** applies tags to all of
+  them at once.
+- **Search by tag**: the search box matches names *and* tags. Prefix your
+  query with `#` (e.g. `#research`) to match tags only, and clicking any tag
+  chip on a card fills that search in for you. Press `/` anywhere in the
+  library to jump to the search box.
+- **Tags travel with the document.** Moving a document between personal and
+  workspace storage keeps its tags, and a document restored from the Trash
+  still has them. Collections behave differently — see below.
+
+### What transfers keep, and what they don't
+
+| When you… | Collection | Tags |
+|-----------|-----------|------|
+| Move a personal document to a workspace | Cleared (arrives Unassigned) | Kept |
+| Move a workspace document to personal | Cleared (arrives Unassigned) | Kept |
+| Trash and restore a document | Cleared (returns Unassigned) | Kept |
+
+A collection belongs to a *place* (this device, or a workspace), so a document
+that changes places always leaves its collection behind. Tags describe the
+document itself, so they follow it everywhere.
 
 ## Where collections are headed
 

--- a/docs-site/guide/recovery-and-undo.md
+++ b/docs-site/guide/recovery-and-undo.md
@@ -31,6 +31,23 @@ Each version offers two actions:
 - **Restore** — brings the document back to that point in time, as a **new document**. Collaborators who have the original open keep an offline local copy of their working state; everyone else finds their copy in Trash rather than losing it outright. This is a meaningful action, so DocuShark asks you to confirm first.
 - **Save to local** — downloads that version's content as a new local (non-cloud) document, without touching the original at all. Use this when you just want a copy, not a rollback.
 
+## Deleting documents and the Trash
+
+Deleting from a document's card in Documents Home is designed to be quick but
+recoverable:
+
+- Deleting one of **your local documents** happens immediately — no dialog —
+  and shows a toast with an **Undo** button that brings it straight back.
+- Deleting a **workspace document** asks you to confirm first, because it's
+  removed for everyone in the workspace; a recoverable copy is kept in *your*
+  Trash.
+- **Delete permanently** (in the card's **⋯ More actions** menu) bypasses the
+  Trash entirely and always asks for confirmation.
+
+Everything soft-deleted lands in the **Trash** view, where you can restore a
+document (it comes back as a local document, outside any collection) or purge
+it for good. Trashed documents expire automatically after a retention window.
+
 ## What this doesn't do yet
 
 Versions are captured automatically rather than on demand — there's no "save a named version now" yet, and no side-by-side visual diff between versions. If you need a guaranteed checkpoint before a risky edit, **Save to local** is the closest thing to a manual save point today. Local (non-cloud) documents don't have version history; they're covered by undo and Trash.

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -240,6 +240,14 @@ pub struct DocumentMetadata {
     /// (absent in pre-collections `index.json` entries).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collection_id: Option<String>,
+    /// Free-form organizational tags (JP-388). Unlike `collection_id` these
+    /// are document *content*, not scope-bound membership: they carry on the
+    /// body under `tags` and are lifted here by `metadata_from_body` so the
+    /// browser can filter/search without fetching bodies. `None` covers both
+    /// "untagged" and pre-tags entries (additive + optional →
+    /// backward-compatible `index.json`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared_with: Option<Vec<DocumentShare>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1702,6 +1710,18 @@ impl DocumentStore {
             owner_id: doc.get("ownerId").and_then(|v| v.as_str()).map(String::from),
             owner_name: doc.get("ownerName").and_then(|v| v.as_str()).map(String::from),
             collection_id: doc.get("collectionId").and_then(|v| v.as_str()).map(String::from),
+            // Non-string members are dropped, an empty list lifts as `None`
+            // (keeps the index lean; absent ≡ untagged).
+            tags: doc
+                .get("tags")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|t| t.as_str())
+                        .map(String::from)
+                        .collect::<Vec<_>>()
+                })
+                .filter(|v| !v.is_empty()),
             shared_with: doc
                 .get("sharedWith")
                 .and_then(|v| serde_json::from_value(v.clone()).ok()),
@@ -2316,6 +2336,49 @@ mod tests {
         store.update_document_collection(&ws, &doc_id, None).unwrap();
         assert_eq!(store.get_metadata(&ws, &doc_id).unwrap().collection_id, None);
         assert!(store.get_document(&ws, &doc_id).unwrap().get("collectionId").is_none());
+    }
+
+    #[test]
+    fn tags_lift_into_metadata() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        // Tagged body → lifted (non-string members dropped).
+        let tagged = DocId::from_http_path("t-doc".to_string()).unwrap();
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({
+                    "id": "t-doc", "name": "T", "pageOrder": ["p"],
+                    "tags": ["alpha", 7, "beta"]
+                }),
+            )
+            .unwrap();
+        assert_eq!(
+            store.get_metadata(&ws, &tagged).unwrap().tags,
+            Some(vec!["alpha".to_string(), "beta".to_string()])
+        );
+
+        // No tags key → None.
+        let untagged = DocId::from_http_path("u-doc".to_string()).unwrap();
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({ "id": "u-doc", "name": "U", "pageOrder": ["p"] }),
+            )
+            .unwrap();
+        assert_eq!(store.get_metadata(&ws, &untagged).unwrap().tags, None);
+
+        // Explicit empty list lifts as None (index stays lean).
+        let cleared = DocId::from_http_path("e-doc".to_string()).unwrap();
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({ "id": "e-doc", "name": "E", "pageOrder": ["p"], "tags": [] }),
+            )
+            .unwrap();
+        assert_eq!(store.get_metadata(&ws, &cleared).unwrap().tags, None);
     }
 
     #[test]
@@ -2994,6 +3057,7 @@ mod tests {
             owner_id: None,
             owner_name: None,
             collection_id: None,
+            tags: None,
             shared_with: None,
             last_modified_by: None,
             last_modified_by_name: None,

--- a/relay/src/server/permissions.rs
+++ b/relay/src/server/permissions.rs
@@ -261,6 +261,7 @@ mod tests {
             owner_id: Some(owner_id.to_string()),
             owner_name: Some("Owner".to_string()),
             collection_id: None,
+            tags: None,
             shared_with: if shares.is_empty() {
                 None
             } else {

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -417,6 +417,7 @@ mod tests {
                 owner_id: Some("user-1".to_string()),
                 owner_name: Some("Test User".to_string()),
                 collection_id: None,
+                tags: None,
                 shared_with: None,
                 last_modified_by: None,
                 last_modified_by_name: None,

--- a/relay/src/sync/flatten.rs
+++ b/relay/src/sync/flatten.rs
@@ -124,10 +124,31 @@ pub fn flatten_into(doc: &Doc, page_id: &str, json: &mut Value) -> bool {
     // `modifiedAt` BEFORE we overwrite it below.
     let stored_modified = json.get("modifiedAt").and_then(Value::as_u64).unwrap_or(0);
     let (meta_title, meta_updated) = metadata_title_and_updated(&meta_any);
+    let meta_fresh = meta_updated.unwrap_or(0) >= stored_modified;
     if let Some(title) = meta_title {
-        if !title.is_empty() && meta_updated.unwrap_or(0) >= stored_modified {
+        if !title.is_empty() && meta_fresh {
             if let Some(obj) = json.as_object_mut() {
                 obj.insert("name".to_string(), Value::String(title));
+            }
+        }
+    }
+
+    // Tags (JP-388) live in the same metadata map and follow the same
+    // freshness rule as the title: a REST tag save bumps `modifiedAt` without
+    // touching the Y.Doc, so a stale CRDT copy must not clobber it. An absent
+    // metadata key leaves the body untouched; an explicit empty array removes
+    // the body key (the "cleared tags" write).
+    if meta_fresh {
+        if let Some(tags) = metadata_tags(&meta_any) {
+            if let Some(obj) = json.as_object_mut() {
+                if tags.is_empty() {
+                    obj.remove("tags");
+                } else {
+                    obj.insert(
+                        "tags".to_string(),
+                        Value::Array(tags.into_iter().map(Value::String).collect()),
+                    );
+                }
             }
         }
     }
@@ -154,6 +175,27 @@ fn metadata_title_and_updated(meta_any: &Any) -> (Option<String>, Option<u64>) {
         _ => None,
     };
     (title, updated)
+}
+
+/// Extract `tags` from the Y.Doc `metadata` map's JSON form (JP-388).
+/// `None` = the key was never written (leave the body alone); `Some(vec![])` =
+/// an explicit cleared list. Non-string members are dropped.
+fn metadata_tags(meta_any: &Any) -> Option<Vec<String>> {
+    let Any::Map(map) = meta_any else {
+        return None;
+    };
+    match map.get("tags") {
+        Some(Any::Array(items)) => Some(
+            items
+                .iter()
+                .filter_map(|t| match t {
+                    Any::String(s) => Some(s.to_string()),
+                    _ => None,
+                })
+                .collect(),
+        ),
+        _ => None,
+    }
 }
 
 /// Project live prose pages (`(page_id, html)`, from the Y.Doc `prose:*`
@@ -764,6 +806,88 @@ mod tests {
         json["modifiedAt"] = json!(1000);
         assert!(flatten_into(&doc, "p1", &mut json));
         assert_eq!(json["name"], json!("RestName"), "stale title did not clobber the REST rename");
+    }
+
+    #[test]
+    fn crdt_tags_flatten_to_body() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page(), &doc);
+
+        // Simulate a CRDT tag edit: fresh metadata.tags + updatedAt.
+        let metadata = doc.get_or_insert_map("metadata");
+        {
+            let mut txn = doc.transact_mut();
+            metadata.insert(
+                &mut txn,
+                "tags",
+                Any::Array(vec![Any::String("alpha".into()), Any::String("beta".into())].into()),
+            );
+            metadata.insert(&mut txn, "updatedAt", Any::Number(100.0));
+        }
+
+        let mut json = multi_page(); // modifiedAt=2
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(json["tags"], json!(["alpha", "beta"]), "CRDT tags flattened into body");
+    }
+
+    #[test]
+    fn crdt_cleared_tags_remove_body_key() {
+        let doc = Doc::new();
+        let mut seeded = multi_page();
+        seeded["tags"] = json!(["old"]);
+        json_to_ydoc(&seeded, &doc);
+
+        // A fresh explicit empty list is the "cleared tags" write.
+        let metadata = doc.get_or_insert_map("metadata");
+        {
+            let mut txn = doc.transact_mut();
+            metadata.insert(&mut txn, "tags", Any::Array(Vec::<Any>::new().into()));
+            metadata.insert(&mut txn, "updatedAt", Any::Number(100.0));
+        }
+
+        let mut json = seeded.clone();
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert!(json.get("tags").is_none(), "cleared tags remove the body key");
+    }
+
+    #[test]
+    fn stale_tags_do_not_clobber_rest_tag_save() {
+        let doc = Doc::new();
+        let mut hydrated = multi_page();
+        hydrated["tags"] = json!(["old"]);
+        json_to_ydoc(&hydrated, &doc); // metadata.tags=["old"], updatedAt=2
+
+        // The stored doc's tags were changed out-of-band (REST): fresher
+        // modifiedAt than the Y.Doc metadata. The stale CRDT tags must not win.
+        let mut json = multi_page();
+        json["tags"] = json!(["rest-fresh"]);
+        json["modifiedAt"] = json!(1000);
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(
+            json["tags"],
+            json!(["rest-fresh"]),
+            "stale CRDT tags did not clobber the REST tag save"
+        );
+    }
+
+    #[test]
+    fn absent_metadata_tags_leave_body_untouched() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page(), &doc); // no tags anywhere
+
+        // Body carries tags the Y.Doc never saw (metadata key absent): a fresh
+        // rename must not strip them (absent ≠ cleared).
+        let metadata = doc.get_or_insert_map("metadata");
+        {
+            let mut txn = doc.transact_mut();
+            metadata.insert(&mut txn, "title", Any::String("Renamed".into()));
+            metadata.insert(&mut txn, "updatedAt", Any::Number(100.0));
+        }
+        let mut json = multi_page();
+        json["tags"] = json!(["body-only"]);
+        assert!(flatten_into(&doc, "p1", &mut json));
+        assert_eq!(json["name"], json!("Renamed"));
+        assert_eq!(json["tags"], json!(["body-only"]), "absent metadata tags left body alone");
     }
 
     #[test]

--- a/relay/src/sync/hydration.rs
+++ b/relay/src/sync/hydration.rs
@@ -78,6 +78,16 @@ pub fn json_to_ydoc(doc_json: &Value, doc: &Doc) {
     if let Some(modified) = doc_json.get("modifiedAt").and_then(Value::as_u64) {
         metadata.insert(&mut txn, "updatedAt", Any::Number(modified as f64));
     }
+    // Tags (JP-388) ride the same metadata map so live peers see them and the
+    // flatten writes them back. Absent key = untagged (nothing seeded).
+    if let Some(tags) = doc_json.get("tags").and_then(Value::as_array) {
+        let seeded: Vec<Any> = tags
+            .iter()
+            .filter_map(Value::as_str)
+            .map(|t| Any::String(t.into()))
+            .collect();
+        metadata.insert(&mut txn, "tags", Any::Array(seeded.into()));
+    }
 }
 
 /// Seed the live `prose:<id>` `Y.XmlFragment`s from a persisted document's
@@ -439,6 +449,39 @@ mod tests {
     use super::{json_references_to_ydoc, json_to_ydoc, total_shape_count};
     use serde_json::{json, Value};
     use yrs::{Any, Array, Doc, Map, Transact};
+
+    #[test]
+    fn hydrates_tags_into_metadata_map() {
+        let mut json = multi_page_doc();
+        json["tags"] = serde_json::json!(["alpha", "beta"]);
+        let doc = Doc::new();
+        json_to_ydoc(&json, &doc);
+
+        let metadata = doc.get_or_insert_map("metadata");
+        let txn = doc.transact();
+        match metadata.get(&txn, "tags") {
+            Some(yrs::Out::Any(Any::Array(items))) => {
+                let tags: Vec<String> = items
+                    .iter()
+                    .filter_map(|t| match t {
+                        Any::String(s) => Some(s.to_string()),
+                        _ => None,
+                    })
+                    .collect();
+                assert_eq!(tags, vec!["alpha".to_string(), "beta".to_string()]);
+            }
+            other => panic!("expected tags array in metadata map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn untagged_body_seeds_no_tags_key() {
+        let doc = Doc::new();
+        json_to_ydoc(&multi_page_doc(), &doc);
+        let metadata = doc.get_or_insert_map("metadata");
+        let txn = doc.transact();
+        assert!(metadata.get(&txn, "tags").is_none(), "absent body tags seed nothing");
+    }
 
     #[test]
     fn total_shape_count_sums_all_pages() {

--- a/src/collaboration/YjsDocument.tags.test.ts
+++ b/src/collaboration/YjsDocument.tags.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Y.Doc tags (JP-388) — the metadata-map write path collab tag edits ride.
+ * Whole-array LWW is the documented merge semantic; the `updatedAt` bump is
+ * what lets the relay flatten adopt a fresh CRDT tag edit over the stored body.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { YjsDocument } from './YjsDocument';
+
+describe('YjsDocument tags (JP-388)', () => {
+  it('round-trips tags through setMetadata/getTags; absent stays undefined', () => {
+    const doc = new YjsDocument();
+    expect(doc.getTags()).toBeUndefined();
+
+    doc.setMetadata({ tags: ['alpha', 'beta'], updatedAt: 42 });
+    expect(doc.getTags()).toEqual(['alpha', 'beta']);
+    expect(doc.getMetadata().tags).toEqual(['alpha', 'beta']);
+    expect(doc.getMetadata().updatedAt).toBe(42);
+  });
+
+  it('an explicit empty list is distinct from absent (cleared vs never-set)', () => {
+    const doc = new YjsDocument();
+    doc.setMetadata({ tags: [] });
+    expect(doc.getTags()).toEqual([]);
+  });
+
+  it('merges whole-array last-writer-wins across two docs', () => {
+    const a = new YjsDocument();
+    const b = new YjsDocument();
+
+    a.setMetadata({ tags: ['from-a'], updatedAt: 1 });
+    // Sync a → b, then b writes over it and syncs back.
+    Y.applyUpdate(b.getDoc(), Y.encodeStateAsUpdate(a.getDoc()));
+    expect(b.getTags()).toEqual(['from-a']);
+
+    b.setMetadata({ tags: ['from-b-1', 'from-b-2'], updatedAt: 2 });
+    Y.applyUpdate(a.getDoc(), Y.encodeStateAsUpdate(b.getDoc()));
+
+    expect(a.getTags()).toEqual(['from-b-1', 'from-b-2']);
+    expect(b.getTags()).toEqual(['from-b-1', 'from-b-2']);
+  });
+
+  it('drops non-string members on read (defensive against foreign writes)', () => {
+    const doc = new YjsDocument();
+    const metadata = doc.getDoc().getMap('metadata');
+    doc.getDoc().transact(() => {
+      metadata.set('tags', ['ok', 7, null, 'also-ok']);
+    });
+    expect(doc.getTags()).toEqual(['ok', 'also-ok']);
+  });
+});

--- a/src/collaboration/YjsDocument.ts
+++ b/src/collaboration/YjsDocument.ts
@@ -39,6 +39,12 @@ export interface YjsDocumentMetadata {
   title: string;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Free-form organizational tags (JP-388). Whole-array last-writer-wins in
+   * the metadata map — acceptable for a short list; no per-item CRDT merge.
+   * Absent = untagged (no default substituted, so a missing key stays absent).
+   */
+  tags?: string[];
 }
 
 /**
@@ -933,11 +939,25 @@ export class YjsDocument {
    * Get document metadata.
    */
   getMetadata(): YjsDocumentMetadata {
+    const tags = this.metadata.get('tags');
     return {
       title: (this.metadata.get('title') as string) ?? 'Untitled',
       createdAt: (this.metadata.get('createdAt') as number) ?? Date.now(),
       updatedAt: (this.metadata.get('updatedAt') as number) ?? Date.now(),
+      ...(Array.isArray(tags)
+        ? { tags: tags.filter((t): t is string => typeof t === 'string') }
+        : {}),
     };
+  }
+
+  /**
+   * Get document tags (JP-388). Raw read — absent means the key was never
+   * written, distinct from an explicit empty list.
+   */
+  getTags(): string[] | undefined {
+    const tags = this.metadata.get('tags');
+    if (!Array.isArray(tags)) return undefined;
+    return tags.filter((t): t is string => typeof t === 'string');
   }
 
   // ============ Bulk Operations ============

--- a/src/collaboration/collaborationStore.ts
+++ b/src/collaboration/collaborationStore.ts
@@ -231,6 +231,13 @@ interface CollaborationActions {
    * stale title vs an out-of-band REST rename.
    */
   syncDocumentName: (name: string) => void;
+  /**
+   * Sync the document's tags (JP-388) to peers via the Y.Doc `metadata` map —
+   * the tags counterpart of `syncDocumentName`. Whole-array LWW; bumps
+   * `updatedAt` so the relay's flatten adopts the fresh value over a stale
+   * CRDT copy after an out-of-band REST tag edit.
+   */
+  syncDocumentTags: (tags: string[]) => void;
 
   // Prose (CRDT-native programmatic writes, JP-193)
   /**
@@ -916,6 +923,14 @@ export const useCollaborationStore = create<CollaborationState & CollaborationAc
         // doc `name` on hydrate and flattens it back). `updatedAt` lets the
         // relay order this against a possibly-concurrent REST rename.
         yjsDoc.setMetadata({ title: name, updatedAt: Date.now() });
+      }
+    },
+
+    syncDocumentTags: (tags: string[]) => {
+      if (yjsDoc) {
+        // Same shape as the rename above: metadata-map write + `updatedAt`
+        // bump so the relay flatten adopts it (JP-388).
+        yjsDoc.setMetadata({ tags, updatedAt: Date.now() });
       }
     },
 

--- a/src/collaboration/useCollaborationSync.test.ts
+++ b/src/collaboration/useCollaborationSync.test.ts
@@ -31,6 +31,8 @@ function makeMockYjs() {
     getShapesForPage: vi.fn(() => [] as Shape[]),
     getShapeOrderForPage: vi.fn(() => [] as string[]),
     getName: vi.fn(() => undefined),
+    // JP-388 tag adoption surface.
+    getTags: vi.fn(() => undefined),
     setShape: vi.fn(),
     setShapes: vi.fn(),
     deleteShape: vi.fn(),

--- a/src/collaboration/useCollaborationSync.ts
+++ b/src/collaboration/useCollaborationSync.ts
@@ -21,7 +21,7 @@ import { useReferenceStore } from '../store/referenceStore';
 import { useFieldStore } from '../store/fieldStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import { usePageStore } from '../store/pageStore';
-import { applyRemoteDocumentName } from '../store/persistenceStore';
+import { applyRemoteDocumentName, applyRemoteDocumentTags } from '../store/persistenceStore';
 import { isAutoSaveSuppressed } from '../store/autoSaveGuard';
 import { getProvenance, runWithProvenance } from '../store/writeProvenance';
 import { useConnectionStore } from '../store/connectionStore';
@@ -152,6 +152,10 @@ export function useCollaborationSync(): void {
       const docId = useCollaborationStore.getState().config?.documentId;
       const name = yjsDoc.getName(); // raw, no "Untitled" default
       if (docId && name) applyRemoteDocumentName(docId, name);
+      // Tags live in the same metadata map (JP-388) — adopt them the same way
+      // (applyRemoteDocumentTags is local-only + idempotent, so no echo loop).
+      const tags = yjsDoc.getTags();
+      if (docId && tags !== undefined) applyRemoteDocumentTags(docId, tags);
     });
 
     // Handle remote reference-library changes (JP-89). Coarse bulk reload from
@@ -269,6 +273,9 @@ export function useCollaborationSync(): void {
       const docId = useCollaborationStore.getState().config?.documentId;
       const name = yjsDoc.getName(); // raw, no "Untitled" default
       if (docId && name) applyRemoteDocumentName(docId, name);
+      // …and the authoritative tags (JP-388), for the same joining-client case.
+      const joinTags = yjsDoc.getTags();
+      if (docId && joinTags !== undefined) applyRemoteDocumentTags(docId, joinTags);
       initializedRef.current = true;
     } else if (isSynced) {
       // The Y.Doc is empty AND the relay confirmed its state (`isSynced`) — the

--- a/src/index.css
+++ b/src/index.css
@@ -77,6 +77,19 @@
   --warning-bg: rgba(184, 118, 31, 0.10);
   --danger-bg: rgba(122, 34, 56, 0.10);
 
+  /* Tag chip palette (JP-388) — 8 muted brand-adjacent hues, indexed
+     deterministically from the tag text (see tagColorIndex). Each hue is a
+     text color + a matching tint background; keep TAG_COLOR_COUNT in
+     DocumentTags.ts equal to the number of entries here. */
+  --tag-hue-0: #1f3354; --tag-hue-0-bg: rgba(31, 51, 84, 0.12);   /* navy */
+  --tag-hue-1: #1d6f6a; --tag-hue-1-bg: rgba(29, 111, 106, 0.12); /* teal */
+  --tag-hue-2: #4b7031; --tag-hue-2-bg: rgba(75, 112, 49, 0.12);  /* moss */
+  --tag-hue-3: #9a6a1a; --tag-hue-3-bg: rgba(154, 106, 26, 0.14); /* ochre */
+  --tag-hue-4: #a14e2c; --tag-hue-4-bg: rgba(161, 78, 44, 0.12);  /* terracotta */
+  --tag-hue-5: #7a2238; --tag-hue-5-bg: rgba(122, 34, 56, 0.10);  /* wine */
+  --tag-hue-6: #6b3f7d; --tag-hue-6-bg: rgba(107, 63, 125, 0.12); /* plum */
+  --tag-hue-7: #4a5d78; --tag-hue-7-bg: rgba(74, 93, 120, 0.12);  /* steel */
+
   /* Tooltip surface — deep navy in both modes (inverted floating label) */
   --bg-tooltip: var(--navy-900);
 
@@ -222,6 +235,16 @@
   --success-bg: rgba(142, 220, 177, 0.12);
   --warning-bg: rgba(224, 198, 144, 0.12);
   --danger-bg: rgba(232, 155, 155, 0.12);
+
+  /* Tag chip palette (JP-388) — same 8 hues, lightened for navy surfaces */
+  --tag-hue-0: #a9c0e4; --tag-hue-0-bg: rgba(169, 192, 228, 0.14); /* navy */
+  --tag-hue-1: #8ed4cf; --tag-hue-1-bg: rgba(142, 212, 207, 0.14); /* teal */
+  --tag-hue-2: #b3d18e; --tag-hue-2-bg: rgba(179, 209, 142, 0.14); /* moss */
+  --tag-hue-3: #e4c088; --tag-hue-3-bg: rgba(228, 192, 136, 0.14); /* ochre */
+  --tag-hue-4: #e5a583; --tag-hue-4-bg: rgba(229, 165, 131, 0.14); /* terracotta */
+  --tag-hue-5: #e89bab; --tag-hue-5-bg: rgba(232, 155, 171, 0.14); /* wine */
+  --tag-hue-6: #cda8de; --tag-hue-6-bg: rgba(205, 168, 222, 0.14); /* plum */
+  --tag-hue-7: #a9b8cd; --tag-hue-7-bg: rgba(169, 184, 205, 0.14); /* steel */
 
   /* Canvas — deepest navy void */
   --canvas-bg: #060c17;

--- a/src/migrations/documentMigrations.test.ts
+++ b/src/migrations/documentMigrations.test.ts
@@ -84,6 +84,22 @@ describe('migrateDocument — version gate', () => {
   });
 });
 
+describe('migrateDocument — tags are additive (JP-388)', () => {
+  it('invents no tags key on a legacy document without one', () => {
+    const doc = sampleDoc({ version: 1 });
+    const out = migrateDocument(doc);
+    expect(out.version).toBe(DOCUMENT_VERSION);
+    expect('tags' in out).toBe(false);
+  });
+
+  it('round-trips a tagged document with tags untouched', () => {
+    const doc = sampleDoc({ version: 1, tags: ['alpha', 'Beta'] });
+    const out = migrateDocument(doc);
+    expect(out.tags).toEqual(['alpha', 'Beta']);
+    expect(migrateDocument(out).tags).toEqual(['alpha', 'Beta']);
+  });
+});
+
 describe('migrateDocument — v2 invariants (JP-347)', () => {
   it('stamps ownerId: null on a group missing it, preserving set owners', () => {
     const doc = sampleDoc();

--- a/src/services/DocumentTransferService.test.ts
+++ b/src/services/DocumentTransferService.test.ts
@@ -213,6 +213,45 @@ describe('DocumentTransferService', () => {
     });
   });
 
+  // JP-385 trait matrix: collection membership is scope-bound and must strip
+  // on EVERY cross-context transfer (JP-366); tags are document content and
+  // must ride along untouched (JP-388). Trash/restore variants are pinned in
+  // the trash store tests.
+  describe('organization traits across transfers (JP-385)', () => {
+    it('promote (to team) strips collectionId and keeps tags', async () => {
+      testDoc = createTestDocument({
+        collectionId: 'local-coll',
+        tags: ['alpha', 'beta'],
+      });
+      const result = await service.transferToTeam(testDoc.id);
+
+      expect(result.success).toBe(true);
+      expect(result.document?.collectionId).toBeUndefined();
+      expect(result.document?.tags).toEqual(['alpha', 'beta']);
+    });
+
+    it('demote (to personal) strips collectionId + team fields and keeps tags', async () => {
+      let teamDoc = createTestDocument({
+        isRelayDocument: true,
+        ownerId: 'user-1',
+        ownerName: 'Test User',
+        collectionId: 'ws-coll',
+        tags: ['alpha', 'beta'],
+      });
+      deps.loadDocument = vi.fn((id: string) => (id === teamDoc.id ? teamDoc : null));
+      deps.saveDocument = vi.fn((doc: DiagramDocument) => {
+        teamDoc = doc;
+      });
+
+      const result = await service.transferToPersonal(teamDoc.id);
+
+      expect(result.success).toBe(true);
+      expect(result.document?.collectionId).toBeUndefined();
+      expect(result.document?.ownerId).toBeUndefined();
+      expect(result.document?.tags).toEqual(['alpha', 'beta']);
+    });
+  });
+
   describe('transferToPersonal', () => {
     let teamDoc: DiagramDocument;
 

--- a/src/services/DocumentTransferService.ts
+++ b/src/services/DocumentTransferService.ts
@@ -491,6 +491,10 @@ export class DocumentTransferService {
     delete updatedDoc.sharedWith;
     delete updatedDoc.lastModifiedBy;
     delete updatedDoc.lastModifiedByName;
+    // A workspace collection can't hold a personal doc (JP-366) — the demoted
+    // copy must not carry the workspace's membership stamp. Tags stay: they're
+    // document content, not scope-bound membership (JP-388).
+    delete updatedDoc.collectionId;
 
     // Save locally
     this.deps.saveDocument(updatedDoc);

--- a/src/storage/TrashStorage.test.ts
+++ b/src/storage/TrashStorage.test.ts
@@ -150,6 +150,17 @@ describe('TrashStorage', () => {
       expect(result.error).toContain('not found');
     });
 
+    it('preserves tags through trash + recover (JP-388)', () => {
+      const doc = createTestDocument('doc-tags', 'Tagged Doc');
+      doc.tags = ['alpha', 'beta'];
+      moveToTrash(doc, createTestMetadata('doc-tags', 'Tagged Doc'));
+
+      const result = recoverFromTrash('doc-tags');
+
+      expect(result.success).toBe(true);
+      expect(result.document?.tags).toEqual(['alpha', 'beta']);
+    });
+
     it('removes document from trash storage after recovery', () => {
       const doc = createTestDocument('doc-1', 'Test Doc');
       const metadata = createTestMetadata('doc-1', 'Test Doc');

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -10,6 +10,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { DiagramDocument, DocumentMetadata } from '../types/Document';
+import { tagsEqual } from '../types/DocumentTags';
 import {
   type DocumentRecord,
   type LocalDocument,
@@ -277,7 +278,8 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
               existing &&
               existing.name === record.name &&
               existing.modifiedAt === record.modifiedAt &&
-              existing.pageCount === record.pageCount
+              existing.pageCount === record.pageCount &&
+              tagsEqual(existing.tags, record.tags)
             ) {
               continue;
             }

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -15,6 +15,7 @@ import {
   getDocumentMetadata,
 } from '../types/Document';
 import { validateDocumentJSON } from '../types/DocumentValidation';
+import { normalizeTags, tagsEqual } from '../types/DocumentTags';
 import { isRichTextEmpty } from '../types/RichText';
 import { migrateDocument, DocumentVersionError } from '../migrations/documentMigrations';
 import { usePageStore, PageStoreSnapshot } from './pageStore';
@@ -358,6 +359,8 @@ export interface PersistenceActions {
   createRelayDocumentAs: (name: string) => Promise<{ ok: true; docId: string } | { ok: false; error: string }>;
   /** Rename any document by id (handles active/non-active, local/relay) */
   renameDocumentById: (docId: string, newName: string) => Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'version-conflict' | 'network-error'; message?: string }>;
+  /** Set a document's tags by id (handles active/non-active, local/relay; JP-388) */
+  setDocumentTags: (docId: string, tags: string[]) => Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'version-conflict' | 'network-error'; message?: string }>;
   /** Load a remote document (from host) directly into the editor */
   loadRemoteDocument: (doc: DiagramDocument) => void;
   /** Reset to initial state */
@@ -639,6 +642,12 @@ function createDocumentFromPageStore(
   // user's per-document PDF preferences (margins, cover-page, etc.).
   if (existingDoc?.pdfSettings) {
     doc.pdfSettings = existingDoc.pdfSettings;
+  }
+
+  // Preserve tags (JP-388) — document-owned like pdfSettings; no live store
+  // holds them, so a save must carry them forward from the stored copy.
+  if (existingDoc?.tags !== undefined) {
+    doc.tags = existingDoc.tags;
   }
 
   // Preserve team-related fields from existing document
@@ -1154,6 +1163,10 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         delete doc.lastModifiedBy;
         delete doc.lastModifiedByName;
         delete doc.serverVersion;
+        // A workspace collection can't hold a local doc (JP-366) — the demoted
+        // copy must not carry the workspace's membership stamp. (Tags stay:
+        // they're document content, not scope-bound membership.)
+        delete doc.collectionId;
         doc.modifiedAt = Date.now();
 
         saveDocumentToStorage(doc);
@@ -1564,6 +1577,60 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
         return { ok: true };
       },
 
+      // Set a document's tags by id (any document, active or not, local or
+      // relay). Tags are document content (JP-388): normalized on this write
+      // seam, stored as an absent key when empty. For the active collab doc
+      // the change rides the Y.Doc metadata map (peers adopt it, the relay
+      // flatten persists it) instead of racing a REST save; other relay docs
+      // REST-save with version conflicts surfaced as a typed result
+      // (mirrors renameDocumentById).
+      setDocumentTags: async (docId: string, tags: string[]) => {
+        const normalized = normalizeTags(tags);
+        const doc = loadDocumentFromStorage(docId);
+        if (!doc) {
+          return { ok: false, reason: 'not-found' };
+        }
+        if (tagsEqual(doc.tags, normalized)) {
+          return { ok: true };
+        }
+
+        if (normalized.length === 0) delete doc.tags;
+        else doc.tags = normalized;
+        doc.modifiedAt = Date.now();
+        saveDocumentToStorage(doc);
+
+        // Update metadata + registry so chips/search reflect the edit immediately.
+        const metadata = getDocumentMetadata(doc);
+        set((state) => ({
+          documents: { ...state.documents, [docId]: metadata },
+        }));
+        useDocumentRegistry.getState().updateRecord(docId, { tags: normalized });
+
+        // Active collab content doc: the CRDT is the write path (REST content
+        // saves are suppressed for collab docs) — push through the metadata map.
+        if (docId === get().currentDocumentId && isCollabContentDoc(docId)) {
+          useCollaborationStore.getState().syncDocumentTags(normalized);
+          return { ok: true };
+        }
+
+        if (doc.isRelayDocument && isRelayAuthenticated()) {
+          const teamDocStore = useRelayDocumentStore.getState();
+          if (teamDocStore.authenticated) {
+            try {
+              await teamDocStore.saveToHost(doc, doc.serverVersion);
+            } catch (err) {
+              if (err instanceof VersionConflictError) {
+                return { ok: false, reason: 'version-conflict' };
+              }
+              const message = err instanceof Error ? err.message : 'Failed to save to relay';
+              return { ok: false, reason: 'network-error', message };
+            }
+          }
+        }
+
+        return { ok: true };
+      },
+
       // Load a remote document (from host) directly into the editor
       loadRemoteDocument: (doc: DiagramDocument) => {
         // Same rationale as loadDocument: flush before switching so we
@@ -1760,6 +1827,29 @@ export function applyRemoteDocumentName(docId: string, name: string): void {
     };
   });
   useDocumentRegistry.getState().updateRecord(docId, { name });
+}
+
+/**
+ * Adopt a peer's tag change from the collab metadata map (JP-388) — the tags
+ * counterpart of {@link applyRemoteDocumentName}. Local-only write (index +
+ * registry, no save/echo); the tags reach this device's stored copy on the
+ * next save, and the relay copy via the flatten.
+ */
+export function applyRemoteDocumentTags(docId: string, tags: unknown): void {
+  if (!docId || !Array.isArray(tags)) return;
+  const next = tags.filter((t): t is string => typeof t === 'string');
+  const s = usePersistenceStore.getState();
+  // Idempotent: skip if nothing would change (avoids churn from echoed updates).
+  if (tagsEqual(s.documents[docId]?.tags, next)) return;
+  usePersistenceStore.setState((prev) => {
+    const meta = prev.documents[docId];
+    if (!meta) return prev;
+    const nextMeta: DocumentMetadata = { ...meta };
+    if (next.length === 0) delete nextMeta.tags;
+    else nextMeta.tags = next;
+    return { documents: { ...prev.documents, [docId]: nextMeta } };
+  });
+  useDocumentRegistry.getState().updateRecord(docId, { tags: next });
 }
 
 /**

--- a/src/store/serializeDocForRest.test.ts
+++ b/src/store/serializeDocForRest.test.ts
@@ -46,6 +46,15 @@ describe('serializeDocForRest (JP-423)', () => {
     expect(out.richTextPages?.pages['rt-b']?.content).toBe('<p>beta</p>');
   });
 
+  it('carries tags through the REST choke point untouched (JP-388)', () => {
+    const doc = makeDoc();
+    doc.tags = ['alpha', 'beta'];
+    // With a pending page (the cloning path) AND without — both must keep tags.
+    expect(serializeDocForRest(doc).tags).toEqual(['alpha', 'beta']);
+    usePendingSyncPages.setState({ pending: { 'rt-a': 'doc-1' } });
+    expect(serializeDocForRest(doc).tags).toEqual(['alpha', 'beta']);
+  });
+
   it('returns the input by reference when nothing is pending', () => {
     const doc = makeDoc();
     expect(serializeDocForRest(doc)).toBe(doc);

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -94,6 +94,19 @@ export interface DiagramDocument {
    */
   collectionId?: string;
 
+  // Tags (JP-388)
+  /**
+   * Free-form organizational tags. Unlike `collectionId` (scope-bound
+   * membership, stripped on transfer), tags are **document content** — like
+   * `references`/`fields` they travel with the document across
+   * personal↔workspace transfers and trash/restore, and sync via the Y.Doc
+   * `metadata` map in collab. Optional/additive: an older document has no
+   * `tags` key (no `version` bump, no migration); an empty list is stored as
+   * an absent key, never `[]`. Normalized by `normalizeTags` on every write
+   * seam. The relay lifts it into `DocumentMetadata` for list responses.
+   */
+  tags?: string[];
+
   // Team document fields (Phase 14.1)
   /** Whether this is a relay document (stored on host, synced via CRDT) */
   isRelayDocument?: boolean;
@@ -184,6 +197,9 @@ export interface DocumentMetadata {
   /** Collection membership (JP-159); absent = unassigned. Lifted by the relay
    *  from the document body's `collectionId`. */
   collectionId?: string;
+  /** Free-form organizational tags (JP-388); absent = untagged. Lifted by the
+   *  relay from the document body's `tags`. */
+  tags?: string[];
 }
 
 /**
@@ -293,6 +309,9 @@ export function getDocumentMetadata(doc: DiagramDocument): DocumentMetadata {
   }
   if (doc.lastModifiedByName !== undefined) {
     metadata.lastModifiedByName = doc.lastModifiedByName;
+  }
+  if (doc.tags !== undefined) {
+    metadata.tags = doc.tags;
   }
 
   return metadata;

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -49,6 +49,8 @@ export interface DocumentEntryBase {
   pageCount: number;
   createdAt: number;
   modifiedAt: number;
+  /** Free-form organizational tags (JP-388); absent = untagged. */
+  tags?: string[];
 }
 
 /**
@@ -201,6 +203,7 @@ export function toLocalDocument(metadata: DocumentMetadata): LocalDocument {
     pageCount: metadata.pageCount,
     createdAt: metadata.createdAt,
     modifiedAt: metadata.modifiedAt,
+    ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
   };
 }
 
@@ -221,6 +224,7 @@ export function toRemoteDocument(
     pageCount: metadata.pageCount,
     createdAt: metadata.createdAt,
     modifiedAt: metadata.modifiedAt,
+    ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
     relayId,
     workspaceId,
     ownerId: metadata.ownerId ?? '',
@@ -242,6 +246,7 @@ export function toCachedDocument(remote: RemoteDocument): CachedDocument {
     pageCount: remote.pageCount,
     createdAt: remote.createdAt,
     modifiedAt: remote.modifiedAt,
+    ...(remote.tags !== undefined ? { tags: remote.tags } : {}),
     relayId: remote.relayId,
     workspaceId: remote.workspaceId,
     originalDocId: remote.id,
@@ -262,6 +267,7 @@ export function toRemoteFromCached(cached: CachedDocument, syncState: SyncState 
     pageCount: cached.pageCount,
     createdAt: cached.createdAt,
     modifiedAt: cached.modifiedAt,
+    ...(cached.tags !== undefined ? { tags: cached.tags } : {}),
     relayId: cached.relayId,
     workspaceId: cached.workspaceId,
     ownerId: '', // Will be populated from host

--- a/src/types/DocumentTags.test.ts
+++ b/src/types/DocumentTags.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Document tags (JP-388) — normalization, matching, and deterministic colors.
+ * `normalizeTags` runs on every write seam, so its invariants (idempotence,
+ * dedupe, `#`-strip, caps) are load-bearing for the search syntax and the
+ * relay round-trip.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_TAGS_PER_DOC,
+  MAX_TAG_LENGTH,
+  TAG_COLOR_COUNT,
+  normalizeTags,
+  tagsEqual,
+  tagsMatch,
+  tagColorIndex,
+} from './DocumentTags';
+
+describe('normalizeTags', () => {
+  it('trims, drops empties, and preserves first-seen order', () => {
+    expect(normalizeTags(['  alpha ', '', '  ', 'beta'])).toEqual(['alpha', 'beta']);
+  });
+
+  it('dedupes case-insensitively keeping the first casing', () => {
+    expect(normalizeTags(['Research', 'research', 'RESEARCH', 'notes'])).toEqual([
+      'Research',
+      'notes',
+    ]);
+  });
+
+  it('strips leading # so a typed "#foo" equals "foo" (search stays unambiguous)', () => {
+    expect(normalizeTags(['#foo', '##bar', '# baz'])).toEqual(['foo', 'bar', 'baz']);
+    // A stored tag never starts with '#'.
+    for (const t of normalizeTags(['#x', 'y'])) {
+      expect(t.startsWith('#')).toBe(false);
+    }
+  });
+
+  it('caps tag length and count', () => {
+    const long = 'x'.repeat(MAX_TAG_LENGTH + 20);
+    expect(normalizeTags([long])[0]).toHaveLength(MAX_TAG_LENGTH);
+    const many = Array.from({ length: MAX_TAGS_PER_DOC + 10 }, (_, i) => `tag-${i}`);
+    expect(normalizeTags(many)).toHaveLength(MAX_TAGS_PER_DOC);
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeTags(['  #Alpha', 'beta', 'ALPHA ']);
+    expect(normalizeTags(once)).toEqual(once);
+  });
+});
+
+describe('tagsEqual', () => {
+  it('is order-sensitive and treats absent as empty', () => {
+    expect(tagsEqual(['a', 'b'], ['a', 'b'])).toBe(true);
+    expect(tagsEqual(['a', 'b'], ['b', 'a'])).toBe(false);
+    expect(tagsEqual(undefined, [])).toBe(true);
+    expect(tagsEqual(undefined, ['a'])).toBe(false);
+  });
+});
+
+describe('tagsMatch', () => {
+  it('matches case-insensitive substrings', () => {
+    expect(tagsMatch(['Research', 'notes'], 'sear')).toBe(true);
+    expect(tagsMatch(['Research'], 'RESEARCH')).toBe(true);
+    expect(tagsMatch(['Research'], 'zzz')).toBe(false);
+  });
+
+  it('empty needle matches any tagged doc, never an untagged one (bare "#")', () => {
+    expect(tagsMatch(['a'], '')).toBe(true);
+    expect(tagsMatch([], '')).toBe(false);
+    expect(tagsMatch(undefined, '')).toBe(false);
+  });
+});
+
+describe('tagColorIndex', () => {
+  it('is stable, case-insensitive, and in palette range', () => {
+    expect(tagColorIndex('Research')).toBe(tagColorIndex('research'));
+    expect(tagColorIndex('alpha')).toBe(tagColorIndex('alpha'));
+    for (const t of ['a', 'bb', 'research', 'ops', 'q3-planning']) {
+      const i = tagColorIndex(t);
+      expect(i).toBeGreaterThanOrEqual(0);
+      expect(i).toBeLessThan(TAG_COLOR_COUNT);
+    }
+  });
+});

--- a/src/types/DocumentTags.ts
+++ b/src/types/DocumentTags.ts
@@ -1,0 +1,71 @@
+/**
+ * Document tags (JP-388) — normalization + matching helpers.
+ *
+ * Tags are free-form document content (see `DiagramDocument.tags`): stored
+ * case-preserving, matched and deduplicated case-insensitively. A leading `#`
+ * is stripped on input so a tag typed as `#foo` equals `foo` — which keeps the
+ * browser's `#tag` search syntax unambiguous (stored tags never start with a
+ * `#`). Normalization runs on every WRITE seam (tag editor commit,
+ * `setDocumentTags`), never on read — legacy bodies display as-is.
+ */
+
+export const MAX_TAGS_PER_DOC = 20;
+export const MAX_TAG_LENGTH = 40;
+
+/**
+ * Normalize a tag list: trim → strip a leading `#` → drop empties → truncate
+ * to MAX_TAG_LENGTH → case-insensitive dedupe keeping the first casing → cap
+ * at MAX_TAGS_PER_DOC. Pure and idempotent; preserves first-seen order.
+ */
+export function normalizeTags(tags: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of tags) {
+    let tag = raw.trim();
+    while (tag.startsWith('#')) tag = tag.slice(1).trimStart();
+    if (!tag) continue;
+    tag = tag.slice(0, MAX_TAG_LENGTH);
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(tag);
+    if (out.length >= MAX_TAGS_PER_DOC) break;
+  }
+  return out;
+}
+
+/** Order-sensitive equality (tags keep insertion order); absent ≡ empty. */
+export function tagsEqual(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  return left.every((t, i) => t === right[i]);
+}
+
+/** Case-insensitive substring match against a document's tags. */
+export function tagsMatch(tags: readonly string[] | undefined, needle: string): boolean {
+  if (!tags || tags.length === 0) return false;
+  const q = needle.toLowerCase();
+  return tags.some((t) => t.toLowerCase().includes(q));
+}
+
+/**
+ * Number of tag-color CSS variables (`--tag-hue-0` … `--tag-hue-{N-1}`)
+ * defined for both themes in index.css.
+ */
+export const TAG_COLOR_COUNT = 8;
+
+/**
+ * Deterministic palette index for a tag: the same tag renders the same chip
+ * color everywhere (case-insensitive), with no per-tag color registry to
+ * store or sync. FNV-1a over the lowercased tag, mod the palette size.
+ */
+export function tagColorIndex(tag: string): number {
+  const s = tag.toLowerCase();
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    hash ^= s.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) % TAG_COLOR_COUNT;
+}

--- a/src/ui/DocumentCard.actions.test.tsx
+++ b/src/ui/DocumentCard.actions.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * DocumentCard actions (JP-385 facelift): two visible quick actions
+ * (contextual transfer + Trash) and an overflow menu holding the rest.
+ * Pins the delete policy split — soft delete is one click (the model owns
+ * confirm/Undo policy), permanent delete always routes through the styled
+ * danger confirm — and that the overflow renders only granted actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { DocumentCard } from './DocumentCard';
+import { confirmDialog } from './confirm/confirmStore';
+import type { LocalDocument } from '../types/DocumentRegistry';
+
+vi.mock('./confirm/confirmStore', () => ({
+  confirmDialog: vi.fn(),
+}));
+
+const confirmMock = vi.mocked(confirmDialog);
+
+const record: LocalDocument = {
+  type: 'local',
+  id: 'l1',
+  name: 'My Doc',
+  pageCount: 1,
+  createdAt: 0,
+  modifiedAt: 0,
+};
+
+function openOverflow() {
+  fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+}
+
+describe('DocumentCard — actions', () => {
+  beforeEach(() => {
+    cleanup();
+    confirmMock.mockReset();
+  });
+
+  it('soft delete is a single click with no inline confirm UI', () => {
+    const onDelete = vi.fn();
+    render(<DocumentCard record={record} onDelete={onDelete} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }));
+
+    expect(onDelete).toHaveBeenCalledWith('l1');
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(screen.queryByText('Delete?')).toBeNull(); // old 3-state confirm is gone
+  });
+
+  it('permanent delete goes through the danger confirm and only fires on OK', async () => {
+    const onPermanentDelete = vi.fn();
+    confirmMock.mockResolvedValueOnce(false);
+    render(<DocumentCard record={record} onPermanentDelete={onPermanentDelete} />);
+
+    openOverflow();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete permanently…' }));
+    await waitFor(() => expect(confirmMock).toHaveBeenCalledTimes(1));
+    expect(confirmMock).toHaveBeenCalledWith(expect.objectContaining({ danger: true }));
+    expect(onPermanentDelete).not.toHaveBeenCalled();
+
+    confirmMock.mockResolvedValueOnce(true);
+    openOverflow();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete permanently…' }));
+    await waitFor(() => expect(onPermanentDelete).toHaveBeenCalledWith('l1'));
+  });
+
+  it('renders only granted actions in the overflow menu', () => {
+    render(<DocumentCard record={record} onRename={vi.fn()} onDelete={vi.fn()} />);
+
+    openOverflow();
+    expect(screen.getByRole('menuitem', { name: 'Rename' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Move to Trash' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Version history' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Manage access' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Delete permanently…' })).toBeNull();
+  });
+
+  it('Rename in the overflow switches the name to an inline input', () => {
+    render(<DocumentCard record={record} onRename={vi.fn()} />);
+
+    openOverflow();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+
+    expect(screen.getByDisplayValue('My Doc')).toBeTruthy();
+  });
+
+  it('keeps the contextual transfer action as a visible quick action', () => {
+    const onPublishToTeam = vi.fn();
+    render(<DocumentCard record={record} onPublishToTeam={onPublishToTeam} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to relay' }));
+    expect(onPublishToTeam).toHaveBeenCalledWith('l1');
+  });
+});

--- a/src/ui/DocumentCard.actions.test.tsx
+++ b/src/ui/DocumentCard.actions.test.tsx
@@ -92,4 +92,46 @@ describe('DocumentCard — actions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Move to relay' }));
     expect(onPublishToTeam).toHaveBeenCalledWith('l1');
   });
+
+  it('renders tag chips and routes chip clicks to onTagClick (JP-388)', () => {
+    const onTagClick = vi.fn();
+    render(
+      <DocumentCard record={{ ...record, tags: ['research', 'ops'] }} onTagClick={onTagClick} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'research' }));
+    expect(onTagClick).toHaveBeenCalledWith('research');
+  });
+
+  it('collapses overflow tags into a +N counter', () => {
+    render(
+      <DocumentCard record={{ ...record, tags: ['a', 'b', 'c', 'd', 'e'] }} onTagClick={vi.fn()} />,
+    );
+    expect(screen.getByText('+2')).toBeTruthy();
+    expect(screen.queryByText('d')).toBeNull();
+  });
+
+  it('shows "Edit tags…" only when onSetTags is granted, and opens the editor', () => {
+    const { rerender } = render(<DocumentCard record={record} onRename={vi.fn()} />);
+    openOverflow();
+    expect(screen.queryByRole('menuitem', { name: 'Edit tags…' })).toBeNull();
+
+    rerender(<DocumentCard record={record} onRename={vi.fn()} onSetTags={vi.fn()} />);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags…' }));
+    expect(screen.getByRole('dialog', { name: 'Edit tags' })).toBeTruthy();
+    expect(screen.getByPlaceholderText('Add a tag…')).toBeTruthy();
+  });
+
+  it('commits normalized tags from the editor input', () => {
+    const onSetTags = vi.fn();
+    render(<DocumentCard record={record} onSetTags={onSetTags} />);
+    openOverflow();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit tags…' }));
+
+    const input = screen.getByPlaceholderText('Add a tag…');
+    fireEvent.change(input, { target: { value: '#Research ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSetTags).toHaveBeenCalledWith('l1', ['Research']);
+  });
 });

--- a/src/ui/DocumentCard.collections.test.tsx
+++ b/src/ui/DocumentCard.collections.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Per-card "Move to collection" menu (JP-365) — single-document collection
  * assignment, which used to be possible only via multi-select bulk actions.
+ * Since JP-385 the menu lives inside the card's overflow ("More actions")
+ * menu as a submenu, so every test opens it through the kebab.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -45,12 +47,20 @@ const mixedCollections: Collection[] = [
   { id: 'team', name: 'Team Space', order: 1, createdAt: 0, scope: 'workspace' },
 ];
 
+/** Open the card's overflow menu, then its "Move to collection" submenu. */
+function openCollectionMenu() {
+  fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Move to collection' }));
+}
+
 describe('DocumentCard — Move to collection', () => {
   beforeEach(() => cleanup());
 
   it('shows no move affordance when onAssignCollection is absent', () => {
     render(<DocumentCard record={record} collections={collections} />);
-    expect(screen.queryByRole('button', { name: 'Move to collection' })).toBeNull();
+    // No granted actions at all → no overflow menu either.
+    expect(screen.queryByRole('button', { name: 'More actions' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Move to collection' })).toBeNull();
   });
 
   it('opens the menu and assigns the doc to a chosen collection', () => {
@@ -64,7 +74,7 @@ describe('DocumentCard — Move to collection', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    openCollectionMenu();
     fireEvent.click(screen.getByRole('menuitem', { name: 'Personal' }));
 
     expect(onAssign).toHaveBeenCalledWith('l1', 'c2');
@@ -81,10 +91,10 @@ describe('DocumentCard — Move to collection', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    openCollectionMenu();
     expect(screen.queryByRole('menuitem', { name: 'Remove from collection' })).toBeNull();
 
-    // Now assigned to c1 → the (still-open) menu gains the remove action.
+    // Now assigned to c1 → the (still-open) submenu gains the remove action.
     rerender(
       <DocumentCard
         record={record}
@@ -110,7 +120,7 @@ describe('DocumentCard — Move to collection', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    openCollectionMenu();
     fireEvent.click(screen.getByRole('menuitem', { name: '+ New collection…' }));
 
     expect(onCreateFor).toHaveBeenCalledWith('l1');
@@ -125,7 +135,7 @@ describe('DocumentCard — Move to collection', () => {
         onAssignCollection={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    openCollectionMenu();
 
     expect(screen.getByRole('menuitem', { name: 'My Local' })).toBeTruthy();
     expect(screen.queryByRole('menuitem', { name: 'Team Space' })).toBeNull();
@@ -140,7 +150,7 @@ describe('DocumentCard — Move to collection', () => {
         onAssignCollection={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }));
+    openCollectionMenu();
 
     expect(screen.getByRole('menuitem', { name: 'Team Space' })).toBeTruthy();
     expect(screen.queryByRole('menuitem', { name: 'My Local' })).toBeNull();

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -26,13 +26,11 @@
   box-shadow: 0 0 0 2px var(--color-primary);
 }
 
-/* While the per-card "move to collection" menu is open, lift the whole card
-   above later sibling cards so the absolutely-positioned dropdown isn't painted
-   underneath the next card (the actions row is opacity<1, which traps the
-   menu's own z-index in a lower stacking context). */
-.document-card--collection-open {
-  position: relative;
-  z-index: 40;
+/* While the card's overflow menu is open the pointer lives in the portaled
+   menu panel, so the card loses :hover — pin the hover-revealed actions row
+   visible until the menu closes. */
+.document-card--menu-open .document-card__actions {
+  opacity: 1;
 }
 
 /* Content */
@@ -269,141 +267,10 @@ button.document-card__offline--action:focus-visible {
   opacity: 0.6;
 }
 
-/* Per-card "Move to collection" menu */
-.document-card__collection-wrap {
-  position: relative;
-  display: inline-flex;
-}
-.document-card__collection-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 30;
-  min-width: 200px;
-  max-width: 260px;
-  max-height: 280px;
-  overflow-y: auto;
-  padding: 4px;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
-  box-shadow: var(--shadow-lg);
-  transform-origin: top right;
-  animation: document-card__collection-menu-in 0.14s ease-out;
-}
-@keyframes document-card__collection-menu-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .document-card__collection-menu {
-    animation: none;
-  }
-}
-.document-card__collection-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 7px 9px;
-  font-size: 13px;
-  text-align: left;
-  color: var(--text-primary);
-  background: transparent;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.document-card__collection-item:hover {
-  background: var(--bg-hover);
-}
-.document-card__collection-item svg {
-  flex: 0 0 auto;
-  color: var(--color-primary);
-}
-.document-card__collection-item--new {
-  color: var(--color-primary);
-  font-weight: 500;
-}
-.document-card__collection-name {
-  flex: 1 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.document-card__collection-swatch {
-  flex: 0 0 auto;
-  width: 10px;
-  height: 10px;
-  border-radius: var(--radius-full, 999px);
-  background: var(--text-faint);
-}
-
 .document-card__action--danger:hover {
   background: var(--danger-bg);
   border-color: rgba(239, 68, 68, 0.3);
   color: var(--danger-text);
-}
-
-/* Delete confirmation */
-.document-card__confirm {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.document-card__confirm-text {
-  font-size: 11px;
-  color: var(--danger-text);
-  font-weight: 500;
-}
-
-.document-card__confirm-btn {
-  font-size: 10px;
-  font-weight: 500;
-  padding: 3px 8px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-/* "Trash" — the recoverable soft delete: neutral, not alarming. */
-.document-card__confirm-yes {
-  background: var(--accent, var(--bg-tertiary));
-  color: var(--accent-contrast, var(--text-primary));
-}
-
-.document-card__confirm-yes:hover {
-  filter: brightness(1.05);
-}
-
-/* "Forever" — the destructive bypass: danger red. */
-.document-card__confirm-forever {
-  background: var(--danger);
-  color: white;
-}
-
-.document-card__confirm-forever:hover {
-  filter: brightness(1.05);
-}
-
-.document-card__confirm-no {
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-}
-
-.document-card__confirm-no:hover {
-  background: var(--bg-tertiary);
 }
 
 /* Relay badge */

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -631,9 +631,12 @@ function DocumentCardImpl({
             {getTypeLabel(record.type)}
           </span>
 
-          {/* Sync status. The connection/offline state lives here only — a
-              separate relay badge would duplicate it and leak the relay host. */}
-          <SyncStatusBadge state={syncState} size="small" showLabel />
+          {/* Sync status — relay-backed docs only. A local doc's sync state is
+              always 'local', which just restates the "Personal" type badge, so
+              it renders nothing extra. The connection/offline state lives here
+              only — a separate relay badge would duplicate it and leak the
+              relay host. */}
+          {record.type !== 'local' && <SyncStatusBadge state={syncState} size="small" showLabel />}
 
           {/* JP-308: document from another relay than the one we're on. Labelled
               generically (no host:port leak — the full host lives in the details

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -5,7 +5,7 @@
  * Used in the DocumentBrowser for unified document listing.
  */
 
-import { memo, useState, useCallback, useEffect } from 'react';
+import { memo, useState, useCallback, useEffect, useRef } from 'react';
 import {
   Check,
   ChevronDown,
@@ -21,6 +21,7 @@ import {
   MoreVertical,
   Network,
   Pencil,
+  Tags,
   Trash2,
   Upload,
   Users,
@@ -37,6 +38,8 @@ import {
   type DropdownMenuEntry,
 } from './components/DropdownMenu';
 import { confirmDialog } from './confirm/confirmStore';
+import { TagChips } from './TagChips';
+import { TagEditorPopover } from './TagEditorPopover';
 import './DocumentCard.css';
 
 interface DocumentCardProps {
@@ -88,6 +91,12 @@ interface DocumentCardProps {
   offlineProgress?: OfflineProgress | null | undefined;
   /** Callback to proactively cache this doc's body + all referenced blobs offline. */
   onMakeAvailableOffline?: ((id: string) => void) | undefined;
+  /** Persist this doc's tags (JP-388). Enables the "Edit tags…" action. */
+  onSetTags?: ((id: string, tags: string[]) => void | Promise<void>) | undefined;
+  /** Click a tag chip to filter by it (the browser fills `#tag` into search). */
+  onTagClick?: ((tag: string) => void) | undefined;
+  /** Union of tags across the library — suggestions for the tag editor. */
+  tagSuggestions?: string[] | undefined;
   /** Display mode */
   mode?: 'compact' | 'full' | 'grid' | undefined;
 }
@@ -278,6 +287,9 @@ function DocumentCardImpl({
   offlineStatus,
   offlineProgress,
   onMakeAvailableOffline,
+  onSetTags,
+  onTagClick,
+  tagSuggestions,
   mode = 'compact',
 }: DocumentCardProps) {
   const [isEditing, setIsEditing] = useState(false);
@@ -288,6 +300,14 @@ function DocumentCardImpl({
   // Overflow menu open state — pins the hover-revealed actions row visible
   // while the (portaled) menu is open, since the pointer leaves the card.
   const [menuOpen, setMenuOpen] = useState(false);
+  // Anchor (viewport rect) for the tag editor popover; null = closed (JP-388).
+  const [tagEditorAnchor, setTagEditorAnchor] = useState<{
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  } | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
 
   // Sync editName when record.name changes externally
   useEffect(() => {
@@ -489,6 +509,26 @@ function DocumentCardImpl({
       entries: collectionEntries,
     });
   }
+  if (onSetTags) {
+    menuEntries.push(
+      menuAction({
+        id: 'tags',
+        label: 'Edit tags…',
+        icon: <Tags size={16} aria-hidden="true" />,
+        onSelect: () => {
+          const rect = cardRef.current?.getBoundingClientRect();
+          if (rect) {
+            setTagEditorAnchor({
+              top: rect.top,
+              bottom: rect.bottom,
+              left: rect.left,
+              right: rect.right,
+            });
+          }
+        },
+      }),
+    );
+  }
   if (onEditPermissions) {
     menuEntries.push(
       menuAction({
@@ -535,7 +575,8 @@ function DocumentCardImpl({
 
   return (
     <div
-      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${menuOpen ? 'document-card--menu-open' : ''}`}
+      ref={cardRef}
+      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${menuOpen || tagEditorAnchor ? 'document-card--menu-open' : ''}`}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
     >
@@ -640,6 +681,12 @@ function DocumentCardImpl({
                 <offline.Icon size={12} aria-hidden="true" />
               </span>
             )
+          )}
+
+          {/* Tags (JP-388) — deterministic-color chips; clicking one filters
+              the browser (`#tag` search). */}
+          {record.tags && record.tags.length > 0 && (
+            <TagChips tags={record.tags} onTagClick={onTagClick} />
           )}
 
           {/* Modified time */}
@@ -782,6 +829,17 @@ function DocumentCardImpl({
           />
         )}
       </div>
+
+      {/* Tag editor (JP-388) — anchored to the card, opened from the overflow menu. */}
+      {tagEditorAnchor && onSetTags && (
+        <TagEditorPopover
+          tags={record.tags ?? []}
+          suggestions={tagSuggestions ?? []}
+          anchor={tagEditorAnchor}
+          onCommit={(next) => void onSetTags(record.id, next)}
+          onClose={() => setTagEditorAnchor(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -5,7 +5,7 @@
  * Used in the DocumentBrowser for unified document listing.
  */
 
-import { memo, useState, useCallback, useEffect, useRef } from 'react';
+import { memo, useState, useCallback, useEffect } from 'react';
 import {
   Check,
   ChevronDown,
@@ -18,6 +18,7 @@ import {
   HardDrive,
   History,
   Loader2,
+  MoreVertical,
   Network,
   Pencil,
   Trash2,
@@ -29,6 +30,13 @@ import { isForeignRelayDoc, type DocumentRecord, type Permission } from '../type
 import type { Collection } from '../store/collectionStore';
 import type { OfflineProgress, OfflineStatus } from '../store/offlineAvailability';
 import { useConnectionStore } from '../store/connectionStore';
+import {
+  DropdownMenu,
+  menuAction,
+  MENU_SEPARATOR,
+  type DropdownMenuEntry,
+} from './components/DropdownMenu';
+import { confirmDialog } from './confirm/confirmStore';
 import './DocumentCard.css';
 
 interface DocumentCardProps {
@@ -274,24 +282,12 @@ function DocumentCardImpl({
 }: DocumentCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(record.name);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [isMovingToPersonal, setIsMovingToPersonal] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [collMenuOpen, setCollMenuOpen] = useState(false);
-  const collMenuRef = useRef<HTMLDivElement | null>(null);
-
-  // Close the collection menu on an outside click.
-  useEffect(() => {
-    if (!collMenuOpen) return;
-    const onDoc = (e: MouseEvent) => {
-      if (collMenuRef.current && !collMenuRef.current.contains(e.target as Node)) {
-        setCollMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', onDoc);
-    return () => document.removeEventListener('mousedown', onDoc);
-  }, [collMenuOpen]);
+  // Overflow menu open state — pins the hover-revealed actions row visible
+  // while the (portaled) menu is open, since the pointer leaves the card.
+  const [menuOpen, setMenuOpen] = useState(false);
 
   // Sync editName when record.name changes externally
   useEffect(() => {
@@ -380,29 +376,27 @@ function DocumentCardImpl({
     [handleRename, record.name]
   );
 
-  const handleDeleteClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    setShowDeleteConfirm(true);
-  }, []);
+  // Soft delete is one click (recoverable — the model owns confirm/Undo policy).
+  const handleTrashClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onDelete) void onDelete(record.id);
+    },
+    [onDelete, record.id],
+  );
 
-  const handleDeleteConfirm = useCallback(() => {
-    if (onDelete) {
-      onDelete(record.id);
-    }
-    setShowDeleteConfirm(false);
-  }, [onDelete, record.id]);
-
-  const handlePermanentDeleteConfirm = useCallback(() => {
-    if (onPermanentDelete) {
-      onPermanentDelete(record.id);
-    }
-    setShowDeleteConfirm(false);
-  }, [onPermanentDelete, record.id]);
-
-  const handleDeleteCancel = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    setShowDeleteConfirm(false);
-  }, []);
+  // Permanent delete bypasses the Trash — always behind a styled danger
+  // confirm, matching the bulk-delete dialog in the browser model.
+  const handlePermanentDelete = useCallback(async () => {
+    if (!onPermanentDelete) return;
+    const ok = await confirmDialog({
+      title: `Delete “${record.name}” permanently?`,
+      message: 'This bypasses the Trash and cannot be undone.',
+      confirmLabel: 'Delete permanently',
+      danger: true,
+    });
+    if (ok) void onPermanentDelete(record.id);
+  }, [onPermanentDelete, record.id, record.name]);
 
   const handleMakeOffline = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -439,9 +433,109 @@ function DocumentCardImpl({
   const offline = isRelayBacked ? offlineBadge(offlineStatus) : null;
   const offlineActionable = Boolean(offline?.actionable && onMakeAvailableOffline);
 
+  // Overflow ("kebab") menu — everything beyond the two visible quick actions
+  // (contextual transfer + Trash). Entries are gated on the same optional
+  // callbacks as before, so permission logic stays in the list renderer.
+  const menuEntries: DropdownMenuEntry[] = [];
+  if (onRename) {
+    menuEntries.push(
+      menuAction({
+        id: 'rename',
+        label: 'Rename',
+        icon: <Pencil size={16} aria-hidden="true" />,
+        onSelect: () => {
+          setEditName(record.name);
+          setIsEditing(true);
+        },
+      }),
+    );
+  }
+  if (onAssignCollection) {
+    const collectionEntries: DropdownMenuEntry[] = (collections ?? [])
+      .filter((c) => collectionMatchesDocScope(c, record))
+      .map((c) =>
+        menuAction({
+          id: `collection-${c.id}`,
+          label: c.name,
+          swatchColor: c.color ?? null,
+          checked: currentCollectionId === c.id,
+          onSelect: () => onAssignCollection(record.id, c.id),
+        }),
+      );
+    if (currentCollectionId) {
+      collectionEntries.push(
+        menuAction({
+          id: 'collection-remove',
+          label: 'Remove from collection',
+          onSelect: () => onAssignCollection(record.id, null),
+        }),
+      );
+    }
+    if (onCreateCollectionFor) {
+      if (collectionEntries.length > 0) collectionEntries.push(MENU_SEPARATOR);
+      collectionEntries.push(
+        menuAction({
+          id: 'collection-new',
+          label: '+ New collection…',
+          onSelect: () => onCreateCollectionFor(record.id),
+        }),
+      );
+    }
+    menuEntries.push({
+      kind: 'submenu',
+      id: 'collection',
+      label: 'Move to collection',
+      icon: <FolderInput size={16} aria-hidden="true" />,
+      entries: collectionEntries,
+    });
+  }
+  if (onEditPermissions) {
+    menuEntries.push(
+      menuAction({
+        id: 'permissions',
+        label: 'Manage access',
+        icon: <Users size={16} aria-hidden="true" />,
+        onSelect: () => onEditPermissions(record.id),
+      }),
+    );
+  }
+  if (onViewBackups) {
+    menuEntries.push(
+      menuAction({
+        id: 'backups',
+        label: 'Version history',
+        icon: <History size={16} aria-hidden="true" />,
+        onSelect: () => onViewBackups(record.id),
+      }),
+    );
+  }
+  if (onDelete || onPermanentDelete) {
+    if (menuEntries.length > 0) menuEntries.push(MENU_SEPARATOR);
+    if (onDelete) {
+      menuEntries.push(
+        menuAction({
+          id: 'trash',
+          label: 'Move to Trash',
+          icon: <Trash2 size={16} aria-hidden="true" />,
+          onSelect: () => void onDelete(record.id),
+        }),
+      );
+    }
+    if (onPermanentDelete) {
+      menuEntries.push(
+        menuAction({
+          id: 'delete-forever',
+          label: 'Delete permanently…',
+          danger: true,
+          onSelect: () => void handlePermanentDelete(),
+        }),
+      );
+    }
+  }
+
   return (
     <div
-      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${collMenuOpen ? 'document-card--collection-open' : ''}`}
+      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${menuOpen ? 'document-card--menu-open' : ''}`}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
     >
@@ -667,148 +761,25 @@ function DocumentCardImpl({
             )}
           </button>
         )}
-        {onEditPermissions && (
-          <button
-            className="document-card__action"
-            onClick={(e) => {
-              e.stopPropagation();
-              onEditPermissions(record.id);
-            }}
-            title="Manage access"
-            aria-label="Manage access"
-          >
-            <Users size={16} aria-hidden="true" />
-          </button>
-        )}
-        {onViewBackups && (
-          <button
-            className="document-card__action"
-            onClick={(e) => {
-              e.stopPropagation();
-              onViewBackups(record.id);
-            }}
-            title="Version history"
-            aria-label="Version history"
-          >
-            <History size={16} aria-hidden="true" />
-          </button>
-        )}
-        {onAssignCollection && (
-          <div className="document-card__collection-wrap" ref={collMenuRef}>
-            <button
-              className="document-card__action"
-              onClick={(e) => {
-                e.stopPropagation();
-                setCollMenuOpen((o) => !o);
-              }}
-              title="Move to collection"
-              aria-label="Move to collection"
-              aria-haspopup="menu"
-              aria-expanded={collMenuOpen}
-            >
-              <FolderInput size={16} aria-hidden="true" />
-            </button>
-            {collMenuOpen && (
-              <div
-                className="document-card__collection-menu"
-                role="menu"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {(collections ?? [])
-                  .filter((c) => collectionMatchesDocScope(c, record))
-                  .map((c) => (
-                  <button
-                    key={c.id}
-                    className="document-card__collection-item"
-                    role="menuitem"
-                    onClick={() => {
-                      onAssignCollection(record.id, c.id);
-                      setCollMenuOpen(false);
-                    }}
-                  >
-                    <span
-                      className="document-card__collection-swatch"
-                      style={c.color ? { background: c.color } : undefined}
-                    />
-                    <span className="document-card__collection-name">{c.name}</span>
-                    {currentCollectionId === c.id && <Check size={14} aria-hidden="true" />}
-                  </button>
-                ))}
-                {currentCollectionId && (
-                  <button
-                    className="document-card__collection-item"
-                    role="menuitem"
-                    onClick={() => {
-                      onAssignCollection(record.id, null);
-                      setCollMenuOpen(false);
-                    }}
-                  >
-                    Remove from collection
-                  </button>
-                )}
-                {onCreateCollectionFor && (
-                  <button
-                    className="document-card__collection-item document-card__collection-item--new"
-                    role="menuitem"
-                    onClick={() => {
-                      onCreateCollectionFor(record.id);
-                      setCollMenuOpen(false);
-                    }}
-                  >
-                    + New collection…
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-        {onRename && (
-          <button
-            className="document-card__action"
-            onClick={(e) => {
-              e.stopPropagation();
-              setEditName(record.name);
-              setIsEditing(true);
-            }}
-            title="Rename"
-            aria-label="Rename"
-          >
-            <Pencil size={16} aria-hidden="true" />
-          </button>
-        )}
-        {onDelete && !showDeleteConfirm && (
+        {onDelete && (
           <button
             className="document-card__action document-card__action--danger"
-            onClick={handleDeleteClick}
-            title="Delete"
-            aria-label="Delete"
+            onClick={handleTrashClick}
+            title="Move to Trash"
+            aria-label="Move to Trash"
           >
             <Trash2 size={16} aria-hidden="true" />
           </button>
         )}
-        {showDeleteConfirm && (
-          <div className="document-card__confirm" onClick={(e) => e.stopPropagation()}>
-            <span className="document-card__confirm-text">Delete?</span>
-            <button
-              className="document-card__confirm-btn document-card__confirm-yes"
-              onClick={handleDeleteConfirm}
-              title="Move to Trash (recoverable)"
-            >
-              Trash
-            </button>
-            {onPermanentDelete && (
-              <button
-                className="document-card__confirm-btn document-card__confirm-forever"
-                onClick={handlePermanentDeleteConfirm}
-                title="Delete permanently — bypasses the Trash"
-              >
-                Forever
-              </button>
-            )}
-            <button className="document-card__confirm-btn document-card__confirm-no" onClick={handleDeleteCancel}>
-              Cancel
-            </button>
-          </div>
+        {menuEntries.length > 0 && (
+          <DropdownMenu
+            trigger={<MoreVertical size={16} aria-hidden="true" />}
+            triggerClassName="document-card__action"
+            triggerTitle="More actions"
+            entries={menuEntries}
+            align="right"
+            onOpenChange={setMenuOpen}
+          />
         )}
       </div>
     </div>

--- a/src/ui/TagChips.css
+++ b/src/ui/TagChips.css
@@ -1,0 +1,39 @@
+/* TagChips (JP-388) — deterministic-color tag chips on document cards. */
+
+.tag-chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.tag-chips__chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 110px;
+  padding: 2px 7px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  border: none;
+  border-radius: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tag-chips__chip--clickable {
+  cursor: pointer;
+  transition: filter 0.12s ease;
+}
+
+.tag-chips__chip--clickable:hover {
+  filter: brightness(1.12);
+}
+
+.tag-chips__more {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}

--- a/src/ui/TagChips.tsx
+++ b/src/ui/TagChips.tsx
@@ -1,0 +1,64 @@
+/**
+ * TagChips (JP-388) — presentational tag chips for a document card's meta row.
+ *
+ * Shows up to `max` chips plus a "+N" overflow counter. Each chip is a button:
+ * clicking one hands the tag to `onTagClick`, which the browser wires to
+ * `setSearchQuery('#' + tag)` — the chip IS the tag filter (no separate
+ * filter axis). Colors are deterministic per tag (see `tagColorIndex`), so
+ * the same tag reads the same everywhere with no color registry.
+ */
+
+import { tagColorIndex } from '../types/DocumentTags';
+import './TagChips.css';
+
+interface TagChipsProps {
+  tags: readonly string[];
+  /** Chips shown before collapsing into a "+N" counter (default 3). */
+  max?: number | undefined;
+  /** Click a chip to filter by it. Chips render as plain spans when absent. */
+  onTagClick?: ((tag: string) => void) | undefined;
+}
+
+export function TagChips({ tags, max = 3, onTagClick }: TagChipsProps) {
+  if (tags.length === 0) return null;
+  const visible = tags.slice(0, max);
+  const overflow = tags.length - visible.length;
+
+  return (
+    <span className="tag-chips">
+      {visible.map((tag) => {
+        const hue = tagColorIndex(tag);
+        const style = {
+          color: `var(--tag-hue-${hue})`,
+          background: `var(--tag-hue-${hue}-bg)`,
+        };
+        return onTagClick ? (
+          <button
+            key={tag}
+            type="button"
+            className="tag-chips__chip tag-chips__chip--clickable"
+            style={style}
+            title={`Filter by #${tag}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTagClick(tag);
+            }}
+          >
+            {tag}
+          </button>
+        ) : (
+          <span key={tag} className="tag-chips__chip" style={style} title={tag}>
+            {tag}
+          </span>
+        );
+      })}
+      {overflow > 0 && (
+        <span className="tag-chips__more" title={tags.slice(max).join(', ')}>
+          +{overflow}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default TagChips;

--- a/src/ui/TagEditorPopover.css
+++ b/src/ui/TagEditorPopover.css
@@ -1,0 +1,107 @@
+/* TagEditorPopover (JP-388) — anchored per-document tag editor. */
+
+.tag-editor {
+  position: fixed;
+  z-index: 10200; /* same layer as DropdownMenu — above every host surface */
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+}
+
+.tag-editor__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-height: 20px;
+}
+
+.tag-editor__empty {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.tag-editor__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  max-width: 100%;
+  padding: 2px 4px 2px 7px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 10px;
+}
+
+.tag-editor__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.tag-editor__remove:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.tag-editor__input {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color-input);
+  border-radius: 6px;
+  outline: none;
+}
+
+.tag-editor__input:focus {
+  border-color: var(--color-primary);
+}
+
+.tag-editor__input:disabled {
+  opacity: 0.6;
+}
+
+.tag-editor__suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tag-editor__suggestion {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 7px;
+  font-size: 12px;
+  text-align: left;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.tag-editor__suggestion:hover {
+  background: var(--bg-hover);
+}
+
+.tag-editor__suggestion-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}

--- a/src/ui/TagEditorPopover.tsx
+++ b/src/ui/TagEditorPopover.tsx
@@ -1,0 +1,172 @@
+/**
+ * TagEditorPopover (JP-388) — a small anchored editor for a document's tags.
+ *
+ * Text input (Enter adds), current tags as removable chips, and a suggestion
+ * listbox drawn from the tags already used across the library (filtered by
+ * the input). A plain listbox, not <datalist> — WebKitGTK styles datalists
+ * poorly. Commits through `onCommit` on every change (the caller persists);
+ * input is normalized by `normalizeTags` at that seam.
+ *
+ * Positioning: fixed panel anchored under the given rect, viewport-clamped —
+ * same approach as DropdownMenu, kept local because this panel is focus-holding
+ * (an input), not a menu.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { MAX_TAGS_PER_DOC, normalizeTags, tagColorIndex } from '../types/DocumentTags';
+import './TagEditorPopover.css';
+
+interface TagEditorPopoverProps {
+  /** Current tags (already normalized — they came from the doc). */
+  tags: readonly string[];
+  /** Union of tags across the library, for suggestions (own tags filtered out here). */
+  suggestions: readonly string[];
+  /** Anchor rect (viewport coords) the panel opens under. */
+  anchor: { top: number; bottom: number; left: number; right: number };
+  /** Called with the full normalized next list on every add/remove. */
+  onCommit: (next: string[]) => void;
+  onClose: () => void;
+}
+
+const PANEL_WIDTH = 260;
+
+export function TagEditorPopover({
+  tags,
+  suggestions,
+  anchor,
+  onCommit,
+  onClose,
+}: TagEditorPopoverProps) {
+  const [input, setInput] = useState('');
+  const panelRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on outside mousedown or Escape.
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) onClose();
+    };
+    const timeoutId = setTimeout(() => document.addEventListener('mousedown', onDown), 0);
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener('mousedown', onDown);
+    };
+  }, [onClose]);
+
+  const addTag = useCallback(
+    (raw: string) => {
+      const next = normalizeTags([...tags, raw]);
+      setInput('');
+      if (next.length !== tags.length || raw.trim()) onCommit(next);
+    },
+    [tags, onCommit],
+  );
+
+  const removeTag = useCallback(
+    (tag: string) => {
+      onCommit(tags.filter((t) => t !== tag));
+    },
+    [tags, onCommit],
+  );
+
+  const filteredSuggestions = useMemo(() => {
+    const own = new Set(tags.map((t) => t.toLowerCase()));
+    const q = input.trim().toLowerCase();
+    return suggestions
+      .filter((s) => !own.has(s.toLowerCase()))
+      .filter((s) => (q ? s.toLowerCase().includes(q) : true))
+      .slice(0, 6);
+  }, [suggestions, tags, input]);
+
+  const atCap = tags.length >= MAX_TAGS_PER_DOC;
+
+  // Viewport-clamped position under the anchor (flips above when tight).
+  const left = Math.max(8, Math.min(anchor.right - PANEL_WIDTH, window.innerWidth - PANEL_WIDTH - 8));
+  const estimatedHeight = 220;
+  const top =
+    anchor.bottom + 4 + estimatedHeight > window.innerHeight - 8
+      ? Math.max(8, anchor.top - 4 - estimatedHeight)
+      : anchor.bottom + 4;
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      className="tag-editor"
+      role="dialog"
+      aria-label="Edit tags"
+      style={{ top, left, width: PANEL_WIDTH }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="tag-editor__chips">
+        {tags.length === 0 && <span className="tag-editor__empty">No tags yet</span>}
+        {tags.map((tag) => {
+          const hue = tagColorIndex(tag);
+          return (
+            <span
+              key={tag}
+              className="tag-editor__chip"
+              style={{ color: `var(--tag-hue-${hue})`, background: `var(--tag-hue-${hue}-bg)` }}
+            >
+              {tag}
+              <button
+                type="button"
+                className="tag-editor__remove"
+                aria-label={`Remove tag ${tag}`}
+                onClick={() => removeTag(tag)}
+              >
+                <X size={11} aria-hidden="true" />
+              </button>
+            </span>
+          );
+        })}
+      </div>
+      <input
+        ref={inputRef}
+        type="text"
+        className="tag-editor__input"
+        placeholder={atCap ? `Tag limit reached (${MAX_TAGS_PER_DOC})` : 'Add a tag…'}
+        value={input}
+        disabled={atCap}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && input.trim()) {
+            e.preventDefault();
+            addTag(input);
+          } else if (e.key === 'Escape') {
+            e.stopPropagation();
+            onClose();
+          }
+        }}
+      />
+      {filteredSuggestions.length > 0 && !atCap && (
+        <div className="tag-editor__suggestions" role="listbox" aria-label="Tag suggestions">
+          {filteredSuggestions.map((s) => (
+            <button
+              key={s}
+              type="button"
+              role="option"
+              aria-selected="false"
+              className="tag-editor__suggestion"
+              onClick={() => addTag(s)}
+            >
+              <span
+                className="tag-editor__suggestion-dot"
+                style={{ background: `var(--tag-hue-${tagColorIndex(s)})` }}
+              />
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
+export default TagEditorPopover;

--- a/src/ui/components/DropdownMenu.css
+++ b/src/ui/components/DropdownMenu.css
@@ -1,0 +1,129 @@
+/* DropdownMenu — shared portal action menu (see DropdownMenu.tsx). */
+
+.dropdown-menu__panel {
+  position: fixed;
+  /* Above every host surface: DocumentsHome overlay (9000), toasts (9999),
+     dialogs (10000–10100). The panel is portaled to <body>, so it competes in
+     the root stacking context and must outrank whichever surface opened it. */
+  z-index: 10200;
+  min-width: 200px;
+  max-width: 280px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+  animation: dropdown-menu-in 0.14s ease-out;
+}
+
+.dropdown-menu__panel--sub {
+  z-index: 10201;
+  overflow-y: auto;
+}
+
+@keyframes dropdown-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-menu__panel {
+    animation: none;
+  }
+}
+
+.dropdown-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 9px;
+  font-size: 13px;
+  text-align: left;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.dropdown-menu__item:hover:not(:disabled),
+.dropdown-menu__item:focus-visible {
+  background: var(--bg-hover);
+}
+
+.dropdown-menu__item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.dropdown-menu__item:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.dropdown-menu__item--danger {
+  color: var(--danger-text);
+}
+
+.dropdown-menu__item--danger:hover:not(:disabled),
+.dropdown-menu__item--danger:focus-visible {
+  background: var(--danger-bg);
+}
+
+.dropdown-menu__item--submenu-open {
+  background: var(--bg-hover);
+}
+
+.dropdown-menu__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+}
+
+.dropdown-menu__item--danger .dropdown-menu__icon {
+  color: inherit;
+}
+
+.dropdown-menu__label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dropdown-menu__check {
+  flex: 0 0 auto;
+  color: var(--color-primary);
+}
+
+.dropdown-menu__chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.dropdown-menu__swatch {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-full, 999px);
+  background: var(--text-faint);
+}
+
+.dropdown-menu__separator {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--border-color);
+}

--- a/src/ui/components/DropdownMenu.test.tsx
+++ b/src/ui/components/DropdownMenu.test.tsx
@@ -101,6 +101,29 @@ describe('DropdownMenu', () => {
     expect(screen.queryByRole('menu')).toBeNull(); // whole menu closed
   });
 
+  it('re-hovering the open submenu trigger keeps the submenu visible (no placement reset)', () => {
+    renderMenu([
+      {
+        kind: 'submenu',
+        id: 'sub',
+        label: 'More…',
+        entries: [menuAction({ id: 'n', label: 'Nested', onSelect: vi.fn() })],
+      },
+    ]);
+    openMenu();
+    const trigger = screen.getByRole('menuitem', { name: 'More…' });
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menuitem', { name: 'Nested' })).toBeTruthy();
+
+    // The regression: mouseenter on the already-open trigger reset the
+    // placement (hiding the panel) without re-running the placement effect.
+    fireEvent.mouseEnter(trigger);
+    const nested = screen.getByRole('menuitem', { name: 'Nested' });
+    const subPanel = nested.closest('.dropdown-menu__panel--sub') as HTMLElement;
+    expect(subPanel).toBeTruthy();
+    expect(getComputedStyle(subPanel).visibility).not.toBe('hidden');
+  });
+
   it('reports open state through onOpenChange', () => {
     const onOpenChange = vi.fn();
     renderMenu([menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })], onOpenChange);

--- a/src/ui/components/DropdownMenu.test.tsx
+++ b/src/ui/components/DropdownMenu.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * DropdownMenu — shared portal menu primitive (JP-385). Pins the interaction
+ * contract every consumer (card kebab, selection bar) relies on: entries
+ * render as menuitems, selection fires-and-closes, disabled items are inert,
+ * Escape closes and restores trigger focus, and submenus open/close.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { DropdownMenu, menuAction, MENU_SEPARATOR, type DropdownMenuEntry } from './DropdownMenu';
+
+function openMenu() {
+  fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+}
+
+function renderMenu(entries: DropdownMenuEntry[], onOpenChange?: (open: boolean) => void) {
+  return render(
+    <DropdownMenu
+      trigger={<span>Menu</span>}
+      triggerTitle="Menu"
+      entries={entries}
+      onOpenChange={onOpenChange}
+    />,
+  );
+}
+
+describe('DropdownMenu', () => {
+  beforeEach(() => cleanup());
+
+  it('renders entries only after the trigger is clicked', () => {
+    renderMenu([menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]);
+    expect(screen.queryByRole('menu')).toBeNull();
+    openMenu();
+    expect(screen.getByRole('menuitem', { name: 'Alpha' })).toBeTruthy();
+  });
+
+  it('fires onSelect and closes on action click', () => {
+    const onSelect = vi.fn();
+    renderMenu([menuAction({ id: 'a', label: 'Alpha', onSelect })]);
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Alpha' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('does not fire disabled actions', () => {
+    const onSelect = vi.fn();
+    renderMenu([menuAction({ id: 'a', label: 'Alpha', disabled: true, onSelect })]);
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Alpha' }));
+    expect(onSelect).not.toHaveBeenCalled();
+    // A disabled item is not a selection — the menu stays open.
+    expect(screen.getByRole('menu')).toBeTruthy();
+  });
+
+  it('closes on Escape and returns focus to the trigger', () => {
+    renderMenu([menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]);
+    openMenu();
+    const item = screen.getByRole('menuitem', { name: 'Alpha' });
+    expect(document.activeElement).toBe(item); // first item auto-focused
+    fireEvent.keyDown(item, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Menu' }));
+  });
+
+  it('moves focus with ArrowDown/ArrowUp, skipping disabled items', () => {
+    renderMenu([
+      menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() }),
+      menuAction({ id: 'b', label: 'Bravo', disabled: true, onSelect: vi.fn() }),
+      menuAction({ id: 'c', label: 'Charlie', onSelect: vi.fn() }),
+    ]);
+    openMenu();
+    const menu = screen.getByRole('menu');
+    fireEvent.keyDown(menu, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Charlie' }));
+    fireEvent.keyDown(menu, { key: 'ArrowDown' }); // wraps past the end
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Alpha' }));
+    fireEvent.keyDown(menu, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Charlie' }));
+  });
+
+  it('renders separators and opens submenus', () => {
+    const onSelect = vi.fn();
+    renderMenu([
+      menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() }),
+      MENU_SEPARATOR,
+      {
+        kind: 'submenu',
+        id: 'sub',
+        label: 'More…',
+        entries: [menuAction({ id: 'n', label: 'Nested', onSelect })],
+      },
+    ]);
+    openMenu();
+    expect(screen.getByRole('separator')).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Nested' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'More…' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Nested' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull(); // whole menu closed
+  });
+
+  it('reports open state through onOpenChange', () => {
+    const onOpenChange = vi.fn();
+    renderMenu([menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })], onOpenChange);
+    openMenu();
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Alpha' }));
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('menu clicks do not bubble to the surface underneath', () => {
+    const surfaceClick = vi.fn();
+    render(
+      <div onClick={surfaceClick}>
+        <DropdownMenu
+          trigger={<span>Menu</span>}
+          triggerTitle="Menu"
+          entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+        />
+      </div>,
+    );
+    openMenu();
+    // Opening via the trigger must not click the surface (cards open on click)…
+    expect(surfaceClick).not.toHaveBeenCalled();
+    // …and neither must selecting an item (the panel is portaled anyway).
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Alpha' }));
+    expect(surfaceClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -1,0 +1,434 @@
+/**
+ * DropdownMenu — shared portal-based action menu primitive.
+ *
+ * A trigger button plus a viewport-positioned menu panel (portal to
+ * document.body, `position: fixed`), with entries described as data:
+ * actions, separators, and one level of submenus. Built for the document
+ * browser's per-card overflow ("kebab") menu and the selection bar's
+ * assign-to-collection menu, but generic — nothing in here knows about
+ * documents.
+ *
+ * Interaction contract:
+ * - Click / Enter / Space on the trigger toggles the menu.
+ * - Arrow Up/Down move focus between enabled items (wrapping); Home/End jump.
+ * - ArrowRight (or hover/click) opens a submenu; ArrowLeft closes it back to
+ *   its parent item; Escape closes everything and returns focus to the trigger.
+ * - Selecting an action fires `onSelect` and closes the menu.
+ * - Clicks inside the menu never bubble to the surface underneath (cards open
+ *   on click — a menu click must not open the card).
+ *
+ * Positioning reuses the ToolbarDropdown strategy (below the trigger, clamped
+ * to the viewport, repositioned on scroll/resize) and `placeFlyout` for
+ * submenu placement (viewport-aware side flip; already unit-tested).
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { Check, ChevronRight } from 'lucide-react';
+import { placeFlyout, type FlyoutPlacement } from '../contextMenuUtils';
+import './DropdownMenu.css';
+
+export interface DropdownMenuAction {
+  id: string;
+  label: string;
+  /** Leading 16px icon (lucide). */
+  icon?: ReactNode | undefined;
+  /** Destructive treatment (red), matching the confirm dialog's danger button. */
+  danger?: boolean | undefined;
+  disabled?: boolean | undefined;
+  /** Trailing check for single-select semantics (e.g. current collection). */
+  checked?: boolean | undefined;
+  /** Leading color dot (collections). `null` renders the neutral dot. */
+  swatchColor?: string | null | undefined;
+  onSelect: () => void;
+}
+
+export type DropdownMenuEntry =
+  | { kind: 'action'; action: DropdownMenuAction }
+  | { kind: 'separator' }
+  | {
+      kind: 'submenu';
+      id: string;
+      label: string;
+      icon?: ReactNode | undefined;
+      entries: DropdownMenuEntry[];
+    };
+
+/** Terse builders so call sites read as a menu description, not object soup. */
+export function menuAction(action: DropdownMenuAction): DropdownMenuEntry {
+  return { kind: 'action', action };
+}
+export const MENU_SEPARATOR: DropdownMenuEntry = { kind: 'separator' };
+
+export interface DropdownMenuProps {
+  /** Trigger button content (icon and/or label). */
+  trigger: ReactNode;
+  triggerClassName?: string | undefined;
+  /** Tooltip + accessible label for the trigger. */
+  triggerTitle?: string | undefined;
+  entries: DropdownMenuEntry[];
+  /** Which trigger edge the panel aligns to (default 'right'). */
+  align?: 'left' | 'right' | undefined;
+  /** Fires on open/close — lets a hover-revealed surface pin itself visible. */
+  onOpenChange?: ((open: boolean) => void) | undefined;
+}
+
+interface PanelPosition {
+  top: number;
+  left: number;
+}
+
+function focusableItems(panel: HTMLElement | null): HTMLButtonElement[] {
+  if (!panel) return [];
+  return Array.from(
+    panel.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'),
+  );
+}
+
+function moveFocus(panel: HTMLElement | null, delta: 1 | -1): void {
+  const items = focusableItems(panel);
+  if (items.length === 0) return;
+  const current = items.indexOf(document.activeElement as HTMLButtonElement);
+  const next =
+    current === -1
+      ? delta === 1
+        ? 0
+        : items.length - 1
+      : (current + delta + items.length) % items.length;
+  items[next]?.focus();
+}
+
+export function DropdownMenu({
+  trigger,
+  triggerClassName,
+  triggerTitle,
+  entries,
+  align = 'right',
+  onOpenChange,
+}: DropdownMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<PanelPosition>({ top: 0, left: 0 });
+  const [openSubId, setOpenSubId] = useState<string | null>(null);
+  const [subPlacement, setSubPlacement] = useState<FlyoutPlacement | null>(null);
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const subPanelRef = useRef<HTMLDivElement>(null);
+  const subAnchorRef = useRef<HTMLButtonElement | null>(null);
+
+  const setOpenNotify = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) {
+        setOpenSubId(null);
+        setSubPlacement(null);
+      }
+      onOpenChange?.(next);
+    },
+    [onOpenChange],
+  );
+
+  const closeAll = useCallback(
+    (refocusTrigger: boolean) => {
+      setOpenNotify(false);
+      if (refocusTrigger) triggerRef.current?.focus();
+    },
+    [setOpenNotify],
+  );
+
+  // Position the panel under the trigger, clamped to the viewport.
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const panelWidth = panelRef.current?.offsetWidth ?? 220;
+    let left = align === 'right' ? rect.right - panelWidth : rect.left;
+    const maxLeft = window.innerWidth - panelWidth - 8;
+    left = Math.max(8, Math.min(left, maxLeft));
+    // Flip above the trigger when there's no room below.
+    const panelHeight = panelRef.current?.offsetHeight ?? 0;
+    let top = rect.bottom + 4;
+    if (panelHeight > 0 && top + panelHeight > window.innerHeight - 8) {
+      top = Math.max(8, rect.top - 4 - panelHeight);
+    }
+    setPosition({ top, left });
+  }, [align]);
+
+  useLayoutEffect(() => {
+    if (open) updatePosition();
+  }, [open, updatePosition]);
+
+  // Reposition on scroll/resize while open.
+  useEffect(() => {
+    if (!open) return;
+    const handleUpdate = () => updatePosition();
+    window.addEventListener('scroll', handleUpdate, true);
+    window.addEventListener('resize', handleUpdate);
+    return () => {
+      window.removeEventListener('scroll', handleUpdate, true);
+      window.removeEventListener('resize', handleUpdate);
+    };
+  }, [open, updatePosition]);
+
+  // Click outside (trigger + both panels count as inside) closes.
+  useEffect(() => {
+    if (!open) return;
+    const handleOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        panelRef.current?.contains(target) ||
+        subPanelRef.current?.contains(target)
+      ) {
+        return;
+      }
+      closeAll(false);
+    };
+    const timeoutId = setTimeout(() => {
+      document.addEventListener('mousedown', handleOutside);
+    }, 0);
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener('mousedown', handleOutside);
+    };
+  }, [open, closeAll]);
+
+  // Focus the first item when the menu opens (keyboard flow starts inside).
+  // Effects run post-commit, so the portaled panel is in the DOM already.
+  useEffect(() => {
+    if (!open) return;
+    focusableItems(panelRef.current)[0]?.focus();
+  }, [open]);
+
+  // Place the submenu next to its anchor item once both are rendered.
+  useLayoutEffect(() => {
+    if (!openSubId || !subAnchorRef.current || !subPanelRef.current || !panelRef.current) {
+      return;
+    }
+    const anchorRect = subAnchorRef.current.getBoundingClientRect();
+    const parentRect = panelRef.current.getBoundingClientRect();
+    const placement = placeFlyout(
+      {
+        top: anchorRect.top,
+        bottom: anchorRect.bottom,
+        left: anchorRect.left,
+        right: anchorRect.right,
+      },
+      { left: parentRect.left, right: parentRect.right },
+      {
+        width: subPanelRef.current.offsetWidth,
+        height: subPanelRef.current.offsetHeight,
+      },
+    );
+    setSubPlacement(placement);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openSubId]);
+
+  useEffect(() => {
+    if (!openSubId) return;
+    focusableItems(subPanelRef.current)[0]?.focus();
+  }, [openSubId]);
+
+  const openSubmenu = useCallback((id: string, anchor: HTMLButtonElement) => {
+    subAnchorRef.current = anchor;
+    setSubPlacement(null); // measured + placed by the layout effect
+    setOpenSubId(id);
+  }, []);
+
+  const closeSubmenu = useCallback((refocusAnchor: boolean) => {
+    setOpenSubId(null);
+    setSubPlacement(null);
+    if (refocusAnchor) subAnchorRef.current?.focus();
+  }, []);
+
+  const handleSelect = useCallback(
+    (action: DropdownMenuAction) => {
+      closeAll(false);
+      action.onSelect();
+    },
+    [closeAll],
+  );
+
+  const handlePanelKeyDown = useCallback(
+    (e: React.KeyboardEvent, panel: 'root' | 'sub') => {
+      const el = panel === 'root' ? panelRef.current : subPanelRef.current;
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          moveFocus(el, 1);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          moveFocus(el, -1);
+          break;
+        case 'Home':
+          e.preventDefault();
+          focusableItems(el)[0]?.focus();
+          break;
+        case 'End': {
+          e.preventDefault();
+          const items = focusableItems(el);
+          items[items.length - 1]?.focus();
+          break;
+        }
+        case 'Escape':
+          e.preventDefault();
+          e.stopPropagation();
+          if (panel === 'sub') closeSubmenu(true);
+          else closeAll(true);
+          break;
+        case 'ArrowLeft':
+          if (panel === 'sub') {
+            e.preventDefault();
+            closeSubmenu(true);
+          }
+          break;
+        default:
+          break;
+      }
+    },
+    [closeAll, closeSubmenu],
+  );
+
+  const renderAction = (action: DropdownMenuAction) => (
+    <button
+      key={action.id}
+      type="button"
+      role="menuitem"
+      className={`dropdown-menu__item ${action.danger ? 'dropdown-menu__item--danger' : ''}`}
+      disabled={action.disabled}
+      onClick={(e) => {
+        e.stopPropagation();
+        handleSelect(action);
+      }}
+      onMouseEnter={() => closeSubmenu(false)}
+    >
+      {action.swatchColor !== undefined && (
+        <span
+          className="dropdown-menu__swatch"
+          style={action.swatchColor ? { background: action.swatchColor } : undefined}
+        />
+      )}
+      {action.icon && <span className="dropdown-menu__icon">{action.icon}</span>}
+      <span className="dropdown-menu__label">{action.label}</span>
+      {action.checked && <Check className="dropdown-menu__check" size={14} aria-hidden="true" />}
+    </button>
+  );
+
+  const renderEntries = (list: DropdownMenuEntry[], panel: 'root' | 'sub'): ReactNode[] =>
+    list.map((entry, i): ReactNode => {
+      if (entry.kind === 'separator') {
+        return <div key={`sep-${i}`} className="dropdown-menu__separator" role="separator" />;
+      }
+      if (entry.kind === 'action') {
+        return renderAction(entry.action);
+      }
+      // Submenus only nest one level: a submenu entry inside a submenu renders
+      // its actions inline (flattened) rather than opening a third panel.
+      if (panel === 'sub') {
+        return renderEntries(entry.entries, 'sub');
+      }
+      const isOpen = openSubId === entry.id;
+      return (
+        <button
+          key={entry.id}
+          type="button"
+          role="menuitem"
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
+          className={`dropdown-menu__item dropdown-menu__item--submenu ${isOpen ? 'dropdown-menu__item--submenu-open' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (isOpen) closeSubmenu(false);
+            else openSubmenu(entry.id, e.currentTarget);
+          }}
+          onMouseEnter={(e) => openSubmenu(entry.id, e.currentTarget)}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowRight') {
+              e.preventDefault();
+              openSubmenu(entry.id, e.currentTarget);
+            }
+          }}
+        >
+          {entry.icon && <span className="dropdown-menu__icon">{entry.icon}</span>}
+          <span className="dropdown-menu__label">{entry.label}</span>
+          <ChevronRight className="dropdown-menu__chevron" size={14} aria-hidden="true" />
+        </button>
+      );
+    });
+
+  const openSubEntries =
+    openSubId !== null
+      ? entries.find((e) => e.kind === 'submenu' && e.id === openSubId)
+      : undefined;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={triggerClassName}
+        title={triggerTitle}
+        aria-label={triggerTitle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpenNotify(!open);
+        }}
+      >
+        {trigger}
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={panelRef}
+            className="dropdown-menu__panel"
+            role="menu"
+            style={{
+              top: position.top,
+              left: position.left - (subPlacement?.parentShift ?? 0),
+            }}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => handlePanelKeyDown(e, 'root')}
+          >
+            {renderEntries(entries, 'root')}
+          </div>,
+          document.body,
+        )}
+
+      {open &&
+        openSubEntries?.kind === 'submenu' &&
+        createPortal(
+          <div
+            ref={subPanelRef}
+            className="dropdown-menu__panel dropdown-menu__panel--sub"
+            role="menu"
+            style={
+              subPlacement
+                ? {
+                    top: subPlacement.y,
+                    left: subPlacement.x,
+                    maxHeight: subPlacement.maxHeight,
+                  }
+                : // First paint is measured (visibility:hidden via the class
+                  // below) before placeFlyout runs in the layout effect.
+                  { top: 0, left: 0, visibility: 'hidden' }
+            }
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => handlePanelKeyDown(e, 'sub')}
+          >
+            {renderEntries(openSubEntries.entries, 'sub')}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -102,7 +102,7 @@ function moveFocus(panel: HTMLElement | null, delta: 1 | -1): void {
         ? 0
         : items.length - 1
       : (current + delta + items.length) % items.length;
-  items[next]?.focus();
+  items[next]?.focus({ preventScroll: true });
 }
 
 export function DropdownMenu({
@@ -201,9 +201,11 @@ export function DropdownMenu({
 
   // Focus the first item when the menu opens (keyboard flow starts inside).
   // Effects run post-commit, so the portaled panel is in the DOM already.
+  // preventScroll: focusing must never scroll the page under a fixed panel —
+  // that shifts the trigger and makes the menu chase its own position.
   useEffect(() => {
     if (!open) return;
-    focusableItems(panelRef.current)[0]?.focus();
+    focusableItems(panelRef.current)[0]?.focus({ preventScroll: true });
   }, [open]);
 
   // Place the submenu next to its anchor item once both are rendered.
@@ -232,14 +234,22 @@ export function DropdownMenu({
 
   useEffect(() => {
     if (!openSubId) return;
-    focusableItems(subPanelRef.current)[0]?.focus();
+    focusableItems(subPanelRef.current)[0]?.focus({ preventScroll: true });
   }, [openSubId]);
 
-  const openSubmenu = useCallback((id: string, anchor: HTMLButtonElement) => {
-    subAnchorRef.current = anchor;
-    setSubPlacement(null); // measured + placed by the layout effect
-    setOpenSubId(id);
-  }, []);
+  const openSubmenu = useCallback(
+    (id: string, anchor: HTMLButtonElement) => {
+      // Re-entering the trigger of the already-open submenu must be a no-op:
+      // resetting the placement here would hide the panel while the layout
+      // effect (keyed on openSubId) never re-runs — the submenu got stuck
+      // hidden and appeared to "fight" its position.
+      if (id === openSubId) return;
+      subAnchorRef.current = anchor;
+      setSubPlacement(null); // measured + placed by the layout effect
+      setOpenSubId(id);
+    },
+    [openSubId],
+  );
 
   const closeSubmenu = useCallback((refocusAnchor: boolean) => {
     setOpenSubId(null);
@@ -392,10 +402,11 @@ export function DropdownMenu({
             ref={panelRef}
             className="dropdown-menu__panel"
             role="menu"
-            style={{
-              top: position.top,
-              left: position.left - (subPlacement?.parentShift ?? 0),
-            }}
+            // Deliberately NOT applying subPlacement.parentShift: sliding the
+            // parent panel mid-interaction made the whole menu jump around.
+            // In the rare too-narrow case the submenu overlaps the parent's
+            // edge instead (placeFlyout already clamps its x), which is stable.
+            style={{ top: position.top, left: position.left }}
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => handlePanelKeyDown(e, 'root')}
           >

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -14,7 +14,7 @@
  * collections, and local storage.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ChevronLeft,
   Clock,
@@ -133,6 +133,28 @@ export function DocumentsHome({
   const [refreshSpin, setRefreshSpin] = useState(false);
   const trashCount = useTrashStore((s) => s.items.length);
   const refreshTrash = useTrashStore((s) => s.refresh);
+
+  // `/` focuses the search box (JP-387) — classic library-surface shortcut.
+  // Ignored while typing anywhere (input/textarea/contenteditable).
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
 
   // On narrow viewports the sidebar is an off-canvas drawer (it overlays the
   // content rather than squeezing it). Open state only matters at <=640px — the
@@ -572,10 +594,12 @@ export function DocumentsHome({
           <div className="dh-search">
             <Search size={16} aria-hidden="true" />
             <input
+              ref={searchInputRef}
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={`Search ${activeLabel.toLowerCase()}…`}
+              title="Search by name or tag — #tag matches tags only. Press / to focus."
             />
           </div>
           <div className="dh-top-actions">

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -409,17 +409,30 @@
   gap: var(--space-2);
 }
 
-/* Selection bar */
+/* Selection bar — sticky at the top of the scrolling content area so bulk
+   actions stay reachable while scrolling a long selection. Background layers
+   the usual selection tint over an opaque base (content scrolls underneath). */
 .document-browser__selection-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  background: rgba(31, 51, 84, 0.08);
+  background:
+    linear-gradient(rgba(31, 51, 84, 0.08), rgba(31, 51, 84, 0.08)),
+    var(--bg-primary);
   border: 1px solid rgba(31, 51, 84, 0.25);
   border-radius: 8px;
+}
+
+.document-browser__selection-state {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
 }
 
 .document-browser__selection-count {
@@ -428,14 +441,43 @@
   color: var(--color-primary);
 }
 
+/* Quiet text-button affordances for selection state (Select all / Clear). */
+.document-browser__selection-link {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 6px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.document-browser__selection-link:hover {
+  color: var(--color-primary);
+  background: var(--bg-hover);
+}
+
 .document-browser__selection-actions {
   display: flex;
   align-items: center;
-  gap: var(--space-1);
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
+/* Visual break before the destructive action. */
+.document-browser__selection-sep {
+  width: 1px;
+  align-self: stretch;
+  margin: 2px 0;
+  background: var(--border-color);
+}
+
 .document-browser__bulk-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
   font-size: 12px;
   font-weight: 500;
   padding: 6px 10px;
@@ -444,6 +486,10 @@
   border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: pointer;
+}
+
+.document-browser__bulk-btn svg {
+  flex-shrink: 0;
 }
 
 .document-browser__bulk-btn:hover {
@@ -456,11 +502,13 @@
   color: var(--danger-text);
 }
 
-.document-browser__assign-wrap {
-  position: relative;
+/* Compact viewports: collapse action labels to icons (title tooltips remain). */
+@media (max-width: 640px) {
+  .document-browser__bulk-label {
+    display: none;
+  }
 }
 
-.document-browser__assign-menu,
 .document-browser__section-menu {
   position: absolute;
   top: calc(100% + 4px);
@@ -494,11 +542,6 @@
   background: var(--bg-hover);
 }
 
-.document-browser__assign-item--new {
-  color: var(--color-primary);
-  font-weight: 500;
-}
-
 .document-browser__assign-item--danger {
   color: var(--danger-text);
 }
@@ -511,14 +554,6 @@
   height: 1px;
   background: var(--border-color);
   margin: 4px 0;
-}
-
-.document-browser__assign-swatch {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  flex-shrink: 0;
 }
 
 /* Collection sections */
@@ -716,7 +751,6 @@
   color: var(--text-primary);
 }
 
-:root[data-theme="dark"] .document-browser__assign-menu,
 :root[data-theme="dark"] .document-browser__section-menu {
   background: var(--bg-secondary);
   border-color: var(--border-color);
@@ -746,7 +780,11 @@
 }
 
 :root[data-theme="dark"] .document-browser__selection-bar {
-  background: rgba(224, 198, 144, 0.1);
+  /* Same layering as light mode: tint over an opaque base so scrolled content
+     doesn't bleed through the sticky bar. */
+  background:
+    linear-gradient(rgba(224, 198, 144, 0.1), rgba(224, 198, 144, 0.1)),
+    var(--bg-secondary);
   border-color: rgba(224, 198, 144, 0.3);
 }
 

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -248,6 +248,23 @@
   line-height: 1.5;
 }
 
+/* "Clear search" affordance in the no-results state (JP-387). */
+.document-browser__empty-clear {
+  margin-top: var(--space-2);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-primary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.document-browser__empty-clear:hover {
+  border-color: var(--color-primary);
+}
+
 /* Compact mode adjustments */
 .document-browser--compact {
   gap: var(--space-3);

--- a/src/ui/settings/DocumentList.test.tsx
+++ b/src/ui/settings/DocumentList.test.tsx
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { DocumentList } from './DocumentList';
+import { DocumentList, SelectionBar } from './DocumentList';
 import type { DocumentBrowserModel } from './useDocumentBrowserModel';
 import type { Collection } from '../../store/collectionStore';
 
@@ -55,5 +55,70 @@ describe('DocumentList — collection management menu', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Rename…' }));
     expect(handleRenameCollection).toHaveBeenCalledWith(collection);
+  });
+});
+
+/* ── SelectionBar (JP-385 facelift) ─────────────────────────────────────────── */
+
+function selectionModel(over: Partial<DocumentBrowserModel> = {}): DocumentBrowserModel {
+  return stubModel({
+    documentList: [
+      { type: 'local', id: 'l1', name: 'One', pageCount: 1, createdAt: 0, modifiedAt: 0 },
+      { type: 'local', id: 'l2', name: 'Two', pageCount: 1, createdAt: 0, modifiedAt: 0 },
+    ] as DocumentBrowserModel['documentList'],
+    selectedIds: new Set(['l1']),
+    collections: [collection],
+    handleSelectAll: vi.fn(),
+    clearSelection: vi.fn(),
+    handleBulkAssign: vi.fn(),
+    handleBulkAssignNewCollection: vi.fn(),
+    handleBulkExport: vi.fn(),
+    handleBulkDelete: vi.fn(),
+    ...over,
+  });
+}
+
+describe('SelectionBar', () => {
+  beforeEach(() => cleanup());
+
+  it('shows the count, Select all for a partial selection, and Clear', () => {
+    const handleSelectAll = vi.fn();
+    const clearSelection = vi.fn();
+    render(<SelectionBar model={selectionModel({ handleSelectAll, clearSelection })} />);
+
+    expect(screen.getByText('1 selected')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Select all (2)' }));
+    expect(handleSelectAll).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(clearSelection).toHaveBeenCalled();
+  });
+
+  it('hides Select all when everything is already selected', () => {
+    render(<SelectionBar model={selectionModel({ selectedIds: new Set(['l1', 'l2']) })} />);
+    expect(screen.queryByRole('button', { name: /Select all/ })).toBeNull();
+  });
+
+  it('assigns the selection through the collection menu', () => {
+    const handleBulkAssign = vi.fn();
+    render(<SelectionBar model={selectionModel({ handleBulkAssign })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to collection' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Work' }));
+    expect(handleBulkAssign).toHaveBeenCalledWith('c1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to collection' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remove from collection' }));
+    expect(handleBulkAssign).toHaveBeenCalledWith(null);
+  });
+
+  it('wires Export and Delete to the bulk handlers', () => {
+    const handleBulkExport = vi.fn();
+    const handleBulkDelete = vi.fn();
+    render(<SelectionBar model={selectionModel({ handleBulkExport, handleBulkDelete })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    expect(handleBulkExport).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(handleBulkDelete).toHaveBeenCalled();
   });
 });

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -8,8 +8,14 @@
  */
 
 import { useState } from 'react';
-import { ChevronDown, Cloud, HardDrive } from 'lucide-react';
+import { ChevronDown, Cloud, Download, FolderInput, HardDrive, Trash2 } from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
+import {
+  DropdownMenu,
+  menuAction,
+  MENU_SEPARATOR,
+  type DropdownMenuEntry,
+} from '../components/DropdownMenu';
 import { VersionHistoryPanel } from '../VersionHistoryPanel';
 import { DocumentPermissionsDialog } from '../DocumentPermissionsDialog';
 import { CollectionActionsMenu } from './CollectionActionsMenu';
@@ -190,72 +196,92 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
 
 /**
  * SelectionBar — bulk-action affordance shown when documents are multi-selected.
- * Extracted so both browser chromes reuse it.
+ * Sticky at the top of the scrolling content area so bulk actions stay in
+ * reach while scrolling a long selection. Left group = selection state
+ * (count / Select all / Clear); right group = actions, with the destructive
+ * one separated. On compact viewports the action labels collapse to icons.
  */
 export function SelectionBar({ model }: { model: DocumentBrowserModel }) {
   const {
+    documentList,
     selectedIds,
     collections,
-    assignMenuOpen,
-    setAssignMenuOpen,
     handleBulkAssign,
     handleBulkAssignNewCollection,
     handleBulkExport,
     handleBulkDelete,
+    handleSelectAll,
     clearSelection,
   } = model;
 
+  const allSelected = selectedIds.size >= documentList.length;
+
+  // Same ordering as the per-card "Move to collection" submenu.
+  const assignEntries: DropdownMenuEntry[] = [
+    ...collections.map((c) =>
+      menuAction({
+        id: `collection-${c.id}`,
+        label: c.name,
+        swatchColor: c.color ?? null,
+        onSelect: () => handleBulkAssign(c.id),
+      }),
+    ),
+    ...(collections.length > 0
+      ? [
+          menuAction({
+            id: 'collection-remove',
+            label: 'Remove from collection',
+            onSelect: () => handleBulkAssign(null),
+          }),
+          MENU_SEPARATOR,
+        ]
+      : []),
+    menuAction({
+      id: 'collection-new',
+      label: '+ New collection…',
+      onSelect: () => void handleBulkAssignNewCollection(),
+    }),
+  ];
+
   return (
     <div className="document-browser__selection-bar">
-      <span className="document-browser__selection-count">{selectedIds.size} selected</span>
-      <div className="document-browser__selection-actions">
-        <div className="document-browser__assign-wrap">
-          <button
-            className="document-browser__bulk-btn"
-            onClick={() => setAssignMenuOpen((v) => !v)}
-          >
-            Assign to collection ▾
+      <div className="document-browser__selection-state">
+        <span className="document-browser__selection-count">{selectedIds.size} selected</span>
+        {!allSelected && (
+          <button className="document-browser__selection-link" onClick={handleSelectAll}>
+            Select all ({documentList.length})
           </button>
-          {assignMenuOpen && (
-            <div className="document-browser__assign-menu" role="menu">
-              <button className="document-browser__assign-item" onClick={() => handleBulkAssign(null)}>
-                Remove from collection
-              </button>
-              {collections.length > 0 && <div className="document-browser__assign-sep" />}
-              {collections.map((c) => (
-                <button
-                  key={c.id}
-                  className="document-browser__assign-item"
-                  onClick={() => handleBulkAssign(c.id)}
-                >
-                  <span
-                    className="document-browser__assign-swatch"
-                    style={c.color ? { background: c.color } : undefined}
-                  />
-                  {c.name}
-                </button>
-              ))}
-              <div className="document-browser__assign-sep" />
-              <button
-                className="document-browser__assign-item document-browser__assign-item--new"
-                onClick={handleBulkAssignNewCollection}
-              >
-                + New collection…
-              </button>
-            </div>
-          )}
-        </div>
-        <button className="document-browser__bulk-btn" onClick={handleBulkExport}>
-          Export
+        )}
+        <button className="document-browser__selection-link" onClick={clearSelection}>
+          Clear
         </button>
+      </div>
+      <div className="document-browser__selection-actions">
+        <DropdownMenu
+          trigger={
+            <>
+              <FolderInput size={14} aria-hidden="true" />
+              <span className="document-browser__bulk-label">Add to collection</span>
+              <ChevronDown size={12} aria-hidden="true" />
+            </>
+          }
+          triggerClassName="document-browser__bulk-btn"
+          triggerTitle="Add to collection"
+          entries={assignEntries}
+          align="left"
+        />
+        <button className="document-browser__bulk-btn" onClick={handleBulkExport} title="Export">
+          <Download size={14} aria-hidden="true" />
+          <span className="document-browser__bulk-label">Export</span>
+        </button>
+        <span className="document-browser__selection-sep" aria-hidden="true" />
         <button
           className="document-browser__bulk-btn document-browser__bulk-btn--danger"
           onClick={handleBulkDelete}
+          title="Delete"
         >
-          Delete
-        </button>
-        <button className="document-browser__bulk-btn" onClick={clearSelection}>
-          Clear
+          <Trash2 size={14} aria-hidden="true" />
+          <span className="document-browser__bulk-label">Delete</span>
         </button>
       </div>
     </div>

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -7,9 +7,10 @@
  * `DocumentBrowser` chrome and the first-class `DocumentsHome` surface (JP-218).
  */
 
-import { useState } from 'react';
-import { ChevronDown, Cloud, Download, FolderInput, HardDrive, Trash2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { ChevronDown, Cloud, Download, FolderInput, HardDrive, Tags, Trash2 } from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
+import { TagEditorPopover } from '../TagEditorPopover';
 import {
   DropdownMenu,
   menuAction,
@@ -80,7 +81,16 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
     relaySessionUsable,
     handlePublishToTeam,
     handleMoveToPersonal,
+    allTags,
+    handleSetTags,
+    setSearchQuery,
   } = model;
+
+  // Chip click IS the tag filter: fill `#tag` into the search box (JP-388).
+  const handleTagClick = useCallback(
+    (tag: string) => setSearchQuery('#' + tag),
+    [setSearchQuery],
+  );
 
   const cardMode: 'compact' | 'full' | 'grid' =
     view === 'grid' ? 'grid' : compact ? 'compact' : 'full';
@@ -99,6 +109,12 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
 
   const renderCard = (record: DocumentRecord) => {
     const accent = accentByDoc.get(record.id);
+    // Tag edits (JP-388): local docs always; workspace docs only with a usable
+    // relay session; cached (offline-only) docs are read-only for tags —
+    // offline tag-queueing is deliberately out of scope for this slice.
+    const canTag =
+      canEdit(record, currentUser?.id, currentUser?.role) &&
+      (record.type === 'local' || (record.type === 'remote' && relaySessionUsable));
     return (
       <DocumentCard
         key={record.id}
@@ -133,6 +149,9 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
         offlineStatus={offlineStatuses.get(record.id)}
         offlineProgress={offlineProgress.get(record.id) ?? null}
         onMakeAvailableOffline={record.type !== 'local' ? handleMakeAvailableOffline : undefined}
+        onSetTags={canTag ? handleSetTags : undefined}
+        onTagClick={handleTagClick}
+        tagSuggestions={allTags}
         mode={cardMode}
       />
     );
@@ -144,7 +163,15 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
       {documentList.length === 0 ? (
         <div className="document-browser__empty">
           {searchQuery ? (
-            <p>No documents match your search.</p>
+            <>
+              <p>No documents match “{searchQuery}”.</p>
+              <button
+                className="document-browser__empty-clear"
+                onClick={() => setSearchQuery('')}
+              >
+                Clear search
+              </button>
+            </>
           ) : filterMode !== 'all' ? (
             <p>No {filterMode === 'local' ? 'personal' : filterMode} documents.</p>
           ) : (
@@ -206,8 +233,10 @@ export function SelectionBar({ model }: { model: DocumentBrowserModel }) {
     documentList,
     selectedIds,
     collections,
+    allTags,
     handleBulkAssign,
     handleBulkAssignNewCollection,
+    handleBulkAddTags,
     handleBulkExport,
     handleBulkDelete,
     handleSelectAll,
@@ -215,6 +244,22 @@ export function SelectionBar({ model }: { model: DocumentBrowserModel }) {
   } = model;
 
   const allSelected = selectedIds.size >= documentList.length;
+
+  // Bulk tagging (JP-388): the popover's chip list is "tags added in this
+  // session" — each newly-entered tag is APPENDED to every selected editable
+  // doc immediately; removing a chip only stops future adds (it never
+  // un-tags). Anchored to the Tags button.
+  const [bulkTagAnchor, setBulkTagAnchor] = useState<{
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  } | null>(null);
+  const [bulkTags, setBulkTags] = useState<string[]>([]);
+  const closeBulkTags = useCallback(() => {
+    setBulkTagAnchor(null);
+    setBulkTags([]);
+  }, []);
 
   // Same ordering as the per-card "Move to collection" submenu.
   const assignEntries: DropdownMenuEntry[] = [
@@ -270,6 +315,35 @@ export function SelectionBar({ model }: { model: DocumentBrowserModel }) {
           entries={assignEntries}
           align="left"
         />
+        <button
+          className="document-browser__bulk-btn"
+          title="Add tags"
+          onClick={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setBulkTagAnchor({
+              top: rect.top,
+              bottom: rect.bottom,
+              left: rect.left,
+              right: rect.right,
+            });
+          }}
+        >
+          <Tags size={14} aria-hidden="true" />
+          <span className="document-browser__bulk-label">Add tags</span>
+        </button>
+        {bulkTagAnchor && (
+          <TagEditorPopover
+            tags={bulkTags}
+            suggestions={allTags}
+            anchor={bulkTagAnchor}
+            onCommit={(next) => {
+              const added = next.filter((t) => !bulkTags.includes(t));
+              setBulkTags(next);
+              if (added.length > 0) void handleBulkAddTags(added);
+            }}
+            onClose={closeBulkTags}
+          />
+        )}
         <button className="document-browser__bulk-btn" onClick={handleBulkExport} title="Export">
           <Download size={14} aria-hidden="true" />
           <span className="document-browser__bulk-label">Export</span>

--- a/src/ui/settings/useDocumentBrowserModel.actions.test.tsx
+++ b/src/ui/settings/useDocumentBrowserModel.actions.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Hook-level coverage for the JP-385 delete + rename policy in
+ * useDocumentBrowserModel, against real stores:
+ *
+ * - Local soft delete is one click — no confirm dialog, an Undo toast.
+ * - Workspace (remote) delete keeps a styled danger confirm (it affects every
+ *   member and Undo can't round-trip), and only deletes on OK.
+ * - Rename of a NON-open document routes through renameDocumentById
+ *   (previously a silent no-op) and surfaces failures as an error toast.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { useDocumentBrowserModel } from './useDocumentBrowserModel';
+import { useDocumentRegistry } from '../../store/documentRegistry';
+import { usePersistenceStore, saveDocumentToStorage } from '../../store/persistenceStore';
+import { useRelayDocumentStore } from '../../store/relayDocumentStore';
+import { useNotificationStore } from '../../store/notificationStore';
+import { useConfirmStore } from '../confirm/confirmStore';
+import { getDocumentMetadata, type DiagramDocument } from '../../types/Document';
+
+// The delete path purges the doc's local CRDT room (y-indexeddb) — not
+// available under jsdom, so stub just that export.
+vi.mock('../../collaboration', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../collaboration')>();
+  return { ...mod, purgeLocalDocRoom: vi.fn().mockResolvedValue(undefined) };
+});
+
+function makeDoc(id: string, name: string): DiagramDocument {
+  return {
+    id,
+    name,
+    pages: {},
+    pageOrder: [],
+    activePageId: '',
+    createdAt: 1,
+    modifiedAt: 1,
+    version: 2,
+  } as unknown as DiagramDocument;
+}
+
+function seedLocalDoc(id: string, name: string): void {
+  const doc = makeDoc(id, name);
+  saveDocumentToStorage(doc);
+  useDocumentRegistry.getState().registerLocal(getDocumentMetadata(doc));
+}
+
+function toastMessages() {
+  return useNotificationStore.getState().notifications;
+}
+
+describe('useDocumentBrowserModel — delete + rename policy (JP-385)', () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    useDocumentRegistry.setState({ entries: {} });
+    useNotificationStore.getState().dismissAll();
+    useConfirmStore.setState({ current: null, queue: [] });
+  });
+
+  it('soft-deletes a local doc with no confirm and an Undo toast', async () => {
+    seedLocalDoc('l1', 'My Doc');
+    const { result } = renderHook(() => useDocumentBrowserModel());
+
+    await act(async () => {
+      await result.current.handleDelete('l1');
+    });
+
+    // No dialog was raised…
+    expect(useConfirmStore.getState().current).toBeNull();
+    // …the doc left the registry…
+    expect(useDocumentRegistry.getState().getRecord('l1')).toBeUndefined();
+    // …and the toast carries the Undo action.
+    const undoToast = toastMessages().find((n) => n.actionLabel === 'Undo');
+    expect(undoToast).toBeTruthy();
+    expect(undoToast?.message).toContain('Trash');
+  });
+
+  it('confirms before deleting a workspace doc, and cancels cleanly', async () => {
+    const trashMock = vi.fn().mockResolvedValue(undefined);
+    useRelayDocumentStore.setState({ trashRelayDocument: trashMock });
+    const remoteDoc = makeDoc('r1', 'Team Doc');
+    useDocumentRegistry
+      .getState()
+      .registerRemote(getDocumentMetadata(remoteDoc), 'localhost:9876', 'owner');
+
+    const { result } = renderHook(() => useDocumentBrowserModel());
+
+    // Cancel path: the dialog appears, resolving false deletes nothing.
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.handleDelete('r1');
+    });
+    await waitFor(() => expect(useConfirmStore.getState().current?.kind).toBe('confirm'));
+    act(() => useConfirmStore.getState()._resolve(false));
+    await act(async () => {
+      await pending;
+    });
+    expect(trashMock).not.toHaveBeenCalled();
+    expect(useDocumentRegistry.getState().getRecord('r1')).toBeTruthy();
+
+    // Confirm path: resolving true performs the relay delete.
+    act(() => {
+      pending = result.current.handleDelete('r1');
+    });
+    await waitFor(() => expect(useConfirmStore.getState().current?.kind).toBe('confirm'));
+    act(() => useConfirmStore.getState()._resolve(true));
+    await act(async () => {
+      await pending;
+    });
+    expect(trashMock).toHaveBeenCalledWith('r1');
+  });
+
+  it('renames a NON-open doc through renameDocumentById', async () => {
+    seedLocalDoc('l2', 'Old Name');
+    const renameMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true } as Awaited<
+        ReturnType<ReturnType<typeof usePersistenceStore.getState>['renameDocumentById']>
+      >);
+    usePersistenceStore.setState({ renameDocumentById: renameMock, currentDocumentId: null });
+
+    const { result } = renderHook(() => useDocumentBrowserModel());
+    act(() => {
+      result.current.handleRename('l2', 'New Name');
+    });
+
+    await waitFor(() => expect(renameMock).toHaveBeenCalledWith('l2', 'New Name'));
+    expect(toastMessages().some((n) => n.severity === 'error')).toBe(false);
+  });
+
+  it('surfaces a rename failure as an error toast', async () => {
+    seedLocalDoc('l3', 'Old Name');
+    const renameMock = vi.fn().mockResolvedValue({ ok: false, reason: 'version-conflict' });
+    usePersistenceStore.setState({ renameDocumentById: renameMock, currentDocumentId: null });
+
+    const { result } = renderHook(() => useDocumentBrowserModel());
+    act(() => {
+      result.current.handleRename('l3', 'New Name');
+    });
+
+    await waitFor(() =>
+      expect(toastMessages().some((n) => n.severity === 'error' && /refresh/i.test(n.message))).toBe(
+        true,
+      ),
+    );
+  });
+
+  it('selects every visible document with handleSelectAll', async () => {
+    seedLocalDoc('a1', 'Alpha');
+    seedLocalDoc('a2', 'Bravo');
+    const { result } = renderHook(() => useDocumentBrowserModel());
+
+    act(() => {
+      result.current.handleSelectAll();
+    });
+
+    await waitFor(() => expect(result.current.selectedIds).toEqual(new Set(['a1', 'a2'])));
+  });
+});

--- a/src/ui/settings/useDocumentBrowserModel.actions.test.tsx
+++ b/src/ui/settings/useDocumentBrowserModel.actions.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../../collaboration', async (importOriginal) => {
   return { ...mod, purgeLocalDocRoom: vi.fn().mockResolvedValue(undefined) };
 });
 
-function makeDoc(id: string, name: string): DiagramDocument {
+function makeDoc(id: string, name: string, tags?: string[]): DiagramDocument {
   return {
     id,
     name,
@@ -36,11 +36,12 @@ function makeDoc(id: string, name: string): DiagramDocument {
     createdAt: 1,
     modifiedAt: 1,
     version: 2,
+    ...(tags ? { tags } : {}),
   } as unknown as DiagramDocument;
 }
 
-function seedLocalDoc(id: string, name: string): void {
-  const doc = makeDoc(id, name);
+function seedLocalDoc(id: string, name: string, tags?: string[]): void {
+  const doc = makeDoc(id, name, tags);
   saveDocumentToStorage(doc);
   useDocumentRegistry.getState().registerLocal(getDocumentMetadata(doc));
 }
@@ -144,6 +145,37 @@ describe('useDocumentBrowserModel — delete + rename policy (JP-385)', () => {
         true,
       ),
     );
+  });
+
+  it('searches tags: plain query matches name OR tags, # targets tags only', async () => {
+    seedLocalDoc('s1', 'Alpha Report', ['research']);
+    seedLocalDoc('s2', 'research notes');
+    seedLocalDoc('s3', 'Misc');
+    const { result } = renderHook(() => useDocumentBrowserModel());
+
+    act(() => result.current.setSearchQuery('research'));
+    await waitFor(() =>
+      expect(result.current.documentList.map((d) => d.id).sort()).toEqual(['s1', 's2']),
+    );
+
+    act(() => result.current.setSearchQuery('#research'));
+    await waitFor(() =>
+      expect(result.current.documentList.map((d) => d.id)).toEqual(['s1']),
+    );
+
+    // Bare '#' lists every tagged document.
+    act(() => result.current.setSearchQuery('#'));
+    await waitFor(() =>
+      expect(result.current.documentList.map((d) => d.id)).toEqual(['s1']),
+    );
+  });
+
+  it('allTags unions registry tags case-insensitively with first casing kept', async () => {
+    seedLocalDoc('t1', 'One', ['Research', 'ops']);
+    seedLocalDoc('t2', 'Two', ['research', 'Draft']);
+    const { result } = renderHook(() => useDocumentBrowserModel());
+
+    await waitFor(() => expect(result.current.allTags).toEqual(['Draft', 'ops', 'Research']));
   });
 
   it('selects every visible document with handleSelectAll', async () => {

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -49,6 +49,7 @@ import { getTransferService, type TransferState } from '../../services/DocumentT
 import { useTransferStore, isTransferRunning } from '../../store/transferStore';
 import { purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
+import { tagsMatch } from '../../types/DocumentTags';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
 import { confirmDialog, promptDialog } from '../confirm/confirmStore';
 
@@ -146,6 +147,12 @@ export interface DocumentBrowserModel {
   collectionsMap: Record<string, Collection>;
   assignments: Record<string, string>;
   accentByDoc: Map<string, { name: string; color?: string }>;
+  // Tags (JP-388)
+  /** Case-insensitive union of tags across the registry — editor suggestions. */
+  allTags: string[];
+  handleSetTags: (docId: string, tags: string[]) => Promise<void>;
+  /** Append tags to every selected (editable) document; warns about skips. */
+  handleBulkAddTags: (tags: string[]) => Promise<void>;
   // Axis / view state
   filterMode: FilterMode;
   setFilterMode: (mode: FilterMode) => void;
@@ -331,13 +338,37 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       filtered = filtered.filter((d) => assignments[d.id] === collectionFilter);
     }
 
+    // Search (JP-387): plain query matches name OR tags; a `#` prefix targets
+    // tags only (chips fill `#tag` in, so tag filtering IS the search). A bare
+    // `#` lists every tagged document. Case-insensitive substring throughout.
     if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter((d) => d.name.toLowerCase().includes(query));
+      const query = searchQuery.trim().toLowerCase();
+      const tagOnly = query.startsWith('#');
+      const needle = tagOnly ? query.slice(1) : query;
+      filtered = filtered.filter((d) => {
+        const tagHit = tagsMatch(d.tags, needle);
+        return tagOnly ? tagHit : d.name.toLowerCase().includes(needle) || tagHit;
+      });
     }
 
     return [...filtered].sort((a, b) => compareRecords(a, b, sort));
   }, [entries, getFilteredDocuments, filterMode, collectionFilter, assignments, searchQuery, sort]);
+
+  // Case-insensitive union of tags across the whole registry — NOT the
+  // filtered documentList, so an active search doesn't starve the tag editor's
+  // suggestions. First-seen casing wins, sorted for stable menus.
+  const allTags = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const entry of Object.values(entries)) {
+      for (const tag of entry.record.tags ?? []) {
+        const key = tag.toLowerCase();
+        if (!seen.has(key)) seen.set(key, tag);
+      }
+    }
+    return Array.from(seen.values()).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: 'base' }),
+    );
+  }, [entries]);
 
   // JP-281: compute each relay-backed doc's offline-ready status from local
   // caches (network-free). Recomputes when the list or registry changes so the
@@ -625,6 +656,59 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     [currentDocumentId, renameDocument]
   );
 
+  // Persist one document's tags (JP-388), surfacing failures as toasts.
+  const handleSetTags = useCallback(async (docId: string, tags: string[]) => {
+    const res = await usePersistenceStore.getState().setDocumentTags(docId, tags);
+    if (!res.ok) {
+      const { useNotificationStore } = await import('../../store/notificationStore');
+      useNotificationStore
+        .getState()
+        .error(
+          res.reason === 'version-conflict'
+            ? 'The workspace copy changed since you opened the list — refresh and try tagging again.'
+            : res.reason === 'not-found'
+              ? 'Couldn’t update tags — the document wasn’t found.'
+              : 'Couldn’t update tags — check your connection and try again.',
+        );
+    }
+  }, []);
+
+  // Bulk tagging (JP-388): APPEND the given tags to every selected editable
+  // document (never removes). Offline/cached and permission-blocked docs are
+  // skipped with one summary toast — the strongest lever for organizing an
+  // existing archive.
+  const handleBulkAddTags = useCallback(
+    async (tags: string[]) => {
+      if (tags.length === 0) return;
+      const ids = Array.from(selectedIds);
+      let applied = 0;
+      let skipped = 0;
+      for (const id of ids) {
+        const record = entries[id]?.record;
+        if (!record) continue;
+        const editable =
+          canEdit(record, currentUser?.id, currentUser?.role) &&
+          (record.type === 'local' || (record.type === 'remote' && relaySessionUsable));
+        if (!editable) {
+          skipped += 1;
+          continue;
+        }
+        const res = await usePersistenceStore
+          .getState()
+          .setDocumentTags(id, [...(record.tags ?? []), ...tags]);
+        if (res.ok) applied += 1;
+        else skipped += 1;
+      }
+      if (skipped > 0) {
+        const { useNotificationStore } = await import('../../store/notificationStore');
+        useNotificationStore
+          .getState()
+          .warning(`Tagged ${applied} of ${ids.length} — ${skipped} couldn’t be updated`);
+      }
+    },
+    [selectedIds, entries, currentUser, relaySessionUsable],
+  );
+
   const handlePublishToTeam = useCallback(
     async (docId: string) => {
       if (!currentUser?.id) return;
@@ -788,6 +872,12 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
           .error(`Move to Personal failed: ${friendlyTransferError(result.error)}`);
         return;
       }
+      // The doc is now personal; a workspace collection can't hold it (JP-366).
+      // The body's `collectionId` is stripped by the transfer service — clear
+      // the client-side assignment too so the store doesn't keep counting it
+      // as a member (mirrors handlePublishToTeam's clear in the other direction).
+      useCollectionStore.getState().assignDocument(docId, null);
+
       // The doc was just DELETEd from the relay, so refresh the remote list
       // (it'll be absent from it now) and then re-register the converted doc as
       // Local. fetchDocumentList only ever registers *remote* docs, so without
@@ -1076,6 +1166,9 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     collectionsMap,
     assignments,
     accentByDoc,
+    allTags,
+    handleSetTags,
+    handleBulkAddTags,
     filterMode,
     setFilterMode,
     searchQuery,

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -166,9 +166,9 @@ export interface DocumentBrowserModel {
   selectedIds: Set<string>;
   hasSelection: boolean;
   handleSelectToggle: (id: string, mods: { shift: boolean; meta: boolean }) => void;
+  /** Select every document currently visible in the filtered list. */
+  handleSelectAll: () => void;
   clearSelection: () => void;
-  assignMenuOpen: boolean;
-  setAssignMenuOpen: (v: boolean | ((p: boolean) => boolean)) => void;
   activeCollectionMenu: string | null;
   setActiveCollectionMenu: (v: string | null) => void;
   // Dialog state
@@ -304,7 +304,6 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const [permissionsDocId, setPermissionsDocId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
-  const [assignMenuOpen, setAssignMenuOpen] = useState(false);
   const [activeCollectionMenu, setActiveCollectionMenu] = useState<string | null>(null);
   // Offline-cache surfacing (JP-281): passive per-doc status + in-flight prefetch progress.
   const [offlineStatuses, setOfflineStatuses] = useState<Map<string, OfflineStatus>>(new Map());
@@ -493,10 +492,12 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     [currentDocumentId, entries, loadRelayDocument, loadDocument]
   );
 
-  // Soft delete → Trash. Relay docs hard-delete on the relay (no relay-side
-  // soft-delete yet — JP-294) but the deleter keeps a recoverable stranded copy
-  // in their own Trash. Local/cached docs move to the local Trash.
-  const handleDelete = useCallback(
+  // Soft delete → Trash, no confirm/toast — shared by the per-card and bulk
+  // paths (which own their own confirmation policy). Relay docs hard-delete on
+  // the relay (no relay-side soft-delete yet — JP-294) but the deleter keeps a
+  // recoverable stranded copy in their own Trash. Local/cached docs move to
+  // the local Trash.
+  const performDelete = useCallback(
     async (docId: string) => {
       const entry = entries[docId];
       if (!entry) return;
@@ -517,6 +518,56 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       }
     },
     [entries, trashRelayDocument, deleteDocument]
+  );
+
+  // Per-card soft delete. Local docs are one click — recoverable, so the
+  // guard is an Undo toast instead of a confirm. Workspace (remote) docs keep
+  // a styled confirm: the delete affects every member, and Undo can't
+  // round-trip (Trash restore always produces a *local* copy).
+  const handleDelete = useCallback(
+    async (docId: string) => {
+      const entry = entries[docId];
+      if (!entry) return;
+      const record = entry.record;
+      if (record.type === 'remote') {
+        const ok = await confirmDialog({
+          title: `Delete “${record.name}”?`,
+          message: 'It’s removed from the workspace for everyone.',
+          details: signedIn
+            ? 'A recoverable copy is kept in your Trash.'
+            : 'You’re offline — it moves to your Trash now and leaves the workspace once you reconnect.',
+          confirmLabel: 'Delete',
+          danger: true,
+        });
+        if (!ok) return;
+      }
+      await performDelete(docId);
+      const { useNotificationStore } = await import('../../store/notificationStore');
+      if (record.type === 'local') {
+        useNotificationStore.getState().success(`“${record.name}” moved to Trash`, {
+          actionLabel: 'Undo',
+          onAction: () => {
+            void (async () => {
+              const { useTrashStore } = await import('../../store/trashStore');
+              const restored = await useTrashStore.getState().restore(docId);
+              if (!restored) {
+                useNotificationStore
+                  .getState()
+                  .error('Couldn’t restore — the document is no longer in the Trash.');
+              }
+            })();
+          },
+          duration: 8000,
+        });
+      } else if (record.type === 'remote') {
+        useNotificationStore
+          .getState()
+          .success(`“${record.name}” removed — a recoverable copy is in your Trash`);
+      } else {
+        useNotificationStore.getState().success(`“${record.name}” moved to Trash`);
+      }
+    },
+    [entries, performDelete, signedIn]
   );
 
   // Permanent delete → bypass the Trash. Relay docs hard-delete on the relay
@@ -545,9 +596,31 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     [entries, deleteFromHost, permanentlyDeleteDocument]
   );
 
+  // Rename any listed document. The open doc renames through the live editor
+  // path; every other doc goes through `renameDocumentById`, which handles
+  // local + relay (with version-conflict detection) — previously non-open
+  // renames silently no-oped here.
   const handleRename = useCallback(
     (docId: string, newName: string) => {
-      if (docId === currentDocumentId) renameDocument(newName);
+      if (docId === currentDocumentId) {
+        renameDocument(newName);
+        return;
+      }
+      void (async () => {
+        const res = await usePersistenceStore.getState().renameDocumentById(docId, newName);
+        if (!res.ok) {
+          const { useNotificationStore } = await import('../../store/notificationStore');
+          useNotificationStore
+            .getState()
+            .error(
+              res.reason === 'version-conflict'
+                ? 'The workspace copy changed since you opened the list — refresh and try renaming again.'
+                : res.reason === 'not-found'
+                  ? 'Couldn’t rename — the document wasn’t found.'
+                  : 'Couldn’t rename — check your connection and try again.',
+            );
+        }
+      })();
     },
     [currentDocumentId, renameDocument]
   );
@@ -795,6 +868,10 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     [documentList, lastSelectedId]
   );
 
+  const handleSelectAll = useCallback(() => {
+    setSelectedIds(new Set(documentList.map((d) => d.id)));
+  }, [documentList]);
+
   const clearSelection = useCallback(() => {
     setSelectedIds(new Set());
     setLastSelectedId(null);
@@ -808,7 +885,6 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const handleBulkAssign = useCallback(
     (collectionId: string | null) => {
       assignDocumentsScoped(Array.from(selectedIds), collectionId);
-      setAssignMenuOpen(false);
     },
     [selectedIds]
   );
@@ -823,7 +899,6 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     if (!name) return;
     const id = syncedActions.createCollection(name);
     if (id) assignDocumentsScoped(Array.from(selectedIds), id);
-    setAssignMenuOpen(false);
   }, [selectedIds]);
 
   const handleBulkDelete = useCallback(async () => {
@@ -849,11 +924,17 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       danger: true,
     });
     if (!ok) return;
+    // performDelete, not handleDelete — this dialog already confirmed the
+    // whole batch (no per-doc re-confirm) and one summary toast beats N.
     for (const id of deletable) {
-      await handleDelete(id);
+      await performDelete(id);
     }
+    const { useNotificationStore } = await import('../../store/notificationStore');
+    useNotificationStore
+      .getState()
+      .success(`${n} document${n === 1 ? '' : 's'} moved to Trash`);
     clearSelection();
-  }, [selectedIds, entries, currentUser, handleDelete, clearSelection, signedIn]);
+  }, [selectedIds, entries, currentUser, performDelete, clearSelection, signedIn]);
 
   const handleBulkExport = useCallback(async () => {
     const ids = Array.from(selectedIds);
@@ -1012,9 +1093,8 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     selectedIds,
     hasSelection,
     handleSelectToggle,
+    handleSelectAll,
     clearSelection,
-    assignMenuOpen,
-    setAssignMenuOpen,
     activeCollectionMenu,
     setActiveCollectionMenu,
     pdfExportOpen,


### PR DESCRIPTION
Distills the JP-385 epic into its safe, effective core — JP-386 Folders was canceled as a duplicate of collections — and gives the document browser the facelift it deserves since collections rolled out. Two self-contained slices, one commit each.

## Slice 1 — browser facelift

- **Shared `DropdownMenu` primitive** (`src/ui/components/`): portal + fixed positioning, keyboard nav (arrows/Home/End/Escape with focus return), one submenu level via the tested `placeFlyout`, danger items, 32px hit targets. The card kebab and selection-bar menus both build on it.
- **DocumentCard**: two visible quick actions (contextual transfer + Trash); Rename / Move to collection / Edit tags / Manage access / Version history / Delete permanently move into a kebab overflow menu. The inline 3-state delete confirm is gone.
- **Delete policy**: local docs soft-delete in one click with an **Undo toast** (restore failure surfaces an error); workspace docs keep a styled danger confirm — removal affects every member and Undo can't round-trip (Trash restore is local-only). Permanent delete sits behind the same styled confirm bulk delete already used; bulk delete now confirms once and shows one summary toast.
- **Rename fix**: renaming a NON-open document from its card now works (routes through `renameDocumentById`; previously a silent no-op).
- **SelectionBar**: sticky at the top of the scroll area; count / Select all / Clear grouped left, actions right with a separator before the destructive one; labels collapse to icons at ≤640px.

## Slice 2 — tags (JP-388), search (JP-387), transfer hardening

Tags are **document content** (like references/fields), not scope-bound membership: `tags?: string[]` on the body — additive, no format-version bump — travels across personal↔workspace transfers and trash/restore, and syncs live through the Y.Doc metadata map (same freshness-guarded flatten path as the title).

- `normalizeTags` on every write seam (trim, `#`-strip, case-insensitive dedupe, 20×40 caps); deterministic chip colors (hash → 8-hue palette in both themes, no color registry).
- Relay lifts `tags` into list metadata exactly like `collectionId`; hydration seeds the metadata map; flatten adopts under the `updatedAt >= modifiedAt` guard (a stale CRDT copy never clobbers a REST tag save; explicit empty clears the key; absent leaves the body alone).
- Search: plain query matches **name OR tags**; `#foo` targets tags only; a bare `#` lists every tagged doc. Clicking a tag chip fills `#tag` in — the chip *is* the tag filter. `/` focuses search; the no-results state gains a Clear button.
- Bulk **Add tags** on the selection bar (append-only; offline/no-permission docs skipped with a summary toast).
- **Transfer hardening**: demote (`transferToPersonal` and `demoteCurrentDocumentToLocal`) now strips `collectionId` the way promote always did, and Move to Personal clears the client-side assignment. Tests pin all four paths: promote/demote strip collection membership + keep tags; trash clears the assignment + the trashed snapshot keeps tags; restore returns Unassigned with tags intact.

## Known gap (flagged, matches existing title behavior)

A REST tag edit on a doc that is *resident* on the relay doesn't push into the live Y.Doc (`set_metadata_tags` would need REST→broadcast wiring the title path doesn't have either). Live peers see browser-made tag edits on next open; the flatten freshness guard prevents any clobbering meanwhile.

## Verification

- `bun run typecheck`, full suite **2988 tests / 256 files green**, `cargo check --all-targets` + `cargo test` (591 lib + integration green), `bun run build` clean.
- New/extended coverage: DropdownMenu interaction contract, card action policy, model delete/rename/search/allTags hook tests, tag normalization + color determinism, Y.Doc tags LWW merge, relay lift/hydrate/flatten (incl. stale-no-clobber + cleared-vs-absent), transfer trait matrix, trash/restore tag round-trip.
- Manually verified in the browser: kebab menu (incl. a z-index fix — the portaled panel rendered under the DocumentsHome overlay), one-click trash + Undo round-trip, non-open rename, sticky SelectionBar with Select all, chips + editor + suggestions, `#tag`/plain search, chip-click filter, `/` shortcut, Clear search.

Closes JP-387, JP-388. Part of JP-385.

Assisted-by: Fable 5