### PR TITLE
JP-443: over-quota UX — at-cap callout, dig-out toasts, doc sizes

### DIFF
--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -120,8 +120,15 @@ export interface RelayCollectionDef {
  * `null` quota/limit means unlimited. Counts only — no doc ids or content.
  */
 export interface RelayUsage {
+  /** Combined storage: document + file bytes (JP-443 — the metered total). */
   storageBytes: number;
   storageQuota: number | null;
+  /** Document half of `storageBytes`. Absent on pre-JP-443 relays. */
+  docBytes?: number;
+  /** File (blob) half of `storageBytes`. Absent on pre-JP-443 relays. */
+  blobBytes?: number;
+  /** Per-document size ceiling; `null` = none. Absent on pre-JP-443 relays. */
+  maxDocBytes?: number | null;
   activeEditors: number;
   editorLimit: number | null;
 }

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -279,6 +279,7 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
               existing.name === record.name &&
               existing.modifiedAt === record.modifiedAt &&
               existing.pageCount === record.pageCount &&
+              existing.sizeBytes === record.sizeBytes &&
               tagsEqual(existing.tags, record.tags)
             ) {
               continue;

--- a/src/store/persistenceStore.offlineRelaySave.test.ts
+++ b/src/store/persistenceStore.offlineRelaySave.test.ts
@@ -204,8 +204,30 @@ describe('pushRelaySaveOrQueue — connected-save failure handling (JP-127)', ()
     await flush();
 
     expect(errorSpy).toHaveBeenCalled();
+    // JP-443: the copy teaches the escape hatch (move a doc to personal /
+    // delete files), not just "free up space".
+    expect(String(errorSpy.mock.calls[0]?.[0])).toMatch(/personal space/i);
     // Terminal: a blind replay can't fix it, so don't queue — but the local
     // copy is kept (not dropped), and reattach won't clobber it.
+    expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('surfaces a document-too-large (413) failure without queuing (JP-443)', async () => {
+    const err = Object.assign(new Error('DOC_TOO_LARGE'), { status: 413 });
+    const saveToHost = vi.fn(async () => {
+      throw err;
+    });
+    useRelayDocumentStore.setState({ authenticated: true, saveToHost } as never);
+    saveDocumentToStorage(makeRelayDoc('relay-toolarge'));
+    const errorSpy = vi.spyOn(useNotificationStore.getState(), 'error');
+
+    saveDocumentPdfSettings('relay-toolarge', pdfSettings);
+    await flush();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0]?.[0])).toMatch(/size limit/i);
+    // Terminal like 507: retrying can't help until content shrinks.
     expect(syncManagerMock.queueSave).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -180,7 +180,8 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
         if (/quota exceeded/i.test(message)) {
           useNotificationStore.getState().error(
             'A file you added is out of storage room and was not uploaded — it’s kept ' +
-              'locally and will upload once you free up space.',
+              'locally and will upload once you free up space. Move a document to your ' +
+              'personal space or delete files to free room.',
             { category: 'permanent' },
           );
         } else {
@@ -243,7 +244,19 @@ function pushRelaySaveOrQueue(doc: DiagramDocument, context: string): void {
     // error wrapper in `saveToHost` (the thrown Error has no `status`).
     if (status === 507 || /quota exceeded/i.test(message)) {
       useNotificationStore.getState().error(
-        'Save failed: the workspace is out of storage. Free up space and try again — ' +
+        'Save failed: the workspace is out of storage. Move a document to your ' +
+          'personal space or delete files to free room — your local copy is kept ' +
+          'and was not lost.',
+        { category: 'permanent' },
+      );
+      return;
+    }
+    // JP-443: the relay refuses a document over the per-document size ceiling
+    // with 413 (`DOC_TOO_LARGE`). Retrying can't help until content shrinks.
+    if (status === 413 || /DOC_TOO_LARGE/.test(message)) {
+      useNotificationStore.getState().error(
+        'Save failed: this document is over the synced-document size limit. ' +
+          'Split content into another document or attach large data as files — ' +
           'your local copy is kept and was not lost.',
         { category: 'permanent' },
       );

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -200,6 +200,11 @@ export interface DocumentMetadata {
   /** Free-form organizational tags (JP-388); absent = untagged. Lifted by the
    *  relay from the document body's `tags`. */
   tags?: string[];
+  /** Serialized size of the stored document body in bytes (JP-443) — recorded
+   *  by the relay at write time; counts toward the workspace storage meter.
+   *  Absent on local docs and on relay entries written before size
+   *  recording. */
+  sizeBytes?: number;
 }
 
 /**

--- a/src/types/DocumentRegistry.test.ts
+++ b/src/types/DocumentRegistry.test.ts
@@ -69,3 +69,25 @@ describe('isForeignRelayDoc', () => {
     expect(isForeignRelayDoc(local, 'relay-b:9876')).toBe(false);
   });
 });
+
+// JP-443: `sizeBytes` (the relay-recorded metered size) must survive every
+// record conversion — including the cached round-trip an offline session
+// takes — or the browser's Size detail silently vanishes.
+describe('sizeBytes conversion carry (JP-443)', () => {
+  it('carries through remote → cached → remote, and omits when absent', async () => {
+    const { toRemoteDocument, toCachedDocument, toRemoteFromCached, toLocalDocument } =
+      await import('./DocumentRegistry');
+    const meta = { ...base, sizeBytes: 4096 };
+
+    const rem = toRemoteDocument(meta, 'relay-a:9876', 'ws-1', 'owner');
+    expect(rem.sizeBytes).toBe(4096);
+    const cach = toCachedDocument(rem);
+    expect(cach.sizeBytes).toBe(4096);
+    expect(toRemoteFromCached(cach).sizeBytes).toBe(4096);
+    expect(toLocalDocument(meta).sizeBytes).toBe(4096);
+
+    // Absent stays absent (exactOptionalPropertyTypes: no `undefined` key).
+    const bare = toRemoteDocument(base, 'relay-a:9876', 'ws-1', 'owner');
+    expect('sizeBytes' in bare).toBe(false);
+  });
+});

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -51,6 +51,10 @@ export interface DocumentEntryBase {
   modifiedAt: number;
   /** Free-form organizational tags (JP-388); absent = untagged. */
   tags?: string[];
+  /** Serialized size of the stored body in bytes (JP-443) — relay-recorded,
+   *  counts toward the workspace storage meter. Absent on local docs and on
+   *  entries from relays that predate size recording. */
+  sizeBytes?: number;
 }
 
 /**
@@ -204,6 +208,7 @@ export function toLocalDocument(metadata: DocumentMetadata): LocalDocument {
     createdAt: metadata.createdAt,
     modifiedAt: metadata.modifiedAt,
     ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
+    ...(metadata.sizeBytes !== undefined ? { sizeBytes: metadata.sizeBytes } : {}),
   };
 }
 
@@ -225,6 +230,7 @@ export function toRemoteDocument(
     createdAt: metadata.createdAt,
     modifiedAt: metadata.modifiedAt,
     ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
+    ...(metadata.sizeBytes !== undefined ? { sizeBytes: metadata.sizeBytes } : {}),
     relayId,
     workspaceId,
     ownerId: metadata.ownerId ?? '',
@@ -247,6 +253,7 @@ export function toCachedDocument(remote: RemoteDocument): CachedDocument {
     createdAt: remote.createdAt,
     modifiedAt: remote.modifiedAt,
     ...(remote.tags !== undefined ? { tags: remote.tags } : {}),
+    ...(remote.sizeBytes !== undefined ? { sizeBytes: remote.sizeBytes } : {}),
     relayId: remote.relayId,
     workspaceId: remote.workspaceId,
     originalDocId: remote.id,
@@ -268,6 +275,7 @@ export function toRemoteFromCached(cached: CachedDocument, syncState: SyncState 
     createdAt: cached.createdAt,
     modifiedAt: cached.modifiedAt,
     ...(cached.tags !== undefined ? { tags: cached.tags } : {}),
+    ...(cached.sizeBytes !== undefined ? { sizeBytes: cached.sizeBytes } : {}),
     relayId: cached.relayId,
     workspaceId: cached.workspaceId,
     ownerId: '', // Will be populated from host

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -38,6 +38,7 @@ import {
   type DropdownMenuEntry,
 } from './components/DropdownMenu';
 import { confirmDialog } from './confirm/confirmStore';
+import { formatFileSize } from '../utils/fileUtils';
 import { TagChips } from './TagChips';
 import { TagEditorPopover } from './TagEditorPopover';
 import './DocumentCard.css';
@@ -743,6 +744,14 @@ function DocumentCardImpl({
               <dt>Pages</dt>
               <dd>{record.pageCount}</dd>
             </div>
+            {typeof record.sizeBytes === 'number' && (
+              /* JP-443: the doc's metered size — makes "move the big one to
+                 personal / delete it to free space" actionable at a glance. */
+              <div className="document-card__detail">
+                <dt>Size</dt>
+                <dd>{formatFileSize(record.sizeBytes)}</dd>
+              </div>
+            )}
             <div className="document-card__detail">
               <dt>Created</dt>
               <dd>{formatDate(record.createdAt)}</dd>

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -309,6 +309,45 @@
   background: var(--brand-gold);
   transition: width 0.3s ease;
 }
