### PR TITLE
JP-475: Navigator panel — per-document hub for pages and sources

### DIFF
--- a/docs-site/guide/layout-modes.md
+++ b/docs-site/guide/layout-modes.md
@@ -40,6 +40,12 @@ Your layout is an **app-level** setting — a single active mode for the whole
 editor, not a per-document one. Customizations you make to one layout (say, moving
 the properties panel) stay scoped to that layout and don't disturb the others.
 
+Beyond the panels each layout shows by default, the opt-in **Navigator** panel
+(every page in the document, with subpage structure and reordering — see
+[Multi-Page Documents](./multi-page-documents#the-navigator-panel)) can be
+enabled per layout under **Settings → Appearance → Layout**, or with **Toggle
+Navigator panel** in the command palette.
+
 ## Focus in Relaxed
 
 Because Relaxed is writing-first, it adds a **Write · Split · Diagram** focus

--- a/docs-site/guide/multi-page-documents.md
+++ b/docs-site/guide/multi-page-documents.md
@@ -56,12 +56,50 @@ Mirrored pages behave differently from normal pages:
 - **Read-only** — the content belongs to the source; edit it there.
 - **The name follows the source** — renaming happens on refresh, not locally.
 - **Right-click the tab** for the mirror actions: **Open in Notion** jumps to
-  the original, **Refresh from source** pulls the latest content, and
-  **Detach** converts it into a normal editable page (keeping the content as
-  last synced — this can't be undone).
+  the original, **Refresh from source** pulls the latest content, **Ingest
+  subpages…** brings the source's subpages in (below), and **Detach** converts
+  it into a normal editable page (keeping the content as last synced — this
+  can't be undone).
 
 Anything the import can't represent faithfully is reported when the page is
 added, so you always know if something was left behind.
+
+### Subpages
+
+When the source page has its own subpages, **Ingest subpages…** (on the tab's
+right-click menu) lists them so you can mirror any or all of them — optionally
+including nested subpages, a few levels deep. Each one becomes its own mirrored
+page, placed directly after its parent so the document reads top-to-bottom in
+the same order as the source.
+
+A page with ingested subpages shows a **single tab for the whole group**, with
+a count and a chevron. Click the chevron to open the group and jump to any
+subpage; the tab shows *Parent › Subpage* while a subpage is active. The
+overflow menu (when tabs don't fit) lists grouped pages indented under their
+parent, so everything stays reachable.
+
+Subpages are ordinary mirrored pages — refresh, detach, and delete work on
+each one individually from the **Navigator** panel (below). Deleting or
+detaching a parent never touches its subpages; they simply become top-level
+pages.
+
+### The Navigator panel
+
+The **Navigator** is a side panel listing every page in the document — prose
+pages (with their subpage structure) and canvas pages — in export order. Turn
+it on per layout under **Settings → Appearance → Layout**, or run **Toggle
+Navigator panel** from the command palette.
+
+From the Navigator you can:
+
+- **Jump** to any page, including subpages, with one click.
+- **Reorder** pages by dragging — a parent drags its whole subpage group.
+- **See freshness** — each mirrored page shows how long ago it was synced.
+- **Act on any mirrored page** via its row menu: refresh, ingest subpages,
+  open the source, detach, or delete.
+- **Refresh all** pages from a source with one button.
+- **Match structure** — if pages have been moved around, one click reorders
+  the document to read depth-first again, subpages under their parents.
 
 ## Working with Multiple Pages
 

--- a/src/engine/CommandRegistry.ts
+++ b/src/engine/CommandRegistry.ts
@@ -24,7 +24,7 @@ import {
   canAutoLayoutSelection,
 } from './selectionLayout';
 import type { ShortcutCategory } from './KeyboardShortcuts';
-import { LAYOUT_LABELS } from '../ui/layout/modes';
+import { LAYOUT_LABELS, LAYOUT_PRESETS } from '../ui/layout/modes';
 import { LAYOUT_MODES, type LayoutMode } from '../ui/layout/types';
 import { parseCombo, eventMatchesAny, formatCombo, type KeyScope } from './keybindings';
 import { navigateActivePage } from './pageNavigation';
@@ -340,6 +340,22 @@ function buildCommands(): Command[] {
       execute: () => useSessionStore.getState().cycleRelaxedFocus(),
       // Focus only applies to the writing-first Relaxed layout.
       canExecute: () => useUIPreferencesStore.getState().layout.defaultMode === 'relaxed',
+    },
+    {
+      id: 'view.toggleNavigator',
+      label: 'Toggle Navigator panel',
+      category: 'View',
+      scope: 'global',
+      // No default binding — Mod+Shift+1..4 belong to layouts; the palette (and
+      // the panel-chrome menu / Settings → Layout) are the affordances (JP-475).
+      execute: () => {
+        const prefs = useUIPreferencesStore.getState();
+        const mode = prefs.layout.defaultMode;
+        const visible =
+          prefs.layout.modeOverrides[mode]?.navigator?.visible ??
+          LAYOUT_PRESETS[mode].navigator.visible;
+        prefs.setPanelVisibleFor(mode, 'navigator', !visible);
+      },
     },
   ];
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -527,7 +527,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             )
           )}
 
-          {/* Navigator on left (JP-475). */}
+          {/* Navigator on left (JP-475). Docked = resizable (DockedPanel), so a
+              deep subpage tree can be given the width it needs. */}
           {!mobileActive && isNavigatorVisible && navigatorPanelState.dock === 'left' && (
             <PanelChromeWrapper panelId="navigator">
               <ErrorBoundary sectionName="Navigator">
@@ -541,7 +542,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
                     <NavigatorPanel />
                   </FlyoutPanel>
                 ) : (
-                  <NavigatorPanel />
+                  <DockedPanel panelId="navigator" side="left" defaultWidth={300} minWidth={240}>
+                    <NavigatorPanel />
+                  </DockedPanel>
                 )}
               </ErrorBoundary>
             </PanelChromeWrapper>
@@ -628,7 +631,8 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             </PanelChromeWrapper>
           )}
 
