### PR TITLE
JP-470: publish lifecycle — teardown seam, frozen-artifact carry, read-only spellcheck

### DIFF
--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -117,6 +117,9 @@ libc = "0.2"
 docushark-relay = { path = ".", features = ["test-helpers"] }
 tempfile = "3"
 tower = { version = "0.4", features = ["util"] }
+# JP-470 (`tests/document_publish.rs`) — in-process fake S3 endpoint for the
+# cold-machine teardown tests. Already a main dep; re-listed for the test.
+axum = "0.7"
 # Phase 21.4 fuzz suite (`tests/cross_tenant_isolation.rs`) — already
 # main deps, re-listed here so the integration test sees them.
 rand = "0.8"

--- a/relay/src/api.rs
+++ b/relay/src/api.rs
@@ -1253,6 +1253,116 @@ async fn list_recovery_handler(
 /// clean break: the source's `Deleted` broadcast kicks them (they strand their
 /// pre-restore copy to Trash via JP-375), and the new doc surfaces via `Created`.
 /// Owner-gated, since it deletes the source. Returns `{ newDocId, serverVersion }`.
+/// What `carry_publish_forward` moved: the new artifact/manifest object keys
+/// (`None` on the filesystem backend, like `PublishAck`) and the carried
+/// entry's byte count. Reported in the restore ack so clients can follow the
+/// publication to the new id.
+struct PublishCarryOutcome {
+    artifact_key: Option<String>,
+    manifest_key: Option<String>,
+    bytes: u64,
+}
+
+/// A doc's frozen public artifact (or manifest) as last published: the local
+/// `public/` file when present, the object store on a cold machine — the
+/// registry mirror restores entries, never artifact bytes, so a recycled
+/// machine has the entry but not the file.
+async fn read_frozen_public_bytes(
+    state: &ServerState,
+    ws: &WorkspaceId,
+    doc_id: &DocId,
+    suffix: &str,
+) -> Option<String> {
+    let path = if suffix == "manifest.json" {
+        state.doc_store().public_manifest_path(ws, doc_id)
+    } else {
+        state.doc_store().public_doc_path(ws, doc_id)
+    };
+    if let Ok(s) = std::fs::read_to_string(&path) {
+        return Some(s);
+    }
+    let s3 = state.s3_backend()?;
+    match s3.get_object_at(&s3.doc_public_key(ws, doc_id, suffix)).await {
+        Ok(Some(bytes)) => String::from_utf8(bytes).ok(),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!(
+                "restore: fetch frozen {} for {}/{} failed: {}",
+                suffix,
+                ws.as_str(),
+                doc_id.as_str(),
+                e
+            );
+            None
+        }
+    }
+}
+
+/// JP-470: move a published document's FROZEN artifact from `old_id` to
+/// `new_id` — byte-for-byte, entry unchanged — so a restore doesn't end the
+/// publication. Upload order mirrors publish (object store first, registry
+/// second: the registry never records an artifact readers can't fetch). The
+/// registry mirror PUT is deliberately left to the retirement teardown that
+/// immediately follows, which uploads it once with both the new entry and the
+/// old removal. Returns `None` when the source wasn't published or any step
+/// failed — teardown then simply ends the publication, and an explicit
+/// republish under the new id starts a fresh one.
+async fn carry_publish_forward(
+    state: &ServerState,
+    ws: &WorkspaceId,
+    old_id: &DocId,
+    new_id: &DocId,
+) -> Option<PublishCarryOutcome> {
+    state.ensure_workspace_published_local(ws).await;
+    let entry = state.doc_store().published_entry(ws, old_id)?;
+
+    let artifact = read_frozen_public_bytes(state, ws, old_id, "json").await;
+    let manifest = read_frozen_public_bytes(state, ws, old_id, "manifest.json").await;
+    let (Some(artifact), Some(manifest)) = (artifact, manifest) else {
+        log::warn!(
+            "restore: publish carry skipped for {}/{} — frozen artifact unreadable",
+            ws.as_str(),
+            old_id.as_str()
+        );
+        return None;
+    };
+
+    let (artifact_key, manifest_key) = match state.s3_backend() {
+        Some(s3) => {
+            let a_key = s3.doc_public_key(ws, new_id, "json");
+            let m_key = s3.doc_public_key(ws, new_id, "manifest.json");
+            for (key, body) in [(&a_key, &artifact), (&m_key, &manifest)] {
+                if let Err(e) =
+                    s3.put_object_at(key, body.clone().into_bytes(), "application/json").await
+                {
+                    log::warn!("restore: publish carry PUT failed for {}: {}", key, e);
+                    return None;
+                }
+            }
+            (Some(a_key), Some(m_key))
+        }
+        None => (None, None),
+    };
+
+    let bytes = entry.bytes;
+    if let Err(e) = state.doc_store().set_published(ws, new_id, entry, &artifact, &manifest) {
+        log::warn!(
+            "restore: publish carry registry write failed for {}/{}: {}",
+            ws.as_str(),
+            new_id.as_str(),
+            e
+        );
+        return None;
+    }
+    log::info!(
+        "restore: publication carried {}/{} -> {}",
+        ws.as_str(),
+        old_id.as_str(),
+        new_id.as_str()
+    );
+    Some(PublishCarryOutcome { artifact_key, manifest_key, bytes })
+}
+
 async fn restore_recovery_handler(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
@@ -1379,15 +1489,23 @@ async fn restore_recovery_handler(
         log::warn!("restore: sync new-doc blob refs: {e}");
     }
 
+    // JP-470: publish follows the document. If the source is published, carry
+    // the FROZEN artifact to the new id before retirement tears the old one
+    // down — never a re-projection: the recovery point can hold since-publish
+    // edits the owner never exposed (the divergence the `stale` flag reports),
+    // could newly exceed the artifact ceiling, and would leak the "(Restored)"
+    // title onto the public page. Entry timestamps and bytes move unchanged,
+    // so the meter is net-neutral and status correctly reads stale until an
+    // explicit republish swaps the public content.
+    let publish_carry = carry_publish_forward(&state, &ws, &doc_id, &new_doc_id).await;
+
     // Retire the source: delete + tombstone (the store records the tombstone),
-    // release its blob refs, and broadcast Deleted so connected clients strand
-    // their pre-restore copy to Trash and leave (no merge-back), then Created so
-    // the new doc surfaces in browsers.
+    // then the shared post-delete seam — publish teardown for the OLD id,
+    // Deleted broadcast (so connected clients strand their pre-restore copy to
+    // Trash and leave, no merge-back), blob-ref release — then Created so the
+    // new doc surfaces in browsers.
     let _ = state.doc_store().delete_document(&ws, &doc_id);
-    if let Err(e) = state.blob_store().release_doc_refs(&ws, doc_id.as_str()) {
-        log::warn!("restore: release source blob refs: {e}");
-    }
-    state.emit_doc_event(&ws, &doc_id, DocEventType::Deleted, Some(claims.sub.clone()));
+    state.after_doc_deleted(&ws, &doc_id, Some(claims.sub.clone())).await;
     state.emit_doc_event(&ws, &new_doc_id, DocEventType::Created, Some(claims.sub.clone()));
 
     log::info!(
@@ -1397,11 +1515,17 @@ async fn restore_recovery_handler(
         point_id,
         new_id
     );
-    (
-        StatusCode::OK,
-        Json(json!({ "newDocId": new_id, "serverVersion": 1 })),
-    )
-        .into_response()
+    let mut body = json!({
+        "newDocId": new_id,
+        "serverVersion": 1,
+        "publishCarried": publish_carry.is_some(),
+    });
+    if let Some(carry) = publish_carry {
+        body["publishArtifactKey"] = json!(carry.artifact_key);
+        body["publishManifestKey"] = json!(carry.manifest_key);
+        body["publishBytes"] = json!(carry.bytes);
+    }
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 async fn save_doc_handler(
@@ -1674,7 +1798,7 @@ async fn delete_doc_handler(
         Ok(true) => {
             // Broadcast Deleted + release blob refs (JP-120). Shared with the MCP
             // delete_document tool via ServerState::after_doc_deleted (JP-350).
-            state.after_doc_deleted(&ws, &doc_id, Some(claims.sub.clone()));
+            state.after_doc_deleted(&ws, &doc_id, Some(claims.sub.clone())).await;
             (StatusCode::OK, Json(WriteAck { success: true })).into_response()
         }
         Ok(false) => (
@@ -2016,8 +2140,6 @@ async fn unpublish_doc_handler(
         Err(resp) => return resp,
     };
 
-    state.ensure_workspace_published_local(&ws).await;
-
     if let Err(e) = check_delete_permission(
         state.doc_store(),
         &ws,
@@ -2028,30 +2150,16 @@ async fn unpublish_doc_handler(
         return permission_error_response(&e);
     }
 
-    let removed = match state.doc_store().remove_published(&ws, &doc_id) {
+    // The shared removal seam (JP-470): registry hydration, entry removal,
+    // best-effort object deletes, and the registry mirror PUT all live in
+    // `teardown_publish` — the same path document delete and restore
+    // retirement take, so the four ways a publication ends cannot drift.
+    let removed = match state.teardown_publish(&ws, &doc_id).await {
         Ok(r) => r,
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, ApiError::body(e)).into_response(),
     };
 
     if removed.is_some() {
-        if let Some(s3) = state.s3_backend() {
-            // Best-effort object deletes: a failure leaves an orphaned object
-            // that nothing can reach (the registry entry is gone), cleaned up
-            // by the next publish's overwrite. Registry mirror keeps the
-            // meter correct on cold machines.
-            for suffix in ["json", "manifest.json"] {
-                let key = s3.doc_public_key(&ws, &doc_id, suffix);
-                if let Err(e) = s3.delete_object_at(&key).await {
-                    log::warn!("unpublish DELETE failed for {}: {}", key, e);
-                }
-            }
-            if let Some(bytes) = state.doc_store().read_workspace_published_bytes(&ws) {
-                let key = s3.workspace_published_key(&ws);
-                if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
-                    log::warn!("published registry mirror PUT failed for {}: {}", key, e);
-                }
-            }
-        }
         log::info!("Unpublished document projection: {}/{}", ws.as_str(), doc_id.as_str());
     }
 

--- a/relay/src/server/mod.rs
+++ b/relay/src/server/mod.rs
@@ -1673,18 +1673,92 @@ impl ServerState {
         }
     }
 
-    /// Shared post-delete side effects (JP-350): broadcast a `Deleted` doc event
-    /// (so connected clients leave/Trash the doc) and release the doc's blob
-    /// references for GC (JP-120). The store delete itself is the caller's
-    /// responsibility — this runs the identical follow-up for both the REST
-    /// `delete_doc_handler` and the MCP `delete_document` tool so the two paths
-    /// can't drift.
-    pub(crate) fn after_doc_deleted(
+    /// Tear down a document's public projection (JP-470): remove the registry
+    /// entry + local artifact files, best-effort delete the public objects,
+    /// and re-mirror the registry so the meter stays correct on cold machines.
+    ///
+    /// Hydrates the registry FIRST — on a cold machine (empty local volume,
+    /// state only in the object-store mirror) an unhydrated registry would
+    /// make the removal a silent no-op: the artifact keeps serving, and
+    /// `remove_published`'s empty-registry default would be persisted over the
+    /// real mirror by the closing PUT, resurrecting nothing and erasing the
+    /// meter for every OTHER published doc in the workspace.
+    ///
+    /// The single removal seam for every path that ends a publication —
+    /// document delete, restore retirement, and explicit unpublish. Only the
+    /// registry write can fail (`Err`); object-store cleanup is best-effort
+    /// (a failed object delete leaves an orphan nothing can reach — the
+    /// registry entry is gone — overwritten by any future publish under the
+    /// same id). Lifecycle callers log and continue; unpublish surfaces the
+    /// `Err` as its 500.
+    pub(crate) async fn teardown_publish(
+        &self,
+        ws: &WorkspaceId,
+        doc_id: &DocId,
+    ) -> Result<Option<crate::server::publish::PublishedEntry>, String> {
+        self.ensure_workspace_published_local(ws).await;
+        let removed = self.doc_store.remove_published(ws, doc_id);
+        // Registry-write failure can land AFTER the in-memory removal, so on
+        // `Err` the object-store state is unknown — and every teardown caller
+        // means this publication is ending, so deleting the (idempotent)
+        // objects is always right. Skipping them here would let a cold boot
+        // from the un-rewritten mirror serve a deleted doc's artifact forever.
+        let cleanup_objects = !matches!(&removed, Ok(None));
+        if cleanup_objects {
+            if let Some(s3) = &self.s3 {
+                for suffix in ["json", "manifest.json"] {
+                    let key = s3.doc_public_key(ws, doc_id, suffix);
+                    if let Err(e) = s3.delete_object_at(&key).await {
+                        log::warn!("publish teardown DELETE failed for {}: {}", key, e);
+                    }
+                }
+            }
+        }
+        let removed = removed?;
+        if removed.is_none() {
+            return Ok(None);
+        }
+        if let Some(s3) = &self.s3 {
+            if let Some(bytes) = self.doc_store.read_workspace_published_bytes(ws) {
+                let key = s3.workspace_published_key(ws);
+                if let Err(e) = s3.put_object_at(&key, bytes, "application/json").await {
+                    log::warn!("published registry mirror PUT failed for {}: {}", key, e);
+                }
+            }
+        }
+        log::info!(
+            "publish teardown: removed public projection for {}/{}",
+            ws.as_str(),
+            doc_id.as_str()
+        );
+        Ok(removed)
+    }
+
+    /// Shared post-delete side effects (JP-350): tear down the doc's public
+    /// projection (JP-470 — a deleted document's published artifact must stop
+    /// serving no matter which surface deleted it), broadcast a `Deleted` doc
+    /// event (so connected clients leave/Trash the doc), and release the doc's
+    /// blob references for GC (JP-120). The store delete itself is the
+    /// caller's responsibility — this runs the identical follow-up for the
+    /// REST `delete_doc_handler`, the MCP `delete_document` tool, and the
+    /// recovery-restore retirement so the paths can't drift.
+    pub(crate) async fn after_doc_deleted(
         &self,
         ws: &WorkspaceId,
         doc_id: &DocId,
         user_id: Option<String>,
     ) {
+        if let Err(e) = self.teardown_publish(ws, doc_id).await {
+            // Deliberately non-fatal: the document is already gone from the
+            // store, so a dangling registry entry only overstates the meter
+            // until the next successful teardown/publish rewrites it.
+            log::warn!(
+                "publish teardown failed for {}/{}: {}",
+                ws.as_str(),
+                doc_id.as_str(),
+                e
+            );
+        }
         self.emit_doc_event(ws, doc_id, DocEventType::Deleted, user_id);
         if let Err(e) = self.blob_store.release_doc_refs(ws, doc_id.as_str()) {
             log::warn!(
@@ -2424,7 +2498,7 @@ impl WebSocketServer {
     pub async fn after_mcp_doc_deleted(&self, ws: &WorkspaceId, doc_id: &DocId) {
         let state_guard = self.state.read().await;
         if let Some(state) = state_guard.as_ref() {
-            state.after_doc_deleted(ws, doc_id, None);
+            state.after_doc_deleted(ws, doc_id, None).await;
         }
     }
 }

--- a/relay/tests/document_publish.rs
+++ b/relay/tests/document_publish.rs
@@ -13,7 +13,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use docushark_relay::auth::WorkspaceRole;
-use docushark_relay::config::{LimitsConfig, TenancyConfig, TenancyMode};
+use docushark_relay::config::{
+    LimitsConfig, S3StorageConfig, StorageConfig, TenancyConfig, TenancyMode,
+};
 use docushark_relay::server::{NetworkMode, ServerConfig, WebSocketServer};
 use docushark_relay::test_support::OidcTestIssuer;
 use reqwest::StatusCode;
@@ -21,6 +23,9 @@ use serde_json::{json, Value};
 use tempfile::TempDir;
 
 const WS: &str = "ws_publish";
+/// Bucket name for the in-process fake object store (path-style addressing —
+/// the first URL segment, which the fake's wildcard route captures).
+const BUCKET: &str = "pub-test-bucket";
 
 struct Harness {
     base: String,
@@ -37,22 +42,50 @@ impl Harness {
     async fn start_with_limits(limits: LimitsConfig) -> Self {
         let tmp = tempfile::tempdir().expect("tempdir");
         let data_dir = tmp.path().to_path_buf();
-        Self::boot(limits, data_dir, Some(tmp)).await
+        Self::boot(limits, data_dir, Some(tmp), None).await
+    }
+
+    /// Boot a relay whose byte store is the S3-compatible endpoint at
+    /// `endpoint` (the in-process fake) — the Cloud shape, where publish
+    /// uploads artifacts and mirrors the registry to the object store.
+    async fn start_on_s3(limits: LimitsConfig, endpoint: &str) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path().to_path_buf();
+        let storage = StorageConfig {
+            backend: "s3".into(),
+            path: data_dir.clone(),
+            s3: Some(S3StorageConfig {
+                endpoint: endpoint.to_string(),
+                bucket: BUCKET.into(),
+                access_key_id: "test-access".into(),
+                secret_access_key: "test-secret".into(),
+                ..S3StorageConfig::default()
+            }),
+        };
+        Self::boot(limits, data_dir, Some(tmp), Some(storage)).await
     }
 
     /// Boot a second relay over an existing data directory — proves the
     /// published registry (and its meter contribution) survives a restart.
     async fn reboot(self, limits: LimitsConfig) -> Self {
         let Harness { data_dir, _tmp, issuer: _, .. } = self;
-        Self::boot(limits, data_dir, _tmp).await
+        Self::boot(limits, data_dir, _tmp, None).await
     }
 
-    async fn boot(limits: LimitsConfig, data_dir: PathBuf, tmp: Option<TempDir>) -> Self {
+    async fn boot(
+        limits: LimitsConfig,
+        data_dir: PathBuf,
+        tmp: Option<TempDir>,
+        storage: Option<StorageConfig>,
+    ) -> Self {
         let issuer = OidcTestIssuer::new().await;
 
         let server = Arc::new(WebSocketServer::new());
         server.set_app_data_dir(data_dir.clone()).await;
         server.set_auth(issuer.auth_state()).await;
+        if let Some(storage) = storage {
+            server.set_storage(storage).await;
+        }
         server
             .set_tenancy(TenancyConfig {
                 mode: TenancyMode::Shared,
@@ -507,6 +540,257 @@ async fn status_flags_stale_after_a_source_edit_and_clears_on_republish() {
     assert!(std::fs::read_to_string(h.artifact_path(doc)).unwrap().contains("v2"));
 }
 
+// ─────────────────────── lifecycle teardown (JP-470) ────────────────────────
+//
+// A publication must end when its document does — through EVERY removal path,
+// not just the explicit unpublish button. These pin the shared seam
+// (`teardown_publish`): document delete tears the artifact down, and a
+// recovery restore carries the FROZEN artifact to the successor id instead of
+// ending (or re-projecting) the publication.
+
+impl Harness {
+    async fn delete_doc(&self, sub: &str, role: WorkspaceRole, id: &str) -> StatusCode {
+        reqwest::Client::new()
+            .delete(format!("{}/api/docs/{}", self.base, id))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("delete doc")
+            .status()
+    }
+
+    async fn get_doc(&self, sub: &str, role: WorkspaceRole, id: &str) -> StatusCode {
+        reqwest::Client::new()
+            .get(format!("{}/api/docs/{}", self.base, id))
+            .bearer_auth(self.token(sub, role))
+            .send()
+            .await
+            .expect("get doc")
+            .status()
+    }
+
+    /// Mint the binary Y.Doc sidecar a collab session would have persisted.
+    /// REST saves deliberately never write one (that's the snapshot path),
+    /// and recovery capture refuses to invent one — `push_recovery_point_if_
+    /// changed` backs up the sidecar, so a doc without one has nothing to
+    /// capture. Built through the real envelope (`DocHandle::encode_binary`),
+    /// so the restore path decodes it exactly like a production point.
+    fn seed_sidecar(&self, doc_id: &str, page_id: &str) {
+        let handle = docushark_relay::sync::DocHandle::from_decoded(
+            yrs::Doc::new(),
+            Some(page_id.to_string()),
+        );
+        handle
+            .insert_shapes(
+                page_id,
+                &[(
+                    "s1".to_string(),
+                    json!({ "type": "rectangle", "x": 0.0, "y": 0.0 }),
+                )],
+            )
+            .expect("seed shape");
+        let dir = self.ws_dir().join("docs");
+        std::fs::create_dir_all(&dir).expect("docs dir");
+        std::fs::write(dir.join(format!("{doc_id}.ydoc")), handle.encode_binary(1))
+            .expect("write sidecar");
+    }
+
+    /// Capture a recovery point and return the newest point's id.
+    async fn capture_point(&self, sub: &str, doc_id: &str) -> String {
+        let resp = reqwest::Client::new()
+            .post(format!("{}/api/docs/{}/recovery/capture", self.base, doc_id))
+            .bearer_auth(self.token(sub, WorkspaceRole::Owner))
+            .send()
+            .await
+            .expect("capture");
+        assert_eq!(resp.status(), StatusCode::OK, "capture failed");
+        let list: Value = reqwest::Client::new()
+            .get(format!("{}/api/docs/{}/recovery", self.base, doc_id))
+            .bearer_auth(self.token(sub, WorkspaceRole::Owner))
+            .send()
+            .await
+            .expect("list points")
+            .json()
+            .await
+            .expect("points json");
+        let points = list["recoveryPoints"].as_array().expect("points array");
+        points
+            .last()
+            .and_then(|p| p["id"].as_str())
+            .expect("newest point id")
+            .to_string()
+    }
+
+    async fn restore_point(&self, sub: &str, doc_id: &str, point_id: &str) -> Value {
+        let resp = reqwest::Client::new()
+            .post(format!(
+                "{}/api/docs/{}/recovery/{}/restore",
+                self.base, doc_id, point_id
+            ))
+            .bearer_auth(self.token(sub, WorkspaceRole::Owner))
+            .send()
+            .await
+            .expect("restore");
+        assert_eq!(resp.status(), StatusCode::OK, "restore failed");
+        resp.json().await.expect("restore json")
+    }
+
+    /// The on-disk `published.json` registry, parsed. `entries` empty when the
+    /// workspace has no live publications.
+    fn published_registry(&self) -> Value {
+        match std::fs::read_to_string(self.ws_dir().join("published.json")) {
+            Ok(s) => serde_json::from_str(&s).expect("registry json"),
+            Err(_) => json!({ "entries": {} }),
+        }
+    }
+}
+
+#[tokio::test]
+async fn document_delete_ends_the_publication_and_frees_the_meter() {
+    let h = Harness::start().await;
+    let doc = "del-doc";
+    let usage_empty = h.usage_storage_bytes("user-owner").await;
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    assert_eq!(h.publish("user-owner", WorkspaceRole::Owner, doc).await.status(), StatusCode::OK);
+    assert!(h.artifact_path(doc).exists());
+
+    assert_eq!(h.delete_doc("user-owner", WorkspaceRole::Owner, doc).await, StatusCode::OK);
+
+    // The artifact stopped existing WITH the document — no unpublish call ever
+    // ran, which is the whole point: readers of the public link fail closed.
+    assert!(!h.artifact_path(doc).exists(), "artifact must die with the doc");
+    assert!(!h.manifest_path(doc).exists(), "manifest must die with the doc");
+    assert_eq!(
+        h.published_registry()["entries"].as_object().map(|m| m.len()),
+        Some(0),
+        "registry entry removed"
+    );
+    assert_eq!(
+        h.usage_storage_bytes("user-owner").await,
+        usage_empty,
+        "doc bytes AND artifact bytes leave the meter together"
+    );
+}
+
+#[tokio::test]
+async fn restore_carries_the_frozen_publication_to_the_new_id() {
+    let h = Harness::start().await;
+    let doc = "carry-doc";
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({
+                "id": doc,
+                "name": "published-v1",
+                "modifiedAt": 1000,
+                "pageOrder": ["p1"],
+                "activePageId": "p1",
+                "pages": { "p1": { "shapes": {}, "shapeOrder": [] } },
+            }),
+        )
+        .await
+        .is_success());
+    let ack: Value =
+        h.publish("user-owner", WorkspaceRole::Owner, doc).await.json().await.unwrap();
+    let published_bytes = ack["bytes"].as_u64().unwrap();
+    let frozen = std::fs::read_to_string(h.artifact_path(doc)).unwrap();
+    let frozen_manifest = std::fs::read_to_string(h.manifest_path(doc)).unwrap();
+
+    // Diverge the source AFTER publishing — the recovery point captures this
+    // v2, and the carry must NOT leak it into the public artifact.
+    assert!(h
+        .put_doc(
+            "user-owner",
+            WorkspaceRole::Owner,
+            doc,
+            json!({
+                "id": doc,
+                "name": "secret-v2",
+                "modifiedAt": 2000,
+                "pageOrder": ["p1"],
+                "activePageId": "p1",
+                "pages": { "p1": { "shapes": {}, "shapeOrder": [] } },
+            }),
+        )
+        .await
+        .is_success());
+    h.seed_sidecar(doc, "p1");
+    let point = h.capture_point("user-owner", doc).await;
+    let usage_before = h.usage_storage_bytes("user-owner").await;
+    let doc_disk = |id: &str| {
+        std::fs::metadata(h.ws_dir().join("docs").join(format!("{id}.json")))
+            .map(|m| m.len())
+            .unwrap_or(0)
+    };
+    let old_doc_bytes = doc_disk(doc);
+
+    let restored = h.restore_point("user-owner", doc, &point).await;
+    let new_id = restored["newDocId"].as_str().expect("newDocId").to_string();
+    assert_ne!(new_id, doc);
+    assert_eq!(restored["publishCarried"], json!(true));
+    assert_eq!(restored["publishBytes"].as_u64().unwrap(), published_bytes);
+    // Filesystem backend: keys are null, exactly like `PublishAck`.
+    assert!(restored["publishArtifactKey"].is_null());
+
+    // The public artifact moved BYTE-FOR-BYTE: readers keep seeing what was
+    // published, never the restored (post-publish) content.
+    let carried = std::fs::read_to_string(h.artifact_path(&new_id)).expect("carried artifact");
+    assert_eq!(carried, frozen, "artifact must be the frozen bytes, not a re-projection");
+    assert_eq!(
+        std::fs::read_to_string(h.manifest_path(&new_id)).expect("carried manifest"),
+        frozen_manifest
+    );
+    assert!(!carried.contains("secret-v2"), "post-publish content must not leak");
+    assert!(!h.artifact_path(doc).exists(), "old id's artifact torn down");
+    assert!(!h.manifest_path(doc).exists());
+    let entries = h.published_registry()["entries"].as_object().cloned().unwrap();
+    assert_eq!(entries.keys().collect::<Vec<_>>(), vec![&new_id], "entry moved, not duplicated");
+
+    // Meter: the carry MOVES the artifact bytes. The only legitimate delta
+    // across a restore is the document body itself (the flattened recovery
+    // point replaces the source body); the published contribution nets to
+    // exactly zero.
+    assert_eq!(
+        h.usage_storage_bytes("user-owner").await,
+        usage_before + doc_disk(&new_id) - old_doc_bytes,
+        "publish contribution must be net-zero across restore"
+    );
+
+    // Status on the successor: published, and STALE — the artifact still
+    // reflects pre-restore content; an explicit republish is what swaps it.
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, &new_id).await;
+    assert_eq!(status["published"], json!(true));
+    assert_eq!(status["stale"], json!(true));
+    assert_eq!(status["bytes"].as_u64().unwrap(), published_bytes);
+}
+
+#[tokio::test]
+async fn restore_of_an_unpublished_doc_reports_no_carry() {
+    let h = Harness::start().await;
+    let doc = "plain-doc";
+    assert!(h
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    h.seed_sidecar(doc, "p1");
+    let point = h.capture_point("user-owner", doc).await;
+    let restored = h.restore_point("user-owner", doc, &point).await;
+    let new_id = restored["newDocId"].as_str().unwrap();
+
+    // The contract the editor keys on: `publishCarried` present and false, no
+    // key fields, successor unpublished.
+    assert_eq!(restored["publishCarried"], json!(false));
+    assert!(restored.get("publishArtifactKey").is_none());
+    assert!(restored.get("publishBytes").is_none());
+    let status = h.publish_status("user-owner", WorkspaceRole::Owner, new_id).await;
+    assert_eq!(status["published"], json!(false));
+}
+
 // ───────────────────────────── durability ───────────────────────────────────
 
 #[tokio::test]
@@ -535,5 +819,129 @@ async fn published_state_and_meter_survive_a_relay_restart() {
         h.usage_storage_bytes("user-owner").await,
         usage_before,
         "meter contribution survives the restart"
+    );
+}
+
+// ──────────────────── cold-machine teardown (JP-470) ────────────────────────
+//
+// The registry hydration inside `teardown_publish` is load-bearing: on a
+// machine whose local volume never saw the publish (state lives only in the
+// object-store mirror), a teardown that forgot to hydrate would find no entry,
+// delete nothing, and leave the artifact serving forever — then persist an
+// EMPTY registry over the real mirror. This drives that exact machine shape
+// with an in-process fake S3 endpoint (the SigV4 client speaks plain HTTP to
+// it; signatures are accepted unverified).
+
+/// In-memory S3 stand-in. Path-style requests (`/{bucket}/{key…}`) land on the
+/// wildcard route; the map key is the full `bucket/key` path.
+#[derive(Clone, Default)]
+struct FakeS3 {
+    objects: Arc<std::sync::Mutex<std::collections::HashMap<String, Vec<u8>>>>,
+}
+
+impl FakeS3 {
+    async fn serve() -> (Self, String) {
+        use axum::extract::{Path as AxPath, State as AxState};
+        use axum::http::StatusCode as AxStatus;
+
+        async fn put(
+            AxState(s): AxState<FakeS3>,
+            AxPath(key): AxPath<String>,
+            body: axum::body::Bytes,
+        ) -> AxStatus {
+            s.objects.lock().unwrap().insert(key, body.to_vec());
+            AxStatus::OK
+        }
+        async fn get(
+            AxState(s): AxState<FakeS3>,
+            AxPath(key): AxPath<String>,
+        ) -> (AxStatus, Vec<u8>) {
+            match s.objects.lock().unwrap().get(&key) {
+                Some(b) => (AxStatus::OK, b.clone()),
+                None => (AxStatus::NOT_FOUND, Vec::new()),
+            }
+        }
+        async fn delete(AxState(s): AxState<FakeS3>, AxPath(key): AxPath<String>) -> AxStatus {
+            s.objects.lock().unwrap().remove(&key);
+            AxStatus::NO_CONTENT
+        }
+
+        let fake = FakeS3::default();
+        let app = axum::Router::new()
+            .route("/*key", axum::routing::get(get).put(put).delete(delete))
+            .with_state(fake.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind fake s3");
+        let addr = listener.local_addr().expect("fake s3 addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        (fake, format!("http://{addr}"))
+    }
+
+    /// Object bytes at a bucket-relative key, `None` when absent.
+    fn object(&self, key: &str) -> Option<Vec<u8>> {
+        self.objects.lock().unwrap().get(&format!("{BUCKET}/{key}")).cloned()
+    }
+
+    /// Wait out an asynchronous mirror write (the JP-200 doc mirror is
+    /// queued, unlike the publish PUTs which are synchronous with the ack).
+    async fn wait_for(&self, key: &str) {
+        for _ in 0..200 {
+            if self.object(key).is_some() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!("fake S3 never received {key}");
+    }
+}
+
+#[tokio::test]
+async fn cold_machine_delete_tears_down_the_publication() {
+    let (fake, endpoint) = FakeS3::serve().await;
+    let doc = "cold-doc";
+
+    // Machine A: create + publish. Artifact, manifest, and registry-mirror
+    // PUTs are synchronous with the publish ack, so no waiting.
+    let a = Harness::start_on_s3(LimitsConfig::default(), &endpoint).await;
+    assert!(a
+        .put_doc("user-owner", WorkspaceRole::Owner, doc, Harness::people_laden_body(doc))
+        .await
+        .is_success());
+    let ack: Value =
+        a.publish("user-owner", WorkspaceRole::Owner, doc).await.json().await.unwrap();
+    let artifact_key = ack["artifactKey"].as_str().expect("s3 ack carries the key").to_string();
+    let manifest_key = ack["manifestKey"].as_str().expect("manifest key").to_string();
+    assert!(fake.object(&artifact_key).is_some(), "artifact uploaded");
+    assert!(fake.object(&manifest_key).is_some(), "manifest uploaded");
+    let registry_key = format!("docs/{WS}/published.json");
+    let mirrored: Value =
+        serde_json::from_slice(&fake.object(&registry_key).expect("registry mirrored")).unwrap();
+    assert!(mirrored["entries"].get(doc).is_some(), "mirror carries the entry");
+    // Machine B's restore-on-miss needs the doc object; that mirror is queued.
+    fake.wait_for(&format!("docs/{WS}/docs/{doc}.json")).await;
+
+    // Machine B: EMPTY volume, same object store — the recycled pod. Warm the
+    // DOCUMENT (restore-on-miss) but never touch a publish endpoint, so the
+    // published registry is exactly as cold as a real pod's would be when the
+    // delete arrives.
+    let b = Harness::start_on_s3(LimitsConfig::default(), &endpoint).await;
+    assert_eq!(b.get_doc("user-owner", WorkspaceRole::Owner, doc).await, StatusCode::OK);
+    assert_eq!(b.delete_doc("user-owner", WorkspaceRole::Owner, doc).await, StatusCode::OK);
+
+    // Fail-closed proof: the public objects are gone from the store readers
+    // fetch through, and the mirror was REWRITTEN minus the entry — neither
+    // left stale (would serve a deleted doc) nor clobbered from an empty
+    // registry (would erase every other publication's meter).
+    assert!(fake.object(&artifact_key).is_none(), "cold delete must remove the artifact");
+    assert!(fake.object(&manifest_key).is_none(), "cold delete must remove the manifest");
+    let mirrored: Value = serde_json::from_slice(
+        &fake.object(&registry_key).expect("registry mirror still present"),
+    )
+    .unwrap();
+    assert_eq!(
+        mirrored["entries"].as_object().map(|m| m.len()),
+        Some(0),
+        "mirror rewritten with the entry removed"
     );
 }

--- a/src/api/relayClient.ts
+++ b/src/api/relayClient.ts
@@ -181,6 +181,19 @@ export interface RelayPublishAck {
   publishedAt: number;
 }
 
+/** Relay ack for a recovery restore (JP-183). JP-470 adds the publish-carry
+ *  report: when the retired source was published, the relay moved the FROZEN
+ *  artifact to `newDocId` and returns the new object keys (`null` keys =
+ *  filesystem-backend relay, mirroring `RelayPublishAck`). */
+export interface RestoreRecoveryAck {
+  newDocId: string;
+  serverVersion: number;
+  publishCarried?: boolean;
+  publishArtifactKey?: string | null;
+  publishManifestKey?: string | null;
+  publishBytes?: number;
+}
+
 /** Relay publish state for a document (JP-464). `maxBytes` is the configured
  *  artifact ceiling (`null` = no ceiling) — the single home of that number;
  *  clients render it and never hardcode a cap. */
@@ -332,11 +345,18 @@ export class RelayClient {
   /**
    * Restore a recovery point (JP-183). The relay writes it as a NEW document
    * and tombstones the source id; returns the new doc id.
+   *
+   * JP-470: when the source was published, the relay carries the FROZEN
+   * artifact to the new id and reports the carry here — `publishCarried` plus
+   * the new object keys — so the editor can move the share row to the
+   * successor (`repointShareLink`). `publishCarried: false` means the source
+   * either wasn't published or its publication could not be carried; the
+   * relay has torn the old artifact down either way.
    */
   async restoreRecoveryPoint(
     docId: string,
     pointId: string,
-  ): Promise<{ newDocId: string; serverVersion: number }> {
+  ): Promise<RestoreRecoveryAck> {
     return this.requestJson(
       'POST',
       `/api/docs/${encodeURIComponent(docId)}/recovery/${encodeURIComponent(pointId)}/restore`,

--- a/src/api/relayLocations.test.ts
+++ b/src/api/relayLocations.test.ts
@@ -4,18 +4,38 @@ import {
   DEFAULT_RELAY_LOCATION,
   DEFAULT_RELAY_BASE_URL,
   locationForUrl,
+  isLocalRelayUrl,
 } from './relayLocations';
 
 describe('relayLocations', () => {
-  it('defaults the primary region to Toronto (yyz)', () => {
-    expect(DEFAULT_RELAY_LOCATION.id).toBe('yyz');
+  it('a localhost relay presents as Development, never as a Cloud region', () => {
+    // No build var is injected in the test env, so the default is the OSS dev
+    // relay — and the location label must be keyed on that URL, not on the
+    // primary region's name ("Toronto, Canada" for :9876 was a lie).
+    expect(DEFAULT_RELAY_BASE_URL).toBe('http://localhost:9876');
+    expect(DEFAULT_RELAY_LOCATION.id).toBe('dev');
+    expect(DEFAULT_RELAY_LOCATION.label).toContain('Development');
+    expect(DEFAULT_RELAY_LOCATION.relayUrl).toBe('http://localhost:9876');
     expect(RELAY_LOCATIONS).toContain(DEFAULT_RELAY_LOCATION);
   });
 
-  it('falls back to the local dev relay when VITE_RELAY_BASE_URL is unset', () => {
-    // No build var is injected in the test env, so the default is the OSS dev relay.
-    expect(DEFAULT_RELAY_BASE_URL).toBe('http://localhost:9876');
-    expect(DEFAULT_RELAY_LOCATION.relayUrl).toBe('http://localhost:9876');
+  it('classifies loopback origins as local; hosted origins as regional', () => {
+    for (const local of [
+      'http://localhost:9876',
+      'http://127.0.0.1:9876',
+      'http://[::1]:9876',
+      'http://localhost:9876/',
+    ]) {
+      expect(isLocalRelayUrl(local)).toBe(true);
+    }
+    for (const hosted of [
+      'https://relay-yyz.docushark.app',
+      'https://docushark-relay-staging.fly.dev',
+      'not a url',
+      '',
+    ]) {
+      expect(isLocalRelayUrl(hosted)).toBe(false);
+    }
   });
 
   describe('locationForUrl', () => {

--- a/src/api/relayLocations.ts
+++ b/src/api/relayLocations.ts
@@ -32,22 +32,38 @@ export interface RelayLocation {
   relayUrl: string;
 }
 
+/**
+ * Loopback test — a localhost relay is the development stack, never a Cloud
+ * region, and the switcher must say so instead of wearing a region's name.
+ */
+export function isLocalRelayUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+  } catch {
+    return false;
+  }
+}
+
 // Declare the location const first, then build the list + default from it — so
 // DEFAULT_RELAY_LOCATION is `RelayLocation`, not `RelayLocation | undefined`
 // (RELAY_LOCATIONS[0] would be `| undefined` under noUncheckedIndexedAccess).
 //
+// The label is KEYED ON THE URL the build actually points at: a hosted build
+// injects its region origin and presents as that region, while a dev/OSS
+// build (localhost default) presents as Development — so "Toronto, Canada"
+// can never name a localhost relay.
+//
 // Only Toronto (`yyz`) is live today. ord/nrt/fra light up on demand; each will
 // get its own `VITE_RELAY_BASE_URL_<region>` build var when it does (YAGNI now).
-const TORONTO: RelayLocation = {
-  id: 'yyz',
-  label: 'Toronto, Canada',
-  relayUrl: DEFAULT_RELAY_BASE_URL,
-};
+const PRIMARY: RelayLocation = isLocalRelayUrl(DEFAULT_RELAY_BASE_URL)
+  ? { id: 'dev', label: 'Development (localhost)', relayUrl: DEFAULT_RELAY_BASE_URL }
+  : { id: 'yyz', label: 'Toronto, Canada', relayUrl: DEFAULT_RELAY_BASE_URL };
 
-export const RELAY_LOCATIONS: RelayLocation[] = [TORONTO];
+export const RELAY_LOCATIONS: RelayLocation[] = [PRIMARY];
 
 /** The location selected by default before the user picks one. */
-export const DEFAULT_RELAY_LOCATION: RelayLocation = TORONTO;
+export const DEFAULT_RELAY_LOCATION: RelayLocation = PRIMARY;
 
 /** Trim trailing slashes so `http://host/` and `http://host` compare equal. */
 function normalizeOrigin(url: string): string {

--- a/src/api/restDocumentProvider.ts
+++ b/src/api/restDocumentProvider.ts
@@ -15,6 +15,7 @@ import type {
   RelayCollectionDef,
   RelayRecoveryPoint,
   RelayUsage,
+  RestoreRecoveryAck,
 } from './relayClient';
 import {
   BlobSyncService,
@@ -101,10 +102,7 @@ export class RestDocumentProvider {
     return this.client.getYdoc(docId);
   }
 
-  async restoreRecoveryPoint(
-    docId: string,
-    pointId: string,
-  ): Promise<{ newDocId: string; serverVersion: number }> {
+  async restoreRecoveryPoint(docId: string, pointId: string): Promise<RestoreRecoveryAck> {
     return this.client.restoreRecoveryPoint(docId, pointId);
   }
 

--- a/src/api/webClient.ts
+++ b/src/api/webClient.ts
@@ -396,10 +396,21 @@ export const webClient = {
    * the relay's publish ack. Called ONLY after a successful relay publish —
    * this is the read-side commit point (the URL goes live when the row does).
    * Re-enabling a revoked link is creator-or-workspace-owner (403 otherwise).
+   *
+   * `previousDocId` (JP-470): a restore retired that id and carried its
+   * publication to `docId` — the control plane MOVES the existing row (same
+   * token, same view count, revocation state preserved) instead of minting a
+   * second URL. Creator-or-owner gated server-side; falls back to a fresh
+   * mint when the retired doc never had a row.
    */
   async mintShareLink(
     docId: string,
-    keys: { artifactKey: string; manifestKey: string; publishedBytes?: number },
+    keys: {
+      artifactKey: string;
+      manifestKey: string;
+      publishedBytes?: number;
+      previousDocId?: string;
+    },
     workspaceId: string = activeWorkspaceId(),
     deps: WebClientDeps = {},
   ): Promise<ShareLink> {

--- a/src/share/publishFlow.test.ts
+++ b/src/share/publishFlow.test.ts
@@ -12,8 +12,17 @@
  * of the cap exists to drift.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { publishDocument, unpublishDocument, shareUrlFor } from './publishFlow';
+import {
+  publishDocument,
+  unpublishDocument,
+  shareUrlFor,
+  repointShareLink,
+  stashPendingRepoint,
+  readPendingRepoint,
+  clearPendingRepoint,
+} from './publishFlow';
 import { RelayError } from '../api/relayClient';
+import { WebClientError } from '../api/webClient';
 
 const calls: string[] = [];
 
@@ -166,5 +175,53 @@ describe('unpublishDocument', () => {
 describe('shareUrlFor', () => {
   it('is same-origin with the editor by construction', () => {
     expect(shareUrlFor('tok')).toBe(`${window.location.origin}/d/tok`);
+  });
+});
+
+describe('repointShareLink + pending-repoint breadcrumb (JP-470)', () => {
+  const KEYS = {
+    artifactKey: 'docs/ws/public/d2.json',
+    manifestKey: 'docs/ws/public/d2.manifest.json',
+    publishedBytes: 1234,
+  };
+
+  it('moves the row by minting on the NEW id with previousDocId attached', async () => {
+    webMock.mintShareLink.mockResolvedValue(LINK);
+    const out = await repointShareLink('d1', 'd2', KEYS);
+    expect(out.ok).toBe(true);
+    expect(webMock.mintShareLink).toHaveBeenCalledWith('d2', {
+      ...KEYS,
+      previousDocId: 'd1',
+    });
+  });
+
+  it('forbidden is terminal (retryable: false) — only creator/owner may retarget', async () => {
+    webMock.mintShareLink.mockRejectedValue(new WebClientError(403, 'forbidden'));
+    const out = await repointShareLink('d1', 'd2', KEYS);
+    expect(out).toMatchObject({ ok: false, retryable: false });
+  });
+
+  it('transient failures are retryable — the breadcrumb path', async () => {
+    webMock.mintShareLink.mockRejectedValue(new Error('network sad'));
+    const out = await repointShareLink('d1', 'd2', KEYS);
+    expect(out).toMatchObject({ ok: false, retryable: true });
+  });
+
+  it('breadcrumb round-trips through storage and clears', () => {
+    const payload = { previousDocId: 'd1', ...KEYS };
+    stashPendingRepoint('d2', payload);
+    expect(readPendingRepoint('d2')).toEqual(payload);
+    clearPendingRepoint('d2');
+    expect(readPendingRepoint('d2')).toBeNull();
+  });
+
+  it('malformed or incomplete breadcrumbs read as null, never throw', () => {
+    localStorage.setItem('docushark:pending-repoint:d3', 'not json');
+    expect(readPendingRepoint('d3')).toBeNull();
+    localStorage.setItem(
+      'docushark:pending-repoint:d4',
+      JSON.stringify({ previousDocId: 'd1' }), // keys missing
+    );
+    expect(readPendingRepoint('d4')).toBeNull();
   });
 });

--- a/src/share/publishFlow.ts
+++ b/src/share/publishFlow.ts
@@ -100,6 +100,87 @@ export async function publishDocument(docId: string): Promise<PublishOutcome> {
   }
 }
 
+// ── Restore carry (JP-470) ───────────────────────────────────────────────────
+//
+// Restore retires a doc id and mints a successor; the relay carries the frozen
+// publish artifact across and reports the new object keys in its ack. The
+// editor's half is moving the share ROW (the public URL's token) to the new
+// id. A failed move must not fork the URL forever, so the failure is stashed
+// as a pending-repoint breadcrumb that `PublishRung` retries when it next
+// observes the telltale state (relay says published, control plane has no
+// row for this doc).
+
+export interface RepointKeys {
+  artifactKey: string;
+  manifestKey: string;
+  publishedBytes?: number;
+}
+
+export interface PendingRepoint extends RepointKeys {
+  previousDocId: string;
+}
+
+const PENDING_REPOINT_PREFIX = 'docushark:pending-repoint:';
+
+/** Persist a failed repoint for the rung's retry. Best-effort (private mode). */
+export function stashPendingRepoint(newDocId: string, payload: PendingRepoint): void {
+  try {
+    localStorage.setItem(PENDING_REPOINT_PREFIX + newDocId, JSON.stringify(payload));
+  } catch {
+    /* storage unavailable — the toast already told the user */
+  }
+}
+
+/** The stashed repoint for `newDocId`, if any. Cleared only on success. */
+export function readPendingRepoint(newDocId: string): PendingRepoint | null {
+  try {
+    const raw = localStorage.getItem(PENDING_REPOINT_PREFIX + newDocId);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PendingRepoint>;
+    if (!parsed.previousDocId || !parsed.artifactKey || !parsed.manifestKey) return null;
+    return parsed as PendingRepoint;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingRepoint(newDocId: string): void {
+  try {
+    localStorage.removeItem(PENDING_REPOINT_PREFIX + newDocId);
+  } catch {
+    /* nothing to clear */
+  }
+}
+
+/**
+ * Move the share row from a retired doc id to its restore successor — same
+ * token, same view count, revocation state preserved (server-side move,
+ * migration 0022). Never throws; the caller decides between the breadcrumb
+ * (transient failure) and giving up (forbidden — only the link's creator or
+ * a workspace owner may retarget a public token).
+ */
+export async function repointShareLink(
+  previousDocId: string,
+  newDocId: string,
+  keys: RepointKeys,
+): Promise<{ ok: true } | { ok: false; retryable: boolean; detail: string }> {
+  try {
+    await webClient.mintShareLink(newDocId, { ...keys, previousDocId });
+    return { ok: true };
+  } catch (e) {
+    const forbidden = e instanceof WebClientError && e.code === 'forbidden';
+    return {
+      ok: false,
+      retryable: !forbidden,
+      detail: forbidden
+        ? 'Only the link creator or a workspace owner can move the public link.'
+        : e instanceof Error
+          ? e.message
+          : String(e),
+    };
+  }
+}
+
 export type UnpublishOutcome = { ok: true } | { ok: false; detail: string };
 
 export async function unpublishDocument(docId: string): Promise<UnpublishOutcome> {

--- a/src/store/relayDocumentStore.deleteRevoke.test.ts
+++ b/src/store/relayDocumentStore.deleteRevoke.test.ts
@@ -1,0 +1,93 @@
+/**
+ * JP-470 — deleting a relay document darkens its public share link.
+ *
+ * The revoke lives in `deleteFromHost` ONLY: it is the single choke point
+ * every delete path funnels through (trash, document browser, transfer to
+ * personal), so no caller carries its own revoke and none can double-fire.
+ * Ordering is the contract — row first (mirroring unpublish: the URL dies
+ * even if later steps fail), relay delete second — and a revoke failure must
+ * never block the delete (the relay's own artifact teardown keeps readers
+ * dark; the row is the tidiness half).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const calls: string[] = [];
+
+const webMock = vi.hoisted(() => ({ revokeShareLink: vi.fn() }));
+vi.mock('../api/webClient', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/webClient')>();
+  return {
+    ...original,
+    webClient: new Proxy(original.webClient, {
+      get(target, prop: string) {
+        if (prop === 'revokeShareLink') {
+          return (...args: unknown[]) => {
+            calls.push('revoke');
+            return webMock.revokeShareLink(...args);
+          };
+        }
+        return (target as Record<string, unknown>)[prop];
+      },
+    }),
+  };
+});
+
+const cacheMock = vi.hoisted(() => ({
+  get: vi.fn(async () => null as unknown),
+  put: vi.fn(async () => {}),
+  getCachedIdsForHost: vi.fn(() => [] as string[]),
+  getMeta: vi.fn(() => null),
+  remove: vi.fn(async () => {}),
+}));
+vi.mock('../storage/RelayDocumentCache', () => ({ RelayDocumentCache: cacheMock }));
+
+import { useRelayDocumentStore, type DocumentProvider } from './relayDocumentStore';
+
+describe('deleteFromHost share-link revoke (JP-470)', () => {
+  beforeEach(() => {
+    calls.length = 0;
+    webMock.revokeShareLink.mockReset().mockResolvedValue(undefined);
+    useRelayDocumentStore.getState().setProvider(null);
+  });
+
+  it('revokes the row BEFORE the relay delete', async () => {
+    const provider = {
+      deleteDocument: vi.fn(async () => {
+        calls.push('relay-delete');
+      }),
+    } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await useRelayDocumentStore.getState().deleteFromHost('doc-a');
+
+    expect(calls).toEqual(['revoke', 'relay-delete']);
+  });
+
+  it('a revoke failure never blocks the delete (relay teardown covers readers)', async () => {
+    webMock.revokeShareLink.mockRejectedValue(new Error('control plane down'));
+    const provider = {
+      deleteDocument: vi.fn(async () => {
+        calls.push('relay-delete');
+      }),
+    } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await useRelayDocumentStore.getState().deleteFromHost('doc-a');
+
+    expect(calls).toEqual(['revoke', 'relay-delete']);
+  });
+
+  it('a relay-delete failure still surfaces (and the revoke already fired)', async () => {
+    const provider = {
+      deleteDocument: vi.fn(async () => {
+        throw new Error('forbidden');
+      }),
+    } as unknown as DocumentProvider;
+    useRelayDocumentStore.getState().setProvider(provider);
+
+    await expect(useRelayDocumentStore.getState().deleteFromHost('doc-a')).rejects.toThrow(
+      'forbidden',
+    );
+    expect(calls).toEqual(['revoke']);
+  });
+});

--- a/src/store/relayDocumentStore.ts
+++ b/src/store/relayDocumentStore.ts
@@ -15,6 +15,7 @@
 import { create } from 'zustand';
 import type { DocumentMetadata, DiagramDocument } from '../types/Document';
 import type { DocEvent } from '../collaboration/protocol';
+import { webClient } from '../api/webClient';
 import { useDocumentRegistry } from './documentRegistry';
 import { useConnectionStore } from './connectionStore';
 import { useUserStore } from './userStore';
@@ -39,7 +40,12 @@ import { useTrashStore } from './trashStore';
 import type { TrashOrigin } from '../storage/TrashStorage';
 import type { BlobSyncProgress, BlobSyncResult } from '../collaboration/BlobSyncService';
 import { RelayError } from '../api/relayClient';
-import type { RelayCollectionDef, RelayRecoveryPoint, RelayUsage } from '../api/relayClient';
+import type {
+  RelayCollectionDef,
+  RelayRecoveryPoint,
+  RelayUsage,
+  RestoreRecoveryAck,
+} from '../api/relayClient';
 import { useUploadStatusStore } from './uploadStatusStore';
 
 /**
@@ -297,10 +303,7 @@ export interface DocumentProvider {
    * offline editing. Optional so non-REST providers opt out; null = no sidecar.
    */
   getYdoc?(docId: string): Promise<Uint8Array | null>;
-  restoreRecoveryPoint?(
-    docId: string,
-    pointId: string,
-  ): Promise<{ newDocId: string; serverVersion: number }>;
+  restoreRecoveryPoint?(docId: string, pointId: string): Promise<RestoreRecoveryAck>;
   /**
    * Collection sync (JP-159). Optional so non-REST providers opt out. The relay
    * scopes all three to the connected workspace from the bearer token. The
@@ -850,6 +853,18 @@ export const useRelayDocumentStore = create<RelayDocumentState & RelayDocumentAc
     deleteFromHost: async (docId) => {
       if (!docProvider) {
         throw new Error('Not connected to host');
+      }
+
+      // JP-470: darken the public link with the document. Row first (mirrors
+      // unpublish — the URL must die even if the rest fails), swallowed on
+      // failure: the relay's own teardown deletes the artifact with the doc,
+      // so readers fail closed regardless; the row is the tidiness half.
+      // This is the single choke point every delete path funnels through
+      // (trash, browser, transfer), so no caller needs its own revoke.
+      try {
+        await webClient.revokeShareLink(docId);
+      } catch {
+        /* self-host without a control plane, or transient — teardown covers readers */
       }
 
       try {

--- a/src/tiptap/SpellcheckExtension.test.ts
+++ b/src/tiptap/SpellcheckExtension.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Spellcheck must be inert on read-only prose (JP-470 S4).
+ *
+ * A published/guest reader and a viewer-role collab member get a clean page:
+ * no squiggles, no dictionary prep, no popover writes, no formatting context
+ * menu. Tiptap's `editable: false` blocks TYPING only — every popover/menu
+ * action is a programmatic chain it does not block, so each layer carries its
+ * own gate. Every read-only assertion here has an editable control asserting
+ * the opposite, so deleting any single gate fails a test (mutation-checked).
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { extensions } from '../ui/TiptapEditor';
+import {
+  rebuildSpellcheck,
+  SPELLCHECK_PLUGIN_KEY,
+} from './SpellcheckExtension';
+import { SpellcheckService } from '../services/SpellcheckService';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+vi.mock('../services/SpellcheckService', () => ({
+  SpellcheckService: {
+    prepare: vi.fn(() => Promise.resolve(null)),
+    isReady: () => true,
+    isMisspelled: (w: string) => w.toLowerCase() === 'mispeled',
+    suggest: () => ['misspelled'],
+    addToSession: vi.fn(),
+    loadCustomWords: vi.fn(),
+  },
+}));
+
+const CONTENT = '<p>one mispeled word</p>';
+
+let editor: Editor | null = null;
+let host: HTMLElement | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUIPreferencesStore.setState((s) => ({
+    appearancePrefs: { ...s.appearancePrefs, spellcheck: 'custom' as const },
+  }));
+});
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  host?.remove();
+  host = null;
+});
+
+function make(editable: boolean): Editor {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  editor = new Editor({ element: host, extensions, content: CONTENT, editable });
+  return editor;
+}
+
+function squiggles(): number {
+  return host?.querySelectorAll('.spellcheck-error').length ?? 0;
+}
+
+describe('SpellcheckExtension on read-only surfaces', () => {
+  it('draws no squiggles even when a full decoration set is dispatched', () => {
+    const ed = make(false);
+    // Adversarial: bypass every scheduling gate and push a complete set
+    // through the meta channel — the `decorations` prop gate must still
+    // blank the view.
+    rebuildSpellcheck(ed.view);
+    expect(squiggles()).toBe(0);
+  });
+
+  it('draws squiggles on the same content when editable (control)', () => {
+    const ed = make(true);
+    rebuildSpellcheck(ed.view);
+    expect(squiggles()).toBeGreaterThan(0);
+  });
+
+  it('skips dictionary prep entirely for a read-only editor', async () => {
+    make(false);
+    // Tiptap emits `create` on a deferred tick — flush it, or this assertion
+    // passes vacuously before `onCreate` ever ran.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(SpellcheckService.prepare).not.toHaveBeenCalled();
+  });
+
+  it('preps the dictionary for an editable editor (control)', async () => {
+    make(true);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(SpellcheckService.prepare).toHaveBeenCalled();
+  });
+
+  it('never populates plugin state from the recheck debounce while read-only', () => {
+    vi.useFakeTimers();
+    try {
+      const ed = make(false);
+      // Programmatic dispatch reaches a read-only view (remote collab updates
+      // do exactly this), which arms the 500ms recheck.
+      ed.view.dispatch(ed.state.tr.insertText('mispeled again ', 1, 1));
+      vi.advanceTimersByTime(1000);
+      const set = SPELLCHECK_PLUGIN_KEY.getState(ed.state);
+      expect(set?.find().length ?? 0).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('populates plugin state from the debounce when editable (control)', () => {
+    vi.useFakeTimers();
+    try {
+      const ed = make(true);
+      ed.view.dispatch(ed.state.tr.insertText('mispeled again ', 1, 1));
+      vi.advanceTimersByTime(1000);
+      const set = SPELLCHECK_PLUGIN_KEY.getState(ed.state);
+      expect(set?.find().length ?? 0).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-enables decorations when a viewer is promoted mid-session (JP-370)', () => {
+    const ed = make(false);
+    rebuildSpellcheck(ed.view);
+    expect(squiggles()).toBe(0);
+    // The collab editor flips editability in place — no remount.
+    ed.setEditable(true);
+    rebuildSpellcheck(ed.view);
+    expect(squiggles()).toBeGreaterThan(0);
+    // And demotion blanks them again through the same prop gate.
+    ed.setEditable(false);
+    rebuildSpellcheck(ed.view);
+    expect(squiggles()).toBe(0);
+  });
+});

--- a/src/tiptap/SpellcheckExtension.ts
+++ b/src/tiptap/SpellcheckExtension.ts
@@ -50,7 +50,14 @@ export const SpellcheckExtension = Extension.create({
   name: 'spellcheck',
 
   onCreate() {
+    // Read-only surfaces (guest ProsePreview, viewer-role collab) never prep
+    // the dictionary or draw squiggles — a reader gets a clean page, and the
+    // preview's recreate-per-render can't burn a full-doc scan each tick.
+    // A later editability flip re-enters through useProseEditorChrome's
+    // editability effect, which runs this same prepare-then-rebuild.
+    if (!this.editor.isEditable) return;
     void SpellcheckService.prepare().then(() => {
+      if (this.editor.isDestroyed) return;
       const view = this.editor.view;
       const decorations = buildDecorations(view.state.doc);
       view.dispatch(view.state.tr.setMeta(SPELLCHECK_PLUGIN_KEY, decorations));
@@ -58,13 +65,22 @@ export const SpellcheckExtension = Extension.create({
   },
 
   addProseMirrorPlugins() {
+    // Every surface below gates on live editability, so a mid-session flip
+    // (JP-370 promotion/demotion via setEditable) takes effect without a
+    // remount — the `decorations` prop gate alone already blanks a demoted
+    // editor on its next render.
+    const editor = this.editor;
     let timer: ReturnType<typeof setTimeout> | null = null;
 
     return [
       new Plugin<DecorationSet>({
         key: SPELLCHECK_PLUGIN_KEY,
         state: {
-          init: (_config, state) => buildDecorations(state.doc),
+          // (During construction `editor.view` isn't assigned yet, so this
+          // reads false even for editable editors — their initial pass comes
+          // from `onCreate` above, which runs once the view exists.)
+          init: (_config, state) =>
+            editor.isEditable ? buildDecorations(state.doc) : DecorationSet.empty,
           apply: (tr, value) => {
             const meta = tr.getMeta(SPELLCHECK_PLUGIN_KEY) as DecorationSet | undefined;
             if (meta) return meta;
@@ -76,6 +92,9 @@ export const SpellcheckExtension = Extension.create({
           const schedule = () => {
             if (timer) clearTimeout(timer);
             timer = setTimeout(() => {
+              // Checked at fire time, not schedule time — editability can
+              // flip inside the debounce window.
+              if (!editor.isEditable) return;
               const decorations = buildDecorations(view.state.doc);
               view.dispatch(view.state.tr.setMeta(SPELLCHECK_PLUGIN_KEY, decorations));
             }, RECHECK_DEBOUNCE_MS);
@@ -91,6 +110,7 @@ export const SpellcheckExtension = Extension.create({
         },
         props: {
           decorations(state) {
+            if (!editor.isEditable) return DecorationSet.empty;
             return SPELLCHECK_PLUGIN_KEY.getState(state) ?? DecorationSet.empty;
           },
         },

--- a/src/ui/SpellcheckPopover.tsx
+++ b/src/ui/SpellcheckPopover.tsx
@@ -38,12 +38,20 @@ export function SpellcheckPopover({ editor, word, range, x, y, onClose }: Spellc
   }, [word]);
 
   const replaceWith = (replacement: string) => {
+    // Defence in depth: the chrome never opens this popover on a read-only
+    // surface, but a permission flip can land while it's open — and
+    // `insertContent` is a programmatic write that `editable: false` does
+    // not block on its own.
+    if (!editor.isEditable) return;
     editor.chain().focus().setTextSelection(range).insertContent(replacement).run();
     rebuildSpellcheck(editor.view);
     onClose();
   };
 
   const addToDictionary = () => {
+    // Same fail-closed rule: the dictionary is document metadata a viewer
+    // has no business writing.
+    if (!editor.isEditable) return;
     SpellcheckService.addToSession(word);
     // Persist via the structural metadata method — never round-trip through
     // loadContent to append a word (that abused the prose content-write path

--- a/src/ui/VersionHistoryPanel.tsx
+++ b/src/ui/VersionHistoryPanel.tsx
@@ -37,6 +37,8 @@ import {
   type VersionSummary,
 } from '../utils/versionSummary';
 import type { RelayRecoveryPoint } from '../api/relayClient';
+import { repointShareLink, stashPendingRepoint } from '../share/publishFlow';
+import { webClient } from '../api/webClient';
 import './VersionHistoryPanel.css';
 
 interface VersionHistoryPanelProps {
@@ -210,7 +212,32 @@ export function VersionHistoryPanel({
       if (!ok) return;
       setBusyId(point.id);
       try {
-        const { newDocId } = await provider.restoreRecoveryPoint(docId, point.id);
+        const ack = await provider.restoreRecoveryPoint(docId, point.id);
+        const { newDocId } = ack;
+        // JP-470: the relay carried the frozen publish artifact to the new id
+        // (or tore it down). Mirror that on the control plane: move the share
+        // row so the public URL keeps working, or darken it when there is
+        // nothing to move — a row left on the retired id would 404 forever.
+        if (ack.publishCarried && ack.publishArtifactKey && ack.publishManifestKey) {
+          const keys = {
+            artifactKey: ack.publishArtifactKey,
+            manifestKey: ack.publishManifestKey,
+            ...(ack.publishBytes !== undefined ? { publishedBytes: ack.publishBytes } : {}),
+          };
+          const moved = await repointShareLink(docId, newDocId, keys);
+          if (!moved.ok && moved.retryable) {
+            stashPendingRepoint(newDocId, { previousDocId: docId, ...keys });
+            useNotificationStore
+              .getState()
+              .warning(
+                'Restored — the public link could not follow yet; it will be retried automatically.',
+              );
+          } else if (!moved.ok) {
+            useNotificationStore.getState().warning(`Restored — ${moved.detail}`);
+          }
+        } else {
+          void webClient.revokeShareLink(docId).catch(() => {});
+        }
         // Refetch the list so the new doc appears immediately — don't rely on the
         // relay's Created broadcast (a REST-only session never receives it, and a
         // list view may not re-subscribe), which left it hidden until a reload.

--- a/src/ui/access/PublishRung.tsx
+++ b/src/ui/access/PublishRung.tsx
@@ -30,6 +30,9 @@ import {
   publishDocument,
   unpublishDocument,
   shareUrlFor,
+  repointShareLink,
+  readPendingRepoint,
+  clearPendingRepoint,
   type PublishOutcome,
 } from '../../share/publishFlow';
 import { confirmDialog } from '../confirm/confirmStore';
@@ -72,7 +75,7 @@ export function PublishRung({ documentId, canManage }: PublishRungProps) {
     setError(null);
     try {
       const provider = getDocProvider();
-      const [s, l] = await Promise.all([
+      let [s, l] = await Promise.all([
         provider?.getPublishStatus?.(documentId) ?? Promise.resolve(null),
         webClient.getShareLink(documentId).catch((e: unknown) => {
           // A workspace without the control plane (self-host) has no links;
@@ -81,6 +84,24 @@ export function PublishRung({ documentId, canManage }: PublishRungProps) {
           throw e;
         }),
       ]);
+      // JP-470: relay says published but the control plane has no row — the
+      // telltale of a restore whose row move failed mid-flight. Replay the
+      // stashed repoint once; on success the same token resumes here.
+      if (s?.published && !l) {
+        const pending = readPendingRepoint(documentId);
+        if (pending) {
+          const { previousDocId, ...keys } = pending;
+          const moved = await repointShareLink(previousDocId, documentId, keys);
+          if (moved.ok) {
+            clearPendingRepoint(documentId);
+            l = await webClient.getShareLink(documentId).catch(() => null);
+          } else if (!moved.retryable) {
+            // Forbidden never self-heals — stop retrying and let the rung
+            // render its normal "publish to mint a link" affordance.
+            clearPendingRepoint(documentId);
+          }
+        }
+      }
       setStatus(s);
       setLink(l);
     } catch (e) {

--- a/src/ui/proseChromeReadOnly.test.tsx
+++ b/src/ui/proseChromeReadOnly.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Read-only prose chrome (JP-470 S4): the right-click surfaces and the
+ * spellcheck popover must be inert when the editor isn't editable.
+ *
+ * `editable: false` blocks typing, NOT programmatic commands — the popover's
+ * `insertContent` and every formatting-menu action are exactly such commands,
+ * and were live for view-only collab members. Each gate is asserted with an
+ * editable control so removing it fails a test.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import { extensions } from './TiptapEditor';
+import { useProseEditorChrome } from './useProseEditorChrome';
+import { SpellcheckPopover } from './SpellcheckPopover';
+import { useRichTextStore } from '../store/richTextStore';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+
+vi.mock('../services/SpellcheckService', () => ({
+  SpellcheckService: {
+    prepare: vi.fn(() => Promise.resolve(null)),
+    isReady: () => true,
+    isMisspelled: (w: string) => w.toLowerCase() === 'mispeled',
+    suggest: () => ['misspelled'],
+    addToSession: vi.fn(),
+    loadCustomWords: vi.fn(),
+  },
+}));
+
+import { SpellcheckService } from '../services/SpellcheckService';
+
+let editor: Editor | null = null;
+let host: HTMLElement | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUIPreferencesStore.setState((s) => ({
+    appearancePrefs: { ...s.appearancePrefs, spellcheck: 'custom' as const },
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  editor?.destroy();
+  editor = null;
+  host?.remove();
+  host = null;
+});
+
+function make(editable: boolean): Editor {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  editor = new Editor({
+    element: host,
+    extensions,
+    content: '<p>one mispeled word</p>',
+    editable,
+  });
+  return editor;
+}
+
+function ChromeHarness({ ed }: { ed: Editor }) {
+  const { onContextMenu, overlay } = useProseEditorChrome(ed);
+  return (
+    <div data-testid="prose-host" onContextMenu={onContextMenu}>
+      {overlay}
+    </div>
+  );
+}
+
+describe('formatting context menu', () => {
+  it('does not open on a read-only surface (native menu keeps copy)', () => {
+    const ed = make(false);
+    render(<ChromeHarness ed={ed} />);
+    const evt = fireEvent.contextMenu(screen.getByTestId('prose-host'));
+    expect(document.querySelector('.doc-editor-context-menu')).toBeNull();
+    // No preventDefault — the browser's own menu (with Copy) must survive.
+    expect(evt).toBe(true);
+  });
+
+  it('opens when editable (control)', () => {
+    const ed = make(true);
+    render(<ChromeHarness ed={ed} />);
+    fireEvent.contextMenu(screen.getByTestId('prose-host'));
+    expect(document.querySelector('.doc-editor-context-menu')).not.toBeNull();
+  });
+});
+
+describe('SpellcheckPopover writes', () => {
+  it('suggestion click writes nothing into a read-only editor', () => {
+    const ed = make(false);
+    const before = ed.getHTML();
+    render(
+      <SpellcheckPopover
+        editor={ed}
+        word="mispeled"
+        range={{ from: 5, to: 13 }}
+        x={0}
+        y={0}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('misspelled'));
+    expect(ed.getHTML()).toBe(before);
+  });
+
+  it('suggestion click replaces the word when editable (control)', () => {
+    const ed = make(true);
+    render(
+      <SpellcheckPopover
+        editor={ed}
+        word="mispeled"
+        range={{ from: 5, to: 13 }}
+        x={0}
+        y={0}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('misspelled'));
+    expect(ed.getHTML()).toContain('misspelled');
+    expect(ed.getHTML()).not.toContain('mispeled');
+  });
+
+  it('Add to Dictionary is inert on a read-only editor', () => {
+    const ed = make(false);
+    const addWord = vi.spyOn(useRichTextStore.getState(), 'addDictionaryWord');
+    render(
+      <SpellcheckPopover
+        editor={ed}
+        word="mispeled"
+        range={{ from: 5, to: 13 }}
+        x={0}
+        y={0}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Add to Dictionary'));
+    expect(SpellcheckService.addToSession).not.toHaveBeenCalled();
+    expect(addWord).not.toHaveBeenCalled();
+    addWord.mockRestore();
+  });
+
+  it('Add to Dictionary works when editable (control)', () => {
+    const ed = make(true);
+    const addWord = vi
+      .spyOn(useRichTextStore.getState(), 'addDictionaryWord')
+      .mockImplementation(() => {});
+    render(
+      <SpellcheckPopover
+        editor={ed}
+        word="mispeled"
+        range={{ from: 5, to: 13 }}
+        x={0}
+        y={0}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Add to Dictionary'));
+    expect(SpellcheckService.addToSession).toHaveBeenCalledWith('mispeled');
+    expect(addWord).toHaveBeenCalledWith('mispeled');
+    addWord.mockRestore();
+  });
+});

--- a/src/ui/useProseEditorChrome.tsx
+++ b/src/ui/useProseEditorChrome.tsx
@@ -72,11 +72,31 @@ export function useProseEditorChrome(
   });
   const [spellPopover, setSpellPopover] = useState<SpellPopoverState | null>(null);
 
+  // Live editability, mirrored into state so the effects below re-run when a
+  // permission flip lands mid-session (JP-370 `setEditable` — which emits
+  // `update` — never remounts the editor, so a plain `editor.isEditable` read
+  // in an effect would be one flip stale).
+  const [editable, setEditableState] = useState(() => editor?.isEditable ?? false);
+  useEffect(() => {
+    if (!editor) return;
+    const sync = () => setEditableState(editor.isEditable);
+    sync();
+    editor.on('update', sync);
+    editor.on('create', sync);
+    return () => {
+      editor.off('update', sync);
+      editor.off('create', sync);
+    };
+  }, [editor]);
+
   // Right-click: show the spellcheck popover when over a misspelled word,
-  // otherwise the formatting context menu.
+  // otherwise the formatting context menu. Read-only surfaces get NEITHER —
+  // both menus lead to programmatic writes (`insertContent`, formatting
+  // chains) that `editable: false` does not block, so the whole handler
+  // returns early. No `preventDefault`: the native menu still offers copy.
   const onContextMenu = useCallback(
     (e: React.MouseEvent) => {
-      if (!editor) return;
+      if (!editor || !editor.isEditable) return;
       const target = e.target as HTMLElement | null;
       const errorSpan = target?.closest('.spellcheck-error') as HTMLElement | null;
       if (errorSpan) {
@@ -111,17 +131,32 @@ export function useProseEditorChrome(
     }
   }, [editor, customDictionary]);
 
-  // Spellcheck mode (custom / system / off). Toggle the contenteditable's NATIVE
-  // browser spellcheck — only `system` wants it on; `custom`/`off` turn it off so
-  // the native red squiggle doesn't stack on the built-in checker's underline (the
-  // double-underline bug). `spellcheck` isn't a ProseMirror-managed attribute, so
-  // an imperative setAttribute sticks. Then rebuild the custom decorations so they
-  // clear when leaving `custom` and re-appear when returning to it.
+  // Spellcheck mode (custom / system / off) × editability. Toggle the
+  // contenteditable's NATIVE browser spellcheck — only `system` on an EDITABLE
+  // surface wants it on; `custom`/`off` turn it off so the native red squiggle
+  // doesn't stack on the built-in checker's underline (the double-underline
+  // bug), and a read-only surface always turns it off (readers aren't
+  // composing text; squiggles there are noise). `spellcheck` isn't a
+  // ProseMirror-managed attribute, so an imperative setAttribute sticks. Then
+  // rebuild the custom decorations so they clear when leaving `custom`/losing
+  // editability and re-appear when returning. The editable+custom arm preps
+  // the dictionary first (idempotent) — an editor born read-only skipped
+  // `onCreate`'s prepare, so a mid-session promotion (JP-370) lands here
+  // needing both the load and the first pass.
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
-    editor.view.dom.setAttribute('spellcheck', spellcheckMode === 'system' ? 'true' : 'false');
-    rebuildSpellcheck(editor.view);
-  }, [editor, spellcheckMode]);
+    editor.view.dom.setAttribute(
+      'spellcheck',
+      editable && spellcheckMode === 'system' ? 'true' : 'false',
+    );
+    if (editable && spellcheckMode === 'custom') {
+      void SpellcheckService.prepare().then(() => {
+        if (!editor.isDestroyed) rebuildSpellcheck(editor.view);
+      });
+    } else {
+      rebuildSpellcheck(editor.view);
+    }
+  }, [editor, spellcheckMode, editable]);
 
   // Inline link click handling (open http(s)/mailto; resolve heading anchors
   // when `headingAnchors`). Shared with `ProsePreview` so every prose surface


### PR DESCRIPTION
## What

Staging verification of published documents (JP-464) surfaced three defects; this is the app-side fix (pairs with JPE-Net-Technologies/docushark-web's JP-470 PR — the web POST change is additive, so merge order is not load-bearing).

1. **Publish state didn't follow the document.** Deleting a published doc left the link serving forever; restoring one orphaned the publication.
2. **Spellcheck ran on read-only prose** — squiggles, popover, "Add to Dictionary", and the formatting context menu were all live for viewers (programmatic chains bypass `editable: false`).
3. (Rider) The connect modal labeled a localhost relay "Toronto, Canada".

## How

- **`teardown_publish` — the single removal seam.** Document delete (REST + MCP via `after_doc_deleted`, now async), restore retirement, and explicit unpublish all end a publication through one path: hydrate the registry first (a cold machine must not fail open), remove the entry + local artifacts, best-effort object deletes (run even when the registry write errs after its in-memory removal — otherwise a cold boot from the un-rewritten mirror serves a deleted doc forever), then one registry mirror PUT.
- **Restore carries the FROZEN artifact** to the successor id — never a re-projection: since-publish edits stay unexposed, the meter is net-neutral, status reads `stale` until an explicit republish. Cold-machine fallback reads the frozen bytes from the object store. The ack reports `publishCarried` + new keys.
- **Editor:** `deleteFromHost` revokes the share row first (single choke point for trash/browser/transfer; failure swallowed — the relay teardown is the guarantee). `VersionHistoryPanel` repoints the row to the successor via the web's transactional move; a failed repoint stashes a breadcrumb that `PublishRung` replays.
- **Spellcheck:** gated on live editability at the decorations prop, recheck debounce, plugin init, `onCreate`, the whole context-menu handler, and both popover writes — with JP-370 promotion/demotion re-entering everything without a remount.

## Verification

- Relay: 783 lib + 13 publish integration tests, including an in-process fake-S3 cold-machine teardown (empty volume, mirror-only state) and a byte-identity carry pin. `cargo check --all-targets` clean.
- Editor: 3253 tests, typecheck clean.
- **Eleven mutation checks** across the relay seam (hydration, seam call, carry) and every editor gate — each killed by exactly its paired test.
- **Live E2E on the local stack:** publish → restore through the Version History panel → carried artifact byte-identical to the frozen snapshot, zero post-publish content leak, status `published + stale`, old id 404 + artifacts gone; trash via UI → publication died with the doc (registry rewritten). The real `move_share_link` SQL exercised against local Supabase (token/view-count/revoked_at/published_at preserved; winner rule holds).
- Guest dead-link handling (review F10) verified already fail-closed in shipped code: the Worker 404s a live-row/dead-object state and the guest shell maps 404 → `unavailable`.
- Reader-facing serving (live URL, guest link, viewer-role spellcheck) is staging-scope — same as JP-464 — and rides the next staging deploy.

Assisted-by: Fable 5