### PR TITLE
JP-429: anchored editing + formatting passthrough for prose

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -108,7 +108,7 @@ All tools are namespaced `docushark_*`.
 | Tool | Purpose |
 | -- | -- |
 | `add_prose_page` | Append a prose page. Markdown by default. |
-| `set_prose` | Write a prose page. Replaces the whole body by default; pass `anchor` (the current text of a block) to replace **only that block** — a targeted edit. Markdown by default. |
+| `set_prose` | Write a prose page. Replaces the whole body by default; pass `anchor` (the current text of a line) to replace **only that line** — a single bullet, table cell, heading, or paragraph anywhere on the page, with its container + siblings untouched. Block formatting (cell colour/alignment, heading/paragraph alignment) round-trips, so it's settable via `format:"html"`. Markdown by default. |
 | `rename_prose_page` | Rename a prose page. |
 
 ### Structure (write)
@@ -222,13 +222,16 @@ reload):
   prose. (A new `add_prose_page` page's *tab* may lag until the prose page list
   syncs; its content lands immediately.)
 - **Anchored prose edits** (`set_prose` with `anchor`) are the *targeted* path:
-  the block whose text matches the anchor is the only one rewritten, so the CRDT
-  delta touches just that block and a concurrent edit elsewhere on the page is
-  preserved. The anchor doubles as a **block-level compare-and-swap** — it must
-  match exactly one block (matched against the live fragment when resident, the
-  JSON content when cold), so a stale anchor is refused (`ERR_ANCHOR_*`) rather
-  than clobbering drifted content. (Full PM-tree diff-merge for *whole-page*
-  writes is future work.)
+  the anchor matches the smallest text-bearing line — a paragraph, heading, or a
+  single bullet/table-cell line **anywhere** on the page (the walk descends through
+  lists, tables, and blockquotes) — and only that line is rewritten, so the CRDT
+  delta touches just it and a concurrent edit elsewhere is preserved. Because a
+  line (never a container) is replaced, the surrounding list/table/quote and every
+  sibling pass through verbatim. `anchorUntil` spans sibling lines under one parent.
+  The anchor doubles as a **compare-and-swap** — it must match exactly one line
+  (against the live fragment when resident, the JSON content when cold), so a stale
+  anchor is refused (`ERR_ANCHOR_*`) rather than clobbering drifted content.
+  Structural moves (indent/outdent/move a bullet) are a separate future path.
 
 **Cold docs (no client connected).** Writes persist through an
 **optimistic-concurrency check** on the document's `serverVersion`: read the

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -43,6 +43,13 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
 - Tables must be rectangular: a <table> of <tr> rows, each row the same number of
   <td>/<th> cells, every cell holding block content. Ragged tables are padded.
 - A page is never truly empty; an empty write leaves one empty paragraph.
+- Block formatting round-trips, so you can read it back and set it: a cell's
+  colour/alignment (<td style="background-color: …; text-align: …">), a header's
+  scope, paragraph/heading alignment (style="text-align: …"), an ordered list's
+  start. Set these by writing the styled HTML with format:"html".
+- To change ONE line without rewriting the page, use set_prose with anchor = that
+  line's current text — it reaches a single bullet, table cell, heading, or
+  paragraph anywhere on the page, leaving its list/table/quote and siblings intact.
 
 ## Shapes (generate_diagram / add_shape / connect)
 - Prefer generate_diagram for anything with edges: pass nodes [{id,label,kind?}]

--- a/relay/src/mcp/skills/meeting-notes-to-doc.SKILL.md
+++ b/relay/src/mcp/skills/meeting-notes-to-doc.SKILL.md
@@ -57,10 +57,14 @@ clearly describe a flow worth drawing.
    - `insert_section(docId, prosePageId, level, title, body, afterIndex?)` to slot a
      new section in a specific spot.
 
-5. **Refine a single section** without touching the rest by calling `set_prose`
-   with `anchor` = the exact current text of the block to replace (read it first
-   with `get_prose`; it's a compare-and-swap that errors rather than clobbering if
-   ambiguous).
+5. **Refine one line in place** — a paragraph, a single bullet, a table cell, or a
+   heading — without touching the rest by calling `set_prose` with `anchor` = the
+   exact current text of that line (read it first with `get_prose`; it's a
+   compare-and-swap that errors rather than clobbering if ambiguous). The anchor
+   reaches a line anywhere on the page; its list/table/quote and every sibling pass
+   through untouched, so you never rewrite a whole list to fix one bullet. To change
+   a line's formatting (e.g. a table cell's colour or a paragraph's alignment),
+   write the styled HTML with `format:"html"` — block formatting round-trips.
 
 6. **Confirm.** `get_prose(docId, prosePageId)` to review, then return the document
    id/name and a one-line recap (e.g. "3 decisions, 5 action items").

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -342,16 +342,16 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark_set_prose",
             description:
-                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' (the current text of the block to change): then 'content' replaces only that block, leaving the rest of the page untouched — preferred when editing one part of a longer page. The anchor must match exactly one block (it doubles as a confirmation lock; if it matches none or several you get an ERR_ANCHOR_* error — read the page first and copy the block's text). Content is Markdown by default (set format:\"html\"). Refuses local (renderer-owned) documents. Unsure what valid content looks like? Call get_skills first for the content contract.",
+                "Write a prose page. By default replaces the entire page body with 'content'. For a TARGETED edit, pass 'anchor' — the current text of the line you want to change: 'content' then replaces only that line, leaving the rest of the page (and all its formatting) untouched. This reaches a single bullet, numbered item, table cell, heading, or paragraph anywhere on the page (you anchor the text you see; the surrounding list/table/quote passes through) — strongly preferred over rewriting the whole page. The anchor must match exactly one line (it doubles as a confirmation lock; none or several → an ERR_ANCHOR_* error, so read the page first and copy the line's text; whitespace is normalized and styling/marks are ignored). Content is Markdown by default (set format:\"html\"). Table cell colour/alignment, heading/paragraph alignment, and other block formatting now round-trip, so you can set them by writing the styled HTML with format:\"html\". Refuses local (renderer-owned) documents. Unsure what valid content looks like? Call get_skills first for the content contract.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "docId": {"type": "string"},
                     "pageId": {"type": "string"},
-                    "content": {"type": "string", "maxLength": MAX_PROSE_CONTENT_BYTES, "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched block(s). Markdown unless format is \"html\". Capped at ~1 MiB."},
+                    "content": {"type": "string", "maxLength": MAX_PROSE_CONTENT_BYTES, "description": "New content. The whole page body, or — with 'anchor' — just the replacement for the matched line(s). Markdown unless format is \"html\". Capped at ~1 MiB."},
                     "format": {"type": "string", "enum": ["markdown", "html"], "description": "Interpretation of content. Default: \"markdown\"."},
-                    "anchor": {"type": "string", "description": "Optional. The current text of the block to replace (a targeted edit). Must match exactly one top-level block; whitespace is normalized and styling/marks are ignored. Omit to replace the whole page."},
-                    "anchorUntil": {"type": "string", "description": "Optional. With 'anchor', replace the inclusive span of blocks from 'anchor' through the block matching this text."}
+                    "anchor": {"type": "string", "description": "Optional. The current text of the line to replace — a single bullet, table cell, heading, or paragraph, anywhere on the page (its container passes through). Must match exactly one line; whitespace is normalized and styling/marks are ignored. Omit to replace the whole page."},
+                    "anchorUntil": {"type": "string", "description": "Optional. With 'anchor', replace the inclusive span of sibling lines (same parent block) from 'anchor' through the line matching this text."}
                 },
                 "required": ["docId", "pageId", "content"],
                 "additionalProperties": false
@@ -1919,13 +1919,14 @@ struct SetProseArgs {
     page_id: String,
     content: String,
     format: Option<String>,
-    /// JP-239: when present, `content` replaces only the block matching this
-    /// text (a targeted edit) instead of the whole page. The block's current
-    /// text — the anchor doubles as a write-confirmation lock (must match
-    /// exactly one block).
+    /// JP-239 / JP-429: when present, `content` replaces only the leaf line
+    /// matching this text (a targeted edit) instead of the whole page — a single
+    /// bullet, table cell, heading, or paragraph anywhere on the page, with its
+    /// container and siblings untouched. Doubles as a write-confirmation lock
+    /// (must match exactly one line).
     anchor: Option<String>,
-    /// JP-239: with `anchor`, replace the inclusive span of blocks from `anchor`
-    /// through the block matching this text.
+    /// JP-239: with `anchor`, replace the inclusive span of sibling lines (same
+    /// parent block) from `anchor` through the line matching this text.
     #[serde(rename = "anchorUntil")]
     anchor_until: Option<String>,
 }

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -30,7 +30,7 @@ use yrs::{
 };
 
 use super::prose_parse::{self, PmChild, PmNode};
