### PR TITLE
JP-459: resolve people to names, and stop listing documents you can't open

### DIFF
--- a/src/api/relayClient.test.ts
+++ b/src/api/relayClient.test.ts
@@ -247,7 +247,17 @@ describe('RelayClient', () => {
       expect(script.calls[0]?.method).toBe('DELETE');
     });
 
-    it('forbidden response maps to RelayError(403) with isAuthError=true', async () => {
+    /**
+     * JP-459: 403 is a *document* denial, not a *session* failure.
+     *
+     * This previously asserted `isAuthError === true`, folding the two
+     * together. They want opposite responses: 401 means the token is no good
+     * and the caller may re-authenticate; 403 means the token is fine and this
+     * document isn't yours. Treating a per-document denial as a session failure
+     * tears down a working session — the same shape as the JP-396 cold-relay
+     * bug, where a transient 401 stranded a perfectly good sign-in.
+     */
+    it('forbidden response is a resource denial, not a session failure', async () => {
       const client = new RelayClient({ baseUrl: 'http://r', token: 'T', fetchImpl: script.fetch });
       script.pushError(403, 'ERR_VIEW_FORBIDDEN: missing permission');
       try {
@@ -257,8 +267,22 @@ describe('RelayClient', () => {
         expect(err).toBeInstanceOf(RelayError);
         const re = err as RelayError;
         expect(re.status).toBe(403);
-        expect(re.isAuthError).toBe(true);
+        expect(re.isForbidden).toBe(true);
+        expect(re.isAuthError).toBe(false);
         expect(re.message).toContain('ERR_VIEW_FORBIDDEN');
+      }
+    });
+
+    it('unauthorized response is a session failure, not a resource denial', async () => {
+      const client = new RelayClient({ baseUrl: 'http://r', token: 'T', fetchImpl: script.fetch });
+      script.pushError(401, 'token expired');
+      try {
+        await client.getDocument('doc-1');
+        throw new Error('should have thrown');
+      } catch (err) {
+        const re = err as RelayError;
+        expect(re.isAuthError).toBe(true);
+        expect(re.isForbidden).toBe(false);
       }
     });
   });

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -54,9 +54,24 @@ export class RelayError extends Error {
     this.name = 'RelayError';
   }
 
-  /** True for 4xx auth failures — caller may want to re-login. */
+  /**
+   * True when the *session* is the problem (401) — the caller may want to
+   * re-authenticate.
+   *
+   * JP-459: 403 was folded in here and is deliberately no longer. The two mean
+   * different things and want opposite responses: 401 says "this token is no
+   * good", 403 says "this token is fine, this *document* isn't yours". Treating
+   * a per-document denial as a session failure tears down a working session —
+   * the same shape as the JP-396 cold-relay bug, where a transient 401 stranded
+   * a perfectly good sign-in.
+   */
   get isAuthError(): boolean {
-    return this.status === 401 || this.status === 403;
+    return this.status === 401;
+  }
+
+  /** True when this specific resource is denied, but the session is valid. */
+  get isForbidden(): boolean {
+    return this.status === 403;
   }
 }
 

--- a/src/services/DocumentTransferService.ts
+++ b/src/services/DocumentTransferService.ts
@@ -391,10 +391,18 @@ export class DocumentTransferService {
         ownerId: currentUser.id,
         lastModifiedBy: currentUser.id,
       } : {}),
-      ...(currentUser?.displayName !== undefined ? {
-        ownerName: currentUser.displayName,
-        lastModifiedByName: currentUser.displayName,
-      } : {}),
+      // JP-459: only record a name that is actually a name. `currentUser.
+      // displayName` falls back to `username`, which the relay sets to the
+      // account id (OIDC tokens carry no username) — so this used to stamp a
+      // UUID into `ownerName` and every surface dutifully displayed it. Names
+      // are resolved from the workspace directory at display time; storing a
+      // wrong one is worse than storing none.
+      ...(currentUser?.displayName && currentUser.displayName !== currentUser.id
+        ? {
+            ownerName: currentUser.displayName,
+            lastModifiedByName: currentUser.displayName,
+          }
+        : {}),
     };
     // Promoting to a workspace clears local collection membership (JP-366) — never
     // carry a local `collectionId` onto the relay body, where it would dangle

