### PR TITLE
Pages explorer indent tree, view popover, and toolbar tidy

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -160,6 +160,10 @@
   --radius-md: 0.375rem;  /* 6px */
   --radius-lg: 0.5rem;    /* 8px */
   --radius-xl: 0.75rem;   /* 12px */
+  /* These two are NOT interchangeable. `pill` is for anything wider than it is
+     tall (chips, badges, progress bars); `full` is 50%, which is a circle only
+     on a square box and an *ellipse* on everything else. Reaching for `full` on
+     a text chip is the mistake — use `pill`. */
   --radius-pill: 999px;
   --radius-full: 50%;
 

--- a/src/ui/NavigatorPanel.css
+++ b/src/ui/NavigatorPanel.css
@@ -12,6 +12,16 @@
   gap: 6px;
   padding: 8px 6px 8px 4px;
   background: var(--bg-primary);
+
+  /* Tree rails. Derived from `--text-muted` (theme-aware) rather than
+     `--border-color`: that token is 10% alpha, tuned for long panel edges, and
+     a 1px vertical hairline drawn in it lands at ~1.3:1 against this panel —
+     present in the DOM, invisible on screen. The lit rail marks the path to the
+     active page and is the one deliberately loud thing here, so it takes the
+     brand accent and an extra pixel. */
+  --nav-guide: color-mix(in srgb, var(--text-muted) 45%, transparent);
+  --nav-guide-lit: color-mix(in srgb, var(--color-primary) 70%, transparent);
+  --nav-row-min-height: 26px;
 }
 
 .navigator-section-head {
@@ -45,21 +55,43 @@
   gap: 4px;
   padding: 3px 8px;
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-full, 999px);
-  background: var(--bg-primary);
+  /* `--radius-full` is 50% — an ellipse on a chip this shape. Pills use
+     `--radius-pill`. */
+  border-radius: var(--radius-pill);
+  /* A surface distinct from the panel: on `--bg-primary` these chips read as
+     floating text held together only by a 10%-alpha border. */
+  background: var(--bg-tertiary, var(--bg-secondary));
   color: var(--text-secondary);
   font-size: var(--font-size-xs, 11px);
+  line-height: var(--line-height-snug, 1.3);
   cursor: pointer;
 }
 
 .navigator-head-btn:hover:not(:disabled) {
   color: var(--text-primary);
-  background: var(--bg-secondary);
+  border-color: var(--text-muted);
 }
 
 .navigator-head-btn:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+.navigator-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border: none;
+  border-radius: var(--radius-sm, 4px);
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.navigator-collapse-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary, var(--bg-secondary));
 }
 
 .navigator-list {
@@ -92,8 +124,11 @@
 
 .navigator-row {
   display: flex;
-  align-items: center;
-  gap: 2px;
+  /* `stretch`, not `center`: the guide columns draw their rail edge-to-edge, so
+     adjacent rows join into one continuous spine. Any vertical gap or padding
+     between rows would break it into dashes. */
+  align-items: stretch;
+  min-height: var(--nav-row-min-height);
   min-width: 0;
   border-radius: var(--radius-sm, 4px);
 }
@@ -104,12 +139,74 @@
 
 .navigator-row.active {
   background: var(--color-primary-light, var(--bg-secondary));
+  /* Same marker the fly-out rail uses for its active panel. */
+  box-shadow: inset 2px 0 0 var(--color-primary);
 }
 
 .navigator-row.active .navigator-row-name {
   color: var(--color-primary, var(--text-primary));
   font-weight: var(--font-weight-medium, 500);
 }
+
+/* --- Tree rails ------------------------------------------------------- */
+
+.navigator-guide {
+  position: relative;
+  flex: none;
+  align-self: stretch;
+}
+
+/* Centred in its column so the rail descends directly under the parent row's
+   twisty chevron rather than hanging off the row's left edge. */
+.navigator-guide::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: var(--nav-guide);
+}
+
+.navigator-guide.lit::before {
+  width: 2px;
+  background: var(--nav-guide-lit);
+}
+
+.navigator-twisty {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  /* Rotation is the whole animation budget for this panel. */
+  transition: transform 120ms ease, color 120ms ease;
+  transform: rotate(90deg);
+}
+
+.navigator-twisty.collapsed {
+  transform: rotate(0deg);
+}
+
+.navigator-twisty:hover {
+  color: var(--text-primary);
+}
+
+.navigator-twisty-spacer {
+  flex: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navigator-twisty {
+    transition: none;
+  }
+}
+
+/* --- Row content ------------------------------------------------------ */
 
 .navigator-row-main {
   flex: 1;
@@ -121,7 +218,7 @@
   border: none;
   background: none;
   color: var(--text-primary);
-  font-size: var(--font-size-sm, 13px);
+  font-size: var(--font-size-md, 13px);
   text-align: left;
   cursor: pointer;
 }
@@ -129,15 +226,6 @@
 /* The name is the point of the row: it takes the slack, everything else is
    sized to content so a deep tree still reads at the minimum panel width. */
 .navigator-row-main > :not(.navigator-row-name) {
-  flex: none;
-}
-
-.navigator-row-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: var(--radius-full, 999px);
-  background: var(--text-muted);
-  opacity: 0.5;
   flex: none;
 }
 
@@ -154,7 +242,7 @@
 .navigator-row-synced {
   flex: none;
   margin-left: auto;
-  font-size: var(--font-size-xs, 10px);
+  font-size: var(--font-size-2xs, 10px);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -173,6 +261,7 @@
 }
 
 .navigator-row:hover .navigator-row-menu,
+.navigator-row:focus-within .navigator-row-menu,
 .navigator-row-menu[aria-expanded='true'] {
   visibility: visible;
 }
@@ -180,4 +269,16 @@
 .navigator-row-menu:hover {
   color: var(--text-primary);
   background: var(--bg-tertiary, var(--bg-secondary));
+}
+
+/* Keyboard users get the same targets the mouse does. `-2px` keeps the ring
+   inside the row so it never overlaps a neighbouring rail. */
+.navigator-row-main:focus-visible,
+.navigator-twisty:focus-visible,
+.navigator-row-menu:focus-visible,
+.navigator-head-btn:focus-visible,
+.navigator-collapse-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm, 4px);
 }

--- a/src/ui/NavigatorPanel.tsx
+++ b/src/ui/NavigatorPanel.tsx
@@ -15,9 +15,35 @@
  * mirror state + integrationHubStore labels. Reordering touches ONLY the
  * physical order; "Match structure" normalizes it to the logical tree
  * (depth-first) — the repair for user-scattered families.
+ *
+ * ## Reading the hierarchy
+ *
+ * Depth is drawn, not padded: a row at depth d renders d guide columns, each a
+ * hairline rail, so sibling sets line up on a shared spine and the row's own
+ * background still spans the full panel width. The guides along the path to the
+ * ACTIVE page render lit — in a 25-page family scrolled past its root, the lit
+ * spine is what tells you which branch you are inside. That is the one loud
+ * thing here; everything else stays quiet on purpose:
+ *
+ *  - No elbow connectors. Continuous rails read faster and cost less ink.
+ *  - Descendants drop the provider glyph, which the root already established.
+ *    A glyph on a descendant therefore means its provider DIFFERS from its
+ *    root's — the only case where repeating it is news rather than noise.
+ *
+ * Branch collapse is deliberately ephemeral (local state, not
+ * `uiPreferencesStore`): persisting it would cost a store version bump and a
+ * migration for a preference that is one click to re-establish.
  */
-import { useMemo, useState } from 'react';
-import { ArrowDownWideNarrow, GripVertical, MoreHorizontal, RefreshCw } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ArrowDownWideNarrow,
+  ChevronRight,
+  GripVertical,
+  MoreHorizontal,
+  PanelLeftClose,
+  PanelRightClose,
+  RefreshCw,
+} from 'lucide-react';
 import { Icon } from './icons';
 
 import { useRichTextPagesStore } from '../store/richTextPagesStore';
@@ -35,9 +61,14 @@ import { IngestSubpagesDialog } from './integrations/IngestSubpagesDialog';
 import { ProviderIcon } from './integrations/ProviderIcon';
 import { ReorderableList } from './properties/ReorderableList';
 import { DropdownMenu, menuAction, MENU_SEPARATOR, type DropdownMenuEntry } from './components/DropdownMenu';
