### PR TITLE
JP-444: Dashboard design pass — DocumentsHome to kit fidelity

### DIFF
--- a/docs-site/getting-started/quick-start.md
+++ b/docs-site/getting-started/quick-start.md
@@ -9,13 +9,13 @@ Let's create your first diagram. This should take about five minutes.
 
 ## Create a New Document
 
-1. **Launch DocuShark** — Open the application. You'll see the Document Browser with your recent documents.
+1. **Launch DocuShark** — Open the application. You'll land on the **Documents** home: your library, with preview cards of what you worked on recently once you have a few documents.
 
-2. **Create a new document** — Click the **+ New Document** button or press `Ctrl+N` (`Cmd+N` on Mac).
+2. **Create a new document** — Click the gold **New** button in the top-right. The document opens immediately.
 
-3. **Name your document** — Enter a name for your diagram and click **Create**.
+3. **Name your document** — Click its name (“Untitled Document”) in the toolbar and type a new one.
 
-Your document opens with an infinite canvas ready for drawing.
+Your document opens with an infinite canvas ready for drawing. To get back to your library at any time, click **Documents** in the top-left.
 
 ## Add Your First Shapes
 

--- a/docs-site/guide/keyboard-shortcuts.md
+++ b/docs-site/guide/keyboard-shortcuts.md
@@ -12,6 +12,7 @@ Most things in DocuShark have a shortcut. If you ever forget one, you don't need
 | Action | Shortcut |
 |--------|----------|
 | Command palette | `Ctrl+K` / `Cmd+K` |
+| Search your library (Documents home) | `/` or `Ctrl+K` |
 | Select tool | `V` |
 | Connector tool | `C` |
 | Undo / Redo | `Ctrl+Z` / `Ctrl+Shift+Z` |

--- a/docs-site/guide/sharing-and-access.md
+++ b/docs-site/guide/sharing-and-access.md
@@ -9,7 +9,7 @@ Once a document lives in a workspace (see [Collaboration](./collaboration)), you
 
 ## Sharing a document
 
-Only a document's **owner** can manage its access. Open **Manage Access** from the document menu:
+Only a document's **owner** can manage its access. Open **Manage Access** from the document menu — or click the **People** avatars on the document's row in your library, which show the owner and everyone it's shared with:
 
 1. Pick a member from your workspace roster and choose their permission — **Viewer** (read-only) or **Editor** (can make changes)
 2. Click **Add** — they now appear in the current shares list
@@ -17,6 +17,10 @@ Only a document's **owner** can manage its access. Open **Manage Access** from t
 4. Save your changes
 
 You can only share with people already in your workspace — invite them first (see below) if they're not listed yet. If someone's access was granted and they've since left the workspace, they're flagged as a **former member** so you can clean up the stale grant.
+
+### Finding documents shared with you
+
+The Documents home sidebar has a **Shared with me** filter (shown while you're signed in to a workspace): it lists the workspace documents owned by someone else that you can see. Each row's **People** column tells you at a glance who owns a document and who else is on it.
 
 ### Transferring ownership
 

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -24,7 +24,9 @@ export type DocumentBrowserSort =
   | 'modified-asc'
   | 'name-asc'
   | 'name-desc'
-  | 'created-desc';
+  | 'created-desc'
+  | 'size-desc'
+  | 'size-asc';
 export type DocumentBrowserGroupBy = 'none' | 'collection';
 
 /**

--- a/src/types/DocumentRegistry.test.ts
+++ b/src/types/DocumentRegistry.test.ts
@@ -91,3 +91,48 @@ describe('sizeBytes conversion carry (JP-443)', () => {
     expect('sizeBytes' in bare).toBe(false);
   });
 });
+
+// JP-444: owner + share metadata must survive the cached round-trip, or the
+// People column and the "Shared with me" filter go blind after an offline
+// spell (`toRemoteFromCached` used to blank the owner unconditionally).
+describe('share metadata conversion carry (JP-444)', () => {
+  it('carries owner, sharedWith, and lastModifiedByName through remote → cached → remote', async () => {
+    const { toRemoteDocument, toCachedDocument, toRemoteFromCached } =
+      await import('./DocumentRegistry');
+    const shares = [{ userId: 'u2', userName: 'Bea', permission: 'edit' as const, sharedAt: 1 }];
+    const meta = {
+      ...base,
+      ownerId: 'u1',
+      ownerName: 'Ada',
+      sharedWith: shares,
+      lastModifiedByName: 'Bea',
+    };
+
+    const rem = toRemoteDocument(meta, 'relay-a:9876', 'ws-1', 'editor');
+    expect(rem.sharedWith).toEqual(shares);
+    expect(rem.lastModifiedByName).toBe('Bea');
+
+    const cach = toCachedDocument(rem);
+    expect(cach.ownerId).toBe('u1');
+    expect(cach.ownerName).toBe('Ada');
+    expect(cach.sharedWith).toEqual(shares);
+    expect(cach.lastModifiedByName).toBe('Bea');
+
+    const back = toRemoteFromCached(cach);
+    expect(back.ownerId).toBe('u1');
+    expect(back.ownerName).toBe('Ada');
+    expect(back.sharedWith).toEqual(shares);
+    expect(back.lastModifiedByName).toBe('Bea');
+  });
+
+  it('omits absent share metadata and never resurrects a blank owner', async () => {
+    const { toRemoteDocument, toCachedDocument, toRemoteFromCached } =
+      await import('./DocumentRegistry');
+    const cach = toCachedDocument(toRemoteDocument(base, 'relay-a:9876', 'ws-1', 'owner'));
+    expect('sharedWith' in cach).toBe(false);
+    expect('lastModifiedByName' in cach).toBe(false);
+    expect('ownerId' in cach).toBe(false);
+    // Promoting an owner-less cache keeps the legacy blank-string sentinel.
+    expect(toRemoteFromCached(cach).ownerId).toBe('');
+  });
+});

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -7,7 +7,7 @@
  * Phase 14.1 Collaboration Overhaul
  */
 
-import type { DocumentMetadata, DiagramDocument } from './Document';
+import type { DocumentMetadata, DocumentShare, DiagramDocument } from './Document';
 
 // ============ Permission Types ============
 
@@ -90,6 +90,11 @@ export interface RemoteDocument extends DocumentEntryBase {
   syncState: SyncState;
   /** Timestamp of last successful sync */
   lastSyncedAt: number;
+  /** Users the document is shared with (JP-444) — relay-provided; absent when
+   *  the doc has no explicit shares or the relay predates share metadata. */
+  sharedWith?: DocumentShare[];
+  /** Display name of the last editor (JP-444); absent on older relay entries. */
+  lastModifiedByName?: string;
 }
 
 /**
@@ -111,6 +116,14 @@ export interface CachedDocument extends DocumentEntryBase {
   pendingChanges: number;
   /** Permission level (preserved from when online) */
   permission: Permission;
+  /** Owner id/name preserved from when online (JP-444) — optional so cached
+   *  snapshots persisted before these fields hydrate cleanly. */
+  ownerId?: string;
+  ownerName?: string;
+  /** Shares preserved from when online (JP-444). */
+  sharedWith?: DocumentShare[];
+  /** Last editor's display name preserved from when online (JP-444). */
+  lastModifiedByName?: string;
 }
 
 /** Discriminated union of all document record types */
@@ -231,6 +244,10 @@ export function toRemoteDocument(
     modifiedAt: metadata.modifiedAt,
     ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
     ...(metadata.sizeBytes !== undefined ? { sizeBytes: metadata.sizeBytes } : {}),
+    ...(metadata.sharedWith !== undefined ? { sharedWith: metadata.sharedWith } : {}),
+    ...(metadata.lastModifiedByName !== undefined
+      ? { lastModifiedByName: metadata.lastModifiedByName }
+      : {}),
     relayId,
     workspaceId,
     ownerId: metadata.ownerId ?? '',
@@ -260,6 +277,12 @@ export function toCachedDocument(remote: RemoteDocument): CachedDocument {
     cachedAt: Date.now(),
     pendingChanges: 0,
     permission: remote.permission,
+    ...(remote.ownerId !== '' ? { ownerId: remote.ownerId } : {}),
+    ...(remote.ownerName !== '' ? { ownerName: remote.ownerName } : {}),
+    ...(remote.sharedWith !== undefined ? { sharedWith: remote.sharedWith } : {}),
+    ...(remote.lastModifiedByName !== undefined
+      ? { lastModifiedByName: remote.lastModifiedByName }
+      : {}),
   };
 }
 
