### PR TITLE
JP-464: publish a document's public projection to storage

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -220,6 +220,7 @@ This table is the canonical inventory — a drift test
 | `RELAY_MAX_EDITORS_PER_WORKSPACE` | `[tenancy.limits].max_editors_per_workspace` (fallback cap; `0` = unlimited) |
 | `RELAY_MAX_BLOB_BYTES` | `[tenancy.limits].max_blob_bytes` (per-blob size ceiling) |
 | `RELAY_MAX_DOC_BYTES` | `[tenancy.limits].max_doc_bytes` (fallback per-document serialized-JSON size ceiling when a token omits the `max_doc_bytes` claim; enforced on REST/MCP document writes — 413 / `ERR_DOC_TOO_LARGE`; collab flushes are never refused, only counted; `0` = no ceiling; also raises the doc-route HTTP body limit above its 128 MiB floor) |
+| `RELAY_PUBLISH_MAX_BYTES` | `[tenancy.limits].publish_max_bytes` (ceiling on a document's public projection artifact, `POST /api/docs/:id/publish` — 413 / `PUBLISH_TOO_LARGE` with the cap echoed in the body; a refused republish never invalidates the previously published snapshot; `0` = no ceiling; default 10 MiB) |
 | `RELAY_MAX_CONCURRENT_BLOB_UPLOADS` | `[tenancy.limits].max_concurrent_blob_uploads` (bounds worst-case upload RAM: permits × max blob bytes) |
 | `RELAY_BLOB_GC_GRACE_SECS` | `[tenancy.limits].blob_gc_grace_secs` (orphaned-blob reclaim delay; default 300, also shields the upload→save window; `0` = reclaim immediately) |
 | `RELAY_BLOB_INGEST_ALLOWED_HOSTS` | `[tenancy.limits].blob_ingest_allowed_hosts` (comma-separated URL-ingest allowlist) |

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -319,6 +319,12 @@ pub fn routes(max_doc_bytes: u64) -> Router<Arc<ServerState>> {
                 .layer(axum::extract::DefaultBodyLimit::max(doc_body_limit)),
         )
         .route("/api/docs/:id/share", post(share_doc_handler))
+        .route(
+            "/api/docs/:id/publish",
+            post(publish_doc_handler)
+                .delete(unpublish_doc_handler)
+                .get(publish_status_handler),
+        )
         .route("/api/docs/:id/transfer", post(transfer_doc_handler))
         .route("/api/docs/:id/collection", put(set_doc_collection_handler))
         .route(
@@ -1540,7 +1546,13 @@ async fn save_doc_handler(
     let effective = state.resolve_limits(limits);
     let gate = DocSaveGate {
         quota_bytes: effective.quota_bytes,
-        blob_bytes: state.blob_store().get_workspace_size(&ws),
+        // Non-live-doc bytes on the meter: blobs + published projection
+        // artifacts (a published snapshot is a second stored copy). The save
+        // adds live doc bytes internally.
+        blob_bytes: state
+            .blob_store()
+            .get_workspace_size(&ws)
+            .saturating_add(state.doc_store().published_bytes_total(&ws, None)),
         max_doc_bytes: effective.max_doc_bytes,
     };
 
@@ -1711,6 +1723,400 @@ async fn share_doc_handler(
     state.emit_doc_event(&ws, &doc_id, DocEventType::Updated, Some(claims.sub.clone()));
 
     (StatusCode::OK, Json(WriteAck { success: true })).into_response()
+}
+
+/// Response body for `POST /api/docs/:id/publish`. `artifact_key` /
+/// `manifest_key` are the object-store keys the artifact landed at (`None` on
+/// the filesystem backend, where the artifact lives under the workspace's
+/// `public/` directory instead).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PublishAck {
+    success: bool,
+    artifact_key: Option<String>,
+    manifest_key: Option<String>,
+    bytes: u64,
+    published_at: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UnpublishAck {
+    success: bool,
+    /// `false` = the doc wasn't published (the delete is idempotent).
+    removed: bool,
+}
+
+/// Response body for `GET /api/docs/:id/publish` — the publish state a client
+/// renders. `max_bytes` is the configured artifact ceiling (`None` = no
+/// ceiling); reporting it here keeps the number single-homed in relay config
+/// rather than duplicated into clients.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PublishStatusBody {
+    published: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    published_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bytes: Option<u64>,
+    /// The source document has changed since publishing (`modified_at`
+    /// comparison — collaborative flushes don't bump `serverVersion`, so a
+    /// version count would miss them).
+    stale: bool,
+    max_bytes: Option<u64>,
+}
+
+/// `POST /api/docs/:id/publish` — write the document's **public projection**
+/// (artifact + manifest) to storage. Owner-only, like share management.
+///
+/// The projection is `publish::project_public` — an allowlist; see that
+/// module for why the raw body must never be the artifact. A resident live
+/// doc is flushed first so the snapshot reflects "now", not the last
+/// persistence tick. Object-store durability is awaited here (not queued):
+/// publishing is rare and explicit, and success must mean the artifact is
+/// really where downstream serving will look for it.
+async fn publish_doc_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+
+    state.ensure_doc_local(&ws, &doc_id).await;
+    state.ensure_workspace_published_local(&ws).await;
+
+    // Owner-only — publishing exposes content beyond the workspace, which is
+    // a bigger grant than any share, so it takes the same gate as share
+    // management and delete.
+    if let Err(e) = check_delete_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        &principal(&claims, role),
+        state.enforce_private_docs(),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    // Flush a resident doc's live CRDT state into the JSON body first —
+    // otherwise the artifact freezes the last persisted tick, not what the
+    // publisher is looking at.
+    if let Some(handle) = state.sync_registry().get(&ws, &doc_id) {
+        state.snapshot_doc(&ws, &doc_id, &handle);
+    }
+
+    let doc = match state.doc_store().get_document(&ws, &doc_id) {
+        Ok(d) => d,
+        Err(e) => return (StatusCode::NOT_FOUND, ApiError::body(e)).into_response(),
+    };
+
+    let projected = crate::server::publish::project_public(&doc);
+    let artifact_json = match serde_json::to_string(&projected) {
+        Ok(s) => s,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e.to_string()))
+                .into_response()
+        }
+    };
+    let artifact_bytes = artifact_json.len() as u64;
+
+    // Artifact ceiling — checked before any byte is written, cap echoed in
+    // the body so clients render the configured number instead of hardcoding
+    // one. An already-published artifact is never invalidated by this: a
+    // refused republish leaves the previous snapshot in place.
+    if let Some(max) = state.publish_max_bytes() {
+        if artifact_bytes > max {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(serde_json::json!({
+                    "errorCode": "PUBLISH_TOO_LARGE",
+                    "sizeBytes": artifact_bytes,
+                    "maxBytes": max,
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // Storage meter: the artifact is a second stored copy of the document and
+    // counts like any other bytes. Delta-aware against this doc's *previous*
+    // artifact, so republishing a shrinking document always lands — same
+    // dig-out principle as the save gate.
+    if let Some(quota) = state.resolve_limits(limits).quota_bytes {
+        let used = state
+            .blob_store()
+            .get_workspace_size(&ws)
+            .saturating_add(state.doc_store().workspace_doc_bytes(&ws))
+            .saturating_add(state.doc_store().published_bytes_total(&ws, Some(&doc_id)));
+        if used.saturating_add(artifact_bytes) > quota {
+            log::info!(
+                "publish refused for {}/{}: {} used + {} artifact > {} quota",
+                ws.as_str(),
+                doc_id.as_str(),
+                used,
+                artifact_bytes,
+                quota
+            );
+            return (
+                StatusCode::INSUFFICIENT_STORAGE,
+                ApiError::body("storage quota exceeded"),
+            )
+                .into_response();
+        }
+    }
+
+    let source_modified_at = state
+        .doc_store()
+        .get_document_metadata(&ws, &doc_id)
+        .map(|m| m.modified_at)
+        .unwrap_or(0);
+    let published_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    // Blob authorization map: hash → full object key, derived from the
+    // *projection* (a blob only a dropped field referenced must not be
+    // resolvable through the artifact). The writer supplies complete keys so
+    // no consumer ever re-derives the layout.
+    let hashes = crate::server::publish::projected_blob_hashes(&projected);
+    let blob_keys: std::collections::BTreeMap<String, String> = hashes
+        .into_iter()
+        .map(|h| {
+            let key = match state.s3_backend() {
+                Some(s3) => s3.object_key(&ws, &h),
+                None => crate::server::publish::sharded_blob_key(ws.as_str(), &h),
+            };
+            (h, key)
+        })
+        .collect();
+    let manifest = crate::server::publish::build_public_manifest(
+        &projected,
+        &blob_keys,
+        published_at,
+        source_modified_at,
+    );
+    let manifest_json = match serde_json::to_string(&manifest) {
+        Ok(s) => s,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e.to_string()))
+                .into_response()
+        }
+    };
+
+    // Object store first, local bookkeeping second: if the upload fails the
+    // registry never records an artifact readers can't fetch, and a stray
+    // uploaded object with no registry entry is unreachable (nothing serves
+    // by key alone) — overwritten by the next successful publish.
+    let (artifact_key, manifest_key) = match state.s3_backend() {
+        Some(s3) => {
+            let a_key = s3.doc_public_key(&ws, &doc_id, "json");
+            let m_key = s3.doc_public_key(&ws, &doc_id, "manifest.json");
+            if let Err(e) = s3
+                .put_object_at(&a_key, artifact_json.clone().into_bytes(), "application/json")
+                .await
+            {
+                log::warn!("publish artifact PUT failed for {}: {}", a_key, e);
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    ApiError::body("object store upload failed — nothing was published"),
+                )
+                    .into_response();
+            }
+            if let Err(e) = s3
+                .put_object_at(&m_key, manifest_json.clone().into_bytes(), "application/json")
+                .await
+            {
+                log::warn!("publish manifest PUT failed for {}: {}", m_key, e);
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    ApiError::body("object store upload failed — nothing was published"),
+                )
+                    .into_response();
+            }
+            (Some(a_key), Some(m_key))
+        }
+        None => (None, None),
+    };
+
+    let entry = crate::server::publish::PublishedEntry {
+        published_at,
+        bytes: artifact_bytes,
+        source_modified_at,
+    };
+    if let Err(e) =
+        state
+            .doc_store()
+            .set_published(&ws, &doc_id, entry, &artifact_json, &manifest_json)
+    {
+        return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response();
+    }
+
+    // Mirror the registry itself (meter + status survive a cold machine).
+    // Best-effort like the collections mirror: on failure the local file is
+    // still authoritative and the next publish/unpublish re-uploads it.
+    if let Some(s3) = state.s3_backend() {
+        if let Some(bytes) = state.doc_store().read_workspace_published_bytes(&ws) {
+            let key = s3.workspace_published_key(&ws);
+            if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                log::warn!("published registry mirror PUT failed for {}: {}", key, e);
+            }
+        }
+    }
+
+    log::info!(
+        "Published document projection: {}/{} ({} bytes)",
+        ws.as_str(),
+        doc_id.as_str(),
+        artifact_bytes
+    );
+
+    (
+        StatusCode::OK,
+        Json(PublishAck {
+            success: true,
+            artifact_key,
+            manifest_key,
+            bytes: artifact_bytes,
+            published_at,
+        }),
+    )
+        .into_response()
+}
+
+/// `DELETE /api/docs/:id/publish` — remove the public projection. Owner-only,
+/// idempotent (`removed: false` when nothing was published). The artifact's
+/// bytes leave the storage meter with the registry entry.
+async fn unpublish_doc_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+
+    state.ensure_workspace_published_local(&ws).await;
+
+    if let Err(e) = check_delete_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        &principal(&claims, role),
+        state.enforce_private_docs(),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    let removed = match state.doc_store().remove_published(&ws, &doc_id) {
+        Ok(r) => r,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
+    };
+
+    if removed.is_some() {
+        if let Some(s3) = state.s3_backend() {
+            // Best-effort object deletes: a failure leaves an orphaned object
+            // that nothing can reach (the registry entry is gone), cleaned up
+            // by the next publish's overwrite. Registry mirror keeps the
+            // meter correct on cold machines.
+            for suffix in ["json", "manifest.json"] {
+                let key = s3.doc_public_key(&ws, &doc_id, suffix);
+                if let Err(e) = s3.delete_object_at(&key).await {
+                    log::warn!("unpublish DELETE failed for {}: {}", key, e);
+                }
+            }
+            if let Some(bytes) = state.doc_store().read_workspace_published_bytes(&ws) {
+                let key = s3.workspace_published_key(&ws);
+                if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                    log::warn!("published registry mirror PUT failed for {}: {}", key, e);
+                }
+            }
+        }
+        log::info!("Unpublished document projection: {}/{}", ws.as_str(), doc_id.as_str());
+    }
+
+    (
+        StatusCode::OK,
+        Json(UnpublishAck { success: true, removed: removed.is_some() }),
+    )
+        .into_response()
+}
+
+/// `GET /api/docs/:id/publish` — publish state for a document. Read-scoped
+/// like `GET /api/docs/:id`: any member who can open the doc can see whether
+/// it is published; changing that state stays owner-only.
+async fn publish_status_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let claims = match require_auth(&state, &headers).await {
+        Ok(c) => c,
+        Err(resp) => return resp,
+    };
+    let doc_id = match parse_doc_path(id) {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let (ws, role, _limits) = match resolve_workspace(&state, &claims) {
+        Ok(ws) => ws,
+        Err(resp) => return resp,
+    };
+
+    state.ensure_doc_local(&ws, &doc_id).await;
+    state.ensure_workspace_published_local(&ws).await;
+
+    if let Err(e) = check_read_permission(
+        state.doc_store(),
+        &ws,
+        &doc_id,
+        &principal(&claims, role),
+        state.enforce_private_docs(),
+    ) {
+        return permission_error_response(&e);
+    }
+
+    let entry = state.doc_store().published_entry(&ws, &doc_id);
+    let stale = match &entry {
+        Some(e) => state
+            .doc_store()
+            .get_document_metadata(&ws, &doc_id)
+            .map(|m| m.modified_at > e.source_modified_at)
+            .unwrap_or(false),
+        None => false,
+    };
+
+    (
+        StatusCode::OK,
+        Json(PublishStatusBody {
+            published: entry.is_some(),
+            published_at: entry.as_ref().map(|e| e.published_at),
+            bytes: entry.as_ref().map(|e| e.bytes),
+            stale,
+            max_bytes: state.publish_max_bytes(),
+        }),
+    )
+        .into_response()
 }
 
 async fn transfer_doc_handler(

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -103,6 +103,14 @@ pub const DEFAULT_STORAGE_QUOTA_BYTES: u64 = 0;
 /// part of the storage meter.
 pub const DEFAULT_MAX_DOC_BYTES: u64 = 0;
 
+/// Default ceiling on a document's **public projection artifact**
+/// (`POST /api/docs/:id/publish`), bytes. Bounds what one published snapshot
+/// can ask downstream serving infrastructure to hold and stream; past this
+/// size the content is better distributed as an exported file. `0` = no
+/// ceiling (self-host). Enforced at publish time only — an already-published
+/// artifact is never invalidated by a later cap change.
+pub const DEFAULT_PUBLISH_MAX_BYTES: u64 = 10_485_760; // 10 MiB
+
 /// Floor for the docs-route HTTP body limit (JP-443). Deliberately DECOUPLED
 /// from `max_doc_bytes`: the config value is only the *fallback* cap — a JWT
 /// claim can carry a larger per-workspace ceiling, and a body limit derived
@@ -478,6 +486,13 @@ pub struct LimitsConfig {
     /// never refused (an over-cap snapshot is logged + counted instead).
     #[serde(default)]
     pub max_doc_bytes: u64,
+    /// Ceiling on a document's public projection artifact (bytes), enforced at
+    /// `POST /api/docs/:id/publish` (413 / `PUBLISH_TOO_LARGE`, cap echoed in
+    /// the body so clients render the configured number). `0` = no ceiling.
+    /// Config-only by design — no JWT claim — so the number has exactly one
+    /// home; the status endpoint reports it to clients.
+    #[serde(default = "default_publish_max_bytes")]
+    pub publish_max_bytes: u64,
     /// Grace (seconds) before an orphaned blob's bytes are reclaimed (JP-127).
     /// `0` = immediate. A positive value defers reclaim so a transient blob
     /// reference-drop (e.g. a bad reconnect save) can be corrected without
@@ -495,6 +510,14 @@ pub struct LimitsConfig {
     pub blob_ingest_allowed_hosts: Vec<String>,
 }
 
+/// Serde field default for `publish_max_bytes`. A plain `#[serde(default)]`
+/// would zero the field on a partial `[tenancy.limits]` section — and `0`
+/// means *no ceiling*, silently removing the cap. The named fn keeps the real
+/// default in that case.
+fn default_publish_max_bytes() -> u64 {
+    DEFAULT_PUBLISH_MAX_BYTES
+}
+
 impl Default for LimitsConfig {
     fn default() -> Self {
         Self {
@@ -509,6 +532,7 @@ impl Default for LimitsConfig {
             storage_quota_bytes: DEFAULT_STORAGE_QUOTA_BYTES,
             max_editors_per_workspace: DEFAULT_MAX_EDITORS_PER_WORKSPACE,
             max_doc_bytes: DEFAULT_MAX_DOC_BYTES,
+            publish_max_bytes: DEFAULT_PUBLISH_MAX_BYTES,
             blob_gc_grace_secs: DEFAULT_BLOB_GC_GRACE_SECS,
             blob_ingest_allowed_hosts: Vec::new(),
         }
@@ -823,6 +847,11 @@ impl RelayConfig {
             self.tenancy.limits.max_doc_bytes = v
                 .parse()
                 .map_err(|_| anyhow::anyhow!("RELAY_MAX_DOC_BYTES must be a u64 (got {v:?})"))?;
+        }
+        if let Some(v) = get("RELAY_PUBLISH_MAX_BYTES") {
+            self.tenancy.limits.publish_max_bytes = v
+                .parse()
+                .map_err(|_| anyhow::anyhow!("RELAY_PUBLISH_MAX_BYTES must be a u64 (got {v:?})"))?;
         }
         if let Some(v) = get("RELAY_MAX_CONCURRENT_BLOB_UPLOADS") {
             self.tenancy.limits.max_concurrent_blob_uploads = v.parse().map_err(|_| {

--- a/relay/src/mcp/tools.rs
+++ b/relay/src/mcp/tools.rs
@@ -1766,7 +1766,13 @@ fn get_storage(ctx: &ToolContext) -> Result<ToolOutcome, String> {
 fn doc_save_gate(ctx: &ToolContext) -> crate::server::documents::DocSaveGate {
     crate::server::documents::DocSaveGate {
         quota_bytes: ctx.quota_bytes,
-        blob_bytes: ctx.blob_store.get_workspace_size(&ctx.workspace_id),
+        // Non-live-doc bytes on the meter: blobs + published projection
+        // artifacts, mirroring the REST save gate. The store adds live doc
+        // bytes internally.
+        blob_bytes: ctx
+            .blob_store
+            .get_workspace_size(&ctx.workspace_id)
+            .saturating_add(ctx.relay.published_bytes_total(&ctx.workspace_id, None)),
         max_doc_bytes: ctx.max_doc_bytes,
     }
 }

--- a/relay/src/server/blob_backend/s3.rs
+++ b/relay/src/server/blob_backend/s3.rs
@@ -139,6 +139,28 @@ impl S3Backend {
         format!("{}docs/{}/collections.json", self.config.key_prefix, ws.as_str())
     }
 
+    /// Object key for a doc's **public projection artifact** or its manifest:
+    /// `{prefix}docs/{ws}/public/{docId}.{json|manifest.json}`. Deliberately
+    /// inside the workspace's `docs/{ws}/` subtree — a region migration that
+    /// copies the subtree carries published artifacts along — and in a sibling
+    /// directory to `docs/`, so no document id can collide with it.
+    pub fn doc_public_key(&self, ws: &WorkspaceId, doc_id: &DocId, suffix: &str) -> String {
+        format!(
+            "{}docs/{}/public/{}.{}",
+            self.config.key_prefix,
+            ws.as_str(),
+            doc_id.as_str(),
+            suffix
+        )
+    }
+
+    /// Object key for a workspace's **published-projection registry**:
+    /// `{prefix}docs/{ws}/published.json`. Sits beside the doc index so a
+    /// region migration carries it along.
+    pub fn workspace_published_key(&self, ws: &WorkspaceId) -> String {
+        format!("{}docs/{}/published.json", self.config.key_prefix, ws.as_str())
+    }
+
     /// Object key for a workspace's **deleted-id tombstone registry** (JP-375):
     /// `{prefix}docs/{ws}/deleted-ids.json`. Sits beside the doc index so a cold
     /// machine restoring from R2 knows which ids are dead and refuses to
@@ -444,6 +466,13 @@ pub trait DocObjectStore: Send + Sync {
         &self,
         ws: &WorkspaceId,
     ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
+
+    /// Fetch a workspace's published-projection registry (best-effort restore
+    /// so a cold machine keeps the meter contribution and status surface).
+    fn get_workspace_published(
+        &self,
+        ws: &WorkspaceId,
+    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, String>> + Send;
 }
 
 impl DocObjectStore for S3Backend {
@@ -466,6 +495,10 @@ impl DocObjectStore for S3Backend {
 
     async fn get_workspace_deleted_ids(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
         self.get_object_at(&self.workspace_deleted_ids_key(ws)).await
+    }
+
+    async fn get_workspace_published(&self, ws: &WorkspaceId) -> Result<Option<Vec<u8>>, String> {
+        self.get_object_at(&self.workspace_published_key(ws)).await
     }
 }
 

--- a/relay/src/server/documents.rs
+++ b/relay/src/server/documents.rs
@@ -12,6 +12,7 @@ use tokio::sync::oneshot;
 
 use super::blob_backend::DocObjectStore;
 use super::protocol::{DocId, WorkspaceId};
+use super::publish::{parse_published_file, PublishedEntry, PublishedRegistry};
 
 /// Crash-safe file write (JP-424): write to a sibling temp file in the same
 /// directory (same filesystem — required for an atomic `rename`), fsync, then
@@ -468,6 +469,11 @@ pub struct DocumentStore {
     /// cold-start R2 restore off that, so an emptied registry isn't re-fetched
     /// (and resurrected) from a stale mirror (JP-424).
     collections: RwLock<HashMap<WorkspaceId, CollectionsRegistry>>,
+    /// Per-workspace published-document registry (`published.json`): which
+    /// docs have a public projection artifact, its size (counted toward the
+    /// storage meter), and the source `modified_at` it froze — the staleness
+    /// baseline. Same presence-keyed cold-start semantics as `collections`.
+    published: RwLock<HashMap<WorkspaceId, PublishedRegistry>>,
     /// JP-200 write-through R2 mirror sink. `Some` enqueues a [`MirrorOp`] after
     /// each successful local write for a background worker to upload; `None`
     /// (self-host / filesystem backend) keeps the store volume-only. The same
@@ -519,6 +525,7 @@ impl DocumentStore {
             documents_dir: documents_dir.clone(),
             index: RwLock::new(HashMap::new()),
             collections: RwLock::new(HashMap::new()),
+            published: RwLock::new(HashMap::new()),
             mirror_tx: None,
             cache: RwLock::new(HashMap::new()),
             index_write_lock: std::sync::Mutex::new(()),
@@ -1283,6 +1290,7 @@ impl DocumentStore {
             let Some(ws) = WorkspaceId::from_configured(&name) else { continue };
             self.load_workspace_index(&ws);
             self.load_workspace_collections(&ws);
+            self.load_workspace_published(&ws);
             self.load_workspace_deleted_ids(&ws);
         }
     }
@@ -1518,6 +1526,192 @@ impl DocumentStore {
             }
             Ok(None) => {}
             Err(e) => log::warn!("restore: R2 get collections {}: {}", ws.as_str(), e),
+        }
+    }
+
+    // ── Published-projection registry (`published.json`) ──────────────────────
+    //
+    // Which documents have a public projection artifact under `public/`, how
+    // many bytes it holds (metered), and the source `modified_at` it froze.
+    // Same lifecycle as the collections registry: local file + object-store
+    // mirror + presence-keyed cold restore. Unlike collections the content is
+    // relay-authoritative — only the publish/unpublish handlers write it.
+
+    /// Path to a workspace's published-registry file.
+    fn published_path(&self, ws: &WorkspaceId) -> PathBuf {
+        self.workspace_root(ws).join("published.json")
+    }
+
+    /// Directory holding a workspace's public projection artifacts.
+    fn public_dir(&self, ws: &WorkspaceId) -> PathBuf {
+        self.workspace_root(ws).join("public")
+    }
+
+    /// Local path of a doc's public artifact (`public/<id>.json`).
+    pub fn public_doc_path(&self, ws: &WorkspaceId, doc_id: &DocId) -> PathBuf {
+        self.public_dir(ws).join(format!("{}.json", doc_id.as_str()))
+    }
+
+    /// Local path of a doc's public manifest (`public/<id>.manifest.json`).
+    pub fn public_manifest_path(&self, ws: &WorkspaceId, doc_id: &DocId) -> PathBuf {
+        self.public_dir(ws).join(format!("{}.manifest.json", doc_id.as_str()))
+    }
+
+    /// Load a single workspace's published registry from disk into memory.
+    /// No-op if the file is missing or unparseable.
+    fn load_workspace_published(&self, ws: &WorkspaceId) {
+        let path = self.published_path(ws);
+        let Ok(data) = std::fs::read_to_string(&path) else { return };
+        let Some(registry) = parse_published_file(&data) else {
+            log::warn!(
+                "published registry for workspace {} is malformed — leaving empty",
+                ws.as_str()
+            );
+            return;
+        };
+        if let Ok(mut current) = self.published.write() {
+            current.insert(ws.clone(), registry);
+        }
+    }
+
+    /// Snapshot the in-memory published registry for a workspace and write it
+    /// to disk. `index_write_lock` serializes sidecar writes, as elsewhere.
+    fn write_workspace_published_file(&self, ws: &WorkspaceId) -> Result<(), String> {
+        let _guard = self
+            .index_write_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let snapshot = {
+            let published = self.published.read().map_err(|e| e.to_string())?;
+            published.get(ws).cloned().unwrap_or_default()
+        };
+        let json = serde_json::to_string_pretty(&snapshot)
+            .map_err(|e| format!("Serialize error: {}", e))?;
+        let _ = std::fs::create_dir_all(self.workspace_root(ws));
+        write_atomic(&self.published_path(ws), json.as_bytes())
+            .map_err(|e| format!("Write error: {}", e))
+    }
+
+    /// Read a workspace's `published.json` bytes off the local volume (for the
+    /// object-store upload). `None` if absent/unreadable.
+    pub fn read_workspace_published_bytes(&self, ws: &WorkspaceId) -> Option<Vec<u8>> {
+        std::fs::read(self.published_path(ws)).ok()
+    }
+
+    /// A doc's published entry, if any.
+    pub fn published_entry(&self, ws: &WorkspaceId, doc_id: &DocId) -> Option<PublishedEntry> {
+        self.published
+            .read()
+            .ok()
+            .and_then(|p| p.get(ws).and_then(|r| r.entries.get(doc_id.as_str()).cloned()))
+    }
+
+    /// Total artifact bytes a workspace has published — these count toward the
+    /// storage meter beside blob bytes and live doc bytes. `exclude` omits one
+    /// doc's current entry, for the check that *replaces* that entry.
+    pub fn published_bytes_total(&self, ws: &WorkspaceId, exclude: Option<&DocId>) -> u64 {
+        self.published
+            .read()
+            .ok()
+            .and_then(|p| {
+                p.get(ws).map(|r| {
+                    r.entries
+                        .iter()
+                        .filter(|(id, _)| exclude.map(|d| d.as_str() != *id).unwrap_or(true))
+                        .map(|(_, e)| e.bytes)
+                        .sum()
+                })
+            })
+            .unwrap_or(0)
+    }
+
+    /// Record (or replace) a doc's published entry, write the artifact +
+    /// manifest locally, persist the registry, and hand the registry bytes to
+    /// the mirror. The artifact bytes themselves are the caller's to upload —
+    /// publish awaits object-store durability directly rather than riding the
+    /// FIFO mirror queue, so success means the artifact is really there.
+    pub fn set_published(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+        entry: PublishedEntry,
+        artifact_json: &str,
+        manifest_json: &str,
+    ) -> Result<(), String> {
+        let _ = std::fs::create_dir_all(self.public_dir(ws));
+        write_atomic(&self.public_doc_path(ws, doc_id), artifact_json.as_bytes())
+            .map_err(|e| format!("Write error: {}", e))?;
+        write_atomic(&self.public_manifest_path(ws, doc_id), manifest_json.as_bytes())
+            .map_err(|e| format!("Write error: {}", e))?;
+        {
+            let mut published = self.published.write().map_err(|e| e.to_string())?;
+            let registry = published.entry(ws.clone()).or_default();
+            registry.version += 1;
+            registry.entries.insert(doc_id.as_str().to_string(), entry);
+        }
+        self.write_workspace_published_file(ws)
+    }
+
+    /// Remove a doc's published entry and delete its local artifact files.
+    /// Returns the removed entry (its `bytes` leave the meter), `None` if the
+    /// doc wasn't published.
+    pub fn remove_published(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+    ) -> Result<Option<PublishedEntry>, String> {
+        let removed = {
+            let mut published = self.published.write().map_err(|e| e.to_string())?;
+            let registry = published.entry(ws.clone()).or_default();
+            let removed = registry.entries.remove(doc_id.as_str());
+            if removed.is_some() {
+                registry.version += 1;
+            }
+            removed
+        };
+        if removed.is_some() {
+            let _ = std::fs::remove_file(self.public_doc_path(ws, doc_id));
+            let _ = std::fs::remove_file(self.public_manifest_path(ws, doc_id));
+            self.write_workspace_published_file(ws)?;
+        }
+        Ok(removed)
+    }
+
+    /// Whether a workspace's published registry has been loaded or probed —
+    /// gates the cold-start restore exactly like the collections registry.
+    pub fn has_workspace_published_loaded(&self, ws: &WorkspaceId) -> bool {
+        self.published.read().ok().is_some_and(|p| p.contains_key(ws))
+    }
+
+    /// Memoize a cold-start probe (hit or miss) so reads don't re-probe.
+    pub fn memoize_published_probe(&self, ws: &WorkspaceId) {
+        if let Ok(mut current) = self.published.write() {
+            current.entry(ws.clone()).or_default();
+        }
+    }
+
+    /// Best-effort cold-machine restore of `published.json` from the object
+    /// store, paralleling `restore_workspace_collections_from`. Restores the
+    /// registry only — artifacts already live in the object store and are
+    /// never read back by the relay.
+    pub async fn restore_workspace_published_from<S: DocObjectStore>(
+        &self,
+        store: &S,
+        ws: &WorkspaceId,
+    ) {
+        match store.get_workspace_published(ws).await {
+            Ok(Some(bytes)) => {
+                let _ = std::fs::create_dir_all(self.workspace_root(ws));
+                if write_atomic(&self.published_path(ws), &bytes).is_ok() {
+                    self.load_workspace_published(ws);
+                    log::info!(
+                        "restored published registry for workspace {} from R2",
+                        ws.as_str()
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::warn!("restore: R2 get published {}: {}", ws.as_str(), e),
         }
     }
 
@@ -2917,6 +3111,7 @@ mod tests {
         index: Option<Vec<u8>>,
         collections: Option<Vec<u8>>,
         deleted_ids: Option<Vec<u8>>,
+        published: Option<Vec<u8>>,
     }
 
     impl DocObjectStore for FakeObjectStore {
@@ -2952,6 +3147,13 @@ mod tests {
             _ws: &WorkspaceId,
         ) -> Result<Option<Vec<u8>>, String> {
             Ok(self.deleted_ids.clone())
+        }
+
+        async fn get_workspace_published(
+            &self,
+            _ws: &WorkspaceId,
+        ) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.published.clone())
         }
     }
 

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod chunk;
 pub mod documents;
 pub mod permissions;
 pub mod protocol;
+pub mod publish;
 
 use axum::{
     body::Body,
@@ -970,6 +971,10 @@ impl ServerState {
     pub(crate) async fn ensure_workspace_index_local(&self, ws: &WorkspaceId) {
         // JP-232: recover blob bookkeeping before serving a cold workspace listing.
         self.ensure_blob_bookkeeping(ws).await;
+        // Published-artifact bytes are part of the storage meter, so restore
+        // the published registry wherever the index is restored — otherwise a
+        // cold machine under-counts usage until a publish endpoint is touched.
+        self.ensure_workspace_published_local(ws).await;
         if !self.doc_store.list_documents(ws).is_empty() {
             return;
         }
@@ -1054,12 +1059,44 @@ impl ServerState {
         }
     }
 
+    /// Ceiling on a public projection artifact (`[tenancy.limits]
+    /// publish_max_bytes`), `None` = no ceiling. Config-only by design — no
+    /// JWT claim — so the number has exactly one home and the status endpoint
+    /// can report it to clients verbatim.
+    pub(crate) fn publish_max_bytes(&self) -> Option<u64> {
+        let v = self.tenancy.limits.publish_max_bytes;
+        (v != 0).then_some(v)
+    }
+
+    /// Best-effort restore of a workspace's published-projection registry from
+    /// R2 before serving publish state on a cold machine. Presence-keyed and
+    /// probe-memoized exactly like `ensure_workspace_collections_local` — a
+    /// workspace that unpublished everything must not have entries resurrected
+    /// from a stale mirror.
+    pub(crate) async fn ensure_workspace_published_local(&self, ws: &WorkspaceId) {
+        if self.doc_store.has_workspace_published_loaded(ws) {
+            return;
+        }
+        if let Some(s3) = &self.s3 {
+            self.doc_store
+                .restore_workspace_published_from(s3.as_ref(), ws)
+                .await;
+        }
+        self.doc_store.memoize_published_probe(ws);
+    }
+
     /// The two halves of the single storage meter for a workspace (JP-443):
-    /// blob bytes (ACL-grant attributed) + recorded document JSON bytes.
+    /// blob bytes (ACL-grant attributed) + document-derived JSON bytes. The
+    /// doc half includes **published projection artifacts** — a published
+    /// snapshot is a second stored copy of the document, and metering it here
+    /// puts it in every consumer (usage reporting, blob-grant headroom) at
+    /// once.
     pub(crate) fn workspace_storage_split(&self, ws: &WorkspaceId) -> (u64, u64) {
         (
             self.blob_store.get_workspace_size(ws),
-            self.doc_store.workspace_doc_bytes(ws),
+            self.doc_store
+                .workspace_doc_bytes(ws)
+                .saturating_add(self.doc_store.published_bytes_total(ws, None)),
         )
     }
 

--- a/relay/src/server/publish.rs
+++ b/relay/src/server/publish.rs
@@ -1,0 +1,375 @@
+//! Public projection of a document (the `publish` REST surface).
+//!
+//! Publishing writes a **sanitized, frozen copy** of a document to storage —
+//! a snapshot an operator can serve to readers who hold no relay credentials.
+//! The relay itself never serves it: there is no anonymous route here, and
+//! `permissions::resolve` still returns `None` for `Principal::Anonymous`.
+//! What downstream serves the artifact (nginx over the `public/` directory,
+//! a CDN over the object store, …) is deliberately out of scope.
+//!
+//! Two invariants carry all of the safety:
+//!
+//! 1. **The projection is an allowlist.** The stored document body embeds its
+//!    access-control state (`sharedWith` — see `update_document_shares`) plus
+//!    ownership and edit attribution. A denylist would fail open the moment a
+//!    new field joins the document model; the allowlist fails closed. Nothing
+//!    about *people* is ever copied.
+//! 2. **The artifact is derived from the flattened JSON, never the Y.Doc.**
+//!    The CRDT binary is an edit log — it retains deleted text and prior
+//!    revisions by construction, which is exactly what a published snapshot
+//!    must not carry.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+/// Top-level document fields copied into the public artifact. Everything not
+/// named here is dropped — notably `sharedWith`, `ownerId`/`ownerName`,
+/// `lastModifiedBy`/`lastModifiedByName`, `collectionId`, `tags`,
+/// `serverVersion`, `blobReferences`, and `id` (readers address the artifact
+/// by its own key; the internal id adds nothing but correlation surface).
+///
+/// `version` is required: the editor's load funnel refuses documents without
+/// a migratable format version.
+pub const PUBLIC_DOC_FIELDS: &[&str] = &[
+    "version",
+    "name",
+    "pages",
+    "pageOrder",
+    "activePageId",
+    "richTextPages",
+    "references",
+    "fields",
+];
+
+/// Build the public projection of `doc`.
+///
+/// This is the first stage of a deliberate **pipeline seam**: later transforms
+/// (per-element exclusion, partial page sets, …) compose after the allowlist
+/// and before serialization. Keep the signature `&Value -> Value` so inserting
+/// a transform never touches callers.
+pub fn project_public(doc: &Value) -> Value {
+    let mut out = Map::new();
+    if let Some(obj) = doc.as_object() {
+        for field in PUBLIC_DOC_FIELDS {
+            if let Some(v) = obj.get(*field) {
+                out.insert((*field).to_string(), v.clone());
+            }
+        }
+    }
+    Value::Object(out)
+}
+
+/// One published document's registry entry (`published.json`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishedEntry {
+    /// Wall-clock publish time (ms since epoch).
+    pub published_at: u64,
+    /// Serialized artifact size — these bytes count toward the workspace
+    /// storage meter for as long as the entry exists.
+    pub bytes: u64,
+    /// The source document's `modified_at` at publish time. The staleness
+    /// signal is `metadata.modified_at > source_modified_at` — a timestamp
+    /// comparison, because collaborative flushes deliberately do not bump
+    /// `serverVersion` and an edit-count would miss them.
+    pub source_modified_at: u64,
+}
+
+/// Per-workspace published-document registry, persisted as `published.json`
+/// beside `collections.json` and mirrored to the object store so a cold
+/// machine keeps both the meter contribution and the status surface.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PublishedRegistry {
+    pub version: u64,
+    #[serde(default)]
+    pub entries: BTreeMap<String, PublishedEntry>,
+}
+
+/// Parse `published.json` bytes. `None` when malformed — the caller keeps the
+/// in-memory state it has rather than replacing it with garbage.
+pub fn parse_published_file(data: &str) -> Option<PublishedRegistry> {
+    serde_json::from_str(data).ok()
+}
+
+/// Canonical sharded blob key relative to the storage root:
+/// `ws/{workspace}/{ab}/{cd}/{hash}` — the same two-level shard both storage
+/// backends use, so a manifest consumer resolves bytes without knowing which
+/// backend produced it. (The S3 backend prepends its configured key prefix;
+/// callers with an S3 handle should prefer its `object_key` for that reason.)
+pub fn sharded_blob_key(ws: &str, hash: &str) -> String {
+    let (a, b) = if hash.len() >= 4 {
+        (&hash[0..2], &hash[2..4])
+    } else {
+        ("zz", "zz")
+    };
+    format!("ws/{}/{}/{}/{}", ws, a, b, hash)
+}
+
+/// Blob hashes referenced by a projected document — the union of every
+/// `blob://<sha256>` URI in its content. Scans the *projection*, not the
+/// source: a blob referenced only by a field the allowlist dropped must not
+/// be resolvable through the artifact's manifest.
+pub fn projected_blob_hashes(projected: &Value) -> HashSet<String> {
+    let mut refs = HashSet::new();
+    collect_blob_uris(projected, &mut refs);
+    refs
+}
+
+fn collect_blob_uris(value: &Value, refs: &mut HashSet<String>) {
+    match value {
+        Value::String(s) => {
+            // Content may embed the URI mid-string (prose HTML `src="blob://…"`),
+            // so scan substrings rather than testing the whole string.
+            let mut rest = s.as_str();
+            while let Some(pos) = rest.find("blob://") {
+                let tail = &rest[pos + "blob://".len()..];
+                let hash: String = tail
+                    .chars()
+                    .take_while(|c| c.is_ascii_hexdigit())
+                    .take(64)
+                    .collect();
+                if hash.len() == 64 {
+                    refs.insert(hash.to_lowercase());
+                }
+                rest = &rest[pos + "blob://".len()..];
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_blob_uris(item, refs);
+            }
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                collect_blob_uris(v, refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Counts surfaced by the manifest (preview cards want "N pages · N shapes ·
+/// N files" without parsing the artifact).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectionCounts {
+    /// Canvas pages + prose pages, matching the metadata `page_count` axis.
+    pub page_count: usize,
+    pub shape_count: usize,
+    /// File shapes (`type == "file"`), the attachment-like subset of shapes.
+    pub file_count: usize,
+}
+
+/// Derive counts from a projected document.
+pub fn projection_counts(projected: &Value) -> ProjectionCounts {
+    let canvas_pages = projected
+        .get("pageOrder")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    let prose_pages = projected
+        .pointer("/richTextPages/pageOrder")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+
+    let mut shape_count = 0usize;
+    let mut file_count = 0usize;
+    if let Some(pages) = projected.get("pages").and_then(|v| v.as_object()) {
+        for page in pages.values() {
+            let Some(shapes) = page.get("shapes").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            shape_count += shapes.len();
+            file_count += shapes
+                .values()
+                .filter(|s| s.get("type").and_then(|t| t.as_str()) == Some("file"))
+                .count();
+        }
+    }
+
+    ProjectionCounts {
+        page_count: canvas_pages + prose_pages,
+        shape_count,
+        file_count,
+    }
+}
+
+/// Build the artifact's companion manifest.
+///
+/// The manifest exists so a consumer can (a) render a preview without parsing
+/// the full artifact and (b) **authorize blob reads**: only hashes listed here
+/// are resolvable through a published document. It carries each blob's full
+/// object key — the writer knows its own key scheme, so the consumer derives
+/// nothing and key-layout drift between writer and reader cannot happen.
+///
+/// Never serve the manifest itself to readers: the keys are storage-internal.
+pub fn build_public_manifest(
+    projected: &Value,
+    blob_keys: &BTreeMap<String, String>,
+    published_at: u64,
+    source_modified_at: u64,
+) -> Value {
+    let counts = projection_counts(projected);
+    json!({
+        "version": 1,
+        "title": projected.get("name").and_then(|v| v.as_str()).unwrap_or("Untitled"),
+        "pageCount": counts.page_count,
+        "shapeCount": counts.shape_count,
+        "fileCount": counts.file_count,
+        "publishedAt": published_at,
+        "sourceModifiedAt": source_modified_at,
+        "blobs": blob_keys,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn people_laden_doc() -> Value {
+        json!({
+            "id": "doc-1",
+            "version": 2,
+            "name": "Relay Notes",
+            "serverVersion": 7,
+            "ownerId": "user-a",
+            "ownerName": "Alice A",
+            "lastModifiedBy": "user-b",
+            "lastModifiedByName": "Bob B",
+            "collectionId": "col-1",
+            "tags": ["secret-project"],
+            "sharedWith": [
+                { "userId": "user-b", "userName": "Bob B", "permission": "edit", "sharedAt": 1 }
+            ],
+            // A field that does not exist in the model today: the projection
+            // must drop it. This is the test that would PASS under a denylist
+            // written against today's fields — which is exactly why it exists.
+            "reviewers": [{ "userId": "user-c", "userName": "Carol C" }],
+            "blobReferences": ["a".repeat(64)],
+            "pageOrder": ["p1"],
+            "activePageId": "p1",
+            "pages": {
+                "p1": {
+                    "shapes": {
+                        "s1": { "type": "rectangle", "x": 0, "y": 0 },
+                        "s2": { "type": "file", "x": 1, "y": 1,
+                                "blobUrl": format!("blob://{}", "b".repeat(64)) }
+                    },
+                    "shapeOrder": ["s1", "s2"]
+                }
+            },
+            "richTextPages": {
+                "pageOrder": ["r1"],
+                "pages": { "r1": { "content": format!("<img src=\"blob://{}\">", "c".repeat(64)) } }
+            },
+            "references": [{ "id": "ref1", "title": "Cited Work" }],
+            "fields": { "defs": [] }
+        })
+    }
+
+    #[test]
+    fn projection_keeps_only_allowlisted_fields() {
+        let projected = project_public(&people_laden_doc());
+        let obj = projected.as_object().unwrap();
+
+        for field in PUBLIC_DOC_FIELDS {
+            if *field == "version" || *field == "name" || *field == "pages" {
+                assert!(obj.contains_key(*field), "expected {} in projection", field);
+            }
+        }
+        for dropped in [
+            "id",
+            "serverVersion",
+            "ownerId",
+            "ownerName",
+            "lastModifiedBy",
+            "lastModifiedByName",
+            "collectionId",
+            "tags",
+            "sharedWith",
+            "blobReferences",
+        ] {
+            assert!(!obj.contains_key(dropped), "{} must not survive projection", dropped);
+        }
+    }
+
+    #[test]
+    fn projection_drops_fields_added_after_the_allowlist_was_written() {
+        // The distinguishing property of an allowlist: a novel people-shaped
+        // field ("reviewers") vanishes even though no rule names it.
+        let projected = project_public(&people_laden_doc());
+        assert!(projected.get("reviewers").is_none());
+        assert!(!serde_json::to_string(&projected).unwrap().contains("user-c"));
+    }
+
+    #[test]
+    fn projection_serialization_carries_no_identity_strings() {
+        let s = serde_json::to_string(&project_public(&people_laden_doc())).unwrap();
+        for needle in ["user-a", "user-b", "Alice A", "Bob B", "sharedWith", "secret-project"] {
+            assert!(!s.contains(needle), "projection leaked {:?}", needle);
+        }
+    }
+
+    #[test]
+    fn blob_hashes_come_from_the_projection_not_the_source() {
+        let doc = people_laden_doc();
+        let projected = project_public(&doc);
+        let hashes = projected_blob_hashes(&projected);
+        // "a"×64 lived only in the dropped `blobReferences` array — a blob the
+        // artifact does not use must not be resolvable through its manifest.
+        assert!(!hashes.contains(&"a".repeat(64)));
+        assert!(hashes.contains(&"b".repeat(64)), "FileShape blob ref");
+        assert!(hashes.contains(&"c".repeat(64)), "prose <img> blob ref");
+    }
+
+    #[test]
+    fn counts_span_canvas_and_prose() {
+        let counts = projection_counts(&project_public(&people_laden_doc()));
+        assert_eq!(counts.page_count, 2, "1 canvas + 1 prose page");
+        assert_eq!(counts.shape_count, 2);
+        assert_eq!(counts.file_count, 1);
+    }
+
+    #[test]
+    fn manifest_lists_exactly_the_provided_blob_keys() {
+        let projected = project_public(&people_laden_doc());
+        let mut keys = BTreeMap::new();
+        keys.insert("b".repeat(64), sharded_blob_key("ws-1", &"b".repeat(64)));
+        let manifest = build_public_manifest(&projected, &keys, 1000, 900);
+        assert_eq!(manifest["title"], "Relay Notes");
+        assert_eq!(manifest["publishedAt"], 1000);
+        assert_eq!(manifest["sourceModifiedAt"], 900);
+        let blobs = manifest["blobs"].as_object().unwrap();
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(
+            blobs[&"b".repeat(64)],
+            format!("ws/ws-1/bb/bb/{}", "b".repeat(64))
+        );
+    }
+
+    #[test]
+    fn sharded_key_matches_backend_shard_layout() {
+        let hash = format!("{}{}", "ab", "c".repeat(62));
+        assert_eq!(
+            sharded_blob_key("w", &hash),
+            format!("ws/w/ab/cc/{}", hash)
+        );
+    }
+
+    #[test]
+    fn registry_file_round_trips() {
+        let mut reg = PublishedRegistry::default();
+        reg.version = 3;
+        reg.entries.insert(
+            "doc-1".into(),
+            PublishedEntry { published_at: 5, bytes: 100, source_modified_at: 4 },
+        );
+        let s = serde_json::to_string(&reg).unwrap();
+        let back = parse_published_file(&s).unwrap();
+        assert_eq!(back.version, 3);
+        assert_eq!(back.entries["doc-1"].bytes, 100);
+        assert!(parse_published_file("not json").is_none());
+    }
+}

--- a/relay/tests/document_privacy.rs
+++ b/relay/tests/document_privacy.rs
@@ -785,11 +785,12 @@ impl Harness {
 
 /// A REST document read must not make the document resident.
 ///
-/// This is the invariant JP-464's share links depend on. Resident documents are
-/// the relay's dominant memory driver (JP-404): `DocRegistry` is unbounded and
-/// documents evict only on last-client disconnect. Once a URL can be opened by
-/// a stranger, a read path that hydrates a Y.Doc lets unauthenticated traffic
-/// pin arbitrary memory — with no signed-in user to rate-limit or bill.
+/// Resident documents are the relay's dominant memory driver (JP-404):
+/// `DocRegistry` is unbounded and documents evict only on last-client
+/// disconnect. Read-only consumers must never pin that memory — a read path
+/// that hydrates a Y.Doc would let bulk read traffic (exports, mirrors,
+/// downstream serving of published projections) grow the working set with no
+/// editing session to bound it.
 ///
 /// The property holds today (`DocRegistry::get` is a pure lookup; only `ensure`
 /// hydrates). This locks it, because the failure mode is silent: nothing else

--- a/relay/tests/document_privacy.rs
+++ b/relay/tests/document_privacy.rs
@@ -761,3 +761,85 @@ async fn doc_events_for_a_private_document_do_not_reach_other_members() {
         }
     }
 }
+
+// ============================================================
+// Non-resident reads (JP-465)
+// ============================================================
+
+impl Harness {
+    /// Read a single gauge out of `/metrics`.
+    async fn gauge(&self, name: &str) -> i64 {
+        let body = reqwest::get(format!("{}/metrics", self.base))
+            .await
+            .expect("metrics")
+            .text()
+            .await
+            .expect("metrics body");
+        body.lines()
+            .find(|l| l.starts_with(name) && !l.starts_with('#'))
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| panic!("gauge {name} not found in /metrics"))
+    }
+}
+
+/// A REST document read must not make the document resident.
+///
+/// This is the invariant JP-464's share links depend on. Resident documents are
+/// the relay's dominant memory driver (JP-404): `DocRegistry` is unbounded and
+/// documents evict only on last-client disconnect. Once a URL can be opened by
+/// a stranger, a read path that hydrates a Y.Doc lets unauthenticated traffic
+/// pin arbitrary memory — with no signed-in user to rate-limit or bill.
+///
+/// The property holds today (`DocRegistry::get` is a pure lookup; only `ensure`
+/// hydrates). This locks it, because the failure mode is silent: nothing else
+/// in the suite would notice a refactor that swapped `get` for `ensure`.
+#[tokio::test]
+async fn rest_reads_do_not_make_a_document_resident() {
+    let h = Harness::start(true).await;
+    let doc = h.create_doc("alice", WorkspaceRole::Owner, "doc-cold").await;
+
+    let before = h.gauge("relay_active_docs_total").await;
+    for _ in 0..5 {
+        assert!(h.get_doc("alice", WorkspaceRole::Owner, &doc).await.is_success());
+    }
+    assert_eq!(
+        h.gauge("relay_active_docs_total").await,
+        before,
+        "REST reads hydrated a Y.Doc — a shared link would let strangers pin memory"
+    );
+
+    // Prove the assertion can actually fail: joining over the WebSocket *is*
+    // supposed to make the document resident. Without this, a broken gauge or a
+    // mis-parsed metric would make the check above pass vacuously forever.
+    //
+    // The socket must stay open while the gauge is read — documents evict on
+    // last-client disconnect, so a join that returns before the check races its
+    // own eviction and reports the same number either way.
+    let url = format!("{}/ws?protocolVersion={}", h.ws_base, PROTOCOL_VERSION);
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.expect("ws connect");
+    let auth = encode_message(MESSAGE_AUTH, &h.token("alice", WorkspaceRole::Owner))
+        .expect("encode auth");
+    ws.send(WsMessage::Binary(auth)).await.expect("send auth");
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("auth timeout")
+            .expect("stream")
+            .expect("msg");
+        if let WsMessage::Binary(d) = msg {
+            if d.first() == Some(&MESSAGE_AUTH_RESPONSE) {
+                break;
+            }
+        }
+    }
+    let join = encode_message(MESSAGE_JOIN_DOC, &json!({ "docId": doc })).expect("encode join");
+    ws.send(WsMessage::Binary(join)).await.expect("send join");
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    assert!(
+        h.gauge("relay_active_docs_total").await > before,
+        "JOIN_DOC did not make the document resident — the gauge is not measuring what this test assumes"
+    );
+    drop(ws);
+}

--- a/relay/tests/document_publish.rs
+++ b/relay/tests/document_publish.rs
@@ -1,0 +1,539 @@
+//! Public projection (`/api/docs/:id/publish`) — behavioural pins.
+//!
+//! The published artifact is served to readers with no relay credentials, so
+//! this suite is written adversarially: it asserts what the artifact must
+//! **never** contain (the identity fields the raw body embeds), that the
+//! meter counts published bytes, that the cap refuses without invalidating a
+//! live snapshot, and that all of it survives a machine restart.
+//!
+//! Harness mirrors `document_privacy.rs`: a real relay on a random port in
+//! `Shared` tenancy, driven over REST only.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use docushark_relay::auth::WorkspaceRole;
+use docushark_relay::config::{LimitsConfig, TenancyConfig, TenancyMode};
+use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
+use docushark_relay::test_support::OidcTestIssuer;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const WS: &str = "ws_publish";
+
+struct Harness {
+    base: String,
+    issuer: OidcTestIssuer,
+    data_dir: PathBuf,
+    _tmp: Option<TempDir>,
+}
+
+impl Harness {
+    async fn start() -> Self {
+        Self::start_with_limits(LimitsConfig::default()).await
+    }
+
+    async fn start_with_limits(limits: LimitsConfig) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().to_path_buf();
+        Self::boot(limits, data_dir, Some(tmp)).await
+    }
+
+    /// Boot a second relay over an existing data directory — proves the
+    /// published registry (and its meter contribution) survives a restart.
+    async fn reboot(self, limits: LimitsConfig) -> Self {
+        let Harness { data_dir, _tmp, issuer: _, .. } = self;
+        Self::boot(limits, data_dir, _tmp).await
+    }
+
+    async fn boot(limits: LimitsConfig, data_dir: PathBuf, tmp: Option<TempDir>) -> Self {
+        let issuer = OidcTestIssuer::new().await;
+
+        let server = Arc::new(WebSocketServer::new());
+        server.set_app_data_dir(data_dir.clone()).await;
+        server.set_auth(issuer.auth_state()).await;
+        server
+            .set_tenancy(TenancyConfig {
+                mode: TenancyMode::Shared,
+                workspace_id: None,
+                limits,
+                ..TenancyConfig::default()
+            })
+            .await;
+        // Publishing must respect per-document privacy the same way every
+        // other surface does, so run with enforcement on — the default.
+        server.set_enforce_private_docs(true);
+        server
+            .set_config(ServerConfig {
+                port: 0,
+                network_mode: NetworkMode::Localhost,
+                max_connections: 0,
+            })
+            .await
+            .expect("set_config");
+
+        let bound = server.start(0).await.expect("start");
+        let http = bound
+            .strip_prefix("ws://")
+            .map(|rest| format!("http://{rest}"))
+            .unwrap_or(bound);
+
+        std::mem::forget(server);
+
+        Self { base: http, issuer, data_dir, _tmp: tmp }
+    }
+
+    fn token(&self, sub: &str, role: WorkspaceRole) -> String {
+        self.issuer.mint(sub, WS, role)
+    }
+
+    fn ws_dir(&self) -> PathBuf {
+        self.data_dir.join("relay_documents/workspaces").join(WS)
+    }
+
+    async fn put_doc(&self, sub: &str, role: WorkspaceRole, id: &str, body: Value) -> StatusCode {
+        reqwest::Client::new()
+            .put(format!("{}/api/docs/{}", self.base, id))
+            .bearer_auth(self.token(sub, role))
+            .json(&body)
+            .send()
+            .await
+            .expect("put doc")
+            .status()
+    }
+
+    /// A document body loaded with every people-shaped field the raw store
+    /// carries — plus one field ("reviewers") that does not exist in the
+    /// model at all, which is what distinguishes an allowlist from a denylist.
+    fn people_laden_body(id: &str) -> Value {
+        json!({
+            "id": id,
+            "name": "Projection Probe",
+            "modifiedAt": 1000,
+            "tags": ["secret-project"],
+            "collectionId": "col-1",
+            "lastModifiedBy": "user-owner",
+            "lastModifiedByName": "Olive Owner",
+            "reviewers": [{ "userId": "user-x", "userName": "Xavier X" }],
+            "blobReferences": ["e".repeat(64)],
+            "pageOrder": ["p1"],
+            "activePageId": "p1",
+            "pages": {
+                "p1": {
+                    "shapes": {
+                        "s1": { "type": "rectangle", "x": 0.0, "y": 0.0 },
+                        "s2": { "type": "file", "x": 1.0, "y": 1.0,
+                                "blobUrl": format!("blob://{}", "f".repeat(64)) }
+                    },
+                    "shapeOrder": ["s1", "s2"]
+                }
+            },
+            "richTextPages": { "pageOrder": [], "pages": {} }
+        })
+    }
+
+    async fn share(&self, owner: &str, doc_id: &str, with: &str, permission: &str) {
+        let resp = reqwest::Client::new()
+            .post(format!("{}/api/docs/{}/share", self.base, doc_id))
+            .bearer_auth(self.token(owner, WorkspaceRole::Owner))
+            .json(&json!({
+                "shares": [{
+                    "userId": with,
+                    "userName": with,
+                    "permission": permission,
+                    "sharedAt": 0,
+                }]
+            }))
+            .send()
+            .await
+            .expect("share");
+        assert!(resp.status().is_success(), "share failed: {}", resp.status());
+    }
+
+    async fn publish(&self, sub: &str, role: WorkspaceRole, doc_id: &str) -> reqwest::Response {
+        reqwest::Client::new()
+            .post(format!("{}/api/docs/{}/publish", self.base, doc_id))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("publish")
+    }
+
+    async fn unpublish(&self, sub: &str, role: WorkspaceRole, doc_id: &str) -> reqwest::Response {
+        reqwest::Client::new()
+            .delete(format!("{}/api/docs/{}/publish", self.base, doc_id))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("unpublish")
+    }
+
+    async fn publish_status(&self, sub: &str, role: WorkspaceRole, doc_id: &str) -> Value {
+        let resp = reqwest::Client::new()
+            .get(format!("{}/api/docs/{}/publish", self.base, doc_id))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("status");
+        assert_eq!(resp.status(), StatusCode::OK, "status GET failed");
+        resp.json().await.expect("status json")
+    }
+
+    async fn usage_storage_bytes(&self, sub: &str) -> u64 {
+        let body: Value = reqwest::Client::new()
+            .get(format!("{}/api/v1/usage", self.base))
+            .bearer_auth(self.token(sub, WorkspaceRole::Owner))
+            .send()
+            .await
+            .expect("usage")
+            .json()
+            .await
+            .expect("usage json");
+        body["storageBytes"].as_u64().expect("storageBytes")
+    }
+
+    fn artifact_path(&self, doc_id: &str) -> PathBuf {
+        self.ws_dir().join("public").join(format!("{doc_id}.json"))
+    }
+
+    fn manifest_path(&self, doc_id: &str) -> PathBuf {
+        self.ws_dir().join("public").join(format!("{doc_id}.manifest.json"))
+    }
+}
+
+// ───────────────────────── the artifact is a projection ─────────────────────
+
+#[tokio::test]
+async fn published_artifact_carries_no_identity_and_no_novel_fields() {
+    let h = Harness::start().await;
+    let doc = "proj-doc";
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    // A share writes `sharedWith` (ids + display names) INTO the stored body —
+    // the exact bytes the projection must strip.
+    h.share("user-owner", doc, "user-collab", "edit").await;
+
+    let resp = h.publish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let ack: Value = resp.json().await.unwrap();
+    assert_eq!(ack["success"], json!(true));
+    assert!(ack["bytes"].as_u64().unwrap() > 0);
+    // Filesystem backend: keys are null, the artifact lives under public/.
+    assert!(ack["artifactKey"].is_null());
+
+    let artifact = std::fs::read_to_string(h.artifact_path(doc)).expect("artifact written");
+    let parsed: Value = serde_json::from_str(&artifact).unwrap();
+
+    // Kept: the content a reader needs.
+    assert_eq!(parsed["name"], "Projection Probe");
+    assert!(parsed["pages"]["p1"]["shapes"]["s1"].is_object());
+
+    // Dropped: every identity-bearing or internal field — including one the
+    // model has never heard of ("reviewers"), which a denylist written against
+    // today's fields would have let through.
+    for gone in [
+        "id",
+        "ownerId",
+        "ownerName",
+        "sharedWith",
+        "lastModifiedBy",
+        "lastModifiedByName",
+        "collectionId",
+        "tags",
+        "serverVersion",
+        "blobReferences",
+        "reviewers",
+    ] {
+        assert!(parsed.get(gone).is_none(), "{gone} must not survive projection");
+    }
+    for needle in ["user-owner", "user-collab", "Olive Owner", "Xavier X", "secret-project"] {
+        assert!(!artifact.contains(needle), "artifact leaked {needle:?}");
+    }
+}
+
+#[tokio::test]
+async fn manifest_authorizes_only_blobs_the_projection_references() {
+    let h = Harness::start().await;
+    let doc = "manifest-doc";
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    assert_eq!(h.publish("user-owner", WorkspaceRole::Owner, doc).await.status(), StatusCode::OK);
+
+    let manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(h.manifest_path(doc)).unwrap()).unwrap();
+    let blobs = manifest["blobs"].as_object().expect("blobs map");
+
+    // "f"×64 is referenced by the FileShape — in. "e"×64 lived only in the
+    // dropped `blobReferences` array — a blob the artifact does not use must
+    // not be resolvable through its manifest.
+    let content_hash = "f".repeat(64);
+    assert_eq!(blobs.len(), 1, "exactly the projection's blobs: {blobs:?}");
+    assert_eq!(
+        blobs[&content_hash].as_str().unwrap(),
+        format!("ws/{}/ff/ff/{}", WS, content_hash),
+        "manifest carries the full sharded key, consumer derives nothing"
+    );
+    assert_eq!(manifest["title"], "Projection Probe");
+    assert_eq!(manifest["pageCount"], 1);
+    assert_eq!(manifest["shapeCount"], 2);
+    assert_eq!(manifest["fileCount"], 1);
+}
+
+// ───────────────────────────── authorization ────────────────────────────────
+
+#[tokio::test]
+async fn publish_and_unpublish_are_owner_only_status_is_read_scoped() {
+    let h = Harness::start().await;
+    let doc = "authz-doc";
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    h.share("user-owner", doc, "user-editor", "edit").await;
+    h.share("user-owner", doc, "user-viewer", "view").await;
+
+    // An edit share is not ownership: publishing exposes content beyond the
+    // workspace, so it takes the owner gate.
+    for (sub, role) in [
+        ("user-editor", WorkspaceRole::Member),
+        ("user-viewer", WorkspaceRole::Member),
+        ("user-stranger", WorkspaceRole::Member),
+    ] {
+        assert_eq!(
+            h.publish(sub, role, doc).await.status(),
+            StatusCode::FORBIDDEN,
+            "{sub} must not publish"
+        );
+    }
+
+    assert_eq!(h.publish("user-owner", WorkspaceRole::Owner, doc).await.status(), StatusCode::OK);
+
+    // Status: anyone who can read the doc can see its publish state…
+    let status = h.publish_status("user-viewer", WorkspaceRole::Member, doc).await;
+    assert_eq!(status["published"], json!(true));
+
+    // …but cannot change it.
+    assert_eq!(
+        h.unpublish("user-editor", WorkspaceRole::Member, doc).await.status(),
+        StatusCode::FORBIDDEN
+    );
+
+    // A workspace owner holds owner rights on every document (grant chain).
+    assert_eq!(
+        h.unpublish("user-admin", WorkspaceRole::Owner, doc).await.status(),
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn publish_of_a_missing_document_is_404() {
+    let h = Harness::start().await;
+    assert_eq!(
+        h.publish("user-owner", WorkspaceRole::Owner, "never-existed").await.status(),
+        StatusCode::NOT_FOUND
+    );
+}
+
+// ───────────────────────────── size + meter ─────────────────────────────────
+
+#[tokio::test]
+async fn over_cap_publish_is_refused_with_the_cap_and_leaves_the_live_snapshot() {
+    let h = Harness::start_with_limits(LimitsConfig {
+        publish_max_bytes: 600,
+        ..LimitsConfig::default()
+    })
+    .await;
+    let doc = "cap-doc";
+
+    // Small body: publishes fine under the 600-byte cap.
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({ "id": doc, "name": "small", "modifiedAt": 1, "pageOrder": [] }),
+        )
+        .await
+        .is_success());
+    let first = h.publish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let first_bytes = first.json::<Value>().await.unwrap()["bytes"].as_u64().unwrap();
+
+    // Grow the source past the cap.
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({
+                "id": doc,
+                "name": "x".repeat(800),
+                "modifiedAt": 2,
+                "pageOrder": [],
+            }),
+        )
+        .await
+        .is_success());
+
+    let refused = h.publish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(refused.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    let body: Value = refused.json().await.unwrap();
+    assert_eq!(body["errorCode"], "PUBLISH_TOO_LARGE");
+    assert_eq!(body["maxBytes"], 600, "cap echoed so clients render the configured number");
+    assert!(body["sizeBytes"].as_u64().unwrap() > 600);
+
+    // The refused republish must NOT have touched the live snapshot: readers
+    // keep the previous artifact, and status still says published (stale).
+    let artifact = std::fs::read_to_string(h.artifact_path(doc)).unwrap();
+    assert!(artifact.contains("small"), "previous artifact still served");
+    assert_eq!(artifact.len() as u64, first_bytes);
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(status["published"], json!(true));
+    assert_eq!(status["stale"], json!(true));
+    assert_eq!(status["maxBytes"], 600);
+}
+
+#[tokio::test]
+async fn published_bytes_join_the_storage_meter_and_leave_on_unpublish() {
+    let h = Harness::start().await;
+    let doc = "meter-doc";
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+
+    let before = h.usage_storage_bytes("user-owner").await;
+    let ack: Value = h
+        .publish("user-owner", WorkspaceRole::Owner, doc)
+        .await
+        .json()
+        .await
+        .unwrap();
+    let artifact_bytes = ack["bytes"].as_u64().unwrap();
+
+    let during = h.usage_storage_bytes("user-owner").await;
+    assert_eq!(
+        during,
+        before + artifact_bytes,
+        "the artifact is a second stored copy and meters as one"
+    );
+
+    let resp = h.unpublish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.json::<Value>().await.unwrap()["removed"], json!(true));
+    assert_eq!(h.usage_storage_bytes("user-owner").await, before, "unpublish frees the bytes");
+
+    // Files gone, status back to unpublished, second delete idempotent.
+    assert!(!h.artifact_path(doc).exists());
+    assert!(!h.manifest_path(doc).exists());
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(status["published"], json!(false));
+    let again = h.unpublish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(again.status(), StatusCode::OK);
+    assert_eq!(again.json::<Value>().await.unwrap()["removed"], json!(false));
+}
+
+#[tokio::test]
+async fn publish_refuses_when_the_quota_cannot_hold_a_second_copy() {
+    // Quota sized to admit the document but not document + artifact.
+    let h = Harness::start_with_limits(LimitsConfig {
+        storage_quota_bytes: 700,
+        ..LimitsConfig::default()
+    })
+    .await;
+    let doc = "quota-doc";
+    // ~400-byte body (pretty-printed on disk): fits the 700-byte quota alone;
+    // its ~300-byte compact artifact would overflow it.
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({ "id": doc, "name": "q".repeat(300), "modifiedAt": 1, "pageOrder": [] }),
+        )
+        .await
+        .is_success());
+
+    let resp = h.publish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(resp.status(), StatusCode::INSUFFICIENT_STORAGE);
+    // Same stable string as the save gate — clients key on it.
+    assert_eq!(resp.json::<Value>().await.unwrap()["error"], "storage quota exceeded");
+    assert!(!h.artifact_path(doc).exists(), "a refused publish writes nothing");
+}
+
+// ───────────────────────────── staleness ────────────────────────────────────
+
+#[tokio::test]
+async fn status_flags_stale_after_a_source_edit_and_clears_on_republish() {
+    let h = Harness::start().await;
+    let doc = "stale-doc";
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({ "id": doc, "name": "v1", "modifiedAt": 1000, "pageOrder": [] }),
+        )
+        .await
+        .is_success());
+
+    assert_eq!(h.publish("user-owner", WorkspaceRole::Owner, doc).await.status(), StatusCode::OK);
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(status["stale"], json!(false));
+
+    // Edit with a later modifiedAt — the staleness axis is the timestamp,
+    // deliberately (collab flushes don't bump serverVersion).
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({ "id": doc, "name": "v2", "modifiedAt": 2000, "pageOrder": [] }),
+        )
+        .await
+        .is_success());
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(status["stale"], json!(true));
+
+    assert_eq!(h.publish("user-owner", WorkspaceRole::Owner, doc).await.status(), StatusCode::OK);
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(status["stale"], json!(false));
+    // And the artifact now reflects the edit.
+    assert!(std::fs::read_to_string(h.artifact_path(doc)).unwrap().contains("v2"));
+}
+
+// ───────────────────────────── durability ───────────────────────────────────
+
+#[tokio::test]
+async fn published_state_and_meter_survive_a_relay_restart() {
+    let h = Harness::start().await;
+    let doc = "durable-doc";
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    let ack: Value = h
+        .publish("user-owner", WorkspaceRole::Owner, doc)
+        .await
+        .json()
+        .await
+        .unwrap();
+    let artifact_bytes = ack["bytes"].as_u64().unwrap();
+    let usage_before = h.usage_storage_bytes("user-owner").await;
+
+    let h = h.reboot(LimitsConfig::default()).await;
+
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(status["published"], json!(true), "registry reloaded from disk");
+    assert_eq!(status["bytes"].as_u64().unwrap(), artifact_bytes);
+    assert_eq!(
+        h.usage_storage_bytes("user-owner").await,
+        usage_before,
+        "meter contribution survives the restart"
+    );
+}


### PR DESCRIPTION
## What

`POST` / `DELETE` / `GET /api/docs/:id/publish` — write (and remove) a **sanitized, frozen copy** of a document to storage: the artifact downstream infrastructure serves to readers holding no relay credentials. The relay gains **no anonymous surface** — `permissions::resolve` still returns `None` for `Principal::Anonymous`, and nothing here serves the artifact.

## Safety model (pinned by `relay/tests/document_publish.rs`, 9 tests)

- **Allowlist projection** (`server/publish.rs`): the stored body embeds `sharedWith`, ownership, and edit attribution; a denylist would fail open when the model grows. Proven by a novel-field test (`reviewers`, a field the model has never heard of, vanishes) and a raw-passthrough **mutation check** that fails by name.
- **Flattened JSON, never the Y.Doc** — the CRDT binary carries deleted text and prior revisions. A resident doc is flushed first so the snapshot reflects live state, not the last persistence tick.
- **Manifest maps blob hash → full object key**, scanned from the *projection* — a blob referenced only by a dropped field is not resolvable through the artifact. Consumers derive no key layout, so writer/reader drift is structurally impossible.
- **`publish_max_bytes`** (config-only, default 10 MiB, `RELAY_PUBLISH_MAX_BYTES` + README row): oversize is refused with the cap echoed in the body; a refused republish **never invalidates** the previously published snapshot.
- **Metered**: artifact bytes join the single storage meter (usage endpoint, REST/MCP save gates, blob-grant headroom) and leave it on unpublish. Registry (`published.json`, beside `collections.json`) is mirrored to the object store with presence-keyed cold restore — state and meter survive a restart, proven by a reboot test.
- **Owner-only mutation** (same gate as share management); status is read-scoped and carries a `modified_at`-based staleness flag.
- **Durability ordering**: object-store PUTs are awaited *before* the registry records anything — success means the artifact is really where downstream will look.

Also folds in the standing JP-465 invariant: REST reads never make a document resident (`rest_reads_do_not_make_a_document_resident`).

## Verification

- `cargo test`: 25 suites, 0 failures (includes the new 9-test publish suite + the 16-test privacy suite)
- `cargo check --all-targets`: clean
- Mutation check: projection swapped for raw passthrough → `published_artifact_carries_no_identity_and_no_novel_fields` fails by name; revert → green
- OSS leak grep on the diff: clean

Assisted-by: Opus 5