### PR TITLE
JP-443: document bytes join the storage meter + volume observability

### DIFF
--- a/docs-site/public/openapi.yaml
+++ b/docs-site/public/openapi.yaml
@@ -30,6 +30,8 @@ tags:
     description: Document CRUD + sharing + transfer.
   - name: blobs
     description: Content-addressed blob storage (SHA-256 keyed).
+  - name: usage
+    description: Workspace storage usage + effective limits.
   - name: sync
     description: WebSocket CRDT sync + awareness.
   - name: mcp
@@ -135,6 +137,30 @@ paths:
           description: |
             The id is tombstoned (deleted, JP-375). Pass `overrideTombstone=true`
             as the owner or a workspace admin to restore it.
+        '413':
+          description: |
+            The serialized document exceeds the effective per-document size
+            ceiling (`max_doc_bytes` claim else `[tenancy.limits].max_doc_bytes`).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errorCode:
+                    type: string
+                    const: DOC_TOO_LARGE
+                  sizeBytes:
+                    type: integer
+                    format: int64
+                  maxBytes:
+                    type: integer
+                    format: int64
+        '507':
+          description: |
+            The save would grow the workspace's combined storage (document +
+            blob bytes) past its quota. Delta-aware — shrinking or equal-size
+            saves and deletes always succeed, so content can be removed to
+            free space while over quota.
     delete:
       tags: [docs]
       summary: Delete a document
@@ -517,6 +543,52 @@ paths:
           description: Provided hash did not match request body.
         '507':
           description: Per-workspace storage quota exceeded.
+
+  /api/v1/usage:
+    get:
+      tags: [usage]
+      summary: The calling workspace's storage usage + effective limits
+      description: |
+        Workspace-scoped from the validated bearer token — a caller can only
+        ever read its own numbers. Counts only; no document ids, no content.
+        `storageBytes` is the combined meter (`docBytes + blobBytes`); a
+        `null` quota/limit means unlimited / no ceiling.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Usage snapshot.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [storageBytes, docBytes, blobBytes, activeEditors]
+                properties:
+                  storageBytes:
+                    type: integer
+                    format: int64
+                    description: Combined storage (docBytes + blobBytes).
+                  docBytes:
+                    type: integer
+                    format: int64
+                    description: Recorded document JSON bytes.
+                  blobBytes:
+                    type: integer
+                    format: int64
+                    description: Blob bytes (full-size-per-grant).
+                  storageQuota:
+                    type: [integer, 'null']
+                    format: int64
+                    description: Effective storage quota; null = unlimited.
+                  maxDocBytes:
+                    type: [integer, 'null']
+                    format: int64
+                    description: Per-document size ceiling; null = none.
+                  activeEditors:
+                    type: integer
+                  editorLimit:
+                    type: [integer, 'null']
+                    description: Concurrent-editor cap; null = unlimited.
 
   /api/v1/blobs/{hash}/upload-url:
     parameters:
@@ -958,6 +1030,13 @@ components:
           description: |
             Collection this document belongs to (at most one). Absent/null means
             Unassigned. Set via PUT /api/docs/{id}/collection.
+        sizeBytes:
+          type: integer
+          format: int64
+          description: |
+            Serialized JSON size of the stored document, recorded at write
+            time; counts toward the workspace storage meter. Absent on
+            entries written before size recording.
 
     CollectionMembershipRequest:
       type: object

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "hex",
  "hmac",
  "jsonwebtoken",
+ "libc",
  "local-ip-address",
  "log",
  "nanoid",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -107,6 +107,12 @@ governor = "0.7"
 # (y-crdt/y-crdt#637) we previously carried as a vendored patch.
 yrs = "0.27.3"
 
+# statvfs for the /metrics volume-usage gauges (JP-443). Already in the tree
+# transitively; taken directly for the one syscall wrapper rather than a
+# higher-level fs-stats crate (matches the hand-rolled /proc RSS stance).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 docushark-relay = { path = ".", features = ["test-helpers"] }
 tempfile = "3"

--- a/relay/README.md
+++ b/relay/README.md
@@ -219,6 +219,7 @@ This table is the canonical inventory — a drift test
 | `RELAY_STORAGE_QUOTA_BYTES` | `[tenancy.limits].storage_quota_bytes` (fallback cap when a token omits the limit claim; `0` = unlimited) |
 | `RELAY_MAX_EDITORS_PER_WORKSPACE` | `[tenancy.limits].max_editors_per_workspace` (fallback cap; `0` = unlimited) |
 | `RELAY_MAX_BLOB_BYTES` | `[tenancy.limits].max_blob_bytes` (per-blob size ceiling) |
+| `RELAY_MAX_DOC_BYTES` | `[tenancy.limits].max_doc_bytes` (fallback per-document serialized-JSON size ceiling when a token omits the `max_doc_bytes` claim; enforced on REST/MCP document writes — 413 / `ERR_DOC_TOO_LARGE`; collab flushes are never refused, only counted; `0` = no ceiling; also raises the doc-route HTTP body limit above its 128 MiB floor) |
 | `RELAY_MAX_CONCURRENT_BLOB_UPLOADS` | `[tenancy.limits].max_concurrent_blob_uploads` (bounds worst-case upload RAM: permits × max blob bytes) |
 | `RELAY_BLOB_GC_GRACE_SECS` | `[tenancy.limits].blob_gc_grace_secs` (orphaned-blob reclaim delay; default 300, also shields the upload→save window; `0` = reclaim immediately) |
 | `RELAY_BLOB_INGEST_ALLOWED_HOSTS` | `[tenancy.limits].blob_ingest_allowed_hosts` (comma-separated URL-ingest allowlist) |

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -30,6 +30,8 @@ tags:
     description: Document CRUD + sharing + transfer.
   - name: blobs
     description: Content-addressed blob storage (SHA-256 keyed).
+  - name: usage
+    description: Workspace storage usage + effective limits.
   - name: sync
     description: WebSocket CRDT sync + awareness.
   - name: mcp
@@ -135,6 +137,30 @@ paths:
           description: |
             The id is tombstoned (deleted, JP-375). Pass `overrideTombstone=true`
             as the owner or a workspace admin to restore it.
+        '413':
+          description: |
+            The serialized document exceeds the effective per-document size
+            ceiling (`max_doc_bytes` claim else `[tenancy.limits].max_doc_bytes`).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errorCode:
+                    type: string
+                    const: DOC_TOO_LARGE
+                  sizeBytes:
+                    type: integer
+                    format: int64
+                  maxBytes:
+                    type: integer
+                    format: int64
+        '507':
+          description: |
+            The save would grow the workspace's combined storage (document +
+            blob bytes) past its quota. Delta-aware — shrinking or equal-size
+            saves and deletes always succeed, so content can be removed to
+            free space while over quota.
     delete:
       tags: [docs]
       summary: Delete a document
@@ -517,6 +543,52 @@ paths:
           description: Provided hash did not match request body.
         '507':
           description: Per-workspace storage quota exceeded.
+
+  /api/v1/usage:
+    get:
+      tags: [usage]
+      summary: The calling workspace's storage usage + effective limits
+      description: |
+        Workspace-scoped from the validated bearer token — a caller can only
+        ever read its own numbers. Counts only; no document ids, no content.
+        `storageBytes` is the combined meter (`docBytes + blobBytes`); a
+        `null` quota/limit means unlimited / no ceiling.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Usage snapshot.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [storageBytes, docBytes, blobBytes, activeEditors]
+                properties:
+                  storageBytes:
+                    type: integer
+                    format: int64
+                    description: Combined storage (docBytes + blobBytes).
+                  docBytes:
+                    type: integer
+                    format: int64
+                    description: Recorded document JSON bytes.
+                  blobBytes:
+                    type: integer
+                    format: int64
+                    description: Blob bytes (full-size-per-grant).
+                  storageQuota:
+                    type: [integer, 'null']
+                    format: int64
+                    description: Effective storage quota; null = unlimited.
+                  maxDocBytes:
+                    type: [integer, 'null']
+                    format: int64
+                    description: Per-document size ceiling; null = none.
+                  activeEditors:
+                    type: integer
+                  editorLimit:
+                    type: [integer, 'null']
+                    description: Concurrent-editor cap; null = unlimited.
 
   /api/v1/blobs/{hash}/upload-url:
     parameters:
@@ -958,6 +1030,13 @@ components:
           description: |
             Collection this document belongs to (at most one). Absent/null means
             Unassigned. Set via PUT /api/docs/{id}/collection.
+        sizeBytes:
+          type: integer
+          format: int64
+          description: |
+            Serialized JSON size of the stored document, recorded at write
+            time; counts toward the workspace storage meter. Absent on
+            entries written before size recording.
 
     CollectionMembershipRequest:
       type: object

--- a/relay/docs/api/token-format.md
+++ b/relay/docs/api/token-format.md
@@ -73,18 +73,22 @@ Other algorithms are not accepted. In particular:
 - `role` — one of `owner`, `member`, `viewer`. Relay enforces role on document operations.
 - `region` — region code the workspace is bound to (e.g. `yyz`, `ord`, `nrt`, `fra`). The relay refuses connections whose `region` does not match the relay's configured `region`.
 