+.dh-storage-fill--over {
+  background: var(--danger);
+}
+
+/* JP-443: at-cap callout under the storage meters — the ways out of a full
+   cloud workspace (manage documents / open the web account). */
+.dh-cap-note {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 8px 9px;
+  border: 1px solid
+    color-mix(in srgb, var(--danger) 35%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+}
+.dh-cap-note-text {
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+.dh-cap-note-actions {
+  display: flex;
+  gap: 6px;
+}
+.dh-cap-note-btn {
+  padding: 3px 9px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-pill);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+.dh-cap-note-btn:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+}
 
 .dh-user {
   display: flex;

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -246,6 +246,9 @@ export function DocumentsHome({
   // same authed REST provider as document CRUD (`GET /api/v1/usage`). Distinct
   // from the local on-device cache above; surfaced as its own labelled meter.
   const [relayUsage, setRelayUsage] = useState<RelayUsage | null>(null);
+  // Keyed on `mainView` too (JP-443): returning from the storage view — where
+  // a document may have been moved to personal or deleted to free space —
+  // re-polls, so the meter (and the at-cap callout) reflects the freed bytes.
   useEffect(() => {
     if (!signedIn) {
       setRelayUsage(null);
@@ -264,7 +267,16 @@ export function DocumentsHome({
     return () => {
       cancelled = true;
     };
-  }, [signedIn]);
+  }, [signedIn, mainView]);
+
+  // JP-443: the cloud workspace is at (or over) its storage quota — new
+  // uploads and growing saves are being refused by the relay. Drives the
+  // meter's over-state and the callout offering the ways out.
+  const atCloudCap =
+    relayUsage !== null &&
+    relayUsage.storageQuota !== null &&
+    relayUsage.storageQuota > 0 &&
+    relayUsage.storageBytes >= relayUsage.storageQuota;
 
   // Cloud account portal URL (docushark-web). Seeded from the persisted
   // connection's cloud base, falling back to the default. The bottom-left user
@@ -502,9 +514,27 @@ export function DocumentsHome({
                 used={relayUsage ? relayUsage.storageBytes : null}
                 quota={relayUsage ? relayUsage.storageQuota : null}
                 pending={relayUsage === null}
+                over={atCloudCap}
               />
             )}
           </button>
+
+          {signedIn && atCloudCap && (
+            <div className="dh-cap-note" role="status">
+              <span className="dh-cap-note-text">
+                Cloud storage is full. Move a document to this device or delete
+                files to free space.
+              </span>
+              <span className="dh-cap-note-actions">
+                <button className="dh-cap-note-btn" onClick={() => goMainView('storage')}>
+                  Manage
+                </button>
+                <button className="dh-cap-note-btn" onClick={openWebAccount}>
+                  Account
+                </button>
+              </span>
+            </div>
+          )}
 
           <div className="dh-user">
             <button
@@ -749,11 +779,14 @@ function StorageMeter({
   used,
   quota,
   pending,
+  over = false,
 }: {
   label: string;
   used: number | null;
   quota: number | null;
   pending: boolean;
+  /** At/over quota (JP-443) — renders the fill in the danger color. */
+  over?: boolean;
 }) {
   const pct = used !== null && quota !== null && quota > 0 ? Math.min(100, (used / quota) * 100) : null;
   const value = pending
@@ -771,7 +804,10 @@ function StorageMeter({
       </div>
       {pct !== null && (
         <div className="dh-storage-bar">
-          <div className="dh-storage-fill" style={{ width: `${pct}%` }} />
+          <div
+            className={`dh-storage-fill${over ? ' dh-storage-fill--over' : ''}`}
+            style={{ width: `${pct}%` }}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## What

The editor half of JP-443 (relay slice: #405). When the cloud workspace hits its storage quota, the user now sees it and gets the ways out.

- **At-cap callout + red meter** (DocumentsHome): derived from the existing usage poll; callout under the Cloud storage meter with **Manage** (storage view) and **Account** (web portal) actions. Usage re-polls when returning from the storage view so freed bytes reflect immediately.
- **Dig-out toasts** (persistenceStore): both 507 copies now teach the escape hatch — "move a document to your personal space or delete files to free room" (moving a doc to personal deletes its relay copy, which the relay's delta-aware gate always allows). New terminal **413 `DOC_TOO_LARGE`** branch with its own copy.
- **Doc sizes surfaced**: `RelayUsage` gains optional `docBytes`/`blobBytes`/`maxDocBytes`; `sizeBytes` rides the doc listing into `DocumentRecord` (surviving the remote → cached → remote conversion) and shows as a Size detail on `DocumentCard` — so "move the big one" is actionable.

Degrades gracefully against pre-#405 relays: every new field is optional, and the at-cap derivation works off the existing `storageBytes`/`storageQuota` pair.

## Verification

- `tsc` clean; full vitest suite green (**3033 tests**), including new coverage: 507 copy teaches the escape hatch, 413 is terminal (no queue, local copy kept), `sizeBytes` conversion carry + absent-stays-absent (exactOptionalPropertyTypes).
- Manual E2E recipe (needs #405's relay): run a local relay with `RELAY_STORAGE_QUOTA_BYTES=4096`, fill the workspace → red meter + callout appear, doc save 507 toast shows the new copy, move-to-personal drops the meter below cap and the callout clears on returning Home.

Part of JP-443. Independent of #405 (safe to merge in either order).

Assisted-by: Fable 5