-import { confirmDialog } from './confirm/confirmStore';
+import { confirmDialog, promptDialog } from './confirm/confirmStore';
+import { useActivePanelState, useLayoutActions } from './layout/useLayout';
 import { opener } from '../platform/opener';
 import './NavigatorPanel.css';
+
+/** Width of one guide column. Also the twisty's box, so a branch toggle costs
+ *  no horizontal room beyond the indent it already occupies. */
+const INDENT_PX = 14;
 
 /** Compact staleness for a mirror row ("23m", "5d") — the row is 260px wide
  *  and the page name always wins; the title attr carries the sentence. */
@@ -53,17 +84,37 @@ function syncedShort(syncedAt: number, now = Date.now()): string {
 /** Same pacing as batch ingest — provider rate limits, no retry infra. */
 const REFRESH_DELAY_MS = 350;
 
+/** Which list a right-clicked row belongs to — the two sections have different
+ *  stores and therefore different action sets. */
+type RowKind = 'prose' | 'canvas';
+
+interface RowMenuTarget {
+  kind: RowKind;
+  pageId: string;
+  x: number;
+  y: number;
+}
+
 export function NavigatorPanel() {
-  const { pages, pageOrder, activePageId, setActivePage, movePages, deletePage } = useRichTextPagesStore();
+  const { pages, pageOrder, activePageId, setActivePage, movePages, deletePage, renamePage } =
+    useRichTextPagesStore();
   const canvasPages = usePageStore((s) => s.pages);
   const canvasOrder = usePageStore((s) => s.pageOrder);
   const canvasActiveId = usePageStore((s) => s.activePageId);
   const setCanvasActive = usePageStore((s) => s.setActivePage);
   const reorderCanvas = usePageStore((s) => s.reorderPages);
+  const renameCanvasPage = usePageStore((s) => s.renamePage);
+  const duplicateCanvasPage = usePageStore((s) => s.duplicatePage);
+  const deleteCanvasPage = usePageStore((s) => s.deletePage);
   const hub = useIntegrationHubStore((s) => s.hub);
+
+  const navigatorState = useActivePanelState('navigator');
+  const { setPanelVisible } = useLayoutActions();
 
   const [ingestPageId, setIngestPageId] = useState<string | null>(null);
   const [refreshingAll, setRefreshingAll] = useState(false);
+  const [collapsedIds, setCollapsedIds] = useState<ReadonlySet<string>>(() => new Set<string>());
+  const [rowMenu, setRowMenu] = useState<RowMenuTarget | null>(null);
 
   const familyIndex = useMemo(() => buildMirrorFamilyIndex(pages, pageOrder), [pages, pageOrder]);
   const topLevel = useMemo(
@@ -74,6 +125,56 @@ export function NavigatorPanel() {
     () => topLevel.map((id) => (familyIndex.childrenOf.has(id) ? familyBlock(familyIndex, pageOrder, id) : [id])),
     [topLevel, familyIndex, pageOrder],
   );
+
+  /** Ancestors of a page, root-first — index `c` is the ancestor at depth `c`,
+   *  which is exactly the guide column that represents it. */
+  const ancestorsOf = useCallback(
+    (pageId: string): string[] => {
+      const chain: string[] = [];
+      let cur = familyIndex.parentOf.get(pageId);
+      // `parentOf` already drops cyclic edges; the seen-check is belt-and-braces
+      // so a malformed index can never spin here.
+      while (cur !== undefined && !chain.includes(cur)) {
+        chain.unshift(cur);
+        cur = familyIndex.parentOf.get(cur);
+      }
+      return chain;
+    },
+    [familyIndex],
+  );
+
+  /** The active page plus every ancestor of it — the ids whose guide columns
+   *  render lit. */
+  const litPath = useMemo(() => {
+    const set = new Set<string>();
+    if (activePageId === null) return set;
+    set.add(activePageId);
+    let cur = familyIndex.parentOf.get(activePageId);
+    while (cur !== undefined && !set.has(cur)) {
+      set.add(cur);
+      cur = familyIndex.parentOf.get(cur);
+    }
+    return set;
+  }, [activePageId, familyIndex]);
+
+  /** Descendants of a root that survive the collapse state. Reordering is
+   *  unaffected: drag still moves the whole `familyBlock`, hidden rows and all. */
+  const visibleDescendants = useCallback(
+    (rootId: string) =>
+      descendantEntries(familyIndex, rootId).filter(
+        ({ pageId }) => !ancestorsOf(pageId).some((a) => collapsedIds.has(a)),
+      ),
+    [familyIndex, ancestorsOf, collapsedIds],
+  );
+
+  const toggleCollapsed = useCallback((pageId: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(pageId)) next.delete(pageId);
+      else next.add(pageId);
+      return next;
+    });
+  }, []);
 
   /** Providers with at least one mirror page in this document. */
   const docProviders = useMemo(() => {
@@ -127,6 +228,31 @@ export function NavigatorPanel() {
     else notifications.success(`Refreshed ${ok} page(s) from ${providerLabel(hub, provider)}.`);
   };
 
+  /** Rename via the shared prompt dialog — the row is 260px wide and an inline
+   *  editor there fights the guides for space. */
+  const promptRename = (currentName: string, apply: (name: string) => void) => {
+    void promptDialog({
+      title: 'Rename page',
+      label: 'Page name',
+      initialValue: currentName,
+      confirmLabel: 'Rename',
+    }).then((name) => {
+      if (name !== null) apply(name);
+    });
+  };
+
+  const promptDelete = (name: string, apply: () => void) => {
+    void confirmDialog({
+      title: `Delete "${name}"?`,
+      message: 'The page and its content are removed from this document.',
+      confirmLabel: 'Delete',
+      danger: true,
+    }).then((confirmed) => {
+      if (confirmed) apply();
+    });
+  };
+
+  /** Mirror-specific actions, appended to a mirror page's menu. */
   const mirrorMenuEntries = (pageId: string): DropdownMenuEntry[] => {
     const page = pages[pageId];
     const m = page?.mirror;
@@ -146,13 +272,12 @@ export function NavigatorPanel() {
       ...(m.url
         ? [
             menuAction({
-              id: 'open',
+              id: 'open-external',
               label: `Open in ${label}`,
               onSelect: () => void opener.openExternalUrl(m.url!),
             }),
           ]
         : []),
-      MENU_SEPARATOR,
       menuAction({
         id: 'detach',
         label: `Detach from ${label}`,
@@ -166,45 +291,159 @@ export function NavigatorPanel() {
           });
         },
       }),
+    ];
+  };
+
+  /** One menu description per prose row, shared by the kebab and the
+   *  right-click menu so the two can never drift. */
+  const proseMenuEntries = (pageId: string): DropdownMenuEntry[] => {
+    const page = pages[pageId];
+    if (!page) return [];
+    const hasChildren = (familyIndex.childrenOf.get(pageId) ?? []).length > 0;
+    const entries: DropdownMenuEntry[] = [
+      menuAction({ id: 'open', label: 'Open', onSelect: () => setActivePage(pageId) }),
+      menuAction({
+        id: 'rename',
+        label: 'Rename…',
+        onSelect: () => promptRename(page.name, (name) => renamePage(pageId, name)),
+      }),
+    ];
+    if (hasChildren) {
+      entries.push(
+        menuAction({
+          id: 'collapse',
+          label: collapsedIds.has(pageId) ? 'Expand subpages' : 'Collapse subpages',
+          onSelect: () => toggleCollapsed(pageId),
+        }),
+      );
+    }
+    const mirror = mirrorMenuEntries(pageId);
+    if (mirror.length > 0) entries.push(MENU_SEPARATOR, ...mirror);
+    entries.push(
+      MENU_SEPARATOR,
       menuAction({
         id: 'delete',
         label: 'Delete page',
         danger: true,
-        onSelect: () => deletePage(pageId),
+        // The store silently refuses to delete the last page; say so instead.
+        disabled: pageOrder.length <= 1,
+        onSelect: () => promptDelete(page.name, () => deletePage(pageId)),
+      }),
+    );
+    return entries;
+  };
+
+  const canvasMenuEntries = (pageId: string): DropdownMenuEntry[] => {
+    const page = canvasPages[pageId];
+    if (!page) return [];
+    return [
+      menuAction({ id: 'open', label: 'Open', onSelect: () => setCanvasActive(pageId) }),
+      menuAction({
+        id: 'rename',
+        label: 'Rename…',
+        onSelect: () => promptRename(page.name, (name) => renameCanvasPage(pageId, name)),
+      }),
+      menuAction({ id: 'duplicate', label: 'Duplicate', onSelect: () => void duplicateCanvasPage(pageId) }),
+      MENU_SEPARATOR,
+      menuAction({
+        id: 'delete',
+        label: 'Delete page',
+        danger: true,
+        disabled: canvasOrder.length <= 1,
+        onSelect: () => promptDelete(page.name, () => deleteCanvasPage(pageId)),
       }),
     ];
   };
