### PR TITLE
JP-301: Style Profile Studio, and a roomier profile grid

### DIFF
--- a/docs-site/guide/styling.md
+++ b/docs-site/guide/styling.md
@@ -81,6 +81,32 @@ Existing profiles are never uploaded automatically, including when you sign in
 for the first time. Syncing is always something you choose.
 :::
 
+### The Studio — see what a profile actually does
+
+A style profile remembers how *each kind of shape* should look, not one style.
+That makes a mature profile genuinely valuable — and, until now, invisible: two
+profiles that behave completely differently both showed up as a single coloured
+square.
+
+Right-click a profile and choose **Open in Studio** to see inside it. Each row is
+a set of shapes that style identically — rectangles, connectors, ERD entities,
+swimlanes — drawn as they'd actually look under this profile, with every style
+that set can receive listed underneath:
+
+- **Saved** — the profile sets this. Applying it changes the shape.
+- **Inherited** — the profile has no value here, so shapes keep their own.
+
+That distinction is the useful one. It's the difference between a profile that
+genuinely knows how your swimlanes should look and one that will only ever paint
+them a fill colour. The header sums it up: *Tuned for 3 of 10 shape sets*.
+
+To drop a style back to inherited, hover it and choose the eraser. This is the
+only way to *remove* something from a profile — saving into one is additive, so
+before the Studio a style could be overwritten but never taken out again. Fill,
+stroke, stroke width and opacity are always present and can't be removed.
+
+Built-in profiles open read-only.
+
 ### How profiles count toward storage
 
 Synced profiles are stored in your workspace, so they count toward its storage

