### PR TITLE
JP-455: Cloud sign-in survives an interrupted flow

### DIFF
--- a/src/api/cloudAuth.test.ts
+++ b/src/api/cloudAuth.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { beginCloudSignIn, DEVICE_CLIENT_ID, DEVICE_GRANT_TYPE } from './cloudAuth';
+import {
+  beginCloudSignIn,
+  resumeCloudSignIn,
+  DEVICE_CLIENT_ID,
+  DEVICE_GRANT_TYPE,
+} from './cloudAuth';
 
 /** Minimal Response stub — cloudAuth only touches `ok`, `status`, `json()`. */
 function jsonRes(body: unknown, status = 200): Response {
@@ -59,7 +64,7 @@ describe('beginCloudSignIn', () => {
         jsonRes({ token: 'RELAY.JWT', jti: 'j1', expires_at: 1000, token_type: 'Bearer' }),
       ],
     });
-    const openExternal = vi.fn(async () => {});
+    const openExternal = vi.fn(async () => true);
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
@@ -99,7 +104,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: noopSleep,
     });
 
@@ -122,7 +127,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: noopSleep,
     });
 
@@ -141,7 +146,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: noopSleep,
     });
 
@@ -157,7 +162,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: noopSleep,
     });
 
@@ -174,7 +179,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: noopSleep,
     });
 
@@ -189,7 +194,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: noopSleep,
       now: () => 1_000,
     });
@@ -212,7 +217,7 @@ describe('beginCloudSignIn', () => {
 
     const handle = await beginCloudSignIn('http://web', {
       fetchImpl,
-      openExternal: async () => {},
+      openExternal: async () => true,
       sleep: gatedSleep,
     });
 
@@ -230,9 +235,93 @@ describe('beginCloudSignIn', () => {
     await expect(
       beginCloudSignIn('http://web', {
         fetchImpl,
-        openExternal: async () => {},
+        openExternal: async () => true,
         sleep: noopSleep,
       }),
     ).rejects.toMatchObject({ name: 'CloudAuthError', code: 'device_code_persist_failed' });
+  });
+});
+
+describe('resumeCloudSignIn (JP-455)', () => {
+  const grant = {
+    deviceCode: 'DEV-CODE',
+    userCode: 'WXYZ-1234',
+    verificationUri: 'http://web/auth/device?user_code=WXYZ-1234',
+    intervalMs: 5000,
+    expiresAt: 10_000,
+    cloudBaseUrl: 'http://web',
+  };
+
+  it('polls a stored grant without requesting a new code', async () => {
+    const { fetchImpl, calls } = mockFetch({
+      tokenQueue: [
+        jsonRes({ token: 'RELAY.JWT', jti: 'j1', expires_at: 1000, token_type: 'Bearer' }),
+      ],
+    });
+
+    const handle = resumeCloudSignIn(grant, {
+      fetchImpl,
+      sleep: noopSleep,
+      now: () => 0,
+    });
+
+    await expect(handle.result).resolves.toMatchObject({ token: 'RELAY.JWT' });
+    // The whole point of resuming: no second device_code is issued, so the code
+    // already shown to the user (and possibly already authorized) stays valid.
+    expect(calls.some((c) => c.url.endsWith('/api/v1/auth/device/code'))).toBe(false);
+    expect(calls[0]?.body).toMatchObject({
+      device_code: 'DEV-CODE',
+      grant_type: DEVICE_GRANT_TYPE,
+      client_id: DEVICE_CLIENT_ID,
+    });
+  });
+
+  it('polls immediately rather than waiting out an interval first', async () => {
+    const { fetchImpl, tokenCallCount } = mockFetch({
+      tokenQueue: [
+        jsonRes({ token: 'RELAY.JWT', jti: 'j1', expires_at: 1000, token_type: 'Bearer' }),
+      ],
+    });
+
+    // A sleep that never resolves: if resume waited before its first poll, the
+    // result would hang forever. The user may already have authorized while the
+    // app was gone, so making them wait another interval is the bug.
+    const neverSleep = (): Promise<void> => new Promise(() => {});
+
+    const handle = resumeCloudSignIn(grant, {
+      fetchImpl,
+      sleep: neverSleep,
+      now: () => 0,
+    });
+
+    await expect(handle.result).resolves.toMatchObject({ token: 'RELAY.JWT' });
+    expect(tokenCallCount()).toBe(1);
+  });
+
+  it('rejects an already-expired grant without polling', async () => {
+    const { fetchImpl, tokenCallCount } = mockFetch({ tokenQueue: [] });
+
+    const handle = resumeCloudSignIn(grant, {
+      fetchImpl,
+      sleep: noopSleep,
+      now: () => grant.expiresAt + 1,
+    });
+
+    await expect(handle.result).rejects.toMatchObject({ code: 'expired_token' });
+    expect(tokenCallCount()).toBe(0);
+  });
+
+  it('surfaces a denial as a terminal error', async () => {
+    const { fetchImpl } = mockFetch({
+      tokenQueue: [jsonRes({ error: 'access_denied' }, 400)],
+    });
+
+    const handle = resumeCloudSignIn(grant, {
+      fetchImpl,
+      sleep: noopSleep,
+      now: () => 0,
+    });
+
+    await expect(handle.result).rejects.toMatchObject({ code: 'access_denied' });
   });
 });

--- a/src/api/cloudAuth.ts
+++ b/src/api/cloudAuth.ts
@@ -15,6 +15,7 @@
  */
 
 import { opener } from '../platform/opener';
+import type { PendingSignIn } from './pendingSignIn';
 
 /** RFC 8628 public client id for the desktop shell. */
 export const DEVICE_CLIENT_ID = 'docushark-desktop';
