### PR TITLE
JP-476: contain yrs decoder panics on untrusted sync input

### DIFF
--- a/relay/src/sync/binary.rs
+++ b/relay/src/sync/binary.rs
@@ -20,6 +20,8 @@
 use yrs::updates::decoder::Decode;
 use yrs::{Doc, ReadTxn, StateVector, Transact, Update};
 
+use crate::sync::decode_guard::guard_decode;
+
 /// Magic prefix identifying a DocuShark binary Y.Doc sidecar.
 const MAGIC: &[u8; 4] = b"DSKY";
 /// Bump when the header or payload framing changes incompatibly.
@@ -61,13 +63,22 @@ pub fn decode_header(bytes: &[u8]) -> Option<(u64, &[u8])> {
 /// Build a fresh `Doc` by applying a lib0-v1 state update. Returns `Err` on a
 /// malformed/corrupt update so the caller can fall back to JSON hydration —
 /// a bad sidecar must never take a document down.
+///
+/// A `Result` alone did not make that promise true: a truncated or corrupt
+/// sidecar can decode a client id wider than `yrs`'s 53-bit space and panic
+/// inside the decoder rather than returning `Err` (JP-476). The whole build
+/// therefore runs under [`guard_decode`] — sound here because the `Doc` is
+/// local and dropped on the error path, so an unwind cannot leave a live
+/// document half-applied.
 pub fn doc_from_update(update: &[u8]) -> Result<Doc, String> {
-    let doc = Doc::new();
-    let decoded = Update::decode_v1(update).map_err(|e| e.to_string())?;
-    doc.transact_mut()
-        .apply_update(decoded)
-        .map_err(|e| e.to_string())?;
-    Ok(doc)
+    guard_decode("binary sidecar", || {
+        let doc = Doc::new();
+        let decoded = Update::decode_v1(update).map_err(|e| e.to_string())?;
+        doc.transact_mut()
+            .apply_update(decoded)
+            .map_err(|e| e.to_string())?;
+        Ok::<_, String>(doc)
+    })
 }
 
 #[cfg(test)]
@@ -169,5 +180,40 @@ mod tests {
     fn corrupt_update_errors_not_panics() {
         // Valid header, garbage payload → Err (caller falls back to JSON).
         assert!(doc_from_update(&[0xff, 0x00, 0x13, 0x37]).is_err());
+    }
+
+    /// JP-476: this test's contract ("errors, not panics") was not actually
+    /// true for every corruption. A truncated or bit-flipped sidecar can decode
+    /// a client id wider than `yrs`'s 53-bit space, which asserts inside the
+    /// decoder (`block.rs:92`) instead of returning `Err` — taking the document
+    /// down rather than falling back to JSON. The byte string above never
+    /// happened to produce one; this one always does.
+    #[test]
+    fn oversized_client_id_in_sidecar_errors_not_panics() {
+        /// lib0 unsigned variable-length integer.
+        fn write_varuint(out: &mut Vec<u8>, mut n: u64) {
+            loop {
+                let mut byte = (n & 0x7f) as u8;
+                n >>= 7;
+                if n != 0 {
+                    byte |= 0x80;
+                }
+                out.push(byte);
+                if n == 0 {
+                    break;
+                }
+            }
+        }
+
+        let mut update = Vec::new();
+        write_varuint(&mut update, 1); // one client block
+        write_varuint(&mut update, 1); // one struct in it
+        write_varuint(&mut update, 1 << 53); // client id: one bit too wide
+        write_varuint(&mut update, 0); // clock
+
+        assert!(
+            doc_from_update(&update).is_err(),
+            "an out-of-range client id must fall back to JSON, not panic"
+        );
     }
 }

--- a/relay/src/sync/decode_guard.rs
+++ b/relay/src/sync/decode_guard.rs
@@ -1,0 +1,80 @@
+//! Panic containment for `yrs` decoders fed untrusted bytes (JP-476).
+//!
+//! `yrs` treats the client-id width as an internal invariant rather than an
+//! input check. `StateVector::decode` (and the update decoder) feed the varint
+//! they just read straight into `ClientID::new`, which asserts the value fits
+//! the 53-bit JS-safe space:
+//!
+//! ```text
+//! yrs-0.27.3/src/block.rs:92:  debug_assert!(value & Self::MASK == 0);
+//! ```
+//!
+//! A remote peer only has to send a client id >= 2^53 to trip it — roughly ten
+//! bytes of well-shaped garbage. `Decode` *is* the untrusted-input boundary and
+//! already returns `Result`, so the correct upstream behaviour is `Err`, not an
+//! assert. Until that lands we contain it here rather than hand-rolling a
+//! second lib0 varint reader to pre-validate: a parallel decoder that can
+//! disagree with the real one is a worse bug than the one being fixed.
+//!
+//! **Debug vs release.** `debug_assert!` is compiled out of release builds, so
+//! release does not panic — it silently accepts the truncated id
+//! (`ClientID::get` masks the high bits straight back off), which is an
+//! identity collision in the CRDT rather than a crash. This guard therefore
+//! fixes the crash class only; the truncation is an upstream correctness bug
+//! and is reported as such.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use crate::server::panic_message;
+
+/// Run an untrusted `yrs` decode, converting an upstream **panic** into an
+/// ordinary `Err`.
+///
+/// Sound by construction: the closures below decode a `&[u8]` into an owned
+/// value, or build and populate a throwaway `Doc` that the caller drops on
+/// error. Neither touches shared state, so unwinding out of one cannot leave a
+/// live document half-mutated — `AssertUnwindSafe` here is a real guarantee,
+/// not a suppression.
+///
+/// Deliberately *not* applied to `apply_update` against the live authoritative
+/// `Doc`: that call mutates shared state, so catching an unwind mid-apply would
+/// trade a loud crash for a silently inconsistent document. A panic there must
+/// stay fatal to the connection.
+pub fn guard_decode<T, E: std::fmt::Display>(
+    what: &str,
+    decode: impl FnOnce() -> Result<T, E>,
+) -> Result<T, String> {
+    match catch_unwind(AssertUnwindSafe(decode)) {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(payload) => {
+            let msg = panic_message(&payload);
+            // Malformed input is a client-side fault, not a relay fault — warn
+            // (not error) so a peer spraying garbage cannot mimic a real
+            // server incident in the logs.
+            log::warn!("{what}: yrs decoder panicked on malformed input: {msg}");
+            Err(format!("decoder panicked on malformed input: {msg}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_ok_and_err() {
+        let ok = guard_decode("t", || Ok::<_, String>(7u8));
+        assert_eq!(ok, Ok(7));
+
+        let err = guard_decode("t", || Err::<u8, _>("bad varint"));
+        assert_eq!(err, Err("bad varint".to_string()));
+    }
+
+    #[test]
+    fn converts_panic_into_err() {
+        let err = guard_decode("t", || -> Result<u8, String> { panic!("boom") })
+            .expect_err("panic must surface as Err");
+        assert!(err.contains("boom"), "message should carry the panic text: {err}");
+    }
+}

--- a/relay/src/sync/mod.rs
+++ b/relay/src/sync/mod.rs
@@ -18,6 +18,7 @@
 //! a transaction is **never** held across an `.await`.
 
 mod binary;
+mod decode_guard;
 mod flatten;
 mod hydration;
 mod prose_block;

--- a/relay/src/sync/protocol.rs
+++ b/relay/src/sync/protocol.rs
@@ -13,6 +13,7 @@ use yrs::updates::encoder::Encode;
 use yrs::{Doc, ReadTxn, Transact, Update};
 
 use crate::server::protocol::MESSAGE_SYNC;
+use crate::sync::decode_guard::guard_decode;
 
 /// What a single inbound sync frame produced. Both fields are already
 /// `MESSAGE_SYNC`-prefixed and ready to put on the wire.
@@ -40,8 +41,14 @@ pub enum SyncError {
 /// * `SyncStep2(update)` / `Update(update)` → apply, then rebroadcast the
 ///   update to peers. (Rebroadcasting the received update is idempotent and
 ///   is exactly what other peers need to converge.)
+///
+/// `body` is attacker-controlled: it arrives straight off a peer's WebSocket
+/// (chunked frames funnel here too, after reassembly). Both decodes therefore
+/// go through [`guard_decode`], which turns a `yrs` decoder panic on malformed
+/// input into an ordinary `SyncError::Decode` — see JP-476.
 pub fn process_sync_message(doc: &Doc, body: &[u8]) -> Result<SyncOutcome, SyncError> {
-    let msg = SyncMessage::decode_v1(body).map_err(|e| SyncError::Decode(e.to_string()))?;
+    let msg = guard_decode("sync frame", || SyncMessage::decode_v1(body))
+        .map_err(SyncError::Decode)?;
     match msg {
         SyncMessage::SyncStep1(sv) => {
             let update = doc.transact().encode_state_as_update_v1(&sv);
@@ -51,8 +58,8 @@ pub fn process_sync_message(doc: &Doc, body: &[u8]) -> Result<SyncOutcome, SyncE
             })
         }
         SyncMessage::SyncStep2(update) | SyncMessage::Update(update) => {
-            let decoded =
-                Update::decode_v1(&update).map_err(|e| SyncError::Decode(e.to_string()))?;
+            let decoded = guard_decode("sync update", || Update::decode_v1(&update))
+                .map_err(SyncError::Decode)?;
             doc.transact_mut()
                 .apply_update(decoded)
                 .map_err(|e| SyncError::Apply(e.to_string()))?;
@@ -231,5 +238,94 @@ mod tests {
                 break;
             }
         }
+    }
+
+    // ============================================================
+    // JP-476: oversized client ids must be rejected, never panic
+    // ============================================================
+    //
+    // `yrs` asserts its 53-bit client-id bound *inside* the decoder
+    // (`block.rs:92`) instead of returning `Err`, so a peer can panic the frame
+    // handler with a client id >= 2^53. Two production call sites read one from
+    // untrusted bytes — `StateVector::decode` (`state_vector.rs:125`, the
+    // SyncStep1 path) and `impl Decode for ClientID` (`block.rs:149`, the update
+    // path) — so both are pinned here.
+    //
+    // These shrink the randomized finding to a fixed input: the original was
+    // `DOCUSHARK_FUZZ_SEED=1785484546059070237` against
+    // `fuzz_ws_awareness_and_mcp_workspace_mismatch`, where a garbage SYNC frame
+    // panicked the handler, dropped the sender's socket, and surfaced as the
+    // *next* iteration's awareness assertion. A seed only reproduces by luck;
+    // these always do.
+
+    /// One bit past the largest client id `yrs` accepts.
+    const OVERSIZED_CLIENT_ID: u64 = 1 << 53;
+
+    #[test]
+    fn oversized_client_id_in_sync_step1_is_rejected_not_panicked() {
+        let mut sv = Vec::new();
+        write_varuint(&mut sv, 1); // one state-vector entry
+        write_varuint(&mut sv, OVERSIZED_CLIENT_ID); // client
+        write_varuint(&mut sv, 0); // clock
+
+        let mut body = Vec::new();
+        write_varuint(&mut body, 0); // MSG_SYNC_STEP_1
+        write_varuint(&mut body, sv.len() as u64); // length-prefixed buf
+        body.extend_from_slice(&sv);
+
+        let doc = doc_with_shape("s1");
+        let err = process_sync_message(&doc, &body)
+            .expect_err("an out-of-range client id must be rejected");
+        assert!(
+            matches!(err, SyncError::Decode(_)),
+            "expected a decode error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn oversized_client_id_in_update_is_rejected_not_panicked() {
+        let mut update = Vec::new();
+        write_varuint(&mut update, 1); // one client block
+        write_varuint(&mut update, 1); // one struct in it
+        write_varuint(&mut update, OVERSIZED_CLIENT_ID); // client
+        write_varuint(&mut update, 0); // clock
+
+        let mut body = Vec::new();
+        write_varuint(&mut body, 2); // MSG_SYNC_UPDATE
+        write_varuint(&mut body, update.len() as u64);
+        body.extend_from_slice(&update);
+
+        let doc = doc_with_shape("s1");
+        let err = process_sync_message(&doc, &body)
+            .expect_err("an out-of-range client id must be rejected");
+        assert!(
+            matches!(err, SyncError::Decode(_)),
+            "expected a decode error, got {err:?}"
+        );
+    }
+
+    /// The relay must survive the frame *and stay usable* — the JP-476 failure
+    /// mode was not the rejection itself but the panic unwinding out of
+    /// `handle_message`, which tore down the sender's connection and made the
+    /// next legitimate frame vanish.
+    #[test]
+    fn doc_still_serves_sync_after_rejecting_an_oversized_client_id() {
+        let mut sv = Vec::new();
+        write_varuint(&mut sv, 1);
+        write_varuint(&mut sv, OVERSIZED_CLIENT_ID);
+        write_varuint(&mut sv, 0);
+        let mut hostile = Vec::new();
+        write_varuint(&mut hostile, 0);
+        write_varuint(&mut hostile, sv.len() as u64);
+        hostile.extend_from_slice(&sv);
+
+        let server = doc_with_shape("s1");
+        assert!(process_sync_message(&server, &hostile).is_err());
+
+        // A well-formed SyncStep1 immediately afterwards still gets an answer.
+        let body = SyncMessage::SyncStep1(StateVector::default()).encode_v1();
+        let outcome = process_sync_message(&server, &body)
+            .expect("relay must keep serving after a rejected frame");
+        assert!(outcome.reply.is_some(), "expected a SyncStep2 answer");
     }
 }


### PR DESCRIPTION
Fixes the nondeterministic CI redness in JP-476. Reproduced, root-caused, and pinned with deterministic tests.

## It is not flake

`yrs` 0.27.3 treats its 53-bit client-id bound as an internal invariant rather than an input check. Two production decode paths read a client id straight off untrusted bytes and hand it to `ClientID::new`, which asserts:

```
yrs-0.27.3/src/block.rs:92:  debug_assert!(value & Self::MASK == 0);
```

- `StateVector::decode` (`state_vector.rs:125`) — the SyncStep1 path
- `impl Decode for ClientID` (`block.rs:149`) — the update path

A peer only has to send a client id `>= 2^53` to panic the frame handler. `Decode` *is* the untrusted-input boundary and already returns `Result`, so the correct upstream behaviour is `Err`, not an assert.

## Why it surfaced as a missing awareness broadcast

The panic unwound out of `process_sync_message` into `handle_message`'s `catch_unwind`, which returns `false` and **drops the sender's socket**. The fuzz surface then failed on the *next* iteration's awareness assertion — the connection was already gone. That indirection is what made this look like a filter bug rather than a decoder crash.

The fuzz test's own comment already asserted the invariant that was untrue:

> `Random frames must never crash the relay or leak to the other tenant.`

## The fix

Both untrusted decodes route through a new `guard_decode`, converting an upstream panic into an ordinary `SyncError::Decode`.

Sound by construction: the closures decode a `&[u8]` into an owned value and touch no shared state, so an unwind cannot leave a live document half-mutated. Deliberately **not** applied to `apply_update` against the authoritative `Doc` — that mutates shared state, where catching an unwind would trade a loud crash for a silently inconsistent document.

No hand-rolled lib0 varint reader to pre-validate: a parallel decoder that can disagree with the real one is a worse bug than the one being fixed.

`binary::doc_from_update` gets the same treatment. Its docstring already promised *"a bad sidecar must never take a document down"*, but a `Result` alone never made that true — a truncated sidecar can decode an oversized client id and panic past the error path. Its `Doc` is local and dropped on error, so the whole build is guarded.

## Scope — what this does not fix

This fixes the **crash** class. `debug_assert!` is compiled out of release, where the same input is instead silently accepted with the id truncated back into range — a CRDT identity collision (the JP-468 class), not a crash. It cannot be detected after the fact because `ClientID::get` masks the high bits straight back off. That is an upstream correctness bug; reporting it against `yrs` is tracked separately, same playbook as the insert-at-0 fix in 0.27.3.

Minor known tradeoff: a caught panic still prints via the default panic hook, so a peer spraying malformed frames produces stderr noise where it previously killed its own connection after one. Installing a process-global panic hook from a library function is worse; the class disappears once upstream returns `Err`.

## Verification

- The reported seed passes: `DOCUSHARK_FUZZ_SEED=1785484546059070237 cargo test --test cross_tenant_isolation fuzz_ws_awareness_and_mcp_workspace_mismatch` — was FAILED at iter 57, now **ok**.
- 4 new tests pin both decode paths, the sidecar, and that the relay keeps serving sync after a rejection.
- **Negative control:** with the guard bypassed, all 4 fail with the identical `block.rs:92` assertion — they catch the real bug rather than passing vacuously.
- Full relay suite green (790 lib tests + all integration suites, 0 failures), clippy clean on `--all-targets`.

Assisted-by: Opus 5