### PR TITLE
JP-398: viewer UX — reading state, bookmarks, A/V handlers, floating viewer, PDF actions

### DIFF
--- a/docs-site/guide/citations.md
+++ b/docs-site/guide/citations.md
@@ -39,6 +39,14 @@ automatically.
 Use the `@` menu to search and insert references you've already added, so the same
 source is only stored once per document.
 
+### Cite an Embedded PDF
+
+Open an embedded PDF in the file viewer and click **Cite** in the header.
+DocuShark scans the PDF's metadata and first pages for its DOI, resolves it,
+and adds the full reference to the library. If no DOI is found you can paste
+one, or add a minimal reference built from the file's details and fill it in
+later.
+
 ## Bibliography
 
 Insert a bibliography to list your sources in a formatted reference list. By

--- a/docs-site/guide/embedded-files.md
+++ b/docs-site/guide/embedded-files.md
@@ -29,9 +29,11 @@ Right-click on an empty area of the canvas and choose **Embed file...** to open 
 
 | Category | File Types | Viewer |
 |----------|-----------|--------|
-| **PDF** | `.pdf` | Continuous scrolling reader with text selection, search, outline, and immersive mode |
+| **PDF** | `.pdf` | Continuous scrolling reader with text selection, search, outline, bookmarks, and immersive mode |
 | **Spreadsheet** | `.xlsx`, `.csv` | Table view with sheet tabs, virtual scrolling |
 | **Image** | `.png`, `.jpg`, `.gif`, `.svg`, etc. | Full-resolution display with zoom and pan |
+| **Audio** | `.mp3`, `.wav`, `.ogg`, `.flac`, etc. | Built-in player (playable formats depend on your system) |
+| **Video** | `.mp4`, `.webm`, `.mov`, etc. | Built-in player (playable formats depend on your system) |
 | **Text** | `.txt`, `.md`, `.log`, etc. | Monospace view with line numbers |
 | **Other** | Any file type | File info display (no preview) |
 
@@ -40,9 +42,18 @@ Right-click on an empty area of the canvas and choose **Embed file...** to open 
 **Double-click** a file shape on the canvas to open it in the built-in viewer.
 
 The viewer opens as a full-screen modal with:
-- File-type-specific rendering (PDF pages, spreadsheet tables, images, etc.)
+- File-type-specific rendering (PDF pages, spreadsheet tables, images, media players, etc.)
+- **File info** — size, type, page count, and the file's content checksum
 - **Download** button to save the file locally
 - **Close** button or press `Escape` to return to the canvas
+
+### Floating Viewer
+
+On desktop-sized screens, click the **pop-out** button in the viewer header to
+detach it into a floating panel — drag it by its header, resize it from the
+right and bottom edges, and keep reading a PDF while you edit the document
+beside it. The panel remembers its position and size; the **dock** button (or
+opening the viewer on a small screen) returns it to the full-screen modal.
 
 ### PDF Viewer
 
@@ -55,6 +66,9 @@ The PDF viewer is a full reading experience:
 - **Zoom** — fit-width, fit-page, stepped zoom buttons, or `Ctrl` + mouse wheel
 - **Immersive reading** — expand to a distraction-free full-screen view; a floating strip keeps page navigation at hand, and `Escape` returns to the normal viewer
 - **Dim pages** — in dark mode, soften bright pages for comfortable reading
+- **Bookmarks + reading position** — press `b` (or use the bookmark button) to mark pages; the Bookmarks sidebar tab lists, renames, and jumps to them. The viewer reopens on the page you left, with your zoom mode — per person, on this device; nothing is written into the shared document
+- **Cite** — add the PDF to the document's [reference library](./citations.md) from its DOI
+- **Send page to canvas** — render the current page as a high-resolution image on the canvas, ready to annotate
 
 ### Spreadsheet Viewer
 

--- a/src/services/canvasImportSeam.ts
+++ b/src/services/canvasImportSeam.ts
@@ -1,0 +1,28 @@
+/**
+ * Seam letting non-canvas UI (the file viewer's "send page to canvas") import
+ * files at the viewport center without a UI→engine import cycle. Mirrors the
+ * registerBlobDownloader pattern in blobResolver: CanvasContainer registers a
+ * handler while an engine exists; callers degrade gracefully when none does.
+ */
+
+type ViewportImporter = (files: File[]) => Promise<boolean>;
+
+let importer: ViewportImporter | null = null;
+
+/** Register (or clear, with null) the active viewport importer. */
+export function registerViewportImporter(fn: ViewportImporter | null): void {
+  importer = fn;
+}
+
+/**
+ * Import files as shapes at the canvas viewport center. Resolves false when
+ * no canvas is mounted (or the import failed) — callers surface that state.
+ */
+export async function importFilesAtViewportCenter(files: File[]): Promise<boolean> {
+  if (!importer) return false;
+  try {
+    return await importer(files);
+  } catch {
+    return false;
+  }
+}

--- a/src/services/citations/citePdf.ts
+++ b/src/services/citations/citePdf.ts
@@ -1,0 +1,117 @@
+/**
+ * Cite-a-PDF orchestration: sniff a DOI (and title) out of an embedded PDF's
+ * metadata + first pages, resolve it to CSL-JSON via the existing DOI pipeline,
+ * and import it into the document's reference library.
+ *
+ * Parses the PDF independently of the viewer (pdf.js lazy-imported, same as
+ * ThumbnailGenerator) so the file-viewer header can offer "Cite" without
+ * coupling to the reader's internals. A one-click action on a paper-sized PDF
+ * parses in well under a second; not worth sharing the viewer's instance.
+ */
+
+import { resolveDoi } from './ingest';
+import { importReferences } from './referenceImport';
+import { extractLikelyDoi } from './pdfDoiExtract';
+import type { CSLItem } from '../../types/Citation';
+
+export interface PdfCitationHints {
+  doi: string | null;
+  title: string | null;
+}
+
+export type CitePdfStatus = 'added' | 'duplicate' | 'no-doi' | 'resolve-failed';
+
+export interface CitePdfResult {
+  status: CitePdfStatus;
+  doi: string | null;
+  title: string | null;
+}
+
+/** Metadata fields worth scanning for a DOI, in priority order. */
+const METADATA_DOI_FIELDS = ['doi', 'DOI', 'Subject', 'Keywords', 'Title'] as const;
+
+/** How many leading pages of text to scan (papers put the DOI on page 1-2). */
+const PAGES_TO_SCAN = 2;
+
+/**
+ * Extract DOI + title hints from PDF bytes. Metadata fields are scanned before
+ * page text so a document-declared DOI outranks DOIs of cited works.
+ */
+export async function extractPdfCitationHints(data: ArrayBuffer): Promise<PdfCitationHints> {
+  const pdfjsLib = await import('pdfjs-dist');
+  if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
+    pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+      'pdfjs-dist/build/pdf.worker.min.mjs',
+      import.meta.url,
+    ).toString();
+  }
+
+  const loadingTask = pdfjsLib.getDocument({ data });
+  try {
+    const doc = await loadingTask.promise;
+    const sources: string[] = [];
+    let title: string | null = null;
+
+    try {
+      const meta = await doc.getMetadata();
+      const info = (meta.info ?? {}) as Record<string, unknown>;
+      const rawTitle = info['Title'];
+      if (typeof rawTitle === 'string' && rawTitle.trim() !== '') {
+        title = rawTitle.trim();
+      }
+      for (const field of METADATA_DOI_FIELDS) {
+        const value = info[field];
+        if (typeof value === 'string') sources.push(value);
+      }
+    } catch {
+      /* metadata is optional */
+    }
+
+    const pageCount = Math.min(PAGES_TO_SCAN, doc.numPages);
+    for (let p = 1; p <= pageCount; p++) {
+      try {
+        const page = await doc.getPage(p);
+        const content = await page.getTextContent();
+        sources.push(
+          content.items.map((item) => ('str' in item ? item.str : '')).join(' '),
+        );
+      } catch {
+        /* a broken page shouldn't kill the whole extraction */
+      }
+    }
+
+    return { doi: extractLikelyDoi(sources), title };
+  } finally {
+    await loadingTask.destroy().catch(() => undefined);
+  }
+}
+
+/** Resolve a DOI and import the result into the reference library. */
+export async function citeDoi(doi: string): Promise<CitePdfStatus> {
+  const result = await resolveDoi(doi);
+  if (result.items.length === 0) return 'resolve-failed';
+  const { added } = importReferences(result.items);
+  return added > 0 ? 'added' : 'duplicate';
+}
+
+/** Full flow: extract hints from the PDF, then resolve + import its DOI. */
+export async function citePdf(blob: Blob): Promise<CitePdfResult> {
+  const hints = await extractPdfCitationHints(await blob.arrayBuffer());
+  if (!hints.doi) return { status: 'no-doi', ...hints };
+  const status = await citeDoi(hints.doi);
+  return { status, ...hints };
+}
+
+/**
+ * Fallback for DOI-less files: a minimal CSL item from the file's own
+ * metadata, so the reference at least exists and can be enriched by hand.
+ */
+export function citeMinimal(fileName: string, title: string | null): CitePdfStatus {
+  const item: CSLItem = {
+    id: '',
+    type: 'document',
+    title: title ?? fileName.replace(/\.pdf$/i, ''),
+  };
+  const { added } = importReferences([item]);
+  return added > 0 ? 'added' : 'duplicate';
+}

--- a/src/services/citations/pdfDoiExtract.test.ts
+++ b/src/services/citations/pdfDoiExtract.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { extractDoiCandidates, extractLikelyDoi } from './pdfDoiExtract';
+
+describe('extractDoiCandidates', () => {
+  it('finds a plain DOI in page text', () => {
+    expect(
+      extractLikelyDoi(['This article: doi 10.1038/s41586-020-2649-2 published in Nature.']),
+    ).toBe('10.1038/s41586-020-2649-2');
+  });
+
+  it('trims sentence punctuation', () => {
+    expect(extractLikelyDoi(['See https://doi.org/10.1145/3517349.3520266.'])).toBe(
+      '10.1145/3517349.3520266',
+    );
+    expect(extractLikelyDoi(['(doi: 10.1109/5.771073),'])).toBe('10.1109/5.771073');
+  });
+
+  it('keeps balanced parentheses that are part of the DOI', () => {
+    expect(extractLikelyDoi(['ref 10.1016/S0140-6736(20)30183-5 here'])).toBe(
+      '10.1016/S0140-6736(20)30183-5',
+    );
+  });
+
+  it('trims an unbalanced closing paren from surrounding prose', () => {
+    expect(extractLikelyDoi(['(see 10.1002/andp.19053221004)'])).toBe(
+      '10.1002/andp.19053221004',
+    );
+  });
+
+  it('ranks earlier sources first and dedupes case-insensitively', () => {
+    const candidates = extractDoiCandidates([
+      'Metadata DOI: 10.5555/META',
+      'Body cites 10.5555/meta and also 10.1234/other-work.1',
+    ]);
+    expect(candidates).toEqual(['10.5555/META', '10.1234/other-work.1']);
+  });
+
+  it('ignores non-DOI decimals and empty suffixes', () => {
+    expect(extractLikelyDoi(['Section 10.2 covers results; ratio was 10.5/12'])).toBeNull();
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(extractLikelyDoi(['no identifiers here'])).toBeNull();
+    expect(extractDoiCandidates([])).toEqual([]);
+  });
+});

--- a/src/services/citations/pdfDoiExtract.ts
+++ b/src/services/citations/pdfDoiExtract.ts
@@ -1,0 +1,58 @@
+/**
+ * DOI extraction from PDF-derived text (metadata fields + page text). Pure
+ * string logic so ranking/trimming is unit-testable without pdf.js.
+ */
+
+/** Registrant prefix `10.NNNN/` followed by a suffix (no whitespace). */
+const DOI_PATTERN = /\b10\.\d{4,9}\/\S+/g;
+
+/**
+ * Punctuation that ends a sentence around a DOI but is never meaningfully the
+ * end of one. Balanced trailing parens do occur in real DOIs, so `)` is only
+ * trimmed when unbalanced within the match.
+ */
+const TRAILING_PUNCTUATION = /[.,;:!?'"”’]+$/;
+
+function trimDoi(raw: string): string {
+  let doi = raw.replace(TRAILING_PUNCTUATION, '');
+  // Trim unbalanced closing brackets picked up from surrounding prose.
+  for (const [open, close] of [
+    ['(', ')'],
+    ['[', ']'],
+    ['{', '}'],
+  ] as const) {
+    while (doi.endsWith(close)) {
+      const opens = doi.split(open).length - 1;
+      const closes = doi.split(close).length - 1;
+      if (closes > opens) doi = doi.slice(0, -1).replace(TRAILING_PUNCTUATION, '');
+      else break;
+    }
+  }
+  return doi;
+}
+
+/**
+ * Collect DOI candidates from ordered text sources (callers pass metadata
+ * fields before page text so document-declared DOIs outrank cited ones).
+ * Deduped case-insensitively (DOIs are case-insensitive), order preserved.
+ */
+export function extractDoiCandidates(sources: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const text of sources) {
+    for (const match of text.matchAll(DOI_PATTERN)) {
+      const doi = trimDoi(match[0]);
+      if (doi.length < 8) continue; // "10.1234/" with an empty suffix
+      const key = doi.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(doi);
+    }
+  }
+  return out;
+}
+
+/** The best DOI candidate, or null when none was found. */
+export function extractLikelyDoi(sources: string[]): string | null {
+  return extractDoiCandidates(sources)[0] ?? null;
+}

--- a/src/shapes/Shape.ts
+++ b/src/shapes/Shape.ts
@@ -7,6 +7,7 @@
  */
 
 import type { LabelOverflow } from './label/LabelSpec';
