### PR TITLE
JP-475: mirror families — subpage ingestion, tab collapse, publish strip

### DIFF
--- a/relay/src/server/publish.rs
+++ b/relay/src/server/publish.rs
@@ -58,7 +58,28 @@ pub fn project_public(doc: &Value) -> Value {
             }
         }
     }
+    strip_mirror_provenance(&mut out);
     Value::Object(out)
+}
+
+/// Second pipeline stage (JP-475): drop inbound-mirror provenance from prose
+/// pages. `richTextPages.pages[*].mirror` carries third-party resource ids and
+/// source URLs (whose slugs embed the source pages' titles) — provenance for
+/// the owner, not content for anonymous readers. Guests lose only the provider
+/// glyph and family grouping; page content and order are untouched.
+fn strip_mirror_provenance(out: &mut Map<String, Value>) {
+    let Some(pages) = out
+        .get_mut("richTextPages")
+        .and_then(|rtp| rtp.get_mut("pages"))
+        .and_then(|p| p.as_object_mut())
+    else {
+        return;
+    };
+    for page in pages.values_mut() {
+        if let Some(page_obj) = page.as_object_mut() {
+            page_obj.remove("mirror");
+        }
+    }
 }
 
 /// One published document's registry entry (`published.json`).
@@ -284,6 +305,43 @@ mod tests {
         for needle in ["user-a", "user-b", "Alice A", "Bob B", "sharedWith", "secret-project"] {
             assert!(!s.contains(needle), "projection leaked {:?}", needle);
         }
+    }
+
+    #[test]
+    fn projection_strips_mirror_provenance_from_prose_pages() {
+        // JP-475: `richTextPages.pages[*].mirror` carries third-party resource
+        // ids and source URLs (their slugs embed source page titles) — owner
+        // provenance, not guest content. The subtree clone must not publish it.
+        let doc = serde_json::json!({
+            "version": 2,
+            "name": "Doc",
+            "richTextPages": {
+                "pages": {
+                    "p1": {
+                        "id": "p1",
+                        "name": "Mirrored",
+                        "content": "<p>hi</p>",
+                        "mirror": {
+                            "provider": "notion",
+                            "externalId": "ext-123",
+                            "parentExternalId": "ext-parent",
+                            "url": "https://www.notion.so/Internal-Title-abc123"
+                        }
+                    },
+                    "p2": { "id": "p2", "name": "Plain", "content": "" }
+                },
+                "pageOrder": ["p1", "p2"],
+                "activePageId": "p1"
+            }
+        });
+        let s = serde_json::to_string(&project_public(&doc)).unwrap();
+        for needle in ["mirror", "ext-123", "ext-parent", "Internal-Title"] {
+            assert!(!s.contains(needle), "projection leaked {:?}", needle);
+        }
+        let projected = project_public(&doc);
+        assert_eq!(projected["richTextPages"]["pageOrder"], serde_json::json!(["p1", "p2"]));
+        assert_eq!(projected["richTextPages"]["pages"]["p1"]["content"], "<p>hi</p>");
+        assert_eq!(projected["richTextPages"]["pages"]["p1"]["name"], "Mirrored");
     }
 
     #[test]

--- a/relay/tests/document_publish.rs
+++ b/relay/tests/document_publish.rs
@@ -945,3 +945,47 @@ async fn cold_machine_delete_tears_down_the_publication() {
         "mirror rewritten with the entry removed"
     );
 }
+
+// ───────────────────── mirror provenance never publishes ─────────────────────
+
+/// JP-475: prose pages can carry inbound-mirror provenance
+/// (`richTextPages.pages[*].mirror` — provider, third-party resource ids, a
+/// parent chain, and source URLs whose slugs embed the source pages' titles).
+/// That is owner provenance, not reader content: the artifact a stranger can
+/// fetch must carry none of it, while page content and order survive intact.
+#[tokio::test]
+async fn published_artifact_strips_mirror_provenance() {
+    let h = Harness::start().await;
+    let doc = "mirror-strip-doc";
+    let mut body = Harness::people_laden_body(doc);
+    body["richTextPages"] = json!({
+        "pageOrder": ["rt1", "rt2"],
+        "activePageId": "rt1",
+        "pages": {
+            "rt1": {
+                "id": "rt1", "name": "Mirrored", "content": "<p>mirrored body</p>", "order": 0,
+                "mirror": {
+                    "provider": "notion",
+                    "externalId": "ext-123",
+                    "parentExternalId": "ext-parent",
+                    "url": "https://www.notion.so/Internal-Title-abc123",
+                    "syncedAt": 1
+                }
+            },
+            "rt2": { "id": "rt2", "name": "Plain", "content": "", "order": 1 }
+        }
+    });
+    assert!(h.put_doc("user-owner", WorkspaceRole::Owner, doc, body).await.is_success());
+
+    let resp = h.publish("user-owner", WorkspaceRole::Owner, doc).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let artifact = std::fs::read_to_string(h.artifact_path(doc)).expect("artifact written");
+    for needle in ["\"mirror\"", "ext-123", "ext-parent", "Internal-Title", "notion.so"] {
+        assert!(!artifact.contains(needle), "published artifact leaked {needle:?}");
+    }
+    let parsed: Value = serde_json::from_str(&artifact).unwrap();
+    assert_eq!(parsed["richTextPages"]["pageOrder"], json!(["rt1", "rt2"]));
+    assert_eq!(parsed["richTextPages"]["pages"]["rt1"]["content"], "<p>mirrored body</p>");
+    assert_eq!(parsed["richTextPages"]["pages"]["rt1"]["name"], "Mirrored");
+}

--- a/src/api/webClient.ts
+++ b/src/api/webClient.ts
@@ -113,6 +113,11 @@ export interface FetchedMirrorContent {
   blobCount: number;
   warnings: ImportWarningInfo[];
   sourceRef: MirrorSourceRef;
+  /** Child resources the connector saw during this fetch (JP-475) — the input
+   *  to subpage ingestion. Optional: an older control plane omits it. Treat
+   *  missing as empty, and never read absence as source-side deletion (the
+   *  listing is best-effort within the provider's fetch budget). */
+  childRefs?: ExternalResource[];
 }
 
 /**

--- a/src/services/mirrorFamily.test.ts
+++ b/src/services/mirrorFamily.test.ts
@@ -1,0 +1,111 @@
+/**
+ * JP-475 — mirror-family derivation. Pure functions over (pages, pageOrder)
+ * snapshots; the invariants here are what the tab bar, ingest service, and
+ * Navigator all lean on: orphans are roots, cycles never loop a traversal,
+ * and the physical block is the contiguous run only.
+ */
+import { describe, it, expect } from 'vitest';
+
+import type { PageMirrorMeta } from '../types/PageMirror';
+import {
+  buildMirrorFamilyIndex,
+  descendantEntries,
+  familyBlock,
+  isFamilyRoot,
+  subtreeInsertionIndex,
+  type MirrorFamilyPage,
+} from './mirrorFamily';
+
+function mirror(externalId: string, parentExternalId?: string, provider = 'notion'): PageMirrorMeta {
+  return { provider, externalId, syncedAt: 1, ...(parentExternalId ? { parentExternalId } : {}) };
+}
+
+function doc(entries: [string, PageMirrorMeta | undefined][]): {
+  pages: Record<string, MirrorFamilyPage>;
+  pageOrder: string[];
+} {
+  const pages: Record<string, MirrorFamilyPage> = {};
+  for (const [id, m] of entries) {
+    pages[id] = m ? { id, mirror: m } : { id };
+  }
+  return { pages, pageOrder: entries.map(([id]) => id) };
+}
+
+describe('buildMirrorFamilyIndex (JP-475)', () => {
+  it('derives parent/child edges within one provider, in pageOrder sequence', () => {
+    const { pages, pageOrder } = doc([
+      ['P', mirror('ext-p')],
+      ['C1', mirror('ext-c1', 'ext-p')],
+      ['C2', mirror('ext-c2', 'ext-p')],
+      ['N', undefined],
+    ]);
+    const index = buildMirrorFamilyIndex(pages, pageOrder);
+    expect(index.childrenOf.get('P')).toEqual(['C1', 'C2']);
+    expect(index.parentOf.get('C1')).toBe('P');
+    expect(isFamilyRoot(index, 'P')).toBe(true);
+    expect(isFamilyRoot(index, 'C1')).toBe(false);
+    expect(isFamilyRoot(index, 'N')).toBe(true);
+  });
+
+  it('a provider boundary breaks the chain (same externalId, different provider)', () => {
+    const { pages, pageOrder } = doc([
+      ['P', mirror('ext-p', undefined, 'confluence')],
+      ['C', mirror('ext-c', 'ext-p', 'notion')],
+    ]);
+    const index = buildMirrorFamilyIndex(pages, pageOrder);
+    expect(index.parentOf.has('C')).toBe(false);
+    expect(isFamilyRoot(index, 'C')).toBe(true);
+  });
+
+  it('an orphan (parent absent) is a root', () => {
+    const { pages, pageOrder } = doc([['C', mirror('ext-c', 'ext-gone')]]);
+    const index = buildMirrorFamilyIndex(pages, pageOrder);
+    expect(isFamilyRoot(index, 'C')).toBe(true);
+  });
+
+  it('breaks parentExternalId cycles instead of looping', () => {
+    const { pages, pageOrder } = doc([
+      ['A', mirror('ext-a', 'ext-b')],
+      ['B', mirror('ext-b', 'ext-a')],
+    ]);
+    const index = buildMirrorFamilyIndex(pages, pageOrder);
+    // One edge dropped — at least one of the two is a root, and traversal ends.
+    const roots = ['A', 'B'].filter((id) => isFamilyRoot(index, id));
+    expect(roots.length).toBeGreaterThanOrEqual(1);
+    expect(descendantEntries(index, 'A').length + descendantEntries(index, 'B').length).toBeLessThan(4);
+  });
+});
+
+describe('descendantEntries / familyBlock / subtreeInsertionIndex (JP-475)', () => {
+  const nested = doc([
+    ['P', mirror('ext-p')],
+    ['C1', mirror('ext-c1', 'ext-p')],
+    ['G1', mirror('ext-g1', 'ext-c1')],
+    ['C2', mirror('ext-c2', 'ext-p')],
+    ['N', undefined],
+  ]);
+  const index = buildMirrorFamilyIndex(nested.pages, nested.pageOrder);
+
+  it('flattens the logical tree depth-first with depths', () => {
+    expect(descendantEntries(index, 'P')).toEqual([
+      { pageId: 'C1', depth: 1 },
+      { pageId: 'G1', depth: 2 },
+      { pageId: 'C2', depth: 1 },
+    ]);
+  });
+
+  it('familyBlock is the contiguous run; insertion lands after it', () => {
+    expect(familyBlock(index, nested.pageOrder, 'P')).toEqual(['P', 'C1', 'G1', 'C2']);
+    expect(subtreeInsertionIndex(index, nested.pageOrder, 'P')).toBe(4);
+    expect(subtreeInsertionIndex(index, nested.pageOrder, 'C1')).toBe(3);
+  });
+
+  it('a scattered descendant ends the physical block but stays in the logical tree', () => {
+    // User dragged C1's subtree apart: order is P, C2, N, C1, G1.
+    const scattered = ['P', 'C2', 'N', 'C1', 'G1'];
+    expect(familyBlock(index, scattered, 'P')).toEqual(['P', 'C2']);
+    expect(descendantEntries(index, 'P').map((e) => e.pageId)).toEqual(['C1', 'G1', 'C2']);
+    // New children of P insert after the contiguous block, not after strays.
+    expect(subtreeInsertionIndex(index, scattered, 'P')).toBe(2);
+  });
+});