-Each entry may also carry two **optional** per-workspace limit fields. When
+Each entry may also carry **optional** per-workspace limit fields. When
 present they are authoritative; when absent the relay falls back to its
 `[tenancy.limits]` config (see [Per-workspace limits](#per-workspace-limits)).
 The relay enforces the raw numbers — it has no notion of plans or tiers.
 
 - `quota_bytes` — integer storage-byte quota for the workspace. New blob
-  uploads / document saves past this return **HTTP 507**.
+  uploads / growing document saves past this return **HTTP 507**.
 - `editor_limit` — integer cap on concurrent **editor** (role `owner`/`member`)
   connections. Viewers are never counted against it.
+- `max_doc_bytes` — integer ceiling on a single document's serialized JSON
+  size. A REST document write over it returns **HTTP 413** with a typed
+  `DOC_TOO_LARGE` body; an MCP write returns `ERR_DOC_TOO_LARGE`. Bounds one
+  document's memory/transfer/snapshot footprint, independent of the quota.
 
 ```json
-{ "id": "ws_01H...", "role": "owner", "region": "yyz", "quota_bytes": 262144000, "editor_limit": 2 }
+{ "id": "ws_01H...", "role": "owner", "region": "yyz", "quota_bytes": 262144000, "editor_limit": 2, "max_doc_bytes": 10485760 }
 ```
 
 Single-workspace deployments may still ship a one-entry `wsp` array — the shape is fixed.
@@ -156,16 +160,19 @@ The `[tenancy.limits]` block configures per-workspace traffic limits, enforced f
 | `max_ws_payload_bytes` | Per-frame payload size cap. Pathologically large WS frames are rejected before dispatch; the connection is dropped. |
 | `storage_quota_bytes` | Per-workspace storage-byte quota. `0` = unlimited. Fallback for the JWT `quota_bytes` claim. |
 | `max_editors_per_workspace` | Per-workspace concurrent-**editor** cap. `0` = unlimited. Fallback for the JWT `editor_limit` claim. |
+| `max_doc_bytes` | Per-document serialized-JSON size ceiling. `0` = no ceiling. Fallback for the JWT `max_doc_bytes` claim. Also raises the doc-route HTTP body limit (128 MiB floor + 25% slack over the configured cap) — a claim minted far above the pod's configured cap may hit the transport limit before the typed 413, so keep pod config ≥ the largest claim you mint. |
 
 Defaults match the project's Free-Tier reference values; self-hosters can override any field. `storage_quota_bytes` and `max_editors_per_workspace` default to `0` (unlimited) so a self-host deploy is unconstrained out of the box.
 
 ### Effective limit resolution
 
-For `quota_bytes` / `editor_limit`, the **effective limit is the JWT claim value if present, else the config fallback**. A resolved `0` (from either source) means unlimited. This lets a control plane mint absolute per-workspace numbers in the token while self-hosters rely on `[tenancy.limits]`.
+For `quota_bytes` / `editor_limit` / `max_doc_bytes`, the **effective limit is the JWT claim value if present, else the config fallback**. A resolved `0` (from either source) means unlimited. This lets a control plane mint absolute per-workspace numbers in the token while self-hosters rely on `[tenancy.limits]`.
 
 ### Storage enforcement (`507`)
 
-Storage is a *level* read live from disk (full-size-per-grant attribution) — no persisted counter. A blob upload (`POST /api/blobs/:hash`) or document save (`PUT /api/docs/:id`) returns **HTTP 507 Insufficient Storage** when the projected workspace total would exceed the effective `quota_bytes`. A re-upload of an already-stored hash adds 0 (dedup) and is never refused. Existing data stays **readable** when over quota (`GET` is unaffected) — only new writes are refused.
+Storage is a *level* read live from server state — no persisted counter. The metered total is **blob bytes (full-size-per-grant attribution) + document JSON bytes** (each document's serialized size, recorded at write time; binary sidecars and recovery points are operational copies and are never metered). A blob upload (`POST /api/blobs/:hash`) or document save (`PUT /api/docs/:id`) returns **HTTP 507 Insufficient Storage** when the projected workspace total would exceed the effective `quota_bytes`.
+
+The document gate is **delta-aware**: only a save that *grows* the document and lands over quota is refused — shrinking or equal-size saves and deletes always succeed, so a caller can always dig out of an over-quota state by removing content. A re-upload of an already-stored blob hash adds 0 (dedup) and is never refused. Collaborative (CRDT) flushes are never refused — the edits are already merged; an over-ceiling flush is only logged and counted (`relay_doc_over_cap_snapshots_total`). Existing data stays **readable** when over quota (`GET` is unaffected) — only new writes are refused. Note the metered document size is the *stored* (pretty-printed) serialization, which is slightly larger than a compact wire body.
 
 ### Editor cap (`ERR_EDITOR_LIMIT`)
 
@@ -176,10 +183,14 @@ When a workspace has an effective `editor_limit`, the Nth + 1 **editor** (role `
 `GET /api/v1/usage` returns the **calling token's own** workspace usage and effective limits (JSON, camelCase). The workspace is resolved from the validated JWT exactly like `/api/docs`, so a caller can never read another workspace's numbers. `null` quota/limit means unlimited.
 
 ```json
-{ "storageBytes": 12345678, "storageQuota": 262144000, "activeEditors": 1, "editorLimit": 2 }
+{ "storageBytes": 12345678, "docBytes": 345678, "blobBytes": 12000000, "storageQuota": 262144000, "maxDocBytes": 10485760, "activeEditors": 1, "editorLimit": 2 }
 ```
 
 The response carries counts only — no document ids and no content.
+`storageBytes` is the combined meter (`docBytes + blobBytes`); the halves ride
+alongside so clients can render a split. `maxDocBytes` is the effective
+per-document ceiling (`null` = none), letting a client warn before a write is
+refused with 413.
 
 ## Token lifetime guidance
 

--- a/relay/docs/mcp/README.md
+++ b/relay/docs/mcp/README.md
@@ -96,7 +96,7 @@ All tools are namespaced `docushark_*`.
 | `list_references` | The document's reference library as CSL-JSON in display order, plus the active `style`. |
 | `resolve_doi` | Resolve a `doi` to a CSL-JSON reference via doi.org content negotiation, **without** writing — preview before `add_reference`. |
 | `list_fields` | The document's fields (reusable `{{name}}` values) in display order, each `{ name, value }`. |
-| `get_storage` | Workspace storage stats: `usedBytes`, `quotaBytes` (`null` = unlimited), `maxBlobBytes` (per-file ceiling), `backend`. Check headroom before a large `add_file` upload. |
+| `get_storage` | Workspace storage stats: `usedBytes` (documents + files combined — the metered total), its halves `docBytes`/`blobBytes`, `quotaBytes` (`null` = unlimited), `maxBlobBytes` (per-file ceiling), `maxDocBytes` (per-document ceiling, `null` = none), `backend`. Check headroom before a large `add_file` upload or a big write. |
 | `get_skills` | Agent onboarding: with no args, the **content contract** (rules for valid prose + shapes) plus a recipe catalogue; with `{ skill }`, that recipe's full steps. Call it first if unsure how a tool expects its input — authoring valid content avoids the relay having to heal it. |
 | `list_icons` | Discover icon IDs to put on shapes: `{ id, name, category }` entries plus the match `total` and available `categories`. Filter with `query` (substring over id + name) and/or `category`; cap with `limit` (default 50, max 200). Apply an id via `add_shape`/`update_shape` (`iconId`). |
 
@@ -298,6 +298,13 @@ current.
   draw from a **separate** bucket (`reads_per_sec`/`reads_burst`, `0` =
   unlimited). Over the bucket → HTTP `429` with `ERR_RATE_LIMIT`. Tunable via
   `RELAY_*` env on Cloud pods.
+- **Storage limits.** Document writes share the workspace storage meter with
+  files (see `get_storage`). A write that would *grow* the workspace past its
+  quota fails with `ERR_STORAGE_QUOTA` — shrinking edits and deletes always
+  land, so content can be removed to free space. A write that would leave one
+  document over the per-document size ceiling fails with `ERR_DOC_TOO_LARGE`
+  (split content across documents, or attach big data as files via
+  `add_file`).
 - **No open-in-editor link yet.** `create_document` returns the document `id`;
   a deep link back into the editor is not yet wired.
 

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -17,7 +17,7 @@ use axum::{
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
-    routing::{delete, get, post, put},
+    routing::{get, post, put},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
@@ -25,7 +25,7 @@ use serde_json::{json, Value};
 
 use crate::auth::{OidcClaims, WorkspaceRole};
 use crate::server::documents::{
-    sanitize_collection_defs, CollectionDef, SaveOutcome, SetCollectionsOutcome,
+    sanitize_collection_defs, CollectionDef, DocSaveGate, SaveOutcome, SetCollectionsOutcome,
 };
 use crate::server::protocol::ShareEntry;
 use crate::server::permissions::{
@@ -266,9 +266,29 @@ fn parse_doc_path(id: String) -> Result<DocId, axum::response::Response> {
     })
 }
 
+/// HTTP body limit for the document routes (JP-443). Deliberately DECOUPLED
+/// from the `max_doc_bytes` enforcement cap: config only carries the
+/// *fallback* cap — a JWT claim can mint a larger per-workspace ceiling, and
+/// a body limit derived from the smaller config number would opaquely 413
+/// those requests before the size gate (which sees the token) could return
+/// its precise, typed error. So: a generous fixed floor, raised further (with
+/// 25% slack — the stored pretty-printed size is ≥ the compact wire body)
+/// when the config cap itself is larger. Replaces Axum's silent 2 MiB
+/// default on `PUT /api/docs/:id` (the doc-route sibling of JP-125).
+fn doc_body_limit_bytes(max_doc_bytes: u64) -> usize {
+    let cap = usize::try_from(max_doc_bytes).unwrap_or(usize::MAX);
+    let cap_with_slack = cap.saturating_add(cap / 4);
+    cap_with_slack.max(crate::config::DEFAULT_DOC_BODY_LIMIT_BYTES)
+}
+
 /// Build the REST router. Merged into the main Axum router in
 /// `WebSocketServer::start` so /api/* shares the listener with /ws.
-pub fn routes() -> Router<Arc<ServerState>> {
+/// `max_doc_bytes` is the configured `[tenancy.limits].max_doc_bytes`
+/// fallback, used only to size the doc-route body limit (see
+/// [`doc_body_limit_bytes`]) — enforcement itself happens per-request in the
+/// save gate with the claim-resolved value.
+pub fn routes(max_doc_bytes: u64) -> Router<Arc<ServerState>> {
+    let doc_body_limit = doc_body_limit_bytes(max_doc_bytes);
     Router::new()
         .route("/api/v1/internal/revoke", post(revoke_handler))
         .route(
@@ -287,10 +307,14 @@ pub fn routes() -> Router<Arc<ServerState>> {
             post(blob_ingest_from_url_handler),
         )
         .route("/api/docs", get(list_docs_handler))
-        .route("/api/docs/:id", get(get_doc_handler))
         .route("/api/docs/:id/ydoc", get(get_doc_ydoc_handler))
-        .route("/api/docs/:id", put(save_doc_handler))
-        .route("/api/docs/:id", delete(delete_doc_handler))
+        .route(
+            "/api/docs/:id",
+            get(get_doc_handler)
+                .put(save_doc_handler)
+                .delete(delete_doc_handler)
+                .layer(axum::extract::DefaultBodyLimit::max(doc_body_limit)),
+        )
         .route("/api/docs/:id/share", post(share_doc_handler))
         .route("/api/docs/:id/transfer", post(transfer_doc_handler))
         .route("/api/docs/:id/collection", put(set_doc_collection_handler))
@@ -337,6 +361,17 @@ struct SaveAck {
 struct VersionConflictBody {
     error_code: &'static str,
     current_version: u64,
+}
+
+/// 413 body for a document write over the per-document size ceiling
+/// (JP-443). Typed like [`VersionConflictBody`] so clients can branch on
+/// `errorCode` and show the actual numbers.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DocTooLargeBody {
+    error_code: &'static str,
+    size_bytes: u64,
+    max_bytes: u64,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -414,8 +449,17 @@ struct CollectionsConflictBody {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UsageResponse {
+    /// Combined storage: `doc_bytes + blob_bytes` (JP-443 — documents joined
+    /// the meter; the field name/shape is unchanged for existing readers).
     storage_bytes: u64,
+    /// Recorded document JSON bytes (the document half of `storage_bytes`).
+    doc_bytes: u64,
+    /// Blob bytes, full-size-per-grant (the blob half of `storage_bytes`).
+    blob_bytes: u64,
     storage_quota: Option<u64>,
+    /// Per-document serialized-size ceiling; `null` = no ceiling. Lets a
+    /// client warn before a write is refused with 413.
+    max_doc_bytes: Option<u64>,
     active_editors: u32,
     editor_limit: Option<u32>,
 }
@@ -630,11 +674,17 @@ async fn usage_handler(
     state.ensure_blob_bookkeeping(&ws).await;
     let effective = state.resolve_limits(limits);
     let counts = state.workspace_conn_for(&ws).await;
+    let (blob_bytes, doc_bytes) = state.workspace_storage_split(&ws);
     (
         StatusCode::OK,
         Json(UsageResponse {
-            storage_bytes: state.blob_store().get_workspace_size(&ws),
+            // JP-443: documents joined the meter — the headline number is the
+            // doc+blob sum; the halves ride alongside for display splits.
+            storage_bytes: blob_bytes.saturating_add(doc_bytes),
+            doc_bytes,
+            blob_bytes,
             storage_quota: effective.quota_bytes,
+            max_doc_bytes: effective.max_doc_bytes,
             active_editors: counts.editors,
             editor_limit: effective.editor_limit,
         }),
@@ -691,7 +741,9 @@ async fn blob_upload_url_handler(
     }
 
     // Projected per-workspace quota — re-checked authoritatively at finalize.
-    if let Some(quota) = state.resolve_limits(limits).quota_bytes {
+    // JP-443: gate against the quota remaining after recorded document bytes,
+    // so blobs + docs share the single storage meter.
+    if let Some(quota) = state.blob_quota_remaining(&ws, limits) {
         let used = state.blob_store().get_workspace_size(&ws);
         if used.saturating_add(req.size) > quota {
             return (
@@ -772,9 +824,10 @@ async fn blob_finalize_handler(
     // Re-run the quota against the *real* size; a new grant that would exceed
     // it is refused and the just-uploaded object reclaimed (closes the
     // lie-about-size hole in the advisory mint check). A re-finalize of an
-    // already-granted hash adds 0 (dedup) and skips the check.
+    // already-granted hash adds 0 (dedup) and skips the check. JP-443: quota =
+    // remaining after recorded document bytes (single storage meter).
     if !state.blob_store().exists(&ws, &hash) {
-        if let Some(quota) = state.resolve_limits(limits).quota_bytes {
+        if let Some(quota) = state.blob_quota_remaining(&ws, limits) {
             let used = state.blob_store().get_workspace_size(&ws);
             if used.saturating_add(size) > quota {
                 if let Err(e) = s3.delete_object(&ws, &hash).await {
@@ -1204,7 +1257,7 @@ async fn restore_recovery_handler(
         Ok(d) => d,
         Err(resp) => return resp,
     };
-    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+    let (ws, role, limits) = match resolve_workspace(&state, &claims) {
         Ok(v) => v,
         Err(resp) => return resp,
     };
@@ -1257,8 +1310,29 @@ async fn restore_recovery_handler(
     // before releasing the source's, so blobs shared by both stay alive.
     let new_refs = save_blob_refs(&json);
 
-    match state.doc_store().save_document_with_expected_version(&ws, json, None) {
+    // JP-443: restore replaces the source (deleted just below), so its net
+    // storage growth is ~0 — the workspace quota is deliberately NOT applied
+    // here (recovery must stay possible for an over-quota workspace). The
+    // per-document size ceiling still holds: a restored point can't exceed
+    // what a fresh write of the same bytes would be allowed.
+    let gate = DocSaveGate {
+        quota_bytes: None,
+        blob_bytes: 0,
+        max_doc_bytes: state.resolve_limits(limits).max_doc_bytes,
+    };
+    match state.doc_store().save_document_with_expected_version(&ws, json, None, Some(&gate)) {
         Ok(SaveOutcome::Created { .. }) | Ok(SaveOutcome::Updated { .. }) => {}
+        Ok(SaveOutcome::DocTooLarge { size, max }) => {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(DocTooLargeBody {
+                    error_code: "DOC_TOO_LARGE",
+                    size_bytes: size,
+                    max_bytes: max,
+                }),
+            )
+                .into_response()
+        }
         Ok(_) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1393,19 +1467,18 @@ async fn save_doc_handler(
         state.doc_store().clear_tombstone(&ws, &doc_id);
     }
 
-    // Storage backpressure (JP-81): once a workspace is at/over its storage
-    // quota, refuse *new* writes with 507 — existing data stays readable
-    // (GET is unaffected). Doc JSON references blobs (not base64) so its own
-    // metered delta is ~0; the precise per-byte clamp lives on blob upload.
-    if let Some(quota) = state.resolve_limits(limits).quota_bytes {
-        if state.blob_store().get_workspace_size(&ws) >= quota {
-            return (
-                StatusCode::INSUFFICIENT_STORAGE,
-                ApiError::body("storage quota exceeded"),
-            )
-                .into_response();
-        }
-    }
+    // Storage gate (JP-81 / JP-443): document bytes count toward the single
+    // storage meter, enforced delta-aware inside the save — a growing save
+    // that lands over quota is refused with 507, while shrinking/equal-size
+    // saves and deletes always pass (that's how a caller digs out). Existing
+    // data stays readable (GET is unaffected). The per-document size ceiling
+    // rides the same gate (413).
+    let effective = state.resolve_limits(limits);
+    let gate = DocSaveGate {
+        quota_bytes: effective.quota_bytes,
+        blob_bytes: state.blob_store().get_workspace_size(&ws),
+        max_doc_bytes: effective.max_doc_bytes,
+    };
 
     // Capture the doc's referenced blob hashes before `document` is moved
     // into the store — used to update the blob refcount after a successful
@@ -1415,13 +1488,39 @@ async fn save_doc_handler(
 
     let outcome = match state
         .doc_store()
-        .save_document_with_expected_version(&ws, document, query.expected_version)
+        .save_document_with_expected_version(&ws, document, query.expected_version, Some(&gate))
     {
         Ok(o) => o,
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
     };
 
     match outcome {
+        // JP-443: keep the "storage quota exceeded" body verbatim — clients
+        // key on the 507 status + this stable string.
+        SaveOutcome::QuotaExceeded { used, quota, incoming } => {
+            log::info!(
+                "doc save refused for {}/{}: {} used + {} incoming > {} quota",
+                ws.as_str(),
+                doc_id.as_str(),
+                used,
+                incoming,
+                quota
+            );
+            (
+                StatusCode::INSUFFICIENT_STORAGE,
+                ApiError::body("storage quota exceeded"),
+            )
+                .into_response()
+        }
+        SaveOutcome::DocTooLarge { size, max } => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(DocTooLargeBody {
+                error_code: "DOC_TOO_LARGE",
+                size_bytes: size,
+                max_bytes: max,
+            }),
+        )
+            .into_response(),
         // JP-375: the store also guards resurrection; the handler clears the
         // tombstone above when overriding, so this is a safety net (e.g. a race
         // re-tombstoned between the check and the save).
@@ -2108,7 +2207,9 @@ async fn blob_ingest_from_url_handler(
     };
     state.ensure_blob_bookkeeping(&ws).await;
 
-    let quota = state.resolve_limits(limits).quota_bytes;
+    // JP-443: quota = storage remaining after recorded document bytes (single
+    // storage meter across docs + blobs).
+    let quota = state.blob_quota_remaining(&ws, limits);
     // RB-3: reuse the process-wide ingest client (built once at startup). Its
     // redirect policy already re-validates every hop against the same allowlist
     // (an open redirect to an internal host is the classic SSRF escape); the

--- a/relay/src/auth/jwt.rs
+++ b/relay/src/auth/jwt.rs
@@ -54,6 +54,12 @@ pub struct WorkspaceClaim {
     /// Same minting/fallback story as `quota_bytes`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub editor_limit: Option<u32>,
+    /// Per-document serialized-JSON size ceiling for REST/MCP document writes
+    /// (JP-443). Same minting/fallback story as `quota_bytes`; absent →
+    /// `[tenancy.limits].max_doc_bytes`. An abuse guard on a single document's
+    /// footprint, independent of the storage quota.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_doc_bytes: Option<u64>,
 }
 
 /// Claim shape published in `relay/docs/api/token-format.md`. Optional

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -96,6 +96,21 @@ pub const DEFAULT_S3_GET_TTL_SECS: u64 = 3600; // 1h
 /// Default per-workspace storage byte quota fallback. `0` = unlimited.
 pub const DEFAULT_STORAGE_QUOTA_BYTES: u64 = 0;
 
+/// Default per-document serialized-JSON size ceiling fallback (JP-443), used
+/// when the JWT claim omits `max_doc_bytes`. `0` = no per-document ceiling —
+/// safe-by-default for self-host; shared pods set a floor via config/env. An
+/// abuse guard bounding a single document's memory/transfer/snapshot cost, not
+/// part of the storage meter.
+pub const DEFAULT_MAX_DOC_BYTES: u64 = 0;
+
+/// Floor for the docs-route HTTP body limit (JP-443). Deliberately DECOUPLED
+/// from `max_doc_bytes`: the config value is only the *fallback* cap — a JWT
+/// claim can carry a larger per-workspace ceiling, and a body limit derived
+/// from the smaller config number would opaquely 413 those requests before
+/// the size gate (which sees the token) could produce its precise error.
+/// Replaces Axum's silent 2 MiB default on the doc routes.
+pub const DEFAULT_DOC_BODY_LIMIT_BYTES: usize = 134_217_728; // 128 MiB
+
 /// Resolve an effective numeric limit: the value minted on the JWT claim if
 /// present, else the config fallback; a resolved `0` (from either source)
 /// normalises to `None` = **unlimited** (JP-81). Shared by REST
@@ -457,6 +472,12 @@ pub struct LimitsConfig {
     /// JWT claim omits `editor_limit`. `0` = unlimited. Viewers are never
     /// counted here; the total-connection ceiling above still applies.
     pub max_editors_per_workspace: u32,
+    /// Fallback per-document serialized-JSON size ceiling (JP-443), used when
+    /// the JWT claim omits `max_doc_bytes`. `0` = no ceiling. Enforced on
+    /// REST/MCP document writes (413 / typed error); collaborative flushes are
+    /// never refused (an over-cap snapshot is logged + counted instead).
+    #[serde(default)]
+    pub max_doc_bytes: u64,
     /// Grace (seconds) before an orphaned blob's bytes are reclaimed (JP-127).
     /// `0` = immediate. A positive value defers reclaim so a transient blob
     /// reference-drop (e.g. a bad reconnect save) can be corrected without
@@ -487,6 +508,7 @@ impl Default for LimitsConfig {
             max_concurrent_blob_uploads: DEFAULT_MAX_CONCURRENT_BLOB_UPLOADS,
             storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
             max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
+            max_doc_bytes: DEFAULT_MAX_DOC_BYTES,
             blob_gc_grace_secs: DEFAULT_BLOB_GC_GRACE_SECS,
             blob_ingest_allowed_hosts: Vec::new(),
         }
@@ -781,6 +803,11 @@ impl RelayConfig {
             self.tenancy.limits.max_blob_bytes = v
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_MAX_BLOB_BYTES must be a usize (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_MAX_DOC_BYTES") {
+            self.tenancy.limits.max_doc_bytes = v
+                .parse()
+                .map_err(|_| anyhow::anyhow!("RELAY_MAX_DOC_BYTES must be a u64 (got {v:?})"))?;
         }
         if let Some(v) = get("RELAY_MAX_CONCURRENT_BLOB_UPLOADS") {
             self.tenancy.limits.max_concurrent_blob_uploads = v.parse().map_err(|_| {

--- a/relay/src/mcp/mod.rs
+++ b/relay/src/mcp/mod.rs
@@ -175,6 +175,10 @@ pub struct BlobWriteHandles {
     /// omits the claim (`0` = unlimited). Resolved per-request against the
     /// claim via `config::effective_limit_u64`.
     pub fallback_quota_bytes: u64,
+    /// `[tenancy.limits] max_doc_bytes` — the per-document size-ceiling
+    /// fallback when a JWT omits the claim (`0` = no ceiling). Resolved
+    /// per-request like the quota (JP-443).
+    pub fallback_max_doc_bytes: u64,
 }
 
 impl BlobWriteHandles {
@@ -190,6 +194,7 @@ impl BlobWriteHandles {
             allowed_hosts: Vec::new(),
             max_blob_bytes: crate::config::DEFAULT_MAX_BLOB_BYTES,
             fallback_quota_bytes: 0,
+            fallback_max_doc_bytes: 0,
         }
     }
 }

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -114,6 +114,11 @@ pub struct ToolContext<'a> {
     /// `[tenancy.limits] max_blob_bytes` — the per-blob size ceiling, enforced
     /// by the `add_file` upload and reported by `get_storage` (JP-430 E3).
     pub max_blob_bytes: usize,
+    /// The effective per-document serialized-size ceiling for this request
+    /// (JWT claim override else config fallback; `None` = no ceiling) —
+    /// enforced by every document write via `mutate_with_retry` /
+    /// `create_document` and reported by `get_storage` (JP-443).
+    pub max_doc_bytes: Option<u64>,
     pub local: &'a Arc<LocalDocumentMirror>,
     pub local_enabled: bool,
     /// Workspace the MCP request authenticates against. Derived in
@@ -1701,19 +1706,55 @@ fn file_shape_mime_for(doc: &Value, blob_ref: &str) -> Option<String> {
 }
 
 /// `docushark_get_storage` (JP-430 E3): workspace-level storage stats — used
-/// bytes (full-size-per-grant, the JP-81 metering rule), the effective quota
-/// for this request (`null` = unlimited), and the per-file ceiling.
+/// bytes (blob full-size-per-grant + recorded document bytes, JP-443), the
+/// halves of that sum, the effective quota for this request (`null` =
+/// unlimited), and the per-file / per-document ceilings.
 fn get_storage(ctx: &ToolContext) -> Result<ToolOutcome, String> {
+    let blob_bytes = ctx.blob_store.get_workspace_size(&ctx.workspace_id);
+    let doc_bytes = ctx.team.workspace_doc_bytes(&ctx.workspace_id);
     Ok(ToolOutcome {
         result: json!({
-            "usedBytes": ctx.blob_store.get_workspace_size(&ctx.workspace_id),
+            "usedBytes": blob_bytes.saturating_add(doc_bytes),
+            "docBytes": doc_bytes,
+            "blobBytes": blob_bytes,
             "quotaBytes": ctx.quota_bytes,
             "maxBlobBytes": ctx.max_blob_bytes,
+            "maxDocBytes": ctx.max_doc_bytes,
             "backend": if ctx.s3.is_some() { "object-storage" } else { "filesystem" },
         }),
         changed_doc_id: None,
         change_detail: None,
     })
+}
+
+/// Build the JP-443 storage gate for an MCP document write, mirroring the
+/// REST `save_doc_handler` gate: full quota + a blob-usage snapshot + the
+/// per-document ceiling. The store applies the delta-aware refusal (growing
+/// saves only) so shrinking edits still land for an over-quota workspace.
+fn doc_save_gate(ctx: &ToolContext) -> crate::server::documents::DocSaveGate {
+    crate::server::documents::DocSaveGate {
+        quota_bytes: ctx.quota_bytes,
+        blob_bytes: ctx.blob_store.get_workspace_size(&ctx.workspace_id),
+        max_doc_bytes: ctx.max_doc_bytes,
+    }
+}
+
+/// Stable error string for an MCP document write refused by the workspace
+/// storage quota (the MCP counterpart of REST's 507).
+fn err_storage_quota() -> String {
+    "ERR_STORAGE_QUOTA: workspace storage quota exceeded — delete content, \
+     files, or documents to free space (shrinking edits are always accepted)"
+        .to_string()
+}
+
+/// Stable error string for a document over the per-document size ceiling
+/// (the MCP counterpart of REST's 413 `DOC_TOO_LARGE`).
+fn err_doc_too_large(size: u64, max: u64) -> String {
+    format!(
+        "ERR_DOC_TOO_LARGE: the write would make this document {size} bytes, \
+         over the {max}-byte per-document limit — split content into another \
+         document or attach large data as files"
+    )
 }
 
 /// Unix-millis now — std-only (house style: no chrono here).
@@ -2008,8 +2049,15 @@ fn create_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
         .map_err(|e| format!("Generated document id was invalid: {}", e))?;
 
     // Brand-new id, so there's nothing to race — the unconditional save
-    // creates it at version 1.
-    ctx.team.save_document(&ctx.workspace_id, doc)?;
+    // creates it at version 1. Gated (JP-443): a fresh doc is pure growth.
+    match ctx.team.save_document_gated(&ctx.workspace_id, doc, &doc_save_gate(ctx))? {
+        SaveOutcome::Created { .. } | SaveOutcome::Updated { .. } => {}
+        SaveOutcome::QuotaExceeded { .. } => return Err(err_storage_quota()),
+        SaveOutcome::DocTooLarge { size, max } => return Err(err_doc_too_large(size, max)),
+        SaveOutcome::VersionConflict { .. } | SaveOutcome::Tombstoned => {
+            return Err("create_document: unexpected save outcome for a fresh id".to_string());
+        }
+    }
 
     Ok(ToolOutcome {
         result: json!({"id": id_str, "name": name}),
@@ -4259,9 +4307,13 @@ fn mutate_with_retry<R>(
         if let Some(obj) = doc.as_object_mut() {
             obj.insert("blobReferences".into(), json!(content_refs));
         }
+        // JP-443: document writes share the REST save's storage gate — quota
+        // parity so the MCP surface can't grow a workspace past its meter.
+        // Rebuilt per attempt (cheap reads) so a retry sees fresh numbers.
+        let gate = doc_save_gate(ctx);
         match ctx
             .team
-            .save_document_with_expected_version(&ctx.workspace_id, doc, expected)?
+            .save_document_with_expected_version(&ctx.workspace_id, doc, expected, Some(&gate))?
         {
             SaveOutcome::Created { .. } | SaveOutcome::Updated { .. } => {
                 // Best-effort, after the save landed (same ordering as REST):
@@ -4291,6 +4343,10 @@ fn mutate_with_retry<R>(
                     "document '{}' was deleted during the write — re-read and try again",
                     doc_id.as_str()
                 ));
+            }
+            SaveOutcome::QuotaExceeded { .. } => return Err(err_storage_quota()),
+            SaveOutcome::DocTooLarge { size, max } => {
+                return Err(err_doc_too_large(size, max));
             }
         }
     }
@@ -5370,6 +5426,7 @@ mod tests {
                 blob_url_ttl_secs: 300,
                 quota_bytes: None,
                 max_blob_bytes: crate::config::DEFAULT_MAX_BLOB_BYTES,
+                max_doc_bytes: None,
                 local: &self.local,
                 local_enabled,
                 workspace_id: WorkspaceId::single_tenant(),
@@ -5395,6 +5452,7 @@ mod tests {
                 blob_url_ttl_secs: 300,
                 quota_bytes: None,
                 max_blob_bytes: crate::config::DEFAULT_MAX_BLOB_BYTES,
+                max_doc_bytes: None,
                 local: &self.local,
                 local_enabled: false,
                 workspace_id: WorkspaceId::single_tenant(),
@@ -8915,9 +8973,61 @@ mod tests {
             .unwrap();
 
         let out = dispatch(&f.ctx(false), "docushark_get_storage", &json!({})).unwrap();
-        assert_eq!(out.result["usedBytes"], bytes.len());
+        // JP-443: usedBytes is the doc+blob sum; the halves ride alongside.
+        let doc_bytes = f.team.workspace_doc_bytes(&ws);
+        assert!(doc_bytes > 0, "the seeded doc must have a recorded size");
+        assert_eq!(out.result["blobBytes"], bytes.len());
+        assert_eq!(out.result["docBytes"], doc_bytes);
+        assert_eq!(out.result["usedBytes"], doc_bytes + bytes.len() as u64);
         assert_eq!(out.result["quotaBytes"], Value::Null, "fixture ctx = unlimited");
         assert_eq!(out.result["maxBlobBytes"], crate::config::DEFAULT_MAX_BLOB_BYTES);
+        assert_eq!(out.result["maxDocBytes"], Value::Null, "fixture ctx = no ceiling");
         assert_eq!(out.result["backend"], "filesystem");
+    }
+
+    // ---- JP-443: MCP document writes share the storage gate ----
+
+    #[test]
+    fn mcp_doc_writes_refuse_over_quota_and_over_doc_cap() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        // The seeded doc1 already exceeds a 1-byte quota → any growing write
+        // and any create is refused with the stable ERR_STORAGE_QUOTA string.
+        let mut ctx = f.ctx(false);
+        ctx.quota_bytes = Some(1);
+        let err = dispatch(
+            &ctx,
+            "docushark_add_prose_page",
+            &json!({"docId": "doc1", "content": "# Growth\n\nmore text"}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_STORAGE_QUOTA"), "{err}");
+        let err =
+            dispatch(&ctx, "docushark_create_document", &json!({"name": "Over"})).unwrap_err();
+        assert!(err.starts_with("ERR_STORAGE_QUOTA"), "{err}");
+
+        // Per-document ceiling: a write that would leave the doc bigger than
+        // max_doc_bytes is refused with ERR_DOC_TOO_LARGE.
+        let mut ctx = f.ctx(false);
+        ctx.max_doc_bytes = Some(64);
+        let err = dispatch(
+            &ctx,
+            "docushark_add_prose_page",
+            &json!({"docId": "doc1", "content": "big"}),
+        )
+        .unwrap_err();
+        assert!(err.starts_with("ERR_DOC_TOO_LARGE"), "{err}");
+
+        // With sane limits the same write lands.
+        let mut ctx = f.ctx(false);
+        ctx.quota_bytes = Some(10 * 1024 * 1024);
+        ctx.max_doc_bytes = Some(1024 * 1024);
+        dispatch(
+            &ctx,
+            "docushark_add_prose_page",
+            &json!({"docId": "doc1", "content": "fits"}),
+        )
+        .unwrap();
     }
 }

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -598,6 +598,12 @@ async fn resolve_file_upload(
     // `uploaded_by` bookkeeping: the JWT subject, or the static loopback
     // token's fixed identity (it has no user).
     let user = ctx.user_id.clone().unwrap_or_else(|| "mcp".to_string());
+    // JP-443: blob writes gate against the storage remaining after recorded
+    // document bytes (docs + blobs share the single meter). `ctx.quota_bytes`
+    // itself stays the true quota so `get_storage` reports honestly.
+    let blob_quota = ctx
+        .quota_bytes
+        .map(|q| q.saturating_sub(ctx.team.workspace_doc_bytes(&ctx.workspace_id)));
 
     let stored = if let Some(url) = url {
         let authorization = args
@@ -612,7 +618,7 @@ async fn resolve_file_upload(
             state.s3.as_deref(),
             &ctx.workspace_id,
             &user,
-            ctx.quota_bytes,
+            blob_quota,
             state.blob_write.max_blob_bytes,
             &url,
             authorization.as_deref(),
@@ -640,7 +646,7 @@ async fn resolve_file_upload(
             state.s3.as_deref(),
             &ctx.workspace_id,
             &user,
-            ctx.quota_bytes,
+            blob_quota,
             &bytes,
             &mime,
         )
@@ -702,6 +708,12 @@ async fn handle_tools_call(
             state.blob_write.fallback_quota_bytes,
         ),
         max_blob_bytes: state.blob_write.max_blob_bytes,
+        // JP-443: the per-document size ceiling, resolved claim-else-config
+        // exactly like the quota.
+        max_doc_bytes: crate::config::effective_limit_u64(
+            auth.limits.max_doc_bytes,
+            state.blob_write.fallback_max_doc_bytes,
+        ),
         local: &state.local_mirror,
         // JP-235: a public mount hard-disables local access (`allow_local =
         // false`) regardless of the persisted feature flag.

--- a/relay/src/server/blobs.rs
+++ b/relay/src/server/blobs.rs
@@ -125,6 +125,11 @@ pub enum SaveBlobError {
     /// Granting this new `(ws, hash)` would push the workspace's
     /// full-size-per-grant total past its storage quota. A re-upload of
     /// an already-granted hash never produces this (dedup adds 0).
+    /// NOTE (JP-443): callers pass the quota REMAINING after the workspace's
+    /// recorded document bytes (`ServerState::blob_quota_remaining`), so the
+    /// `used`/`quota` numbers here are blob-only / doc-adjusted respectively —
+    /// clients key on the 507 status + the stable "storage quota exceeded"
+    /// prefix, not on these figures.
     QuotaExceeded { used: u64, quota: u64, incoming: u64 },
     /// Filesystem / index-persistence failure.
     Io(String),

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -211,6 +211,14 @@ pub struct DocumentMetadata {
     /// pre-JP-349 `index.json` loadable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prose_page_count: Option<usize>,
+    /// Byte length of the persisted doc JSON (`docs/<id>.json`), recorded at
+    /// write time. Counts toward the workspace storage meter alongside blob
+    /// bytes (JP-443). Lives in the mirrored `index.json`, so the number
+    /// survives eviction and R2 restore. `None` on entries written before
+    /// this field — backfilled from the local body in `load_workspace_index`;
+    /// an evicted legacy entry stays `None` until its next save/restore.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
     pub modified_at: u64,
     pub created_at: u64,
 
@@ -333,6 +341,35 @@ pub enum SaveOutcome {
     /// resurrect it. Refused unless the caller first clears the tombstone via
     /// an explicit, permission-gated override (`clear_tombstone`).
     Tombstoned,
+    /// The save would grow the workspace's storage (doc + blob bytes) past its
+    /// quota (JP-443). Only a *growing* save is refused — shrinking/equal-size
+    /// saves and deletes always pass, so a caller can dig out of an over-quota
+    /// state by removing content.
+    QuotaExceeded {
+        /// Combined doc+blob bytes before this save.
+        used: u64,
+        /// The effective storage quota that refused the write.
+        quota: u64,
+        /// Serialized size of the incoming document.
+        incoming: u64,
+    },
+    /// The serialized document exceeds the per-document size ceiling (JP-443).
+    DocTooLarge { size: u64, max: u64 },
+}
+
+/// Caller-supplied storage-gate inputs for a document save (JP-443). `None`
+/// fields disable that check. Built by the HTTP/MCP layers from the request's
+/// effective limits; the store enforces raw numbers only and never learns
+/// where they came from (claim vs config).
+#[derive(Debug, Clone, Default)]
+pub struct DocSaveGate {
+    /// Effective workspace storage quota (doc + blob bytes).
+    pub quota_bytes: Option<u64>,
+    /// Workspace blob usage snapshot (the caller reads the blob store; this
+    /// store only knows documents).
+    pub blob_bytes: u64,
+    /// Per-document byte ceiling for the serialized JSON body.
+    pub max_doc_bytes: Option<u64>,
 }
 
 /// Wall-clock millis since the epoch (0 if the clock is before 1970).
@@ -679,6 +716,44 @@ impl DocumentStore {
             .unwrap_or(0)
     }
 
+    /// JP-443: recorded document bytes for one workspace — the document half of
+    /// the storage meter (serialized JSON only; sidecars and recovery points
+    /// are operational copies and never counted). Sums the mirrored index, so
+    /// the number survives eviction; legacy entries without a recorded size
+    /// contribute 0 until their next save/restore.
+    pub fn workspace_doc_bytes(&self, ws: &WorkspaceId) -> u64 {
+        self.index
+            .read()
+            .ok()
+            .and_then(|index| {
+                index
+                    .get(ws)
+                    .map(|m| m.values().map(|meta| meta.size_bytes.unwrap_or(0)).sum())
+            })
+            .unwrap_or(0)
+    }
+
+    /// JP-443: recorded document bytes across all workspaces (pod-wide, for
+    /// `/metrics`). Indexes are preloaded at startup, so this sum is complete.
+    pub fn total_doc_bytes(&self) -> u64 {
+        self.index
+            .read()
+            .map(|index| {
+                index
+                    .values()
+                    .flat_map(|m| m.values())
+                    .map(|meta| meta.size_bytes.unwrap_or(0))
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+
+    /// Root of the relay-owned document tree — the filesystem the /metrics
+    /// volume gauges describe (JP-443).
+    pub fn documents_dir(&self) -> &std::path::Path {
+        &self.documents_dir
+    }
+
     /// JP-231: number of docs currently resident on this volume.
     pub fn cache_present_count(&self) -> usize {
         self.cache
@@ -805,7 +880,10 @@ impl DocumentStore {
                 .map_err(|e| format!("restore: write ydoc: {}", e))?;
         }
 
-        let metadata = Self::metadata_from_body(&doc, doc_id.clone(), version);
+        let mut metadata = Self::metadata_from_body(&doc, doc_id.clone(), version);
+        // Restores stay size-accurate even when the mirrored index copy was
+        // stale — the body bytes in hand are the exact on-disk length (JP-443).
+        metadata.size_bytes = Some(json_bytes.len() as u64);
         {
             let mut index = self.index.write().map_err(|e| e.to_string())?;
             index.entry(ws.clone()).or_default().insert(id, metadata);
@@ -1209,6 +1287,17 @@ impl DocumentStore {
         // (acceptable pre-GA). `meta.id` is the doc's `DocId`, so no key parse.
         let mut backfilled = false;
         for meta in parsed.values_mut() {
+            // JP-443 backfill: pre-JP-443 entries lack `size_bytes` — derive it
+            // from the local body's on-disk length (`write_atomic` writes
+            // exactly the serialized bytes, so the stat is exact). An
+            // evicted-to-R2 body stays `None` until its next save/restore; the
+            // save gate is deliberately lenient for that case.
+            if meta.size_bytes.is_none() {
+                if let Ok(m) = std::fs::metadata(self.doc_path(ws, &meta.id)) {
+                    meta.size_bytes = Some(m.len());
+                    backfilled = true;
+                }
+            }
             if meta.prose_page_count.is_some() {
                 continue;
             }
@@ -1639,7 +1728,7 @@ impl DocumentStore {
         ws: &WorkspaceId,
         doc: serde_json::Value,
     ) -> Result<(), String> {
-        match self.save_document_with_expected_version(ws, doc, None)? {
+        match self.save_document_with_expected_version(ws, doc, None, None)? {
             SaveOutcome::Created { .. } | SaveOutcome::Updated { .. } => Ok(()),
             // `expected = None` cannot produce a conflict — collapse to
             // a string error to preserve the existing signature.
@@ -1650,7 +1739,24 @@ impl DocumentStore {
             // This non-versioned helper is used for internal writes to existing
             // docs (locks, shares); a tombstoned id here is a logic error.
             SaveOutcome::Tombstoned => Err("document is tombstoned (deleted)".to_string()),
+            // `gate = None` cannot produce storage outcomes (JP-443).
+            SaveOutcome::QuotaExceeded { .. } | SaveOutcome::DocTooLarge { .. } => {
+                Err("unexpected storage-gate outcome on ungated save".to_string())
+            }
         }
+    }
+
+    /// Save without a version expectation but **with** the JP-443 storage gate
+    /// — the create/last-writer-wins twin of
+    /// [`Self::save_document_with_expected_version`] for callers (MCP create)
+    /// that need quota/size enforcement and the full [`SaveOutcome`].
+    pub fn save_document_gated(
+        &self,
+        ws: &WorkspaceId,
+        doc: serde_json::Value,
+        gate: &DocSaveGate,
+    ) -> Result<SaveOutcome, String> {
+        self.save_document_with_expected_version(ws, doc, None, Some(gate))
     }
 
     /// Build [`DocumentMetadata`] from a document body at a given server
@@ -1697,6 +1803,9 @@ impl DocumentStore {
             // total). JP-349.
             page_count: (canvas + prose).max(1),
             prose_page_count: Some(prose),
+            // Set by the write seams (save / snapshot / restore) that hold the
+            // serialized bytes; this body-only derivation has none (JP-443).
+            size_bytes: None,
             modified_at,
             created_at,
             is_relay_document: doc
@@ -1750,6 +1859,7 @@ impl DocumentStore {
         ws: &WorkspaceId,
         mut doc: serde_json::Value,
         expected: Option<u64>,
+        gate: Option<&DocSaveGate>,
     ) -> Result<SaveOutcome, String> {
         let id_str = doc.get("id")
             .and_then(|v| v.as_str())
@@ -1767,14 +1877,23 @@ impl DocumentStore {
             return Ok(SaveOutcome::Tombstoned);
         }
 
-        // Read current stored version (if any) for the concurrency
-        // check. Holding the read lock briefly is fine; the rest of
-        // the save runs outside the lock.
-        let (prior_version, doc_existed) = {
+        // Read current stored version (if any) for the concurrency check, plus
+        // the storage-gate inputs (this doc's recorded size + the workspace
+        // doc-bytes sum) in the same lock hold so they're mutually consistent.
+        // Holding the read lock briefly is fine; the rest of the save runs
+        // outside the lock.
+        let (prior_version, doc_existed, old_size, ws_doc_bytes) = {
             let index = self.index.read().map_err(|e| e.to_string())?;
-            match index.get(ws).and_then(|m| m.get(&id)) {
-                Some(meta) => (meta.server_version.unwrap_or(0), true),
-                None => (0, false),
+            let ws_map = index.get(ws);
+            let ws_doc_bytes: u64 = ws_map
+                .map(|m| m.values().map(|meta| meta.size_bytes.unwrap_or(0)).sum())
+                .unwrap_or(0);
+            match ws_map.and_then(|m| m.get(&id)) {
+                // `old_size = None` means the entry predates size recording and
+                // its body isn't locally stat-able (evicted) — see the lenient
+                // branch in the gate below.
+                Some(meta) => (meta.server_version.unwrap_or(0), true, meta.size_bytes, ws_doc_bytes),
+                None => (0, false, Some(0), ws_doc_bytes),
             }
         };
 
@@ -1793,10 +1912,48 @@ impl DocumentStore {
             obj.insert("serverVersion".to_string(), serde_json::json!(new_version));
         }
 
-        let metadata = Self::metadata_from_body(&doc, doc_id.clone(), new_version);
+        let mut metadata = Self::metadata_from_body(&doc, doc_id.clone(), new_version);
 
         let doc_json = serde_json::to_string_pretty(&doc)
             .map_err(|e| format!("Serialize error: {}", e))?;
+        let new_size = doc_json.len() as u64;
+        metadata.size_bytes = Some(new_size);
+
+        // JP-443 storage gate — runs before any byte hits the disk.
+        if let Some(gate) = gate {
+            if let Some(max) = gate.max_doc_bytes {
+                if max > 0 && new_size > max {
+                    return Ok(SaveOutcome::DocTooLarge { size: new_size, max });
+                }
+            }
+            if let Some(quota) = gate.quota_bytes {
+                match old_size {
+                    // Refuse only a GROWING save that lands over quota. A
+                    // shrinking or equal-size save always passes — deleting
+                    // content is how a caller digs out of an over-quota state.
+                    Some(old) if new_size > old => {
+                        let used = gate.blob_bytes.saturating_add(ws_doc_bytes);
+                        let projected = used.saturating_sub(old).saturating_add(new_size);
+                        if projected > quota {
+                            return Ok(SaveOutcome::QuotaExceeded {
+                                used,
+                                quota,
+                                incoming: new_size,
+                            });
+                        }
+                    }
+                    Some(_) => {}
+                    // Legacy entry with unknown recorded size: skip the quota
+                    // check for this one save (the projection would over-charge
+                    // by the full new size and could refuse a non-growing
+                    // edit). The save records the true size, so the next one
+                    // is gated normally — a false lockout is worse than one
+                    // lenient write.
+                    None => {}
+                }
+            }
+        }
+
         // Ensure the per-workspace docs dir exists (first-touch for a
         // new tenant on shared-mode Cloud).
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
@@ -1840,8 +1997,11 @@ impl DocumentStore {
     /// the clients are already CRDT-synced with this exact content.
     ///
     /// Returns `Err` if the doc isn't in this workspace's index (the relay only
-    /// snapshots docs it hydrated from an existing body).
-    pub fn persist_snapshot(&self, ws: &WorkspaceId, mut doc: serde_json::Value) -> Result<(), String> {
+    /// snapshots docs it hydrated from an existing body). On success returns the
+    /// serialized byte size that was written, so the caller can observe
+    /// per-document size overages (JP-443) — the snapshot itself is **never**
+    /// gated: refusing a CRDT flush would drop already-merged edits.
+    pub fn persist_snapshot(&self, ws: &WorkspaceId, mut doc: serde_json::Value) -> Result<u64, String> {
         let id = doc
             .get("id")
             .and_then(|v| v.as_str())
@@ -1867,9 +2027,11 @@ impl DocumentStore {
             obj.insert("serverVersion".to_string(), serde_json::json!(version));
         }
 
-        let metadata = Self::metadata_from_body(&doc, doc_id.clone(), version);
+        let mut metadata = Self::metadata_from_body(&doc, doc_id.clone(), version);
 
         let doc_json = serde_json::to_string_pretty(&doc).map_err(|e| format!("Serialize error: {}", e))?;
+        let written_size = doc_json.len() as u64;
+        metadata.size_bytes = Some(written_size);
         let _ = std::fs::create_dir_all(self.workspace_root(ws).join("docs"));
         write_atomic(&self.doc_path(ws, &doc_id), doc_json.as_bytes())
             .map_err(|e| format!("Write error: {}", e))?;
@@ -1889,7 +2051,7 @@ impl DocumentStore {
         });
 
         log::debug!("relay snapshot persisted: {}/{} (v{}, unchanged)", ws.as_str(), id, version);
-        Ok(())
+        Ok(written_size)
     }
 
     /// Delete a document scoped to the requesting workspace. Returns
@@ -2598,6 +2760,7 @@ mod tests {
                 &ws,
                 serde_json::json!({ "id": "t-doc", "name": "T again" }),
                 None,
+                None,
             )
             .unwrap();
         assert_eq!(outcome, SaveOutcome::Tombstoned);
@@ -2609,6 +2772,7 @@ mod tests {
             .save_document_with_expected_version(
                 &ws,
                 serde_json::json!({ "id": "t-doc", "name": "T restored" }),
+                None,
                 None,
             )
             .unwrap();
@@ -3047,6 +3211,7 @@ mod tests {
             name: "legacy".into(),
             page_count: 1,
             prose_page_count: None,
+            size_bytes: None,
             modified_at: 1,
             created_at: 1,
             is_relay_document: Some(true),
@@ -3172,6 +3337,189 @@ mod tests {
         let meta = store.get_metadata(&ws, &doc_id).unwrap();
         assert_eq!(meta.page_count, 4, "backfilled to canvas + prose");
         assert_eq!(meta.prose_page_count, Some(3));
+    }
+
+    // ---- JP-443 doc-size accounting + storage gate ---------------------------
+
+    #[test]
+    fn save_records_size_bytes_and_snapshot_updates_it() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("sz-doc".into()).unwrap();
+
+        store.save_document(&ws, serde_json::json!({"id": "sz-doc", "name": "S"})).unwrap();
+        let meta = store.get_metadata(&ws, &doc_id).unwrap();
+        let recorded = meta.size_bytes.expect("save records size");
+        let on_disk = std::fs::metadata(store.doc_path(&ws, &doc_id)).unwrap().len();
+        assert_eq!(recorded, on_disk, "recorded size is the exact on-disk length");
+        assert_eq!(store.workspace_doc_bytes(&ws), recorded);
+        assert_eq!(store.total_doc_bytes(), recorded);
+
+        // A snapshot (quiet CRDT flush — never gated by construction: it has
+        // no gate parameter) updates the recorded size and reports it back.
+        let snap =
+            serde_json::json!({"id": "sz-doc", "name": "S", "filler": "x".repeat(512)});
+        let written = store.persist_snapshot(&ws, snap).unwrap();
+        let meta = store.get_metadata(&ws, &doc_id).unwrap();
+        assert_eq!(meta.size_bytes, Some(written));
+        assert!(written > recorded);
+        assert_eq!(store.workspace_doc_bytes(&ws), written);
+    }
+
+    #[test]
+    fn load_workspace_index_backfills_legacy_size_bytes() {
+        // A pre-JP-443 index.json entry: no `sizeBytes`.
+        let dir = tempdir().unwrap();
+        let ws_dir = dir
+            .path()
+            .join("relay_documents")
+            .join("workspaces")
+            .join("default");
+        std::fs::create_dir_all(ws_dir.join("docs")).unwrap();
+        std::fs::write(
+            ws_dir.join("index.json"),
+            r#"{"legacy-doc":{"id":"legacy-doc","name":"L","pageCount":1,"prosePageCount":0,"modifiedAt":1,"createdAt":1}}"#,
+        )
+        .unwrap();
+        let body = r#"{"id":"legacy-doc","name":"L"}"#;
+        std::fs::write(ws_dir.join("docs").join("legacy-doc.json"), body).unwrap();
+
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("legacy-doc".into()).unwrap();
+        let meta = store.get_metadata(&ws, &doc_id).unwrap();
+        assert_eq!(meta.size_bytes, Some(body.len() as u64), "stat-derived backfill");
+        assert_eq!(store.workspace_doc_bytes(&ws), body.len() as u64);
+
+        // The backfill persisted once, so the next boot skips the re-derive.
+        let raw = std::fs::read_to_string(ws_dir.join("index.json")).unwrap();
+        assert!(raw.contains("sizeBytes"), "backfill persisted to index.json");
+    }
+
+    #[test]
+    fn doc_save_gate_refuses_growth_over_quota() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        store.save_document(&ws, serde_json::json!({"id": "q-doc", "name": "Q"})).unwrap();
+        let base = store.workspace_doc_bytes(&ws);
+        let gate =
+            DocSaveGate { quota_bytes: Some(base + 64), blob_bytes: 0, max_doc_bytes: None };
+
+        // Growing well past the quota is refused with the gate's numbers…
+        let big = serde_json::json!({"id": "q-doc", "name": "Q", "filler": "x".repeat(1024)});
+        let outcome =
+            store.save_document_with_expected_version(&ws, big, None, Some(&gate)).unwrap();
+        assert!(matches!(
+            outcome,
+            SaveOutcome::QuotaExceeded { used, quota, .. } if used == base && quota == base + 64
+        ));
+        // …and nothing was persisted (recorded size unchanged).
+        assert_eq!(store.workspace_doc_bytes(&ws), base);
+    }
+
+    #[test]
+    fn doc_save_gate_allows_shrinking_save_while_over_quota() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        store
+            .save_document(
+                &ws,
+                serde_json::json!({"id": "s-doc", "name": "S", "filler": "x".repeat(2048)}),
+            )
+            .unwrap();
+        let big = store.workspace_doc_bytes(&ws);
+        // The workspace is now far over this quota…
+        let gate =
+            DocSaveGate { quota_bytes: Some(big / 4), blob_bytes: 0, max_doc_bytes: None };
+
+        // …but a shrinking save still lands — deleting content is the dig-out
+        // path, and refusing it would deadlock an over-quota workspace.
+        let smaller = serde_json::json!({"id": "s-doc", "name": "S"});
+        let outcome = store
+            .save_document_with_expected_version(&ws, smaller, None, Some(&gate))
+            .unwrap();
+        assert!(matches!(outcome, SaveOutcome::Updated { .. }));
+        assert!(store.workspace_doc_bytes(&ws) < big);
+
+        // A growing save from the same over-quota state is refused.
+        let bigger =
+            serde_json::json!({"id": "s-doc", "name": "S", "filler": "y".repeat(4096)});
+        let outcome = store
+            .save_document_with_expected_version(&ws, bigger, None, Some(&gate))
+            .unwrap();
+        assert!(matches!(outcome, SaveOutcome::QuotaExceeded { .. }));
+    }
+
+    #[test]
+    fn doc_save_gate_lenient_when_legacy_old_size_unknown() {
+        // An index entry without a recorded size whose body isn't local (an
+        // evicted legacy doc — the boot backfill had nothing to stat): the
+        // quota check is skipped for that one save, which records the true
+        // size, so the next growing save is gated normally.
+        let dir = tempdir().unwrap();
+        let ws_dir = dir
+            .path()
+            .join("relay_documents")
+            .join("workspaces")
+            .join("default");
+        std::fs::create_dir_all(ws_dir.join("docs")).unwrap();
+        std::fs::write(
+            ws_dir.join("index.json"),
+            r#"{"ghost-doc":{"id":"ghost-doc","name":"G","pageCount":1,"prosePageCount":0,"modifiedAt":1,"createdAt":1,"serverVersion":3}}"#,
+        )
+        .unwrap();
+
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+        let doc_id = DocId::from_http_path("ghost-doc".into()).unwrap();
+        assert_eq!(store.get_metadata(&ws, &doc_id).unwrap().size_bytes, None);
+
+        // Even a 1-byte quota doesn't refuse this save (old size unknown →
+        // lenient: a false 507 lockout is worse than one lenient write).
+        let gate = DocSaveGate { quota_bytes: Some(1), blob_bytes: 0, max_doc_bytes: None };
+        let doc =
+            serde_json::json!({"id": "ghost-doc", "name": "G", "filler": "x".repeat(256)});
+        let outcome =
+            store.save_document_with_expected_version(&ws, doc, None, Some(&gate)).unwrap();
+        assert!(matches!(outcome, SaveOutcome::Updated { .. }));
+
+        // Self-healed: the size is recorded, so growth is now gated.
+        assert!(store.get_metadata(&ws, &doc_id).unwrap().size_bytes.unwrap() > 0);
+        let bigger =
+            serde_json::json!({"id": "ghost-doc", "name": "G", "filler": "x".repeat(4096)});
+        let outcome = store
+            .save_document_with_expected_version(&ws, bigger, None, Some(&gate))
+            .unwrap();
+        assert!(matches!(outcome, SaveOutcome::QuotaExceeded { .. }));
+    }
+
+    #[test]
+    fn doc_save_gate_refuses_doc_over_max_doc_bytes() {
+        let dir = tempdir().unwrap();
+        let store = DocumentStore::new(dir.path().to_path_buf());
+        let ws = WorkspaceId::single_tenant();
+
+        let gate = DocSaveGate { quota_bytes: None, blob_bytes: 0, max_doc_bytes: Some(256) };
+        let big = serde_json::json!({"id": "cap-doc", "name": "C", "filler": "x".repeat(512)});
+        let outcome =
+            store.save_document_with_expected_version(&ws, big, None, Some(&gate)).unwrap();
+        assert!(matches!(
+            outcome,
+            SaveOutcome::DocTooLarge { size, max } if size > 256 && max == 256
+        ));
+        let doc_id = DocId::from_http_path("cap-doc".into()).unwrap();
+        assert!(store.get_metadata(&ws, &doc_id).is_none(), "nothing persisted");
+
+        // Under the ceiling → lands.
+        let small = serde_json::json!({"id": "cap-doc", "name": "C"});
+        let outcome =
+            store.save_document_with_expected_version(&ws, small, None, Some(&gate)).unwrap();
+        assert!(matches!(outcome, SaveOutcome::Created { .. }));
     }
 
     // ---- JP-231 working-set cache / eviction --------------------------------

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -431,6 +431,8 @@ impl WorkspaceConnCounts {
 pub(crate) struct EffectiveLimits {
     pub quota_bytes: Option<u64>,
     pub editor_limit: Option<u32>,
+    /// Per-document serialized-JSON size ceiling (JP-443).
+    pub max_doc_bytes: Option<u64>,
 }
 
 /// Shared state for the WebSocket server
@@ -511,6 +513,11 @@ pub struct ServerState {
     /// Total recovery points captured this process (periodic + session-end +
     /// poison guard). Read by `/metrics` as `relay_version_points_total`.
     version_points: AtomicU64,
+    /// Collaborative snapshots persisted past the configured per-document
+    /// size ceiling (JP-443) — flushes are never refused, so this counter is
+    /// the observability for docs that grew over the cap mid-session. Read by
+    /// `/metrics` as `relay_doc_over_cap_snapshots_total`.
+    doc_over_cap_snapshots: AtomicU64,
     /// Snapshot of `config.permissions.enforce_private_docs` (JP-370). When
     /// true, the document listing and the WS join are gated by the document's
     /// owner/share set; when false (default) access is workspace-scoped only.
@@ -665,6 +672,7 @@ impl ServerState {
             poison_guard,
             version_interval_secs,
             version_points: AtomicU64::new(0),
+            doc_over_cap_snapshots: AtomicU64::new(0),
             enforce_private_docs,
             #[cfg(debug_assertions)]
             panic_tenant_trigger,
@@ -1027,7 +1035,33 @@ impl ServerState {
                 cfg.storage_quota_bytes,
             ),
             editor_limit: (editors != 0).then_some(editors),
+            max_doc_bytes: crate::config::effective_limit_u64(
+                claim.max_doc_bytes,
+                cfg.max_doc_bytes,
+            ),
         }
+    }
+
+    /// The two halves of the single storage meter for a workspace (JP-443):
+    /// blob bytes (ACL-grant attributed) + recorded document JSON bytes.
+    pub(crate) fn workspace_storage_split(&self, ws: &WorkspaceId) -> (u64, u64) {
+        (
+            self.blob_store.get_workspace_size(ws),
+            self.doc_store.workspace_doc_bytes(ws),
+        )
+    }
+
+    /// Storage quota available to NEW BLOB grants (JP-443): the effective
+    /// workspace quota minus recorded document bytes. The blob store keeps its
+    /// blob-only ledger and unchanged signatures — the document share of the
+    /// meter is pre-charged here, so gating blobs on this *remaining* quota is
+    /// arithmetically identical to gating on `blob + doc ≤ quota`. When docs
+    /// alone exceed the quota this saturates to 0 — every new grant refused.
+    /// `None` = unlimited.
+    pub(crate) fn blob_quota_remaining(&self, ws: &WorkspaceId, claim: ClaimLimits) -> Option<u64> {
+        self.resolve_limits(claim)
+            .quota_bytes
+            .map(|q| q.saturating_sub(self.doc_store.workspace_doc_bytes(ws)))
     }
 
     /// Mirror of `try_register_workspace_connection` used on clean
@@ -1468,15 +1502,34 @@ impl ServerState {
                 e
             );
         }
-        if let Err(e) = self.doc_store.persist_snapshot(ws, json) {
-            // Retry on the next tick rather than dropping the edit.
-            handle.mark_dirty();
-            log::warn!(
-                "snapshot persist failed for {}/{}: {} — will retry",
-                ws.as_str(),
-                doc_id.as_str(),
-                e
-            );
+        match self.doc_store.persist_snapshot(ws, json) {
+            Ok(written_size) => {
+                // JP-443: a collaborative flush is NEVER refused (the edits are
+                // already CRDT-merged) — but a doc growing past the configured
+                // per-document ceiling is worth observing. Config-only check:
+                // no claims exist mid-session on this path.
+                let cap = self.tenancy.limits.max_doc_bytes;
+                if cap > 0 && written_size > cap {
+                    self.doc_over_cap_snapshots.fetch_add(1, Ordering::Relaxed);
+                    log::warn!(
+                        "snapshot for {}/{} is {} bytes (over the {}-byte document ceiling) — persisted anyway",
+                        ws.as_str(),
+                        doc_id.as_str(),
+                        written_size,
+                        cap
+                    );
+                }
+            }
+            Err(e) => {
+                // Retry on the next tick rather than dropping the edit.
+                handle.mark_dirty();
+                log::warn!(
+                    "snapshot persist failed for {}/{}: {} — will retry",
+                    ws.as_str(),
+                    doc_id.as_str(),
+                    e
+                );
+            }
         }
     }
 
@@ -1816,6 +1869,7 @@ impl WebSocketServer {
             allowed_hosts: state.blob_ingest_allowed_hosts().to_vec(),
             max_blob_bytes: state.max_blob_bytes(),
             fallback_quota_bytes: state.tenancy.limits.storage_quota_bytes,
+            fallback_max_doc_bytes: state.tenancy.limits.max_doc_bytes,
         }
     }
 
@@ -2128,6 +2182,7 @@ impl WebSocketServer {
                         allowed_hosts: server_state.blob_ingest_allowed_hosts().to_vec(),
                         max_blob_bytes: server_state.max_blob_bytes(),
                         fallback_quota_bytes: server_state.tenancy.limits.storage_quota_bytes,
+                        fallback_max_doc_bytes: server_state.tenancy.limits.max_doc_bytes,
                     },
                 };
                 log::info!("MCP endpoint folded onto the public HTTP listener at /mcp (expose=public)");
@@ -2149,7 +2204,7 @@ impl WebSocketServer {
             .route("/api/blobs/:hash", post(blob_upload_handler))
             .route("/api/blobs/:hash", get(blob_download_handler))
             .route("/api/blobs/:hash", head(blob_exists_handler))
-            .merge(crate::api::routes())
+            .merge(crate::api::routes(server_state.tenancy.limits.max_doc_bytes))
             .with_state(server_state);
         if let Some(mcp_router) = mcp_public_router {
             app = app.merge(mcp_router);
@@ -2362,6 +2417,14 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
     let active_viewers = state.active_viewer_count().await;
     let rate_limit_rejections = state.rate_limit_rejections();
     let version_points = state.version_points.load(Ordering::Relaxed);
+    // JP-443: the document half of the storage meter (recorded serialized-JSON
+    // bytes, from the durable index — survives eviction) + the on-volume cache
+    // footprint (json + ydoc sidecar + recovery points for locally-present
+    // docs). The gap between the two is the operational sidecar/recovery
+    // overhead, which is observed but never metered.
+    let doc_bytes = state.doc_store.total_doc_bytes();
+    let doc_cache_bytes = state.doc_store.cache_bytes();
+    let doc_over_cap_snapshots = state.doc_over_cap_snapshots.load(Ordering::Relaxed);
 
     // Opt-in per-workspace breakdown at debug level. Pod-level series go
     // on the wire below regardless; the per-workspace detail stays in
@@ -2377,9 +2440,10 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
             let bytes = sizes.get(ws).copied().unwrap_or(0);
             let c = conns.get(ws).copied().unwrap_or_default();
             log::debug!(
-                "metering workspace_id={} storage_bytes={} editors={} viewers={}",
+                "metering workspace_id={} storage_bytes={} doc_bytes={} editors={} viewers={}",
                 ws.as_str(),
                 bytes,
+                state.doc_store.workspace_doc_bytes(ws),
                 c.editors,
                 c.viewers,
             );
@@ -2405,9 +2469,18 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
          # HELP relay_revocation_set_size Number of revoked JTIs held in memory.\n\
          # TYPE relay_revocation_set_size gauge\n\
          relay_revocation_set_size {revocation_set_size}\n\
-         # HELP relay_storage_bytes_total Pod-wide blob bytes stored (the metered storage axis; deduped on disk).\n\
+         # HELP relay_storage_bytes_total Pod-wide blob bytes stored (blob half of the storage meter; deduped on disk).\n\
          # TYPE relay_storage_bytes_total gauge\n\
          relay_storage_bytes_total {storage_bytes}\n\
+         # HELP relay_doc_bytes_total Pod-wide recorded document JSON bytes (document half of the storage meter; survives eviction).\n\
+         # TYPE relay_doc_bytes_total gauge\n\
+         relay_doc_bytes_total {doc_bytes}\n\
+         # HELP relay_doc_cache_bytes On-volume footprint of locally-present docs (json + ydoc sidecar + recovery points; operational, unmetered).\n\
+         # TYPE relay_doc_cache_bytes gauge\n\
+         relay_doc_cache_bytes {doc_cache_bytes}\n\
+         # HELP relay_doc_over_cap_snapshots_total Collaborative snapshots persisted past the configured per-document size ceiling (never refused).\n\
+         # TYPE relay_doc_over_cap_snapshots_total counter\n\
+         relay_doc_over_cap_snapshots_total {doc_over_cap_snapshots}\n\
          # HELP relay_active_editors_total Live editor (read-write) connections across all workspaces.\n\
          # TYPE relay_active_editors_total gauge\n\
          relay_active_editors_total {active_editors}\n\
@@ -2446,6 +2519,27 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
              relay_process_rss_bytes {rss_bytes}\n"
         ));
     }
+    // Volume capacity of the filesystem holding the data dir (JP-443). statvfs
+    // is unix-only, so like RSS the series may be absent — never read as 0.
+    // On Fly this is the mounted volume; the doc LRU cache + blob bytes +
+    // recovery rings all live inside it, so this is the disk-pressure signal.
+    #[cfg(unix)]
+    if let Some(v) = volume_stats(state.doc_store.documents_dir()) {
+        body.push_str(&format!(
+            "# HELP relay_volume_total_bytes Total capacity of the filesystem holding the relay data dir.\n\
+             # TYPE relay_volume_total_bytes gauge\n\
+             relay_volume_total_bytes {total}\n\
+             # HELP relay_volume_used_bytes Used bytes on the filesystem holding the relay data dir.\n\
+             # TYPE relay_volume_used_bytes gauge\n\
+             relay_volume_used_bytes {used}\n\
+             # HELP relay_volume_available_bytes Bytes available to the relay on its data-dir filesystem.\n\
+             # TYPE relay_volume_available_bytes gauge\n\
+             relay_volume_available_bytes {available}\n",
+            total = v.total,
+            used = v.used,
+            available = v.available,
+        ));
+    }
 
     (
         [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
@@ -2461,6 +2555,35 @@ fn process_rss_bytes() -> Option<u64> {
     let line = status.lines().find(|l| l.starts_with("VmRSS:"))?;
     let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
     Some(kb * 1024)
+}
+
+/// Capacity/usage of the filesystem holding `path` (JP-443), via statvfs.
+#[cfg(unix)]
+struct VolumeStats {
+    total: u64,
+    used: u64,
+    available: u64,
+}
+
+/// statvfs on `path`. `used` counts root-reserved blocks as used (f_bfree),
+/// while `available` is what this process can actually still write (f_bavail).
+#[cfg(unix)]
+fn volume_stats(path: &std::path::Path) -> Option<VolumeStats> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).ok()?;
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
+        return None;
+    }
+    let frsize = stat.f_frsize as u64;
+    let total = (stat.f_blocks as u64).saturating_mul(frsize);
+    let free = (stat.f_bfree as u64).saturating_mul(frsize);
+    let available = (stat.f_bavail as u64).saturating_mul(frsize);
+    Some(VolumeStats {
+        total,
+        used: total.saturating_sub(free),
+        available,
+    })
 }
 
 // ============ Blob HTTP Endpoints ============
@@ -2575,7 +2698,10 @@ async fn blob_upload_handler(
         .unwrap_or("application/octet-stream")
         .to_string();
 
-    let quota = state.resolve_limits(claim_limits).quota_bytes;
+    // JP-443: the quota handed to the blob paths is the storage REMAINING
+    // after the workspace's recorded document bytes — so blob + doc bytes
+    // gate against the single quota without a blob-store signature change.
+    let quota = state.blob_quota_remaining(&ws, claim_limits);
 
     // s3 backend: proxy the bytes straight to object storage, then record the
     // blob (the back half of finalize). Keeps the proxy upload coherent with the
@@ -4524,6 +4650,7 @@ mod tests {
         let eff = state.resolve_limits(ClaimLimits {
             quota_bytes: Some(2048),
             editor_limit: Some(3),
+            max_doc_bytes: Some(4096),
         });
         assert_eq!(eff.quota_bytes, Some(2048));
         assert_eq!(eff.editor_limit, Some(3));
@@ -4532,6 +4659,7 @@ mod tests {
         let eff = state.resolve_limits(ClaimLimits {
             quota_bytes: Some(0),
             editor_limit: Some(0),
+            max_doc_bytes: Some(0),
         });
         assert_eq!(eff.quota_bytes, None);
         assert_eq!(eff.editor_limit, None);

--- a/relay/src/server/permissions.rs
+++ b/relay/src/server/permissions.rs
@@ -251,6 +251,7 @@ mod tests {
             name: "Test".to_string(),
             page_count: 1,
             prose_page_count: None,
+            size_bytes: None,
             modified_at: 0,
             created_at: 0,
             is_relay_document: Some(true),

--- a/relay/src/server/protocol.rs
+++ b/relay/src/server/protocol.rs
@@ -42,6 +42,8 @@ pub struct WorkspaceId(String);
 pub struct ClaimLimits {
     pub quota_bytes: Option<u64>,
     pub editor_limit: Option<u32>,
+    /// Per-document serialized-JSON size ceiling (JP-443).
+    pub max_doc_bytes: Option<u64>,
 }
 
 impl WorkspaceId {
@@ -102,6 +104,7 @@ impl WorkspaceId {
             ClaimLimits {
                 quota_bytes: chosen.quota_bytes,
                 editor_limit: chosen.editor_limit,
+                max_doc_bytes: chosen.max_doc_bytes,
             },
         ))
     }
@@ -407,6 +410,7 @@ mod tests {
                 name: "Test Doc".to_string(),
                 page_count: 1,
                 prose_page_count: None,
+                size_bytes: None,
                 modified_at: 1000,
                 created_at: 1000,
                 is_relay_document: Some(true),

--- a/relay/src/test_support.rs
+++ b/relay/src/test_support.rs
@@ -107,6 +107,7 @@ impl OidcTestIssuer {
                 region: "default".to_string(),
                 quota_bytes: None,
                 editor_limit: None,
+                max_doc_bytes: None,
             }],
         };
         let mut header = Header::new(Algorithm::RS256);
@@ -151,7 +152,7 @@ impl OidcTestIssuer {
         region: &str,
         ttl_seconds: u64,
     ) -> String {
-        self.mint_full(sub, workspace, role, region, ttl_seconds, None, None)
+        self.mint_full(sub, workspace, role, region, ttl_seconds, None, None, None)
     }
 
     /// Mint a token carrying per-workspace `quota_bytes` / `editor_limit`
@@ -165,7 +166,19 @@ impl OidcTestIssuer {
         quota_bytes: Option<u64>,
         editor_limit: Option<u32>,
     ) -> String {
-        self.mint_full(sub, workspace, role, "default", 3600, quota_bytes, editor_limit)
+        self.mint_full(sub, workspace, role, "default", 3600, quota_bytes, editor_limit, None)
+    }
+
+    /// Mint a token additionally carrying the `max_doc_bytes` per-document
+    /// size-ceiling claim field (JP-443).
+    pub fn mint_with_max_doc_bytes(
+        &self,
+        sub: &str,
+        workspace: &str,
+        role: WorkspaceRole,
+        max_doc_bytes: Option<u64>,
+    ) -> String {
+        self.mint_full(sub, workspace, role, "default", 3600, None, None, max_doc_bytes)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -178,6 +191,7 @@ impl OidcTestIssuer {
         ttl_seconds: u64,
         quota_bytes: Option<u64>,
         editor_limit: Option<u32>,
+        max_doc_bytes: Option<u64>,
     ) -> String {
         let now = Utc::now().timestamp() as u64;
         let claims = OidcClaims {
@@ -193,6 +207,7 @@ impl OidcTestIssuer {
                 region: region.to_string(),
                 quota_bytes,
                 editor_limit,
+                max_doc_bytes,
             }],
         };
         let mut header = Header::new(Algorithm::RS256);

--- a/relay/tests/blob_gc.rs
+++ b/relay/tests/blob_gc.rs
@@ -101,6 +101,9 @@ async fn delete_doc(http: &str, token: &str, doc_id: &str) -> reqwest::StatusCod
         .status()
 }
 
+/// The blob half of the storage meter. This suite exercises blob ACL/GC
+/// lifecycle, so it reads `blobBytes` rather than the combined `storageBytes`
+/// (which since JP-443 also carries the referencing documents' JSON bytes).
 async fn usage_storage(http: &str, token: &str) -> u64 {
     let v: Value = reqwest::Client::new()
         .get(format!("{http}/api/v1/usage"))
@@ -111,7 +114,7 @@ async fn usage_storage(http: &str, token: &str) -> u64 {
         .json()
         .await
         .expect("usage json");
-    v["storageBytes"].as_u64().expect("storageBytes")
+    v["blobBytes"].as_u64().expect("blobBytes")
 }
 
 #[tokio::test]

--- a/relay/tests/free_tier_enforcement.rs
+++ b/relay/tests/free_tier_enforcement.rs
@@ -154,6 +154,171 @@ async fn blob_upload_returns_507_over_quota_but_dedup_reupload_is_free() {
     assert_eq!(usage["storageQuota"], 15);
 }
 
+async fn put_doc(http: &str, token: &str, id: &str, doc: &Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .put(format!("{http}/api/docs/{id}"))
+        .bearer_auth(token)
+        .json(doc)
+        .send()
+        .await
+        .expect("doc save request")
+}
+
+/// A minimal doc body owned by `sub` (so delete-permission checks pass) with
+/// a `filler` payload to control its serialized size.
+fn doc_body(id: &str, sub: &str, filler_len: usize) -> Value {
+    json!({
+        "id": id,
+        "name": "Metered",
+        "ownerId": sub,
+        "filler": "x".repeat(filler_len),
+    })
+}
+
+// ---- JP-443: document bytes join the single storage meter ----
+
+#[tokio::test]
+async fn doc_bytes_count_toward_usage_and_507_is_delta_aware() {
+    let (_server, http, _ws_base, issuer, _tmp) = start_relay().await;
+    let token = issuer.mint_with_limits("user-e", "epsilon", WorkspaceRole::Owner, Some(4096), None);
+
+    // A small doc lands and its serialized bytes appear on the meter.
+    let resp = put_doc(&http, &token, "meter-doc", &doc_body("meter-doc", "user-e", 16)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let usage = get_usage(&http, &token).await;
+    let small = usage["docBytes"].as_u64().expect("docBytes present");
+    assert!(small > 0, "doc bytes metered: {usage}");
+    assert_eq!(usage["blobBytes"], 0);
+    assert_eq!(usage["storageBytes"], small, "storageBytes = docBytes + blobBytes");
+    assert_eq!(usage["storageQuota"], 4096);
+
+    // Growing past the quota is refused with 507 + the stable body string.
+    let resp = put_doc(&http, &token, "meter-doc", &doc_body("meter-doc", "user-e", 8192)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::INSUFFICIENT_STORAGE);
+    assert!(resp.text().await.unwrap().contains("storage quota exceeded"));
+
+    // Delta-aware: a growing save that still FITS lands…
+    let resp = put_doc(&http, &token, "meter-doc", &doc_body("meter-doc", "user-e", 1024)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    // …and a shrinking save is always accepted.
+    let resp = put_doc(&http, &token, "meter-doc", &doc_body("meter-doc", "user-e", 16)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    // Delete frees the metered bytes (the dig-out path).
+    let resp = reqwest::Client::new()
+        .delete(format!("{http}/api/docs/meter-doc"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("doc delete request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let usage = get_usage(&http, &token).await;
+    assert_eq!(usage["docBytes"], 0, "delete releases doc bytes: {usage}");
+}
+
+#[tokio::test]
+async fn blob_upload_507_when_docs_consume_quota() {
+    let (_server, http, _ws_base, issuer, _tmp) = start_relay().await;
+    let token = issuer.mint_with_limits("user-f", "zeta", WorkspaceRole::Owner, Some(2048), None);
+
+    // Park ~600+ bytes of document on the meter.
+    let resp = put_doc(&http, &token, "hog-doc", &doc_body("hog-doc", "user-f", 600)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let usage = get_usage(&http, &token).await;
+    let doc_bytes = usage["docBytes"].as_u64().unwrap();
+    assert!(doc_bytes > 600);
+
+    // A blob that would fit a doc-less quota no longer does: docs + blobs
+    // share the single meter.
+    let big_blob = vec![7u8; 1600];
+    assert_eq!(
+        upload_blob(&http, &token, &big_blob).await,
+        reqwest::StatusCode::INSUFFICIENT_STORAGE
+    );
+    // A smaller blob that fits alongside the doc is granted.
+    let small_blob = vec![9u8; 512];
+    assert_eq!(upload_blob(&http, &token, &small_blob).await, reqwest::StatusCode::OK);
+    let usage = get_usage(&http, &token).await;
+    assert_eq!(usage["blobBytes"], 512);
+    assert_eq!(
+        usage["storageBytes"].as_u64().unwrap(),
+        doc_bytes + 512,
+        "combined meter: {usage}"
+    );
+}
+
+#[tokio::test]
+async fn doc_save_413_over_minted_max_doc_bytes() {
+    let (_server, http, _ws_base, issuer, _tmp) = start_relay().await;
+    let token =
+        issuer.mint_with_max_doc_bytes("user-g", "eta", WorkspaceRole::Owner, Some(300));
+    let usage = get_usage(&http, &token).await;
+    assert_eq!(usage["maxDocBytes"], 300, "ceiling surfaces on usage: {usage}");
+
+    // Over the per-document ceiling → 413 with the typed body.
+    let resp = put_doc(&http, &token, "cap-doc", &doc_body("cap-doc", "user-g", 1024)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+    let body: Value = resp.json().await.expect("typed 413 body");
+    assert_eq!(body["errorCode"], "DOC_TOO_LARGE");
+    assert_eq!(body["maxBytes"], 300);
+    assert!(body["sizeBytes"].as_u64().unwrap() > 300);
+
+    // Under the ceiling → lands.
+    let resp = put_doc(&http, &token, "cap-doc", &doc_body("cap-doc", "user-g", 8)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// The JP-443 observability series ride /metrics: the doc-bytes half of the
+/// storage meter, the on-volume cache footprint, the over-cap snapshot
+/// counter, and (on unix) the data-dir volume gauges.
+#[tokio::test]
+async fn metrics_expose_doc_bytes_and_volume_series() {
+    let (_server, http, _ws_base, issuer, _tmp) = start_relay().await;
+    let token = issuer.mint_with_limits("user-m", "mu", WorkspaceRole::Owner, None, None);
+    let resp = put_doc(&http, &token, "metric-doc", &doc_body("metric-doc", "user-m", 64)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let usage = get_usage(&http, &token).await;
+    let doc_bytes = usage["docBytes"].as_u64().unwrap();
+
+    let body = reqwest::Client::new()
+        .get(format!("{http}/metrics"))
+        .send()
+        .await
+        .expect("metrics request")
+        .text()
+        .await
+        .expect("metrics body");
+    assert!(
+        body.contains(&format!("relay_doc_bytes_total {doc_bytes}")),
+        "doc-bytes gauge must match usage: {body}"
+    );
+    assert!(body.contains("relay_doc_cache_bytes "), "cache footprint gauge: {body}");
+    assert!(
+        body.contains("relay_doc_over_cap_snapshots_total 0"),
+        "over-cap counter present at 0: {body}"
+    );
+    #[cfg(unix)]
+    {
+        assert!(body.contains("relay_volume_total_bytes "), "volume total gauge: {body}");
+        assert!(body.contains("relay_volume_used_bytes "), "volume used gauge: {body}");
+        assert!(body.contains("relay_volume_available_bytes "), "volume avail gauge: {body}");
+    }
+}
+
+/// Regression for the implicit Axum 2 MiB body limit (the doc-route sibling
+/// of JP-125): an uncapped relay must accept a multi-MiB document body.
+#[tokio::test]
+async fn large_doc_body_not_413_by_default() {
+    let (_server, http, _ws_base, issuer, _tmp) = start_relay().await;
+    let token = issuer.mint_with_limits("user-h", "theta", WorkspaceRole::Owner, None, None);
+
+    let resp =
+        put_doc(&http, &token, "big-doc", &doc_body("big-doc", "user-h", 3 * 1024 * 1024)).await;
+    assert_eq!(resp.status(), reqwest::StatusCode::OK, "3 MiB doc body must not 413");
+    let usage = get_usage(&http, &token).await;
+    assert!(usage["docBytes"].as_u64().unwrap() > 3 * 1024 * 1024);
+}
+
 /// Minimal WS client: connect + auth, returning the parsed `AUTH_RESPONSE`.
 /// The auth payload is a JSON-encoded bare string (not `{"token": ...}`),
 /// matching `handle_auth`. Lifted from `tests/metering_conn_counts.rs`.


### PR DESCRIPTION
## What

Closes the storage-metering gap where document JSON bytes were entirely unmetered (only blobs counted), plus adds volume observability for the relay pod.

### Metering (single meter: docs + blobs)
- `DocumentMetadata.sizeBytes` recorded at every write seam (save / snapshot / restore), carried in the mirrored `index.json` so accounting **survives JP-231 eviction + R2 restore**. Boot backfill stats local bodies for legacy entries; evicted legacy entries self-heal on next save (with a deliberate one-save leniency instead of a false-507 lockout).
- **Delta-aware 507** on REST `PUT /api/docs/:id` and (new — previously completely ungated) MCP document writes: only a *growing* save that lands over quota is refused. Shrinking/equal saves and deletes always pass, so users can dig out of an over-quota state by removing content — the escape hatch the over-quota UX (follow-up PR) points at.
- Blob paths now gate against the quota **remaining after doc bytes** (`blob_quota_remaining`), with unchanged `BlobStore` signatures.
- Recovery-point restore is deliberately quota-exempt (it deletes the source doc, so net growth ≈ 0) but still honors the per-document ceiling.

### Per-document size ceiling (operational abuse guard, not metered)
- Optional `max_doc_bytes` JWT claim + `[tenancy.limits].max_doc_bytes` / `RELAY_MAX_DOC_BYTES` fallback (default 0 = no ceiling; self-host unconstrained).
- REST: typed 413 `DOC_TOO_LARGE` body; MCP: `ERR_DOC_TOO_LARGE`. Collaborative flushes are **never** refused — over-cap snapshots are logged + counted instead.
- Doc routes get an explicit `DefaultBodyLimit` (128 MiB floor, +25% slack above a larger config cap), replacing the silent Axum 2 MiB default that 413'd legit >2 MiB doc saves. The transport ceiling is deliberately decoupled from the claim-resolved cap so a claim larger than the pod's config fallback isn't opaquely refused before the gate.

### Wire (additive, non-breaking)
- `GET /api/v1/usage`: `storageBytes` becomes the doc+blob sum (shape unchanged); new `docBytes`, `blobBytes`, `maxDocBytes`. MCP `get_storage` mirrors the split. Doc listings carry `sizeBytes`.

### Observability
- `/metrics`: `relay_doc_bytes_total` (durable index sum), `relay_doc_cache_bytes` (on-volume json+ydoc+recovery footprint — the delta vs doc bytes is the unmetered sidecar/ring overhead), `relay_doc_over_cap_snapshots_total`, and statvfs volume gauges `relay_volume_{total,used,available}_bytes` on the data dir (unix-only, absent ≠ 0).

### Docs
`token-format.md` (claim + resolution + delta semantics), `openapi.yaml` (adds the previously-missing `/api/v1/usage` path + 413/507 on PUT docs; docs-site copy synced), MCP README, relay README env-table row (drift-tested).

## Verification
- `cargo check --all-targets` clean; **full test suite green** (756 lib tests + all integration suites).
- New coverage: delta-507 grow/shrink/delete over HTTP, blob-507-when-docs-consume-quota, minted `max_doc_bytes` → typed 413, >2 MiB body regression, metrics series assertions, MCP `ERR_STORAGE_QUOTA`/`ERR_DOC_TOO_LARGE` parity, index backfill, legacy-leniency self-heal.

Part of JP-443 (relay slice). Follow-ups: editor over-quota UX (app), tier mapping + webmaster volume card (web).

Assisted-by: Fable 5