### PR TITLE
JP-432: prose parity — inline-mark attrs, node-level fidelity, bidirectional CI guard

### DIFF
--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -1240,12 +1240,20 @@ fn heal_doubled_prose_in(doc: &Doc) -> bool {
 fn marks_to_attrs(marks: &[prose_parse::PmMark]) -> Attrs {
     let mut attrs = Attrs::new();
     for m in marks {
-        let value = match &m.href {
-            Some(href) => Any::Map(Arc::new(std::collections::HashMap::from([(
-                "href".to_string(),
-                Any::String(href.as_str().into()),
-            )]))),
-            None => Any::Bool(true),
+        // A mark with an href (`link`) or allowlisted attrs (a highlight /
+        // textStyle `color` — JP-432) is stored as a `Map` keyed by the PM attr
+        // name (`href` / `color`); a bare boolean mark stays `true`.
+        let value = if m.href.is_some() || !m.attrs.is_empty() {
+            let mut map: std::collections::HashMap<String, Any> = std::collections::HashMap::new();
+            if let Some(href) = &m.href {
+                map.insert("href".to_string(), Any::String(href.as_str().into()));
+            }
+            for (k, v) in &m.attrs {
+                map.insert(k.clone(), Any::String(v.as_str().into()));
+            }
+            Any::Map(Arc::new(map))
+        } else {
+            Any::Bool(true)
         };
         attrs.insert(Arc::from(m.name.as_str()), value);
     }

--- a/relay/src/sync/prose_html.rs
+++ b/relay/src/sync/prose_html.rs
@@ -138,10 +138,15 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
                 },
             }
         }
-        "codeBlock" => Block::Wrap {
-            open: "<pre><code>".to_string(),
-            close: "</code></pre>",
-        },
+        "codeBlock" => {
+            // Language (JP-432) → the inner `<code class="language-…">`, matching
+            // CodeBlockLowlight's getHTML so the editor re-highlights on load.
+            let open = match str_attr(el, txn, "language").filter(|l| !l.is_empty()) {
+                Some(lang) => format!("<pre><code class=\"language-{}\">", escape_attr(&lang)),
+                None => "<pre><code>".to_string(),
+            };
+            Block::Wrap { open, close: "</code></pre>" }
+        }
         "horizontalRule" => Block::Void("<hr>".to_string()),
         "hardBreak" => Block::Void("<br>".to_string()),
         "image" => Block::Void(image_html(el, txn)),
@@ -184,10 +189,24 @@ fn block_for<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> Block {
                 close: "</div></div>",
             }
         }
-        // Task list/item are read-only aliases of ul/li (not in the shared
-        // round-trip table — a write never re-emits these PM types).
-        "taskList" => wrap("ul", "taskList"),
-        "taskItem" => wrap("li", "taskItem"),
+        // Embedded canvas group (JP-432): a childless atom, re-emitted with its
+        // `data-*` attrs so it survives instead of being deleted on read.
+        "embeddedGroup" => Block::Void(embedded_group_html(el, txn)),
+        // Task list/item (JP-432): re-emit the editor's `data-type` markers +
+        // per-item `data-checked` (previously aliased to bare `ul`/`li`, dropping
+        // the task identity + checked state). The simple form — no checkbox
+        // chrome — re-parses to a task item; the nodeView re-adds the checkbox.
+        "taskList" => Block::Wrap {
+            open: "<ul data-type=\"taskList\">".to_string(),
+            close: "</ul>",
+        },
+        "taskItem" => {
+            let checked = bool_attr(el, txn, "checked");
+            Block::Wrap {
+                open: format!("<li data-type=\"taskItem\" data-checked=\"{checked}\">"),
+                close: "</li>",
+            }
+        }
         // Everything else round-trips 1:1 via the shared schema (paragraph,
         // lists, blockquote, tables); unmapped types degrade to their children.
         // JP-429: `other` is the PM type, so allowlisted block attrs (cell
@@ -245,6 +264,32 @@ fn attr_value<T: ReadTxn>(el: &XmlElementRef, txn: &T, key: &str) -> Option<Stri
         Out::Any(Any::BigInt(i)) => Some(i.to_string()),
         _ => None,
     })
+}
+
+/// JP-432: read a boolean attribute (a taskItem's `checked`), tolerating the
+/// `Any::Bool` the live y-prosemirror binding stores and the `"true"`/`"false"`
+/// string the deterministic seed path writes.
+fn bool_attr<T: ReadTxn>(el: &XmlElementRef, txn: &T, key: &str) -> bool {
+    match el.get_attribute(txn, key) {
+        Some(Out::Any(Any::Bool(b))) => b,
+        Some(Out::Any(Any::String(s))) => s.as_ref() == "true" || s.is_empty(),
+        _ => false,
+    }
+}
+
+/// JP-432: serialize an embedded canvas group atom back to its editor HTML —
+/// `<div data-type="embedded-group" data-group-id data-group-name></div>` —
+/// omitting absent attrs. `cachedImageUrl` is runtime-only (never persisted).
+fn embedded_group_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    let mut s = String::from("<div data-type=\"embedded-group\"");
+    if let Some(id) = str_attr(el, txn, "groupId").filter(|v| !v.is_empty()) {
+        let _ = write!(s, " data-group-id=\"{}\"", escape_attr(&id));
+    }
+    if let Some(name) = str_attr(el, txn, "groupName").filter(|v| !v.is_empty()) {
+        let _ = write!(s, " data-group-name=\"{}\"", escape_attr(&name));
+    }
+    s.push_str("></div>");
+    s
 }
 
 /// Closing tag for a simple `<tag>` (static lifetime for the common set).