@@ -57,7 +58,8 @@ export class CloudAuthError extends Error {
 /** Injectable dependencies — defaults are production; tests override. */
 export interface CloudAuthDeps {
   fetchImpl?: typeof fetch;
-  openExternal?: (url: string) => void | Promise<void>;
+  /** Resolves whether the browser actually opened (false = popup blocked). */
+  openExternal?: (url: string) => boolean | Promise<boolean>;
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;
 }
@@ -70,9 +72,27 @@ export interface CloudSignInHandle {
   verificationUri: string;
   /** Verification URL with `user_code` pre-filled (what we open). */
   verificationUriComplete: string;
+  /**
+   * The durable half of this grant (JP-455). Persist it so a page teardown
+   * mid-flow can resume polling instead of stranding an authorized device.
+   * `relayUrl` is filled in by the caller, which owns that choice.
+   */
+  grant: Omit<PendingSignIn, 'relayUrl'>;
+  /**
+   * True when the verification page could NOT be opened (popup blocked, or no
+   * opener available), so the UI can tell the truth instead of asserting
+   * "your browser should have opened".
+   */
+  browserOpenFailed: boolean;
   /** Resolves with the relay token, or rejects with a `CloudAuthError`. */
   result: Promise<CloudSignInResult>;
   /** Stop polling; `result` rejects with code `cancelled`. */
+  cancel(): void;
+}
+
+/** Handle for a grant resumed from storage — no codes to re-display beyond the stored ones. */
+export interface ResumedSignInHandle {
+  result: Promise<CloudSignInResult>;
   cancel(): void;
 }
 
@@ -97,10 +117,53 @@ interface DeviceTokenSuccess {
   workspace_slug?: string;
 }
 
-const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Minimum of a wait that must elapse before a tab-return may cut it short.
+ * Without it, flicking between tabs would fire a poll per switch and trip the
+ * relay's `slow_down` backoff — making the flow slower, not faster.
+ */
+const WAKE_MIN_ELAPSED_MS = 1_000;
 
-function defaultOpenExternal(url: string): Promise<void> {
+/**
+ * Sleep that ends early when the tab becomes visible again (JP-455).
+ *
+ * A backgrounded page can have its timers throttled (Chrome aligns them to ~1
+ * minute after ~5 minutes hidden), so a user returning from the verification
+ * page could sit in front of an "awaiting" panel whose next poll is far away.
+ * Waking on `visibilitychange` collapses that to the moment they come back.
+ *
+ * Only `visibilitychange` is observed — not `focus` — so one tab return
+ * produces one wake rather than the double-fire `connectionWakeWatcher` has to
+ * throttle away.
+ */
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    if (typeof document === 'undefined') {
+      setTimeout(resolve, ms);
+      return;
+    }
+    const startedAt = Date.now();
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      resolve();
+    };
+    const onVisibilityChange = (): void => {
+      if (
+        document.visibilityState === 'visible' &&
+        Date.now() - startedAt >= WAKE_MIN_ELAPSED_MS
+      ) {
+        finish();
+      }
+    };
+    const timer = setTimeout(finish, ms);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  });
+
+function defaultOpenExternal(url: string): Promise<boolean> {
   // platform.opener opens via the system browser on desktop and a new tab
   // on web (the device-code verification page).
   return opener.openExternalUrl(url);
@@ -128,27 +191,83 @@ export async function beginCloudSignIn(
     { client_id: DEVICE_CLIENT_ID },
   );
 
-  // Best-effort browser launch. A failure here isn't fatal — the UI
-  // surfaces the verification URL + code so the user can open it by hand.
+  // Best-effort browser launch. A failure here isn't fatal — the UI surfaces
+  // the verification URL + code so the user can open it by hand — but we do
+  // report it, so the panel can say so instead of asserting the browser opened.
+  let browserOpenFailed = false;
   try {
-    await openExternal(code.verification_uri_complete);
+    browserOpenFailed = (await openExternal(code.verification_uri_complete)) === false;
   } catch {
-    /* ignore — user can open the URL manually */
+    browserOpenFailed = true;
   }
 
-  let cancelled = false;
-  const cancel = (): void => {
-    cancelled = true;
+  const grant = {
+    deviceCode: code.device_code,
+    userCode: code.user_code,
+    verificationUri: code.verification_uri_complete,
+    intervalMs: Math.max(1, code.interval) * 1000,
+    expiresAt: now() + code.expires_in * 1000,
+    cloudBaseUrl: base,
   };
 
-  const result = pollForToken({ fetchImpl, sleep, now, base, code, isCancelled: () => cancelled });
+  const { result, cancel } = startPoll({ fetchImpl, sleep, now, grant });
 
   return {
     userCode: code.user_code,
     verificationUri: code.verification_uri,
     verificationUriComplete: code.verification_uri_complete,
+    grant,
+    browserOpenFailed,
     result,
     cancel,
+  };
+}
+
+/**
+ * Resume polling a grant that was issued earlier and persisted (JP-455) — the
+ * path that keeps the authorize page's "it will finish signing in
+ * automatically" promise across a page teardown.
+ *
+ * Unlike `beginCloudSignIn` this opens no browser and requests no new code: the
+ * user has already been sent to the verification page, and may well have
+ * authorized while the editor was gone. It therefore polls **immediately**
+ * rather than waiting out an interval first.
+ */
+export function resumeCloudSignIn(
+  grant: Omit<PendingSignIn, 'relayUrl'>,
+  deps: CloudAuthDeps = {},
+): ResumedSignInHandle {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? Date.now;
+  return startPoll({ fetchImpl, sleep, now, grant, pollImmediately: true });
+}
+
+interface StartPollArgs {
+  fetchImpl: typeof fetch;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  grant: Omit<PendingSignIn, 'relayUrl'>;
+  /** Skip the leading interval — used when resuming an already-issued grant. */
+  pollImmediately?: boolean;
+}
+
+/** Shared plumbing: run the poll loop behind a cancel flag. */
+function startPoll(args: StartPollArgs): ResumedSignInHandle {
+  let cancelled = false;
+  const result = pollForToken({
+    fetchImpl: args.fetchImpl,
+    sleep: args.sleep,
+    now: args.now,
+    grant: args.grant,
+    pollImmediately: args.pollImmediately ?? false,
+    isCancelled: () => cancelled,
+  });
+  return {
+    result,
+    cancel: () => {
+      cancelled = true;
+    },
   };
 }
 
@@ -156,31 +275,37 @@ interface PollArgs {
   fetchImpl: typeof fetch;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
-  base: string;
-  code: DeviceCodeResponse;
+  grant: Omit<PendingSignIn, 'relayUrl'>;
+  /** Poll before the first sleep (a resumed grant may already be authorized). */
+  pollImmediately: boolean;
   isCancelled: () => boolean;
 }
 
 async function pollForToken(args: PollArgs): Promise<CloudSignInResult> {
-  const { fetchImpl, sleep, now, base, code, isCancelled } = args;
+  const { fetchImpl, sleep, now, grant, pollImmediately, isCancelled } = args;
+  const base = grant.cloudBaseUrl;
 
   // Relay enforces `slow_down` from a per-row `last_polled_at`; we honor
   // the advertised interval (min 1s) and back off +5s on `slow_down`.
-  let intervalMs = Math.max(1, code.interval) * 1000;
-  const deadline = now() + code.expires_in * 1000;
+  let intervalMs = grant.intervalMs;
 
-  // The user has to switch to the browser first, so wait one interval
-  // before the first poll rather than burning a guaranteed pending hit.
-  await sleep(intervalMs);
+  // On a fresh grant the user has to switch to the browser first, so wait one
+  // interval rather than burning a guaranteed pending hit. A *resumed* grant
+  // skips that: the authorization may already have happened while we were gone,
+  // and making the user wait an extra interval for a token that is sitting there
+  // is the exact "why isn't it connecting?" feeling this work exists to remove.
+  if (!pollImmediately) {
+    await sleep(intervalMs);
+  }
 
   while (!isCancelled()) {
-    if (now() >= deadline) {
+    if (now() >= grant.expiresAt) {
       throw new CloudAuthError('expired_token', 'Device code expired before authorization.');
     }
 
     const res = await postJsonRaw(fetchImpl, `${base}/api/v1/auth/device/token`, {
       grant_type: DEVICE_GRANT_TYPE,
-      device_code: code.device_code,
+      device_code: grant.deviceCode,
       client_id: DEVICE_CLIENT_ID,
     });
 

--- a/src/api/pendingSignIn.test.ts
+++ b/src/api/pendingSignIn.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Durable in-flight sign-in grant (JP-455).
+ *
+ * Pins the two properties the resume path depends on: a grant survives a
+ * round-trip, and a grant that can no longer succeed (expired, malformed,
+ * written by an older build) is rejected AND cleared rather than handed back to
+ * drive a doomed poll.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  savePendingSignIn,
+  loadPendingSignIn,
+  clearPendingSignIn,
+  type PendingSignIn,
+} from './pendingSignIn';
+
+const { store } = vi.hoisted(() => ({ store: new Map<string, string>() }));
+
+vi.mock('../platform/secureStore', () => ({
+  secureStore: {
+    getItem: (k: string) => Promise.resolve(store.get(k) ?? null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+      return Promise.resolve();
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+      return Promise.resolve();
+    },
+  },
+}));
+
+const KEY = 'docushark-pending-signin';
+
+const grant: PendingSignIn = {
+  deviceCode: 'dev-code-abc',
+  userCode: 'WXYZ-1234',
+  verificationUri: 'http://web/auth/device?user_code=WXYZ-1234',
+  intervalMs: 5000,
+  expiresAt: 10_000,
+  cloudBaseUrl: 'http://web',
+  relayUrl: 'http://relay',
+};
+
+describe('pendingSignIn', () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it('round-trips a live grant', async () => {
+    await savePendingSignIn(grant);
+    expect(await loadPendingSignIn(() => 5_000)).toEqual(grant);
+  });
+
+  it('returns null when nothing is stored', async () => {
+    expect(await loadPendingSignIn(() => 0)).toBeNull();
+  });
+
+  it('rejects AND clears an expired grant so it can never be re-polled', async () => {
+    await savePendingSignIn(grant);
+
+    // Exactly at expiry counts as expired — the relay would reject it anyway.
+    expect(await loadPendingSignIn(() => grant.expiresAt)).toBeNull();
+    expect(store.has(KEY)).toBe(false);
+  });
+
+  it('rejects AND clears a malformed record', async () => {
+    store.set(KEY, '{not json');
+    expect(await loadPendingSignIn(() => 0)).toBeNull();
+    expect(store.has(KEY)).toBe(false);
+  });
+
+  it('rejects AND clears a record missing required fields', async () => {
+    // Shape an older build might have written: no deviceCode, so a poll built
+    // from it could never succeed.
+    store.set(KEY, JSON.stringify({ userCode: 'AAAA-1111', expiresAt: 9_999 }));
+    expect(await loadPendingSignIn(() => 0)).toBeNull();
+    expect(store.has(KEY)).toBe(false);
+  });
+
+  it('clearPendingSignIn removes the record', async () => {
+    await savePendingSignIn(grant);
+    await clearPendingSignIn();
+    expect(await loadPendingSignIn(() => 0)).toBeNull();
+  });
+});

--- a/src/api/pendingSignIn.ts
+++ b/src/api/pendingSignIn.ts
@@ -1,0 +1,126 @@
+/**
+ * Durable record of an **in-flight** device-code sign-in (JP-455).
+ *
+ * The OAuth device grant is a two-party affair: the user authorizes in a
+ * browser while the editor polls for the token. Before this module the grant
+ * existed only in a closure inside `cloudAuth.pollForToken` plus `phase` state
+ * in `CloudConnectPanel`, whose unmount cleanup cancels the poll — so anything
+ * that tore the page down mid-flow (an evicted backgrounded PWA, a same-tab
+ * navigation) stranded a device the server had **already authorized**, and the
+ * user came back to a pristine sign-in form.
+ *
+ * The web authorize page promises "Return to DocuShark — it will finish
+ * signing in automatically." Persisting the grant is what lets the editor keep
+ * that promise.
+ *
+ * **Why `secureStore` and not localStorage:** `deviceCode` is a bearer
+ * credential — whoever holds it can exchange it for a relay token once the user
+ * authorizes. It therefore lives in the same store as the relay JWT
+ * (`platform/secureStore` → IndexedDB, localStorage only as a fallback), is
+ * bounded by the grant's own short `expiresAt`, and is cleared the moment the
+ * flow reaches any terminal state.
+ *
+ * Kept as its own key rather than as fields on the `RelayConnection` record:
+ * the lifetimes are unrelated (this one is minutes and self-expiring, that one
+ * is the durable session) and conflating them would mean a token save could
+ * resurrect or clobber a grant.
+ */
+
+import { secureStore } from '../platform/secureStore';
+
+const STORAGE_KEY = 'docushark-pending-signin';
+
+/** An issued-but-not-yet-redeemed device grant. */
+export interface PendingSignIn {
+  /** RFC 8628 `device_code` — the credential polled with. Bearer; see module doc. */
+  deviceCode: string;
+  /** Human-typed code, shown so a resumed flow displays the same one. */
+  userCode: string;
+  /** Verification page URL with the code pre-filled. */
+  verificationUri: string;
+  /** Poll interval in ms (already max'd against the RFC minimum). */
+  intervalMs: number;
+  /** Absolute expiry (Unix ms). Stored absolute so it survives a restart. */
+  expiresAt: number;
+  /** docushark-web origin the grant was issued by. */
+  cloudBaseUrl: string;
+  /** Relay origin the resulting session should target. */
+  relayUrl: string;
+}
+
+/** Persist the grant. Best-effort: a storage failure must not break sign-in. */
+export async function savePendingSignIn(pending: PendingSignIn): Promise<void> {
+  try {
+    await secureStore.setItem(STORAGE_KEY, JSON.stringify(pending));
+  } catch {
+    /* storage-disabled context — the flow still works in-memory */
+  }
+}
+
+/**
+ * Read the stored grant, or `null` when there is none, it is malformed, or it
+ * has expired. An expired/malformed record is cleared as a side effect so a
+ * dead grant can never accumulate or be retried.
+ *
+ * `now` is injectable for tests.
+ */
+export async function loadPendingSignIn(
+  now: () => number = Date.now,
+): Promise<PendingSignIn | null> {
+  let raw: string | null = null;
+  try {
+    raw = await secureStore.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    void clearPendingSignIn();
+    return null;
+  }
+
+  if (!isPendingSignIn(parsed)) {
+    void clearPendingSignIn();
+    return null;
+  }
+  if (now() >= parsed.expiresAt) {
+    void clearPendingSignIn();
+    return null;
+  }
+  return parsed;
+}
+
+/** Drop the stored grant. Call on every terminal outcome. */
+export async function clearPendingSignIn(): Promise<void> {
+  try {
+    await secureStore.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Structural guard. A record written by an older build (or corrupted) must be
+ * rejected rather than half-used — a grant missing `deviceCode` or `expiresAt`
+ * would otherwise drive an unbounded poll against a code that cannot succeed.
+ */
+function isPendingSignIn(value: unknown): value is PendingSignIn {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v['deviceCode'] === 'string' &&
+    v['deviceCode'].length > 0 &&
+    typeof v['userCode'] === 'string' &&
+    typeof v['verificationUri'] === 'string' &&
+    typeof v['intervalMs'] === 'number' &&
+    Number.isFinite(v['intervalMs']) &&
+    typeof v['expiresAt'] === 'number' &&
+    Number.isFinite(v['expiresAt']) &&
+    typeof v['cloudBaseUrl'] === 'string' &&
+    typeof v['relayUrl'] === 'string'
+  );
+}

--- a/src/api/resumeInterruptedSignIn.test.ts
+++ b/src/api/resumeInterruptedSignIn.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Resume service for an interrupted device-code sign-in (JP-455).
+ *
+ * This module is the single owner of a resumed grant: it polls, redeems the
+ * token, and clears the stored grant. Two callers race for it (app boot and the
+ * Cloud panel mounting), so the properties that matter are single-flight — a
+ * token must never be redeemed twice — and that a terminal outcome always drops
+ * the grant so a dead code can't be retried forever.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  loadPendingSignIn: vi.fn(),
+  clearPendingSignIn: vi.fn(async () => {}),
+  completeCloudSignIn: vi.fn(async () => {}),
+  resumeCloudSignIn: vi.fn(),
+  authenticated: false,
+}));
+
+vi.mock('./pendingSignIn', () => ({
+  loadPendingSignIn: h.loadPendingSignIn,
+  clearPendingSignIn: h.clearPendingSignIn,
+}));
+vi.mock('./completeCloudSignIn', () => ({ completeCloudSignIn: h.completeCloudSignIn }));
+vi.mock('./cloudAuth', () => ({ resumeCloudSignIn: h.resumeCloudSignIn }));
+vi.mock('../store/relayDocumentStore', () => ({
+  useRelayDocumentStore: { getState: () => ({ authenticated: h.authenticated }) },
+}));
+vi.mock('../store/persistenceStore', () => ({
+  usePersistenceStore: { getState: () => ({ currentDocumentId: null }) },
+}));
+
+import {
+  ensureSignInResumed,
+  getActiveResume,
+  __resetActiveResumeForTests,
+} from './resumeInterruptedSignIn';
+
+const GRANT = {
+  deviceCode: 'DEV-CODE',
+  userCode: 'WXYZ-1234',
+  verificationUri: 'http://web/auth/device?user_code=WXYZ-1234',
+  intervalMs: 5000,
+  expiresAt: Date.now() + 600_000,
+  cloudBaseUrl: 'http://web',
+  relayUrl: 'http://relay',
+};
+
+const TOKEN = { token: 'RELAY.JWT', expiresAt: 123, workspaceName: 'Alpha' };
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetActiveResumeForTests();
+  h.authenticated = false;
+  h.loadPendingSignIn.mockResolvedValue(GRANT);
+});
+
+describe('ensureSignInResumed', () => {
+  it('returns null when there is no stored grant', async () => {
+    h.loadPendingSignIn.mockResolvedValue(null);
+    expect(await ensureSignInResumed()).toBeNull();
+    expect(h.resumeCloudSignIn).not.toHaveBeenCalled();
+  });
+
+  it('drops the grant without polling when already signed in', async () => {
+    h.authenticated = true;
+    expect(await ensureSignInResumed()).toBeNull();
+    expect(h.resumeCloudSignIn).not.toHaveBeenCalled();
+    expect(h.clearPendingSignIn).toHaveBeenCalled();
+  });
+
+  it('keeps exactly ONE poller when boot and the panel both ask', async () => {
+    const d = deferred<typeof TOKEN>();
+    h.resumeCloudSignIn.mockReturnValue({ result: d.promise, cancel: vi.fn() });
+
+    const [a, b] = await Promise.all([ensureSignInResumed(), ensureSignInResumed()]);
+
+    // Two callers, one poll loop — otherwise both hammer the same device_code
+    // and trip the relay's slow_down backoff.
+    expect(h.resumeCloudSignIn).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+
+    d.resolve(TOKEN);
+    await a!.done;
+    // ...and one redemption. Redeeming twice is the bug this guards.
+    expect(h.completeCloudSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('redeems the token, clears the grant, and releases the singleton', async () => {
+    const d = deferred<typeof TOKEN>();
+    h.resumeCloudSignIn.mockReturnValue({ result: d.promise, cancel: vi.fn() });
+
+    const active = await ensureSignInResumed();
+    expect(getActiveResume()).toBe(active);
+
+    d.resolve(TOKEN);
+    await expect(active!.done).resolves.toMatchObject({ token: 'RELAY.JWT' });
+
+    expect(h.completeCloudSignIn).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'RELAY.JWT', relayUrl: 'http://relay' }),
+    );
+    expect(h.clearPendingSignIn).toHaveBeenCalled();
+    expect(getActiveResume()).toBeNull();
+  });
+
+  it('prefers the region-resolved relay URL from the token response', async () => {
+    const d = deferred<typeof TOKEN & { relayUrl: string }>();
+    h.resumeCloudSignIn.mockReturnValue({ result: d.promise, cancel: vi.fn() });
+
+    const active = await ensureSignInResumed();
+    d.resolve({ ...TOKEN, relayUrl: 'https://yyz.relay.example' });
+    await active!.done;
+
+    expect(h.completeCloudSignIn).toHaveBeenCalledWith(
+      expect.objectContaining({ relayUrl: 'https://yyz.relay.example' }),
+    );
+  });
+
+  it('clears the grant on a terminal failure so a dead code is never retried', async () => {
+    const d = deferred<never>();
+    h.resumeCloudSignIn.mockReturnValue({ result: d.promise, cancel: vi.fn() });
+
+    const active = await ensureSignInResumed();
+    d.reject(new Error('access_denied'));
+
+    await expect(active!.done).rejects.toThrow('access_denied');
+    expect(h.clearPendingSignIn).toHaveBeenCalled();
+    expect(h.completeCloudSignIn).not.toHaveBeenCalled();
+    // Released, so a later attempt can start fresh rather than joining a corpse.
+    expect(getActiveResume()).toBeNull();
+  });
+});

