### PR TITLE
JP-435: structural delete verb (docushark_delete_block)

### DIFF
--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -110,6 +110,7 @@ All tools are namespaced `docushark_*`.
 | `add_prose_page` | Append a prose page. Markdown by default. |
 | `set_prose` | Write a prose page. Replaces the whole body by default; pass `anchor` (the current text of a line) to replace **only that line** — a single bullet, table cell, heading, or paragraph anywhere on the page, with its container + siblings untouched. Block formatting (cell colour/alignment, heading/paragraph alignment, ordered-list start/type), inline formatting (highlight + text colour, marks), task lists, and a code block's language all round-trip, so they're settable via `format:"html"`. Markdown by default. |
 | `insert_block` | Insert a **new** block beside an anchored one without rewriting the page — the additive companion to `set_prose`'s anchored edit (`set_prose`+`anchor` **changes** a line; `insert_block` **adds** one). Anchor a bullet → the content becomes a sibling bullet (a task item under a task list); anchor a top-level block, or a line inside a blockquote/cell → inserted at that level. `side` is `before`/`after` (default `after`). Markdown by default. |
+| `delete_block` | Delete a whole block by anchoring it — a bullet (and its nested sub-items), paragraph, heading, or table-cell line — removing the entire structural unit, not just its text. Deleting the last bullet removes the now-empty list; the page never goes truly empty. |
 | `rename_prose_page` | Rename a prose page. |
 
 ### Structure (write)

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -60,6 +60,9 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
   you can see + the new content: it's placed as a structural sibling (a new bullet
   beside a bullet, a top-level block beside one), side "before"/"after". Rule of
   thumb: set_prose+anchor CHANGES a line, insert_block ADDS one.