@@ -368,9 +413,19 @@ fn field_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
 /// (JP-89). Childless; the rendered entries live (escaped) in `bibHtml`. Emits
 /// `data-bib-html` only when non-empty, matching the editor's `renderHTML`.
 fn bibliography_html<T: ReadTxn>(el: &XmlElementRef, txn: &T) -> String {
+    // `scope` (JP-432) defaults to 'cited' (attr omitted); only 'all' is emitted,
+    // mirroring the editor's renderHTML — losing it silently reverted a user's
+    // "show all references" bibliography back to cited-only.
+    let scope = if str_attr(el, txn, "scope").as_deref() == Some("all") {
+        " data-scope=\"all\""
+    } else {
+        ""
+    };
     match str_attr(el, txn, "bibHtml").filter(|v| !v.is_empty()) {
-        Some(bib) => format!("<div data-bibliography data-bib-html=\"{}\"></div>", escape_attr(&bib)),
-        None => "<div data-bibliography></div>".to_string(),
+        Some(bib) => {
+            format!("<div data-bibliography data-bib-html=\"{}\"{scope}></div>", escape_attr(&bib))
+        }
+        None => format!("<div data-bibliography{scope}></div>"),
     }
 }
 
@@ -419,8 +474,14 @@ fn inline_marks(attrs: Option<&Attrs>) -> (String, String) {
         closes_rev.push("</a>".to_string());
     }
     for (name, tag) in prose_schema::MARKS {
-        if attrs.contains_key(*name) {
-            let _ = write!(opens, "<{tag}>");
+        if let Some(value) = attrs.get(*name) {
+            let mark_attrs = mark_attr_html(name, value);
+            // textStyle is a bare `<span>` — meaningless without an attr; skip it,
+            // mirroring the parser (which never creates an empty textStyle mark).
+            if *name == "textStyle" && mark_attrs.is_empty() {
+                continue;
+            }
+            let _ = write!(opens, "<{tag}{mark_attrs}>");
             closes_rev.push(format!("</{tag}>"));
         }
     }
@@ -439,6 +500,45 @@ fn link_href(v: &Any) -> Option<String> {
         Any::String(s) => Some(s.to_string()),
         _ => None,
     }
+}
+
+/// A string field inside a mark's Y.Doc value `Map` (the shape `marks_to_attrs`
+/// writes), or `None` when the value isn't a map or the field isn't a string.
+fn any_map_str(v: &Any, key: &str) -> Option<String> {
+    match v {
+        Any::Map(m) => match m.get(key) {
+            Some(Any::String(s)) => Some(s.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// JP-432: serialize an inline mark's allowlisted attributes
+/// ([`prose_schema::MARK_ATTRS`]) into its open tag — the inline twin of
+/// [`block_attr_html`], reading from the mark's Y.Doc value `Map` (a highlight's
+/// `color` → `background-color`, a textStyle's `color`) rather than element
+/// attrs. Style-encoded attrs merge into one deterministic `style="…"` (row
+/// order). Empty when the mark carries none, so a bare `<mark>`/`<strong>` stays
+/// bare.
+fn mark_attr_html(mark: &str, value: &Any) -> String {
+    let mut plain = String::new();
+    let mut styles: Vec<String> = Vec::new();
+    for (pm_attr, enc) in prose_schema::mark_attrs_for(mark) {
+        let Some(v) = any_map_str(value, pm_attr).filter(|v| !v.is_empty()) else {
+            continue;
+        };
+        match enc {
+            prose_schema::AttrEnc::Attr => {
+                let _ = write!(plain, " {}=\"{}\"", pm_attr, escape_attr(&v));
+            }
+            prose_schema::AttrEnc::Style(prop) => styles.push(format!("{prop}: {v}")),
+        }
+    }
+    if !styles.is_empty() {
+        let _ = write!(plain, " style=\"{}\"", escape_attr(&styles.join("; ")));
+    }
+    plain
 }
 
 fn out_to_u8(o: Out) -> Option<u8> {

--- a/relay/src/sync/prose_parse.rs
+++ b/relay/src/sync/prose_parse.rs
@@ -32,6 +32,10 @@ pub struct PmMark {
     pub name: String,
     /// `href` for a `link` mark; `None` for the boolean marks.
     pub href: Option<String>,
+    /// JP-432: allowlisted formatting attributes ([`prose_schema::MARK_ATTRS`])
+    /// the mark carries — a highlight / textStyle `color`. Empty for boolean
+    /// marks and for `link` (whose `href` lives above).
+    pub attrs: Vec<(String, String)>,
 }
 
 /// Parse prose HTML into top-level PM block nodes.
@@ -53,7 +57,10 @@ enum Token {
 
 /// Tags that never have children / closing tags in our subset.
 fn is_void(tag: &str) -> bool {
-    matches!(tag, "br" | "hr" | "img")
+    // `input` is void — the checkbox chrome the editor's getHTML nests inside a
+    // `<li data-type="taskItem">…<input type="checkbox">…` (JP-432). Without this
+    // the tokenizer opens it and mis-nests the rest of the item's content.
+    matches!(tag, "br" | "hr" | "img" | "input")
 }
 
 fn tokenize(html: &str) -> Vec<Token> {
@@ -413,6 +420,25 @@ fn read_block_attrs(pm_type: &str, attrs: &[(String, String)]) -> Vec<(String, S
     out
 }
 
+/// JP-432: read the allowlisted mark attributes ([`prose_schema::MARK_ATTRS`])
+/// for `mark` off an element's HTML attrs — the inline twin of
+/// [`read_block_attrs`], so a highlight's colour / a textStyle's text colour
+/// survive the HTML→PM parse instead of being dropped. Unknown attrs are ignored.
+fn read_mark_attrs(mark: &str, attrs: &[(String, String)]) -> Vec<(String, String)> {
+    let style = get_attr(attrs, "style");
+    let mut out = Vec::new();
+    for (pm_attr, enc) in prose_schema::mark_attrs_for(mark) {
+        let value = match enc {
+            prose_schema::AttrEnc::Attr => get_attr(attrs, pm_attr).map(|s| s.to_string()),
+            prose_schema::AttrEnc::Style(prop) => style.and_then(|s| style_prop(s, prop)),
+        };
+        if let Some(v) = value.filter(|v| !v.is_empty()) {
+            out.push((pm_attr.to_string(), v));
+        }
+    }
+    out
+}
+
 /// Pull one CSS property's value out of a `style="a: 1; b: 2"` string
 /// (case-insensitive property name, trimmed value).
 fn style_prop(style: &str, prop: &str) -> Option<String> {
@@ -488,6 +514,11 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
         if let Some(b) = get_attr(attrs, "data-bib-html") {
             a.push(("bibHtml".to_string(), b.to_string()));
         }
+        // `scope` (JP-432): 'cited' (default, no attr) vs 'all'. Mirrors
+        // `CitationExtension` bibliography addAttributes.
+        if get_attr(attrs, "data-scope") == Some("all") {
+            a.push(("scope".to_string(), "all".to_string()));
+        }
         return Some(PmNode { node_type: "bibliography".to_string(), attrs: a, children: vec![] });
     }
     // Callout block: `<div data-callout data-variant="…">` with block children.
@@ -555,6 +586,43 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
             children: images,
         });
     }
+    // Embedded canvas group (JP-432): `<div data-type="embedded-group"
+    // data-group-id data-group-name>` — an atom (`atom: true`), no children;
+    // `cachedImageUrl` is runtime-only and never serialized. Without this the
+    // node had no relay handler and was deleted on read. Mirrors
+    // `EmbeddedGroupExtension`.
+    if tag == "div" && get_attr(attrs, "data-type") == Some("embedded-group") {
+        let mut a = vec![];
+        if let Some(id) = get_attr(attrs, "data-group-id").filter(|s| !s.is_empty()) {
+            a.push(("groupId".to_string(), id.to_string()));
+        }
+        if let Some(name) = get_attr(attrs, "data-group-name").filter(|s| !s.is_empty()) {
+            a.push(("groupName".to_string(), name.to_string()));
+        }
+        return Some(PmNode { node_type: "embeddedGroup".to_string(), attrs: a, children: vec![] });
+    }
+    // Task list (JP-432): `<ul data-type="taskList">`. Detected before the generic
+    // `ul`→`bulletList` mapping, or a checkable list silently degrades to bullets.
+    if tag == "ul" && get_attr(attrs, "data-type") == Some("taskList") {
+        return Some(PmNode {
+            node_type: "taskList".to_string(),
+            attrs: vec![],
+            children: map_blocks(children).into_iter().map(PmChild::Node).collect(),
+        });
+    }
+    // Task item (JP-432): `<li data-type="taskItem" data-checked>`. The editor's
+    // getHTML wraps the content in checkbox chrome (`<label><input>…</label>
+    // <div>content</div>`); `input` is void and label/div unwrap (`map_blocks`),
+    // so the real content is recovered. `data-checked` is `""`/`"true"` when
+    // checked (mirrors TaskItem.parseHTML).
+    if tag == "li" && get_attr(attrs, "data-type") == Some("taskItem") {
+        let checked = matches!(get_attr(attrs, "data-checked"), Some("true") | Some(""));
+        return Some(PmNode {
+            node_type: "taskItem".to_string(),
+            attrs: vec![("checked".to_string(), checked.to_string())],
+            children: map_blocks(children).into_iter().map(PmChild::Node).collect(),
+        });
+    }
     // Figure: `<figure><img …><figcaption>…</figcaption></figure>`. The client
     // content model is the strict `image figcaption`, so only emit a `figure`
     // when a usable `<img>` is present, and always pair it with a `figcaption`
@@ -604,12 +672,27 @@ fn map_block_element(tag: &str, attrs: &[(String, String)], children: &[HtmlNode
             attrs: read_block_attrs("paragraph", attrs), // JP-429: textAlign
             children: collect_block_inline(children),
         }),
-        "pre" => Some(PmNode {
-            node_type: "codeBlock".to_string(),
-            attrs: vec![],
-            // Code block content is plain text (unwrap any inner <code>).
-            children: vec![PmChild::Text { text: text_content(children), marks: vec![] }],
-        }),
+        "pre" => {
+            // Code block content is plain text (unwrap any inner <code>). The
+            // language (JP-432) lives on the inner `<code class="language-…">`
+            // (CodeBlockLowlight) — read it off the first child code element.
+            let language = children.iter().find_map(|c| match c {
+                HtmlNode::Element { tag: t, attrs: a, .. } if t == "code" => get_attr(a, "class")
+                    .and_then(|cls| cls.split_whitespace().find_map(|w| w.strip_prefix("language-")))
+                    .filter(|l| !l.is_empty())
+                    .map(str::to_string),
+                _ => None,
+            });
+            let attrs = match language {
+                Some(l) => vec![("language".to_string(), l)],
+                None => vec![],
+            };
+            Some(PmNode {
+                node_type: "codeBlock".to_string(),
+                attrs,
+                children: vec![PmChild::Text { text: text_content(children), marks: vec![] }],
+            })
+        }
         "hr" => Some(PmNode { node_type: "horizontalRule".to_string(), attrs: vec![], children: vec![] }),
         "img" => {
             // The client image node is an atom that parses only `img[src]`
@@ -664,7 +747,7 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                 } else if tag == "a" {
                     let href = attrs.iter().find(|(k, _)| k == "href").map(|(_, v)| v.clone());
                     let mut m = marks.to_vec();
-                    m.push(PmMark { name: "link".to_string(), href });
+                    m.push(PmMark { name: "link".to_string(), href, attrs: vec![] });
                     out.extend(collect_inline(children, &m));
                 } else if prose_schema::custom_node_pm(tag, |m| has_attr(attrs, m))
                     == Some("citationInline")
@@ -691,9 +774,18 @@ fn collect_inline(nodes: &[HtmlNode], marks: &[PmMark]) -> Vec<PmChild> {
                     // span is useless, so fall through to the unwrap and keep text.
                     out.push(PmChild::Node(math_inline_node(attrs)));
                 } else if let Some(mark) = prose_schema::mark_pm(tag) {
-                    let mut m = marks.to_vec();
-                    m.push(PmMark { name: mark.to_string(), href: None });
-                    out.extend(collect_inline(children, &m));
+                    let mark_attrs = read_mark_attrs(mark, attrs);
+                    // A `textStyle` `<span>` with no recognized attr is a plain
+                    // span — unwrap it (preserve the empty-span degrade contract;
+                    // keep the CRDT free of empty textStyle marks). All the other
+                    // marks are bare tags carrying no attrs.
+                    if mark == "textStyle" && mark_attrs.is_empty() {
+                        out.extend(collect_inline(children, marks));
+                    } else {
+                        let mut m = marks.to_vec();
+                        m.push(PmMark { name: mark.to_string(), href: None, attrs: mark_attrs });
+                        out.extend(collect_inline(children, &m));
+                    }
                 } else {
                     // Unknown inline tag → unwrap (keep text + current marks).
                     out.extend(collect_inline(children, marks));
@@ -809,7 +901,7 @@ mod tests {
     fn marked(t: &str, marks: &[&str]) -> PmChild {
         PmChild::Text {
             text: t.to_string(),
-            marks: marks.iter().map(|m| PmMark { name: m.to_string(), href: None }).collect(),
+            marks: marks.iter().map(|m| PmMark { name: m.to_string(), href: None, attrs: vec![] }).collect(),
         }
     }
 

--- a/relay/src/sync/prose_schema.rs
+++ b/relay/src/sync/prose_schema.rs
@@ -35,6 +35,11 @@ pub const SIMPLE_BLOCKS: &[(&str, &str)] = &[
 /// separately — it carries an `href`.)
 pub const MARKS: &[(&str, &str)] = &[
     ("highlight", "mark"),
+    // Text colour (the `TextStyle` mark + `Color` extension) → `<span style="color">`.
+    // Carries a `color` attr (see `MARK_ATTRS`); a *plain* `<span>` never becomes a
+    // `textStyle` mark (the parser only creates one when a recognized attr is
+    // present) so the empty-span degrade is preserved. (JP-432)
+    ("textStyle", "span"),
     ("bold", "strong"),
     ("italic", "em"),
     ("underline", "u"),
@@ -80,8 +85,9 @@ pub const BLOCK_ATTRS: &[(&str, &str, AttrEnc)] = &[
     // Paragraph / heading alignment (TextAlign extension).
     ("paragraph", "textAlign", AttrEnc::Style("text-align")),
     ("heading", "textAlign", AttrEnc::Style("text-align")),
-    // Ordered-list starting number.
+    // Ordered-list starting number + numbering style (`<ol type="a">`, JP-432).
     ("orderedList", "start", AttrEnc::Attr),
+    ("orderedList", "type", AttrEnc::Attr),
 ];
 
 /// The allowlisted block attributes for a PM node type (may be empty). Returns a
@@ -90,6 +96,39 @@ pub fn block_attrs_for(pm_type: &str) -> Vec<(&'static str, AttrEnc)> {
     BLOCK_ATTRS
         .iter()
         .filter(|(t, _, _)| *t == pm_type)
+        .map(|(_, a, e)| (*a, *e))
+        .collect()
+}
+
+// ---- JP-432: inline-mark-attribute passthrough (the inline twin of BLOCK_ATTRS) -
+
+/// Per-mark allowlist of the formatting attributes the editor persists on an
+/// **inline mark**, `(pm_mark, pm_attr, html_encoding)`. Without this the relay's
+/// HTML round-trip drops them: a highlight's colour and a `textStyle`'s text
+/// colour serialize as a bare `<mark>`/`<span>` and the parser discards the attr
+/// — silently flattening peer-review highlighting and coloured text on any
+/// reserialize (and leaving them un-seeable / un-settable over MCP).
+///
+/// Same discipline as [`BLOCK_ATTRS`] — **this table is the single knob**: a
+/// future coloured/attributed mark gains fidelity + anchored-edit passthrough by
+/// adding a row, never by touching the parse/serialize code. The value lives on
+/// the mark's Y.Doc formatting value (a `Map`), keyed by the **PM attr name**.
+///
+/// Mirrors the editor marks: `Highlight.configure({ multicolor: true })` (a
+/// `color` the editor renders as `data-color` + `background-color`; we emit
+/// style-only, which the editor's `parseHTML` reads back via `style.backgroundColor`)
+/// + `TextStyle` with the `Color` extension (a `color`) (`src/ui/TiptapEditor.tsx`).
+pub const MARK_ATTRS: &[(&str, &str, AttrEnc)] = &[
+    ("highlight", "color", AttrEnc::Style("background-color")),
+    ("textStyle", "color", AttrEnc::Style("color")),
+];
+
+/// The allowlisted attributes for an inline mark (may be empty), mirroring
+/// [`block_attrs_for`].
+pub fn mark_attrs_for(mark: &str) -> Vec<(&'static str, AttrEnc)> {
+    MARK_ATTRS
+        .iter()
+        .filter(|(m, _, _)| *m == mark)
         .map(|(_, a, e)| (*a, *e))
         .collect()
 }

--- a/relay/src/sync/prose_validate.rs
+++ b/relay/src/sync/prose_validate.rs
@@ -74,6 +74,12 @@ fn is_known_type(t: &str) -> bool {
             | "mathInline"
             | "mathBlock"
             | "hardBreak"
+            // JP-432: task lists (checkable items) + embedded canvas-group atom —
+            // previously unknown here, so a parsed taskList/embeddedGroup was
+            // unwrapped (task lists downgraded to bullet lists, embeds deleted).
+            | "taskList"
+            | "taskItem"
+            | "embeddedGroup"
     )
 }
 
@@ -91,6 +97,9 @@ fn is_atom(t: &str) -> bool {
             | "horizontalRule"
             | "bibliography"
             | "hardBreak"
+            // JP-432: an embedded canvas group is an atom (`atom: true` in
+            // `EmbeddedGroupExtension`) — childless, self-describing via `data-*`.
+            | "embeddedGroup"
     )
 }
 

--- a/relay/src/sync/roundtrip_tests.rs
+++ b/relay/src/sync/roundtrip_tests.rs
@@ -312,6 +312,149 @@ fn formatting_round_trip_is_a_fixed_point() {
     assert_eq!(once, twice, "formatting round-trip not idempotent:\n once={once}\ntwice={twice}");
 }
 
+// ---- JP-432: inline-mark-attribute passthrough (highlight / text colour) ----
+// The inline twin of the BLOCK_ATTRS suite above. Before JP-432 the relay's mark
+// model was attribute-free, so a highlight's colour and a textStyle's text colour
+// were dropped on every parse/serialize — un-seeable / un-settable over MCP and
+// lost on any flatten→rehydrate. These pin the MARK_ATTRS round-trip.
+
+/// Minimal editor-shaped HTML embedding a `mark` carrying `attr_html`, wrapped in
+/// a paragraph. The registry contract test uses it; a NEW mark in `MARK_ATTRS`
+/// resolves its tag from `MARKS` (panics if the mark has no tag — a prompt to
+/// wire it).
+fn embed_mark_with_attr(mark: &str, attr_html: &str) -> String {
+    let tag = super::prose_schema::MARKS
+        .iter()
+        .find(|(m, _)| *m == mark)
+        .map(|(_, t)| *t)
+        .unwrap_or_else(|| panic!("mark {mark} in MARK_ATTRS has no MARKS tag"));
+    format!("<p><{tag}{attr_html}>x</{tag}></p>")
+}
+
+/// Registry-driven contract test (JP-432): every `MARK_ATTRS` row must survive a
+/// round-trip — the inline twin of `registry_every_block_attr_round_trips`. A row
+/// wired on only one side (parse xor serialize) fails here, so a future coloured
+/// mark can't be half-added silently.
+#[test]
+fn registry_every_mark_attr_round_trips() {
+    use super::prose_schema::{AttrEnc, MARK_ATTRS};
+    for (mark, pm_attr, enc) in MARK_ATTRS {
+        let (attr_html, needle) = match enc {
+            AttrEnc::Attr => (format!(" {pm_attr}=\"9\""), format!("{pm_attr}=\"9\"")),
+            AttrEnc::Style(prop) => (format!(" style=\"{prop}: probe\""), format!("{prop}: probe")),
+        };
+        let out = seed_round_trip(&embed_mark_with_attr(mark, &attr_html));
+        assert!(
+            out.contains(&needle),
+            "MARK_ATTRS ({mark}, {pm_attr}) not round-tripped — parse or serialize side unwired: {out}"
+        );
+    }
+}
+
+#[test]
+fn highlight_and_text_colour_round_trip() {
+    // The exact editor getHTML shape: multicolor Highlight emits data-color +
+    // background-color (we read/emit style-only); TextStyle+Color → <span style="color">.
+    let html = "<p><mark data-color=\"#ff0\" style=\"background-color: #ff0; color: inherit\">hi</mark>\
+        <span style=\"color: rgb(200, 0, 0)\">warn</span></p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("background-color: #ff0"), "highlight colour lost: {out}");
+    assert!(out.contains("color: rgb(200, 0, 0)"), "text colour lost: {out}");
+}
+
+#[test]
+fn plain_span_and_bare_marks_stay_bare() {
+    // Doc-safety: a plain <span> still unwraps (no empty textStyle mark), and
+    // boolean marks emit bare tags with no spurious attrs — additive change.
+    let out = seed_round_trip("<p><span>plain</span><strong>b</strong><em>i</em></p>");
+    assert!(out.contains("plain"), "plain span text lost: {out}");
+    assert!(!out.contains("<span"), "plain span should unwrap, not become a textStyle: {out}");
+    assert!(out.contains("<strong>b</strong>"), "bold lost: {out}");
+    assert!(!out.contains("style="), "no spurious style on bare marks: {out}");
+}
+
+#[test]
+fn mark_formatting_round_trip_is_a_fixed_point() {
+    let html = "<p><mark style=\"background-color: #abc\">h</mark><span style=\"color: #123\">t</span></p>";
+    let once = seed_round_trip(html);
+    let twice = seed_round_trip(&once);
+    assert_eq!(once, twice, "mark round-trip not idempotent:\n once={once}\ntwice={twice}");
+}
+
+// ---- JP-432: node-level parity (task lists, embedded groups, code language, ol type) ----
+// Editor-schema nodes the relay previously downgraded or deleted: task lists were
+// aliased to bullet lists (checked state lost), embeddedGroup had no handler (the
+// node was deleted on read), and codeBlock dropped its language. Each is a live
+// silent-loss until wired on both legs.
+
+#[test]
+fn task_list_and_checked_state_round_trip() {
+    // The editor getHTML shape: <li data-type="taskItem" data-checked> wrapping
+    // its content in checkbox chrome (<label><input><span></label><div>…</div>).
+    let html = "<ul data-type=\"taskList\">\
+        <li data-type=\"taskItem\" data-checked=\"true\"><label><input type=\"checkbox\" checked><span></span></label><div><p>done</p></div></li>\
+        <li data-type=\"taskItem\" data-checked=\"false\"><label><input type=\"checkbox\"><span></span></label><div><p>todo</p></div></li>\
+        </ul><p>after</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("data-type=\"taskList\""), "taskList downgraded to bullet list: {out}");
+    assert!(out.contains("data-checked=\"true\""), "checked item lost: {out}");
+    assert!(out.contains("data-checked=\"false\""), "unchecked item lost: {out}");
+    assert!(out.contains("done") && out.contains("todo"), "task content lost: {out}");
+    assert!(out.contains("<p>after</p>"), "trailing sibling lost: {out}");
+    assert!(!out.contains("<input"), "checkbox chrome leaked into stored HTML: {out}");
+}
+
+#[test]
+fn task_list_round_trip_is_a_fixed_point() {
+    let html = "<ul data-type=\"taskList\"><li data-type=\"taskItem\" data-checked=\"true\"><p>x</p></li></ul>";
+    let once = seed_round_trip(html);
+    let twice = seed_round_trip(&once);
+    assert_eq!(once, twice, "task list not idempotent:\n once={once}\ntwice={twice}");
+}
+
+#[test]
+fn code_block_language_round_trips() {
+    let out = seed_round_trip("<pre><code class=\"language-rust\">fn main() {}</code></pre>");
+    assert!(out.contains("class=\"language-rust\""), "code language lost: {out}");
+    assert!(out.contains("fn main()"), "code content lost: {out}");
+}
+
+#[test]
+fn code_block_without_language_stays_bare() {
+    let out = seed_round_trip("<pre><code>plain</code></pre>");
+    assert!(out.contains("<pre><code>plain</code></pre>"), "bare code block gained markup: {out}");
+    assert!(!out.contains("language-"), "bare code block gained a language class: {out}");
+}
+
+#[test]
+fn embedded_group_survives_round_trip() {
+    let html = "<p>before</p>\
+        <div data-type=\"embedded-group\" data-group-id=\"grp-1\" data-group-name=\"Arch\"></div>\
+        <p>after</p>";
+    let out = seed_round_trip(html);
+    assert!(out.contains("data-type=\"embedded-group\""), "embedded group deleted on read: {out}");
+    assert!(out.contains("data-group-id=\"grp-1\""), "group id lost: {out}");
+    assert!(out.contains("data-group-name=\"Arch\""), "group name lost: {out}");
+    assert!(out.contains("<p>before</p>") && out.contains("<p>after</p>"), "siblings lost: {out}");
+}
+
+#[test]
+fn ordered_list_type_round_trips() {
+    let out = seed_round_trip("<ol type=\"a\" start=\"3\"><li><p>c</p></li></ol>");
+    assert!(out.contains("type=\"a\""), "ol type lost: {out}");
+    assert!(out.contains("start=\"3\""), "ol start lost: {out}");
+}
+
+#[test]
+fn bibliography_scope_round_trips() {
+    // Found by the bidirectional schema-contract guard: scope='all' (show every
+    // reference, not just cited) must survive; default 'cited' stays bare.
+    let all = seed_round_trip("<div data-bibliography data-bib-html=\"refs\" data-scope=\"all\"></div>");
+    assert!(all.contains("data-scope=\"all\""), "bibliography scope=all lost: {all}");
+    let cited = seed_round_trip("<div data-bibliography data-bib-html=\"refs\"></div>");
+    assert!(!cited.contains("data-scope"), "default cited scope gained a spurious attr: {cited}");
+}
+
 // ---- JP-428: recovery-point reconstruction semantics ----
 // "The version wins wherever the point's doc carries the corresponding root;
 // absence never erases."

--- a/src/ui/proseSchemaContract.test.ts
+++ b/src/ui/proseSchemaContract.test.ts
@@ -1,65 +1,111 @@
 /**
- * T3 — relay ↔ client prose schema contract (JP-319).
+ * Relay ↔ client prose schema contract (JP-319 crash-safety + JP-432 parity).
  *
- * The relay's prose parser (`relay/src/sync/prose_parse.rs` + `prose_schema.rs`)
- * seeds a `prose:<page>` Y.XmlFragment with a fixed set of ProseMirror node
- * types. The client adopts that fragment and renders it via ReactNodeViews — so
- * if the relay can emit a node type the client schema doesn't define, or emits
- * an atom the client doesn't treat as a leaf, the desc-tree walk throws
- * "Cannot read properties of undefined (reading 'children')" on open.
+ * Two directions, both derived from the real editor schema (`getSchema`) so
+ * neither can silently drift:
  *
- * This pins the contract from the client side: every type the relay can emit
- * must exist in the schema the collab editor builds, and the relay's atoms must
- * be atoms here. Keep `RELAY_EMITTABLE_*` in sync with `prose_schema.rs`
- * (SIMPLE_BLOCKS + CUSTOM_PROSE_NODES) and the explicit cases in
- * `prose_parse.rs::map_block_element` (heading / codeBlock / hr / img).
+ * 1. **relay ⊆ client (crash-safety, JP-319).** Every node the relay parser can
+ *    emit must exist in the client schema, and the relay's atoms must be atoms
+ *    here — else the desc-tree walk throws "Cannot read properties of undefined
+ *    (reading 'children')" on open and y-prosemirror DELETES the node.
+ *
+ * 2. **client ⊆ relay (parity, JP-432).** Every node/mark/persisted-attr the
+ *    editor can store must be modeled by the relay's prose round-trip — else it
+ *    is silently lost on any reserialize / flatten→rehydrate (how task lists,
+ *    embedded groups, code-block language, and highlight/text colour were being
+ *    dropped). A new editor node/mark/attr that is neither modeled nor an
+ *    explicit render-only carve-out fails CI, forcing a conscious choice: wire
+ *    the relay, or declare it unpersisted.
+ *
+ * The RELAY_* manifests below mirror `relay/src/sync/prose_schema.rs`
+ * (SIMPLE_BLOCKS / MARKS / CUSTOM_PROSE_NODES / BLOCK_ATTRS / MARK_ATTRS) plus
+ * the explicit hand-written arms in `prose_parse.rs` / `prose_html.rs`
+ * (heading / codeBlock / image / hr / callout / figure / gallery / task list /
+ * embeddedGroup). Keep them in sync when the relay's prose model changes.
  */
 
 import { getSchema } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import { sharedProseExtensions } from './TiptapEditor';
 
-// Every ProseMirror node type the relay parser can produce.
-const RELAY_EMITTABLE_NODES = [
-  'paragraph',
-  'heading',
-  'bulletList',
-  'orderedList',
-  'listItem',
-  'blockquote',
-  'table',
-  'tableRow',
-  'tableCell',
-  'tableHeader',
-  'codeBlock',
-  'horizontalRule',
-  'image',
-  'bibliography',
-  'citationInline',
-  'fieldRef',
-  'hardBreak',
-  // Structural custom blocks (JP-319 2d) — round-tripped by the relay parser.
-  'callout',
-  'figure',
-  'figcaption',
-  'gallery',
-] as const;
+// ---- relay-modeled prose schema (mirror of prose_schema.rs + explicit arms) ----
 
-// Relay-emitted nodes that are atoms/leaves on the relay side (built childless).
-// The client MUST treat these as atoms — otherwise an unexpected child crashes
-// the node-view reconciliation.
-const RELAY_EMITTABLE_ATOMS = [
-  'image',
-  'citationInline',
-  'fieldRef',
-  'horizontalRule',
-  'hardBreak',
-] as const;
+/** Every ProseMirror node type the relay parser can produce / round-trip. */
+const RELAY_NODES = new Set<string>([
+  'paragraph', 'heading', 'bulletList', 'orderedList', 'listItem', 'blockquote',
+  'table', 'tableRow', 'tableCell', 'tableHeader', 'codeBlock', 'horizontalRule',
+  'hardBreak', 'image', 'citationInline', 'bibliography', 'fieldRef', 'mathInline',
+  'mathBlock', 'callout', 'figure', 'figcaption', 'gallery',
+  // JP-432
+  'taskList', 'taskItem', 'embeddedGroup',
+]);
 
-describe('relay↔client prose schema contract (JP-319)', () => {
-  // Mirror the collaborative editor's extension set (CollaborativeProseEditor:
-  // history-disabled StarterKit with the lowlight codeBlock, plus the shared
-  // extensions). Collaboration adds no schema nodes, so it's omitted here.
+/** Relay-emitted nodes built childless — the client MUST treat these as atoms. */
+const RELAY_ATOMS = new Set<string>([
+  'image', 'citationInline', 'fieldRef', 'mathInline', 'mathBlock',
+  'horizontalRule', 'bibliography', 'hardBreak', 'embeddedGroup',
+]);
+
+/** Every inline mark the relay round-trips (prose_schema.rs MARKS + link). */
+const RELAY_MARKS = new Set<string>([
+  'highlight', 'textStyle', 'bold', 'italic', 'underline', 'strike',
+  'superscript', 'subscript', 'code', 'link',
+]);
+
+/**
+ * Per-node/mark attributes the relay persists (mirror of BLOCK_ATTRS + MARK_ATTRS
+ * + the attrs each hand-written node/mark carries). An editor attr absent here
+ * and from RENDER_ONLY_ATTRS is a parity gap.
+ */
+const RELAY_ATTRS: Record<string, Set<string>> = {
+  heading: new Set(['level', 'textAlign']),
+  paragraph: new Set(['textAlign']),
+  orderedList: new Set(['start', 'type']),
+  tableCell: new Set(['backgroundColor', 'align']),
+  tableHeader: new Set(['backgroundColor', 'align', 'scope']),
+  codeBlock: new Set(['language']),
+  image: new Set(['src', 'alt', 'title', 'width', 'height', 'float']),
+  taskItem: new Set(['checked']),
+  embeddedGroup: new Set(['groupId', 'groupName']),
+  callout: new Set(['variant']),
+  gallery: new Set(['layout']),
+  figure: new Set([]),
+  citationInline: new Set(['refId', 'locator', 'label']),
+  fieldRef: new Set(['name', 'label']),
+  mathInline: new Set(['latex']),
+  mathBlock: new Set(['latex']),
+  bibliography: new Set(['bibHtml', 'scope']),
+  highlight: new Set(['color']),
+  textStyle: new Set(['color']),
+  link: new Set(['href']),
+};
+
+/**
+ * Editor attrs the relay intentionally does NOT persist — render-only config the
+ * editor re-applies from constant `HTMLAttributes`, or runtime-only state. Each
+ * is a conscious carve-out, not a silent gap. Documented per JP-432 review.
+ */
+const RENDER_ONLY_ATTRS: Record<string, Set<string>> = {
+  // Link `class`/`rel` are constant HTMLAttributes (`tiptap-link`,
+  // `noopener noreferrer`) the editor re-applies at render; `target` isn't
+  // settable via the link UI today. Relay stores href only (explicit decision).
+  link: new Set(['target', 'rel', 'class']),
+  // Runtime PNG cache for the embed preview — deliberately not serialized.
+  embeddedGroup: new Set(['cachedImageUrl']),
+  // Cell spans + column widths are deferred to JP-432 Pillar D (tables: merged
+  // cells need colspan/rowspan + a span-aware normalizer, colwidth needs a
+  // non-scalar encoding). Move these into RELAY_ATTRS when Pillar D lands.
+  tableCell: new Set(['colwidth', 'colspan', 'rowspan']),
+  tableHeader: new Set(['colwidth', 'colspan', 'rowspan']),
+};
+
+/** Base ProseMirror nodes with no persisted content of their own. */
+const STRUCTURAL_NODES = new Set<string>(['doc', 'text']);
+
+describe('relay↔client prose schema contract', () => {
+  // Mirror the collaborative editor's schema: history-disabled StarterKit with the
+  // lowlight codeBlock disabled (replaced by CodeBlock in sharedProseExtensions),
+  // plus the shared extensions. Collaboration adds no schema nodes.
   const schema = getSchema([
     StarterKit.configure({
       heading: { levels: [1, 2, 3, 4, 5, 6] },
@@ -69,14 +115,16 @@ describe('relay↔client prose schema contract (JP-319)', () => {
     ...sharedProseExtensions,
   ]);
 
-  it('defines every node type the relay can emit', () => {
-    for (const name of RELAY_EMITTABLE_NODES) {
+  // ---- 1. relay ⊆ client (crash-safety, JP-319) ----
+
+  it('client defines every node the relay can emit', () => {
+    for (const name of RELAY_NODES) {
       expect(schema.nodes[name], `client schema must define relay node '${name}'`).toBeDefined();
     }
   });
 
-  it('treats every relay-emitted atom as a leaf/atom node', () => {
-    for (const name of RELAY_EMITTABLE_ATOMS) {
+  it('client treats every relay-emitted atom as an atom/leaf', () => {
+    for (const name of RELAY_ATOMS) {
       const nodeType = schema.nodes[name];
       expect(nodeType, `relay atom '${name}' missing from client schema`).toBeDefined();
       expect(
@@ -84,5 +132,56 @@ describe('relay↔client prose schema contract (JP-319)', () => {
         `relay atom '${name}' must be an atom/leaf in the client schema`,
       ).toBe(true);
     }
+  });
+
+  // ---- 2. client ⊆ relay (parity — no silent loss, JP-432) ----
+
+  it('relay models every node the editor persists', () => {
+    for (const name of Object.keys(schema.nodes)) {
+      if (STRUCTURAL_NODES.has(name)) continue;
+      expect(
+        RELAY_NODES.has(name),
+        `editor node '${name}' is not modeled by the relay prose round-trip — it will be ` +
+          `silently lost on reserialize/rehydrate. Wire it in prose_schema.rs/prose_parse.rs/` +
+          `prose_html.rs (and add it to RELAY_NODES), or add it to STRUCTURAL_NODES if it is ` +
+          `a non-persisted base node.`,
+      ).toBe(true);
+    }
+  });
+
+  it('relay models every mark the editor persists', () => {
+    for (const name of Object.keys(schema.marks)) {
+      expect(
+        RELAY_MARKS.has(name),
+        `editor mark '${name}' is not modeled by the relay (prose_schema.rs MARKS) — it will ` +
+          `be silently lost on round-trip. Add it to MARKS/MARK_ATTRS and RELAY_MARKS.`,
+      ).toBe(true);
+    }
+  });
+
+  it('relay models every persisted attribute the editor stores', () => {
+    const violations: string[] = [];
+    const check = (kind: 'node' | 'mark', name: string, attrs: Record<string, unknown>) => {
+      const modeled = RELAY_ATTRS[name] ?? new Set<string>();
+      const renderOnly = RENDER_ONLY_ATTRS[name] ?? new Set<string>();
+      for (const attr of Object.keys(attrs)) {
+        if (!modeled.has(attr) && !renderOnly.has(attr)) {
+          violations.push(`${kind} '${name}' persists unmodeled attr '${attr}'`);
+        }
+      }
+    };
+    for (const [name, type] of Object.entries(schema.nodes)) {
+      if (STRUCTURAL_NODES.has(name) || !RELAY_NODES.has(name)) continue;
+      check('node', name, type.spec.attrs ?? {});
+    }
+    for (const [name, type] of Object.entries(schema.marks)) {
+      check('mark', name, type.spec.attrs ?? {});
+    }
+    expect(
+      violations,
+      `editor persists attributes the relay neither models (RELAY_ATTRS) nor carves out ` +
+        `(RENDER_ONLY_ATTRS) — each is a silent round-trip loss. Wire a BLOCK_ATTRS/MARK_ATTRS ` +
+        `row, or declare it render-only:\n  ${violations.join('\n  ')}`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes the first slice of **JP-432** (the prose-parity epic). Follow-up to JP-429 (#389): #389 gave the relay a `BLOCK_ATTRS` round-trip registry for block attributes; this brings the relay prose model to **parity with the editor's Tiptap schema** so editor-persisted formatting stops being silently dropped, and installs a CI guard so it can't regress.

Motivated by a live MCP dogfood session that found the relay model is narrower than the editor schema — every un-modeled attr/node was a silent-loss landmine (a user's text colour vanished when an agent edited its line; a merged table cell corrupted; task lists downgraded to bullets).

Purely additive HTML fidelity — **no `PROTOCOL_VERSION` bump, no migration** (old docs parse to bare marks/cells).

## A1 — inline-attr passthrough (the inline twin of `BLOCK_ATTRS`)
- New `MARK_ATTRS` registry + `mark_attrs_for()` in `prose_schema.rs`.
- **Highlight `color`** (style-only `background-color`; the editor's `parseHTML` reads it back) and a new **`textStyle` mark** (`<span style="color">`) now round-trip through all three legs (parse → CRDT → serialize). `PmMark` gained an `attrs` field; `marks_to_attrs` stores a `Map` when a mark carries attrs (never `Bool(true)`).
- A plain `<span>` still unwraps — the parser only creates a `textStyle` mark when a recognized attr is present, keeping the CRDT free of empty marks.

## A2 — node-level parity (explicit-arm gaps the registry can't cover)
- **Task lists** — `taskList`/`taskItem` + `checked` were aliased to plain `ul`/`li` (checkbox state lost). Now round-trip with `data-type`/`data-checked`; parse tolerates the editor's checkbox chrome (`<input>` is now void, `<label>`/`<div>` unwrap).
- **`embeddedGroup`** — had no relay handler, so the atom was **deleted on read**. Now preserved (`data-group-id`/`data-group-name`).
- **codeBlock `language`** — `<code class="language-…">` (was dropped to a bare `<pre><code>`).
- **orderedList `type`** (`<ol type="a">`); **bibliography `scope`** (see A3).

## A3 — bidirectional schema-contract guard
`proseSchemaContract.test.ts` reworked from a hardcoded, one-direction (`relay ⊆ client`) node list to a **schema-derived, bidirectional** check: it enumerates the full node + mark + attr set from `getSchema(extensions)` and asserts **`editor ⊆ relay-modeled`** (+ documented render-only carve-outs). Any future editor addition unmirrored in the relay now **fails CI** — the guarantee behind "no silent loss," not a discipline.

The guard immediately earned its keep: it caught **bibliography `scope`** (`'cited'` vs `'all'`) being dropped — silently reverting a user's "show all references" setting. Now wired on both legs.

**Documented carve-outs** (render-only config, not persisted): link `target`/`rel`/`class` (constant `HTMLAttributes` the editor re-applies; the link UI doesn't set `target`); `embeddedGroup.cachedImageUrl` (runtime PNG cache); table cell `colspan`/`rowspan`/`colwidth` (**deferred to JP-432 Pillar D — richer tables**).

## Verification
- Relay: **623 lib tests** pass, incl. new registry-driven round-trip contracts for marks + the node-level nodes (each panics if a row is half-wired). `cargo check --all-targets`; clippy introduces no new warnings.
- Editor: contract test **5/5**; `tsc --noEmit` clean.
- Live MCP probe pass on a real doc (highlight/text colour, task-list `checked`, code language, embedded group) is the remaining end-to-end confirmation — needs a running stack.

Structural verbs (Pillar B), durable IDs (C), and richer tables/spans (D) are the follow-on slices under JP-432, each with its own plan pass.

Assisted-by: Opus 4.8