--- a/src/store/deniedDocument.test.ts
+++ b/src/store/deniedDocument.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Denied documents leave the browser — but never take unsynced work with them
+ * (JP-459).
+ *
+ * Observed live: a document the relay refuses stayed in the list rendered as
+ * "offline / idle". That is wrong twice over — it can never load, so it isn't
+ * offline, and its title is on screen for someone with no access to it.
+ *
+ * The dangerous half of the fix is the cache purge. A share can be revoked while
+ * the holder is offline with edits still queued, and a blind purge would delete
+ * them silently. Losing access to the server's copy is not permission to destroy
+ * the user's own writing, so the purge is gated on there being nothing pending.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  hasPendingChanges: vi.fn(() => false),
+  cacheRemove: vi.fn(async () => {}),
+  removeDocument: vi.fn(),
+  notifyError: vi.fn(),
+  getDocument: vi.fn(),
+  registerRemote: vi.fn(),
+}));
+
+vi.mock('../storage/RelayDocumentCache', () => ({
+  RelayDocumentCache: {
+    get: vi.fn(async () => null),
+    put: vi.fn(async () => {}),
+    remove: h.cacheRemove,
+    has: vi.fn(() => false),
+    getCachedIds: vi.fn(() => [] as string[]),
+    getCachedIdsForHost: vi.fn(() => [] as string[]),
+  },
+}));
+vi.mock('../collaboration/SyncStateManager', () => ({
+  getSyncStateManager: () => ({ hasPendingChanges: h.hasPendingChanges }),
+}));
+vi.mock('./documentRegistry', () => ({
+  useDocumentRegistry: Object.assign(
+    (sel: (s: unknown) => unknown) => sel({ removeDocument: h.removeDocument }),
+    {
+      getState: () => ({
+        removeDocument: h.removeDocument,
+        setDocumentLoading: vi.fn(),
+        setDocumentContent: vi.fn(),
+        getDocumentContent: () => null,
+        registerRemote: h.registerRemote,
+      }),
+    },
+  ),
+}));
+vi.mock('./notificationStore', () => ({
+  useNotificationStore: {
+    getState: () => ({ error: h.notifyError, success: vi.fn(), info: vi.fn() }),
+  },
+}));
+
+import { RelayError } from '../api/relayClient';
+import {
+  useRelayDocumentStore,
+  RelayDocumentAccessRevokedError,
+} from './relayDocumentStore';
+
+const DOC = 'doc-revoked';
+
+function forbidden(): RelayError {
+  return new RelayError(403, `/api/docs/${DOC}`, 'ERR_VIEW_FORBIDDEN');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.hasPendingChanges.mockReturnValue(false);
+  // A provider that refuses this document, and an online-looking connection so
+  // the load actually attempts the network rather than short-circuiting.
+  useRelayDocumentStore.setState({
+    documentCache: {},
+    relayDocuments: {},
+    loadingDocs: new Set(),
+  });
+  useRelayDocumentStore.getState().setProvider({
+    listDocuments: vi.fn(async () => []),
+    getDocument: h.getDocument,
+    saveDocument: vi.fn(),
+    deleteDocument: vi.fn(),
+  } as never);
+  h.getDocument.mockRejectedValue(forbidden());
+});
+
+describe('a 403 on open', () => {
+  it('reports revoked access rather than a generic failure', async () => {
+    await expect(useRelayDocumentStore.getState().loadRelayDocument(DOC)).rejects.toBeInstanceOf(
+      RelayDocumentAccessRevokedError,
+    );
+  });
+
+  it('removes the document from the registry so it stops being listed', async () => {
+    await useRelayDocumentStore.getState().loadRelayDocument(DOC).catch(() => {});
+    expect(h.removeDocument).toHaveBeenCalledWith(DOC);
+  });
+
+  it('purges the offline copy when there is nothing unsynced', async () => {
+    await useRelayDocumentStore.getState().loadRelayDocument(DOC).catch(() => {});
+    expect(h.cacheRemove).toHaveBeenCalled();
+  });
+
+  it('KEEPS the offline copy when there are pending edits', async () => {
+    // The load-bearing case. A revoked share must not delete work the user has
+    // written but not yet synced.
+    h.hasPendingChanges.mockReturnValue(true);
+    await useRelayDocumentStore.getState().loadRelayDocument(DOC).catch(() => {});
+
+    expect(h.cacheRemove).not.toHaveBeenCalled();
+    expect(h.notifyError).toHaveBeenCalledWith(expect.stringContaining('unsaved changes'));
+  });
+});

--- a/src/store/documentRegistry.test.ts
+++ b/src/store/documentRegistry.test.ts
@@ -294,3 +294,30 @@ describe('useActiveDocReadOnly (JP-370)', () => {
     }
   });
 });
