### PR TITLE
JP-462: a read-only document gets a View only strip, not a dead ribbon

### DIFF
--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -443,3 +443,26 @@
 [data-theme="dark"] .ribbon-tab.active {
   background: var(--bg-secondary);
 }
+
+/* Read-only strip (JP-462) — replaces the ribbon on a document the caller
+   cannot edit. Deliberately occupies the ribbon's slot rather than collapsing
+   to nothing: the space vanishing would read as a broken layout, and the strip
+   is where the answer to "why can't I type?" belongs. */
+.document-editor-toolbar--readonly {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ribbon-readonly {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+}
+
+.ribbon-readonly svg {
+  flex-shrink: 0;
+  opacity: 0.75;
+}

--- a/src/ui/DocumentEditorToolbar.readonly.test.tsx
+++ b/src/ui/DocumentEditorToolbar.readonly.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * The prose ribbon on a read-only document (JP-462).
+ *
+ * Found live: a document shared view-only opened correctly read-only, and then
+ * rendered the full formatting ribbon anyway — sixty-odd controls driving an
+ * editor that is already `editable: false`. Nothing was corrupted, and the
+ * relay drops a viewer's writes regardless (JP-457), so this was never a
+ * data-integrity bug. It is a truthfulness bug: the surface answered "here is
+ * everything you can do" when the answer was "nothing".
+ *
+ * This matters more now than when it was filed. Every visitor arriving on a
+ * share link is a read-only viewer, so this ribbon is the first thing a reader
+ * sees — it has to say what it means.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+const h = vi.hoisted(() => ({ readOnly: false }));
+
+vi.mock('../store/documentRegistry', () => ({
+  useActiveDocReadOnly: () => h.readOnly,
+}));
+vi.mock('./TiptapEditorContext', () => ({
+  useTiptapEditor: () => ({
+    isActive: () => false,
+    on: vi.fn(),
+    off: vi.fn(),
+    can: () => ({ chain: () => ({ focus: () => ({ run: () => true }) }) }),
+    state: { selection: {} },
+  }),
+}));
+vi.mock('../tiptap/slashUi', () => ({ registerSlashUiHandler: () => () => {} }));
+
+import { DocumentEditorToolbar } from './DocumentEditorToolbar';
+
+beforeEach(() => {
+  h.readOnly = false;
+});
+afterEach(cleanup);
+
+describe('DocumentEditorToolbar', () => {
+  it('offers the full ribbon on an editable document', () => {
+    render(<DocumentEditorToolbar />);
+    expect(screen.getByRole('button', { name: 'Bold' })).toBeTruthy();
+    expect(screen.queryByText(/View only/)).toBeNull();
+  });
+
+  it('replaces the ribbon with a View only strip when the document is read-only', () => {
+    h.readOnly = true;
+    render(<DocumentEditorToolbar />);
+
+    // The load-bearing assertion: no formatting control is offered at all.
+    expect(screen.queryByRole('button', { name: 'Bold' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Italic' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Insert or edit link' })).toBeNull();
+
+    // And the reason is on screen, rather than left to be discovered by clicking.
+    expect(screen.getByText(/View only/)).toBeTruthy();
+  });
+
+  it('says why, not just that', () => {
+    h.readOnly = true;
+    render(<DocumentEditorToolbar />);
+    expect(screen.getByText(/permission to edit/)).toBeTruthy();
+  });
+});

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -5,6 +5,19 @@
  * - Home: Text formatting, colors, lists, alignment
  * - Insert: Tables, math, images, search
  * - Table: Table-specific tools (always visible, tools enabled when in table)
+ *
+ * **Read-only documents get a "View only" strip instead of the ribbon (JP-462).**
+ * Every control here drives an editor that is already `editable: false` on a
+ * read-only document, so nothing was ever corrupted — but offering someone
+ * sixty-odd formatting controls that silently do nothing is its own failure, and
+ * it answers the wrong question. A viewer's first question is "can I edit this?";
+ * a dead ribbon makes them discover the answer by clicking. This surface is now
+ * the *shared* experience too — anyone arriving on a share link is a viewer.
+ *
+ * Hiding rather than disabling: a viewer has no use for formatting controls, and
+ * `disabled` on sixty-three buttons is more code that communicates less. The
+ * canvas side (`CanvasToolbar`) has gated on read-only since JP-370; this closes
+ * the asymmetry.
  */
 
 import { useState, useEffect, useCallback } from 'react';
@@ -16,10 +29,11 @@ import {
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
   BookMarked, Library, Info, Braces,
   BetweenVerticalStart, BetweenVerticalEnd, BetweenHorizontalStart, BetweenHorizontalEnd,
-  ArrowLeft, ArrowRight, ArrowUp, ArrowDown,
+  ArrowLeft, ArrowRight, ArrowUp, ArrowDown, Eye,
 } from 'lucide-react';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
+import { useActiveDocReadOnly } from '../store/documentRegistry';
 import * as cmd from './editorCommands';
 import { registerSlashUiHandler } from '../tiptap/slashCommands';
 import { ImageUploadButton } from './ImageUploadButton';
@@ -77,6 +91,7 @@ const HEADING_ITEMS: RichSelectItem<HeadingValue>[] = (
 
 export function DocumentEditorToolbar() {
   const editor = useTiptapEditor();
+  const docReadOnly = useActiveDocReadOnly();
   const [, forceUpdate] = useState({});
   const [activeTab, setActiveTab] = useState<RibbonTab>('home');
 
@@ -199,6 +214,19 @@ export function DocumentEditorToolbar() {
 
   const isActive = (type: string, attrs?: Record<string, unknown>) =>
     editor?.isActive(type, attrs) ?? false;
+
+  // Placed after every hook above — an early return before them would change
+  // hook order between renders when a document's permission flips in place.
+  if (docReadOnly) {
+    return (
+      <div className="document-editor-toolbar document-editor-toolbar--readonly">
+        <div className="ribbon-readonly" role="status">
+          <Eye size={14} aria-hidden="true" />
+          <span>View only — you don’t have permission to edit this document.</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="document-editor-toolbar">

--- a/src/ui/mobile/MobileProseToolbar.css
+++ b/src/ui/mobile/MobileProseToolbar.css
@@ -76,3 +76,14 @@
   color: var(--text-primary);
   border-color: var(--color-primary);
 }
+
+/* Read-only strip (JP-462) — the mobile counterpart of `.ribbon-readonly`.
+   One line: screen space is scarce and the message is short. */
+.mobile-prose-toolbar--readonly {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}

--- a/src/ui/mobile/MobileProseToolbar.tsx
+++ b/src/ui/mobile/MobileProseToolbar.tsx
@@ -25,10 +25,12 @@ import { Icon } from '../icons';
 import { useTiptapEditor } from '../TiptapEditorContext';
 import * as cmd from '../editorCommands';
 import { DocumentEditorToolbar } from '../DocumentEditorToolbar';
+import { useActiveDocReadOnly } from '../../store/documentRegistry';
 import './MobileProseToolbar.css';
 
 export function MobileProseToolbar() {
   const editor = useTiptapEditor();
+  const docReadOnly = useActiveDocReadOnly();
   const [, force] = useState({});
   const [showFormat, setShowFormat] = useState(false);
 
@@ -47,6 +49,18 @@ export function MobileProseToolbar() {
 
   // No live editor (e.g. a read-only ProsePreview) → nothing to format.
   if (!editor) return null;
+
+  // JP-462: same rule as the desktop ribbon — a viewer gets a statement, not a
+  // set of controls that do nothing. Kept as a strip rather than removed
+  // entirely so the answer to "why can't I type?" is on screen; screen space is
+  // tighter here, so it is one line.
+  if (docReadOnly) {
+    return (
+      <div className="mobile-prose-toolbar mobile-prose-toolbar--readonly" role="status">
+        View only
+      </div>
+    );
+  }
 
   const isH2 = editor.isActive('heading', { level: 2 });
 


### PR DESCRIPTION
Closes JP-462. Found live during the JP-459 E2E — you opened a view-only shared document and noticed it "shows all the tools still".

## What was wrong

The document opened correctly read-only, and then rendered the full formatting ribbon: **63 controls driving an editor that is already `editable: false`.**

Nothing was corrupted — Tiptap is non-editable on a read-only document and the relay drops a viewer's writes regardless (JP-457), so every one of those controls was already a no-op. This is a truthfulness bug rather than a data one. The surface answered *"here is everything you can do"* when the answer was *"nothing"*, leaving the reader to find that out by clicking.

It was an asymmetry, not a blanket gap — `CanvasToolbar` has gated on `useActiveDocReadOnly` since JP-370. `DocumentEditorToolbar` had no reference to read-only at all.

## Hidden, not disabled

A viewer has no use for formatting controls, and `disabled` on 63 buttons is more code that communicates less. The strip also has somewhere to put the *reason*, which a greyed-out button does not.

The space is kept rather than collapsed — a toolbar that vanishes reads as broken layout, and the strip is exactly where "why can't I type?" belongs.

The mobile ribbon gets the same treatment in one line. Its expandable panel embeds this component, so it would otherwise have inherited the fix inside the panel but not on its slim bar.

## Why this is ordered ahead of the share work

Every visitor arriving on a share link (JP-464) is a read-only viewer, so this ribbon becomes **the first thing an article reader sees**. The read-only experience *is* the shared experience — shipping share links first would have made a dead ribbon the front door. I originally had this slice last; that was an ordering error caught in plan review.

## Verification

- `tsc --noEmit` clean
- **3215 tests / 271 files** green
- **Mutation-checked**: restoring the ribbon on a read-only document fails two tests by name

Assisted-by: Opus 5