### PR TITLE
JP-430: MCP file read - list_files + get_file (Pillar E, E1+E2)

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -213,6 +213,7 @@ This table is the canonical inventory — a drift test
 | `RELAY_MCP_ENABLED` | `[mcp].enabled` |
 | `RELAY_MCP_PORT` | `[mcp].port` |
 | `RELAY_MCP_EXPOSE` | `[mcp].expose` (`local` = loopback-only, `public` = folded onto the main listener) |
+| `RELAY_MCP_BLOB_URL_TTL_SECS` | `[mcp].blob_url_ttl_secs` (lifetime of presigned blob GET URLs minted by the MCP `get_file` tool; s3 backend only) |
 | `RELAY_TENANCY_MODE` | `[tenancy].mode` (`shared`/`dedicated`) |
 | `RELAY_TENANCY_WORKSPACE` | `[tenancy].workspace_id` |
 | `RELAY_STORAGE_QUOTA_BYTES` | `[tenancy.limits].storage_quota_bytes` (fallback cap when a token omits the limit claim; `0` = unlimited) |

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -88,7 +88,9 @@ All tools are namespaced `docushark_*`.
 | `get_document` | Document metadata + canvas `pages` summary + `prosePages` summary + `fields` (the document's `{{name}}` values). The map of what exists. |
 | `get_page` | The shapes on one canvas page, as DSL objects. |
 | `get_shape` | One shape on a page, by id, as a DSL object (the read-one companion to `get_page`). |
-| `get_prose` | All prose pages (or one, with `pageId`): `id`, `name`, `order`, HTML `content`. |
+| `get_prose` | All prose pages (or one, with `pageId`): `id`, `name`, `order`, HTML `content`. Embedded images appear as `blob://<hash>` references — list them with `list_files`, fetch bytes with `get_file`. |
+| `list_files` | Every file attached to the document: canvas file shapes (`fileName`, `mimeType`, `sizeBytes`, `fileCategory`) and prose-embedded images, each with its `blobRef` (content hash) and whether the bytes are `inStore` on this relay. |
+| `get_file` | Fetch an attached file's bytes by `blobRef`. Object-storage backend → a short-lived presigned `url` to GET directly (`expiresAtMs`); filesystem backend → `base64` inline (small files only). The blob must be referenced by the given document. |
 | `get_outline` | A prose page's heading outline: ordered `{ index, level, title }`. `index` is used by the structural tools. |
 | `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
 | `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -102,12 +102,7 @@ fn collect_blob_refs_walk(
             }
             // Rich-text images embed `blob://<hash>` in HTML (e.g. an <img src>);
             // a single content string may carry several.
-            for seg in s.split("blob://").skip(1) {
-                let hash: String = seg.chars().take_while(|c| c.is_ascii_hexdigit()).take(64).collect();
-                if is_valid_blob_hash(&hash) {
-                    out.insert(hash);
-                }
-            }
+            collect_blob_uris_in_str(s, out);
         }
         Value::Array(a) => {
             for item in a {
@@ -120,6 +115,19 @@ fn collect_blob_refs_walk(
             }
         }
         _ => {}
+    }
+}
+
+/// Collect every well-formed `blob://<hash>` reference embedded in a string
+/// (rich-text HTML carries them in `<img src>`; one string may hold several).
+/// Shared with the MCP file tools (JP-430), which list a prose page's blobs
+/// from the same grammar the refcount walk recognizes.
+pub(crate) fn collect_blob_uris_in_str(s: &str, out: &mut std::collections::BTreeSet<String>) {
+    for seg in s.split("blob://").skip(1) {
+        let hash: String = seg.chars().take_while(|c| c.is_ascii_hexdigit()).take(64).collect();
+        if is_valid_blob_hash(&hash) {
+            out.insert(hash);
+        }
     }
 }
 