-          {/* Navigator on right (JP-475). */}
+          {/* Navigator on right (JP-475). Docked = resizable (DockedPanel), so a
+              deep subpage tree can be given the width it needs. */}
           {!mobileActive && isNavigatorVisible && navigatorPanelState.dock === 'right' && (
             <PanelChromeWrapper panelId="navigator">
               <ErrorBoundary sectionName="Navigator">
@@ -642,7 +646,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
                     <NavigatorPanel />
                   </FlyoutPanel>
                 ) : (
-                  <NavigatorPanel />
+                  <DockedPanel panelId="navigator" side="right" defaultWidth={300} minWidth={240}>
+                    <NavigatorPanel />
+                  </DockedPanel>
                 )}
               </ErrorBoundary>
             </PanelChromeWrapper>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,6 +4,7 @@ import './mobile/mobile.css';
 import { CanvasContainer } from './CanvasContainer';
 import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
+import { NavigatorPanel } from './NavigatorPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
 import { isFlyoutLayout, propertiesDockedVisible, resolveRegions } from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
@@ -129,6 +130,7 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   const documentPanelState = useActivePanelState('document');
   const propertiesPanelState = useActivePanelState('properties');
   const layersPanelState = useActivePanelState('layers');
+  const navigatorPanelState = useActivePanelState('navigator');
   const layoutActions = useLayoutActions();
   const isDocumentVisible = documentPanelState.visible;
   // Relaxed never docks Properties (selection-only overlay) even if a stale
@@ -136,6 +138,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   // otherwise it shows docked over the prose, including in `write` focus.
   const isPropertiesVisible = propertiesDockedVisible(activeMode, propertiesPanelState);
   const isLayersVisible = layersPanelState.visible;
+  const isNavigatorVisible = navigatorPanelState.visible;
+  const navigatorUsesFlyout =
+    isNavigatorVisible && isFlyoutLayout(activeMode) && !navigatorPanelState.pinned;
   // Properties panel uses the fly-out wrapper in Designer/Technician unless the
   // user has pinned it for this layout. Power keeps it docked; Relaxed hides
   // it (unless selection triggers the transient overlay — see below).
@@ -522,6 +527,26 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
             )
           )}
 
