### PR TITLE
Fix collection submenu rendering over its parent near the right edge

### DIFF
--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -227,6 +227,10 @@ export function DropdownMenu({
         width: subPanelRef.current.offsetWidth,
         height: subPanelRef.current.offsetHeight,
       },
+      // This menu never slides its parent panel (that made the whole menu jump
+      // around). Tell placeFlyout so a tight right edge flips the submenu to
+      // the left instead of leaving it to overlap the un-shifted parent.
+      { allowParentShift: false },
     );
     setSubPlacement(placement);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -404,8 +408,10 @@ export function DropdownMenu({
             role="menu"
             // Deliberately NOT applying subPlacement.parentShift: sliding the
             // parent panel mid-interaction made the whole menu jump around.
-            // In the rare too-narrow case the submenu overlaps the parent's
-            // edge instead (placeFlyout already clamps its x), which is stable.
+            // placeFlyout is called with allowParentShift:false so it flips the
+            // submenu to the left when the right edge is tight, rather than
+            // returning a shift we'd ignore (which left the submenu overlapping
+            // the un-shifted parent).
             style={{ top: position.top, left: position.left }}
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => handlePanelKeyDown(e, 'root')}

--- a/src/ui/contextMenuUtils.test.ts
+++ b/src/ui/contextMenuUtils.test.ts
@@ -60,6 +60,31 @@ describe('placeFlyout', () => {
       expect(p.x).toBe(14);
     });
 
+    it('flips to the left instead of shifting the parent when allowParentShift is false', () => {
+      // A parent pinned near the right edge: the submenu would need the parent
+      // to slide left to fit on the right. Callers that never render the shift
+      // (e.g. DropdownMenu) must get a clean left flip, not an overlap.
+      const rightParent = { left: 1040, right: 1260 };
+      const rightAnchor = { ...anchor, left: 1040, right: 1260 };
+      const sub = { width: 220, height: 260 };
+      const big = { viewportWidth: 1280, viewportHeight: 800, padding: 8, gap: 4 };
+
+      // Default (shift allowed): rides the shifted parent, overlapping it.
+      const shifted = placeFlyout(rightAnchor, rightParent, sub, big);
+      expect(shifted.side).toBe('right');
+      expect(shifted.parentShift).toBeGreaterThan(0);
+
+      // Pinned parent: flip left, no shift, fully clear of the parent.
+      const flipped = placeFlyout(rightAnchor, rightParent, sub, {
+        ...big,
+        allowParentShift: false,
+      });
+      expect(flipped.side).toBe('left');
+      expect(flipped.parentShift).toBe(0);
+      expect(flipped.x).toBe(1040 - 4 - 220); // 816
+      expect(flipped.x + sub.width).toBeLessThanOrEqual(rightParent.left); // no overlap
+    });
+
     it('clamps into the viewport when neither side fits (very narrow)', () => {
       const narrowVp = { viewportWidth: 360, viewportHeight: 640, padding: 8, gap: 4 };
       const p = placeFlyout(

--- a/src/ui/contextMenuUtils.ts
+++ b/src/ui/contextMenuUtils.ts
@@ -85,6 +85,14 @@ export interface FlyoutOptions {
   viewportWidth?: number;
   /** Override viewport height (defaults to window.innerHeight). */
   viewportHeight?: number;
+  /**
+   * Whether the parent menu may slide left to free room on the right
+   * (default true). Callers that render `parentShift` (moving the parent)
+   * keep this on. Callers that pin the parent in place must pass `false` so
+   * a tight right edge flips the submenu to the *left* instead of leaving it
+   * to overlap the un-shifted parent. See `parentShift`.
+   */
+  allowParentShift?: boolean;
 }
 
 interface AnchorRect {
@@ -102,7 +110,9 @@ interface AnchorRect {
  * Horizontal strategy is "hybrid":
  *   1. Open to the right of the parent if it fits.
  *   2. Otherwise slide the parent left (parentShift) to free room on the right,
- *      as long as the parent stays on-screen.
+ *      as long as the parent stays on-screen. Skipped when
+ *      `allowParentShift === false` (caller pins the parent), so a tight right
+ *      edge flips instead of overlapping.
  *   3. Otherwise flip the submenu to the left of the parent.
  *   4. Otherwise (neither side fits — very narrow) clamp into the viewport;
  *      the caller also caps width in CSS so it can't exceed the viewport.
@@ -124,6 +134,7 @@ export function placeFlyout(
   const gap = opts.gap ?? 4;
   const vw = opts.viewportWidth ?? window.innerWidth;
   const vh = opts.viewportHeight ?? window.innerHeight;
+  const allowParentShift = opts.allowParentShift ?? true;
 
   const { width, height } = submenu;
   const rightLimit = vw - padding;
@@ -141,7 +152,7 @@ export function placeFlyout(
   } else {
     const overflow = rightX + width - rightLimit;
     const maxShift = parent.left - padding; // how far parent can slide left
-    if (overflow <= maxShift) {
+    if (allowParentShift && overflow <= maxShift) {
       // 2. Slide the parent left to free room on the right.
       side = 'right';
       parentShift = overflow;


### PR DESCRIPTION
## Problem

The document browser's **Move to collection** submenu (a `DropdownMenu` flyout) rendered *on top of* its parent kebab menu when the card's menu sat near the right viewport edge — instead of flipping to the open left side. It looked like the submenu was spilling off / mispositioned.

## Root cause

Submenu placement goes through `placeFlyout` in `contextMenuUtils.ts`. Its hybrid strategy *prefers* sliding the parent panel left (`parentShift`) over flipping the submenu to the left. But `DropdownMenu` **deliberately never applies `parentShift`** (sliding the parent mid-interaction made the whole menu jump). So near the right edge it was left placing the submenu at the shifted-right coordinate while the parent stayed put — covering the parent (measured ~926→1126 in a 1134px viewport, over an 895–1095 parent).

## Fix

- Add an `allowParentShift` option to `placeFlyout` (default `true`, so the canvas `ContextMenu` — which *does* render the shift — is unchanged).
- When `false`, the slide branch is skipped, so a tight right edge flips the submenu to the **left** instead.
- `DropdownMenu` now passes `allowParentShift: false`, matching its no-shift rendering.

## Verification

- New `placeFlyout` unit test asserts the left-flip (no overlap) when shift is disallowed, while the default still rides the shifted parent.
- Verified live in the dev preview (viewport 1134px, right-edge card): the submenu now flips left (691→891), fully clear of the parent (895–1095), on-screen.
- `bun run typecheck` clean; 26 tests pass across `contextMenuUtils`, `DropdownMenu`, and `DocumentCard.collections`.

Assisted-by: Opus 4.8