@@ -156,7 +164,7 @@ fn append_capped(buf: &mut Vec<u8>, chunk: &[u8], max: usize) -> bool {
 /// (e.g. `/` or `..`) could escape the workspace prefix. The bytes are never
 /// re-hashed server-side under direct-to-R2, so the format check is the only
 /// structural guard at mint time.
-fn is_valid_blob_hash(hash: &str) -> bool {
+pub(crate) fn is_valid_blob_hash(hash: &str) -> bool {
     hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
@@ -174,22 +182,47 @@ fn caller_can_read_blob(
     sub: &str,
     role: WorkspaceRole,
 ) -> bool {
-    if !state.enforce_private_docs() {
+    blob_read_allowed(
+        state.blob_store(),
+        state.doc_store(),
+        state.enforce_private_docs(),
+        ws,
+        hash,
+        Some(sub),
+        Some(role_str(role)),
+    )
+}
+
+/// The parts-based core of [`caller_can_read_blob`], shared with the MCP file
+/// tools (JP-430) which hold the stores but no `ServerState`. `sub == None` is
+/// the static loopback MCP token — no user identity, treated as workspace
+/// admin, mirroring `ToolContext::ensure_doc_permission`.
+pub(crate) fn blob_read_allowed(
+    blob_store: &crate::server::blobs::BlobStore,
+    doc_store: &crate::server::documents::DocumentStore,
+    enforce_private_docs: bool,
+    ws: &WorkspaceId,
+    hash: &str,
+    sub: Option<&str>,
+    role: Option<&str>,
+) -> bool {
+    if !enforce_private_docs {
         return true;
     }
-    let role = role_str(role);
+    let Some(sub) = sub else {
+        return true; // static loopback token → workspace admin
+    };
     // Owner/admin can always read (manages the whole workspace).
-    if role == "owner" || role == "admin" {
+    if matches!(role, Some("owner") | Some("admin")) {
         return true;
     }
-    let referencing = state.blob_store().docs_referencing(ws, hash);
+    let referencing = blob_store.docs_referencing(ws, hash);
     referencing.iter().any(|doc_id| {
         match DocId::from_http_path(doc_id.clone()) {
-            Ok(doc_id) => state
-                .doc_store()
+            Ok(doc_id) => doc_store
                 .get_metadata(ws, &doc_id)
                 .map(|m| {
-                    crate::server::permissions::get_user_permission(&m, sub, Some(role))
+                    crate::server::permissions::get_user_permission(&m, sub, role)
                         != crate::server::permissions::Permission::None
                 })
                 .unwrap_or(false),

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -19,6 +19,12 @@ pub const DEFAULT_LISTEN_PORT: u16 = 9876;
 /// MCP is exposed only on loopback for now).
 pub const DEFAULT_MCP_PORT: u16 = 9877;
 
+/// Default lifetime of presigned blob GET URLs minted by the MCP `get_file`
+/// tool (JP-430). Deliberately tighter than `DEFAULT_S3_GET_TTL_SECS`: a URL
+/// returned from a tool call persists in the agent's chat transcript, so it
+/// should outlive the fetch, not the conversation.
+pub const DEFAULT_MCP_BLOB_URL_TTL_SECS: u64 = 300; // 5m
+
 /// Default storage root, relative to the working directory at startup.
 pub const DEFAULT_DATA_DIR: &str = "data";
 
@@ -348,6 +354,12 @@ pub struct McpConfig {
     /// refuses the static bearer token: callers must present a JWT whose
     /// `wsp` claim scopes the request to a workspace.
     pub expose: McpExpose,
+    /// Lifetime (seconds) of presigned blob GET URLs minted by the MCP
+    /// `get_file` tool (JP-430). Applies only under `backend = "s3"`; the
+    /// filesystem backend inlines small files instead. Tighter than the
+    /// editor's `[storage.s3].get_ttl_secs` because the URL persists in the
+    /// agent's transcript.
+    pub blob_url_ttl_secs: u64,
 }
 
 /// Reachability of the MCP endpoint. See [`McpConfig::expose`].
@@ -372,6 +384,7 @@ impl Default for McpConfig {
             enabled: true,
             port: DEFAULT_MCP_PORT,
             expose: McpExpose::default(),
+            blob_url_ttl_secs: DEFAULT_MCP_BLOB_URL_TTL_SECS,
         }
     }
 }
@@ -698,6 +711,11 @@ impl RelayConfig {
                     anyhow::bail!("RELAY_MCP_EXPOSE must be 'local' or 'public' (got {other:?})")
                 }
             };
+        }
+        if let Some(v) = get("RELAY_MCP_BLOB_URL_TTL_SECS") {
+            self.mcp.blob_url_ttl_secs = v.parse().map_err(|_| {
+                anyhow::anyhow!("RELAY_MCP_BLOB_URL_TTL_SECS must be a u64 (got {v:?})")
+            })?;
         }
         if let Some(v) = get("RELAY_DATA_DIR") {
             self.storage.path = PathBuf::from(v);

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -358,6 +358,7 @@ async fn run_serve(
             make_doc_changed(&server),
             make_doc_deleted(&server),
             mcp_read_limiter.clone(),
+            config.mcp.blob_url_ttl_secs,
         )
         .map_err(|e| anyhow::anyhow!("init public MCP mount: {}", e))?;
         // AU-7 (JP-300): never write the bearer to logs that ship to
@@ -397,6 +398,10 @@ async fn run_serve(
         // live on `ServerState`, so this must run after `server.start()` above.
         let sync_registry = server.sync_registry_handle().await;
         let on_doc_update = server.doc_update_broadcaster().await;
+        // JP-430: the MCP file tools share the WS/REST blob bookkeeping + byte
+        // store, so list_files/get_file see the same ACL/ref gates.
+        let blob_store = server.blob_store_handle().await;
+        let s3_backend = server.s3_backend_handle().await;
         // JP-230: the MCP server shares the WS server's single `DocumentStore`
         // (one in-memory index, one writer) so MCP- and editor-authored docs
         // never clobber each other's `index.json`. It's available after start, and
@@ -423,6 +428,9 @@ async fn run_serve(
                 on_doc_update,
                 shared_doc_store,
                 config.permissions.enforce_private_docs,
+                blob_store,
+                s3_backend,
+                config.mcp.blob_url_ttl_secs,
             ) {
                 Ok(mcp) => {
                     let mcp = Arc::new(mcp);

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -30,9 +30,10 @@ use tokio::sync::oneshot;
 use tokio::sync::RwLock;
 
 use crate::auth::OidcAuthState;
+use crate::server::blobs::BlobStore;
 use crate::server::documents::DocumentStore;
 use crate::server::protocol::{DocId, WorkspaceId};
-use crate::server::WorkspaceWriteLimiter;
+use crate::server::{S3Backend, WorkspaceWriteLimiter};
 use crate::sync::DocRegistry;
 use tools::OnDocUpdate;
 
@@ -118,6 +119,15 @@ pub struct McpServer {
     /// `config.permissions.enforce_private_docs`; the static loopback token
     /// always bypasses.
     enforce_private_docs: bool,
+    /// Blob bookkeeping store (index/ACL/refs), shared with the WS/REST path —
+    /// the MCP file tools (JP-430) read the same metadata + gates.
+    blob_store: Arc<BlobStore>,
+    /// S3/R2 byte store — `None` under the filesystem backend. `get_file`
+    /// mints presigned GET URLs through it.
+    s3: Option<Arc<S3Backend>>,
+    /// Lifetime of MCP-minted presigned blob GET URLs (`[mcp]
+    /// blob_url_ttl_secs`, JP-430).
+    blob_url_ttl_secs: u64,
 }
 
 /// The MCP-owned pieces needed to fold the endpoint onto the relay's public
@@ -136,6 +146,9 @@ pub struct PublicMount {
     /// Per-workspace MCP read limiter (JP-249). `None` = unlimited. MCP-local,
     /// so it's carried on the mount rather than `McpSharedHandles`.
     read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
+    /// Lifetime of MCP-minted presigned blob GET URLs (`[mcp]
+    /// blob_url_ttl_secs`, JP-430). MCP-local config, carried on the mount.
+    blob_url_ttl_secs: u64,
 }
 
 /// The server-owned handles a [`PublicMount`] needs to build its router. The
@@ -145,6 +158,11 @@ pub struct PublicMount {
 /// one panic counter, one live Y.Doc registry).
 pub struct McpSharedHandles {
     pub doc_store: Arc<DocumentStore>,
+    /// Blob bookkeeping store — the MCP file tools (JP-430) share the REST
+    /// surface's index/ACL/ref gates.
+    pub blob_store: Arc<BlobStore>,
+    /// S3/R2 byte store; `None` under the filesystem backend.
+    pub s3: Option<Arc<S3Backend>>,
     pub panic_counter: Arc<AtomicU64>,
     pub rate_limit_rejections: Arc<AtomicU64>,
     pub write_limiter: Arc<WorkspaceWriteLimiter>,
@@ -166,6 +184,7 @@ impl PublicMount {
         on_doc_changed: Arc<DocChangedSink>,
         on_doc_deleted: Arc<DocDeletedSink>,
         read_limiter: Option<Arc<WorkspaceWriteLimiter>>,
+        blob_url_ttl_secs: u64,
     ) -> Result<Self, String> {
         Ok(Self {
             token: Arc::new(TokenStore::load_or_create(&app_data_dir)?),
@@ -174,6 +193,7 @@ impl PublicMount {
             on_doc_changed,
             on_doc_deleted,
             read_limiter,
+            blob_url_ttl_secs,
         })
     }
 
@@ -190,6 +210,9 @@ impl PublicMount {
     pub fn into_public_router(self, shared: McpSharedHandles) -> axum::Router {
         let state = McpAppState {
             doc_store: shared.doc_store,
+            blob_store: shared.blob_store,
+            s3: shared.s3,
+            blob_url_ttl_secs: self.blob_url_ttl_secs,
             local_mirror: self.local_mirror,
             feature_config: self.feature_config,
             token: self.token,
@@ -238,6 +261,9 @@ impl McpServer {
         on_doc_update: Arc<OnDocUpdate>,
         doc_store: Arc<DocumentStore>,
         enforce_private_docs: bool,
+        blob_store: Arc<BlobStore>,
+        s3: Option<Arc<S3Backend>>,
+        blob_url_ttl_secs: u64,
     ) -> Result<Self, String> {
         let token = Arc::new(TokenStore::load_or_create(&app_data_dir)?);
         let feature_config = Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir));
@@ -266,6 +292,9 @@ impl McpServer {
             sync_registry,
             on_doc_update,
             enforce_private_docs,
+            blob_store,
+            s3,
+            blob_url_ttl_secs,
         })
     }
 
@@ -331,6 +360,9 @@ impl McpServer {
 
         let state = McpAppState {
             doc_store: self.doc_store.clone(),
+            blob_store: self.blob_store.clone(),
+            s3: self.s3.clone(),
+            blob_url_ttl_secs: self.blob_url_ttl_secs,
             local_mirror: self.local_mirror.clone(),
             feature_config: self.feature_config.clone(),
             token: self.token.clone(),

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -23,8 +23,10 @@ use std::sync::Arc;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::server::blobs::BlobStore;
 use crate::server::documents::{DocumentStore, SaveOutcome};
 use crate::server::protocol::{DocId, WorkspaceId};
+use crate::server::S3Backend;
 use crate::sync::{DocHandle, DocRegistry};
 
 use super::DocDeletedSink;
@@ -96,6 +98,15 @@ const SOURCE_LOCAL: &str = "local";
 /// alongside team-shared ones.
 pub struct ToolContext<'a> {
     pub team: &'a Arc<DocumentStore>,
+    /// Blob bookkeeping store (index/ACL/refs), shared with the WS/REST path.
+    /// The file tools (JP-430) read the same metadata + gates the REST blob
+    /// surface enforces.
+    pub blob_store: &'a Arc<BlobStore>,
+    /// S3/R2 byte store; `None` under the filesystem backend. `get_file`
+    /// mints presigned GET URLs through it.
+    pub s3: Option<&'a Arc<S3Backend>>,
+    /// Lifetime of MCP-minted presigned blob GET URLs (JP-430).
+    pub blob_url_ttl_secs: u64,
     pub local: &'a Arc<LocalDocumentMirror>,
     pub local_enabled: bool,
     /// Workspace the MCP request authenticates against. Derived in
@@ -199,7 +210,9 @@ fn tool_required_permission(name: &str) -> Option<crate::server::permissions::Pe
         | "docushark_get_prose"
         | "docushark_get_outline"
         | "docushark_list_references"
-        | "docushark_list_fields" => Some(Permission::Viewer),
+        | "docushark_list_fields"
+        | "docushark_list_files"
+        | "docushark_get_file" => Some(Permission::Viewer),
         // Everything else mutates a specific existing document → Editor.
         _ => Some(Permission::Editor),
     }
@@ -264,6 +277,33 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                     "id": {"type": "string", "description": "The shape id."}
                 },
                 "required": ["docId", "pageId", "id"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark_list_files",
+            description:
+                "List every file attached to a document: canvas file shapes (name, MIME type, size, category) and images embedded in prose pages. Each entry carries a blobRef — the content hash to pass to get_file for the bytes. inStore=false means the bytes are not on this relay (e.g. a local-only attachment that was never uploaded).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"}
+                },
+                "required": ["docId"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark_get_file",
+            description:
+                "Fetch an attached file's bytes by blobRef (from list_files or a file shape). Returns either a short-lived download URL to GET directly (object-storage backend) or the base64 bytes inline (filesystem backend, small files only). The blob must be referenced by the given document.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "blobRef": {"type": "string", "description": "SHA-256 content hash of the file (64 lowercase hex chars)."}
+                },
+                "required": ["docId", "blobRef"],
                 "additionalProperties": false
             }),
         },
@@ -938,6 +978,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark_rename_document" => rename_document(ctx, args),
         "docushark_delete_document" => delete_document(ctx, args),
         "docushark_get_prose" => get_prose(ctx, args),
+        "docushark_list_files" => list_files(ctx, args),
+        "docushark_get_file" => get_file(ctx, args),
         "docushark_add_prose_page" => add_prose_page(ctx, args),
         "docushark_set_prose" => set_prose(ctx, args),
         "docushark_insert_block" => insert_block(ctx, args),
@@ -1278,6 +1320,27 @@ fn get_page(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
 /// doesn't model yet (mirrors `get_page`'s fallback).
 fn shape_to_dsl_or_generic(shape: &Value) -> Value {
     shape_json_to_dsl(shape).unwrap_or_else(|| {
+        // JP-430: a FileShape used to fall through as an `_unmapped` stub, so
+        // an agent couldn't even discover that a file existed. Surface its
+        // metadata read-only here (NOT in the bidirectional DSL adapter —
+        // agents must not author file shapes via add_shape; bytes are fetched
+        // with get_file).
+        if shape.get("type").and_then(|v| v.as_str()) == Some("file") {
+            return json!({
+                "id": shape.get("id"),
+                "kind": "file",
+                "x": shape.get("x"),
+                "y": shape.get("y"),
+                "w": shape.get("width"),
+                "h": shape.get("height"),
+                "fileName": shape.get("fileName"),
+                "mimeType": shape.get("mimeType"),
+                "fileSize": shape.get("fileSize"),
+                "fileCategory": shape.get("fileCategory"),
+                "blobRef": shape.get("blobRef"),
+                "label": shape.get("label"),
+            });
+        }
         json!({
             "id": shape.get("id"),
             "kind": shape.get("type"),
@@ -1286,6 +1349,242 @@ fn shape_to_dsl_or_generic(shape: &Value) -> Value {
             "_unmapped": true,
         })
     })
+}
+
+// ---- JP-430: MCP-accessible files (read) ------------------------------------
+
+/// Max byte size `get_file` inlines as base64 on the filesystem backend (no
+/// presign there). Aligned with the ~1 MiB prose input cap: a tool result is
+/// serialized into BOTH the text and structuredContent blocks, so an uncapped
+/// inline would land megabytes in the agent's context twice.
+const MAX_INLINE_FILE_BYTES: u64 = 1_048_576;
+
+#[derive(Deserialize)]
+struct ListFilesArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+}
+
+/// Fetch the doc body, folding in the live Y.Doc surfaces when the doc is
+/// resident — so a file attached seconds ago (not yet snapshot-flattened)
+/// still lists. Mirrors the resident-accurate reads (JP-251).
+fn fetch_doc_resident(ctx: &ToolContext, doc_id: &DocId) -> Result<(Value, &'static str), String> {
+    let (mut doc, source) = fetch_doc(ctx, doc_id)?;
+    if let Some(handle) = resident_handle(ctx, doc_id) {
+        handle.flatten_into(&mut doc);
+    }
+    Ok((doc, source))
+}
+
+fn list_files(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: ListFilesArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    let (doc, source) = fetch_doc_resident(ctx, &parsed.doc_id)?;
+
+    let mut files: Vec<Value> = Vec::new();
+
+    // Canvas file shapes carry their own name/mime/size (the relay blob index
+    // has no name field — the shape is the only place a human name lives).
+    if let Some(pages) = doc.get("pages").and_then(|p| p.as_object()) {
+        for (page_id, page) in pages {
+            let Some(shapes) = page.get("shapes").and_then(|s| s.as_object()) else {
+                continue;
+            };
+            for (shape_id, shape) in shapes {
+                if shape.get("type").and_then(|v| v.as_str()) != Some("file") {
+                    continue;
+                }
+                let blob_ref = shape.get("blobRef").and_then(|v| v.as_str()).unwrap_or("");
+                let meta = ctx.blob_store.get_metadata(&ctx.workspace_id, blob_ref);
+                files.push(json!({
+                    "source": "canvas",
+                    "pageId": page_id,
+                    "shapeId": shape_id,
+                    "blobRef": blob_ref,
+                    "fileName": shape.get("fileName"),
+                    "mimeType": shape
+                        .get("mimeType")
+                        .cloned()
+                        .or_else(|| meta.as_ref().map(|m| json!(m.mime_type))),
+                    "sizeBytes": shape
+                        .get("fileSize")
+                        .cloned()
+                        .or_else(|| meta.as_ref().map(|m| json!(m.size))),
+                    "fileCategory": shape.get("fileCategory"),
+                    "inStore": meta.is_some(),
+                }));
+            }
+        }
+    }
+
+    // Prose pages embed images as `blob://<hash>` in their HTML; metadata
+    // (mime/size) comes from the blob index — prose refs carry no file name.
+    if let Some(pages) = doc
+        .get("richTextPages")
+        .and_then(|p| p.get("pages"))
+        .and_then(|p| p.as_object())
+    {
+        for (page_id, page) in pages {
+            let Some(content) = page.get("content").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let mut hashes = std::collections::BTreeSet::new();
+            crate::api::collect_blob_uris_in_str(content, &mut hashes);
+            for hash in hashes {
+                let meta = ctx.blob_store.get_metadata(&ctx.workspace_id, &hash);
+                files.push(json!({
+                    "source": "prose",
+                    "pageId": page_id,
+                    "blobRef": hash,
+                    "mimeType": meta.as_ref().map(|m| m.mime_type.clone()),
+                    "sizeBytes": meta.as_ref().map(|m| m.size),
+                    "inStore": meta.is_some(),
+                }));
+            }
+        }
+    }
+
+    Ok(ToolOutcome {
+        result: json!({"files": files, "source": source}),
+        changed_doc_id: None,
+        change_detail: None,
+    })
+}
+
+#[derive(Deserialize)]
+struct GetFileArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "blobRef")]
+    blob_ref: String,
+}
+
+fn get_file(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: GetFileArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+    if !crate::api::is_valid_blob_hash(&parsed.blob_ref) {
+        return Err(
+            "ERR_BAD_BLOB_REF: blobRef must be a 64-char lowercase SHA-256 hex digest \
+             (take it from list_files or a file shape's blobRef)"
+                .to_string(),
+        );
+    }
+
+    // Scope: the request's document must actually reference the blob —
+    // get_file is never a workspace-wide fetch-by-hash. This is what ties the
+    // dispatch-level Viewer permission check on docId to the bytes.
+    let (doc, _source) = fetch_doc_resident(ctx, &parsed.doc_id)?;
+    let referenced = crate::api::collect_blob_references(&doc)
+        .iter()
+        .any(|h| h == &parsed.blob_ref);
+    if !referenced {
+        return Err(format!(
+            "ERR_FILE_NOT_FOUND: document '{}' does not reference blob '{}'",
+            parsed.doc_id.as_str(),
+            parsed.blob_ref
+        ));
+    }
+
+    // Workspace ACL gate (opaque not-found — same shape as the REST handlers,
+    // never leaks that a hash exists in another tenant), then the JP-370
+    // private-doc gate, mirroring `blob_download_url_handler`.
+    if !ctx.blob_store.exists(&ctx.workspace_id, &parsed.blob_ref) {
+        return Err(format!(
+            "ERR_FILE_NOT_FOUND: blob '{}' is not in this workspace's store",
+            parsed.blob_ref
+        ));
+    }
+    if !crate::api::blob_read_allowed(
+        ctx.blob_store,
+        ctx.team,
+        ctx.enforce_private_docs,
+        &ctx.workspace_id,
+        &parsed.blob_ref,
+        ctx.user_id.as_deref(),
+        ctx.user_role.as_deref(),
+    ) {
+        return Err(format!(
+            "ERR_FILE_NOT_FOUND: blob '{}' is not in this workspace's store",
+            parsed.blob_ref
+        ));
+    }
+
+    let meta = ctx.blob_store.get_metadata(&ctx.workspace_id, &parsed.blob_ref);
+    let (mime_type, size_bytes) = meta
+        .map(|m| (m.mime_type, m.size))
+        .unwrap_or_else(|| ("application/octet-stream".to_string(), 0));
+
+    // Object-storage backend: hand out a short-lived presigned GET — the
+    // agent fetches the bytes straight from storage (they never transit the
+    // relay or the tool result).
+    if let Some(s3) = ctx.s3 {
+        let url = s3.presign_get_with_ttl(&ctx.workspace_id, &parsed.blob_ref, ctx.blob_url_ttl_secs);
+        let expires_at_ms = now_millis().saturating_add(ctx.blob_url_ttl_secs.saturating_mul(1000));
+        return Ok(ToolOutcome {
+            result: json!({
+                "blobRef": parsed.blob_ref,
+                "mimeType": mime_type,
+                "sizeBytes": size_bytes,
+                "transport": "url",
+                "url": url,
+                "expiresAtMs": expires_at_ms,
+                "note": "GET this URL directly (no auth headers); it expires — re-call get_file for a fresh one.",
+            }),
+            changed_doc_id: None,
+            change_detail: None,
+        });
+    }
+
+    // Filesystem backend (no presign): inline small files as base64.
+    let bytes = ctx
+        .blob_store
+        .load_blob(&ctx.workspace_id, &parsed.blob_ref)
+        .map_err(|e| format!("ERR_FILE_NOT_FOUND: {}", e))?;
+    if bytes.len() as u64 > MAX_INLINE_FILE_BYTES {
+        return Err(format!(
+            "ERR_FILE_TOO_LARGE_FOR_INLINE: {} bytes exceeds the {} byte inline cap on the \
+             filesystem backend. Open the file in the DocuShark app instead, or run the relay \
+             on an object-storage backend to get download URLs.",
+            bytes.len(),
+            MAX_INLINE_FILE_BYTES
+        ));
+    }
+    Ok(ToolOutcome {
+        result: json!({
+            "blobRef": parsed.blob_ref,
+            "mimeType": mime_type,
+            "sizeBytes": bytes.len(),
+            "transport": "inline",
+            "base64": base64_encode(&bytes),
+        }),
+        changed_doc_id: None,
+        change_detail: None,
+    })
+}
+
+/// Unix-millis now — std-only (house style: no chrono here).
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// RFC 4648 §4 base64 (standard alphabet, padded). Hand-rolled like the
+/// relay's other encoders (SigV4, the JWK base64url) — not worth a crate for
+/// one encode direction.
+fn base64_encode(bytes: &[u8]) -> String {
+    const TBL: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
+        let n = u32::from_be_bytes([0, b[0], b[1], b[2]]);
+        out.push(TBL[(n >> 18) as usize & 63] as char);
+        out.push(TBL[(n >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 { TBL[(n >> 6) as usize & 63] as char } else { '=' });
+        out.push(if chunk.len() > 2 { TBL[(n as usize) & 63] as char } else { '=' });
+    }
+    out
 }
 
 #[derive(Deserialize)]
@@ -4218,6 +4517,7 @@ mod tests {
 
     struct Fixture {
         team: Arc<DocumentStore>,
+        blob_store: Arc<BlobStore>,
         local: Arc<LocalDocumentMirror>,
         registry: Arc<DocRegistry>,
         broadcasts: Arc<std::sync::Mutex<Vec<(WorkspaceId, DocId, Vec<u8>)>>>,
@@ -4230,6 +4530,9 @@ mod tests {
         fn ctx(&self, local_enabled: bool) -> ToolContext<'_> {
             ToolContext {
                 team: &self.team,
+                blob_store: &self.blob_store,
+                s3: None,
+                blob_url_ttl_secs: 300,
                 local: &self.local,
                 local_enabled,
                 workspace_id: WorkspaceId::single_tenant(),
@@ -4250,6 +4553,9 @@ mod tests {
         fn ctx_as(&self, user_id: &str, role: &str, enforce: bool) -> ToolContext<'_> {
             ToolContext {
                 team: &self.team,
+                blob_store: &self.blob_store,
+                s3: None,
+                blob_url_ttl_secs: 300,
                 local: &self.local,
                 local_enabled: false,
                 workspace_id: WorkspaceId::single_tenant(),
@@ -4306,6 +4612,7 @@ mod tests {
 
     fn seed(dir: &PathBuf) -> Fixture {
         let team = Arc::new(DocumentStore::new(dir.clone()));
+        let blob_store = Arc::new(BlobStore::new(dir.clone()));
         let local = Arc::new(LocalDocumentMirror::new(dir.clone()));
         team.save_document(&WorkspaceId::single_tenant(), make_doc("doc1", "p1", "Team Doc")).unwrap();
         let registry = Arc::new(DocRegistry::new());
@@ -4321,7 +4628,7 @@ mod tests {
             Arc::new(move |ws: &WorkspaceId, doc: &DocId| {
                 del_sink.lock().unwrap().push((ws.clone(), doc.clone()));
             });
-        Fixture { team, local, registry, broadcasts, on_doc_update, deletions, on_doc_deleted }
+        Fixture { team, blob_store, local, registry, broadcasts, on_doc_update, deletions, on_doc_deleted }
     }
 
     // ---- JP-35: live Y.Doc write path ----
@@ -6822,6 +7129,8 @@ mod tests {
             "docushark_get_outline",
             "docushark_list_references",
             "docushark_list_fields",
+            "docushark_list_files",
+            "docushark_get_file",
         ];
         let no_doc = [
             "docushark_list_documents",
@@ -6927,5 +7236,182 @@ mod tests {
             dispatch(&ctx, "docushark_get_document", &json!({ "docId": "owned1" })).is_ok(),
             "static loopback token must bypass the per-doc gate"
         );
+    }
+
+    // ---- JP-430: MCP-accessible files (read) ----
+
+    fn sha256_hex(data: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(data))
+    }
+
+    /// A doc carrying one canvas FileShape (`canvas_hash`) and one prose page
+    /// embedding `prose_hash` as an image — the two reference grammars.
+    fn make_file_doc(doc_id: &str, canvas_hash: &str, prose_hash: &str) -> Value {
+        let mut doc = make_doc(doc_id, "p1", "File Doc");
+        doc["pages"]["p1"]["shapes"]["f1"] = json!({
+            "id": "f1",
+            "type": "file",
+            "x": 10.0, "y": 20.0, "width": 200.0, "height": 160.0,
+            "rotation": 0.0, "opacity": 1.0, "locked": false, "visible": true,
+            "fill": "#f8fafc", "stroke": "#cbd5e1", "strokeWidth": 1,
+            "blobRef": canvas_hash,
+            "fileName": "spec.pdf",
+            "mimeType": "application/pdf",
+            "fileSize": 12,
+            "fileCategory": "pdf",
+        });
+        doc["pages"]["p1"]["shapeOrder"] = json!(["f1"]);
+        doc["richTextPages"] = json!({
+            "pages": {
+                "rp1": {
+                    "id": "rp1",
+                    "name": "Prose 1",
+                    "content": format!("<p>see <img src=\"blob://{prose_hash}\"></p>"),
+                }
+            },
+            "pageOrder": ["rp1"],
+            "activePageId": "rp1",
+        });
+        doc
+    }
+
+    #[test]
+    fn file_shape_serializes_with_metadata_not_unmapped() {
+        let dsl = shape_to_dsl_or_generic(&json!({
+            "id": "f1", "type": "file", "x": 1.0, "y": 2.0,
+            "width": 200.0, "height": 160.0,
+            "blobRef": "ab".repeat(32), "fileName": "notes.txt",
+            "mimeType": "text/plain", "fileSize": 42, "fileCategory": "text",
+        }));
+        assert_eq!(dsl["kind"], "file");
+        assert_eq!(dsl["fileName"], "notes.txt");
+        assert_eq!(dsl["mimeType"], "text/plain");
+        assert_eq!(dsl["fileSize"], 42);
+        assert_eq!(dsl["blobRef"], "ab".repeat(32));
+        assert!(dsl.get("_unmapped").is_none(), "file shapes are mapped now");
+    }
+
+    #[test]
+    fn list_files_reports_canvas_and_prose_files() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let bytes = b"hello file!!";
+        let canvas_hash = sha256_hex(bytes);
+        f.blob_store
+            .save_blob(&ws, &canvas_hash, bytes, "application/pdf", "tester")
+            .unwrap();
+        // The prose image's bytes are deliberately NOT in the store.
+        let prose_hash = sha256_hex(b"missing image bytes");
+        f.team
+            .save_document(&ws, make_file_doc("fdoc", &canvas_hash, &prose_hash))
+            .unwrap();
+
+        let out = dispatch(&f.ctx(false), "docushark_list_files", &json!({"docId": "fdoc"})).unwrap();
+        let files = out.result["files"].as_array().unwrap();
+        assert_eq!(files.len(), 2);
+
+        let canvas = files.iter().find(|e| e["source"] == "canvas").unwrap();
+        assert_eq!(canvas["blobRef"], json!(canvas_hash));
+        assert_eq!(canvas["fileName"], "spec.pdf");
+        assert_eq!(canvas["shapeId"], "f1");
+        assert_eq!(canvas["inStore"], true);
+
+        let prose = files.iter().find(|e| e["source"] == "prose").unwrap();
+        assert_eq!(prose["blobRef"], json!(prose_hash));
+        assert_eq!(prose["pageId"], "rp1");
+        assert_eq!(prose["inStore"], false, "bytes never uploaded to this relay");
+    }
+
+    #[test]
+    fn get_file_inlines_small_files_on_filesystem_backend() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let bytes = b"hello file!!";
+        let hash = sha256_hex(bytes);
+        f.blob_store.save_blob(&ws, &hash, bytes, "application/pdf", "tester").unwrap();
+        f.team
+            .save_document(&ws, make_file_doc("fdoc", &hash, &sha256_hex(b"other")))
+            .unwrap();
+
+        let out = dispatch(
+            &f.ctx(false),
+            "docushark_get_file",
+            &json!({"docId": "fdoc", "blobRef": hash}),
+        )
+        .unwrap();
+        assert_eq!(out.result["transport"], "inline");
+        assert_eq!(out.result["mimeType"], "application/pdf");
+        assert_eq!(out.result["sizeBytes"], bytes.len());
+        // RFC 4648 of b"hello file!!"
+        assert_eq!(out.result["base64"], "aGVsbG8gZmlsZSEh");
+    }
+
+    #[test]
+    fn get_file_refuses_unreferenced_blob_and_bad_hash() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        // A real stored blob that "doc1" (the plain seed doc) never references:
+        // fetch-by-hash must stay scoped to the named document.
+        let bytes = b"unreferenced";
+        let hash = sha256_hex(bytes);
+        f.blob_store.save_blob(&ws, &hash, bytes, "text/plain", "tester").unwrap();
+
+        let err = dispatch(
+            &f.ctx(false),
+            "docushark_get_file",
+            &json!({"docId": "doc1", "blobRef": hash}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_FILE_NOT_FOUND"), "got: {err}");
+
+        let err = dispatch(
+            &f.ctx(false),
+            "docushark_get_file",
+            &json!({"docId": "doc1", "blobRef": "not-a-hash"}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_BAD_BLOB_REF"), "got: {err}");
+    }
+
+    #[test]
+    fn get_file_caps_inline_size() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let big = vec![0x5au8; (MAX_INLINE_FILE_BYTES + 1) as usize];
+        let hash = sha256_hex(&big);
+        f.blob_store
+            .save_blob(&ws, &hash, &big, "application/octet-stream", "tester")
+            .unwrap();
+        f.team
+            .save_document(&ws, make_file_doc("fdoc", &hash, &sha256_hex(b"other")))
+            .unwrap();
+
+        let err = dispatch(
+            &f.ctx(false),
+            "docushark_get_file",
+            &json!({"docId": "fdoc", "blobRef": hash}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_FILE_TOO_LARGE_FOR_INLINE"), "got: {err}");
+    }
+
+    #[test]
+    fn base64_encode_matches_rfc4648_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
     }
 }

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -30,9 +30,10 @@ use futures_util::stream;
 use serde_json::{json, Value};
 
 use crate::auth::{OidcAuthState, WorkspaceRole};
+use crate::server::blobs::BlobStore;
 use crate::server::documents::DocumentStore;
 use crate::server::protocol::WorkspaceId;
-use crate::server::WorkspaceWriteLimiter;
+use crate::server::{S3Backend, WorkspaceWriteLimiter};
 
 use super::config::McpFeatureConfigStore;
 use super::local_mirror::LocalDocumentMirror;
@@ -47,6 +48,15 @@ const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 #[derive(Clone)]
 pub struct McpAppState {
     pub doc_store: Arc<DocumentStore>,
+    /// Blob bookkeeping store (index/ACL/refs), shared with the WS/REST path —
+    /// the file tools (JP-430) read the same metadata + gates.
+    pub blob_store: Arc<BlobStore>,
+    /// S3/R2 byte store; `None` under the filesystem backend. `get_file`
+    /// mints presigned GET URLs through it.
+    pub s3: Option<Arc<S3Backend>>,
+    /// Lifetime of MCP-minted presigned blob GET URLs (`[mcp]
+    /// blob_url_ttl_secs`, JP-430).
+    pub blob_url_ttl_secs: u64,
     pub local_mirror: Arc<LocalDocumentMirror>,
     pub feature_config: Arc<McpFeatureConfigStore>,
     pub token: Arc<TokenStore>,
@@ -483,6 +493,9 @@ async fn handle_tools_call(
 
     let ctx = ToolContext {
         team: &state.doc_store,
+        blob_store: &state.blob_store,
+        s3: state.s3.as_ref(),
+        blob_url_ttl_secs: state.blob_url_ttl_secs,
         local: &state.local_mirror,
         // JP-235: a public mount hard-disables local access (`allow_local =
         // false`) regardless of the persisted feature flag.
@@ -652,6 +665,9 @@ mod tests {
         let token_str = token.current();
         let state = McpAppState {
             doc_store: store,
+            blob_store: Arc::new(BlobStore::new(dir.path().to_path_buf())),
+            s3: None,
+            blob_url_ttl_secs: 300,
             local_mirror: local,
             feature_config: cfg,
             token,
@@ -830,7 +846,9 @@ mod tests {
         assert!(names.contains(&"docushark_insert_block"));
         assert!(names.contains(&"docushark_delete_block"));
         assert!(names.contains(&"docushark_move_block"));
-        assert_eq!(tools.len(), 37);
+        assert!(names.contains(&"docushark_list_files"));
+        assert!(names.contains(&"docushark_get_file"));
+        assert_eq!(tools.len(), 39);
     }
 
     #[tokio::test]

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -212,8 +212,18 @@ impl S3Backend {
     /// Mint a presigned GET URL for a workspace's blob (host-only signature; a
     /// GET has no body or pinned headers).
     pub fn presign_get(&self, ws: &WorkspaceId, hash: &str) -> String {
+        self.presign_get_with_ttl(ws, hash, self.config.get_ttl_secs)
+    }
+
+    /// [`presign_get`] with an explicit TTL. The MCP surface (JP-430) passes a
+    /// tighter lifetime than the editor's `get_ttl_secs`: a URL returned from a
+    /// tool call lands in a chat transcript, so it should outlive the fetch,
+    /// not the conversation.
+    ///
+    /// [`presign_get`]: Self::presign_get
+    pub fn presign_get_with_ttl(&self, ws: &WorkspaceId, hash: &str, ttl_secs: u64) -> String {
         let key = self.object_key(ws, hash);
-        self.presign("GET", &key, self.config.get_ttl_secs, &[], Utc::now())
+        self.presign("GET", &key, ttl_secs, &[], Utc::now())
     }
 
     /// Core SigV4 query-string presigner. `extra_signed` are header

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -54,7 +54,7 @@ use crate::sync::{
     version_point_due,
     DocHandle, DocRegistry,
 };
-use blob_backend::S3Backend;
+pub(crate) use blob_backend::S3Backend;
 
 /// Per-workspace token-bucket limiter shared between WS sync handlers
 /// and MCP write tools. Phase 21.3.
@@ -1767,6 +1767,32 @@ impl WebSocketServer {
             .clone()
     }
 
+    /// Handle to the blob bookkeeping store (index/ACL/refs). Valid only after
+    /// `start()`. `main.rs` hands it to `McpServer::new` so the MCP file tools
+    /// (JP-430) read the same metadata + gates the REST blob surface uses.
+    pub async fn blob_store_handle(&self) -> Arc<BlobStore> {
+        self.state
+            .read()
+            .await
+            .as_ref()
+            .expect("blob_store_handle() requires start() first")
+            .blob_store()
+            .clone()
+    }
+
+    /// Handle to the S3/R2 byte store — `None` under the filesystem backend.
+    /// Valid only after `start()`. The MCP `get_file` tool mints presigned GET
+    /// URLs through it (JP-430), same as the REST `download-url` handler.
+    pub async fn s3_backend_handle(&self) -> Option<Arc<S3Backend>> {
+        self.state
+            .read()
+            .await
+            .as_ref()
+            .expect("s3_backend_handle() requires start() first")
+            .s3_backend()
+            .cloned()
+    }
+
     /// A synchronous sink that broadcasts a framed CRDT update to the clients
     /// joined to `(workspace, doc)` — the relay-originated counterpart of an
     /// inbound SYNC frame's rebroadcast. Wired into the MCP write path so an
@@ -2060,6 +2086,8 @@ impl WebSocketServer {
                     });
                 let shared = crate::mcp::McpSharedHandles {
                     doc_store: server_state.doc_store.clone(),
+                    blob_store: server_state.blob_store().clone(),
+                    s3: server_state.s3_backend().cloned(),
                     panic_counter: server_state.panic_count.clone(),
                     rate_limit_rejections: server_state.rate_limit_rejections.clone(),
                     write_limiter: server_state.write_limiter.clone(),

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -168,6 +168,9 @@ impl Harness {
                 on_doc_update,
                 shared_doc_store,
                 false, // JP-370: private-doc enforcement off in this test
+                self.server.blob_store_handle().await,
+                self.server.s3_backend_handle().await,
+                300, // JP-430: MCP blob URL TTL (unused here)
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -66,6 +66,9 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
             on_doc_update,
             shared_doc_store,
             false, // JP-370: private-doc enforcement off in this test
+            server.blob_store_handle().await,
+            server.s3_backend_handle().await,
+            300, // JP-430: MCP blob URL TTL (unused here)
         )
         .expect("McpServer::new"),
     );

--- a/relay/tests/public_mcp.rs
+++ b/relay/tests/public_mcp.rs
@@ -42,7 +42,7 @@ async fn public_mcp_rides_main_listener_and_requires_jwt() {
             routed_sink.lock().unwrap().push(ws.as_str().to_string());
         });
     let on_doc_deleted: Arc<docushark_relay::mcp::DocDeletedSink> = Arc::new(|_, _| {});
-    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed, on_doc_deleted, None)
+    let mount = PublicMount::new(tmp.path().to_path_buf(), on_doc_changed, on_doc_deleted, None, 300)
         .expect("mount");
     let static_token = mount.token();
     server.set_mcp_public_mount(mount).await;

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -99,6 +99,9 @@ impl Harness {
                 on_doc_update,
                 shared_doc_store,
                 false, // JP-370: private-doc enforcement off in this test
+                server.blob_store_handle().await,
+                server.s3_backend_handle().await,
+                300, // JP-430: MCP blob URL TTL (unused here)
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -752,6 +752,9 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             on_doc_update,
             shared_doc_store,
             false, // JP-370: private-doc enforcement off in this test
+            relay.server.blob_store_handle().await,
+            relay.server.s3_backend_handle().await,
+            300, // JP-430: MCP blob URL TTL (unused here)
         )
         .expect("McpServer::new"),
     );


### PR DESCRIPTION
**JP-430 (MCP Tool Parity) — file read, Pillar E slices E1+E2.** Files stop being invisible to agents: two new read tools plus FileShape metadata in every shape read.

## Before / after

Before: a FileShape came back as `{id, kind: "file", _unmapped: true}` — an agent couldn't discover a file existed, let alone read it; `get_prose` returned dead `blob://<hash>` refs; the MCP layer held no blob handle at all.

After:
- **`get_page`/`get_shape`** surface file shapes with `fileName`/`mimeType`/`fileSize`/`fileCategory`/`blobRef`. The mapping lives in the read-only generic serializer, deliberately **not** in the bidirectional DSL adapter — `add_shape` still cannot author file shapes (writes are the E3 follow-up).
- **`docushark_list_files`** — every file attached to a document: canvas file shapes (with names) and prose-embedded `blob://` images, each with its `blobRef` and an `inStore` flag (bytes present on this relay). Resident-accurate: folds the live Y.Doc surfaces in via `flatten_into` before walking.
- **`docushark_get_file`** — bytes by `blobRef`, scoped to blobs **the named document references** (never a workspace-wide fetch-by-hash), then the same gates as the REST `download-url` handler: workspace ACL `exists()` + the JP-370 private-doc rule, refactored into a shared `api::blob_read_allowed` so REST and MCP can't drift.
  - Object-storage backend → `{url, expiresAtMs}`: a **short-lived presigned GET** the agent fetches directly (bytes never transit the relay or the tool result). New knob `[mcp].blob_url_ttl_secs` / `RELAY_MCP_BLOB_URL_TTL_SECS`, default 300s — deliberately tighter than the editor's 3600s because the URL persists in the agent's transcript. CORS is irrelevant here: it's a browser-only enforcement, and MCP agents fetch with plain HTTP.
  - Filesystem backend (no presign) → base64 inline under a 1 MiB cap; `ERR_FILE_TOO_LARGE_FOR_INLINE` above it (tool results are serialized into both text and structuredContent, so uncapped inline would double megabytes into context).

## Plumbing

`BlobStore` + optional `S3Backend` handles threaded into `McpAppState`/`ToolContext` via `McpSharedHandles` (public mount) and `McpServer::new` (loopback), with new `blob_store_handle`/`s3_backend_handle` accessors on `WebSocketServer` — the file tools read the same index/ACL/ref gates as the REST blob surface. `S3Backend::presign_get_with_ttl` added (existing `presign_get` now delegates). Tool-count guard 37 → 39.

## Files

- `relay/src/mcp/tools.rs` — file mapping, `list_files`, `get_file`, hand-rolled RFC 4648 base64 (house style; encode-only), 6 new tests.
- `relay/src/api.rs` — `blob_read_allowed` (shared JP-370 core), `collect_blob_uris_in_str`, `is_valid_blob_hash` visibility.
- `relay/src/mcp/{mod,transport}.rs`, `relay/src/server/mod.rs`, `relay/src/main.rs` — handle plumbing.
- `relay/src/server/blob_backend/s3.rs`, `relay/src/config.rs`, `relay/README.md` — TTL knob.
- `relay/docs/mcp/README.md` — tool reference rows.

## Verify

- Full `cargo test` green: 657 lib tests (6 new: file mapping, canvas+prose listing, inline round-trip against an RFC 4648 vector, unreferenced-blob + bad-hash refusals, inline-size cap, base64 vectors) + every integration suite; `cargo check --all-targets`; clippy warning count identical to the master baseline.
- The JP-427 env drift test covers the new `RELAY_MCP_BLOB_URL_TTL_SECS` README row.
- Live E2E (needs a rebuilt stack): `list_files` on a doc with attachments, then `curl` the presigned URL and `sha256sum` the bytes — must equal `blobRef`.

## Follow-up (Pillar E3, separate PR)

`add_file` (upload + attach): reuse the JP-264 ingest-from-url internals + presigned PUT, emit a FileShape through the shape-write path, and register the reference on the MCP write path (`sync_doc_refs`) so agent-added files survive the blob GC. A `files` skill recipe ships with that write flow.

Assisted-by: Fable 5