-use super::{build_prose_children, build_prose_node, prose_html};
+use super::{build_prose_children, build_prose_node, prose_html, prose_schema};
 
 /// One addressable prose leaf in the fragment tree (JP-429): the smallest
 /// text-bearing block (a paragraph, heading, or code block) — a bullet's line,
@@ -122,12 +122,26 @@ pub fn replace_block_in_fragment(
 fn collect_targets<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> Vec<Target> {
     let mut out = Vec::new();
     for (i, node) in frag.children(txn).enumerate() {
-        walk_target(&node, txn, vec![i as u32], &mut out);
+        walk_target(&node, txn, vec![i as u32], 0, &mut out);
     }
     out
 }
 
-fn walk_target<T: ReadTxn>(node: &XmlOut, txn: &T, path: Vec<u32>, out: &mut Vec<Target>) {
+/// Depth-bounded like the serializer and parser (JP-248): a live `prose:`
+/// fragment can be nested arbitrarily deep via the raw WS sync path (bypassing
+/// the parser's cap), so an unbounded walk here would overflow the stack and
+/// abort the relay on a pathological doc. Beyond [`prose_schema::MAX_PROSE_DEPTH`]
+/// leaves are simply unaddressable — the same content the serializer omits.
+fn walk_target<T: ReadTxn>(
+    node: &XmlOut,
+    txn: &T,
+    path: Vec<u32>,
+    depth: usize,
+    out: &mut Vec<Target>,
+) {
+    if depth >= prose_schema::MAX_PROSE_DEPTH {
+        return;
+    }
     let XmlOut::Element(el) = node else {
         return; // stray text/fragment at block level — not addressable
     };
@@ -139,7 +153,7 @@ fn walk_target<T: ReadTxn>(node: &XmlOut, txn: &T, path: Vec<u32>, out: &mut Vec
     for (i, child) in el.children(txn).enumerate() {
         let mut p = path.clone();
         p.push(i as u32);
-        walk_target(&child, txn, p, out);
+        walk_target(&child, txn, p, depth + 1, out);
     }
 }
 
@@ -223,14 +237,20 @@ fn descend<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T, path: &[u32]) -> Option<X
 /// All descendant text of a leaf element (its inline content), concatenated.
 fn all_text<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
     let mut out = String::new();
-    collect_all_text(el, txn, &mut out);
+    collect_all_text(el, txn, 0, &mut out);
     out
 }
 
-fn collect_all_text<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String) {
+/// Depth-bounded (JP-248): a leaf normally holds only shallow inline content,
+/// but a raw-sync fragment can nest elements arbitrarily inside one, so cap the
+/// recursion to keep anchor matching from overflowing the stack.
+fn collect_all_text<T: ReadTxn>(el: &XmlElementRef, txn: &T, depth: usize, out: &mut String) {
+    if depth >= prose_schema::MAX_PROSE_DEPTH {
+        return;
+    }
     for child in el.children(txn) {
         match child {
-            XmlOut::Element(cel) => collect_all_text(&cel, txn, out),
+            XmlOut::Element(cel) => collect_all_text(&cel, txn, depth + 1, out),
             XmlOut::Text(t) => {
                 for run in t.diff(txn, |_| ()) {
                     if let Out::Any(Any::String(s)) = &run.insert {
@@ -241,7 +261,7 @@ fn collect_all_text<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String) {
             XmlOut::Fragment(f) => {
                 for c in f.children(txn) {
                     if let XmlOut::Element(cel) = &c {
-                        collect_all_text(cel, txn, out);
+                        collect_all_text(cel, txn, depth + 1, out);
                     }
                 }
             }
@@ -605,6 +625,35 @@ mod tests {
             b,
             "<blockquote><p>quote</p><ul><li><p>b1!</p></li><li><p>b2</p></li></ul></blockquote>"
         );
+    }
+
+    #[test]
+    fn deep_resident_fragment_does_not_overflow_the_anchor_walk() {
+        // JP-248: a live prose: fragment can be nested arbitrarily deep via the
+        // raw WS sync path (bypassing the parser's cap). The anchor walk must be
+        // depth-bounded like the serializer, or it overflows the stack (aborting
+        // the relay) on an anchored set_prose. Build a pathologically deep
+        // subtree beside a shallow, addressable leaf; anchoring the shallow leaf
+        // must complete — the walk stops at the cap instead of recursing to the
+        // bottom. The test *finishing* is the proof.
+        use yrs::XmlTextPrelim;
+        let doc = Doc::new();
+        let frag = doc.get_or_insert_xml_fragment("prose:deep");
+        {
+            let mut txn = doc.transact_mut();
+            let p = frag.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(&mut txn, XmlTextPrelim::new("top"));
+            let mut cur = frag.push_back(&mut txn, XmlElementPrelim::empty("blockquote"));
+            for _ in 0..10_000 {
+                cur = cur.push_back(&mut txn, XmlElementPrelim::empty("blockquote"));
+            }
+            let deep_p = cur.push_back(&mut txn, XmlElementPrelim::empty("paragraph"));
+            deep_p.push_back(&mut txn, XmlTextPrelim::new("bottom"));
+            replace_block_in_fragment(&frag, &mut txn, "top", None, "<p>TOP</p>").unwrap();
+        }
+        let txn = doc.transact();
+        let out = prose_html::fragment_to_html(&frag, &txn);
+        assert!(out.starts_with("<p>TOP</p>"), "shallow leaf not replaced: {}", &out[..out.len().min(40)]);
     }
 
     #[test]

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -25,70 +25,228 @@
 //! [`super::prose_html`].
 
 use yrs::{
-    Any, Doc, Out, ReadTxn, Text, Transact, TransactionMut, Xml, XmlElementPrelim, XmlFragment,
-    XmlOut,
+    Any, Doc, Out, ReadTxn, Text, Transact, TransactionMut, Xml, XmlElementPrelim, XmlElementRef,
+    XmlFragment, XmlFragmentRef, XmlOut,
 };
 
 use super::prose_parse::{self, PmChild, PmNode};
 use super::{build_prose_children, build_prose_node, prose_html};
 
-/// Replace the top-level block(s) matching `anchor` (through `anchor_until`, if
+/// One addressable prose leaf in the fragment tree (JP-429): the smallest
+/// text-bearing block (a paragraph, heading, or code block) — a bullet's line,
+/// a table cell's line, a quote's line — *wherever* it sits. `path` is the raw
+/// child-index chain from the fragment root; `text` is its normalized text, the
+/// anchor. Addressing the leaf (never a container) means a targeted edit can
+/// never destroy surrounding structure: the leaf's container and every sibling —
+/// including nested lists/tables — are untouched by the splice.
+struct Target {
+    path: Vec<u32>,
+    text: String,
+}
+
+/// The text-bearing leaf blocks an anchor can target. Everything else is a
+/// container the walk descends *through* to reach these (lists, tables, cells,
+/// list items, blockquotes, callouts, and any unknown wrapper).
+const TEXT_LEAVES: &[&str] = &["paragraph", "heading", "codeBlock"];
+
+/// Replace the addressable leaf(s) matching `anchor` (through `anchor_until`, if
 /// given) with the blocks parsed from `new_html`, in a single transaction.
 ///
+/// Anchoring reaches leaves at any depth (JP-429): a bullet's line, a cell's
+/// line, a quote's line — matched by their text. Because a *leaf* is replaced in
+/// its own container, every sibling and all surrounding structure (lists, tables,
+/// nested blocks) pass through verbatim; a targeted edit can't destroy them.
 /// Anchor resolution happens before any mutation, so an `Err` (no match /
-/// ambiguous / bad range) leaves the fragment untouched. An edit that would empty
-/// the fragment re-seeds a single empty paragraph (the editor's "a page is never
-/// truly empty" invariant, matching [`super::DocHandle::replace_prose`]).
-pub fn replace_block_in_fragment<F: XmlFragment>(
-    frag: &F,
+/// ambiguous / bad range) leaves the fragment untouched. An edit that empties the
+/// leaf's container (or the page) re-seeds a single empty paragraph (the editor's
+/// "a page is never truly empty" invariant).
+pub fn replace_block_in_fragment(
+    frag: &XmlFragmentRef,
     txn: &mut TransactionMut,
     anchor: &str,
     anchor_until: Option<&str>,
     new_html: &str,
 ) -> Result<(), String> {
-    // Snapshot each top-level block's normalized text up front (owned, so the
-    // read-borrow is released before we mutate below).
-    let block_texts: Vec<String> = {
-        let mut v = Vec::new();
-        for node in frag.children(&*txn) {
-            v.push(normalize(&xml_block_text(&node, &*txn)));
-        }
-        v
-    };
+    // Snapshot the addressable leaves up front (owned, so the read-borrow is
+    // released before we mutate).
+    let targets = collect_targets(frag, &*txn);
 
-    let start = resolve_anchor(&block_texts, anchor, "anchor")?;
-    let end = match anchor_until {
-        None => start,
+    let start = resolve_target(&targets, anchor, "anchor")?;
+    let start_path = start.path.clone();
+    let start_idx = *start_path.last().expect("target path is non-empty");
+
+    let end_idx = match anchor_until {
+        None => start_idx,
         Some(until) => {
-            let e = resolve_anchor(&block_texts, until, "anchorUntil")?;
-            if e < start {
-                return Err(
-                    "ERR_ANCHOR_RANGE: anchorUntil matches a block before anchor".into(),
-                );
+            let end = resolve_target(&targets, until, "anchorUntil")?;
+            // Must be a sibling of `anchor` (same parent block) — a span across
+            // different containers (e.g. two separate bullets, each its own list
+            // item) has no single slot to splice, so it's refused.
+            let same_parent = end.path.len() == start_path.len()
+                && end.path[..end.path.len() - 1] == start_path[..start_path.len() - 1];
+            if !same_parent {
+                return Err("ERR_ANCHOR_RANGE: anchorUntil must be a sibling of anchor \
+                            (same parent block)"
+                    .into());
             }
-            e
+            let ei = *end.path.last().unwrap();
+            if ei < start_idx {
+                return Err("ERR_ANCHOR_RANGE: anchorUntil matches a block before anchor".into());
+            }
+            ei
         }
     };
-    let count = (end - start + 1) as u32;
+    let parent_path: Vec<u32> = start_path[..start_path.len() - 1].to_vec();
+    let count = end_idx - start_idx + 1;
 
     // Gate (JP-328): validate + normalize the inserted blocks before they reach
     // the fragment, so an anchored write can't smuggle a malformed node past the
-    // whole-page gate. Covers both the live path (replace_prose_block) and the
-    // cold path (replace_block_in_html delegates here).
+    // whole-page gate. Covers the live path (replace_prose_block) and the cold
+    // path (replace_block_in_html delegates here).
     let (new_blocks, fixes) =
         super::prose_validate::sanitize_blocks(prose_parse::html_to_blocks(new_html));
     if !fixes.is_empty() {
         log::info!("prose_validate healed {} defect(s) in anchored prose write: {fixes:?}", fixes.len());
     }
 
-    frag.remove_range(txn, start as u32, count);
-    for (i, node) in new_blocks.iter().enumerate() {
-        build_prose_node_at(frag, txn, start as u32 + i as u32, node);
-    }
-    if frag.len(txn) == 0 {
-        build_prose_node(frag, txn, &empty_paragraph());
-    }
+    splice(frag, txn, &parent_path, start_idx, count, &new_blocks);
+    reseed_if_empty(frag, txn, &parent_path);
     Ok(())
+}
+
+/// Walk the fragment into a flat list of addressable leaf [`Target`]s: descend
+/// through every container (lists, tables, cells, list items, blockquotes,
+/// callouts, unknown wrappers) and emit each text-bearing leaf ([`TEXT_LEAVES`])
+/// with its path + normalized text. A leaf holds only inline content, so it's
+/// never descended into.
+fn collect_targets<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T) -> Vec<Target> {
+    let mut out = Vec::new();
+    for (i, node) in frag.children(txn).enumerate() {
+        walk_target(&node, txn, vec![i as u32], &mut out);
+    }
+    out
+}
+
+fn walk_target<T: ReadTxn>(node: &XmlOut, txn: &T, path: Vec<u32>, out: &mut Vec<Target>) {
+    let XmlOut::Element(el) = node else {
+        return; // stray text/fragment at block level — not addressable
+    };
+    if TEXT_LEAVES.contains(&el.tag().as_ref()) {
+        out.push(Target { path, text: normalize(&all_text(el, txn)) });
+        return; // a leaf holds only inline content
+    }
+    // A container → descend to reach the leaves inside it.
+    for (i, child) in el.children(txn).enumerate() {
+        let mut p = path.clone();
+        p.push(i as u32);
+        walk_target(&child, txn, p, out);
+    }
+}
+
+/// Find the single leaf whose normalized text equals the anchor's. `field` names
+/// the offending argument in the error.
+fn resolve_target<'a>(targets: &'a [Target], raw: &str, field: &str) -> Result<&'a Target, String> {
+    let needle = normalize(&anchor_to_text(raw));
+    if needle.is_empty() {
+        return Err(format!("ERR_ANCHOR_EMPTY: {field} has no text content"));
+    }
+    let hits: Vec<&Target> = targets.iter().filter(|t| t.text == needle).collect();
+    match hits.len() {
+        0 => Err(format!(
+            "ERR_ANCHOR_NOT_FOUND: no prose block matches {field}={raw:?} — its text may have \
+             changed, or you must pass the block's full text"
+        )),
+        1 => Ok(hits[0]),
+        n => Err(format!(
+            "ERR_ANCHOR_AMBIGUOUS: {n} prose blocks match {field}={raw:?} — include more of the \
+             block's text to identify exactly one"
+        )),
+    }
+}
+
+/// Remove `count` children starting at `start` under the element at `parent_path`
+/// (the fragment root when the path is empty) and insert `nodes` in their place.
+fn splice(
+    frag: &XmlFragmentRef,
+    txn: &mut TransactionMut,
+    parent_path: &[u32],
+    start: u32,
+    count: u32,
+    nodes: &[PmNode],
+) {
+    if parent_path.is_empty() {
+        frag.remove_range(txn, start, count);
+        for (i, node) in nodes.iter().enumerate() {
+            build_prose_node_at(frag, txn, start + i as u32, node);
+        }
+    } else if let Some(parent) = descend(frag, &*txn, parent_path) {
+        parent.remove_range(txn, start, count);
+        for (i, node) in nodes.iter().enumerate() {
+            build_prose_node_at(&parent, txn, start + i as u32, node);
+        }
+    }
+}
+
+/// If a delete emptied the leaf's container (the page root, or a content block
+/// like a list item / cell / blockquote that must hold `block+`), re-seed one
+/// empty paragraph — the editor's "never truly empty" invariant. A leaf's parent
+/// is always the root or a block-holding container (never a list/table/row, which
+/// hold items/rows/cells, not leaves), so a single-level reseed suffices.
+fn reseed_if_empty(frag: &XmlFragmentRef, txn: &mut TransactionMut, parent_path: &[u32]) {
+    if parent_path.is_empty() {
+        if frag.len(&*txn) == 0 {
+            build_prose_node(frag, txn, &empty_paragraph());
+        }
+    } else if let Some(el) = descend(frag, &*txn, parent_path) {
+        if el.len(&*txn) == 0 {
+            build_prose_node(&el, txn, &empty_paragraph());
+        }
+    }
+}
+
+/// Resolve the element at `path` (non-empty) by walking child indices from the
+/// fragment root. `None` if any step is missing or not an element.
+fn descend<T: ReadTxn>(frag: &XmlFragmentRef, txn: &T, path: &[u32]) -> Option<XmlElementRef> {
+    let mut el = match frag.get(txn, *path.first()?)? {
+        XmlOut::Element(e) => e,
+        _ => return None,
+    };
+    for &idx in &path[1..] {
+        el = match el.get(txn, idx)? {
+            XmlOut::Element(e) => e,
+            _ => return None,
+        };
+    }
+    Some(el)
+}
+
+/// All descendant text of a leaf element (its inline content), concatenated.
+fn all_text<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let mut out = String::new();
+    collect_all_text(el, txn, &mut out);
+    out
+}
+
+fn collect_all_text<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String) {
+    for child in el.children(txn) {
+        match child {
+            XmlOut::Element(cel) => collect_all_text(&cel, txn, out),
+            XmlOut::Text(t) => {
+                for run in t.diff(txn, |_| ()) {
+                    if let Out::Any(Any::String(s)) = &run.insert {
+                        out.push_str(s);
+                    }
+                }
+            }
+            XmlOut::Fragment(f) => {
+                for c in f.children(txn) {
+                    if let XmlOut::Element(cel) = &c {
+                        collect_all_text(cel, txn, out);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Apply [`replace_block_in_fragment`] to a page's HTML without a live `Doc`:
@@ -112,32 +270,6 @@ pub fn replace_block_in_html(
     }
     let txn = doc.transact();
     Ok(prose_html::fragment_to_html(&frag, &txn))
-}
-
-/// Find the single block whose normalized text equals the anchor's normalized
-/// text. `field` names the offending argument in the error.
-fn resolve_anchor(block_texts: &[String], raw: &str, field: &str) -> Result<usize, String> {
-    let needle = normalize(&anchor_to_text(raw));
-    if needle.is_empty() {
-        return Err(format!("ERR_ANCHOR_EMPTY: {field} has no text content"));
-    }
-    let hits: Vec<usize> = block_texts
-        .iter()
-        .enumerate()
-        .filter(|(_, t)| t.as_str() == needle)
-        .map(|(i, _)| i)
-        .collect();
-    match hits.len() {
-        0 => Err(format!(
-            "ERR_ANCHOR_NOT_FOUND: no prose block matches {field}={raw:?} — its text may have \
-             changed, or you must pass the block's full text"
-        )),
-        1 => Ok(hits[0]),
-        n => Err(format!(
-            "ERR_ANCHOR_AMBIGUOUS: {n} prose blocks match {field}={raw:?} — include more of the \
-             block's text to identify exactly one"
-        )),
-    }
 }
 
 /// Insert one PM node (and subtree) at `index` among `parent`'s children. The
@@ -179,35 +311,6 @@ fn pm_node_text(node: &PmNode, out: &mut String) {
         match child {
             PmChild::Text { text, .. } => out.push_str(text),
             PmChild::Node(n) => pm_node_text(n, out),
-        }
-    }
-}
-
-/// All descendant text of one top-level fragment block, concatenated.
-fn xml_block_text<T: ReadTxn>(node: &XmlOut, txn: &T) -> String {
-    let mut out = String::new();
-    collect_xml_text(node, txn, &mut out);
-    out
-}
-
-fn collect_xml_text<T: ReadTxn>(node: &XmlOut, txn: &T, out: &mut String) {
-    match node {
-        XmlOut::Element(el) => {
-            for child in el.children(txn) {
-                collect_xml_text(&child, txn, out);
-            }
-        }
-        XmlOut::Text(t) => {
-            for run in t.diff(txn, |_| ()) {
-                if let Out::Any(Any::String(s)) = &run.insert {
-                    out.push_str(s);
-                }
-            }
-        }
-        XmlOut::Fragment(f) => {
-            for child in f.children(txn) {
-                collect_xml_text(&child, txn, out);
-            }
         }
     }
 }
@@ -371,6 +474,261 @@ mod tests {
         assert_eq!(
             out,
             "<h2>Goals</h2><ul><li><p>one</p></li></ul><p>replaced</p>"
+        );
+    }
+
+    // ---- JP-429: nested-unit anchoring (bullets, cells, blockquotes) ----------
+
+    #[test]
+    fn replaces_a_single_bullet_leaving_the_list_and_siblings() {
+        // The reported bug: an agent must be able to change ONE bullet without
+        // rewriting the whole list.
+        let out = apply(
+            "<ul><li><p>one</p></li><li><p>two</p></li><li><p>three</p></li></ul>",
+            "two",
+            None,
+            "two revised",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "<ul><li><p>one</p></li><li><p>two revised</p></li><li><p>three</p></li></ul>"
+        );
+    }
+
+    #[test]
+    fn a_bullet_stays_a_bullet_when_replaced_with_a_paragraph() {
+        // Coercion: replacing a list item with `<p>` content keeps it an <li>.
+        let out = apply("<ol><li><p>a</p></li></ol>", "a", None, "<p>b</p>").unwrap();
+        assert_eq!(out, "<ol><li><p>b</p></li></ol>");
+    }
+
+    #[test]
+    fn clearing_a_bullets_text_keeps_an_empty_bullet() {
+        // A content edit (empty replacement) clears the bullet's text but keeps
+        // the bullet — removing the item is a structural op (deferred), so we
+        // never destroy list structure from a text edit.
+        let out = apply("<ul><li><p>only</p></li></ul>", "only", None, "").unwrap();
+        assert_eq!(out, "<ul><li><p></p></li></ul>");
+    }
+
+    #[test]
+    fn nested_sub_bullet_is_addressed_independently_of_its_parent() {
+        // The parent item's own text ("outer") and the sub-bullet ("inner") are
+        // distinct anchors; editing the sub-bullet leaves the parent line intact.
+        let out = apply(
+            "<ul><li><p>outer</p><ul><li><p>inner</p></li></ul></li></ul>",
+            "inner",
+            None,
+            "inner!",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "<ul><li><p>outer</p><ul><li><p>inner!</p></li></ul></li></ul>"
+        );
+    }
+
+    #[test]
+    fn anchor_until_spans_sibling_leaves_in_one_parent() {
+        // Sibling leaves under the SAME parent (here two top-level paragraphs)
+        // collapse into the replacement; surrounding blocks are untouched.
+        let out = apply(
+            "<h1>T</h1><p>a</p><p>b</p><p>c</p>",
+            "a",
+            Some("b"),
+            "merged",
+        )
+        .unwrap();
+        assert_eq!(out, "<h1>T</h1><p>merged</p><p>c</p>");
+    }
+
+    #[test]
+    fn cross_parent_range_is_refused() {
+        // Two bullets live in separate list items (separate parents), so a span
+        // across them has no single slot — refuse rather than corrupt.
+        let err = apply(
+            "<ul><li><p>a</p></li><li><p>b</p></li></ul>",
+            "a",
+            Some("b"),
+            "x",
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_RANGE"), "{err}");
+    }
+
+    #[test]
+    fn replaces_a_single_table_cell_keeping_the_row() {
+        let out = apply(
+            "<table><tr><td><p>a</p></td><td><p>b</p></td></tr></table>",
+            "b",
+            None,
+            "b2",
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "<table><tr><td><p>a</p></td><td><p>b2</p></td></tr></table>"
+        );
+    }
+
+    #[test]
+    fn a_deeply_nested_leaf_is_edited_without_touching_its_ancestors() {
+        // The generative regression: a heading buried in nested blockquotes beside
+        // a list — editing it must leave the list and wrappers verbatim.
+        let doc = "<blockquote><blockquote>\
+            <ul><li><p>b0</p></li><li><p>b1</p></li></ul><h2>deep</h2>\
+            </blockquote></blockquote>";
+        // Supply HTML to keep it a heading; the surrounding list + wrappers are
+        // untouched.
+        let out = apply(doc, "deep", None, "<h2>DEEP</h2>").unwrap();
+        assert_eq!(
+            out,
+            "<blockquote><blockquote>\
+             <ul><li><p>b0</p></li><li><p>b1</p></li></ul><h2>DEEP</h2>\
+             </blockquote></blockquote>"
+        );
+    }
+
+    #[test]
+    fn inner_lines_of_a_blockquote_are_addressable_and_isolated() {
+        // A blockquote wrapping a list: the quote's own line and each inner bullet
+        // are separately addressable, and editing one leaves the rest intact.
+        let doc = "<blockquote><p>quote</p><ul><li><p>b1</p></li><li><p>b2</p></li></ul></blockquote>";
+        let q = apply(doc, "quote", None, "quote!").unwrap();
+        assert_eq!(
+            q,
+            "<blockquote><p>quote!</p><ul><li><p>b1</p></li><li><p>b2</p></li></ul></blockquote>"
+        );
+        let b = apply(doc, "b1", None, "b1!").unwrap();
+        assert_eq!(
+            b,
+            "<blockquote><p>quote</p><ul><li><p>b1!</p></li><li><p>b2</p></li></ul></blockquote>"
+        );
+    }
+
+    #[test]
+    fn identical_bullets_are_ambiguous() {
+        let err = apply(
+            "<ul><li><p>dup</p></li><li><p>dup</p></li></ul>",
+            "dup",
+            None,
+            "x",
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_AMBIGUOUS"), "{err}");
+    }
+
+    // ---- JP-429: generative invariants (seed-logged, house fuzz style) --------
+
+    /// Build a random valid prose doc with **uniquely-labelled** leaf text, plus
+    /// the set of every leaf label it contains. Bounded depth so it terminates.
+    fn gen_doc(rng: &mut impl rand::Rng, next: &mut u32, depth: u32) -> (String, Vec<String>) {
+        let mut html = String::new();
+        let mut labels = Vec::new();
+        let blocks = 1 + rng.gen_range(0..4u32);
+        for _ in 0..blocks {
+            match rng.gen_range(0..if depth == 0 { 3 } else { 5 }) {
+                0 => {
+                    let l = format!("t{}", *next);
+                    *next += 1;
+                    html.push_str(&format!("<p>{l}</p>"));
+                    labels.push(l);
+                }
+                1 => {
+                    let l = format!("t{}", *next);
+                    *next += 1;
+                    html.push_str(&format!("<h2>{l}</h2>"));
+                    labels.push(l);
+                }
+                2 => {
+                    // A list of leaf items (no nested lists here — that's covered
+                    // by the recursive case below, which the guard refuses to
+                    // wholesale-replace, so its items are edited instead).
+                    html.push_str("<ul>");
+                    for _ in 0..1 + rng.gen_range(0..3u32) {
+                        let l = format!("t{}", *next);
+                        *next += 1;
+                        html.push_str(&format!("<li><p>{l}</p></li>"));
+                        labels.push(l);
+                    }
+                    html.push_str("</ul>");
+                }
+                3 => {
+                    // A single-row table of leaf cells.
+                    html.push_str("<table><tr>");
+                    for _ in 0..1 + rng.gen_range(0..3u32) {
+                        let l = format!("t{}", *next);
+                        *next += 1;
+                        html.push_str(&format!("<td><p>{l}</p></td>"));
+                        labels.push(l);
+                    }
+                    html.push_str("</tr></table>");
+                }
+                _ => {
+                    let (inner, inner_labels) = gen_doc(rng, next, depth - 1);
+                    html.push_str(&format!("<blockquote>{inner}</blockquote>"));
+                    labels.extend(inner_labels);
+                }
+            }
+        }
+        (html, labels)
+    }
+
+    /// Invariants over random nested docs: every uniquely-texted, non-wrapping
+    /// unit is editable; the edit changes ONLY that unit's text (no other label is
+    /// lost or altered); and re-applying the same anchor is a fixed point. Prints
+    /// the seed on failure for deterministic repro (`DOCUSHARK_FUZZ_SEED`).
+    #[test]
+    fn generative_anchored_edits_never_lose_sibling_content() {
+        use rand::SeedableRng;
+        let seed: u64 = std::env::var("DOCUSHARK_FUZZ_SEED")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| rand::random());
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+        for _ in 0..300 {
+            let mut next = 0u32;
+            let (doc, labels) = gen_doc(&mut rng, &mut next, 2);
+            // Pick a label to edit that is unambiguous and not a wrapping unit.
+            let frag_html = doc.clone();
+            let target = labels.iter().find(|l| {
+                // resolvable to exactly one unit, and editing it is allowed
+                matches!(apply(&frag_html, l, None, &format!("{l}_X")), Ok(_))
+            });
+            let Some(label) = target else { continue };
+            let out = apply(&doc, label, None, &format!("{label}_X"))
+                .unwrap_or_else(|e| panic!("seed={seed} doc={doc:?} anchor={label:?}: {e}"));
+            // The edited label is gone-as-standalone (now `{label}_X`), every OTHER
+            // label survives verbatim, and the new text is present.
+            assert!(out.contains(&format!("{label}_X")), "seed={seed}: edit not applied: {out}");
+            for other in labels.iter().filter(|l| *l != label) {
+                assert!(
+                    out.contains(&format!(">{other}<")),
+                    "seed={seed}: sibling label {other:?} lost editing {label:?}\n doc={doc}\n out={out}"
+                );
+            }
+            // Fixed point: serialize→parse→serialize is stable.
+            let twice = apply(&out, &format!("{label}_X"), None, &format!("{label}_X"))
+                .unwrap_or_else(|e| panic!("seed={seed} refixed: {e}"));
+            assert_eq!(out, twice, "seed={seed}: not a fixed point");
+        }
+    }
+
+    /// No-collateral-damage invariant: after an anchored edit, every unit whose
+    /// own text isn't the anchor serializes byte-identically to before. Here the
+    /// whole surrounding document is asserted verbatim, which is the strongest
+    /// form for a fixed fixture.
+    #[test]
+    fn edit_touches_only_the_matched_unit() {
+        let before = "<h2>H</h2><ul><li><p>a</p></li><li><p>target</p></li></ul>\
+                      <table><tr><td><p>c1</p></td><td><p>c2</p></td></tr></table><p>tail</p>";
+        let out = apply(before, "target", None, "TARGET").unwrap();
+        assert_eq!(
+            out,
+            "<h2>H</h2><ul><li><p>a</p></li><li><p>TARGET</p></li></ul>\
+             <table><tr><td><p>c1</p></td><td><p>c2</p></td></tr></table><p>tail</p>"
         );
     }
 }

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -112,12 +112,14 @@ fn write_element<T: ReadTxn>(el: &XmlElementRef, txn: &T, out: &mut String, dept
 /// node set (StarterKit + table/task-list/etc.); unmapped types degrade to
 /// [`Block::Transparent`].
 fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
-    let wrap = |tag: &'static str| Block::Wrap {
-        open: format!("<{tag}>"),
+    // JP-429: `pm_type` is the same as `tag` here (paragraph, tableCell, …), so a
+    // single call injects the allowlisted formatting attrs into the open tag.
+    let wrap = |tag: &'static str, pm_type: &str| Block::Wrap {
+        open: format!("<{tag}{}>", block_attr_html(el, txn, pm_type)),
         close: leading_close(tag),
     };
     match el.tag().as_ref() {
-        "paragraph" => wrap("p"),
+        "paragraph" => wrap("p", "paragraph"),
         "heading" => {
             let level = el
                 .get_attribute(txn, "level")
@@ -125,7 +127,7 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
                 .filter(|l| (1..=6).contains(l))
                 .unwrap_or(1);
             Block::Wrap {
-                open: format!("<h{level}>"),
+                open: format!("<h{level}{}>", block_attr_html(el, txn, "heading")),
                 close: match level {
                     1 => "</h1>",
                     2 => "</h2>",
@@ -184,15 +186,56 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
         }
         // Task list/item are read-only aliases of ul/li (not in the shared
         // round-trip table — a write never re-emits these PM types).
-        "taskList" => wrap("ul"),
-        "taskItem" => wrap("li"),
+        "taskList" => wrap("ul", "taskList"),
+        "taskItem" => wrap("li", "taskItem"),
         // Everything else round-trips 1:1 via the shared schema (paragraph,
         // lists, blockquote, tables); unmapped types degrade to their children.
+        // JP-429: `other` is the PM type, so allowlisted block attrs (cell
+        // background/align/scope, ordered-list start) round-trip.
         other => match prose_schema::simple_block_html(other) {
-            Some(html) => wrap(html),
+            Some(html) => wrap(html, other),
             None => Block::Transparent,
         },
     }
+}
+
+/// JP-429: serialize the allowlisted block attributes ([`prose_schema::BLOCK_ATTRS`])
+/// for `pm_type` into the element's open tag — plain attrs (`scope`, `start`) as
+/// `name="v"`, and all `Style`-encoded attrs merged into one deterministic
+/// `style="prop: v; …"` (row order), matching the shape the editor's `renderHTML`
+/// emits so the editor re-parses it cleanly. Empty string when the node carries
+/// none, so an unformatted `<td>`/`<p>` stays bare.
+fn block_attr_html<T: ReadTxn>(el: &XmlElementRef, txn: &T, pm_type: &str) -> String {
+    let mut plain = String::new();
+    let mut styles: Vec<String> = Vec::new();
+    for (pm_attr, enc) in prose_schema::block_attrs_for(pm_type) {
+        let Some(v) = attr_value(el, txn, pm_attr).filter(|v| !v.is_empty()) else {
+            continue;
+        };
+        match enc {
+            prose_schema::AttrEnc::Attr => {
+                let _ = write!(plain, " {}=\"{}\"", pm_attr, escape_attr(&v));
+            }
+            prose_schema::AttrEnc::Style(prop) => styles.push(format!("{prop}: {v}")),
+        }
+    }
+    if !styles.is_empty() {
+        let _ = write!(plain, " style=\"{}\"", escape_attr(&styles.join("; ")));
+    }
+    plain
+}
+
+/// Read a block attribute as a string, tolerating the number form the live
+/// y-prosemirror binding may store (e.g. `start`), mirroring [`image_html`]'s
+/// dimension reader.
+fn attr_value<T: ReadTxn>(el: &XmlElementRef, txn: &T, key: &str) -> Option<String> {
+    el.get_attribute(txn, key).and_then(|o| match o {
+        Out::Any(Any::String(s)) => Some(s.to_string()),
+        Out::Any(Any::Number(n)) if n.is_finite() && n.fract() == 0.0 => Some(format!("{}", n as i64)),
+        Out::Any(Any::Number(n)) if n.is_finite() => Some(n.to_string()),
+        Out::Any(Any::BigInt(i)) => Some(i.to_string()),
+        _ => None,
+    })
 }
 
 /// Closing tag for a simple `<tag>` (static lifetime for the common set).

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -212,6 +212,15 @@ fn block_attr_html<T: ReadTxn>(el: &XmlElementRef, txn: &T, pm_type: &str) -> St
         let Some(v) = attr_value(el, txn, pm_attr).filter(|v| !v.is_empty()) else {
             continue;
         };
+        // Mirror the editor's `renderHTML`, which omits an attribute left at its
+        // default. y-prosemirror persists `orderedList.start` = 1 (the default)
+        // as a number on *every* list, but the editor drops `start` when it's 1
+        // — so emit it only when non-default, keeping a plain `<ol>` bare
+        // (JP-429; the seed path never hits this since a parsed `<ol>` without
+        // `start` carries no attr).
+        if pm_attr == "start" && v == "1" {
+            continue;
+        }
         match enc {
             prose_schema::AttrEnc::Attr => {
                 let _ = write!(plain, " {}=\"{}\"", pm_attr, escape_attr(&v));
@@ -543,6 +552,35 @@ mod tests {
             h.push_back(txn, XmlTextPrelim::new("Title"));
         });
         assert_eq!(html, "<h3>Title</h3>");
+    }
+
+    #[test]
+    fn ordered_list_default_start_is_omitted() {
+        // y-prosemirror persists `orderedList.start` = 1 (the default) as a
+        // NUMBER on every list (like image width/height), but the editor's
+        // getHTML omits `start` when it's 1. The serializer must match, so a
+        // plain ordered list stays bare instead of gaining a spurious
+        // `start="1"` on every flatten/get_prose (JP-429).
+        let html = render(|_doc, frag, txn| {
+            let ol = frag.push_back(txn, XmlElementPrelim::empty("orderedList"));
+            ol.insert_attribute(txn, "start", Any::Number(1.0));
+            let li = ol.push_back(txn, XmlElementPrelim::empty("listItem"));
+            let p = li.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("x"));
+        });
+        assert_eq!(html, "<ol><li><p>x</p></li></ol>", "spurious default start emitted: {html}");
+    }
+
+    #[test]
+    fn ordered_list_non_default_start_is_kept() {
+        let html = render(|_doc, frag, txn| {
+            let ol = frag.push_back(txn, XmlElementPrelim::empty("orderedList"));
+            ol.insert_attribute(txn, "start", Any::BigInt(3));
+            let li = ol.push_back(txn, XmlElementPrelim::empty("listItem"));
+            let p = li.push_back(txn, XmlElementPrelim::empty("paragraph"));
+            p.push_back(txn, XmlTextPrelim::new("x"));
+        });
+        assert_eq!(html, "<ol start=\"3\"><li><p>x</p></li></ol>", "non-default start dropped: {html}");
     }
 
     #[test]

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -392,6 +392,42 @@ fn get_attr<'a>(attrs: &'a [(String, String)], name: &str) -> Option<&'a str> {
     attrs.iter().find(|(k, _)| k == name).map(|(_, v)| v.as_str())
 }
 
+/// JP-429: read the allowlisted block attributes ([`prose_schema::BLOCK_ATTRS`])
+/// for `pm_type` off an element's HTML attrs, so formatting the editor stores as
+/// node attributes (a cell's `background-color`, a paragraph's `text-align`,
+/// `scope`, `start`) survives the HTML→PM parse instead of being dropped. Unknown
+/// attributes are still ignored. Style-encoded attrs are pulled out of the
+/// element's `style="…"` by CSS property name.
+fn read_block_attrs(pm_type: &str, attrs: &[(String, String)]) -> Vec<(String, String)> {
+    let style = get_attr(attrs, "style");
+    let mut out = Vec::new();
+    for (pm_attr, enc) in prose_schema::block_attrs_for(pm_type) {
+        let value = match enc {
+            prose_schema::AttrEnc::Attr => get_attr(attrs, pm_attr).map(|s| s.to_string()),
+            prose_schema::AttrEnc::Style(prop) => style.and_then(|s| style_prop(s, prop)),
+        };
+        if let Some(v) = value.filter(|v| !v.is_empty()) {
+            out.push((pm_attr.to_string(), v));
+        }
+    }
+    out
+}
+
+/// Pull one CSS property's value out of a `style="a: 1; b: 2"` string
+/// (case-insensitive property name, trimmed value).
+fn style_prop(style: &str, prop: &str) -> Option<String> {
+    for decl in style.split(';') {
+        let mut kv = decl.splitn(2, ':');
+        let k = kv.next()?.trim();
+        if k.eq_ignore_ascii_case(prop) {
+            if let Some(v) = kv.next().map(str::trim).filter(|v| !v.is_empty()) {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Build a `citationInline` PM node from a `<span data-citation …>` element's
 /// attributes. Caller guarantees `data-ref-id` is present. `locator`/`label` are
 /// emitted only when non-empty, symmetric with the editor's `renderHTML`
@@ -554,16 +590,18 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
     // Heading h1..h6.
     if tag.len() == 2 && tag.as_bytes()[0] == b'h' && tag.as_bytes()[1].is_ascii_digit() {
         let level = (tag.as_bytes()[1] - b'0').clamp(1, 6);
+        let mut a = vec![("level".to_string(), level.to_string())];
+        a.extend(read_block_attrs("heading", attrs)); // JP-429: textAlign
         return Some(PmNode {
             node_type: "heading".to_string(),
-            attrs: vec![("level".to_string(), level.to_string())],
+            attrs: a,
             children: collect_block_inline(children),
         });
     }
     match tag {
         "p" => Some(PmNode {
             node_type: "paragraph".to_string(),
-            attrs: vec![],
+            attrs: read_block_attrs("paragraph", attrs), // JP-429: textAlign
             children: collect_block_inline(children),
         }),
         "pre" => Some(PmNode {
@@ -599,10 +637,11 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
             Some(PmNode { node_type: "image".to_string(), attrs: a, children: vec![] })
         }
         // Block containers — children are blocks (map_blocks wraps stray inline
-        // into paragraphs, so a loose `<li>text` still works).
+        // into paragraphs, so a loose `<li>text` still works). JP-429: carry the
+        // allowlisted block attrs (cell background/align/scope, ordered-list start).
         _ => prose_schema::simple_block_pm(tag).map(|pm| PmNode {
             node_type: pm.to_string(),
-            attrs: vec![],
+            attrs: read_block_attrs(pm, attrs),
             children: map_blocks(children).into_iter().map(PmChild::Node).collect(),
         }),
     }

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -44,6 +44,84 @@ pub const MARKS: &[(&str, &str)] = &[
     ("code", "code"),
 ];
 
+// ---- JP-429: container classification for anchored, unit-level editing -------
+
+/// Pure structural wrappers an anchored edit walks *through* — never themselves
+/// an addressable target (their text is the concatenation of their items). The
+/// walk descends into their children to address the units inside. Adding a
+/// container type here (with the matching content unit below) is all a future
+/// prose feature needs to make its inner units anchor-editable.
+pub const DESCEND_CONTAINERS: &[&str] = &["bulletList", "orderedList", "table", "tableRow"];
+
+/// Block-holding nodes that ARE the smallest addressable unit (a bullet, a table
+/// cell, a quote) *and* into which the walk descends to find nested
+/// [`DESCEND_CONTAINERS`] (a sub-list inside a `listItem`, a nested table in a
+/// cell). Their anchor text is their *own direct* text — the text of their block
+/// children, stopping at any nested descend-container — so each unit's own line
+/// is an unambiguous anchor.
+pub const CONTENT_UNITS: &[&str] = &["listItem", "tableCell", "tableHeader", "blockquote"];
+
+/// Is `pm_type` a pure structural container the anchor walk descends through
+/// without emitting a target?
+pub fn is_descend_container(pm_type: &str) -> bool {
+    DESCEND_CONTAINERS.contains(&pm_type)
+}
+
+/// Is `pm_type` a block-holding addressable content unit (a bullet, cell, quote)?
+pub fn is_content_unit(pm_type: &str) -> bool {
+    CONTENT_UNITS.contains(&pm_type)
+}
+
+// ---- JP-429: block-attribute passthrough (formatting round-trip) -------------
+
+/// How a PM block attribute is encoded in HTML, so the parser + serializer agree.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AttrEnc {
+    /// A plain HTML attribute of the same name (`scope="col"`).
+    Attr,
+    /// A property inside the element's `style="…"` (`text-align: center`). The
+    /// `&str` is the CSS property name.
+    Style(&'static str),
+}
+
+/// Per-node-type allowlist of the formatting attributes the editor persists on a
+/// **block** node, `(pm_type, pm_attr, html_encoding)`. Without this the relay's
+/// HTML round-trip drops them: `prose_parse` discards a simple block's attrs and
+/// `prose_html` emits a bare `<td>` — so a table header's colour or a paragraph's
+/// alignment is silently lost on any reserialize (and can't be set over MCP).
+///
+/// The parser reads only these (unknown attrs still dropped); the serializer
+/// emits only these. **This table is the single knob** — a future prose feature
+/// that stores a block attribute gains fidelity + anchored-edit passthrough by
+/// adding a row, never by touching the parse/serialize code.
+///
+/// Mirrors the editor extensions: `TableCell`/`TableHeader.extend` +
+/// `TextAlign.configure({ types: ['heading','paragraph'] })` +
+/// StarterKit `orderedList` (`src/ui/TiptapEditor.tsx`).
+pub const BLOCK_ATTRS: &[(&str, &str, AttrEnc)] = &[
+    // Table cells: background colour + per-column alignment (JP-416) + header scope.
+    ("tableCell", "backgroundColor", AttrEnc::Style("background-color")),
+    ("tableCell", "align", AttrEnc::Style("text-align")),
+    ("tableHeader", "backgroundColor", AttrEnc::Style("background-color")),
+    ("tableHeader", "align", AttrEnc::Style("text-align")),
+    ("tableHeader", "scope", AttrEnc::Attr),
+    // Paragraph / heading alignment (TextAlign extension).
+    ("paragraph", "textAlign", AttrEnc::Style("text-align")),
+    ("heading", "textAlign", AttrEnc::Style("text-align")),
+    // Ordered-list starting number.
+    ("orderedList", "start", AttrEnc::Attr),
+];
+
+/// The allowlisted block attributes for a PM node type (may be empty). Returns a
+/// small owned `Vec` (the table is tiny) so callers don't borrow `pm_type`.
+pub fn block_attrs_for(pm_type: &str) -> Vec<(&'static str, AttrEnc)> {
+    BLOCK_ATTRS
+        .iter()
+        .filter(|(t, _, _)| *t == pm_type)
+        .map(|(_, a, e)| (*a, *e))
+        .collect()
+}
+
 /// HTML wrapper tag for a simple block PM node (read side).
 pub fn simple_block_html(pm_type: &str) -> Option<&'static str> {
     SIMPLE_BLOCKS.iter().find(|(p, _)| *p == pm_type).map(|(_, h)| *h)

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -44,34 +44,6 @@ pub const MARKS: &[(&str, &str)] = &[
     ("code", "code"),
 ];
 
-// ---- JP-429: container classification for anchored, unit-level editing -------
-
-/// Pure structural wrappers an anchored edit walks *through* — never themselves
-/// an addressable target (their text is the concatenation of their items). The
-/// walk descends into their children to address the units inside. Adding a
-/// container type here (with the matching content unit below) is all a future
-/// prose feature needs to make its inner units anchor-editable.
-pub const DESCEND_CONTAINERS: &[&str] = &["bulletList", "orderedList", "table", "tableRow"];
-
-/// Block-holding nodes that ARE the smallest addressable unit (a bullet, a table
-/// cell, a quote) *and* into which the walk descends to find nested
-/// [`DESCEND_CONTAINERS`] (a sub-list inside a `listItem`, a nested table in a
-/// cell). Their anchor text is their *own direct* text — the text of their block
-/// children, stopping at any nested descend-container — so each unit's own line
-/// is an unambiguous anchor.
-pub const CONTENT_UNITS: &[&str] = &["listItem", "tableCell", "tableHeader", "blockquote"];
-
-/// Is `pm_type` a pure structural container the anchor walk descends through
-/// without emitting a target?
-pub fn is_descend_container(pm_type: &str) -> bool {
-    DESCEND_CONTAINERS.contains(&pm_type)
-}
-
-/// Is `pm_type` a block-holding addressable content unit (a bullet, cell, quote)?
-pub fn is_content_unit(pm_type: &str) -> bool {
-    CONTENT_UNITS.contains(&pm_type)
-}
-
 // ---- JP-429: block-attribute passthrough (formatting round-trip) -------------
 
 /// How a PM block attribute is encoded in HTML, so the parser + serializer agree.

--- a/relay/src/sync/roundtrip_tests.rs
+++ b/relay/src/sync/roundtrip_tests.rs
@@ -219,6 +219,99 @@ fn live_numeric_image_attrs_serialize() {
     assert!(out.contains("height=\"140\""), "numeric height dropped: {out}");
 }
 
+// ---- JP-429: block-attribute formatting passthrough --------------------------
+//
+// The relay prose model was attribute-free for blocks, so a table header's colour
+// or a paragraph's alignment (attrs the editor persists on the node) were dropped
+// on every parse/serialize — un-seeable and un-settable over MCP, and lost on any
+// flatten→rehydrate. These pin the round-trip for the declarative BLOCK_ATTRS
+// registry. Written red-first: they fail on the pre-JP-429 attribute-free code.
+
+/// Minimal editor-shaped HTML embedding a node of `pm_type` with `attr_html` in
+/// its open tag, in a schema-valid position. The registry contract test uses it;
+/// a NEW node type in `BLOCK_ATTRS` must add a case here (else the test panics —
+/// a deliberate prompt to wire it).
+fn embed_with_attr(pm_type: &str, attr_html: &str) -> String {
+    match pm_type {
+        "paragraph" => format!("<p{attr_html}>x</p>"),
+        "heading" => format!("<h2{attr_html}>x</h2>"),
+        "orderedList" => format!("<ol{attr_html}><li><p>x</p></li></ol>"),
+        "tableCell" => format!("<table><tr><td{attr_html}><p>x</p></td></tr></table>"),
+        "tableHeader" => format!("<table><tr><th{attr_html}><p>x</p></th></tr></table>"),
+        other => panic!("embed_with_attr needs a schema-valid context for {other}"),
+    }
+}
+
+/// Registry-driven contract test (JP-429): every `BLOCK_ATTRS` row must survive a
+/// round-trip. A row wired on only one side (parse xor serialize) fails here — so
+/// a future formatting attribute can't be half-added silently.
+#[test]
+fn registry_every_block_attr_round_trips() {
+    use super::prose_schema::{AttrEnc, BLOCK_ATTRS};
+    for (pm_type, pm_attr, enc) in BLOCK_ATTRS {
+        let (attr_html, needle) = match enc {
+            AttrEnc::Attr => (format!(" {pm_attr}=\"9\""), format!("{pm_attr}=\"9\"")),
+            AttrEnc::Style(prop) => (format!(" style=\"{prop}: probe\""), format!("{prop}: probe")),
+        };
+        let out = seed_round_trip(&embed_with_attr(pm_type, &attr_html));
+        assert!(
+            out.contains(&needle),
+            "BLOCK_ATTRS ({pm_type}, {pm_attr}) not round-tripped — parse or serialize side unwired: {out}"
+        );
+    }
+}
+
+#[test]
+fn table_cell_background_align_and_scope_round_trip() {
+    // The exact editor getHTML shape: TableCell/TableHeader.extend merges
+    // backgroundColor + align into one `style`, header adds `scope`.
+    let html = "<table>\
+        <tr><th style=\"background-color: #eef; text-align: center\" scope=\"col\"><p>H</p></th></tr>\
+        <tr><td style=\"background-color: rgb(240, 240, 240); text-align: right\"><p>c</p></td></tr>\
+        </table>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("background-color: #eef"), "th bg lost: {out}");
+    assert!(out.contains("text-align: center"), "th align lost: {out}");
+    assert!(out.contains("scope=\"col\""), "th scope lost: {out}");
+    assert!(out.contains("background-color: rgb(240, 240, 240)"), "td bg lost: {out}");
+    assert!(out.contains("text-align: right"), "td align lost: {out}");
+}
+
+#[test]
+fn paragraph_and_heading_text_align_round_trip() {
+    let html = "<h2 style=\"text-align: center\">Title</h2><p style=\"text-align: right\">body</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("<h2 style=\"text-align: center\">"), "heading align lost: {out}");
+    assert!(out.contains("<p style=\"text-align: right\">"), "paragraph align lost: {out}");
+}
+
+#[test]
+fn ordered_list_start_round_trips() {
+    let out = seed_round_trip("<ol start=\"3\"><li><p>c</p></li></ol>");
+    assert!(out.contains("start=\"3\""), "ol start lost: {out}");
+}
+
+#[test]
+fn unformatted_block_stays_bare_no_spurious_markup() {
+    // Doc-safety (additive change): the pre-JP-429 stored shape gains no markup,
+    // so existing docs are untouched by the new attribute plumbing.
+    let out = seed_round_trip("<table><tr><td><p>x</p></td></tr></table><p>y</p>");
+    assert!(out.contains("<td><p>x</p></td>"), "bare cell gained markup: {out}");
+    assert!(out.contains("<p>y</p>"), "bare paragraph gained markup: {out}");
+    assert!(!out.contains("style="), "no spurious style attr: {out}");
+}
+
+#[test]
+fn formatting_round_trip_is_a_fixed_point() {
+    // Idempotence: the merged `style` string must be deterministic + re-parseable,
+    // so editor→relay→relay doesn't drift the attribute shape.
+    let html = "<h1 style=\"text-align: center\">T</h1>\
+        <table><tr><th style=\"background-color: #fff; text-align: left\" scope=\"col\"><p>h</p></th></tr></table>";
+    let once = seed_round_trip(html);
+    let twice = seed_round_trip(&once);
+    assert_eq!(once, twice, "formatting round-trip not idempotent:\n once={once}\ntwice={twice}");
+}
+
 // ---- JP-428: recovery-point reconstruction semantics ----
 // "The version wins wherever the point's doc carries the corresponding root;
 // absence never erases."

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -1132,6 +1132,91 @@ async fn jp239_mcp_anchored_set_prose_replaces_only_matched_block() {
     relay.server.stop().await.expect("stop");
 }
 
+/// JP-429: an anchored `set_prose` targeting a **nested bullet** on a resident
+/// doc rewrites only that bullet's line in the live Y.Doc and broadcasts the
+/// delta — the surrounding list and the sibling bullet are preserved. Proves the
+/// live path (`replace_prose_block`) reaches leaves nested inside lists, not just
+/// top-level blocks (the whole point of the issue).
+#[tokio::test]
+async fn jp429_anchored_edit_reaches_a_nested_bullet() {
+    let relay = start_relay().await;
+    let (mcp, mcp_base) = enable_mcp(&relay).await;
+    let token = relay.issuer.mint("alice", "default", WorkspaceRole::Owner);
+
+    put_doc(
+        &relay.http,
+        &token,
+        json!({
+            "id": "doc-nested", "name": "Nested", "pageOrder": ["p1"],
+            "activePageId": "p1", "ownerId": "alice", "ownerName": "alice",
+            "pages": {"p1": {"id": "p1", "shapes": {}, "shapeOrder": []}},
+            "richTextPages": {
+                "pageOrder": ["rt1"],
+                "pages": {"rt1": {"name": "Page 1", "order": 0,
+                    "content": "<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>"}}
+            }
+        }),
+    )
+    .await;
+
+    // Editor joins → doc resident; the relay hydrates the list into the live
+    // fragment (JP-239 cold-seed), so there's a nested bullet to anchor against.
+    let mut editor = WsClient::connect(&relay.ws_base).await;
+    editor.auth(&token).await;
+    let local = LocalDoc::new();
+    join_and_sync(&mut editor, &local, "doc-nested").await;
+    let mut seeded = false;
+    for _ in 0..25 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.prose_fragment_string("rt1").contains("beta") {
+            seeded = true;
+            break;
+        }
+    }
+    assert!(seeded, "editor never received the hydrated list");
+
+    // Agent edits ONLY the second bullet, anchored by its text.
+    let res = mcp_set_prose_anchored(
+        &mcp_base,
+        &token,
+        "doc-nested",
+        "rt1",
+        "beta",
+        "<p>beta revised</p>",
+    )
+    .await;
+    assert_eq!(res["result"]["structuredContent"]["ok"], true, "anchored bullet edit failed: {res}");
+
+    // The editor receives the targeted delta: the bullet changed, and the sibling
+    // bullet + the list structure are preserved.
+    let mut ok = false;
+    for _ in 0..25 {
+        if let Some((ty, bytes)) = editor.recv_within(200).await {
+            if ty == MESSAGE_SYNC {
+                local.apply_frame(&bytes);
+            }
+        }
+        if local.prose_fragment_string("rt1").contains("beta revised") {
+            ok = true;
+            break;
+        }
+    }
+    let s = local.prose_fragment_string("rt1");
+    assert!(ok, "editor never got the anchored bullet replace: {s:?}");
+    assert!(s.contains("alpha"), "sibling bullet lost: {s:?}");
+    assert!(
+        s.contains("bulletList") || s.contains("listItem"),
+        "list structure lost — the container did not pass through: {s:?}"
+    );
+
+    mcp.stop().await.ok();
+    relay.server.stop().await.expect("stop");
+}
+
 /// JP-239 follow-up: prose that exists only in a doc's JSON `richTextPages`
 /// (authored cold via MCP, never opened in an editor) is seeded into the live
 /// `prose:` fragment on hydration — so a joining editor receives it via the

--- a/skills/meeting-notes-to-doc/SKILL.md
+++ b/skills/meeting-notes-to-doc/SKILL.md
@@ -57,10 +57,14 @@ clearly describe a flow worth drawing.
    - `insert_section(docId, prosePageId, level, title, body, afterIndex?)` to slot a
      new section in a specific spot.
 
-5. **Refine a single section** without touching the rest by calling `set_prose`
-   with `anchor` = the exact current text of the block to replace (read it first
-   with `get_prose`; it's a compare-and-swap that errors rather than clobbering if
-   ambiguous).
+5. **Refine one line in place** — a paragraph, a single bullet, a table cell, or a
+   heading — without touching the rest by calling `set_prose` with `anchor` = the
+   exact current text of that line (read it first with `get_prose`; it's a
+   compare-and-swap that errors rather than clobbering if ambiguous). The anchor
+   reaches a line anywhere on the page; its list/table/quote and every sibling pass
+   through untouched, so you never rewrite a whole list to fix one bullet. To change
+   a line's formatting (e.g. a table cell's colour or a paragraph's alignment),
+   write the styled HTML with `format:"html"` — block formatting round-trips.
 
 6. **Confirm.** `get_prose(docId, prosePageId)` to review, then return the document
    id/name and a one-line recap (e.g. "3 decisions, 5 action items").


### PR DESCRIPTION
Closes JP-429.

An agent editing prose over MCP had to replace a whole page to change one bullet — the anti-pattern this issue was filed against. Investigating from the agent's side surfaced two distinct gaps, both fixed here (structural moves like re-indenting a bullet are a separate, deferred verb).

## 1. Anchored editing reaches nested leaves
`set_prose`'s `anchor` (JP-239) resolved against **top-level fragment children only**, so a bullet — a paragraph nested in a `listItem`/`bulletList` — could only be reached by anchoring the whole list. `prose_block` now addresses the smallest **text-bearing leaf** (paragraph/heading/codeBlock) wherever it sits: the walk descends through every container (lists, tables, cells, list items, blockquotes, unknown wrappers) and the splice replaces only that leaf in its own container. Because a leaf — never a container — is replaced, a targeted edit **cannot destroy surrounding structure**: the container and every sibling, including nested lists/tables, pass through verbatim. `anchorUntil` spans sibling leaves under one parent; a cross-parent span is refused. Live (`replace_prose_block`) and cold (`replace_block_in_html`) paths share the one function.

An earlier container-unit model could wholesale-replace a unit wrapping nested structure and lose it — a **seed-logged generative test** (random nested lists/tables/blockquotes; edit each unique leaf; assert no sibling is lost + round-trip is a fixed point; repro via `DOCUSHARK_FUZZ_SEED`) caught it, which is why the leaf model is what shipped.

## 2. Formatting passthrough (the "colour a table header" case)
The relay prose model was **attribute-free for blocks**, so a cell's `backgroundColor`, a cell/paragraph `text-align`, a header `scope`, an ordered-list `start` — attributes the editor persists on the node — were silently dropped on every parse/serialize (un-seeable and un-settable over MCP, and a latent fidelity loss on flatten→rehydrate). A declarative `BLOCK_ATTRS` registry in `prose_schema` (pm-type, pm-attr, HTML encoding) is now read by `prose_parse` and re-emitted by `prose_html` (style props merged into one deterministic `style="…"`). A **registry-driven contract test** makes a half-wired future row fail CI.

## 3. Discoverability
`set_prose` description + args, the prose skill, the `get_skills` content contract, and `relay/docs/mcp/README.md` updated so agents reach for a targeted edit and know block formatting is settable via `format:"html"`.

## Tests
- `prose_block`: single bullet / cell / deeply-nested-leaf edits; sibling-range; cross-parent-range refusal; no-collateral-damage; **generative invariant**.
- `roundtrip_tests` (JP-428 harness): registry-driven passthrough contract; cell background/align/scope; paragraph/heading alignment; ordered-list start; fixed-point/idempotence; additive-change doc-safety (unformatted blocks stay bare).
- `yjs_authority`: live-path E2E — anchored edit of a nested bullet reaches a joined editor with the list preserved.
- Full suite green (609 lib + 24 integration), bin builds, clippy clean. No `PROTOCOL_VERSION`/document `version` bump — the stored-HTML change is purely additive.

Structural prose ops (indent/outdent/move a bullet, row/column ops) are noted as a separate future issue.

Assisted-by: Opus 4.8