### PR TITLE
JP-448: MCP — teach agents to cite sources by default

### DIFF
--- a/relay/src/mcp/skills.rs
+++ b/relay/src/mcp/skills.rs
@@ -38,6 +38,18 @@ pub const CONTENT_CONTRACT: &str = r#"# DocuShark content contract (read before 
   literal; `$` inside code stays literal. (Equivalent HTML with format:"html":
   `<div data-math-block data-latex="…"></div>` /
   `<span data-math-inline data-latex="…"></span>`.)
+- Citations: to cite a source inline, first add it to the document's reference
+  library with `add_reference` (by DOI or CSL-JSON), then reference it in prose as
+  `<span data-citation data-ref-id="<id>" data-label="(Author, Year)">(Author, Year)</span>`
+  (format:"html"), where `<id>` is a library id you added. **For any researched or
+  scholarly content, cite real sources this way — don't hand-type a "References"
+  list.** The formatted bibliography (`<div data-bibliography>`) is generated in
+  the editor from the library, so you don't emit it yourself.
+- Fields: define a reusable value with `set_fields`, then reference it as `{{name}}`
+  (Markdown). If the doc won't be opened in an editor before you hand it off (e.g.
+  export), bake the value into the stored HTML directly with
+  `<span data-field data-name="name" data-label="value">value</span>` (format:"html")
+  so it isn't blank.
 - Every <img> needs a real src (a blob:, https:, or data: URL). A src-less image
   is dropped — it would crash the editor.
 - Tables must be rectangular *counting spans*: a <table> of <tr> rows whose
@@ -124,6 +136,11 @@ const SKILLS: &[(&str, &str, &str)] = &[
         "edit-tables",
         "Restructure a prose table: add/delete/move rows or columns, merge/split cells, headers, widths.",
         include_str!("skills/edit-tables.SKILL.md"),
+    ),
+    (
+        "research-writeup",
+        "Write a researched/scholarly document that cites real sources (inline citations, references, tables, math).",
+        include_str!("skills/research-writeup.SKILL.md"),
     ),
 ];
 

