### PR TITLE
JP-457: document authorization — ownership provenance + grant-chain resolver

### DIFF
--- a/docs-site/public/openapi.yaml
+++ b/docs-site/public/openapi.yaml
@@ -60,13 +60,13 @@ paths:
       tags: [docs]
       summary: List documents visible to the caller
       description: |
-        Lists the workspace's documents. When the relay is configured with
-        `permissions.enforce_private_docs = true`, the listing is filtered to
-        documents the caller may read — those they own, are explicitly shared
-        on (`sharedWith`), or (as a workspace owner/admin) manage. When that
-        setting is off (the default), every document in the caller's workspace
-        is returned. Access is always scoped to the workspace resolved from the
-        token's `wsp` claim.
+        Lists the workspace's documents the caller may read — those they own,
+        are explicitly shared on (`sharedWith`), or (as a workspace owner)
+        manage. This is the default posture
+        (`permissions.enforce_private_docs`, on unless disabled). A relay
+        configured with that setting off returns every document in the caller's
+        workspace instead. Access is always scoped to the workspace resolved
+        from the token's `wsp` claim.
       security:
         - bearerAuth: []
       responses:
@@ -792,12 +792,16 @@ paths:
 
         A JOIN_DOC frame is answered with an ERROR frame (the connection stays
         open) when the document is unknown (`ERR_UNKNOWN_DOC`) or deleted
-        (`ERR_DELETED`). When `permissions.enforce_private_docs = true`, a
-        JOIN_DOC for a document the caller may not read is refused with
-        `ERR_VIEW_FORBIDDEN` and the client is not joined — the same
-        owner/share rules the document listing applies. With that setting off
-        (the default), any authenticated member of the workspace may join any
-        of its documents.
+        (`ERR_DELETED`). A JOIN_DOC for a document the caller may not read is
+        refused with `ERR_VIEW_FORBIDDEN` and the client is not joined — the
+        same owner/share rules the document listing applies. On a relay with
+        `permissions.enforce_private_docs` disabled, any authenticated member
+        of the workspace may join any of its documents.
+
+        Live edits are gated separately: a caller who may read but not write
+        (a `view` share, or the workspace `viewer` role) has its write-bearing
+        SYNC frames dropped with `ERR_EDIT_FORBIDDEN` while still receiving
+        state.
       parameters:
         - name: Sec-WebSocket-Protocol
           in: header

--- a/relay/README.md
+++ b/relay/README.md
@@ -229,7 +229,7 @@ This table is the canonical inventory — a drift test
 | `RELAY_DOC_CACHE_MAX_BYTES` | `[sync].doc_cache_max_bytes` (working-set cache cap driving LRU eviction; `0` disables) |
 | `RELAY_VERSION_INTERVAL_SECS` | `[sync].version_interval_secs` (minimum spacing between automatic recovery-point captures while a doc is edited; `0` disables periodic capture) |
 | `RELAY_VERSION_RING` | `[sync].version_ring` (recovery points retained per document) |
-| `RELAY_ENFORCE_PRIVATE_DOCS` | `[permissions].enforce_private_docs` (gate document reads on owner/share set; default off) |
+| `RELAY_ENFORCE_PRIVATE_DOCS` | `[permissions].enforce_private_docs` (gate document access on the owner/share set; **default on** — set `0` for workspace-wide access) |
 | `RELAY_REGION` | the `--region` value (used to enforce `wsp[].region`) |
 | `RELAY_TOMBSTONE_TTL_DAYS` | deleted-id tombstone retention window (no toml key; default 30) |
 | `RELAY_SHOW_MCP_TOKEN` | diagnostic only: print the static MCP token unredacted in CLI output (truthy values) |

--- a/relay/docs/api/openapi.yaml
+++ b/relay/docs/api/openapi.yaml
@@ -60,13 +60,13 @@ paths:
       tags: [docs]
       summary: List documents visible to the caller
       description: |
-        Lists the workspace's documents. When the relay is configured with
-        `permissions.enforce_private_docs = true`, the listing is filtered to
-        documents the caller may read — those they own, are explicitly shared
-        on (`sharedWith`), or (as a workspace owner/admin) manage. When that
-        setting is off (the default), every document in the caller's workspace
-        is returned. Access is always scoped to the workspace resolved from the
-        token's `wsp` claim.
+        Lists the workspace's documents the caller may read — those they own,
+        are explicitly shared on (`sharedWith`), or (as a workspace owner)
+        manage. This is the default posture
+        (`permissions.enforce_private_docs`, on unless disabled). A relay
+        configured with that setting off returns every document in the caller's
+        workspace instead. Access is always scoped to the workspace resolved
+        from the token's `wsp` claim.
       security:
         - bearerAuth: []
       responses:
@@ -792,12 +792,16 @@ paths:
 
         A JOIN_DOC frame is answered with an ERROR frame (the connection stays
         open) when the document is unknown (`ERR_UNKNOWN_DOC`) or deleted
