### PR TITLE
JP-430: MCP file write - add_file + get_storage (Pillar E, E3)

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -220,7 +220,7 @@ This table is the canonical inventory — a drift test
 | `RELAY_MAX_EDITORS_PER_WORKSPACE` | `[tenancy.limits].max_editors_per_workspace` (fallback cap; `0` = unlimited) |
 | `RELAY_MAX_BLOB_BYTES` | `[tenancy.limits].max_blob_bytes` (per-blob size ceiling) |
 | `RELAY_MAX_CONCURRENT_BLOB_UPLOADS` | `[tenancy.limits].max_concurrent_blob_uploads` (bounds worst-case upload RAM: permits × max blob bytes) |
-| `RELAY_BLOB_GC_GRACE_SECS` | `[tenancy.limits].blob_gc_grace_secs` (orphaned-blob reclaim delay) |
+| `RELAY_BLOB_GC_GRACE_SECS` | `[tenancy.limits].blob_gc_grace_secs` (orphaned-blob reclaim delay; default 300, also shields the upload→save window; `0` = reclaim immediately) |
 | `RELAY_BLOB_INGEST_ALLOWED_HOSTS` | `[tenancy.limits].blob_ingest_allowed_hosts` (comma-separated URL-ingest allowlist) |
 | `RELAY_SNAPSHOT_INTERVAL_SECS` | `[sync].snapshot_interval_secs` (Y.Doc → JSON flush cadence; `0` disables the timer) |
 | `RELAY_BINARY_PERSISTENCE` | `[sync].binary_persistence` (binary Y.Doc sidecar on snapshot; default on) |

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -95,6 +95,7 @@ All tools are namespaced `docushark_*`.
 | `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
 | `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |
 | `list_fields` | The document's fields (reusable `{{name}}` values) in display order, each `{ name, value }`. |
+| `get_storage` | Workspace storage stats: `usedBytes`, `quotaBytes` (`null` = unlimited), `maxBlobBytes` (per-file ceiling), `backend`. Check headroom before a large `add_file` upload. |
 | `get_skills` | Agent onboarding: with no args, the **content contract** (rules for valid prose + shapes) plus a recipe catalogue; with `{ skill }`, that recipe's full steps. Call it first if unsure how a tool expects its input — authoring valid content avoids the relay having to heal it. |
 | `list_icons` | Discover icon IDs to put on shapes: `{ id, name, category }` entries plus the match `total` and available `categories`. Filter with `query` (substring over id + name) and/or `category`; cap with `limit` (default 50, max 200). Apply an id via `add_shape`/`update_shape` (`iconId`). |
 
@@ -133,6 +134,7 @@ All tools are namespaced `docushark_*`.
 | `add_shapes` | Add many shapes in one all-or-nothing call. |
 | `connect` | Connect two existing shapes with a connector. |
 | `update_shape` | Patch an existing shape (`x`, `y`, `w`, `h`, `text`, `style`, and icon fields `iconId`/`iconDisplayMode`/`iconSize` — an empty `iconId` clears it). |
+| `add_file` | Upload a file and attach it as a canvas file card. Exactly one source: `base64` (small files — the request body caps at 8 MiB), `url` (fetched server-side; https-only, host must be on the relay's ingest allowlist), or `blobRef` (attach an already-stored blob without re-uploading). Enforces the workspace storage quota; returns `{ shapeId, blobRef, mimeType, sizeBytes, fileCategory }`. File shapes stay un-authorable via `add_shape`. |
 | `generate_diagram` | Build a whole diagram from a `nodes` + `edges` graph; the relay auto-positions (`layered` with crossing minimization, or `grid`) and wires connectors to typed anchors with orthogonal obstacle-avoiding routing (`routing: "straight"` opts out). Writes the live Y.Doc on a resident doc (a connected editor sees the shapes immediately) — like the other shape tools. |
 
 **Icons on shapes.** Call `list_icons` (filter by `query`/`category`) to find an

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1871,6 +1871,223 @@ pub(crate) fn ingest_url_ok(url: &reqwest::Url, allow: &[String]) -> bool {
     }
 }
 
+/// Identity of a blob persisted by the shared write core (JP-430 E3): the
+/// content hash, authoritative size, and the mime recorded in the index.
+pub(crate) struct StoredBlob {
+    pub hash: String,
+    pub size: u64,
+    pub mime: String,
+}
+
+/// Failure taxonomy shared by the REST ingest handler and the MCP file
+/// preflight (JP-430 E3). REST maps variants to the exact HTTP statuses the
+/// pre-refactor handler returned; MCP maps them to typed `ERR_*` tool errors.
+pub(crate) enum BlobWriteError {
+    /// `blob_ingest_allowed_hosts` is empty — URL ingest is disabled. The gate
+    /// lives *inside* the shared helper so no caller can become an open fetch
+    /// proxy by forgetting it.
+    NotConfigured,
+    /// The source URL failed to parse.
+    InvalidUrl,
+    /// The source URL failed the SSRF/allowlist gate.
+    UrlNotAllowed,
+    /// Downloading the source failed (network error, non-2xx, body read).
+    Fetch(String),
+    /// Declared or streamed size exceeds `max_blob_bytes`.
+    TooLarge,
+    /// The shared upload-concurrency gate is closed (shutdown).
+    GateUnavailable,
+    /// Workspace storage quota exceeded (507 class).
+    Quota(String),
+    /// The object store rejected the write (s3 PUT).
+    StoreUnavailable,
+    /// Bookkeeping failure after the bytes were stored.
+    Backend(String),
+}
+
+/// Persist a blob's bytes for `ws`, mirroring the proxy upload's
+/// s3-vs-filesystem split: on s3/R2 an existing `(ws, hash)` grant is reused
+/// (dedup), else quota is checked against the workspace ledger before
+/// `put_object` + `record_finalized_blob`; on the filesystem backend
+/// `save_blob_with_quota` owns hashing, dedup, and the quota check. The one
+/// write core under REST ingest and the MCP `add_file` preflight (JP-430 E3).
+pub(crate) async fn store_blob_bytes(
+    blob_store: &BlobStore,
+    s3: Option<&crate::server::S3Backend>,
+    ws: &WorkspaceId,
+    user: &str,
+    quota: Option<u64>,
+    body: &[u8],
+    mime: &str,
+) -> Result<StoredBlob, BlobWriteError> {
+    let hash = BlobStore::compute_hash(body);
+    let (size, hash) = if let Some(s3) = s3 {
+        if blob_store.exists(ws, &hash) {
+            let size = blob_store
+                .get_metadata(ws, &hash)
+                .map(|m| m.size)
+                .unwrap_or(body.len() as u64);
+            (size, hash)
+        } else {
+            if let Some(q) = quota {
+                if blob_store
+                    .get_workspace_size(ws)
+                    .saturating_add(body.len() as u64)
+                    > q
+                {
+                    return Err(BlobWriteError::Quota("storage quota exceeded".to_string()));
+                }
+            }
+            if let Err(e) = s3.put_object(ws, &hash, body.to_vec(), mime).await {
+                log::warn!("blob s3 put failed {}/{}: {e}", ws.as_str(), hash);
+                return Err(BlobWriteError::StoreUnavailable);
+            }
+            match blob_store.record_finalized_blob(ws, &hash, body.len() as u64, mime, user) {
+                Ok(m) => (m.size, m.hash),
+                Err(e) => return Err(BlobWriteError::Backend(e)),
+            }
+        }
+    } else {
+        match blob_store.save_blob_with_quota(ws, &hash, body, mime, user, quota) {
+            Ok(m) => (m.size, m.hash),
+            Err(e @ SaveBlobError::QuotaExceeded { .. }) => {
+                return Err(BlobWriteError::Quota(e.to_string()))
+            }
+            Err(e) => return Err(BlobWriteError::Backend(e.to_string())),
+        }
+    };
+    Ok(StoredBlob {
+        hash,
+        size,
+        mime: mime.to_string(),
+    })
+}
+
+/// Fetch a blob from an allowlisted https URL and persist it via
+/// [`store_blob_bytes`]. Owns every ingest gate: the allowlist-empty disable,
+/// the SSRF check (`ingest_url_ok`, re-validated on every redirect hop by the
+/// client's policy), the declared-length early reject, the shared upload-
+/// concurrency permit, and the streamed `append_capped` size ceiling (RB-1).
+/// `authorization` is sent verbatim as the `Authorization` header — omitted
+/// entirely when `None`. Mime precedence: `mime_override`, else the response
+/// `Content-Type`, else `application/octet-stream`.
+#[allow(clippy::too_many_arguments)] // a deliberate free function: both callers hold these handles under different state types
+pub(crate) async fn ingest_blob_from_url(
+    http: &reqwest::Client,
+    allowed_hosts: &[String],
+    gate: &Arc<tokio::sync::Semaphore>,
+    blob_store: &BlobStore,
+    s3: Option<&crate::server::S3Backend>,
+    ws: &WorkspaceId,
+    user: &str,
+    quota: Option<u64>,
+    max_bytes: usize,
+    url: &str,
+    authorization: Option<&str>,
+    mime_override: Option<&str>,
+) -> Result<StoredBlob, BlobWriteError> {
+    if allowed_hosts.is_empty() {
+        return Err(BlobWriteError::NotConfigured);
+    }
+    let url = reqwest::Url::parse(url).map_err(|_| BlobWriteError::InvalidUrl)?;
+    if !ingest_url_ok(&url, allowed_hosts) {
+        return Err(BlobWriteError::UrlNotAllowed);
+    }
+
+    let mut req = http.get(url);
+    if let Some(auth) = authorization {
+        req = req.header(reqwest::header::AUTHORIZATION, auth);
+    }
+    let mut resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            log::info!("ingest fetch failed for ws {}: {e}", ws.as_str());
+            return Err(BlobWriteError::Fetch("fetch_failed".to_string()));
+        }
+    };
+    if !resp.status().is_success() {
+        return Err(BlobWriteError::Fetch(format!(
+            "source returned {}",
+            resp.status()
+        )));
+    }
+
+    // Early reject on a declared length over the ceiling.
+    if let Some(len) = resp.content_length() {
+        if len > max_bytes as u64 {
+            return Err(BlobWriteError::TooLarge);
+        }
+    }
+
+    let mime = mime_override
+        .map(str::to_string)
+        .or_else(|| {
+            resp.headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+
+    // RB-1b: bound concurrent in-memory uploads (shared gate with the proxy
+    // path) before buffering the body.
+    let _permit = match gate.clone().acquire_owned().await {
+        Ok(p) => p,
+        Err(_) => return Err(BlobWriteError::GateUnavailable),
+    };
+
+    // RB-1: stream the body in chunks, aborting the moment the running total
+    // exceeds `max_bytes` — a host that omits or lies about Content-Length
+    // can't make us buffer an unbounded response into RAM (the post-hoc
+    // `.bytes()` check read the whole body first).
+    let mut body: Vec<u8> = Vec::new();
+    loop {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                if !append_capped(&mut body, &chunk, max_bytes) {
+                    return Err(BlobWriteError::TooLarge);
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                log::info!("ingest body read failed for ws {}: {e}", ws.as_str());
+                return Err(BlobWriteError::Fetch("fetch_failed".to_string()));
+            }
+        }
+    }
+
+    store_blob_bytes(blob_store, s3, ws, user, quota, &body, &mime).await
+}
+
+/// Map a [`BlobWriteError`] to the REST response the pre-refactor ingest
+/// handler returned — the status/message table is the wire contract.
+fn blob_write_error_response(e: BlobWriteError) -> axum::response::Response {
+    let (status, msg) = match e {
+        BlobWriteError::NotConfigured => {
+            (StatusCode::FORBIDDEN, "ingest_not_configured".to_string())
+        }
+        BlobWriteError::InvalidUrl => (StatusCode::BAD_REQUEST, "invalid url".to_string()),
+        BlobWriteError::UrlNotAllowed => (StatusCode::FORBIDDEN, "url_not_allowed".to_string()),
+        BlobWriteError::Fetch(msg) => (StatusCode::BAD_GATEWAY, msg),
+        BlobWriteError::TooLarge => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "blob exceeds max size".to_string(),
+        ),
+        BlobWriteError::GateUnavailable => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "upload gate unavailable".to_string(),
+        ),
+        BlobWriteError::Quota(msg) => (StatusCode::INSUFFICIENT_STORAGE, msg),
+        BlobWriteError::StoreUnavailable => (
+            StatusCode::BAD_GATEWAY,
+            "blob store unavailable".to_string(),
+        ),
+        BlobWriteError::Backend(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+    };
+    (status, ApiError::body(msg)).into_response()
+}
+
 /// `POST /api/v1/blobs/ingest-from-url` — fetch a blob from an allowlisted URL
 /// and store it content-addressed for the caller's workspace. Generic: the
 /// relay has no knowledge of any specific integration; the `source`/`tags` are
@@ -1891,172 +2108,30 @@ async fn blob_ingest_from_url_handler(
     };
     state.ensure_blob_bookkeeping(&ws).await;
 
-    let allow: Vec<String> = state.blob_ingest_allowed_hosts().to_vec();
-    if allow.is_empty() {
-        return (
-            StatusCode::FORBIDDEN,
-            ApiError::body("ingest_not_configured"),
-        )
-            .into_response();
-    }
-
-    let url = match reqwest::Url::parse(&req.url) {
-        Ok(u) => u,
-        Err(_) => return (StatusCode::BAD_REQUEST, ApiError::body("invalid url")).into_response(),
-    };
-    if !ingest_url_ok(&url, &allow) {
-        return (StatusCode::FORBIDDEN, ApiError::body("url_not_allowed")).into_response();
-    }
-
-    let max = state.max_blob_bytes();
-
+    let quota = state.resolve_limits(limits).quota_bytes;
     // RB-3: reuse the process-wide ingest client (built once at startup). Its
     // redirect policy already re-validates every hop against the same allowlist
     // (an open redirect to an internal host is the classic SSRF escape); the
     // allowlist is process-global config, so the startup-built policy matches
     // what a per-request build would have produced.