+import type { FileCategory } from '../utils/fileUtils';
 
 /**
  * Standard handle types for resize/rotate operations.
@@ -59,8 +60,12 @@ export interface Handle {
   metadata?: HandleMetadata;
 }
 
-/** File category for embedded file shapes */
-export type FileCategory = 'pdf' | 'spreadsheet' | 'image' | 'text' | 'generic';
+/**
+ * File category for embedded file shapes. Defined in fileUtils (detection
+ * lives there); re-exported type-only so shape consumers keep importing it
+ * from here without a runtime shapes→utils edge.
+ */
+export type { FileCategory };
 
 /**
  * Core shape type discriminator.

--- a/src/store/fileViewState.test.ts
+++ b/src/store/fileViewState.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_VIEW_RECORDS,
+  viewKey,
+  upsertRecord,
+  toggleBookmark,
+  renameBookmark,
+  removeBookmark,
+  reconcileRecord,
+  type FileViewRecord,
+  type PdfBookmark,
+} from './fileViewState';
+
+const NOW = 1_000_000;
+
+function record(overrides: Partial<FileViewRecord> = {}): FileViewRecord {
+  return {
+    hash: 'hash-a',
+    lastPage: 5,
+    zoomMode: 'page-width',
+    bookmarks: [],
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('viewKey', () => {
+  it('composes docId and shapeId', () => {
+    expect(viewKey('doc1', 'shape9')).toBe('doc1:shape9');
+  });
+});
+
+describe('upsertRecord', () => {
+  it('creates a record with defaults + patch', () => {
+    const out = upsertRecord({}, 'k', { hash: 'h', lastPage: 3 }, NOW);
+    expect(out['k']).toEqual({
+      hash: 'h',
+      lastPage: 3,
+      zoomMode: 'page-width',
+      bookmarks: [],
+      updatedAt: NOW,
+    });
+  });
+
+  it('merges into an existing record and stamps updatedAt', () => {
+    const initial = { k: record({ lastPage: 2, updatedAt: 1 }) };
+    const out = upsertRecord(initial, 'k', { lastPage: 7 }, NOW);
+    expect(out['k']!.lastPage).toBe(7);
+    expect(out['k']!.hash).toBe('hash-a');
+    expect(out['k']!.updatedAt).toBe(NOW);
+    // Input untouched (pure)
+    expect(initial['k']!.lastPage).toBe(2);
+  });
+
+  it('evicts oldest records over the cap', () => {
+    let records: Record<string, FileViewRecord> = {};
+    for (let i = 0; i < MAX_VIEW_RECORDS; i++) {
+      records = upsertRecord(records, `k${i}`, { hash: 'h' }, i);
+    }
+    const out = upsertRecord(records, 'new', { hash: 'h' }, NOW);
+    expect(Object.keys(out)).toHaveLength(MAX_VIEW_RECORDS);
+    expect(out['new']).toBeDefined();
+    expect(out['k0']).toBeUndefined(); // oldest evicted
+    expect(out['k1']).toBeDefined();
+  });
+
+  it('prefers evicting bookmark-less records over bookmarked ones', () => {
+    const bookmark: PdfBookmark = { page: 1, createdAt: 0 };
+    let records: Record<string, FileViewRecord> = {};
+    // Oldest record is bookmarked; the next-oldest is not.
+    records = upsertRecord(records, 'bookmarked-old', { hash: 'h', bookmarks: [bookmark] }, 0);
+    for (let i = 1; i < MAX_VIEW_RECORDS; i++) {
+      records = upsertRecord(records, `plain${i}`, { hash: 'h' }, i);
+    }
+    const out = upsertRecord(records, 'new', { hash: 'h' }, NOW);
+    expect(out['bookmarked-old']).toBeDefined(); // survived despite being oldest
+    expect(out['plain1']).toBeUndefined(); // oldest bookmark-less evicted instead
+  });
+
+  it('never evicts the just-updated key', () => {
+    let records: Record<string, FileViewRecord> = {};
+    for (let i = 0; i < MAX_VIEW_RECORDS + 5; i++) {
+      records = upsertRecord(records, `k${i}`, { hash: 'h' }, i);
+    }
+    // The final key has the newest stamp, but even updating with an old-looking
+    // timestamp must keep it.
+    const out = upsertRecord(records, 'target', { hash: 'h' }, 0);
+    expect(out['target']).toBeDefined();
+    expect(Object.keys(out)).toHaveLength(MAX_VIEW_RECORDS);
+  });
+});
+
+describe('toggleBookmark', () => {
+  it('adds when absent, sorted by page', () => {
+    const out = toggleBookmark([{ page: 8, createdAt: 1 }], 3, NOW);
+    expect(out.map((b) => b.page)).toEqual([3, 8]);
+    expect(out[0]!.createdAt).toBe(NOW);
+  });
+
+  it('removes when present', () => {
+    const out = toggleBookmark(
+      [
+        { page: 3, createdAt: 1 },
+        { page: 8, createdAt: 2 },
+      ],
+      3,
+      NOW,
+    );
+    expect(out.map((b) => b.page)).toEqual([8]);
+  });
+
+  it('round-trips to the original set', () => {
+    const start: PdfBookmark[] = [{ page: 2, createdAt: 1 }];
+    const out = toggleBookmark(toggleBookmark(start, 5, NOW), 5, NOW);
+    expect(out.map((b) => b.page)).toEqual([2]);
+  });
+});
+
+describe('renameBookmark', () => {
+  const marks: PdfBookmark[] = [
+    { page: 2, createdAt: 1 },
+    { page: 5, createdAt: 2, label: 'Results' },
+  ];
+
+  it('sets a trimmed label', () => {
+    const out = renameBookmark(marks, 2, '  Methods  ');
+    expect(out[0]!.label).toBe('Methods');
+    expect(out[1]!.label).toBe('Results');
+  });
+
+  it('clears the label on empty input', () => {
+    const out = renameBookmark(marks, 5, '   ');
+    expect(out[1]!.label).toBeUndefined();
+    expect('label' in out[1]!).toBe(false);
+  });
+
+  it('ignores pages without a bookmark', () => {
+    expect(renameBookmark(marks, 9, 'x')).toEqual(marks);
+  });
+});
+
+describe('removeBookmark', () => {
+  it('removes only the targeted page', () => {
+    const out = removeBookmark(
+      [
+        { page: 2, createdAt: 1 },
+        { page: 5, createdAt: 2 },
+      ],
+      2,
+    );
+    expect(out.map((b) => b.page)).toEqual([5]);
+  });
+});
+
+describe('reconcileRecord', () => {
+  it('returns the same reference when hash matches and lastPage is in range', () => {
+    const rec = record({ lastPage: 5 });
+    expect(reconcileRecord(rec, 'hash-a', 10)).toBe(rec);
+  });
+
+  it('clamps a corrupt lastPage even without a replacement', () => {
+    const rec = record({ lastPage: 40 });
+    const out = reconcileRecord(rec, 'hash-a', 10);
+    expect(out.lastPage).toBe(10);
+    expect(out.hash).toBe('hash-a');
+  });
+
+  it('on replacement: rewrites hash, clamps lastPage, prunes out-of-range bookmarks', () => {
+    const rec = record({
+      lastPage: 11,
+      bookmarks: [
+        { page: 2, createdAt: 1, label: 'Intro' },
+        { page: 12, createdAt: 2 },
+      ],
+    });
+    const out = reconcileRecord(rec, 'hash-b', 6);
+    expect(out.hash).toBe('hash-b');
+    expect(out.lastPage).toBe(6);
+    expect(out.bookmarks.map((b) => b.page)).toEqual([2]);
+    expect(out.bookmarks[0]!.label).toBe('Intro'); // in-range bookmarks keep labels
+  });
+
+  it('on replacement with everything in range: keeps page and bookmarks', () => {
+    const rec = record({ lastPage: 3, bookmarks: [{ page: 2, createdAt: 1 }] });
+    const out = reconcileRecord(rec, 'hash-b', 20);
+    expect(out.hash).toBe('hash-b');
+    expect(out.lastPage).toBe(3);
+    expect(out.bookmarks).toHaveLength(1);
+  });
+
+  it('handles a degenerate page count', () => {
+    const rec = record({ lastPage: 5, bookmarks: [{ page: 3, createdAt: 1 }] });
+    const out = reconcileRecord(rec, 'hash-b', 0);
+    expect(out.lastPage).toBe(1);
+    expect(out.bookmarks).toHaveLength(0);
+  });
+});

--- a/src/store/fileViewState.ts
+++ b/src/store/fileViewState.ts
@@ -1,0 +1,143 @@
+/**
+ * fileViewState — pure reducers for per-user file reading state (last-viewed
+ * page, zoom mode, page bookmarks), keyed `docId:shapeId`. Deliberately free
+ * of zustand/pdf.js so ordering, eviction, and staleness reconciliation are
+ * unit-testable; fileViewStateStore.ts is the thin persisted wrapper.
+ *
+ * Reading state is per-user and local-only — it never enters the document or
+ * the CRDT (a collaborator's page turns must not sync-fight or dirty the doc).
+ */
+
+export interface PdfBookmark {
+  /** 1-based page number. */
+  page: number;
+  /** Optional user label; absent = show "Page N". */
+  label?: string;
+  createdAt: number;
+}
+
+export type FileViewZoomMode = 'page-width' | 'page-fit' | 'custom';
+
+export interface FileViewRecord {
+  /** Content hash (`FileShape.blobRef`) the state was recorded against. */
+  hash: string;
+  /** 1-based last-viewed page. */
+  lastPage: number;
+  zoomMode: FileViewZoomMode;
+  /** Numeric zoom (percent) when zoomMode is 'custom'. */
+  zoomPercent?: number;
+  bookmarks: PdfBookmark[];
+  updatedAt: number;
+}
+
+/** Hard cap on stored records; oldest bookmark-less records evict first. */
+export const MAX_VIEW_RECORDS = 200;
+
+export function viewKey(docId: string, shapeId: string): string {
+  return `${docId}:${shapeId}`;
+}
+
+function defaultRecord(now: number): FileViewRecord {
+  return { hash: '', lastPage: 1, zoomMode: 'page-width', bookmarks: [], updatedAt: now };
+}
+
+/**
+ * Merge `patch` into the record at `key` (creating it if absent), stamp
+ * `updatedAt`, and evict down to `cap`. Eviction prefers records WITHOUT
+ * bookmarks first (a bookmarked file is user-invested; don't silently drop it
+ * before trivially-opened ones), oldest `updatedAt` first within each class.
+ * The just-updated key is never evicted.
+ */
+export function upsertRecord(
+  records: Record<string, FileViewRecord>,
+  key: string,
+  patch: Partial<Omit<FileViewRecord, 'updatedAt'>>,
+  now: number,
+  cap: number = MAX_VIEW_RECORDS,
+): Record<string, FileViewRecord> {
+  const existing = records[key] ?? defaultRecord(now);
+  const next: Record<string, FileViewRecord> = {
+    ...records,
+    [key]: { ...existing, ...patch, updatedAt: now },
+  };
+
+  const keys = Object.keys(next);
+  if (keys.length <= cap) return next;
+
+  const evictable = keys
+    .filter((k) => k !== key)
+    .sort((a, b) => {
+      const ra = next[a] as FileViewRecord;
+      const rb = next[b] as FileViewRecord;
+      const aHasBookmarks = ra.bookmarks.length > 0 ? 1 : 0;
+      const bHasBookmarks = rb.bookmarks.length > 0 ? 1 : 0;
+      if (aHasBookmarks !== bHasBookmarks) return aHasBookmarks - bHasBookmarks;
+      return ra.updatedAt - rb.updatedAt;
+    });
+
+  for (const k of evictable) {
+    if (Object.keys(next).length <= cap) break;
+    delete next[k];
+  }
+  return next;
+}
+
+/** Toggle a bookmark on `page`: present → removed; absent → appended. */
+export function toggleBookmark(
+  bookmarks: PdfBookmark[],
+  page: number,
+  now: number,
+): PdfBookmark[] {
+  if (bookmarks.some((b) => b.page === page)) {
+    return bookmarks.filter((b) => b.page !== page);
+  }
+  return [...bookmarks, { page, createdAt: now }].sort((a, b) => a.page - b.page);
+}
+
+/** Set (or clear, with an empty string) the label of the bookmark on `page`. */
+export function renameBookmark(
+  bookmarks: PdfBookmark[],
+  page: number,
+  label: string,
+): PdfBookmark[] {
+  const trimmed = label.trim();
+  return bookmarks.map((b) => {
+    if (b.page !== page) return b;
+    if (trimmed === '') {
+      const { label: _dropped, ...rest } = b;
+      return rest;
+    }
+    return { ...b, label: trimmed };
+  });
+}
+
+export function removeBookmark(bookmarks: PdfBookmark[], page: number): PdfBookmark[] {
+  return bookmarks.filter((b) => b.page !== page);
+}
+
+/**
+ * Reconcile a stored record against the file's current content hash and live
+ * page count. When the hash differs (the file was replaced upstream), clamp
+ * `lastPage` and drop bookmarks past the new end — in-range bookmarks are kept
+ * as still-useful anchors even though their labels may be semantically stale —
+ * and rewrite `hash` so the clamp happens once per replacement. Returns the
+ * input record unchanged (same reference) when nothing needs fixing.
+ */
+export function reconcileRecord(
+  record: FileViewRecord,
+  currentHash: string,
+  numPages: number,
+): FileViewRecord {
+  const maxPage = Math.max(1, numPages);
+  if (record.hash === currentHash) {
+    // Same content; still defend against a corrupt lastPage.
+    if (record.lastPage <= maxPage && record.lastPage >= 1) return record;
+    return { ...record, lastPage: Math.min(maxPage, Math.max(1, record.lastPage)) };
+  }
+  return {
+    ...record,
+    hash: currentHash,
+    lastPage: Math.min(maxPage, Math.max(1, record.lastPage)),
+    bookmarks: record.bookmarks.filter((b) => b.page <= maxPage),
+  };
+}