+
+describe('registerRemote refuses documents the caller cannot open (JP-459)', () => {
+  const RELAY = 'relay-denied:9876';
+
+  beforeEach(() => {
+    clearRememberedWorkspaceId();
+    useDocumentRegistry.setState({ entries: {}, activeDocumentId: null });
+  });
+
+  it('does not admit a record whose permission is none', () => {
+    // Observed live: a document the relay denies rendered in the browser as
+    // "offline / idle" — a row that can never load, whose title is itself
+    // exposure to someone with no access to it.
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('denied', 'Someone Else’s Plan'), RELAY, 'none', 'synced');
+    expect(useDocumentRegistry.getState().entries['denied']).toBeUndefined();
+  });
+
+  it('still admits every level that grants access', () => {
+    const r = useDocumentRegistry.getState();
+    r.registerRemote(meta('a', 'A'), RELAY, 'viewer', 'synced');
+    r.registerRemote(meta('b', 'B'), RELAY, 'editor', 'synced');
+    r.registerRemote(meta('c', 'C'), RELAY, 'owner', 'synced');
+    const { entries } = useDocumentRegistry.getState();
+    expect(Object.keys(entries).sort()).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -292,6 +292,17 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
       },
 
       registerRemote: (metadata, relayId, permission, syncState = 'synced') => {
+        // JP-459: a document the caller holds no grant on must not enter the
+        // registry at all. It would render as an offline/idle row that can never
+        // load, and its title alone is exposure.
+        //
+        // This is safe only because `getEffectivePermission` never returns
+        // 'none' when identity hasn't loaded yet — it falls back to a viewer /
+        // editor floor, because the document list arrives over REST before the
+        // WebSocket auth populates `currentUser`. If that floor ever became
+        // 'none', this guard would silently empty the browser on every boot;
+        // `getEffectivePermission.test.ts` pins the invariant.
+        if (permission === 'none') return;
         set((state) => {
           const originRelayId = resolveOriginRelayId(state.entries[metadata.id], metadata.id, relayId);
           // JP-370: stamp the active workspace so the browser can scope the list

--- a/src/store/getEffectivePermission.test.ts
+++ b/src/store/getEffectivePermission.test.ts
@@ -176,3 +176,30 @@ describe('getEffectivePermission — client-specific behaviour', () => {
     });
   });
 });
+
+describe('the identity floor is load-bearing for the registry guard', () => {
+  // `registerRemote` (src/store/documentRegistry.ts) refuses any record whose
+  // permission is 'none', so a document the caller can't open never enters the
+  // browser. That guard is only safe because this function never returns 'none'
+  // while identity is still loading — the document list arrives over REST before
+  // the WebSocket auth populates `currentUser`.
+  //
+  // If the floor below ever became 'none', every boot would silently empty the
+  // user's document list, and nothing else in the suite would notice. This test
+  // is the tripwire; read it before changing the `!userId` branch.
+  it('never yields none while identity is unloaded, whatever the document', () => {
+    const cases: Array<Partial<DocumentMetadata>> = [
+      { ownerId: 'someone-else' },
+      {}, // unowned legacy document
+      { ownerId: 'someone-else', sharedWith: [] } as Partial<DocumentMetadata>,
+      {
+        ownerId: 'someone-else',
+        sharedWith: [{ userId: 'unrelated', userName: 'U', permission: 'view' }],
+      } as Partial<DocumentMetadata>,
+    ];
+    for (const over of cases) {
+      expect(getEffectivePermission(meta(over), undefined, undefined)).not.toBe('none');
+      expect(getEffectivePermission(meta(over), undefined, 'member')).not.toBe('none');
+    }
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -38,6 +38,7 @@ import { useNotificationStore } from './notificationStore';
 import { useTrashStore } from './trashStore';
 import type { TrashOrigin } from '../storage/TrashStorage';
 import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
+import { RelayError } from '../api/relayClient';
 import type { RelayCollectionDef, RelayRecoveryPoint, RelayUsage } from '../api/relayClient';
 import { useUploadStatusStore } from './uploadStatusStore';
 
@@ -191,6 +192,54 @@ export class RelayDocumentUnavailableOfflineError extends Error {
     super('Document is not available offline');
     this.name = 'RelayDocumentUnavailableOfflineError';
   }
+}
+
+/**
+ * Thrown when the relay refuses a document the caller used to be able to open
+ * (JP-459) — a share revoked, or ownership transferred away. Distinct from the
+ * offline error because the remedy is different: waiting won't help, and the
+ * document has been removed from the browser rather than left looking stale.
+ */
+export class RelayDocumentAccessRevokedError extends Error {
+  constructor(public readonly docId: string) {
+    super('You no longer have access to this document');
+    this.name = 'RelayDocumentAccessRevokedError';
+  }
+}
+
+/**
+ * Forget a document the relay now denies: drop it from the registry so it stops
+ * being listed, and drop its offline copy so a stale snapshot can't resurrect
+ * the title on the next boot.
+ *
+ * **Unsynced work is never destroyed.** A share can be revoked while the holder
+ * is offline with edits still queued, and purging the cache would silently take
+ * those with it — the one outcome that is worse than a stale row. When there are
+ * pending changes the bytes stay put and the caller is told; losing access to
+ * the server's copy is not permission to delete the user's own writing.
+ */
+async function forgetDeniedDocument(docId: string): Promise<void> {
+  const registry = useDocumentRegistry.getState();
+  const hasUnsynced = getSyncStateManager().hasPendingChanges(docId);
+
+  registry.removeDocument(docId);
+  useRelayDocumentStore.setState((state) => {
+    const { [docId]: _dropped, ...documentCache } = state.documentCache;
+    const { [docId]: _meta, ...relayDocuments } = state.relayDocuments;
+    return { documentCache, relayDocuments };
+  });
+
+  if (hasUnsynced) {
+    useNotificationStore
+      .getState()
+      .error(
+        'Access to a document was revoked, but it has unsaved changes — its offline copy has been kept.',
+      );
+    return;
+  }
+  await RelayDocumentCache.remove(activeWorkspaceId(), docId).catch(() => {
+    /* best-effort: the registry removal is what stops it being listed */
+  });
 }
 
 export interface DocumentProvider {
@@ -464,6 +513,16 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
           registry.registerRemote(doc, relayId, permission, 'synced');
         }
 
+        // JP-459: the rows we just registered carry account ids where a person's
+        // name belongs, so warm the workspace directory that resolves them.
+        // Lazy + fire-and-forget: names are decoration, and a listing must never
+        // wait on (or fail because of) the control plane.
+        void import('./workspaceDirectoryStore')
+          .then((m) => m.useWorkspaceDirectory.getState().ensureLoaded())
+          .catch(() => {
+            /* self-host / offline — names fall back, the list still renders */
+          });
+
         // JP-159: reconcile this workspace's collection definitions + per-doc
         // membership into the client store. Lazy import breaks the module cycle
         // (collectionSync imports this store); best-effort — never fails the list.
@@ -624,6 +683,16 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
             error: e instanceof Error ? e.message : 'Failed to load document',
           };
         });
+
+        // JP-459: a 403 is not a transient failure — access to this document is
+        // gone. Leaving the entry made it render as an offline/idle document
+        // that could never load, which both misdescribes the state and leaves
+        // the title on screen; a title is itself exposure.
+        if (e instanceof RelayError && e.isForbidden) {
+          await forgetDeniedDocument(docId);
+          throw new RelayDocumentAccessRevokedError(docId);
+        }
+
         registry.setDocumentLoading(docId, false, e instanceof Error ? e.message : 'Failed to load');
         throw e;
       }