-    let client = state.ingest_http_client();
-
-    let mut resp = match client
-        .get(url)
-        .header(reqwest::header::AUTHORIZATION, &req.authorization)
-        .send()
-        .await
+    let stored = match ingest_blob_from_url(
+        state.ingest_http_client(),
+        state.blob_ingest_allowed_hosts(),
+        state.blob_upload_gate(),
+        state.blob_store(),
+        state.s3_backend().map(|s| s.as_ref()),
+        &ws,
+        &claims.sub,
+        quota,
+        state.max_blob_bytes(),
+        &req.url,
+        Some(&req.authorization),
+        req.mime_type.as_deref(),
+    )
+    .await
     {
-        Ok(r) => r,
-        Err(e) => {
-            log::info!("ingest fetch failed for ws {}: {e}", ws.as_str());
-            return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
-        }
-    };
-    if !resp.status().is_success() {
-        return (
-            StatusCode::BAD_GATEWAY,
-            ApiError::body(format!("source returned {}", resp.status())),
-        )
-            .into_response();
-    }
-
-    // Early reject on a declared length over the ceiling.
-    if let Some(len) = resp.content_length() {
-        if len > max as u64 {
-            return (
-                StatusCode::PAYLOAD_TOO_LARGE,
-                ApiError::body("blob exceeds max size"),
-            )
-                .into_response();
-        }
-    }
-
-    let mime = req
-        .mime_type
-        .clone()
-        .or_else(|| {
-            resp.headers()
-                .get(reqwest::header::CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
-        })
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-
-    // RB-1b: bound concurrent in-memory uploads (shared gate with the proxy
-    // path) before buffering the body.
-    let _permit = match state.blob_upload_gate().clone().acquire_owned().await {
-        Ok(p) => p,
-        Err(_) => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                ApiError::body("upload gate unavailable"),
-            )
-                .into_response()
-        }
-    };
-
-    // RB-1: stream the body in chunks, aborting the moment the running total
-    // exceeds `max` — a host that omits or lies about Content-Length can't make
-    // us buffer an unbounded response into RAM (the post-hoc `.bytes()` check
-    // read the whole body first).
-    let mut body: Vec<u8> = Vec::new();
-    loop {
-        match resp.chunk().await {
-            Ok(Some(chunk)) => {
-                if !append_capped(&mut body, &chunk, max) {
-                    return (
-                        StatusCode::PAYLOAD_TOO_LARGE,
-                        ApiError::body("blob exceeds max size"),
-                    )
-                        .into_response();
-                }
-            }
-            Ok(None) => break,
-            Err(e) => {
-                log::info!("ingest body read failed for ws {}: {e}", ws.as_str());
-                return (StatusCode::BAD_GATEWAY, ApiError::body("fetch_failed")).into_response();
-            }
-        }
-    }
-
-    let hash = BlobStore::compute_hash(&body);
-    let quota = state.resolve_limits(limits).quota_bytes;
-
-    // Persist, mirroring the proxy upload's s3-vs-filesystem split.
-    let (size, hash) = if let Some(s3) = state.s3_backend() {
-        if state.blob_store().exists(&ws, &hash) {
-            let size = state
-                .blob_store()
-                .get_metadata(&ws, &hash)
-                .map(|m| m.size)
-                .unwrap_or(body.len() as u64);
-            (size, hash)
-        } else {
-            if let Some(q) = quota {
-                if state
-                    .blob_store()
-                    .get_workspace_size(&ws)
-                    .saturating_add(body.len() as u64)
-                    > q
-                {
-                    return (
-                        StatusCode::INSUFFICIENT_STORAGE,
-                        ApiError::body("storage quota exceeded"),
-                    )
-                        .into_response();
-                }
-            }
-            if let Err(e) = s3.put_object(&ws, &hash, body.to_vec(), &mime).await {
-                log::warn!("ingest s3 put failed {}/{}: {e}", ws.as_str(), hash);
-                return (
-                    StatusCode::BAD_GATEWAY,
-                    ApiError::body("blob store unavailable"),
-                )
-                    .into_response();
-            }
-            match state
-                .blob_store()
-                .record_finalized_blob(&ws, &hash, body.len() as u64, &mime, &claims.sub)
-            {
-                Ok(m) => (m.size, m.hash),
-                Err(e) => {
-                    return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response()
-                }
-            }
-        }
-    } else {
-        match state
-            .blob_store()
-            .save_blob_with_quota(&ws, &hash, &body, &mime, &claims.sub, quota)
-        {
-            Ok(m) => (m.size, m.hash),
-            Err(e @ SaveBlobError::QuotaExceeded { .. }) => {
-                return (StatusCode::INSUFFICIENT_STORAGE, ApiError::body(e.to_string()))
-                    .into_response()
-            }
-            Err(e) => {
-                return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e.to_string()))
-                    .into_response()
-            }
-        }
+        Ok(s) => s,
+        Err(e) => return blob_write_error_response(e),
     };
 
     // Record opaque provenance (source + tags), additive; advisory only.
@@ -2064,13 +2139,16 @@ async fn blob_ingest_from_url_handler(
     if let Some(s) = req.source.clone() {
         tags.push(s);
     }
-    if let Err(e) = state.blob_store().record_provenance(&ws, &hash, &tags) {
-        log::warn!("provenance record failed {}/{}: {e}", ws.as_str(), hash);
+    if let Err(e) = state
+        .blob_store()
+        .record_provenance(&ws, &stored.hash, &tags)
+    {
+        log::warn!("provenance record failed {}/{}: {e}", ws.as_str(), stored.hash);
     }
 
     (
         StatusCode::OK,
-        Json(json!({ "hash": hash, "size": size, "mimeType": mime })),
+        Json(json!({ "hash": stored.hash, "size": stored.size, "mimeType": stored.mime })),
     )
         .into_response()
 }

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -95,16 +95,28 @@ pub const DEFAULT_S3_GET_TTL_SECS: u64 = 3600; // 1h
 
 /// Default per-workspace storage byte quota fallback. `0` = unlimited.
 pub const DEFAULT_STORAGE_QUOTA_BYTES: u64 = 0;
+
+/// Resolve an effective numeric limit: the value minted on the JWT claim if
+/// present, else the config fallback; a resolved `0` (from either source)
+/// normalises to `None` = **unlimited** (JP-81). Shared by REST
+/// (`ServerState::resolve_limits`) and the MCP blob-write path (JP-430 E3) so
+/// the two surfaces can't drift.
+pub(crate) fn effective_limit_u64(claim: Option<u64>, fallback: u64) -> Option<u64> {
+    let v = claim.unwrap_or(fallback);
+    (v != 0).then_some(v)
+}
 /// Default per-workspace concurrent-editor cap fallback. `0` = unlimited.
 /// Distinct from `max_ws_connections_per_workspace` (the total-connection
 /// safety ceiling that also guards pure-viewer flooding).
 pub const DEFAULT_MAX_EDITORS_PER_WORKSPACE: u32 = 0;
 
 /// Grace period (seconds) before an orphaned blob's bytes are reclaimed
-/// (JP-127 defense-in-depth). `0` = reclaim immediately (default; preserves
-/// self-host behavior). A positive value defers reclaim so a transient blob
-/// reference-drop followed by a correction can't irreversibly delete bytes.
-pub const DEFAULT_BLOB_GC_GRACE_SECS: u64 = 0;
+/// (JP-127 defense-in-depth). A positive value defers reclaim so a transient
+/// blob reference-drop followed by a correction can't irreversibly delete
+/// bytes, and shields the upload→save window (bytes stored, reference not yet
+/// recorded) from a concurrent stale-body save's ref-diff. `0` = reclaim
+/// immediately (the pre-JP-430 default; set explicitly to restore it).
+pub const DEFAULT_BLOB_GC_GRACE_SECS: u64 = 300;
 
 /// Network exposure for the sync listener.
 ///

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -399,9 +399,11 @@ async fn run_serve(
         let sync_registry = server.sync_registry_handle().await;
         let on_doc_update = server.doc_update_broadcaster().await;
         // JP-430: the MCP file tools share the WS/REST blob bookkeeping + byte
-        // store, so list_files/get_file see the same ACL/ref gates.
+        // store, so list_files/get_file see the same ACL/ref gates — and the
+        // E3 write path shares the ingest client, upload gate, and limits.
         let blob_store = server.blob_store_handle().await;
         let s3_backend = server.s3_backend_handle().await;
+        let blob_write = server.blob_write_handles().await;
         // JP-230: the MCP server shares the WS server's single `DocumentStore`
         // (one in-memory index, one writer) so MCP- and editor-authored docs
         // never clobber each other's `index.json`. It's available after start, and
@@ -431,6 +433,7 @@ async fn run_serve(
                 blob_store,
                 s3_backend,
                 config.mcp.blob_url_ttl_secs,
+                blob_write,
             ) {
                 Ok(mcp) => {
                     let mcp = Arc::new(mcp);

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -128,6 +128,8 @@ pub struct McpServer {
     /// Lifetime of MCP-minted presigned blob GET URLs (`[mcp]
     /// blob_url_ttl_secs`, JP-430).
     blob_url_ttl_secs: u64,
+    /// Blob-write handles for the `add_file` upload preflight (JP-430 E3).
+    blob_write: BlobWriteHandles,
 }
 
 /// The MCP-owned pieces needed to fold the endpoint onto the relay's public
@@ -149,6 +151,47 @@ pub struct PublicMount {
     /// Lifetime of MCP-minted presigned blob GET URLs (`[mcp]
     /// blob_url_ttl_secs`, JP-430). MCP-local config, carried on the mount.
     blob_url_ttl_secs: u64,
+}
+
+/// The blob-write handle bundle the MCP `add_file` preflight needs (JP-430
+/// E3): the process-wide ingest HTTP client (SSRF redirect policy baked in),
+/// the shared upload-concurrency gate, and the tenancy blob limits — so an
+/// MCP upload observes the same allowlist, size ceiling, concurrency bound,
+/// and quota fallback as the REST blob surface. Cheap to clone (the client is
+/// an `Arc`'d pool).
+#[derive(Clone)]
+pub struct BlobWriteHandles {
+    /// RB-3: the startup-built ingest client whose redirect policy re-validates
+    /// every hop against the allowlist.
+    pub http: reqwest::Client,
+    /// RB-1b: bounds concurrent in-memory uploads, shared with the REST
+    /// proxy/ingest paths.
+    pub gate: Arc<tokio::sync::Semaphore>,
+    /// `[tenancy.limits] blob_ingest_allowed_hosts`; empty = URL source disabled.
+    pub allowed_hosts: Vec<String>,
+    /// `[tenancy.limits] max_blob_bytes` — the per-blob size ceiling.
+    pub max_blob_bytes: usize,
+    /// `[tenancy.limits] storage_quota_bytes` — the quota fallback when a JWT
+    /// omits the claim (`0` = unlimited). Resolved per-request against the
+    /// claim via `config::effective_limit_u64`.
+    pub fallback_quota_bytes: u64,
+}
+
+impl BlobWriteHandles {
+    /// A standalone bundle for tests and fixtures that don't exercise the
+    /// upload path: URL ingest disabled (empty allowlist), default size
+    /// ceiling and upload concurrency, unlimited quota fallback.
+    pub fn defaults_for_tests() -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            gate: Arc::new(tokio::sync::Semaphore::new(
+                crate::config::DEFAULT_MAX_CONCURRENT_BLOB_UPLOADS,
+            )),
+            allowed_hosts: Vec::new(),
+            max_blob_bytes: crate::config::DEFAULT_MAX_BLOB_BYTES,
+            fallback_quota_bytes: 0,
+        }
+    }
 }
 
 /// The server-owned handles a [`PublicMount`] needs to build its router. The
@@ -173,6 +216,8 @@ pub struct McpSharedHandles {
     /// JP-370: per-document access enforcement for JWT callers on the public
     /// pod. Mirrors `config.permissions.enforce_private_docs`.
     pub enforce_private_docs: bool,
+    /// Blob-write handles for the `add_file` upload preflight (JP-430 E3).
+    pub blob_write: BlobWriteHandles,
 }
 
 impl PublicMount {
@@ -234,6 +279,7 @@ impl PublicMount {
             // network regardless of `feature_config`. JP-235.
             allow_local: false,
             enforce_private_docs: shared.enforce_private_docs,
+            blob_write: shared.blob_write,
         };
         transport::public_router(state)
     }
@@ -264,6 +310,7 @@ impl McpServer {
         blob_store: Arc<BlobStore>,
         s3: Option<Arc<S3Backend>>,
         blob_url_ttl_secs: u64,
+        blob_write: BlobWriteHandles,
     ) -> Result<Self, String> {
         let token = Arc::new(TokenStore::load_or_create(&app_data_dir)?);
         let feature_config = Arc::new(McpFeatureConfigStore::load_or_create(&app_data_dir));
@@ -295,6 +342,7 @@ impl McpServer {
             blob_store,
             s3,
             blob_url_ttl_secs,
+            blob_write,
         })
     }
 
@@ -382,6 +430,7 @@ impl McpServer {
             // the renderer expose personal documents read-only to MCP. JP-235.
             allow_local: true,
             enforce_private_docs: self.enforce_private_docs,
+            blob_write: self.blob_write.clone(),
         };
         let app = transport::router(state);
 

--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -76,6 +76,9 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
 - Styling is inline per shape ({fill,stroke,strokeWidth,labelColor} or "AUTO").
 - Use the exact field names — an unrecognized key (e.g. fillColor for style.fill)
   is dropped, and an out-of-range value (heading level, labelPosition) is clamped.
+- Files attach via add_file (never add_shape): it uploads the bytes (base64 /
+  url / an existing blobRef) and places a file card on a canvas page. Read
+  attachments with list_files + get_file; check headroom with get_storage.
 
 If a write reports a `fixes` array, the relay adjusted your input: it healed
 malformed prose, **dropped** an unrecognized/invalid field (`dropped_unknown` /
@@ -105,6 +108,11 @@ const SKILLS: &[(&str, &str, &str)] = &[
         "meeting-notes-to-doc",
         "Turn raw notes into a structured, outlined document.",
         include_str!("skills/meeting-notes-to-doc.SKILL.md"),
+    ),
+    (
+        "attach-files",
+        "Attach, read, or manage document files (upload, download, storage headroom).",
+        include_str!("skills/attach-files.SKILL.md"),
     ),
 ];
 

--- a/relay/src/mcp/skills/attach-files.SKILL.md
+++ b/relay/src/mcp/skills/attach-files.SKILL.md
@@ -1,0 +1,66 @@
+---
+name: docushark-attach-files
+description: Use when the user wants to attach, read, or manage files in a DocuShark document over MCP — uploading a report/image/CSV as a canvas file card, downloading an attachment's bytes, or checking storage headroom. Requires the DocuShark MCP server to be connected.
+---
+
+# Work with document files in DocuShark
+
+Documents carry files two ways: **canvas file cards** (a FileShape with a name,
+type, and size — the general attachment surface) and **prose-embedded images**
+(`blob://<hash>` image srcs inside a prose page). Bytes live in the workspace's
+content-addressed blob store; every reference is a `blobRef` (the SHA-256 of
+the bytes). Work in one **team** document.
+
+## Read files
+
+1. **Discover.** `list_files(docId)` → every attachment with `source`
+   (canvas/prose), `pageId`, `blobRef`, `fileName`, `mimeType`, `sizeBytes`,
+   and `inStore`. `inStore: false` means the bytes never reached this relay
+   (e.g. a desktop-local attachment) — you can see it but not fetch it.
+2. **Fetch bytes.** `get_file(docId, blobRef)` → either a short-lived
+   `{transport:"url", url}` to GET directly (no auth headers — it's presigned
+   and expires; re-call for a fresh one), or `{transport:"inline", base64}`
+   for small files on a filesystem-backed relay. Files over the inline cap on
+   a filesystem relay are only viewable in the app.
+
+## Attach a file
+
+`add_file(docId, pageId, fileName, <source>, x?, y?, label?)` — `pageId` is a
+**canvas** page id (from `get_document`). Provide exactly ONE source:
+
+- `base64` — the file's bytes, standard padded base64. For small files (the
+  request body caps around 8 MB total, ~5.5 MB of real bytes). Ideal for
+  content you just generated (a CSV, an SVG, a small PDF).
+- `url` — an `https` URL the relay fetches server-side (optionally with an
+  `authorization` header value you supply). The relay operator must allowlist
+  the host (`RELAY_BLOB_INGEST_ALLOWED_HOSTS`); expect
+  `ERR_INGEST_NOT_CONFIGURED` when no allowlist is set. Use for anything too
+  big for base64.
+- `blobRef` — attach a blob already in the workspace store (from `list_files`
+  on another document, or a previous upload) without moving bytes.
+
+It returns `{shapeId, blobRef, mimeType, sizeBytes, fileCategory}`. Pass
+`mimeType` explicitly when you know it; otherwise the relay infers from the
+URL response or the `fileName` extension. `x`/`y` are the card's center in
+world units — omit for the origin, or place it near related shapes.
+
+If the attach step fails after an upload, the error carries the stored
+`blobRef` — retry with that `blobRef` as the source instead of re-uploading.
+
+## Storage headroom
+
+`get_storage()` → `{usedBytes, quotaBytes, maxBlobBytes}`. `quotaBytes: null`
+means unlimited. Check before a large upload; a quota overrun fails the
+upload with `ERR_QUOTA_EXCEEDED` and nothing is attached.
+
+## Tips
+
+- The card renders with a category icon (pdf / spreadsheet / image / text /
+  generic) plus the file name; users open it in a viewer from the canvas.
+  Give `fileName` a real extension — it drives both the icon and the viewer.
+- Prose-embedded images: reference an **already-stored** blob as
+  `<img src="blob://<hash>">` via `set_prose` with `format:"html"`. Upload
+  new bytes with `add_file` first (the card can live on any canvas page),
+  then reuse its `blobRef` in the prose image.
+- Don't base64 multi-megabyte files into a tool call reflexively — prefer the
+  `url` source, or ask the user to drag the file into the app.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -107,6 +107,13 @@ pub struct ToolContext<'a> {
     pub s3: Option<&'a Arc<S3Backend>>,
     /// Lifetime of MCP-minted presigned blob GET URLs (JP-430).
     pub blob_url_ttl_secs: u64,