--- a/src/store/fileViewStateStore.ts
+++ b/src/store/fileViewStateStore.ts
@@ -1,0 +1,52 @@
+/**
+ * Persisted per-user file reading state (last page, zoom, bookmarks), keyed
+ * `docId:shapeId`. Deliberately isolated from the versioned uiPreferencesStore
+ * (shapePickerStore pattern): its own localStorage key, no migration chain,
+ * capped by the bookmark-preferring LRU in fileViewState.ts. Local-only by
+ * design — reading position must never enter the document or the CRDT.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import {
+  upsertRecord,
+  viewKey,
+  type FileViewRecord,
+} from './fileViewState';
+
+export interface FileViewStateState {
+  records: Record<string, FileViewRecord>;
+  /** Merge a patch into the record for this file (creates it if absent). */
+  upsert: (
+    docId: string,
+    shapeId: string,
+    patch: Partial<Omit<FileViewRecord, 'updatedAt'>>,
+  ) => void;
+  clear: () => void;
+}
+
+export const useFileViewStateStore = create<FileViewStateState>()(
+  persist(
+    (set) => ({
+      records: {},
+      upsert: (docId, shapeId, patch) =>
+        set((state) => ({
+          records: upsertRecord(state.records, viewKey(docId, shapeId), patch, Date.now()),
+        })),
+      clear: () => set({ records: {} }),
+    }),
+    {
+      name: 'docushark-file-view-state',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ records: state.records }),
+    },
+  ),
+);
+
+/** Non-hook read for imperative call-sites. */
+export function getFileViewRecord(
+  docId: string,
+  shapeId: string,
+): FileViewRecord | undefined {
+  return useFileViewStateStore.getState().records[viewKey(docId, shapeId)];
+}

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -127,6 +127,12 @@ export interface SessionState {
   editingTextId: string | null;
   /** ID of file shape currently being viewed in modal (null if not viewing) */
   viewingFileShapeId: string | null;
+  /**
+   * How the file viewer hosts its content: full-screen modal or the floating
+   * side panel. Sticky for the session — opening another file keeps the mode.
+   * Mobile-adapted viewports coerce to 'modal' at render (fileViewerMode.ts).
+   */
+  fileViewerMode: 'modal' | 'floating';
   /** Snapping settings */
   snapSettings: SnapSettings;
   /** Active snap guides for visual feedback */
@@ -199,6 +205,7 @@ export interface SessionActions {
   // File viewing
   openFileViewer: (id: string) => void;
   closeFileViewer: () => void;
+  setFileViewerMode: (mode: 'modal' | 'floating') => void;
   isViewingFile: () => boolean;
 
   // Snapping
@@ -288,6 +295,7 @@ const initialState: SessionState = {
   hoveredId: null,
   editingTextId: null,
   viewingFileShapeId: null,
+  fileViewerMode: 'modal',
   snapSettings: { ...DEFAULT_SNAP_SETTINGS },
   snapGuides: {},
   emphasizedShapeId: null,
@@ -420,6 +428,10 @@ export const useSessionStore = create<SessionState & SessionActions>()((set, get
 
   closeFileViewer: () => {
     set({ viewingFileShapeId: null });
+  },
+
+  setFileViewerMode: (mode: 'modal' | 'floating') => {
+    set({ fileViewerMode: mode });
   },
 
   isViewingFile: (): boolean => {

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -149,6 +149,13 @@ export interface UIPreferencesState {
    */
   collabIndicatorPos: { x: number; y: number } | null;
   /**
+   * Persisted bounds (viewport px) of the floating file viewer (JP-398).
+   * `null` = right-side default sized to the window; the first drag/resize
+   * pins it. App-level (a placement preference, not per-doc state), clamped
+   * into the viewport at render time.
+   */
+  floatingViewerBounds: { x: number; y: number; w: number; h: number } | null;
+  /**
    * Whether the user accepted the experimental mobile-preview layout (JP-332).
    * Persisted so the one-time prompt fires at most once per browser. Gates the
    * mobile chrome together with `forceDesktopSite` — see `useMobileAdaptation`.
@@ -181,6 +188,8 @@ export interface UIPreferencesActions {
   setRelaxedSplitCanvasWidth: (width: number | null) => void;
   /** Pin the floating collaboration indicator's top-left (viewport px). */
   setCollabIndicatorPos: (pos: { x: number; y: number }) => void;
+  /** Pin the floating file viewer's bounds (viewport px). */
+  setFloatingViewerBounds: (bounds: { x: number; y: number; w: number; h: number }) => void;
   /** Set the document browser view (list/grid) */
   setDocumentBrowserView: (view: DocumentBrowserView) => void;
   /** Set the document browser sort key */
@@ -329,6 +338,7 @@ const initialState: UIPreferencesState = {
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
   collabIndicatorPos: null,
+  floatingViewerBounds: null,
   mobilePreviewAccepted: false,
   forceDesktopSite: false,
 };
@@ -460,6 +470,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setCollabIndicatorPos: (pos: { x: number; y: number }) => {
         set({ collabIndicatorPos: { x: pos.x, y: pos.y } });
+      },
+
+      setFloatingViewerBounds: (bounds: { x: number; y: number; w: number; h: number }) => {
+        set({ floatingViewerBounds: { ...bounds } });
       },
 
       setDocumentBrowserView: (view) => set({ documentBrowserView: view }),
@@ -635,6 +649,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
         collabIndicatorPos: state.collabIndicatorPos,
+        floatingViewerBounds: state.floatingViewerBounds,
         mobilePreviewAccepted: state.mobilePreviewAccepted,
         forceDesktopSite: state.forceDesktopSite,
       }),

--- a/src/ui/CanvasContainer.tsx
+++ b/src/ui/CanvasContainer.tsx
@@ -6,6 +6,9 @@ import { ContextMenu } from './ContextMenu';
 import { ExportDialog } from './ExportDialog';
 import { SaveToLibraryDialog } from './SaveToLibraryDialog';
 import { FileViewerModal } from './FileViewerModal';
+import { FloatingFileViewer } from './FloatingFileViewer';
+import { resolveViewerMode } from './fileViewerMode';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { CollaborativeCursors } from './CollaborativeCursors';
 import { SelectionHighlight } from './SelectionHighlight';
 import { Minimap } from './Minimap';
@@ -20,7 +23,9 @@ import { shapeRegistry } from '../shapes/ShapeRegistry';
 import { Vec2 } from '../math/Vec2';
 import { nanoid } from 'nanoid';
 import type { ImportContext } from '../services/FileImportService';
+import { importFiles } from '../services/FileImportService';
 import { routeImportFiles, importDiagramText } from '../services/importPipeline';
+import { registerViewportImporter } from '../services/canvasImportSeam';
 import { dialog } from '../platform/dialog';
 import { getMimeType } from '../utils/fileUtils';
 import { isTauri } from '../tauri/commands';
@@ -93,6 +98,21 @@ export function CanvasContainer({
   // File viewer state
   const viewingFileShapeId = useSessionStore((state) => state.viewingFileShapeId);
   const closeFileViewer = useSessionStore((state) => state.closeFileViewer);
+  const fileViewerMode = useSessionStore((state) => state.fileViewerMode);
+  const { mobileActive } = useMobileAdaptation();
+
+  // Let non-canvas UI (file viewer "send page to canvas") import at the
+  // viewport center while this canvas is mounted.
+  useEffect(() => {
+    registerViewportImporter(async (files) => {
+      const engine = engineRef.current;
+      if (!engine) return false;
+      const center = engine.camera.getViewportCenter();
+      const result = await importFiles(files, center, { engine });
+      return result.shapeIds.length > 0;
+    });
+    return () => registerViewportImporter(null);
+  }, []);
 
   const getImportContext = useCallback((): ImportContext | null => {
     const engine = engineRef.current;
@@ -615,12 +635,18 @@ export function CanvasContainer({
         isOpen={saveToLibraryOpen}
         onClose={handleCloseSaveToLibrary}
       />
-      {viewingFileShapeId && (
-        <FileViewerModal
-          shapeId={viewingFileShapeId}
-          onClose={closeFileViewer}
-        />
-      )}
+      {viewingFileShapeId &&
+        (resolveViewerMode(fileViewerMode, mobileActive) === 'floating' ? (
+          <FloatingFileViewer
+            shapeId={viewingFileShapeId}
+            onClose={closeFileViewer}
+          />
+        ) : (
+          <FileViewerModal
+            shapeId={viewingFileShapeId}
+            onClose={closeFileViewer}
+          />
+        ))}
     </div>
   );
 }

--- a/src/ui/FileViewerContent.tsx
+++ b/src/ui/FileViewerContent.tsx
@@ -1,0 +1,527 @@
+/**
+ * FileViewerContent — the host-independent core of the file viewer: blob
+ * resolution, header (name/meta/actions/info), missing-blob recovery, and the
+ * per-category viewer dispatch. Hosted by FileViewerModal (full-screen) and
+ * FloatingFileViewer (side panel) — hosts own chrome, Escape, and placement.
+ */
+
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
+import { useDocumentStore } from '../store/documentStore';
+import { blobStorage } from '../storage/BlobStorage';
+import { resolveBlobObjectUrl } from '../storage/blobResolver';
+import { isFile, type FileShape } from '../shapes/Shape';
+import {
+  Copy,
+  Download,
+  FolderOpen,
+  Info,
+  Quote,
+  RotateCw,
+  TriangleAlert,
+  X,
+} from 'lucide-react';
+import { formatFileSize, resolveViewerCategory } from '../utils/fileUtils';
+import { downloadBlob } from '../utils/downloadUtils';
+import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { Icon } from './icons';
+import { replaceFileContents, reuploadMissingBlob } from '../services/FileReplaceService';
+import { citePdf, citeDoi, citeMinimal, type CitePdfStatus } from '../services/citations/citePdf';
+import { useNotificationStore } from '../store/notificationStore';
+import './FileViewerModal.css';
+
+// Lazy-load viewer components to keep main bundle small
+const PdfViewer = lazy(() => import('./viewers/PdfViewer'));
+const SpreadsheetViewer = lazy(() => import('./viewers/SpreadsheetViewer'));
+const ImageViewer = lazy(() => import('./viewers/ImageViewer'));
+const AudioViewer = lazy(() => import('./viewers/AudioViewer'));
+const VideoViewer = lazy(() => import('./viewers/VideoViewer'));
+const TextViewer = lazy(() => import('./viewers/TextViewer'));
+const GenericFileViewer = lazy(() => import('./viewers/GenericFileViewer'));
+
+/** Resolve a shape id to its FileShape, or null when absent/not a file. */
+export function useFileShape(shapeId: string): FileShape | null {
+  const shapes = useDocumentStore((state) => state.shapes);
+  const shape = shapes[shapeId];
+  return shape && isFile(shape) ? shape : null;
+}
+
+export interface FileViewerContentProps {
+  shapeId: string;
+  onClose: () => void;
+  /** Host-owned immersive reading mode (PDF only). */
+  immersive?: boolean | undefined;
+  /** Absent hides the immersive affordance (e.g. in the floating host). */
+  onImmersiveChange?: ((immersive: boolean) => void) | undefined;
+  /** Collapse the header (the modal does this while immersive). */
+  hideHeader?: boolean | undefined;
+  /** Host-provided header buttons (pop-out / dock-back). */
+  headerExtras?: React.ReactNode;
+  /** Host drag-start hook — makes the header the floating panel's handle. */
+  headerPointerDown?: ((e: React.PointerEvent<HTMLDivElement>) => void) | undefined;
+}
+
+export function FileViewerContent({
+  shapeId,
+  onClose,
+  immersive,
+  onImmersiveChange,
+  hideHeader,
+  headerExtras,
+  headerPointerDown,
+}: FileViewerContentProps) {
+  const fileShape = useFileShape(shapeId);
+
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isMissingBlob, setIsMissingBlob] = useState(false);
+  const [isReplacing, setIsReplacing] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+  const [hashCopied, setHashCopied] = useState(false);
+  const [citing, setCiting] = useState(false);
+  // Non-null opens the manual-DOI popover (auto-detect found nothing).
+  const [citePrompt, setCitePrompt] = useState<{ title: string | null } | null>(null);
+  const [doiInput, setDoiInput] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const recoveryInputRef = useRef<HTMLInputElement>(null);
+
+  const blobRef = fileShape?.blobRef;
+  const fileName = fileShape?.fileName ?? '';
+
+  // Load blob on mount. resolveBlobObjectUrl checks the shared object-URL cache,
+  // then local IndexedDB, then downloads from the relay/R2 on a miss — so a file
+  // uploaded on another device (or never pulled locally) still opens (JP-129).
+  // The returned URL is owned by the resolver cache; we never revoke it here.
+  useEffect(() => {
+    if (!blobRef) return;
+
+    let cancelled = false;
+
+    async function loadBlob() {
+      setLoading(true);
+      setError(null);
+      setIsMissingBlob(false);
+
+      try {
+        const url = await resolveBlobObjectUrl(blobRef!);
+        if (cancelled) return;
+        if (!url) {
+          // Truly unavailable: not local, and not downloadable (local-only doc
+          // or the relay fetch failed). resolveBlobObjectUrl already marked the
+          // blob missing, so the canvas overlay reflects it too.
+          setIsMissingBlob(true);
+          setError('File not found in storage.');
+          setLoading(false);
+          return;
+        }
+        setBlobUrl(url);
+      } catch (err) {
+        if (!cancelled) {
+          setError('Failed to load file.');
+          console.error('FileViewerContent: Failed to load blob', err);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadBlob();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [blobRef]);
+
+  // Download file
+  const handleDownload = useCallback(async () => {
+    if (!blobRef) return;
+    try {
+      const blob = await blobStorage.loadBlob(blobRef);
+      if (!blob) return;
+      downloadBlob(blob, fileName);
+    } catch (err) {
+      console.error('Download failed:', err);
+    }
+  }, [blobRef, fileName]);
+
+  // Replace file
+  const handleReplaceClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleReplaceFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      setIsReplacing(true);
+      try {
+        const result = await replaceFileContents(shapeId, file);
+        if (result.success) {
+          // Trigger reload. The old object URL is owned by the resolver cache
+          // (content-addressed, reclaimed on doc switch) — don't revoke it here.
+          // The new blobRef makes the load effect re-resolve the replacement.
+          setBlobUrl(null);
+          setLoading(true);
+          setError(null);
+          setIsMissingBlob(false);
+        }
+      } finally {
+        setIsReplacing(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [shapeId]
+  );
+
+  // Recovery: re-upload missing blob
+  const handleRecoveryClick = useCallback(() => {
+    recoveryInputRef.current?.click();
+  }, []);
+
+  const handleRecoveryFile = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      setIsReplacing(true);
+      try {
+        const result = await reuploadMissingBlob(shapeId, file);
+        if (result.success) {
+          setIsMissingBlob(false);
+          setError(null);
+          setLoading(true);
+        }
+      } finally {
+        setIsReplacing(false);
+        if (recoveryInputRef.current) {
+          recoveryInputRef.current.value = '';
+        }
+      }
+    },
+    [shapeId]
+  );
+
+  // Cite this PDF: auto-detect the DOI, resolve, import. No DOI → popover.
+  const notifyCiteStatus = useCallback((status: CitePdfStatus, doi: string | null) => {
+    const notifications = useNotificationStore.getState();
+    if (status === 'added') {
+      notifications.success('Reference added to the library');
+    } else if (status === 'duplicate') {
+      notifications.info('This reference is already in the library');
+    } else if (status === 'resolve-failed') {
+      notifications.warning(
+        doi ? `Couldn't resolve DOI ${doi}` : "Couldn't resolve that DOI",
+      );
+    }
+  }, []);
+
+  const handleCite = useCallback(async () => {
+    if (!blobRef || citing) return;
+    setCiting(true);
+    try {
+      const blob = await blobStorage.loadBlob(blobRef);
+      if (!blob) return;
+      const result = await citePdf(blob);
+      if (result.status === 'no-doi' || result.status === 'resolve-failed') {
+        if (result.status === 'resolve-failed') notifyCiteStatus(result.status, result.doi);
+        setDoiInput(result.doi ?? '');
+        setCitePrompt({ title: result.title });
+      } else {
+        notifyCiteStatus(result.status, result.doi);
+        setCitePrompt(null);
+      }
+    } catch (err) {
+      console.error('Cite failed:', err);
+      useNotificationStore.getState().error('Citing this PDF failed');
+    } finally {
+      setCiting(false);
+    }
+  }, [blobRef, citing, notifyCiteStatus]);
+
+  const handleCiteDoiSubmit = useCallback(async () => {
+    const doi = doiInput.trim();
+    if (doi === '' || citing) return;
+    setCiting(true);
+    try {
+      const status = await citeDoi(doi);
+      notifyCiteStatus(status, doi);
+      if (status === 'added' || status === 'duplicate') setCitePrompt(null);
+    } finally {
+      setCiting(false);
+    }
+  }, [doiInput, citing, notifyCiteStatus]);
+
+  const handleCiteMinimal = useCallback(() => {
+    const status = citeMinimal(fileName, citePrompt?.title ?? null);
+    notifyCiteStatus(status, null);
+    setCitePrompt(null);
+  }, [fileName, citePrompt, notifyCiteStatus]);
+
+  const handleCopyHash = useCallback(async () => {
+    if (!blobRef) return;
+    try {
+      await navigator.clipboard.writeText(blobRef);
+      setHashCopied(true);
+      setTimeout(() => setHashCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — the short hash is still visible to copy by hand */
+    }
+  }, [blobRef]);
+
+  if (!fileShape) {
+    return null;
+  }
+
+  const displayName = fileShape.label || fileShape.fileName;
+  const FileIcon = getFileTypeLucideIcon(fileShape.fileCategory);
+
+  return (
+    <div className="file-viewer-content">
+      {/* Header */}
+      <div
+        className="file-viewer-header"
+        hidden={hideHeader === true}
+        onPointerDown={headerPointerDown}
+      >
+        <div className="file-viewer-header-info">
+          <span className="file-viewer-icon"><Icon icon={FileIcon} size={18} /></span>
+          <span className="file-viewer-filename" title={fileShape.fileName}>
+            {displayName}
+          </span>
+          <span className="file-viewer-meta">
+            {formatFileSize(fileShape.fileSize)}
+          </span>
+          <span className="file-viewer-meta file-viewer-mime">
+            {fileShape.mimeType}
+          </span>
+        </div>
+        <div className="file-viewer-header-actions">
+          {headerExtras}
+          {resolveViewerCategory(fileShape.fileCategory, fileShape.mimeType) === 'pdf' && (
+            <button
+              className="file-viewer-action-btn"
+              onClick={handleCite}
+              title="Cite this PDF — add it to the reference library"
+              disabled={citing || isMissingBlob}
+            >
+              <Icon icon={Quote} size={14} />
+              {citing ? 'Citing…' : 'Cite'}
+            </button>
+          )}
+          <button
+            className={`file-viewer-action-btn${showInfo ? ' file-viewer-action-btn--active' : ''}`}
+            onClick={() => setShowInfo((v) => !v)}
+            title="File info"
+            aria-pressed={showInfo}
+          >
+            <Icon icon={Info} size={14} />
+          </button>
+          <button
+            className="file-viewer-action-btn"
+            onClick={handleReplaceClick}
+            title="Replace with different file"
+            disabled={isReplacing}
+          >
+            {isReplacing ? '...' : <><Icon icon={RotateCw} size={14} />Replace</>}
+          </button>
+          <button
+            className="file-viewer-action-btn"
+            onClick={handleDownload}
+            title="Download file"
+            disabled={isMissingBlob}
+          >
+            <Icon icon={Download} size={14} />Download
+          </button>
+          <button
+            className="file-viewer-close-btn"
+            onClick={onClose}
+            title="Close (Escape)"
+          >
+            <Icon icon={X} size={16} />
+          </button>
+          {/* Hidden file inputs */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={handleReplaceFile}
+          />
+          <input
+            ref={recoveryInputRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={handleRecoveryFile}
+          />
+        </div>
+      </div>
+
+      {/* Manual-DOI popover — auto-detection found no DOI in the PDF */}
+      {citePrompt && !hideHeader && (
+        <div className="file-viewer-info file-viewer-cite" role="dialog" aria-label="Cite this PDF">
+          <p className="file-viewer-cite-text">
+            No DOI was found in this PDF. Paste one, or add a minimal reference
+            from the file's details.
+          </p>
+          <div className="file-viewer-cite-row">
+            <input
+              className="file-viewer-cite-input"
+              placeholder="10.xxxx/…"
+              value={doiInput}
+              onChange={(e) => setDoiInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleCiteDoiSubmit();
+                else if (e.key === 'Escape') {
+                  e.stopPropagation();
+                  setCitePrompt(null);
+                }
+              }}
+              aria-label="DOI"
+            />
+            <button
+              className="file-viewer-action-btn"
+              onClick={handleCiteDoiSubmit}
+              disabled={citing || doiInput.trim() === ''}
+            >
+              Add
+            </button>
+          </div>
+          <div className="file-viewer-cite-row">
+            <button className="file-viewer-cite-minimal" onClick={handleCiteMinimal}>
+              Add minimal reference instead
+            </button>
+            <button className="file-viewer-cite-minimal" onClick={() => setCitePrompt(null)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* File info popover — the shape's storage properties at a glance */}
+      {showInfo && !hideHeader && (
+        <div className="file-viewer-info" role="dialog" aria-label="File info">
+          <dl className="file-viewer-info-grid">
+            <dt>Name</dt>
+            <dd title={fileShape.fileName}>{fileShape.fileName}</dd>
+            <dt>Size</dt>
+            <dd>{formatFileSize(fileShape.fileSize)}</dd>
+            <dt>Type</dt>
+            <dd>{fileShape.mimeType}</dd>
+            {fileShape.preview?.pageCount !== undefined && (
+              <>
+                <dt>Pages</dt>
+                <dd>{fileShape.preview.pageCount}</dd>
+              </>
+            )}
+            <dt>Checksum</dt>
+            <dd className="file-viewer-info-hash">
+              <code title={fileShape.blobRef}>{fileShape.blobRef.slice(0, 12)}…</code>
+              <button
+                className="file-viewer-info-copy"
+                onClick={handleCopyHash}
+                title="Copy full SHA-256"
+              >
+                <Icon icon={Copy} size={12} />
+                {hashCopied ? 'Copied' : 'Copy'}
+              </button>
+            </dd>
+            <dt>Storage</dt>
+            <dd>{isMissingBlob ? 'Missing from this device' : 'Stored on this device'}</dd>
+          </dl>
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="file-viewer-body">
+        {loading && (
+          <div className="file-viewer-loading">
+            <div className="file-viewer-spinner" />
+            <span>Loading file…</span>
+          </div>
+        )}
+        {error && !isMissingBlob && (
+          <div className="file-viewer-error">
+            <span className="file-viewer-error-icon"><Icon icon={TriangleAlert} size={20} /></span>
+            <span>{error}</span>
+          </div>
+        )}
+        {isMissingBlob && (
+          <div className="file-viewer-recovery">
+            <span className="file-viewer-recovery-icon"><Icon icon={FolderOpen} size={28} /></span>
+            <span className="file-viewer-recovery-title">File Not Found</span>
+            <p className="file-viewer-recovery-message">
+              The file content is missing from local storage.
+              Re-upload the original file to restore it.
+            </p>
+            <button
+              className="file-viewer-recovery-btn"
+              onClick={handleRecoveryClick}
+              disabled={isReplacing}
+            >
+              {isReplacing ? 'Uploading...' : 'Re-upload File'}
+            </button>
+          </div>
+        )}
+        {!loading && !error && blobUrl && (
+          <Suspense
+            fallback={
+              <div className="file-viewer-loading">
+                <div className="file-viewer-spinner" />
+                <span>Loading viewer…</span>
+              </div>
+            }
+          >
+            {renderViewer(fileShape, blobUrl, immersive === true, onImmersiveChange)}
+          </Suspense>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderViewer(
+  shape: FileShape,
+  blobUrl: string,
+  immersive: boolean,
+  onImmersiveChange: ((immersive: boolean) => void) | undefined,
+) {
+  // resolveViewerCategory upgrades pre-audio/video 'generic' shapes at view
+  // time from their stored MIME — no doc migration needed.
+  switch (resolveViewerCategory(shape.fileCategory, shape.mimeType)) {
+    case 'pdf':
+      return (
+        <PdfViewer
+          blobUrl={blobUrl}
+          fileName={shape.fileName}
+          shapeId={shape.id}
+          blobHash={shape.blobRef}
+          immersive={immersive}
+          onImmersiveChange={onImmersiveChange}
+        />
+      );
+    case 'spreadsheet':
+      return <SpreadsheetViewer blobUrl={blobUrl} fileName={shape.fileName} />;
+    case 'image':
+      return <ImageViewer blobUrl={blobUrl} fileName={shape.fileName} />;
+    case 'audio':
+      return <AudioViewer blobUrl={blobUrl} fileName={shape.fileName} />;
+    case 'video':
+      return <VideoViewer blobUrl={blobUrl} fileName={shape.fileName} />;
+    case 'text':
+      return <TextViewer blobUrl={blobUrl} fileName={shape.fileName} />;
+    case 'generic':
+    default:
+      return (
+        <GenericFileViewer
+          fileName={shape.fileName}
+          fileSize={shape.fileSize}
+          mimeType={shape.mimeType}
+          blobRef={shape.blobRef}
+        />
+      );
+  }
+}
+
+export default FileViewerContent;

--- a/src/ui/FileViewerContent.tsx
+++ b/src/ui/FileViewerContent.tsx
@@ -308,7 +308,7 @@ export function FileViewerContent({
               disabled={citing || isMissingBlob}
             >
               <Icon icon={Quote} size={14} />
-              {citing ? 'Citing…' : 'Cite'}
+              <span className="file-viewer-action-label">{citing ? 'Citing…' : 'Cite'}</span>
             </button>
           )}
           <button
@@ -325,7 +325,14 @@ export function FileViewerContent({
             title="Replace with different file"
             disabled={isReplacing}
           >
-            {isReplacing ? '...' : <><Icon icon={RotateCw} size={14} />Replace</>}
+            {isReplacing ? (
+              '...'
+            ) : (
+              <>
+                <Icon icon={RotateCw} size={14} />
+                <span className="file-viewer-action-label">Replace</span>
+              </>
+            )}
           </button>
           <button
             className="file-viewer-action-btn"
@@ -333,7 +340,8 @@ export function FileViewerContent({
             title="Download file"
             disabled={isMissingBlob}
           >
-            <Icon icon={Download} size={14} />Download
+            <Icon icon={Download} size={14} />
+            <span className="file-viewer-action-label">Download</span>
           </button>
           <button
             className="file-viewer-close-btn"

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -44,6 +44,140 @@
   animation: file-viewer-slide-in 0.2s ease-out;
 }
 
+/* The host-independent content column (FileViewerContent) — fills whichever
+   host (modal or floating panel) it renders in. */
+.file-viewer-content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+/* File info popover — storage properties at a glance */
+.file-viewer-info {
+  position: absolute;
+  top: 52px;
+  right: 12px;
+  z-index: 2;
+  min-width: 260px;
+  max-width: 340px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-md);
+}
+
+.file-viewer-info-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 12px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.file-viewer-info-grid dt {
+  color: var(--text-secondary);
+}
+
+.file-viewer-info-grid dd {
+  margin: 0;
+  color: var(--text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-viewer-info-hash {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-viewer-info-hash code {
+  font-size: 11px;
+  background: var(--bg-tertiary);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.file-viewer-info-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.file-viewer-info-copy:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.file-viewer-action-btn--active {
+  background: var(--bg-hover);
+  border-color: var(--color-primary);
+}
+
+/* Cite popover (manual DOI entry) */
+.file-viewer-cite {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-viewer-cite-text {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  white-space: normal;
+}
+
+.file-viewer-cite-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-viewer-cite-input {
+  flex: 1;
+  min-width: 0;
+  padding: 4px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.file-viewer-cite-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.file-viewer-cite-minimal {
+  padding: 2px 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.file-viewer-cite-minimal:hover {
+  color: var(--text-primary);
+}
+
 /* Immersive reading: the modal frame goes full-bleed and its header collapses
    (the PDF reader shows its own minimal floating strip instead). */
 .file-viewer-overlay--immersive .file-viewer-modal {

--- a/src/ui/FileViewerModal.css
+++ b/src/ui/FileViewerModal.css
@@ -187,11 +187,15 @@
   border-radius: 0;
 }
 
-/* Header */
+/* Header. Wraps when the host is narrower than its content (the floating
+   panel at small sizes) — actions drop to a second row instead of spilling
+   past the panel edge. */
 .file-viewer-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  row-gap: 6px;
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
@@ -238,10 +242,11 @@
 
 .file-viewer-header-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
-  flex-shrink: 0;
-  margin-left: 16px;
+  margin-left: auto;
 }
 
 .file-viewer-action-btn {

--- a/src/ui/FileViewerModal.tsx
+++ b/src/ui/FileViewerModal.tsx
@@ -1,33 +1,16 @@
 /**
- * FileViewerModal — Full-screen modal for viewing embedded file content.
- *
- * Dispatches to specialized viewers based on file category:
- * - PDF → PdfViewer
- * - Spreadsheet → SpreadsheetViewer
- * - Image → ImageViewer
- * - Text → TextViewer
- * - Generic → GenericFileViewer
+ * FileViewerModal — full-screen modal host for FileViewerContent. Owns the
+ * overlay, Escape handling (exit immersive before closing), immersive state,
+ * and the pop-out-to-floating-panel affordance (desktop only).
  */
 
-import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
-import { useDocumentStore } from '../store/documentStore';
-import { blobStorage } from '../storage/BlobStorage';
-import { resolveBlobObjectUrl } from '../storage/blobResolver';
-import { isFile, type FileShape } from '../shapes/Shape';
-import { RotateCw, Download, X, TriangleAlert, FolderOpen } from 'lucide-react';
-import { formatFileSize } from '../utils/fileUtils';
-import { downloadBlob } from '../utils/downloadUtils';
-import { getFileTypeLucideIcon } from '../utils/fileTypeIcons';
+import { useState, useEffect, useCallback } from 'react';
+import { PictureInPicture2 } from 'lucide-react';
 import { Icon } from './icons';
-import { replaceFileContents, reuploadMissingBlob } from '../services/FileReplaceService';
+import { useSessionStore } from '../store/sessionStore';
+import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { FileViewerContent, useFileShape } from './FileViewerContent';
 import './FileViewerModal.css';
-
-// Lazy-load viewer components to keep main bundle small
-const PdfViewer = lazy(() => import('./viewers/PdfViewer'));
-const SpreadsheetViewer = lazy(() => import('./viewers/SpreadsheetViewer'));
-const ImageViewer = lazy(() => import('./viewers/ImageViewer'));
-const TextViewer = lazy(() => import('./viewers/TextViewer'));
-const GenericFileViewer = lazy(() => import('./viewers/GenericFileViewer'));
 
 export interface FileViewerModalProps {
   shapeId: string;
@@ -35,68 +18,12 @@ export interface FileViewerModalProps {
 }
 
 export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
-  const shapes = useDocumentStore((state) => state.shapes);
-  const shape = shapes[shapeId];
-
-  const [blobUrl, setBlobUrl] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isMissingBlob, setIsMissingBlob] = useState(false);
-  const [isReplacing, setIsReplacing] = useState(false);
   // Immersive reading (PDF): the modal owns it because it's the modal's own
   // chrome (header, rounded frame) that collapses alongside the viewer's.
   const [immersive, setImmersive] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const recoveryInputRef = useRef<HTMLInputElement>(null);
-
-  // Derive file shape properties safely (hooks must run unconditionally)
-  const fileShape = shape && isFile(shape) ? shape : null;
-  const blobRef = fileShape?.blobRef;
-  const fileName = fileShape?.fileName ?? '';
-
-  // Load blob on mount. resolveBlobObjectUrl checks the shared object-URL cache,
-  // then local IndexedDB, then downloads from the relay/R2 on a miss — so a file
-  // uploaded on another device (or never pulled locally) still opens (JP-129).
-  // The returned URL is owned by the resolver cache; we never revoke it here.
-  useEffect(() => {
-    if (!blobRef) return;
-
-    let cancelled = false;
-
-    async function loadBlob() {
-      setLoading(true);
-      setError(null);
-      setIsMissingBlob(false);
-
-      try {
-        const url = await resolveBlobObjectUrl(blobRef!);
-        if (cancelled) return;
-        if (!url) {
-          // Truly unavailable: not local, and not downloadable (local-only doc
-          // or the relay fetch failed). resolveBlobObjectUrl already marked the
-          // blob missing, so the canvas overlay reflects it too.
-          setIsMissingBlob(true);
-          setError('File not found in storage.');
-          setLoading(false);
-          return;
-        }
-        setBlobUrl(url);
-      } catch (err) {
-        if (!cancelled) {
-          setError('Failed to load file.');
-          console.error('FileViewerModal: Failed to load blob', err);
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    loadBlob();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [blobRef]);
+  const { mobileActive } = useMobileAdaptation();
+  const setFileViewerMode = useSessionStore((s) => s.setFileViewerMode);
+  const fileShape = useFileShape(shapeId);
 
   // Escape: exit immersive first, close second. (The PDF reader's find bar
   // handles its own Escape and stops propagation before this window listener.)
@@ -112,81 +39,6 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onClose, immersive]);
 
-  // Download file
-  const handleDownload = useCallback(async () => {
-    if (!blobRef) return;
-    try {
-      const blob = await blobStorage.loadBlob(blobRef);
-      if (!blob) return;
-      downloadBlob(blob, fileName);
-    } catch (err) {
-      console.error('Download failed:', err);
-    }
-  }, [blobRef, fileName]);
-
-  // Replace file
-  const handleReplaceClick = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
-
-  const handleReplaceFile = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-
-      setIsReplacing(true);
-      try {
-        const result = await replaceFileContents(shapeId, file);
-        if (result.success) {
-          // Trigger reload. The old object URL is owned by the resolver cache
-          // (content-addressed, reclaimed on doc switch) — don't revoke it here.
-          // The new blobRef makes the load effect re-resolve the replacement.
-          setBlobUrl(null);
-          setLoading(true);
-          setError(null);
-          setIsMissingBlob(false);
-        }
-      } finally {
-        setIsReplacing(false);
-        // Reset file input
-        if (fileInputRef.current) {
-          fileInputRef.current.value = '';
-        }
-      }
-    },
-    [shapeId]
-  );
-
-  // Recovery: re-upload missing blob
-  const handleRecoveryClick = useCallback(() => {
-    recoveryInputRef.current?.click();
-  }, []);
-
-  const handleRecoveryFile = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-
-      setIsReplacing(true);
-      try {
-        const result = await reuploadMissingBlob(shapeId, file);
-        if (result.success) {
-          // Trigger reload
-          setIsMissingBlob(false);
-          setError(null);
-          setLoading(true);
-        }
-      } finally {
-        setIsReplacing(false);
-        // Reset file input
-        if (recoveryInputRef.current) {
-          recoveryInputRef.current.value = '';
-        }
-      }
-    },
-    [shapeId]
-  );
-
   // Close when clicking the overlay background
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
@@ -197,13 +49,9 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
     [onClose]
   );
 
-  // Early return AFTER all hooks
   if (!fileShape) {
     return null;
   }
-
-  const displayName = fileShape.label || fileShape.fileName;
-  const FileIcon = getFileTypeLucideIcon(fileShape.fileCategory);
 
   const overlayClass = immersive
     ? 'file-viewer-overlay file-viewer-overlay--immersive'
@@ -212,142 +60,27 @@ export function FileViewerModal({ shapeId, onClose }: FileViewerModalProps) {
   return (
     <div className={overlayClass} onClick={handleOverlayClick}>
       <div className="file-viewer-modal">
-        {/* Header (hidden while reading immersively) */}
-        <div className="file-viewer-header" hidden={immersive}>
-          <div className="file-viewer-header-info">
-            <span className="file-viewer-icon"><Icon icon={FileIcon} size={18} /></span>
-            <span className="file-viewer-filename" title={fileShape.fileName}>
-              {displayName}
-            </span>
-            <span className="file-viewer-meta">
-              {formatFileSize(fileShape.fileSize)}
-            </span>
-            <span className="file-viewer-meta file-viewer-mime">
-              {fileShape.mimeType}
-            </span>
-          </div>
-          <div className="file-viewer-header-actions">
-            <button
-              className="file-viewer-action-btn"
-              onClick={handleReplaceClick}
-              title="Replace with different file"
-              disabled={isReplacing}
-            >
-              {isReplacing ? '...' : <><Icon icon={RotateCw} size={14} />Replace</>}
-            </button>
-            <button
-              className="file-viewer-action-btn"
-              onClick={handleDownload}
-              title="Download file"
-              disabled={isMissingBlob}
-            >
-              <Icon icon={Download} size={14} />Download
-            </button>
-            <button
-              className="file-viewer-close-btn"
-              onClick={onClose}
-              title="Close (Escape)"
-            >
-              <Icon icon={X} size={16} />
-            </button>
-            {/* Hidden file inputs */}
-            <input
-              ref={fileInputRef}
-              type="file"
-              style={{ display: 'none' }}
-              onChange={handleReplaceFile}
-            />
-            <input
-              ref={recoveryInputRef}
-              type="file"
-              style={{ display: 'none' }}
-              onChange={handleRecoveryFile}
-            />
-          </div>
-        </div>
-
-        {/* Body */}
-        <div className="file-viewer-body">
-          {loading && (
-            <div className="file-viewer-loading">
-              <div className="file-viewer-spinner" />
-              <span>Loading file…</span>
-            </div>
-          )}
-          {error && !isMissingBlob && (
-            <div className="file-viewer-error">
-              <span className="file-viewer-error-icon"><Icon icon={TriangleAlert} size={20} /></span>
-              <span>{error}</span>
-            </div>
-          )}
-          {isMissingBlob && (
-            <div className="file-viewer-recovery">
-              <span className="file-viewer-recovery-icon"><Icon icon={FolderOpen} size={28} /></span>
-              <span className="file-viewer-recovery-title">File Not Found</span>
-              <p className="file-viewer-recovery-message">
-                The file content is missing from local storage.
-                Re-upload the original file to restore it.
-              </p>
+        <FileViewerContent
+          shapeId={shapeId}
+          onClose={onClose}
+          immersive={immersive}
+          onImmersiveChange={setImmersive}
+          hideHeader={immersive}
+          headerExtras={
+            !mobileActive ? (
               <button
-                className="file-viewer-recovery-btn"
-                onClick={handleRecoveryClick}
-                disabled={isReplacing}
+                className="file-viewer-action-btn"
+                onClick={() => setFileViewerMode('floating')}
+                title="Pop out to a floating panel"
               >
-                {isReplacing ? 'Uploading...' : 'Re-upload File'}
+                <Icon icon={PictureInPicture2} size={14} />
               </button>
-            </div>
-          )}
-          {!loading && !error && blobUrl && (
-            <Suspense
-              fallback={
-                <div className="file-viewer-loading">
-                  <div className="file-viewer-spinner" />
-                  <span>Loading viewer…</span>
-                </div>
-              }
-            >
-              {renderViewer(fileShape, blobUrl, immersive, setImmersive)}
-            </Suspense>
-          )}
-        </div>
+            ) : undefined
+          }
+        />
       </div>
     </div>
   );
-}
-
-function renderViewer(
-  shape: FileShape,
-  blobUrl: string,
-  immersive: boolean,
-  onImmersiveChange: (immersive: boolean) => void,
-) {
-  switch (shape.fileCategory) {
-    case 'pdf':
-      return (
-        <PdfViewer
-          blobUrl={blobUrl}
-          fileName={shape.fileName}
-          immersive={immersive}
-          onImmersiveChange={onImmersiveChange}
-        />
-      );
-    case 'spreadsheet':
-      return <SpreadsheetViewer blobUrl={blobUrl} fileName={shape.fileName} />;
-    case 'image':
-      return <ImageViewer blobUrl={blobUrl} fileName={shape.fileName} />;
-    case 'text':
-      return <TextViewer blobUrl={blobUrl} fileName={shape.fileName} />;
-    case 'generic':
-    default:
-      return (
-        <GenericFileViewer
-          fileName={shape.fileName}
-          fileSize={shape.fileSize}
-          mimeType={shape.mimeType}
-          blobRef={shape.blobRef}
-        />
-      );
-  }
 }
 
 export default FileViewerModal;

--- a/src/ui/FloatingFileViewer.css
+++ b/src/ui/FloatingFileViewer.css
@@ -40,9 +40,21 @@
   cursor: grabbing;
 }
 
-/* Compact header metadata in narrow panels */
-.floating-file-viewer .file-viewer-mime {
+/* Compact header in the panel: drop the size/mime metadata and go icon-only
+   on the action buttons (title tooltips keep the labels discoverable) so the
+   header fits at the 360px minimum width. */
+.floating-file-viewer .file-viewer-mime,
+.floating-file-viewer .file-viewer-meta,
+.floating-file-viewer .file-viewer-action-label {
   display: none;
+}
+
+.floating-file-viewer .file-viewer-header {
+  padding: 8px 10px;
+}
+
+.floating-file-viewer .file-viewer-header-actions {
+  gap: 4px;
 }
 
 /* Resize handles */

--- a/src/ui/FloatingFileViewer.css
+++ b/src/ui/FloatingFileViewer.css
@@ -1,0 +1,76 @@
+/* FloatingFileViewer — draggable/resizable side-panel host.
+
+   z-index tier map (hardcoded per-component across the app):
+     9999   toasts
+     10000  modals (SettingsModal, FileViewerModal overlay)
+     10050  confirm / sign-in dialogs
+     10200+ portal menus (JP-385)
+     10300  MirrorResourcePicker (topmost transient)
+   This panel is a persistent worksurface, so it sits BELOW all transient
+   chrome at 9500 — menus and dialogs opened from the panel itself must
+   render above it. */
+
+.floating-file-viewer {
+  position: fixed;
+  z-index: 9500;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+}
+
+/* The content fills the panel; its header doubles as the drag handle. */
+.floating-file-viewer .file-viewer-content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.floating-file-viewer .file-viewer-header {
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.floating-file-viewer .file-viewer-header:active {
+  cursor: grabbing;
+}
+
+/* Compact header metadata in narrow panels */
+.floating-file-viewer .file-viewer-mime {
+  display: none;
+}
+
+/* Resize handles */
+.floating-file-viewer__resize {
+  position: absolute;
+  z-index: 1;
+}
+
+.floating-file-viewer__resize--right {
+  top: 0;
+  right: -3px;
+  width: 8px;
+  height: 100%;
+  cursor: ew-resize;
+}
+
+.floating-file-viewer__resize--bottom {
+  left: 0;
+  bottom: -3px;
+  width: 100%;
+  height: 8px;
+  cursor: ns-resize;
+}
+
+.floating-file-viewer__resize--corner {
+  right: -3px;
+  bottom: -3px;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+}

--- a/src/ui/FloatingFileViewer.tsx
+++ b/src/ui/FloatingFileViewer.tsx
@@ -1,0 +1,183 @@
+/**
+ * FloatingFileViewer — draggable, resizable side-panel host for
+ * FileViewerContent (desktop only), so a PDF can be read next to the document.
+ *
+ * Non-modal on purpose: no backdrop, no focus trap, the canvas stays live.
+ * Escape closes only when focus is inside the panel. Dragging uses pointer
+ * events with window-level move/up listeners (HTML5 DnD is dead in WebKitGTK;
+ * same pattern as FloatingCollabIndicator), applies a transform during the
+ * drag, and commits bounds to uiPreferencesStore only on release.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { PictureInPicture2 } from 'lucide-react';
+import { Icon } from './icons';
+import { useSessionStore } from '../store/sessionStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+import {
+  clampPanelBounds,
+  resolveViewerPanelBounds,
+  type PanelBounds,
+} from './floatingPosition';
+import { FileViewerContent, useFileShape } from './FileViewerContent';
+import './FloatingFileViewer.css';
+
+export interface FloatingFileViewerProps {
+  shapeId: string;
+  onClose: () => void;
+}
+
+type ResizeEdge = 'right' | 'bottom' | 'corner';
+
+interface DragState {
+  pointerStart: { x: number; y: number };
+  boundsStart: PanelBounds;
+  mode: 'move' | ResizeEdge;
+}
+
+function viewportSize() {
+  return { w: window.innerWidth, h: window.innerHeight };
+}
+
+export function FloatingFileViewer({ shapeId, onClose }: FloatingFileViewerProps) {
+  const fileShape = useFileShape(shapeId);
+  const setFileViewerMode = useSessionStore((s) => s.setFileViewerMode);
+  const storedBounds = useUIPreferencesStore((s) => s.floatingViewerBounds);
+  const setStoredBounds = useUIPreferencesStore((s) => s.setFloatingViewerBounds);
+
+  // Effective bounds: stored (clamped) or the right-side default. Local state
+  // during drag/resize; committed to the store on release only.
+  const [bounds, setBounds] = useState<PanelBounds>(() =>
+    resolveViewerPanelBounds(storedBounds ?? null, viewportSize()),
+  );
+  const boundsRef = useRef(bounds);
+  boundsRef.current = bounds;
+  const dragRef = useRef<DragState | null>(null);
+
+  // Re-clamp (render-only) when the window resizes so the panel can't strand.
+  useEffect(() => {
+    const onResize = () => {
+      setBounds((b) => clampPanelBounds(b, viewportSize()));
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const beginGesture = useCallback((e: React.PointerEvent, mode: DragState['mode']) => {
+    // Header buttons/inputs must keep working — only bare header surface drags.
+    if (mode === 'move' && (e.target as HTMLElement).closest('button, input, a')) {
+      return;
+    }
+    e.preventDefault();
+    dragRef.current = {
+      pointerStart: { x: e.clientX, y: e.clientY },
+      boundsStart: boundsRef.current,
+      mode,
+    };
+  }, []);
+
+  // Window-level move/up so the pointer can leave the handle mid-gesture.
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      const dx = e.clientX - drag.pointerStart.x;
+      const dy = e.clientY - drag.pointerStart.y;
+      const { boundsStart, mode } = drag;
+      let next: PanelBounds;
+      if (mode === 'move') {
+        next = { ...boundsStart, x: boundsStart.x + dx, y: boundsStart.y + dy };
+      } else {
+        next = {
+          ...boundsStart,
+          w: mode !== 'bottom' ? boundsStart.w + dx : boundsStart.w,
+          h: mode !== 'right' ? boundsStart.h + dy : boundsStart.h,
+        };
+      }
+      setBounds(clampPanelBounds(next, viewportSize()));
+    };
+    const onUp = () => {
+      if (!dragRef.current) return;
+      dragRef.current = null;
+      setStoredBounds(boundsRef.current);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [setStoredBounds]);
+
+  // Escape closes only when focus is inside the panel (non-modal behavior).
+  // The PDF reader's find bar stops propagation first, keeping its ordering.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!fileShape) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="floating-file-viewer"
+      style={{
+        left: `${bounds.x}px`,
+        top: `${bounds.y}px`,
+        width: `${bounds.w}px`,
+        height: `${bounds.h}px`,
+      }}
+      role="complementary"
+      aria-label={`File viewer: ${fileShape.fileName}`}
+      onKeyDown={handleKeyDown}
+    >
+      <FileViewerContent
+        shapeId={shapeId}
+        onClose={onClose}
+        headerPointerDown={(e) => beginGesture(e, 'move')}
+        headerExtras={
+          <button
+            className="file-viewer-action-btn"
+            onClick={() => setFileViewerMode('modal')}
+            title="Dock back to full-screen"
+          >
+            <Icon icon={PictureInPicture2} size={14} />
+          </button>
+        }
+      />
+      <div
+        className="floating-file-viewer__resize floating-file-viewer__resize--right"
+        onPointerDown={(e) => beginGesture(e, 'right')}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panel width"
+      />
+      <div
+        className="floating-file-viewer__resize floating-file-viewer__resize--bottom"
+        onPointerDown={(e) => beginGesture(e, 'bottom')}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize panel height"
+      />
+      <div
+        className="floating-file-viewer__resize floating-file-viewer__resize--corner"
+        onPointerDown={(e) => beginGesture(e, 'corner')}
+        role="separator"
+        aria-label="Resize panel"
+      />
+    </div>,
+    document.body,
+  );
+}
+
+export default FloatingFileViewer;

--- a/src/ui/fileViewerMode.test.ts
+++ b/src/ui/fileViewerMode.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { resolveViewerMode } from './fileViewerMode';
+
+describe('resolveViewerMode', () => {
+  it('honors the requested mode on desktop', () => {
+    expect(resolveViewerMode('modal', false)).toBe('modal');
+    expect(resolveViewerMode('floating', false)).toBe('floating');
+  });
+
+  it('coerces to modal when the mobile adaptation is active', () => {
+    expect(resolveViewerMode('floating', true)).toBe('modal');
+    expect(resolveViewerMode('modal', true)).toBe('modal');
+  });
+});

--- a/src/ui/fileViewerMode.ts
+++ b/src/ui/fileViewerMode.ts
@@ -1,0 +1,14 @@
+/**
+ * File-viewer host mode resolution. The floating panel is a desktop affordance
+ * — on mobile-adapted viewports the viewer always renders as the full-screen
+ * modal regardless of the session's requested mode.
+ */
+
+export type FileViewerMode = 'modal' | 'floating';
+
+export function resolveViewerMode(
+  requested: FileViewerMode,
+  mobileActive: boolean,
+): FileViewerMode {
+  return mobileActive ? 'modal' : requested;
+}

--- a/src/ui/floatingPosition.test.ts
+++ b/src/ui/floatingPosition.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   clampToViewport,
+  clampPanelBounds,
   resolveIndicatorPosition,
+  resolveViewerPanelBounds,
+  MIN_PANEL_SIZE,
   VIEWPORT_MARGIN,
   DEFAULT_TOP,
 } from './floatingPosition';
@@ -62,5 +65,59 @@ describe('resolveIndicatorPosition', () => {
       x: 200,
       y: 150,
     });
+  });
+});
+
+describe('clampPanelBounds', () => {
+  const VIEWPORT = { w: 1400, h: 900 };
+
+  it('passes through in-range bounds', () => {
+    const b = { x: 100, y: 100, w: 500, h: 600 };
+    expect(clampPanelBounds(b, VIEWPORT)).toEqual(b);
+  });
+
+  it('enforces the minimum size', () => {
+    const out = clampPanelBounds({ x: 50, y: 50, w: 100, h: 100 }, VIEWPORT);
+    expect(out.w).toBe(MIN_PANEL_SIZE.w);
+    expect(out.h).toBe(MIN_PANEL_SIZE.h);
+  });
+
+  it('caps size to the viewport minus margins', () => {
+    const out = clampPanelBounds({ x: 0, y: 0, w: 5000, h: 5000 }, VIEWPORT);
+    expect(out.w).toBe(VIEWPORT.w - 2 * VIEWPORT_MARGIN);
+    expect(out.h).toBe(VIEWPORT.h - 2 * VIEWPORT_MARGIN);
+    expect(out.x).toBe(VIEWPORT_MARGIN);
+    expect(out.y).toBe(VIEWPORT_MARGIN);
+  });
+
+  it('pulls an off-screen panel back into view', () => {
+    const out = clampPanelBounds({ x: 2000, y: -50, w: 400, h: 500 }, VIEWPORT);
+    expect(out.x).toBe(VIEWPORT.w - 400 - VIEWPORT_MARGIN);
+    expect(out.y).toBe(VIEWPORT_MARGIN);
+  });
+});
+
+describe('resolveViewerPanelBounds', () => {
+  const VIEWPORT = { w: 1400, h: 900 };
+
+  it('defaults to a right-side panel below the toolbar', () => {
+    const out = resolveViewerPanelBounds(null, VIEWPORT);
+    expect(out.y).toBe(DEFAULT_TOP);
+    expect(out.x + out.w).toBe(VIEWPORT.w - VIEWPORT_MARGIN);
+    expect(out.w).toBeGreaterThanOrEqual(MIN_PANEL_SIZE.w);
+    expect(out.h).toBeGreaterThanOrEqual(MIN_PANEL_SIZE.h);
+  });
+
+  it('clamps stored bounds after a window shrink', () => {
+    const stored = { x: 1200, y: 700, w: 560, h: 720 };
+    const small = { w: 800, h: 600 };
+    const out = resolveViewerPanelBounds(stored, small);
+    expect(out.x + out.w).toBeLessThanOrEqual(small.w - VIEWPORT_MARGIN);
+    expect(out.y + out.h).toBeLessThanOrEqual(small.h - VIEWPORT_MARGIN);
+  });
+
+  it('respects stored in-range bounds', () => {
+    const stored = { x: 100, y: 120, w: 480, h: 560 };
+    expect(resolveViewerPanelBounds(stored, VIEWPORT)).toEqual(stored);
   });
 });

--- a/src/ui/floatingPosition.ts
+++ b/src/ui/floatingPosition.ts
@@ -45,6 +45,57 @@ export function clampToViewport(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Floating file-viewer panel (JP-398)
+// ---------------------------------------------------------------------------
+
+export interface PanelBounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Smallest usable floating-viewer size (toolbar + a readable page column). */
+export const MIN_PANEL_SIZE: Size = { w: 360, h: 420 };
+
+/**
+ * Clamp a panel's size into [min, viewport − margins] and then its position
+ * fully on-screen. Used on drag, resize, restore, and window resize so a
+ * stored panel can never be stranded off-screen or larger than the window.
+ */
+export function clampPanelBounds(
+  bounds: PanelBounds,
+  viewport: Viewport,
+  min: Size = MIN_PANEL_SIZE,
+  margin: number = VIEWPORT_MARGIN
+): PanelBounds {
+  const maxW = Math.max(min.w, viewport.w - 2 * margin);
+  const maxH = Math.max(min.h, viewport.h - 2 * margin);
+  const w = Math.min(Math.max(bounds.w, min.w), maxW);
+  const h = Math.min(Math.max(bounds.h, min.h), maxH);
+  const pos = clampToViewport({ x: bounds.x, y: bounds.y }, { w, h }, viewport, margin);
+  return { x: pos.x, y: pos.y, w, h };
+}
+
+/**
+ * Effective bounds for the floating file viewer: stored bounds clamped into
+ * the viewport, or a right-side default sized to the window (reading a PDF
+ * beside the document is the point, so the default leaves the canvas usable).
+ */
+export function resolveViewerPanelBounds(
+  stored: PanelBounds | null,
+  viewport: Viewport
+): PanelBounds {
+  if (stored) return clampPanelBounds(stored, viewport);
+  const w = Math.min(560, Math.max(MIN_PANEL_SIZE.w, Math.round(viewport.w * 0.42)));
+  const h = Math.min(720, Math.max(MIN_PANEL_SIZE.h, Math.round(viewport.h * 0.7)));
+  return clampPanelBounds(
+    { x: viewport.w - w - VIEWPORT_MARGIN, y: DEFAULT_TOP, w, h },
+    viewport
+  );
+}
+
 /**
  * Resolve the effective top-left for the indicator. A `null` stored position
  * falls back to the top-right anchor; a stored position is clamped into the

--- a/src/ui/viewers/AudioViewer.tsx
+++ b/src/ui/viewers/AudioViewer.tsx
@@ -1,0 +1,52 @@
+/**
+ * AudioViewer — native <audio> playback for embedded audio files. Codec
+ * support depends on the platform (WebKitGTK needs the matching GStreamer
+ * plugins), so a decode failure falls back to a download prompt instead of a
+ * dead player.
+ */
+
+import { useState } from 'react';
+import { FileAudio, TriangleAlert } from 'lucide-react';
+import { Icon } from '../icons';
+import './MediaViewer.css';
+
+export interface AudioViewerProps {
+  blobUrl: string;
+  fileName: string;
+}
+
+export function AudioViewer({ blobUrl, fileName }: AudioViewerProps) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div className="media-viewer media-viewer--error">
+        <span className="media-viewer__error-icon">
+          <Icon icon={TriangleAlert} size={24} />
+        </span>
+        <span>This audio format can't be played on this system.</span>
+        <span className="media-viewer__hint">Use Download to save and play it in another app.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="media-viewer">
+      <span className="media-viewer__glyph">
+        <Icon icon={FileAudio} size={48} />
+      </span>
+      <span className="media-viewer__name" title={fileName}>
+        {fileName}
+      </span>
+      {/* Object URL is owned by the blobResolver cache — never revoked here. */}
+      <audio
+        className="media-viewer__audio"
+        src={blobUrl}
+        controls
+        onError={() => setFailed(true)}
+      />
+    </div>
+  );
+}
+
+export default AudioViewer;

--- a/src/ui/viewers/MediaViewer.css
+++ b/src/ui/viewers/MediaViewer.css
@@ -1,0 +1,61 @@
+/* MediaViewer — shared chrome for the audio/video playback viewers */
+
+.media-viewer {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 24px;
+  background: var(--bg-tertiary);
+}
+
+[data-theme='dark'] .media-viewer {
+  background: var(--bg-primary);
+}
+
+.media-viewer__glyph {
+  color: var(--text-secondary);
+  display: inline-flex;
+}
+
+.media-viewer__name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  max-width: 80%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.media-viewer__audio {
+  width: min(480px, 90%);
+}
+
+.media-viewer--video {
+  padding: 0;
+}
+
+.media-viewer__video {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.media-viewer--error {
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  text-align: center;
+}
+
+.media-viewer__error-icon {
+  display: inline-flex;
+  color: var(--color-error, #dc2626);
+}
+
+.media-viewer__hint {
+  font-size: 12px;
+}

--- a/src/ui/viewers/PdfViewer.tsx
+++ b/src/ui/viewers/PdfViewer.tsx
@@ -2,8 +2,13 @@
  * PdfViewer — continuous-scroll PDF reader built on pdf.js viewer components
  * (PDFViewer + EventBus + PDFLinkService + PDFFindController). The pdf.js
  * lifecycle lives in usePdfViewerController; this shell composes the toolbar,
- * find bar, outline sidebar, and the scroll container, and owns the reader's
- * UI-only state (find/sidebar visibility, page dimming).
+ * find bar, outline/bookmarks sidebar, and the scroll container, and owns the
+ * reader's UI-only state (find/sidebar visibility, page dimming).
+ *
+ * Reading state (last page, zoom, bookmarks) persists per-user via
+ * fileViewStateStore, keyed by the active document + shape — never into the
+ * document itself. Hosts that can't provide `shapeId`/`blobHash` still get a
+ * fully working (just stateless) reader.
  *
  * Immersive mode is host-owned (the modal's chrome collapses too): the host
  * passes `immersive` + `onImmersiveChange`, and this shell swaps its toolbar
@@ -11,30 +16,174 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Minimize2, TriangleAlert } from 'lucide-react';
+import { Bookmark, Minimize2, TriangleAlert } from 'lucide-react';
 import { Icon } from '../icons';
+import { useActiveDocumentId } from '../../store/documentRegistry';
+import {
+  getFileViewRecord,
+  useFileViewStateStore,
+} from '../../store/fileViewStateStore';
+import {
+  reconcileRecord,
+  removeBookmark,
+  renameBookmark,
+  toggleBookmark,
+  viewKey,
+} from '../../store/fileViewState';
 import { usePdfViewerController } from './pdf/usePdfViewerController';
 import { PdfToolbar } from './pdf/PdfToolbar';
 import { PdfFindBar } from './pdf/PdfFindBar';
 import { PdfSidebar } from './pdf/PdfSidebar';
 import { clampPage } from './pdf/zoom';
+import { exportPdfPageAsPngFile } from './pdf/exportPageImage';
+import { importFilesAtViewportCenter } from '../../services/canvasImportSeam';
+import { useNotificationStore } from '../../store/notificationStore';
+import { useSessionStore } from '../../store/sessionStore';
 import 'pdfjs-dist/web/pdf_viewer.css';
 import './pdf/PdfReader.css';
 
 export interface PdfViewerProps {
   blobUrl: string;
   fileName: string;
+  /** Identity for per-user reading state; omit to disable persistence. */
+  shapeId?: string | undefined;
+  /** Content hash (`FileShape.blobRef`) for replacement staleness detection. */
+  blobHash?: string | undefined;
   /** Host-owned immersive reading mode (modal chrome collapses with it). */
   immersive?: boolean | undefined;
   onImmersiveChange?: ((immersive: boolean) => void) | undefined;
 }
 
-export function PdfViewer({ blobUrl, immersive, onImmersiveChange }: PdfViewerProps) {
-  const controller = usePdfViewerController(blobUrl);
+export function PdfViewer({
+  blobUrl,
+  fileName,
+  shapeId,
+  blobHash,
+  immersive,
+  onImmersiveChange,
+}: PdfViewerProps) {
   const [showFind, setShowFind] = useState(false);
   const [showSidebar, setShowSidebar] = useState(false);
   const [dimmed, setDimmed] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+
+  // ---------------------------------------------------------------------------
+  // Per-user reading state (skipped entirely when identity is unavailable)
+  // ---------------------------------------------------------------------------
+  const docId = useActiveDocumentId();
+  const persistId = docId && shapeId && blobHash ? { docId, shapeId, hash: blobHash } : null;
+  const upsert = useFileViewStateStore((s) => s.upsert);
+  const bookmarks = useFileViewStateStore((s) =>
+    persistId ? s.records[viewKey(persistId.docId, persistId.shapeId)]?.bookmarks : undefined,
+  );
+  const persistRef = useRef(persistId);
+  persistRef.current = persistId;
+
+  const controller = usePdfViewerController(blobUrl, {
+    getInitialView: (numPages) => {
+      const id = persistRef.current;
+      if (!id) return null;
+      const rec = getFileViewRecord(id.docId, id.shapeId);
+      if (!rec) return null;
+      const reconciled = reconcileRecord(rec, id.hash, numPages);
+      if (reconciled !== rec) {
+        // Write the clamp back so a replacement reconciles once, not per open.
+        upsert(id.docId, id.shapeId, reconciled);
+      }
+      return {
+        page: reconciled.lastPage,
+        zoomMode: reconciled.zoomMode,
+        zoomPercent: reconciled.zoomPercent,
+      };
+    },
+  });
+
+  // Debounced write of page + zoom; gated on the restore-guard so the initial
+  // page-1/scale events during load never stomp the stored position.
+  const { currentPage, zoomMode, zoomPercent, viewRestored } = controller;
+  useEffect(() => {
+    if (!persistId || !viewRestored) return undefined;
+    const { docId: d, shapeId: s, hash } = persistId;
+    const t = setTimeout(() => {
+      upsert(d, s, {
+        hash,
+        lastPage: currentPage,
+        zoomMode,
+        ...(zoomMode === 'custom' ? { zoomPercent } : {}),
+      });
+    }, 500);
+    return () => clearTimeout(t);
+    // persistId is identity-stable per (docId, shapeId, hash) via the strings below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [docId, shapeId, blobHash, viewRestored, currentPage, zoomMode, zoomPercent, upsert]);
+
+  const isCurrentBookmarked =
+    bookmarks?.some((b) => b.page === controller.currentPage) ?? false;
+
+  const handleToggleBookmark = useCallback(() => {
+    const id = persistRef.current;
+    if (!id) return;
+    const current = getFileViewRecord(id.docId, id.shapeId)?.bookmarks ?? [];
+    upsert(id.docId, id.shapeId, {
+      hash: id.hash,
+      bookmarks: toggleBookmark(current, controller.currentPage, Date.now()),
+    });
+  }, [controller.currentPage, upsert]);
+
+  const handleRenameBookmark = useCallback(
+    (page: number, label: string) => {
+      const id = persistRef.current;
+      if (!id) return;
+      const current = getFileViewRecord(id.docId, id.shapeId)?.bookmarks ?? [];
+      upsert(id.docId, id.shapeId, { hash: id.hash, bookmarks: renameBookmark(current, page, label) });
+    },
+    [upsert],
+  );
+
+  const handleRemoveBookmark = useCallback(
+    (page: number) => {
+      const id = persistRef.current;
+      if (!id) return;
+      const current = getFileViewRecord(id.docId, id.shapeId)?.bookmarks ?? [];
+      upsert(id.docId, id.shapeId, { hash: id.hash, bookmarks: removeBookmark(current, page) });
+    },
+    [upsert],
+  );
+
+  // Send the current page to the canvas as a high-res PNG file shape.
+  const sendingPageRef = useRef(false);
+  const handleSendPageToCanvas = useCallback(async () => {
+    if (sendingPageRef.current) return;
+    sendingPageRef.current = true;
+    const notifications = useNotificationStore.getState();
+    const page = controller.currentPage;
+    try {
+      const blob = await (await fetch(blobUrl)).blob();
+      const file = await exportPdfPageAsPngFile(blob, page, fileName);
+      if (!file) {
+        notifications.error('Rendering that page failed');
+        return;
+      }
+      const imported = await importFilesAtViewportCenter([file]);
+      if (!imported) {
+        notifications.warning('No canvas available to receive the page');
+        return;
+      }
+      notifications.success(`Page ${page} sent to the canvas`, {
+        actionLabel: 'Show',
+        onAction: () => useSessionStore.getState().closeFileViewer(),
+      });
+    } catch (err) {
+      console.error('Send page to canvas failed:', err);
+      notifications.error('Sending the page to the canvas failed');
+    } finally {
+      sendingPageRef.current = false;
+    }
+  }, [blobUrl, fileName, controller.currentPage]);
+
+  // ---------------------------------------------------------------------------
+  // Reader chrome state + keyboard
+  // ---------------------------------------------------------------------------
 
   // Focus the reader so keyboard scrolling and shortcuts work immediately.
   useEffect(() => {
@@ -69,15 +218,25 @@ export function PdfViewer({ blobUrl, immersive, onImmersiveChange }: PdfViewerPr
   }, []);
 
   // Escape closes the find bar before the host's window-level handler sees it
-  // (host handles immersive-exit, then close).
+  // (host handles immersive-exit, then close). `b` bookmarks the current page.
   const handleRootKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Escape' && showFind) {
         e.stopPropagation();
         closeFindBar();
+        return;
+      }
+      const target = e.target as HTMLElement;
+      const inField =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable;
+      if (e.key === 'b' && !e.ctrlKey && !e.metaKey && !e.altKey && !inField && persistRef.current) {
+        e.stopPropagation();
+        handleToggleBookmark();
       }
     },
-    [showFind, closeFindBar],
+    [showFind, closeFindBar, handleToggleBookmark],
   );
 
   const rootClass = [
@@ -100,6 +259,10 @@ export function PdfViewer({ blobUrl, immersive, onImmersiveChange }: PdfViewerPr
           dimmed={dimmed}
           onToggleDimmed={() => setDimmed((v) => !v)}
           onEnterImmersive={onImmersiveChange ? () => onImmersiveChange(true) : undefined}
+          bookmarkState={
+            persistId ? { active: isCurrentBookmarked, onToggle: handleToggleBookmark } : undefined
+          }
+          onSendPageToCanvas={handleSendPageToCanvas}
         />
       )}
 
@@ -107,7 +270,16 @@ export function PdfViewer({ blobUrl, immersive, onImmersiveChange }: PdfViewerPr
 
       <div className="pdf-reader__main">
         {showSidebar && !immersive && (
-          <PdfSidebar outline={controller.outline} onNavigate={controller.goToDestination} />
+          <PdfSidebar
+            outline={controller.outline}
+            onNavigate={controller.goToDestination}
+            bookmarks={persistId ? (bookmarks ?? []) : undefined}
+            currentPage={controller.currentPage}
+            onJumpToPage={controller.goToPage}
+            onRenameBookmark={handleRenameBookmark}
+            onRemoveBookmark={handleRemoveBookmark}
+            onBookmarkCurrent={handleToggleBookmark}
+          />
         )}
         <div className="pdf-reader__body">
           {/* pdf.js container contract: absolutely-positioned scroll container
@@ -137,6 +309,16 @@ export function PdfViewer({ blobUrl, immersive, onImmersiveChange }: PdfViewerPr
       {immersive && (
         <div className="pdf-reader__immersive-strip">
           <ImmersivePageInput controller={controller} />
+          {persistId && (
+            <button
+              className={`pdf-reader__btn${isCurrentBookmarked ? ' pdf-reader__btn--active' : ''}`}
+              onClick={handleToggleBookmark}
+              title={isCurrentBookmarked ? 'Remove bookmark (b)' : 'Bookmark this page (b)'}
+              aria-pressed={isCurrentBookmarked}
+            >
+              <Icon icon={Bookmark} size={16} />
+            </button>
+          )}
           <button
             className="pdf-reader__btn"
             onClick={() => onImmersiveChange?.(false)}

--- a/src/ui/viewers/VideoViewer.tsx
+++ b/src/ui/viewers/VideoViewer.tsx
@@ -1,0 +1,47 @@
+/**
+ * VideoViewer — native <video> playback for embedded video files. Codec
+ * support depends on the platform (WebKitGTK needs the matching GStreamer
+ * plugins), so a decode failure falls back to a download prompt instead of a
+ * dead player.
+ */
+
+import { useState } from 'react';
+import { TriangleAlert } from 'lucide-react';
+import { Icon } from '../icons';
+import './MediaViewer.css';
+
+export interface VideoViewerProps {
+  blobUrl: string;
+  fileName: string;
+}
+
+export function VideoViewer({ blobUrl, fileName }: VideoViewerProps) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div className="media-viewer media-viewer--error">
+        <span className="media-viewer__error-icon">
+          <Icon icon={TriangleAlert} size={24} />
+        </span>
+        <span>This video format can't be played on this system.</span>
+        <span className="media-viewer__hint">Use Download to save and play it in another app.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="media-viewer media-viewer--video">
+      {/* Object URL is owned by the blobResolver cache — never revoked here. */}
+      <video
+        className="media-viewer__video"
+        src={blobUrl}
+        controls
+        onError={() => setFailed(true)}
+        aria-label={fileName}
+      />
+    </div>
+  );
+}
+
+export default VideoViewer;

--- a/src/ui/viewers/pdf/PdfReader.css
+++ b/src/ui/viewers/pdf/PdfReader.css
@@ -264,6 +264,123 @@
   background: var(--bg-hover);
 }
 
+/* Bookmarks tab */
+
+.pdf-reader__bookmark-add {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: calc(100% - 16px);
+  margin: 0 8px 8px;
+  padding: 6px 10px;
+  border: 1px dashed var(--border-color);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.pdf-reader__bookmark-add:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.pdf-reader__bookmark-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pdf-reader__bookmark-row {
+  display: flex;
+  align-items: center;
+}
+
+.pdf-reader__bookmark-jump {
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  padding: 5px 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.pdf-reader__bookmark-jump:hover {
+  background: var(--bg-hover);
+}
+
+.pdf-reader__bookmark-jump[aria-current='page'] .pdf-reader__bookmark-page {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.pdf-reader__bookmark-page {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.pdf-reader__bookmark-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pdf-reader__bookmark-actions {
+  display: none;
+  align-items: center;
+  gap: 2px;
+  padding-right: 6px;
+}
+
+.pdf-reader__bookmark-row:hover .pdf-reader__bookmark-actions,
+.pdf-reader__bookmark-row:focus-within .pdf-reader__bookmark-actions {
+  display: inline-flex;
+}
+
+.pdf-reader__bookmark-action {
+  padding: 3px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+}
+
+.pdf-reader__bookmark-action:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.pdf-reader__bookmark-rename {
+  flex: 1;
+  margin: 2px 8px;
+  padding: 4px 6px;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.pdf-reader__sidebar-empty kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  background: var(--bg-primary);
+  font-size: 11px;
+  font-family: inherit;
+}
+
 /* The pdf.js scroll container: MUST be absolutely positioned (PDFViewer
    computes visible pages from the container's scroll geometry). */
 

--- a/src/ui/viewers/pdf/PdfReader.css
+++ b/src/ui/viewers/pdf/PdfReader.css
@@ -18,9 +18,12 @@
 
 .pdf-reader__toolbar {
   display: flex;
+  /* Wraps whenever the CONTAINER is narrow (floating panel, split pane) —
+     a viewport media query can't see container width. */
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 8px 12px;
   padding: 6px 12px;
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
@@ -137,8 +140,9 @@
 
 .pdf-reader__findbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 6px 8px;
   padding: 6px 12px;
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);

--- a/src/ui/viewers/pdf/PdfSidebar.tsx
+++ b/src/ui/viewers/pdf/PdfSidebar.tsx
@@ -1,14 +1,29 @@
 /**
- * PdfSidebar — tabbed side panel for the PDF reader. Ships with the document
- * Outline tab; the Bookmarks tab joins it with the reading-state work.
+ * PdfSidebar — tabbed side panel for the PDF reader: the document's own
+ * Outline, and the user's page Bookmarks (per-user reading state). The
+ * Bookmarks tab only appears when the host provides bookmark props (i.e.
+ * reading-state persistence is available).
  */
 
+import { useState } from 'react';
+import { Bookmark, Pencil, Trash2 } from 'lucide-react';
+import { Icon } from '../../icons';
+import type { PdfBookmark } from '../../../store/fileViewState';
 import type { PdfOutlineNode } from './usePdfViewerController';
 
 export interface PdfSidebarProps {
   outline: PdfOutlineNode[] | null;
   onNavigate: (dest: unknown) => void;
+  /** Undefined disables the Bookmarks tab entirely. */
+  bookmarks?: PdfBookmark[] | undefined;
+  currentPage?: number | undefined;
+  onJumpToPage?: ((page: number) => void) | undefined;
+  onRenameBookmark?: ((page: number, label: string) => void) | undefined;
+  onRemoveBookmark?: ((page: number) => void) | undefined;
+  onBookmarkCurrent?: (() => void) | undefined;
 }
+
+type SidebarTab = 'outline' | 'bookmarks';
 
 function OutlineList({
   items,
@@ -40,25 +55,162 @@ function OutlineList({
   );
 }
 
-export function PdfSidebar({ outline, onNavigate }: PdfSidebarProps) {
+function BookmarkRow({
+  bookmark,
+  isCurrent,
+  onJump,
+  onRename,
+  onRemove,
+}: {
+  bookmark: PdfBookmark;
+  isCurrent: boolean;
+  onJump: () => void;
+  onRename: (label: string) => void;
+  onRemove: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(bookmark.label ?? '');
+
+  const commit = () => {
+    setEditing(false);
+    onRename(draft);
+  };
+
+  if (editing) {
+    return (
+      <li className="pdf-reader__bookmark-row">
+        <input
+          className="pdf-reader__bookmark-rename"
+          value={draft}
+          placeholder={`Page ${bookmark.page}`}
+          autoFocus
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit();
+            else if (e.key === 'Escape') {
+              e.stopPropagation();
+              setEditing(false);
+              setDraft(bookmark.label ?? '');
+            }
+          }}
+          aria-label={`Rename bookmark on page ${bookmark.page}`}
+        />
+      </li>
+    );
+  }
+
+  return (
+    <li className="pdf-reader__bookmark-row">
+      <button
+        className="pdf-reader__bookmark-jump"
+        onClick={onJump}
+        aria-current={isCurrent ? 'page' : undefined}
+        title={`Go to page ${bookmark.page}`}
+      >
+        <span className="pdf-reader__bookmark-page">p. {bookmark.page}</span>
+        <span className="pdf-reader__bookmark-label">
+          {bookmark.label ?? `Page ${bookmark.page}`}
+        </span>
+      </button>
+      <span className="pdf-reader__bookmark-actions">
+        <button
+          className="pdf-reader__bookmark-action"
+          onClick={() => {
+            setDraft(bookmark.label ?? '');
+            setEditing(true);
+          }}
+          title="Rename bookmark"
+        >
+          <Icon icon={Pencil} size={13} />
+        </button>
+        <button
+          className="pdf-reader__bookmark-action"
+          onClick={onRemove}
+          title="Delete bookmark"
+        >
+          <Icon icon={Trash2} size={13} />
+        </button>
+      </span>
+    </li>
+  );
+}
+
+export function PdfSidebar({
+  outline,
+  onNavigate,
+  bookmarks,
+  currentPage,
+  onJumpToPage,
+  onRenameBookmark,
+  onRemoveBookmark,
+  onBookmarkCurrent,
+}: PdfSidebarProps) {
+  const bookmarksEnabled = bookmarks !== undefined;
+  const [activeTab, setActiveTab] = useState<SidebarTab>('outline');
+  const tab: SidebarTab = bookmarksEnabled ? activeTab : 'outline';
+
   return (
     <div className="pdf-reader__sidebar">
       <div className="pdf-reader__sidebar-tabs" role="tablist">
         <button
-          className="pdf-reader__sidebar-tab pdf-reader__sidebar-tab--active"
+          className={`pdf-reader__sidebar-tab${tab === 'outline' ? ' pdf-reader__sidebar-tab--active' : ''}`}
           role="tab"
-          aria-selected="true"
+          aria-selected={tab === 'outline'}
+          onClick={() => setActiveTab('outline')}
         >
           Outline
         </button>
+        {bookmarksEnabled && (
+          <button
+            className={`pdf-reader__sidebar-tab${tab === 'bookmarks' ? ' pdf-reader__sidebar-tab--active' : ''}`}
+            role="tab"
+            aria-selected={tab === 'bookmarks'}
+            onClick={() => setActiveTab('bookmarks')}
+          >
+            Bookmarks
+          </button>
+        )}
       </div>
+
       <div className="pdf-reader__sidebar-content" role="tabpanel">
-        {outline && outline.length > 0 ? (
-          <OutlineList items={outline} onNavigate={onNavigate} depth={0} />
-        ) : (
-          <div className="pdf-reader__sidebar-empty">
-            No outline in this document.
-          </div>
+        {tab === 'outline' &&
+          (outline && outline.length > 0 ? (
+            <OutlineList items={outline} onNavigate={onNavigate} depth={0} />
+          ) : (
+            <div className="pdf-reader__sidebar-empty">
+              No outline in this document.
+              {bookmarksEnabled && ' Use bookmarks to mark pages yourself.'}
+            </div>
+          ))}
+
+        {tab === 'bookmarks' && bookmarksEnabled && (
+          <>
+            {onBookmarkCurrent && (
+              <button className="pdf-reader__bookmark-add" onClick={onBookmarkCurrent}>
+                <Icon icon={Bookmark} size={14} />
+                Bookmark current page
+              </button>
+            )}
+            {bookmarks.length > 0 ? (
+              <ul className="pdf-reader__bookmark-list">
+                {bookmarks.map((b) => (
+                  <BookmarkRow
+                    key={b.page}
+                    bookmark={b}
+                    isCurrent={b.page === currentPage}
+                    onJump={() => onJumpToPage?.(b.page)}
+                    onRename={(label) => onRenameBookmark?.(b.page, label)}
+                    onRemove={() => onRemoveBookmark?.(b.page)}
+                  />
+                ))}
+              </ul>
+            ) : (
+              <div className="pdf-reader__sidebar-empty">
+                No bookmarks yet. Press <kbd>b</kbd> while reading to mark a page.
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/ui/viewers/pdf/PdfToolbar.tsx
+++ b/src/ui/viewers/pdf/PdfToolbar.tsx
@@ -5,8 +5,10 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import {
+  Bookmark,
   ChevronDown,
   ChevronUp,
+  ImagePlus,
   Maximize2,
   PanelLeft,
   Search,
@@ -28,6 +30,10 @@ export interface PdfToolbarProps {
   onToggleDimmed: () => void;
   /** Absent when the host doesn't support immersive mode. */
   onEnterImmersive?: (() => void) | undefined;
+  /** Absent when reading-state persistence is unavailable (no doc identity). */
+  bookmarkState?: { active: boolean; onToggle: () => void } | undefined;
+  /** Send the current page to the canvas as an image shape; absent hides it. */
+  onSendPageToCanvas?: (() => void) | undefined;
 }
 
 export function PdfToolbar({
@@ -39,6 +45,8 @@ export function PdfToolbar({
   dimmed,
   onToggleDimmed,
   onEnterImmersive,
+  bookmarkState,
+  onSendPageToCanvas,
 }: PdfToolbarProps) {
   const { currentPage, numPages, zoomPercent, zoomMode } = controller;
   const [pageInput, setPageInput] = useState(String(currentPage));
@@ -160,6 +168,25 @@ export function PdfToolbar({
       <div className="pdf-reader__toolbar-divider" />
 
       <div className="pdf-reader__toolbar-group">
+        {bookmarkState && (
+          <button
+            className={`pdf-reader__btn${bookmarkState.active ? ' pdf-reader__btn--active' : ''}`}
+            onClick={bookmarkState.onToggle}
+            title={bookmarkState.active ? 'Remove bookmark (b)' : 'Bookmark this page (b)'}
+            aria-pressed={bookmarkState.active}
+          >
+            <Icon icon={Bookmark} size={16} />
+          </button>
+        )}
+        {onSendPageToCanvas && (
+          <button
+            className="pdf-reader__btn"
+            onClick={onSendPageToCanvas}
+            title="Send this page to the canvas as an image"
+          >
+            <Icon icon={ImagePlus} size={16} />
+          </button>
+        )}
         <button
           className={`pdf-reader__btn pdf-reader__dim-btn${dimmed ? ' pdf-reader__btn--active' : ''}`}
           onClick={onToggleDimmed}

--- a/src/ui/viewers/pdf/exportPageImage.ts
+++ b/src/ui/viewers/pdf/exportPageImage.ts
@@ -1,0 +1,59 @@
+/**
+ * Render a single PDF page to a high-resolution PNG File — the "send page to
+ * canvas" export. Same lazy pdf.js + OffscreenCanvas pattern as
+ * ThumbnailGenerator, but at reading resolution and lossless.
+ * Untestable in jsdom (canvas); deliberately kept thin.
+ */
+
+/** Target bitmap width — high enough to stay legible when scaled on canvas. */
+const TARGET_WIDTH = 1600;
+const MAX_SCALE = 4;
+
+export async function exportPdfPageAsPngFile(
+  source: Blob,
+  pageNumber: number,
+  baseName: string,
+): Promise<File | null> {
+  try {
+    const pdfjsLib = await import('pdfjs-dist');
+    if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
+      pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+        'pdfjs-dist/build/pdf.worker.min.mjs',
+        import.meta.url,
+      ).toString();
+    }
+
+    const loadingTask = pdfjsLib.getDocument({ data: await source.arrayBuffer() });
+    try {
+      const doc = await loadingTask.promise;
+      const page = await doc.getPage(Math.min(Math.max(1, pageNumber), doc.numPages));
+
+      const base = page.getViewport({ scale: 1.0 });
+      const scale = Math.min(MAX_SCALE, TARGET_WIDTH / base.width);
+      const viewport = page.getViewport({ scale });
+
+      const canvas = new OffscreenCanvas(
+        Math.ceil(viewport.width),
+        Math.ceil(viewport.height),
+      );
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return null;
+
+      // pdf.js v5 requires explicit `canvas: null` when passing canvasContext.
+      await page.render({
+        canvas: null,
+        canvasContext: ctx as unknown as CanvasRenderingContext2D,
+        viewport,
+      }).promise;
+
+      const png = await canvas.convertToBlob({ type: 'image/png' });
+      const stem = baseName.replace(/\.pdf$/i, '');
+      return new File([png], `${stem}-p${pageNumber}.png`, { type: 'image/png' });
+    } finally {
+      await loadingTask.destroy().catch(() => undefined);
+    }
+  } catch (err) {
+    console.error('exportPdfPageAsPngFile failed:', err);
+    return null;
+  }
+}

--- a/src/ui/viewers/pdf/usePdfViewerController.ts
+++ b/src/ui/viewers/pdf/usePdfViewerController.ts
@@ -73,6 +73,8 @@ export interface PdfViewerController {
   outline: PdfOutlineNode[] | null;
   findMatches: PdfMatchesCount | null;
   findNotFound: boolean;
+  /** True once the initial view restore has applied for the current document. */
+  viewRestored: boolean;
 
   goToPage(page: number): void;
   zoomIn(): void;
@@ -109,12 +111,35 @@ interface FindControlStateEvent {
   matchesCount: PdfMatchesCount;
 }
 
+/** Initial view to restore when a document finishes initializing. */
+export interface PdfInitialView {
+  /** 1-based page to land on (clamped to the live page count). */
+  page: number;
+  zoomMode: PdfZoomMode;
+  /** Numeric zoom (percent) applied when zoomMode is 'custom'. */
+  zoomPercent?: number | undefined;
+}
+
+export interface PdfViewerControllerOptions {
+  /**
+   * Called once per document load at pagesinit with the live page count;
+   * return the view to restore, or null for the default fit-width first page.
+   * Page-change/scale events are not considered user navigation until after
+   * this restore applies (the restore-guard) — persistence subscribers should
+   * gate on {@link PdfViewerController.viewRestored}.
+   */
+  getInitialView?: (numPages: number) => PdfInitialView | null;
+}
+
 const DEFAULT_FIT_MODE: PdfFitMode = 'page-width';
 
 /** Wheel deltas accumulate to this threshold before a zoom step fires. */
 const WHEEL_ZOOM_THRESHOLD = 50;
 
-export function usePdfViewerController(blobUrl: string): PdfViewerController {
+export function usePdfViewerController(
+  blobUrl: string,
+  options: PdfViewerControllerOptions = {},
+): PdfViewerController {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<HTMLDivElement>(null);
   const partsRef = useRef<ViewerParts | null>(null);
@@ -129,10 +154,13 @@ export function usePdfViewerController(blobUrl: string): PdfViewerController {
   const [outline, setOutline] = useState<PdfOutlineNode[] | null>(null);
   const [findMatches, setFindMatches] = useState<PdfMatchesCount | null>(null);
   const [findNotFound, setFindNotFound] = useState(false);
+  const [viewRestored, setViewRestored] = useState(false);
 
   // Listener-visible mirrors (event handlers must not close over stale state).
   const zoomModeRef = useRef<PdfZoomMode>(DEFAULT_FIT_MODE);
   const fitModeRef = useRef<PdfFitMode>(DEFAULT_FIT_MODE);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   // -------------------------------------------------------------------------
   // Component graph lifecycle
@@ -155,10 +183,26 @@ export function usePdfViewerController(blobUrl: string): PdfViewerController {
     linkService.setViewer(viewer);
 
     const onPagesInit = () => {
-      // Apply the active fit mode once the pages exist; if the user had
-      // switched to a custom zoom before a reload, fall back to the last fit.
-      viewer.currentScaleValue =
-        zoomModeRef.current === 'custom' ? fitModeRef.current : zoomModeRef.current;
+      // Restore the stored view when the host provides one; otherwise apply
+      // the active fit mode (custom zoom pre-reload falls back to last fit).
+      const initial =
+        optionsRef.current.getInitialView?.(viewer.pagesCount) ?? null;
+      if (initial) {
+        if (initial.zoomMode === 'custom' && typeof initial.zoomPercent === 'number') {
+          viewer.currentScale = Math.max(0.1, initial.zoomPercent / 100);
+        } else if (initial.zoomMode !== 'custom') {
+          fitModeRef.current = initial.zoomMode;
+          viewer.currentScaleValue = initial.zoomMode;
+        } else {
+          viewer.currentScaleValue = fitModeRef.current;
+        }
+        viewer.currentPageNumber = clampPage(initial.page, viewer.pagesCount);
+      } else {
+        viewer.currentScaleValue =
+          zoomModeRef.current === 'custom' ? fitModeRef.current : zoomModeRef.current;
+      }
+      // Restore-guard: only events after this point count as user navigation.
+      setViewRestored(true);
     };
     const onPageChanging = (evt: PageChangingEvent) => {
       setCurrentPage(evt.pageNumber);
@@ -211,6 +255,7 @@ export function usePdfViewerController(blobUrl: string): PdfViewerController {
     setOutline(null);
     setFindMatches(null);
     setFindNotFound(false);
+    setViewRestored(false);
 
     const loadingTask = pdfjsLib.getDocument(blobUrl);
 
@@ -377,6 +422,7 @@ export function usePdfViewerController(blobUrl: string): PdfViewerController {
     outline,
     findMatches,
     findNotFound,
+    viewRestored,
     goToPage,
     zoomIn,
     zoomOut,

--- a/src/utils/fileTypeIcons.ts
+++ b/src/utils/fileTypeIcons.ts
@@ -7,7 +7,7 @@
  * format) that `FileShape` rasterises via `iconCache.drawRawSvgIcon`. The React
  * side uses the lucide-react components directly. Keep the two in sync.
  */
-import { File, FileText, FileType, Image as ImageIcon, Sheet, type LucideIcon } from 'lucide-react';
+import { File, FileText, FileType, FileAudio, FileVideo, Image as ImageIcon, Sheet, type LucideIcon } from 'lucide-react';
 import { drawRawSvgIcon } from './iconCache';
 import type { FileCategory } from './fileUtils';
 
@@ -25,6 +25,10 @@ const FILE_TYPE_SVG: Record<FileCategory, string> = {
   spreadsheet: `<svg ${SVG_ATTRS}><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></svg>`,
   // Image
   image: `<svg ${SVG_ATTRS}><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>`,
+  // FileAudio
+  audio: `<svg ${SVG_ATTRS}><path d="M17.5 22h.5a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v3"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M2 19a2 2 0 1 1 4 0v1a2 2 0 1 1-4 0v-4a6 6 0 0 1 12 0v4a2 2 0 1 1-4 0v-1a2 2 0 1 1 4 0"/></svg>`,
+  // FileVideo
+  video: `<svg ${SVG_ATTRS}>${FILE_BODY}<path d="m10 11 5 3-5 3v-6Z"/></svg>`,
   // FileType
   text: `<svg ${SVG_ATTRS}>${FILE_BODY}<path d="M9 13v-1h6v1"/><path d="M11 18h2"/><path d="M12 12v6"/></svg>`,
   // File
@@ -39,6 +43,8 @@ const FILE_TYPE_COMPONENT: Record<FileCategory, LucideIcon> = {
   pdf: FileText,
   spreadsheet: Sheet,
   image: ImageIcon,
+  audio: FileAudio,
+  video: FileVideo,
   text: FileType,
   generic: File,
 };

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -4,6 +4,7 @@ import {
   formatFileSize,
   getMimeType,
   isPreviewableFile,
+  resolveViewerCategory,
 } from './fileUtils';
 
 describe('detectFileCategory', () => {
@@ -36,9 +37,37 @@ describe('detectFileCategory', () => {
     expect(detectFileCategory('text/markdown', 'README.md')).toBe('text');
   });
 
+  it('detects audio by MIME prefix and extension fallback', () => {
+    expect(detectFileCategory('audio/mpeg', 'song.mp3')).toBe('audio');
+    expect(detectFileCategory('audio/ogg', 'clip.oga')).toBe('audio');
+    expect(detectFileCategory('application/octet-stream', 'take.flac')).toBe('audio');
+  });
+
+  it('detects video by MIME prefix and extension fallback', () => {
+    expect(detectFileCategory('video/mp4', 'demo.mp4')).toBe('video');
+    expect(detectFileCategory('video/webm', 'screen.webm')).toBe('video');
+    expect(detectFileCategory('application/octet-stream', 'clip.mkv')).toBe('video');
+  });
+
   it('falls back to generic for unknown types', () => {
     expect(detectFileCategory('application/octet-stream', 'file.xyz')).toBe('generic');
     expect(detectFileCategory('application/octet-stream', 'archive.7z')).toBe('generic');
+  });
+});
+
+describe('resolveViewerCategory', () => {
+  it('upgrades pre-media generic shapes from their stored MIME', () => {
+    expect(resolveViewerCategory('generic', 'audio/mpeg')).toBe('audio');
+    expect(resolveViewerCategory('generic', 'video/mp4')).toBe('video');
+  });
+
+  it('leaves non-generic categories untouched', () => {
+    expect(resolveViewerCategory('pdf', 'audio/mpeg')).toBe('pdf');
+    expect(resolveViewerCategory('image', 'video/mp4')).toBe('image');
+  });
+
+  it('keeps truly generic files generic', () => {
+    expect(resolveViewerCategory('generic', 'application/octet-stream')).toBe('generic');
   });
 });
 

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -5,8 +5,18 @@
  * and icon mapping for the file embedding system.
  */
 
-/** File category for viewer dispatch */
-export type FileCategory = 'pdf' | 'spreadsheet' | 'image' | 'text' | 'generic';
+/**
+ * File category for viewer dispatch. Single source of truth — Shape.ts
+ * re-exports this type for shape consumers.
+ */
+export type FileCategory =
+  | 'pdf'
+  | 'spreadsheet'
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'text'
+  | 'generic';
 
 /**
  * Detect the file category from MIME type and filename.
@@ -34,6 +44,17 @@ export function detectFileCategory(mimeType: string, fileName: string): FileCate
     ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'avif', 'bmp', 'ico', 'tiff', 'tif'].includes(ext)
   ) return 'image';
 
+  // Audio / video (playback support depends on platform codecs — the viewers
+  // fall back to a download prompt when the media element can't decode)
+  if (
+    mime.startsWith('audio/') ||
+    ['mp3', 'wav', 'ogg', 'oga', 'm4a', 'flac', 'aac', 'opus'].includes(ext)
+  ) return 'audio';
+  if (
+    mime.startsWith('video/') ||
+    ['mp4', 'webm', 'mov', 'mkv', 'm4v', 'avi'].includes(ext)
+  ) return 'video';
+
   // Text/code files
   if (
     mime.startsWith('text/') ||
@@ -56,6 +77,19 @@ export function detectFileCategory(mimeType: string, fileName: string): FileCate
   ) return 'text';
 
   return 'generic';
+}
+
+/**
+ * Category to dispatch a viewer for. Files imported before audio/video became
+ * distinct categories are stored as 'generic'; upgrade them at view time from
+ * the stored MIME so older documents start playing without a doc migration.
+ */
+export function resolveViewerCategory(category: FileCategory, mimeType: string): FileCategory {
+  if (category !== 'generic') return category;
+  const mime = mimeType.toLowerCase();
+  if (mime.startsWith('audio/')) return 'audio';
+  if (mime.startsWith('video/')) return 'video';
+  return category;
 }
 
 /**


### PR DESCRIPTION
Second PR of the JP-398 File Shape Upgrades epic (after #410): everything user-facing in the file viewer, as one coherent subject. A final small PR (blob integrity + progress toasts) follows with zero file overlap.

## Reading state + bookmarks (issue item 2, completing it)

- New `fileViewState` pure reducers + persisted `fileViewStateStore` (own localStorage key, shapePickerStore pattern): last page, zoom mode, bookmarks — keyed `docId:shapeId`, **per-user local only, never in the Y.Doc** (page turns must not sync-fight or dirty the doc).
- LRU cap (200) with bookmark-preferring eviction; stored content hash reconciles state after a file Replace (clamp page, prune out-of-range bookmarks, keep in-range ones).
- Reader restores page + zoom behind a restore-guard (load events can't stomp the stored position); 500ms-debounced writes.
- Bookmarks: toolbar + immersive-strip toggle, `b` shortcut, sidebar Bookmarks tab (jump / inline rename / delete / empty state).

## Audio + video handlers (item 3)

- `FileCategory` single-sourced in `fileUtils` (+`audio`/`video`); `Shape.ts` re-exports type-only. Native `<audio>`/`<video>` viewers with a download fallback when the platform lacks the codec (WebKitGTK/GStreamer reality).
- Pre-existing media files stored as `generic` upgrade at **view time** from their MIME — old docs start playing with no migration.

## Floating viewer (item 4)

- `FileViewerContent` extracted from the modal (mechanical); `FileViewerModal` is now a thin overlay host and `FloatingFileViewer` a portal host: header-drag (pointer events, commit-on-release), right/bottom/corner resize, bounds persisted app-level and clamped on restore/window-resize, desktop-only (`mobileActive` coerces to modal).
- New **9500** z-tier: a persistent worksurface sits *below* menus/dialogs/toasts (tier map documented in the CSS).

## PDF actions + file info (stretch + item 1's "expose storage properties")

- **Cite**: DOI extracted from metadata + first two pages (pure, tested `pdfDoiExtract`), resolved via the existing `resolveDoi` → `importReferences` pipeline; no-DOI popover offers paste-a-DOI or a minimal reference.
- **Send page to canvas**: page rendered to a ~1600px PNG and imported at the viewport center through a new `canvasImportSeam` (registerBlobDownloader pattern). Lands as a file-card image shape (no dedicated inline image shape exists — known form).
- **File info popover**: size, MIME, page count, copyable SHA-256 checksum, on-device storage status.

## Verification

- `bun run typecheck` / `bun run test --run` (3102 tests, +39 new across fileViewState, fileUtils, floatingPosition, fileViewerMode, pdfDoiExtract) / `bun run build` all green.
- Live-driven in the dev preview: page-8 restore across close/reopen with bookmark intact; sidebar bookmark row + jump; pop-out → drag (−120,+60 exact) → corner-resize (−60,+40 exact) → bounds persisted → dock; send-page produced the page-8 PNG shape + toast with Show action; Cite correctly hit the no-DOI popover on a DOI-less file, added a minimal reference, and resolved a real pasted DOI (10.1038/s41586-020-2649-2) live through doi.org; file-info popover shows checksum + page count.
- Not live-driven: audio/video playback (no media fixture in the session) — detection is unit-tested and the viewers are deliberately defensive; worth a quick E2E with an mp3/mp4.

Docs: `embedded-files.md` (bookmarks/reading position, floating viewer, A/V table rows, file info, cite/send-page), `citations.md` (Cite an Embedded PDF).

Assisted-by: Fable 5