--- a/src/services/mirrorFamily.ts
+++ b/src/services/mirrorFamily.ts
@@ -1,0 +1,148 @@
+/**
+ * Mirror families (JP-475) — pure derivation of the LOGICAL subpage tree from
+ * `PageMirrorMeta.parentExternalId`, decoupled from the PHYSICAL page sequence.
+ *
+ * The two axes never merge: `pageOrder` stays a flat array (it is the export
+ * order); a family is derived by chaining `parentExternalId` → `externalId`
+ * among the document's mirror pages of the same provider. An orphan (parent
+ * page deleted or detached) is a root. Ingestion inserts contiguously, but the
+ * user may scatter a family by dragging — a family's physical *block* is the
+ * contiguous descendant run starting at the root, while the logical tree
+ * (flyout, Navigator) renders complete regardless of scatter.
+ *
+ * Everything here is pure over `(pages, pageOrder)` snapshots — no store
+ * imports, no React — so it unit-tests directly and both the tab bar and the
+ * Navigator consume one implementation.
+ */
+
+import type { PageMirrorMeta } from '../types/PageMirror';
+
+/** The minimal page shape the derivation needs (RichTextPage satisfies it). */
+export interface MirrorFamilyPage {
+  id: string;
+  mirror?: PageMirrorMeta;
+}
+
+export interface MirrorFamilyIndex {
+  /** `(provider, externalId)` → owning pageId, for mirror pages in the doc. */
+  byExternal: Map<string, string>;
+  /** parent pageId → child pageIds, in `pageOrder` sequence. */
+  childrenOf: Map<string, string[]>;
+  /** child pageId → parent pageId (only when the parent page is in the doc,
+   *  and the edge is not part of a cycle). */
+  parentOf: Map<string, string>;
+}
+
+export function externalKey(provider: string, externalId: string): string {
+  return `${provider}:${externalId}`;
+}
+
+/**
+ * Build the family index for one page-list snapshot. Cycle-defensive: an edge
+ * that would close a `parentExternalId` loop is dropped (its child renders as
+ * a root) rather than ever looping a traversal.
+ */
+export function buildMirrorFamilyIndex(
+  pages: Record<string, MirrorFamilyPage>,
+  pageOrder: string[],
+): MirrorFamilyIndex {
+  const byExternal = new Map<string, string>();
+  for (const id of pageOrder) {
+    const m = pages[id]?.mirror;
+    if (m) byExternal.set(externalKey(m.provider, m.externalId), id);
+  }
+
+  const parentOf = new Map<string, string>();
+  for (const id of pageOrder) {
+    const m = pages[id]?.mirror;
+    if (!m?.parentExternalId) continue;
+    const parentId = byExternal.get(externalKey(m.provider, m.parentExternalId));
+    if (parentId !== undefined && parentId !== id) parentOf.set(id, parentId);
+  }
+
+  // Break cycles: walk each page toward the root; any edge that revisits a
+  // node in the current walk is removed (deterministic — earlier pages win).
+  for (const start of pageOrder) {
+    const seen = new Set<string>([start]);
+    let cur = start;
+    for (;;) {
+      const parent = parentOf.get(cur);
+      if (parent === undefined) break;
+      if (seen.has(parent)) {
+        parentOf.delete(cur);
+        break;
+      }
+      seen.add(parent);
+      cur = parent;
+    }
+  }
+
+  const childrenOf = new Map<string, string[]>();
+  for (const id of pageOrder) {
+    const parent = parentOf.get(id);
+    if (parent === undefined) continue;
+    const list = childrenOf.get(parent);
+    if (list) list.push(id);
+    else childrenOf.set(parent, [id]);
+  }
+
+  return { byExternal, childrenOf, parentOf };
+}
+
+/** True when the page has no in-doc parent (top-level in every surface). */
+export function isFamilyRoot(index: MirrorFamilyIndex, pageId: string): boolean {
+  return !index.parentOf.has(pageId);
+}
+
+/** One node of the logical tree, depth relative to the requested root. */
+export interface FamilyTreeEntry {
+  pageId: string;
+  depth: number;
+}
+
+/**
+ * Depth-first flatten of a page's LOGICAL descendants (excluding the page
+ * itself), children in `pageOrder` sequence. Complete regardless of physical
+ * scatter.
+ */
+export function descendantEntries(index: MirrorFamilyIndex, pageId: string, depth = 1): FamilyTreeEntry[] {
+  const out: FamilyTreeEntry[] = [];
+  for (const child of index.childrenOf.get(pageId) ?? []) {
+    out.push({ pageId: child, depth });
+    out.push(...descendantEntries(index, child, depth + 1));
+  }
+  return out;
+}
+
+/**
+ * The PHYSICAL block a root drags as one unit: the root plus the contiguous
+ * run of its descendants directly following it in `pageOrder`. Descendants the
+ * user moved elsewhere stay where the user put them.
+ */
+export function familyBlock(index: MirrorFamilyIndex, pageOrder: string[], rootId: string): string[] {
+  const start = pageOrder.indexOf(rootId);
+  if (start === -1) return [];
+  const descendants = new Set(descendantEntries(index, rootId).map((e) => e.pageId));
+  const block = [rootId];
+  for (let i = start + 1; i < pageOrder.length; i++) {
+    const id = pageOrder[i];
+    if (id === undefined || !descendants.has(id)) break;
+    block.push(id);
+  }
+  return block;
+}
+
+/**
+ * Where ingestion inserts a new child of `parentId`: directly after the
+ * parent's contiguous block, so out of the box the physical order reads
+ * depth-first. Falls back to appending when the parent left the order.
+ */
+export function subtreeInsertionIndex(
+  index: MirrorFamilyIndex,
+  pageOrder: string[],
+  parentId: string,
+): number {
+  const start = pageOrder.indexOf(parentId);
+  if (start === -1) return pageOrder.length;
+  return start + familyBlock(index, pageOrder, parentId).length;
+}

--- a/src/services/mirrorPageService.test.ts
+++ b/src/services/mirrorPageService.test.ts
@@ -11,7 +11,7 @@ import { YjsDocument } from '../collaboration/YjsDocument';
 import { registerProseSchema, __resetProseSchemaForTests } from '../collaboration/proseSchema';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import type { FetchedMirrorContent } from '../api/webClient';
-import { addMirrorPage, refreshMirrorPage, detachMirrorPage, MirrorPageError } from './mirrorPageService';
+import { addMirrorPage, refreshMirrorPage, detachMirrorPage, ingestSubpages, listSubpages, MirrorPageError } from './mirrorPageService';
 
 const schema = getSchema([StarterKit.configure({ history: false })]);
 
@@ -121,5 +121,162 @@ describe('mirrorPageService (JP-415)', () => {
     });
     // Nothing half-created.
     expect(useRichTextPagesStore.getState().pageOrder).toEqual([]);