+
+  const openRowMenu = (kind: RowKind, pageId: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setRowMenu({ kind, pageId, x: e.clientX, y: e.clientY });
+  };
+
+  /** The guide columns for a row, lit along the active page's ancestry. */
+  const guides = (chain: string[]) =>
+    chain.map((ancestorId, depth) => (
+      <span
+        key={`${ancestorId}-${depth}`}
+        className={`navigator-guide ${litPath.has(ancestorId) ? 'lit' : ''}`}
+        style={{ width: INDENT_PX }}
+        aria-hidden="true"
+      />
+    ));
 
   const proseRow = (pageId: string, depth: number) => {
     const page = pages[pageId];
     if (!page) return null;
     const m = page.mirror;
+    const chain = ancestorsOf(pageId);
+    const rootId = chain[0];
+    const rootProvider = rootId !== undefined ? pages[rootId]?.mirror?.provider : undefined;
+    // Depth 0 establishes the family's provider; deeper rows only show a glyph
+    // when theirs differs, which is the anomaly worth noticing.
+    const showGlyph = m !== undefined && (depth === 0 || m.provider !== rootProvider);
+    const childCount = (familyIndex.childrenOf.get(pageId) ?? []).length;
+    const isCollapsed = collapsedIds.has(pageId);
+
     return (
       <div
         key={pageId}
         className={`navigator-row ${activePageId === pageId ? 'active' : ''}`}
-        style={depth > 0 ? { paddingLeft: depth * 12 } : undefined}
+        onContextMenu={(e) => openRowMenu('prose', pageId, e)}
       >
-        <button type="button" className="navigator-row-main" onClick={() => setActivePage(pageId)}>
-          {m ? <ProviderIcon provider={m.provider} size={13} /> : <span className="navigator-row-dot" />}
+        {guides(chain)}
+        {childCount > 0 ? (
+          <button
+            type="button"
+            className={`navigator-twisty ${isCollapsed ? 'collapsed' : ''}`}
+            style={{ width: INDENT_PX }}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleCollapsed(pageId);
+            }}
+            aria-expanded={!isCollapsed}
+            title={
+              isCollapsed
+                ? `Show ${childCount} subpage${childCount === 1 ? '' : 's'}`
+                : `Hide ${childCount} subpage${childCount === 1 ? '' : 's'}`
+            }
+          >
+            <Icon icon={ChevronRight} size={12} />
+          </button>
+        ) : (
+          <span className="navigator-twisty-spacer" style={{ width: INDENT_PX }} aria-hidden="true" />
+        )}
+        <button
+          type="button"
+          className="navigator-row-main"
+          onClick={() => setActivePage(pageId)}
+          // Without this the name and the staleness badge run together into
+          // "Concepts8d" for a screen reader.
+          aria-label={m ? `${page.name}, synced ${syncedShort(m.syncedAt)} ago` : page.name}
+        >
+          {showGlyph && m && <ProviderIcon provider={m.provider} size={13} />}
           <span className="navigator-row-name">{page.name}</span>
           {m && (
-            <span className="navigator-row-synced" title={`Last synced ${syncedShort(m.syncedAt)} ago`}>
+            <span
+              className="navigator-row-synced"
+              title={`Last synced ${syncedShort(m.syncedAt)} ago`}
+              aria-hidden="true"
+            >
               {syncedShort(m.syncedAt)}
             </span>
           )}
         </button>
-        {m && (
-          <DropdownMenu
-            trigger={<Icon icon={MoreHorizontal} size={14} />}
-            triggerTitle={`Actions for ${page.name}`}
-            triggerClassName="navigator-row-menu"
-            entries={mirrorMenuEntries(pageId)}
-          />
-        )}
+        <DropdownMenu
+          trigger={<Icon icon={MoreHorizontal} size={14} />}
+          triggerTitle={`Actions for ${page.name}`}
+          triggerClassName="navigator-row-menu"
+          entries={proseMenuEntries(pageId)}
+        />
       </div>
     );
   };
+
+  const dockedRight = navigatorState.dock === 'right';
 
   return (
     <div className="navigator-panel" aria-label="Navigator">
@@ -235,6 +474,15 @@ export function NavigatorPanel() {
               Match structure
             </button>
           )}
+          <button
+            type="button"
+            className="navigator-collapse-btn"
+            onClick={() => setPanelVisible('navigator', false)}
+            title="Hide the Navigator — reopen it from the layout menu in the toolbar"
+            aria-label="Hide Navigator panel"
+          >
+            <Icon icon={dockedRight ? PanelRightClose : PanelLeftClose} size={14} />
+          </button>
         </div>
       </div>
 
@@ -251,7 +499,7 @@ export function NavigatorPanel() {
             </span>
             <div className="navigator-block-rows">
               {proseRow(id, 0)}
-              {descendantEntries(familyIndex, id).map(({ pageId, depth }) => proseRow(pageId, depth))}
+              {visibleDescendants(id).map(({ pageId, depth }) => proseRow(pageId, depth))}
             </div>
           </div>
         )}
@@ -278,15 +526,44 @@ export function NavigatorPanel() {
             <span className="navigator-drag-handle" {...handleProps}>
               <Icon icon={GripVertical} size={13} />
             </span>
-            <div className={`navigator-row ${canvasActiveId === id ? 'active' : ''}`}>
-              <button type="button" className="navigator-row-main" onClick={() => setCanvasActive(id)}>
-                <span className="navigator-row-dot" />
+            <div
+              className={`navigator-row ${canvasActiveId === id ? 'active' : ''}`}
+              onContextMenu={(e) => openRowMenu('canvas', id, e)}
+            >
+              <span className="navigator-twisty-spacer" style={{ width: INDENT_PX }} aria-hidden="true" />
+              <button
+                type="button"
+                className="navigator-row-main"
+                onClick={() => setCanvasActive(id)}
+                aria-label={canvasPages[id]?.name ?? 'Untitled'}
+              >
                 <span className="navigator-row-name">{canvasPages[id]?.name ?? 'Untitled'}</span>
               </button>
+              <DropdownMenu
+                trigger={<Icon icon={MoreHorizontal} size={14} />}
+                triggerTitle={`Actions for ${canvasPages[id]?.name ?? 'this page'}`}
+                triggerClassName="navigator-row-menu"
+                entries={canvasMenuEntries(id)}
+              />
             </div>
           </div>
         )}
       />
+
+      {/* One controlled, trigger-less menu serves every right-click in the
+          panel — the entries come from the same builders the kebabs use. */}
+      {rowMenu && (
+        <DropdownMenu
+          open
+          onOpenChange={(next) => {
+            if (!next) setRowMenu(null);
+          }}
+          anchorPoint={{ x: rowMenu.x, y: rowMenu.y }}
+          entries={
+            rowMenu.kind === 'prose' ? proseMenuEntries(rowMenu.pageId) : canvasMenuEntries(rowMenu.pageId)
+          }
+        />
+      )}
 
       {ingestPageId && <IngestSubpagesDialog pageId={ingestPageId} onClose={() => setIngestPageId(null)} />}
     </div>

--- a/src/ui/StyleProfilePanel.css
+++ b/src/ui/StyleProfilePanel.css
@@ -236,38 +236,9 @@
   gap: var(--space-2);
 }
 
