### PR TITLE
JP-327: re-stamp the relay build identity when the checkout moves

### DIFF
--- a/relay/build.rs
+++ b/relay/build.rs
@@ -21,9 +21,43 @@ fn main() {
     println!("cargo:rerun-if-env-changed=GIT_SHA");
     println!("cargo:rerun-if-env-changed=BUILD_TIME");
     println!("cargo:rerun-if-changed=build.rs");
+    // Local builds: re-stamp when the checkout moves. Emitting ANY rerun-if
+    // directive (above) opts this script out of cargo's default rerun-on-any-
+    // source-change, so without these the stamp freezes at whatever HEAD was on
+    // the target dir's first-ever build — /version then reports a commit that
+    // can be days stale. Watch the git files that change on commit / branch
+    // switch; when git or .git is absent (the Docker build context — identity
+    // arrives via the GIT_SHA build-arg instead) nothing extra is watched.
+    for path in git_stamp_paths() {
+        println!("cargo:rerun-if-changed={path}");
+    }
 
     println!("cargo:rustc-env=RELAY_GIT_SHA={}", resolve_git_sha());
     println!("cargo:rustc-env=RELAY_BUILD_TIME={}", resolve_build_time());
+}
+
+/// The files that move when the checkout does: `.git/HEAD` (branch switch,
+/// detached-HEAD commit) plus the loose ref file HEAD points at (commit on a
+/// branch). Resolved via `git rev-parse --git-path`, which handles the relay
+/// living in a subdirectory and `git worktree` checkouts (where `.git` is a
+/// file, not a directory). A packed/absent loose ref is skipped rather than
+/// named: cargo treats a missing rerun-if-changed path as always-dirty, which
+/// would re-stamp BUILD_TIME — and so recompile the crate — on every build.
+fn git_stamp_paths() -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(head) = git_stdout(&["rev-parse", "--git-path", "HEAD"]) {
+        if std::path::Path::new(&head).exists() {
+            out.push(head);
+        }
+    }
+    if let Some(sym) = git_stdout(&["symbolic-ref", "-q", "HEAD"]) {
+        if let Some(ref_file) = git_stdout(&["rev-parse", "--git-path", &sym]) {
+            if std::path::Path::new(&ref_file).exists() {
+                out.push(ref_file);
+            }
+        }
+    }
+    out
 }
 
 /// `GIT_SHA` env (CI / Docker build-arg) → local `git rev-parse --short HEAD`
@@ -35,15 +69,19 @@ fn resolve_git_sha() -> String {
         return short_sha(&sha);
     }
 
+    git_stdout(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Trimmed stdout of a `git` invocation, `None` on any failure or empty output.
+fn git_stdout(args: &[&str]) -> Option<String> {
     Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(args)
         .output()
         .ok()
         .filter(|out| out.status.success())
         .and_then(|out| String::from_utf8(out.stdout).ok())
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// `BUILD_TIME` env (CI passes RFC3339 UTC) → wall-clock epoch seconds →


### PR DESCRIPTION
Fixes the stale `/version` stamp: the running local relay was reporting a commit + build time from **nine days earlier** (`29d4513`, July 3) regardless of what was actually built.

## Root cause

`build.rs` emits `rerun-if-env-changed` for the CI-injected `GIT_SHA`/`BUILD_TIME` — and emitting *any* rerun-if directive opts a build script out of cargo's default rerun-on-any-source-change. Locally those envs never change and `build.rs` never changes, so the script ran **once per target dir, ever**, freezing the stamp at whatever HEAD was on the first build. `/version`, the `relay_build_info` metric, and Settings-facing identity all inherited the lie.

## Fix

Additionally watch the git files that actually move on commit / branch switch: `.git/HEAD` plus the loose ref file HEAD points at, resolved via `git rev-parse --git-path` — correct for the relay living in a subdirectory *and* for `git worktree` checkouts. A packed/absent ref is skipped rather than named (cargo treats a missing watch path as always-dirty, which would re-stamp `BUILD_TIME` and recompile the crate on every build). Docker/CI builds are untouched — no `.git` in the build context, identity still arrives via the `GIT_SHA` build-arg.

## Verify (performed in a worktree)

| Step | Result |
|---|---|
| Build at `d33c19e7` | stamp `RELAY_GIT_SHA=d33c19e`; watches worktree `HEAD` + branch ref |
| Commit (HEAD moves) → rebuild | script reran, stamp `RELAY_GIT_SHA=3e36638` |
| Immediate rebuild | fresh in 0.13s — no rerun, no `BUILD_TIME` churn |

No Taskfile changes needed — `task up` / `task dev:relay` (docushark-web) run `cargo run`, which now inherits truthful stamps.

Assisted-by: Fable 5