### PR TITLE
JP-464: guest view + publish controls — the editor half of published documents

### DIFF
--- a/relay/src/server/publish.rs
+++ b/relay/src/server/publish.rs
@@ -107,47 +107,18 @@ pub fn sharded_blob_key(ws: &str, hash: &str) -> String {
     format!("ws/{}/{}/{}/{}", ws, a, b, hash)
 }
 
-/// Blob hashes referenced by a projected document — the union of every
-/// `blob://<sha256>` URI in its content. Scans the *projection*, not the
-/// source: a blob referenced only by a field the allowlist dropped must not
-/// be resolvable through the artifact's manifest.
+/// Blob hashes referenced by a projected document. Scans the *projection*,
+/// not the source: a blob referenced only by a field the allowlist dropped
+/// must not be resolvable through the artifact's manifest.
+///
+/// Delegates to the save path's canonical content walker
+/// (`crate::api::collect_blob_references`) rather than keeping a twin: the
+/// walker knows every reference shape — FileShape's bare-hash `blobRef` AND
+/// prose `blob://<hash>` URIs — and a private copy here already missed the
+/// former once (caught live: a published document's files resolved to
+/// nothing because only the URI form was scanned).
 pub fn projected_blob_hashes(projected: &Value) -> HashSet<String> {
-    let mut refs = HashSet::new();
-    collect_blob_uris(projected, &mut refs);
-    refs
-}
-
-fn collect_blob_uris(value: &Value, refs: &mut HashSet<String>) {
-    match value {
-        Value::String(s) => {
-            // Content may embed the URI mid-string (prose HTML `src="blob://…"`),
-            // so scan substrings rather than testing the whole string.
-            let mut rest = s.as_str();
-            while let Some(pos) = rest.find("blob://") {
-                let tail = &rest[pos + "blob://".len()..];
-                let hash: String = tail
-                    .chars()
-                    .take_while(|c| c.is_ascii_hexdigit())
-                    .take(64)
-                    .collect();
-                if hash.len() == 64 {
-                    refs.insert(hash.to_lowercase());
-                }
-                rest = &rest[pos + "blob://".len()..];
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                collect_blob_uris(item, refs);
-            }
-        }
-        Value::Object(map) => {
-            for v in map.values() {
-                collect_blob_uris(v, refs);
-            }
-        }
-        _ => {}
-    }
+    crate::api::collect_blob_references(projected).into_iter().collect()
 }
 
 /// Counts surfaced by the manifest (preview cards want "N pages · N shapes ·
@@ -254,8 +225,11 @@ mod tests {
                 "p1": {
                     "shapes": {
                         "s1": { "type": "rectangle", "x": 0, "y": 0 },
+                        // The REAL FileShape reference shape: a bare hash under
+                        // `blobRef`, no `blob://` prefix. The live E2E caught a
+                        // scanner that only knew the URI form.
                         "s2": { "type": "file", "x": 1, "y": 1,
-                                "blobUrl": format!("blob://{}", "b".repeat(64)) }
+                                "blobRef": "b".repeat(64) }
                     },
                     "shapeOrder": ["s1", "s2"]
                 }
@@ -320,8 +294,8 @@ mod tests {
         // "a"×64 lived only in the dropped `blobReferences` array — a blob the
         // artifact does not use must not be resolvable through its manifest.
         assert!(!hashes.contains(&"a".repeat(64)));
-        assert!(hashes.contains(&"b".repeat(64)), "FileShape blob ref");
-        assert!(hashes.contains(&"c".repeat(64)), "prose <img> blob ref");
+        assert!(hashes.contains(&"b".repeat(64)), "FileShape bare-hash blobRef");
+        assert!(hashes.contains(&"c".repeat(64)), "prose <img> blob:// ref");
     }
 
     #[test]

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -49,6 +49,13 @@ export class RelayError extends Error {
     public readonly status: number,
     public readonly url: string,
     public override readonly message: string,
+    /**
+     * The parsed JSON error body, when the response carried one (JP-464).
+     * Structured refusals (`PUBLISH_TOO_LARGE` with `sizeBytes`/`maxBytes`,
+     * `DOC_TOO_LARGE`) put their numbers here so callers render the server's
+     * configured values instead of hardcoding a copy.
+     */
+    public readonly body?: unknown,
   ) {
     super(message);
     this.name = 'RelayError';
@@ -161,6 +168,29 @@ export interface RelayRecoveryPoint {
   serverVersion: number;
   /** On-disk size of the backup (a rough content-size proxy). */
   sizeBytes: number;
+}
+
+/** Relay ack for `POST /api/docs/:id/publish` (JP-464). The object keys are
+ *  handed verbatim to the control plane's share-link row — this client never
+ *  interprets them. `null` keys = filesystem-backend relay (self-host). */
+export interface RelayPublishAck {
+  success: boolean;
+  artifactKey: string | null;
+  manifestKey: string | null;
+  bytes: number;
+  publishedAt: number;
+}
+
+/** Relay publish state for a document (JP-464). `maxBytes` is the configured
+ *  artifact ceiling (`null` = no ceiling) — the single home of that number;
+ *  clients render it and never hardcode a cap. */
+export interface RelayPublishStatus {
+  published: boolean;
+  publishedAt?: number;
+  bytes?: number;
+  /** The source has changed since publishing (timestamp comparison). */
+  stale: boolean;
+  maxBytes: number | null;
 }
 
 // ============ Client ============
@@ -343,6 +373,32 @@ export class RelayClient {
     return this.requestJson('POST', `/api/docs/${encodeURIComponent(docId)}/share`, {
       auth: true,
       body: { shares },
+    });
+  }
+
+  /**
+   * Write the document's public projection artifact (JP-464). Owner-only;
+   * the relay flushes live CRDT state first, so the snapshot reflects "now".
+   * 413 (`PUBLISH_TOO_LARGE`, cap echoed) and 507 map to RelayError codes the
+   * publish flow renders verbatim.
+   */
+  async publishDocument(docId: string): Promise<RelayPublishAck> {
+    return this.requestJson('POST', `/api/docs/${encodeURIComponent(docId)}/publish`, {
+      auth: true,
+    });
+  }
+
+  /** Remove the public projection (idempotent — `removed:false` when none). */
+  async unpublishDocument(docId: string): Promise<{ success: boolean; removed: boolean }> {
+    return this.requestJson('DELETE', `/api/docs/${encodeURIComponent(docId)}/publish`, {
+      auth: true,
+    });
+  }
+
+  /** Publish state for a document — read-scoped, carries the configured cap. */
+  async getPublishStatus(docId: string): Promise<RelayPublishStatus> {
+    return this.requestJson('GET', `/api/docs/${encodeURIComponent(docId)}/publish`, {
+      auth: true,
     });
   }
 
@@ -691,5 +747,5 @@ async function buildRelayError(res: Response, url: string): Promise<RelayError> 
     }
   }
 
-  return new RelayError(res.status, url, message);
+  return new RelayError(res.status, url, message, parsed);
 }

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -115,6 +115,18 @@ export class RestDocumentProvider {
     await this.client.updateDocumentShares(docId, shares);
   }
 