+  });
+});
+
+describe('subpage ingestion (JP-475)', () => {
+  let yjsDoc: YjsDocument;
+
+  beforeEach(() => {
+    registerProseSchema(schema);
+    yjsDoc = new YjsDocument();
+    useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
+  });
+  afterEach(() => {
+    yjsDoc.destroy();
+    __resetProseSchemaForTests();
+  });
+
+  /** Per-source fake control plane; unknown ids fail like the route's 502. */
+  function sourceMap(sources: Record<string, FetchedMirrorContent>) {
+    return async (_provider: string, externalId: string): Promise<FetchedMirrorContent> => {
+      const f = sources[externalId];
+      if (!f) throw new Error(`fetch failed for ${externalId}`);
+      return f;
+    };
+  }
+
+  function src(externalId: string, title: string, childRefs: { externalId: string; title: string }[] = []): FetchedMirrorContent {
+    return {
+      title,
+      proseHtml: `<p>${title} body</p>`,
+      blobCount: 0,
+      warnings: [],
+      sourceRef: { provider: 'notion', externalId },
+      childRefs,
+    };
+  }
+
+  function orderNames(): string[] {
+    const { pages, pageOrder } = useRichTextPagesStore.getState();
+    return pageOrder.map((id) => pages[id]?.name ?? '?');
+  }
+
+  it('refreshMirrorPage PRESERVES parentExternalId (child-orphaning defect)', async () => {
+    const sources = {
+      'ext-p': src('ext-p', 'Parent', [{ externalId: 'ext-c', title: 'Child' }]),
+      'ext-c': src('ext-c', 'Child'),
+    };
+    const deps = { yjsDoc, fetchResource: sourceMap(sources) };
+    const { pageId: parentId } = await addMirrorPage('notion', 'ext-p', deps);
+    await ingestSubpages(parentId, [{ externalId: 'ext-c', title: 'Child' }], {}, deps);
+
+    const childId = useRichTextPagesStore.getState().pageOrder[1]!;
+    expect(useRichTextPagesStore.getState().pages[childId]?.mirror?.parentExternalId).toBe('ext-p');
+
+    // The server sourceRef never carries parentExternalId — refresh must not drop it.
+    await refreshMirrorPage(childId, deps);
+    expect(useRichTextPagesStore.getState().pages[childId]?.mirror?.parentExternalId).toBe('ext-p');
+  });
+
+  it('ingest inserts children depth-first after the parent, before later pages', async () => {
+    const sources = {
+      'ext-p': src('ext-p', 'Parent', [
+        { externalId: 'ext-c1', title: 'C1' },
+        { externalId: 'ext-c2', title: 'C2' },
+      ]),
+      'ext-c1': src('ext-c1', 'C1', [{ externalId: 'ext-g1', title: 'G1' }]),
+      'ext-c2': src('ext-c2', 'C2'),
+      'ext-g1': src('ext-g1', 'G1'),
+    };
+    const deps = { yjsDoc, fetchResource: sourceMap(sources) };
+    const { pageId: parentId } = await addMirrorPage('notion', 'ext-p', deps);
+    useRichTextPagesStore.getState().createPage('Notes');
+
+    const outcome = await ingestSubpages(
+      parentId,
+      [
+        { externalId: 'ext-c1', title: 'C1' },
+        { externalId: 'ext-c2', title: 'C2' },
+      ],
+      { recurse: true },
+      deps,
+    );
+
+    expect(outcome.added).toBe(3);
+    expect(outcome.failed).toEqual([]);
+    // G1 (processed LAST via the recursion queue) still lands under C1 —
+    // physical order reads depth-first, and 'Notes' stays after the family.
+    expect(orderNames()).toEqual(['Parent', 'C1', 'G1', 'C2', 'Notes']);
+    // Batch ingest never steals the active page.
+    expect(useRichTextPagesStore.getState().activePageId).toBe(parentId);
+  }, 15000);
+
+  it('listSubpages diffs candidates against the document and reports unseen children', async () => {
+    const sources = {
+      'ext-p': src('ext-p', 'Parent', [
+        { externalId: 'ext-c1', title: 'C1' },
+        { externalId: 'ext-c2', title: 'C2' },
+      ]),
+      'ext-c1': src('ext-c1', 'C1'),
+    };
+    const deps = { yjsDoc, fetchResource: sourceMap(sources) };
+    const { pageId: parentId } = await addMirrorPage('notion', 'ext-p', deps);
+    await ingestSubpages(parentId, [{ externalId: 'ext-c1', title: 'C1' }], {}, deps);
+
+    // Simulate a child that exists in-doc but vanished from the source listing.
+    const ghostId = useRichTextPagesStore.getState().createPage('Ghost');
+    useRichTextPagesStore.getState().setPageMirror(ghostId, {
+      provider: 'notion',
+      externalId: 'ext-ghost',
+      parentExternalId: 'ext-p',
+      syncedAt: 1,
+    });
+
+    const listing = await listSubpages(parentId, deps);
+    expect(listing.candidates).toEqual([
+      { externalId: 'ext-c1', title: 'C1', status: 'present' },
+      { externalId: 'ext-c2', title: 'C2', status: 'new' },
+    ]);
+    expect(listing.unseen).toEqual([{ pageId: ghostId, name: 'Ghost' }]);
+  });
+
+  it('collects per-child failures and keeps going; peers ingesting mid-run cause skips', async () => {
+    const sources = {
+      'ext-p': src('ext-p', 'Parent', [
+        { externalId: 'ext-bad', title: 'Bad' },
+        { externalId: 'ext-c2', title: 'C2' },
+      ]),
+      'ext-c2': src('ext-c2', 'C2'),
+    };
+    const deps = { yjsDoc, fetchResource: sourceMap(sources) };
+    const { pageId: parentId } = await addMirrorPage('notion', 'ext-p', deps);
+    // 'ext-c2' appears mid-run as if a collab peer mirrored it first.
+    await addMirrorPage('notion', 'ext-c2', deps, { activate: false });
+
+    const outcome = await ingestSubpages(
+      parentId,
+      [
+        { externalId: 'ext-bad', title: 'Bad' },
+        { externalId: 'ext-c2', title: 'C2' },
+      ],
+      {},
+      deps,
+    );
+    expect(outcome.failed).toEqual([{ title: 'Bad', message: 'fetch failed for ext-bad' }]);
+    expect(outcome.skipped).toBe(1);
+    expect(outcome.added).toBe(0);
+  });
+
+  it('an aborted signal stops the run before the next child', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const sources = { 'ext-p': src('ext-p', 'Parent', [{ externalId: 'ext-c1', title: 'C1' }]) };
+    const deps = { yjsDoc, fetchResource: sourceMap(sources) };
+    const { pageId: parentId } = await addMirrorPage('notion', 'ext-p', deps);
+
+    const outcome = await ingestSubpages(parentId, [{ externalId: 'ext-c1', title: 'C1' }], { signal: ac.signal }, deps);
+    expect(outcome.aborted).toBe(true);
+    expect(outcome.added).toBe(0);
   });
 });

--- a/src/services/mirrorPageService.ts
+++ b/src/services/mirrorPageService.ts
@@ -18,12 +18,20 @@
 import { DOMParser as PMDOMParser } from '@tiptap/pm/model';
 import type { JSONContent } from '@tiptap/core';
 
-import { webClient, type FetchedMirrorContent, type ImportWarningInfo, type MirrorSourceRef } from '../api/webClient';
+import {
+  webClient,
+  type ExternalResource,
+  type FetchedMirrorContent,
+  type ImportWarningInfo,
+  type MirrorSourceRef,
+} from '../api/webClient';
 import { getProseSchema } from '../collaboration/proseSchema';
 import { useCollaborationStore } from '../collaboration/collaborationStore';
 import type { YjsDocument } from '../collaboration/YjsDocument';
+import { usePersistenceStore } from '../store/persistenceStore';
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
 import type { PageMirrorMeta } from '../types/PageMirror';