+          {/* Navigator on left (JP-475). */}
+          {!mobileActive && isNavigatorVisible && navigatorPanelState.dock === 'left' && (
+            <PanelChromeWrapper panelId="navigator">
+              <ErrorBoundary sectionName="Navigator">
+                {navigatorUsesFlyout ? (
+                  <FlyoutPanel
+                    panelId="navigator"
+                    label="Navigator"
+                    icon={<span style={{ fontSize: 12, fontWeight: 700 }}>N</span>}
+                    side="left"
+                  >
+                    <NavigatorPanel />
+                  </FlyoutPanel>
+                ) : (
+                  <NavigatorPanel />
+                )}
+              </ErrorBoundary>
+            </PanelChromeWrapper>
+          )}
+
           {/* Properties on left (suppressed on mobile — the full-screen
               MobilePropertySheet below takes over). */}
           {!mobileActive && renderProperties && propertiesPanelState.dock === 'left' && (
@@ -598,6 +623,26 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
                   </FlyoutPanel>
                 ) : (
                   <PropertyPanel />
+                )}
+              </ErrorBoundary>
+            </PanelChromeWrapper>
+          )}
+
+          {/* Navigator on right (JP-475). */}
+          {!mobileActive && isNavigatorVisible && navigatorPanelState.dock === 'right' && (
+            <PanelChromeWrapper panelId="navigator">
+              <ErrorBoundary sectionName="Navigator">
+                {navigatorUsesFlyout ? (
+                  <FlyoutPanel
+                    panelId="navigator"
+                    label="Navigator"
+                    icon={<span style={{ fontSize: 12, fontWeight: 700 }}>N</span>}
+                    side="right"
+                  >
+                    <NavigatorPanel />
+                  </FlyoutPanel>
+                ) : (
+                  <NavigatorPanel />
                 )}
               </ErrorBoundary>
             </PanelChromeWrapper>

--- a/src/ui/NavigatorPanel.css
+++ b/src/ui/NavigatorPanel.css
@@ -1,15 +1,17 @@
 /* NavigatorPanel (JP-475) — per-document hub: pages tree + mirror sources. */
 
+/* Fills its container: docked it lives inside a resizable DockedPanel (which
+   owns the width + edge border); in a flyout it fills the flyout body. */
 .navigator-panel {
-  width: 260px;
+  width: 100%;
   height: 100%;
+  min-width: 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px;
+  padding: 8px 6px 8px 4px;
   background: var(--bg-primary);
-  border-left: 1px solid var(--border-color);
 }
 
 .navigator-section-head {
@@ -115,13 +117,19 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 6px;
+  padding: 4px 4px;
   border: none;
   background: none;
   color: var(--text-primary);
   font-size: var(--font-size-sm, 13px);
   text-align: left;
   cursor: pointer;
+}
+
+/* The name is the point of the row: it takes the slack, everything else is
+   sized to content so a deep tree still reads at the minimum panel width. */
+.navigator-row-main > :not(.navigator-row-name) {
+  flex: none;
 }
 
 .navigator-row-dot {
@@ -134,6 +142,10 @@
 }
 
 .navigator-row-name {
+  flex: 1 1 auto;
+  /* min-width:0 is what actually lets a flex child ellipsize instead of
+     forcing the row wider than the panel. */
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/ui/NavigatorPanel.css
+++ b/src/ui/NavigatorPanel.css
@@ -1,0 +1,171 @@
+/* NavigatorPanel (JP-475) — per-document hub: pages tree + mirror sources. */
+
+.navigator-panel {
+  width: 260px;
+  height: 100%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  background: var(--bg-primary);
+  border-left: 1px solid var(--border-color);
+}
+
+.navigator-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.navigator-section-head h3 {
+  margin: 0;
+  font-size: var(--font-size-xs, 11px);
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.navigator-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.navigator-head-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full, 999px);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs, 11px);
+  cursor: pointer;
+}
+
+.navigator-head-btn:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.navigator-head-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.navigator-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.navigator-block-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 2px 0;
+}
+
+.navigator-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 2px;
+  color: var(--text-muted);
+  cursor: grab;
+  flex: none;
+}
+
+.navigator-block-rows {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.navigator-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.navigator-row:hover {
+  background: var(--bg-secondary);
+}
+
+.navigator-row.active {
+  background: var(--color-primary-light, var(--bg-secondary));
+}
+
+.navigator-row.active .navigator-row-name {
+  color: var(--color-primary, var(--text-primary));
+  font-weight: var(--font-weight-medium, 500);
+}
+
+.navigator-row-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm, 13px);
+  text-align: left;
+  cursor: pointer;
+}
+
+.navigator-row-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full, 999px);
+  background: var(--text-muted);
+  opacity: 0.5;
+  flex: none;
+}
+
+.navigator-row-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.navigator-row-synced {
+  flex: none;
+  margin-left: auto;
+  font-size: var(--font-size-xs, 10px);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.navigator-row-menu {
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  padding: 4px;
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+  flex: none;
+  /* Names win the width fight — the kebab appears on row hover (or while its
+     menu is open) rather than reserving space on every row. */
+  visibility: hidden;
+}
+
+.navigator-row:hover .navigator-row-menu,
+.navigator-row-menu[aria-expanded='true'] {
+  visibility: visible;
+}
+
+.navigator-row-menu:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary, var(--bg-secondary));
+}