+- To REMOVE a block, use delete_block with anchor = the line: it removes the whole
+  unit (a bullet + its sub-items, a paragraph, a heading), not just the text —
+  deleting the last bullet removes the empty list; the page never goes fully empty.
 
 ## Shapes (generate_diagram / add_shape / connect)
 - Prefer generate_diagram for anything with edges: pass nodes [{id,label,kind?}]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -376,6 +376,21 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
             }),
         },
         ToolDescriptor {
+            name: "docushark_delete_block",
+            description:
+                "Delete a whole block by anchoring it — remove a bullet (and its nested sub-items), a paragraph, a heading, or a table cell's line, without rewriting the page. Pass 'anchor' — the current text of the block. Removes the entire structural unit, not just its text: deleting the last bullet removes the now-empty list, and the page never goes truly empty (a last-block delete leaves one empty paragraph). The anchor must match exactly one line (else an ERR_ANCHOR_* error). Refuses local (renderer-owned) documents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string"},
+                    "anchor": {"type": "string", "description": "The current text of the block to delete — a bullet, heading, or paragraph you can see. Must match exactly one line; whitespace is normalized and styling/marks are ignored."}
+                },
+                "required": ["docId", "pageId", "anchor"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
             name: "docushark_rename_prose_page",
             description:
                 "Rename a prose page. Refuses local documents.",
@@ -909,6 +924,7 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark_add_prose_page" => add_prose_page(ctx, args),
         "docushark_set_prose" => set_prose(ctx, args),
         "docushark_insert_block" => insert_block(ctx, args),
+        "docushark_delete_block" => delete_block(ctx, args),
         "docushark_rename_prose_page" => rename_prose_page(ctx, args),
         "docushark_add_canvas_page" => add_canvas_page(ctx, args),
         "docushark_rename_canvas_page" => rename_canvas_page(ctx, args),
@@ -2043,6 +2059,31 @@ fn insert_block(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> 
 }
 
 #[derive(Deserialize)]
+struct DeleteBlockArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    /// The current text of the block to delete (matches exactly one leaf).
+    anchor: String,
+}
+
+/// JP-435 (Pillar B): structural delete. Resolves `anchor` to a leaf, walks up to
+/// its structural unit, and removes the whole unit — a bullet + its subtree, a
+/// paragraph, a heading — pruning an emptied list and keeping the page non-empty.
+fn delete_block(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: DeleteBlockArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    reject_if_local(ctx, &parsed.doc_id)?;
+    write_delete_block_live_or_json(ctx, &parsed.doc_id, &parsed.page_id, &parsed.anchor)?;
+    Ok(ToolOutcome {
+        result: json!({"pageId": parsed.page_id, "ok": true}),
+        changed_doc_id: Some(parsed.doc_id),
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
 struct RenameProsePageArgs {
     #[serde(rename = "docId")]
     doc_id: DocId,
@@ -3078,6 +3119,39 @@ fn write_insert_block_live_or_json(
             let now = now_ms();
             let current = read_prose_content(doc, page_id)?;
             let new_html = crate::sync::insert_block_in_html(&current, anchor, side, html)?;
+            let rtp = rich_text_pages_mut(doc)?;
+            let page = rtp
+                .get_mut("pages")
+                .and_then(|v| v.as_object_mut())
+                .and_then(|pages| pages.get_mut(page_id))
+                .and_then(|p| p.as_object_mut())
+                .ok_or_else(|| format!("Prose page '{}' not found", page_id))?;
+            page.insert("content".into(), json!(new_html));
+            page.insert("modifiedAt".into(), json!(now));
+            stamp_doc_modified(doc, now);
+            Ok(())
+        })
+        .map(|_| ())
+    }
+}
+
+/// JP-435 structural delete, live-or-cold — the delete analog of
+/// [`write_insert_block_live_or_json`]. Anchor matched against authoritative state.
+fn write_delete_block_live_or_json(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    page_id: &str,
+    anchor: &str,
+) -> Result<(), String> {
+    if let Some(handle) = resident_handle(ctx, doc_id) {
+        let framed = handle.delete_prose_block(page_id, anchor)?;
+        ctx.broadcast_update(doc_id, framed);
+        Ok(())
+    } else {
+        mutate_with_retry(ctx, doc_id, |doc| {
+            let now = now_ms();
+            let current = read_prose_content(doc, page_id)?;
+            let new_html = crate::sync::delete_block_in_html(&current, anchor)?;
             let rtp = rich_text_pages_mut(doc)?;
             let page = rtp
                 .get_mut("pages")

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -828,7 +828,8 @@ mod tests {
         assert!(names.contains(&"docushark_get_skills"));
         assert!(names.contains(&"docushark_list_icons"));
         assert!(names.contains(&"docushark_insert_block"));
-        assert_eq!(tools.len(), 35);
+        assert!(names.contains(&"docushark_delete_block"));
+        assert_eq!(tools.len(), 36);
     }
 
     #[tokio::test]

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -32,7 +32,7 @@ mod roundtrip_tests;
 /// Apply an anchored, block-level prose edit to a page's HTML off the live path
 /// (the MCP cold path for a non-resident document). See [`prose_block`].
 pub use prose_block::replace_block_in_html;
-pub use prose_block::{insert_block_in_html, InsertSide};
+pub use prose_block::{delete_block_in_html, insert_block_in_html, InsertSide};
 
 pub use prose_validate::ProseFix;
 
@@ -1083,6 +1083,22 @@ impl DocHandle {
         let mut txn = self.doc.transact_mut();
         let before = txn.before_state().clone();
         prose_block::insert_block_in_fragment(&frag, &mut txn, anchor, side, html)?;
+        let update = txn.encode_state_as_update_v1(&before);
+        drop(txn);
+        self.dirty.store(true, Ordering::Relaxed);
+        Ok(protocol::frame_update(update))
+    }
+
+    /// Anchored, structural delete (JP-435 / B4): remove the whole block the
+    /// `anchor` resolves to (a bullet + its subtree, a paragraph, a heading), not
+    /// just blank its text. Returns the framed CRDT delta; marks dirty. An `Err`
+    /// leaves the live fragment untouched. See [`prose_block`].
+    pub fn delete_prose_block(&self, page_id: &str, anchor: &str) -> Result<Vec<u8>, String> {
+        let name = format!("prose:{page_id}");
+        let frag = self.doc.get_or_insert_xml_fragment(name.as_str());
+        let mut txn = self.doc.transact_mut();
+        let before = txn.before_state().clone();
+        prose_block::delete_block_in_fragment(&frag, &mut txn, anchor)?;
         let update = txn.encode_state_as_update_v1(&before);
         drop(txn);
         self.dirty.store(true, Ordering::Relaxed);

--- a/relay/src/sync/prose_block.rs
+++ b/relay/src/sync/prose_block.rs
@@ -229,6 +229,77 @@ fn wrap_as_items(blocks: Vec<PmNode>, item_type: &str) -> Vec<PmNode> {
         .collect()
 }
 
+/// Delete the structural unit the `anchor` resolves to (JP-435 / B4) — remove a
+/// whole bullet / paragraph / heading, not just blank its text (an empty write
+/// only clears a leaf's inline content). Reuses the same leaf→unit resolution as
+/// insert. Emptied containers are fixed up ([`prune_or_reseed_empty`]): an empty
+/// list is removed, the page and block+ containers never go truly empty.
+pub fn delete_block_in_fragment(
+    frag: &XmlFragmentRef,
+    txn: &mut TransactionMut,
+    anchor: &str,
+) -> Result<(), String> {
+    let targets = collect_targets(frag, &*txn);
+    let leaf_path = resolve_target(&targets, anchor, "anchor")?.path.clone();
+    let unit = resolve_structural_unit(frag, &*txn, &leaf_path);
+    splice(frag, txn, &unit.parent_path, unit.index, 1, &[]);
+    prune_or_reseed_empty(frag, txn, &unit.parent_path);
+    Ok(())
+}
+
+/// [`delete_block_in_fragment`] on a page's HTML without a live `Doc` — the MCP
+/// cold path, the structural-delete analog of [`replace_block_in_html`].
+pub fn delete_block_in_html(current_html: &str, anchor: &str) -> Result<String, String> {
+    let doc = Doc::new();
+    let frag = doc.get_or_insert_xml_fragment("prose:scratch");
+    {
+        let mut txn = doc.transact_mut();
+        for node in &prose_parse::html_to_blocks(current_html) {
+            build_prose_node(&frag, &mut txn, node);
+        }
+        delete_block_in_fragment(&frag, &mut txn, anchor)?;
+    }
+    let txn = doc.transact();
+    Ok(prose_html::fragment_to_html(&frag, &txn))
+}
+
+/// Node types that hold *items* (list items / rows / cells), not flow content —
+/// an empty one is invalid and gets removed. Everything else that can be emptied
+/// (the root, or a block+ container like a list item / cell / blockquote /
+/// callout) instead reseeds a paragraph to stay schema-valid.
+fn is_item_container(tag: &str) -> bool {
+    matches!(tag, "bulletList" | "orderedList" | "taskList" | "table" | "tableRow")
+}
+
+/// Fix up a container a structural delete may have emptied: an empty item
+/// container (list / table / row) is removed, recursing up to its now-maybe-empty
+/// parent; any other emptied container (root / list item / cell / blockquote /
+/// callout) reseeds one empty paragraph. A no-op when the container is non-empty.
+fn prune_or_reseed_empty(frag: &XmlFragmentRef, txn: &mut TransactionMut, container_path: &[u32]) {
+    if container_path.is_empty() {
+        if frag.len(&*txn) == 0 {
+            build_prose_node(frag, txn, &empty_paragraph());
+        }
+        return;
+    }
+    let Some(el) = descend(frag, &*txn, container_path) else {
+        return;
+    };
+    if el.len(&*txn) > 0 {
+        return;
+    }
+    if is_item_container(el.tag().as_ref()) {
+        // Remove the empty list/table/row, then prune the parent it left behind.
+        let parent = &container_path[..container_path.len() - 1];
+        let idx = *container_path.last().unwrap();
+        splice(frag, txn, parent, idx, 1, &[]);
+        prune_or_reseed_empty(frag, txn, parent);
+    } else {
+        // root / list item / cell / blockquote / callout must hold block+.
+        build_prose_node(&el, txn, &empty_paragraph());
+    }
+}
+
 /// Walk the fragment into a flat list of addressable leaf [`Target`]s: descend
 /// through every container (lists, tables, cells, list items, blockquotes,
 /// callouts, unknown wrappers) and emit each text-bearing leaf ([`TEXT_LEAVES`])
@@ -666,6 +737,60 @@ mod tests {
     fn insert_of_empty_content_is_an_error() {
         let err = ins("<p>a</p>", "a", InsertSide::After, "").unwrap_err();
         assert!(err.starts_with("ERR_INSERT_EMPTY"), "{err}");
+    }
+
+    // ---- JP-435 (Pillar B): structural delete ----
+
+    fn del(current: &str, anchor: &str) -> Result<String, String> {
+        delete_block_in_html(current, anchor)
+    }
+
+    #[test]
+    fn delete_a_middle_bullet_keeps_the_others() {
+        let out = del("<ul><li><p>a</p></li><li><p>b</p></li><li><p>c</p></li></ul>", "b").unwrap();
+        assert_eq!(out, "<ul><li><p>a</p></li><li><p>c</p></li></ul>");
+    }
+
+    #[test]
+    fn delete_the_only_bullet_removes_the_empty_list() {
+        let out = del("<p>keep</p><ul><li><p>only</p></li></ul><p>tail</p>", "only").unwrap();
+        assert_eq!(out, "<p>keep</p><p>tail</p>");
+    }
+
+    #[test]
+    fn delete_a_top_level_paragraph_keeps_siblings() {
+        let out = del("<p>a</p><p>b</p><p>c</p>", "b").unwrap();
+        assert_eq!(out, "<p>a</p><p>c</p>");
+    }
+
+    #[test]
+    fn delete_the_only_block_reseeds_an_empty_paragraph() {
+        let out = del("<p>only</p>", "only").unwrap();
+        assert_eq!(out, "<p></p>");
+    }
+
+    #[test]
+    fn delete_a_nested_sub_bullet_removes_the_emptied_sub_list() {
+        let out = del("<ul><li><p>parent</p><ul><li><p>child</p></li></ul></li></ul>", "child").unwrap();
+        assert_eq!(out, "<ul><li><p>parent</p></li></ul>");
+    }
+
+    #[test]
+    fn delete_a_line_in_a_blockquote_keeps_the_quote() {
+        let out = del("<blockquote><p>q1</p><p>q2</p></blockquote>", "q1").unwrap();
+        assert_eq!(out, "<blockquote><p>q2</p></blockquote>");
+    }
+
+    #[test]
+    fn delete_the_last_quote_line_reseeds_inside_the_quote() {
+        let out = del("<blockquote><p>lone</p></blockquote>", "lone").unwrap();
+        assert_eq!(out, "<blockquote><p></p></blockquote>");
+    }
+
+    #[test]
+    fn delete_with_a_bad_anchor_errors() {
+        let err = del("<p>a</p>", "missing").unwrap_err();
+        assert!(err.starts_with("ERR_ANCHOR_NOT_FOUND"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
Second slice of **JP-435 (Pillar B)** — the structural **delete** verb, on top of the merged insert verb (#392). Adds `docushark_delete_block`: remove a whole block by anchoring it, not just blank its text.

## What it does
- Anchor a **bullet** → the whole bullet (and its nested sub-items) is removed; anchor a **paragraph / heading / table-cell line** → that block is removed.
- Removes the entire **structural unit** (reusing insert's leaf→unit resolver), then fixes up what the removal emptied:
  - deleting the **last bullet** removes the now-empty `<ul>`/`<ol>`/task list (recursing up if that empties its parent),
  - a block+ container (list item / cell / blockquote / callout) that empties reseeds one empty paragraph,
  - the **page never goes truly empty** — a last-block delete leaves one empty paragraph.
- Same rails as insert: exactly-one-line anchor (`ERR_ANCHOR_*`), `Editor` permission, refuses local docs, live (resident Y.Doc) + cold (JSON) paths.

## Files
- `relay/src/sync/prose_block.rs` — `delete_block_in_fragment`, `delete_block_in_html`, `prune_or_reseed_empty`, `is_item_container` + 8 tests.
- `relay/src/sync/mod.rs` — `DocHandle::delete_prose_block` + re-export.
- `relay/src/mcp/tools.rs` — `DeleteBlockArgs`, `delete_block`, `write_delete_block_live_or_json`, descriptor + dispatch.
- `relay/src/mcp/transport.rs` — tool-count guard 35 → 36.
- `relay/docs/mcp/README.md` + `relay/src/mcp/skills.rs` — surface docs.

## Verify
- **639 relay lib tests** (8 new delete cases: middle bullet, last-bullet → empty-list removal, top-level, last-block → reseed, nested sub-list pruning, blockquote line, last-quote-line reseed, bad anchor). `cargo check --all-targets`; clippy clean.

## Deferred: move (B5)
The last Pillar-B verb, `move`, is intentionally **not** in this PR. It's materially harder — it needs to read a live Y.Doc subtree back out to relocate it, resolve cross-context **lift/sink/wrap** semantics (a bullet moved to top level, a paragraph moved into a list), and guard self-move / move-into-own-child. That deserves its own design pass and PR rather than a rushed addition. Filed/tracked as the remaining slice of JP-435.

Assisted-by: Opus 4.8