+import { buildMirrorFamilyIndex, externalKey, subtreeInsertionIndex } from './mirrorFamily';
 
 /** A mirror operation the user can understand failed — message is UI-ready. */
 export class MirrorPageError extends Error {
@@ -48,6 +56,9 @@ export interface MirrorPageResult {
   pageId: string;
   /** Constructs the provider transform couldn't mirror faithfully. */
   warnings: ImportWarningInfo[];
+  /** Child resources the source carried at fetch time (JP-475) — best-effort;
+   *  empty against an older control plane. */
+  childRefs: ExternalResource[];
 }
 
 function resolveYjsDoc(deps: MirrorPageDeps): YjsDocument {
@@ -75,7 +86,11 @@ function proseJsonFromHtml(html: string): JSONContent {
   return PMDOMParser.fromSchema(schema).parse(dom.body).toJSON() as JSONContent;
 }
 
-function mirrorMetaFrom(sourceRef: MirrorSourceRef, syncedAt: number): PageMirrorMeta {
+function mirrorMetaFrom(
+  sourceRef: MirrorSourceRef,
+  syncedAt: number,
+  parentExternalId?: string,
+): PageMirrorMeta {
   return {
     provider: sourceRef.provider,
     externalId: sourceRef.externalId,
@@ -83,35 +98,54 @@ function mirrorMetaFrom(sourceRef: MirrorSourceRef, syncedAt: number): PageMirro
     ...(sourceRef.url ? { url: sourceRef.url } : {}),
     ...(sourceRef.iconEmoji ? { iconEmoji: sourceRef.iconEmoji } : {}),
     ...(sourceRef.version ? { version: sourceRef.version } : {}),
+    ...(parentExternalId ? { parentExternalId } : {}),
   };
+}
+
+export interface AddMirrorPageOpts {
+  /** Insert position in `pageOrder` (default: append). */
+  index?: number;
+  /** Stamp the new page as a subpage of this source (JP-475). */
+  parentExternalId?: string;
+  /** Make the new page active (default true; batch ingest passes false). */
+  activate?: boolean;
 }
 
 /**
  * Mirror one external resource into a NEW read-only page of the open document
- * and make it active. Returns the page id + the provider's fidelity warnings
- * (surface them — silently dropped content erodes trust in mirrors).
+ * and (by default) make it active. Returns the page id + the provider's
+ * fidelity warnings (surface them — silently dropped content erodes trust in
+ * mirrors) + the source's child refs (the subpage-ingestion input).
  */
 export async function addMirrorPage(
   provider: string,
   externalId: string,
   deps: MirrorPageDeps = {},
+  opts: AddMirrorPageOpts = {},
 ): Promise<MirrorPageResult> {
   const yjsDoc = resolveYjsDoc(deps);
   const fetched = await (deps.fetchResource ?? defaultFetch)(provider, externalId);
   const content = proseJsonFromHtml(fetched.proseHtml);
 
   const pages = useRichTextPagesStore.getState();
-  const pageId = pages.createPage(fetched.title || 'Untitled mirror');
+  const pageId = pages.createPage(
+    fetched.title || 'Untitled mirror',
+    undefined,
+    undefined,
+    opts.index !== undefined ? { index: opts.index } : undefined,
+  );
   yjsDoc.setProse(pageId, content);
-  pages.setPageMirror(pageId, mirrorMetaFrom(fetched.sourceRef, (deps.now ?? Date.now)()));
-  pages.setActivePage(pageId);
+  pages.setPageMirror(pageId, mirrorMetaFrom(fetched.sourceRef, (deps.now ?? Date.now)(), opts.parentExternalId));
+  if (opts.activate !== false) pages.setActivePage(pageId);
 
-  return { pageId, warnings: fetched.warnings };
+  return { pageId, warnings: fetched.warnings, childRefs: fetched.childRefs ?? [] };
 }
 
 /**
  * Re-fetch a mirror page's source and update content (merge-safe fragment
  * diff), title (follows the source), and provenance stamps in place.
+ * `parentExternalId` is CLIENT-side provenance the server never echoes — it
+ * must be carried over, or refreshing a subpage silently orphans its family.
  */
 export async function refreshMirrorPage(pageId: string, deps: MirrorPageDeps = {}): Promise<MirrorPageResult> {
   const page = useRichTextPagesStore.getState().pages[pageId];
@@ -127,15 +161,16 @@ export async function refreshMirrorPage(pageId: string, deps: MirrorPageDeps = {
   if (fetched.title && fetched.title !== page.name) {
     pages.renamePage(pageId, fetched.title);
   }
-  pages.setPageMirror(pageId, mirrorMetaFrom(fetched.sourceRef, (deps.now ?? Date.now)()));
+  pages.setPageMirror(pageId, mirrorMetaFrom(fetched.sourceRef, (deps.now ?? Date.now)(), mirror.parentExternalId));
 
-  return { pageId, warnings: fetched.warnings };
+  return { pageId, warnings: fetched.warnings, childRefs: fetched.childRefs ?? [] };
 }
 
 /**
  * Detach a mirror page: clear its provenance so it becomes a normal editable
  * page. Content stays exactly as last synced. Irreversible (re-adding creates
- * a new mirror page) — confirm in the UI before calling.
+ * a new mirror page) — confirm in the UI before calling. Detaching a family
+ * parent leaves its subpages as roots (derivation orphans, no cascades).
  */
 export function detachMirrorPage(pageId: string): void {
   const page = useRichTextPagesStore.getState().pages[pageId];
@@ -143,4 +178,182 @@ export function detachMirrorPage(pageId: string): void {
     throw new MirrorPageError('not_a_mirror', 'This page is not a mirror — nothing to detach.');
   }
   useRichTextPagesStore.getState().setPageMirror(pageId, undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Subpage ingestion (JP-475)
+// ---------------------------------------------------------------------------
+
+/** Inter-request delay for batch ingest — Notion allows ~3 req/s and neither
+ *  the control plane nor the framework retries a 429 (it surfaces as 502). */
+const INGEST_DELAY_MS = 350;
+/** Recursion floor/ceiling: children of the requested parent are depth 1. */
+const MAX_INGEST_DEPTH = 3;
+/** Pages per ingest run — bounds latency, storage growth, and rate exposure. */
+const MAX_INGEST_TOTAL = 25;
+
+export interface SubpageCandidate {
+  externalId: string;
+  title: string;
+  url?: string;
+  /** 'present' = a mirror of this source already exists in the document. */
+  status: 'new' | 'present';
+}
+
+export interface SubpageListing {
+  parentPageId: string;
+  provider: string;
+  /** The parent's children as of the fresh fetch, in source order. */
+  candidates: SubpageCandidate[];
+  /** In-doc subpages of this parent NOT seen in the latest fetch — possibly
+   *  nested deeper than the fetch budget, possibly removed at source. Info
+   *  only; never auto-deleted. */
+  unseen: { pageId: string; name: string }[];
+  /** Warnings from the parent refresh that rode along. */
+  warnings: ImportWarningInfo[];
+}
+
+/**
+ * Fresh listing for the ingest dialog. Refreshes the parent (ingestion always
+ * works against current source state — the fetch is the refresh) and diffs its
+ * `childRefs` against the document's existing mirrors.
+ */
+export async function listSubpages(parentPageId: string, deps: MirrorPageDeps = {}): Promise<SubpageListing> {
+  const parentMirror = useRichTextPagesStore.getState().pages[parentPageId]?.mirror;
+  if (!parentMirror) {
+    throw new MirrorPageError('not_a_mirror', 'This page is not a mirror — subpages come from the source.');
+  }
+  const { warnings, childRefs } = await refreshMirrorPage(parentPageId, deps);
+
+  const state = useRichTextPagesStore.getState();
+  const index = buildMirrorFamilyIndex(state.pages, state.pageOrder);
+  const candidates: SubpageCandidate[] = childRefs.map((c) => ({
+    externalId: c.externalId,
+    title: c.title,
+    ...(c.url ? { url: c.url } : {}),
+    status: index.byExternal.has(externalKey(parentMirror.provider, c.externalId)) ? 'present' : 'new',
+  }));
+
+  const seen = new Set(childRefs.map((c) => c.externalId));
+  const unseen = (index.childrenOf.get(parentPageId) ?? [])
+    .filter((id) => {
+      const m = state.pages[id]?.mirror;
+      return m !== undefined && !seen.has(m.externalId);
+    })
+    .map((id) => ({ pageId: id, name: state.pages[id]?.name ?? 'Untitled' }));
+
+  return { parentPageId, provider: parentMirror.provider, candidates, unseen, warnings };
+}
+
+export interface IngestSubpagesOpts {
+  /** Also ingest the children's children (depth-capped). */
+  recurse?: boolean;
+  onProgress?: (done: number, total: number, currentTitle: string) => void;
+  signal?: AbortSignal;
+}
+
+export interface IngestOutcome {
+  added: number;
+  skipped: number;
+  failed: { title: string; message: string }[];
+  warnings: ImportWarningInfo[];
+  /** Children left out by the per-run total/depth caps. */
+  truncated: number;
+  /** True when the run stopped early (cancel, or the active doc changed). */
+  aborted: boolean;
+}
+
+interface IngestQueueItem {
+  externalId: string;
+  title: string;
+  parentPageId: string;
+  depth: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Ingest the selected subpages of a mirror page, sequentially (provider rate
+ * limits; failures collect instead of stopping the run). Each child lands
+ * directly after its parent's contiguous block, so the physical order reads
+ * depth-first out of the box. Race-guarded: a child a collab peer mirrored
+ * mid-run is skipped, and the run aborts if the active document changes.
+ */
+export async function ingestSubpages(
+  parentPageId: string,
+  selection: { externalId: string; title: string }[],
+  opts: IngestSubpagesOpts = {},
+  deps: MirrorPageDeps = {},
+): Promise<IngestOutcome> {
+  const parentMirror = useRichTextPagesStore.getState().pages[parentPageId]?.mirror;
+  if (!parentMirror) {
+    throw new MirrorPageError('not_a_mirror', 'This page is not a mirror — subpages come from the source.');
+  }
+  const provider = parentMirror.provider;
+  const docAtStart = usePersistenceStore.getState().currentDocumentId;
+
+  const outcome: IngestOutcome = { added: 0, skipped: 0, failed: [], warnings: [], truncated: 0, aborted: false };
+  const queue: IngestQueueItem[] = selection.map((s) => ({ ...s, parentPageId, depth: 1 }));
+  let processed = 0;
+
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (item === undefined) break;
+
+    if (opts.signal?.aborted || usePersistenceStore.getState().currentDocumentId !== docAtStart) {
+      outcome.aborted = true;
+      break;
+    }
+    if (processed >= MAX_INGEST_TOTAL) {
+      outcome.truncated = queue.length + 1;
+      break;
+    }
+
+    const state = useRichTextPagesStore.getState();
+    const index = buildMirrorFamilyIndex(state.pages, state.pageOrder);
+
+    // Peer race: someone mirrored this source while the run was underway.
+    if (index.byExternal.has(externalKey(provider, item.externalId))) {
+      outcome.skipped += 1;
+      continue;
+    }
+    // The parent page can vanish mid-run (peer delete); land the child at the
+    // end rather than dropping it — the derivation treats it as an orphan-root.
+    const parentPage = state.pages[item.parentPageId];
+    const parentExternalId = parentPage?.mirror?.externalId ?? parentMirror.externalId;
+
+    opts.onProgress?.(processed, processed + queue.length + 1, item.title);
+    if (processed > 0) await sleep(INGEST_DELAY_MS);
+
+    try {
+      const result = await addMirrorPage(provider, item.externalId, deps, {
+        index: subtreeInsertionIndex(index, state.pageOrder, item.parentPageId),
+        parentExternalId,
+        activate: false,
+      });
+      outcome.added += 1;
+      outcome.warnings.push(...result.warnings);
+      if (opts.recurse && result.childRefs.length > 0) {
+        if (item.depth >= MAX_INGEST_DEPTH) {
+          outcome.truncated += result.childRefs.length;
+        } else {
+          queue.push(
+            ...result.childRefs.map((c) => ({
+              externalId: c.externalId,
+              title: c.title,
+              parentPageId: result.pageId,
+              depth: item.depth + 1,
+            })),
+          );
+        }
+      }
+    } catch (e) {
+      outcome.failed.push({ title: item.title, message: e instanceof Error ? e.message : 'Fetch failed.' });
+    }
+    processed += 1;
+  }
+
+  return outcome;
 }

--- a/src/store/richTextPagesStore.test.ts
+++ b/src/store/richTextPagesStore.test.ts
@@ -148,3 +148,58 @@ describe('richTextPagesStore — page mirror provenance (JP-415)', () => {
     expect(snapshot.pages['m1']?.mirror).toEqual(mirror);
   });
 });
+
+describe('richTextPagesStore — positional insert + block move (JP-475)', () => {
+  beforeEach(() => {
+    useRichTextPagesStore.setState({ pages: {}, pageOrder: [], activePageId: null });
+  });
+
+  function seed(names: string[]): string[] {
+    return names.map((n) => useRichTextPagesStore.getState().createPage(n));
+  }
+
+  function orderNames(): string[] {
+    const { pages, pageOrder } = useRichTextPagesStore.getState();
+    return pageOrder.map((id) => pages[id]?.name ?? '?');
+  }
+
+  it('createPage with an index splices instead of appending, renumbering order', () => {
+    seed(['A', 'B', 'C']);
+    useRichTextPagesStore.getState().createPage('X', undefined, undefined, { index: 1 });
+    expect(orderNames()).toEqual(['A', 'X', 'B', 'C']);
+    const { pages, pageOrder } = useRichTextPagesStore.getState();
+    pageOrder.forEach((id, i) => expect(pages[id]?.order).toBe(i));
+  });
+
+  it('createPage clamps an out-of-range index to the ends', () => {
+    seed(['A']);
+    useRichTextPagesStore.getState().createPage('End', undefined, undefined, { index: 99 });
+    useRichTextPagesStore.getState().createPage('Start', undefined, undefined, { index: -5 });
+    expect(orderNames()).toEqual(['Start', 'A', 'End']);
+  });
+
+  it('movePages moves a contiguous block, preserving relative order', () => {
+    seed(['A', 'B', 'C', 'D', 'E']);
+    const { pageOrder } = useRichTextPagesStore.getState();
+    const b = pageOrder[1]!;
+    const c = pageOrder[2]!;
+    // Move [B, C] to the end (toIndex counted against the order minus the block).
+    useRichTextPagesStore.getState().movePages([b, c], 3);
+    expect(orderNames()).toEqual(['A', 'D', 'E', 'B', 'C']);
+    const after = useRichTextPagesStore.getState();
+    after.pageOrder.forEach((id, i) => expect(after.pages[id]?.order).toBe(i));
+  });
+
+  it('movePages preserves current relative order even for an unordered id set', () => {
+    seed(['A', 'B', 'C', 'D']);
+    const { pageOrder } = useRichTextPagesStore.getState();
+    useRichTextPagesStore.getState().movePages([pageOrder[3]!, pageOrder[0]!], 0);
+    expect(orderNames()).toEqual(['A', 'D', 'B', 'C']);
+  });
+
+  it('movePages ignores unknown ids and does nothing for an empty match', () => {
+    seed(['A', 'B']);
+    useRichTextPagesStore.getState().movePages(['nope'], 0);
+    expect(orderNames()).toEqual(['A', 'B']);
+  });
+});

--- a/src/store/richTextPagesStore.ts
+++ b/src/store/richTextPagesStore.ts
@@ -59,8 +59,10 @@ interface RichTextPagesState {
  */
 interface RichTextPagesActions {
   /** Create a new page. `id` lets callers pin a deterministic id (e.g. the
-   *  default page on a relay doc, so collaborators' fragments align). */
-  createPage: (name?: string, color?: string, id?: string) => string;
+   *  default page on a relay doc, so collaborators' fragments align).
+   *  `opts.index` inserts at a position in `pageOrder` (default: append) —
+   *  a single store transition, so collab peers see one page-list delta. */
+  createPage: (name?: string, color?: string, id?: string, opts?: { index?: number }) => string;
   /** Delete a page by ID */
   deletePage: (id: string) => void;
   /** Rename a page */
@@ -76,6 +78,11 @@ interface RichTextPagesActions {
   updatePageContent: (id: string, content: string) => void;
   /** Reorder pages */
   reorderPages: (fromIndex: number, toIndex: number) => void;
+  /** Move a set of pages as ONE contiguous block. `toIndex` is the insertion
+   *  position computed against the order with the moved pages removed (the
+   *  usual DnD convention). The pages keep their current relative order;
+   *  single transition = one collab delta. Unknown ids are ignored. */
+  movePages: (ids: string[], toIndex: number) => void;
   /** Get the active page */
   getActivePage: () => RichTextPage | null;
   /** Initialize with default page if empty */
@@ -130,10 +137,10 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
     activePageId: null,
     pageOrder: [],
 
-    createPage: (name?: string, color?: string, id?: string) => {
+    createPage: (name?: string, color?: string, id?: string, opts?: { index?: number }) => {
       const pageId = id ?? generatePageId();
       const state = get();
-      const order = state.pageOrder.length;
+      const index = Math.max(0, Math.min(opts?.index ?? state.pageOrder.length, state.pageOrder.length));
       const existingNames = state.pageOrder.map((pid) => state.pages[pid]?.name ?? '');
       const pageName = name || nextDefaultPageName(PROSE_PAGE_BASE, existingNames);
       const now = Date.now();
@@ -143,7 +150,7 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
           id: pageId,
           name: pageName,
           content: '',
-          order,
+          order: index,
           createdAt: now,
           modifiedAt: now,
         };
@@ -151,7 +158,12 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
           page.color = color;
         }
         draft.pages[pageId] = page;
-        draft.pageOrder.push(pageId);
+        draft.pageOrder.splice(index, 0, pageId);
+        // Renumber the denormalized order to match the authoritative array.
+        draft.pageOrder.forEach((pid, i) => {
+          const p = draft.pages[pid];
+          if (p) p.order = i;
+        });
         if (!draft.activePageId) {
           draft.activePageId = pageId;
         }
@@ -264,6 +276,22 @@ export const useRichTextPagesStore = create<RichTextPagesState & RichTextPagesAc
             }
           });
         }
+      });
+    },
+
+    movePages: (ids: string[], toIndex: number) => {
+      set((draft) => {
+        const moving = new Set(ids);
+        const block = draft.pageOrder.filter((pid) => moving.has(pid));
+        if (block.length === 0) return;
+        const rest = draft.pageOrder.filter((pid) => !moving.has(pid));
+        const at = Math.max(0, Math.min(toIndex, rest.length));
+        rest.splice(at, 0, ...block);
+        draft.pageOrder = rest;
+        draft.pageOrder.forEach((pid, i) => {
+          const p = draft.pages[pid];
+          if (p) p.order = i;
+        });
       });
     },
 

--- a/src/types/PageMirror.test.ts
+++ b/src/types/PageMirror.test.ts
@@ -1,0 +1,46 @@
+/**
+ * JP-475 — pageMirrorEquals must see every PageMirrorMeta field: it is the
+ * ONLY field-enumerating site on the collab page-list path, so a field it
+ * misses syncs on first write and then silently never re-syncs.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { pageMirrorEquals, type PageMirrorMeta } from './PageMirror';
+
+const base: PageMirrorMeta = {
+  provider: 'notion',
+  externalId: 'ext-1',
+  url: 'https://www.notion.so/x',
+  iconEmoji: '📄',
+  version: 'v1',
+  syncedAt: 100,
+};
+
+describe('pageMirrorEquals', () => {
+  it('is reflexive and handles undefined sides', () => {
+    expect(pageMirrorEquals(base, { ...base })).toBe(true);
+    expect(pageMirrorEquals(undefined, undefined)).toBe(true);
+    expect(pageMirrorEquals(base, undefined)).toBe(false);
+  });
+
+  it('differs on every field, parentExternalId included', () => {
+    const variants: Partial<PageMirrorMeta>[] = [
+      { provider: 'confluence' },
+      { externalId: 'ext-2' },
+      { url: 'https://www.notion.so/y' },
+      { iconEmoji: '🗂️' },
+      { version: 'v2' },
+      { syncedAt: 101 },
+      { parentExternalId: 'ext-parent' },
+    ];
+    for (const delta of variants) {
+      expect(pageMirrorEquals(base, { ...base, ...delta })).toBe(false);
+    }
+    expect(
+      pageMirrorEquals({ ...base, parentExternalId: 'p1' }, { ...base, parentExternalId: 'p2' }),
+    ).toBe(false);
+    expect(
+      pageMirrorEquals({ ...base, parentExternalId: 'p1' }, { ...base, parentExternalId: 'p1' }),
+    ).toBe(true);
+  });
+});

--- a/src/types/PageMirror.ts
+++ b/src/types/PageMirror.ts
@@ -24,6 +24,15 @@ export interface PageMirrorMeta {
   version?: string;
   /** Local wall-clock ms of the last successful sync. */
   syncedAt: number;
+  /**
+   * The provider-native id of this page's PARENT source, when the page was
+   * ingested as a subpage (JP-475). Families are DERIVED from this field:
+   * chain `parentExternalId` → `externalId` among the document's mirror pages
+   * of the same provider. An orphan (parent deleted or detached) renders as a
+   * root — no cascades, non-destructive. Logical structure only: the physical
+   * page sequence (`pageOrder`, the export order) never becomes a tree.
+   */
+  parentExternalId?: string;
 }
 
 /** Field-wise equality — the collab meta-diff uses this to decide whether a
@@ -37,6 +46,7 @@ export function pageMirrorEquals(a: PageMirrorMeta | undefined, b: PageMirrorMet
     a.url === b.url &&
     a.iconEmoji === b.iconEmoji &&
     a.version === b.version &&
-    a.syncedAt === b.syncedAt
+    a.syncedAt === b.syncedAt &&
+    a.parentExternalId === b.parentExternalId
   );
 }

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -234,3 +234,45 @@
   align-items: center;
   gap: 8px;
 }
+
+/* JP-475: mirror families — subpage chevron on a root tab + the family flyout. */
+.rich-text-tab-family-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: none;
+  margin-left: 2px;
+  padding: 1px 4px;
+  border: none;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+}
+.rich-text-tab-family-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary, var(--bg-secondary));
+}
+.rich-text-tab-family-count {
+  font-variant-numeric: tabular-nums;
+}
+.rich-text-tab-family-flyout {
+  min-width: 180px;
+  max-width: 300px;
+}
+.rich-text-tab-family-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.rich-text-tab-family-row.active {
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium, 500);
+}
+.rich-text-tab-family-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/ui/RichTextTabBar.css
+++ b/src/ui/RichTextTabBar.css
@@ -266,6 +266,9 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  /* The context-item base uses space-between (submenu arrows); family rows
+     are icon + name and read left-aligned. */
+  justify-content: flex-start;
 }
 .rich-text-tab-family-row.active {
   color: var(--color-primary);
@@ -275,4 +278,21 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Active-child breadcrumb: the root half yields, the child half never clips. */
+.rich-text-tab-breadcrumb {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+}
+.rich-text-tab-breadcrumb-root {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 24px;
+}
+.rich-text-tab-breadcrumb-child {
+  flex: none;
 }

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -489,10 +489,15 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
                   onKeyDown={handleEditKeyDown}
                   onClick={(e) => e.stopPropagation()}
                 />
-              ) : (
-                <span className="rich-text-tab-name">
-                  {activeChild ? `${page.name} › ${activeChild.name}` : page.name}
+              ) : activeChild ? (
+                // Two spans so the ROOT truncates first — the child name is the
+                // informative half of the breadcrumb and must stay visible.
+                <span className="rich-text-tab-name rich-text-tab-breadcrumb">
+                  <span className="rich-text-tab-breadcrumb-root">{page.name}</span>
+                  <span className="rich-text-tab-breadcrumb-child">› {activeChild.name}</span>
                 </span>
+              ) : (
+                <span className="rich-text-tab-name">{page.name}</span>
               )}
               {item.children && (
                 <button

--- a/src/ui/RichTextTabBar.tsx
+++ b/src/ui/RichTextTabBar.tsx
@@ -10,8 +10,8 @@
  * - Add new page button
  */
 
-import { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
-import { FileText } from 'lucide-react';
+import { useState, useCallback, useMemo, useRef, useEffect, type ReactNode } from 'react';
+import { ChevronDown, FileText } from 'lucide-react';
 import { Icon } from './icons';
 import { createPortal } from 'react-dom';
 import { PageTabStrip, type PageTabStripItem } from './components/PageTabStrip';
@@ -27,7 +27,14 @@ import { confirmDialog } from './confirm/confirmStore';
 import { opener } from '../platform/opener';
 import { loadConnection, DEFAULT_CLOUD_BASE_URL } from '../api/relayConnection';
 import { MirrorResourcePicker } from './integrations/MirrorResourcePicker';
+import { IngestSubpagesDialog } from './integrations/IngestSubpagesDialog';
 import { ProviderIcon } from './integrations/ProviderIcon';
+import {
+  buildMirrorFamilyIndex,
+  descendantEntries,
+  familyBlock,
+  isFamilyRoot,
+} from '../services/mirrorFamily';
 import { clampToViewport } from './contextMenuUtils';
 import type { IntegrationProvider } from '../api/webClient';
 import './RichTextTabBar.css';
@@ -61,7 +68,7 @@ interface ContextMenuState {
 }
 
 export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
-  const { pages, pageOrder, activePageId, setActivePage, createPage, deletePage, renamePage, setPageColor, reorderPages } = useRichTextPagesStore();
+  const { pages, pageOrder, activePageId, setActivePage, createPage, deletePage, renamePage, setPageColor, movePages } = useRichTextPagesStore();
   
   const [editingPageId, setEditingPageId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
@@ -73,7 +80,13 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
   // workspace has integration options) and the resource-browser modal.
   const [addMenu, setAddMenu] = useState<{ x: number; y: number } | null>(null);
   const [pickerProvider, setPickerProvider] = useState<IntegrationProvider | null>(null);
+  // JP-475 mirror families: descendants collapse under their root's tab. The
+  // flyout navigates a family; the ingest dialog mirrors new subpages.
+  const [familyFlyout, setFamilyFlyout] = useState<{ rootId: string; x: number; y: number } | null>(null);
+  const [ingestPageId, setIngestPageId] = useState<string | null>(null);
   const hub = useIntegrationHubStore((s) => s.hub);
+
+  const familyIndex = useMemo(() => buildMirrorFamilyIndex(pages, pageOrder), [pages, pageOrder]);
   // Measured-then-clamped portal positions (the InlinePageTabs pattern) so
   // neither menu can render out of the viewport.
   const [adjustedCtxPos, setAdjustedCtxPos] = useState<{ x: number; y: number } | null>(null);
@@ -82,7 +95,29 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
   const editInputRef = useRef<HTMLInputElement>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const addMenuRef = useRef<HTMLDivElement>(null);
+  const familyFlyoutRef = useRef<HTMLDivElement>(null);
+  const [adjustedFlyoutPos, setAdjustedFlyoutPos] = useState<{ x: number; y: number } | null>(null);
   const colorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Family flyout: same measured-then-clamped portal + outside-click pattern
+  // as the context menu and add-menu.
+  useEffect(() => {
+    if (!familyFlyout || !familyFlyoutRef.current) {
+      setAdjustedFlyoutPos(null);
+      return;
+    }
+    const rect = familyFlyoutRef.current.getBoundingClientRect();
+    setAdjustedFlyoutPos(clampToViewport(familyFlyout.x, familyFlyout.y, rect.width, rect.height));
+  }, [familyFlyout]);
+
+  useEffect(() => {
+    if (!familyFlyout) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (familyFlyoutRef.current && !familyFlyoutRef.current.contains(e.target as Node)) setFamilyFlyout(null);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [familyFlyout]);
 
   // Clamp the tab context menu inside the viewport once it has real bounds.
   useEffect(() => {
@@ -314,6 +349,18 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
     setContextMenu({ isOpen: false, x: 0, y: 0, pageId: '' });
   }, [contextMenu.pageId, setPageColor]);
 
+  // One strip item per family ROOT (or plain page); descendants collapse under
+  // their root. Item index ≠ pageOrder index from here on — every reorder
+  // translates through `itemBlocks` (a root drags its contiguous block).
+  const rootIds = useMemo(
+    () => pageOrder.filter((id) => pages[id] !== undefined && isFamilyRoot(familyIndex, id)),
+    [pageOrder, pages, familyIndex],
+  );
+  const itemBlocks = useMemo(
+    () => rootIds.map((id) => (familyIndex.childrenOf.has(id) ? familyBlock(familyIndex, pageOrder, id) : [id])),
+    [rootIds, familyIndex, pageOrder],
+  );
+
   // Drag handlers
   const handleDragStart = useCallback((e: React.DragEvent, index: number) => {
     setDraggedIndex(index);
@@ -334,11 +381,20 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
   const handleDrop = useCallback((e: React.DragEvent, toIndex: number) => {
     e.preventDefault();
     if (draggedIndex !== null && draggedIndex !== toIndex) {
-      reorderPages(draggedIndex, toIndex);
+      const moved = itemBlocks[draggedIndex];
+      if (moved && moved.length > 0) {
+        // Translate the ITEM-level drop into page coordinates: the insertion
+        // point is the page count of the item blocks that precede the target
+        // position once the dragged block is removed (movePages convention).
+        const rest = itemBlocks.filter((_, i) => i !== draggedIndex);
+        const itemTo = Math.max(0, Math.min(toIndex, rest.length));
+        const pagesBefore = rest.slice(0, itemTo).reduce((n, b) => n + b.length, 0);
+        movePages(moved, pagesBefore);
+      }
     }
     setDraggedIndex(null);
     setDragOverIndex(null);
-  }, [draggedIndex, reorderPages]);
+  }, [draggedIndex, itemBlocks, movePages]);
 
   const handleDragEnd = useCallback(() => {
     setDraggedIndex(null);
@@ -351,17 +407,26 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
     <ProviderIcon provider={provider} size={13} className="page-tab-kind-icon" />
   );
 
-  const items: PageTabStripItem[] = pageOrder.flatMap((pageId) => {
+  // Items are a TREE: one entry per root, descendants nested under `children`
+  // (the strip's overflow menu renders them indented; the flyout navigates).
+  const toStripItem = (pageId: string): PageTabStripItem | null => {
     const page = pages[pageId];
-    if (!page) return [];
+    if (!page) return null;
     const item: PageTabStripItem = {
       id: pageId,
       label: page.name,
       icon: page.mirror ? mirrorGlyph(page.mirror.provider) : proseKindIcon,
     };
     if (page.color) item.color = page.color;
-    return [item];
-  });
+    const children = (familyIndex.childrenOf.get(pageId) ?? [])
+      .map(toStripItem)
+      .filter((c): c is PageTabStripItem => c !== null);
+    if (children.length > 0) item.children = children;
+    return item;
+  };
+  const items: PageTabStripItem[] = rootIds
+    .map(toStripItem)
+    .filter((c): c is PageTabStripItem => c !== null);
 
   return (
     <>
@@ -375,7 +440,12 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
         renderTab={(item, index) => {
           const page = pages[item.id];
           if (!page) return null;
-          const isActive = item.id === activePageId;
+          const descendants = item.children ? descendantEntries(familyIndex, item.id) : [];
+          const activeChild =
+            activePageId !== null && descendants.some((d) => d.pageId === activePageId)
+              ? pages[activePageId]
+              : undefined;
+          const isActive = item.id === activePageId || activeChild !== undefined;
           const isEditing = item.id === editingPageId;
           const isDragging = index === draggedIndex;
           const isDragOver = index === dragOverIndex;
@@ -420,7 +490,28 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
                   onClick={(e) => e.stopPropagation()}
                 />
               ) : (
-                <span className="rich-text-tab-name">{page.name}</span>
+                <span className="rich-text-tab-name">
+                  {activeChild ? `${page.name} › ${activeChild.name}` : page.name}
+                </span>
+              )}
+              {item.children && (
+                <button
+                  type="button"
+                  className="rich-text-tab-family-btn"
+                  title={`${descendants.length} subpage${descendants.length === 1 ? '' : 's'}`}
+                  aria-haspopup="menu"
+                  aria-expanded={familyFlyout?.rootId === item.id}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const r = e.currentTarget.getBoundingClientRect();
+                    setFamilyFlyout((f) =>
+                      f?.rootId === item.id ? null : { rootId: item.id, x: r.left, y: r.bottom + 4 },
+                    );
+                  }}
+                >
+                  <span className="rich-text-tab-family-count">{descendants.length}</span>
+                  <Icon icon={ChevronDown} size={11} />
+                </button>
               )}
             </div>
           );
@@ -451,6 +542,16 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
                   )}
                   <div className="rich-text-tab-context-item" onClick={() => handleRefreshMirror(contextMenu.pageId)}>
                     Refresh from source
+                  </div>
+                  <div
+                    className="rich-text-tab-context-item"
+                    onClick={() => {
+                      const pid = contextMenu.pageId;
+                      setContextMenu({ isOpen: false, x: 0, y: 0, pageId: '' });
+                      setIngestPageId(pid);
+                    }}
+                  >
+                    Ingest subpages…
                   </div>
                   <div
                     className="rich-text-tab-context-item"
@@ -512,6 +613,56 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
         document.body
       )}
 