+  async publishDocument(docId: string) {
+    return this.client.publishDocument(docId);
+  }
+
+  async unpublishDocument(docId: string) {
+    return this.client.unpublishDocument(docId);
+  }
+
+  async getPublishStatus(docId: string) {
+    return this.client.getPublishStatus(docId);
+  }
+
   /** True when there's a JWT to send. Used by `SyncStateManager` to gate queue flushes. */
   isReady(): boolean {
     return this.client.getToken() !== undefined;

--- a/src/api/webClient.ts
+++ b/src/api/webClient.ts
@@ -115,6 +115,21 @@ export interface FetchedMirrorContent {
   sourceRef: MirrorSourceRef;
 }
 
+/**
+ * A document's public share link, as the control plane reports it (JP-464).
+ * `revokedAt === null` means the link is live. The token composes with the
+ * editor's own origin: `${location.origin}/d/${token}` — guest links are
+ * same-origin with the PWA by design (the Worker route sits on this host).
+ */
+export interface ShareLink {
+  token: string;
+  createdBy: string;
+  createdAt: string | null;
+  publishedAt: string | null;
+  revokedAt: string | null;
+  viewCount: number;
+}
+
 /** A failed control-plane call. `status` is the HTTP status (0 = network/no-auth). */
 export class WebClientError extends Error {
   constructor(
@@ -370,6 +385,54 @@ export const webClient = {
     await request<void>(
       'POST',
       `/api/v1/workspace/${encodeURIComponent(workspaceId)}/leave`,
+      deps,
+    );
+  },
+
+  // ── Public share links (JP-464) ──────────────────────────────────────────
+
+  /**
+   * Register (or refresh) a document's share link with the object keys from
+   * the relay's publish ack. Called ONLY after a successful relay publish —
+   * this is the read-side commit point (the URL goes live when the row does).
+   * Re-enabling a revoked link is creator-or-workspace-owner (403 otherwise).
+   */
+  async mintShareLink(
+    docId: string,
+    keys: { artifactKey: string; manifestKey: string; publishedBytes?: number },
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<ShareLink> {
+    return request<ShareLink>('POST', `/api/v1/share-links`, deps, {
+      workspaceId,
+      docId,
+      ...keys,
+    });
+  },
+
+  /** The document's share link, or null when none was ever minted. */
+  async getShareLink(
+    docId: string,
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<ShareLink | null> {
+    const { link } = await request<{ link: ShareLink | null }>(
+      'GET',
+      `/api/v1/share-links?workspaceId=${encodeURIComponent(workspaceId)}&docId=${encodeURIComponent(docId)}`,
+      deps,
+    );
+    return link;
+  },
+
+  /** Revoke a document's share link (creator or workspace owner; idempotent). */
+  async revokeShareLink(
+    docId: string,
+    workspaceId: string = activeWorkspaceId(),
+    deps: WebClientDeps = {},
+  ): Promise<void> {
+    await request<{ revoked: boolean }>(
+      'DELETE',
+      `/api/v1/share-links?workspaceId=${encodeURIComponent(workspaceId)}&docId=${encodeURIComponent(docId)}`,
       deps,
     );
   },

--- a/src/guest/GuestBar.tsx
+++ b/src/guest/GuestBar.tsx
@@ -1,0 +1,83 @@
+/**
+ * Guest header bar (JP-464) — the one piece of chrome a share-link reader
+ * always sees. Identity (this is a DocuShark document), provenance (name +
+ * published date, the line a citation wants), and the two actions a reader
+ * can take without an account: keep a copy of the data, or try the product.
+ *
+ * Deliberately not a sign-up wall: reading never prompts for anything. The
+ * document is the pitch.
+ */
+import { Download, ExternalLink } from 'lucide-react';
+import { useDocumentRegistry } from '../store/documentRegistry';
+import { useGuestStore } from './guestSession';
+import './guest.css';
+
+function formatPublished(ms: number): string {
+  if (!ms) return '';
+  const date = new Date(ms);
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
+  });
+}
+
+/** Download the rendered snapshot as a JSON file — the reader keeps the data
+ *  with no account and no server round-trip (the document is already here). */
+function downloadSnapshot(name: string, docId: string | null): void {
+  if (!docId) return;
+  const doc = useDocumentRegistry.getState().entries[docId]?.document;
+  if (!doc) return;
+  const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${name.replace(/[^\w.-]+/g, '_') || 'document'}.docushark.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function GuestBar() {
+  const documentName = useGuestStore((s) => s.documentName);
+  const publishedAt = useGuestStore((s) => s.publishedAt);
+  const activeDocId = useDocumentRegistry((s) => s.activeDocumentId);
+  const published = formatPublished(publishedAt);
+
+  return (
+    <header className="guest-bar" role="banner">
+      <div className="guest-bar__identity">
+        <span className="guest-bar__brand">DocuShark</span>
+        <span className="guest-bar__divider" aria-hidden="true" />
+        <span className="guest-bar__name" title={documentName}>
+          {documentName}
+        </span>
+        {published ? (
+          <span className="guest-bar__published">Published {published}</span>
+        ) : null}
+      </div>
+      <div className="guest-bar__actions">
+        <button
+          type="button"
+          className="guest-bar__btn"
+          onClick={() => downloadSnapshot(documentName, activeDocId)}
+          title="Download this document's data as JSON"
+        >
+          <Download size={14} aria-hidden="true" />
+          <span>Download copy</span>
+        </button>
+        <a
+          className="guest-bar__btn guest-bar__btn--cta"
+          href="/"
+          target="_blank"
+          rel="noopener"
+          title="Open DocuShark and start your own document — free"
+        >
+          <ExternalLink size={14} aria-hidden="true" />
+          <span>Try DocuShark free</span>
+        </a>
+      </div>
+    </header>
+  );
+}
+
+export default GuestBar;

--- a/src/guest/GuestBar.tsx
+++ b/src/guest/GuestBar.tsx
@@ -1,14 +1,20 @@
 /**
  * Guest header bar (JP-464) — the one piece of chrome a share-link reader
  * always sees. Identity (this is a DocuShark document), provenance (name +
- * published date, the line a citation wants), and the two actions a reader
- * can take without an account: keep a copy of the data, or try the product.
+ * published date, the line a citation wants), and one forward action.
  *
  * Deliberately not a sign-up wall: reading never prompts for anything. The
  * document is the pitch.
+ *
+ * **No "take a copy" action here, on purpose (JP-467).** A copy is only
+ * useful as a `.docushark` archive — document *plus* its blob bytes — and
+ * handing that to an anonymous reader is a distribution decision, not a
+ * button. The right shape is **Add to Workspace**: sign in, and the document
+ * lands in a workspace you own, where the archive machinery already works.
+ * Until that exists, offering a download would either emit JSON full of
+ * dangling `blob://` references or quietly publish a full archive.
  */
-import { Download, ExternalLink } from 'lucide-react';
-import { useDocumentRegistry } from '../store/documentRegistry';
+import { ExternalLink } from 'lucide-react';
 import { useGuestStore } from './guestSession';
 import './guest.css';
 
@@ -22,25 +28,9 @@ function formatPublished(ms: number): string {
   });
 }
 
-/** Download the rendered snapshot as a JSON file — the reader keeps the data
- *  with no account and no server round-trip (the document is already here). */
-function downloadSnapshot(name: string, docId: string | null): void {
-  if (!docId) return;
-  const doc = useDocumentRegistry.getState().entries[docId]?.document;
-  if (!doc) return;
-  const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `${name.replace(/[^\w.-]+/g, '_') || 'document'}.docushark.json`;
-  a.click();
-  URL.revokeObjectURL(url);
-}
-
 export function GuestBar() {
   const documentName = useGuestStore((s) => s.documentName);
   const publishedAt = useGuestStore((s) => s.publishedAt);
-  const activeDocId = useDocumentRegistry((s) => s.activeDocumentId);
   const published = formatPublished(publishedAt);
 
   return (
@@ -56,15 +46,6 @@ export function GuestBar() {
         ) : null}
       </div>
       <div className="guest-bar__actions">
-        <button
-          type="button"
-          className="guest-bar__btn"
-          onClick={() => downloadSnapshot(documentName, activeDocId)}
-          title="Download this document's data as JSON"
-        >
-          <Download size={14} aria-hidden="true" />
-          <span>Download copy</span>
-        </button>
         <a
           className="guest-bar__btn guest-bar__btn--cta"
           href="/"

--- a/src/guest/GuestRoot.tsx
+++ b/src/guest/GuestRoot.tsx
@@ -1,0 +1,71 @@
+/**
+ * Guest mount root (JP-464). Chosen over a bespoke viewer on purpose: `ready`
+ * mounts the REAL editor — full canvas fidelity, layouts, prose — with the
+ * `external` registry record holding every existing read-only guard closed.
+ * A diagramming product whose shared artifact can't render diagrams would
+ * defeat the feature.
+ *
+ * The terminal states mirror the server's uniform miss: `unavailable` says
+ * nothing about WHY (revoked, never existed — deliberately
+ * indistinguishable), while `error` is infra-shaped and retryable.
+ */
+import App from '../ui/App';
+import { GuestBar } from './GuestBar';
+import { useGuestStore } from './guestSession';
+import './guest.css';
+
+export function GuestRoot() {
+  const phase = useGuestStore((s) => s.phase);
+  const errorDetail = useGuestStore((s) => s.errorDetail);
+
+  if (phase === 'loading') {
+    return (
+      <div className="guest-terminal">
+        <div className="guest-terminal__card" role="status">
+          <div className="guest-terminal__spinner" aria-hidden="true" />
+          <h1>Opening document…</h1>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'unavailable') {
+    return (
+      <div className="guest-terminal">
+        <main className="guest-terminal__card">
+          <h1>This document isn't available</h1>
+          <p>The link may have been turned off by its owner, or it never existed.</p>
+        </main>
+      </div>
+    );
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className="guest-terminal">
+        <main className="guest-terminal__card">
+          <h1>Something went wrong</h1>
+          <p>{errorDetail}</p>
+          <button
+            type="button"
+            className="guest-terminal__retry"
+            onClick={() => window.location.reload()}
+          >
+            Retry
+          </button>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <GuestBar />
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <App authCallbackConsumed={false} />
+      </div>
+    </div>
+  );
+}
+
+export default GuestRoot;

--- a/src/guest/guest.css
+++ b/src/guest/guest.css
@@ -1,0 +1,154 @@
+/* Guest surfaces (JP-464): the share-link header bar + the terminal screens.
+ * Navy rail treatment (brand tokens from index.css) — the bar reads as
+ * product chrome, distinct from the document below it, in both themes. */
+
+.guest-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px;
+  height: 40px;
+  flex: 0 0 auto;
+  background: var(--navy-950);
+  color: var(--steel-100);
+  border-bottom: 1px solid var(--navy-700);
+}
+
+.guest-bar__identity {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.guest-bar__brand {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  color: var(--brand-gold, #c9a262);
+  flex: 0 0 auto;
+}
+
+.guest-bar__divider {
+  width: 1px;
+  height: 14px;
+  background: var(--navy-600);
+  align-self: center;
+  flex: 0 0 auto;
+}
+
+.guest-bar__name {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.guest-bar__published {
+  font-size: 12px;
+  color: var(--steel-400, #8d9bb1);
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+.guest-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.guest-bar__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-weight: 600;
+  border: 1px solid var(--navy-600);
+  background: transparent;
+  color: var(--steel-100);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 120ms ease;
+}
+
+.guest-bar__btn:hover {
+  background: var(--navy-800);
+}
+
+.guest-bar__btn--cta {
+  background: var(--color-cta);
+  border-color: var(--color-cta);
+  color: var(--color-cta-text);
+}
+
+.guest-bar__btn--cta:hover {
+  background: var(--color-cta-hover);
+  border-color: var(--color-cta-hover);
+}
+
+/* Terminal screens: loading / unavailable / error. Full-viewport, calm. */
+.guest-terminal {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--bg-secondary, #f6f4ec);
+  color: var(--text-primary, #0a1525);
+  font-family: inherit;
+}
+
+.guest-terminal__card {
+  text-align: center;
+  padding: 2rem;
+  max-width: 26rem;
+}
+
+.guest-terminal__card h1 {
+  font-size: 1.2rem;
+  margin: 0 0 0.5rem;
+}
+
+.guest-terminal__card p {
+  margin: 0 0 1rem;
+  color: var(--text-secondary, #4a5a72);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.guest-terminal__spinner {
+  width: 26px;
+  height: 26px;
+  margin: 0 auto 12px;
+  border-radius: 50%;
+  border: 3px solid var(--steel-200, #d5dbe4);
+  border-top-color: var(--navy-700, #1f3354);
+  animation: guest-spin 0.9s linear infinite;
+}
+
+@keyframes guest-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .guest-terminal__spinner {
+    animation-duration: 2.5s;
+  }
+}
+
+.guest-terminal__retry {
+  padding: 7px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--navy-700, #1f3354);
+  background: var(--navy-900, #0e1c30);
+  color: var(--steel-100, #e7ebf2);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/src/guest/guestSession.ts
+++ b/src/guest/guestSession.ts
@@ -1,0 +1,177 @@
+/**
+ * Guest session (JP-464) — the read-only view a stranger gets when opening a
+ * published document's share link, `/d/<token>`.
+ *
+ * The PWA boots with NO session on this route: no relay connection, no cloud
+ * sign-in prompt, no library. The Worker on this same origin serves the
+ * published artifact (`/api/share/<token>`) and its blobs; this module
+ * fetches, hydrates the live stores through the normal migration funnel, and
+ * registers an `external` record — which is what makes the entire existing
+ * read-only machinery (Engine pan-only, prose non-editable, commands gated,
+ * the ribbon) engage without a single new guard.
+ *
+ * The artifact was projected server-side (allowlist; no identity fields), so
+ * nothing here filters content — it renders what it is given.
+ */
+import { create } from 'zustand';
+import { usePersistenceStore } from '../store/persistenceStore';
+import { registerBlobDownloader } from '../storage/blobResolver';
+import { blobStorage } from '../storage/BlobStorage';
+import { DocumentVersionError } from '../migrations/documentMigrations';
+import type { DiagramDocument } from '../types/Document';
+import type { ExternalDocument } from '../types/DocumentRegistry';
+
+/** `/d/<token>` — the guest route. Token shape mirrors the server's gate. */
+const GUEST_PATH = /^\/d\/([A-Za-z0-9_-]{43})$/;
+
+export interface GuestManifestSummary {
+  title?: string;
+  pageCount?: number;
+  shapeCount?: number;
+  fileCount?: number;
+  publishedAt?: number;
+}
+
+export type GuestPhase = 'loading' | 'ready' | 'unavailable' | 'error';
+
+interface GuestState {
+  /** Non-null exactly when this tab is a guest view. */
+  token: string | null;
+  phase: GuestPhase;
+  /** Document name for the bar (post-hydration). */
+  documentName: string;
+  /** Publish time, ms — provenance line on the bar; 0 = unknown. */
+  publishedAt: number;
+  /** Human-readable failure detail for `error` (never for `unavailable` —
+   *  the miss deliberately carries no detail). */
+  errorDetail: string;
+}
+
+export const useGuestStore = create<GuestState>(() => ({
+  token: null,
+  phase: 'loading',
+  documentName: '',
+  publishedAt: 0,
+  errorDetail: '',
+}));
+
+/** Whether the current location is a guest share route. */
+export function guestTokenFromLocation(pathname: string): string | null {
+  const match = GUEST_PATH.exec(pathname);
+  return match ? match[1]! : null;
+}
+
+/** True when this tab is a guest view (any phase). */
+export function isGuestSession(): boolean {
+  return useGuestStore.getState().token !== null;
+}
+
+/**
+ * The share artifact is content-only; the editor still needs a document id
+ * for store bookkeeping. Derive a stable session-local id from the token so
+ * reloads look identical — prefixed so it can never collide with a real
+ * relay/local id, and never leaves this tab (external records don't persist).
+ */
+function guestDocId(token: string): string {
+  return `guest-${token.slice(0, 16)}`;
+}
+
+/**
+ * Boot the guest view for `token`. Fetches the artifact + manifest summary,
+ * hydrates the editor, and registers the share-scoped blob downloader.
+ * Resolves when the store phase is terminal (`ready` / `unavailable` /
+ * `error`); the caller mounts the shell either way.
+ */
+export async function bootGuestSession(token: string): Promise<void> {
+  useGuestStore.setState({ token, phase: 'loading' });
+
+  let artifact: DiagramDocument;
+  let manifest: GuestManifestSummary = {};
+  try {
+    const res = await fetch(`/api/share/${encodeURIComponent(token)}`, {
+      headers: { accept: 'application/json' },
+    });
+    if (res.status === 404) {
+      // Revoked, unknown, malformed — one state, matching the server's
+      // deliberate refusal to distinguish them.
+      useGuestStore.setState({ phase: 'unavailable' });
+      return;
+    }
+    if (!res.ok) {
+      useGuestStore.setState({
+        phase: 'error',
+        errorDetail: `The document service returned ${res.status}. Try again in a minute.`,
+      });
+      return;
+    }
+    artifact = (await res.json()) as DiagramDocument;
+  } catch {
+    useGuestStore.setState({
+      phase: 'error',
+      errorDetail: 'Could not reach the document service. Check your connection and retry.',
+    });
+    return;
+  }
+
+  // Display summary for the bar's provenance line — a server-side projection
+  // of the manifest (title/counts/publishedAt only; the manifest itself, with
+  // its storage keys, never leaves the server). Best-effort: the document
+  // renders fine without it.
+  try {
+    const res = await fetch(`/api/share/${encodeURIComponent(token)}/meta`, {
+      headers: { accept: 'application/json' },
+    });
+    if (res.ok) manifest = (await res.json()) as GuestManifestSummary;
+  } catch {
+    /* provenance degrades to blank; content is unaffected */
+  }
+
+  // Blob resolution for the snapshot: the share blob endpoint, authorized by
+  // the artifact's manifest server-side. Stored content-addressed locally, so
+  // the id IS the hash and the in-document `blob://` URIs resolve untouched.
+  registerBlobDownloader(async (hash) => {
+    try {
+      const res = await fetch(`/api/share/${encodeURIComponent(token)}/blobs/${hash}`);
+      if (!res.ok) return false;
+      const blob = await res.blob();
+      await blobStorage.saveBlob(blob, hash);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  const id = guestDocId(token);
+  const name =
+    (typeof artifact.name === 'string' && artifact.name) || manifest.title || 'Untitled document';
+  const now = Date.now();
+  const record: ExternalDocument = {
+    type: 'external',
+    source: 'share-link',
+    id,
+    name,
+    pageCount: manifest.pageCount ?? artifact.pageOrder?.length ?? 1,
+    createdAt: manifest.publishedAt ?? now,
+    modifiedAt: manifest.publishedAt ?? now,
+    ...(manifest.publishedAt !== undefined ? { publishedAt: manifest.publishedAt } : {}),
+  };
+
+  try {
+    usePersistenceStore.getState().loadExternalDocument({ ...artifact, id, name }, record);
+  } catch (e) {
+    useGuestStore.setState({
+      phase: 'error',
+      errorDetail:
+        e instanceof DocumentVersionError
+          ? 'This document was published from a newer DocuShark. Refresh to update, then retry.'
+          : 'This document could not be opened.',
+    });
+    return;
+  }
+
+  useGuestStore.setState({
+    phase: 'ready',
+    documentName: name,
+    publishedAt: manifest.publishedAt ?? 0,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,8 @@ import './shapes/import/registerImportAdapters';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './ui/App';
+import GuestRoot from './guest/GuestRoot';
+import { bootGuestSession, guestTokenFromLocation } from './guest/guestSession';
 import { registerPwa } from './pwa/registerPwa';
 import { initInstallPrompt } from './pwa/installPrompt';
 import { handleAuthCallbackIfPresent } from './api/authCallback';
@@ -44,9 +46,39 @@ function mountApp(authCallbackConsumed: boolean): void {
   initInstallPrompt();
 }
 
-// Intercept the PWA web one-click handoff (`/auth/callback?handoff_code=…`)
-// before mounting: consume the code, connect the relay, then mount. A no-op on
-// every other route (and in the Tauri build). The boolean it resolves with
-// (`true` = it signed in on this load) is threaded to App so boot auto-sign-in
-// doesn't double-connect on the callback route.
-void handleAuthCallbackIfPresent().then(mountApp);
+/** Mount the guest (share-link) view: hydrate from the share API, then render
+ *  the read-only editor behind the guest bar. No session machinery runs. */
+function mountGuest(token: string): void {
+  const root = document.getElementById('root');
+  if (!root) {
+    throw new Error('Root element not found');
+  }
+  const reactRoot = ReactDOM.createRoot(root);
+  const render = () =>
+    reactRoot.render(
+      <React.StrictMode>
+        <GuestRoot />
+      </React.StrictMode>
+    );
+  render();
+  void bootGuestSession(token);
+  // The PWA still registers its SW on this route — an installed app serves
+  // `/d/` navigations from the shell, and the client route (this code) must
+  // exist there too.
+  registerPwa();
+}
+
+// JP-464: a `/d/<token>` navigation is a GUEST view — published-document
+// reading with no session. It branches before any auth machinery: no handoff
+// interception, no boot auto-sign-in, no last-document restore.
+const guestToken = guestTokenFromLocation(window.location.pathname);
+if (guestToken) {
+  mountGuest(guestToken);
+} else {
+  // Intercept the PWA web one-click handoff (`/auth/callback?handoff_code=…`)
+  // before mounting: consume the code, connect the relay, then mount. A no-op on
+  // every other route (and in the Tauri build). The boolean it resolves with
+  // (`true` = it signed in on this load) is threaded to App so boot auto-sign-in
+  // doesn't double-connect on the callback route.
+  void handleAuthCallbackIfPresent().then(mountApp);
+}

--- a/src/share/publishFlow.test.ts
+++ b/src/share/publishFlow.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Publish orchestration pins (JP-464). The ORDER is the contract:
+ *
+ * - publish: relay artifact first, control-plane row second — a mint failure
+ *   must report "published but link missing", never mint before the artifact
+ *   exists (a link that 404s for readers);
+ * - unpublish: row revoke first (the URL dies), relay delete second and
+ *   best-effort (stale metered bytes are recoverable; a live URL after
+ *   "turn off" is not).
+ *
+ * Failure mapping renders the SERVER's numbers (413 body) — no client copy
+ * of the cap exists to drift.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { publishDocument, unpublishDocument, shareUrlFor } from './publishFlow';
+import { RelayError } from '../api/relayClient';
+
+const calls: string[] = [];
+
+const provider: Record<string, unknown> = {};
+vi.mock('../store/relayDocumentStore', () => ({
+  getDocProvider: () => provider,
+}));
+vi.mock('../store/autoSaveGuard', () => ({
+  flushAutoSaveNow: () => calls.push('flush'),
+}));
+
+const webMock = {
+  mintShareLink: vi.fn(),
+  revokeShareLink: vi.fn(),
+};
+vi.mock('../api/webClient', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/webClient')>();
+  return {
+    ...original,
+    webClient: new Proxy(original.webClient, {
+      get(target, prop: string) {
+        if (prop in webMock) {
+          return (...args: unknown[]) => {
+            calls.push(prop);
+            return (webMock as Record<string, ReturnType<typeof vi.fn>>)[prop]!(...args);
+          };
+        }
+        return (target as Record<string, unknown>)[prop];
+      },
+    }),
+  };
+});
+
+const ACK = {
+  success: true,
+  artifactKey: 'docs/ws/public/d1.json',
+  manifestKey: 'docs/ws/public/d1.manifest.json',
+  bytes: 1234,
+  publishedAt: 1000,
+};
+const LINK = {
+  token: 'A'.repeat(43),
+  createdBy: 'u1',
+  createdAt: 'now',
+  publishedAt: 'now',
+  revokedAt: null,
+  viewCount: 0,
+};
+
+beforeEach(() => {
+  calls.length = 0;
+  provider['publishDocument'] = vi.fn(async () => {
+    calls.push('relay-publish');
+    return ACK;
+  });
+  provider['unpublishDocument'] = vi.fn(async () => {
+    calls.push('relay-unpublish');
+    return { success: true, removed: true };
+  });
+  webMock.mintShareLink.mockResolvedValue(LINK);
+  webMock.revokeShareLink.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('publishDocument', () => {
+  it('publishes relay-first, mints second, and flushes pending edits before either', async () => {
+    const outcome = await publishDocument('d1');
+    expect(outcome.ok).toBe(true);
+    expect(calls).toEqual(['flush', 'relay-publish', 'mintShareLink']);
+    if (outcome.ok) {
+      expect(outcome.link.token).toBe(LINK.token);
+      expect(outcome.bytes).toBe(1234);
+    }
+  });
+
+  it('a mint failure reports link-mint-failed — the artifact half succeeded', async () => {
+    webMock.mintShareLink.mockRejectedValue(new Error('network sad'));
+    const outcome = await publishDocument('d1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.kind).toBe('link-mint-failed');
+    expect(calls).toContain('relay-publish');
+  });
+
+  it('renders the RELAY’s cap numbers on a 413 — no client-side copy', async () => {
+    provider['publishDocument'] = vi.fn(async () => {
+      throw new RelayError(413, 'u', 'Payload Too Large', {
+        errorCode: 'PUBLISH_TOO_LARGE',
+        sizeBytes: 999,
+        maxBytes: 600,
+      });
+    });
+    const outcome = await publishDocument('d1');
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok && outcome.kind === 'too-large') {
+      expect(outcome.sizeBytes).toBe(999);
+      expect(outcome.maxBytes).toBe(600);
+    } else {
+      throw new Error(`expected too-large, got ${JSON.stringify(outcome)}`);
+    }
+    expect(webMock.mintShareLink).not.toHaveBeenCalled();
+  });
+
+  it('maps 507 to quota and 403 to forbidden', async () => {
+    for (const [status, kind] of [
+      [507, 'quota'],
+      [403, 'forbidden'],
+    ] as const) {
+      provider['publishDocument'] = vi.fn(async () => {
+        throw new RelayError(status, 'u', 'nope');
+      });
+      const outcome = await publishDocument('d1');
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.kind).toBe(kind);
+    }
+  });
+
+  it('a keyless ack (filesystem relay) never mints a dead link', async () => {
+    provider['publishDocument'] = vi.fn(async () => ({ ...ACK, artifactKey: null, manifestKey: null }));
+    const outcome = await publishDocument('d1');
+    expect(outcome.ok).toBe(false);
+    expect(webMock.mintShareLink).not.toHaveBeenCalled();
+  });
+});
+
+describe('unpublishDocument', () => {
+  it('revokes the row FIRST, then the relay artifact', async () => {
+    const outcome = await unpublishDocument('d1');
+    expect(outcome.ok).toBe(true);
+    expect(calls).toEqual(['revokeShareLink', 'relay-unpublish']);
+  });
+
+  it('a relay-delete failure still counts as unpublished — the URL is already dark', async () => {
+    provider['unpublishDocument'] = vi.fn(async () => {
+      throw new Error('relay down');
+    });
+    const outcome = await unpublishDocument('d1');
+    expect(outcome.ok).toBe(true);
+  });
+
+  it('a row-revoke failure fails the action — the URL would still be live', async () => {
+    webMock.revokeShareLink.mockRejectedValue(new Error('db sad'));
+    const outcome = await unpublishDocument('d1');
+    expect(outcome.ok).toBe(false);
+  });
+});
+
+describe('shareUrlFor', () => {
+  it('is same-origin with the editor by construction', () => {
+    expect(shareUrlFor('tok')).toBe(`${window.location.origin}/d/tok`);
+  });
+});

--- a/src/share/publishFlow.ts
+++ b/src/share/publishFlow.ts
@@ -1,0 +1,120 @@
+/**
+ * Publish orchestration (JP-464): the two-system handshake behind the
+ * Publish rung.
+ *
+ * Order is load-bearing, in both directions:
+ *
+ * - PUBLISH: relay first (writes the sanitized artifact; owner-gated there),
+ *   control-plane row second. The ROW is the read-side commit point — if the
+ *   mint fails, the artifact exists but no URL resolves (safe, retryable);
+ *   the reverse order could mint a link that 404s for a reader.
+ * - UNPUBLISH: row first (revoking the row is what makes the URL dark),
+ *   relay second (deletes the artifact, frees the metered bytes). If the
+ *   relay half fails the link is already dead and only quota is stale —
+ *   corrected by the next publish/unpublish.
+ *
+ * Errors are returned typed, not thrown: the rung renders each failure
+ * differently (cap exceeded shows the configured number, quota points at
+ * storage, network says retry), and the distinction is the UX.
+ */
+import { flushAutoSaveNow } from '../store/autoSaveGuard';
+import { getDocProvider } from '../store/relayDocumentStore';
+import { webClient, WebClientError, type ShareLink } from '../api/webClient';
+import { RelayError } from '../api/relayClient';
+
+export type PublishFailure =
+  | { kind: 'too-large'; sizeBytes: number; maxBytes: number }
+  | { kind: 'quota' }
+  | { kind: 'forbidden' }
+  | { kind: 'link-mint-failed'; detail: string }
+  | { kind: 'error'; detail: string };
+
+export type PublishOutcome =
+  | { ok: true; link: ShareLink; bytes: number }
+  | ({ ok: false } & PublishFailure);
+
+/** The public URL for a share token — same origin as the editor by design
+ *  (the serving Worker routes `/d/*` on this very host). */
+export function shareUrlFor(token: string): string {
+  return `${window.location.origin}/d/${token}`;
+}
+
+export async function publishDocument(docId: string): Promise<PublishOutcome> {
+  const provider = getDocProvider();
+  if (!provider?.publishDocument) {
+    return { ok: false, kind: 'error', detail: 'Not connected to your workspace.' };
+  }
+
+  // Push any debounced local edit before snapshotting; the relay also
+  // flushes live CRDT state server-side, so the artifact reflects "now"
+  // from both directions.
+  flushAutoSaveNow();
+
+  let ack;
+  try {
+    ack = await provider.publishDocument(docId);
+  } catch (e) {
+    if (e instanceof RelayError) {
+      if (e.status === 413 && e.body && typeof e.body === 'object') {
+        const body = e.body as { sizeBytes?: number; maxBytes?: number };
+        return {
+          ok: false,
+          kind: 'too-large',
+          sizeBytes: body.sizeBytes ?? 0,
+          maxBytes: body.maxBytes ?? 0,
+        };
+      }
+      if (e.status === 507) return { ok: false, kind: 'quota' };
+      if (e.status === 403) return { ok: false, kind: 'forbidden' };
+    }
+    return { ok: false, kind: 'error', detail: e instanceof Error ? e.message : String(e) };
+  }
+
+  if (!ack.artifactKey || !ack.manifestKey) {
+    // Filesystem-backend relay (self-host): the artifact exists on the relay
+    // volume, but this deployment has no link-serving surface to point at.
+    return {
+      ok: false,
+      kind: 'error',
+      detail: 'This relay has no public serving configured — the projection was written locally.',
+    };
+  }
+
+  try {
+    const link = await webClient.mintShareLink(docId, {
+      artifactKey: ack.artifactKey,
+      manifestKey: ack.manifestKey,
+      publishedBytes: ack.bytes,
+    });
+    return { ok: true, link, bytes: ack.bytes };
+  } catch (e) {
+    // The artifact IS published relay-side; only the URL is missing. Say so
+    // precisely — "retry" here means retrying the mint, not re-publishing.
+    const detail =
+      e instanceof WebClientError && e.code === 'forbidden'
+        ? 'This link was turned off by its owner; only they (or a workspace owner) can turn it back on.'
+        : e instanceof Error
+          ? e.message
+          : String(e);
+    return { ok: false, kind: 'link-mint-failed', detail };
+  }
+}
+
+export type UnpublishOutcome = { ok: true } | { ok: false; detail: string };
+
+export async function unpublishDocument(docId: string): Promise<UnpublishOutcome> {
+  // Row first: the URL must die even if the relay half fails.
+  try {
+    await webClient.revokeShareLink(docId);
+  } catch (e) {
+    return { ok: false, detail: e instanceof Error ? e.message : String(e) };
+  }
+  try {
+    const provider = getDocProvider();
+    await provider?.unpublishDocument?.(docId);
+  } catch {
+    // Link is already dark; the artifact's metered bytes linger until the
+    // next publish/unpublish round-trip. Not worth failing the action over.
+  }
+  return { ok: true };
+}

--- a/src/store/documentRegistry.ts
+++ b/src/store/documentRegistry.ts
@@ -16,6 +16,7 @@ import {
   type LocalDocument,
   type RemoteDocument,
   type CachedDocument,
+  type ExternalDocument,
   type DocumentRegistryEntry,
   type DocumentFilter,
   type SyncState,
@@ -86,6 +87,13 @@ interface DocumentRegistryActions {
 
   /** Register a local document */
   registerLocal: (metadata: DocumentMetadata) => void;
+
+  /**
+   * Register an external (guest) document record (JP-464) — read-only by
+   * construction (`recordIsReadOnly`'s editable allowlist excludes it),
+   * session-only (never persisted, never listed, never synced).
+   */
+  registerExternal: (record: ExternalDocument) => void;
 
   /**
    * Reconcile the registry's LOCAL entries against the authoritative local
@@ -256,6 +264,15 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
               record,
               isLoading: false,
             },
+          },
+        }));
+      },
+
+      registerExternal: (record) => {
+        set((state) => ({
+          entries: {
+            ...state.entries,
+            [record.id]: { record, isLoading: false },
           },
         }));
       },
@@ -620,6 +637,10 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
         return Object.values(entries)
           .map((entry) => entry.record)
           .filter((record) => {
+            // External (guest) records never appear in the browser — they are
+            // session-only render state, not library membership (JP-464). The
+            // filter's type vocabulary deliberately doesn't know them.
+            if (record.type === 'external') return false;
             // Filter by type
             if (!filter.types.includes(record.type)) return false;
 
@@ -749,8 +770,13 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
       // version-bump pattern in uiPreferencesStore / settingsStore.
       migrate: (persisted) => persisted as DocumentRegistryState,
       partialize: (state) => ({
-        // Persist entries (record metadata) and filter preferences
-        entries: state.entries,
+        // Persist entries (record metadata) and filter preferences — except
+        // external (guest) records: a share-link snapshot is render state for
+        // one tab, and persisting it would leave a "Shared with you" ghost in
+        // the visitor's storage across sessions (JP-464).
+        entries: Object.fromEntries(
+          Object.entries(state.entries).filter(([, e]) => e.record.type !== 'external'),
+        ),
         filter: state.filter,
         // Don't persist: activeDocumentId, lastSyncAt, isFetchingRemote, error
       }),
@@ -768,6 +794,11 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
             typeof (rec as { workspaceId?: unknown }).workspaceId !== 'string'
           ) {
             continue; // un-scoped relay ghost → drop; refetch re-registers it
+          }
+          if (rec.type === 'external') {
+            // Guest snapshots are session-only; one persisted before the
+            // partialize filter existed is a ghost — drop on load (JP-464).
+            continue;
           }
           cleanedEntries[id] = {
             record: entry.record,
@@ -805,24 +836,51 @@ export const useDocumentRegistry = create<DocumentRegistryState & DocumentRegist
  * below delegates to the same predicate so there's a single source of truth.
  */
 function recordIsReadOnly(rec: DocumentRecord | undefined): boolean {
-  if (!rec) return false;
-  if (rec.type !== 'remote' && rec.type !== 'cached') return false;
-  return rec.permission !== 'owner' && rec.permission !== 'editor';
+  // JP-464: fails CLOSED. An absent record means nothing established the
+  // right to write — every read-only guard in the app (Engine,
+  // CommandRegistry, both prose editors, the toolbars) hangs off this one
+  // predicate, so this is the line a guest document must not slip past.
+  if (!rec) return true;
+  switch (rec.type) {
+    // Editable ALLOWLIST — the same fail-closed principle as the relay's
+    // publish projection: a future record type is read-only until someone
+    // decides otherwise here, not writable because a denylist never heard of
+    // it. `external` (guest content, JP-464) is deliberately not listed.
+    case 'local':
+      return false;
+    case 'remote':
+    case 'cached':
+      return rec.permission !== 'owner' && rec.permission !== 'editor';
+    default:
+      return true;
+  }
 }
 
+/**
+ * Read-only resolution for the ACTIVE document. Two distinct "nothing there"
+ * cases, deliberately opposite:
+ *
+ * - `activeDocumentId === null` — no registered document is active. This is
+ *   the fresh scratch document (registered only on first save,
+ *   `createNewDocument` → `registerLocal`), which must stay editable or new
+ *   documents are born read-only.
+ * - an id IS claimed but has no registry entry — something asserted a
+ *   document without establishing it. Fails closed via
+ *   `recordIsReadOnly(undefined)`; the guest path and any future
+ *   partially-registered state land here.
+ */
 export function isActiveDocReadOnly(): boolean {
   const state = useDocumentRegistry.getState();
-  return recordIsReadOnly(
-    state.activeDocumentId ? state.entries[state.activeDocumentId]?.record : undefined,
-  );
+  if (state.activeDocumentId === null) return false;
+  return recordIsReadOnly(state.entries[state.activeDocumentId]?.record);
 }
 
 /** Reactive hook form of {@link isActiveDocReadOnly} for React components. */
 export function useActiveDocReadOnly(): boolean {
   return useDocumentRegistry((state) =>
-    recordIsReadOnly(
-      state.activeDocumentId ? state.entries[state.activeDocumentId]?.record : undefined,
-    ),
+    state.activeDocumentId === null
+      ? false
+      : recordIsReadOnly(state.entries[state.activeDocumentId]?.record),
   );
 }
 

--- a/src/store/persistenceStore.ts
+++ b/src/store/persistenceStore.ts
@@ -376,6 +376,16 @@ export interface PersistenceActions {
   setDocumentTags: (docId: string, tags: string[]) => Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'version-conflict' | 'network-error'; message?: string }>;
   /** Load a remote document (from host) directly into the editor */
   loadRemoteDocument: (doc: DiagramDocument) => void;
+  /**
+   * Load an EXTERNAL document (JP-464 guest view) into the editor: hydrate
+   * the live stores and register the read-only `external` record — and
+   * nothing else. Deliberately no localStorage write, no CURRENT_DOCUMENT
+   * pointer, no collab session: a guest snapshot is render state, not
+   * library membership, and must leave no trace on the visitor's machine
+   * beyond the tab. Throws `DocumentVersionError` upward — the guest shell
+   * owns the "newer than this build" message.
+   */
+  loadExternalDocument: (doc: DiagramDocument, record: import('../types/DocumentRegistry').ExternalDocument) => void;
   /** Reset to initial state */
   reset: () => void;
 }
@@ -1706,6 +1716,28 @@ export const usePersistenceStore = create<PersistenceState & PersistenceActions>
 
         // Save current document ID
         localStorage.setItem(STORAGE_KEYS.CURRENT_DOCUMENT, docWithRelayFlag.id);
+      },
+
+      loadExternalDocument: (doc, record) => {
+        // Migration-gated like every load path (JP-347). Version errors
+        // propagate: the guest shell renders them, since there is no
+        // notification chrome yet at guest boot.
+        loadDocumentToPageStore(doc);
+
+        set({
+          currentDocumentId: doc.id,
+          currentDocumentName: doc.name,
+          isDirty: false,
+          // Autosave must never fire for a guest snapshot; the record is
+          // read-only so edits can't occur, but belt-and-braces here costs
+          // nothing and survives future read-only-bypass bugs.
+          autoSaveEnabled: false,
+        });
+
+        const registry = useDocumentRegistry.getState();
+        registry.registerExternal(record);
+        registry.setActiveDocument(doc.id);
+        registry.setDocumentContent(doc.id, doc);
       },
 
       // Reset to initial state

--- a/src/store/readOnlyGuard.test.ts
+++ b/src/store/readOnlyGuard.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The fail-closed read-only guard (JP-464).
+ *
+ * Every read-only enforcement point in the app (Engine, CommandRegistry, both
+ * prose editors, the toolbars) resolves through `isActiveDocReadOnly` /
+ * `useActiveDocReadOnly`. These tests pin the guard's shape:
+ *
+ * - an ACTIVE id with no registry record is READ-ONLY (the guest invariant —
+ *   before JP-464 this arm failed open, and a guest document would have
+ *   rendered fully editable);
+ * - `external` records are read-only by allowlist omission, not by naming;
+ * - the null-active state stays editable (a fresh scratch document is only
+ *   registered on first save — flipping this arm breaks new-document flow).
+ *
+ * Mutation check (verification step): revert either arm and the named test
+ * here fails.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { isActiveDocReadOnly, useDocumentRegistry } from './documentRegistry';
+import type { ExternalDocument } from '../types/DocumentRegistry';
+
+function externalRecord(id: string): ExternalDocument {
+  return {
+    type: 'external',
+    source: 'share-link',
+    id,
+    name: 'Guest Doc',
+    pageCount: 1,
+    createdAt: 1,
+    modifiedAt: 1,
+  };
+}
+
+beforeEach(() => {
+  useDocumentRegistry.setState({ entries: {}, activeDocumentId: null });
+});
+
+describe('isActiveDocReadOnly (fail-closed, JP-464)', () => {
+  it('no active document → editable (the unsaved scratch doc)', () => {
+    expect(isActiveDocReadOnly()).toBe(false);
+  });
+
+  it('an active id WITHOUT a registry record → read-only (the guest invariant)', () => {
+    useDocumentRegistry.setState({ activeDocumentId: 'ghost-doc' });
+    expect(isActiveDocReadOnly()).toBe(true);
+  });
+
+  it('an external (share-link) record → read-only', () => {
+    useDocumentRegistry.getState().registerExternal(externalRecord('guest-1'));
+    useDocumentRegistry.getState().setActiveDocument('guest-1');
+    expect(isActiveDocReadOnly()).toBe(true);
+  });
+
+  it('regression: local docs and remote editors stay editable; remote viewers do not', () => {
+    const base = { id: 'd', name: 'D', pageCount: 1, createdAt: 1, modifiedAt: 1 };
+    const cases: Array<[Record<string, unknown>, boolean]> = [
+      [{ ...base, type: 'local' }, false],
+      [
+        {
+          ...base,
+          type: 'remote',
+          relayId: 'r',
+          workspaceId: 'w',
+          ownerId: 'o',
+          ownerName: 'O',
+          permission: 'editor',
+          syncState: 'synced',
+          lastSyncedAt: 1,
+        },
+        false,
+      ],
+      [
+        {
+          ...base,
+          type: 'remote',
+          relayId: 'r',
+          workspaceId: 'w',
+          ownerId: 'o',
+          ownerName: 'O',
+          permission: 'viewer',
+          syncState: 'synced',
+          lastSyncedAt: 1,
+        },
+        true,
+      ],
+      [
+        {
+          ...base,
+          type: 'remote',
+          relayId: 'r',
+          workspaceId: 'w',
+          ownerId: 'o',
+          ownerName: 'O',
+          permission: 'none',
+          syncState: 'synced',
+          lastSyncedAt: 1,
+        },
+        true,
+      ],
+    ];
+    for (const [record, expected] of cases) {
+      useDocumentRegistry.setState({
+        entries: {
+          d: { record: record as never, isLoading: false },
+        },
+        activeDocumentId: 'd',
+      });
+      expect(isActiveDocReadOnly(), `${String(record['type'])}/${String(record['permission'])}`).toBe(expected);
+    }
+  });
+
+  it('external records never reach the persisted snapshot', () => {
+    // Caught live: the registry's persist middleware serialized the guest
+    // record wholesale, leaving a "Shared with you" ghost in the visitor's
+    // localStorage across sessions. Session-only means session-only.
+    useDocumentRegistry.getState().registerExternal(externalRecord('guest-persist'));
+    const partialize = useDocumentRegistry.persist.getOptions().partialize!;
+    const snapshot = partialize(useDocumentRegistry.getState()) as {
+      entries: Record<string, unknown>;
+    };
+    expect(Object.keys(snapshot.entries)).not.toContain('guest-persist');
+  });
+
+  it('external records never surface in browser listings', () => {
+    useDocumentRegistry.getState().registerExternal(externalRecord('guest-2'));
+    const listed = useDocumentRegistry
+      .getState()
+      .getFilteredDocuments()
+      .map((r) => r.id);
+    expect(listed).not.toContain('guest-2');
+  });
+});

--- a/src/store/readOnlyGuard.test.tsx
+++ b/src/store/readOnlyGuard.test.tsx
@@ -109,6 +109,47 @@ describe('isActiveDocReadOnly (fail-closed, JP-464)', () => {
     }
   });
 
+  it('a read-only doc hides the add-page control (found live on a guest view)', async () => {
+    // Adding a page is a write. The control had no guard, so a workspace
+    // viewer — and a share-link reader — could add pages the relay refuses.
+    // Gated centrally in PageTabStrip via this predicate.
+    const { render, screen } = await import('@testing-library/react');
+    const { PageTabStrip } = await import('../ui/components/PageTabStrip');
+    const items = [{ id: 'p1', label: 'Page 1' }];
+    const renderTab = (item: { id: string; label: string }) => (
+      <button key={item.id} data-page-id={item.id}>
+        {item.label}
+      </button>
+    );
+
+    useDocumentRegistry.getState().registerExternal(externalRecord('guest-tabs'));
+    useDocumentRegistry.getState().setActiveDocument('guest-tabs');
+    const readOnly = render(
+      <PageTabStrip
+        items={items}
+        activeId="p1"
+        onSelect={() => {}}
+        onAdd={() => {}}
+        renderTab={renderTab}
+      />,
+    );
+    expect(screen.queryByLabelText('Add page')).toBeNull();
+    readOnly.unmount();
+
+    // Same strip, an editable document → the control is back.
+    useDocumentRegistry.setState({ entries: {}, activeDocumentId: null });
+    render(
+      <PageTabStrip
+        items={items}
+        activeId="p1"
+        onSelect={() => {}}
+        onAdd={() => {}}
+        renderTab={renderTab}
+      />,
+    );
+    expect(screen.queryByLabelText('Add page')).not.toBeNull();
+  });
+
   it('external records never reach the persisted snapshot', () => {
     // Caught live: the registry's persist middleware serialized the guest
     // record wholesale, leaving a "Shared with you" ghost in the visitor's

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -261,6 +261,14 @@ export interface DocumentProvider {
     newOwnerName: string
   ): Promise<void>;
   /**
+   * Public projection (JP-464). Optional so non-REST providers opt out.
+   * Publish writes the sanitized artifact server-side (owner-only there);
+   * status carries the configured artifact cap so no client hardcodes it.
+   */
+  publishDocument?(docId: string): Promise<import('../api/relayClient').RelayPublishAck>;
+  unpublishDocument?(docId: string): Promise<{ success: boolean; removed: boolean }>;
+  getPublishStatus?(docId: string): Promise<import('../api/relayClient').RelayPublishStatus>;
+  /**
    * Upload referenced blobs to the relay blob store before a doc save.
    * Optional: when absent the store falls back to base64-embedding assets
    * in the doc (legacy path). When present, assets are stored as deduped,

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -138,6 +138,13 @@ export interface UIPreferencesState {
    * Persisted so the install toast nags at most once per browser. Web-only.
    */
   installAppHintSeen: boolean;
+  /**
+   * The "View only" notice has been permanently dismissed (JP-464). The
+   * notice is a one-time explanation, not status: it auto-retires after a
+   * few seconds anyway, and dismissing it says "I know, stop showing me."
+   * App-level, not per document — the fact doesn't change per document.
+   */
+  viewOnlyNoticeDismissed: boolean;
   /** Layout manager slice — modes, per-doc memory, per-mode overrides, chrome. */
   layout: LayoutState;
   /** Appearance slice — accent + motion (theme is in `themeStore`). */
@@ -202,6 +209,8 @@ export interface UIPreferencesActions {
   markStorageInfoToastSeen: () => void;
   /** Record that the one-time install-app PWA hint has been shown/dismissed. */
   markInstallAppHintSeen: () => void;
+  /** Permanently dismiss the "View only" notice (JP-464). */
+  dismissViewOnlyNotice: () => void;
   /** Accept (or clear) the experimental mobile-preview layout. */
   setMobilePreviewAccepted: (accepted: boolean) => void;
   /** Force the desktop layout on a touch device (mobile-preview opt-out). */
@@ -335,6 +344,7 @@ const initialState: UIPreferencesState = {
   documentBrowserCollapsed: {},
   storageInfoToastSeen: false,
   installAppHintSeen: false,
+  viewOnlyNoticeDismissed: false,
   layout: initialLayoutState,
   appearancePrefs: { ...initialAppearancePrefs },
   collabIndicatorPos: null,
@@ -493,6 +503,8 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       markInstallAppHintSeen: () => set({ installAppHintSeen: true }),
 
+      dismissViewOnlyNotice: () => set({ viewOnlyNoticeDismissed: true }),
+
       setMobilePreviewAccepted: (accepted) => set({ mobilePreviewAccepted: accepted }),
       setForceDesktopSite: (force) => set({ forceDesktopSite: force }),
 
@@ -646,6 +658,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         documentBrowserCollapsed: state.documentBrowserCollapsed,
         storageInfoToastSeen: state.storageInfoToastSeen,
         installAppHintSeen: state.installAppHintSeen,
+        viewOnlyNoticeDismissed: state.viewOnlyNoticeDismissed,
         layout: state.layout,
         appearancePrefs: state.appearancePrefs,
         collabIndicatorPos: state.collabIndicatorPos,
@@ -786,6 +799,7 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
         // (never shown) so existing users get the hint once, like a new install.
         if (fromVersion < 12) {
           next['installAppHintSeen'] = next['installAppHintSeen'] ?? false;
+          next['viewOnlyNoticeDismissed'] = next['viewOnlyNoticeDismissed'] ?? false;
         }
         // v12 → v13: appearance slice gained roundedTables (JP-416). Default on
         // (opt-out) without clobbering existing appearance choices. (The `merge`

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -139,8 +139,24 @@ export interface CachedDocument extends DocumentEntryBase {
   lastModifiedByName?: string;
 }
 
+/**
+ * External Document (JP-464) — content the editor renders but does not own:
+ * today a published document opened through a share link; later, an external
+ * mirror preview. Always read-only (`recordIsReadOnly` treats every type
+ * outside its editable allowlist as read-only, and `external` is deliberately
+ * not on it), never persisted, never listed in the browser, never synced.
+ */
+export interface ExternalDocument extends DocumentEntryBase {
+  type: 'external';
+  /** Where the content came from, for chrome copy ("published document"). */
+  source: 'share-link';
+  /** Publish time reported by the serving manifest/row, ms — provenance for
+   *  the guest bar ("Published May 12"); absent when the source omits it. */
+  publishedAt?: number;
+}
+
 /** Discriminated union of all document record types */
-export type DocumentRecord = LocalDocument | RemoteDocument | CachedDocument;
+export type DocumentRecord = LocalDocument | RemoteDocument | CachedDocument | ExternalDocument;
 
 // ============ Registry Types ============
 
@@ -341,6 +357,8 @@ export function getDocumentTypeLabel(record: DocumentRecord): string {
       return 'Relay';
     case 'cached':
       return 'Offline';
+    case 'external':
+      return 'Shared with you';
   }
 }
 
@@ -350,6 +368,11 @@ export function getDocumentTypeLabel(record: DocumentRecord): string {
 export function getSyncStateInfo(record: DocumentRecord): { label: string; icon: string } {
   if (record.type === 'local') {
     return { label: 'Local only', icon: 'laptop' };
+  }
+
+  // JP-464: a guest view is a frozen published snapshot — it never syncs.
+  if (record.type === 'external') {
+    return { label: 'Published snapshot', icon: 'eye' };
   }
 
   if (record.type === 'cached') {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -73,6 +73,7 @@ import { useAutoSave } from '../hooks/useAutoSave';
 import { useCollaborationSync } from '../collaboration';
 import { getSyncStateManager } from '../collaboration/SyncStateManager';
 import type { ImportContext } from '../services/FileImportService';
+import { isGuestSession } from '../guest/guestSession';
 
 // Lazy-load the rich-text editor panel so the tiptap stack (+ katex via
 // LatexExtension, + nspell via SpellcheckService) is split out of the main
@@ -317,6 +318,12 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   useEffect(() => {
     if (persistenceInitializedRef.current) return;
     persistenceInitializedRef.current = true;
+
+    // JP-464: a guest (share-link) mount hydrated its document BEFORE this
+    // component existed and must run NONE of the session boot — no cloud
+    // restore, no last-document reopen (which would replace the guest doc),
+    // no cache warmup, no migrations. The guest tab is render-only.
+    if (isGuestSession()) return;
 
     // Warmup relay document cache from IndexedDB (async, non-blocking)
     useRelayDocumentStore.getState().warmupCache().catch(console.error);

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -27,7 +27,7 @@ import {
   Users,
 } from 'lucide-react';
 import { SyncStatusBadge, type ExtendedSyncState } from './SyncStatusBadge';
-import { isForeignRelayDoc, type DocumentRecord, type Permission } from '../types/DocumentRegistry';
+import { isForeignRelayDoc, isSyncedDocument, type DocumentRecord, type Permission } from '../types/DocumentRegistry';
 import type { Collection } from '../store/collectionStore';
 import type { OfflineProgress, OfflineStatus } from '../store/offlineAvailability';
 import { useConnectionStore } from '../store/connectionStore';
@@ -172,6 +172,10 @@ function getTypeLabel(type: DocumentRecord['type']): string {
       return 'Cloud';
     case 'cached':
       return 'Offline';
+    // Unreachable from the browser (external records are filtered out of
+    // listings), but the type system rightly demands the case exist.
+    case 'external':
+      return 'Shared';
   }
 }
 
@@ -184,6 +188,8 @@ function TypeIcon({ type }: { type: DocumentRecord['type'] }) {
       return <Cloud size={12} aria-hidden="true" />;
     case 'cached':
       return <CloudOff size={12} aria-hidden="true" />;
+    case 'external':
+      return <Cloud size={12} aria-hidden="true" />;
   }
 }
 
@@ -208,6 +214,9 @@ export function getSyncState(
       return record.syncState;
     case 'cached':
       return reconnectable ? 'idle' : 'offline';
+    // A guest snapshot never syncs; 'local' renders as the no-sync state.
+    case 'external':
+      return 'local';
   }
 }
 
@@ -303,8 +312,8 @@ function DocumentCardImpl({
   // JP-459: resolve the last editor to a person. Returns '' when we can't —
   // the tooltip is then omitted rather than showing a raw account id.
   const lastEditedByRaw = usePersonName(
-    record.type !== 'local' ? record.lastModifiedBy : undefined,
-    record.type !== 'local' ? record.lastModifiedByName : undefined,
+    isSyncedDocument(record) ? record.lastModifiedBy : undefined,
+    isSyncedDocument(record) ? record.lastModifiedByName : undefined,
   );
   const lastEditedBy = lastEditedByRaw === UNKNOWN_PERSON ? '' : lastEditedByRaw;
 

--- a/src/ui/DocumentEditorToolbar.css
+++ b/src/ui/DocumentEditorToolbar.css
@@ -466,3 +466,23 @@
   flex-shrink: 0;
   opacity: 0.75;
 }
+
+/* JP-464: the "View only" notice retires itself; the × retires it for good. */
+.ribbon-readonly__dismiss {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+}
+
+.ribbon-readonly__dismiss:hover {
+  opacity: 1;
+  background: var(--bg-hover);
+}

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -29,7 +29,7 @@ import {
   Table, Sigma, SquareSigma, Minus, Search, Settings2, PaintBucket, Trash2,
   BookMarked, Library, Info, Braces,
   BetweenVerticalStart, BetweenVerticalEnd, BetweenHorizontalStart, BetweenHorizontalEnd,
-  ArrowLeft, ArrowRight, ArrowUp, ArrowDown, Eye,
+  ArrowLeft, ArrowRight, ArrowUp, ArrowDown, Eye, X,
 } from 'lucide-react';
 import type { CalloutVariant } from '../tiptap/CalloutExtension';
 import { useTiptapEditor } from './TiptapEditorContext';
@@ -46,6 +46,7 @@ import { CitationPickerDialog } from './CitationPickerDialog';
 import { ReferenceManagerDialog } from './ReferenceManagerDialog';
 import { FieldsManagerDialog } from './FieldsManagerDialog';
 import { useNotificationStore } from '../store/notificationStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { isGuestSession } from '../guest/guestSession';
 import { ICON } from './icons';
 import './DocumentEditorToolbar.css';
@@ -90,9 +91,32 @@ const HEADING_ITEMS: RichSelectItem<HeadingValue>[] = (
   ),
 }));
 
+/**
+ * How long the "View only" notice stays up before retiring itself (JP-464).
+ * Long enough to read and register on a page you just opened; short enough
+ * that it isn't a permanent toolbar row restating something the absence of
+ * every editing control already says.
+ */
+const VIEW_ONLY_NOTICE_MS = 30_000;
+
 export function DocumentEditorToolbar() {
   const editor = useTiptapEditor();
   const docReadOnly = useActiveDocReadOnly();
+  const viewOnlyNoticeDismissed = useUIPreferencesStore((s) => s.viewOnlyNoticeDismissed);
+  const dismissViewOnlyNotice = useUIPreferencesStore((s) => s.dismissViewOnlyNotice);
+  const [viewOnlyNoticeExpired, setViewOnlyNoticeExpired] = useState(false);
+
+  // Start the retire timer when the notice actually becomes visible, and reset
+  // it if the document flips back to editable — so re-entering a read-only doc
+  // shows it again (unless permanently dismissed).
+  useEffect(() => {
+    if (!docReadOnly) {
+      setViewOnlyNoticeExpired(false);
+      return;
+    }
+    const timer = setTimeout(() => setViewOnlyNoticeExpired(true), VIEW_ONLY_NOTICE_MS);
+    return () => clearTimeout(timer);
+  }, [docReadOnly]);
   const [, forceUpdate] = useState({});
   const [activeTab, setActiveTab] = useState<RibbonTab>('home');
 
@@ -219,6 +243,11 @@ export function DocumentEditorToolbar() {
   // Placed after every hook above — an early return before them would change
   // hook order between renders when a document's permission flips in place.
   if (docReadOnly) {
+    // The notice explains a state the user discovers once; after that it is a
+    // full toolbar row spent on a sentence. It retires itself after
+    // VIEW_ONLY_NOTICE_MS, and the × retires it for good (JP-464). Read-only
+    // itself is still evident everywhere else — no editing controls exist.
+    if (viewOnlyNoticeDismissed || viewOnlyNoticeExpired) return null;
     return (
       <div className="document-editor-toolbar document-editor-toolbar--readonly">
         <div className="ribbon-readonly" role="status">
@@ -231,6 +260,15 @@ export function DocumentEditorToolbar() {
               ? 'View only — a published snapshot of this document.'
               : 'View only — you don’t have permission to edit this document.'}
           </span>
+          <button
+            type="button"
+            className="ribbon-readonly__dismiss"
+            onClick={dismissViewOnlyNotice}
+            title="Don’t show this again"
+            aria-label="Dismiss view-only notice"
+          >
+            <X size={13} aria-hidden="true" />
+          </button>
         </div>
       </div>
     );

--- a/src/ui/DocumentEditorToolbar.tsx
+++ b/src/ui/DocumentEditorToolbar.tsx
@@ -46,6 +46,7 @@ import { CitationPickerDialog } from './CitationPickerDialog';
 import { ReferenceManagerDialog } from './ReferenceManagerDialog';
 import { FieldsManagerDialog } from './FieldsManagerDialog';
 import { useNotificationStore } from '../store/notificationStore';
+import { isGuestSession } from '../guest/guestSession';
 import { ICON } from './icons';
 import './DocumentEditorToolbar.css';
 
@@ -222,7 +223,14 @@ export function DocumentEditorToolbar() {
       <div className="document-editor-toolbar document-editor-toolbar--readonly">
         <div className="ribbon-readonly" role="status">
           <Eye size={14} aria-hidden="true" />
-          <span>View only — you don’t have permission to edit this document.</span>
+          {/* JP-464: a guest is reading a published snapshot by design — the
+              permission framing reads as a denial to someone who was simply
+              handed a link, and "permission" is meaningless with no account. */}
+          <span>
+            {isGuestSession()
+              ? 'View only — a published snapshot of this document.'
+              : 'View only — you don’t have permission to edit this document.'}
+          </span>
         </div>
       </div>
     );

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -38,6 +38,7 @@ import { opener } from '../platform/opener';
 import { LayoutSelector } from './layout/LayoutSelector';
 import { RelaxedFocusControl } from './layout/RelaxedFocusControl';
 import { useActiveLayoutMode } from './layout/useLayout';
+import { isGuestSession } from '../guest/guestSession';
 import './UnifiedToolbar.css';
 
 /**
@@ -175,6 +176,15 @@ export function UnifiedToolbar({
   // JP-370: import writes into the active doc → disable it on a view-only doc.
   // Whiteboard (scratch overlay), Export, Help and Settings stay read-safe.
   const isReadOnly = useActiveDocReadOnly();
+  /**
+   * JP-464: a guest reading a published link is not an app user. Affordances
+   * that assume a library, a session, or ownership (Documents, the document
+   * identity/rename cluster, Import, Whiteboard, Version history, Settings)
+   * are hidden — they would lead a stranger into an empty or irrelevant
+   * surface. What stays is what serves *reading*: the layout/focus controls,
+   * PDF export, and help.
+   */
+  const guest = isGuestSession();
   // JP-185: version history is a cloud-doc, REST-backed affordance — show it
   // only for the active relay doc while the cached session token is usable.
   const activeDocId = useActiveDocumentId();
@@ -223,7 +233,7 @@ export function UnifiedToolbar({
     <div className="unified-toolbar">
       {/* Left: Documents launcher + document identity */}
       <div className="unified-toolbar-left">
-        {onOpenDocuments && (
+        {onOpenDocuments && !guest && (
           <button
             className="toolbar-documents-btn"
             onClick={onOpenDocuments}
@@ -234,7 +244,10 @@ export function UnifiedToolbar({
             <span>Documents</span>
           </button>
         )}
-        {mobileActive ? <MobileDocumentInfo /> : <DocumentInfo />}
+        {/* JP-464: a guest already has the document's identity (name +
+            published date) in the guest bar above, and `DocumentInfo` carries
+            rename + sync affordances that mean nothing to a reader. */}
+        {guest ? null : mobileActive ? <MobileDocumentInfo /> : <DocumentInfo />}
       </div>
 
       {/* Right: view controls (the context cluster) + app actions */}
@@ -260,6 +273,7 @@ export function UnifiedToolbar({
             </button>
           ) : (
             <>
+              {!guest && (
               <button
                 className="toolbar-help-btn"
                 onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
@@ -273,6 +287,8 @@ export function UnifiedToolbar({
               >
                 <Icon icon={FileInput} />
               </button>
+              )}
+              {!guest && (
               <button
                 className="toolbar-whiteboard-btn"
                 onClick={() => useWhiteboardStore.getState().toggleVisibility()}
@@ -281,6 +297,7 @@ export function UnifiedToolbar({
               >
                 <Icon icon={StickyNote} />
               </button>
+              )}
               <button
                 className="toolbar-export-btn"
                 onClick={() => setShowPdfExport(true)}
@@ -289,7 +306,7 @@ export function UnifiedToolbar({
               >
                 <PdfIcon />
               </button>
-              {versionHistoryAvailable && (
+              {versionHistoryAvailable && !guest && (
                 <button
                   className="toolbar-help-btn"
                   onClick={() => setShowVersionHistory(true)}
@@ -308,7 +325,7 @@ export function UnifiedToolbar({
               </button>
             </>
           )}
-          {onOpenSettings && (
+          {onOpenSettings && !guest && (
             <button
               className="toolbar-settings-btn"
               onClick={onOpenSettings}

--- a/src/ui/access/AccessPanel.css
+++ b/src/ui/access/AccessPanel.css
@@ -409,3 +409,62 @@
 @media (prefers-reduced-motion: reduce) {
   .access-panel__spin { animation: none; }
 }
+
+/* ── Publish rung (JP-464) ────────────────────────────────────────────── */
+
+.publish-rung__linkrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.publish-rung__globe {
+  color: var(--text-secondary);
+  flex: 0 0 auto;
+}
+
+.publish-rung__url {
+  flex: 1;
+  min-width: 0;
+  font-size: 12.5px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary, var(--steel-200));
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.publish-rung__meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.publish-rung__notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  background: color-mix(in srgb, var(--color-cta) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-cta) 45%, transparent);
+  color: var(--text-primary);
+}
+
+.publish-rung__notice--soft {
+  display: block;
+  background: var(--bg-tertiary);
+  border-color: var(--border-primary, var(--steel-200));
+  color: var(--text-secondary);
+}
+
+.publish-rung__footer {
+  margin-top: 10px;
+}

--- a/src/ui/access/AccessPanel.tsx
+++ b/src/ui/access/AccessPanel.tsx
@@ -40,6 +40,7 @@ import { useAccessPanelStore, type AccessScope } from './accessPanelStore';
 import { useWorkspaceDirectory } from '../../store/workspaceDirectoryStore';
 import { WorkspaceRung } from './WorkspaceRung';
 import { DocumentRung } from './DocumentRung';
+import { PublishRung } from './PublishRung';
 import type { RemoteDocument } from '../../types/DocumentRegistry';
 import './AccessPanel.css';
 
@@ -197,6 +198,21 @@ export function AccessPanel({ scope, documentId, onClose }: AccessPanelProps) {
                 share it with people.
               </p>
             )}
+          </Rung>
+        ) : null}
+
+        {showDocumentRung && remote ? (
+          <Rung
+            name="Anyone with the link"
+            summary={'Publish a read-only snapshot to the web'}
+            granting={false}
+          >
+            {/* Publishing is the widest grant on the ladder — the rung itself
+                reports live/stale/off state and owns all publish actions. */}
+            <PublishRung
+              documentId={documentId!}
+              canManage={remote.permission === 'owner'}
+            />
           </Rung>
         ) : null}
       </ol>

--- a/src/ui/access/PublishRung.tsx
+++ b/src/ui/access/PublishRung.tsx
@@ -1,0 +1,324 @@
+/**
+ * Publish rung of the access ladder (JP-464) — "anyone with the link can
+ * view", the widest grant on the ladder and therefore its last rung.
+ *
+ * The states the rung renders map one-to-one to the design's status table:
+ *
+ *   unpublished          → one primary action: Publish
+ *   published, current   → the link, Copy, view count, published date
+ *   published, stale     → the above + "changed since publishing" + Republish
+ *   over the cap         → the LINK STAYS UP on the last snapshot; republish
+ *                          is blocked with the configured number, never a
+ *                          silent failure and never an auto-revoke (a link
+ *                          embedded in an article must not die because the
+ *                          source grew)
+ *   turned off           → Publish re-enables the SAME URL (deliberate:
+ *                          Google-Docs semantics, article links survive)
+ *
+ * Size handling is warn-then-confirm: ≥80% of the cap shows an inline note;
+ * at/over the cap the publish button still works but leads with a
+ * confirmation that explains the refusal will come from the relay. All
+ * numbers render from the status endpoint — no client-side copy of the cap.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Check, Copy, Eye, Globe, Loader2, RefreshCw } from 'lucide-react';
+import { getDocProvider } from '../../store/relayDocumentStore';
+import { useDocumentRegistry } from '../../store/documentRegistry';
+import { webClient, WebClientError, type ShareLink } from '../../api/webClient';
+import type { RelayPublishStatus } from '../../api/relayClient';
+import {
+  publishDocument,
+  unpublishDocument,
+  shareUrlFor,
+  type PublishOutcome,
+} from '../../share/publishFlow';
+import { confirmDialog } from '../confirm/confirmStore';
+
+export interface PublishRungProps {
+  documentId: string;
+  /** Whether the caller may publish (doc owner or workspace owner). */
+  canManage: boolean;
+}
+
+function formatBytes(n: number): string {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  if (n >= 1024) return `${Math.round(n / 1024)} KB`;
+  return `${n} B`;
+}
+
+function formatDay(input: number | string | null | undefined): string {
+  if (!input) return '';
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
+  });
+}
+
+export function PublishRung({ documentId, canManage }: PublishRungProps) {
+  const [status, setStatus] = useState<RelayPublishStatus | null>(null);
+  const [link, setLink] = useState<ShareLink | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const document = useDocumentRegistry((s) => s.entries[documentId]?.document);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const provider = getDocProvider();
+      const [s, l] = await Promise.all([
+        provider?.getPublishStatus?.(documentId) ?? Promise.resolve(null),
+        webClient.getShareLink(documentId).catch((e: unknown) => {
+          // A workspace without the control plane (self-host) has no links;
+          // publish state still renders from the relay half.
+          if (e instanceof WebClientError && e.status === 0) return null;
+          throw e;
+        }),
+      ]);
+      setStatus(s);
+      setLink(l);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load publish state');
+    } finally {
+      setLoading(false);
+    }
+  }, [documentId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  /**
+   * Advisory size estimate from the in-memory body — the projection drops
+   * fields, so this slightly OVERSTATES the artifact, which is the safe
+   * direction for a warning. The relay's post-flush measurement is the
+   * authority; this only decides whether to warn before the round-trip.
+   */
+  const estimatedBytes = useMemo(() => {
+    if (!document) return 0;
+    try {
+      return JSON.stringify(document).length;
+    } catch {
+      return 0;
+    }
+  }, [document]);
+
+  const maxBytes = status?.maxBytes ?? null;
+  const nearCap = maxBytes !== null && estimatedBytes >= maxBytes * 0.8 && estimatedBytes <= maxBytes;
+  const overCap = maxBytes !== null && estimatedBytes > maxBytes;
+
+  const liveLink = link && link.revokedAt === null ? link : null;
+  const published = status?.published ?? false;
+  const url = liveLink ? shareUrlFor(liveLink.token) : null;
+
+  const failureMessage = (outcome: Extract<PublishOutcome, { ok: false }>): string => {
+    switch (outcome.kind) {
+      case 'too-large':
+        return `This document is ${formatBytes(outcome.sizeBytes)} — over the ${formatBytes(outcome.maxBytes)} publishing limit. The current published version (if any) is untouched; make the document smaller and republish.`;
+      case 'quota':
+        return 'Publishing stores a public copy, and your workspace is out of storage. Free some space and try again.';
+      case 'forbidden':
+        return 'Only this document’s owner (or a workspace owner) can publish it.';
+      case 'link-mint-failed':
+        return `The document was published, but the link could not be ${published ? 'refreshed' : 'created'}: ${outcome.detail}`;
+      case 'error':
+        return outcome.detail;
+    }
+  };
+
+  const handlePublish = useCallback(async () => {
+    setError(null);
+    // At/over the cap the relay will refuse — lead with that instead of a
+    // surprise error. The user may still try (the estimate can overstate).
+    if (overCap && maxBytes !== null) {
+      const ok = await confirmDialog({
+        title: 'Probably too large to publish',
+        message: `This document is about ${formatBytes(estimatedBytes)}; the publishing limit is ${formatBytes(maxBytes)}.`,
+        details:
+          'Publishing will likely be refused. Nothing already published is affected. You can reduce the document (large tables and pasted text are the usual culprits — images don’t count) and try again.',
+        confirmLabel: 'Try anyway',
+      });
+      if (!ok) return;
+    }
+    setBusy(true);
+    try {
+      const outcome = await publishDocument(documentId);
+      if (!outcome.ok) {
+        setError(failureMessage(outcome));
+        // The relay half may have succeeded (mint failures) — re-read truth.
+        await refresh();
+        return;
+      }
+      setLink(outcome.link);
+      await refresh();
+      // Copy immediately on FIRST publish: the reason someone publishes is to
+      // paste the link somewhere, so save them the second click. Never on
+      // republish (their clipboard is not ours to overwrite in a refresh).
+      if (!published && navigator.clipboard) {
+        void navigator.clipboard.writeText(shareUrlFor(outcome.link.token)).catch(() => {});
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2500);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [documentId, estimatedBytes, maxBytes, overCap, published, refresh]);
+
+  const handleUnpublish = useCallback(async () => {
+    const ok = await confirmDialog({
+      title: 'Turn off the public link?',
+      message: 'Anyone opening the link will see “document unavailable” within a minute.',
+      details:
+        'The link address is kept: publishing again later turns the SAME link back on, so a link in a published article can be restored.',
+      confirmLabel: 'Turn off link',
+      danger: true,
+    });
+    if (!ok) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const outcome = await unpublishDocument(documentId);
+      if (!outcome.ok) setError(outcome.detail);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }, [documentId, refresh]);
+
+  const handleCopy = useCallback(() => {
+    if (!url || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    });
+  }, [url]);
+
+  if (loading) {
+    return (
+      <p className="access-panel__loading" role="status">
+        <Loader2 size={14} className="access-panel__spin" aria-hidden="true" /> Checking publish
+        state…
+      </p>
+    );
+  }
+
+  return (
+    <div className="access-rung__content publish-rung">
+      {published && url ? (
+        <>
+          <div className="publish-rung__linkrow">
+            <Globe size={14} aria-hidden="true" className="publish-rung__globe" />
+            <input
+              className="publish-rung__url"
+              value={url}
+              readOnly
+              onFocus={(e) => e.currentTarget.select()}
+              aria-label="Public link"
+            />
+            <button
+              type="button"
+              className="access-panel__btn access-panel__btn--compact"
+              onClick={handleCopy}
+              disabled={busy}
+            >
+              {copied ? <Check size={14} aria-hidden="true" /> : <Copy size={14} aria-hidden="true" />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+
+          <p className="publish-rung__meta">
+            <Eye size={12} aria-hidden="true" />{' '}
+            {link ? `${link.viewCount} ${link.viewCount === 1 ? 'view' : 'views'}` : ''}
+            {status?.publishedAt ? ` · Published ${formatDay(status.publishedAt)}` : ''}
+            {status?.bytes ? ` · ${formatBytes(status.bytes)} of storage` : ''}
+          </p>
+
+          {status?.stale ? (
+            <div className="publish-rung__notice" role="status">
+              <span>The document has changed since it was published — readers see the older version.</span>
+              {canManage ? (
+                <button
+                  type="button"
+                  className="access-panel__btn access-panel__btn--primary"
+                  onClick={() => void handlePublish()}
+                  disabled={busy}
+                >
+                  {busy ? (
+                    <Loader2 size={14} className="access-panel__spin" aria-hidden="true" />
+                  ) : (
+                    <RefreshCw size={14} aria-hidden="true" />
+                  )}
+                  Republish
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+
+          {canManage ? (
+            <div className="publish-rung__footer">
+              <button
+                type="button"
+                className="access-panel__btn"
+                onClick={() => void handleUnpublish()}
+                disabled={busy}
+              >
+                Turn off link
+              </button>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <>
+          <p className="access-panel__hint">
+            Publish a read-only snapshot anyone with the link can view — no account needed.
+            Readers see the version you publish, not your live edits. The public copy uses
+            document-size storage.
+          </p>
+          {link && link.revokedAt !== null ? (
+            <p className="publish-rung__meta">
+              This document had a link before — publishing turns the <b>same address</b> back on.
+            </p>
+          ) : null}
+          {canManage ? (
+            <button
+              type="button"
+              className="access-panel__btn access-panel__btn--primary"
+              onClick={() => void handlePublish()}
+              disabled={busy}
+            >
+              {busy ? (
+                <Loader2 size={14} className="access-panel__spin" aria-hidden="true" />
+              ) : (
+                <Globe size={14} aria-hidden="true" />
+              )}
+              Publish to the web
+            </button>
+          ) : (
+            <p className="access-panel__hint">Only the document’s owner can publish it.</p>
+          )}
+        </>
+      )}
+
+      {nearCap && maxBytes !== null ? (
+        <p className="publish-rung__notice publish-rung__notice--soft">
+          This document is near the {formatBytes(maxBytes)} publishing limit
+          (about {formatBytes(estimatedBytes)}). Images don’t count toward it.
+        </p>
+      ) : null}
+
+      {error ? (
+        <p className="access-panel__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export default PublishRung;

--- a/src/ui/components/PageTabStrip.tsx
+++ b/src/ui/components/PageTabStrip.tsx
@@ -19,6 +19,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import { MoreHorizontal, Plus } from 'lucide-react';
 import { Icon } from '../icons';
+import { useActiveDocReadOnly } from '../../store/documentRegistry';
 import './PageTabStrip.css';
 
 export interface PageTabStripItem {
@@ -72,6 +73,16 @@ export function PageTabStrip({
   className,
   ariaLabel,
 }: PageTabStripProps) {
+  /**
+   * Adding a page is a WRITE. Gated here rather than at each consumer
+   * (`InlinePageTabs`, `RichTextTabBar`) because both are document page
+   * strips and a per-consumer guard is the exact pattern that let this ship:
+   * the rule lived in one predicate while the decision to consult it lived at
+   * every call site (the JP-457 lesson). Found live on a published document,
+   * but it applied to any view-only doc — a workspace viewer could add pages
+   * the relay would then refuse.
+   */
+  const docReadOnly = useActiveDocReadOnly();
   const scrollRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -159,7 +170,7 @@ export function PageTabStrip({
         {items.map((item, index) => renderTab(item, index))}
       </div>
 
-      {onAdd && (
+      {onAdd && !docReadOnly && (
         <button
           type="button"
           className="page-tab-strip-add"

--- a/src/ui/home/PeopleStack.tsx
+++ b/src/ui/home/PeopleStack.tsx
@@ -34,7 +34,9 @@ export type NameResolver = (id: string, stored: string | undefined) => string;
  * UUIDs (JP-459), so `PeopleStack` always passes the real resolver.
  */
 export function peopleForRecord(record: DocumentRecord, resolve?: NameResolver): Person[] {
-  if (record.type === 'local') return [];
+  // Local docs have no roster; external (guest) snapshots carry NO people
+  // fields at all — the published projection strips identity by design.
+  if (record.type === 'local' || record.type === 'external') return [];
   const out: Person[] = [];
   const seen = new Set<string>();
   const push = (id: string | undefined, name: string | undefined) => {

--- a/src/ui/home/RecentCard.tsx
+++ b/src/ui/home/RecentCard.tsx
@@ -19,6 +19,8 @@ function sourceLabel(record: DocumentRecord): string {
       return 'Offline';
     case 'remote':
       return 'Cloud';
+    case 'external':
+      return 'Shared';
   }
 }
 

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -50,7 +50,7 @@ import { useTransferStore, isTransferRunning } from '../../store/transferStore';
 import { purgeLocalDocRoom } from '../../collaboration';
 import { getDocumentMetadata } from '../../types/Document';
 import { tagsMatch } from '../../types/DocumentTags';
-import type { DocumentRecord } from '../../types/DocumentRegistry';
+import { isSyncedDocument, type DocumentRecord } from '../../types/DocumentRegistry';
 import { confirmDialog, promptDialog } from '../confirm/confirmStore';
 
 /** Document type axis the nav rail / filter row toggles. `'shared'` (JP-444)
@@ -63,7 +63,7 @@ export type FilterMode = 'all' | 'local' | 'relay' | 'cached' | 'shared';
  * relays, caches that never captured it) are excluded rather than guessed.
  */
 export function isSharedWithMe(record: DocumentRecord, userId: string | undefined): boolean {
-  if (record.type === 'local' || !userId) return false;
+  if (!isSyncedDocument(record) || !userId) return false;
   return !!record.ownerId && record.ownerId !== userId;
 }
 
@@ -477,7 +477,7 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   const documentCounts = useMemo(() => {
     const ws = activeWorkspaceId();
     const inActiveWs = (d: DocumentRecord): boolean =>
-      d.type === 'local' || d.workspaceId === ws;
+      d.type === 'local' || (isSyncedDocument(d) && d.workspaceId === ws);
     const allDocs = Object.values(entries)
       .map((e) => e.record)
       .filter(inActiveWs);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,6 +109,17 @@ export default defineConfig({
     watch: {
       ignored: ['**/src-tauri/target/**', '**/docs-site/**', '**/NEW-ICONS/**', '**/dist/**'],
     },
+    // JP-464: in production the share surfaces (`/api/share/*`) are served on
+    // THIS origin by an edge worker route in front of the deployed PWA. In dev
+    // the control plane runs on :3000, so proxy the same paths there — the
+    // guest code stays origin-relative in both worlds. Dev-only by nature
+    // (build output has no dev server).
+    proxy: {
+      '/api/share': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## What

The editor half of "anyone with the link can view": the **guest view** a stranger gets at `/d/<token>`, and the **Publish rung** on the access ladder. Builds on the relay publish surface ([#424](https://github.com/JPE-Net-Technologies/docushark/pull/424), merged) and the serving Worker ([web#105](https://github.com/JPE-Net-Technologies/docushark-web/pull/105), open).

## The security core

`recordIsReadOnly` now **fails closed on both arms** — this is the change everything else leans on:

- an active id **without** a registry record is read-only (this arm used to fail open; a guest document would have rendered fully editable — every guard in the app resolves through this one predicate);
- the type test is an editable **allowlist** (`local`, permissioned `remote`/`cached`) — a future record type is read-only until someone decides otherwise, the same principle as the relay's projection;
- the null-active scratch-document state stays editable (a fresh doc is registered only on first save — flipping that arm would ship documents born read-only).

Mutation-checked: reverting the fail-closed arm fails `an active id WITHOUT a registry record → read-only (the guest invariant)` by name.

## Guest view

- `main.tsx` branches before any auth machinery — no session, no sign-in prompt, no last-doc restore. The full editor renders (canvas fidelity is the point), held read-only by an `external` record.
- `ExternalDocument` is session-only: filtered from listings, from the persist snapshot (caught live — the record leaked into localStorage as a "Shared with you" ghost), and from every people surface.
- Guest bar: document name, **published date** (citation provenance), Download copy, try-it CTA. Reading never prompts for anything.

## Publish rung

One derived status — unpublished / published (link + Copy + **view count** + date + bytes) / **stale** (+ Republish) / turned off (Publish re-enables the **same URL**). Size handling is warn-then-confirm; every number renders from the relay's status endpoint, so no client copy of the cap exists to drift. `publishFlow` pins the two-system order both ways (relay artifact → row mint; row revoke → relay delete) with 9 order/failure-mapping tests.

## Found by the live E2E and fixed here

- relay `projected_blob_hashes` missed FileShape's bare-hash `blobRef` (only knew `blob://` URIs) — published documents' files resolved to nothing. Now delegates to the save path's canonical walker; the projection test pins the reference shape.

## Verification (full local stack: relay+MinIO, web+miniflare R2, Supabase, editor)

- publish → artifact/manifest/registry in object storage + row minted, URL issued from the rung
- edit → **stale** badge → Republish → manifest gained all 3 blob keys
- guest render on a **storage-cleared profile**: bar + read-only ribbon + republished content
- blob authorized by manifest; cross-document hash → 404; uniform 404s + credential headers (curl)
- revoke → uniform 404 → re-enable → **same URL**, same artifact; view count 0 → 1
- 273 files / 3243 tests, typecheck, `bun run build`, cargo publish suites — green

Left open for E2E sign-off per session agreement.

Assisted-by: Opus 5