+    /// The effective storage quota for this request (JWT claim override else
+    /// config fallback; `None` = unlimited) — enforced by the `add_file`
+    /// upload and reported by `get_storage` (JP-430 E3).
+    pub quota_bytes: Option<u64>,
+    /// `[tenancy.limits] max_blob_bytes` — the per-blob size ceiling, enforced
+    /// by the `add_file` upload and reported by `get_storage` (JP-430 E3).
+    pub max_blob_bytes: usize,
     pub local: &'a Arc<LocalDocumentMirror>,
     pub local_enabled: bool,
     /// Workspace the MCP request authenticates against. Derived in
@@ -195,11 +202,13 @@ impl ToolContext<'_> {
 fn tool_required_permission(name: &str) -> Option<crate::server::permissions::Permission> {
     use crate::server::permissions::Permission;
     match name {
-        // No specific target document.
+        // No specific target document. (`get_storage` reads workspace-level
+        // totals — anyone in the workspace may see them, like `list_documents`.)
         "docushark_list_documents"
         | "docushark_create_document"
         | "docushark_get_skills"
         | "docushark_list_icons"
+        | "docushark_get_storage"
         | "docushark_resolve_doi" => None,
         // Owner-only (matches REST DELETE /api/docs/:id).
         "docushark_delete_document" => Some(Permission::Owner),
@@ -304,6 +313,41 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
                     "blobRef": {"type": "string", "description": "SHA-256 content hash of the file (64 lowercase hex chars)."}
                 },
                 "required": ["docId", "blobRef"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark_get_storage",
+            description:
+                "Workspace storage stats: bytes used by stored files, the storage quota (null = unlimited), and the per-file size ceiling. Check before large add_file uploads.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        },
+        ToolDescriptor {
+            name: "docushark_add_file",
+            description:
+                "Upload a file and attach it to a document as a canvas file card. Provide exactly one source: url (fetched server-side; https-only and the host must be on the relay's ingest allowlist), base64 (small files — the request body caps around 8 MB), or blobRef (attach a file already in the workspace store, e.g. from list_files or a previous upload). The relay stores the bytes content-addressed, enforces the workspace storage quota, and returns the new shape id + blobRef.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "docId": {"type": "string"},
+                    "pageId": {"type": "string", "description": "Canvas page to attach the file card to."},
+                    "fileName": {"type": "string", "description": "Human file name shown on the card (e.g. \"report.pdf\"); also drives MIME/category inference."},
+                    "url": {"type": "string", "description": "https source to fetch server-side. The relay operator must allowlist the host (RELAY_BLOB_INGEST_ALLOWED_HOSTS)."},
+                    "authorization": {"type": "string", "description": "Optional Authorization header value sent verbatim to the url source."},
+                    "base64": {"type": "string", "description": "File bytes as standard base64 (RFC 4648, padded). For larger files use url or blobRef."},
+                    "blobRef": {"type": "string", "description": "SHA-256 hash of a blob already in the workspace store — attaches without uploading."},
+                    "mimeType": {"type": "string", "description": "Overrides MIME detection (else: url Content-Type / fileName extension)."},
+                    "x": {"type": "number", "description": "Card center X in world units (default 0)."},
+                    "y": {"type": "number", "description": "Card center Y in world units (default 0)."},
+                    "width": {"type": "number"},
+                    "height": {"type": "number"},
+                    "label": {"type": "string", "description": "Card label override; defaults to fileName."}
+                },
+                "required": ["docId", "pageId", "fileName"],
                 "additionalProperties": false
             }),
         },
@@ -980,6 +1024,8 @@ pub fn dispatch(ctx: &ToolContext, name: &str, args: &Value) -> Result<ToolOutco
         "docushark_get_prose" => get_prose(ctx, args),
         "docushark_list_files" => list_files(ctx, args),
         "docushark_get_file" => get_file(ctx, args),
+        "docushark_add_file" => add_file(ctx, args),
+        "docushark_get_storage" => get_storage(ctx),
         "docushark_add_prose_page" => add_prose_page(ctx, args),
         "docushark_set_prose" => set_prose(ctx, args),
         "docushark_insert_block" => insert_block(ctx, args),
@@ -1510,9 +1556,18 @@ fn get_file(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     }
 
     let meta = ctx.blob_store.get_metadata(&ctx.workspace_id, &parsed.blob_ref);
-    let (mime_type, size_bytes) = meta
+    let (mut mime_type, size_bytes) = meta
         .map(|m| (m.mime_type, m.size))
         .unwrap_or_else(|| ("application/octet-stream".to_string(), 0));
+    // JP-430 E3: the index only knows what the upload declared — historically
+    // often `application/octet-stream` (the editor's presign finalize omitted
+    // the mime). The referencing FileShape carries the real type, and `doc` is
+    // already in hand from the reference gate above — prefer it.
+    if mime_type == "application/octet-stream" {
+        if let Some(shape_mime) = file_shape_mime_for(&doc, &parsed.blob_ref) {
+            mime_type = shape_mime;
+        }
+    }
 
     // Object-storage backend: hand out a short-lived presigned GET — the
     // agent fetches the bytes straight from storage (they never transit the
@@ -1562,6 +1617,48 @@ fn get_file(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
     })
 }
 