+      {/* Family flyout (JP-475): the logical descendants of one root, indented;
+          complete regardless of physical scatter in pageOrder. */}
+      {familyFlyout && createPortal(
+        (() => {
+          const root = pages[familyFlyout.rootId];
+          if (!root) return null;
+          const pos = adjustedFlyoutPos ?? { x: familyFlyout.x, y: familyFlyout.y };
+          const pick = (pageId: string) => {
+            setActivePage(pageId);
+            setFamilyFlyout(null);
+          };
+          return (
+            <div
+              ref={familyFlyoutRef}
+              className="rich-text-tab-context-menu rich-text-tab-family-flyout"
+              role="menu"
+              style={{ left: pos.x, top: pos.y }}
+            >
+              <div
+                className={`rich-text-tab-context-item rich-text-tab-family-row ${
+                  activePageId === familyFlyout.rootId ? 'active' : ''
+                }`}
+                onClick={() => pick(familyFlyout.rootId)}
+              >
+                {root.mirror ? mirrorGlyph(root.mirror.provider) : proseKindIcon}
+                <span className="rich-text-tab-family-row-name">{root.name}</span>
+              </div>
+              {descendantEntries(familyIndex, familyFlyout.rootId).map(({ pageId, depth }) => {
+                const p = pages[pageId];
+                if (!p) return null;
+                return (
+                  <div
+                    key={pageId}
+                    className={`rich-text-tab-context-item rich-text-tab-family-row ${
+                      activePageId === pageId ? 'active' : ''
+                    }`}
+                    style={{ paddingLeft: 10 + depth * 14 }}
+                    onClick={() => pick(pageId)}
+                  >
+                    {p.mirror ? mirrorGlyph(p.mirror.provider) : proseKindIcon}
+                    <span className="rich-text-tab-family-row-name">{p.name}</span>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })(),
+        document.body
+      )}
+
       {/* Add-menu (JP-415): "New page" + the workspace's integration sources. */}
       {addMenu && createPortal(
         <div
@@ -553,6 +704,11 @@ export function RichTextTabBar({ trailing }: RichTextTabBarProps = {}) {
       {/* Resource browser (JP-415). */}
       {pickerProvider && (
         <MirrorResourcePicker provider={pickerProvider} onClose={() => setPickerProvider(null)} />
+      )}
+
+      {/* Subpage ingestion (JP-475). */}
+      {ingestPageId && (
+        <IngestSubpagesDialog pageId={ingestPageId} onClose={() => setIngestPageId(null)} />
       )}
     </>
   );

--- a/src/ui/components/PageTabStrip.css
+++ b/src/ui/components/PageTabStrip.css
@@ -167,6 +167,11 @@
   flex-shrink: 0;
 }
 
+/* Indent spacer for grouped (family) rows — width set inline per depth. */
+.page-tab-strip-menu-indent {
+  flex-shrink: 0;
+}
+
 .page-tab-strip-menu-label {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ui/components/PageTabStrip.tsx
+++ b/src/ui/components/PageTabStrip.tsx
@@ -31,6 +31,16 @@ export interface PageTabStripItem {
   color?: string;
   /** Optional kind icon (canvas vs prose), shown in the overflow-menu row. */
   icon?: ReactNode;
+  /** Pages grouped UNDER this tab (JP-475 mirror families). They render no
+   *  tab of their own; the overflow menu lists them indented so every page
+   *  stays reachable, and the consumer provides its own expanded navigation
+   *  (e.g. a flyout on the tab). */
+  children?: PageTabStripItem[];
+}
+
+/** Overflow-menu rows: the item tree flattened depth-first with indent depth. */
+function menuRows(items: PageTabStripItem[], depth = 0): { item: PageTabStripItem; depth: number }[] {
+  return items.flatMap((item) => [{ item, depth }, ...menuRows(item.children ?? [], depth + 1)]);
 }
 
 interface PageTabStripProps {
@@ -204,7 +214,7 @@ export function PageTabStrip({
 
           {menuOpen && (
             <div className="page-tab-strip-menu" role="menu">
-              {items.map((item) => (
+              {menuRows(items).map(({ item, depth }) => (
                 <button
                   key={item.id}
                   type="button"
@@ -213,6 +223,7 @@ export function PageTabStrip({
                   className={`page-tab-strip-menu-item ${item.id === activeId ? 'active' : ''}`}
                   onClick={() => handlePick(item.id)}
                 >
+                  {depth > 0 && <span className="page-tab-strip-menu-indent" style={{ width: depth * 14 }} />}
                   {item.color ? (
                     <span
                       className="page-tab-strip-menu-dot"

--- a/src/ui/integrations/IngestSubpagesDialog.css
+++ b/src/ui/integrations/IngestSubpagesDialog.css
@@ -1,0 +1,159 @@
+/* IngestSubpagesDialog (JP-475) — overlay/card chrome per MirrorResourcePicker. */
+
+.ingest-subpages-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--bg-primary) 55%, transparent);
+}
+
+.ingest-subpages {
+  width: min(440px, calc(100vw - 32px));
+  max-height: min(70vh, 560px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg, 10px);
+  background: var(--bg-primary);
+  box-shadow: var(--shadow-lg, 0 12px 32px rgba(0, 0, 0, 0.25));
+}
+
+.ingest-subpages-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ingest-subpages-head h2 {
+  margin: 0;
+  font-size: var(--font-size-md, 14px);
+  font-weight: var(--font-weight-semibold, 600);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ingest-subpages-close {
+  display: inline-flex;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.ingest-subpages-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.ingest-subpages-list {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
+}
+
+.ingest-subpages-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  font-size: var(--font-size-sm, 13px);
+  cursor: pointer;
+}
+
+.ingest-subpages-row:not(:last-child) {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ingest-subpages-row[data-present] {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.ingest-subpages-row-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ingest-subpages-badge {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full, 999px);
+  padding: 1px 7px;
+  flex-shrink: 0;
+}
+
+.ingest-subpages-recurse {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm, 13px);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.ingest-subpages-hint {
+  margin: 0;
+  font-size: var(--font-size-sm, 13px);
+  color: var(--text-muted);
+}
+
+.ingest-subpages-error {
+  margin: 0;
+  font-size: var(--font-size-sm, 13px);
+  color: var(--color-danger, #b4232a);
+}
+
+.ingest-subpages-progress {
+  height: 6px;
+  border-radius: var(--radius-full, 999px);
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.ingest-subpages-progress-fill {
+  height: 100%;
+  background: var(--color-primary);
+  transition: width 200ms ease;
+}
+
+.ingest-subpages-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.ingest-subpages-foot button {
+  padding: 6px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm, 13px);
+  cursor: pointer;
+}
+
+.ingest-subpages-primary {
+  background: var(--color-primary) !important;
+  border-color: var(--color-primary) !important;
+  color: var(--color-primary-contrast, #fff) !important;
+}
+
+.ingest-subpages-primary:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/src/ui/integrations/IngestSubpagesDialog.tsx
+++ b/src/ui/integrations/IngestSubpagesDialog.tsx
@@ -1,0 +1,240 @@
+/**
+ * IngestSubpagesDialog (JP-475) — "Ingest subpages…" on a mirror page's tab.
+ *
+ * Opens with a FRESH listing (listSubpages refreshes the parent — ingestion
+ * always works against current source state), lets the user pick which
+ * children to mirror, then runs the sequential batch with progress + cancel.
+ * Modal chrome mirrors <MirrorResourcePicker/> (overlay + card + Escape),
+ * except mid-run: the Cancel button is the only mid-run exit, so a stray
+ * Escape can't silently abandon a half-ingested family.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { Icon } from '../icons';
+
+import {
+  ingestSubpages,
+  listSubpages,
+  type IngestOutcome,
+  type SubpageListing,
+} from '../../services/mirrorPageService';
+import { providerLabel, useIntegrationHubStore } from '../../store/integrationHubStore';
+import { useRichTextPagesStore } from '../../store/richTextPagesStore';
+import { ProviderIcon } from './ProviderIcon';
+import './IngestSubpagesDialog.css';
+
+interface IngestSubpagesDialogProps {
+  pageId: string;
+  onClose: () => void;
+}
+
+type Phase =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'list'; listing: SubpageListing }
+  | { kind: 'running'; done: number; total: number; currentTitle: string }
+  | { kind: 'done'; outcome: IngestOutcome };
+
+export function IngestSubpagesDialog({ pageId, onClose }: IngestSubpagesDialogProps) {
+  const [phase, setPhase] = useState<Phase>({ kind: 'loading' });
+  const [checked, setChecked] = useState<Set<string>>(new Set());
+  const [recurse, setRecurse] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const hub = useIntegrationHubStore((s) => s.hub);
+  const parentName = useRichTextPagesStore((s) => s.pages[pageId]?.name ?? 'Untitled');
+
+  const running = phase.kind === 'running';
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !running) {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey, true);
+    return () => document.removeEventListener('keydown', handleKey, true);
+  }, [onClose, running]);
+
+  // Abandoning the dialog mid-run (unmount) cancels the run.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    listSubpages(pageId)
+      .then((listing) => {
+        if (cancelled) return;
+        setChecked(new Set(listing.candidates.filter((c) => c.status === 'new').map((c) => c.externalId)));
+        setPhase({ kind: 'list', listing });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setPhase({ kind: 'error', message: e instanceof Error ? e.message : 'Could not load subpages.' });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pageId]);
+
+  const toggle = useCallback((externalId: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(externalId)) next.delete(externalId);
+      else next.add(externalId);
+      return next;
+    });
+  }, []);
+
+  const start = useCallback(
+    (listing: SubpageListing) => {
+      const selection = listing.candidates
+        .filter((c) => c.status === 'new' && checked.has(c.externalId))
+        .map(({ externalId, title }) => ({ externalId, title }));
+      if (selection.length === 0) return;
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setPhase({ kind: 'running', done: 0, total: selection.length, currentTitle: '' });
+      void ingestSubpages(pageId, selection, {
+        recurse,
+        signal: ac.signal,
+        onProgress: (done, total, currentTitle) => setPhase({ kind: 'running', done, total, currentTitle }),
+      })
+        .then((outcome) => setPhase({ kind: 'done', outcome }))
+        .catch((e: unknown) => {
+          setPhase({ kind: 'error', message: e instanceof Error ? e.message : 'Ingest failed.' });
+        });
+    },
+    [pageId, checked, recurse],
+  );
+
+  const label = phase.kind === 'list' ? providerLabel(hub, phase.listing.provider) : '';
+  const newCount = phase.kind === 'list' ? phase.listing.candidates.filter((c) => c.status === 'new').length : 0;
+  const selectedCount =
+    phase.kind === 'list'
+      ? phase.listing.candidates.filter((c) => c.status === 'new' && checked.has(c.externalId)).length
+      : 0;
+
+  return (
+    <div
+      className="ingest-subpages-overlay"
+      onMouseDown={(e) => e.target === e.currentTarget && !running && onClose()}
+    >
+      <div className="ingest-subpages" role="dialog" aria-modal="true" aria-label={`Ingest subpages of ${parentName}`}>
+        <div className="ingest-subpages-head">
+          <h2>Ingest subpages of “{parentName}”</h2>
+          {!running && (
+            <button type="button" className="ingest-subpages-close" onClick={onClose} aria-label="Close">
+              <Icon icon={X} size={16} />
+            </button>
+          )}
+        </div>
+
+        {phase.kind === 'loading' && <p className="ingest-subpages-hint">Checking the source for subpages…</p>}
+        {phase.kind === 'error' && <p className="ingest-subpages-error">{phase.message}</p>}
+
+        {phase.kind === 'list' && (
+          <>
+            {phase.listing.candidates.length === 0 ? (
+              <p className="ingest-subpages-hint">
+                No subpages found on the source page. A subpage nested deep inside other content may not be visible
+                to the fetch.
+              </p>
+            ) : (
+              <div className="ingest-subpages-list">
+                {phase.listing.candidates.map((c) => (
+                  <label key={c.externalId} className="ingest-subpages-row" data-present={c.status === 'present' || undefined}>
+                    <input
+                      type="checkbox"
+                      checked={c.status === 'present' || checked.has(c.externalId)}
+                      disabled={c.status === 'present'}
+                      onChange={() => toggle(c.externalId)}
+                    />
+                    <ProviderIcon provider={phase.listing.provider} size={13} />
+                    <span className="ingest-subpages-row-title">{c.title}</span>
+                    {c.status === 'present' && <span className="ingest-subpages-badge">In document</span>}
+                  </label>
+                ))}
+              </div>
+            )}
+
+            {phase.listing.unseen.length > 0 && (
+              <p className="ingest-subpages-hint">
+                Not seen in the latest fetch (possibly nested deeper, possibly removed at the source):{' '}
+                {phase.listing.unseen.map((u) => u.name).join(', ')}. Nothing is deleted automatically.
+              </p>
+            )}
+
+            <label className="ingest-subpages-recurse">
+              <input type="checkbox" checked={recurse} onChange={(e) => setRecurse(e.target.checked)} />
+              Include nested subpages (depth-limited)
+            </label>
+
+            <div className="ingest-subpages-foot">
+              <span className="ingest-subpages-hint">
+                {newCount === 0 ? 'Everything is already mirrored.' : `${selectedCount} of ${newCount} new subpage(s) selected`}
+              </span>
+              <button
+                type="button"
+                className="ingest-subpages-primary"
+                disabled={selectedCount === 0}
+                onClick={() => start(phase.listing)}
+              >
+                Ingest from {label}
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase.kind === 'running' && (
+          <>
+            <p className="ingest-subpages-hint">
+              Ingesting {phase.done + 1} of {phase.total}
+              {phase.currentTitle ? ` — “${phase.currentTitle}”` : ''}…
+            </p>
+            <div className="ingest-subpages-progress">
+              <div
+                className="ingest-subpages-progress-fill"
+                style={{ width: `${phase.total > 0 ? Math.round((phase.done / phase.total) * 100) : 0}%` }}
+              />
+            </div>
+            <div className="ingest-subpages-foot">
+              <span />
+              <button type="button" onClick={() => abortRef.current?.abort()}>
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase.kind === 'done' && (
+          <>
+            <p className="ingest-subpages-hint">
+              Added {phase.outcome.added} page(s)
+              {phase.outcome.skipped > 0 ? `, skipped ${phase.outcome.skipped} already present` : ''}
+              {phase.outcome.truncated > 0 ? `, ${phase.outcome.truncated} left out by the per-run limit` : ''}
+              {phase.outcome.aborted ? ' — run cancelled early' : ''}.
+            </p>
+            {phase.outcome.failed.length > 0 && (
+              <p className="ingest-subpages-error">
+                Failed: {phase.outcome.failed.map((f) => f.title).join(', ')}. Re-run to retry.
+              </p>
+            )}
+            {phase.outcome.warnings.length > 0 && (
+              <p className="ingest-subpages-hint">
+                {phase.outcome.warnings.reduce((n, w) => n + (w.count ?? 1), 0)} element(s) could not be mirrored
+                faithfully.
+              </p>
+            )}
+            <div className="ingest-subpages-foot">
+              <span />
+              <button type="button" className="ingest-subpages-primary" onClick={onClose}>
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Slice 2 of JP-475 (nested integration pages), consuming the `childRefs` contract from docushark-web#108. Degrades gracefully against a control plane without the field (missing = empty listing).

## Design invariant

**Physical composition never becomes a tree.** `pageOrder` stays flat (it is the PDF export order); the subpage hierarchy is derived from one optional field, `PageMirrorMeta.parentExternalId`, and rendered by navigation surfaces only.

## What

- **Model:** `parentExternalId` + the `pageMirrorEquals` extension (the only field-enumerating site on the collab page-list path). Additive-optional: no migration, no `DOCUMENT_VERSION` bump, no relay sync changes (hydrate/flatten/broadcast handle page meta generically — verified).
- **Refresh preserves the family:** the server `sourceRef` never echoes `parentExternalId`, so `refreshMirrorPage` now carries the existing value through the meta rebuild. Unpatched, refreshing any subpage silently orphaned it — test-pinned.
- **Derivation** (`services/mirrorFamily.ts`, pure + unit-tested): family index, cycle-breaking, logical depth-first flatten, physical `familyBlock` (contiguous run only; user-scattered strays are respected).
- **Ingestion:** `listSubpages` (fresh fetch, diff: new / present / unseen-in-latest-fetch — info only) + `ingestSubpages` (sequential with 350 ms spacing, failure collection, cancel, depth 3 / total 25 caps, optional recursion, depth-first insertion). Race-guarded against collab peers mirroring the same source mid-run and against document switches.
- **Tab bar:** families collapse to the root tab (chevron + count, flyout tree, "Root › Child" active label); collapsed pages stay reachable via the strip overflow menu (indented); drag translates item blocks → `movePages` (item index ≠ pageOrder index once collapsed). Context menu gains "Ingest subpages…".
- **Relay:** `project_public` gains a second pipeline stage stripping `richTextPages.pages[*].mirror` from published artifacts — provider ids and source URLs (whose slugs embed source page titles) are owner provenance, not guest content. Guest impact: no provider glyph, flat tabs (pageOrder is depth-first reading order anyway).

## Verification

- Typecheck clean; **full vitest suite 3272/3272** (279 files — includes the tab bar/strip consumers).
- New coverage: family derivation (orphans, provider boundaries, cycles, scatter), positional insert/`movePages` invariants, `pageMirrorEquals` per-field, **refresh-preserves-parent**, ingest ordering (recursed grandchild lands under its parent, later pages stay after the family), failure/skip/abort semantics, `listSubpages` diff.
- Relay: `cargo check --all-targets` clean; publish module tests 9/9 including the new strip test (leak needles + content/order intact).
- E2E (tab collapse against a real Notion tree, publish artifact inspection, second collab client) queued for the local-stack pass before the issue closes.

Assisted-by: Fable 5