-/* Fluid columns: tighter cells in a narrow panel, roomier when docked wide. */
-/* Only a genuinely narrow dock drops to one card per row. Two columns stay
-   comfortable down to about 200px (~90px each); collapsing earlier just made a
-   wide, short card with a small centred swatch and a lot of dead space. */
-@container (max-width: 200px) {
-  .style-profile-container.grid {
-    grid-template-columns: 1fr;
-    /* At one-per-row the vertical stack stops making sense — a 180px-wide card
-       with a centred 40px swatch is mostly empty. Lay it out horizontally
-       instead: swatch left, name reading naturally beside it. */
-    grid-auto-rows: 48px;
-  }
-
-  .style-profile-grid-apply {
-    flex-direction: row;
-    justify-content: flex-start;
-    gap: var(--space-2);
-    padding: 6px 8px;
-  }
-
-  .style-profile-grid-name {
-    text-align: left;
-    -webkit-line-clamp: 2;
-  }
-
-  /* The rail would sit on top of the name in a row layout; give it the trailing
-     edge and let the name stop short of it. */
-  .style-profile-grid-apply .style-profile-grid-name {
-    padding-right: 52px;
-  }
-}
-
+/* Fluid columns: tighter cells in a narrow panel, roomier when docked wide.
+   The narrow (max-width: 200px) rules live further down, AFTER the card and
+   name base rules they override — see the note there. */
 @container (min-width: 440px) {
   .style-profile-container.grid {
     grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
@@ -378,6 +349,51 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+/* --- Narrow dock: one card per row, laid out horizontally ------------------
+   MUST stay below `.style-profile-grid-apply` and `.style-profile-grid-name`.
+   A container query adds NO specificity, so when this block sat above them
+   (where the other column rules live) the base declarations won on source
+   order alone: `flex-direction: row` never applied, the card stayed a centred
+   column, and squeezing that column into the 48px row collapsed the name to
+   *zero height* — cards rendered as a bare swatch with no title.
+
+   Budget at ~160px: 8 + swatch 40 + 8 + name + 8. The coverage badge is the
+   one thing that does not fit, so it steps out here and keeps reporting
+   through the card's `title` — the name is what the panel is for. Nothing
+   reserves room for the hover rail either: it is `max-width: 0` until hover
+   and fades in over its own gradient, so holding 52px open for it permanently
+   was starving the name for a control that is not there. */
+@container (max-width: 200px) {
+  .style-profile-container.grid {
+    grid-template-columns: 1fr;
+    /* At one-per-row the vertical stack stops making sense — a 180px-wide card
+       with a centred 40px swatch is mostly empty. Lay it out horizontally
+       instead: swatch left, name reading naturally beside it. */
+    grid-auto-rows: 48px;
+  }
+
+  .style-profile-grid-apply {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: var(--space-2);
+    padding: 6px 8px;
+  }
+
+  .style-profile-grid-name {
+    flex: 1 1 auto;
+    /* Lets the flex child ellipsize instead of forcing the card wider. */
+    min-width: 0;
+    text-align: left;
+    /* One line: a 48px row with a 40px swatch has no second line to give. */
+    -webkit-line-clamp: 1;
+  }
+
+  .style-profile-coverage {
+    display: none;
+  }
 }
 
 

--- a/src/ui/UnifiedToolbar.css
+++ b/src/ui/UnifiedToolbar.css
@@ -40,6 +40,79 @@
   gap: var(--space-2);
 }
 
+/* ---------------------------------------------------------------------------
+   Menu-trigger chips (the layout selector and Tools).
+
+   ONE rule for both. They do the same kind of thing — open a popover of view
+   or document actions — so they must not drift into two visual languages, and
+   they were: the layout chip sat at 28px with a border while Tools rendered as
+   bare text, next to 32px icon buttons and a 29px Settings. Every control in
+   the app bar now resolves to --control-height-lg, so the bar has one baseline
+   instead of four.
+   ------------------------------------------------------------------------ */
+.toolbar-menu-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  height: var(--control-height-lg);
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+.toolbar-menu-chip:hover,
+.toolbar-menu-chip[aria-expanded='true'],
+.toolbar-menu-chip.open {
+  background: var(--bg-secondary);
+  border-color: var(--color-primary);
+}
+
+.toolbar-menu-chip:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha);
+}
+
+.toolbar-menu-chip svg {
+  flex-shrink: 0;
+}
+
+/* The chevron is the "this opens something" tell — quiet, and it flips when the
+   popover is open so the chip reads as a state, not just a button. */
+.toolbar-menu-chip .toolbar-tools-chevron,
+.toolbar-menu-chip .layout-selector-chip-chevron {
+  font-size: var(--font-size-2xs);
+  line-height: 1;
+  opacity: 0.55;
+  transition: transform 0.12s ease, opacity 0.12s ease;
+}
+
+.toolbar-menu-chip:hover .toolbar-tools-chevron,
+.toolbar-menu-chip:hover .layout-selector-chip-chevron {
+  opacity: 0.9;
+}
+
+.toolbar-menu-chip[aria-expanded='true'] .toolbar-tools-chevron,
+.toolbar-menu-chip.open .layout-selector-chip-chevron {
+  transform: rotate(180deg);
+  opacity: 0.9;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toolbar-menu-chip,
+  .toolbar-menu-chip .toolbar-tools-chevron,
+  .toolbar-menu-chip .layout-selector-chip-chevron {
+    transition: none;
+  }
+}
+
 /* On a narrow viewport, collapse Settings to icon-only so the app bar keeps its
  * full action set without crowding the document name. */
 @media (max-width: 640px) {
@@ -493,14 +566,17 @@
   box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
-/* Help button */
-.toolbar-help-btn,
-.toolbar-export-btn {
+/* Help button — the one icon-only control left in the bar (and the mobile
+   "more actions" trigger). Sized to the same 32px box as its chip neighbours so
+   the row keeps one baseline; quiet until hover, since it is tertiary.
+   The Whiteboard + PDF-export button rules that used to live here went with
+   their buttons into the Tools menu. */
+.toolbar-help-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: var(--control-height-lg);
+  height: var(--control-height-lg);
   padding: 0;
   color: var(--text-secondary);
   background: transparent;
@@ -510,83 +586,19 @@
   transition: all 0.15s ease;
 }
 
-.toolbar-help-btn:hover,
-.toolbar-export-btn:hover {
+.toolbar-help-btn:hover {
   background: var(--bg-hover);
   border-color: var(--border-color);
   color: var(--color-primary, var(--color-primary));
 }
 
-.toolbar-help-btn:focus,
-.toolbar-export-btn:focus {
+.toolbar-help-btn:focus-visible {
   outline: none;
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
-.toolbar-help-btn svg,
-.toolbar-export-btn svg {
-  width: 16px;
-  height: 16px;
-}
-
-/* Whiteboard button */
-.toolbar-whiteboard-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  color: var(--text-primary);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover);
-  color: var(--color-primary, var(--color-primary));
-}
-
-.toolbar-whiteboard-btn:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-alpha);
-}
-
-.toolbar-whiteboard-btn svg {
-  width: 16px;
-  height: 16px;
-}
-
-/* Whiteboard button */
-.toolbar-whiteboard-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  color: var(--text-primary);
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover);
-  color: var(--color-primary, var(--color-primary));
-}
-
-.toolbar-whiteboard-btn:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-alpha);
-}
-
-.toolbar-whiteboard-btn svg {
+.toolbar-help-btn svg {
   width: 16px;
   height: 16px;
 }
@@ -597,7 +609,10 @@
   display: flex;
   align-items: center;
   gap: var(--space-1-5);
-  padding: var(--space-1-5) var(--space-3);
+  /* Same baseline as the menu chips and the icon buttons — the bar used to
+     mix 28 / 29 / 32px heights, which read as a ragged edge. */
+  height: var(--control-height-lg);
+  padding: 0 var(--space-3);
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-medium);
   color: var(--text-primary);
@@ -821,22 +836,3 @@
   border-color: var(--color-primary);
 }
 
-/* Dark mode for whiteboard button */
-[data-theme="dark"] .toolbar-whiteboard-btn {
-  color: var(--text-secondary);
-}
-
-[data-theme="dark"] .toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover);
-  color: var(--color-primary);
-}
-
-/* Dark mode for whiteboard button */
-[data-theme="dark"] .toolbar-whiteboard-btn {
-  color: var(--text-secondary);
-}
-
-[data-theme="dark"] .toolbar-whiteboard-btn:hover {
-  background: var(--bg-hover);
-  color: var(--color-primary);
-}