--- a/src/store/styleProfile/facets.ts
+++ b/src/store/styleProfile/facets.ts
@@ -56,6 +56,9 @@ function makeCustomPropsFacet(config: CustomPropsFacetConfig): StyleFacet {
   return {
     id: config.id,
     names: config.names,
+    // Derived, not restated: the field descriptors already are the key list, so
+    // adding a field to a customProperties shape can't leave `keys` stale.
+    keys: config.fields.map((f) => f.key),
     appliesTo: (type) => typeSet.has(type),
     extract: (shape) => {
       const raw = asRecord(shape)['customProperties'];
@@ -87,6 +90,7 @@ function makeCustomPropsFacet(config: CustomPropsFacetConfig): StyleFacet {
 const universalFacet: StyleFacet = {
   id: 'universal',
   names: ['Fill', 'Stroke', 'Stroke Width', 'Opacity'],
+  keys: ['fill', 'stroke', 'strokeWidth', 'opacity'],
   appliesTo: () => true,
   extract: (shape) => ({
     fill: shape.fill ?? null,
@@ -106,6 +110,7 @@ const universalFacet: StyleFacet = {
 const cornerRadiusFacet: StyleFacet = {
   id: 'cornerRadius',
   names: ['Corner Radius'],
+  keys: ['cornerRadius'],
   appliesTo: (type) => type === 'rectangle' || type === 'group',
   extract: (shape) => {
     const extra = asRecord(shape);
@@ -118,6 +123,7 @@ const cornerRadiusFacet: StyleFacet = {
 const labelFacet: StyleFacet = {
   id: 'label',
   names: ['Label Font Size', 'Label Color'],
+  keys: ['labelFontSize', 'labelColor'],
   appliesTo: shapeSupportsLabel,
   extract: (shape, opts) => {
     if (!opts.includeLabelStyle) return {};
@@ -139,6 +145,7 @@ const labelFacet: StyleFacet = {
 const textFacet: StyleFacet = {
   id: 'text',
   names: ['Font Size', 'Font Family'],
+  keys: ['fontSize', 'fontFamily'],
   appliesTo: (type) => type === 'text',
   extract: (shape) => {
     const extra = asRecord(shape);
@@ -159,6 +166,7 @@ const textFacet: StyleFacet = {
 const arrowsFacet: StyleFacet = {
   id: 'arrows',
   names: ['Start Arrow', 'End Arrow'],
+  keys: ['startArrow', 'endArrow'],
   appliesTo: (type) => type === 'line' || type === 'connector',
   extract: (shape) => {
     const extra = asRecord(shape);
@@ -179,6 +187,7 @@ const arrowsFacet: StyleFacet = {
 const lineStyleFacet: StyleFacet = {
   id: 'lineStyle',
   names: ['Line Style'],
+  keys: ['lineStyle'],
   appliesTo: (type) => type === 'connector',
   extract: (shape) => {
     const extra = asRecord(shape);
@@ -191,6 +200,7 @@ const lineStyleFacet: StyleFacet = {
 const groupFacet: StyleFacet = {
   id: 'group',
   names: ['Background Color', 'Border Color', 'Border Width'],
+  keys: ['backgroundColor', 'borderColor', 'borderWidth'],
   appliesTo: (type) => type === 'group',
   extract: (shape) => {
     const extra = asRecord(shape);
@@ -247,6 +257,16 @@ const swimlaneFacet: StyleFacet = makeCustomPropsFacet({
 const iconFacet: StyleFacet = {
   id: 'icon',
   names: ['Icon', 'Icon Size', 'Icon Position'],
+  keys: [
+    'iconId',
+    'iconSize',
+    'iconPadding',
+    'iconColor',
+    'iconPosition',
+    'iconDisplayMode',
+    'iconBadge',
+    'icons',
+  ],
   appliesTo: shapeSupportsIcon,
   extract: (shape, opts) => {
     if (!opts.includeIconStyle) return {};

--- a/src/store/styleProfile/types.ts
+++ b/src/store/styleProfile/types.ts
@@ -170,6 +170,21 @@ export interface StyleFacet {
   readonly id: string;
   /** Human-readable property names this facet contributes (drives the UI hint). */
   readonly names: readonly string[];
+  /**
+   * The profile keys this facet owns.
+   *
+   * Deliberately NOT derivable from {@link names} — the two are not 1:1 (the
+   * ERD facet presents three labels over five keys), and they answer different
+   * questions: `names` is what to *show*, `keys` is what the facet actually
+   * reads and writes.
+   *
+   * Declaring it makes the registry self-describing, which is what lets the
+   * Style Profile Studio say whether a given key is **saved** into a profile or
+   * **inherited** from defaults. Inferring that by running `extract` on a probe
+   * shape would report what the probe happened to carry, not what the facet
+   * owns.
+   */
+  readonly keys: readonly (keyof StyleProfileProperties)[];
   /** Whether this facet applies to the given shape type. */
   appliesTo(type: string): boolean;
   /** Pull this facet's concrete fields off a shape into the flat profile bag. */

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -223,25 +223,54 @@
 
 .style-profile-container.grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
   /* Pin the row height. Cards used to size to content, so a name that wrapped
-     to two lines grew its card and left the grid visibly ragged (measured:
-     95px against 80px siblings). Names are single-line + ellipsis now, and a
-     fixed row keeps the alignment true even if that ever changes again. */
-  grid-auto-rows: 86px;
+     grew its card and left the grid visibly ragged (measured: 95px against
+     80px siblings).
+
+     Pinning the row is what makes a two-line name SAFE again: the raggedness
+     came from cards sizing to content, not from wrapping per se. So the name
+     gets its second line back — the single-line version truncated most real
+     profile names to "E2E Deep …" — while the grid stays perfectly aligned. */
+  grid-auto-rows: 104px;
   gap: var(--space-2);
 }
 
 /* Fluid columns: tighter cells in a narrow panel, roomier when docked wide. */
-@container (max-width: 260px) {
+/* Only a genuinely narrow dock drops to one card per row. Two columns stay
+   comfortable down to about 200px (~90px each); collapsing earlier just made a
+   wide, short card with a small centred swatch and a lot of dead space. */
+@container (max-width: 200px) {
   .style-profile-container.grid {
-    grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+    grid-template-columns: 1fr;
+    /* At one-per-row the vertical stack stops making sense — a 180px-wide card
+       with a centred 40px swatch is mostly empty. Lay it out horizontally
+       instead: swatch left, name reading naturally beside it. */
+    grid-auto-rows: 48px;
+  }
+
+  .style-profile-grid-apply {
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: var(--space-2);
+    padding: 6px 8px;
+  }
+
+  .style-profile-grid-name {
+    text-align: left;
+    -webkit-line-clamp: 2;
+  }
+
+  /* The rail would sit on top of the name in a row layout; give it the trailing
+     edge and let the name stop short of it. */
+  .style-profile-grid-apply .style-profile-grid-name {
+    padding-right: 52px;
   }
 }
 
 @container (min-width: 440px) {
   .style-profile-container.grid {
-    grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
   }
 }
 
@@ -275,10 +304,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: var(--space-1);
+  gap: 6px;
   width: 100%;
   height: 100%;
-  padding: 6px;
+  padding: 8px 6px;
   border: none;
   background: none;
   color: inherit;
@@ -338,15 +367,17 @@
 
 .style-profile-grid-name {
   font-size: var(--font-size-xs);
-  color: var(--text-secondary);
+  color: var(--text-primary);
   max-width: 100%;
   text-align: center;
-  line-height: 1.3;
-  /* One line, clipped. Wrapping to two is what made the grid ragged; the full
-     name is still available via the button's title + aria-label. */
-  white-space: nowrap;
+  line-height: 1.35;
+  word-break: break-word;
+  /* Two lines, then ellipsis. Safe because the row height is pinned above, so
+     a wrapping name can no longer push its card taller than its neighbours. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 
@@ -800,4 +831,18 @@
 .style-profile-collection-select:focus-visible {
   outline: 2px solid var(--accent-color, var(--brand-gold));
   outline-offset: -1px;
+}
+
+/* Coverage indicator (JP-301). The swatch shows what a profile looks like on
+   ONE shape; this shows how broadly it has been taught. Shown only when there
+   is something to report — "0 tuned" on every fresh profile would be noise. */
+.style-profile-coverage {
+  font-size: 9.5px;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: var(--radius-pill, 999px);
+  background: var(--bg-primary);
+  color: var(--text-tertiary, var(--text-secondary));
+  box-shadow: inset 0 0 0 1px var(--border-color);
+  white-space: nowrap;
 }

--- a/src/ui/StyleProfilePanel.tsx
+++ b/src/ui/StyleProfilePanel.tsx
@@ -7,6 +7,7 @@ import { useSettingsStore } from '../store/settingsStore';
 import { clampToViewport, MENU_SIZE_ESTIMATES } from './contextMenuUtils';
 import { useProfileActions } from './styleProfile/useProfileActions';
 import { ProfileCard, type MenuAnchor } from './styleProfile/ProfileCard';
+import { StudioModal } from './styleProfile/studio/StudioModal';
 import './StyleProfilePanel.css';
 
 type ViewMode = 'grid' | 'list';
@@ -49,6 +50,8 @@ export function StyleProfilePanel() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   /** Collection filter (JP-301). `null` = show everything. */
   const [collectionFilter, setCollectionFilter] = useState<string | null>(null);
+  /** Profile currently open in the Studio, if any. */
+  const [studioProfileId, setStudioProfileId] = useState<string | null>(null);
 
   // Only workspace collections can scope a profile, so those are the only ones
   // worth offering — a local collection has no counterpart in the registry.
@@ -324,6 +327,10 @@ export function StyleProfilePanel() {
 
       {!hasSelection && <div className="style-profile-hint">Select a shape to apply or save styles</div>}
 
+      {studioProfileId && (
+        <StudioModal profileId={studioProfileId} onClose={() => setStudioProfileId(null)} />
+      )}
+
       {contextMenu && menuProfile && (
         <div
           className="style-profile-context-menu"
@@ -349,6 +356,15 @@ export function StyleProfilePanel() {
             }}
           >
             {menuProfile.favorite ? 'Remove from Favorites' : 'Add to Favorites'}
+          </button>
+          <button
+            className="style-profile-context-menu-item"
+            onClick={() => {
+              setStudioProfileId(menuProfile.id);
+              closeMenu();
+            }}
+          >
+            Open in Studio
           </button>
           <button
             className="style-profile-context-menu-item"

--- a/src/ui/styleProfile/ProfileCard.tsx
+++ b/src/ui/styleProfile/ProfileCard.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState, type CSSProperties, type MouseEvent } from
 import { Star, MoreHorizontal, Cloud, RefreshCw } from 'lucide-react';
 import type { StyleProfile } from '../../store/styleProfileStore';
 import { renderProfileSwatch } from './profilePreview';
+import { getStudioCoverage } from './studio/coverage';
 
 export interface MenuAnchor {
   x: number;
@@ -30,8 +31,11 @@ const SYNCED_TITLE = 'Synced to this workspace';
 
 /** Swatch edge length in CSS pixels, per view. Fixed so the grid can pin its
  *  row height — a swatch that sized itself to content is half of what made the
- *  grid ragged in the first place. */
-const SWATCH_SIZE = { grid: 44, list: 20 } as const;
+ *  grid ragged in the first place. The grid swatch is deliberately smaller than
+ *  the space it used to claim: the card now splits its height between the
+ *  preview and a two-line name, rather than giving nearly all of it to a
+ *  swatch and leaving the name a truncated sliver. */
+const SWATCH_SIZE = { grid: 40, list: 20 } as const;
 
 interface ProfileCardProps {
   profile: StyleProfile;
@@ -127,6 +131,13 @@ export function ProfileCard(props: ProfileCardProps) {
   const synced = profile.scope === 'workspace';
   const isBuiltIn = profile.id.startsWith('default-');
 
+  /* How many shape families this profile has actually been taught about, beyond
+     the universal fill/stroke. This is the breadth the swatch alone can never
+     show: a profile tuned across swimlanes and ERD entities looks identical to
+     a bare one until you say so. */
+  const coverage = getStudioCoverage(profile);
+  const coverageTitle = `Tuned for ${coverage.saved} of ${coverage.reachable} shape sets`;
+
   /**
    * The action rail. Favorite and (when a shape is selected) Update-with-current
    * are the two actions frequent enough to earn a permanent slot; everything
@@ -202,6 +213,15 @@ export function ProfileCard(props: ProfileCardProps) {
             className="style-profile-grid-preview"
           />
           <span className="style-profile-grid-name">{profile.name}</span>
+          {coverage.saved > 0 && (
+            <span
+              className="style-profile-coverage"
+              title={coverageTitle}
+              aria-hidden="true"
+            >
+              {coverage.saved} tuned
+            </span>
+          )}
         </button>
         {profile.favorite && <span className="style-profile-grid-star" aria-hidden="true">★</span>}
         {synced && (

--- a/src/ui/styleProfile/studio/StudioModal.css
+++ b/src/ui/styleProfile/studio/StudioModal.css
@@ -1,0 +1,275 @@
+/**
+ * Style Profile Studio.
+ *
+ * Structural rule the layout encodes: a family that is genuinely tuned is
+ * visually distinct from one that only inherits. That single distinction is the
+ * whole point of the surface, so it gets the one piece of emphasis here (an
+ * accent edge + a filled state dot) and everything else stays quiet.
+ */
+
+.sps-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4, 16px);
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.sps-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(760px, 100%);
+  max-height: min(80vh, 720px);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg, 10px);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
+.sps-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3, 12px);
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.sps-title h2 {
+  margin: 0;
+  font-size: var(--font-size-lg, 16px);
+  color: var(--text-primary);
+}
+
+.sps-sub {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 3px 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.sps-synced,
+.sps-readonly {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill, 999px);
+  background: var(--bg-secondary);
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.sps-head-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+  flex-shrink: 0;
+}
+
+.sps-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.sps-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.sps-close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* ── Body ───────────────────────────────────────────────────────────────── */
+
+.sps-body {
+  padding: var(--space-3, 12px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 12px);
+}
+
+.sps-family {
+  /* The body is a flex column, so without this the sections get SQUASHED by
+     flex-shrink instead of scrolling — rows collapsed into each other and the
+     key lists were clipped to a sliver. */
+  flex-shrink: 0;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+/* The one emphasis in the surface: a tuned family reads as substantive, an
+   inherit-only one recedes. */
+.sps-family.is-tuned {
+  border-left: 3px solid var(--accent-color, var(--brand-gold));
+}
+
+.sps-family-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  padding: 10px 12px;
+}
+
+.sps-preview {
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  box-shadow: inset 0 0 0 1px var(--border-color);
+}
+
+.sps-family-name {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.sps-family-sub {
+  margin: 2px 0 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+/* ── Keys ───────────────────────────────────────────────────────────────── */
+
+.sps-keys {
+  list-style: none;
+  margin: 0;
+  padding: 0 12px 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 2px 12px;
+}
+
+.sps-key {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 0;
+  font-size: var(--font-size-xs);
+}
+
+/* Saved vs inherited, stated twice — a filled/hollow dot AND the value text —
+   so the distinction never rests on colour alone. */
+.sps-key-state {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px var(--text-tertiary, var(--text-secondary));
+}
+
+.sps-key.is-saved .sps-key-state {
+  background: var(--accent-color, var(--brand-gold));
+  box-shadow: none;
+}
+
+.sps-key-label {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sps-key.is-saved .sps-key-label {
+  color: var(--text-primary);
+}
+
+.sps-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  color: var(--text-secondary);
+}
+
+.sps-value code {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+}
+
+.sps-value--inherited {
+  font-style: italic;
+  color: var(--text-tertiary, var(--text-secondary));
+  opacity: 0.75;
+}
+
+.sps-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.sps-forget {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--text-tertiary, var(--text-secondary));
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.sps-key:hover .sps-forget,
+.sps-key:focus-within .sps-forget {
+  opacity: 1;
+}
+
+.sps-forget:hover {
+  color: var(--danger);
+  background: var(--bg-hover);
+}
+
+/* ── Empty ──────────────────────────────────────────────────────────────── */
+
+.sps-empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.sps-empty-hint {
+  margin-top: 6px;
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sps-forget {
+    transition: none;
+  }
+}

--- a/src/ui/styleProfile/studio/StudioModal.tsx
+++ b/src/ui/styleProfile/studio/StudioModal.tsx
@@ -1,0 +1,249 @@
+/**
+ * Style Profile Studio — what a profile actually does, per shape family.
+ *
+ * The manager answers "which profile?"; the Studio answers "what *is* this
+ * profile?". Each row is a set of shapes that are styleable identically, drawn
+ * by the real shape handler under this profile, with every key it can receive
+ * marked **saved** (the profile sets it) or **inherited** (the shape keeps its
+ * own). See `coverage.ts` for why families are grouped by facet signature.
+ *
+ * Built-in profiles open read-only: `updateProfile` refuses to mutate them
+ * (they're seeded from code), so offering edits that silently no-op would be
+ * worse than not offering them.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { X, Cloud, Eraser } from 'lucide-react';
+import { useStyleProfileStore, type StyleProfile } from '../../../store/styleProfileStore';
+import { pushStyleProfiles } from '../../../store/styleProfileSync';
+import { renderProfileSwatch } from '../profilePreview';
+import {
+  resolveStudioFamilies,
+  forgetKey,
+  UNIVERSAL_KEYS,
+  type StudioFamily,
+  type StudioKey,
+} from './coverage';
+import './StudioModal.css';
+
+const PREVIEW_SIZE = 56;
+
+/** Live preview of one family under the profile, drawn by the real handler. */
+function FamilyPreview({ profile, shapeType }: { profile: StyleProfile; shapeType: string }) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  const propsKey = JSON.stringify(profile.properties);
+
+  useEffect(() => {
+    if (ref.current) {
+      renderProfileSwatch(ref.current, profile, { size: PREVIEW_SIZE, shapeType });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [propsKey, shapeType]);
+
+  return (
+    <canvas
+      ref={ref}
+      className="sps-preview"
+      style={{ width: PREVIEW_SIZE, height: PREVIEW_SIZE }}
+      aria-hidden="true"
+    />
+  );
+}
+
+/** Render a saved value compactly — colours as a chip, everything else as text. */
+function ValueChip({ value }: { value: unknown }) {
+  if (typeof value === 'string' && /^#[0-9a-f]{3,8}$/i.test(value)) {
+    return (
+      <span className="sps-value">
+        <span className="sps-swatch" style={{ background: value }} />
+        <code>{value}</code>
+      </span>
+    );
+  }
+  if (value === null) return <span className="sps-value"><code>none</code></span>;
+  if (typeof value === 'object') {
+    const count = Array.isArray(value) ? value.length : Object.keys(value as object).length;
+    return <span className="sps-value"><code>{Array.isArray(value) ? `${count} items` : 'configured'}</code></span>;
+  }
+  return <span className="sps-value"><code>{String(value)}</code></span>;
+}
+
+function KeyRow({
+  entry,
+  readOnly,
+  onForget,
+}: {
+  entry: StudioKey;
+  readOnly: boolean;
+  onForget: (key: StudioKey['key']) => void;
+}) {
+  const universal = UNIVERSAL_KEYS.includes(entry.key);
+  return (
+    <li className={`sps-key ${entry.saved ? 'is-saved' : 'is-inherited'}`}>
+      <span className="sps-key-state" aria-hidden="true" />
+      <span className="sps-key-label">{entry.label}</span>
+      {entry.saved ? (
+        <ValueChip value={entry.value} />
+      ) : (
+        <span className="sps-value sps-value--inherited">inherited</span>
+      )}
+      {entry.saved && !readOnly && !universal && (
+        <button
+          className="sps-forget"
+          onClick={() => onForget(entry.key)}
+          title={`Forget ${entry.label} — shapes keep their own value`}
+          aria-label={`Forget ${entry.label} from this profile`}
+        >
+          <Eraser size={13} />
+        </button>
+      )}
+    </li>
+  );
+}
+
+function FamilyRow({
+  family,
+  profile,
+  readOnly,
+  onForget,
+}: {
+  family: StudioFamily;
+  profile: StyleProfile;
+  readOnly: boolean;
+  onForget: (key: StudioKey['key']) => void;
+}) {
+  const savedCount = family.keys.filter((k) => k.saved).length;
+  return (
+    <section className={`sps-family ${family.hasSavedKeys ? 'is-tuned' : ''}`}>
+      <header className="sps-family-head">
+        <FamilyPreview profile={profile} shapeType={family.representativeType} />
+        <div className="sps-family-meta">
+          <h3 className="sps-family-name">{family.label}</h3>
+          <p className="sps-family-sub">
+            {savedCount} of {family.keys.length} styles saved
+            {family.types.length > 1 && ` · ${family.types.length} shapes`}
+          </p>
+        </div>
+      </header>
+      <ul className="sps-keys">
+        {family.keys.map((entry) => (
+          <KeyRow
+            key={`${family.id}:${entry.key}`}
+            entry={entry}
+            readOnly={readOnly}
+            onForget={onForget}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function StudioModal({
+  profileId,
+  onClose,
+}: {
+  profileId: string;
+  onClose: () => void;
+}) {
+  const profiles = useStyleProfileStore((s) => s.profiles);
+  const updateProfile = useStyleProfileStore((s) => s.updateProfile);
+  const profile = profiles.find((p) => p.id === profileId);
+  const [onlyTuned, setOnlyTuned] = useState(false);
+
+  const families = useMemo(
+    () => (profile ? resolveStudioFamilies(profile) : []),
+    [profile],
+  );
+  const visible = onlyTuned ? families.filter((f) => f.hasSavedKeys) : families;
+  const readOnly = !profile || profile.id.startsWith('default-');
+
+  const handleForget = useCallback(
+    (key: StudioKey['key']) => {
+      if (!profile || readOnly) return;
+      updateProfile(profile.id, { properties: forgetKey(profile.properties, key) });
+      if (profile.scope === 'workspace') void pushStyleProfiles();
+    },
+    [profile, readOnly, updateProfile],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  if (!profile) return null;
+
+  const tunedCount = families.filter((f) => f.hasSavedKeys).length;
+
+  return (
+    <div className="sps-backdrop" onClick={onClose} role="presentation">
+      <div
+        className="sps-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Style Profile Studio — ${profile.name}`}
+      >
+        <header className="sps-head">
+          <div className="sps-title">
+            <h2>{profile.name}</h2>
+            <p className="sps-sub">
+              Tuned for <strong>{tunedCount}</strong> of {families.length} shape sets
+              {profile.scope === 'workspace' && (
+                <span className="sps-synced">
+                  <Cloud size={12} /> synced
+                </span>
+              )}
+              {readOnly && <span className="sps-readonly">built-in · read-only</span>}
+            </p>
+          </div>
+          <div className="sps-head-actions">
+            <label className="sps-toggle">
+              <input
+                type="checkbox"
+                checked={onlyTuned}
+                onChange={(e) => setOnlyTuned(e.target.checked)}
+              />
+              Only tuned
+            </label>
+            <button className="sps-close" onClick={onClose} aria-label="Close the Studio">
+              <X size={18} />
+            </button>
+          </div>
+        </header>
+
+        <div className="sps-body">
+          {visible.length === 0 ? (
+            <div className="sps-empty">
+              {onlyTuned ? (
+                <p>Nothing tuned yet. Clear the filter to see everything this profile can reach.</p>
+              ) : (
+                <>
+                  <p>No shape styles saved yet.</p>
+                  <p className="sps-empty-hint">
+                    Select a shape on the canvas and choose <strong>Update with current</strong> to
+                    teach this profile how that shape should look.
+                  </p>
+                </>
+              )}
+            </div>
+          ) : (
+            visible.map((family) => (
+              <FamilyRow
+                key={family.id}
+                family={family}
+                profile={profile}
+                readOnly={readOnly}
+                onForget={handleForget}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/styleProfile/studio/coverage.test.ts
+++ b/src/ui/styleProfile/studio/coverage.test.ts
@@ -1,0 +1,135 @@
+/**
+ * JP-301 — the Studio's coverage model.
+ *
+ * These pin the two claims the surface makes: that families are grouped by what
+ * can actually style them (not by shape type, which would be unreadable once the
+ * libraries register), and that a key is reported saved only when the profile
+ * genuinely carries a value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveStudioFamilies,
+  getStudioCoverage,
+  forgetKey,
+  prettifyKey,
+  UNIVERSAL_KEYS,
+} from './coverage';
+// Side-effect import: registers every built-in shape handler synchronously, the
+// same way `main.tsx` does. Without it the registry is empty and the families
+// resolve against nothing.
+import '../../../shapes/registerBuiltInShapes';
+import { shapeRegistry } from '../../../shapes/ShapeRegistry';
+import type { StyleProfile } from '../../../store/styleProfileStore';
+import type { StyleProfileProperties } from '../../../store/styleProfile';
+
+function profile(properties: Partial<StyleProfileProperties>): StyleProfile {
+  return {
+    id: 'p1',
+    name: 'Test',
+    properties: {
+      fill: '#111111',
+      stroke: '#222222',
+      strokeWidth: 2,
+      opacity: 1,
+      ...properties,
+    },
+    createdAt: 1,
+    favorite: false,
+    scope: 'local',
+  };
+}
+
+describe('resolveStudioFamilies', () => {
+  it('groups shape types by what can style them, not one row per type', () => {
+    const families = resolveStudioFamilies(profile({}));
+    expect(families.length).toBeGreaterThan(0);
+    // The whole point of signature bucketing: far fewer families than types.
+    expect(families.length).toBeLessThanOrEqual(shapeRegistry.getRegisteredTypes().length);
+    // Every registered type lands in exactly one family.
+    const assigned = families.flatMap((f) => f.types);
+    expect(new Set(assigned).size).toBe(assigned.length);
+    expect(assigned.length).toBe(shapeRegistry.getRegisteredTypes().length);
+  });
+
+  it('gives every family a stable, order-independent id', () => {
+    const a = resolveStudioFamilies(profile({}));
+    const b = resolveStudioFamilies(profile({}));
+    expect(a.map((f) => f.id)).toEqual(b.map((f) => f.id));
+    // The id is the sorted facet signature, so it never depends on registry order.
+    for (const f of a) expect(f.id).toBe([...f.facetIds].sort().join('+'));
+  });
+
+  it('always reports the universal keys as saved — every profile carries them', () => {
+    const families = resolveStudioFamilies(profile({}));
+    for (const family of families) {
+      for (const key of family.keys) {
+        if (UNIVERSAL_KEYS.includes(key.key)) expect(key.saved).toBe(true);
+      }
+    }
+  });
+
+  it('marks a key inherited when the profile has no value for it', () => {
+    const families = resolveStudioFamilies(profile({}));
+    const withCornerRadius = families.find((f) => f.keys.some((k) => k.key === 'cornerRadius'));
+    expect(withCornerRadius).toBeDefined();
+    const entry = withCornerRadius!.keys.find((k) => k.key === 'cornerRadius')!;
+    expect(entry.saved).toBe(false);
+    expect(entry.value).toBeUndefined();
+  });
+
+  it('marks a key saved once the profile carries it', () => {
+    const families = resolveStudioFamilies(profile({ cornerRadius: 12 }));
+    const entry = families
+      .flatMap((f) => f.keys)
+      .find((k) => k.key === 'cornerRadius')!;
+    expect(entry.saved).toBe(true);
+    expect(entry.value).toBe(12);
+  });
+
+  it('sorts tuned families ahead of inherit-only ones', () => {
+    const families = resolveStudioFamilies(profile({ cornerRadius: 8 }));
+    const firstUntuned = families.findIndex((f) => !f.hasSavedKeys);
+    const lastTuned = families.map((f) => f.hasSavedKeys).lastIndexOf(true);
+    if (firstUntuned !== -1) expect(lastTuned).toBeLessThan(firstUntuned);
+  });
+});
+
+describe('getStudioCoverage', () => {
+  it('counts families with at least one saved key', () => {
+    const cov = getStudioCoverage(profile({}));
+    expect(cov.reachable).toBeGreaterThan(0);
+    // A bare profile still carries the four universal keys, so every family it
+    // reaches is "tuned" in the minimal sense.
+    expect(cov.saved).toBeLessThanOrEqual(cov.reachable);
+  });
+});
+
+describe('forgetKey', () => {
+  it('removes an optional key', () => {
+    const props = profile({ cornerRadius: 8 }).properties;
+    const next = forgetKey(props, 'cornerRadius');
+    expect(next).not.toHaveProperty('cornerRadius');
+    expect(props).toHaveProperty('cornerRadius'); // original untouched
+  });
+
+  it('refuses to remove a universal key', () => {
+    // `fill` is required by StyleProfileProperties — deleting it would produce a
+    // profile the type says cannot exist.
+    const props = profile({}).properties;
+    expect(forgetKey(props, 'fill')).toEqual(props);
+    expect(forgetKey(props, 'strokeWidth')).toEqual(props);
+  });
+
+  it('is a no-op for a key that was never saved', () => {
+    const props = profile({}).properties;
+    expect(forgetKey(props, 'cornerRadius')).toEqual(props);
+  });
+});
+
+describe('prettifyKey', () => {
+  it('turns a camelCase key into readable text', () => {
+    expect(prettifyKey('rowSeparatorColor')).toBe('Row separator color');
+    expect(prettifyKey('iconId')).toBe('Icon id');
+  });
+});

--- a/src/ui/styleProfile/studio/coverage.ts
+++ b/src/ui/styleProfile/studio/coverage.ts
@@ -1,0 +1,255 @@
+/**
+ * What a style profile actually covers — the model behind the Style Profile
+ * Studio.
+ *
+ * A profile is a **master memory**: a non-destructive union of every shape ever
+ * saved into it (JP-399). That model is powerful and completely invisible in
+ * the UI, because a profile has always been presented as one colour swatch. Two
+ * profiles that behave entirely differently — one tuned across swimlanes, ERD
+ * entities and icons, one carrying a fill and nothing else — look identical.
+ *
+ * This module makes the union legible by answering two questions:
+ *
+ *  1. **Which sets of shapes can this profile reach?** Not one row per shape
+ *     type: the shape libraries register hundreds of types and a per-type list
+ *     would be unreadable. Types are bucketed by their **facet signature** —
+ *     the set of style facets that apply to them — so every shape that is
+ *     styleable *identically* collapses into one family. That grouping is also
+ *     the truer statement, and it is what "editable sets of shapes with their
+ *     reachable styles" means.
+ *
+ *  2. **For each family, which keys are saved and which are inherited?** Saved =
+ *     the profile carries a value, so applying it sets that field. Inherited =
+ *     the family reads the key but the profile has no value, so the shape keeps
+ *     its own. This is the distinction that separates "genuinely tuned for
+ *     swimlanes" from "swimlanes just get the universal fill", and nothing in
+ *     the product has ever surfaced it.
+ *
+ * Pure and registry-driven: no hardcoded family list to drift out of date as
+ * shapes are added.
+ */
+
+import { shapeRegistry } from '../../../shapes/ShapeRegistry';
+import { resolveStyleAdapter } from '../../../store/styleProfile';
+import type { StyleProfileProperties } from '../../../store/styleProfile';
+import type { StyleProfile } from '../../../store/styleProfileStore';
+
+/** One profile key within a family, and whether the profile carries a value. */
+export interface StudioKey {
+  /** The profile property key. */
+  key: keyof StyleProfileProperties;
+  /** Human label from the owning facet, falling back to the key itself. */
+  label: string;
+  /** Facet that owns this key — used to group keys within a family. */
+  facetId: string;
+  /** True when the profile has a value: applying it will set this field. */
+  saved: boolean;
+  /** The saved value, when there is one. */
+  value: StyleProfileProperties[keyof StyleProfileProperties] | undefined;
+}
+
+/** A set of shape types that are styleable identically. */
+export interface StudioFamily {
+  /** Stable id: the sorted facet signature, so it survives registry order. */
+  id: string;
+  /** Display label, from the representative type. */
+  label: string;
+  /** The type rendered as this family's preview. */
+  representativeType: string;
+  /** Every registered type in this family (may be large for library shapes). */
+  types: string[];
+  /** The facet ids that apply to this family. */
+  facetIds: string[];
+  /** Every key this family can receive, saved and inherited alike. */
+  keys: StudioKey[];
+  /**
+   * True when the profile saves something for this family **beyond** the
+   * universal fill/stroke/width/opacity.
+   *
+   * Deliberately not "has any saved key": every profile carries the four
+   * universal keys by construction, so that definition makes every reachable
+   * family tuned and the coverage number reads a useless "10 of 10". The
+   * question worth answering is whether the profile has been taught anything
+   * specific to this family — which is exactly what separates a profile that
+   * genuinely knows about swimlanes from one that will only ever paint them
+   * the universal fill.
+   */
+  hasSavedKeys: boolean;
+}
+
+/** Coverage summary for the manager's card indicator. */
+export interface StudioCoverage {
+  /** Families tuned beyond the universal facet (see `hasSavedKeys`). */
+  saved: number;
+  /** Families the profile could reach at all. */
+  reachable: number;
+}
+
+/** The four keys every profile carries by construction — they are required by
+ *  `StyleProfileProperties`, so they can be neither absent nor forgotten. */
+export const UNIVERSAL_KEYS: readonly string[] = ['fill', 'stroke', 'strokeWidth', 'opacity'];
+
+/**
+ * Core shapes register handlers but no metadata (JP-33 found the same gap when
+ * resolving capabilities), so a label has to fall back to something. These are
+ * the display names the rest of the UI already uses.
+ */
+const CORE_LABELS: Record<string, string> = {
+  rectangle: 'Rectangle',
+  ellipse: 'Ellipse',
+  line: 'Line',
+  connector: 'Connector',
+  text: 'Text',
+  group: 'Group',
+  image: 'Image',
+  file: 'File',
+};
+
+/** Prefer a core shape as a family's face — a recognisable rectangle reads
+ *  better than whichever library shape happened to sort first. */
+const REPRESENTATIVE_PRIORITY = [
+  'rectangle',
+  'ellipse',
+  'text',
+  'connector',
+  'line',
+  'group',
+];
+
+function labelForType(type: string): string {
+  const meta = shapeRegistry.getMetadata(type);
+  if (meta?.name) return meta.name;
+  const core = CORE_LABELS[type];
+  if (core) return core;
+  // `erd-weak-entity` → `Erd weak entity`. Not beautiful, but honest and never
+  // wrong, which beats a hardcoded list that silently misses new shapes.
+  return type.replace(/[-_]/g, ' ').replace(/^\w/, (c) => c.toUpperCase());
+}
+
+function pickRepresentative(types: string[]): string {
+  for (const preferred of REPRESENTATIVE_PRIORITY) {
+    if (types.includes(preferred)) return preferred;
+  }
+  return [...types].sort()[0] ?? 'rectangle';
+}
+
+/**
+ * Build the family list for a profile.
+ *
+ * Every registered shape type is bucketed by its facet signature; each bucket
+ * becomes one family whose keys are the union of its facets' keys, marked saved
+ * or inherited against `profile`.
+ */
+export function resolveStudioFamilies(profile: StyleProfile): StudioFamily[] {
+  const buckets = new Map<string, { types: string[]; facetIds: string[] }>();
+
+  for (const type of shapeRegistry.getRegisteredTypes()) {
+    const facets = resolveStyleAdapter(type);
+    // Sorted so the signature is order-independent — a registry that returns
+    // facets in a different order must not produce a different family.
+    const facetIds = facets.map((f) => f.id).sort();
+    const signature = facetIds.join('+');
+    const existing = buckets.get(signature);
+    if (existing) existing.types.push(type);
+    else buckets.set(signature, { types: [type], facetIds });
+  }
+
+  const families: StudioFamily[] = [];
+  for (const [signature, { types, facetIds }] of buckets) {
+    const representativeType = pickRepresentative(types);
+    // Re-resolve from the representative so key order matches apply order.
+    const facets = resolveStyleAdapter(representativeType);
+
+    const keys: StudioKey[] = [];
+    for (const facet of facets) {
+      facet.keys.forEach((key, index) => {
+        const saved = Object.prototype.hasOwnProperty.call(profile.properties, key)
+          && profile.properties[key] !== undefined;
+        keys.push({
+          key,
+          // Facets present fewer labels than keys (ERD: 3 labels, 5 keys), so a
+          // positional label is only used where one exists.
+          label: facet.names[index] ?? prettifyKey(key),
+          facetId: facet.id,
+          saved,
+          value: saved ? profile.properties[key] : undefined,
+        });
+      });
+    }
+
+    families.push({
+      id: signature,
+      label: labelForType(representativeType),
+      representativeType,
+      types: types.sort(),
+      facetIds,
+      keys,
+      hasSavedKeys: keys.some((k) => k.saved && !UNIVERSAL_KEYS.includes(k.key)),
+    });
+  }
+
+  // Families with saved keys first (the interesting ones), then by breadth —
+  // a family covering many shape types matters more than a one-off — then
+  // alphabetically for stability.
+  return families.sort((a, b) => {
+    if (a.hasSavedKeys !== b.hasSavedKeys) return a.hasSavedKeys ? -1 : 1;
+    if (a.types.length !== b.types.length) return b.types.length - a.types.length;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+/** `rowSeparatorColor` → `Row separator color`. */
+export function prettifyKey(key: string): string {
+  return key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase())
+    .toLowerCase()
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+/**
+ * Coverage summary, reused as the manager's card indicator.
+ *
+ * Memoized on the profile's serialized properties **and** the registered-type
+ * count. Resolving families walks every registered shape type — several hundred
+ * once the libraries load — which is fine once for a modal but not once per
+ * card per render. Including the type count in the key means a library
+ * registering later invalidates the cache rather than serving a stale number.
+ */
+const coverageCache = new Map<string, StudioCoverage>();
+
+export function getStudioCoverage(profile: StyleProfile): StudioCoverage {
+  const cacheKey = `${shapeRegistry.getRegisteredTypes().length}:${JSON.stringify(profile.properties)}`;
+  const hit = coverageCache.get(cacheKey);
+  if (hit) return hit;
+
+  const families = resolveStudioFamilies(profile);
+  const coverage: StudioCoverage = {
+    saved: families.filter((f) => f.hasSavedKeys).length,
+    reachable: families.length,
+  };
+  // Bound the cache: profiles are few, but a user editing one in the Studio
+  // produces a fresh key on every keystroke-level change.
+  if (coverageCache.size > 64) coverageCache.clear();
+  coverageCache.set(cacheKey, coverage);
+  return coverage;
+}
+
+/**
+ * Remove a key from a profile — the inverse the master-memory union has never
+ * had. Saving into a profile is additive by design, so until now a key, once
+ * present, could only be overwritten and never dropped back to inherited.
+ *
+ * Returns a new properties bag; the four universal keys are required by the
+ * type and are refused rather than deleted (a profile without a fill isn't
+ * representable, and pretending otherwise would produce an invalid profile).
+ */
+export function forgetKey(
+  properties: StyleProfileProperties,
+  key: keyof StyleProfileProperties,
+): StyleProfileProperties {
+  if (UNIVERSAL_KEYS.includes(key)) return properties;
+  const next = { ...properties };
+  delete next[key];
+  return next;
+}


### PR DESCRIPTION
Third slice, on top of [#434](https://github.com/JPE-Net-Technologies/docushark/pull/434) and [#435](https://github.com/JPE-Net-Technologies/docushark/pull/435).

## The Studio

A profile is a **master memory** — a non-destructive union of every shape ever saved into it (JP-399) — and that model has been completely invisible. A profile tuned across swimlanes, ERD entities and icons looked *identical* to one carrying a fill and nothing else, because both rendered as a single swatch.

The Studio makes the union legible: one row per **set of shapes that style identically**, drawn by the real shape handler under the profile, with every key that set can receive marked **saved** (the profile sets it) or **inherited** (the shape keeps its own).

**Rows are bucketed by facet signature, not shape type.** One row per type would emit hundreds once the libraries register; bucketing collapses them to ~10 and is the truer statement anyway. Verified live: 23 shape types share the "Accept Event" family, 20 share "Decision".

### Two design calls worth your eye

**"Tuned" means beyond the universal facet.** Every profile carries fill/stroke/strokeWidth/opacity by construction, so counting *any* saved key made every reachable family tuned and the header read a useless **10 of 10**. It now reads *2 of 10*, and drops to *0 of 10* when the last non-universal key is forgotten. Caught by looking at the running UI — the first version shipped the useless number.

**Forget-key is the inverse the union never had.** Saving into a profile is additive, so a key could be overwritten but never *removed*. The eraser drops one back to inherited. The four universal keys are refused rather than deleted, because a profile without a fill isn't representable.

### Registry change

Facets now declare the profile `keys` they own — deliberately *not* derived from `names`, which aren't 1:1 (ERD presents 3 labels over 5 keys) and answer a different question: `names` is what to show, `keys` is what the facet reads and writes. `makeCustomPropsFacet` derives its keys from the field descriptors it already has, so config-only shapes can't go stale.

Coverage is memoized on the profile's properties **plus the registered-type count** — resolving families walks every registered type, fine once for a modal but not once per card per render, and a library registering later must invalidate rather than serve a stale number.

## Grid polish

The card display was cramped and truncated most names to a sliver ("E2E Deep …", "Warm Ora…"). Neat unlock: pinning the row height in #435 is what makes a **two-line name safe again** — the raggedness came from cards sizing to *content*, not from wrapping — so the name gets its second line back while the grid stays aligned. Plus wider columns, more padding, a smaller swatch so preview and name are balanced, and a genuinely narrow dock (<200px) now lays a card out *horizontally* rather than stacking a small centred swatch over a wide empty card.

## Verification

- **283 files / 3315 tests pass**; typecheck clean; docs site builds.
- 11 new tests on the coverage model: every registered type lands in exactly one family, ids are order-independent, universal keys always saved, saved-vs-inherited flips correctly, tuned families sort first, and `forgetKey` refuses universal keys / no-ops on absent ones.
- **Live, against the local stack, on a synced profile:** opened the Studio, confirmed per-family previews are genuinely different shapes drawn by their real handlers, forgot `cornerRadius` → both affected families flipped to *inherited*, header updated to *0 of 10*, and the change **propagated to the relay** (`style-profiles.json` went to `version: 2` with the key gone). Grid measured at 2 columns × 111×104 with no name truncated.

Two defects were found by looking at the running UI rather than reading the code: the meaningless coverage number above, and family rows being squashed by `flex-shrink` in the modal's flex column instead of scrolling.

⚠️ GitHub Actions is still in the [outage](https://www.githubstatus.com) that began 15:22 UTC. The four required checks were reproduced locally.

Assisted-by: Opus 5