### PR TITLE
JP-301: style profile manager ergonomics

### DIFF
--- a/src/engine/Engine.ts
+++ b/src/engine/Engine.ts
@@ -1,3 +1,4 @@
+import { applyDefaultStyleProfile } from '../store/defaultStyleProfile';
 import { Camera } from './Camera';
 import { Renderer } from './Renderer';
 import { InputHandler, NormalizedPointerEvent } from './InputHandler';
@@ -420,7 +421,13 @@ export class Engine {
       addToSelection: (ids) => sessionStore.getState().addToSelection(ids),
       removeFromSelection: (ids) => sessionStore.getState().removeFromSelection(ids),
       clearSelection: () => sessionStore.getState().clearSelection(),
-      addShape: (shape) => documentStore.getState().addShape(shape),
+      // Tool-drawn shapes pick up the configured default style profile
+      // (JP-301). This is the seam every drawing tool routes through, which is
+      // why the setting is applied here rather than in each tool — and why
+      // paste/import, which call `documentStore.addShape` directly, are
+      // correctly unaffected: adopting someone else's shape should preserve
+      // how it looked, not restyle it.
+      addShape: (shape) => documentStore.getState().addShape(applyDefaultStyleProfile(shape)),
       updateShape: (id, updates) => documentStore.getState().updateShape(id, updates),
       updateShapes: (updates) => documentStore.getState().updateShapes(updates),
       deleteShape: (id) => documentStore.getState().deleteShape(id),

--- a/src/store/defaultStyleProfile.test.ts
+++ b/src/store/defaultStyleProfile.test.ts
@@ -1,0 +1,96 @@
+/**
+ * JP-301 — the Default Style Profile setting finally does something.
+ *
+ * The setting has existed (and been persisted, and been included in backups)
+ * since long before this, promising "New shapes will be created with this style
+ * applied" while nothing read it back. These cases pin the reader, and in
+ * particular the two degradations that must never throw: no default set, and a
+ * default pointing at a profile that has since been deleted.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyDefaultStyleProfile } from './defaultStyleProfile';
+import { useSettingsStore } from './settingsStore';
+import { useStyleProfileStore, seedProfiles, type StyleProfile } from './styleProfileStore';
+import type { Shape } from '../shapes/Shape';
+
+function rect(over: Partial<Shape> = {}): Shape {
+  return {
+    id: 's1',
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 60,
+    rotation: 0,
+    fill: '#ffffff',
+    stroke: '#000000',
+    strokeWidth: 1,
+    opacity: 1,
+    visible: true,
+    locked: false,
+    ...over,
+  } as Shape;
+}
+
+const NEON: StyleProfile = {
+  id: 'p-neon',
+  name: 'Dark Neon',
+  properties: { fill: '#111111', stroke: '#39ff14', strokeWidth: 3, opacity: 0.9, cornerRadius: 8 },
+  createdAt: 1,
+  favorite: false,
+  scope: 'local',
+};
+
+beforeEach(() => {
+  useStyleProfileStore.setState({ profiles: seedProfiles([NEON], []), favoriteDefaultIds: [] });
+  useSettingsStore.setState({ defaultStyleProfileId: null });
+});
+
+describe('applyDefaultStyleProfile', () => {
+  it('leaves the shape untouched when no default is configured', () => {
+    const shape = rect();
+    expect(applyDefaultStyleProfile(shape)).toEqual(shape);
+  });
+
+  it('applies the configured profile to a new shape', () => {
+    useSettingsStore.setState({ defaultStyleProfileId: 'p-neon' });
+    const styled = applyDefaultStyleProfile(rect());
+    expect(styled.fill).toBe('#111111');
+    expect(styled.stroke).toBe('#39ff14');
+    expect(styled.strokeWidth).toBe(3);
+  });
+
+  it('degrades to tool defaults when the configured profile was deleted', () => {
+    // A dangling id is entirely reachable: delete a profile that is set as the
+    // default and the setting keeps pointing at it. It must not throw, and it
+    // must not silently produce a half-styled shape.
+    useSettingsStore.setState({ defaultStyleProfileId: 'p-does-not-exist' });
+    const shape = rect();
+    expect(applyDefaultStyleProfile(shape)).toEqual(shape);
+  });
+
+  it('preserves the shape identity and geometry it was given', () => {
+    useSettingsStore.setState({ defaultStyleProfileId: 'p-neon' });
+    const styled = applyDefaultStyleProfile(rect({ id: 'keep-me', x: 42, y: 7 }));
+    expect(styled.id).toBe('keep-me');
+    expect(styled.x).toBe(42);
+    expect(styled.y).toBe(7);
+    expect(styled.type).toBe('rectangle');
+  });
+
+  it('hands a shape only the fields its own facets own', () => {
+    // The gated apply is what stops a rectangle-shaped default smearing
+    // irrelevant chrome onto other families.
+    useSettingsStore.setState({ defaultStyleProfileId: 'p-neon' });
+    const styled = applyDefaultStyleProfile(rect({ id: 'c1', type: 'connector' }));
+    expect(styled.stroke).toBe('#39ff14');
+    expect(styled).not.toHaveProperty('cornerRadius');
+  });
+
+  it('works with a built-in default profile', () => {
+    useSettingsStore.setState({ defaultStyleProfileId: 'default-green' });
+    const styled = applyDefaultStyleProfile(rect());
+    expect(styled.fill).toBe('#48bb78');
+  });
+});

--- a/src/store/defaultStyleProfile.ts
+++ b/src/store/defaultStyleProfile.ts
@@ -1,0 +1,36 @@
+/**
+ * Apply the user's configured default style profile to a newly-drawn shape.
+ *
+ * Settings → General has offered a **Default Style Profile** picker since long
+ * before JP-301, with the hint "New shapes will be created with this style
+ * applied". It never did: `defaultStyleProfileId` was written by the settings
+ * UI, persisted, and included in backups — but no code ever read it back. The
+ * control was a promise the app didn't keep.
+ *
+ * This is the missing reader. It routes through `getProfileUpdates`, the same
+ * primitive the Style Profiles panel uses to apply a profile by hand, so a
+ * shape created with a default looks exactly like one styled with that profile
+ * afterwards — there is no second interpretation of what a profile means.
+ */
+
+import { useSettingsStore } from './settingsStore';
+import { useStyleProfileStore, getProfileUpdates } from './styleProfileStore';
+import type { Shape } from '../shapes/Shape';
+
+/**
+ * Return `shape` with the default profile merged in, or unchanged when no
+ * default is configured (or the configured one has since been deleted — a
+ * dangling id must degrade to "tool defaults", never throw).
+ */
+export function applyDefaultStyleProfile<T extends Shape>(shape: T): T {
+  const profileId = useSettingsStore.getState().defaultStyleProfileId;
+  if (!profileId) return shape;
+
+  const profile = useStyleProfileStore.getState().getProfile(profileId);
+  if (!profile) return shape;
+
+  // The gated per-shape apply means a profile hands each shape only the fields
+  // its own facets own — a rectangle default won't smear swimlane chrome onto
+  // a connector.
+  return { ...shape, ...getProfileUpdates(profile, shape) } as T;
+}

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -224,6 +224,11 @@
 .style-profile-container.grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  /* Pin the row height. Cards used to size to content, so a name that wrapped
+     to two lines grew its card and left the grid visibly ragged (measured:
+     95px against 80px siblings). Names are single-line + ellipsis now, and a
+     fixed row keeps the alignment true even if that ever changes again. */
+  grid-auto-rows: 86px;
   gap: var(--space-2);
 }
 