--- a/src/ui/UnifiedToolbar.tsx
+++ b/src/ui/UnifiedToolbar.tsx
@@ -7,7 +7,7 @@
  * live in CanvasToolbar inside the canvas region so they don't leak app-wide.
  */
 
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import {
   StickyNote,
   CircleHelp,
@@ -16,8 +16,14 @@ import {
   FolderOpen,
   MoreHorizontal,
   History,
+  Wrench,
 } from 'lucide-react';
 import { Icon, PdfIcon } from './icons';
+import {
+  DropdownMenu,
+  menuAction,
+  type DropdownMenuEntry,
+} from './components/DropdownMenu';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { MobileDocumentInfo } from './mobile/MobileDocumentInfo';
 import { ToolbarGroup } from './ToolbarGroup';
@@ -228,6 +234,53 @@ export function UnifiedToolbar({
     return () => window.removeEventListener('docushark:open-pdf-export', open);
   }, []);
 
+  /**
+   * The document-scoped actions, gathered into one menu (JP — toolbar tidy).
+   * These were four loose icon buttons whose glyphs had to carry their whole
+   * meaning; as menu rows they get names, and the bar gets its width back.
+   * Availability stays declarative — a row the session can't use isn't built.
+   */
+  const toolEntries = useMemo((): DropdownMenuEntry[] => {
+    const entries: DropdownMenuEntry[] = [];
+    if (!guest) {
+      entries.push(
+        menuAction({
+          id: 'import',
+          label: 'Import diagram…',
+          icon: <Icon icon={FileInput} size={16} />,
+          disabled: isReadOnly,
+          onSelect: () => window.dispatchEvent(new CustomEvent('docushark:import-diagram')),
+        }),
+        menuAction({
+          id: 'whiteboard',
+          label: 'Whiteboard',
+          icon: <Icon icon={StickyNote} size={16} />,
+          onSelect: () => useWhiteboardStore.getState().toggleVisibility(),
+        }),
+      );
+    }
+    entries.push(
+      menuAction({
+        id: 'export-pdf',
+        label: 'Export to PDF…',
+        icon: <PdfIcon />,
+        onSelect: () => setShowPdfExport(true),
+      }),
+    );
+    if (versionHistoryAvailable && !guest) {
+      entries.push(
+        menuAction({
+          id: 'version-history',
+          label: 'Version history',
+          icon: <Icon icon={History} size={16} />,
+          onSelect: () => setShowVersionHistory(true),
+        }),
+      );
+    }
+    return entries;
+  }, [guest, isReadOnly, versionHistoryAvailable]);
+
+
   return (
     <>
     <div className="unified-toolbar">
@@ -273,53 +326,24 @@ export function UnifiedToolbar({
             </button>
           ) : (
             <>
-              {!guest && (
-              <button
-                className="toolbar-help-btn"
-                onClick={() => window.dispatchEvent(new CustomEvent('docushark:import-diagram'))}
-                disabled={isReadOnly}
-                title={
-                  isReadOnly
-                    ? 'Import is unavailable on a view-only document'
-                    : 'Import diagram (Excalidraw, drawio, Mermaid)'
+              <DropdownMenu
+                trigger={
+                  <>
+                    <Icon icon={Wrench} size={14} />
+                    <span>Tools</span>
+                    <span className="toolbar-tools-chevron" aria-hidden="true">▾</span>
+                  </>
                 }
-                aria-label="Import diagram (Excalidraw, drawio, Mermaid)"
-              >
-                <Icon icon={FileInput} />
-              </button>
-              )}
-              {!guest && (
-              <button
-                className="toolbar-whiteboard-btn"
-                onClick={() => useWhiteboardStore.getState().toggleVisibility()}
-                title="Whiteboard — sticky notes for brainstorming (Ctrl+I)"
-                aria-label="Whiteboard"
-              >
-                <Icon icon={StickyNote} />
-              </button>
-              )}
-              <button
-                className="toolbar-export-btn"
-                onClick={() => setShowPdfExport(true)}
-                title="Export to PDF"
-                aria-label="Export to PDF"
-              >
-                <PdfIcon />
-              </button>
-              {versionHistoryAvailable && !guest && (
-                <button
-                  className="toolbar-help-btn"
-                  onClick={() => setShowVersionHistory(true)}
-                  title="Version history"
-                  aria-label="Version history"
-                >
-                  <Icon icon={History} />
-                </button>
-              )}
+                triggerClassName="toolbar-menu-chip toolbar-tools-btn"
+                triggerTitle="Tools — import, whiteboard, export, version history"
+                entries={toolEntries}
+                openOnHover
+              />
               <button
                 className="toolbar-help-btn"
                 onClick={() => void openDocsHandler()}
                 title="Open documentation (F1)"
+                aria-label="Open documentation"
               >
                 <Icon icon={CircleHelp} />
               </button>

--- a/src/ui/components/DropdownMenu.test.tsx
+++ b/src/ui/components/DropdownMenu.test.tsx
@@ -192,4 +192,132 @@ describe('DropdownMenu', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: 'Alpha' }));
     expect(surfaceClick).not.toHaveBeenCalled();
   });
+
+  /**
+   * Context-menu mode: a controlled, trigger-less menu placed at a cursor
+   * point. Every prop involved is additive and defaults off, so the suite
+   * above doubles as the regression guard for existing consumers.
+   */
+  describe('controlled + anchorPoint (right-click menus)', () => {
+    it('renders with no trigger button and opens from the `open` prop', () => {
+      render(
+        <DropdownMenu
+          open
+          anchorPoint={{ x: 40, y: 60 }}
+          entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+        />,
+      );
+      // No trigger was passed, so none should be rendered.
+      expect(screen.queryByRole('button', { name: 'Menu' })).toBeNull();
+      expect(screen.getByRole('menuitem', { name: 'Alpha' })).toBeTruthy();
+    });
+
+    it('positions the panel at the anchor point rather than under a trigger', () => {
+      render(
+        <DropdownMenu
+          open
+          anchorPoint={{ x: 120, y: 200 }}
+          entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+        />,
+      );
+      const panel = screen.getByRole('menu') as HTMLElement;
+      // jsdom reports zero-size elements, so the clamp leaves x untouched and
+      // the panel opens down-right of the point (y + 4px offset).
+      expect(panel.style.left).toBe('120px');
+      expect(panel.style.top).toBe('204px');
+    });
+
+    it('a controlled parent is asked to close, and stays open until it agrees', () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu
+          open
+          anchorPoint={{ x: 10, y: 10 }}
+          onOpenChange={onOpenChange}
+          entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+        />,
+      );
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Alpha' }));
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+      // `open` is still true from the parent, so the menu must not self-close —
+      // that is what "controlled" means.
+      expect(screen.getByRole('menu')).toBeTruthy();
+    });
+  });
+
+  describe('openOnHover', () => {
+    it('opens on pointer enter without stealing focus', () => {
+      render(
+        <DropdownMenu
+          trigger={<span>Menu</span>}
+          triggerTitle="Menu"
+          openOnHover
+          entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+        />,
+      );
+      fireEvent.mouseEnter(screen.getByRole('button', { name: 'Menu' }));
+      const item = screen.getByRole('menuitem', { name: 'Alpha' });
+      expect(item).toBeTruthy();
+      // Hover is pointer-driven: yanking focus out of whatever the user was
+      // doing would be a bug, not a convenience.
+      expect(document.activeElement).not.toBe(item);
+    });
+
+    it('survives the trip from trigger to the portaled panel', () => {
+      vi.useFakeTimers();
+      try {
+        render(
+          <DropdownMenu
+            trigger={<span>Menu</span>}
+            triggerTitle="Menu"
+            openOnHover
+            entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+          />,
+        );
+        const trigger = screen.getByRole('button', { name: 'Menu' });
+        fireEvent.mouseEnter(trigger);
+        // Leaving the trigger starts the grace timer; the panel is portaled, so
+        // this fires the instant the pointer sets off toward the menu.
+        fireEvent.mouseLeave(trigger);
+        fireEvent.mouseEnter(screen.getByRole('menu'));
+        act(() => void vi.advanceTimersByTime(500));
+        expect(screen.getByRole('menuitem', { name: 'Alpha' })).toBeTruthy();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('closes once the pointer leaves the panel too', () => {
+      vi.useFakeTimers();
+      try {
+        render(
+          <DropdownMenu
+            trigger={<span>Menu</span>}
+            triggerTitle="Menu"
+            openOnHover
+            entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+          />,
+        );
+        fireEvent.mouseEnter(screen.getByRole('button', { name: 'Menu' }));
+        fireEvent.mouseLeave(screen.getByRole('menu'));
+        act(() => void vi.advanceTimersByTime(500));
+        expect(screen.queryByRole('menu')).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('a click still focuses the first item (keyboard-equivalent intent)', () => {
+      render(
+        <DropdownMenu
+          trigger={<span>Menu</span>}
+          triggerTitle="Menu"
+          openOnHover
+          entries={[menuAction({ id: 'a', label: 'Alpha', onSelect: vi.fn() })]}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+      expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Alpha' }));
+    });
+  });
 });

--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -68,17 +68,54 @@ export function menuAction(action: DropdownMenuAction): DropdownMenuEntry {
 export const MENU_SEPARATOR: DropdownMenuEntry = { kind: 'separator' };
 
 export interface DropdownMenuProps {
-  /** Trigger button content (icon and/or label). */
-  trigger: ReactNode;
+  /**
+   * Trigger button content (icon and/or label). Omit for a menu with no
+   * affordance of its own — a right-click menu, driven entirely by `open` +
+   * `anchorPoint` from the parent.
+   */
+  trigger?: ReactNode | undefined;
   triggerClassName?: string | undefined;
   /** Tooltip + accessible label for the trigger. */
   triggerTitle?: string | undefined;
   entries: DropdownMenuEntry[];
   /** Which trigger edge the panel aligns to (default 'right'). */
   align?: 'left' | 'right' | undefined;
+  /**
+   * Controlled open state. Omit (the default) to let the trigger own it; pass
+   * a boolean to drive the menu from the parent, in which case `onOpenChange`
+   * is how the menu asks to close (outside click, Escape, item selected).
+   */
+  open?: boolean | undefined;
   /** Fires on open/close — lets a hover-revealed surface pin itself visible. */
   onOpenChange?: ((open: boolean) => void) | undefined;
+  /**
+   * Place the panel at this viewport point instead of under the trigger — the
+   * context-menu case. Implies left-alignment (a cursor menu opens down-right)
+   * regardless of `align`, which describes a trigger edge that isn't in play.
+   */
+  anchorPoint?: { x: number; y: number } | null | undefined;
+  /**
+   * Move focus to the first item on open (default true — the keyboard flow
+   * starts inside the menu). Set false for a menu that opens on *hover*: there
+   * the pointer, not the keyboard, is driving, and yanking focus out of
+   * whatever the user was doing is a bug rather than a convenience.
+   */
+  autoFocusFirstItem?: boolean | undefined;
+  /**
+   * Also open on hover, with a grace period before closing. Handled here
+   * rather than by the caller because the panel is portaled to `document.body`
+   * — it is NOT a DOM descendant of the trigger, so a wrapper's `mouseleave`
+   * fires the moment the pointer sets off toward the menu it is aiming for.
+   * Only the component that owns both ends can bridge that gap.
+   *
+   * Hover-opening never moves focus, whatever `autoFocusFirstItem` says.
+   * Uncontrolled use only — pass `open` or this, not both.
+   */
+  openOnHover?: boolean | undefined;
 }
+
+/** Grace period for travelling between the trigger and the portaled panel. */
+const HOVER_CLOSE_DELAY_MS = 200;
 
 interface PanelPosition {
   top: number;
@@ -111,9 +148,17 @@ export function DropdownMenu({
   triggerTitle,
   entries,
   align = 'right',
+  open: openProp,
   onOpenChange,
+  anchorPoint,
+  autoFocusFirstItem = true,
+  openOnHover = false,
 }: DropdownMenuProps) {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  // Controlled only when the parent actually passes `open`; every existing
+  // consumer omits it and keeps the original self-owned behaviour.
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : uncontrolledOpen;
   const [position, setPosition] = useState<PanelPosition>({ top: 0, left: 0 });
   const [openSubId, setOpenSubId] = useState<string | null>(null);
   const [subPlacement, setSubPlacement] = useState<FlyoutPlacement | null>(null);
@@ -125,14 +170,14 @@ export function DropdownMenu({
 
   const setOpenNotify = useCallback(
     (next: boolean) => {
-      setOpen(next);
+      if (!isControlled) setUncontrolledOpen(next);
       if (!next) {
         setOpenSubId(null);
         setSubPlacement(null);
       }
       onOpenChange?.(next);
     },
-    [onOpenChange],
+    [isControlled, onOpenChange],
   );
 
   const closeAll = useCallback(
@@ -143,22 +188,59 @@ export function DropdownMenu({
     [setOpenNotify],
   );
 
-  // Position the panel under the trigger, clamped to the viewport.
+  // --- Hover open (opt-in via `openOnHover`) ---------------------------
+  // `hoverOpenedRef` is a ref, not state: it gates the focus effect, and as
+  // state it would re-run that effect a tick after opening and pull focus in
+  // anyway — the exact thing hover-opening must not do.
+  const hoverOpenedRef = useRef(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelHoverClose = useCallback(() => {
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current);
+      hoverTimer.current = null;
+    }
+  }, []);
+  useEffect(() => () => cancelHoverClose(), [cancelHoverClose]);
+
+  const handleHoverEnter = useCallback(() => {
+    if (!openOnHover) return;
+    cancelHoverClose();
+    hoverOpenedRef.current = true;
+    setOpenNotify(true);
+  }, [openOnHover, cancelHoverClose, setOpenNotify]);
+
+  const handleHoverLeave = useCallback(() => {
+    if (!openOnHover) return;
+    cancelHoverClose();
+    hoverTimer.current = setTimeout(() => {
+      hoverOpenedRef.current = false;
+      setOpenNotify(false);
+    }, HOVER_CLOSE_DELAY_MS);
+  }, [openOnHover, cancelHoverClose, setOpenNotify]);
+
+  // Position the panel under the trigger (or at the cursor point), clamped to
+  // the viewport. A cursor point is a zero-size rect, so the same flip/clamp
+  // maths covers both cases.
   const updatePosition = useCallback(() => {
-    if (!triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
+    const rect = anchorPoint
+      ? { top: anchorPoint.y, bottom: anchorPoint.y, left: anchorPoint.x, right: anchorPoint.x }
+      : triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
     const panelWidth = panelRef.current?.offsetWidth ?? 220;
-    let left = align === 'right' ? rect.right - panelWidth : rect.left;
+    // A cursor menu always opens down-right from the point; `align` describes a
+    // trigger edge, which a point does not have.
+    const alignRight = anchorPoint ? false : align === 'right';
+    let left = alignRight ? rect.right - panelWidth : rect.left;
     const maxLeft = window.innerWidth - panelWidth - 8;
     left = Math.max(8, Math.min(left, maxLeft));
-    // Flip above the trigger when there's no room below.
+    // Flip above the anchor when there's no room below.
     const panelHeight = panelRef.current?.offsetHeight ?? 0;
     let top = rect.bottom + 4;
     if (panelHeight > 0 && top + panelHeight > window.innerHeight - 8) {
       top = Math.max(8, rect.top - 4 - panelHeight);
     }
     setPosition({ top, left });
-  }, [align]);
+  }, [align, anchorPoint]);
 
   useLayoutEffect(() => {
     if (open) updatePosition();
@@ -199,14 +281,23 @@ export function DropdownMenu({
     };
   }, [open, closeAll]);
 
+  // A controlled parent can close the menu without routing through
+  // `setOpenNotify` (it just flips its own state), so a submenu left open at
+  // that moment would reappear on the next open. Reset it on every close.
+  useEffect(() => {
+    if (open) return;
+    setOpenSubId(null);
+    setSubPlacement(null);
+  }, [open]);
+
   // Focus the first item when the menu opens (keyboard flow starts inside).
   // Effects run post-commit, so the portaled panel is in the DOM already.
   // preventScroll: focusing must never scroll the page under a fixed panel —
   // that shifts the trigger and makes the menu chase its own position.
   useEffect(() => {
-    if (!open) return;
+    if (!open || !autoFocusFirstItem || hoverOpenedRef.current) return;
     focusableItems(panelRef.current)[0]?.focus({ preventScroll: true });
-  }, [open]);
+  }, [open, autoFocusFirstItem]);
 
   // Place the submenu next to its anchor item once both are rendered.
   useLayoutEffect(() => {
@@ -415,21 +506,29 @@ export function DropdownMenu({
 
   return (
     <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className={triggerClassName}
-        title={triggerTitle}
-        aria-label={triggerTitle}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpenNotify(!open);
-        }}
-      >
-        {trigger}
-      </button>
+      {trigger !== undefined && (
+        <button
+          ref={triggerRef}
+          type="button"
+          className={triggerClassName}
+          title={triggerTitle}
+          aria-label={triggerTitle}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={(e) => {
+            e.stopPropagation();
+            // An explicit click is keyboard-equivalent intent: drop the
+            // hover flag so the panel takes focus as it normally would.
+            cancelHoverClose();
+            hoverOpenedRef.current = false;
+            setOpenNotify(!open);
+          }}
+          onMouseEnter={handleHoverEnter}
+          onMouseLeave={handleHoverLeave}
+        >
+          {trigger}
+        </button>
+      )}
 
       {open &&
         createPortal(
@@ -446,6 +545,10 @@ export function DropdownMenu({
             style={{ top: position.top, left: position.left }}
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => handlePanelKeyDown(e, 'root')}
+            // The panel is portaled, so it must carry the hover handlers
+            // itself — the trigger's `mouseleave` already fired on the way in.
+            onMouseEnter={handleHoverEnter}
+            onMouseLeave={handleHoverLeave}
           >
             {renderEntries(entries, 'root')}
           </div>,
@@ -472,7 +575,11 @@ export function DropdownMenu({
             }
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => handlePanelKeyDown(e, 'sub')}
-            onMouseEnter={cancelScheduledSubClose}
+            onMouseEnter={() => {
+              cancelScheduledSubClose();
+              handleHoverEnter();
+            }}
+            onMouseLeave={handleHoverLeave}
           >
             {renderEntries(openSubEntries.entries, 'sub')}
           </div>,

--- a/src/ui/integrations/IngestSubpagesDialog.css
+++ b/src/ui/integrations/IngestSubpagesDialog.css
@@ -91,7 +91,7 @@
   font-size: var(--font-size-xs, 11px);
   color: var(--text-muted);
   border: 1px solid var(--border-color);
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--radius-pill);
   padding: 1px 7px;
   flex-shrink: 0;
 }
@@ -119,7 +119,7 @@
 
 .ingest-subpages-progress {
   height: 6px;
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--radius-pill);
   background: var(--bg-secondary);
   overflow: hidden;
 }

--- a/src/ui/layout/LayoutSelector.css
+++ b/src/ui/layout/LayoutSelector.css
@@ -6,46 +6,20 @@
   align-items: center;
 }
 
-.layout-selector-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1-5);
-  height: 28px;
-  padding: 0 var(--space-2);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  transition: background-color 0.12s ease, border-color 0.12s ease;
-}
+/* Box, border, height, hover + chevron behaviour all come from
+   `.toolbar-menu-chip` in UnifiedToolbar.css, shared with the Tools chip. Only
+   the layout-specific bits live here. */
 
 /* Compact (mobile) trigger: a square icon button, no label/chevron. */
 .layout-selector-chip.compact {
   gap: 0;
-  width: 32px;
-  height: 32px;
+  width: var(--control-height-lg);
   padding: 0;
   justify-content: center;
 }
 
-.layout-selector-chip:hover,
-.layout-selector-chip.open,
-.layout-selector-chip:focus-visible {
-  background: var(--bg-secondary);
-  border-color: var(--color-primary, var(--color-primary));
-  outline: none;
-}
-
 .layout-selector-chip-label {
   white-space: nowrap;
-}
-
-.layout-selector-chip-chevron {
-  font-size: var(--font-size-2xs);
-  opacity: 0.6;
 }
 
 .layout-selector-dropdown {
@@ -119,6 +93,74 @@
   font-size: var(--font-size-xs);
   color: var(--text-secondary);
   line-height: var(--line-height-snug);
+}
+
+/* Section labels — the popover carries two unrelated groups (presets and
+   panel visibility) and needs to say which is which. */
+.layout-selector-section-label {
+  padding: var(--space-1) var(--space-2) var(--space-0-5);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.layout-selector-panels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+  margin-top: var(--space-1);
+  padding-top: var(--space-1);
+  border-top: 1px solid var(--border-color);
+}
+
+.layout-selector-panel-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: 6px var(--space-2);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.layout-selector-panel-item:hover:not(:disabled),
+.layout-selector-panel-item:focus-visible:not(:disabled) {
+  background: var(--bg-secondary);
+  outline: none;
+}
+
+.layout-selector-panel-item:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* Fixed box so the labels form a column whether or not a row is checked. */
+.layout-selector-panel-check {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  color: var(--color-primary);
+}
+
+.layout-selector-panel-label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.layout-selector-panel-note {
+  flex: none;
+  font-size: var(--font-size-2xs);
+  color: var(--text-muted);
 }
 
 .layout-selector-footer {

--- a/src/ui/layout/LayoutSelector.tsx
+++ b/src/ui/layout/LayoutSelector.tsx
@@ -1,22 +1,48 @@
 /**
- * LayoutSelector — toolbar chip + dropdown for switching layouts.
+ * LayoutSelector — toolbar chip + the app's "view" popover.
  *
  * Lives in `UnifiedToolbar`, never in the titlebar. The toolbar is always our
  * own UI regardless of chrome choice, so this control is guaranteed to render.
  *
- * The dropdown footer hosts a "Customize layout…" link into Settings. The
- * custom-chrome opt-in lives in Settings → Appearance → Window (gated to the
- * desktop shell), not here.
+ * Two sections:
+ *  - **Layout** — the four presets, with thumbnails and shortcuts.
+ *  - **Panels** — per-panel show/hide for the active layout. This is the only
+ *    always-visible affordance for bringing a hidden panel back. The Navigator
+ *    in particular ships `visible: false` in every preset, so without this row
+ *    it is reachable only from Settings or the command palette — a panel you
+ *    cannot find is a panel that does not exist.
+ *
+ * The footer hosts a "Customize layout…" link into Settings. The custom-chrome
+ * opt-in lives in Settings → Appearance → Window (gated to the desktop shell),
+ * not here.
+ *
+ * The popover opens on hover as well as click (same delayed-close pattern as
+ * the page tab strip's overflow menu), so scanning the view controls costs no
+ * clicks; the delay is what keeps a diagonal pointer path from dismissing it.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { PanelsTopLeft } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, PanelsTopLeft } from 'lucide-react';
 import { Icon } from '../icons';
-import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS } from './modes';
+import { useUIPreferencesStore } from '../../store/uiPreferencesStore';
+import { LAYOUT_DESCRIPTIONS, LAYOUT_LABELS, propertiesDockedVisible, resolvePanelState } from './modes';
 import { useActiveLayoutMode, useLayoutActions } from './useLayout';
-import { LAYOUT_MODES, type LayoutMode } from './types';
+import { LAYOUT_MODES, PANEL_IDS, type LayoutMode, type PanelId } from './types';
 import { LayoutThumbnail } from './LayoutThumbnail';
 import './LayoutSelector.css';
+
+/** Panel names as the user meets them elsewhere (Settings → Layout, the
+ *  command palette, the docs). One name per panel, everywhere. */
+const PANEL_LABELS: Record<PanelId, string> = {
+  document: 'Document',
+  properties: 'Properties',
+  layers: 'Layers',
+  navigator: 'Navigator',
+};
+
+/** Matches the tab strip's overflow menu — long enough to cross the gap
+ *  between the chip and the panel without the menu evaporating. */
+const CLOSE_DELAY_MS = 200;
 
 export interface LayoutSelectorProps {
   /** Called when the user clicks "Customize layout…" — wires to Settings. */
@@ -27,12 +53,36 @@ export interface LayoutSelectorProps {
 
 export function LayoutSelector({ onOpenLayoutSettings, compact = false }: LayoutSelectorProps) {
   const activeMode = useActiveLayoutMode();
-  const { setActiveLayout } = useLayoutActions();
+  const { setActiveLayout, togglePanelVisible } = useLayoutActions();
+  const overrides = useUIPreferencesStore((s) => s.layout.modeOverrides[activeMode]);
 
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const close = useCallback(() => setIsOpen(false), []);
+  const cancelClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    cancelClose();
+    setIsOpen(false);
+  }, [cancelClose]);
+
+  const open = useCallback(() => {
+    cancelClose();
+    setIsOpen(true);
+  }, [cancelClose]);
+
+  const scheduleClose = useCallback(() => {
+    cancelClose();
+    closeTimer.current = setTimeout(() => setIsOpen(false), CLOSE_DELAY_MS);
+  }, [cancelClose]);
+
+  useEffect(() => () => cancelClose(), [cancelClose]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -61,15 +111,39 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
     onOpenLayoutSettings?.();
   };
 
+  /**
+   * Effective visibility per panel. Properties reports the layout's real
+   * answer, not the stored flag: in Relaxed it is a selection-only overlay and
+   * never docks, so a checked box there would be a lie.
+   */
+  const panels = useMemo(
+    () =>
+      PANEL_IDS.map((id) => {
+        const state = resolvePanelState(activeMode, id, overrides[id]);
+        const layoutOwned = id === 'properties' && activeMode === 'relaxed';
+        return {
+          id,
+          layoutOwned,
+          visible: id === 'properties' ? propertiesDockedVisible(activeMode, state) : state.visible,
+        };
+      }),
+    [activeMode, overrides],
+  );
+
   return (
-    <div className="layout-selector-wrapper" ref={wrapperRef}>
+    <div
+      className="layout-selector-wrapper"
+      ref={wrapperRef}
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+    >
       <button
         type="button"
-        className={`layout-selector-chip ${compact ? 'compact' : ''} ${isOpen ? 'open' : ''}`}
-        onClick={() => setIsOpen((v) => !v)}
+        className={`toolbar-menu-chip layout-selector-chip ${compact ? 'compact' : ''} ${isOpen ? 'open' : ''}`}
+        onClick={() => (isOpen ? close() : open())}
         aria-haspopup="menu"
         aria-expanded={isOpen}
-        aria-label={`Layout: ${LAYOUT_LABELS[activeMode]}. Click to change.`}
+        aria-label={`View: ${LAYOUT_LABELS[activeMode]} layout. Click to change layout and panels.`}
         title={`Layout: ${LAYOUT_LABELS[activeMode]} (Cmd+Shift+1..4)`}
       >
         {compact ? (
@@ -84,7 +158,8 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
       </button>
 
       {isOpen && (
-        <div className="layout-selector-dropdown" role="menu" aria-label="Switch layout">
+        <div className="layout-selector-dropdown" role="menu" aria-label="View">
+          <div className="layout-selector-section-label">Layout</div>
           <div className="layout-selector-list">
             {LAYOUT_MODES.map((mode, idx) => (
               <button
@@ -92,6 +167,9 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
                 type="button"
                 role="menuitemradio"
                 aria-checked={mode === activeMode}
+                // The visible text lives in nested divs alongside an
+                // aria-hidden thumbnail, which left these options nameless.
+                aria-label={`${LAYOUT_LABELS[mode]} layout — ${LAYOUT_DESCRIPTIONS[mode]}`}
                 className={`layout-selector-option ${mode === activeMode ? 'active' : ''}`}
                 onClick={() => handlePick(mode)}
               >
@@ -103,6 +181,37 @@ export function LayoutSelector({ onOpenLayoutSettings, compact = false }: Layout
                   </div>
                   <div className="layout-selector-option-desc">{LAYOUT_DESCRIPTIONS[mode]}</div>
                 </div>
+              </button>
+            ))}
+          </div>
+
+          <div className="layout-selector-panels">
+            <div className="layout-selector-section-label">Panels</div>
+            {panels.map(({ id, visible, layoutOwned }) => (
+              <button
+                key={id}
+                type="button"
+                role="menuitemcheckbox"
+                aria-checked={visible}
+                disabled={layoutOwned}
+                className="layout-selector-panel-item"
+                // A checkbox is named for the thing, not the action — the
+                // action is already carried by the role plus aria-checked.
+                aria-label={PANEL_LABELS[id]}
+                // The popover stays open: showing a panel is the kind of thing
+                // you do two or three of in a row.
+                onClick={() => togglePanelVisible(id)}
+                title={
+                  layoutOwned
+                    ? 'Relaxed shows Properties only while something is selected'
+                    : `${visible ? 'Hide' : 'Show'} the ${PANEL_LABELS[id]} panel`
+                }
+              >
+                <span className="layout-selector-panel-check" aria-hidden="true">
+                  {visible && <Icon icon={Check} size={13} />}
+                </span>
+                <span className="layout-selector-panel-label">{PANEL_LABELS[id]}</span>
+                {layoutOwned && <span className="layout-selector-panel-note">on selection</span>}
               </button>
             ))}
           </div>


### PR DESCRIPTION
Reshapes the Navigator into a readable tree, gives hidden panels a way back, and collapses the app bar's loose buttons into one menu.

## Navigator — the indent tree

Hierarchy was carried entirely by `paddingLeft: depth * 12`. Depth is now **drawn**: a row at depth `d` renders `d` hairline guide columns, so sibling sets share a spine and the row background spans the full panel width instead of being inset by its own indent.

**The one deliberately loud thing:** guides along the path to the active page render **lit**. In a 25-page family scrolled past its root, the lit spine is what tells you which branch you are inside.

```
   Netcore — Engineering Docs
  ┃ Concepts
  ┃│ Authentication
  ┃ ADRs
  ┃┃ ADR 001
* ┃┃ ADR 003     ← active
  ┃ Turborepo Quickstart
```

Everything else got quieter on purpose:

- **No elbow connectors.** Continuous rails read faster and cost less ink.
- **Descendants drop the provider glyph** the root already established — so a glyph on a descendant now means its provider *differs*, the only case where repeating it is news. 25 identical Notion marks were noise.
- **Branch collapse** via a twisty inside the guide column, costing no width. State is local, not persisted: a `uiPreferences` version bump for a preference that is one click to re-establish isn't worth it.
- Rows 22 → 26px, 12 → 13px, the inset accent bar the fly-out rail already uses, focus rings throughout.
- **Right-click any row** — Open, Rename, Collapse, mirror actions, Delete. Delete now confirms, and reports the last-page guard as a *disabled* item instead of silently doing nothing.
- Rows had no usable accessible name (`"Concepts8d"`). Fixed.

## DropdownMenu — additive, all defaults off

Existing consumers are behaviourally unchanged; the suite that covered them is the regression guard.

- `open` + `anchorPoint` for controlled, cursor-anchored menus — so the right-click menu **reuses** this primitive rather than becoming the fifth bespoke menu in the tree.
- `openOnHover`, owned by the component because the panel is portaled: a caller's wrapper cannot bridge trigger → panel, since its `mouseleave` fires the moment the pointer sets off toward the menu it is aiming for. Hover-opening never moves focus.

7 new tests cover both paths.

## Toolbar + layout

- Import / Whiteboard / Export / Version history collapse into one **Tools** menu beside Help. As menu rows they get names; the bar gets its width back.
- The layout chip and Tools now share one `.toolbar-menu-chip` rule. They do the same kind of thing and had drifted into two visual languages (28px bordered vs unstyled text). Every app-bar control resolves to `--control-height-lg` — replacing a 28/29/32px ragged edge.
- The layout popover gains a **Panels** section. Navigator ships `visible: false` in all four presets, so it was reachable only from Settings or the command palette — a panel you cannot find is a panel that does not exist. Properties reports the layout's real answer and is disabled in Relaxed, where it never docks.
- Layout options and panel toggles had no accessible names.

## Tokens

`--radius-full` is `50%` — an **ellipse** on anything not square. Three pill-shaped consumers were reaching for it (the Navigator header chips rendered as visible ellipses). They now use `--radius-pill`, which already existed one line below. Documented at the definition so it doesn't recur; the seven genuine circles are untouched.

## Drive-by

Reported mid-review: **style profile cards rendered as a bare swatch with no title** in a narrow dock. The `@container (max-width: 200px)` block sat *above* the base rules it overrides — container queries add no specificity, so source order won, `flex-direction: row` never applied, and squeezing the centred column into a 48px row collapsed the name to **zero height**. Moved below the base rules, with the coverage badge standing down at that width and the hover-only rail no longer reserving 52px it doesn't need.

## Verification

Driven against a live 25-page Notion mirror tree in both themes.

- Guide rails measured **2.26:1 unlit / 5.65:1 lit** (dark), **1.73 / 4.80** (light) — `--border-color` at 10% alpha landed at 1.28:1, present in the DOM and invisible on screen, so the rails derive from `--text-muted` instead.
- Hover bridge confirmed surviving trigger → portaled panel with focus left on `body`.
- Collapse, both context menus, and the hide → restore round trip exercised in-browser.
- **3315 tests pass** across 283 files; typecheck clean.

## Notes

- Linear MCP needed authorization in this session, so no issue is attached — happy to retro-link.
- Left alone deliberately: an edge-tab rail for the collapsed Navigator (a second rail on the same edge needs collision logic the popover makes unnecessary), and the `Navigator` / `Pages` naming tension — `Navigator` is what `docs-site/guide/` ships, and renaming is doc churn outside this scope.
- Worth a follow-up: `Match structure` is a bulk reorder with no undo affordance, one click from the tree.

Assisted-by: Opus 5