--- a/src/api/resumeInterruptedSignIn.ts
+++ b/src/api/resumeInterruptedSignIn.ts
@@ -1,0 +1,127 @@
+/**
+ * Resume an interrupted device-code sign-in (JP-455).
+ *
+ * When the editor is torn down mid-flow the grant survives in
+ * [[pendingSignIn]], but something has to pick the poll back up. Two callers
+ * want that: app boot (so the authorize page's "it will finish signing in
+ * automatically" promise holds across a restart) and the Cloud panel mounting
+ * (so reopening the modal shows the live flow rather than a fresh form).
+ *
+ * **Single owner.** Both go through `ensureSignInResumed`, which is idempotent
+ * and keeps exactly one poller for a given grant. If boot and the panel each
+ * ran their own loop they would double-poll the same `device_code` and trip the
+ * relay's `slow_down` backoff — making a flow that is *already* late even
+ * slower. For the same reason the session-committing side effects
+ * (`completeCloudSignIn`, clearing the grant) live here rather than in each
+ * caller, so a token can never be redeemed twice.
+ *
+ * Callers observe `done` purely to drive UI; the session is stood up either way.
+ */
+
+import { resumeCloudSignIn, type CloudSignInResult } from './cloudAuth';
+import { loadPendingSignIn, clearPendingSignIn, type PendingSignIn } from './pendingSignIn';
+import { completeCloudSignIn } from './completeCloudSignIn';
+import { useRelayDocumentStore } from '../store/relayDocumentStore';
+import { usePersistenceStore } from '../store/persistenceStore';
+
+export interface ActiveResume {
+  /** The grant being polled — the panel renders its code + verification link. */
+  grant: PendingSignIn;
+  /**
+   * Settles once the flow terminates. Resolves with the result **after** the
+   * session has been committed; rejects with the terminal `CloudAuthError`.
+   */
+  done: Promise<CloudSignInResult>;
+  /** Stop polling. Does not clear the stored grant — a later mount may resume. */
+  cancel(): void;
+}
+
+let active: ActiveResume | null = null;
+/**
+ * The *in-flight* start, memoised separately from the settled `active`.
+ *
+ * Checking `active` alone is not single-flight: it is set after an `await`, so
+ * two concurrent callers (boot and the panel mounting on the same tick) both
+ * see `null`, both proceed, and both spin up a poller for the same
+ * `device_code` — double-polling into the relay's `slow_down` backoff and, on
+ * success, redeeming the same grant twice.
+ */
+let starting: Promise<ActiveResume | null> | null = null;
+
+/**
+ * Start — or join — the resume of a stored grant. Returns `null` when there is
+ * nothing to resume (no grant, an expired one, or we're already signed in).
+ */
+export function ensureSignInResumed(): Promise<ActiveResume | null> {
+  if (active) return Promise.resolve(active);
+  if (starting) return starting;
+  starting = start().finally(() => {
+    // Release the latch once settled: `active` now guards a live resume, and a
+    // null outcome should be retryable rather than cached forever.
+    starting = null;
+  });
+  return starting;
+}
+
+async function start(): Promise<ActiveResume | null> {
+  const pending = await loadPendingSignIn();
+  if (!pending) return null;
+
+  // Already signed in — the grant is moot (e.g. a cached token was reused, or
+  // another surface completed first). Drop it rather than poll a dead code.
+  if (useRelayDocumentStore.getState().authenticated) {
+    await clearPendingSignIn();
+    return null;
+  }
+
+  const handle = resumeCloudSignIn(pending);
+
+  const done = (async (): Promise<CloudSignInResult> => {
+    try {
+      const result = await handle.result;
+      await completeCloudSignIn({
+        relayUrl: result.relayUrl?.trim() || pending.relayUrl,
+        cloudBaseUrl: pending.cloudBaseUrl,
+        token: result.token,
+        expiresAt: result.expiresAt,
+        documentId: usePersistenceStore.getState().currentDocumentId,
+        ...(result.workspaceName !== undefined ? { workspaceName: result.workspaceName } : {}),
+        ...(result.workspaceSlug !== undefined ? { workspaceSlug: result.workspaceSlug } : {}),
+      });
+      await clearPendingSignIn();
+      return result;
+    } catch (err) {
+      // Terminal: denied, expired, or a transport failure. The grant is spent
+      // either way — keeping it would retry a code that cannot succeed.
+      await clearPendingSignIn();
+      throw err;
+    } finally {
+      active = null;
+    }
+  })();
+
+  // The caller may not attach a handler (boot fires and forgets), and an
+  // unobserved rejection would surface as an unhandled promise rejection.
+  void done.catch(() => {});
+
+  active = {
+    grant: pending,
+    done,
+    cancel: () => {
+      handle.cancel();
+      active = null;
+    },
+  };
+  return active;
+}
+
+/** The in-flight resume, if any — lets a mounting panel render the live flow. */
+export function getActiveResume(): ActiveResume | null {
+  return active;
+}
+
+/** Test-only: drop the module-level singleton between cases. */
+export function __resetActiveResumeForTests(): void {
+  active = null;
+  starting = null;
+}