@@ -246,23 +251,51 @@
   gap: var(--space-1);
 }
 
-/* Grid view items */
+/* Grid view items. The card is a positioned container; the inner
+   `.style-profile-grid-apply` button is the real control, so the card is
+   keyboard-reachable and screen-reader-announced rather than a bare div. */
 .style-profile-grid-item {
   position: relative;
+  border-radius: 6px;
+  transition: background 0.15s ease, border-color 0.15s ease;
+  background: var(--bg-secondary);
+  border: 1px solid transparent;
+  overflow: hidden;
+}
+
+.style-profile-grid-item:hover:not(.disabled),
+.style-profile-grid-item:focus-within:not(.disabled) {
+  background: var(--bg-hover);
+  border-color: var(--border-color);
+}
+
+/* The apply target fills the card so the whole tile stays clickable. */
+.style-profile-grid-apply {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  width: 100%;
+  height: 100%;
   padding: 6px;
-  border-radius: 6px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
   cursor: pointer;
-  transition: all 0.15s ease;
-  background: var(--bg-secondary);
-  border: 1px solid transparent;
 }
 
-.style-profile-grid-item:hover:not(.disabled) {
-  background: var(--bg-hover);
-  border-color: var(--border-color);
+.style-profile-grid-apply[aria-disabled='true'] {
+  cursor: not-allowed;
+}
+
+/* Keyboard focus must be visible — the card is now a real tab stop. */
+.style-profile-grid-apply:focus-visible,
+.style-profile-apply:focus-visible {
+  outline: 2px solid var(--accent-color, var(--brand-gold));
+  outline-offset: -2px;
+  border-radius: 6px;
 }
 
 .style-profile-grid-item.disabled {
@@ -275,13 +308,9 @@
 }
 
 .style-profile-grid-preview {
-  width: 100%;
-  max-width: 48px;
-  aspect-ratio: 1;
   border-radius: var(--radius-sm);
   flex-shrink: 0;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-  margin-bottom: var(--space-1);
 }
 
 .style-profile-grid-star {
@@ -312,45 +341,16 @@
   color: var(--text-secondary);
   max-width: 100%;
   text-align: center;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
   line-height: 1.3;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  /* One line, clipped. Wrapping to two is what made the grid ragged; the full
+     name is still available via the button's title + aria-label. */
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 
 /* Grid ⋯ actions button (revealed on hover) */
-.style-profile-grid-menu {
-  position: absolute;
-  top: var(--space-1);
-  right: var(--space-1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--control-height-sm);
-  height: var(--control-height-sm);
-  padding: 0;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-muted);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
-}
-
-.style-profile-grid-item:hover .style-profile-grid-menu {
-  opacity: 0.85;
-}
-
-.style-profile-grid-menu:hover {
-  opacity: 1;
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
 
 /* List view items */
 .style-profile-item {
@@ -408,15 +408,78 @@
 }
 
 /* Actions */
-.style-profile-actions {
+/* ── Auto-expanding action rail (JP-301) ────────────────────────────────────
+   Replaces the old opacity flip on a single lone "⋯". The rail sits over the
+   card's trailing edge and expands on hover OR keyboard focus, so the two
+   input methods reach the same actions — the previous hover-only reveal was a
+   dead end for anyone tabbing through.
+
+   It is absolutely positioned and animates `max-width`, never layout: an
+   expanding rail that pushed siblings would reflow the whole grid on every
+   mouse-over. The scrim keeps a long profile name from colliding with the
+   buttons as they slide in. */
+.style-profile-rail {
+  position: absolute;
+  top: 2px;
+  right: 2px;
   display: flex;
-  gap: 2px;
+  align-items: center;
+  gap: 1px;
+  max-width: 0;
+  overflow: hidden;
   opacity: 0;
-  transition: opacity 0.15s ease;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    to left,
+    var(--bg-hover) 0%,
+    var(--bg-hover) 78%,
+    transparent 100%
+  );
+  padding-left: 10px;
+  transition: max-width 0.18s ease, opacity 0.12s ease;
+  pointer-events: none;
 }
 
-.style-profile-item:hover .style-profile-actions {
+.style-profile-grid-item:hover .style-profile-rail,
+.style-profile-grid-item:focus-within .style-profile-rail,
+.style-profile-item:hover .style-profile-rail,
+.style-profile-item:focus-within .style-profile-rail {
+  max-width: 140px;
   opacity: 1;
+  pointer-events: auto;
+}
+
+/* A disabled card (nothing selected) still allows management actions —
+   favoriting, renaming, deleting don't need a selection. */
+.style-profile-grid-item.disabled .style-profile-rail,
+.style-profile-item.disabled .style-profile-rail {
+  pointer-events: auto;
+}
+
+.style-profile-item .style-profile-rail {
+  position: static;
+  background: none;
+  padding-left: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .style-profile-rail {
+    transition: none;
+  }
+}
+
+/* List-view apply target: swatch-sized button, no chrome of its own. */
+.style-profile-apply {
+  display: inline-flex;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.style-profile-apply[aria-disabled='true'] {
+  cursor: not-allowed;
 }
 
 .style-profile-action {
@@ -429,9 +492,21 @@
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--text-primary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+/* Inside the rail the buttons sit over the card, so they carry their own
+   surface — otherwise they read as faint glyphs floating on the swatch. */
+.style-profile-rail .style-profile-action {
+  background: var(--bg-secondary);
+  box-shadow: 0 0 0 1px var(--border-color);
+}
+
+.style-profile-rail .style-profile-action:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .style-profile-action.menu:hover:not(:disabled) {
@@ -454,14 +529,10 @@
   color: var(--danger);
 }
 
-/* Favorite star button - always visible */
-.style-profile-action.favorite {
-  opacity: 0.4;
-}
-
-.style-profile-item:hover .style-profile-action.favorite {
-  opacity: 1;
-}
+/* The favorite star no longer dims itself: the rail controls when actions are
+   visible, and a second layer of per-button opacity on top of that just made
+   them washed out (the old rule was lifted only by a LIST-view row hover, so
+   the grid never recovered from it). */
 
 .style-profile-action.favorite.active {
   opacity: 1;
@@ -706,4 +777,27 @@
 
 :root[data-theme='dark'] .style-profile-context-menu-separator {
   background: var(--border-color);
+}
+
+/* Collection filter (JP-301). Rendered only when the workspace has collections
+   — see the component. Styled as a quiet inline control rather than a prominent
+   selector: it narrows a list you are already looking at. */
+.style-profile-collection-filter {
+  padding: 0 var(--space-2) var(--space-1);
+}
+
+.style-profile-collection-select {
+  width: 100%;
+  padding: 3px 6px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.style-profile-collection-select:focus-visible {
+  outline: 2px solid var(--accent-color, var(--brand-gold));
+  outline-offset: -1px;
 }

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef, useMemo, type CSSProperties }
 import { Search, LayoutGrid, List, Plus, X, RefreshCw } from 'lucide-react';
 import { getSelectedShapes, useSessionStore } from '../store/sessionStore';
 import { useStyleProfileStore, type StyleProfile } from '../store/styleProfileStore';
+import { useCollectionStore, isWorkspaceCollection } from '../store/collectionStore';
 import { useSettingsStore } from '../store/settingsStore';
 import { clampToViewport, MENU_SIZE_ESTIMATES } from './contextMenuUtils';
 import { useProfileActions } from './styleProfile/useProfileActions';
@@ -46,6 +47,19 @@ export function StyleProfilePanel() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  /** Collection filter (JP-301). `null` = show everything. */
+  const [collectionFilter, setCollectionFilter] = useState<string | null>(null);
+
+  // Only workspace collections can scope a profile, so those are the only ones
+  // worth offering — a local collection has no counterpart in the registry.
+  const collections = useCollectionStore((s) => s.collections);
+  const filterableCollections = useMemo(
+    () =>
+      Object.values(collections)
+        .filter(isWorkspaceCollection)
+        .sort((a, b) => a.order - b.order),
+    [collections],
+  );
 
   // Sorted (favorites first) via the store's own comparator; filtered locally.
   const sorted = useMemo(() => useStyleProfileStore.getState().getSortedProfiles(), [profilesRaw]);
@@ -53,8 +67,17 @@ export function StyleProfilePanel() {
     () =>
       sorted
         .filter((p) => !hideDefaultStyleProfiles || !p.id.startsWith('default-'))
-        .filter((p) => !searchQuery || p.name.toLowerCase().includes(searchQuery.toLowerCase())),
-    [sorted, hideDefaultStyleProfiles, searchQuery]
+        .filter((p) => !searchQuery || p.name.toLowerCase().includes(searchQuery.toLowerCase()))
+        // A profile with no collection tags belongs everywhere, so it survives
+        // every filter — tagging is opt-in narrowing, not a requirement.
+        .filter(
+          (p) =>
+            collectionFilter === null ||
+            !p.collectionIds ||
+            p.collectionIds.length === 0 ||
+            p.collectionIds.includes(collectionFilter),
+        ),
+    [sorted, hideDefaultStyleProfiles, searchQuery, collectionFilter]
   );
 
   useEffect(() => {
@@ -199,6 +222,27 @@ export function StyleProfilePanel() {
         </div>
       )}
 
+      {/* Collection filter — only worth showing once the workspace actually has
+          collections to filter by; an always-visible control offering a single
+          "All" option is chrome, not a feature. */}
+      {filterableCollections.length > 0 && (
+        <div className="style-profile-collection-filter">
+          <select
+            className="style-profile-collection-select"
+            value={collectionFilter ?? ''}
+            onChange={(e) => setCollectionFilter(e.target.value === '' ? null : e.target.value)}
+            aria-label="Filter style profiles by collection"
+          >
+            <option value="">All profiles</option>
+            {filterableCollections.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
       {searchQuery && !isSearching && (
         <div className="style-profile-filter-active">
           <span>Filtered: "{searchQuery}"</span>
@@ -269,6 +313,11 @@ export function StyleProfilePanel() {
             onCancelEdit={cancelEdit}
             onPreviewEnter={() => actions.previewProfile(profile)}
             onPreviewLeave={endPreview}
+            onUpdateFromShape={
+              hasSelection && !profile.id.startsWith('default-')
+                ? () => actions.updateProfileFromShape(profile.id)
+                : undefined
+            }
           />
         ))}
       </div>

--- a/src/ui/styleProfile/ProfileCard.tsx
+++ b/src/ui/styleProfile/ProfileCard.tsx
@@ -1,12 +1,25 @@
 /**
- * A single style-profile card, shared by the grid and list views (collapsing
- * what used to be two near-duplicate renderings). Click applies; hover previews
- * live on the canvas; the ⋯ button / right-click opens the actions menu.
+ * A single style-profile card, shared by the grid and list views.
+ *
+ * Click applies; hover previews live on the canvas; the action rail (hover or
+ * keyboard focus) carries the per-profile actions.
+ *
+ * Three things here are deliberate rather than incidental:
+ *
+ * 1. **The card is a real `<button>`.** It used to be a `<div onClick>` with no
+ *    role and `tabIndex: -1`, which made the entire panel unreachable by
+ *    keyboard — profiles could be applied only with a mouse.
+ * 2. **The swatch is rendered by the real shape handlers** (`profilePreview`),
+ *    not approximated in CSS from four profile keys. See that module for why.
+ * 3. **The action rail expands on `:focus-within` as well as `:hover`**, so the
+ *    keyboard path reaches the same actions the mouse does instead of a
+ *    hover-only dead end.
  */
 
-import type { CSSProperties, MouseEvent } from 'react';
-import { Star, MoreHorizontal, Cloud } from 'lucide-react';
+import { useEffect, useRef, useState, type CSSProperties, type MouseEvent } from 'react';
+import { Star, MoreHorizontal, Cloud, RefreshCw } from 'lucide-react';
 import type { StyleProfile } from '../../store/styleProfileStore';
+import { renderProfileSwatch } from './profilePreview';
 
 export interface MenuAnchor {
   x: number;
@@ -15,12 +28,18 @@ export interface MenuAnchor {
 
 const SYNCED_TITLE = 'Synced to this workspace';
 
+/** Swatch edge length in CSS pixels, per view. Fixed so the grid can pin its
+ *  row height — a swatch that sized itself to content is half of what made the
+ *  grid ragged in the first place. */
+const SWATCH_SIZE = { grid: 44, list: 20 } as const;
+
 interface ProfileCardProps {
   profile: StyleProfile;
   viewMode: 'grid' | 'list';
   hasSelection: boolean;
   isEditing: boolean;
   editingName: string;
+  /** CSS fallback used when the shape registry can't draw this profile. */
   previewStyle: CSSProperties;
   /** Tooltip describing what applying this profile affects on the selection. */
   titleText: string;
@@ -33,13 +52,58 @@ interface ProfileCardProps {
   onCancelEdit: () => void;
   onPreviewEnter: () => void;
   onPreviewLeave: () => void;
+  /** Merge the current selection's style into this profile. Absent = unavailable. */
+  onUpdateFromShape?: (() => void) | undefined;
+}
+
+/**
+ * Canvas swatch drawn by the registered shape handler. Falls back to the CSS
+ * approximation when the handler can't draw (unregistered type, or no 2D
+ * context — jsdom in tests), so a card is never a blank hole.
+ */
+function ProfileSwatch({
+  profile,
+  size,
+  fallbackStyle,
+  className,
+}: {
+  profile: StyleProfile;
+  size: number;
+  fallbackStyle: CSSProperties;
+  className: string;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [drawn, setDrawn] = useState(true);
+
+  // Redraw whenever the profile's visual content changes — a profile edited via
+  // "Update with current" must not keep showing its old look.
+  const propsKey = JSON.stringify(profile.properties);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setDrawn(renderProfileSwatch(canvas, profile, { size }));
+    // `propsKey` is the dependency that matters; profile identity is unstable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [propsKey, size]);
+
+  if (!drawn) {
+    return <div className={className} style={fallbackStyle} aria-hidden="true" />;
+  }
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    />
+  );
 }
 
 export function ProfileCard(props: ProfileCardProps) {
   const {
     profile, viewMode, hasSelection, isEditing, editingName, previewStyle, titleText,
     onApply, onToggleFavorite, onOpenMenu, onStartEdit, onEditNameChange,
-    onCommitEdit, onCancelEdit, onPreviewEnter, onPreviewLeave,
+    onCommitEdit, onCancelEdit, onPreviewEnter, onPreviewLeave, onUpdateFromShape,
   } = props;
 
   const handleContextMenu = (e: MouseEvent) => {
@@ -61,33 +125,91 @@ export function ProfileCard(props: ProfileCardProps) {
   /** Workspace-scoped profiles carry a quiet marker so it's obvious at a glance
    *  which styles follow you between devices and which are local to this one. */
   const synced = profile.scope === 'workspace';
+  const isBuiltIn = profile.id.startsWith('default-');
+
+  /**
+   * The action rail. Favorite and (when a shape is selected) Update-with-current
+   * are the two actions frequent enough to earn a permanent slot; everything
+   * else stays behind the overflow menu. Each button stops propagation so
+   * pressing one never also applies the profile.
+   *
+   * The buttons are `tabIndex={-1}`: the card itself is the tab stop, and the
+   * rail is reachable from it. Putting three extra stops on every card would
+   * make tabbing through a panel of twenty profiles punishing.
+   */
+  const rail = (
+    <div className="style-profile-rail">
+      <button
+        className={`style-profile-action favorite ${profile.favorite ? 'active' : ''}`}
+        onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}
+        title={profile.favorite ? 'Remove from favorites' : 'Add to favorites'}
+        aria-label={profile.favorite ? `Remove ${profile.name} from favorites` : `Add ${profile.name} to favorites`}
+        aria-pressed={profile.favorite}
+        tabIndex={-1}
+      >
+        <Star size={14} fill={profile.favorite ? 'currentColor' : 'none'} />
+      </button>
+      {onUpdateFromShape && !isBuiltIn && (
+        <button
+          className="style-profile-action"
+          onClick={(e) => { e.stopPropagation(); onUpdateFromShape(); }}
+          title="Update with current style"
+          aria-label={`Update ${profile.name} with the current style`}
+          tabIndex={-1}
+        >
+          <RefreshCw size={14} />
+        </button>
+      )}
+      <button
+        className="style-profile-action menu"
+        onClick={handleMenuButton}
+        title="More options"
+        aria-label={`More options for ${profile.name}`}
+        tabIndex={-1}
+      >
+        <MoreHorizontal size={14} />
+      </button>
+    </div>
+  );
 
   if (viewMode === 'grid') {
     return (
       <div
         className={`style-profile-grid-item ${!hasSelection ? 'disabled' : ''} ${profile.favorite ? 'favorite' : ''}`}
-        onClick={apply}
         onContextMenu={handleContextMenu}
         onMouseEnter={() => hasSelection && onPreviewEnter()}
         onMouseLeave={onPreviewLeave}
-        title={titleText}
       >
-        <div className="style-profile-grid-preview" style={previewStyle} />
-        {profile.favorite && <span className="style-profile-grid-star">★</span>}
+        <button
+          type="button"
+          className="style-profile-grid-apply"
+          onClick={apply}
+          onFocus={() => hasSelection && onPreviewEnter()}
+          onBlur={onPreviewLeave}
+          title={titleText}
+          aria-label={titleText}
+          // Deliberately `aria-disabled`, not `disabled`. A real `disabled`
+          // button drops out of the tab order, which would put the action rail
+          // (favorite / rename / delete — none of which need a selection)
+          // permanently out of keyboard reach whenever nothing is selected.
+          // That is the same dead end this card rework exists to remove.
+          aria-disabled={!hasSelection}
+        >
+          <ProfileSwatch
+            profile={profile}
+            size={SWATCH_SIZE.grid}
+            fallbackStyle={previewStyle}
+            className="style-profile-grid-preview"
+          />
+          <span className="style-profile-grid-name">{profile.name}</span>
+        </button>
+        {profile.favorite && <span className="style-profile-grid-star" aria-hidden="true">★</span>}
         {synced && (
-          <span className="style-profile-synced" title={SYNCED_TITLE} aria-label={SYNCED_TITLE}>
+          <span className="style-profile-synced" title={SYNCED_TITLE} aria-hidden="true">
             <Cloud size={11} />
           </span>
         )}
-        <span className="style-profile-grid-name">{profile.name}</span>
-        <button
-          className="style-profile-grid-menu"
-          onClick={handleMenuButton}
-          title="More options"
-          aria-label="More options"
-        >
-          <MoreHorizontal size={14} />
-        </button>
+        {rail}
       </div>
     );
   }
@@ -99,20 +221,22 @@ export function ProfileCard(props: ProfileCardProps) {
       onMouseEnter={() => hasSelection && onPreviewEnter()}
       onMouseLeave={onPreviewLeave}
     >
-      <div
-        className="style-profile-preview"
-        style={previewStyle}
-        onClick={apply}
-        role="button"
-        title={hasSelection ? 'Apply to selection' : titleText}
-      />
-
       <button
-        className={`style-profile-action favorite ${profile.favorite ? 'active' : ''}`}
-        onClick={(e) => { e.stopPropagation(); onToggleFavorite(); }}
-        title={profile.favorite ? 'Remove from favorites' : 'Add to favorites'}
+        type="button"
+        className="style-profile-apply"
+        onClick={apply}
+        onFocus={() => hasSelection && onPreviewEnter()}
+        onBlur={onPreviewLeave}
+        title={hasSelection ? `Apply ${profile.name} to selection` : titleText}
+        aria-label={hasSelection ? `Apply ${profile.name} to selection` : titleText}
+        aria-disabled={!hasSelection}
       >
-        <Star size={15} fill={profile.favorite ? 'currentColor' : 'none'} />
+        <ProfileSwatch
+          profile={profile}
+          size={SWATCH_SIZE.list}
+          fallbackStyle={previewStyle}
+          className="style-profile-preview"
+        />
       </button>
 
       {isEditing ? (
@@ -121,6 +245,7 @@ export function ProfileCard(props: ProfileCardProps) {
           value={editingName}
           onChange={(e) => onEditNameChange(e.target.value)}
           className="style-profile-edit-input"
+          aria-label={`Rename ${profile.name}`}
           autoFocus
           onKeyDown={(e) => {
             if (e.key === 'Enter') onCommitEdit();
@@ -132,28 +257,19 @@ export function ProfileCard(props: ProfileCardProps) {
         <span
           className="style-profile-name"
           onDoubleClick={onStartEdit}
-          title={titleText}
+          title={profile.name}
         >
           {profile.name}
         </span>
       )}
 
       {synced && (
-        <span className="style-profile-synced" title={SYNCED_TITLE} aria-label={SYNCED_TITLE}>
+        <span className="style-profile-synced" title={SYNCED_TITLE} aria-hidden="true">
           <Cloud size={12} />
         </span>
       )}
 
-      <div className="style-profile-actions">
-        <button
-          className="style-profile-action menu"
-          onClick={handleMenuButton}
-          title="More options"
-          aria-label="More options"
-        >
-          <MoreHorizontal size={15} />
-        </button>
-      </div>
+      {rail}
     </div>
   );
 }

--- a/src/ui/styleProfile/profilePreview.ts
+++ b/src/ui/styleProfile/profilePreview.ts
@@ -1,0 +1,114 @@
+/**
+ * Faithful style-profile previews, drawn by the real shape handlers.
+ *
+ * The card swatch used to be a CSS `<div>` styled from four profile keys
+ * (fill / stroke / strokeWidth / cornerRadius) — the universal facet and
+ * nothing else. That made a profile carrying swimlane header chrome, ERD zebra
+ * striping and a full icon configuration look identical to one carrying a fill
+ * and nothing more. The preview was not merely incomplete, it actively
+ * misrepresented what applying the profile would do.
+ *
+ * This module renders through `shapeRegistry` instead: create a real shape of
+ * the requested type, apply the profile with the same `getProfileUpdates` the
+ * canvas uses, and let the registered handler draw it. That is the construction
+ * that keeps PNG export accurate, and it is deliberate here — memory of
+ * JP-468/472/473 says every one of those was the same defect class: a second
+ * implementation of something with no guard tying it to the first. A preview
+ * hand-drawn from profile keys is exactly that second implementation.
+ *
+ * Shared by the manager's card swatch and (JP-301 PR 3) the Studio's per-family
+ * matrix, so both are faithful for the same reason rather than by coincidence.
+ */
+
+import { shapeRegistry } from '../../shapes/ShapeRegistry';
+import { Vec2 } from '../../math/Vec2';
+import { getProfileUpdates, type StyleProfile } from '../../store/styleProfileStore';
+import type { Shape } from '../../shapes/Shape';
+
+/** Options for a single swatch render. */
+export interface ProfilePreviewOptions {
+  /** Shape type to draw. Defaults to a rectangle — the most legible carrier of
+   *  the universal facet plus corner radius and icons. */
+  shapeType?: string;
+  /** CSS pixel size of the square swatch. */
+  size: number;
+  /** Device pixel ratio to render at (crispness on HiDPI). */
+  dpr?: number;
+}
+
+/**
+ * Build a shape of `shapeType` with `profile` applied, sized to fill a
+ * `size`×`size` box with a small inset so strokes aren't clipped at the edge.
+ *
+ * Exported for the Studio, which needs the shape itself (not just a bitmap) to
+ * report which fields actually took effect.
+ */
+export function buildPreviewShape(
+  profile: StyleProfile,
+  shapeType: string,
+  size: number,
+): Shape | null {
+  if (!shapeRegistry.hasHandler(shapeType)) return null;
+  const handler = shapeRegistry.getHandler(shapeType);
+
+  // Inset by the widest stroke the profile could draw, so a thick border is
+  // fully visible rather than half-clipped by the swatch edge.
+  const inset = Math.max(2, Math.min(6, profile.properties.strokeWidth ?? 2));
+  const base = handler.create(new Vec2(inset, inset), `preview-${profile.id}`);
+
+  // `create` returns the handler's default geometry; override it to fit the
+  // swatch. Width/height live on BaseShape for every registered type.
+  const sized = {
+    ...base,
+    x: size / 2,
+    y: size / 2,
+    width: Math.max(1, size - inset * 2),
+    height: Math.max(1, size - inset * 2),
+  } as Shape;
+
+  // The same translation the canvas performs — no parallel interpretation of
+  // profile keys lives here.
+  return { ...sized, ...getProfileUpdates(profile, sized) } as Shape;
+}
+
+/**
+ * Render a profile onto a canvas element. Returns `false` when the shape type
+ * isn't registered or a 2D context isn't available, so callers can fall back
+ * rather than show an empty box.
+ *
+ * The canvas is cleared first: swatches are re-rendered in place when a profile
+ * changes, and a stale underdraw would show through a translucent fill.
+ */
+export function renderProfileSwatch(
+  canvas: HTMLCanvasElement,
+  profile: StyleProfile,
+  options: ProfilePreviewOptions,
+): boolean {
+  const { size, shapeType = 'rectangle' } = options;
+  const dpr = options.dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return false;
+
+  const shape = buildPreviewShape(profile, shapeType, size);
+  if (!shape) return false;
+
+  canvas.width = Math.max(1, Math.round(size * dpr));
+  canvas.height = Math.max(1, Math.round(size * dpr));
+  canvas.style.width = `${size}px`;
+  canvas.style.height = `${size}px`;
+
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, size, size);
+
+  // A handler may throw on a shape it considers malformed (a library shape
+  // whose definition isn't loaded, say). A broken swatch must never take the
+  // panel down with it — the caller falls back to the CSS approximation.
+  try {
+    shapeRegistry.getHandlerForShape(shape).render(ctx, shape);
+  } catch (e) {
+    console.warn('[profilePreview] handler render failed:', e);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Second slice of the style-profile overhaul, on top of [#434](https://github.com/JPE-Net-Technologies/docushark/pull/434). Four things the panel needed — three of them defects found by *looking* at it rather than reading it.

## The card swatch was lying

It rendered a CSS `<div>` from four profile keys (fill / stroke / strokeWidth / cornerRadius) — the universal facet and nothing else. A profile carrying swimlane header chrome, ERD zebra striping and a full icon configuration looked **identical** to one carrying a fill and nothing more.

New `profilePreview` module renders through the registered shape handler instead: create a real shape, apply the profile with the same `getProfileUpdates` the canvas uses, let the handler draw it. That's the construction that keeps PNG export accurate — and it's deliberate, because JP-468/472/473 were all one defect class: a second implementation with no guard tying it to the first. A preview hand-drawn from profile keys was exactly that. Shared with PR 3's Studio so both are faithful for the same reason rather than by coincidence.

## The panel was mouse-only

Cards were `<div onClick>` with no role and `tabIndex: -1` — the entire panel was unreachable by keyboard.

**The obvious fix was wrong, and live verification caught it.** Marking the apply button `disabled` when nothing is selected drops it out of the tab order, which puts the action rail — favorite, rename, delete, none of which need a selection — permanently out of keyboard reach. That's the same dead end the rework exists to remove. It uses `aria-disabled` instead: still announced as unavailable, still a tab stop.

## The grid went ragged

`-webkit-line-clamp: 2` let a wrapping name grow its card — measured live at **95px against 80px** siblings. Rows are pinned and names single-line with ellipsis; the full name rides on the button's `title` + `aria-label`, so nothing is lost.

## The action rail

Replaces the opacity flip on a lone "⋯". Expands on `:hover` **or** `:focus-within` so both input methods reach the same actions, and animates `max-width` rather than layout — an expanding rail that pushed siblings would reflow the grid on every mouse-over.

Removing the old per-button `opacity: 0.4` mattered more than it looks: that rule was only ever lifted by a **list**-view row hover, so in grid view the buttons sat permanently washed out. (Reported independently while testing: "the hover buttons are super faint.") Measured after: `rgb(213,219,228)` on `rgb(10,21,37)`, ~13:1.

## The Default Style Profile setting finally does something

It has been written, persisted, and included in backups since long before this, with the hint *"New shapes will be created with this style applied"* — and **nothing ever read it back**. The control was a promise the app didn't keep.

`applyDefaultStyleProfile` is the missing reader, wired at Engine's ToolContext `addShape` — the single seam every drawing tool routes through, which is also why paste and import are correctly unaffected: adopting someone else's shape should preserve how it looked, not restyle it.

**JP-403** ("Default Style Profile select has no data") does **not** reproduce — 7 options render correctly. JP-401's default-hardening appears to have fixed it; worth closing.

## Also

Collection filter for the `collectionIds` the registry already ships, shown only when the workspace actually has collections (an always-visible control offering one "All" option is chrome, not a feature). Deletes the now-dead `.style-profile-grid-menu` rules.

## Verification

- **282 files / 3304 tests pass**; typecheck clean; docs site builds.
- 6 new tests on `applyDefaultStyleProfile`: applied, no-default, **dangling id** (deleting a profile that is set as the default must degrade to tool defaults, not throw), geometry preserved, facet gating, built-ins.
- **Live in the running editor**, against the local stack: uniform 86px rows (was 80/95), swatch is a `CANVAS` with 91% of pixels painted by the real handler, apply is a `BUTTON` at `tabIndex 0`, rail expands to 140px on focus-within, and a rectangle drawn with the default set to Fresh Green came out `#48bb78` / `#276749` / radius 8.

⚠️ GitHub Actions is still in the [major outage](https://www.githubstatus.com) that started 15:22 UTC, so CI may not run on this PR either. The four required checks were reproduced locally.

Assisted-by: Opus 5