--- a/src/ui/NavigatorPanel.tsx
+++ b/src/ui/NavigatorPanel.tsx
@@ -183,7 +183,7 @@ export function NavigatorPanel() {
       <div
         key={pageId}
         className={`navigator-row ${activePageId === pageId ? 'active' : ''}`}
-        style={depth > 0 ? { paddingLeft: depth * 16 } : undefined}
+        style={depth > 0 ? { paddingLeft: depth * 12 } : undefined}
       >
         <button type="button" className="navigator-row-main" onClick={() => setActivePage(pageId)}>
           {m ? <ProviderIcon provider={m.provider} size={13} /> : <span className="navigator-row-dot" />}

--- a/src/ui/NavigatorPanel.tsx
+++ b/src/ui/NavigatorPanel.tsx
@@ -1,0 +1,294 @@
+/**
+ * NavigatorPanel (JP-475) — the per-document hub: composition + sources.
+ *
+ * Two sections, matching how export actually works (prose and canvas are two
+ * independent `pageOrder` sequences in the PDF pipeline):
+ *  - Prose pages: top-level rows in physical order; a family root renders its
+ *    LOGICAL descendants indented beneath it, and the whole block drags as one
+ *    unit (a ReorderableList row = one top-level block). Mirror rows carry the
+ *    provider glyph, staleness, and a kebab of mirror actions — including the
+ *    per-SUBPAGE actions the tab bar cannot offer (its context menu binds to
+ *    the root tab).
+ *  - Canvas pages: flat list, reorder + jump.
+ *
+ * Provider-agnostic by construction: everything rendered comes from page
+ * mirror state + integrationHubStore labels. Reordering touches ONLY the
+ * physical order; "Match structure" normalizes it to the logical tree
+ * (depth-first) — the repair for user-scattered families.
+ */
+import { useMemo, useState } from 'react';
+import { ArrowDownWideNarrow, GripVertical, MoreHorizontal, RefreshCw } from 'lucide-react';
+import { Icon } from './icons';
+
+import { useRichTextPagesStore } from '../store/richTextPagesStore';
+import { usePageStore } from '../store/pageStore';
+import { providerLabel, useIntegrationHubStore } from '../store/integrationHubStore';
+import { useNotificationStore } from '../store/notificationStore';
+import {
+  buildMirrorFamilyIndex,
+  descendantEntries,
+  familyBlock,
+  isFamilyRoot,
+} from '../services/mirrorFamily';
+import { refreshMirrorPage, detachMirrorPage } from '../services/mirrorPageService';
+import { IngestSubpagesDialog } from './integrations/IngestSubpagesDialog';
+import { ProviderIcon } from './integrations/ProviderIcon';
+import { ReorderableList } from './properties/ReorderableList';
+import { DropdownMenu, menuAction, MENU_SEPARATOR, type DropdownMenuEntry } from './components/DropdownMenu';
+import { confirmDialog } from './confirm/confirmStore';
+import { opener } from '../platform/opener';
+import './NavigatorPanel.css';
+
+/** Compact staleness for a mirror row ("23m", "5d") — the row is 260px wide
+ *  and the page name always wins; the title attr carries the sentence. */
+function syncedShort(syncedAt: number, now = Date.now()): string {
+  const mins = Math.max(0, Math.floor((now - syncedAt) / 60_000));
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/** Same pacing as batch ingest — provider rate limits, no retry infra. */
+const REFRESH_DELAY_MS = 350;
+
+export function NavigatorPanel() {
+  const { pages, pageOrder, activePageId, setActivePage, movePages, deletePage } = useRichTextPagesStore();
+  const canvasPages = usePageStore((s) => s.pages);
+  const canvasOrder = usePageStore((s) => s.pageOrder);
+  const canvasActiveId = usePageStore((s) => s.activePageId);
+  const setCanvasActive = usePageStore((s) => s.setActivePage);
+  const reorderCanvas = usePageStore((s) => s.reorderPages);
+  const hub = useIntegrationHubStore((s) => s.hub);
+
+  const [ingestPageId, setIngestPageId] = useState<string | null>(null);
+  const [refreshingAll, setRefreshingAll] = useState(false);
+
+  const familyIndex = useMemo(() => buildMirrorFamilyIndex(pages, pageOrder), [pages, pageOrder]);
+  const topLevel = useMemo(
+    () => pageOrder.filter((id) => pages[id] !== undefined && isFamilyRoot(familyIndex, id)),
+    [pageOrder, pages, familyIndex],
+  );
+  const blocks = useMemo(
+    () => topLevel.map((id) => (familyIndex.childrenOf.has(id) ? familyBlock(familyIndex, pageOrder, id) : [id])),
+    [topLevel, familyIndex, pageOrder],
+  );
+
+  /** Providers with at least one mirror page in this document. */
+  const docProviders = useMemo(() => {
+    const set = new Set<string>();
+    for (const id of pageOrder) {
+      const m = pages[id]?.mirror;
+      if (m) set.add(m.provider);
+    }
+    return [...set];
+  }, [pages, pageOrder]);
+
+  const handleTopLevelReorder = (fromIndex: number, toIndex: number) => {
+    const moved = blocks[fromIndex];
+    if (!moved) return;
+    const rest = blocks.filter((_, i) => i !== fromIndex);
+    const itemTo = Math.max(0, Math.min(toIndex, rest.length));
+    const pagesBefore = rest.slice(0, itemTo).reduce((n, b) => n + b.length, 0);
+    movePages(moved, pagesBefore);
+  };
+
+  /** Normalize physical order to the logical tree: each root block (root plus
+   *  ALL logical descendants — strays pulled home) moves to the end in current
+   *  top-level order, so the result reads depth-first. */
+  const handleOrderToStructure = () => {
+    for (const rootId of topLevel) {
+      const ids = [rootId, ...descendantEntries(familyIndex, rootId).map((e) => e.pageId)];
+      movePages(ids, useRichTextPagesStore.getState().pageOrder.length);
+    }
+  };
+
+  const handleRefreshAll = async (provider: string) => {
+    if (refreshingAll) return;
+    setRefreshingAll(true);
+    const notifications = useNotificationStore.getState();
+    const targets = useRichTextPagesStore
+      .getState()
+      .pageOrder.filter((id) => useRichTextPagesStore.getState().pages[id]?.mirror?.provider === provider);
+    let ok = 0;
+    let failed = 0;
+    for (const id of targets) {
+      try {
+        if (ok + failed > 0) await new Promise((r) => setTimeout(r, REFRESH_DELAY_MS));
+        await refreshMirrorPage(id);
+        ok += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+    setRefreshingAll(false);
+    if (failed > 0) notifications.error(`Refreshed ${ok} page(s); ${failed} failed.`);
+    else notifications.success(`Refreshed ${ok} page(s) from ${providerLabel(hub, provider)}.`);
+  };
+
+  const mirrorMenuEntries = (pageId: string): DropdownMenuEntry[] => {
+    const page = pages[pageId];
+    const m = page?.mirror;
+    if (!page || !m) return [];
+    const label = providerLabel(hub, m.provider);
+    return [
+      menuAction({
+        id: 'refresh',
+        label: 'Refresh from source',
+        onSelect: () => {
+          void refreshMirrorPage(pageId).catch((e: unknown) => {
+            useNotificationStore.getState().error(e instanceof Error ? e.message : 'Refresh failed.');
+          });
+        },
+      }),
+      menuAction({ id: 'ingest', label: 'Ingest subpages…', onSelect: () => setIngestPageId(pageId) }),
+      ...(m.url
+        ? [
+            menuAction({
+              id: 'open',
+              label: `Open in ${label}`,
+              onSelect: () => void opener.openExternalUrl(m.url!),
+            }),
+          ]
+        : []),
+      MENU_SEPARATOR,
+      menuAction({
+        id: 'detach',
+        label: `Detach from ${label}`,
+        onSelect: () => {
+          void confirmDialog({
+            title: `Detach from ${label}?`,
+            message: 'The page becomes a normal, editable page with the content as last synced.',
+            confirmLabel: 'Detach',
+          }).then((confirmed) => {
+            if (confirmed) detachMirrorPage(pageId);
+          });
+        },
+      }),
+      menuAction({
+        id: 'delete',
+        label: 'Delete page',
+        danger: true,
+        onSelect: () => deletePage(pageId),
+      }),
+    ];
+  };
+
+  const proseRow = (pageId: string, depth: number) => {
+    const page = pages[pageId];
+    if (!page) return null;
+    const m = page.mirror;
+    return (
+      <div
+        key={pageId}
+        className={`navigator-row ${activePageId === pageId ? 'active' : ''}`}
+        style={depth > 0 ? { paddingLeft: depth * 16 } : undefined}
+      >
+        <button type="button" className="navigator-row-main" onClick={() => setActivePage(pageId)}>
+          {m ? <ProviderIcon provider={m.provider} size={13} /> : <span className="navigator-row-dot" />}
+          <span className="navigator-row-name">{page.name}</span>
+          {m && (
+            <span className="navigator-row-synced" title={`Last synced ${syncedShort(m.syncedAt)} ago`}>
+              {syncedShort(m.syncedAt)}
+            </span>
+          )}
+        </button>
+        {m && (
+          <DropdownMenu
+            trigger={<Icon icon={MoreHorizontal} size={14} />}
+            triggerTitle={`Actions for ${page.name}`}
+            triggerClassName="navigator-row-menu"
+            entries={mirrorMenuEntries(pageId)}
+          />
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="navigator-panel" aria-label="Navigator">
+      <div className="navigator-section-head">
+        <h3>Pages</h3>
+        <div className="navigator-head-actions">
+          {docProviders.map((p) => (
+            <button
+              key={p}
+              type="button"
+              className="navigator-head-btn"
+              disabled={refreshingAll}
+              title={`Refresh every ${providerLabel(hub, p)} page from its source`}
+              onClick={() => void handleRefreshAll(p)}
+            >
+              <Icon icon={RefreshCw} size={13} />
+              {providerLabel(hub, p)}
+            </button>
+          ))}
+          {familyIndex.parentOf.size > 0 && (
+            <button
+              type="button"
+              className="navigator-head-btn"
+              title="Reorder pages to read depth-first, matching the subpage structure"
+              onClick={handleOrderToStructure}
+            >
+              <Icon icon={ArrowDownWideNarrow} size={13} />
+              Match structure
+            </button>
+          )}
+        </div>
+      </div>
+
+      <ReorderableList
+        items={topLevel}
+        getKey={(id) => id}
+        onReorder={handleTopLevelReorder}
+        listClassName="navigator-list"
+        rowClassName="navigator-block"
+        renderItem={(id, _index, handleProps) => (
+          <div className="navigator-block-inner">
+            <span className="navigator-drag-handle" {...handleProps}>
+              <Icon icon={GripVertical} size={13} />
+            </span>
+            <div className="navigator-block-rows">
+              {proseRow(id, 0)}
+              {descendantEntries(familyIndex, id).map(({ pageId, depth }) => proseRow(pageId, depth))}
+            </div>
+          </div>
+        )}
+      />
+
+      <div className="navigator-section-head">
+        <h3>Canvas pages</h3>
+      </div>
+      <ReorderableList
+        items={canvasOrder}
+        getKey={(id) => id}
+        onReorder={(from, to) => {
+          const next = [...canvasOrder];
+          const [moved] = next.splice(from, 1);
+          if (moved !== undefined) {
+            next.splice(to, 0, moved);
+            reorderCanvas(next);
+          }
+        }}
+        listClassName="navigator-list"
+        rowClassName="navigator-block"
+        renderItem={(id, _index, handleProps) => (
+          <div className="navigator-block-inner">
+            <span className="navigator-drag-handle" {...handleProps}>
+              <Icon icon={GripVertical} size={13} />
+            </span>
+            <div className={`navigator-row ${canvasActiveId === id ? 'active' : ''}`}>
+              <button type="button" className="navigator-row-main" onClick={() => setCanvasActive(id)}>
+                <span className="navigator-row-dot" />
+                <span className="navigator-row-name">{canvasPages[id]?.name ?? 'Untitled'}</span>
+              </button>
+            </div>
+          </div>
+        )}
+      />
+
+      {ingestPageId && <IngestSubpagesDialog pageId={ingestPageId} onClose={() => setIngestPageId(null)} />}
+    </div>
+  );
+}

--- a/src/ui/layout/modes.ts
+++ b/src/ui/layout/modes.ts
@@ -48,26 +48,26 @@ export const LAYOUT_PRESETS: Record<LayoutMode, LayoutPanelMap> = {
     document: { dock: 'left', visible: true, order: 0 },
     properties: { dock: 'right', visible: false, order: 0, width: 240 },
     layers: { dock: 'right', visible: false, order: 0 },
-    navigator: { dock: 'right', visible: false, order: 1, width: 260 },
+    navigator: { dock: 'right', visible: false, order: 1, width: 300 },
   },
   designer: {
     document: { dock: 'left', visible: false, order: 0, width: 320 },
     properties: { dock: 'right', visible: true, order: 0, width: 240 },
     layers: { dock: 'right', visible: true, order: 1 },
-    navigator: { dock: 'right', visible: false, order: 2, width: 260 },
+    navigator: { dock: 'right', visible: false, order: 2, width: 300 },
   },
   technician: {
     document: { dock: 'left', visible: true, order: 0, width: 320 },
     properties: { dock: 'right', visible: true, order: 0, width: 240 },
     layers: { dock: 'right', visible: true, order: 1 },
-    navigator: { dock: 'right', visible: false, order: 2, width: 260 },
+    navigator: { dock: 'right', visible: false, order: 2, width: 300 },
   },
   power: {
     document: { dock: 'left', visible: true, order: 0, width: 320 },
     properties: { dock: 'right', visible: true, order: 0, width: 240, pinned: true },
     layers: { dock: 'right', visible: true, order: 1, pinned: true },
     // Opt-in everywhere (AGENTS.md: new panels default hidden), Power included.
-    navigator: { dock: 'right', visible: false, order: 2, width: 260, pinned: true },
+    navigator: { dock: 'right', visible: false, order: 2, width: 300, pinned: true },
   },
 };
 

--- a/src/ui/layout/modes.ts
+++ b/src/ui/layout/modes.ts
@@ -48,21 +48,26 @@ export const LAYOUT_PRESETS: Record<LayoutMode, LayoutPanelMap> = {
     document: { dock: 'left', visible: true, order: 0 },
     properties: { dock: 'right', visible: false, order: 0, width: 240 },
     layers: { dock: 'right', visible: false, order: 0 },
+    navigator: { dock: 'right', visible: false, order: 1, width: 260 },
   },
   designer: {
     document: { dock: 'left', visible: false, order: 0, width: 320 },
     properties: { dock: 'right', visible: true, order: 0, width: 240 },
     layers: { dock: 'right', visible: true, order: 1 },
+    navigator: { dock: 'right', visible: false, order: 2, width: 260 },
   },
   technician: {
     document: { dock: 'left', visible: true, order: 0, width: 320 },
     properties: { dock: 'right', visible: true, order: 0, width: 240 },
     layers: { dock: 'right', visible: true, order: 1 },
+    navigator: { dock: 'right', visible: false, order: 2, width: 260 },
   },
   power: {
     document: { dock: 'left', visible: true, order: 0, width: 320 },
     properties: { dock: 'right', visible: true, order: 0, width: 240, pinned: true },
     layers: { dock: 'right', visible: true, order: 1, pinned: true },
+    // Opt-in everywhere (AGENTS.md: new panels default hidden), Power included.
+    navigator: { dock: 'right', visible: false, order: 2, width: 260, pinned: true },
   },
 };
 

--- a/src/ui/layout/types.ts
+++ b/src/ui/layout/types.ts
@@ -9,7 +9,7 @@
 export type LayoutMode = 'relaxed' | 'designer' | 'technician' | 'power';
 
 /** Side panels addressable by the layout system. */
-export type PanelId = 'document' | 'properties' | 'layers';
+export type PanelId = 'document' | 'properties' | 'layers' | 'navigator';
 
 /** Which side of the canvas a panel docks to when visible. */
 export type DockSide = 'left' | 'right';
@@ -80,4 +80,4 @@ export const LAYOUT_MODES: readonly LayoutMode[] = [
 ] as const;
 
 /** Ordered tuple of all known panels. */
-export const PANEL_IDS: readonly PanelId[] = ['document', 'properties', 'layers'] as const;
+export const PANEL_IDS: readonly PanelId[] = ['document', 'properties', 'layers', 'navigator'] as const;

--- a/src/ui/settings/LayoutSettings.tsx
+++ b/src/ui/settings/LayoutSettings.tsx
@@ -20,6 +20,7 @@ const PANEL_LABELS: Record<PanelId, string> = {
   document: 'Document',
   properties: 'Properties',
   layers: 'Layers',
+  navigator: 'Navigator',
 };
 
 const DOCK_LABELS: Record<DockSide, string> = {


### PR DESCRIPTION
Slice 3 of JP-475 (final slice) — the "customs office": one panel for document composition and integration sources.

## What

- **New dockable `navigator` panel** via the documented layout 3-step: `PanelId` + `PANEL_IDS`, presets in all four modes (hidden by default — opt-in per AGENTS.md), left/right dock mounts in `App.tsx` (FlyoutPanel in Designer/Technician when unpinned), `PANEL_LABELS` so Settings → Layout lists it, and a `view.toggleNavigator` palette command (no default binding; `Mod+Shift+1..4` belong to layouts).
- **Content**: prose pages as their logical subpage tree (families indented under roots, in export order) + canvas pages, matching how PDF export actually walks the two sequences. Rows carry provider glyph + compact staleness; hover kebab exposes per-page mirror actions.
- **Closes Slice 2's known gap**: subpages now have refresh / ingest / open-source / detach / delete — the tab bar's context menu only ever binds to the root tab.
- **Reorder** drags a parent's whole contiguous block (same block→`movePages` translation as the tab bar; `ReorderableList` pointer events per the WebKitGTK lesson). **Match structure** normalizes physical order depth-first, pulling scattered strays home. **Refresh all** per provider, sequential at ingest pacing.
- **Docs (same PR)**: `multi-page-documents.md` gains *Subpages* and *The Navigator panel*; `layout-modes.md` points at the opt-in panel.

## Verification

- Typecheck clean; full vitest suite **3272/3272**; OSS leak grep clean.
- Live on the local stack against the 26-page real-Notion family from the Slice 2 E2E: per-layout settings pickup, docked render in Power, row navigation (breadcrumb confirms), Match-structure idempotence, per-subpage kebab, and the panel + family surviving a full reload (uiPreferences needed no version bump; family meta round-tripped relay persistence).
- One environment finding during verification, not caused by this change: next-dev module re-evaluation can double-register source connectors and 500 the integrations routes (`lib/integrations/registry.ts` throws on duplicate). Restarting the web dev server clears it; a one-line idempotent re-register in docushark-web would remove the trap — left as a follow-up note.

Assisted-by: Fable 5