--- a/src/platform/opener.tauri.ts
+++ b/src/platform/opener.tauri.ts
@@ -27,8 +27,11 @@ export function createTauriOpener(): Opener {
         }
       }
     },
-    openExternalUrl(url) {
-      return invoke<void>('open_external_url', { url });
+    async openExternalUrl(url) {
+      // The host command either launches the browser or throws, so a resolved
+      // invoke is the strongest success signal available on desktop.
+      await invoke<void>('open_external_url', { url });
+      return true;
     },
     applyCustomChrome(enabled) {
       return invoke<void>('apply_custom_chrome', { enabled });

--- a/src/platform/opener.ts
+++ b/src/platform/opener.ts
@@ -19,8 +19,16 @@ export interface Opener {
    * opens {@link DOCS_URL} in a new tab.
    */
   openDocs(): Promise<void>;
-  /** Open an arbitrary http(s) URL in the system browser / a new tab. */
-  openExternalUrl(url: string): Promise<void>;
+  /**
+   * Open an arbitrary http(s) URL in the system browser / a new tab.
+   *
+   * Resolves `true` when the open is believed to have succeeded and `false`
+   * when it demonstrably did not — on web a popup blocker makes `window.open`
+   * return null (JP-455). Best-effort callers can ignore the result; the
+   * device-code sign-in uses it so the UI doesn't claim "your browser should
+   * have opened" when nothing did.
+   */
+  openExternalUrl(url: string): Promise<boolean>;
   /**
    * Persist the custom-chrome flag and apply it (desktop restarts so the
    * window is rebuilt with the new decoration setting). No-op on web — the

--- a/src/platform/opener.web.ts
+++ b/src/platform/opener.web.ts
@@ -7,10 +7,14 @@
 import type { Opener } from './opener';
 import { DOCS_URL } from './opener';
 
-function openInNewTab(url: string): void {
-  if (typeof window !== 'undefined') {
-    window.open(url, '_blank', 'noopener,noreferrer');
-  }
+/**
+ * Open `url` in a new tab. Returns whether it worked: a popup blocker makes
+ * `window.open` return `null`, and callers (the device-code sign-in) need to
+ * know rather than assume (JP-455).
+ */
+function openInNewTab(url: string): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.open(url, '_blank', 'noopener,noreferrer') !== null;
 }
 
 export function createWebOpener(): Opener {
@@ -20,8 +24,7 @@ export function createWebOpener(): Opener {
       return Promise.resolve();
     },
     openExternalUrl(url) {
-      openInNewTab(url);
-      return Promise.resolve();
+      return Promise.resolve(openInNewTab(url));
     },
     applyCustomChrome() {
       return Promise.resolve();

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -13,7 +13,8 @@ import { opener } from '../platform/opener';
 export { isTauri } from '../platform/runtime';
 
 export const openDocs = (): Promise<void> => opener.openDocs();
-export const openExternalUrl = (url: string): Promise<void> => opener.openExternalUrl(url);
+/** Resolves whether the browser opened — see `Opener.openExternalUrl` (JP-455). */
+export const openExternalUrl = (url: string): Promise<boolean> => opener.openExternalUrl(url);
 export const applyCustomChrome = (enabled: boolean): Promise<void> =>
   opener.applyCustomChrome(enabled);
 export const persistCustomChrome = (enabled: boolean): Promise<void> =>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -47,6 +47,7 @@ import {
   getLastOpenedDocId,
 } from '../store/persistenceStore';
 import { restoreCloudSession, notifyCloudSessionExpired } from '../api/restoreCloudSession';
+import { ensureSignInResumed } from '../api/resumeInterruptedSignIn';
 import { useDocumentStore } from '../store/documentStore';
 import { initConnectionNotifications } from '../store/connectionStore';
 import { registerTokenRefresher } from '../api/tokenRefresh';
@@ -415,6 +416,18 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
           const bootRelay = isRelayDocId(getLastOpenedDocId());
           const result = await restoreCloudSession({ proactiveList: !bootRelay });
           if (result.status === 'expired') notifyCloudSessionExpired();
+
+          // JP-455: a sign-in interrupted by this restart (an evicted PWA, a
+          // navigation) left a still-live grant. Pick the poll back up so the
+          // authorize page's "it will finish signing in automatically" promise
+          // holds. Deliberately silent and non-blocking — no modal is opened,
+          // matching the existing rule that the user chooses when to re-pair;
+          // if it succeeds they simply find themselves signed in.
+          if (result.status !== 'restored') {
+            void ensureSignInResumed().catch((err) => {
+              console.error('[App] Resuming interrupted sign-in failed:', err);
+            });
+          }
         } catch (err) {
           console.error('[App] Boot cloud-session restore failed:', err);
         }

--- a/src/ui/cloud/CloudConnectPanel.test.tsx
+++ b/src/ui/cloud/CloudConnectPanel.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * CloudConnectPanel — the sign-in state machine (JP-455).
+ *
+ * This component owns `phase`, drives the device-code flow, and decides when
+ * the surrounding modal may be dismissed. Until this file it had **no test at
+ * all**, which is how the two defects here shipped:
+ *
+ *  - the in-flight grant was destroyed by the panel's unmount cleanup, so an
+ *    interrupted sign-in stranded an already-authorized device; and
+ *  - the backdrop-dismiss guard covered only the polling window, leaving
+ *    `success` and the WS connect dismissable — exactly when the signed-in view
+ *    hasn't painted and a click-out looks reasonable to the user.
+ *
+ * The mocks follow the `vi.hoisted` + per-module `vi.mock` shape already used
+ * by `src/api/restoreCloudSession.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
+import { CloudConnectPanel } from './CloudConnectPanel';
+
+const h = vi.hoisted(() => ({
+  connState: {
+    status: 'disconnected' as string,
+    user: null as { id: string; username: string; role?: string } | null,
+    host: null as { url: string } | null,
+  },
+  cloudSignedIn: false,
+  beginCloudSignIn: vi.fn(),
+  ensureSignInResumed: vi.fn(),
+  savePendingSignIn: vi.fn(async () => {}),
+  clearPendingSignIn: vi.fn(async () => {}),
+  completeCloudSignIn: vi.fn(async () => {}),
+  loadConnection: vi.fn(async () => null as unknown),
+}));
+
+vi.mock('../../store/connectionStore', () => ({
+  useConnectionStore: Object.assign(
+    (sel: (s: typeof h.connState) => unknown) => sel(h.connState),
+    { getState: () => h.connState },
+  ),
+}));
+vi.mock('../../store/relayDocumentStore', () => ({
+  useIsCloudSignedIn: () => h.cloudSignedIn,
+}));
+vi.mock('../../collaboration', () => ({
+  useCollaborationStore: (sel: (s: unknown) => unknown) =>
+    sel({ error: null, stopSession: vi.fn() }),
+  useIsRelaySessionLive: () => false,
+}));
+vi.mock('../../store/persistenceStore', () => ({
+  usePersistenceStore: (sel: (s: unknown) => unknown) => sel({ currentDocumentId: null }),
+}));
+vi.mock('../../store/notificationStore', () => ({
+  useNotificationStore: { getState: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }) },
+}));
+vi.mock('../../services/removeWorkspace', () => ({ removeCurrentWorkspace: vi.fn() }));
+vi.mock('../../api/webClient', () => ({
+  webClient: { leaveWorkspace: vi.fn() },
+  WebClientError: class extends Error {},
+}));
+vi.mock('../confirm/confirmStore', () => ({ confirmDialog: vi.fn() }));
+vi.mock('../../api/relayConnection', () => ({
+  loadConnection: h.loadConnection,
+  clearJwt: vi.fn(),
+  DEFAULT_CLOUD_BASE_URL: 'http://web',
+  WORKSPACE_URL_BASE: 'space.docushark.app',
+}));
+vi.mock('../../api/completeCloudSignIn', () => ({ completeCloudSignIn: h.completeCloudSignIn }));
+vi.mock('../../api/cloudAuth', async () => {
+  const actual = await vi.importActual<typeof import('../../api/cloudAuth')>('../../api/cloudAuth');
+  return { ...actual, beginCloudSignIn: h.beginCloudSignIn };
+});
+vi.mock('../../api/pendingSignIn', () => ({
+  savePendingSignIn: h.savePendingSignIn,
+  clearPendingSignIn: h.clearPendingSignIn,
+}));
+vi.mock('../../api/resumeInterruptedSignIn', () => ({
+  ensureSignInResumed: h.ensureSignInResumed,
+}));
+// Child surfaces talk to the control plane; they aren't under test here.
+vi.mock('./WorkspaceMembersSection', () => ({ WorkspaceMembersSection: () => null }));
+vi.mock('./WorkspaceSwitcher', () => ({ WorkspaceSwitcher: () => null }));
+vi.mock('../components/RichSelect', () => ({
+  RichSelect: ({ ariaLabel }: { ariaLabel?: string }) => <button type="button">{ariaLabel}</button>,
+}));
+
+const GRANT = {
+  deviceCode: 'DEV-CODE',
+  userCode: 'WXYZ-1234',
+  verificationUri: 'http://web/auth/device?user_code=WXYZ-1234',
+  intervalMs: 5000,
+  expiresAt: Date.now() + 600_000,
+  cloudBaseUrl: 'http://web',
+  relayUrl: 'http://relay',
+};
+
+/** A promise with externally-callable settle functions. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.connState.status = 'disconnected';
+  h.connState.user = null;
+  h.connState.host = null;
+  h.cloudSignedIn = false;
+  h.loadConnection.mockResolvedValue(null);
+  h.ensureSignInResumed.mockResolvedValue(null);
+});
+afterEach(cleanup);
+
+describe('CloudConnectPanel — resuming an interrupted sign-in', () => {
+  it('shows the stored code and joins the in-flight resume instead of a fresh form', async () => {
+    const done = deferred<{ workspaceName?: string }>();
+    h.ensureSignInResumed.mockResolvedValue({
+      grant: GRANT,
+      done: done.promise,
+      cancel: vi.fn(),
+    });
+
+    render(<CloudConnectPanel onClose={vi.fn()} />);
+
+    // The user sees the code they were already given — not "Sign in" again.
+    expect(await screen.findByText('WXYZ-1234')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Sign in with DocuShark Cloud' })).toBeNull();
+
+    // No new grant is requested; the existing one is what the user authorized.
+    expect(h.beginCloudSignIn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT redeem the token itself — the resume service owns that', async () => {
+    const done = deferred<{ workspaceName?: string }>();
+    h.ensureSignInResumed.mockResolvedValue({
+      grant: GRANT,
+      done: done.promise,
+      cancel: vi.fn(),
+    });
+
+    render(<CloudConnectPanel onClose={vi.fn()} successBeatMs={10_000} />);
+    await screen.findByText('WXYZ-1234');
+
+    await act(async () => {
+      done.resolve({ workspaceName: 'Workspace Alpha' });
+    });
+
+    await waitFor(() => expect(screen.getByText('Connected to Workspace Alpha')).toBeTruthy());
+    // Boot may already have committed the session; a second call here would
+    // redeem the same token twice.
+    expect(h.completeCloudSignIn).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a terminal resume failure as an error, not a silent reset', async () => {
+    const done = deferred<never>();
+    h.ensureSignInResumed.mockResolvedValue({
+      grant: GRANT,
+      done: done.promise,
+      cancel: vi.fn(),
+    });
+
+    render(<CloudConnectPanel onClose={vi.fn()} />);
+    await screen.findByText('WXYZ-1234');
+
+    await act(async () => {
+      done.reject(new Error('Device code expired. Please try again.'));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Device code expired. Please try again.')).toBeTruthy(),
+    );
+  });
+});
+
+describe('CloudConnectPanel — dismissal guard', () => {
+  it('stays busy during the success beat, when phase has LEFT the poll window', async () => {
+    // The discriminating case. Under the old `onBusyChange(isAwaiting)` rule
+    // this window reported NOT busy, so a backdrop click during the "Connected"
+    // beat — before the signed-in view paints — dismissed the panel.
+    const onBusyChange = vi.fn();
+    const result = deferred<{ token: string; expiresAt: number; workspaceName?: string }>();
+    h.beginCloudSignIn.mockResolvedValue({
+      userCode: 'WXYZ-1234',
+      verificationUri: 'http://web/auth/device',
+      verificationUriComplete: 'http://web/auth/device?user_code=WXYZ-1234',
+      grant: GRANT,
+      browserOpenFailed: false,
+      result: result.promise,
+      cancel: vi.fn(),
+    });
+
+    render(
+      <CloudConnectPanel onClose={vi.fn()} onBusyChange={onBusyChange} successBeatMs={10_000} />,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with DocuShark Cloud' }));
+    await screen.findByText('WXYZ-1234');
+
+    await act(async () => {
+      result.resolve({ token: 'JWT', expiresAt: Date.now() + 60_000, workspaceName: 'Alpha' });
+    });
+
+    // phase === 'success' (not 'awaiting'), so this asserts the widened window.
+    await waitFor(() => expect(screen.getByText('Connected to Alpha')).toBeTruthy());
+    // Let the busy effect flush. Without this the assertion races the passive
+    // effect and passes even against the old rule — which is exactly how this
+    // test read as green while proving nothing.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(onBusyChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('stays busy during the WS connect, with no device-code poll running', async () => {
+    // Second discriminating case: `phase` is idle, so only `isConnecting` can
+    // hold the guard open. Old rule reported not-busy here too.
+    const onBusyChange = vi.fn();
+    h.connState.status = 'connecting';
+
+    render(<CloudConnectPanel onClose={vi.fn()} onBusyChange={onBusyChange} />);
+    await waitFor(() => expect(onBusyChange).toHaveBeenLastCalledWith(true));
+
+    h.connState.status = 'authenticating';
+    cleanup();
+    render(<CloudConnectPanel onClose={vi.fn()} onBusyChange={onBusyChange} />);
+    await waitFor(() => expect(onBusyChange).toHaveBeenLastCalledWith(true));
+  });
+
+  it('reports not-busy once signed in, so the panel can be dismissed normally', async () => {
+    const onBusyChange = vi.fn();
+    h.cloudSignedIn = true;
+    h.connState.user = { id: 'u1', username: 'justin', role: 'owner' };
+
+    render(<CloudConnectPanel onClose={vi.fn()} onBusyChange={onBusyChange} />);
+    await waitFor(() => expect(onBusyChange).toHaveBeenLastCalledWith(false));
+  });
+});
+
+describe('CloudConnectPanel — grant lifecycle', () => {
+  it('persists the grant before awaiting the token', async () => {
+    const result = deferred<never>();
+    h.beginCloudSignIn.mockResolvedValue({
+      userCode: 'WXYZ-1234',
+      verificationUri: 'http://web/auth/device',
+      verificationUriComplete: 'http://web/auth/device?user_code=WXYZ-1234',
+      grant: GRANT,
+      browserOpenFailed: false,
+      result: result.promise,
+      cancel: vi.fn(),
+    });
+
+    render(<CloudConnectPanel onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with DocuShark Cloud' }));
+
+    // Saved while still awaiting — the whole point is surviving a teardown
+    // that happens during the wait.
+    await waitFor(() =>
+      expect(h.savePendingSignIn).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceCode: 'DEV-CODE' }),
+      ),
+    );
+  });
+
+  it('clears the grant on explicit Cancel but NOT on unmount', async () => {
+    const result = deferred<never>();
+    const cancel = vi.fn();
+    h.beginCloudSignIn.mockResolvedValue({
+      userCode: 'WXYZ-1234',
+      verificationUri: 'http://web/auth/device',
+      verificationUriComplete: 'http://web/auth/device?user_code=WXYZ-1234',
+      grant: GRANT,
+      browserOpenFailed: false,
+      result: result.promise,
+      cancel,
+    });
+
+    const { unmount } = render(<CloudConnectPanel onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with DocuShark Cloud' }));
+    await screen.findByText('WXYZ-1234');
+    h.clearPendingSignIn.mockClear();
+
+    // Unmount is a dismissal or a re-render, NOT abandonment. Clearing here is
+    // precisely what used to strand an already-authorized device.
+    unmount();
+    expect(cancel).toHaveBeenCalled();
+    expect(h.clearPendingSignIn).not.toHaveBeenCalled();
+  });
+
+  it('clears the grant when the user cancels explicitly', async () => {
+    const result = deferred<never>();
+    h.beginCloudSignIn.mockResolvedValue({
+      userCode: 'WXYZ-1234',
+      verificationUri: 'http://web/auth/device',
+      verificationUriComplete: 'http://web/auth/device?user_code=WXYZ-1234',
+      grant: GRANT,
+      browserOpenFailed: false,
+      result: result.promise,
+      cancel: vi.fn(),
+    });
+
+    render(<CloudConnectPanel onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with DocuShark Cloud' }));
+    await screen.findByText('WXYZ-1234');
+    h.clearPendingSignIn.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(h.clearPendingSignIn).toHaveBeenCalled());
+  });
+});
+
+describe('CloudConnectPanel — blocked-popup copy', () => {
+  it('tells the user to open the link when the browser did not open', async () => {
+    const result = deferred<never>();
+    h.beginCloudSignIn.mockResolvedValue({
+      userCode: 'WXYZ-1234',
+      verificationUri: 'http://web/auth/device',
+      verificationUriComplete: 'http://web/auth/device?user_code=WXYZ-1234',
+      grant: GRANT,
+      browserOpenFailed: true,
+      result: result.promise,
+      cancel: vi.fn(),
+    });
+
+    render(<CloudConnectPanel onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with DocuShark Cloud' }));
+
+    // Claiming the browser opened when it didn't leaves the user staring at a
+    // code with nowhere to type it.
+    expect(await screen.findByText(/Open the verification page below/)).toBeTruthy();
+    expect(screen.queryByText(/Your browser should have opened/)).toBeNull();
+  });
+});

--- a/src/ui/cloud/CloudConnectPanel.tsx
+++ b/src/ui/cloud/CloudConnectPanel.tsx
@@ -49,7 +49,18 @@ import {
   WORKSPACE_URL_BASE,
 } from '../../api/relayConnection';
 import { completeCloudSignIn } from '../../api/completeCloudSignIn';
-import { beginCloudSignIn, CloudAuthError, type CloudSignInHandle } from '../../api/cloudAuth';
+import {
+  beginCloudSignIn,
+  CloudAuthError,
+  type CloudSignInResult,
+  type ResumedSignInHandle,
+} from '../../api/cloudAuth';
+import {
+  savePendingSignIn,
+  clearPendingSignIn,
+  type PendingSignIn,
+} from '../../api/pendingSignIn';
+import { ensureSignInResumed } from '../../api/resumeInterruptedSignIn';
 import {
   RELAY_LOCATIONS,
   DEFAULT_RELAY_LOCATION,
@@ -112,7 +123,12 @@ export function CloudConnectPanel({
   const [signInError, setSignInError] = useState<string | null>(null);
   /** Workspace name shown in the post-sign-in confirmation beat. */
   const [successName, setSuccessName] = useState<string | null>(null);
-  const handleRef = useRef<CloudSignInHandle | null>(null);
+  /** True when the verification page could not be opened (popup blocked). */
+  const [browserOpenFailed, setBrowserOpenFailed] = useState(false);
+  const handleRef = useRef<ResumedSignInHandle | null>(null);
+  /** Mirrors `phase` for the mount-only resume effect, which must not re-run on it. */
+  const phaseRef = useRef<SignInPhase>('idle');
+  phaseRef.current = phase;
 
   // Seed the URL fields once from persisted state (async since JP-100 moved
   // the connection record into IndexedDB). Guard against a late resolve after
@@ -149,8 +165,14 @@ export function CloudConnectPanel({
     };
   }, [status]);
 
-  // Cancel any in-flight device-code poll if the modal unmounts (dismissed
-  // mid-flow) — otherwise the poll loop leaks until the device code expires.
+  // Stop the in-flight poll if the modal unmounts, so the loop doesn't leak
+  // until the device code expires.
+  //
+  // Deliberately does NOT clear the persisted grant (JP-455): an unmount is not
+  // the user abandoning the sign-in — it's a dismissal, a re-render, or the page
+  // going away — and destroying the grant here is exactly what stranded an
+  // already-authorized device. Only genuinely terminal outcomes (success,
+  // failure, explicit Cancel) clear it.
   useEffect(() => {
     return () => handleRef.current?.cancel();
   }, []);
@@ -177,12 +199,20 @@ export function CloudConnectPanel({
   const isAwaiting = phase === 'starting' || phase === 'awaiting';
   const isBusy = isConnecting || isAwaiting;
 
-  // Tell the modal while the device-code wait is pending, so a backdrop click
-  // can't silently cancel it (JP-420). Only the poll window counts — during
-  // the WS connect the token is already committed, so dismissal is harmless.
+  // Block accidental backdrop dismissal for the whole NON-TERMINAL window
+  // (JP-455), not just the poll (JP-420's original, narrower rule).
+  //
+  // The old rule reasoned that after the token lands dismissal is harmless —
+  // true of the token, false of the user: `success` and the WS connect are
+  // exactly when the signed-in view hasn't painted yet, so the panel still
+  // looks unfinished and a stray click-out reads as "get me out of here",
+  // stranding the flow. The invariant is now: the backdrop dismisses only on a
+  // state the user can act on — the signed-out form, an error, or the
+  // signed-in view. Escape and Cancel remain the explicit exits.
+  const isTransitional = isAwaiting || phase === 'success' || isConnecting;
   useEffect(() => {
-    onBusyChange?.(isAwaiting);
-  }, [isAwaiting, onBusyChange]);
+    onBusyChange?.(isTransitional);
+  }, [isTransitional, onBusyChange]);
 
   // Success beat (JP-420): hold a brief "Connected" confirmation, then let the
   // signed-in view take over.
@@ -204,6 +234,100 @@ export function CloudConnectPanel({
     if (locationForUrl(relayUrl) === undefined) setAdvancedOpen(true);
   }, [relayUrl]);
 
+  /**
+   * Shared tail for both paths that can land a token — a fresh sign-in and a
+   * grant resumed from storage (JP-455). Commits the session and clears the
+   * persisted grant, since the flow has now terminated successfully.
+   */
+  const finishWithToken = useCallback(
+    async (result: CloudSignInResult, fallbackRelayUrl: string, cloudBase: string) => {
+      const { token, expiresAt, relayUrl: serverRelayUrl, workspaceName, workspaceSlug } = result;
+
+      // The relay's device-token response carries the workspace's region-resolved
+      // relay origin; adopt it as authoritative so a hosted sign-in lands on the
+      // right region relay regardless of the switcher/form default. Fall back to
+      // the form value for older relays / self-hosts that don't return one.
+      const effectiveRelay = serverRelayUrl?.trim() || fallbackRelayUrl;
+
+      await completeCloudSignIn({
+        relayUrl: effectiveRelay,
+        cloudBaseUrl: cloudBase,
+        token,
+        expiresAt,
+        documentId: currentDocumentId,
+        ...(workspaceName !== undefined ? { workspaceName } : {}),
+        ...(workspaceSlug !== undefined ? { workspaceSlug } : {}),
+      });
+
+      await clearPendingSignIn();
+      setSuccessName(workspaceName ?? null);
+      setPhase('success');
+      setUserCode(null);
+      setVerificationUri(null);
+      setBrowserOpenFailed(false);
+    },
+    [currentDocumentId],
+  );
+
+  /** Terminal failure handling shared by both paths. */
+  const failSignIn = useCallback(async (err: unknown) => {
+    handleRef.current = null;
+    await clearPendingSignIn();
+    if (err instanceof CloudAuthError && err.code === 'cancelled') {
+      setPhase('idle');
+      return;
+    }
+    const message = err instanceof Error ? err.message : 'Sign-in failed. Please try again.';
+    setSignInError(message);
+    setPhase('error');
+  }, []);
+
+  // Resume an interrupted sign-in (JP-455). If a grant issued before the page
+  // went away is still live, show the live flow rather than a fresh form — the
+  // user may already have authorized, and the verification page promised the app
+  // would finish signing in automatically.
+  //
+  // `ensureSignInResumed` owns the poll and the session commit (one poller per
+  // grant, see its module doc), so this effect only mirrors it into the UI —
+  // notably it does NOT call `finishWithToken`, or the token would be redeemed
+  // twice when boot resumed first.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      // Never stomp a flow the user has already started in this mount.
+      if (handleRef.current || phaseRef.current !== 'idle') return;
+      const resume = await ensureSignInResumed();
+      if (!active || !resume) return;
+      if (handleRef.current || phaseRef.current !== 'idle') return;
+
+      setUserCode(resume.grant.userCode);
+      setVerificationUri(resume.grant.verificationUri);
+      setPhase('awaiting');
+
+      try {
+        const result = await resume.done;
+        if (!active) return;
+        setSuccessName(result.workspaceName ?? null);
+        setPhase('success');
+        setUserCode(null);
+        setVerificationUri(null);
+      } catch (err) {
+        if (!active) return;
+        if (err instanceof CloudAuthError && err.code === 'cancelled') {
+          setPhase('idle');
+          return;
+        }
+        setSignInError(err instanceof Error ? err.message : 'Sign-in failed. Please try again.');
+        setPhase('error');
+      }
+    })();
+    return () => {
+      active = false;
+    };
+    // Mount-only: a resume is a boot-time concern, not a reaction to state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleSignIn = useCallback(async () => {
     const trimmedRelay = relayUrl.trim();
     const trimmedCloud = cloudUrl.trim().replace(/\/+$/, '');
@@ -212,6 +336,7 @@ export function CloudConnectPanel({
     setSignInError(null);
     setUserCode(null);
     setVerificationUri(null);
+    setBrowserOpenFailed(false);
     setPhase('starting');
 
     try {
@@ -240,56 +365,33 @@ export function CloudConnectPanel({
       handleRef.current = handle;
       setUserCode(handle.userCode);
       setVerificationUri(handle.verificationUriComplete);
+      setBrowserOpenFailed(handle.browserOpenFailed);
       setPhase('awaiting');
 
-      const {
-        token,
-        expiresAt,
-        relayUrl: serverRelayUrl,
-        workspaceName,
-        workspaceSlug,
-      } = await handle.result;
+      // Persist BEFORE awaiting the token: the whole point is to survive a
+      // teardown that happens while we're waiting (JP-455).
+      const pending: PendingSignIn = { ...handle.grant, relayUrl: trimmedRelay };
+      await savePendingSignIn(pending);
+
+      const result = await handle.result;
       handleRef.current = null;
-
-      // The relay's device-token response carries the workspace's region-resolved
-      // relay origin; adopt it as authoritative so a hosted sign-in lands on the
-      // right region relay regardless of the switcher/form default. Fall back to
-      // the form value for older relays / self-hosts that don't return one.
-      const effectiveRelay = serverRelayUrl?.trim() || trimmedRelay;
-
-      await completeCloudSignIn({
-        relayUrl: effectiveRelay,
-        cloudBaseUrl: trimmedCloud,
-        token,
-        expiresAt,
-        documentId: currentDocumentId,
-        ...(workspaceName !== undefined ? { workspaceName } : {}),
-        ...(workspaceSlug !== undefined ? { workspaceSlug } : {}),
-      });
-
-      setSuccessName(workspaceName ?? null);
-      setPhase('success');
-      setUserCode(null);
-      setVerificationUri(null);
+      await finishWithToken(result, trimmedRelay, trimmedCloud);
     } catch (err) {
-      handleRef.current = null;
-      if (err instanceof CloudAuthError && err.code === 'cancelled') {
-        setPhase('idle');
-        return;
-      }
-      const message =
-        err instanceof Error ? err.message : 'Sign-in failed. Please try again.';
-      setSignInError(message);
-      setPhase('error');
+      await failSignIn(err);
     }
-  }, [relayUrl, cloudUrl, currentDocumentId]);
+  }, [relayUrl, cloudUrl, finishWithToken, failSignIn]);
 
   const handleCancelSignIn = useCallback(() => {
     handleRef.current?.cancel();
     handleRef.current = null;
+    // An explicit Cancel is terminal, so the grant is dropped and will NOT be
+    // resumed on the next mount. Contrast the unmount cleanup below, which only
+    // stops the poll and deliberately leaves the grant standing (JP-455).
+    void clearPendingSignIn();
     setPhase('idle');
     setUserCode(null);
     setVerificationUri(null);
+    setBrowserOpenFailed(false);
   }, []);
 
   const handleDisconnect = useCallback(() => {
@@ -509,9 +611,13 @@ export function CloudConnectPanel({
 
       {phase === 'awaiting' && userCode ? (
         <div className="cloud-connect__device" role="status">
+          {/* Don't assert the browser opened when it demonstrably didn't — a
+              blocked popup used to leave the user staring at a code with no page
+              to type it into, and no hint that the link below was the way out. */}
           <p className="cloud-connect__device-hint">
-            Your browser should have opened. Confirm this code matches, then
-            authorize the device:
+            {browserOpenFailed
+              ? 'Open the verification page below, then check this code matches and authorize the device:'
+              : 'Your browser should have opened. Confirm this code matches, then authorize the device:'}
           </p>
           <div className="cloud-connect__device-code">{userCode}</div>
           {verificationUri ? (


### PR DESCRIPTION
Fixes [JP-455](https://linear.app/justins-awesome-apps/issue/JP-455/cloud-sign-in-is-lost-when-the-page-is-torn-down-mid-flow).

## The bug

An in-flight device-code grant had **no durable existence** — it lived in a closure inside `cloudAuth.pollForToken` plus `phase` state in `CloudConnectPanel`, and the panel's unmount cleanup cancelled the poll:

```ts
useEffect(() => () => handleRef.current?.cancel(), []);
```

So anything that tore the page down mid-flow — an evicted backgrounded PWA, a same-tab navigation — stranded a device the server had **already authorized**, and the user returned to a pristine sign-in form. The web authorize page promises *"Return to DocuShark — it will finish signing in automatically."* The editor could not keep that promise.

The sharp edge reported by the user: *"I could click out of the modal leaving the auth in limbo since the management screen wasn't displayed."*

### Not the cause

Timer throttling was the leading hypothesis; an instrumented poll killed it. Measured sleep overshoot while hidden: **+2ms / +525ms / +1ms** against a 5000ms request — polls kept firing and the sign-in completed with the tab backgrounded. A visibility poll-wake is still included as insurance, since the observed hide (~2s) cannot clear Chrome's 5-minute intensive throttling.

## The fix

- **`pendingSignIn.ts`** persists the grant via the existing `secureStore` seam (IndexedDB, same store as the relay JWT — `device_code` is a bearer credential), with a hard absolute expiry. Malformed/expired records are rejected **and cleared**.
- **`resumeCloudSignIn(grant)`** polls an already-issued grant; `beginCloudSignIn` becomes "request a grant, then resume it". A resumed grant polls **immediately** — the user may already have authorized while the app was gone.
- **`resumeInterruptedSignIn.ts`** is the single owner. Boot and the panel join one poller, and the session commit lives there so a token cannot be redeemed twice.
- The grant clears on every terminal outcome and **deliberately not on unmount** — that was the destroying step.
- **Dismissal guard** widened from the poll window to the whole non-terminal window. `success` and the WS connect are exactly when the signed-in view hasn't painted.
- **`Opener.openExternalUrl`** now reports whether the browser opened, so the panel stops asserting "Your browser should have opened" when a popup was blocked.

## Two bugs the tests caught during development

1. `CloudConnectPanel.test.tsx` **did not exist** — the component owning the entire state machine was untested, which is how both defects shipped. The dismissal tests are mutation-verified: they fail when the old `onBusyChange(isAwaiting)` rule *and* its deps array are restored. (My first mutation attempt changed only the call and not the deps, so it wasn't reproducing the old behaviour — worth knowing if you re-check it.)
2. The new `resumeInterruptedSignIn` test caught a **real race in this PR's own code**: the single-flight guard checked a value assigned *after* an `await`, so two concurrent callers both started a poller. Fixed by memoising the in-flight promise.

## Verification

- `bun run typecheck` clean; **3179 tests / 269 files** pass.
- End-to-end on the local stack (Supabase + web :3000 + relay :9876 + editor :5173):
  - the grant persisted to `docushark-pending-signin` on sign-in start;
  - a forced reload — confirmed genuinely fresh via a page marker and a new `timeOrigin` — **silently resumed polling with no modal and no interaction**;
  - authorizing afterwards completed sign-in into Workspace Alpha (7 documents, all Cloud/Synced) **without the editor tab being touched**.

## Follow-up

The unified access panel (document/workspace scope) and the sign-in de-jargon pass are deliberately a **separate PR** — this one is a self-contained correctness fix that can merge without waiting on design iteration.

Assisted-by: Opus 5