--- a/relay/src/mcp/skills/research-writeup.SKILL.md
+++ b/relay/src/mcp/skills/research-writeup.SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docushark-research-writeup
+description: Use when the user wants a researched or scholarly document in DocuShark — a lab/study write-up, literature note, or any prose that should cite real sources. Produces structured prose with inline citations, tables, math, and an optional diagram. Requires the DocuShark MCP server to be connected.
+---
+
+# Author a cited research write-up in DocuShark
+
+Produce a scholarly document that **cites real sources** — inline citations backed
+by the document's reference library — rather than a hand-typed list. Work in one
+**team** document (MCP can't write local documents).
+
+## Steps
+
+1. **Create the document.** Call `create_document` with a clear `name`. Keep the
+   returned `id` — it's `docId` for every later call.
+
+2. **Find the pages.** Call `get_document(docId)` for `prosePages` (write here) and
+   `pages` (a canvas page, if you want a figure).
+
+3. **Add your sources to the library FIRST.** Call `add_reference(docId, …)` for
+   each source — by `doi` (resolved for you via doi.org) or a CSL-JSON `items`
+   object with a stable `id` (e.g. `"smith2020"`). Keep each id; you cite by it.
+
+4. **Write the body with inline citations.** Call `set_prose(docId, prosePageId,
+   content)`. Where you make a claim from a source, cite it inline (format:"html"):
+
+   ```html
+   Faster tempo loads attention during encoding
+   <span data-citation data-ref-id="smith2020" data-label="(Smith, 2020)">(Smith, 2020)</span>.
+   ```
+
+   The `data-ref-id` must match an id you added in step 3. A typical structure:
+
+   ```markdown
+   # {{Title}}
+
+   > **Field:** {{Field}} · **Author:** {{Author}}
+
+   ## Background      (claims -> inline citations)
+   ## Method
+   ## Results         (a table; stats inline as $F(2,57)=8.1,\ p<.01$)
+   ## Discussion
+   ## References      (leave this heading empty — the bibliography is generated)
+   ```
+
+   Set field values with `set_fields`. If the doc won't be opened in an editor
+   before you hand it off, bake fields as
+   `<span data-field data-name="Author" data-label="…">…</span>` so they aren't blank.
+
+5. **(Optional) Add a figure.** Use `generate_diagram(docId, canvasPageId, nodes,
+   edges)` for a study-design or concept diagram, and refer to it from the prose.
+
+6. **Leave the bibliography to the editor.** You populate the library and place the
+   inline citations; the formatted `<div data-bibliography>` reference list is
+   generated in the editor. Don't hand-type it.
+
+7. **Confirm.** Call `get_document(docId)` — check the prose page and any canvas
+   `shapeCount`. Give the user the document `id`/name.
+
+## Tips
+
+- **Cite by default.** Any factual claim drawn from a source gets an inline
+  citation — never a manual "References" paragraph. The library + inline citations
+  are the real, editor-native way, and they power the generated bibliography.
+- **DOIs are easiest.** `resolve_doi` previews a reference; `add_reference` with a
+  `doi` fills clean metadata automatically.
+- **Math and tables** live in the same prose: `$…$` / `$$…$$` for equations, and
+  Markdown tables for results.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -886,7 +886,7 @@ pub fn descriptors() -> Vec<ToolDescriptor> {
         ToolDescriptor {
             name: "docushark_add_reference",
             description:
-                "Add one or more references (citations) to a document's reference library. Supply EITHER 'doi' (resolved via doi.org to CSL-JSON) OR 'items' (raw CSL-JSON object(s)). Deduplicates by DOI then id; returns the ids added and how many were skipped as duplicates. This populates the library only — it does not insert an inline citation or bibliography into the prose (do that in the editor). A connected editor sees new references on reload (references aren't live-synced yet). Refuses local (renderer-owned) documents.",
+                "Add one or more references (citations) to a document's reference library. Supply EITHER 'doi' (resolved via doi.org to CSL-JSON) OR 'items' (raw CSL-JSON object(s)). Deduplicates by DOI then id; returns the ids added and how many were skipped as duplicates. This populates the library. To CITE a reference inline, write <span data-citation data-ref-id=\"<id>\" data-label=\"(Author, Year)\">(Author, Year)</span> via set_prose (format:\"html\"), where <id> is an id returned here — for scholarly or researched content, prefer real citations over a hand-typed reference list. The formatted bibliography (<div data-bibliography>) is generated in the editor from the library. A connected editor sees new references on reload (references aren't live-synced yet). Refuses local (renderer-owned) documents.",
             input_schema: json!({
                 "type": "object",
                 "properties": {

--- a/skills/research-writeup/SKILL.md
+++ b/skills/research-writeup/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docushark-research-writeup
+description: Use when the user wants a researched or scholarly document in DocuShark — a lab/study write-up, literature note, or any prose that should cite real sources. Produces structured prose with inline citations, tables, math, and an optional diagram. Requires the DocuShark MCP server to be connected.
+---
+
+# Author a cited research write-up in DocuShark
+
+Produce a scholarly document that **cites real sources** — inline citations backed
+by the document's reference library — rather than a hand-typed list. Work in one
+**team** document (MCP can't write local documents).
+
+## Steps
+
+1. **Create the document.** Call `create_document` with a clear `name`. Keep the
+   returned `id` — it's `docId` for every later call.
+
+2. **Find the pages.** Call `get_document(docId)` for `prosePages` (write here) and
+   `pages` (a canvas page, if you want a figure).
+
+3. **Add your sources to the library FIRST.** Call `add_reference(docId, …)` for
+   each source — by `doi` (resolved for you via doi.org) or a CSL-JSON `items`
+   object with a stable `id` (e.g. `"smith2020"`). Keep each id; you cite by it.
+
+4. **Write the body with inline citations.** Call `set_prose(docId, prosePageId,
+   content)`. Where you make a claim from a source, cite it inline (format:"html"):
+
+   ```html
+   Faster tempo loads attention during encoding
+   <span data-citation data-ref-id="smith2020" data-label="(Smith, 2020)">(Smith, 2020)</span>.
+   ```
+
+   The `data-ref-id` must match an id you added in step 3. A typical structure:
+
+   ```markdown
+   # {{Title}}
+
+   > **Field:** {{Field}} · **Author:** {{Author}}
+
+   ## Background      (claims -> inline citations)
+   ## Method
+   ## Results         (a table; stats inline as $F(2,57)=8.1,\ p<.01$)
+   ## Discussion
+   ## References      (leave this heading empty — the bibliography is generated)
+   ```
+
+   Set field values with `set_fields`. If the doc won't be opened in an editor
+   before you hand it off, bake fields as
+   `<span data-field data-name="Author" data-label="…">…</span>` so they aren't blank.
+
+5. **(Optional) Add a figure.** Use `generate_diagram(docId, canvasPageId, nodes,
+   edges)` for a study-design or concept diagram, and refer to it from the prose.
+
+6. **Leave the bibliography to the editor.** You populate the library and place the
+   inline citations; the formatted `<div data-bibliography>` reference list is
+   generated in the editor. Don't hand-type it.
+
+7. **Confirm.** Call `get_document(docId)` — check the prose page and any canvas
+   `shapeCount`. Give the user the document `id`/name.
+
+## Tips
+
+- **Cite by default.** Any factual claim drawn from a source gets an inline
+  citation — never a manual "References" paragraph. The library + inline citations
+  are the real, editor-native way, and they power the generated bibliography.
+- **DOIs are easiest.** `resolve_doi` previews a reference; `add_reference` with a
+  `doi` fills clean metadata automatically.
+- **Math and tables** live in the same prose: `$…$` / `$$…$$` for equations, and
+  Markdown tables for results.


### PR DESCRIPTION
Part of [JP-448](https://linear.app/justins-awesome-apps/issue/JP-448/mcp-tools-improvements-collector) (finding #1).

## Problem
Authoring a scholarly doc over MCP, an agent falls back to a hand-typed "References" list instead of DocuShark citations — because the guidance actively steered it wrong:
- `CONTENT_CONTRACT` (returned by every `get_skills`) lists "an inline citation" as an atom but never shows its **format**.
- `add_reference`'s description said the inline citation + bibliography are *"do that in the editor"* — but `set_prose` **does** accept `<span data-citation data-ref-id=… data-label=…>` and it round-trips (verified while dogfooding the persona example docs).

## Change
- **`CONTENT_CONTRACT`** — document the inline-citation format + a *"cite real sources, don't hand-type a References list"* default; plus a note on baking `{{field}}` values as `data-field` HTML for docs that won't be opened before hand-off (finding #2 workaround).
- **`add_reference` description** — replace the misleading line with the inline-citation how-to; the CSL bibliography stays editor-generated.
- **New `research-writeup` recipe** — canonical `skills/research-writeup/SKILL.md` + byte-identical vendored `relay/src/mcp/skills/`, registered in the `SKILLS` table, so scholarly writing cites by default.

## Verify
`cargo check --all-targets` + `cargo test --lib skills` — all green, including `vendored_skills_match_source` (drift test) and the catalogue test (now 7 recipes).

Assisted-by: Opus 4.8