@@ -276,10 +299,15 @@ export function toRemoteFromCached(cached: CachedDocument, syncState: SyncState 
     modifiedAt: cached.modifiedAt,
     ...(cached.tags !== undefined ? { tags: cached.tags } : {}),
     ...(cached.sizeBytes !== undefined ? { sizeBytes: cached.sizeBytes } : {}),
+    ...(cached.sharedWith !== undefined ? { sharedWith: cached.sharedWith } : {}),
+    ...(cached.lastModifiedByName !== undefined
+      ? { lastModifiedByName: cached.lastModifiedByName }
+      : {}),
     relayId: cached.relayId,
     workspaceId: cached.workspaceId,
-    ownerId: '', // Will be populated from host
-    ownerName: '',
+    // Preserved owner when the cache captured it; the host refetch repopulates.
+    ownerId: cached.ownerId ?? '',
+    ownerName: cached.ownerName ?? '',
     permission: cached.permission,
     syncState,
     lastSyncedAt: cached.cachedAt,

--- a/src/ui/DocumentCard.actions.test.tsx
+++ b/src/ui/DocumentCard.actions.test.tsx
@@ -1,9 +1,11 @@
 /**
  * DocumentCard actions (JP-385 facelift): two visible quick actions
  * (contextual transfer + Trash) and an overflow menu holding the rest.
- * Pins the delete policy split — soft delete is one click (the model owns
- * confirm/Undo policy), permanent delete always routes through the styled
- * danger confirm — and that the overflow renders only granted actions.
+ * Pins the delete policy split — the always-visible Trash quick-action is
+ * confirm-guarded for local/cached docs (JP-444: it's one misclick away)
+ * while remote docs defer to the model's shared-impact dialog, and permanent
+ * delete always routes through the styled danger confirm — and that the
+ * overflow renders only granted actions.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -37,15 +39,41 @@ describe('DocumentCard — actions', () => {
     confirmMock.mockReset();
   });
 
-  it('soft delete is a single click with no inline confirm UI', () => {
+  it('the Trash quick-action confirms before soft-deleting a local doc (JP-444)', async () => {
     const onDelete = vi.fn();
+    confirmMock.mockResolvedValueOnce(false);
     render(<DocumentCard record={record} onDelete={onDelete} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }));
+    await waitFor(() => expect(confirmMock).toHaveBeenCalledTimes(1));
+    // Soft delete is recoverable — the confirm is NOT the danger variant.
+    expect(confirmMock).not.toHaveBeenCalledWith(expect.objectContaining({ danger: true }));
+    expect(onDelete).not.toHaveBeenCalled();
 
-    expect(onDelete).toHaveBeenCalledWith('l1');
+    confirmMock.mockResolvedValueOnce(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }));
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith('l1'));
+    expect(screen.queryByText('Delete?')).toBeNull(); // old 3-state inline confirm is gone
+  });
+
+  it('the Trash quick-action skips the card confirm for remote docs (the model owns that dialog)', () => {
+    const onDelete = vi.fn();
+    const remote = {
+      ...record,
+      type: 'remote' as const,
+      relayId: 'relay-a:9876',
+      workspaceId: 'ws-1',
+      ownerId: 'u1',
+      ownerName: 'User',
+      permission: 'owner' as const,
+      syncState: 'synced' as const,
+      lastSyncedAt: 0,
+    };
+    render(<DocumentCard record={remote} onDelete={onDelete} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Trash' }));
     expect(confirmMock).not.toHaveBeenCalled();
-    expect(screen.queryByText('Delete?')).toBeNull(); // old 3-state confirm is gone
+    expect(onDelete).toHaveBeenCalledWith('l1');
   });
 
   it('permanent delete goes through the danger confirm and only fires on OK', async () => {

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -377,9 +377,15 @@ button.document-card__offline--action:focus-visible {
   font-size: 10px;
 }
 
-/* Full mode */
+/* Full mode — a table row (JP-444): name column flexes, then fixed
+   last-edited / people / size tracks shared with the DocumentsHome column
+   header via the --dh-col-* variables, then a fixed-width trailing actions
+   area so the size column lines up regardless of how many action buttons a
+   given row's permissions produce. */
 .document-card--full {
-  padding: 14px 16px;
+  align-items: center;
+  padding: 9px 14px;
+  border-radius: 10px;
 }
 
 .document-card--full .document-card__name {
@@ -387,12 +393,45 @@ button.document-card__offline--action:focus-visible {
 }
 
 .document-card--full .document-card__name-row {
-  margin-bottom: 10px;
+  margin-bottom: 4px;
 }
 
 .document-card--full .document-card__meta {
   gap: 10px;
   row-gap: 6px;
+}
+
+/* The modified date moved to its own column cell in full mode. */
+.document-card--full .document-card__date {
+  display: none;
+}
+
+.document-card__cell {
+  flex: 0 0 auto;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.document-card__cell--time {
+  width: var(--dh-col-time, 110px);
+  padding-left: 8px;
+}
+.document-card__cell--people {
+  width: var(--dh-col-people, 108px);
+  padding-left: 8px;
+  display: inline-flex;
+}
+.document-card__cell--size {
+  width: var(--dh-col-size, 76px);
+  text-align: right;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  padding-right: 4px;
+}
+
+.document-card--full .document-card__actions {
+  width: var(--dh-col-actions, 140px);
+  justify-content: flex-end;
 }
 
 /* Compact mode adjustments */
@@ -430,6 +469,21 @@ button.document-card__offline--action:focus-visible {
 .document-card--grid .document-card__actions {
   margin-top: 6px;
   justify-content: flex-end;
+}
+
+/* Grid-card foot (JP-444): people stack + mono size. */
+.document-card__grid-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+}
+.document-card__grid-size {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }
 
 /* Selection checkbox */

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -398,13 +398,28 @@ function DocumentCardImpl({
     [handleRename, record.name]
   );
 
-  // Soft delete is one click (recoverable — the model owns confirm/Undo policy).
+  // The always-visible row/card Trash button is one misclick from trashing a
+  // doc (JP-444) — guard it with a confirm. Remote docs skip the local confirm
+  // because the model already shows its shared-impact dialog (don't stack
+  // two); the overflow menu's "Move to Trash" stays one-step, since opening
+  // the menu is already a deliberate second click.
   const handleTrashClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (onDelete) void onDelete(record.id);
+      if (!onDelete) return;
+      void (async () => {
+        if (record.type !== 'remote') {
+          const ok = await confirmDialog({
+            title: `Move “${record.name}” to Trash?`,
+            message: 'You can restore it from the Trash later.',
+            confirmLabel: 'Move to Trash',
+          });
+          if (!ok) return;
+        }
+        void onDelete(record.id);
+      })();
     },
-    [onDelete, record.id],
+    [onDelete, record.id, record.name, record.type],
   );
 
   // Permanent delete bypasses the Trash — always behind a styled danger

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -143,7 +143,7 @@ function offlineBadge(status: OfflineStatus | undefined): OfflineBadge {
   }
 }
 
-function formatDate(timestamp: number): string {
+export function formatDate(timestamp: number): string {
   const date = new Date(timestamp);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -39,6 +39,7 @@ import {
 } from './components/DropdownMenu';
 import { confirmDialog } from './confirm/confirmStore';
 import { formatFileSize } from '../utils/fileUtils';
+import { PeopleStack } from './home/PeopleStack';
 import { TagChips } from './TagChips';
 import { TagEditorPopover } from './TagEditorPopover';
 import './DocumentCard.css';
@@ -693,9 +694,23 @@ function DocumentCardImpl({
             <TagChips tags={record.tags} onTagClick={onTagClick} />
           )}
 
-          {/* Modified time */}
+          {/* Modified time — hidden in full/list mode, where it lives in its
+              own column cell instead (JP-444). */}
           <span className="document-card__date">{formatDate(record.modifiedAt)}</span>
         </div>
+
+        {/* Grid-card foot (JP-444): people + size in the kit's mono style. */}
+        {mode === 'grid' && (
+          <div className="document-card__grid-foot">
+            <PeopleStack
+              record={record}
+              onOpenAccess={onEditPermissions ? () => onEditPermissions(record.id) : undefined}
+            />
+            {typeof record.sizeBytes === 'number' && (
+              <span className="document-card__grid-size">{formatFileSize(record.sizeBytes)}</span>
+            )}
+          </div>
+        )}
 
         {/* Expandable details panel */}
         {showDetails && isExpanded && (
@@ -767,6 +782,33 @@ function DocumentCardImpl({
           </dl>
         )}
       </div>
+
+      {/* Table cells (JP-444, full/list mode only): last-edited, people, size.
+          Widths come from the shared --dh-col-* tracks so every row lines up
+          under the DocumentsHome column header. */}
+      {mode === 'full' && (
+        <>
+          <span
+            className="document-card__cell document-card__cell--time"
+            title={
+              record.type !== 'local' && record.lastModifiedByName
+                ? `Last edited by ${record.lastModifiedByName}`
+                : undefined
+            }
+          >
+            {formatDate(record.modifiedAt)}
+          </span>
+          <span className="document-card__cell document-card__cell--people">
+            <PeopleStack
+              record={record}
+              onOpenAccess={onEditPermissions ? () => onEditPermissions(record.id) : undefined}
+            />
+          </span>
+          <span className="document-card__cell document-card__cell--size">
+            {typeof record.sizeBytes === 'number' ? formatFileSize(record.sizeBytes) : '—'}
+          </span>
+        </>
+      )}
 
       {/* Details toggle (full mode only) — sibling of actions so it stays visible */}
       {showDetails && (

--- a/src/ui/components/DropdownMenu.test.tsx
+++ b/src/ui/components/DropdownMenu.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { act, render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { DropdownMenu, menuAction, MENU_SEPARATOR, type DropdownMenuEntry } from './DropdownMenu';
 
 function openMenu() {
@@ -122,6 +122,47 @@ describe('DropdownMenu', () => {
     const subPanel = nested.closest('.dropdown-menu__panel--sub') as HTMLElement;
     expect(subPanel).toBeTruthy();
     expect(getComputedStyle(subPanel).visibility).not.toBe('hidden');
+  });
+
+  it('hovering items INSIDE the submenu never closes it; root siblings close it after a grace delay (JP-444)', () => {
+    vi.useFakeTimers();
+    try {
+      renderMenu([
+        menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() }),
+        {
+          kind: 'submenu',
+          id: 'sub',
+          label: 'More…',
+          entries: [menuAction({ id: 'n', label: 'Nested', onSelect: vi.fn() })],
+        },
+      ]);
+      openMenu();
+      fireEvent.click(screen.getByRole('menuitem', { name: 'More…' }));
+      const nested = screen.getByRole('menuitem', { name: 'Nested' });
+
+      // The regression: every action carried the close-on-hover handler, so
+      // hovering the submenu's own items closed the panel out from under the
+      // pointer. Submenu items must be safe to hover indefinitely.
+      fireEvent.mouseEnter(nested);
+      act(() => vi.advanceTimersByTime(1000));
+      expect(screen.getByRole('menuitem', { name: 'Nested' })).toBeTruthy();
+
+      // Clipping a ROOT sibling schedules the close (diagonal travel)…
+      fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Alpha' }));
+      // …but reaching the sub panel within the grace period cancels it.
+      fireEvent.mouseEnter(
+        nested.closest('.dropdown-menu__panel--sub') as HTMLElement,
+      );
+      act(() => vi.advanceTimersByTime(1000));
+      expect(screen.getByRole('menuitem', { name: 'Nested' })).toBeTruthy();
+
+      // Genuinely resting on a root sibling still closes it after the delay.
+      fireEvent.mouseEnter(screen.getByRole('menuitem', { name: 'Alpha' }));
+      act(() => vi.advanceTimersByTime(1000));
+      expect(screen.queryByRole('menuitem', { name: 'Nested' })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('reports open state through onOpenChange', () => {

--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -241,8 +241,24 @@ export function DropdownMenu({
     focusableItems(subPanelRef.current)[0]?.focus({ preventScroll: true });
   }, [openSubId]);
 
+  // Hover-close grace timer (JP-444): moving the pointer diagonally from the
+  // submenu trigger toward the (portaled) sub panel clips the sibling items
+  // below, whose hover used to close the submenu instantly — it vanished
+  // before you could reach it. Sibling hover now *schedules* the close;
+  // reaching the sub panel (or the trigger again) cancels it, while genuinely
+  // resting on a sibling still closes after the grace period.
+  const subCloseTimerRef = useRef<number | null>(null);
+  const cancelScheduledSubClose = useCallback(() => {
+    if (subCloseTimerRef.current !== null) {
+      window.clearTimeout(subCloseTimerRef.current);
+      subCloseTimerRef.current = null;
+    }
+  }, []);
+  useEffect(() => cancelScheduledSubClose, [cancelScheduledSubClose]);
+
   const openSubmenu = useCallback(
     (id: string, anchor: HTMLButtonElement) => {
+      cancelScheduledSubClose();
       // Re-entering the trigger of the already-open submenu must be a no-op:
       // resetting the placement here would hide the panel while the layout
       // effect (keyed on openSubId) never re-runs — the submenu got stuck
@@ -252,14 +268,26 @@ export function DropdownMenu({
       setSubPlacement(null); // measured + placed by the layout effect
       setOpenSubId(id);
     },
-    [openSubId],
+    [openSubId, cancelScheduledSubClose],
   );
 
-  const closeSubmenu = useCallback((refocusAnchor: boolean) => {
-    setOpenSubId(null);
-    setSubPlacement(null);
-    if (refocusAnchor) subAnchorRef.current?.focus();
-  }, []);
+  const closeSubmenu = useCallback(
+    (refocusAnchor: boolean) => {
+      cancelScheduledSubClose();
+      setOpenSubId(null);
+      setSubPlacement(null);
+      if (refocusAnchor) subAnchorRef.current?.focus();
+    },
+    [cancelScheduledSubClose],
+  );
+
+  const scheduleSubmenuClose = useCallback(() => {
+    if (openSubId === null || subCloseTimerRef.current !== null) return;
+    subCloseTimerRef.current = window.setTimeout(() => {
+      subCloseTimerRef.current = null;
+      closeSubmenu(false);
+    }, 220);
+  }, [openSubId, closeSubmenu]);
 
   const handleSelect = useCallback(
     (action: DropdownMenuAction) => {
@@ -310,7 +338,7 @@ export function DropdownMenu({
     [closeAll, closeSubmenu],
   );
 
-  const renderAction = (action: DropdownMenuAction) => (
+  const renderAction = (action: DropdownMenuAction, panel: 'root' | 'sub') => (
     <button
       key={action.id}
       type="button"
@@ -321,7 +349,10 @@ export function DropdownMenu({
         e.stopPropagation();
         handleSelect(action);
       }}
-      onMouseEnter={() => closeSubmenu(false)}
+      // Only ROOT-panel siblings schedule the submenu close — the submenu's
+      // own items must never close the panel they live in (hovering them is
+      // exactly how the user reaches "+ New collection…").
+      onMouseEnter={panel === 'root' ? scheduleSubmenuClose : cancelScheduledSubClose}
     >
       {action.swatchColor !== undefined && (
         <span
@@ -341,7 +372,7 @@ export function DropdownMenu({
         return <div key={`sep-${i}`} className="dropdown-menu__separator" role="separator" />;
       }
       if (entry.kind === 'action') {
-        return renderAction(entry.action);
+        return renderAction(entry.action, panel);
       }
       // Submenus only nest one level: a submenu entry inside a submenu renders
       // its actions inline (flattened) rather than opening a third panel.
@@ -441,6 +472,7 @@ export function DropdownMenu({
             }
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => handlePanelKeyDown(e, 'sub')}
+            onMouseEnter={cancelScheduledSubClose}
           >
             {renderEntries(openSubEntries.entries, 'sub')}
           </div>,

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -659,12 +659,16 @@
      actions to a second line rather than overflowing. 180px clears a 320px
      viewport. */
   min-width: 180px;
-  max-width: 460px;
-  padding: 8px 12px;
+  max-width: 520px;
+  padding: 9px 12px;
   border: 1px solid var(--border-color-input);
   border-radius: var(--radius-lg);
   background: var(--bg-primary);
   color: var(--text-muted);
+  transition: border-color 0.12s ease;
+}
+.dh-search:focus-within {
+  border-color: var(--color-primary);
 }
 .dh-search input {
   flex: 1 1 auto;
@@ -673,6 +677,18 @@
   color: var(--text-primary);
   font-size: var(--font-size-base);
   outline: none;
+}
+.dh-search-kbd {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  background: var(--bg-tertiary);
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1;
 }
 .dh-top-actions {
   flex: 0 0 auto;
@@ -778,10 +794,79 @@
 }
 
 .dh-content {
+  /* Shared list-column tracks (JP-444): the column header AND every
+     DocumentCard row cell read these, so alignment holds by construction. */
+  --dh-col-time: 110px;
+  --dh-col-people: 108px;
+  --dh-col-size: 76px;
+  --dh-col-actions: 140px;
+
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
   padding: 22px;
+}
+
+/* Sortable column header over the list view (JP-444). Left inset = card side
+   padding (14) + selection checkbox (18 + 8 margin); tail = expand toggle
+   (34) + fixed actions track, so labels sit over their cells. Sticky so the
+   labels survive a long scroll. */
+.dh-colhead {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  padding: 6px 14px 6px 40px;
+  margin-bottom: 6px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+.dh-colhead-col {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border: none;
+  background: transparent;
+  padding: 2px 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-faint);
+}
+button.dh-colhead-col {
+  cursor: pointer;
+  transition: color 0.12s ease;
+}
+button.dh-colhead-col:hover {
+  color: var(--text-secondary);
+}
+.dh-colhead-glyph-idle {
+  opacity: 0.45;
+}
+.dh-colhead-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  justify-content: flex-start;
+}
+.dh-colhead-time {
+  width: var(--dh-col-time);
+  padding-left: 8px;
+}
+.dh-colhead-people {
+  width: var(--dh-col-people);
+  padding-left: 8px;
+}
+.dh-colhead-size {
+  width: var(--dh-col-size);
+  justify-content: flex-end;
+  padding-right: 4px;
+}
+.dh-colhead-tail {
+  flex: 0 0 auto;
+  width: calc(var(--dh-col-actions) + 34px);
 }
 /* Embedded panel (StorageSettings) keeps a readable measure on wide screens;
    it brings its own internal padding/sections. (Cloud connect is now a modal.) */

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -16,86 +16,233 @@
   overflow: hidden;
 }
 
-/* ── Sidebar ── */
+/* ── Sidebar ──
+   The rail is CONSTANT navy in both themes (JP-444, kit fidelity) — it cannot
+   consume the theme-flipping semantic tokens. The `--rail-*` block below is
+   the one sanctioned set of hardcoded colors on this surface (kit steel/paper
+   scale + navy edges); every rail rule reads these, nothing else. */
 .dh-side {
-  flex: 0 0 264px;
+  --rail-text: #b6c1d1;
+  --rail-text-bright: #d5dbe4;
+  --rail-text-dim: #8d9bb1;
+  --rail-text-faint: #6a7a93;
+  --rail-paper: #f6f4ec;
+  --rail-edge: rgba(214, 224, 240, 0.1);
+  --rail-edge-strong: rgba(214, 224, 240, 0.2);
+  --rail-hover: rgba(214, 224, 240, 0.05);
+  --rail-gold-wash: rgba(201, 162, 98, 0.12);
+  --rail-gold-edge: rgba(201, 162, 98, 0.34);
+
+  flex: 0 0 272px;
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: var(--bg-primary);
-  border-right: 1px solid var(--border-color);
+  background: radial-gradient(
+    120% 50% at 0% 0%,
+    #15263e 0%,
+    var(--navy-950) 45%,
+    var(--navy-1000) 100%
+  );
+  border-right: 1px solid var(--rail-edge);
+  color: var(--rail-text);
+}
+.dh-side button:focus-visible {
+  outline: 2px solid var(--brand-gold-soft);
+  outline-offset: 1px;
 }
 
 .dh-identity {
   display: flex;
   align-items: stretch;
   gap: 6px;
-  padding: 12px 12px 10px;
-  border-bottom: 1px solid var(--border-color-light);
+  padding: 14px 12px 10px;
 }
 
-.dh-workspace {
+/* Rail-top workspace switcher trigger (RailWorkspaceSwitcher). */
+.dh-switch {
   flex: 1 1 auto;
-  display: flex;
+  display: grid;
+  grid-template-columns: 36px 1fr 16px;
   align-items: center;
   gap: 10px;
   min-width: 0;
   padding: 8px 10px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--rail-edge-strong);
   border-radius: var(--radius-lg);
-  background: var(--bg-tertiary);
+  background: rgba(214, 224, 240, 0.05);
   color: inherit;
   cursor: pointer;
   text-align: left;
-  transition: background 0.12s ease, border-color 0.12s ease;
+  transition: background 0.15s ease, border-color 0.15s ease;
 }
-.dh-workspace:hover {
-  border-color: var(--border-color-input);
-  background: var(--bg-hover);
+.dh-switch:hover {
+  background: rgba(214, 224, 240, 0.08);
+  border-color: rgba(214, 224, 240, 0.28);
 }
-.dh-workspace-avatar {
+.dh-switch-avatar {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: linear-gradient(135deg, var(--brand-gold-soft), var(--brand-gold));
+  color: var(--navy-1000);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.02em;
+}
+.dh-switch-avatar--local {
+  background: rgba(214, 224, 240, 0.08);
+  color: var(--rail-text-bright);
+}
+.dh-switch-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.dh-switch-name {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--rail-paper);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-switch-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--rail-text-dim);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-switch-chev {
+  color: var(--rail-text-dim);
+  justify-self: end;
+}
+
+/* Switcher dropdown — fixed + viewport-clamped (the surface clips overflow),
+   rail-owned so it stays navy in both themes like its anchor. */
+.dh-swmenu {
+  position: fixed;
+  z-index: 10250;
+  min-width: 264px;
+  max-width: 320px;
+  padding: 6px;
+  border: 1px solid var(--rail-edge-strong);
+  border-radius: var(--radius-lg);
+  background: var(--navy-900);
+  color: var(--rail-text);
+  box-shadow: 0 12px 32px rgba(6, 12, 23, 0.55);
+}
+.dh-swmenu-sect {
+  padding: 8px 10px 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--rail-text-faint);
+}
+.dh-swmenu-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--rail-text);
+  font-size: var(--font-size-md);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.dh-swmenu-item:hover:not(:disabled) {
+  background: rgba(214, 224, 240, 0.07);
+  color: var(--rail-paper);
+}
+.dh-swmenu-item:disabled {
+  cursor: default;
+}
+.dh-swmenu-item--active {
+  color: var(--rail-paper);
+}
+.dh-swmenu-ws-avatar {
   flex: 0 0 auto;
   display: grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-md);
-  background: var(--brand-navy);
-  color: var(--brand-gold-soft);
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: linear-gradient(135deg, var(--brand-gold-soft), var(--brand-gold));
+  color: var(--navy-1000);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-bold);
 }
-.dh-workspace-info {
+.dh-swmenu-ws-info {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+  gap: 1px;
   min-width: 0;
 }
-.dh-workspace-name {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
+.dh-swmenu-ws-name {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.dh-workspace-meta {
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
+.dh-swmenu-ws-region {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--rail-text-faint);
+}
+.dh-swmenu-check {
+  flex: 0 0 auto;
+  color: var(--brand-gold-soft);
+}
+.dh-swmenu-slot {
+  flex: 0 0 auto;
+  width: 14px;
+}
+.dh-swmenu-spin {
+  flex: 0 0 auto;
+  animation: dh-refresh-spin 0.8s linear infinite;
+}
+.dh-swmenu-sep {
+  height: 1px;
+  margin: 6px 4px;
+  background: var(--rail-edge);
+}
+.dh-swmenu-label {
+  flex: 1 1 auto;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
 .dh-manage {
   flex: 0 0 auto;
   display: grid;
   place-items: center;
-  width: 34px;
-  border: 1px solid var(--border-color);
+  width: 36px;
+  border: 1px solid var(--rail-edge);
   border-radius: var(--radius-lg);
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
+  background: transparent;
+  color: var(--rail-text-dim);
   cursor: pointer;
-  transition: background 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 .dh-manage:hover {
-  background: var(--bg-hover);
+  background: var(--rail-hover);
+  color: var(--rail-paper);
 }
 
 .dh-nav {
@@ -116,19 +263,29 @@
   border: none;
   border-radius: var(--radius-md);
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--rail-text);
   font-size: var(--font-size-base);
   cursor: pointer;
   transition: background 0.1s ease, color 0.1s ease;
 }
+.dh-nav-item svg {
+  color: var(--rail-text-dim);
+  transition: color 0.1s ease;
+}
 .dh-nav-item:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+  background: var(--rail-hover);
+  color: var(--rail-paper);
+}
+.dh-nav-item:hover svg {
+  color: var(--rail-text-bright);
 }
 .dh-nav-item--on {
-  background: var(--color-primary-light);
-  color: var(--text-primary);
+  background: var(--rail-gold-wash);
+  color: var(--rail-paper);
   font-weight: var(--font-weight-medium);
+}
+.dh-nav-item--on svg {
+  color: var(--brand-gold);
 }
 .dh-nav-item--disabled {
   opacity: 0.5;
@@ -136,7 +293,7 @@
 }
 .dh-nav-item--disabled:hover {
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--rail-text);
 }
 .dh-nav-label {
   flex: 1 1 auto;
@@ -147,26 +304,32 @@
 }
 .dh-nav-count {
   flex: 0 0 auto;
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--rail-text-faint);
   font-variant-numeric: tabular-nums;
+}
+.dh-nav-item--on .dh-nav-count {
+  color: var(--brand-gold-soft);
 }
 .dh-nav-soon {
   flex: 0 0 auto;
   font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-faint);
-  border: 1px solid var(--border-color);
+  color: var(--rail-text-faint);
+  border: 1px solid var(--rail-edge);
   border-radius: var(--radius-pill);
   padding: 1px 6px;
 }
 .dh-nav-section {
-  padding: 14px 10px 4px;
-  font-size: var(--font-size-xs);
+  padding: 16px 10px 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-faint);
+  letter-spacing: 0.1em;
+  color: var(--rail-text-faint);
 }
 .dh-nav-section--with-action {
   display: flex;
@@ -182,31 +345,40 @@
   border: none;
   border-radius: var(--radius-sm, 6px);
   background: transparent;
-  color: var(--text-faint);
+  color: var(--rail-text-faint);
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
 }
 .dh-nav-add:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+  background: var(--rail-hover);
+  color: var(--rail-paper);
 }
 .dh-nav-empty {
   padding: 2px 12px 6px;
   font-size: var(--font-size-xs);
-  color: var(--text-faint);
+  color: var(--rail-text-faint);
   font-style: italic;
 }
 .dh-collection-dot {
   flex: 0 0 auto;
-  width: 10px;
-  height: 10px;
-  border-radius: var(--radius-full);
-  background: var(--text-faint);
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+  background: var(--rail-text-faint);
 }
 /* Local (HardDrive) vs workspace (Cloud) scope marker on a collection entry. */
 .dh-collection-scope {
   flex: 0 0 auto;
-  color: var(--text-faint);
+  color: var(--rail-text-faint);
+}
+/* The collection actions trigger (shared DropdownMenu markup) sits IN the navy
+   rail — retint the trigger; the popup itself stays a themed floating panel. */
+.dh-side .document-browser__section-menu-btn {
+  color: var(--rail-text-dim);
+}
+.dh-side .document-browser__section-menu-btn:hover {
+  background: var(--rail-hover);
+  color: var(--rail-paper);
 }
 
 /* A collection rail entry: the filter button plus its actions menu (JP-380).
@@ -238,8 +410,8 @@
 
 .dh-side-foot {
   flex: 0 0 auto;
-  padding: 10px;
-  border-top: 1px solid var(--border-color-light);
+  padding: 12px 10px 10px;
+  border-top: 1px solid var(--rail-edge);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -247,35 +419,39 @@
 .dh-storage {
   display: block;
   width: 100%;
-  padding: 9px 11px;
-  border: 1px solid var(--border-color);
+  padding: 11px 12px;
+  border: 1px solid var(--rail-edge);
   border-radius: var(--radius-lg);
-  background: var(--bg-tertiary);
+  background: rgba(214, 224, 240, 0.04);
   color: inherit;
   cursor: pointer;
   text-align: left;
-  transition: background 0.12s ease;
+  transition: background 0.12s ease, border-color 0.12s ease;
 }
 .dh-storage:hover {
-  background: var(--bg-hover);
+  background: rgba(214, 224, 240, 0.07);
 }
 .dh-storage--on {
-  border-color: var(--color-primary);
-  background: var(--color-primary-light);
+  border-color: var(--rail-gold-edge);
+  background: var(--rail-gold-wash);
 }
 .dh-storage-top {
   display: flex;
   align-items: center;
   gap: 7px;
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-medium);
-  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--rail-text-bright);
 }
 .dh-storage-manage {
   margin-left: auto;
-  font-size: var(--font-size-xs);
+  font-size: 10px;
   font-weight: var(--font-weight-normal);
-  color: var(--brand-gold-deep);
+  letter-spacing: 0.02em;
+  color: var(--brand-gold-soft);
 }
 .dh-storage-row {
   margin-top: 8px;
@@ -288,11 +464,12 @@
 }
 .dh-storage-rowlabel {
   font-size: var(--font-size-xs);
-  color: var(--text-secondary);
+  color: var(--rail-text-dim);
 }
 .dh-storage-rowval {
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--rail-text-dim);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -300,7 +477,7 @@
   height: 5px;
   margin: 5px 0 0;
   border-radius: var(--radius-pill);
-  background: var(--bg-active);
+  background: rgba(214, 224, 240, 0.12);
   overflow: hidden;
 }
 .dh-storage-fill {
@@ -329,7 +506,7 @@
 .dh-cap-note-text {
   font-size: var(--font-size-xs);
   line-height: 1.4;
-  color: var(--text-secondary);
+  color: var(--rail-text);
 }
 .dh-cap-note-actions {
   display: flex;
@@ -337,10 +514,10 @@
 }
 .dh-cap-note-btn {
   padding: 3px 9px;
-  border: 1px solid var(--border-primary);
+  border: 1px solid var(--rail-edge-strong);
   border-radius: var(--radius-pill);
-  background: var(--bg-primary);
-  color: var(--text-secondary);
+  background: transparent;
+  color: var(--rail-text-bright);
   font-size: var(--font-size-xs);
   cursor: pointer;
 }
@@ -371,14 +548,14 @@
   transition: background 0.12s ease, border-color 0.12s ease;
 }
 .dh-user-main:hover {
-  background: var(--bg-hover);
+  background: var(--rail-hover);
 }
 .dh-user-main:hover .dh-user-ext {
-  color: var(--color-primary);
+  color: var(--brand-gold-soft);
 }
 .dh-user-ext {
   flex: 0 0 auto;
-  color: var(--text-faint);
+  color: var(--rail-text-faint);
 }
 .dh-user-avatar {
   flex: 0 0 auto;
@@ -387,7 +564,7 @@
   width: 30px;
   height: 30px;
   border-radius: var(--radius-full);
-  background: var(--brand-navy);
+  background: var(--navy-700);
   color: var(--brand-gold-soft);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
@@ -401,13 +578,14 @@
 .dh-user-name {
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
+  color: var(--rail-text-bright);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .dh-user-meta {
   font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  color: var(--rail-text-dim);
 }
 .dh-user-theme {
   flex: 0 0 auto;
@@ -415,15 +593,16 @@
   place-items: center;
   width: 30px;
   height: 30px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--rail-edge);
   border-radius: var(--radius-md);
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--rail-text-dim);
   cursor: pointer;
-  transition: background 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 .dh-user-theme:hover {
-  background: var(--bg-hover);
+  background: var(--rail-hover);
+  color: var(--rail-paper);
 }
 
 /* ── Main ── */
@@ -731,12 +910,16 @@
 @media (prefers-reduced-motion: reduce) {
   .dh-storage-fill,
   .dh-rcard,
-  .dh-workspace,
+  .dh-switch,
+  .dh-swmenu-item,
   .dh-nav-item,
   .dh-side {
     transition: none;
   }
   .dh-side-backdrop {
+    animation: none;
+  }
+  .dh-swmenu-spin {
     animation: none;
   }
 }
@@ -748,9 +931,9 @@
    index.css (CSS @media can't read custom properties). */
 @media (max-width: 1024px) {
   .dh-side {
-    /* Reclaim width for the content area; the fixed 264px crowds it on a
+    /* Reclaim width for the content area; the fixed 272px crowds it on a
        narrow window. */
-    flex-basis: 208px;
+    flex-basis: 224px;
   }
 }
 @media (max-width: 640px) {

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -937,14 +937,19 @@ button.dh-colhead-col:hover {
 
 .dh-recents {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 12px;
 }
+
+/* Continue-working card (JP-444): preview area over a title strip. The
+   `--rcard-accent` variable (set from the doc's collection color) tints the
+   placeholder primitives and the hover edge; gold is the default accent. */
 .dh-rcard {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  overflow: hidden;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
   background: var(--bg-primary);
@@ -954,23 +959,99 @@ button.dh-colhead-col:hover {
   transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
 }
 .dh-rcard:hover {
-  border-color: var(--border-color-input);
+  border-color: var(--rcard-accent, var(--brand-gold));
   box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
 }
-.dh-rcard-ico {
-  flex: 0 0 auto;
-  display: grid;
-  place-items: center;
-  width: 38px;
-  height: 38px;
-  border-radius: var(--radius-lg);
-  background: var(--bg-tertiary);
-  color: var(--brand-gold-deep);
+.dh-rcard-preview {
+  position: relative;
+  display: block;
+  height: 92px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border-color);
+  /* Dot-grid canvas surface behind thumbnails and placeholders alike. */
+  background-color: var(--bg-secondary);
+  background-image: radial-gradient(color-mix(in srgb, var(--text-faint) 42%, transparent) 1px, transparent 1px);
+  background-size: 14px 14px;
 }
+.dh-rcard-thumb {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 8px;
+}
+
+/* Canvas placeholder: node chips + connector paths on the dot grid. */
+.dh-rcard-ph {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+.dh-rcard-ph-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.dh-rcard-ph-edges path {
+  fill: none;
+  stroke: color-mix(in srgb, var(--text-faint) 60%, transparent);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  vector-effect: non-scaling-stroke;
+}
+.dh-rcard-ph-node {
+  position: absolute;
+  width: 26%;
+  height: 20%;
+  border-radius: 5px;
+  border: 1px solid color-mix(in srgb, var(--rcard-accent, var(--brand-gold)) 55%, transparent);
+  background: color-mix(in srgb, var(--rcard-accent, var(--brand-gold)) 16%, transparent);
+}
+.dh-rcard-ph-node--a {
+  left: 10%;
+  top: 18%;
+}
+.dh-rcard-ph-node--b {
+  left: 60%;
+  top: 48%;
+}
+.dh-rcard-ph-node--c {
+  left: 16%;
+  top: 62%;
+  width: 18%;
+  height: 16%;
+}
+
+/* Doc placeholder: skeleton text lines on a paper gradient. */
+.dh-rcard-ph--doc {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  background: linear-gradient(180deg, #fffefa, #f6f4ec);
+}
+.dh-rcard-ph-line {
+  height: 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--navy-900) 14%, transparent);
+}
+.dh-rcard-ph-line--title {
+  width: 55%;
+  height: 8px;
+  background: color-mix(in srgb, var(--rcard-accent, var(--navy-900)) 34%, transparent);
+}
+.dh-rcard-ph-line--short {
+  width: 40%;
+}
+
 .dh-rcard-meta {
   display: flex;
   flex-direction: column;
+  gap: 2px;
   min-width: 0;
+  padding: 10px 12px 11px;
 }
 .dh-rcard-title {
   font-size: var(--font-size-base);
@@ -980,8 +1061,21 @@ button.dh-colhead-col:hover {
   text-overflow: ellipsis;
 }
 .dh-rcard-sub {
-  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
   color: var(--text-muted);
+}
+
+/* Dark theme: the doc placeholder's paper gradient flips to the kit's navy
+   card surfaces (the dot grid + accent chips already follow the tokens). */
+.documents-home[data-theme='dark'] .dh-rcard-ph--doc {
+  background: linear-gradient(180deg, #13233a, #0e1c30);
+}
+.documents-home[data-theme='dark'] .dh-rcard-ph-line {
+  background: rgba(214, 224, 240, 0.14);
+}
+.documents-home[data-theme='dark'] .dh-rcard-ph-line--title {
+  background: color-mix(in srgb, var(--rcard-accent, var(--brand-gold-soft)) 45%, transparent);
 }
 
 /* The shared DocumentList renders the editor's existing `.document-browser__*`

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -51,7 +51,8 @@ import { useDocumentRegistry } from '../../store/documentRegistry';
 import { useThemeStore } from '../../store/themeStore';
 import { getDocProvider } from '../../store/relayDocumentStore';
 import type { RelayUsage } from '../../api/relayClient';
-import { loadConnection, DEFAULT_CLOUD_BASE_URL, WORKSPACE_URL_BASE } from '../../api/relayConnection';
+import { loadConnection, DEFAULT_CLOUD_BASE_URL } from '../../api/relayConnection';
+import { RailWorkspaceSwitcher } from './RailWorkspaceSwitcher';
 import { opener } from '../../platform/opener';
 import { blobStorage } from '../../storage/BlobStorage';
 import type { StorageStats } from '../../storage/BlobTypes';
@@ -299,24 +300,6 @@ export function DocumentsHome({
     void opener.openExternalUrl(`${cloudBaseUrl.replace(/\/+$/, '')}/account`);
   };
 
-  // Cloud workspace identity (name + slug) for the workspace chip — the same
-  // values the connect modal shows (JP-343), read from the persisted connection
-  // record. Keyed on `signedIn`, NOT a status, so a REST-only sign-in (which
-  // leaves connectionStore.status 'disconnected') still refreshes the display.
-  const [wsName, setWsName] = useState<string | null>(null);
-  const [wsSlug, setWsSlug] = useState<string | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    void loadConnection().then((c) => {
-      if (cancelled) return;
-      setWsName(c?.workspaceName ?? null);
-      setWsSlug(c?.workspaceSlug ?? null);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [signedIn]);
-
   // Keep the Trash nav count accurate on open (other surfaces mutate the bin).
   useEffect(() => {
     refreshTrash();
@@ -370,29 +353,11 @@ export function DocumentsHome({
       {/* ── Sidebar ── */}
       <aside className={`dh-side${sidebarOpen ? ' dh-side--open' : ''}`}>
         <div className="dh-identity">
-          <button
-            className="dh-workspace"
-            onClick={() => openCloudSignIn()}
-            title={signedIn ? 'Manage cloud connection' : 'Sign in to DocuShark Cloud'}
-          >
-            <span className="dh-workspace-avatar">
-              {signedIn ? <Cloud size={18} aria-hidden="true" /> : <HardDrive size={18} aria-hidden="true" />}
-            </span>
-            <span className="dh-workspace-info">
-              <span className="dh-workspace-name">
-                {signedIn ? (wsName ?? 'Cloud workspace') : 'Local workspace'}
-              </span>
-              <span className="dh-workspace-meta">
-                {signedIn
-                  ? wsSlug
-                    ? `${WORKSPACE_URL_BASE}/${wsSlug}`
-                    : isConnectedToHost
-                      ? 'Connected'
-                      : 'Signed in'
-                  : 'Sign in to sync'}
-              </span>
-            </span>
-          </button>
+          <RailWorkspaceSwitcher
+            signedIn={signedIn}
+            isConnectedToHost={isConnectedToHost}
+            onOpenWebAccount={openWebAccount}
+          />
           <button
             className="dh-manage"
             onClick={() => onOpenSettings?.()}

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -37,6 +37,7 @@ import {
   Sun,
   Trash2,
   Upload,
+  Users,
 } from 'lucide-react';
 import { useDocumentBrowserModel, SORT_LABELS } from '../settings/useDocumentBrowserModel';
 import { DocumentList, SelectionBar } from '../settings/DocumentList';
@@ -70,13 +71,14 @@ export interface DocumentsHomeProps {
   onOpenSettings?: () => void;
 }
 
-type NavId = 'all' | 'recents' | 'local' | 'cloud' | 'cached';
+type NavId = 'all' | 'recents' | 'local' | 'cloud' | 'shared' | 'cached';
 
 const NAV_LABELS: Record<NavId, string> = {
   all: 'All documents',
   recents: 'Recents',
   local: 'Local',
   cloud: 'Cloud',
+  shared: 'Shared with me',
   cached: 'Offline',
 };
 
@@ -194,6 +196,8 @@ export function DocumentsHome({
       setFilterMode('local');
     } else if (id === 'cloud') {
       setFilterMode('team');
+    } else if (id === 'shared') {
+      setFilterMode('shared');
     } else if (id === 'cached') {
       setFilterMode('cached');
     }
@@ -340,6 +344,7 @@ export function DocumentsHome({
   ];
   if (isInTeamMode) {
     navItems.push({ id: 'cloud', label: NAV_LABELS.cloud, icon: Cloud, count: documentCounts.team });
+    navItems.push({ id: 'shared', label: NAV_LABELS.shared, icon: Users, count: documentCounts.shared });
     if (documentCounts.cached > 0) {
       navItems.push({ id: 'cached', label: NAV_LABELS.cached, icon: Database, count: documentCounts.cached });
     }

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -16,7 +16,10 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  ChevronDown,
   ChevronLeft,
+  ChevronsUpDown,
+  ChevronUp,
   Clock,
   Cloud,
   Database,
@@ -139,9 +142,16 @@ export function DocumentsHome({
 
   // `/` focuses the search box (JP-387) — classic library-surface shortcut.
   // Ignored while typing anywhere (input/textarea/contenteditable).
+  // `Ctrl/Cmd+K` (JP-444) also focuses it — cross-tool muscle memory — and
+  // deliberately skips the typing guard, matching how command bars behave.
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && !e.altKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
       if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
       const target = e.target as HTMLElement | null;
       if (
@@ -599,20 +609,25 @@ export function DocumentsHome({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={`Search ${activeLabel.toLowerCase()}…`}
-              title="Search by name or tag — #tag matches tags only. Press / to focus."
+              title="Search by name or tag — #tag matches tags only. Press / or Ctrl+K to focus."
             />
+            <kbd className="dh-search-kbd" aria-hidden="true">/</kbd>
           </div>
           <div className="dh-top-actions">
-            <label className="dh-sort">
-              <span className="dh-sort-label">Sort</span>
-              <select value={sort} onChange={(e) => setSort(e.target.value as DocumentBrowserSort)}>
-                {Object.entries(SORT_LABELS).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            {/* In list view the sortable column headers own sorting (JP-444);
+                the dropdown remains for grid view, which has no headers. */}
+            {view === 'grid' && (
+              <label className="dh-sort">
+                <span className="dh-sort-label">Sort</span>
+                <select value={sort} onChange={(e) => setSort(e.target.value as DocumentBrowserSort)}>
+                  {Object.entries(SORT_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
             <label className="dh-sort">
               <span className="dh-sort-label">Group</span>
               <select
@@ -727,6 +742,9 @@ export function DocumentsHome({
                   {documentList.length} {documentList.length === 1 ? 'item' : 'items'}
                 </span>
               </h2>
+              {view === 'list' && documentList.length > 0 && (
+                <ColumnHeader sort={sort} setSort={setSort} />
+              )}
               <DocumentList model={model} onOpened={onLeaveToEditor} />
             </section>
           )}
@@ -734,6 +752,76 @@ export function DocumentsHome({
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Sortable column header over the list view (JP-444). Tracks (widths) are the
+ * shared `--dh-col-*` variables the DocumentCard row cells consume, so header
+ * and cells stay aligned by construction. Clicking a header toggles that
+ * axis's direction; People is display-only (no meaningful order).
+ */
+type SortAxis = 'name' | 'modified' | 'size';
+
+const SORT_CYCLES: Record<SortAxis, [DocumentBrowserSort, DocumentBrowserSort]> = {
+  name: ['name-asc', 'name-desc'],
+  modified: ['modified-desc', 'modified-asc'],
+  size: ['size-desc', 'size-asc'],
+};
+
+function sortDir(sort: DocumentBrowserSort, axis: SortAxis): 'asc' | 'desc' | null {
+  if (sort === `${axis}-asc`) return 'asc';
+  if (sort === `${axis}-desc`) return 'desc';
+  return null;
+}
+
+function SortGlyph({ dir }: { dir: 'asc' | 'desc' | null }) {
+  if (dir === 'asc') return <ChevronUp size={12} aria-hidden="true" />;
+  if (dir === 'desc') return <ChevronDown size={12} aria-hidden="true" />;
+  return <ChevronsUpDown size={12} className="dh-colhead-glyph-idle" aria-hidden="true" />;
+}
+
+function ColumnHeader({
+  sort,
+  setSort,
+}: {
+  sort: DocumentBrowserSort;
+  setSort: (sort: DocumentBrowserSort) => void;
+}) {
+  const toggle = (axis: SortAxis) => {
+    const [first, second] = SORT_CYCLES[axis];
+    setSort(sort === first ? second : first);
+  };
+  const ariaSort = (axis: SortAxis): 'ascending' | 'descending' | undefined => {
+    const dir = sortDir(sort, axis);
+    return dir === 'asc' ? 'ascending' : dir === 'desc' ? 'descending' : undefined;
+  };
+  return (
+    <div className="dh-colhead" role="row">
+      <button
+        className="dh-colhead-col dh-colhead-name"
+        onClick={() => toggle('name')}
+        aria-sort={ariaSort('name')}
+      >
+        Name <SortGlyph dir={sortDir(sort, 'name')} />
+      </button>
+      <button
+        className="dh-colhead-col dh-colhead-time"
+        onClick={() => toggle('modified')}
+        aria-sort={ariaSort('modified')}
+      >
+        Last edited <SortGlyph dir={sortDir(sort, 'modified')} />
+      </button>
+      <span className="dh-colhead-col dh-colhead-people">People</span>
+      <button
+        className="dh-colhead-col dh-colhead-size"
+        onClick={() => toggle('size')}
+        aria-sort={ariaSort('size')}
+      >
+        Size <SortGlyph dir={sortDir(sort, 'size')} />
+      </button>
+      <span className="dh-colhead-tail" aria-hidden="true" />
     </div>
   );
 }

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -28,7 +28,6 @@ import {
   FolderOpen,
   FolderPlus,
   HardDrive,
-  Layers,
   LayoutGrid,
   List,
   Menu,
@@ -52,6 +51,7 @@ import { ShapeLibraryManager } from '../ShapeLibraryManager';
 import { useTrashStore } from '../../store/trashStore';
 import { useDocumentRegistry } from '../../store/documentRegistry';
 import { useThemeStore } from '../../store/themeStore';
+import { RecentCard } from './RecentCard';
 import { getDocProvider } from '../../store/relayDocumentStore';
 import type { RelayUsage } from '../../api/relayClient';
 import { loadConnection, DEFAULT_CLOUD_BASE_URL } from '../../api/relayConnection';
@@ -322,9 +322,12 @@ export function DocumentsHome({
     handleRefresh();
   }, [handleRefresh]);
 
-  // "Continue working" strip: the most recent docs, shown on All without a query.
-  const recents = useMemo(() => documentList.slice(0, 3), [documentList]);
-  const showRecents = nav === 'all' && collectionFilter === null && !searchQuery && recents.length > 0;
+  // "Continue working" strip: the most recent docs, shown on All without a
+  // query. Skipped for tiny libraries (≤4 docs) where it would just duplicate
+  // the table below (JP-444).
+  const recents = useMemo(() => documentList.slice(0, 6), [documentList]);
+  const showRecents =
+    nav === 'all' && collectionFilter === null && !searchQuery && documentList.length > 4;
 
   const activeLabel = collectionFilter
     ? (collections.find((c) => c.id === collectionFilter)?.name ?? 'Collection')
@@ -698,24 +701,15 @@ export function DocumentsHome({
               </h2>
               <div className="dh-recents">
                 {recents.map((r) => (
-                  <button
+                  <RecentCard
                     key={r.id}
-                    className="dh-rcard"
-                    onClick={async () => {
+                    record={r}
+                    accent={model.accentByDoc.get(r.id)}
+                    onOpen={async () => {
                       await model.handleOpen(r.id);
                       onLeaveToEditor();
                     }}
-                  >
-                    <span className="dh-rcard-ico">
-                      <Layers size={18} aria-hidden="true" />
-                    </span>
-                    <span className="dh-rcard-meta">
-                      <span className="dh-rcard-title">{r.name}</span>
-                      <span className="dh-rcard-sub">
-                        {r.type === 'local' ? 'Local' : r.type === 'cached' ? 'Offline' : 'Cloud'}
-                      </span>
-                    </span>
-                  </button>
+                  />
                 ))}
               </div>
             </section>

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -142,13 +142,18 @@ export function DocumentsHome({
 
   // `/` focuses the search box (JP-387) — classic library-surface shortcut.
   // Ignored while typing anywhere (input/textarea/contenteditable).
-  // `Ctrl/Cmd+K` (JP-444) also focuses it — cross-tool muscle memory — and
-  // deliberately skips the typing guard, matching how command bars behave.
+  // `Ctrl/Cmd+K` (JP-444) also focuses it — cross-tool muscle memory; skips
+  // the typing guard, matching how command bars behave. Registered in the
+  // CAPTURE phase with stopPropagation: Mod+K is the editor's command-palette
+  // binding (CommandRegistry, window bubble listener), and while this surface
+  // overlays the editor the library search must win — the palette's commands
+  // target the canvas behind the overlay.
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && !e.altKey && e.key.toLowerCase() === 'k') {
         e.preventDefault();
+        e.stopPropagation();
         searchInputRef.current?.focus();
         return;
       }
@@ -165,8 +170,8 @@ export function DocumentsHome({
       e.preventDefault();
       searchInputRef.current?.focus();
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
   }, []);
 
   // On narrow viewports the sidebar is an off-canvas drawer (it overlays the

--- a/src/ui/home/PeopleStack.css
+++ b/src/ui/home/PeopleStack.css
@@ -1,0 +1,54 @@
+/* PeopleStack (JP-444) — overlapping initials avatars on document rows. */
+
+.people-stack {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+}
+.people-stack--button {
+  cursor: pointer;
+  border-radius: var(--radius-pill);
+}
+.people-stack--button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.people-stack--none {
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.people-stack__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--bg-primary);
+  color: #fff;
+  font-size: 9px;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.02em;
+  transition: transform 0.12s ease;
+}
+.people-stack__avatar + .people-stack__avatar {
+  margin-left: -7px;
+}
+.people-stack--button:hover .people-stack__avatar {
+  transform: translateY(-1px);
+}
+.people-stack__avatar--more {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 9px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .people-stack__avatar {
+    transition: none;
+  }
+}

--- a/src/ui/home/PeopleStack.tsx
+++ b/src/ui/home/PeopleStack.tsx
@@ -1,0 +1,116 @@
+/**
+ * PeopleStack (JP-444) — the People cell on document rows/cards: an
+ * initials-avatar stack of everyone on the document (owner first, then
+ * shares), overflowing into "+N". Colors are deterministic per user id so the
+ * same person reads consistently across rows.
+ *
+ * When the caller can manage access, the stack is a button opening the
+ * permissions dialog — the avatars ARE the sharing entry, not decoration.
+ */
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+import './PeopleStack.css';
+
+interface Person {
+  id: string;
+  name: string;
+}
+
+/** Owner first, then shares; skips entries without identity, dedupes by id. */
+export function peopleForRecord(record: DocumentRecord): Person[] {
+  if (record.type === 'local') return [];
+  const out: Person[] = [];
+  const seen = new Set<string>();
+  const push = (id: string | undefined, name: string | undefined) => {
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    out.push({ id, name: name || 'Unknown user' });
+  };
+  push(record.ownerId, record.ownerName);
+  for (const share of record.sharedWith ?? []) push(share.userId, share.userName);
+  return out;
+}
+
+/** Stable small hash → hue, so a user's avatar color never shifts. */
+export function personHue(id: string): number {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return ((h % 360) + 360) % 360;
+}
+
+function initials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '?';
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return (words[0]![0]! + words[1]![0]!).toUpperCase();
+}
+
+const MAX_AVATARS = 3;
+
+export interface PeopleStackProps {
+  record: DocumentRecord;
+  /** Open the permissions dialog; when absent the stack is display-only. */
+  onOpenAccess?: (() => void) | undefined;
+}
+
+export function PeopleStack({ record, onOpenAccess }: PeopleStackProps) {
+  const people = peopleForRecord(record);
+  if (people.length === 0) {
+    return (
+      <span className="people-stack people-stack--none" aria-label="No collaborator information">
+        —
+      </span>
+    );
+  }
+
+  const shown = people.slice(0, MAX_AVATARS);
+  const overflow = people.length - shown.length;
+  const names = people.map((p) => p.name);
+  const label =
+    `Owner: ${names[0]}` +
+    (names.length > 1 ? ` · Shared with ${names.slice(1).join(', ')}` : '') +
+    (onOpenAccess ? ' · Click to manage access' : '');
+
+  const body = (
+    <>
+      {shown.map((p) => (
+        <span
+          key={p.id}
+          className="people-stack__avatar"
+          style={{ background: `hsl(${personHue(p.id)} 38% 46%)` }}
+          aria-hidden="true"
+        >
+          {initials(p.name)}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span className="people-stack__avatar people-stack__avatar--more" aria-hidden="true">
+          +{overflow}
+        </span>
+      )}
+    </>
+  );
+
+  if (onOpenAccess) {
+    return (
+      <button
+        type="button"
+        className="people-stack people-stack--button"
+        title={label}
+        aria-label={label}
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpenAccess();
+        }}
+      >
+        {body}
+      </button>
+    );
+  }
+  return (
+    <span className="people-stack" title={label} aria-label={label}>
+      {body}
+    </span>
+  );
+}
+
+export default PeopleStack;

--- a/src/ui/home/RailWorkspaceSwitcher.tsx
+++ b/src/ui/home/RailWorkspaceSwitcher.tsx
@@ -1,0 +1,274 @@
+/**
+ * RailWorkspaceSwitcher (JP-444) — the identity block at the top of the
+ * DocumentsHome navy rail. Shows the active workspace (initials avatar, name,
+ * role · region meta) and opens a dropdown for switching between the user's
+ * workspaces, managing the cloud connection, or opening the web account.
+ *
+ * Replaces the old sign-in pill. Reuses the same services as the connect
+ * modal's switcher (`listWorkspaces` / `switchWorkspace` / `RoleBadge`); the
+ * modal remains the connection-management surface, this is the fast path.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Check,
+  ChevronDown,
+  Cloud,
+  ExternalLink,
+  HardDrive,
+  Loader2,
+  LogIn,
+} from 'lucide-react';
+import { webClient, type WorkspaceSummary } from '../../api/webClient';
+import { switchWorkspace } from '../../services/switchWorkspace';
+import { workspaceIdFromRelayToken } from '../../api/relayTokenUser';
+import { DEFAULT_WORKSPACE_ID } from '../../store/activeWorkspace';
+import { useConnectionStore } from '../../store/connectionStore';
+import { useNotificationStore } from '../../store/notificationStore';
+import { RoleBadge, type BadgeRole } from '../components/RoleBadge';
+import { loadConnection, WORKSPACE_URL_BASE } from '../../api/relayConnection';
+import { openCloudSignIn } from '../cloud/cloudSignInStore';
+import { clampToViewport } from '../contextMenuUtils';
+
+export interface RailWorkspaceSwitcherProps {
+  signedIn: boolean;
+  isConnectedToHost: boolean;
+  /** Open the docushark-web account portal in the system browser. */
+  onOpenWebAccount: () => void;
+}
+
+/** Two-letter initials for the avatar tile ("Acme Docs" → "AD"). */
+export function workspaceInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '?';
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return (words[0]![0]! + words[1]![0]!).toUpperCase();
+}
+
+export function RailWorkspaceSwitcher({
+  signedIn,
+  isConnectedToHost,
+  onOpenWebAccount,
+}: RailWorkspaceSwitcherProps) {
+  const [wsName, setWsName] = useState<string | null>(null);
+  const [wsSlug, setWsSlug] = useState<string | null>(null);
+  const [workspaces, setWorkspaces] = useState<WorkspaceSummary[]>([]);
+  const [switchingId, setSwitchingId] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  // Active workspace derived reactively from the live relay token, so a
+  // switch (which swaps the token) re-highlights without a refetch.
+  const token = useConnectionStore((s) => s.token);
+  const activeId = workspaceIdFromRelayToken(token) ?? DEFAULT_WORKSPACE_ID;
+
+  // Workspace display identity from the persisted connection record — same
+  // source the connect modal shows. Keyed on `signedIn` (not a status) so a
+  // REST-only sign-in still refreshes it.
+  useEffect(() => {
+    let cancelled = false;
+    void loadConnection().then((c) => {
+      if (cancelled) return;
+      setWsName(c?.workspaceName ?? null);
+      setWsSlug(c?.workspaceSlug ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [signedIn]);
+
+  // The user's workspace roster — feeds both the meta line (role · region for
+  // the active entry) and the dropdown list. Best-effort: a failed fetch just
+  // leaves the roster empty (meta falls back to the slug).
+  const loadWorkspaces = useCallback(async () => {
+    if (!signedIn) {
+      setWorkspaces([]);
+      return;
+    }
+    try {
+      setWorkspaces(await webClient.listWorkspaces());
+    } catch {
+      setWorkspaces([]);
+    }
+  }, [signedIn]);
+
+  useEffect(() => {
+    void loadWorkspaces();
+  }, [loadWorkspaces]);
+
+  const active = workspaces.find((w) => w.id === activeId);
+
+  // Position the dropdown under the trigger in viewport space (the surface
+  // clips overflow, so the menu is fixed-position + clamped). Re-clamps on
+  // size change: the roster loads async, growing the menu after first paint.
+  useEffect(() => {
+    const el = menuRef.current;
+    const anchor = triggerRef.current;
+    if (!open || !el || !anchor) {
+      setMenuPos(null);
+      return undefined;
+    }
+    const reclamp = () => {
+      const a = anchor.getBoundingClientRect();
+      const m = el.getBoundingClientRect();
+      setMenuPos(clampToViewport(a.left, a.bottom + 6, m.width, m.height));
+    };
+    reclamp();
+    const ro = new ResizeObserver(reclamp);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [open, workspaces.length]);
+
+  // Refresh the roster on open so the list reflects invites/renames; close on
+  // outside press or Escape.
+  useEffect(() => {
+    if (!open) return undefined;
+    void loadWorkspaces();
+    const onPress = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (menuRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onPress);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPress);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, loadWorkspaces]);
+
+  const handleSwitch = useCallback(
+    async (ws: WorkspaceSummary) => {
+      if (ws.id === activeId || switchingId) return;
+      setSwitchingId(ws.id);
+      try {
+        await switchWorkspace(ws.id);
+        useNotificationStore.getState().success(`Switched to ${ws.name}`);
+        setOpen(false);
+      } catch (err) {
+        useNotificationStore
+          .getState()
+          .error(err instanceof Error ? err.message : `Could not switch to ${ws.name}`);
+      } finally {
+        setSwitchingId(null);
+      }
+    },
+    [activeId, switchingId]
+  );
+
+  const name = signedIn ? (wsName ?? 'Cloud workspace') : 'Local workspace';
+  const meta = signedIn
+    ? active
+      ? `${active.role} · ${active.region}`
+      : wsSlug
+        ? `${WORKSPACE_URL_BASE}/${wsSlug}`
+        : isConnectedToHost
+          ? 'Connected'
+          : 'Signed in'
+    : 'Sign in to sync';
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        className="dh-switch"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        title={signedIn ? 'Switch workspace' : 'Sign in to DocuShark Cloud'}
+      >
+        <span className={`dh-switch-avatar${signedIn ? '' : ' dh-switch-avatar--local'}`}>
+          {signedIn ? workspaceInitials(name) : <HardDrive size={16} aria-hidden="true" />}
+        </span>
+        <span className="dh-switch-info">
+          <span className="dh-switch-name">{name}</span>
+          <span className="dh-switch-meta">{meta}</span>
+        </span>
+        <ChevronDown size={15} className="dh-switch-chev" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          className="dh-swmenu"
+          role="menu"
+          style={
+            menuPos
+              ? { left: menuPos.x, top: menuPos.y }
+              : { left: 14, top: 64, visibility: 'hidden' }
+          }
+        >
+          {signedIn && workspaces.length > 0 && (
+            <>
+              <div className="dh-swmenu-sect">Workspaces</div>
+              {workspaces.map((ws) => {
+                const isActive = ws.id === activeId;
+                return (
+                  <button
+                    key={ws.id}
+                    className={`dh-swmenu-item${isActive ? ' dh-swmenu-item--active' : ''}`}
+                    role="menuitem"
+                    onClick={() => void handleSwitch(ws)}
+                    disabled={isActive || switchingId !== null}
+                    aria-current={isActive}
+                  >
+                    <span className="dh-swmenu-ws-avatar">{workspaceInitials(ws.name)}</span>
+                    <span className="dh-swmenu-ws-info">
+                      <span className="dh-swmenu-ws-name">{ws.name}</span>
+                      <span className="dh-swmenu-ws-region">{ws.region}</span>
+                    </span>
+                    <RoleBadge role={ws.role as BadgeRole} />
+                    {switchingId === ws.id ? (
+                      <Loader2 size={14} className="dh-swmenu-spin" aria-hidden="true" />
+                    ) : isActive ? (
+                      <Check size={14} className="dh-swmenu-check" aria-hidden="true" />
+                    ) : (
+                      <span className="dh-swmenu-slot" aria-hidden="true" />
+                    )}
+                  </button>
+                );
+              })}
+              <div className="dh-swmenu-sep" aria-hidden="true" />
+            </>
+          )}
+
+          <button
+            className="dh-swmenu-item"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              openCloudSignIn();
+            }}
+          >
+            {signedIn ? (
+              <Cloud size={15} aria-hidden="true" />
+            ) : (
+              <LogIn size={15} aria-hidden="true" />
+            )}
+            <span className="dh-swmenu-label">
+              {signedIn ? 'Manage cloud connection' : 'Sign in to DocuShark Cloud'}
+            </span>
+          </button>
+          <button
+            className="dh-swmenu-item"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onOpenWebAccount();
+            }}
+          >
+            <ExternalLink size={15} aria-hidden="true" />
+            <span className="dh-swmenu-label">Open web account</span>
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default RailWorkspaceSwitcher;

--- a/src/ui/home/RecentCard.tsx
+++ b/src/ui/home/RecentCard.tsx
@@ -1,0 +1,103 @@
+/**
+ * RecentCard (JP-444) — one "Continue working" card: a preview area (real
+ * canvas mini-thumbnail when the doc's content is locally available, else a
+ * stylized placeholder) over a title + mono meta strip. The card's accent
+ * (placeholder chips, hover edge) picks up the doc's collection color.
+ */
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+import { formatDate } from '../DocumentCard';
+import { getRecentPreview, type RecentPreview } from './recentThumbnails';
+
+function sourceLabel(record: DocumentRecord): string {
+  switch (record.type) {
+    case 'local':
+      return 'Local';
+    case 'cached':
+      return 'Offline';
+    case 'remote':
+      return 'Cloud';
+  }
+}
+
+/** Dotted-canvas placeholder with a few node chips — reads as "a diagram". */
+function CanvasPlaceholder() {
+  return (
+    <span className="dh-rcard-ph dh-rcard-ph--canvas" aria-hidden="true">
+      <svg className="dh-rcard-ph-edges" viewBox="0 0 100 60" preserveAspectRatio="none">
+        <path d="M28 20 C 44 20, 48 34, 62 36" />
+        <path d="M30 44 C 44 44, 52 40, 62 38" />
+      </svg>
+      <span className="dh-rcard-ph-node dh-rcard-ph-node--a" />
+      <span className="dh-rcard-ph-node dh-rcard-ph-node--b" />
+      <span className="dh-rcard-ph-node dh-rcard-ph-node--c" />
+    </span>
+  );
+}
+
+/** Skeleton text lines — reads as "a written document". */
+function DocPlaceholder() {
+  return (
+    <span className="dh-rcard-ph dh-rcard-ph--doc" aria-hidden="true">
+      <span className="dh-rcard-ph-line dh-rcard-ph-line--title" />
+      <span className="dh-rcard-ph-line" />
+      <span className="dh-rcard-ph-line" />
+      <span className="dh-rcard-ph-line dh-rcard-ph-line--short" />
+    </span>
+  );
+}
+
+export interface RecentCardProps {
+  record: DocumentRecord;
+  /** Collection accent for the preview (name for tooltip, color for tint). */
+  accent?: { name: string; color?: string | undefined } | undefined;
+  onOpen: () => void;
+}
+
+export function RecentCard({ record, accent, onOpen }: RecentCardProps) {
+  const [preview, setPreview] = useState<RecentPreview | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getRecentPreview(record).then((p) => {
+      if (!cancelled) setPreview(p);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Re-render only when the doc actually changed (id or edit time).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [record.id, record.modifiedAt]);
+
+  const style = accent?.color
+    ? ({ '--rcard-accent': accent.color } as CSSProperties)
+    : undefined;
+
+  return (
+    <button
+      className="dh-rcard"
+      onClick={onOpen}
+      style={style}
+      title={accent ? `${record.name} — ${accent.name}` : record.name}
+    >
+      <span className="dh-rcard-preview">
+        {preview?.uri ? (
+          <img className="dh-rcard-thumb" src={preview.uri} alt="" loading="lazy" />
+        ) : preview?.kind === 'doc' ? (
+          <DocPlaceholder />
+        ) : (
+          <CanvasPlaceholder />
+        )}
+      </span>
+      <span className="dh-rcard-meta">
+        <span className="dh-rcard-title">{record.name}</span>
+        <span className="dh-rcard-sub">
+          {sourceLabel(record)} · {formatDate(record.modifiedAt)}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+export default RecentCard;

--- a/src/ui/home/RecentCard.tsx
+++ b/src/ui/home/RecentCard.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from 'react';
 import type { CSSProperties } from 'react';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
+import { useThemeStore } from '../../store/themeStore';
 import { formatDate } from '../DocumentCard';
 import { getRecentPreview, type RecentPreview } from './recentThumbnails';
 
@@ -57,18 +58,22 @@ export interface RecentCardProps {
 
 export function RecentCard({ record, accent, onOpen }: RecentCardProps) {
   const [preview, setPreview] = useState<RecentPreview | null>(null);
+  // AUTO-coloured shapes resolve against the theme (white ink on dark) — a
+  // theme flip re-renders the thumbnail with the matching ink.
+  const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
 
   useEffect(() => {
     let cancelled = false;
-    void getRecentPreview(record).then((p) => {
+    void getRecentPreview(record, resolvedTheme).then((p) => {
       if (!cancelled) setPreview(p);
     });
     return () => {
       cancelled = true;
     };
-    // Re-render only when the doc actually changed (id or edit time).
+    // Re-render only when the doc actually changed (id or edit time) or the
+    // surface theme flipped.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [record.id, record.modifiedAt]);
+  }, [record.id, record.modifiedAt, resolvedTheme]);
 
   const style = accent?.color
     ? ({ '--rcard-accent': accent.color } as CSSProperties)

--- a/src/ui/home/recentThumbnails.ts
+++ b/src/ui/home/recentThumbnails.ts
@@ -29,6 +29,10 @@ export interface RecentPreview {
   kind: 'canvas' | 'doc' | 'unknown';
 }
 
+/** The preview surface's theme — AUTO-colour shapes resolve to a contrasting
+ *  ink (white on dark, black on light), so it's part of the render identity. */
+export type PreviewTheme = 'light' | 'dark';
+
 /** Z-order cap — a thumbnail needs the gist, not all 10k shapes. */
 const MAX_SHAPES = 40;
 /** Bounded memo keyed `id:modifiedAt` — an edit invalidates naturally. */
@@ -48,7 +52,7 @@ async function contentFor(record: DocumentRecord): Promise<DiagramDocument | nul
   }
 }
 
-function toPreview(doc: DiagramDocument): RecentPreview {
+function toPreview(doc: DiagramDocument, theme: PreviewTheme): RecentPreview {
   const pageId = doc.pages[doc.activePageId] ? doc.activePageId : doc.pageOrder[0];
   const page = pageId ? doc.pages[pageId] : undefined;
   const order = (page?.shapeOrder ?? []).filter((id) => page?.shapes[id]).slice(0, MAX_SHAPES);
@@ -68,6 +72,10 @@ function toPreview(doc: DiagramDocument): RecentPreview {
         background: null,
         padding: 24,
         filename: 'thumbnail',
+        // Transparent background defaults AUTO shapes to black ink — pin the
+        // ink to the theme instead, so auto-coloured connectors/labels stay
+        // visible on the dark preview surface.
+        autoInk: theme === 'dark' ? 'white' : 'black',
       }
     );
     return {
@@ -79,12 +87,15 @@ function toPreview(doc: DiagramDocument): RecentPreview {
   }
 }
 
-export async function getRecentPreview(record: DocumentRecord): Promise<RecentPreview> {
-  const key = `${record.id}:${record.modifiedAt}`;
+export async function getRecentPreview(
+  record: DocumentRecord,
+  theme: PreviewTheme
+): Promise<RecentPreview> {
+  const key = `${record.id}:${record.modifiedAt}:${theme}`;
   const hit = cache.get(key);
   if (hit) return hit;
   const doc = await contentFor(record);
-  const preview: RecentPreview = doc ? toPreview(doc) : { uri: null, kind: 'unknown' };
+  const preview: RecentPreview = doc ? toPreview(doc, theme) : { uri: null, kind: 'unknown' };
   if (cache.size >= MAX_CACHE) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) cache.delete(oldest);

--- a/src/ui/home/recentThumbnails.ts
+++ b/src/ui/home/recentThumbnails.ts
@@ -1,0 +1,94 @@
+/**
+ * recentThumbnails (JP-444) — best-effort mini previews for the home screen's
+ * "Continue working" cards.
+ *
+ * Content ladder (cheapest first, all local — never a network fetch):
+ *   1. registry in-memory content (doc already loaded this session)
+ *   2. localStorage body (local docs, synchronous)
+ *   3. IndexedDB relay cache (offline-available workspace docs)
+ * A doc whose content isn't locally available gets no thumbnail — the card
+ * falls back to a stylized placeholder.
+ *
+ * Rendering reuses the pure `exportToSvg` shape renderer over the active
+ * page's first shapes. Known limit: image/file shapes reference unresolved
+ * blob:// URLs, so they render as empty frames — acceptable at card size.
+ */
+import type { DiagramDocument } from '../../types/Document';
+import type { Shape } from '../../shapes/Shape';
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+import { useDocumentRegistry } from '../../store/documentRegistry';
+import { loadDocumentFromStorage } from '../../store/persistenceStore';
+import { RelayDocumentCache } from '../../storage/RelayDocumentCache';
+import { activeWorkspaceId } from '../../store/activeWorkspace';
+import { exportToSvg } from '../../utils/exportUtils';
+
+export interface RecentPreview {
+  /** SVG data URI of the canvas thumbnail, or null when not renderable. */
+  uri: string | null;
+  /** What the doc's content looks like — picks the placeholder variant. */
+  kind: 'canvas' | 'doc' | 'unknown';
+}
+
+/** Z-order cap — a thumbnail needs the gist, not all 10k shapes. */
+const MAX_SHAPES = 40;
+/** Bounded memo keyed `id:modifiedAt` — an edit invalidates naturally. */
+const MAX_CACHE = 32;
+const cache = new Map<string, RecentPreview>();
+
+async function contentFor(record: DocumentRecord): Promise<DiagramDocument | null> {
+  const inMemory = useDocumentRegistry.getState().getDocumentContent(record.id);
+  if (inMemory) return inMemory;
+  if (record.type === 'local') return loadDocumentFromStorage(record.id);
+  const ws = activeWorkspaceId();
+  if (!RelayDocumentCache.has(ws, record.id)) return null;
+  try {
+    return await RelayDocumentCache.get(ws, record.id);
+  } catch {
+    return null;
+  }
+}
+
+function toPreview(doc: DiagramDocument): RecentPreview {
+  const pageId = doc.pages[doc.activePageId] ? doc.activePageId : doc.pageOrder[0];
+  const page = pageId ? doc.pages[pageId] : undefined;
+  const order = (page?.shapeOrder ?? []).filter((id) => page?.shapes[id]).slice(0, MAX_SHAPES);
+  if (!page || order.length === 0) {
+    const hasProse = (doc.richTextPages?.pageOrder.length ?? 0) > 0 || !!doc.richTextContent;
+    return { uri: null, kind: hasProse ? 'doc' : 'canvas' };
+  }
+  const shapes: Record<string, Shape> = {};
+  for (const id of order) shapes[id] = page.shapes[id]!;
+  try {
+    const svg = exportToSvg(
+      { shapes, shapeOrder: order, selectedIds: [] },
+      {
+        format: 'svg',
+        scope: 'all',
+        scale: 1,
+        background: null,
+        padding: 24,
+        filename: 'thumbnail',
+      }
+    );
+    return {
+      uri: `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`,
+      kind: 'canvas',
+    };
+  } catch {
+    return { uri: null, kind: 'canvas' };
+  }
+}
+
+export async function getRecentPreview(record: DocumentRecord): Promise<RecentPreview> {
+  const key = `${record.id}:${record.modifiedAt}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+  const doc = await contentFor(record);
+  const preview: RecentPreview = doc ? toPreview(doc) : { uri: null, kind: 'unknown' };
+  if (cache.size >= MAX_CACHE) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, preview);
+  return preview;
+}

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -265,6 +265,53 @@
   border-color: var(--color-primary);
 }
 
+/* Tailored empty states (JP-444): icon tile, secondary line, CTA row. */
+.document-browser__empty-ico {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-2);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--bg-primary);
+  color: var(--brand-gold-deep, var(--text-muted));
+}
+
+.document-browser__empty-sub {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-faint);
+  max-width: 320px;
+  line-height: 1.5;
+}
+
+.document-browser__empty-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: var(--space-3);
+}
+
+.document-browser__empty-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border: none;
+  border-radius: 8px;
+  background: var(--color-cta);
+  color: var(--color-cta-text);
+  font-size: 12.5px;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+
+.document-browser__empty-cta:hover {
+  background: var(--color-cta-hover);
+}
+
 /* Compact mode adjustments */
 .document-browser--compact {
   gap: var(--space-3);

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -8,7 +8,18 @@
  */
 
 import { useCallback, useState } from 'react';
-import { ChevronDown, Cloud, Download, FolderInput, HardDrive, Tags, Trash2 } from 'lucide-react';
+import {
+  ChevronDown,
+  Cloud,
+  Download,
+  FilePlus2,
+  FolderInput,
+  FolderOpen,
+  HardDrive,
+  Tags,
+  Trash2,
+  UsersRound,
+} from 'lucide-react';
 import { DocumentCard } from '../DocumentCard';
 import { TagEditorPopover } from '../TagEditorPopover';
 import {
@@ -172,10 +183,55 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
                 Clear search
               </button>
             </>
+          ) : model.collectionFilter !== null ? (
+            <>
+              <span className="document-browser__empty-ico" aria-hidden="true">
+                <FolderOpen size={22} />
+              </span>
+              <p>This collection is empty.</p>
+              <span className="document-browser__empty-sub">
+                Use a document&apos;s “Move to collection” action to file it here.
+              </span>
+            </>
+          ) : filterMode === 'shared' ? (
+            <>
+              <span className="document-browser__empty-ico" aria-hidden="true">
+                <UsersRound size={22} />
+              </span>
+              <p>Nothing shared with you yet.</p>
+              <span className="document-browser__empty-sub">
+                Documents teammates share with you appear here.
+              </span>
+            </>
           ) : filterMode !== 'all' ? (
             <p>No {filterMode === 'local' ? 'personal' : filterMode} documents.</p>
           ) : (
-            <p>No documents yet. Create a new one to get started!</p>
+            <>
+              <span className="document-browser__empty-ico" aria-hidden="true">
+                <FilePlus2 size={22} />
+              </span>
+              <p>Create your first document.</p>
+              <span className="document-browser__empty-sub">
+                Start from scratch, or import an existing .docushark file.
+              </span>
+              <div className="document-browser__empty-actions">
+                <button
+                  className="document-browser__empty-cta"
+                  onClick={() => {
+                    model.handleNewDocument();
+                    onOpened?.('new');
+                  }}
+                >
+                  <FilePlus2 size={14} aria-hidden="true" /> New document
+                </button>
+                <button
+                  className="document-browser__empty-clear"
+                  onClick={model.handleImport}
+                >
+                  Import
+                </button>
+              </div>
+            </>
           )}
         </div>
       ) : groupedSections ? (

--- a/src/ui/settings/useDocumentBrowserModel.test.ts
+++ b/src/ui/settings/useDocumentBrowserModel.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import {
   compareRecords,
   friendlyTransferError,
+  isSharedWithMe,
   canDelete,
   canEdit,
   canManagePermissions,
@@ -59,6 +60,44 @@ describe('compareRecords', () => {
     const list = [older, newer];
     const sorted = [...list].sort((x, y) => compareRecords(x, y, 'modified-desc'));
     expect(sorted.map((r) => r.id)).toEqual(['b', 'a']);
+  });
+
+  it('size-desc / size-asc order by sizeBytes with unsized docs last (JP-444)', () => {
+    const big = rec({ id: 'big', sizeBytes: 9000, modifiedAt: 1 });
+    const small = rec({ id: 'small', sizeBytes: 100, modifiedAt: 2 });
+    const unsized = rec({ id: 'unsized', modifiedAt: 999 });
+
+    const desc = [unsized, small, big].sort((x, y) => compareRecords(x, y, 'size-desc'));
+    expect(desc.map((r) => r.id)).toEqual(['big', 'small', 'unsized']);
+
+    const asc = [unsized, small, big].sort((x, y) => compareRecords(x, y, 'size-asc'));
+    expect(asc.map((r) => r.id)).toEqual(['small', 'big', 'unsized']);
+
+    // Two unsized docs fall back to recency, keeping the order stable.
+    const other = rec({ id: 'other', modifiedAt: 5 });
+    expect(compareRecords(unsized, other, 'size-desc')).toBeLessThan(0);
+  });
+});
+
+// JP-444: the "Shared with me" discriminant. Owner metadata is optional on
+// cached records, so absence must mean "not shared", never a crash or a guess.
+describe('isSharedWithMe', () => {
+  const me = 'u-me';
+
+  it('is true for a relay doc owned by someone else', () => {
+    expect(isSharedWithMe(rec({ type: 'remote', ownerId: 'u-other' }), me)).toBe(true);
+    expect(isSharedWithMe(rec({ type: 'cached', ownerId: 'u-other' }), me)).toBe(true);
+  });
+
+  it('is false for my own docs, local docs, and unknown owners', () => {
+    expect(isSharedWithMe(rec({ type: 'remote', ownerId: me }), me)).toBe(false);
+    expect(isSharedWithMe(rec({ type: 'local' }), me)).toBe(false);
+    expect(isSharedWithMe(rec({ type: 'remote', ownerId: '' }), me)).toBe(false);
+    expect(isSharedWithMe(rec({ type: 'cached' }), me)).toBe(false);
+  });
+
+  it('is false when signed out (no user id to compare against)', () => {
+    expect(isSharedWithMe(rec({ type: 'remote', ownerId: 'u-other' }), undefined)).toBe(false);
   });
 });
 

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -53,8 +53,19 @@ import { tagsMatch } from '../../types/DocumentTags';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
 import { confirmDialog, promptDialog } from '../confirm/confirmStore';
 
-/** Document type axis the nav rail / filter row toggles. */
-export type FilterMode = 'all' | 'local' | 'team' | 'cached';
+/** Document type axis the nav rail / filter row toggles. `'shared'` (JP-444)
+ *  is relay-backed docs owned by someone other than the signed-in user. */
+export type FilterMode = 'all' | 'local' | 'team' | 'cached' | 'shared';
+
+/**
+ * A relay-backed doc someone else owns and this user can see (JP-444). Owner
+ * identity comes from the relay listing; docs without owner metadata (older
+ * relays, caches that never captured it) are excluded rather than guessed.
+ */
+export function isSharedWithMe(record: DocumentRecord, userId: string | undefined): boolean {
+  if (record.type === 'local' || !userId) return false;
+  return !!record.ownerId && record.ownerId !== userId;
+}
 
 /** Section key for documents that belong to no collection. */
 export const UNASSIGNED_KEY = '__unassigned__';
@@ -71,6 +82,17 @@ export function compareRecords(a: DocumentRecord, b: DocumentRecord, sort: Docum
       return b.name.localeCompare(a.name, undefined, { sensitivity: 'base' });
     case 'created-desc':
       return b.createdAt - a.createdAt;
+    case 'size-desc':
+    case 'size-asc': {
+      // Docs without a recorded size (local docs, pre-JP-443 relay entries)
+      // sort after every sized doc in either direction, then by recency.
+      const av = a.sizeBytes;
+      const bv = b.sizeBytes;
+      if (av === undefined && bv === undefined) return b.modifiedAt - a.modifiedAt;
+      if (av === undefined) return 1;
+      if (bv === undefined) return -1;
+      return sort === 'size-desc' ? bv - av : av - bv;
+    }
   }
 }
 
@@ -128,6 +150,8 @@ export const SORT_LABELS: Record<DocumentBrowserSort, string> = {
   'name-asc': 'Name (A–Z)',
   'name-desc': 'Name (Z–A)',
   'created-desc': 'Recently created',
+  'size-desc': 'Largest first',
+  'size-asc': 'Smallest first',
 };
 
 /** A grouping bucket: a collection (or the synthetic "Unassigned") + its docs. */
@@ -141,7 +165,7 @@ export interface DocumentBrowserModel {
   // Filtered data
   documentList: DocumentRecord[];
   groupedSections: GroupedSection[] | null;
-  documentCounts: { total: number; local: number; team: number; cached: number };
+  documentCounts: { total: number; local: number; team: number; cached: number; shared: number };
   // Collections
   collections: Collection[];
   collectionsMap: Record<string, Collection>;
@@ -330,6 +354,8 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       filtered = allDocs.filter((d) => d.type === 'remote');
     } else if (filterMode === 'cached') {
       filtered = allDocs.filter((d) => d.type === 'cached');
+    } else if (filterMode === 'shared') {
+      filtered = allDocs.filter((d) => isSharedWithMe(d, currentUser?.id));
     }
 
     // Nav-rail single-collection filter (DocumentsHome). Independent of the
@@ -352,7 +378,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
     }
 
     return [...filtered].sort((a, b) => compareRecords(a, b, sort));
-  }, [entries, getFilteredDocuments, filterMode, collectionFilter, assignments, searchQuery, sort]);
+  }, [entries, getFilteredDocuments, filterMode, collectionFilter, assignments, searchQuery, sort, currentUser?.id]);
 
   // Case-insensitive union of tags across the whole registry — NOT the
   // filtered documentList, so an active search doesn't starve the tag editor's
@@ -463,8 +489,9 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
       local: allDocs.filter((d) => d.type === 'local').length,
       team: allDocs.filter((d) => d.type === 'remote').length,
       cached: allDocs.filter((d) => d.type === 'cached').length,
+      shared: allDocs.filter((d) => isSharedWithMe(d, currentUser?.id)).length,
     };
-  }, [entries]);
+  }, [entries, currentUser?.id]);
 
   // Clear selection when the visible list changes meaningfully.
   useEffect(() => {


### PR DESCRIPTION
Hard frontend design pass over the Documents home, aligning it to the design kit. App-only — zero relay changes (the relay listing already returns everything the new UI shows).

## What changed

**Navy rail, both themes.** The rail is now constant navy (kit radial gradient, steel text scale, gold-soft actives, mono counts/section labels) via a single sanctioned `--rail-*` constant block; the main area keeps flipping with the theme tokens.

**Rail-top workspace switcher.** `RailWorkspaceSwitcher` replaces the sign-in pill: initials avatar + workspace name + role/region mono meta, with a viewport-clamped dropdown listing the user's workspaces (roster-refreshed on open, reusing `listWorkspaces`/`switchWorkspace`/`RoleBadge`) plus manage-connection and web-account actions.

**List view is a real table.** Full-mode cards become aligned rows — flexing name column, then fixed last-edited / people / size tracks shared with a sticky column header through `--dh-col-*` variables. Name / Last edited / Size headers click-toggle sorting (new `size-desc`/`size-asc` sorts; unsized docs sort last); the Sort dropdown now renders only in grid view. The People cell is a `PeopleStack` (owner + shares as deterministic-hue initials avatars, `+N` overflow) that opens the permissions dialog when the viewer may manage access.

**Share metadata survives the registry.** `sharedWith`, `lastModifiedByName`, and owner identity now carry through remote → cached → remote conversions (previously `toRemoteFromCached` blanked the owner), backing the People column and a new **Shared with me** nav filter (`isSharedWithMe` on the relay-provided owner vs the signed-in user).

**Hybrid Continue-working cards.** Six preview cards: real mini canvas thumbnails when content is locally available (registry in-memory → localStorage → IndexedDB relay cache, rendered through the pure `exportToSvg` over the active page's first 40 shapes) and stylized placeholders otherwise (dot-grid node chips for canvas docs, paper-gradient skeleton lines for prose-only), tinted by the doc's collection accent. The strip skips libraries of ≤4 docs.

**Polish.** `Ctrl/Cmd+K` focuses the library search on this surface (capture-phase so the editor's palette keeps the key elsewhere), `/` kbd hint in the field, tailored empty states (first-run CTAs, empty collection, empty Shared with me), gold-ring `:focus-visible`, `prefers-reduced-motion` respected, mobile drawer keeps the navy rail.

**Docs-site** (same PR): quick-start reflects the real Documents-home flow, keyboard shortcuts list the library search keys, sharing-and-access documents the People-avatars entry point and the Shared with me filter.

## Verification

- `bun run typecheck` clean; **3047 tests / 260 files green**, including new coverage for the conversion carry-through, `isSharedWithMe`, and the size sorts.
- Verified live on the dev preview: navy rail constant in light + dark, table alignment + header sorting, grid view, switcher dropdown (signed-out state), hybrid thumbnails (4 real SVG renders + prose skeletons), 375px drawer with no horizontal overflow.
- Signed-in states (people avatars, sizes, Shared with me, workspace roster) render from relay-listing fields already in production — E2E against a live workspace pends the usual staging pass.

Known limit (documented in `recentThumbnails.ts`): image/file shapes render as empty frames in thumbnails (unresolved `blob://` at card size).

Assisted-by: Fable 5