+/// The `mimeType` of a canvas FileShape referencing `blob_ref`, if any page
+/// carries one (JP-430 E3): the shape is where the editor records the real
+/// type when the blob index only got `application/octet-stream`.
+fn file_shape_mime_for(doc: &Value, blob_ref: &str) -> Option<String> {
+    let pages = doc.get("pages")?.as_object()?;
+    for page in pages.values() {
+        let Some(shapes) = page.get("shapes").and_then(|s| s.as_object()) else {
+            continue;
+        };
+        for shape in shapes.values() {
+            if shape.get("type").and_then(|v| v.as_str()) == Some("file")
+                && shape.get("blobRef").and_then(|v| v.as_str()) == Some(blob_ref)
+            {
+                if let Some(mime) = shape
+                    .get("mimeType")
+                    .and_then(|v| v.as_str())
+                    .filter(|m| !m.trim().is_empty())
+                {
+                    return Some(mime.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// `docushark_get_storage` (JP-430 E3): workspace-level storage stats — used
+/// bytes (full-size-per-grant, the JP-81 metering rule), the effective quota
+/// for this request (`null` = unlimited), and the per-file ceiling.
+fn get_storage(ctx: &ToolContext) -> Result<ToolOutcome, String> {
+    Ok(ToolOutcome {
+        result: json!({
+            "usedBytes": ctx.blob_store.get_workspace_size(&ctx.workspace_id),
+            "quotaBytes": ctx.quota_bytes,
+            "maxBlobBytes": ctx.max_blob_bytes,
+            "backend": if ctx.s3.is_some() { "object-storage" } else { "filesystem" },
+        }),
+        changed_doc_id: None,
+        change_detail: None,
+    })
+}
+
 /// Unix-millis now — std-only (house style: no chrono here).
 fn now_millis() -> u64 {
     std::time::SystemTime::now()
@@ -1585,6 +1682,165 @@ fn base64_encode(bytes: &[u8]) -> String {
         out.push(if chunk.len() > 2 { TBL[(n as usize) & 63] as char } else { '=' });
     }
     out
+}
+
+/// Strict RFC 4648 §4 base64 decode (standard alphabet, padding required) —
+/// the inverse of [`base64_encode`], for the `add_file` base64 source (JP-430
+/// E3). Rejects whitespace, the URL-safe alphabet (`-`/`_`), missing padding,
+/// and trailing garbage: an agent-supplied payload that doesn't round-trip
+/// exactly is more likely corrupt than creatively encoded.
+pub(super) fn base64_decode(s: &str) -> Result<Vec<u8>, String> {
+    fn val(c: u8) -> Result<u32, String> {
+        match c {
+            b'A'..=b'Z' => Ok((c - b'A') as u32),
+            b'a'..=b'z' => Ok((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Ok((c - b'0' + 52) as u32),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err(format!("invalid base64 character {:?}", c as char)),
+        }
+    }
+    let bytes = s.as_bytes();
+    if bytes.len() % 4 != 0 {
+        return Err("base64 length must be a multiple of 4 (standard alphabet, padded)".into());
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+    for (i, chunk) in bytes.chunks(4).enumerate() {
+        let is_last = (i + 1) * 4 == bytes.len();
+        let pad = chunk.iter().rev().take_while(|&&c| c == b'=').count();
+        if pad > 2 || (pad > 0 && !is_last) {
+            return Err("misplaced base64 padding".into());
+        }
+        // '=' may only appear as the trailing pad just counted.
+        if chunk[..4 - pad].contains(&b'=') {
+            return Err("misplaced base64 padding".into());
+        }
+        let mut n: u32 = 0;
+        for &c in &chunk[..4 - pad] {
+            n = (n << 6) | val(c)?;
+        }
+        n <<= 6 * pad as u32;
+        let b = n.to_be_bytes();
+        out.push(b[1]);
+        if pad < 2 {
+            out.push(b[2]);
+        }
+        if pad < 1 {
+            out.push(b[3]);
+        }
+    }
+    Ok(out)
+}
+
+/// File category for viewer dispatch on a FileShape. Rust twin of the
+/// editor's `detectFileCategory` (`src/utils/fileUtils.ts`) — keep the two in
+/// sync, category order included (csv is a spreadsheet before `text/` gets a
+/// look). JP-430 E3.
+fn detect_file_category(mime_type: &str, file_name: &str) -> &'static str {
+    let mime = mime_type.to_ascii_lowercase();
+    let ext = file_name
+        .rsplit('.')
+        .next()
+        .filter(|e| *e != file_name)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    if mime == "application/pdf" || ext == "pdf" {
+        return "pdf";
+    }
+    if mime == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        || mime == "application/vnd.ms-excel"
+        || mime == "application/vnd.oasis.opendocument.spreadsheet"
+        || mime == "text/csv"
+        || ["xlsx", "xls", "ods", "csv", "tsv"].contains(&ext.as_str())
+    {
+        return "spreadsheet";
+    }
+    if mime.starts_with("image/")
+        || ["png", "jpg", "jpeg", "gif", "svg", "webp", "avif", "bmp", "ico", "tiff", "tif"]
+            .contains(&ext.as_str())
+    {
+        return "image";
+    }
+    if mime.starts_with("text/")
+        || [
+            "application/json",
+            "application/xml",
+            "application/javascript",
+            "application/typescript",
+            "application/x-yaml",
+            "application/toml",
+        ]
+        .contains(&mime.as_str())
+        || [
+            "txt", "md", "markdown", "json", "xml", "yaml", "yml", "toml", "js", "ts", "jsx",
+            "tsx", "css", "scss", "less", "html", "htm", "py", "rb", "rs", "go", "java", "kt",
+            "swift", "c", "cpp", "h", "hpp", "sh", "bash", "zsh", "fish", "ps1", "bat", "cmd",
+            "sql", "graphql", "gql", "proto", "env", "ini", "cfg", "conf", "config", "log",
+            "diff", "patch", "dockerfile", "makefile", "cmake",
+        ]
+        .contains(&ext.as_str())
+    {
+        return "text";
+    }
+    "generic"
+}
+
+/// Guess a MIME type from a file name's extension — Rust twin of the editor's
+/// `getMimeType` (`src/utils/fileUtils.ts`); keep in sync. Falls back to
+/// `application/octet-stream`. JP-430 E3: gives base64 uploads (no transport
+/// header to inherit) a meaningful index + FileShape mime.
+pub(super) fn mime_from_file_name(file_name: &str) -> &'static str {
+    let ext = file_name
+        .rsplit('.')
+        .next()
+        .filter(|e| *e != file_name)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "pdf" => "application/pdf",
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xls" => "application/vnd.ms-excel",
+        "ods" => "application/vnd.oasis.opendocument.spreadsheet",
+        "csv" => "text/csv",
+        "tsv" => "text/tab-separated-values",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "bmp" => "image/bmp",
+        "ico" => "image/x-icon",
+        "tiff" | "tif" => "image/tiff",
+        "txt" | "log" => "text/plain",
+        "md" => "text/markdown",
+        "json" => "application/json",
+        "xml" => "application/xml",
+        "yaml" | "yml" => "application/x-yaml",
+        "toml" => "application/toml",
+        "html" | "htm" => "text/html",
+        "css" => "text/css",
+        "js" | "jsx" => "application/javascript",
+        "ts" | "tsx" => "application/typescript",
+        "py" => "text/x-python",
+        "rb" => "text/x-ruby",
+        "rs" => "text/x-rust",
+        "go" => "text/x-go",
+        "java" => "text/x-java",
+        "sh" => "text/x-shellscript",
+        "sql" => "text/x-sql",
+        "zip" => "application/zip",
+        "gz" => "application/gzip",
+        "tar" => "application/x-tar",
+        "7z" => "application/x-7z-compressed",
+        "rar" => "application/x-rar-compressed",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        _ => "application/octet-stream",
+    }
 }
 
 #[derive(Deserialize)]
@@ -3568,7 +3824,20 @@ fn write_move_block_live_or_json(
 fn append_shape_in_place(doc: &mut Value, page_id: &str, shape: &DslShape) -> Result<String, String> {
     let id = shape_id_or_gen(shape);
     let shape_json = build_shape_json(shape, &id);
+    append_shape_json_in_place(doc, page_id, &id, shape_json)?;
+    Ok(id)
+}
 
+/// [`append_shape_in_place`] for a pre-built shape JSON `Value` — the path
+/// for shapes the DSL adapter deliberately doesn't author (`add_file`'s
+/// FileShape, JP-430 E3). Inserts into `pages[page_id].shapes` + pushes
+/// `shapeOrder` exactly once (JP-330: an id must never be double-pushed).
+fn append_shape_json_in_place(
+    doc: &mut Value,
+    page_id: &str,
+    id: &str,
+    shape_json: Value,
+) -> Result<(), String> {
     let pages = doc
         .get_mut("pages")
         .and_then(|v| v.as_object_mut())
@@ -3583,19 +3852,19 @@ fn append_shape_in_place(doc: &mut Value, page_id: &str, shape: &DslShape) -> Re
         .or_insert_with(|| json!({}))
         .as_object_mut()
         .ok_or("Page 'shapes' is not an object")?;
-    if shapes.contains_key(&id) {
+    if shapes.contains_key(id) {
         return Err(format!("Shape id '{}' already exists on page", id));
     }
-    shapes.insert(id.clone(), shape_json);
+    shapes.insert(id.to_string(), shape_json);
 
     let order = page
         .entry("shapeOrder")
         .or_insert_with(|| json!([]))
         .as_array_mut()
         .ok_or("Page 'shapeOrder' is not an array")?;
-    order.push(json!(id.clone()));
+    order.push(json!(id));
 
-    Ok(id)
+    Ok(())
 }
 
 /// Maximum optimistic-concurrency retries before a write gives up. A
@@ -3631,11 +3900,43 @@ fn mutate_with_retry<R>(
         let mut doc = ctx.team.get_document(&ctx.workspace_id, doc_id)?;
         let expected = doc.get("serverVersion").and_then(|v| v.as_u64());
         let value = mutate(&mut doc)?;
+        // JP-430 E3: REST-save blob-ref parity. Every cold MCP write now
+        // registers the doc's blob references exactly like `save_doc_handler`:
+        // the *sync* set is the conservative union (the pre-overwrite
+        // `blobReferences` array ∪ post-mutation content — a save never
+        // releases an in-use blob, RB-2), while the persisted array is
+        // rewritten **content-derived only** (the flatten's semantics; a
+        // union here would re-add dropped refs forever and leak quota).
+        // The array is what the startup seed reads, so this also makes an
+        // MCP-attached file crash-restart-safe. Computed per attempt — each
+        // retry re-reads the doc, so both sets stay pure.
+        let sync_refs = crate::api::save_blob_refs(&doc);
+        let mut content_refs: Vec<String> =
+            crate::api::collect_blob_references(&doc).into_iter().collect();
+        content_refs.sort();
+        if let Some(obj) = doc.as_object_mut() {
+            obj.insert("blobReferences".into(), json!(content_refs));
+        }
         match ctx
             .team
             .save_document_with_expected_version(&ctx.workspace_id, doc, expected)?
         {
-            SaveOutcome::Created { .. } | SaveOutcome::Updated { .. } => return Ok(value),
+            SaveOutcome::Created { .. } | SaveOutcome::Updated { .. } => {
+                // Best-effort, after the save landed (same ordering as REST):
+                // a bookkeeping failure must not fail a persisted write.
+                if let Err(e) =
+                    ctx.blob_store
+                        .sync_doc_refs(&ctx.workspace_id, doc_id.as_str(), sync_refs)
+                {
+                    log::warn!(
+                        "mcp write: blob ref sync failed for {}/{}: {}",
+                        ctx.workspace_id.as_str(),
+                        doc_id.as_str(),
+                        e
+                    );
+                }
+                return Ok(value);
+            }
             SaveOutcome::VersionConflict { current } => {
                 last_seen = current;
                 continue;
@@ -3946,6 +4247,198 @@ fn stamp_modified(doc: &mut Value, page_id: &str) {
     if let Some(o) = doc.as_object_mut() {
         o.insert("modifiedAt".into(), json!(now));
     }
+}
+
+/// `docushark_add_file` (JP-430 E3). By dispatch time the transport preflight
+/// has stored any `url`/`base64` source and injected its `blobRef`/
+/// `mimeType`/`fileSize` — so this sync handler only validates the blob and
+/// attaches a FileShape. It's also directly reachable with a caller-supplied
+/// `blobRef` (attach-only: re-attach an already-stored blob, or the retry
+/// path after an attach failure).
+#[derive(Deserialize)]
+struct AddFileArgs {
+    #[serde(rename = "docId")]
+    doc_id: DocId,
+    #[serde(rename = "pageId")]
+    page_id: String,
+    #[serde(rename = "fileName")]
+    file_name: String,
+    #[serde(rename = "blobRef")]
+    blob_ref: Option<String>,
+    #[serde(rename = "mimeType")]
+    mime_type: Option<String>,
+    #[serde(rename = "fileSize")]
+    file_size: Option<u64>,
+    x: Option<f64>,
+    y: Option<f64>,
+    width: Option<f64>,
+    height: Option<f64>,
+    label: Option<String>,
+}
+
+/// Everything the async upload preflight must check BEFORE storing bytes
+/// (JP-430 E3): the doc exists as a writable team doc (not a local-mirror
+/// doc), the caller may edit it (JP-370), and the target canvas page exists.
+/// Failing here keeps an unauthorized or misaddressed call from leaving
+/// orphan bytes in the store (they'd sit ACL'd-but-unreferenced until the
+/// grace-gated sweep reclaims them).
+pub(super) fn validate_add_file_target(
+    ctx: &ToolContext,
+    doc_id: &DocId,
+    page_id: &str,
+) -> Result<(), String> {
+    reject_if_local(ctx, doc_id)?;
+    ctx.ensure_doc_permission(doc_id, crate::server::permissions::Permission::Editor)?;
+    let doc = ctx
+        .team
+        .get_document(&ctx.workspace_id, doc_id)
+        .map_err(|e| format!("Document not found: {}", e))?;
+    if doc
+        .get("pages")
+        .and_then(|p| p.get(page_id))
+        .is_none()
+    {
+        return Err(format!("Page '{}' not found", page_id));
+    }
+    Ok(())
+}
+
+fn add_file(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
+    let parsed: AddFileArgs =
+        serde_json::from_value(args.clone()).map_err(|e| format!("Invalid arguments: {}", e))?;
+
+    reject_if_local(ctx, &parsed.doc_id)?;
+    let file_name = parsed.file_name.trim();
+    if file_name.is_empty() || file_name.chars().any(char::is_control) {
+        return Err("ERR_BAD_FILE_NAME: fileName must be non-empty printable text".into());
+    }
+
+    // The preflight injects `blobRef` for url/base64 sources; a bare dispatch
+    // call reaches here only in attach-only form.
+    let Some(blob_ref) = parsed.blob_ref.clone() else {
+        return Err(
+            "ERR_BAD_SOURCE: provide exactly one of url, base64, or blobRef".to_string(),
+        );
+    };
+    if !crate::api::is_valid_blob_hash(&blob_ref) {
+        return Err(
+            "ERR_BAD_BLOB_REF: blobRef must be a 64-char lowercase SHA-256 hex digest \
+             (take it from list_files or a file shape's blobRef)"
+                .to_string(),
+        );
+    }
+    // Attach-only gate: the blob must already be in this workspace's store.
+    // Opaque wording (same as get_file) — never a cross-tenant hash oracle.
+    let meta = ctx.blob_store.get_metadata(&ctx.workspace_id, &blob_ref);
+    if !ctx.blob_store.exists(&ctx.workspace_id, &blob_ref) {
+        return Err(format!(
+            "ERR_FILE_NOT_FOUND: blob '{}' is not in this workspace's store",
+            blob_ref
+        ));
+    }
+
+    // Mime precedence: caller/preflight-resolved value, else the blob index
+    // (when it recorded something real), else the extension guess — matching
+    // the editor's extension-first fallback for octet-stream uploads
+    // (FileImportService.ts).
+    let mime = parsed
+        .mime_type
+        .clone()
+        .filter(|m| !m.trim().is_empty())
+        .or_else(|| {
+            meta.as_ref()
+                .map(|m| m.mime_type.clone())
+                .filter(|m| m != "application/octet-stream")
+        })
+        .unwrap_or_else(|| mime_from_file_name(file_name).to_string());
+    let size = parsed
+        .file_size
+        .or_else(|| meta.as_ref().map(|m| m.size))
+        .unwrap_or(0);
+    let category = detect_file_category(&mime, file_name);
+
+    // Hand-built FileShape JSON — field-for-field what the editor's import
+    // flow creates (FileImportService.ts / DEFAULT_FILE_SHAPE, Shape.ts).
+    // Deliberately NOT routed through the DSL adapter: `file` stays
+    // unauthorable via add_shape (blob integrity owns the write door).
+    let id = format!("shape-{}", nanoid::nanoid!(10));
+    let mut shape = json!({
+        "id": id,
+        "type": "file",
+        "x": parsed.x.unwrap_or(0.0),
+        "y": parsed.y.unwrap_or(0.0),
+        "rotation": 0.0,
+        "opacity": 1.0,
+        "locked": false,
+        "visible": true,
+        "fill": "#f8fafc",
+        "stroke": "#cbd5e1",
+        "strokeWidth": 1.0,
+        "width": parsed.width.unwrap_or(200.0),
+        "height": parsed.height.unwrap_or(160.0),
+        "blobRef": blob_ref,
+        "fileName": file_name,
+        "mimeType": mime,
+        "fileSize": size,
+        "fileCategory": category,
+        "labelFontSize": 12.0,
+        "labelColor": "#475569",
+    });
+    if let Some(label) = parsed.label.as_deref().map(str::trim).filter(|l| !l.is_empty()) {
+        // The editor leaves `label` unset (render falls back to fileName);
+        // only persist an explicit caller override.
+        shape["label"] = json!(label);
+    }
+    stamp_provenance(&mut shape);
+
+    let result = json!({
+        "shapeId": id,
+        "pageId": parsed.page_id,
+        "blobRef": blob_ref,
+        "fileName": file_name,
+        "mimeType": mime,
+        "sizeBytes": size,
+        "fileCategory": category,
+    });
+
+    let outcome = write_shape_live_or_json(
+        ctx,
+        &parsed.doc_id,
+        &parsed.page_id,
+        |handle, page_id| {
+            let framed = handle.insert_shapes(page_id, &[(id.clone(), shape.clone())])?;
+            Ok((framed, result.clone()))
+        },
+        |doc| {
+            append_shape_json_in_place(doc, &parsed.page_id, &id, shape.clone())?;
+            stamp_modified(doc, &parsed.page_id);
+            Ok(result.clone())
+        },
+    )
+    .map_err(|e| {
+        // The bytes are already stored; hand the agent the attach-only retry
+        // handle so a transient failure doesn't force a re-upload.
+        format!("{e} (the file's bytes are stored — retry with blobRef=\"{blob_ref}\" to attach without re-uploading)")
+    })?;
+
+    // Register the blob reference NOW, additively. On the live path the JSON
+    // body (and its save-path ref sync) lags until the next snapshot flatten;
+    // on the cold path `mutate_with_retry` already synced the full set and
+    // this union is a no-op. Best-effort: the write itself succeeded, and the
+    // JP-127 grace shields the blob until the next full sync.
+    if let Err(e) = ctx
+        .blob_store
+        .add_doc_ref(&ctx.workspace_id, parsed.doc_id.as_str(), &blob_ref)
+    {
+        log::warn!(
+            "add_file: doc-ref registration failed for {}/{}: {}",
+            parsed.doc_id.as_str(),
+            blob_ref,
+            e
+        );
+    }
+
+    Ok(outcome)
 }
 
 #[derive(Deserialize)]
@@ -4533,6 +5026,8 @@ mod tests {
                 blob_store: &self.blob_store,
                 s3: None,
                 blob_url_ttl_secs: 300,
+                quota_bytes: None,
+                max_blob_bytes: crate::config::DEFAULT_MAX_BLOB_BYTES,
                 local: &self.local,
                 local_enabled,
                 workspace_id: WorkspaceId::single_tenant(),
@@ -4556,6 +5051,8 @@ mod tests {
                 blob_store: &self.blob_store,
                 s3: None,
                 blob_url_ttl_secs: 300,
+                quota_bytes: None,
+                max_blob_bytes: crate::config::DEFAULT_MAX_BLOB_BYTES,
                 local: &self.local,
                 local_enabled: false,
                 workspace_id: WorkspaceId::single_tenant(),
@@ -7137,6 +7634,7 @@ mod tests {
             "docushark_create_document",
             "docushark_get_skills",
             "docushark_list_icons",
+            "docushark_get_storage",
             "docushark_resolve_doi",
         ];
         for d in descriptors() {
@@ -7413,5 +7911,292 @@ mod tests {
         assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
         assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
         assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    // ---- JP-430 E3: add_file / get_storage ----
+
+    #[test]
+    fn base64_decode_matches_rfc4648_vectors_and_rejects_garbage() {
+        assert_eq!(base64_decode("").unwrap(), b"");
+        assert_eq!(base64_decode("Zg==").unwrap(), b"f");
+        assert_eq!(base64_decode("Zm8=").unwrap(), b"fo");
+        assert_eq!(base64_decode("Zm9v").unwrap(), b"foo");
+        assert_eq!(base64_decode("Zm9vYg==").unwrap(), b"foob");
+        assert_eq!(base64_decode("Zm9vYmE=").unwrap(), b"fooba");
+        assert_eq!(base64_decode("Zm9vYmFy").unwrap(), b"foobar");
+        // Round-trip against the encoder over binary data.
+        let all: Vec<u8> = (0u8..=255).collect();
+        assert_eq!(base64_decode(&base64_encode(&all)).unwrap(), all);
+
+        // Strictness: padding-less, whitespace, the URL-safe alphabet, and
+        // misplaced padding are all refused.
+        assert!(base64_decode("Zg").is_err(), "missing padding");
+        assert!(base64_decode("Zm9v\n").is_err(), "trailing newline");
+        assert!(base64_decode("Zm 9v").is_err(), "inner whitespace");
+        assert!(base64_decode("-_9v").is_err(), "url-safe alphabet");
+        assert!(base64_decode("Z===").is_err(), "over-padded");
+        assert!(base64_decode("=Zg=").is_err(), "leading pad");
+        assert!(base64_decode("Zg==Zg==").is_err(), "pad mid-stream");
+    }
+
+    #[test]
+    fn detect_file_category_matches_ts_twin() {
+        // Keep in sync with src/utils/fileUtils.ts `detectFileCategory`.
+        assert_eq!(detect_file_category("application/pdf", "x"), "pdf");
+        assert_eq!(detect_file_category("", "report.PDF"), "pdf");
+        // Ordering pin: csv is a spreadsheet even though text/* would match.
+        assert_eq!(detect_file_category("text/csv", "data.csv"), "spreadsheet");
+        assert_eq!(detect_file_category("", "sheet.xlsx"), "spreadsheet");
+        assert_eq!(detect_file_category("image/png", ""), "image");
+        assert_eq!(detect_file_category("", "photo.jpeg"), "image");
+        assert_eq!(detect_file_category("text/plain", ""), "text");
+        assert_eq!(detect_file_category("application/json", ""), "text");
+        assert_eq!(detect_file_category("", "main.rs"), "text");
+        assert_eq!(detect_file_category("application/zip", "a.zip"), "generic");
+        assert_eq!(detect_file_category("", "no-extension"), "generic");
+    }
+
+    #[test]
+    fn mime_from_file_name_matches_ts_twin() {
+        // Keep in sync with src/utils/fileUtils.ts `getMimeType`.
+        assert_eq!(mime_from_file_name("report.pdf"), "application/pdf");
+        assert_eq!(mime_from_file_name("DATA.CSV"), "text/csv");
+        assert_eq!(mime_from_file_name("logo.svg"), "image/svg+xml");
+        assert_eq!(mime_from_file_name("notes.md"), "text/markdown");
+        assert_eq!(mime_from_file_name("no-extension"), "application/octet-stream");
+        assert_eq!(mime_from_file_name("weird.xyz"), "application/octet-stream");
+    }
+
+    /// Attach-only `add_file` (cold path): the shape lands field-for-field like
+    /// an editor upload, the doc's `blobReferences` array is rewritten
+    /// content-derived (mutate_with_retry parity), the runtime refcount is
+    /// registered — and with grace forced to 0, the blob still survives a
+    /// destructive sweep because it is *referenced*, not because of grace.
+    #[test]
+    fn add_file_attach_only_builds_editor_parity_shape_and_registers_ref() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        f.blob_store.set_gc_grace_secs(0);
+
+        let bytes = b"attached bytes";
+        let hash = sha256_hex(bytes);
+        f.blob_store.save_blob(&ws, &hash, bytes, "text/plain", "tester").unwrap();
+
+        let out = dispatch(
+            &f.ctx(false),
+            "docushark_add_file",
+            &json!({
+                "docId": "doc1", "pageId": "p1",
+                "fileName": "notes.txt", "blobRef": hash,
+                "x": 40.0, "y": -10.0,
+            }),
+        )
+        .unwrap();
+        assert_eq!(out.result["blobRef"], json!(hash));
+        assert_eq!(out.result["mimeType"], "text/plain");
+        assert_eq!(out.result["fileCategory"], "text");
+        assert_eq!(out.result["sizeBytes"], bytes.len());
+        let shape_id = out.result["shapeId"].as_str().unwrap().to_string();
+        assert!(out.changed_doc_id.is_some(), "cold write nudges a reload");
+
+        let doc = f
+            .team
+            .get_document(&ws, &DocId::from_http_path("doc1".into()).unwrap())
+            .unwrap();
+        let shape = &doc["pages"]["p1"]["shapes"][&shape_id];
+        // Editor parity (FileImportService.ts + DEFAULT_FILE_SHAPE).
+        assert_eq!(shape["type"], "file");
+        assert_eq!(shape["x"], 40.0);
+        assert_eq!(shape["y"], -10.0);
+        assert_eq!(shape["width"], 200.0);
+        assert_eq!(shape["height"], 160.0);
+        assert_eq!(shape["fill"], "#f8fafc");
+        assert_eq!(shape["stroke"], "#cbd5e1");
+        assert_eq!(shape["labelColor"], "#475569");
+        assert_eq!(shape["fileName"], "notes.txt");
+        assert_eq!(shape["provenance"]["source"], "mcp");
+        assert!(shape.get("label").is_none(), "no label unless the caller set one");
+        assert_eq!(
+            doc["pages"]["p1"]["shapeOrder"].as_array().unwrap().iter().filter(|v| *v == &json!(shape_id)).count(),
+            1,
+            "shapeOrder carries the id exactly once (JP-330)"
+        );
+
+        // The GC-trap fix, both layers: the persisted array (what a restart
+        // seeds from) and the live refcount.
+        let refs: Vec<&str> = doc["blobReferences"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(refs, vec![hash.as_str()], "content-derived blobReferences array");
+        assert_eq!(f.blob_store.docs_referencing(&ws, &hash), vec!["doc1"]);
+
+        // Grace is 0 — survival below is purely the reference registration.
+        assert_eq!(f.blob_store.sweep_unreferenced(), 0);
+        assert!(f.blob_store.exists(&ws, &hash), "referenced blob survives the sweep");
+    }
+
+    #[test]
+    fn add_file_refuses_missing_source_bad_hash_and_unstored_blob() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        // No source at all (a bare dispatch call — the transport preflight
+        // enforces exactly-one; dispatch still refuses zero).
+        let err = dispatch(
+            &f.ctx(false),
+            "docushark_add_file",
+            &json!({"docId": "doc1", "pageId": "p1", "fileName": "a.txt"}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_BAD_SOURCE"), "got: {err}");
+
+        let err = dispatch(
+            &f.ctx(false),
+            "docushark_add_file",
+            &json!({"docId": "doc1", "pageId": "p1", "fileName": "a.txt", "blobRef": "nope"}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_BAD_BLOB_REF"), "got: {err}");
+
+        // Valid hash format, but nothing stored under it in this workspace —
+        // opaque wording, no cross-tenant hash oracle.
+        let err = dispatch(
+            &f.ctx(false),
+            "docushark_add_file",
+            &json!({
+                "docId": "doc1", "pageId": "p1", "fileName": "a.txt",
+                "blobRef": sha256_hex(b"never stored"),
+            }),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_FILE_NOT_FOUND"), "got: {err}");
+    }
+
+    /// Live path: a resident doc takes the FileShape into the Y.Doc (broadcast,
+    /// no JSON rewrite) — and the additive `add_doc_ref` covers the blob until
+    /// the next flatten recomputes the full set.
+    #[test]
+    fn add_file_live_path_broadcasts_and_registers_ref() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        f.blob_store.set_gc_grace_secs(0);
+
+        let bytes = b"live attach";
+        let hash = sha256_hex(bytes);
+        f.blob_store.save_blob(&ws, &hash, bytes, "image/png", "tester").unwrap();
+
+        let handle = f.make_resident("doc1");
+        let out = dispatch(
+            &f.ctx(true),
+            "docushark_add_file",
+            &json!({"docId": "doc1", "pageId": "p1", "fileName": "shot.png", "blobRef": hash}),
+        )
+        .unwrap();
+        assert!(out.changed_doc_id.is_none(), "live path broadcasts instead of reloading");
+        assert_eq!(f.broadcasts().len(), 1, "one framed CRDT delta");
+
+        let shape_id = out.result["shapeId"].as_str().unwrap();
+        assert!(handle.get_shape_json("p1", shape_id).is_some(), "shape is in the live Y.Doc");
+        // The JSON body lags (flatten owns it) …
+        let doc = f
+            .team
+            .get_document(&ws, &DocId::from_http_path("doc1".into()).unwrap())
+            .unwrap();
+        assert!(doc["pages"]["p1"]["shapes"].get(shape_id).is_none());
+        // … so the additive registration is what shields the blob.
+        assert_eq!(f.blob_store.docs_referencing(&ws, &hash), vec!["doc1"]);
+        assert_eq!(f.blob_store.sweep_unreferenced(), 0);
+        assert!(f.blob_store.exists(&ws, &hash));
+    }
+
+    /// Deleting a FileShape via a cold MCP write drops the hash from BOTH the
+    /// persisted `blobReferences` array (content-derived, not a union — the
+    /// leak the review caught) and the runtime refcount.
+    #[test]
+    fn delete_file_shape_releases_its_ref_via_write_parity() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        f.blob_store.set_gc_grace_secs(0);
+
+        let bytes = b"doomed attachment";
+        let canvas_hash = sha256_hex(bytes);
+        let prose_hash = sha256_hex(b"prose image stays");
+        f.blob_store.save_blob(&ws, &canvas_hash, bytes, "application/pdf", "t").unwrap();
+        f.team.save_document(&ws, make_file_doc("fdoc", &canvas_hash, &prose_hash)).unwrap();
+
+        dispatch(
+            &f.ctx(false),
+            "docushark_delete_shape",
+            &json!({"docId": "fdoc", "pageId": "p1", "id": "f1"}),
+        )
+        .unwrap();
+
+        let doc = f
+            .team
+            .get_document(&ws, &DocId::from_http_path("fdoc".into()).unwrap())
+            .unwrap();
+        let refs: Vec<&str> = doc["blobReferences"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(!refs.contains(&canvas_hash.as_str()), "deleted shape's ref must LEAVE the array");
+        assert!(refs.contains(&prose_hash.as_str()), "the prose image ref stays");
+        assert!(
+            f.blob_store.docs_referencing(&ws, &canvas_hash).is_empty(),
+            "runtime refcount dropped with the shape"
+        );
+    }
+
+    /// The blob index only knows the (often generic) upload-time mime; when it
+    /// says octet-stream, `get_file` reports the referencing FileShape's type.
+    #[test]
+    fn get_file_prefers_file_shape_mime_when_index_is_generic() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let bytes = b"hello file!!";
+        let hash = sha256_hex(bytes);
+        f.blob_store
+            .save_blob(&ws, &hash, bytes, "application/octet-stream", "tester")
+            .unwrap();
+        // make_file_doc's f1 carries mimeType application/pdf for this hash.
+        f.team
+            .save_document(&ws, make_file_doc("fdoc", &hash, &sha256_hex(b"other")))
+            .unwrap();
+
+        let out = dispatch(
+            &f.ctx(false),
+            "docushark_get_file",
+            &json!({"docId": "fdoc", "blobRef": hash}),
+        )
+        .unwrap();
+        assert_eq!(out.result["mimeType"], "application/pdf");
+    }
+
+    #[test]
+    fn get_storage_reports_usage_quota_and_backend() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let bytes = b"metered bytes";
+        f.blob_store
+            .save_blob(&ws, &sha256_hex(bytes), bytes, "text/plain", "t")
+            .unwrap();
+
+        let out = dispatch(&f.ctx(false), "docushark_get_storage", &json!({})).unwrap();
+        assert_eq!(out.result["usedBytes"], bytes.len());
+        assert_eq!(out.result["quotaBytes"], Value::Null, "fixture ctx = unlimited");
+        assert_eq!(out.result["maxBlobBytes"], crate::config::DEFAULT_MAX_BLOB_BYTES);
+        assert_eq!(out.result["backend"], "filesystem");
     }
 }

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -32,7 +32,7 @@ use serde_json::{json, Value};
 use crate::auth::{OidcAuthState, WorkspaceRole};
 use crate::server::blobs::BlobStore;
 use crate::server::documents::DocumentStore;
-use crate::server::protocol::WorkspaceId;
+use crate::server::protocol::{ClaimLimits, WorkspaceId};
 use crate::server::{S3Backend, WorkspaceWriteLimiter};
 
 use super::config::McpFeatureConfigStore;
@@ -57,6 +57,9 @@ pub struct McpAppState {
     /// Lifetime of MCP-minted presigned blob GET URLs (`[mcp]
     /// blob_url_ttl_secs`, JP-430).
     pub blob_url_ttl_secs: u64,
+    /// Blob-write handles for the `add_file` upload preflight (JP-430 E3):
+    /// shared ingest client + upload gate + tenancy blob limits.
+    pub blob_write: super::BlobWriteHandles,
     pub local_mirror: Arc<LocalDocumentMirror>,
     pub feature_config: Arc<McpFeatureConfigStore>,
     pub token: Arc<TokenStore>,
@@ -148,6 +151,15 @@ pub fn public_router(state: McpAppState) -> Router {
     mcp_routes().with_state(state)
 }
 
+/// Request-body ceiling for `/mcp` (JP-430 E3). Axum's default 2 MiB Json
+/// limit capped `add_file`'s base64 source at ~1.5 MiB decoded; 8 MiB admits
+/// ~5.5 MiB of real bytes — enough for agent-generated PDFs/images — while
+/// keeping the pre-auth buffering bound tight (the JSON body is read before
+/// any `blob_upload_gate` permit). Larger files go via the `url` source.
+/// An oversized POST is refused by the extractor with a plain 413 (not an
+/// MCP `isError` result — the body never parses far enough to be a call).
+const MCP_MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+
 /// The MCP route set shared by the loopback and public routers.
 fn mcp_routes() -> Router<McpAppState> {
     Router::new()
@@ -156,6 +168,7 @@ fn mcp_routes() -> Router<McpAppState> {
             "/.well-known/oauth-protected-resource",
             get(oauth_protected_resource),
         )
+        .layer(axum::extract::DefaultBodyLimit::max(MCP_MAX_BODY_BYTES))
 }
 
 /// RFC 9728 OAuth Protected Resource Metadata (JP-203). Public — no auth: an
@@ -318,6 +331,10 @@ struct AuthOutcome {
     /// desktop / self-host flow is unaffected.
     user_id: Option<String>,
     role: Option<String>,
+    /// Raw per-workspace limits minted on the chosen `wsp[]` entry (JP-81) —
+    /// the quota the `add_file` upload enforces (JP-430 E3). Default (no
+    /// overrides) for the static token; the config fallback then applies.
+    limits: ClaimLimits,
 }
 
 /// Stringified workspace role, matching the values the permissions layer
@@ -363,14 +380,16 @@ async fn authenticate(
             workspace: WorkspaceId::single_tenant(),
             user_id: None,
             role: None,
+            limits: ClaimLimits::default(),
         });
     }
     if let Ok(claims) = auth.validate(presented).await {
-        if let Ok((ws, role, _limits)) = WorkspaceId::from_oidc_array(&claims, None, relay_region) {
+        if let Ok((ws, role, limits)) = WorkspaceId::from_oidc_array(&claims, None, relay_region) {
             return Some(AuthOutcome {
                 workspace: ws,
                 user_id: Some(claims.sub.clone()),
                 role: Some(role_str(role)),
+                limits,
             });
         }
     }
@@ -412,6 +431,7 @@ fn is_mcp_write_tool(name: &str) -> bool {
         name,
         "docushark_add_shape"
             | "docushark_add_shapes"
+            | "docushark_add_file"
             | "docushark_connect"
             | "docushark_update_shape"
             | "docushark_delete_shape"
@@ -478,6 +498,183 @@ async fn resolve_citation_doi(name: &str, args: &mut Value) -> DoiPreflight {
     }
 }
 
+/// Result of the JP-430 E3 file-upload preflight for `add_file`.
+enum FilePreflight {
+    /// Not `add_file`, or the source is already a `blobRef` — proceed to sync
+    /// dispatch with `args` (possibly mutated to carry the stored blob).
+    Continue,
+    /// A tool error message (validation, decode, fetch, quota, store).
+    Error(String),
+}
+
+/// Map a shared-core [`crate::api::BlobWriteError`] to the typed `ERR_*`
+/// string an MCP tool error carries (the REST twin maps the same variants to
+/// HTTP statuses — `blob_write_error_response`).
+fn file_upload_error(e: crate::api::BlobWriteError) -> String {
+    use crate::api::BlobWriteError as E;
+    match e {
+        E::NotConfigured => "ERR_INGEST_NOT_CONFIGURED: url sources are disabled on this relay \
+             (no ingest allowlist is configured). Use a base64 source, or ask the operator to \
+             set RELAY_BLOB_INGEST_ALLOWED_HOSTS."
+            .to_string(),
+        E::InvalidUrl => "ERR_BAD_URL: the url could not be parsed".to_string(),
+        E::UrlNotAllowed => "ERR_URL_NOT_ALLOWED: url sources must be https, on the relay's \
+             ingest allowlist, and not an IP-literal/private host"
+            .to_string(),
+        E::Fetch(msg) => format!("ERR_FETCH_FAILED: {msg}"),
+        E::TooLarge => "ERR_FILE_TOO_LARGE: the file exceeds the relay's max blob size".to_string(),
+        E::GateUnavailable | E::StoreUnavailable => {
+            "ERR_STORE_UNAVAILABLE: the blob store is unavailable — try again".to_string()
+        }
+        E::Quota(msg) => format!("ERR_QUOTA_EXCEEDED: {msg}"),
+        E::Backend(msg) => format!("ERR_INTERNAL: {msg}"),
+    }
+}
+
+/// `add_file`'s upload leg (JP-430 E3). `dispatch` is synchronous, but the
+/// upload needs async I/O (the reqwest download for a `url` source, the S3
+/// PUT on the object-storage backend) — so, exactly like the JP-89 DOI
+/// preflight, it runs here before dispatch and injects the stored blob's
+/// identity (`blobRef`/`mimeType`/`fileSize`) into `args`; the sync tool then
+/// only attaches the FileShape. Target validation (doc/page/permission) runs
+/// BEFORE any byte is stored so an unauthorized or misaddressed call can't
+/// leave orphan bytes. Runs after the write-limiter gate — an upload draws
+/// from the same per-workspace write bucket as any other write.
+async fn resolve_file_upload(
+    state: &McpAppState,
+    ctx: &ToolContext<'_>,
+    name: &str,
+    args: &mut Value,
+) -> FilePreflight {
+    if name != "docushark_add_file" {
+        return FilePreflight::Continue;
+    }
+
+    // Minimal arg surface for the upload leg; `add_file` does full parsing.
+    let Ok(doc_id) = serde_json::from_value::<crate::server::protocol::DocId>(
+        args.get("docId").cloned().unwrap_or(Value::Null),
+    ) else {
+        return FilePreflight::Error("Invalid arguments: missing or invalid docId".into());
+    };
+    let Some(page_id) = args.get("pageId").and_then(|v| v.as_str()).map(str::to_string) else {
+        return FilePreflight::Error("Invalid arguments: missing pageId".into());
+    };
+    let file_name = args
+        .get("fileName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let url = args.get("url").and_then(|v| v.as_str()).map(str::to_string);
+    let base64 = args.get("base64").and_then(|v| v.as_str()).map(str::to_string);
+    let blob_ref = args.get("blobRef").and_then(|v| v.as_str()).map(str::to_string);
+    let source_count = [url.is_some(), base64.is_some(), blob_ref.is_some()]
+        .iter()
+        .filter(|&&b| b)
+        .count();
+    if source_count != 1 {
+        return FilePreflight::Error(
+            "ERR_BAD_SOURCE: provide exactly one of url, base64, or blobRef".into(),
+        );
+    }
+
+    // Validate the attach target before storing a single byte.
+    if let Err(e) = super::tools::validate_add_file_target(ctx, &doc_id, &page_id) {
+        return FilePreflight::Error(e);
+    }
+    if blob_ref.is_some() {
+        // Attach-only: no upload; `add_file` validates the hash against the
+        // workspace store.
+        return FilePreflight::Continue;
+    }
+
+    let declared_mime = args
+        .get("mimeType")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(str::to_string);
+    // `uploaded_by` bookkeeping: the JWT subject, or the static loopback
+    // token's fixed identity (it has no user).
+    let user = ctx.user_id.clone().unwrap_or_else(|| "mcp".to_string());
+
+    let stored = if let Some(url) = url {
+        let authorization = args
+            .get("authorization")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        crate::api::ingest_blob_from_url(
+            &state.blob_write.http,
+            &state.blob_write.allowed_hosts,
+            &state.blob_write.gate,
+            &state.blob_store,
+            state.s3.as_deref(),
+            &ctx.workspace_id,
+            &user,
+            ctx.quota_bytes,
+            state.blob_write.max_blob_bytes,
+            &url,
+            authorization.as_deref(),
+            declared_mime.as_deref(),
+        )
+        .await
+    } else {
+        let encoded = base64.unwrap_or_default();
+        let bytes = match super::tools::base64_decode(&encoded) {
+            Ok(b) => b,
+            Err(e) => return FilePreflight::Error(format!("ERR_BAD_BASE64: {e}")),
+        };
+        if bytes.is_empty() {
+            return FilePreflight::Error("ERR_BAD_BASE64: the payload is empty".into());
+        }
+        if bytes.len() > state.blob_write.max_blob_bytes {
+            return FilePreflight::Error(file_upload_error(crate::api::BlobWriteError::TooLarge));
+        }
+        // Mime precedence for a headerless base64 source: caller override,
+        // else the fileName extension (the editor's own fallback order).
+        let mime = declared_mime
+            .unwrap_or_else(|| super::tools::mime_from_file_name(&file_name).to_string());
+        crate::api::store_blob_bytes(
+            &state.blob_store,
+            state.s3.as_deref(),
+            &ctx.workspace_id,
+            &user,
+            ctx.quota_bytes,
+            &bytes,
+            &mime,
+        )
+        .await
+    };
+
+    match stored {
+        Ok(s) => {
+            // Advisory provenance, same as the REST ingest path.
+            if let Err(e) = state.blob_store.record_provenance(
+                &ctx.workspace_id,
+                &s.hash,
+                &["mcp:add_file".to_string()],
+            ) {
+                log::warn!(
+                    "add_file provenance record failed {}/{}: {e}",
+                    ctx.workspace_id.as_str(),
+                    s.hash
+                );
+            }
+            let Some(obj) = args.as_object_mut() else {
+                return FilePreflight::Error("invalid arguments".into());
+            };
+            obj.insert("blobRef".into(), json!(s.hash));
+            obj.insert("mimeType".into(), json!(s.mime));
+            obj.insert("fileSize".into(), json!(s.size));
+            obj.remove("url");
+            obj.remove("base64");
+            obj.remove("authorization");
+            FilePreflight::Continue
+        }
+        Err(e) => FilePreflight::Error(file_upload_error(e)),
+    }
+}
+
 async fn handle_tools_call(
     state: &McpAppState,
     auth: &AuthOutcome,
@@ -496,6 +693,14 @@ async fn handle_tools_call(
         blob_store: &state.blob_store,
         s3: state.s3.as_ref(),
         blob_url_ttl_secs: state.blob_url_ttl_secs,
+        // JP-430 E3: the effective storage quota for this request — the JWT
+        // claim override else the config fallback, `0` → unlimited. Resolved
+        // through the same helper as REST (`ServerState::resolve_limits`).
+        quota_bytes: crate::config::effective_limit_u64(
+            auth.limits.quota_bytes,
+            state.blob_write.fallback_quota_bytes,
+        ),
+        max_blob_bytes: state.blob_write.max_blob_bytes,
         local: &state.local_mirror,
         // JP-235: a public mount hard-disables local access (`allow_local =
         // false`) regardless of the persisted feature flag.
@@ -553,35 +758,76 @@ async fn handle_tools_call(
     // CSL item directly; `add_reference` gets the resolved item injected into
     // `args.items` and then falls through to the normal sync write dispatch. The
     // rate-limit gate above already ran, so a DOI-lookup storm is throttled.
-    let outcome = match resolve_citation_doi(name, &mut args).await {
+    //
+    // Both async preflights (DOI, file upload) run under the same panic guard
+    // philosophy as the sync dispatch below (Phase 21.2) — via the futures
+    // `catch_unwind` combinator, so a preflight panic is a clean tool error
+    // instead of a dropped connection.
+    let doi = futures_util::FutureExt::catch_unwind(AssertUnwindSafe(resolve_citation_doi(
+        name, &mut args,
+    )))
+    .await
+    .unwrap_or_else(|panic| {
+        state.panic_counter.fetch_add(1, Ordering::Relaxed);
+        log::error!(
+            "mcp preflight panic tool={} workspace_id={} panic={}",
+            name,
+            ctx.workspace_id.as_str(),
+            crate::server::panic_message(&panic),
+        );
+        DoiPreflight::Error("internal error".into())
+    });
+    let outcome = match doi {
         DoiPreflight::Reply(result) => {
             Ok(ToolOutcome { result, changed_doc_id: None, change_detail: None })
         }
         DoiPreflight::Error(msg) => Err(msg),
         DoiPreflight::Continue => {
-            // Phase 21.2: catch tool panics so one bad tool call can't take
-            // down the MCP HTTP server. `dispatch` is sync, so we use the
-            // stdlib catch_unwind directly (no future combinator needed).
-            match std::panic::catch_unwind(AssertUnwindSafe(|| dispatch(&ctx, name, &args))) {
-                Ok(result) => result,
-                Err(panic) => {
-                    state.panic_counter.fetch_add(1, Ordering::Relaxed);
-                    let correlation_id = nanoid::nanoid!(10);
-                    log::error!(
-                        "mcp tool panic tool={} workspace_id={} correlation_id={} panic={}",
-                        name,
-                        ctx.workspace_id.as_str(),
-                        correlation_id,
-                        crate::server::panic_message(&panic),
-                    );
-                    return Json(rpc_result(
-                        id,
-                        json!({
-                            "content": [{"type": "text", "text": "internal error"}],
-                            "isError": true,
-                        }),
-                    ))
-                    .into_response();
+            // JP-430 E3: `add_file`'s upload leg (validation → download/decode
+            // → blob store) — injects blobRef/mimeType/fileSize into `args` so
+            // the sync tool only attaches the shape.
+            let file = futures_util::FutureExt::catch_unwind(AssertUnwindSafe(
+                resolve_file_upload(state, &ctx, name, &mut args),
+            ))
+            .await
+            .unwrap_or_else(|panic| {
+                state.panic_counter.fetch_add(1, Ordering::Relaxed);
+                log::error!(
+                    "mcp preflight panic tool={} workspace_id={} panic={}",
+                    name,
+                    ctx.workspace_id.as_str(),
+                    crate::server::panic_message(&panic),
+                );
+                FilePreflight::Error("internal error".into())
+            });
+            match file {
+                FilePreflight::Error(msg) => Err(msg),
+                FilePreflight::Continue => {
+                    // Phase 21.2: catch tool panics so one bad tool call can't take
+                    // down the MCP HTTP server. `dispatch` is sync, so we use the
+                    // stdlib catch_unwind directly (no future combinator needed).
+                    match std::panic::catch_unwind(AssertUnwindSafe(|| dispatch(&ctx, name, &args))) {
+                        Ok(result) => result,
+                        Err(panic) => {
+                            state.panic_counter.fetch_add(1, Ordering::Relaxed);
+                            let correlation_id = nanoid::nanoid!(10);
+                            log::error!(
+                                "mcp tool panic tool={} workspace_id={} correlation_id={} panic={}",
+                                name,
+                                ctx.workspace_id.as_str(),
+                                correlation_id,
+                                crate::server::panic_message(&panic),
+                            );
+                            return Json(rpc_result(
+                                id,
+                                json!({
+                                    "content": [{"type": "text", "text": "internal error"}],
+                                    "isError": true,
+                                }),
+                            ))
+                            .into_response();
+                        }
+                    }
                 }
             }
         }
@@ -684,6 +930,7 @@ mod tests {
             allow_static_token: true,
             allow_local: true,
             enforce_private_docs: false,
+            blob_write: crate::mcp::BlobWriteHandles::defaults_for_tests(),
         };
         (state, token_str)
     }
@@ -848,7 +1095,228 @@ mod tests {
         assert!(names.contains(&"docushark_move_block"));
         assert!(names.contains(&"docushark_list_files"));
         assert!(names.contains(&"docushark_get_file"));
-        assert_eq!(tools.len(), 39);
+        assert!(names.contains(&"docushark_add_file"));
+        assert!(names.contains(&"docushark_get_storage"));
+        assert_eq!(tools.len(), 41);
+    }
+
+    // ---- JP-430 E3: add_file over the full transport (preflight + dispatch) ----
+
+    /// Seed a minimal one-canvas-page team doc into `state.doc_store`.
+    fn seed_canvas_doc(state: &McpAppState, doc_id: &str, page_id: &str) {
+        state
+            .doc_store
+            .save_document(
+                &WorkspaceId::single_tenant(),
+                json!({
+                    "id": doc_id, "name": "File Target", "version": 1,
+                    "createdAt": 1u64, "modifiedAt": 1u64,
+                    "activePageId": page_id, "pageOrder": [page_id],
+                    "pages": { page_id: {
+                        "id": page_id, "name": "P1", "shapes": {}, "shapeOrder": [],
+                        "createdAt": 1u64, "modifiedAt": 1u64,
+                    }},
+                }),
+            )
+            .unwrap();
+    }
+
+    /// POST one `tools/call` through the router; returns the JSON-RPC body.
+    async fn call_tool(app: Router, token: &str, name: &str, args: Value) -> Value {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {}", token))
+            .body(axum::body::Body::from(
+                serde_json::to_vec(&json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                    "params": {"name": name, "arguments": args}
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        body_json(resp).await
+    }
+
+    /// The full base64 upload path: preflight decodes + stores + injects, the
+    /// sync tool attaches, the parity fix registers the reference — so the
+    /// blob survives a destructive sweep at grace 0.
+    #[tokio::test]
+    async fn add_file_base64_uploads_attaches_and_survives_sweep() {
+        let dir = TempDir::new().unwrap();
+        let (state, token) = make_state(&dir);
+        seed_canvas_doc(&state, "fdoc", "p1");
+        let blob_store = state.blob_store.clone();
+        let doc_store = state.doc_store.clone();
+        blob_store.set_gc_grace_secs(0);
+        let app = router(state);
+
+        let bytes: &[u8] = b"hello file!!";
+        let expected_hash = crate::server::blobs::BlobStore::compute_hash(bytes);
+        let body = call_tool(
+            app,
+            &token,
+            "docushark_add_file",
+            json!({
+                "docId": "fdoc", "pageId": "p1",
+                "fileName": "greeting.txt",
+                "base64": "aGVsbG8gZmlsZSEh",
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], json!(false), "{body}");
+        let sc = &body["result"]["structuredContent"];
+        assert_eq!(sc["blobRef"], json!(expected_hash));
+        assert_eq!(sc["mimeType"], "text/plain", "inferred from the .txt extension");
+        assert_eq!(sc["sizeBytes"], bytes.len());
+
+        let ws = WorkspaceId::single_tenant();
+        assert!(blob_store.exists(&ws, &expected_hash), "bytes stored under the workspace ACL");
+        // Attached + referenced: the shape is in the doc and the array + refcount
+        // shield the blob from the sweep.
+        let doc = doc_store
+            .get_document(&ws, &crate::server::protocol::DocId::from_http_path("fdoc".into()).unwrap())
+            .unwrap();
+        let shape_id = sc["shapeId"].as_str().unwrap();
+        assert!(doc["pages"]["p1"]["shapes"].get(shape_id).is_some());
+        assert!(doc["blobReferences"]
+            .as_array()
+            .unwrap()
+            .contains(&json!(expected_hash)));
+        assert_eq!(blob_store.sweep_unreferenced(), 0);
+        assert!(blob_store.exists(&ws, &expected_hash));
+    }
+
+    #[tokio::test]
+    async fn add_file_rejects_zero_or_multiple_sources() {
+        let dir = TempDir::new().unwrap();
+        let (state, token) = make_state(&dir);
+        seed_canvas_doc(&state, "fdoc", "p1");
+        let app = router(state);
+
+        let body = call_tool(
+            app.clone(),
+            &token,
+            "docushark_add_file",
+            json!({
+                "docId": "fdoc", "pageId": "p1", "fileName": "a.txt",
+                "base64": "Zm9v", "url": "https://example.com/a.txt",
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], json!(true));
+        assert!(
+            body["result"]["content"][0]["text"].as_str().unwrap().starts_with("ERR_BAD_SOURCE"),
+            "{body}"
+        );
+
+        let body = call_tool(
+            app,
+            &token,
+            "docushark_add_file",
+            json!({"docId": "fdoc", "pageId": "p1", "fileName": "a.txt"}),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], json!(true));
+        assert!(
+            body["result"]["content"][0]["text"].as_str().unwrap().starts_with("ERR_BAD_SOURCE"),
+            "{body}"
+        );
+    }
+
+    /// With no ingest allowlist configured (the default), a `url` source is a
+    /// typed refusal — the shared helper owns the gate, so MCP can never be an
+    /// open fetch proxy. Nothing is stored and nothing attaches.
+    #[tokio::test]
+    async fn add_file_url_source_requires_allowlist() {
+        let dir = TempDir::new().unwrap();
+        let (state, token) = make_state(&dir);
+        seed_canvas_doc(&state, "fdoc", "p1");
+        let blob_store = state.blob_store.clone();
+        let app = router(state);
+
+        let body = call_tool(
+            app,
+            &token,
+            "docushark_add_file",
+            json!({
+                "docId": "fdoc", "pageId": "p1", "fileName": "a.pdf",
+                "url": "https://example.com/a.pdf",
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], json!(true));
+        assert!(
+            body["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .starts_with("ERR_INGEST_NOT_CONFIGURED"),
+            "{body}"
+        );
+        assert_eq!(blob_store.get_blob_count(), 0, "nothing stored");
+    }
+
+    /// The upload enforces the effective storage quota (the config fallback
+    /// here — a JWT claim would override it via the same helper REST uses).
+    #[tokio::test]
+    async fn add_file_enforces_storage_quota() {
+        let dir = TempDir::new().unwrap();
+        let (mut state, token) = make_state(&dir);
+        state.blob_write.fallback_quota_bytes = 4; // tiny cap
+        seed_canvas_doc(&state, "fdoc", "p1");
+        let blob_store = state.blob_store.clone();
+        let app = router(state);
+
+        let body = call_tool(
+            app,
+            &token,
+            "docushark_add_file",
+            json!({
+                "docId": "fdoc", "pageId": "p1", "fileName": "big.txt",
+                "base64": "aGVsbG8gZmlsZSEh", // 12 bytes > 4-byte quota
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], json!(true));
+        assert!(
+            body["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .starts_with("ERR_QUOTA_EXCEEDED"),
+            "{body}"
+        );
+        assert_eq!(blob_store.get_blob_count(), 0, "over-quota upload stores nothing");
+    }
+
+    /// The preflight validates the attach target BEFORE storing bytes — a bad
+    /// page leaves no orphan blob behind.
+    #[tokio::test]
+    async fn add_file_validates_target_before_storing_bytes() {
+        let dir = TempDir::new().unwrap();
+        let (state, token) = make_state(&dir);
+        seed_canvas_doc(&state, "fdoc", "p1");
+        let blob_store = state.blob_store.clone();
+        let app = router(state);
+
+        let body = call_tool(
+            app,
+            &token,
+            "docushark_add_file",
+            json!({
+                "docId": "fdoc", "pageId": "no-such-page", "fileName": "a.txt",
+                "base64": "Zm9v",
+            }),
+        )
+        .await;
+        assert_eq!(body["result"]["isError"], json!(true));
+        assert!(
+            body["result"]["content"][0]["text"].as_str().unwrap().contains("not found"),
+            "{body}"
+        );
+        assert_eq!(blob_store.get_blob_count(), 0, "validation failed before any byte was stored");
     }
 
     #[tokio::test]

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -908,6 +908,26 @@ impl BlobStore {
         Ok(())
     }
 
+    /// Additively register a single blob reference for `(ws, doc_id)`
+    /// (JP-430 E3, the `add_file` live path): a live-CRDT attach touches only
+    /// the resident Y.Doc, so the doc's JSON body — and with it the save-path
+    /// ref sync — lags until the next snapshot flatten. This union keeps the
+    /// refcount correct in that window. Never releases anything; the next
+    /// full `sync_doc_refs` (flatten or save) recomputes the authoritative set.
+    pub fn add_doc_ref(&self, ws: &WorkspaceId, doc_id: &str, hash: &str) -> Result<(), String> {
+        let changed = {
+            let mut refs = self.doc_refs.write().map_err(|e| e.to_string())?;
+            refs.entry((ws.clone(), doc_id.to_string()))
+                .or_default()
+                .insert(hash.to_string())
+        };
+        if changed {
+            self.save_doc_refs()?;
+            self.mark_ledger_dirty(ws);
+        }
+        Ok(())
+    }
+
     /// Drop all of a document's blob references (called on doc delete) and
     /// release/GC anything the workspace no longer references.
     pub fn release_doc_refs(&self, ws: &WorkspaceId, doc_id: &str) -> Result<(), String> {
@@ -974,23 +994,14 @@ impl BlobStore {
             // the save records the reference, which is the data-loss the user
             // hit. A later sweep (post-grace) or the incremental ref-diff still
             // reclaims it if it truly stays unreferenced.
-            if grace > 0 {
-                let recently_uploaded = self
-                    .index
-                    .read()
-                    .ok()
-                    .and_then(|idx| idx.get(&hash).map(|m| m.created_at))
-                    .map(|created| now_ms.saturating_sub(created) < grace_ms)
-                    .unwrap_or(false);
-                if recently_uploaded {
-                    log::info!(
-                        "sweep: skipping {}/{} — uploaded within {}s grace (in-flight save?)",
-                        ws.as_str(),
-                        hash,
-                        grace
-                    );
-                    continue;
-                }
+            if grace > 0 && self.uploaded_within_grace(&hash, grace_ms, now_ms) {
+                log::info!(
+                    "sweep: skipping {}/{} — uploaded within {}s grace (in-flight save?)",
+                    ws.as_str(),
+                    hash,
+                    grace
+                );
+                continue;
             }
             // release_acl_if_unreferenced re-checks the referenced condition
             // and GCs orphaned bytes; count only ACLs it actually removes.
@@ -1005,10 +1016,46 @@ impl BlobStore {
         released
     }
 
+    /// Whether `hash`'s bytes were recorded in the index within the grace
+    /// window ending at `now_ms`. Shared by the sweep and the incremental
+    /// release path (JP-127 / JP-430 E3).
+    fn uploaded_within_grace(&self, hash: &str, grace_ms: u64, now_ms: u64) -> bool {
+        self.index
+            .read()
+            .ok()
+            .and_then(|idx| idx.get(hash).map(|m| m.created_at))
+            .map(|created| now_ms.saturating_sub(created) < grace_ms)
+            .unwrap_or(false)
+    }
+
     /// Release the `(ws,hash)` ACL iff no document in `ws` still references
     /// `hash`, then GC the bytes if no workspace holds an ACL. Returns
     /// `true` if the ACL was removed.
+    ///
+    /// JP-430 E3: a blob uploaded within the JP-127 grace window is never
+    /// released here either — previously only the sweep honored the grace,
+    /// so a stale-body save landing between an upload and the save that
+    /// records its reference (`sync_doc_refs` diffs against the *incoming*
+    /// set) would release the fresh blob's bytes immediately at grace 0.
+    /// The deferred reclaim still happens: a post-grace sweep or ref-diff
+    /// releases it if it truly stays unreferenced.
     fn release_acl_if_unreferenced(&self, ws: &WorkspaceId, hash: &str) -> Result<bool, String> {
+        let grace = self.gc_grace_secs.load(Ordering::Relaxed);
+        if grace > 0 {
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            if self.uploaded_within_grace(hash, grace.saturating_mul(1000), now_ms) {
+                log::info!(
+                    "release: skipping {}/{} — uploaded within {}s grace (in-flight save?)",
+                    ws.as_str(),
+                    hash,
+                    grace
+                );
+                return Ok(false);
+            }
+        }
         let still_referenced = {
             let refs = self.doc_refs.read().map_err(|e| e.to_string())?;
             refs.iter()
@@ -1477,8 +1524,10 @@ mod tests {
 
     // JP-127: with a grace, dropping the last reference must NOT reclaim the
     // bytes immediately — a transient ref-drop followed by a correction keeps
-    // the asset. `get_blob_count` tracks the index, which is cleared only on an
-    // actual byte delete, so it detects whether reclaim happened.
+    // the asset. Since JP-430 E3 a *recently-uploaded* blob doesn't even lose
+    // its ACL here (the release path shares the sweep's grace skip), so this
+    // fresh-blob sequence rides the skip; the aged-blob deferral path is
+    // pinned separately below.
     #[test]
     fn gc_grace_defers_reclaim_and_regrant_cancels_it() {
         let dir = tempdir().unwrap();
@@ -1492,19 +1541,101 @@ mod tests {
         store.sync_doc_refs(&ws, "doc-1", HashSet::from([hash.clone()])).unwrap();
         assert_eq!(store.get_blob_count(), 1);
 
-        // Drop the reference (the data-loss trigger). ACL releases, but the
-        // bytes are deferred — the blob survives the grace window.
+        // Drop the reference (the data-loss trigger) — the blob survives the
+        // grace window.
         store.sync_doc_refs(&ws, "doc-1", HashSet::new()).unwrap();
         assert_eq!(store.get_blob_count(), 1, "bytes must survive the grace window");
         // Not yet aged → reclaim is a no-op.
         assert_eq!(store.reclaim_expired_orphans(), 0);
         assert_eq!(store.get_blob_count(), 1);
 
-        // A correction re-uploads + re-references → cancels the deferred GC.
+        // A correction re-uploads + re-references → the asset is intact.
         store.save_blob(&ws, &hash, data, "application/octet-stream", "u1").unwrap();
         store.sync_doc_refs(&ws, "doc-1", HashSet::from([hash.clone()])).unwrap();
         assert!(store.exists(&ws, &hash), "blob restored after the correction");
         assert_eq!(store.get_blob_count(), 1);
+    }
+
+    // JP-430 E3 (review-found race): a stale-body save landing between an
+    // upload and the save that records its reference used to release the
+    // fresh blob's ACL instantly — `sync_doc_refs` diffs against the incoming
+    // set and the incremental release path had no grace skip (only the sweep
+    // did). The fresh blob must now keep its ACL through the grace window.
+    #[test]
+    fn release_skips_recently_uploaded_blob_within_grace() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.set_gc_grace_secs(3600);
+        let ws = WorkspaceId::single_tenant();
+        let data = b"freshly uploaded, save in flight";
+        let hash = BlobStore::compute_hash(data);
+
+        store.save_blob(&ws, &hash, data, "application/pdf", "u1").unwrap();
+        store.sync_doc_refs(&ws, "doc-1", HashSet::from([hash.clone()])).unwrap();
+
+        // The stale-body save: a reconnecting client re-sends a pre-upload
+        // body → the ref set no longer carries the hash.
+        store.sync_doc_refs(&ws, "doc-1", HashSet::new()).unwrap();
+
+        assert!(
+            store.exists(&ws, &hash),
+            "a recently-uploaded blob must keep its ACL through the grace window"
+        );
+        assert_eq!(store.get_blob_count(), 1);
+    }
+
+    // The aged-blob counterpart: past the grace window the incremental release
+    // path behaves as before — ACL released, bytes deferred (JP-127), a
+    // post-grace sweep/reclaim owns the actual delete.
+    #[test]
+    fn release_still_frees_aged_blobs_after_grace() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        store.set_gc_grace_secs(3600);
+        let ws = WorkspaceId::single_tenant();
+        let data = b"old asset, genuinely dropped";
+        let hash = BlobStore::compute_hash(data);
+
+        store.save_blob(&ws, &hash, data, "application/pdf", "u1").unwrap();
+        store.sync_doc_refs(&ws, "doc-1", HashSet::from([hash.clone()])).unwrap();
+        // Age the upload past the grace window (tests share the module, so we
+        // can backdate the index row directly).
+        {
+            let mut idx = store.index.write().unwrap();
+            idx.get_mut(&hash).unwrap().created_at -= 2 * 3600 * 1000;
+        }
+
+        store.sync_doc_refs(&ws, "doc-1", HashSet::new()).unwrap();
+        assert!(!store.exists(&ws, &hash), "aged orphan's ACL is released");
+        assert_eq!(store.get_blob_count(), 1, "bytes deferred, not deleted (JP-127)");
+    }
+
+    // JP-430 E3: `add_doc_ref` is the live-attach registration — additive
+    // only, idempotent, never a release trigger.
+    #[test]
+    fn add_doc_ref_is_additive_and_idempotent() {
+        let dir = tempdir().unwrap();
+        let store = BlobStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let a = BlobStore::compute_hash(b"aaa");
+        let b = BlobStore::compute_hash(b"bbb");
+
+        store.save_blob(&ws, &a, b"aaa", "text/plain", "u1").unwrap();
+        store.save_blob(&ws, &b, b"bbb", "text/plain", "u1").unwrap();
+        store.sync_doc_refs(&ws, "doc-1", HashSet::from([a.clone()])).unwrap();
+
+        // Union in a second hash — the first stays.
+        store.add_doc_ref(&ws, "doc-1", &b).unwrap();
+        assert_eq!(store.docs_referencing(&ws, &a), vec!["doc-1"]);
+        assert_eq!(store.docs_referencing(&ws, &b), vec!["doc-1"]);
+        // Idempotent.
+        store.add_doc_ref(&ws, "doc-1", &b).unwrap();
+        assert_eq!(store.docs_referencing(&ws, &b), vec!["doc-1"]);
+
+        // Both survive a destructive sweep at grace 0 — they're referenced.
+        assert_eq!(store.sweep_unreferenced(), 0);
+        assert!(store.exists(&ws, &a));
+        assert!(store.exists(&ws, &b));
     }
 
     #[test]

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1020,10 +1020,12 @@ impl ServerState {
     /// lives in the control plane (JP-81).
     pub(crate) fn resolve_limits(&self, claim: ClaimLimits) -> EffectiveLimits {
         let cfg = &self.tenancy.limits;
-        let quota = claim.quota_bytes.unwrap_or(cfg.storage_quota_bytes);
         let editors = claim.editor_limit.unwrap_or(cfg.max_editors_per_workspace);
         EffectiveLimits {
-            quota_bytes: (quota != 0).then_some(quota),
+            quota_bytes: crate::config::effective_limit_u64(
+                claim.quota_bytes,
+                cfg.storage_quota_bytes,
+            ),
             editor_limit: (editors != 0).then_some(editors),
         }
     }
@@ -1149,7 +1151,12 @@ impl ServerState {
         for ws in self.doc_store.known_workspaces() {
             for meta in self.doc_store.list_documents(&ws) {
                 if let Ok(doc) = self.doc_store.get_document(&ws, &meta.id) {
-                    let hashes = crate::api::blob_refs_from_doc(&doc);
+                    // JP-430 E3: seed from the same array ∪ content union the
+                    // save path records — array-only seeding under-counted any
+                    // doc whose body carried refs (FileShape / prose blob://)
+                    // its `blobReferences` array lagged, and the sweep below
+                    // is destructive.
+                    let hashes = crate::api::save_blob_refs(&doc);
                     if let Err(e) = self.blob_store.seed_doc_refs(&ws, meta.id.as_str(), hashes) {
                         log::warn!(
                             "blob doc-ref seed failed for {}/{}: {}",
@@ -1793,6 +1800,25 @@ impl WebSocketServer {
             .cloned()
     }
 
+    /// The blob-write handle bundle the MCP `add_file` preflight needs (JP-430
+    /// E3): the shared ingest client + upload gate plus the tenancy blob
+    /// limits, so an MCP upload observes the same SSRF allowlist, size
+    /// ceiling, concurrency bound, and quota fallback as the REST blob
+    /// surface. Valid only after `start()`.
+    pub async fn blob_write_handles(&self) -> crate::mcp::BlobWriteHandles {
+        let guard = self.state.read().await;
+        let state = guard
+            .as_ref()
+            .expect("blob_write_handles() requires start() first");
+        crate::mcp::BlobWriteHandles {
+            http: state.ingest_http_client().clone(),
+            gate: state.blob_upload_gate().clone(),
+            allowed_hosts: state.blob_ingest_allowed_hosts().to_vec(),
+            max_blob_bytes: state.max_blob_bytes(),
+            fallback_quota_bytes: state.tenancy.limits.storage_quota_bytes,
+        }
+    }
+
     /// A synchronous sink that broadcasts a framed CRDT update to the clients
     /// joined to `(workspace, doc)` — the relay-originated counterpart of an
     /// inbound SYNC frame's rebroadcast. Wired into the MCP write path so an
@@ -2096,6 +2122,13 @@ impl WebSocketServer {
                     sync_registry: server_state.sync_registry.clone(),
                     on_doc_update,
                     enforce_private_docs: server_state.enforce_private_docs(),
+                    blob_write: crate::mcp::BlobWriteHandles {
+                        http: server_state.ingest_http_client().clone(),
+                        gate: server_state.blob_upload_gate().clone(),
+                        allowed_hosts: server_state.blob_ingest_allowed_hosts().to_vec(),
+                        max_blob_bytes: server_state.max_blob_bytes(),
+                        fallback_quota_bytes: server_state.tenancy.limits.storage_quota_bytes,
+                    },
                 };
                 log::info!("MCP endpoint folded onto the public HTTP listener at /mcp (expose=public)");
                 Some(mount.into_public_router(shared))

--- a/relay/tests/blob_gc.rs
+++ b/relay/tests/blob_gc.rs
@@ -23,11 +23,17 @@ async fn start_relay() -> (Arc<WebSocketServer>, String, OidcTestIssuer, TempDir
     let server = Arc::new(WebSocketServer::new());
     server.set_app_data_dir(tmp.path().to_path_buf()).await;
     server.set_auth(issuer.auth_state()).await;
+    // Grace 0: this suite pins the release/refcount mechanics themselves —
+    // with the (JP-430 E3) default 300s grace a freshly-uploaded blob defers
+    // its release instead. Grace behavior has its own tests in blobs.rs.
     server
         .set_tenancy(TenancyConfig {
             mode: TenancyMode::Shared,
             workspace_id: None,
-            ..TenancyConfig::default()
+            limits: docushark_relay::config::LimitsConfig {
+                blob_gc_grace_secs: 0,
+                ..Default::default()
+            },
         })
         .await;
     server

--- a/relay/tests/cross_tenant_isolation.rs
+++ b/relay/tests/cross_tenant_isolation.rs
@@ -171,6 +171,7 @@ impl Harness {
                 self.server.blob_store_handle().await,
                 self.server.s3_backend_handle().await,
                 300, // JP-430: MCP blob URL TTL (unused here)
+                docushark_relay::mcp::BlobWriteHandles::defaults_for_tests(),
             )
             .expect("McpServer::new"),
         );

--- a/relay/tests/index_no_clobber.rs
+++ b/relay/tests/index_no_clobber.rs
@@ -69,6 +69,7 @@ async fn mcp_create_and_editor_save_dont_clobber_the_index() {
             server.blob_store_handle().await,
             server.s3_backend_handle().await,
             300, // JP-430: MCP blob URL TTL (unused here)
+            docushark_relay::mcp::BlobWriteHandles::defaults_for_tests(),
         )
         .expect("McpServer::new"),
     );

--- a/relay/tests/rate_limits.rs
+++ b/relay/tests/rate_limits.rs
@@ -102,6 +102,7 @@ impl Harness {
                 server.blob_store_handle().await,
                 server.s3_backend_handle().await,
                 300, // JP-430: MCP blob URL TTL (unused here)
+                docushark_relay::mcp::BlobWriteHandles::defaults_for_tests(),
             )
             .expect("McpServer::new"),
         );
@@ -271,6 +272,66 @@ async fn mcp_writes_burst_then_rate_limit_with_429() {
     assert_eq!(
         rejections, limited_count as u64,
         "relay_rate_limit_rejections_total ({rejections}) should match the 429 count ({limited_count})"
+    );
+
+    h.stop().await;
+}
+
+/// JP-430 E3: `add_file` draws from the WRITE bucket. This is the first test
+/// pinning `is_mcp_write_tool` membership at all — a tool missing from that
+/// list silently drops to the read bucket (unlimited here), so the 429
+/// assertion below fails if `add_file` ever falls out of the write set. The
+/// upload preflight runs *after* the throttle, so a rejected call also never
+/// stores bytes.
+#[tokio::test]
+async fn mcp_add_file_draws_from_the_write_bucket() {
+    let limits = LimitsConfig {
+        writes_per_sec: 1,
+        writes_burst: 2,
+        ..LimitsConfig::default()
+    };
+    let tenancy = TenancyConfig {
+        mode: TenancyMode::Dedicated,
+        workspace_id: None,
+        limits,
+    };
+    let h = Harness::start(tenancy).await;
+    h.seed_doc_via_store("doc-1", "p1").await;
+
+    // Distinct single-byte payloads per call ("0".."5") so blob dedup can't
+    // shortcut a write. RFC 4648 of ASCII digits 0x30..0x35.
+    let payloads = ["MA==", "MQ==", "Mg==", "Mw==", "NA==", "NQ=="];
+    let client = reqwest::Client::new();
+    let mut statuses = Vec::new();
+    for (i, b64) in payloads.iter().enumerate() {
+        let body = json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {
+                "name": "docushark_add_file",
+                "arguments": {
+                    "docId": "doc-1", "pageId": "p1",
+                    "fileName": format!("f{i}.txt"),
+                    "base64": b64,
+                }
+            }
+        });
+        statuses.push(
+            client
+                .post(format!("{}/mcp", h.mcp_base))
+                .bearer_auth(&h.mcp_token)
+                .json(&body)
+                .send()
+                .await
+                .expect("POST /mcp")
+                .status(),
+        );
+    }
+    let ok = statuses.iter().filter(|s| s.as_u16() == 200).count();
+    let limited = statuses.iter().filter(|s| s.as_u16() == 429).count();
+    assert!(ok >= 2, "burst should pass at least 2 uploads; statuses={statuses:?}");
+    assert!(
+        limited >= 1,
+        "add_file past the burst must 429 from the write bucket; statuses={statuses:?}"
     );
 
     h.stop().await;

--- a/relay/tests/yjs_authority.rs
+++ b/relay/tests/yjs_authority.rs
@@ -755,6 +755,7 @@ async fn enable_mcp(relay: &Relay) -> (Arc<McpServer>, String) {
             relay.server.blob_store_handle().await,
             relay.server.s3_backend_handle().await,
             300, // JP-430: MCP blob URL TTL (unused here)
+            docushark_relay::mcp::BlobWriteHandles::defaults_for_tests(),
         )
         .expect("McpServer::new"),
     );

--- a/skills/attach-files/SKILL.md
+++ b/skills/attach-files/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: docushark-attach-files
+description: Use when the user wants to attach, read, or manage files in a DocuShark document over MCP — uploading a report/image/CSV as a canvas file card, downloading an attachment's bytes, or checking storage headroom. Requires the DocuShark MCP server to be connected.
+---
+
+# Work with document files in DocuShark
+
+Documents carry files two ways: **canvas file cards** (a FileShape with a name,
+type, and size — the general attachment surface) and **prose-embedded images**
+(`blob://<hash>` image srcs inside a prose page). Bytes live in the workspace's
+content-addressed blob store; every reference is a `blobRef` (the SHA-256 of
+the bytes). Work in one **team** document.
+
+## Read files
+
+1. **Discover.** `list_files(docId)` → every attachment with `source`
+   (canvas/prose), `pageId`, `blobRef`, `fileName`, `mimeType`, `sizeBytes`,
+   and `inStore`. `inStore: false` means the bytes never reached this relay
+   (e.g. a desktop-local attachment) — you can see it but not fetch it.
+2. **Fetch bytes.** `get_file(docId, blobRef)` → either a short-lived
+   `{transport:"url", url}` to GET directly (no auth headers — it's presigned
+   and expires; re-call for a fresh one), or `{transport:"inline", base64}`
+   for small files on a filesystem-backed relay. Files over the inline cap on
+   a filesystem relay are only viewable in the app.
+
+## Attach a file
+
+`add_file(docId, pageId, fileName, <source>, x?, y?, label?)` — `pageId` is a
+**canvas** page id (from `get_document`). Provide exactly ONE source:
+
+- `base64` — the file's bytes, standard padded base64. For small files (the
+  request body caps around 8 MB total, ~5.5 MB of real bytes). Ideal for
+  content you just generated (a CSV, an SVG, a small PDF).
+- `url` — an `https` URL the relay fetches server-side (optionally with an
+  `authorization` header value you supply). The relay operator must allowlist
+  the host (`RELAY_BLOB_INGEST_ALLOWED_HOSTS`); expect
+  `ERR_INGEST_NOT_CONFIGURED` when no allowlist is set. Use for anything too
+  big for base64.
+- `blobRef` — attach a blob already in the workspace store (from `list_files`
+  on another document, or a previous upload) without moving bytes.
+
+It returns `{shapeId, blobRef, mimeType, sizeBytes, fileCategory}`. Pass
+`mimeType` explicitly when you know it; otherwise the relay infers from the
+URL response or the `fileName` extension. `x`/`y` are the card's center in
+world units — omit for the origin, or place it near related shapes.
+
+If the attach step fails after an upload, the error carries the stored
+`blobRef` — retry with that `blobRef` as the source instead of re-uploading.
+
+## Storage headroom
+
+`get_storage()` → `{usedBytes, quotaBytes, maxBlobBytes}`. `quotaBytes: null`
+means unlimited. Check before a large upload; a quota overrun fails the
+upload with `ERR_QUOTA_EXCEEDED` and nothing is attached.
+
+## Tips
+
+- The card renders with a category icon (pdf / spreadsheet / image / text /
+  generic) plus the file name; users open it in a viewer from the canvas.
+  Give `fileName` a real extension — it drives both the icon and the viewer.
+- Prose-embedded images: reference an **already-stored** blob as
+  `<img src="blob://<hash>">` via `set_prose` with `format:"html"`. Upload
+  new bytes with `add_file` first (the card can live on any canvas page),
+  then reuse its `blobRef` in the prose image.
+- Don't base64 multi-megabyte files into a tool call reflexively — prefer the
+  `url` source, or ask the user to drag the file into the app.


### PR DESCRIPTION
**JP-430 (MCP Tool Parity) — file write, Pillar E slice E3.** Agents can now attach files, not just read them: `docushark_add_file` (upload + attach) and `docushark_get_storage` (headroom check), plus the blob-reference correctness work that makes agent-attached files durable. Tool count 39 → 41.

## The tools

- **`docushark_add_file(docId, pageId, fileName, <source>, …)`** — exactly one source:
  - `base64` — small files (the `/mcp` body now has an explicit 8 MiB limit → ~5.5 MiB decoded). Mime inferred caller → fileName extension (Rust twins of the editor's `getMimeType`/`detectFileCategory`, pinned by vector tests).
  - `url` — fetched server-side through the **shared JP-264 ingest core** (refactored out of the REST handler, behavior-preserving): https-only, SSRF gate, host allowlist (the allowlist-empty → refuse gate lives *inside* the shared helper so no caller can become an open fetch proxy), streamed size cap, shared upload-concurrency gate. Optional `authorization` header, omitted entirely when absent.
  - `blobRef` — attach an already-stored blob without moving bytes (also the retry handle: an attach failure after upload reports the hash so the agent never re-uploads).
  - Places an **editor-parity FileShape** (field-for-field `FileImportService.ts` + `DEFAULT_FILE_SHAPE`, provenance-stamped) through `write_shape_live_or_json` — live CRDT broadcast on a resident doc, optimistic-concurrency JSON save otherwise. Deliberately NOT in the DSL adapter: `add_shape` still can't author file shapes.
- **`docushark_get_storage`** — `{usedBytes, quotaBytes (null = unlimited), maxBlobBytes, backend}`.
- `get_file` mime fix (E2 live-probe nit): when the blob index only recorded `application/octet-stream`, report the referencing FileShape's real mime.
- New **attach-files** skill recipe (canonical + vendored, drift-tested) + content-contract line + docs README rows.

## Blob-reference correctness (the load-bearing part)

The GC reclaims any ACL'd blob no document references, and MCP's write path registered **no references at all** — an agent-attached file would have been swept. Three layers, adversarially reviewed before implementation:

1. **`mutate_with_retry` parity (every cold MCP write, not just add_file):** sync the conservative union (old array ∪ content — a save never releases an in-use blob, RB-2) to the refcount, and persist a **content-derived** `blobReferences` array (what the startup seed reads → crash-restart-safe; writing the union instead would re-add dropped refs forever and leak quota — review catch). Prose `blob://` images written via `set_prose` get protected by the same fix.
2. **Live path:** new additive `BlobStore::add_doc_ref` registers the ref immediately (the JSON body and its save-path sync lag until the JP-278 flatten).
3. **Review-found data-loss race (pre-existing, affects editor uploads too):** `release_acl_if_unreferenced` had no recently-uploaded grace skip — only the sweep did — so a stale-body save racing any fresh upload released the new blob's bytes instantly at grace 0. The skip is now shared, and `DEFAULT_BLOB_GC_GRACE_SECS` goes **0 → 300** (README row updated; `0` restores immediate reclaim). Startup seeding also hardened: `seed_doc_refs` now consumes the same array ∪ content union as the save path.

## Plumbing

- Upload runs as an **async preflight** before the sync dispatch (the JP-89 DOI-preflight pattern): target validation (doc exists / page exists / not-local / JP-370 Editor) happens BEFORE any byte is stored, it runs behind the per-workspace **write** rate bucket (`is_mcp_write_tool` += add_file — and gains its first test), and both preflights now sit under a `catch_unwind` panic guard.
- **Quota threads into MCP for the first time:** `AuthOutcome` keeps the `wsp[]` claim's `ClaimLimits` (previously dropped), resolved through a shared `effective_limit_u64` helper that `ServerState::resolve_limits` now also uses — REST and MCP can't drift. Static token → config fallback.
- `BlobWriteHandles` bundles the ingest client, upload gate, allowlist, `max_blob_bytes`, and quota fallback into `McpServer::new` / `PublicMount` (via `McpSharedHandles`); `ToolContext` gains `quota_bytes` + `max_blob_bytes`.
- Strict hand-rolled RFC 4648 `base64_decode` (rejects whitespace, URL-safe alphabet, missing/misplaced padding), inverse of the E2 encoder.

## Verify

- **674 relay lib tests** (17 new: decode vectors + rejects, category/mime twin vectors, attach-only editor-parity shape + array + refcount + **survives a grace-0 sweep**, live-path broadcast + additive ref, delete-shape parity (hash leaves array + refcount), grace-race pin (fresh blob keeps its ACL) + aged-blob release, add_doc_ref idempotence, get_file shape-mime preference, get_storage) — plus full-transport tests: base64 upload end-to-end, zero/multiple-source refusal, allowlist refusal, quota 507-class refusal, validate-before-store (bad page leaves zero bytes).
- All integration suites green, including a new **write-bucket 429 test for add_file** and `blob_gc.rs` pinned to grace 0 (it tests release mechanics; grace semantics have their own tests).
- `cargo check --all-targets`; clippy at the master baseline (37); env drift test covers the README row change; OSS-leak grep clean.
- Live E2E after merge (rebuilt local stack): add_file base64 on "#389 Testing" → card renders + viewer opens; relay restart → blob survives; get_storage sanity; URL source with an allowlisted host.

## Notes

- `blobReferences` on MCP-written docs is now relay-maintained (content-derived, sorted) — same semantics the JP-278 flatten already applied.
- The wider `is_mcp_write_tool` coverage gap (several older write tools still draw from the read bucket) is flagged to the Review Backlog rather than folded in here.

Assisted-by: Fable 5