--- a/src/store/workspaceDirectoryStore.test.ts
+++ b/src/store/workspaceDirectoryStore.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Workspace directory (JP-459).
+ *
+ * The claims worth pinning are the ones that were wrong before this existed:
+ * a user id must never reach a reader as a label, and the fetch that turns ids
+ * into people must not stampede or go stale across a workspace switch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WorkspaceMember } from '../api/webClient';
+
+const h = vi.hoisted(() => ({
+  getWorkspaceMembers: vi.fn(),
+  workspaceId: 'ws-1',
+}));
+
+vi.mock('../api/webClient', () => ({
+  webClient: { getWorkspaceMembers: h.getWorkspaceMembers },
+}));
+vi.mock('./activeWorkspace', () => ({
+  activeWorkspaceId: () => h.workspaceId,
+}));
+
+import {
+  useWorkspaceDirectory,
+  resolvePersonName,
+  UNKNOWN_PERSON,
+} from './workspaceDirectoryStore';
+
+const PRIYA: WorkspaceMember = {
+  userId: 'u-priya',
+  email: 'priya@example.com',
+  displayName: 'Priya Raman',
+  role: 'member',
+};
+const NAMELESS: WorkspaceMember = {
+  userId: 'u-nameless',
+  email: 'someone@example.com',
+  displayName: '',
+  role: 'member',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.workspaceId = 'ws-1';
+  useWorkspaceDirectory.getState().clear();
+  h.getWorkspaceMembers.mockResolvedValue([PRIYA, NAMELESS]);
+});
+
+describe('resolvePersonName', () => {
+  it('never renders a raw account id', async () => {
+    // The bug this whole change exists for: `ownerName` on every pre-JP-459
+    // record IS the account id, so the "fall back to the stored name" path
+    // rendered a UUID. A UUID tells a reader nothing.
+    const id = 'c6df1e26-508b-447e-8fc8-3ac529b58b53';
+    expect(resolvePersonName(id, id)).toBe(UNKNOWN_PERSON);
+  });
+
+  it('prefers the roster display name over whatever the record stored', async () => {
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    expect(resolvePersonName('u-priya', 'u-priya')).toBe('Priya Raman');
+  });
+
+  it('falls back to the roster email when the display name is blank', async () => {
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    expect(resolvePersonName('u-nameless', undefined)).toBe('someone@example.com');
+  });
+
+  it('accepts a stored name that is genuinely a name', () => {
+    // Self-host with no control plane: the record's own string is all we have,
+    // and it is usable precisely because it differs from the id.
+    expect(resolvePersonName('u-x', 'Sam Okafor')).toBe('Sam Okafor');
+  });
+
+  it('is Unknown when there is nothing to go on', () => {
+    expect(resolvePersonName('u-x', undefined)).toBe(UNKNOWN_PERSON);
+    expect(resolvePersonName('u-x', '   ')).toBe(UNKNOWN_PERSON);
+  });
+});
+
+describe('ensureLoaded', () => {
+  it('is single-flight under concurrent callers', async () => {
+    // The document list and the Cloud panel both warm the directory, often on
+    // the same tick. Checking a `loaded` flag alone is not enough: it is set
+    // after an await, so both callers would see false and both would fetch.
+    await Promise.all([
+      useWorkspaceDirectory.getState().ensureLoaded(),
+      useWorkspaceDirectory.getState().ensureLoaded(),
+      useWorkspaceDirectory.getState().ensureLoaded(),
+    ]);
+    expect(h.getWorkspaceMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch once loaded', async () => {
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    expect(h.getWorkspaceMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates on a workspace switch rather than mixing rosters', async () => {
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    expect(resolvePersonName('u-priya')).toBe('Priya Raman');
+
+    h.workspaceId = 'ws-2';
+    h.getWorkspaceMembers.mockResolvedValue([]);
+    await useWorkspaceDirectory.getState().ensureLoaded();
+
+    // Membership and roles are per-workspace; carrying an entry across would
+    // report someone as a member of a workspace they aren't in.
+    expect(h.getWorkspaceMembers).toHaveBeenCalledTimes(2);
+    expect(resolvePersonName('u-priya', 'u-priya')).toBe(UNKNOWN_PERSON);
+  });
+
+  it('does not cache a failure — the next caller retries', async () => {
+    h.getWorkspaceMembers.mockRejectedValueOnce(new Error('control plane down'));
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    expect(resolvePersonName('u-priya', 'u-priya')).toBe(UNKNOWN_PERSON);
+
+    // A blip must not leave every name unresolvable for the rest of the session.
+    await useWorkspaceDirectory.getState().ensureLoaded();
+    expect(resolvePersonName('u-priya')).toBe('Priya Raman');
+  });
+
+  it('survives a failure without throwing — names are decoration', async () => {
+    h.getWorkspaceMembers.mockRejectedValue(new Error('offline'));
+    await expect(useWorkspaceDirectory.getState().ensureLoaded()).resolves.toBeUndefined();
+  });
+});

--- a/src/store/workspaceDirectoryStore.ts
+++ b/src/store/workspaceDirectoryStore.ts
@@ -1,0 +1,154 @@
+/**
+ * Workspace directory (JP-459) — the one place a user id becomes a person.
+ *
+ * ## Why this exists
+ *
+ * The relay has no display names to give. OIDC tokens don't carry a `username`,
+ * so `handle_auth` surfaces `claims.sub` as one, and everything downstream that
+ * stored or rendered a "name" ended up holding an account UUID — visible on
+ * document cards, the People tooltips, "Last edited by", and share rows alike.
+ *
+ * Names belong to the control plane, which is the only thing that knows them and
+ * the only thing that sees them change. So they are **resolved at display time,
+ * never stored next to a grant**: a copy on the relay is stale the moment
+ * someone renames themselves, and a cache nobody can invalidate is worse than no
+ * cache at all.
+ *
+ * Two surfaces already fetched the roster ad hoc (the access panel and the Cloud
+ * panel). This replaces both with a single cache rather than adding a third.
+ *
+ * ## What it is not
+ *
+ * Not an authorization input. A directory entry is a label; permission decisions
+ * key on `userId` and only on `userId` (`permissions::resolve` in the relay does
+ * the same). Keep it that way — a future self-hosted directory would be
+ * populated from what connecting clients *claim* their name is, which is fine
+ * for a label and unacceptable for a grant.
+ */
+
+import { create } from 'zustand';
+import { webClient, type WorkspaceMember } from '../api/webClient';
+import { activeWorkspaceId } from './activeWorkspace';
+
+/** Shown when nobody can tell us who this is. Never a raw account id. */
+export const UNKNOWN_PERSON = 'Unknown user';
+
+interface WorkspaceDirectoryState {
+  /** Members of `workspaceId`, by user id. Empty until loaded. */
+  members: Record<string, WorkspaceMember>;
+  /** Which workspace `members` describes — the cache key. */
+  workspaceId: string | null;
+  /** True once a fetch has completed for the current workspace. */
+  loaded: boolean;
+}
+
+interface WorkspaceDirectoryActions {
+  /**
+   * Populate the directory for the active workspace, at most once.
+   *
+   * Idempotent and single-flight. The in-flight promise is memoised
+   * *separately* from `loaded`, because `loaded` is only set after an `await`:
+   * two callers on the same tick would both observe `false`, both fetch, and
+   * both write. The same shape as `ensureSignInResumed` in
+   * `src/api/resumeInterruptedSignIn.ts`, which needed it for the same reason.
+   *
+   * Failures are deliberately **not** cached. A control plane that blips for one
+   * request must not leave every name in the session unresolvable; the
+   * single-flight guard already stops a retry storm.
+   */
+  ensureLoaded: () => Promise<void>;
+  /** Replace the directory wholesale (used by callers that already hold a roster). */
+  setMembers: (members: WorkspaceMember[], workspaceId?: string) => void;
+  /** Forget everything — sign-out, or a workspace switch. */
+  clear: () => void;
+}
+
+let inFlight: Promise<void> | null = null;
+
+export const useWorkspaceDirectory = create<
+  WorkspaceDirectoryState & WorkspaceDirectoryActions
+>()((set, get) => ({
+  members: {},
+  workspaceId: null,
+  loaded: false,
+
+  ensureLoaded: async () => {
+    const ws = activeWorkspaceId();
+    // A workspace switch invalidates rather than merging two rosters — ids are
+    // unique per person, but membership and roles are not shared across
+    // workspaces, so a stale entry would misreport both.
+    if (get().workspaceId !== ws) {
+      set({ members: {}, workspaceId: ws, loaded: false });
+      inFlight = null;
+    }
+    if (get().loaded) return;
+    if (inFlight) return inFlight;
+
+    inFlight = (async () => {
+      try {
+        const members = await webClient.getWorkspaceMembers(ws);
+        // Guard against a switch that landed mid-flight: the response describes
+        // the workspace we asked about, not necessarily the current one.
+        if (activeWorkspaceId() !== ws) return;
+        get().setMembers(members, ws);
+      } catch {
+        // Self-hosted workspaces have no control plane, and a transient failure
+        // is not a fact about the workspace. Leave `loaded` false so the next
+        // caller retries; names fall back until then.
+      } finally {
+        inFlight = null;
+      }
+    })();
+    return inFlight;
+  },
+
+  setMembers: (members, workspaceId) => {
+    const byId: Record<string, WorkspaceMember> = {};
+    for (const m of members) byId[m.userId] = m;
+    set({ members: byId, workspaceId: workspaceId ?? activeWorkspaceId(), loaded: true });
+  },
+
+  clear: () => {
+    inFlight = null;
+    set({ members: {}, workspaceId: null, loaded: false });
+  },
+}));
+
+/**
+ * A user id rendered as a person.
+ *
+ * Resolution order, most to least authoritative:
+ *
+ *   1. the roster's display name
+ *   2. the roster's email — a real identifier when the name is blank
+ *   3. `stored`, the name carried on the record, **unless it is the id itself**
+ *   4. {@link UNKNOWN_PERSON}
+ *
+ * Step 4 is the point. The obvious last resort — "fall back to the id" — is a
+ * no-op against the data we actually have: when the stored name *is* the id,
+ * falling back to the id renders the identical UUID. A raw account id tells a
+ * reader nothing, so it is never the label. Callers that need it for support can
+ * put it in a `title`.
+ */
+export function resolvePersonName(userId: string | undefined, stored?: string): string {
+  if (!userId) return stored?.trim() || UNKNOWN_PERSON;
+  const member = useWorkspaceDirectory.getState().members[userId];
+  const fromRoster = member?.displayName?.trim() || member?.email?.trim();
+  if (fromRoster) return fromRoster;
+  const trimmed = stored?.trim();
+  if (trimmed && trimmed !== userId) return trimmed;
+  return UNKNOWN_PERSON;
+}
+
+/** Reactive form of {@link resolvePersonName} for React components. */
+export function usePersonName(userId: string | undefined, stored?: string): string {
+  return useWorkspaceDirectory((s) => {
+    if (!userId) return stored?.trim() || UNKNOWN_PERSON;
+    const member = s.members[userId];
+    const fromRoster = member?.displayName?.trim() || member?.email?.trim();
+    if (fromRoster) return fromRoster;
+    const trimmed = stored?.trim();
+    if (trimmed && trimmed !== userId) return trimmed;
+    return UNKNOWN_PERSON;
+  });
+}

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -101,6 +101,9 @@ export interface RemoteDocument extends DocumentEntryBase {
   /** Users the document is shared with (JP-444) — relay-provided; absent when
    *  the doc has no explicit shares or the relay predates share metadata. */
   sharedWith?: DocumentShare[];
+  /** Account id of the last editor (JP-459) — the resolvable identity. The
+   *  name below is only a fallback, and on older records it *is* this id. */
+  lastModifiedBy?: string;
   /** Display name of the last editor (JP-444); absent on older relay entries. */
   lastModifiedByName?: string;
 }
@@ -130,6 +133,8 @@ export interface CachedDocument extends DocumentEntryBase {
   ownerName?: string;
   /** Shares preserved from when online (JP-444). */
   sharedWith?: DocumentShare[];
+  /** Last editor's account id preserved from when online (JP-459). */
+  lastModifiedBy?: string;
   /** Last editor's display name preserved from when online (JP-444). */
   lastModifiedByName?: string;
 }
@@ -253,6 +258,9 @@ export function toRemoteDocument(
     ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
     ...(metadata.sizeBytes !== undefined ? { sizeBytes: metadata.sizeBytes } : {}),
     ...(metadata.sharedWith !== undefined ? { sharedWith: metadata.sharedWith } : {}),
+    ...(metadata.lastModifiedBy !== undefined
+      ? { lastModifiedBy: metadata.lastModifiedBy }
+      : {}),
     ...(metadata.lastModifiedByName !== undefined
       ? { lastModifiedByName: metadata.lastModifiedByName }
       : {}),

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -40,6 +40,7 @@ import {
 import { confirmDialog } from './confirm/confirmStore';
 import { formatFileSize } from '../utils/fileUtils';
 import { PeopleStack } from './home/PeopleStack';
+import { usePersonName, UNKNOWN_PERSON } from '../store/workspaceDirectoryStore';
 import { TagChips } from './TagChips';
 import { TagEditorPopover } from './TagEditorPopover';
 import './DocumentCard.css';
@@ -299,6 +300,14 @@ function DocumentCardImpl({
   tagSuggestions,
   mode = 'compact',
 }: DocumentCardProps) {
+  // JP-459: resolve the last editor to a person. Returns '' when we can't —
+  // the tooltip is then omitted rather than showing a raw account id.
+  const lastEditedByRaw = usePersonName(
+    record.type !== 'local' ? record.lastModifiedBy : undefined,
+    record.type !== 'local' ? record.lastModifiedByName : undefined,
+  );
+  const lastEditedBy = lastEditedByRaw === UNKNOWN_PERSON ? '' : lastEditedByRaw;
+
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(record.name);
   const [isPublishing, setIsPublishing] = useState(false);
@@ -811,9 +820,11 @@ function DocumentCardImpl({
           <span
             className="document-card__cell document-card__cell--time"
             title={
-              record.type !== 'local' && record.lastModifiedByName
-                ? `Last edited by ${record.lastModifiedByName}`
-                : undefined
+              // JP-459: `lastModifiedByName` is an account UUID on every record
+              // written before names were resolved at display time. Resolve it,
+              // and say nothing rather than show an id we can't turn into a
+              // person.
+              lastEditedBy ? `Last edited by ${lastEditedBy}` : undefined
             }
           >
             {formatDate(record.modifiedAt)}

--- a/src/ui/access/AccessPanel.tsx
+++ b/src/ui/access/AccessPanel.tsx
@@ -37,6 +37,7 @@ import { ModalShell } from '../components/ModalShell';
 import { webClient, type WorkspaceMember } from '../../api/webClient';
 import { useDocumentRegistry } from '../../store/documentRegistry';
 import { useAccessPanelStore, type AccessScope } from './accessPanelStore';
+import { useWorkspaceDirectory } from '../../store/workspaceDirectoryStore';
 import { WorkspaceRung } from './WorkspaceRung';
 import { DocumentRung } from './DocumentRung';
 import type { RemoteDocument } from '../../types/DocumentRegistry';
@@ -93,7 +94,13 @@ export function AccessPanel({ scope, documentId, onClose }: AccessPanelProps) {
     setLoading(true);
     setRosterError(null);
     try {
-      setRoster(await webClient.getWorkspaceMembers());
+      const members = await webClient.getWorkspaceMembers();
+      setRoster(members);
+      // JP-459: seed the shared directory from the fetch we just made, so the
+      // document browser's avatars and "last edited by" resolve to people
+      // without a second round-trip. This panel keeps its own copy because it
+      // also renders roles and drives invites — the directory is names only.
+      useWorkspaceDirectory.getState().setMembers(members);
     } catch (err) {
       setRoster([]);
       setRosterError(err instanceof Error ? err.message : 'Could not load members');

--- a/src/ui/access/DocumentRung.tsx
+++ b/src/ui/access/DocumentRung.tsx
@@ -23,6 +23,7 @@ import { confirmDialog } from '../confirm/confirmStore';
 import { RichSelect, type RichSelectItem } from '../components/RichSelect';
 import { InitialsAvatar } from '../components/InitialsAvatar';
 import { RoleBadge } from '../components/RoleBadge';
+import { resolvePersonName } from '../../store/workspaceDirectoryStore';
 import type { WorkspaceMember } from '../../api/webClient';
 import type { Permission, RemoteDocument } from '../../types/DocumentRegistry';
 import type { DocumentShare } from '../../types/Document';
@@ -74,7 +75,14 @@ export function DocumentRung({ documentId, record, roster }: DocumentRungProps) 
     setShares(
       existing
         .filter((s) => s.userId !== record.ownerId && s.userId !== currentUser?.id)
-        .map((s) => ({ userId: s.userId, username: s.userName, permission: s.permission })),
+        // JP-459: `userName` on a stored share is an account UUID on anything
+        // written before names were resolved at display time. Resolve it here,
+        // once, so every use below (rows, confirm copy, transfer) reads a person.
+        .map((s) => ({
+          userId: s.userId,
+          username: resolvePersonName(s.userId, s.userName),
+          permission: s.permission,
+        })),
     );
     setDirty(false);
   }, [metadata, record.ownerId, currentUser?.id]);
@@ -155,9 +163,18 @@ export function DocumentRung({ documentId, record, roster }: DocumentRungProps) 
     setError(null);
     setSaved(null);
     try {
+      // JP-459: `s.username` is resolved for display and may be the
+      // "Unknown user" placeholder, which must never be persisted as someone's
+      // name. Write the roster's real name when we have one, else the id — the
+      // same value the field held before, and harmless now that every surface
+      // resolves at display time.
       const next = shares
         .filter((s) => s.permission !== 'none')
-        .map((s) => ({ userId: s.userId, userName: s.username, permission: s.permission }));
+        .map((s) => ({
+          userId: s.userId,
+          userName: roster.find((m) => m.userId === s.userId)?.displayName || s.userId,
+          permission: s.permission,
+        }));
       await updateDocumentShares(documentId, next);
       setSaved(`Saved — ${next.length} ${next.length === 1 ? 'person has' : 'people have'} access`);
       setDirty(false);

--- a/src/ui/cloud/CloudConnectPanel.tsx
+++ b/src/ui/cloud/CloudConnectPanel.tsx
@@ -41,6 +41,7 @@ import { useCollaborationStore, useIsRelaySessionLive } from '../../collaboratio
 import { usePersistenceStore } from '../../store/persistenceStore';
 import { useNotificationStore } from '../../store/notificationStore';
 import { removeCurrentWorkspace } from '../../services/removeWorkspace';
+import { useWorkspaceDirectory } from '../../store/workspaceDirectoryStore';
 import { webClient, WebClientError } from '../../api/webClient';
 import { confirmDialog } from '../confirm/confirmStore';
 import {
@@ -218,17 +219,18 @@ export function CloudConnectPanel({
       return;
     }
     let active = true;
-    webClient
-      .getWorkspaceMembers()
-      .then((members) => {
+    // JP-459: go through the shared directory rather than a private fetch —
+    // it is single-flight, so opening this panel while the document browser is
+    // already resolving names costs nothing extra.
+    void useWorkspaceDirectory
+      .getState()
+      .ensureLoaded()
+      .then(() => {
         if (!active) return;
-        const me = members.find((m) => m.userId === user.id);
+        const me = useWorkspaceDirectory.getState().members[user.id];
         if (me) {
           setIdentity({ name: me.displayName, ...(me.email ? { email: me.email } : {}) });
         }
-      })
-      .catch(() => {
-        /* no directory (self-host / offline) — the id fallback stands */
       });
     return () => {
       active = false;
@@ -437,6 +439,10 @@ export function CloudConnectPanel({
   const handleDisconnect = useCallback(() => {
     stopSession();
     void clearJwt();
+    // JP-459: the directory is other people's names and emails, scoped to a
+    // workspace we're leaving. Drop it with the session rather than leaving it
+    // to be re-shown against whatever is signed in next.
+    useWorkspaceDirectory.getState().clear();
   }, [stopSession]);
 
   // Remove Workspace (JP-237) — the destructive counterpart to Disconnect. Uses

--- a/src/ui/home/PeopleStack.tsx
+++ b/src/ui/home/PeopleStack.tsx
@@ -7,7 +7,13 @@
  * When the caller can manage access, the stack is a button opening the
  * permissions dialog — the avatars ARE the sharing entry, not decoration.
  */
+import { useMemo } from 'react';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
+import {
+  resolvePersonName,
+  useWorkspaceDirectory,
+  UNKNOWN_PERSON,
+} from '../../store/workspaceDirectoryStore';
 import './PeopleStack.css';
 
 interface Person {
@@ -15,15 +21,26 @@ interface Person {
   name: string;
 }
 
-/** Owner first, then shares; skips entries without identity, dedupes by id. */
-export function peopleForRecord(record: DocumentRecord): Person[] {
+/** Turns a user id + whatever name the record carries into a display name. */
+export type NameResolver = (id: string, stored: string | undefined) => string;
+
+/**
+ * Owner first, then shares; skips entries without identity, dedupes by id.
+ *
+ * `resolve` is injected rather than read from a store so this stays a pure
+ * function — it is the unit-testable half, and the store subscription belongs to
+ * the component. Defaults to the record's own strings, which is what the caller
+ * wants in tests and is never what it wants in the UI: those strings are account
+ * UUIDs (JP-459), so `PeopleStack` always passes the real resolver.
+ */
+export function peopleForRecord(record: DocumentRecord, resolve?: NameResolver): Person[] {
   if (record.type === 'local') return [];
   const out: Person[] = [];
   const seen = new Set<string>();
   const push = (id: string | undefined, name: string | undefined) => {
     if (!id || seen.has(id)) return;
     seen.add(id);
-    out.push({ id, name: name || 'Unknown user' });
+    out.push({ id, name: resolve ? resolve(id, name) : name || UNKNOWN_PERSON });
   };
   push(record.ownerId, record.ownerName);
   for (const share of record.sharedWith ?? []) push(share.userId, share.userName);
@@ -53,7 +70,16 @@ export interface PeopleStackProps {
 }
 
 export function PeopleStack({ record, onOpenAccess }: PeopleStackProps) {
-  const people = peopleForRecord(record);
+  // Subscribe so avatars re-label the moment the directory loads, rather than
+  // showing UUIDs until something else happens to re-render the row.
+  const members = useWorkspaceDirectory((s) => s.members);
+  const people = useMemo(
+    () => peopleForRecord(record, (id, stored) => resolvePersonName(id, stored)),
+    // `members` is not read directly here — it is the subscription that makes
+    // `resolvePersonName`'s store read produce a fresh answer.
+    [record, members],
+  );
+
   if (people.length === 0) {
     return (
       <span className="people-stack people-stack--none" aria-label="No collaborator information">


### PR DESCRIPTION
Closes JP-459. The client half of the access work, both halves found by driving a real second account against the JP-457 relay.

## Every "name" in the editor was a UUID

The People tooltip is where you spotted it, but the root is upstream — OIDC tokens carry no username, so the relay surfaces `claims.sub` as one:

```rust
// relay/src/server/mod.rs — handle_auth
// OIDC tokens don't carry `username`; surface `sub` for logs.
client.username = Some(claims.sub.clone());
```

Everything downstream dutifully stored and rendered an account id, across **five** display sites. Patching the tooltip alone would have left four wrong.

Names now resolve at display time from a shared workspace directory and are never read off a record. Display names belong to the control plane — a copy stored next to a grant is stale the moment someone renames themselves, and today it isn't even a name. Live proof from the E2E: one document's stored `ownerName` was `3f35f5c8…` while its `ownerId` was `f90bff18…` — a *different account's* id. It wasn't merely useless, it was wrong.

The directory is single-flight, invalidates on workspace switch, and **doesn't cache failures** — a control plane that blips for one request must not leave every name unresolvable for the session. It replaces the two ad-hoc roster fetches rather than adding a third.

**The last resort is "Unknown user", not the id.** The obvious fallback is a no-op against real data: when the stored name *is* the id, falling back to it renders the identical UUID.

## Documents you can't open now leave the browser

They were kept and rendered as offline/idle — a row that can never load, whose title is exposure to someone with no access. A 403 drops the entry, and `registerRemote` refuses a record resolving to `'none'` so one never enters.

**That guard rests on a subtle invariant.** `getEffectivePermission` returns a viewer/editor *floor* while identity is loading, because the list arrives over REST before the WebSocket auth populates `currentUser`. If that floor ever became `'none'`, this would silently empty the browser on every boot — so the coupling has a named tripwire test.

**Unsynced work is never destroyed.** A share can be revoked while the holder is offline with edits queued; the cache purge is gated on nothing being pending. Losing access to the server's copy is not permission to delete the user's own writing.

## 403 is no longer 401

`RelayError` conflated them. They want opposite responses — a per-document denial must not tear down a working session, which is the JP-396 failure mode in a new costume. One existing test encoded the old contract and is updated with the reasoning.

## Verification

- `tsc --noEmit` clean, **3212 tests / 270 files** green
- **Both new guards mutation-checked**: letting `registerRemote` accept `'none'`, and dropping the pending-changes check, each fail a test by name
- **Live, against a real second account**: names resolve everywhere (zero UUIDs in the DOM), a view-only share opens read-only, and revoking it makes the row *vanish* rather than go idle

## Found while verifying, filed not fixed

- **JP-462** — the prose ribbon offers full editing on a read-only document (`CanvasToolbar` gates; `DocumentEditorToolbar` doesn't)
- **JP-463** — a revoked document with unsynced edits is stranded, and disappears *silently* after a transfer attempt

Assisted-by: Opus 5