-        (`ERR_DELETED`). When `permissions.enforce_private_docs = true`, a
-        JOIN_DOC for a document the caller may not read is refused with
-        `ERR_VIEW_FORBIDDEN` and the client is not joined — the same
-        owner/share rules the document listing applies. With that setting off
-        (the default), any authenticated member of the workspace may join any
-        of its documents.
+        (`ERR_DELETED`). A JOIN_DOC for a document the caller may not read is
+        refused with `ERR_VIEW_FORBIDDEN` and the client is not joined — the
+        same owner/share rules the document listing applies. On a relay with
+        `permissions.enforce_private_docs` disabled, any authenticated member
+        of the workspace may join any of its documents.
+
+        Live edits are gated separately: a caller who may read but not write
+        (a `view` share, or the workspace `viewer` role) has its write-bearing
+        SYNC frames dropped with `ERR_EDIT_FORBIDDEN` while still receiving
+        state.
       parameters:
         - name: Sec-WebSocket-Protocol
           in: header

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1457,10 +1457,10 @@ async fn save_doc_handler(
     // On create the owner is the authenticated caller. On update the stored
     // owner is re-asserted over whatever the body says. `POST /transfer` stays
     // the only route that changes ownership, and it re-checks Owner permission.
-    match existing.as_ref().and_then(|m| m.owner_id.as_deref()) {
+    match (doc_exists, existing.as_ref().and_then(|m| m.owner_id.as_deref())) {
         // Established owner — re-assert it, and the display name with it so the
         // pair can't drift.
-        Some(owner) => {
+        (_, Some(owner)) => {
             document["ownerId"] = json!(owner);
             match existing.as_ref().and_then(|m| m.owner_name.as_deref()) {
                 Some(name) => document["ownerName"] = json!(name),
@@ -1469,10 +1469,26 @@ async fn save_doc_handler(
                 }
             }
         }
-        // A new document, or a legacy one with no recorded owner: the writer
-        // becomes the owner. The latter is what drains the unowned carve-out in
-        // `permissions::resolve` toward zero.
-        None => {
+        // An existing document with no recorded owner — a legacy one, predating
+        // ownership stamping. Deliberately left alone.
+        //
+        // An earlier revision adopted the writer here, on the theory that it
+        // would drain the carve-out. Running it showed that to be wrong twice
+        // over. It doesn't drain: a document open in a collaborative session
+        // persists through the CRDT snapshot path, which never touches this
+        // handler, so content saves while ownership stays absent. And where it
+        // *did* fire it was harmful — silently transferring a legacy document
+        // to whoever saved first, which revokes it from every other member who
+        // could previously see it. Editing a document is not a claim of
+        // ownership over it.
+        //
+        // Leaving these unowned preserves exactly the pre-enforcement status
+        // quo. `relay_unowned_documents` reports the population; draining it is
+        // a deliberate act (an operator backfill, or an explicit "claim"
+        // affordance), never a side effect of typing.
+        (true, None) => {}
+        // A new document: the caller creating it is its owner.
+        (false, None) => {
             document["ownerId"] = json!(claims.sub);
         }
     }

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -30,7 +30,7 @@ use crate::server::documents::{
 use crate::server::protocol::ShareEntry;
 use crate::server::permissions::{
     check_delete_permission, check_read_permission, check_write_permission, to_error_string,
-    PermissionError,
+    PermissionError, Principal,
 };
 use crate::server::blobs::{BlobStore, SaveBlobError};
 use crate::server::protocol::{ClaimLimits, DocEventType, DocId, WorkspaceId};
@@ -188,32 +188,25 @@ fn caller_can_read_blob(
         state.enforce_private_docs(),
         ws,
         hash,
-        Some(sub),
-        Some(role_str(role)),
+        &principal_for(sub, role),
     )
 }
 
 /// The parts-based core of [`caller_can_read_blob`], shared with the MCP file
-/// tools (JP-430) which hold the stores but no `ServerState`. `sub == None` is
-/// the static loopback MCP token — no user identity, treated as workspace
-/// admin, mirroring `ToolContext::ensure_doc_permission`.
+/// tools (JP-430) which hold the stores but no `ServerState`.
 pub(crate) fn blob_read_allowed(
     blob_store: &crate::server::blobs::BlobStore,
     doc_store: &crate::server::documents::DocumentStore,
     enforce_private_docs: bool,
     ws: &WorkspaceId,
     hash: &str,
-    sub: Option<&str>,
-    role: Option<&str>,
+    principal: &Principal,
 ) -> bool {
     if !enforce_private_docs {
         return true;
     }
-    let Some(sub) = sub else {
-        return true; // static loopback token → workspace admin
-    };
-    // Owner/admin can always read (manages the whole workspace).
-    if matches!(role, Some("owner") | Some("admin")) {
+    // The trusted loopback caller manages the whole workspace.
+    if matches!(principal, Principal::Service) {
         return true;
     }
     let referencing = blob_store.docs_referencing(ws, hash);
@@ -222,8 +215,11 @@ pub(crate) fn blob_read_allowed(
             Ok(doc_id) => doc_store
                 .get_metadata(ws, &doc_id)
                 .map(|m| {
-                    crate::server::permissions::get_user_permission(&m, sub, role)
-                        != crate::server::permissions::Permission::None
+                    crate::server::permissions::get_user_permission(
+                        &m,
+                        principal,
+                        enforce_private_docs,
+                    ) != crate::server::permissions::Permission::None
                 })
                 .unwrap_or(false),
             Err(_) => false,
@@ -231,13 +227,20 @@ pub(crate) fn blob_read_allowed(
     })
 }
 
-/// Stringified role value used by the permissions layer.
-fn role_str(role: WorkspaceRole) -> &'static str {
-    match role {
-        WorkspaceRole::Owner => "owner",
-        WorkspaceRole::Member => "user",
-        WorkspaceRole::Viewer => "viewer",
-    }
+/// Build the authorization principal for an authenticated REST caller.
+///
+/// Replaces the previous `role_str` stringification. Two different spellings of
+/// `WorkspaceRole` used to reach the permissions layer — REST mapped `Member`
+/// to `"user"` while the WebSocket handler debug-formatted it to `"member"` —
+/// and a legacy `"admin"` branch was matched but never produced by anything.
+/// Passing the enum through removes all three problems at the type level.
+fn principal_for(user_id: &str, role: WorkspaceRole) -> Principal<'_> {
+    Principal::User { user_id, workspace_role: role }
+}
+
+/// Principal for a REST caller, from validated claims.
+fn principal(claims: &OidcClaims, role: WorkspaceRole) -> Principal<'_> {
+    principal_for(&claims.sub, role)
 }
 
 /// Translate a `PermissionError` into the right HTTP response.
@@ -642,17 +645,17 @@ async fn list_docs_handler(
     // populated in-memory index).
     state.ensure_workspace_index_local(&ws).await;
     let mut docs = state.doc_store().list_documents(&ws);
-    // JP-370: when private-doc enforcement is on, a member only sees documents
-    // they own, are shared on, or (as workspace owner/admin) manage — the same
-    // owner/share rules the per-document read path applies. Off by default →
-    // the full workspace listing, unchanged.
-    if state.enforce_private_docs() {
-        let role = role_str(role);
-        docs.retain(|m| {
-            crate::server::permissions::get_user_permission(m, &claims.sub, Some(role))
-                != crate::server::permissions::Permission::None
-        });
-    }
+    // JP-370/JP-457: the listing shows exactly the documents the caller can
+    // then open. The resolver owns the enforcement flag, so this filter runs
+    // unconditionally — when enforcement is off it simply grants every member
+    // Editor and nothing is filtered. Deciding here whether to filter is what
+    // previously let the listing advertise documents REST would refuse.
+    let caller = principal(&claims, role);
+    let enforce = state.enforce_private_docs();
+    docs.retain(|m| {
+        crate::server::permissions::get_user_permission(m, &caller, enforce)
+            != crate::server::permissions::Permission::None
+    });
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()
 }
 
@@ -942,8 +945,8 @@ async fn get_doc_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -991,8 +994,8 @@ async fn get_doc_ydoc_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1133,8 +1136,8 @@ async fn capture_recovery_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1183,8 +1186,8 @@ async fn recovery_point_content_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1229,8 +1232,8 @@ async fn list_recovery_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1272,8 +1275,8 @@ async fn restore_recovery_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1392,7 +1395,7 @@ async fn save_doc_handler(
     headers: HeaderMap,
     Path(id): Path<String>,
     Query(query): Query<SaveQuery>,
-    Json(document): Json<Value>,
+    Json(mut document): Json<Value>,
 ) -> impl IntoResponse {
     let claims = match require_auth(&state, &headers).await {
         Ok(c) => c,
@@ -1419,17 +1422,50 @@ async fn save_doc_handler(
             .into_response();
     }
 
-    let doc_exists = state.doc_store().get_metadata(&ws, &doc_id).is_some();
+    let existing = state.doc_store().get_metadata(&ws, &doc_id);
+    let doc_exists = existing.is_some();
 
     if doc_exists {
         if let Err(e) = check_write_permission(
             state.doc_store(),
             &ws,
             &doc_id,
-            Some(&claims.sub),
-            Some(role_str(role)),
+            &principal(&claims, role),
+            state.enforce_private_docs(),
         ) {
             return permission_error_response(&e);
+        }
+    }
+
+    // JP-457: ownership is assigned by the relay, never accepted from the body.
+    //
+    // `DocumentStore` derives `owner_id` from the document's `ownerId` field,
+    // which meant ownership was whatever the client last claimed. Two
+    // consequences, both test-proven: a caller holding only an `edit` share
+    // could PUT `"ownerId": "<self>"` and seize the document (gaining share
+    // management and delete), and a document created without the field had no
+    // owner at all — unreadable by its own creator once enforcement is on.
+    //
+    // On create the owner is the authenticated caller. On update the stored
+    // owner is re-asserted over whatever the body says. `POST /transfer` stays
+    // the only route that changes ownership, and it re-checks Owner permission.
+    match existing.as_ref().and_then(|m| m.owner_id.as_deref()) {
+        // Established owner — re-assert it, and the display name with it so the
+        // pair can't drift.
+        Some(owner) => {
+            document["ownerId"] = json!(owner);
+            match existing.as_ref().and_then(|m| m.owner_name.as_deref()) {
+                Some(name) => document["ownerName"] = json!(name),
+                None => {
+                    document.as_object_mut().map(|o| o.remove("ownerName"));
+                }
+            }
+        }
+        // A new document, or a legacy one with no recorded owner: the writer
+        // becomes the owner. The latter is what drains the unowned carve-out in
+        // `permissions::resolve` toward zero.
+        None => {
+            document["ownerId"] = json!(claims.sub);
         }
     }
 
@@ -1449,13 +1485,17 @@ async fn save_doc_handler(
             )
                 .into_response();
         }
-        let is_admin = role_str(role) == "admin";
+        // A workspace owner manages every document, including restoring a
+        // deleted one. This previously read `role_str(role) == "admin"`, a
+        // value nothing ever produced — so the branch was dead and only the
+        // document's own owner could restore.
+        let manages_workspace = role == WorkspaceRole::Owner;
         let is_owner = state
             .doc_store()
             .tombstone_owner(&ws, &doc_id)
             .map(|owner| owner == claims.sub)
             .unwrap_or(false);
-        if !is_admin && !is_owner {
+        if !manages_workspace && !is_owner {
             return (
                 StatusCode::FORBIDDEN,
                 ApiError::body(
@@ -1588,8 +1628,8 @@ async fn delete_doc_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1634,8 +1674,8 @@ async fn share_doc_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1672,8 +1712,8 @@ async fn transfer_doc_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         // 404 for cross-workspace probes; 403 + "Only owner" for the
         // owner-vs-editor case.
@@ -1732,8 +1772,8 @@ async fn set_doc_collection_handler(
         state.doc_store(),
         &ws,
         &doc_id,
-        Some(&claims.sub),
-        Some(role_str(role)),
+        &principal(&claims, role),
+        state.enforce_private_docs(),
     ) {
         return permission_error_response(&e);
     }
@@ -1779,18 +1819,15 @@ async fn list_collection_docs_handler(
     // GET /api/docs. Without it, the collection view leaked every private doc's
     // metadata (including its share list) to any workspace member.
     let enforce = state.enforce_private_docs();
+    let caller = principal(&claims, role);
     let docs: Vec<_> = state
         .doc_store()
         .list_documents(&ws)
         .into_iter()
         .filter(|d| d.collection_id.as_deref() == Some(collection_id.as_str()))
         .filter(|d| {
-            !enforce
-                || crate::server::permissions::get_user_permission(
-                    d,
-                    &claims.sub,
-                    Some(role_str(role)),
-                ) != crate::server::permissions::Permission::None
+            crate::server::permissions::get_user_permission(d, &caller, enforce)
+                != crate::server::permissions::Permission::None
         })
         .collect();
     (StatusCode::OK, Json(json!({ "documents": docs }))).into_response()

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1300,6 +1300,14 @@ async fn restore_recovery_handler(
         obj.insert("createdAt".into(), json!(now));
         obj.insert("modifiedAt".into(), json!(now));
         obj.remove("serverVersion"); // the save assigns v1
+        // JP-457: this creates a document, so it must leave one owned. The
+        // recovery point carries the source's `ownerId` and that is kept —
+        // restoring someone's document must not transfer it to whoever pressed
+        // the button. Only a source that had no owner adopts the restorer,
+        // which keeps the restored copy out of the legacy carve-out.
+        if !obj.get("ownerId").is_some_and(Value::is_string) {
+            obj.insert("ownerId".into(), json!(claims.sub));
+        }
     }
     let new_doc_id = match DocId::from_body_id(new_id.clone()) {
         Ok(d) => d,

--- a/relay/src/auth/jwt.rs
+++ b/relay/src/auth/jwt.rs
@@ -38,6 +38,23 @@ pub enum WorkspaceRole {
     Viewer,
 }
 
+impl WorkspaceRole {
+    /// The one canonical spelling of a role on the wire.
+    ///
+    /// Three spellings used to coexist: REST stringified `Member` as `"user"`,
+    /// the WebSocket handler debug-formatted it as `"member"`, and the
+    /// permissions layer matched a legacy `"admin"` that nothing produced. The
+    /// editor keyed off `"admin"` as a result and every one of its checks was
+    /// dead. This is the value clients see in `AuthResponse.role`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WorkspaceRole::Owner => "owner",
+            WorkspaceRole::Member => "member",
+            WorkspaceRole::Viewer => "viewer",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceClaim {
     pub id: String,

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -647,23 +647,38 @@ impl Default for SyncConfig {
 }
 
 /// Access-control section. Gates whether the relay enforces per-document
-/// access (owner + explicit shares + workspace owner/admin) on the read
-/// paths — the document listing and the WebSocket join. The share metadata
-/// and the permission model are always present; this flag only decides
-/// whether a non-owner, non-shared workspace member is *refused* an unshared
-/// document, versus the legacy behaviour where any workspace member could
-/// read any document in the workspace.
+/// access (owner + explicit shares + workspace owner) across every surface —
+/// the document listing, single-document REST reads and writes, the WebSocket
+/// join, live sync writes, and blob reads. The share metadata and the
+/// permission model are always present; this flag decides whether a
+/// non-owner, non-shared workspace member is *refused* an unshared document,
+/// versus workspace-scoped access where any member may read and edit anything
+/// in the workspace.
 ///
-/// Default **off** so an operator upgrading an existing relay never silently
-/// hides documents from members who could previously see them; a deployment
-/// that wants document-level privacy opts in explicitly.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// **Default on** (JP-457). It previously defaulted off, on the reasoning that
+/// an operator upgrading should never have documents silently hidden from
+/// members — but the off state was never coherent: single-document REST reads
+/// were enforced unconditionally while the listing and the WebSocket sync path
+/// were not, so a member saw documents in the list that REST refused, and
+/// could still read and write them over the sync path. Private-by-default is
+/// the safer posture for the multi-tenant case, and a self-hoster who wants
+/// workspace-wide access opts out explicitly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct PermissionsConfig {
-    /// When true, document reads (REST listing + WebSocket join) are gated by
-    /// the document's owner/share set. When false (the `bool` default), access
-    /// is workspace-scoped only.
+    /// When true, document access is gated by the document's owner/share set.
+    /// When false, access is workspace-scoped: any member may read and edit any
+    /// document in their workspace.
     pub enforce_private_docs: bool,
+}
+
+impl Default for PermissionsConfig {
+    fn default() -> Self {
+        // Container-level `#[serde(default)]` means this covers both an absent
+        // `[permissions]` section and a present-but-empty one, so a config that
+        // never mentions the key gets enforcement.
+        Self { enforce_private_docs: true }
+    }
 }
 
 /// Top-level relay config. All sections optional in the TOML; missing

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -307,16 +307,18 @@ async fn run_serve(
         config.tenancy.workspace_id.as_deref().unwrap_or(""),
         region,
     );
-    // JP-370: make the access-control posture loud at boot. OFF (the default) is
-    // the correct self-host story, but on a multi-tenant/Cloud pod it means any
-    // workspace member can read AND write any document — easy to forget to flip.
+    // JP-457: make the access-control posture loud at boot. ON is now the
+    // default; a deployment that has opted out grants every workspace member
+    // read and write on every document, which is a deliberate self-host choice
+    // and a serious mistake on a multi-tenant pod.
     if config.permissions.enforce_private_docs {
         log::info!("permissions: per-document access enforcement ENABLED (private-by-default)");
     } else {
         log::warn!(
             "permissions: per-document access enforcement is DISABLED — any workspace member \
-             can read and write any document (owner/editor/viewer shares are NOT enforced). \
-             Set [permissions] enforce_private_docs = true (or RELAY_ENFORCE_PRIVATE_DOCS=1) to enable."
+             can read and edit any document in their workspace (owner/editor/viewer shares are \
+             NOT enforced). Unset [permissions] enforce_private_docs (or \
+             RELAY_ENFORCE_PRIVATE_DOCS=1) to restore the default."
         );
     }
     #[cfg(debug_assertions)]

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -151,7 +151,7 @@ pub struct ToolContext<'a> {
     pub user_id: Option<String>,
     /// JP-370: the caller's workspace role string (`"owner"` short-circuits to
     /// full access). Paired with `user_id`.
-    pub user_role: Option<String>,
+    pub user_role: Option<crate::auth::WorkspaceRole>,
     /// JP-370: whether to enforce per-document access for JWT callers. Mirrors
     /// `config.permissions.enforce_private_docs`; `false` (default) keeps the
     /// legacy workspace-scoped behaviour.
@@ -181,6 +181,21 @@ impl ToolContext<'_> {
         (self.on_doc_update)(&self.workspace_id, doc_id, framed);
     }
 
+    /// The authorization principal for this MCP caller.
+    ///
+    /// A JWT caller is a workspace user. The static loopback token has no user
+    /// identity and is the trusted service principal — explicitly `Service`,
+    /// not "anonymous", because those two must never collapse into one case
+    /// once public documents introduce a genuinely untrusted caller.
+    fn principal(&self) -> crate::server::permissions::Principal<'_> {
+        match (self.user_id.as_deref(), self.user_role) {
+            (Some(user_id), Some(workspace_role)) => {
+                crate::server::permissions::Principal::User { user_id, workspace_role }
+            }
+            _ => crate::server::permissions::Principal::Service,
+        }
+    }
+
     /// JP-370: enforce per-document access for a JWT caller. Returns the
     /// permission error string when the caller lacks `required` on a *relay*
     /// document, else `Ok`. Bypassed entirely when enforcement is off or the
@@ -193,9 +208,9 @@ impl ToolContext<'_> {
         doc_id: &DocId,
         required: crate::server::permissions::Permission,
     ) -> Result<(), String> {
-        let Some(user_id) = self.user_id.as_deref() else {
+        if self.user_id.is_none() {
             return Ok(()); // static loopback token → workspace admin
-        };
+        }
         if !self.enforce_private_docs {
             return Ok(());
         }
@@ -208,8 +223,8 @@ impl ToolContext<'_> {
             self.relay,
             &self.workspace_id,
             doc_id,
-            Some(user_id),
-            self.user_role.as_deref(),
+            &self.principal(),
+            self.enforce_private_docs,
             required,
         ) {
             Ok(_) => Ok(()),
@@ -1227,14 +1242,13 @@ fn list_documents(ctx: &ToolContext) -> Result<ToolOutcome, String> {
     // JP-370: a JWT caller only lists relay docs they may read (owner / shared /
     // workspace owner-admin), mirroring the REST listing. The static loopback
     // token (user_id None) and enforcement-off keep the full listing.
-    if ctx.enforce_private_docs {
-        if let Some(user_id) = ctx.user_id.as_deref() {
-            let role = ctx.user_role.as_deref();
-            relay_docs.retain(|m| {
-                crate::server::permissions::get_user_permission(m, user_id, role)
-                    != crate::server::permissions::Permission::None
-            });
-        }
+    if ctx.user_id.is_some() {
+        let caller = ctx.principal();
+        let enforce = ctx.enforce_private_docs;
+        relay_docs.retain(|m| {
+            crate::server::permissions::get_user_permission(m, &caller, enforce)
+                != crate::server::permissions::Permission::None
+        });
     }
     let mut payload: Vec<Value> = relay_docs
         .into_iter()
@@ -1627,8 +1641,7 @@ fn get_file(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, String> {
         ctx.enforce_private_docs,
         &ctx.workspace_id,
         &parsed.blob_ref,
-        ctx.user_id.as_deref(),
-        ctx.user_role.as_deref(),
+        &ctx.principal(),
     ) {
         return Err(format!(
             "ERR_FILE_NOT_FOUND: blob '{}' is not in this workspace's store",
@@ -5463,7 +5476,12 @@ mod tests {
 
         /// JP-370: a ToolContext as a specific JWT-authed user with the
         /// per-document gate enabled (vs `ctx`'s static-token, gate-off shape).
-        fn ctx_as(&self, user_id: &str, role: &str, enforce: bool) -> ToolContext<'_> {
+        fn ctx_as(
+            &self,
+            user_id: &str,
+            role: crate::auth::WorkspaceRole,
+            enforce: bool,
+        ) -> ToolContext<'_> {
             ToolContext {
                 relay: &self.relay,
                 blob_store: &self.blob_store,
@@ -5476,7 +5494,7 @@ mod tests {
                 local_enabled: false,
                 workspace_id: WorkspaceId::single_tenant(),
                 user_id: Some(user_id.to_string()),
-                user_role: Some(role.to_string()),
+                user_role: Some(role),
                 enforce_private_docs: enforce,
                 registry: &self.registry,
                 on_doc_update: &*self.on_doc_update,
@@ -8471,7 +8489,7 @@ mod tests {
             )
             .unwrap();
 
-        let member = f.ctx_as("member-2", "member", true);
+        let member = f.ctx_as("member-2", crate::auth::WorkspaceRole::Member, true);
         let args = json!({ "docId": "owned1" });
 
         assert!(
@@ -8485,7 +8503,7 @@ mod tests {
         );
 
         // Owner-role caller (workspace owner/admin) is allowed by the role short-circuit.
-        let owner = f.ctx_as("someone", "owner", true);
+        let owner = f.ctx_as("someone", crate::auth::WorkspaceRole::Owner, true);
         assert!(dispatch(&owner, "docushark_get_document", &args).is_ok());
 
         // Grant member-2 a view share → read now allowed, write still denied.

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -2075,10 +2075,30 @@ fn create_document(ctx: &ToolContext, args: &Value) -> Result<ToolOutcome, Strin
         .filter(|n| !n.is_empty())
         .unwrap_or_else(|| "Untitled Document".to_string());
 
-    let doc = build_new_document(&name);
+    let mut doc = build_new_document(&name);
     let id_str = doc["id"].as_str().expect("factory always sets id").to_string();
     let doc_id = DocId::from_body_id(id_str.clone())
         .map_err(|e| format!("Generated document id was invalid: {}", e))?;
+
+    // JP-457: stamp ownership, exactly as the REST write path does. Without
+    // this, every agent-created document lands unowned and leans on the legacy
+    // access carve-out — which would then never drain, because MCP keeps
+    // refilling it faster than edits stamp old documents.
+    //
+    // A JWT caller is acting as a person, so the document is that person's. The
+    // static loopback token authenticates an integration with no human behind
+    // it; it gets the service owner rather than being left unowned, because
+    // unowned grants every workspace member Editor — which would make every
+    // agent-created document readable from anyone else's MCP session.
+    match ctx.user_id.as_deref() {
+        Some(user_id) => {
+            doc["ownerId"] = json!(user_id);
+        }
+        None => {
+            doc["ownerId"] = json!(crate::server::permissions::SERVICE_OWNER_MCP);
+            doc["ownerName"] = json!(crate::server::permissions::SERVICE_OWNER_MCP_NAME);
+        }
+    }
 
     // Brand-new id, so there's nothing to race — the unconditional save
     // creates it at version 1. Gated (JP-443): a fresh doc is pure growth.
@@ -6536,6 +6556,91 @@ mod tests {
         let f = seed(&dir.path().to_path_buf());
         let err = dispatch(&f.ctx(true), "docushark_nope", &json!({})).unwrap_err();
         assert!(err.contains("Unknown tool"));
+    }
+
+    /// JP-457: every creation path must leave a document owned. A JWT caller is
+    /// acting as a person, so the document is theirs — the same answer the REST
+    /// write path gives.
+    #[test]
+    fn create_document_stamps_the_authenticated_user_as_owner() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        let ctx = f.ctx_as("member-2", crate::auth::WorkspaceRole::Member, true);
+        let out = dispatch(&ctx, "docushark_create_document", &json!({"name": "Agent Doc"})).unwrap();
+        let new_id = out.result["id"].as_str().unwrap().to_string();
+
+        let doc_id = DocId::from_body_id(new_id.clone()).unwrap();
+        let meta = f
+            .relay
+            .get_metadata(&WorkspaceId::single_tenant(), &doc_id)
+            .expect("created doc is in the index");
+        assert_eq!(meta.owner_id.as_deref(), Some("member-2"));
+
+        // And the creator can read it back — the point of stamping at all.
+        assert_eq!(
+            crate::server::permissions::resolve(
+                &crate::server::permissions::Principal::User {
+                    user_id: "member-2",
+                    workspace_role: crate::auth::WorkspaceRole::Member,
+                },
+                &crate::server::permissions::ResourceContext::new(&meta),
+                true,
+            ),
+            crate::server::permissions::Permission::Owner
+        );
+    }
+
+    /// The static loopback token authenticates an integration, not a person. Its
+    /// documents get the service owner rather than being left unowned — unowned
+    /// grants every workspace member Editor, which would make every
+    /// agent-created document readable from anyone else's MCP session.
+    #[test]
+    fn create_document_via_static_token_is_service_owned_not_world_readable() {
+        let dir = TempDir::new().unwrap();
+        let f = seed(&dir.path().to_path_buf());
+
+        // `ctx` is the static-token shape (no user identity).
+        let out = dispatch(&f.ctx(true), "docushark_create_document", &json!({})).unwrap();
+        let new_id = out.result["id"].as_str().unwrap().to_string();
+        let doc_id = DocId::from_body_id(new_id).unwrap();
+        let meta = f
+            .relay
+            .get_metadata(&WorkspaceId::single_tenant(), &doc_id)
+            .expect("created doc is in the index");
+
+        assert_eq!(
+            meta.owner_id.as_deref(),
+            Some(crate::server::permissions::SERVICE_OWNER_MCP),
+            "a static-token document must be service-owned, not unowned"
+        );
+
+        // The load-bearing assertion: another member gets nothing. If this ever
+        // returns Editor, the document fell into the legacy unowned carve-out.
+        assert_eq!(
+            crate::server::permissions::resolve(
+                &crate::server::permissions::Principal::User {
+                    user_id: "someone-else",
+                    workspace_role: crate::auth::WorkspaceRole::Member,
+                },
+                &crate::server::permissions::ResourceContext::new(&meta),
+                true,
+            ),
+            crate::server::permissions::Permission::None
+        );
+
+        // A workspace owner still manages it, so it is never orphaned.
+        assert_eq!(
+            crate::server::permissions::resolve(
+                &crate::server::permissions::Principal::User {
+                    user_id: "boss",
+                    workspace_role: crate::auth::WorkspaceRole::Owner,
+                },
+                &crate::server::permissions::ResourceContext::new(&meta),
+                true,
+            ),
+            crate::server::permissions::Permission::Owner
+        );
     }
 
     #[test]

--- a/relay/src/mcp/transport.rs
+++ b/relay/src/mcp/transport.rs
@@ -330,23 +330,11 @@ struct AuthOutcome {
     /// which has no user identity and is treated as a workspace admin so the
     /// desktop / self-host flow is unaffected.
     user_id: Option<String>,
-    role: Option<String>,
+    role: Option<WorkspaceRole>,
     /// Raw per-workspace limits minted on the chosen `wsp[]` entry (JP-81) —
     /// the quota the `add_file` upload enforces (JP-430 E3). Default (no
     /// overrides) for the static token; the config fallback then applies.
     limits: ClaimLimits,
-}
-
-/// Stringified workspace role, matching the values the permissions layer
-/// recognises (`"owner"` short-circuits to full access; api.rs uses the same
-/// mapping). JP-370.
-fn role_str(role: WorkspaceRole) -> String {
-    match role {
-        WorkspaceRole::Owner => "owner",
-        WorkspaceRole::Member => "user",
-        WorkspaceRole::Viewer => "viewer",
-    }
-    .to_string()
 }
 
 fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
@@ -388,7 +376,7 @@ async fn authenticate(
             return Some(AuthOutcome {
                 workspace: ws,
                 user_id: Some(claims.sub.clone()),
-                role: Some(role_str(role)),
+                role: Some(role),
                 limits,
             });
         }

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -748,6 +748,24 @@ impl DocumentStore {
             .unwrap_or(0)
     }
 
+    /// JP-457: pod-wide count of documents with no recorded owner — the size of
+    /// the legacy carve-out in `permissions::resolve`, which keeps such
+    /// documents workspace-visible so they aren't orphaned by private-by-default.
+    ///
+    /// Exposed on `/metrics` so the population is observable rather than
+    /// assumed. It should trend to zero: the REST write path stamps an owner on
+    /// every save, so a document leaves this set the next time anyone edits it.
+    /// A number that stays high means documents nobody writes are relying on
+    /// the carve-out for access, and a one-time backfill is worth considering.
+    pub fn unowned_doc_count(&self) -> usize {
+        self.index
+            .read()
+            .map(|index| {
+                crate::server::permissions::unowned_count(index.values().flat_map(|m| m.values()))
+            })
+            .unwrap_or(0)
+    }
+
     /// Root of the relay-owned document tree — the filesystem the /metrics
     /// volume gauges describe (JP-443).
     pub fn documents_dir(&self) -> &std::path::Path {

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -373,6 +373,14 @@ enum BroadcastTarget {
     /// REST save). Pre-21.4-B used `broadcast_to_all` here, which
     /// leaked DocumentMetadata across tenants.
     Workspace(WorkspaceId),
+    /// Clients in one workspace who may READ a specific document (JP-457).
+    ///
+    /// `DocEvent` carries the document's name, owner and full share list, so a
+    /// plain workspace broadcast hands every member the title of a document
+    /// they have no access to — the listing filters it out, and then the event
+    /// puts it straight back. Titles alone are exposure. This target applies
+    /// the same read rule the listing and the REST read path apply.
+    WorkspaceDocReaders(WorkspaceId, DocId),
     /// Every authenticated client regardless of workspace. No live
     /// caller today; reserved for future admin / system events.
     #[allow(dead_code)]
@@ -1615,10 +1623,16 @@ impl ServerState {
             user_id: user_id.unwrap_or_else(|| "system".to_string()),
         };
         if let Ok(data) = encode_message(MESSAGE_DOC_EVENT, &event) {
-            // DOC_EVENT carries DocumentMetadata (name, shares, owner) —
-            // scope to the originating workspace so beta's clients
-            // don't see alpha's saves.
-            self.broadcast_to_workspace(ws, data, None);
+            // DOC_EVENT carries DocumentMetadata (name, shares, owner), so it
+            // is scoped twice: to the originating workspace (so beta's clients
+            // don't see alpha's saves) and, within it, to the members who may
+            // actually read the document (JP-457 — otherwise a private
+            // document's title is broadcast to the whole workspace).
+            let _ = self.broadcast_tx.send(BroadcastMessage {
+                target: BroadcastTarget::WorkspaceDocReaders(ws.clone(), doc_id.clone()),
+                exclude_client: None,
+                data,
+            });
         }
     }
 
@@ -3040,6 +3054,18 @@ async fn handle_socket(socket: WebSocket, state: Arc<ServerState>) {
                             }
                             BroadcastTarget::Workspace(ws) => {
                                 client.authenticated && &client.current_workspace_id == ws
+                            }
+                            BroadcastTarget::WorkspaceDocReaders(ws, doc_id) => {
+                                client.authenticated
+                                    && &client.current_workspace_id == ws
+                                    && crate::server::permissions::check_read_permission(
+                                        state_for_broadcast.doc_store(),
+                                        ws,
+                                        doc_id,
+                                        &ws_principal(client.user_id.as_deref(), client.role),
+                                        state_for_broadcast.enforce_private_docs(),
+                                    )
+                                    .is_ok()
                             }
                             BroadcastTarget::Global => client.authenticated,
                         }

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -48,6 +48,7 @@ use governor::{
 use std::num::NonZeroU32;
 use protocol::*;
 use crate::auth::{AuthError, OidcAuthState, OidcClaims, WorkspaceRole};
+use crate::server::permissions::Principal;
 use crate::config::{StorageConfig, SyncConfig, TenancyConfig, TenancyMode};
 use crate::sync::{
     prose_count_in_binary, suspicious_prose_zeroing, suspicious_zeroing, total_shape_count,
@@ -334,7 +335,10 @@ struct ClientState {
     id: u64,
     user_id: Option<String>,
     username: Option<String>,
-    role: Option<String>,
+    /// JP-457: the typed workspace role, not a stringified one. Three
+    /// different spellings used to reach the permissions layer; carrying the
+    /// enum makes that class of drift unrepresentable.
+    role: Option<WorkspaceRole>,
     current_doc_id: Option<DocId>,
     /// Workspace the client is authenticated against. Phase 21.1
     /// plumbs this through every storage / sync call; Phase 21.5 will
@@ -2500,6 +2504,17 @@ async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResp
         jwks_keys = jwks.key_count,
     );
 
+    // JP-457: how many documents still rely on the unowned legacy carve-out in
+    // `permissions::resolve`. Should trend to zero as documents are written —
+    // a flat non-zero line means documents nobody edits are only reachable
+    // because of the carve-out.
+    let unowned_docs = state.doc_store.unowned_doc_count();
+    body.push_str(&format!(
+        "# HELP relay_unowned_documents Documents with no recorded owner, reachable via the legacy access carve-out.\n\
+         # TYPE relay_unowned_documents gauge\n\
+         relay_unowned_documents {unowned_docs}\n"
+    ));
+
     // Surge-visibility signals (JP-404). Resident hydrated Y.Docs are the
     // pod's dominant memory driver, so scrapers need the count alongside the
     // process RSS to see memory pressure building before the kernel does.
@@ -3149,7 +3164,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<ServerState>) {
         if client.authenticated {
             // Classify from the stored role string so release balances the
             // same editor/viewer bucket that registration incremented.
-            let is_editor = client.role.as_deref() != Some("viewer");
+            let is_editor = client.role != Some(WorkspaceRole::Viewer);
             state
                 .release_workspace_connection(&client.current_workspace_id, is_editor)
                 .await;
@@ -3350,14 +3365,14 @@ async fn handle_auth(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
         }
     }
 
-    let role_str = format!("{:?}", role).to_lowercase();
+    let role_str = role.as_str().to_string();
     {
         let mut clients = state.clients.write().await;
         if let Some(client) = clients.get_mut(&client_id) {
             client.user_id = Some(claims.sub.clone());
             // OIDC tokens don't carry `username`; surface `sub` for logs.
             client.username = Some(claims.sub.clone());
-            client.role = Some(role_str.clone());
+            client.role = Some(role);
             client.current_workspace_id = claim_ws.clone();
             client.authenticated = true;
             // AU-3: remember the token identity for the live recheck.
@@ -3388,6 +3403,18 @@ async fn handle_auth(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
 
 /// Send authentication response
 #[allow(clippy::too_many_arguments)]
+/// Authorization principal for a WebSocket client.
+///
+/// A client that hasn't completed AUTH has no identity and no role; it resolves
+/// to `Anonymous`, which grants nothing. Note this is deliberately *not* the
+/// same as the loopback MCP token's `Principal::Service` — that one is trusted.
+fn ws_principal(user_id: Option<&str>, role: Option<WorkspaceRole>) -> Principal<'_> {
+    match (user_id, role) {
+        (Some(user_id), Some(workspace_role)) => Principal::User { user_id, workspace_role },
+        _ => Principal::Anonymous,
+    }
+}
+
 async fn send_auth_response(
     client_id: u64,
     success: bool,
@@ -3480,7 +3507,7 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
         Option<DocId>,
         WorkspaceId,
         Option<String>,
-        Option<String>,
+        Option<WorkspaceRole>,
     ) = {
         let clients = state.clients.read().await;
         clients
@@ -3525,15 +3552,17 @@ async fn handle_sync(client_id: u64, data: &[u8], state: &Arc<ServerState>) {
     // we must always allow so a viewer can receive state; 1 = SyncStep2, 2 =
     // Update — both carry the client's updates). A non-editor's write frame is
     // dropped before it touches the authoritative Y.Doc, and the client is told
-    // it's view-only (ERR_EDIT_FORBIDDEN). Behind `enforce_private_docs` to match
-    // the read gate — flag-off keeps the legacy open-editing behavior.
-    if state.enforce_private_docs() && data.len() > 1 && data[1] != 0 {
+    // it's view-only (ERR_EDIT_FORBIDDEN). JP-457: the gate is unconditional —
+    // `enforce_private_docs` is an input to the resolver, which grants every
+    // member Editor when enforcement is off. Deciding *here* whether to check
+    // is what let an unshared member write over the sync path while REST 403'd.
+    if data.len() > 1 && data[1] != 0 {
         if let Err(e) = crate::server::permissions::check_write_permission(
             state.doc_store(),
             &workspace_id,
             &doc_id,
-            user_id.as_deref(),
-            role.as_deref(),
+            &ws_principal(user_id.as_deref(), role),
+            state.enforce_private_docs(),
         ) {
             log::info!(
                 "dropping SYNC write (edit forbidden) client_id={} workspace_id={} doc_id={}",
@@ -3742,17 +3771,18 @@ async fn handle_join_doc(client_id: u64, data: &[u8], state: &Arc<ServerState>) 
     // JP-370: per-document read gate. When enforcement is on, a workspace
     // member who is neither the owner, an explicit share, nor a workspace
     // owner/admin is refused the join — the same owner/share rules the REST
-    // read path applies, now closing the WS-sync path that previously trusted
-    // any authenticated member of the workspace. Off by default → unchanged
-    // workspace-scoped behaviour. The error frame mirrors the ERR_UNKNOWN_DOC
-    // branch so the client strands its local copy rather than syncing blind.
-    if state.enforce_private_docs() {
+    // read path applies, closing the WS-sync path that previously trusted any
+    // authenticated member of the workspace. JP-457: unconditional for the same
+    // reason as the write gate below — the resolver owns the flag. The error
+    // frame mirrors the ERR_UNKNOWN_DOC branch so the client strands its local
+    // copy rather than syncing blind.
+    {
         if let Err(e) = crate::server::permissions::check_read_permission(
             state.doc_store(),
             &workspace_id,
             &request.doc_id,
-            user_id.as_deref(),
-            role.as_deref(),
+            &ws_principal(user_id.as_deref(), role),
+            state.enforce_private_docs(),
         ) {
             log::info!(
                 "rejecting JOIN_DOC (access denied) client_id={} workspace_id={} doc_id={}",
@@ -3969,7 +3999,10 @@ mod tests {
                     id: client_id,
                     user_id: Some("user-1".to_string()),
                     username: None,
-                    role: None,
+                    // An authenticated client always carries a role (handle_auth
+                    // sets both in one block); a role-less one resolves to
+                    // `Principal::Anonymous` and is refused, by design.
+                    role: Some(WorkspaceRole::Member),
                     current_doc_id: None,
                     current_workspace_id: WorkspaceId::single_tenant(),
                     authenticated: true,
@@ -4008,7 +4041,10 @@ mod tests {
                     id: client_id,
                     user_id: Some("user-1".to_string()),
                     username: None,
-                    role: None,
+                    // An authenticated client always carries a role (handle_auth
+                    // sets both in one block); a role-less one resolves to
+                    // `Principal::Anonymous` and is refused, by design.
+                    role: Some(WorkspaceRole::Member),
                     current_doc_id: None,
                     current_workspace_id: WorkspaceId::single_tenant(),
                     authenticated: true,
@@ -4128,7 +4164,7 @@ mod tests {
                 id,
                 user_id: Some("u".to_string()),
                 username: None,
-                role: None,
+                role: Some(WorkspaceRole::Member),
                 current_doc_id: None,
                 current_workspace_id: WorkspaceId::single_tenant(),
                 authenticated: authed,
@@ -4229,7 +4265,10 @@ mod tests {
                     id: client_id,
                     user_id: Some("user-1".to_string()),
                     username: None,
-                    role: None,
+                    // An authenticated client always carries a role (handle_auth
+                    // sets both in one block); a role-less one resolves to
+                    // `Principal::Anonymous` and is refused, by design.
+                    role: Some(WorkspaceRole::Member),
                     current_doc_id: None,
                     current_workspace_id: WorkspaceId::single_tenant(),
                     authenticated: true,
@@ -4296,7 +4335,10 @@ mod tests {
                     id: client_id,
                     user_id: Some("user-1".to_string()),
                     username: None,
-                    role: None,
+                    // An authenticated client always carries a role (handle_auth
+                    // sets both in one block); a role-less one resolves to
+                    // `Principal::Anonymous` and is refused, by design.
+                    role: Some(WorkspaceRole::Member),
                     current_doc_id: None,
                     current_workspace_id: ws.clone(),
                     authenticated: true,
@@ -4358,7 +4400,7 @@ mod tests {
                     id: client_id,
                     user_id: Some("member-2".to_string()),
                     username: None,
-                    role: Some("user".to_string()),
+                    role: Some(WorkspaceRole::Member),
                     current_doc_id: None,
                     current_workspace_id: ws.clone(),
                     authenticated: true,
@@ -4471,7 +4513,7 @@ mod tests {
                     id: client_id,
                     user_id: Some(uid.to_string()),
                     username: None,
-                    role: Some("user".to_string()),
+                    role: Some(WorkspaceRole::Member),
                     current_doc_id: Some(DocId::from_http_path("doc1".to_string()).unwrap()),
                     current_workspace_id: WorkspaceId::single_tenant(),
                     authenticated: true,

--- a/relay/src/server/permissions.rs
+++ b/relay/src/server/permissions.rs
@@ -144,9 +144,29 @@ pub fn resolve(principal: &Principal, ctx: &ResourceContext, enforce: bool) -> P
     granted.min(cap)
 }
 
+/// Owner recorded for a document created through the static loopback MCP token,
+/// which authenticates an integration rather than a person.
+///
+/// Such a document has no human creator to attribute, but it must not be left
+/// *unowned* — `owner_id: None` means "legacy document from before the write
+/// path stamped owners" and grants every workspace member Editor. Leaving
+/// agent-created documents in that bucket would make every one of them readable
+/// by anyone else's MCP session in the workspace.
+///
+/// No real `sub` can collide with this value, so the document resolves to
+/// exactly: the service principal (Owner), workspace owners (Owner), and
+/// nobody else — until somebody shares it deliberately.
+pub const SERVICE_OWNER_MCP: &str = "service:mcp";
+
+/// Display name paired with [`SERVICE_OWNER_MCP`], so the editor's access panel
+/// shows a person-shaped label instead of a raw id it can't resolve.
+pub const SERVICE_OWNER_MCP_NAME: &str = "MCP integration";
+
 /// Count of documents in `metadata` carrying no owner — the size of the legacy
 /// carve-out in [`resolve`]. Surfaced so the population is measurable rather
 /// than assumed; it should trend to zero as documents are written.
+///
+/// Service-owned documents are *not* counted: they have an owner, deliberately.
 pub fn unowned_count<'a>(docs: impl IntoIterator<Item = &'a DocumentMetadata>) -> usize {
     docs.into_iter().filter(|m| m.owner_id.is_none()).count()
 }

--- a/relay/src/server/permissions.rs
+++ b/relay/src/server/permissions.rs
@@ -1,18 +1,155 @@
-//! Document permission management
+//! Document authorization (JP-457).
 //!
-//! Implements a 3-tier permission model for document access control:
-//! - Owner: Full access including delete, transfer ownership, manage sharing
-//! - Editor: Read and write access
-//! - Viewer: Read-only access
+//! Access is resolved by walking an ordered list of **grant sources**, each of
+//! which either *grants* a permission level or *caps* one. The effective
+//! permission is the highest grant, clamped by the lowest cap.
 //!
-//! Permission hierarchy:
-//! - Document owner is set on creation
-//! - Admins have implicit Owner access to all documents (full management)
-//! - Users with explicit shares have their assigned permission level
-//! - No implicit access for unshared documents
+//! This shape replaces an if-ladder. The ladder itself was fine; what wasn't is
+//! that the *decision to consult it* lived in ~20 call sites, five of which
+//! checked `enforce_private_docs` and fifteen of which didn't — so document
+//! content was readable and writable over the WebSocket sync path while REST
+//! refused it. Folding the flag into the resolver means no call site can
+//! forget it. [`crate::server::ServerState::authorize`] is the single entry
+//! point; the `check_*_permission` helpers below are thin wrappers over it.
+//!
+//! Adding a source is the extension point: collection-level grants and public
+//! visibility are each one entry in [`resolve`], not another branch in another
+//! handler.
 
 use super::documents::{DocumentMetadata, DocumentStore};
 use super::protocol::{DocId, WorkspaceId};
+use crate::auth::WorkspaceRole;
+
+/// Who is asking.
+///
+/// Deliberately an enum rather than `user_id: Option<&str>`. The absent-user
+/// case is currently the loopback MCP token — a *fully trusted* caller — and
+/// public documents will introduce an unauthenticated visitor, which is the
+/// exact opposite. Conflating the two behind one `None` is how a public-docs
+/// change would silently hand workspace authority to anonymous callers.
+#[derive(Debug, Clone, Copy)]
+pub enum Principal<'a> {
+    /// The static loopback MCP token: no user identity, full workspace
+    /// authority. Mirrors `ToolContext::ensure_doc_permission`.
+    Service,
+    /// An authenticated member of the workspace.
+    User {
+        user_id: &'a str,
+        workspace_role: WorkspaceRole,
+    },
+    /// An unauthenticated caller. Grants nothing today; the seam public
+    /// documents will resolve against once a `visibility` source exists.
+    Anonymous,
+}
+
+impl<'a> Principal<'a> {
+    /// The user id, when the principal has one. Service and anonymous callers
+    /// have no identity to compare against `owner_id`.
+    pub fn user_id(&self) -> Option<&'a str> {
+        match self {
+            Principal::User { user_id, .. } => Some(user_id),
+            _ => None,
+        }
+    }
+}
+
+/// What is being asked about. One field today; the commented growth points are
+/// the whole reason this is a struct rather than a bare `&DocumentMetadata`.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceContext<'a> {
+    pub document: &'a DocumentMetadata,
+    // Growth points — adding either is a new source in `resolve`, nothing else:
+    //   pub collection: Option<&'a CollectionGrants>,
+    //   pub visibility: Visibility,
+}
+
+impl<'a> ResourceContext<'a> {
+    pub fn new(document: &'a DocumentMetadata) -> Self {
+        Self { document }
+    }
+}
+
+/// Resolve the effective permission for `principal` on `ctx`.
+///
+/// `enforce` is `config.permissions.enforce_private_docs`. When false, the
+/// deployment has opted out of per-document privacy and any workspace member
+/// may edit — which is what the old flag-off path *claimed* but did not do.
+///
+/// Sources are applied in order; grants accumulate as a maximum, caps as a
+/// minimum, and the result is `max(grants).min(min(caps))`.
+pub fn resolve(principal: &Principal, ctx: &ResourceContext, enforce: bool) -> Permission {
+    let (user_id, workspace_role) = match principal {
+        // Trusted loopback caller — manages the whole workspace.
+        Principal::Service => return Permission::Owner,
+        // No identity, and no visibility source exists to grant against yet.
+        Principal::Anonymous => return Permission::None,
+        Principal::User { user_id, workspace_role } => (*user_id, *workspace_role),
+    };
+
+    let doc = ctx.document;
+    let mut granted = Permission::None;
+
+    // GRANT: enforcement disabled → workspace-scoped editing for any member.
+    if !enforce {
+        granted = granted.max(Permission::Editor);
+    }
+
+    // GRANT: the document's owner.
+    if doc.owner_id.as_deref() == Some(user_id) {
+        granted = granted.max(Permission::Owner);
+    }
+
+    // GRANT: workspace owners manage every document in the workspace. This is
+    // the inheritance the editor's access panel draws as "via workspace".
+    if workspace_role == WorkspaceRole::Owner {
+        granted = granted.max(Permission::Owner);
+    }
+
+    // GRANT: legacy documents with no recorded owner stay workspace-visible.
+    //
+    // The relay historically never assigned ownership — it read `ownerId` out
+    // of the client-sent body, and the editor doesn't send one — so documents
+    // predating the write-path stamp have no owner at all. Without this they
+    // become unreachable by everyone except workspace owners, including the
+    // person who created them. `Editor` and not `Viewer` deliberately: the
+    // holder must be able to *write* the document, because the write is what
+    // stamps a real owner and drains this carve-out toward zero.
+    if doc.owner_id.is_none() {
+        granted = granted.max(Permission::Editor);
+    }
+
+    // GRANT: explicit per-document shares.
+    if let Some(shares) = &doc.shared_with {
+        for share in shares {
+            if share.user_id == user_id {
+                granted = granted.max(Permission::from_str(&share.permission));
+            }
+        }
+    }
+
+    // CAP: the workspace Viewer role is a ceiling, not a starting point. A
+    // share cannot promote a read-only member to a writer — the invite copy
+    // promises "read-only, even where shared". This is the first cap-kind
+    // source; future read-only access policies reuse the shape.
+    //
+    // The cap applies even to a Viewer who owns the document. That is the
+    // stricter reading, and the safe one: the fix for a viewer who needs to
+    // edit is to change their workspace role, not to leave a hole here.
+    let cap = if workspace_role == WorkspaceRole::Viewer {
+        Permission::Viewer
+    } else {
+        Permission::Owner
+    };
+
+    granted.min(cap)
+}
+
+/// Count of documents in `metadata` carrying no owner — the size of the legacy
+/// carve-out in [`resolve`]. Surfaced so the population is measurable rather
+/// than assumed; it should trend to zero as documents are written.
+pub fn unowned_count<'a>(docs: impl IntoIterator<Item = &'a DocumentMetadata>) -> usize {
+    docs.into_iter().filter(|m| m.owner_id.is_none()).count()
+}
 
 /// Permission levels for document access (ordered from most to least privileged)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -116,69 +253,46 @@ pub mod error_codes {
     pub const VIEW_FORBIDDEN: &str = "ERR_VIEW_FORBIDDEN";
 }
 
-/// Get effective permission for a user on a document
+/// Effective permission for a principal on one document's metadata.
 ///
-/// Priority order:
-/// 1. Owner - full access
-/// 2. Admin users - implicit Editor access
-/// 3. Explicit share permission
-/// 4. None - no access
+/// Thin wrapper over [`resolve`] for call sites that already hold metadata and
+/// don't need a store lookup (the listing filters, blob read checks).
 pub fn get_user_permission(
     metadata: &DocumentMetadata,
-    user_id: &str,
-    user_role: Option<&str>,
+    principal: &Principal,
+    enforce: bool,
 ) -> Permission {
-    // Check if user is owner
-    if let Some(owner_id) = &metadata.owner_id {
-        if owner_id == user_id {
-            return Permission::Owner;
-        }
-    }
-
-    // Admin users (legacy role) and workspace owners (OIDC `wsp[].role`
-    // = "owner", JP-77) get implicit Owner access for management
-    // purposes (manage shares, transfer ownership, delete).
-    if user_role == Some("admin") || user_role == Some("owner") {
-        return Permission::Owner;
-    }
-
-    // Check explicit shares
-    if let Some(shares) = &metadata.shared_with {
-        for share in shares {
-            if share.user_id == user_id {
-                return Permission::from_str(&share.permission);
-            }
-        }
-    }
-
-    // No access
-    Permission::None
+    resolve(principal, &ResourceContext::new(metadata), enforce)
 }
 
-/// Check if user has required permission level
+/// Check that `principal` holds at least `required` on the document.
+///
+/// `enforce` must come from `ServerState::enforce_private_docs()` — prefer
+/// [`crate::server::ServerState::authorize`], which supplies it for you, over
+/// calling this directly.
 pub fn check_permission(
     doc_store: &DocumentStore,
     ws: &WorkspaceId,
     doc_id: &DocId,
-    user_id: Option<&str>,
-    user_role: Option<&str>,
+    principal: &Principal,
+    enforce: bool,
     required: Permission,
 ) -> Result<Permission, PermissionError> {
-    // Require authentication
-    let user_id = match user_id {
-        Some(id) if !id.is_empty() => id,
+    // An authenticated identity is still required for anything that isn't the
+    // trusted loopback caller: `Anonymous` has nothing to resolve against, and
+    // an empty user id is a malformed token, not a valid principal.
+    match principal {
+        Principal::Service => {}
+        Principal::User { user_id, .. } if !user_id.is_empty() => {}
         _ => return Err(PermissionError::NotAuthenticated),
-    };
+    }
 
-    // Get document metadata
     let metadata = doc_store
         .get_metadata(ws, doc_id)
         .ok_or(PermissionError::DocumentNotFound)?;
 
-    // Get user's effective permission
-    let actual = get_user_permission(&metadata, user_id, user_role);
+    let actual = resolve(principal, &ResourceContext::new(&metadata), enforce);
 
-    // Check if sufficient
     if actual >= required {
         Ok(actual)
     } else {
@@ -191,10 +305,10 @@ pub fn check_read_permission(
     doc_store: &DocumentStore,
     ws: &WorkspaceId,
     doc_id: &DocId,
-    user_id: Option<&str>,
-    user_role: Option<&str>,
+    principal: &Principal,
+    enforce: bool,
 ) -> Result<Permission, PermissionError> {
-    check_permission(doc_store, ws, doc_id, user_id, user_role, Permission::Viewer)
+    check_permission(doc_store, ws, doc_id, principal, enforce, Permission::Viewer)
 }
 
 /// Check write permission (at least Editor)
@@ -202,10 +316,10 @@ pub fn check_write_permission(
     doc_store: &DocumentStore,
     ws: &WorkspaceId,
     doc_id: &DocId,
-    user_id: Option<&str>,
-    user_role: Option<&str>,
+    principal: &Principal,
+    enforce: bool,
 ) -> Result<Permission, PermissionError> {
-    check_permission(doc_store, ws, doc_id, user_id, user_role, Permission::Editor)
+    check_permission(doc_store, ws, doc_id, principal, enforce, Permission::Editor)
 }
 
 /// Check delete permission (requires Owner)
@@ -213,10 +327,10 @@ pub fn check_delete_permission(
     doc_store: &DocumentStore,
     ws: &WorkspaceId,
     doc_id: &DocId,
-    user_id: Option<&str>,
-    user_role: Option<&str>,
+    principal: &Principal,
+    enforce: bool,
 ) -> Result<Permission, PermissionError> {
-    check_permission(doc_store, ws, doc_id, user_id, user_role, Permission::Owner)
+    check_permission(doc_store, ws, doc_id, principal, enforce, Permission::Owner)
 }
 
 /// Convert PermissionError to protocol error string
@@ -245,7 +359,7 @@ mod tests {
     use super::*;
     use crate::server::documents::DocumentShare;
 
-    fn make_metadata(owner_id: &str, shares: Vec<(&str, &str)>) -> DocumentMetadata {
+    fn make_metadata(owner_id: Option<&str>, shares: Vec<(&str, &str)>) -> DocumentMetadata {
         DocumentMetadata {
             id: DocId::from_http_path("doc-1".to_string()).unwrap(),
             name: "Test".to_string(),
@@ -259,8 +373,8 @@ mod tests {
             locked_by: None,
             locked_by_name: None,
             locked_at: None,
-            owner_id: Some(owner_id.to_string()),
-            owner_name: Some("Owner".to_string()),
+            owner_id: owner_id.map(String::from),
+            owner_name: owner_id.map(|_| "Owner".to_string()),
             collection_id: None,
             tags: None,
             shared_with: if shares.is_empty() {
@@ -283,77 +397,168 @@ mod tests {
         }
     }
 
+    fn user(id: &str, role: WorkspaceRole) -> Principal<'_> {
+        Principal::User { user_id: id, workspace_role: role }
+    }
+
+    // ========================================================
+    // The shared matrix — see relay/tests/fixtures/permission-matrix.json
+    // ========================================================
+
+    /// Drives [`resolve`] from the same table the editor's mirror test reads.
+    /// A row that disagrees fails in whichever language drifted, which is the
+    /// entire point: client/relay divergence becomes a red test rather than
+    /// something a person notices while building a UI.
     #[test]
-    fn test_owner_permission() {
-        let metadata = make_metadata("user-1", vec![]);
+    fn matrix_fixture_matches_the_resolver() {
+        let raw = include_str!("../../tests/fixtures/permission-matrix.json");
+        let fixture: serde_json::Value =
+            serde_json::from_str(raw).expect("permission-matrix.json parses");
+        let cases = fixture["cases"].as_array().expect("cases array");
+        assert!(!cases.is_empty(), "fixture must not be empty");
+
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("<unnamed>");
+            let enforce = case["enforce"].as_bool().expect("enforce bool");
+
+            let doc = &case["document"];
+            let owner = doc["ownerId"].as_str();
+            let shares: Vec<(&str, &str)> = doc["sharedWith"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .map(|s| {
+                            (
+                                s["userId"].as_str().expect("share userId"),
+                                s["permission"].as_str().expect("share permission"),
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let metadata = make_metadata(owner, shares);
+
+            let p = &case["principal"];
+            let principal = match p["kind"].as_str().expect("principal kind") {
+                "service" => Principal::Service,
+                "anonymous" => Principal::Anonymous,
+                "user" => Principal::User {
+                    user_id: p["userId"].as_str().expect("userId"),
+                    workspace_role: match p["workspaceRole"].as_str().expect("workspaceRole") {
+                        "owner" => WorkspaceRole::Owner,
+                        "member" => WorkspaceRole::Member,
+                        "viewer" => WorkspaceRole::Viewer,
+                        other => panic!("unknown workspaceRole {other:?} in case {name:?}"),
+                    },
+                },
+                other => panic!("unknown principal kind {other:?} in case {name:?}"),
+            };
+
+            let expected = match case["expect"].as_str().expect("expect") {
+                "owner" => Permission::Owner,
+                "editor" => Permission::Editor,
+                "viewer" => Permission::Viewer,
+                "none" => Permission::None,
+                other => panic!("unknown expect {other:?} in case {name:?}"),
+            };
+
+            let actual = resolve(&principal, &ResourceContext::new(&metadata), enforce);
+            assert_eq!(actual, expected, "matrix case failed: {name}");
+        }
+    }
+
+    // ========================================================
+    // Focused cases — the invariants worth naming individually
+    // ========================================================
+
+    #[test]
+    fn owner_outranks_a_self_share() {
+        let metadata = make_metadata(Some("user-1"), vec![("user-1", "view")]);
         assert_eq!(
-            get_user_permission(&metadata, "user-1", None),
+            resolve(&user("user-1", WorkspaceRole::Member), &ResourceContext::new(&metadata), true),
             Permission::Owner
         );
     }
 
     #[test]
-    fn test_admin_has_owner_permission() {
-        // Admins have implicit Owner access for management purposes
-        let metadata = make_metadata("user-1", vec![]);
+    fn membership_alone_grants_nothing() {
+        let metadata = make_metadata(Some("user-1"), vec![]);
         assert_eq!(
-            get_user_permission(&metadata, "user-2", Some("admin")),
-            Permission::Owner
+            resolve(&user("user-2", WorkspaceRole::Member), &ResourceContext::new(&metadata), true),
+            Permission::None
         );
     }
 
+    /// The workspace Viewer role is a ceiling, not a floor. A share must never
+    /// promote a read-only member — the invite copy promises exactly this.
     #[test]
-    fn test_admin_can_manage_any_document() {
-        let metadata = make_metadata("user-1", vec![]);
-        let permission = get_user_permission(&metadata, "admin-user", Some("admin"));
-        
-        // Admin should have full management capabilities
-        assert!(permission.can_read());
-        assert!(permission.can_write());
-        assert!(permission.can_delete());
-        assert!(permission.can_manage_shares());
-    }
-
-    #[test]
-    fn test_owner_takes_precedence_over_share() {
-        // Even if owner is in shares with lower permission, they're still owner
-        let metadata = make_metadata("user-1", vec![("user-1", "view")]);
+    fn viewer_role_caps_an_edit_share() {
+        let metadata = make_metadata(Some("user-1"), vec![("user-2", "edit")]);
         assert_eq!(
-            get_user_permission(&metadata, "user-1", None),
-            Permission::Owner
-        );
-    }
-
-    #[test]
-    fn test_explicit_share() {
-        let metadata = make_metadata("user-1", vec![("user-2", "edit"), ("user-3", "view")]);
-        assert_eq!(
-            get_user_permission(&metadata, "user-2", None),
-            Permission::Editor
-        );
-        assert_eq!(
-            get_user_permission(&metadata, "user-3", None),
+            resolve(&user("user-2", WorkspaceRole::Viewer), &ResourceContext::new(&metadata), true),
             Permission::Viewer
         );
     }
 
     #[test]
-    fn test_no_access() {
-        let metadata = make_metadata("user-1", vec![]);
+    fn viewer_role_caps_even_document_ownership() {
+        let metadata = make_metadata(Some("user-2"), vec![]);
         assert_eq!(
-            get_user_permission(&metadata, "user-2", None),
+            resolve(&user("user-2", WorkspaceRole::Viewer), &ResourceContext::new(&metadata), true),
+            Permission::Viewer
+        );
+    }
+
+    /// Disabling enforcement opts the deployment out of per-document privacy.
+    /// It must not also dissolve the Viewer ceiling.
+    #[test]
+    fn enforcement_off_opens_documents_but_keeps_the_viewer_cap() {
+        let metadata = make_metadata(Some("user-1"), vec![]);
+        assert_eq!(
+            resolve(&user("user-2", WorkspaceRole::Member), &ResourceContext::new(&metadata), false),
+            Permission::Editor
+        );
+        assert_eq!(
+            resolve(&user("user-3", WorkspaceRole::Viewer), &ResourceContext::new(&metadata), false),
+            Permission::Viewer
+        );
+    }
+
+    /// A legacy document with no recorded owner stays reachable, and at Editor
+    /// specifically — the holder must be able to write it, because the write is
+    /// what stamps a real owner and drains the carve-out.
+    #[test]
+    fn unowned_document_is_workspace_visible_and_writable() {
+        let metadata = make_metadata(None, vec![]);
+        assert_eq!(
+            resolve(&user("anyone", WorkspaceRole::Member), &ResourceContext::new(&metadata), true),
+            Permission::Editor
+        );
+    }
+
+    /// `Service` (the loopback MCP token) and `Anonymous` both lack a user id
+    /// but sit at opposite ends of trust. If these ever collapse into one case,
+    /// public documents would hand workspace authority to unauthenticated
+    /// callers.
+    #[test]
+    fn service_and_anonymous_are_opposites() {
+        let metadata = make_metadata(Some("user-1"), vec![]);
+        assert_eq!(
+            resolve(&Principal::Service, &ResourceContext::new(&metadata), true),
+            Permission::Owner
+        );
+        assert_eq!(
+            resolve(&Principal::Anonymous, &ResourceContext::new(&metadata), true),
             Permission::None
         );
     }
 
     #[test]
-    fn test_no_access_with_user_role() {
-        // Non-admin user role should not grant access
-        let metadata = make_metadata("user-1", vec![]);
-        assert_eq!(
-            get_user_permission(&metadata, "user-2", Some("user")),
-            Permission::None
-        );
+    fn unowned_count_reports_the_carve_out_population() {
+        let owned = make_metadata(Some("user-1"), vec![]);
+        let orphan = make_metadata(None, vec![]);
+        assert_eq!(unowned_count([&owned, &orphan, &orphan]), 2);
+        assert_eq!(unowned_count([&owned]), 0);
     }
 
     #[test]
@@ -403,5 +608,13 @@ mod tests {
         assert_eq!(Permission::Editor.as_str(), "edit");
         assert_eq!(Permission::Viewer.as_str(), "view");
         assert_eq!(Permission::None.as_str(), "none");
+    }
+
+    /// One canonical spelling of the role on the wire (JP-457).
+    #[test]
+    fn workspace_role_has_a_single_spelling() {
+        assert_eq!(WorkspaceRole::Owner.as_str(), "owner");
+        assert_eq!(WorkspaceRole::Member.as_str(), "member");
+        assert_eq!(WorkspaceRole::Viewer.as_str(), "viewer");
     }
 }

--- a/relay/tests/document_privacy.rs
+++ b/relay/tests/document_privacy.rs
@@ -1,0 +1,560 @@
+//! JP-457 — document access-control matrix.
+//!
+//! JP-370 introduced per-document privacy behind `[permissions]
+//! enforce_private_docs`, but the gate was applied to *some* surfaces and not
+//! others. This suite pins the behaviour of every read/write surface against
+//! both settings of the flag, so the two are either consistently open or
+//! consistently gated — and a future surface that forgets the gate fails here.
+//!
+//! Roles under test map to the OIDC `wsp[].role` claim the control plane mints
+//! (`relay/src/auth/jwt.rs`): Owner / Member / Viewer. `role_str` in `api.rs`
+//! stringifies them for `get_user_permission`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{TenancyConfig, TenancyMode};
+use docushark_relay::server::protocol::{
+    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_ERROR, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
+    PROTOCOL_VERSION,
+};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use futures_util::{SinkExt, StreamExt};
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+const WS: &str = "ws_privacy";
+
+struct Harness {
+    base: String,
+    ws_base: String,
+    issuer: OidcTestIssuer,
+    #[allow(dead_code)]
+    data_dir: PathBuf,
+    _tmp: TempDir,
+}
+
+impl Harness {
+    async fn start(enforce_private_docs: bool) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().to_path_buf();
+        let issuer = OidcTestIssuer::new().await;
+
+        let server = Arc::new(WebSocketServer::new());
+        server.set_app_data_dir(data_dir.clone()).await;
+        server.set_auth(issuer.auth_state()).await;
+        // `Shared` (Cloud) mode: several people in one workspace is precisely
+        // the deployment where per-document privacy has to hold. The default
+        // `Dedicated` mode pins the relay to the `default` workspace and would
+        // 403 this harness's own workspace id before any permission check ran.
+        server
+            .set_tenancy(TenancyConfig {
+                mode: TenancyMode::Shared,
+                workspace_id: None,
+                ..TenancyConfig::default()
+            })
+            .await;
+        server.set_enforce_private_docs(enforce_private_docs);
+        server
+            .set_config(ServerConfig {
+                port: 0,
+                network_mode: NetworkMode::Localhost,
+                max_connections: 0,
+            })
+            .await
+            .expect("set_config");
+
+        let bound = server.start(0).await.expect("start");
+        let ws_base = bound.clone();
+        let http = bound
+            .strip_prefix("ws://")
+            .map(|rest| format!("http://{rest}"))
+            .unwrap_or(bound);
+
+        // Leak the server for the process lifetime of the test — dropping the
+        // Arc would tear the listener down while requests are in flight.
+        std::mem::forget(server);
+
+        Self { base: http, ws_base, issuer, data_dir, _tmp: tmp }
+    }
+
+    fn token(&self, sub: &str, role: WorkspaceRole) -> String {
+        self.issuer.mint(sub, WS, role)
+    }
+
+    /// Create a document owned by `sub`. Returns the doc id.
+    async fn create_doc(&self, sub: &str, role: WorkspaceRole, id: &str) -> String {
+        let resp = reqwest::Client::new()
+            .put(format!("{}/api/docs/{}", self.base, id))
+            .bearer_auth(self.token(sub, role))
+            .json(&json!({ "id": id, "name": "Private Doc", "pageOrder": [] }))
+            .send()
+            .await
+            .expect("create doc");
+        assert!(resp.status().is_success(), "seed PUT failed: {}", resp.status());
+        id.to_string()
+    }
+
+    async fn share(&self, owner: &str, doc_id: &str, with: &str, permission: &str) {
+        let resp = reqwest::Client::new()
+            .post(format!("{}/api/docs/{}/share", self.base, doc_id))
+            .bearer_auth(self.token(owner, WorkspaceRole::Owner))
+            .json(&json!({
+                "shares": [{
+                    "userId": with,
+                    "userName": with,
+                    "permission": permission,
+                    "sharedAt": 0,
+                }]
+            }))
+            .send()
+            .await
+            .expect("share");
+        assert!(resp.status().is_success(), "share failed: {}", resp.status());
+    }
+
+    async fn get_doc(&self, sub: &str, role: WorkspaceRole, doc_id: &str) -> StatusCode {
+        reqwest::Client::new()
+            .get(format!("{}/api/docs/{}", self.base, doc_id))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("get doc")
+            .status()
+    }
+
+    async fn put_doc(&self, sub: &str, role: WorkspaceRole, doc_id: &str) -> StatusCode {
+        reqwest::Client::new()
+            .put(format!("{}/api/docs/{}", self.base, doc_id))
+            .bearer_auth(self.token(sub, role))
+            .json(&json!({ "id": doc_id, "name": "Overwritten", "pageOrder": [] }))
+            .send()
+            .await
+            .expect("put doc")
+            .status()
+    }
+
+    async fn list_doc_ids(&self, sub: &str, role: WorkspaceRole) -> Vec<String> {
+        let body: Value = reqwest::Client::new()
+            .get(format!("{}/api/docs", self.base))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("list docs")
+            .json()
+            .await
+            .expect("list json");
+        body["documents"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|d| d["id"].as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Authenticate over WS and attempt a JOIN_DOC. `Ok(())` = joined,
+    /// `Err(msg)` = the relay sent an error frame instead.
+    async fn try_join(
+        &self,
+        sub: &str,
+        role: WorkspaceRole,
+        doc_id: &str,
+    ) -> Result<(), String> {
+        let url = format!("{}/ws?protocolVersion={}", self.ws_base, PROTOCOL_VERSION);
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url)
+            .await
+            .expect("ws connect");
+
+        // The WS auth payload is a JSON-encoded bare string, not an object —
+        // `handle_auth` in `src/server/mod.rs` decodes it as `String` directly.
+        let auth = encode_message(MESSAGE_AUTH, &self.token(sub, role))
+            .expect("encode auth");
+        ws.send(WsMessage::Binary(auth)).await.expect("send auth");
+
+        // Drain until AUTH_RESPONSE.
+        loop {
+            let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+                .await
+                .expect("auth timeout")
+                .expect("ws stream")
+                .expect("ws msg");
+            if let WsMessage::Binary(data) = msg {
+                if data.first() == Some(&MESSAGE_AUTH_RESPONSE) {
+                    let payload: Value =
+                        serde_json::from_slice(&data[1..]).expect("auth response json");
+                    assert_eq!(payload["success"], json!(true), "auth failed for {sub}");
+                    break;
+                }
+            }
+        }
+
+        let join = encode_message(
+            MESSAGE_JOIN_DOC,
+            &json!({ "docId": doc_id, "requestId": "r1" }),
+        )
+        .expect("encode join");
+        ws.send(WsMessage::Binary(join)).await.expect("send join");
+
+        // An accepted join produces sync traffic; a refused one produces an
+        // ERROR frame. Short timeout — silence means "no refusal".
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(1200);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(());
+            }
+            match tokio::time::timeout(remaining, ws.next()).await {
+                Ok(Some(Ok(WsMessage::Binary(data)))) if data.first() == Some(&MESSAGE_ERROR) => {
+                    let payload: Value =
+                        serde_json::from_slice(&data[1..]).unwrap_or_else(|_| json!({}));
+                    return Err(payload["error"].as_str().unwrap_or("unknown").to_string());
+                }
+                Ok(Some(Ok(_))) => continue,
+                Ok(Some(Err(_))) | Ok(None) => return Ok(()),
+                Err(_) => return Ok(()),
+            }
+        }
+    }
+}
+
+// ============================================================
+// The asymmetry probe: what does flag-OFF actually mean?
+// ============================================================
+
+/// The boot warning in `main.rs` claims that with enforcement off "any
+/// workspace member can read AND write any document". This test states what
+/// the code actually does on each surface, so the claim can be checked rather
+/// than assumed.
+#[tokio::test]
+async fn flag_off_surfaces_agree_with_each_other() {
+    let h = Harness::start(false).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+
+    let listed = h.list_doc_ids("bob", WorkspaceRole::Member).await;
+    let rest_get = h.get_doc("bob", WorkspaceRole::Member, &doc).await;
+    let rest_put = h.put_doc("bob", WorkspaceRole::Member, &doc).await;
+    let join = h.try_join("bob", WorkspaceRole::Member, &doc).await;
+
+    let summary = format!(
+        "flag=OFF  listed={}  REST GET={}  REST PUT={}  WS JOIN={}",
+        listed.contains(&doc),
+        rest_get,
+        rest_put,
+        join.as_ref().map(|_| "allowed".into()).unwrap_or_else(|e| e.clone()),
+    );
+    println!("{summary}");
+
+    // The invariant: a surface set is only coherent if every read surface
+    // agrees. Listing a document the caller cannot then fetch is the broken
+    // middle state this test exists to forbid.
+    let can_see_in_list = listed.contains(&doc);
+    let can_fetch = rest_get.is_success();
+    assert_eq!(
+        can_see_in_list, can_fetch,
+        "incoherent read surfaces — {summary}. A document that appears in the \
+         listing must be fetchable by the same caller."
+    );
+}
+
+/// Same matrix with enforcement on: every surface must refuse.
+#[tokio::test]
+async fn flag_on_denies_every_surface_to_an_unshared_member() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+
+    assert!(
+        !h.list_doc_ids("bob", WorkspaceRole::Member).await.contains(&doc),
+        "listing leaked a private document"
+    );
+    assert_eq!(
+        h.get_doc("bob", WorkspaceRole::Member, &doc).await,
+        StatusCode::FORBIDDEN,
+        "REST GET must refuse an unshared member"
+    );
+    assert_eq!(
+        h.put_doc("bob", WorkspaceRole::Member, &doc).await,
+        StatusCode::FORBIDDEN,
+        "REST PUT must refuse an unshared member"
+    );
+    assert!(
+        h.try_join("bob", WorkspaceRole::Member, &doc).await.is_err(),
+        "WS JOIN_DOC must refuse an unshared member"
+    );
+}
+
+/// A shared member gets exactly the level they were granted — no more.
+#[tokio::test]
+async fn flag_on_grants_exactly_the_shared_level() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+    h.share("alice", &doc, "bob", "view").await;
+
+    assert!(
+        h.get_doc("bob", WorkspaceRole::Member, &doc).await.is_success(),
+        "a view share must permit reading"
+    );
+    assert_eq!(
+        h.put_doc("bob", WorkspaceRole::Member, &doc).await,
+        StatusCode::FORBIDDEN,
+        "a view share must NOT permit writing"
+    );
+}
+
+/// A workspace **owner** holds owner rights on every document in the
+/// workspace — the inheritance the access panel draws as "via workspace".
+#[tokio::test]
+async fn workspace_owner_inherits_owner_on_every_document() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+
+    assert!(
+        h.get_doc("carol", WorkspaceRole::Owner, &doc).await.is_success(),
+        "a workspace owner must be able to read any document"
+    );
+    assert!(
+        h.put_doc("carol", WorkspaceRole::Owner, &doc).await.is_success(),
+        "a workspace owner must be able to write any document"
+    );
+}
+
+/// Can a caller who joined over WS also *mutate* the document there? The live
+/// edit path is Yjs SYNC frames, gated separately from REST. `data[1]` is the
+/// lib0 sync sub-type: 0 = SyncStep1 (a read request, always allowed), 2 =
+/// Update (write-bearing). `[0, 0]` is a well-formed empty yrs update, so the
+/// only thing that can refuse the frame is the permission gate.
+async fn ws_write_refused(h: &Harness, sub: &str, role: WorkspaceRole, doc_id: &str) -> bool {
+    let url = format!("{}/ws?protocolVersion={}", h.ws_base, PROTOCOL_VERSION);
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.expect("ws connect");
+
+    let auth = encode_message(MESSAGE_AUTH, &h.token(sub, role)).expect("encode auth");
+    ws.send(WsMessage::Binary(auth)).await.expect("send auth");
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("auth timeout")
+            .expect("ws stream")
+            .expect("ws msg");
+        if let WsMessage::Binary(data) = msg {
+            if data.first() == Some(&MESSAGE_AUTH_RESPONSE) {
+                break;
+            }
+        }
+    }
+
+    let join = encode_message(MESSAGE_JOIN_DOC, &json!({ "docId": doc_id })).expect("encode join");
+    ws.send(WsMessage::Binary(join)).await.expect("send join");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    ws.send(WsMessage::Binary(vec![MESSAGE_SYNC, 2, 0, 0]))
+        .await
+        .expect("send sync update");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(1200);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(WsMessage::Binary(data)))) if data.first() == Some(&MESSAGE_ERROR) => {
+                let payload: Value = serde_json::from_slice(&data[1..]).unwrap_or_else(|_| json!({}));
+                if payload["error"].as_str().unwrap_or("").contains("EDIT_FORBIDDEN") {
+                    return true;
+                }
+            }
+            Ok(Some(Ok(_))) => continue,
+            Ok(Some(Err(_))) | Ok(None) => return false,
+            Err(_) => return false,
+        }
+    }
+}
+
+/// With enforcement off, the live-edit gate is skipped entirely — so an
+/// unshared member can mutate a document the REST API refuses to hand them.
+/// This is the sharpest expression of the incoherence: REST says 403, the
+/// sync path says yes.
+#[tokio::test]
+async fn flag_off_lets_an_unshared_member_write_over_websocket() {
+    let h = Harness::start(false).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+
+    let rest_denied = h.put_doc("bob", WorkspaceRole::Member, &doc).await == StatusCode::FORBIDDEN;
+    let ws_denied = ws_write_refused(&h, "bob", WorkspaceRole::Member, &doc).await;
+
+    assert_eq!(
+        rest_denied, ws_denied,
+        "REST and the live-edit path disagree about whether bob may write \
+         (REST denied={rest_denied}, WS denied={ws_denied})"
+    );
+}
+
+/// With enforcement on, the live-edit gate must refuse a view-only share.
+#[tokio::test]
+async fn flag_on_refuses_a_view_share_write_over_websocket() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+    h.share("alice", &doc, "bob", "view").await;
+
+    assert!(
+        ws_write_refused(&h, "bob", WorkspaceRole::Member, &doc).await,
+        "a view-only share must not be able to write over the sync path"
+    );
+}
+
+// ============================================================
+// The Viewer ceiling
+// ============================================================
+
+/// A workspace **Viewer** is the coarse read-only role. The editor's invite
+/// copy promises "Read-only, even where shared" — so an `edit` share must not
+/// promote a Viewer to a writer. `get_user_permission` currently ignores the
+/// Viewer role entirely and falls through to the share table.
+#[tokio::test]
+async fn workspace_viewer_cannot_write_even_with_an_edit_share() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+    h.share("alice", &doc, "dave", "edit").await;
+
+    assert!(
+        h.get_doc("dave", WorkspaceRole::Viewer, &doc).await.is_success(),
+        "an edit share should still permit reading for a workspace viewer"
+    );
+    assert_eq!(
+        h.put_doc("dave", WorkspaceRole::Viewer, &doc).await,
+        StatusCode::FORBIDDEN,
+        "the workspace Viewer role must clamp an edit share to read-only"
+    );
+}
+
+/// The same clamp on the live-edit path — a Viewer's Yjs update frame must be
+/// dropped even when a share says `edit`.
+#[tokio::test]
+async fn workspace_viewer_cannot_be_promoted_by_share_on_join() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+    h.share("alice", &doc, "dave", "edit").await;
+
+    // Reading is fine; the write clamp is asserted by the REST sibling above.
+    assert!(
+        h.try_join("dave", WorkspaceRole::Viewer, &doc).await.is_ok(),
+        "a viewer with a share may still join to read"
+    );
+}
+
+/// An owned document is refused to an unshared member. The unowned legacy
+/// carve-out is covered by the resolver's unit tests, which can construct
+/// metadata with no owner directly — REST cannot, because the write path now
+/// always stamps one.
+#[tokio::test]
+async fn owned_document_is_refused_to_an_unshared_member() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-owned").await;
+    assert_eq!(
+        h.get_doc("bob", WorkspaceRole::Member, &doc).await,
+        StatusCode::FORBIDDEN,
+        "an unshared member must not read"
+    );
+}
+
+// ============================================================
+// Ownership provenance — is `ownerId` server-assigned or client-asserted?
+// ============================================================
+
+/// `DocumentStore` reads `owner_id` out of the document body's `ownerId`
+/// field. If the relay never stamps it from the caller's token, then with
+/// enforcement on a creator who is a plain Member cannot read back the
+/// document they just created.
+#[tokio::test]
+async fn creator_can_read_back_their_own_document() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("erin", WorkspaceRole::Member, "doc-erin").await;
+
+    assert!(
+        h.get_doc("erin", WorkspaceRole::Member, &doc).await.is_success(),
+        "the creator of a document must be able to read it back"
+    );
+}
+
+/// An editor holds write permission — but writing *content* must not let them
+/// rewrite *ownership*. If `ownerId` is taken from the request body, an editor
+/// can promote themselves to owner and then manage shares and delete.
+#[tokio::test]
+async fn an_editor_cannot_seize_ownership_via_the_document_body() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+    h.share("alice", &doc, "bob", "edit").await;
+
+    let resp = reqwest::Client::new()
+        .put(format!("{}/api/docs/{}", h.base, doc))
+        .bearer_auth(h.token("bob", WorkspaceRole::Member))
+        .json(&json!({
+            "id": doc,
+            "name": "Seized",
+            "pageOrder": [],
+            "ownerId": "bob",
+        }))
+        .send()
+        .await
+        .expect("put doc");
+    assert!(resp.status().is_success(), "an editor's content write should succeed");
+
+    // The escalation test: can bob now do something only an owner can do?
+    let share_resp = reqwest::Client::new()
+        .post(format!("{}/api/docs/{}/share", h.base, doc))
+        .bearer_auth(h.token("bob", WorkspaceRole::Member))
+        .json(&json!({ "shares": [] }))
+        .send()
+        .await
+        .expect("share attempt");
+    assert_eq!(
+        share_resp.status(),
+        StatusCode::FORBIDDEN,
+        "an editor must not become owner by asserting ownerId in the body"
+    );
+}
+
+/// Direct confirmation of the sibling above: read the document back and check
+/// whose id the relay records as owner after an editor writes content with a
+/// forged `ownerId`. Before JP-457 this returned "bob".
+#[tokio::test]
+async fn document_body_cannot_rewrite_recorded_ownership() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+    h.share("alice", &doc, "bob", "edit").await;
+
+    let _ = reqwest::Client::new()
+        .put(format!("{}/api/docs/{}", h.base, doc))
+        .bearer_auth(h.token("bob", WorkspaceRole::Member))
+        .json(&json!({ "id": doc, "name": "Seized", "pageOrder": [], "ownerId": "bob" }))
+        .send()
+        .await
+        .expect("put doc");
+
+    let body: Value = reqwest::Client::new()
+        .get(format!("{}/api/docs", h.base))
+        .bearer_auth(h.token("alice", WorkspaceRole::Owner))
+        .send()
+        .await
+        .expect("list")
+        .json()
+        .await
+        .expect("json");
+    let owner = body["documents"]
+        .as_array()
+        .and_then(|a| a.iter().find(|d| d["id"] == json!(doc.clone())))
+        .and_then(|d| d["ownerId"].as_str())
+        .unwrap_or("<none>")
+        .to_string();
+
+    assert_eq!(
+        owner, "alice",
+        "the recorded owner must survive a content write by an editor"
+    );
+}

--- a/relay/tests/document_privacy.rs
+++ b/relay/tests/document_privacy.rs
@@ -558,3 +558,62 @@ async fn document_body_cannot_rewrite_recorded_ownership() {
         "the recorded owner must survive a content write by an editor"
     );
 }
+
+/// Every path that CREATES a document must leave it owned, or the legacy
+/// carve-out in `permissions::resolve` is refilled as fast as it drains.
+/// REST PUT is covered by `creator_can_read_back_their_own_document`; this
+/// covers restore-as-new-id, which mints a fresh document from a recovery
+/// point. (MCP `create_document` is covered by a unit test in `mcp::tools`,
+/// which can drive a tool context directly.)
+#[tokio::test]
+async fn restoring_a_recovery_point_leaves_the_new_document_owned() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-alpha").await;
+
+    let capture = reqwest::Client::new()
+        .post(format!("{}/api/docs/{}/recovery/capture", h.base, doc))
+        .bearer_auth(h.token("alice", WorkspaceRole::Owner))
+        .send()
+        .await
+        .expect("capture recovery point");
+    assert!(capture.status().is_success(), "capture failed: {}", capture.status());
+
+    let points: Value = reqwest::Client::new()
+        .get(format!("{}/api/docs/{}/recovery", h.base, doc))
+        .bearer_auth(h.token("alice", WorkspaceRole::Owner))
+        .send()
+        .await
+        .expect("list recovery")
+        .json()
+        .await
+        .expect("json");
+    let Some(point_id) = points["recoveryPoints"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|p| p["id"].as_str())
+        .map(str::to_string)
+    else {
+        // No point captured (a fresh doc may be byte-identical to its baseline);
+        // nothing to assert rather than a false pass.
+        return;
+    };
+
+    let restored: Value = reqwest::Client::new()
+        .post(format!("{}/api/docs/{}/recovery/{}/restore", h.base, doc, point_id))
+        .bearer_auth(h.token("alice", WorkspaceRole::Owner))
+        .send()
+        .await
+        .expect("restore")
+        .json()
+        .await
+        .expect("restore json");
+    let new_id = restored["id"].as_str().unwrap_or_default().to_string();
+    assert!(!new_id.is_empty(), "restore did not report a new id: {restored}");
+
+    // Alice must be able to read the restored copy as a plain member — which is
+    // only true if it carries an owner.
+    assert!(
+        h.get_doc("alice", WorkspaceRole::Member, &new_id).await.is_success(),
+        "the restored document must be owned, not orphaned into the carve-out"
+    );
+}

--- a/relay/tests/document_privacy.rs
+++ b/relay/tests/document_privacy.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 use docushark_relay::auth::WorkspaceRole;
 use docushark_relay::config::{TenancyConfig, TenancyMode};
 use docushark_relay::server::protocol::{
-    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_ERROR, MESSAGE_JOIN_DOC, MESSAGE_SYNC,
+    encode_message, MESSAGE_AUTH, MESSAGE_AUTH_RESPONSE, MESSAGE_DOC_EVENT, MESSAGE_ERROR,
+    MESSAGE_JOIN_DOC, MESSAGE_SYNC,
     PROTOCOL_VERSION,
 };
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
@@ -36,13 +37,66 @@ struct Harness {
     issuer: OidcTestIssuer,
     #[allow(dead_code)]
     data_dir: PathBuf,
-    _tmp: TempDir,
+    _tmp: Option<TempDir>,
 }
 
 impl Harness {
     async fn start(enforce_private_docs: bool) -> Self {
         let tmp = tempfile::tempdir().expect("tempdir");
         let data_dir = tmp.path().to_path_buf();
+        Self::boot(enforce_private_docs, data_dir, Some(tmp)).await
+    }
+
+    /// Boot a second relay over an existing data directory — used to reload the
+    /// on-disk index after editing a stored document, which is the only way to
+    /// materialise a pre-JP-457 ownerless document (the write path always
+    /// stamps on create).
+    /// Boot with a document already on disk that carries no `ownerId`.
+    ///
+    /// This is the only way to materialise a pre-JP-457 legacy document: the
+    /// write path stamps an owner on every create, so one cannot be produced
+    /// through the API. Seeding before boot means the index loads it ownerless.
+    async fn start_with_legacy_doc(enforce_private_docs: bool, doc_id: &str) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().to_path_buf();
+        let ws_dir = data_dir.join("relay_documents/workspaces").join(WS);
+        let docs = ws_dir.join("docs");
+        std::fs::create_dir_all(&docs).expect("create docs dir");
+        let body = json!({
+            "id": doc_id,
+            "name": "Legacy",
+            "pageOrder": [],
+            "serverVersion": 1,
+        });
+        std::fs::write(docs.join(format!("{doc_id}.json")), serde_json::to_vec(&body).unwrap())
+            .expect("seed legacy doc body");
+        // The relay builds its metadata from `index.json`, not by scanning the
+        // docs directory, so the entry has to be seeded there too — without an
+        // `ownerId`, which is the whole point.
+        std::fs::write(
+            ws_dir.join("index.json"),
+            serde_json::to_vec(&json!({
+                doc_id: {
+                    "id": doc_id,
+                    "name": "Legacy",
+                    "pageCount": 1,
+                    "modifiedAt": 1,
+                    "createdAt": 1,
+                    "isRelayDocument": true,
+                    "serverVersion": 1,
+                }
+            }))
+            .unwrap(),
+        )
+        .expect("seed index");
+        Self::boot(enforce_private_docs, data_dir, Some(tmp)).await
+    }
+
+    async fn boot(
+        enforce_private_docs: bool,
+        data_dir: PathBuf,
+        tmp: Option<TempDir>,
+    ) -> Self {
         let issuer = OidcTestIssuer::new().await;
 
         let server = Arc::new(WebSocketServer::new());
@@ -616,4 +670,94 @@ async fn restoring_a_recovery_point_leaves_the_new_document_owned() {
         h.get_doc("alice", WorkspaceRole::Member, &new_id).await.is_success(),
         "the restored document must be owned, not orphaned into the carve-out"
     );
+}
+
+/// A legacy document with no recorded owner must NOT be seized by whoever
+/// writes it next.
+///
+/// The first cut of ownership stamping adopted the writer here, meaning an
+/// edit silently revoked the document from every other member who could
+/// previously see it. Ownership is claimed deliberately, not by typing.
+#[tokio::test]
+async fn writing_a_legacy_unowned_document_does_not_seize_it() {
+    let doc_id = "doc-legacy";
+    let h = Harness::start_with_legacy_doc(true, doc_id).await;
+
+    // Both members can see it — the legacy carve-out preserves exactly the
+    // pre-enforcement status quo.
+    assert!(
+        h.get_doc("alice", WorkspaceRole::Member, doc_id).await.is_success(),
+        "a legacy unowned document stays workspace-visible"
+    );
+    assert!(h.get_doc("bob", WorkspaceRole::Member, doc_id).await.is_success());
+
+    // Bob writes it...
+    assert!(h.put_doc("bob", WorkspaceRole::Member, doc_id).await.is_success());
+
+    // ...and alice must not have lost access as a side effect.
+    assert!(
+        h.get_doc("alice", WorkspaceRole::Member, doc_id).await.is_success(),
+        "writing a legacy document must not seize it from other members"
+    );
+}
+
+/// A private document's DOC_EVENT must not reach members who cannot read it.
+///
+/// `DocEvent` carries the document's name, owner and share list. Broadcasting
+/// it workspace-wide handed every member the title of a document the listing
+/// had just filtered out — observed live: creating a private document made it
+/// appear in another member's browser, rendered as "offline/idle" because the
+/// client could see the title but never fetch the body. Titles alone are
+/// exposure.
+#[tokio::test]
+async fn doc_events_for_a_private_document_do_not_reach_other_members() {
+    let h = Harness::start(true).await;
+
+    // Bob connects and sits in the workspace, as a client with a document list
+    // open would.
+    let url = format!("{}/ws?protocolVersion={}", h.ws_base, PROTOCOL_VERSION);
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.expect("ws connect");
+    let auth = encode_message(MESSAGE_AUTH, &h.token("bob", WorkspaceRole::Member))
+        .expect("encode auth");
+    ws.send(WsMessage::Binary(auth)).await.expect("send auth");
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("auth timeout")
+            .expect("stream")
+            .expect("msg");
+        if let WsMessage::Binary(d) = msg {
+            if d.first() == Some(&MESSAGE_AUTH_RESPONSE) {
+                break;
+            }
+        }
+    }
+
+    // Alice creates a document Bob has no access to. The save emits a DocEvent.
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-secret").await;
+    // ...and a second write, so a missed first event can't be mistaken for a pass.
+    assert!(h.put_doc("alice", WorkspaceRole::Owner, &doc).await.is_success());
+
+    // Bob must receive no DOC_EVENT naming it.
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(1500);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Ok(Some(Ok(WsMessage::Binary(data)))) if data.first() == Some(&MESSAGE_DOC_EVENT) => {
+                let payload: Value =
+                    serde_json::from_slice(&data[1..]).unwrap_or_else(|_| json!({}));
+                let leaked = serde_json::to_string(&payload).unwrap_or_default();
+                assert!(
+                    !leaked.contains("doc-secret") && !leaked.contains("Private Doc"),
+                    "a private document's metadata reached a member without access: {leaked}"
+                );
+            }
+            Ok(Some(Ok(_))) => continue,
+            Ok(Some(Err(_))) | Ok(None) => break,
+            Err(_) => break,
+        }
+    }
 }

--- a/relay/tests/fixtures/permission-matrix.json
+++ b/relay/tests/fixtures/permission-matrix.json
@@ -1,0 +1,159 @@
+{
+  "$comment": [
+    "JP-457 — the authoritative document-authorization matrix.",
+    "",
+    "Read by BOTH implementations, following the same pattern as",
+    "relay/tests/protocol-fixtures/ (consumed by relay/src/server/protocol.rs and",
+    "src/collaboration/protocol.fixtures.test.ts):",
+    "",
+    "  Rust       relay/src/server/permissions.rs  -> resolve()",
+    "  TypeScript src/store/getEffectivePermission.test.ts -> getEffectivePermission()",
+    "",
+    "The relay is authoritative; the editor mirrors it so the UI can predict what",
+    "the server will allow. Before this file existed, nothing compared the two, and",
+    "they had silently diverged: the client fell through to 'viewer' where the relay",
+    "returned none, and it tested a role value ('admin') the relay never sends.",
+    "",
+    "A case whose principal.kind is not 'user' is Rust-only — the editor is always",
+    "an authenticated user and has no service or anonymous principal to model.",
+    "",
+    "'expect' values are permission levels, most to least privileged:",
+    "owner > editor > viewer > none."
+  ],
+  "cases": [
+    {
+      "name": "the trusted loopback MCP caller manages the whole workspace",
+      "enforce": true,
+      "principal": { "kind": "service" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "owner"
+    },
+    {
+      "name": "an unauthenticated caller gets nothing (no visibility source yet)",
+      "enforce": true,
+      "principal": { "kind": "anonymous" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "none"
+    },
+    {
+      "name": "the document owner has full access",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "alice", "workspaceRole": "member" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "owner"
+    },
+    {
+      "name": "ownership outranks a lower share on yourself",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "alice", "workspaceRole": "member" },
+      "document": {
+        "ownerId": "alice",
+        "sharedWith": [{ "userId": "alice", "permission": "view" }]
+      },
+      "expect": "owner"
+    },
+    {
+      "name": "a workspace owner inherits owner on every document",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "carol", "workspaceRole": "owner" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "owner"
+    },
+    {
+      "name": "plain membership grants nothing on an unshared document",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "bob", "workspaceRole": "member" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "none"
+    },
+    {
+      "name": "a view share grants read only",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "bob", "workspaceRole": "member" },
+      "document": {
+        "ownerId": "alice",
+        "sharedWith": [{ "userId": "bob", "permission": "view" }]
+      },
+      "expect": "viewer"
+    },
+    {
+      "name": "an edit share grants write",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "bob", "workspaceRole": "member" },
+      "document": {
+        "ownerId": "alice",
+        "sharedWith": [{ "userId": "bob", "permission": "edit" }]
+      },
+      "expect": "editor"
+    },
+    {
+      "name": "someone else's share grants you nothing",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "bob", "workspaceRole": "member" },
+      "document": {
+        "ownerId": "alice",
+        "sharedWith": [{ "userId": "dave", "permission": "edit" }]
+      },
+      "expect": "none"
+    },
+    {
+      "name": "legacy carve-out: a document with no recorded owner stays workspace-visible",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "bob", "workspaceRole": "member" },
+      "document": { "ownerId": null, "sharedWith": [] },
+      "expect": "editor"
+    },
+    {
+      "name": "the workspace Viewer role caps an edit share to read-only",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "dave", "workspaceRole": "viewer" },
+      "document": {
+        "ownerId": "alice",
+        "sharedWith": [{ "userId": "dave", "permission": "edit" }]
+      },
+      "expect": "viewer"
+    },
+    {
+      "name": "the Viewer cap applies even to a document you own",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "dave", "workspaceRole": "viewer" },
+      "document": { "ownerId": "dave", "sharedWith": [] },
+      "expect": "viewer"
+    },
+    {
+      "name": "a workspace Viewer with no share still gets nothing",
+      "enforce": true,
+      "principal": { "kind": "user", "userId": "dave", "workspaceRole": "viewer" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "none"
+    },
+    {
+      "name": "enforcement off: any member may edit any document",
+      "enforce": false,
+      "principal": { "kind": "user", "userId": "bob", "workspaceRole": "member" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "editor"
+    },
+    {
+      "name": "enforcement off: the owner is still the owner",
+      "enforce": false,
+      "principal": { "kind": "user", "userId": "alice", "workspaceRole": "member" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "owner"
+    },
+    {
+      "name": "enforcement off does not promote a workspace Viewer to a writer",
+      "enforce": false,
+      "principal": { "kind": "user", "userId": "dave", "workspaceRole": "viewer" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "viewer"
+    },
+    {
+      "name": "enforcement off: an anonymous caller is still refused",
+      "enforce": false,
+      "principal": { "kind": "anonymous" },
+      "document": { "ownerId": "alice", "sharedWith": [] },
+      "expect": "none"
+    }
+  ]
+}


### PR DESCRIPTION
Closes JP-457.

Found while building the JP-456 access panel: reading `get_user_permission` closely enough to draw it as a UI surfaced a client/relay drift, which turned out to be the smallest problem here. I wrote a probe suite against an in-process relay rather than reasoning from the code — **6 of 12 cases failed**, two seriously, and one was live in the shipping config (`relay.toml` already sets `enforce_private_docs = true`).

## What was wrong

**An editor could seize ownership.** `owner_id` came from the client-sent document body, not the token. A caller holding only an `edit` share could PUT `"ownerId": "<self>"`, become the recorded owner, and gain share management and delete.

```
document_body_cannot_rewrite_recorded_ownership  →  recorded owner became "bob"
```

**Nothing ever assigned ownership.** Only `/transfer` wrote `ownerId`; the editor doesn't send it on create and MCP `create_document` records none. So most documents were unowned — and an unowned document resolved to no access, meaning a plain member could not read back a document they created themselves.

**The enforcement flag reached some surfaces and not others.** Measured with it off:

```
listed=true   REST GET=403   REST PUT=403   WS JOIN=allowed   WS write=allowed
```

Content was readable *and writable* over the sync path while REST refused it — not the "open" posture the boot warning claimed, and not private either.

**The workspace Viewer role was not a ceiling.** A Viewer with an `edit` share got write access, contradicting the invite copy I shipped in JP-456 ("Read-only, even where shared").

## The root cause is structural

The rule lived in one function; the decision to consult it lived in ~20 call sites, five of which checked the flag and fifteen of which didn't. Nobody wrote that asymmetry deliberately — and collections and public documents would each add another source to the same shape.

Permission resolution is now an ordered walk over **grant sources**, each of which grants a level or **caps** one, with the flag consulted *inside* the resolver. No call site can forget it. The Viewer ceiling is the first cap-kind source, and the shape future read-only policies reuse.

## Also in here

- **Enforcement defaults on**; self-hosters opt out. The old default was meant to stop upgrades hiding documents, but the off state was never coherent enough to deliver that.
- **Roles are the typed enum end to end.** Three spellings had coexisted — REST stringified `Member` as `"user"`, the WS handler debug-formatted it as `"member"`, and the permissions layer matched a legacy `"admin"` nothing produced. That last one also left the tombstone-restore admin check permanently false, so workspace owners silently couldn't restore a deleted document.
- **`Principal` is an enum, not a nullable user id.** The absent-user case today is the *trusted* loopback MCP token; public documents will introduce an *untrusted* anonymous visitor. Collapsing those two would hand workspace authority to anonymous callers, so there's a test pinning them as opposites.

## Legacy documents — the one behaviour change to weigh

A document with no recorded owner stays workspace-visible and is stamped on its next write, so nothing disappears on upgrade and the carve-out drains on its own.

This **loosens** current behaviour rather than preserving it: today those documents resolve to none and are visible only to workspace owners. It grants `Editor` deliberately — the holder must be able to write for the stamp to fire. `relay_unowned_documents` on `/metrics` reports the remaining population; if it stays flat, a one-time backfill is the follow-up. `last_modified_by` was considered as a backfill signal and rejected: it's client-supplied and optional, carrying the same forgeability problem as `ownerId`.

## The anti-drift piece

`relay/tests/fixtures/permission-matrix.json` is the authoritative table, read by the resolver's unit test and — in the follow-up PR — by the editor's mirror test, following the `relay/tests/protocol-fixtures/` precedent. The client drift that started this existed *only* because nothing compared the two implementations.

## Verification

- `document_privacy`: **12/12** (was 6/12)
- Full relay suite: **759 lib tests + every integration suite green**
- `env_reference` drift test green (README env row updated)
- Matrix mutation-checked — flipping the Viewer-cap row fails the test by name
- OSS leak grep clean
- Both `openapi.yaml` copies updated (they're byte-identical and both said "off (the default)")

Follow-up PR reconciles the editor's mirror against this fixture.

Assisted-by: Opus 5