### PR TITLE
JP-477: document browser polish — view menu, preview grid, capacity ring

### DIFF
--- a/docs-site/guide/collections.md
+++ b/docs-site/guide/collections.md
@@ -30,14 +30,22 @@ your way around at a glance.
 
 ## Creating and managing collections
 
-Open the **document browser** and switch the **Group by** control to
-*Collection*. From there you can:
+Your collections are listed in the document browser's sidebar, under
+**Collections**. Select one to show only its documents, or use the **+** beside
+the heading to create a new one.
+
+To group the whole library by collection instead of filtering to one, open the
+**View** menu in the browser's header and set **Group by** to *Collection*. From
+there you can:
 
 - **Create a collection** — give it a name (and optionally pick a colour).
 - **Rename** or **recolour** a collection from its header menu.
 - **Reorder** collections so your most-used groups come first.
 - **Delete** a collection — the documents inside it aren't deleted, they just
   return to **Unassigned**.
+
+Only collections that currently hold documents get a heading, so grouping a
+filtered list shows you that list — not every collection you've ever made.
 
 ### Adding a document to a collection
 

--- a/docs-site/guide/settings.md
+++ b/docs-site/guide/settings.md
@@ -67,8 +67,8 @@ View and manage stored data:
 - **Garbage collection**: Clean up orphaned blobs (icons are protected by default)
 - Storage usage statistics
 
-When you're signed in to a workspace, the storage meter on Documents Home breaks
-its usage into three parts:
+When you're signed in to a workspace, the storage ring on Documents Home breaks
+its usage into three parts, one arc each:
 
 | Part | What it holds |
 |---|---|
@@ -76,7 +76,10 @@ its usage into three parts:
 | **Files** | Images, icons, and files you've embedded |
 | **Configuration** | [Style profiles](./styling#using-your-profiles-on-more-than-one-device) synced across your devices |
 
-Configuration is typically a few kilobytes — it's listed separately so every
+Hover the ring for the exact amount in each part, or select it to open Storage
+for the full breakdown.
+
+Configuration is typically a few kilobytes — it's counted separately so every
 part of your workspace is accounted for, not because settings take meaningful
 space.
 

--- a/docs-site/guide/styling.md
+++ b/docs-site/guide/styling.md
@@ -110,11 +110,11 @@ Built-in profiles open read-only.
 ### How profiles count toward storage
 
 Synced profiles are stored in your workspace, so they count toward its storage
-allowance under **Configuration** — shown as its own line alongside Documents
-and Files in the storage meter.
+allowance under **Configuration** — its own arc alongside Documents and Files in
+the storage ring on Documents Home.
 
 In practice this is a rounding error: a profile holds a few dozen style values,
-so a thousand of them is a fraction of a megabyte. The line exists so nothing in
+so a thousand of them is a fraction of a megabyte. The arc exists so nothing in
 your workspace is unaccounted for, not because styling is expected to compete
 with your documents for space.
 

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -443,18 +443,38 @@ button.document-card__offline--action:focus-visible {
   margin-bottom: 4px;
 }
 
-/* Grid mode */
+/* Grid mode — a preview plate over a meta block (JP-477). Padding moves off
+   the card and onto the content, so the thumbnail runs edge to edge. */
 .document-card--grid {
   flex-direction: column;
   align-items: stretch;
-  padding: 10px;
-  min-height: 96px;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* 16:10 plate. `aspect-ratio` rather than a fixed height so the preview scales
+   with the column width — the tracks are fluid between the 220px floor and
+   whatever the viewport gives them. */
+.document-card__preview {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border-color);
+  /* Same dot-grid canvas surface the recents strip uses, so a document reads
+     identically in both places. */
+  background-color: var(--bg-secondary);
+  background-image: radial-gradient(
+    color-mix(in srgb, var(--text-faint) 42%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 14px 14px;
 }
 
 .document-card--grid .document-card__content {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  padding: 9px 10px 10px;
 }
 
 .document-card--grid .document-card__name-row {
@@ -466,18 +486,33 @@ button.document-card__offline--action:focus-visible {
   gap: 6px;
 }
 
+/* Actions ride the preview plate rather than a row of their own. They're
+   hover-revealed, so a reserved row cost every card ~38px of permanent blank
+   space for controls that are usually invisible — and it put them at the far
+   end of the card from where the pointer already is. */
 .document-card--grid .document-card__actions {
-  margin-top: 6px;
-  justify-content: flex-end;
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--radius-md);
+  /* Its own plate: the actions sit over a thumbnail of unknown contrast. */
+  background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+  backdrop-filter: blur(3px);
+  box-shadow: var(--shadow-sm);
 }
 
-/* Grid-card foot (JP-444): people stack + mono size. */
+/* Grid-card foot (JP-444): people stack + mono size. Pushed to the bottom so
+   cards in a row share a baseline even when their names wrap differently. */
 .document-card__grid-foot {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  margin-top: 2px;
+  margin-top: auto;
+  padding-top: 2px;
 }
 .document-card__grid-size {
   font-family: var(--font-mono, ui-monospace, monospace);
@@ -520,18 +555,16 @@ button.document-card__offline--action:focus-visible {
   opacity: 1;
 }
 
+/* The checkbox floats over the preview plate now, not the title row — so the
+   name gets the full card width back instead of ceding 24px to a control that
+   is invisible until hover. */
 .document-card--grid .document-card__select {
   position: absolute;
   top: 8px;
   left: 8px;
   margin: 0;
   z-index: 2;
-}
-
-/* Reserve room so the title never sits under the absolute checkbox. */
-.document-card--grid .document-card__name-row {
-  padding-left: 24px;
-  min-height: 22px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.28);
 }
 
 .document-card--grid {

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -40,6 +40,7 @@ import {
 import { confirmDialog } from './confirm/confirmStore';
 import { formatFileSize } from '../utils/fileUtils';
 import { PeopleStack } from './home/PeopleStack';
+import { DocumentPreview, useDocumentPreview } from './home/DocumentPreview';
 import { usePersonName, UNKNOWN_PERSON } from '../store/workspaceDirectoryStore';
 import { TagChips } from './TagChips';
 import { TagEditorPopover } from './TagEditorPopover';
@@ -333,6 +334,9 @@ function DocumentCardImpl({
     right: number;
   } | null>(null);
   const cardRef = useRef<HTMLDivElement | null>(null);
+
+  // Grid cards lead with a thumbnail (JP-477); every other mode skips the work.
+  const gridPreview = useDocumentPreview(record, mode === 'grid');
 
   // Sync editName when record.name changes externally
   useEffect(() => {
@@ -630,6 +634,15 @@ function DocumentCardImpl({
         >
           {isSelected ? <Check size={14} aria-hidden="true" /> : null}
         </button>
+      )}
+      {/* Grid cards lead with the document itself (JP-477). The same preview
+          engine the "Continue working" strip uses — without it the grid was a
+          strictly worse view of the same documents shown as thumbnails
+          immediately above it. */}
+      {mode === 'grid' && (
+        <div className="document-card__preview">
+          <DocumentPreview preview={gridPreview} />
+        </div>
       )}
       <div className="document-card__content">
         {/* Name */}

--- a/src/ui/components/DropdownMenu.css
+++ b/src/ui/components/DropdownMenu.css
@@ -127,3 +127,19 @@
   margin: 4px 0;
   background: var(--border-color);
 }
+
+/* Group label above a run of items — the same mono micro-label the app uses for
+   section eyebrows, so a menu with two axes reads as two labelled groups. */
+.dropdown-menu__heading {
+  padding: 7px 10px 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+/* A heading directly under a separator would double the gap. */
+.dropdown-menu__separator + .dropdown-menu__heading {
+  padding-top: 3px;
+}

--- a/src/ui/components/DropdownMenu.tsx
+++ b/src/ui/components/DropdownMenu.tsx
@@ -53,6 +53,7 @@ export interface DropdownMenuAction {
 export type DropdownMenuEntry =
   | { kind: 'action'; action: DropdownMenuAction }
   | { kind: 'separator' }
+  | { kind: 'heading'; label: string }
   | {
       kind: 'submenu';
       id: string;
@@ -66,6 +67,15 @@ export function menuAction(action: DropdownMenuAction): DropdownMenuEntry {
   return { kind: 'action', action };
 }
 export const MENU_SEPARATOR: DropdownMenuEntry = { kind: 'separator' };
+/**
+ * A group label above a run of items. Needed once a single menu holds more than
+ * one axis of choice (the browser's View menu carries both Sort and Group), where
+ * a bare separator leaves the reader to infer which checkmark answers which
+ * question. Not focusable — it's a label, not a target.
+ */
+export function menuHeading(label: string): DropdownMenuEntry {
+  return { kind: 'heading', label };
+}
 
 export interface DropdownMenuProps {
   /**
@@ -461,6 +471,13 @@ export function DropdownMenu({
     list.map((entry, i): ReactNode => {
       if (entry.kind === 'separator') {
         return <div key={`sep-${i}`} className="dropdown-menu__separator" role="separator" />;
+      }
+      if (entry.kind === 'heading') {
+        return (
+          <div key={`head-${i}`} className="dropdown-menu__heading" role="presentation">
+            {entry.label}
+          </div>
+        );
       }
       if (entry.kind === 'action') {
         return renderAction(entry.action, panel);

--- a/src/ui/home/BrowserViewMenu.tsx
+++ b/src/ui/home/BrowserViewMenu.tsx
@@ -1,0 +1,109 @@
+/**
+ * BrowserViewMenu (JP-477) — the document browser's Sort + Group control.
+ *
+ * These were two bare `<select>` elements in the header. They were the only
+ * un-designed chrome on the surface, they cost 337px of a 657px action row for
+ * two low-frequency choices, and because the Sort select renders in grid view
+ * only, toggling the view mode grew the header from one row to two — a layout
+ * jump triggered by a control that has nothing to do with layout.
+ *
+ * One trigger of fixed width, present in both views, fixes all three. Sorting
+ * in list view still belongs to the column headers (JP-444), so the menu says
+ * so rather than offering a second control that silently disagrees with them.
+ */
+
+import { SlidersHorizontal, ChevronDown } from 'lucide-react';
+import {
+  DropdownMenu,
+  menuAction,
+  menuHeading,
+  MENU_SEPARATOR,
+  type DropdownMenuEntry,
+} from '../components/DropdownMenu';
+import { SORT_LABELS } from '../settings/useDocumentBrowserModel';
+import type {
+  DocumentBrowserGroupBy,
+  DocumentBrowserSort,
+  DocumentBrowserView,
+} from '../../store/uiPreferencesStore';
+
+export interface BrowserViewMenuProps {
+  view: DocumentBrowserView;
+  sort: DocumentBrowserSort;
+  setSort: (sort: DocumentBrowserSort) => void;
+  groupBy: DocumentBrowserGroupBy;
+  setGroupBy: (groupBy: DocumentBrowserGroupBy) => void;
+}
+
+const GROUP_LABELS: Record<DocumentBrowserGroupBy, string> = {
+  none: 'None',
+  collection: 'Collection',
+};
+
+export function BrowserViewMenu({
+  view,
+  sort,
+  setSort,
+  groupBy,
+  setGroupBy,
+}: BrowserViewMenuProps) {
+  const entries: DropdownMenuEntry[] = [menuHeading('Sort')];
+
+  if (view === 'list') {
+    // Sorting is the column headers' job here. Offering a duplicate control
+    // would leave two places to change one thing.
+    entries.push(
+      menuAction({
+        id: 'sort-columns',
+        label: 'Click a column header to sort',
+        disabled: true,
+        onSelect: () => {},
+      }),
+    );
+  } else {
+    for (const [value, label] of Object.entries(SORT_LABELS)) {
+      entries.push(
+        menuAction({
+          id: `sort-${value}`,
+          label,
+          checked: sort === value,
+          onSelect: () => setSort(value as DocumentBrowserSort),
+        }),
+      );
+    }
+  }
+
+  entries.push(MENU_SEPARATOR, menuHeading('Group by'));
+  for (const value of ['none', 'collection'] as const) {
+    entries.push(
+      menuAction({
+        id: `group-${value}`,
+        label: GROUP_LABELS[value],
+        checked: groupBy === value,
+        onSelect: () => setGroupBy(value),
+      }),
+    );
+  }
+
+  // The trigger reports the active grouping, so the one non-default state a
+  // user can forget about is visible without opening the menu.
+  const activeHint = groupBy === 'collection' ? 'Collections' : 'View';
+
+  return (
+    <DropdownMenu
+      trigger={
+        <>
+          <SlidersHorizontal size={16} aria-hidden="true" />
+          <span className="dh-viewmenu-label">{activeHint}</span>
+          <ChevronDown size={12} aria-hidden="true" />
+        </>
+      }
+      triggerClassName={`dh-viewmenu${groupBy === 'collection' ? ' dh-viewmenu--active' : ''}`}
+      triggerTitle="Sorting and grouping"
+      entries={entries}
+      align="right"
+    />
+  );
+}
+
+export default BrowserViewMenu;

--- a/src/ui/home/CapacityRing.test.tsx
+++ b/src/ui/home/CapacityRing.test.tsx
@@ -1,0 +1,117 @@
+import { render } from '@testing-library/react';
+import { CapacityRing, toArcs, type CapacitySegment } from './CapacityRing';
+
+const GB = 1024 * 1024 * 1024;
+
+const seg = (key: string, bytes: number): CapacitySegment => ({ key, label: key, bytes });
+
+/** Total arc length, i.e. where the ring's outer edge lands. */
+const total = (arcs: { length: number }[]) => arcs.reduce((s, a) => s + a.length, 0);
+
+describe('toArcs', () => {
+  it('maps each share to its percentage of the quota', () => {
+    const arcs = toArcs([seg('docs', 2 * GB), seg('files', 3 * GB)], 10 * GB);
+    expect(arcs.map((a) => a.length)).toEqual([20, 30]);
+  });
+
+  it('leaves a zero share undrawn', () => {
+    const arcs = toArcs([seg('docs', GB), seg('config', 0)], 10 * GB);
+    expect(arcs.find((a) => a.key === 'config')!.length).toBe(0);
+  });
+
+  it('floors a tiny-but-nonzero share so it stays visible', () => {
+    // 285 bytes against 20 GB is ~0.0000013% — invisible without the floor.
+    const arcs = toArcs([seg('docs', 4 * GB), seg('config', 285)], 20 * GB);
+    expect(arcs.find((a) => a.key === 'config')!.length).toBeGreaterThan(1);
+  });
+
+  it('pays for the floor out of the largest arc, so the edge stays honest', () => {
+    const arcs = toArcs([seg('docs', 4 * GB), seg('config', 285)], 20 * GB);
+    // True fill is 20% + a rounding crumb; the boosted config arc must not
+    // push the ring past it.
+    expect(total(arcs)).toBeCloseTo(20, 4);
+  });
+
+  it('keeps the borrowed length off the largest arc even when it is not first', () => {
+    const arcs = toArcs([seg('config', 285), seg('docs', 4 * GB)], 20 * GB);
+    expect(total(arcs)).toBeCloseTo(20, 4);
+    expect(arcs.find((a) => a.key === 'config')!.length).toBeGreaterThan(1);
+  });
+
+  it('never draws past a full circle', () => {
+    const arcs = toArcs([seg('docs', 30 * GB)], 10 * GB);
+    expect(arcs[0]!.length).toBe(100);
+  });
+
+  it('keeps every share visible when they are all tiny', () => {
+    // Nothing large enough to borrow from — the floor wins over the edge here,
+    // which is the right trade at a near-empty workspace.
+    const arcs = toArcs([seg('docs', 100), seg('files', 100), seg('config', 100)], 20 * GB);
+    expect(arcs.every((a) => a.length >= 1)).toBe(true);
+  });
+});
+
+describe('CapacityRing rendering', () => {
+  const q = 20 * GB;
+
+  it('draws one continuous arc when no share breakdown is supplied', () => {
+    // The signed-out path (device storage) and any relay that predates the
+    // share fields land here — it must still report the fill, not fall back to
+    // a bare track that reads as "no data".
+    const { container } = render(<CapacityRing used={5 * GB} quota={q} />);
+    const arcs = container.querySelectorAll('.dh-ring-arc');
+    expect(arcs).toHaveLength(1);
+    expect(arcs[0]!.classList.contains('dh-ring-arc--all')).toBe(true);
+    expect(arcs[0]!.getAttribute('stroke-dasharray')).toBe('25 100');
+  });
+
+  it('draws one arc per share when the breakdown is supplied', () => {
+    const { container } = render(
+      <CapacityRing
+        used={5 * GB}
+        quota={q}
+        segments={[seg('docs', 3 * GB), seg('files', 2 * GB), seg('config', 0)]}
+      />,
+    );
+    // config is zero, so it contributes no arc.
+    expect(container.querySelectorAll('.dh-ring-arc')).toHaveLength(2);
+    expect(container.querySelector('.dh-ring-centre')?.textContent).toBe('25%');
+  });
+
+  it('collapses to a single danger arc at cap, so "full" reads unambiguously', () => {
+    const { container } = render(
+      <CapacityRing
+        used={q}
+        quota={q}
+        over
+        segments={[seg('docs', 3 * GB), seg('files', 17 * GB)]}
+      />,
+    );
+    expect(container.querySelectorAll('.dh-ring-arc')).toHaveLength(1);
+    expect(container.querySelector('.dh-ring')?.classList.contains('dh-ring--over')).toBe(true);
+  });
+
+  it('draws no fill and says so when there is no quota to divide by', () => {
+    const { container } = render(<CapacityRing used={5 * GB} quota={null} />);
+    expect(container.querySelectorAll('.dh-ring-arc')).toHaveLength(0);
+    expect(container.querySelector('.dh-ring-centre')?.textContent).toBe('—');
+    expect(container.querySelector('.dh-ring')?.getAttribute('aria-label')).toMatch(
+      /no allowance/i,
+    );
+  });
+
+  it('reports a pending read rather than an empty one', () => {
+    const { container } = render(<CapacityRing used={null} quota={null} pending />);
+    expect(container.querySelector('.dh-ring-centre')?.textContent).toBe('···');
+    expect(container.querySelector('.dh-ring')?.getAttribute('aria-label')).toMatch(
+      /calculated/i,
+    );
+  });
+
+  it('labels the fill for screen readers', () => {
+    const { container } = render(<CapacityRing used={q / 4} quota={q} />);
+    expect(container.querySelector('.dh-ring')?.getAttribute('aria-label')).toBe(
+      'Storage 25 percent full',
+    );
+  });
+});

--- a/src/ui/home/CapacityRing.tsx
+++ b/src/ui/home/CapacityRing.tsx
@@ -1,0 +1,171 @@
+/**
+ * CapacityRing (JP-477) — the rail's storage readout.
+ *
+ * A donut whose arcs carry the metered shares (documents / files /
+ * configuration) around a single track, with the fill percentage at its
+ * centre. It replaces the stacked pair of 5px bars plus a three-item text
+ * legend that had grown to a third of the sidebar's foot: the ring says the
+ * same thing in a quarter of the height, and the shares stay *visible* as arcs
+ * rather than being dropped — the named byte counts move to the tooltip and
+ * the full Storage view.
+ *
+ * Honesty rules the geometry:
+ *  - No quota (unknown or unmetered) means no fraction to draw. The ring goes
+ *    to an idle track and the centre reads "—" rather than implying empty.
+ *  - Shares that don't sum to the headline number aren't drawn as shares (see
+ *    `resolveShares`); the ring falls back to one continuous fill.
+ *  - A tiny-but-nonzero share is floored to a visible sliver, but the floor is
+ *    paid for out of the largest share, so the ring's outer edge still lands on
+ *    the true fill percentage.
+ */
+
+import type { CSSProperties } from 'react';
+
+/** One metered share of the total. `bytes` may be 0 — it simply won't draw. */
+export interface CapacitySegment {
+  key: string;
+  /** Human label, used in the tooltip. */
+  label: string;
+  bytes: number;
+}
+
+export interface CapacityRingProps {
+  used: number | null;
+  quota: number | null;
+  /** Per-category breakdown. Omit for a single continuous fill. */
+  segments?: CapacitySegment[] | null;
+  /** At or over quota — the whole ring goes to the danger colour. */
+  over?: boolean;
+  /** Usage hasn't resolved yet. */
+  pending?: boolean;
+  /** Outer diameter in px. */
+  size?: number;
+}
+
+/** Arc units are percentages of the circle (`pathLength={100}`). */
+const TRACK_LENGTH = 100;
+/** Smallest arc that still reads as a slice rather than a rendering artifact. */
+const MIN_VISIBLE_ARC = 1.4;
+
+/**
+ * Turn byte shares into drawable arcs.
+ *
+ * Each share becomes its percentage of the *quota*. Nonzero shares below
+ * `MIN_VISIBLE_ARC` are raised to it — configuration is routinely kilobytes
+ * against gigabytes and would otherwise round away to nothing — and the
+ * borrowed length is taken back off the largest arc so the ring's outer edge
+ * still ends at the true fill.
+ */
+export function toArcs(
+  segments: CapacitySegment[],
+  quota: number,
+): { key: string; length: number }[] {
+  const raw = segments.map((s) => ({
+    key: s.key,
+    length: s.bytes > 0 ? Math.min(TRACK_LENGTH, (s.bytes / quota) * TRACK_LENGTH) : 0,
+  }));
+
+  const trueTotal = raw.reduce((sum, a) => sum + a.length, 0);
+  const boosted = raw.map((a) =>
+    a.length > 0 && a.length < MIN_VISIBLE_ARC ? { ...a, length: MIN_VISIBLE_ARC } : a,
+  );
+  const borrowed = boosted.reduce((sum, a) => sum + a.length, 0) - trueTotal;
+  if (borrowed <= 0) return boosted;
+
+  // Repay from the largest arc, but never shrink it below the visible floor —
+  // a ring a fraction of a percent long is a fair price for not lying about
+  // which categories exist.
+  let largest = 0;
+  for (let i = 1; i < boosted.length; i += 1) {
+    if (boosted[i]!.length > boosted[largest]!.length) largest = i;
+  }
+  const target = boosted[largest]!.length - borrowed;
+  boosted[largest] = { ...boosted[largest]!, length: Math.max(MIN_VISIBLE_ARC, target) };
+  return boosted;
+}
+
+export function CapacityRing({
+  used,
+  quota,
+  segments = null,
+  over = false,
+  pending = false,
+  size = 46,
+}: CapacityRingProps) {
+  const metered = used !== null && quota !== null && quota > 0;
+  const pct = metered ? Math.max(0, Math.min(100, (used / quota) * 100)) : null;
+
+  // Shares are suppressed at cap so the danger state reads as one unambiguous
+  // "full" signal rather than a tricolour ring that happens to be red.
+  const drawSegments = metered && !over && segments && segments.length > 0;
+  const arcs = drawSegments ? toArcs(segments, quota) : [];
+
+  const centre = pending ? '···' : pct === null ? '—' : `${Math.round(pct)}`;
+  const label = pending
+    ? 'Storage usage is still being calculated'
+    : pct === null
+      ? 'Storage usage — no allowance reported'
+      : `Storage ${Math.round(pct)} percent full`;
+
+  // Stroke geometry: the radius is derived so the ring's outer edge sits flush
+  // with the box regardless of `size`.
+  const stroke = Math.max(4, Math.round(size * 0.13));
+  const radius = (size - stroke) / 2;
+
+  let offset = 0;
+  return (
+    <span
+      className={`dh-ring${over ? ' dh-ring--over' : ''}${pending ? ' dh-ring--pending' : ''}`}
+      style={{ '--dh-ring-size': `${size}px` } as CSSProperties}
+      role="img"
+      aria-label={label}
+    >
+      <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} aria-hidden="true">
+        {/* Rotated so arcs start at 12 o'clock and run clockwise. */}
+        <g transform={`rotate(-90 ${size / 2} ${size / 2})`} fill="none" strokeWidth={stroke}>
+          <circle
+            className="dh-ring-track"
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            pathLength={TRACK_LENGTH}
+          />
+          {drawSegments
+            ? arcs.map((arc) => {
+                const dash = `${arc.length} ${TRACK_LENGTH}`;
+                const dashOffset = -offset;
+                offset += arc.length;
+                return arc.length > 0 ? (
+                  <circle
+                    key={arc.key}
+                    className={`dh-ring-arc dh-ring-arc--${arc.key}`}
+                    cx={size / 2}
+                    cy={size / 2}
+                    r={radius}
+                    pathLength={TRACK_LENGTH}
+                    strokeDasharray={dash}
+                    strokeDashoffset={dashOffset}
+                  />
+                ) : null;
+              })
+            : pct !== null && (
+                <circle
+                  className="dh-ring-arc dh-ring-arc--all"
+                  cx={size / 2}
+                  cy={size / 2}
+                  r={radius}
+                  pathLength={TRACK_LENGTH}
+                  strokeDasharray={`${pct} ${TRACK_LENGTH}`}
+                />
+              )}
+        </g>
+      </svg>
+      <span className="dh-ring-centre" aria-hidden="true">
+        {centre}
+        {pct !== null && !pending && <span className="dh-ring-pct">%</span>}
+      </span>
+    </span>
+  );
+}
+
+export default CapacityRing;

--- a/src/ui/home/DocumentPreview.css
+++ b/src/ui/home/DocumentPreview.css
@@ -1,0 +1,92 @@
+/* DocumentPreview (JP-477) — the shared thumbnail surface.
+   Moved out of DocumentsHome.css when the browser's grid cards started
+   rendering the same markup: the component that draws it owns its styles, so a
+   second consumer can't depend on a sibling's stylesheet happening to be
+   loaded. Class names keep the `dh-rcard-*` prefix they shipped under — renaming
+   them buys nothing and would churn the dark-theme overrides below. */
+
+.dh-rcard-thumb {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 8px;
+}
+
+/* Canvas placeholder: node chips + connector paths on the dot grid. */
+.dh-rcard-ph {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+.dh-rcard-ph-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.dh-rcard-ph-edges path {
+  fill: none;
+  stroke: color-mix(in srgb, var(--text-faint) 60%, transparent);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  vector-effect: non-scaling-stroke;
+}
+.dh-rcard-ph-node {
+  position: absolute;
+  width: 26%;
+  height: 20%;
+  border-radius: 5px;
+  border: 1px solid color-mix(in srgb, var(--rcard-accent, var(--brand-gold)) 55%, transparent);
+  background: color-mix(in srgb, var(--rcard-accent, var(--brand-gold)) 16%, transparent);
+}
+.dh-rcard-ph-node--a {
+  left: 10%;
+  top: 18%;
+}
+.dh-rcard-ph-node--b {
+  left: 60%;
+  top: 48%;
+}
+.dh-rcard-ph-node--c {
+  left: 16%;
+  top: 62%;
+  width: 18%;
+  height: 16%;
+}
+
+/* Doc placeholder: skeleton text lines on a paper gradient. */
+.dh-rcard-ph--doc {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  background: linear-gradient(180deg, #fffefa, #f6f4ec);
+}
+.dh-rcard-ph-line {
+  height: 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--navy-900) 14%, transparent);
+}
+.dh-rcard-ph-line--title {
+  width: 55%;
+  height: 8px;
+  background: color-mix(in srgb, var(--rcard-accent, var(--navy-900)) 34%, transparent);
+}
+.dh-rcard-ph-line--short {
+  width: 40%;
+}
+
+/* Dark theme: the doc placeholder's paper gradient flips to the kit's navy
+   card surfaces (the dot grid + accent chips already follow the tokens).
+   Scoped to the surface rather than a card class — both the recents strip and
+   the browser grid live inside it, and both need the flip. */
+.documents-home[data-theme='dark'] .dh-rcard-ph--doc {
+  background: linear-gradient(180deg, #13233a, #0e1c30);
+}
+.documents-home[data-theme='dark'] .dh-rcard-ph-line {
+  background: rgba(214, 224, 240, 0.14);
+}
+.documents-home[data-theme='dark'] .dh-rcard-ph-line--title {
+  background: color-mix(in srgb, var(--rcard-accent, var(--brand-gold-soft)) 45%, transparent);
+}

--- a/src/ui/home/DocumentPreview.tsx
+++ b/src/ui/home/DocumentPreview.tsx
@@ -1,0 +1,88 @@
+/**
+ * DocumentPreview (JP-477) — the shared thumbnail surface for a document card.
+ *
+ * Extracted from `RecentCard` when the browser's grid cards needed the same
+ * preview. Deliberately one implementation rather than two: a parallel renderer
+ * with no shared boundary is how the canvas/prose placeholders would drift into
+ * saying different things about the same document on the same screen.
+ *
+ * The thumbnail itself comes from `recentThumbnails` — a local-only ladder
+ * (in-memory → localStorage → IndexedDB cache) that never hits the network, so
+ * a document whose content isn't on this device gets a placeholder instead of a
+ * spinner or a fetch.
+ */
+
+import { useEffect, useState } from 'react';
+import type { DocumentRecord } from '../../types/DocumentRegistry';
+import { useThemeStore } from '../../store/themeStore';
+import { getRecentPreview, type RecentPreview } from './recentThumbnails';
+import './DocumentPreview.css';
+
+/** Dotted-canvas placeholder with a few node chips — reads as "a diagram". */
+export function CanvasPlaceholder() {
+  return (
+    <span className="dh-rcard-ph dh-rcard-ph--canvas" aria-hidden="true">
+      <svg className="dh-rcard-ph-edges" viewBox="0 0 100 60" preserveAspectRatio="none">
+        <path d="M28 20 C 44 20, 48 34, 62 36" />
+        <path d="M30 44 C 44 44, 52 40, 62 38" />
+      </svg>
+      <span className="dh-rcard-ph-node dh-rcard-ph-node--a" />
+      <span className="dh-rcard-ph-node dh-rcard-ph-node--b" />
+      <span className="dh-rcard-ph-node dh-rcard-ph-node--c" />
+    </span>
+  );
+}
+
+/** Skeleton text lines — reads as "a written document". */
+export function DocPlaceholder() {
+  return (
+    <span className="dh-rcard-ph dh-rcard-ph--doc" aria-hidden="true">
+      <span className="dh-rcard-ph-line dh-rcard-ph-line--title" />
+      <span className="dh-rcard-ph-line" />
+      <span className="dh-rcard-ph-line" />
+      <span className="dh-rcard-ph-line dh-rcard-ph-line--short" />
+    </span>
+  );
+}
+
+/**
+ * Resolve a document's mini preview, re-rendering when the document changes or
+ * the surface theme flips (AUTO-coloured shapes resolve their ink against it).
+ *
+ * `enabled` gates the work, not the hook: a card that isn't showing a preview
+ * (list and compact modes) must still call this to keep hook order stable, but
+ * shouldn't pay to read the document body and rasterize it.
+ */
+export function useDocumentPreview(
+  record: DocumentRecord,
+  enabled = true,
+): RecentPreview | null {
+  const [preview, setPreview] = useState<RecentPreview | null>(null);
+  const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void getRecentPreview(record, resolvedTheme).then((p) => {
+      if (!cancelled) setPreview(p);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Re-render only when the doc actually changed (id or edit time), the
+    // surface theme flipped, or the card started needing a preview.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [record.id, record.modifiedAt, resolvedTheme, enabled]);
+
+  return enabled ? preview : null;
+}
+
+/** The preview image, or the placeholder that matches the document's kind. */
+export function DocumentPreview({ preview }: { preview: RecentPreview | null }) {
+  if (preview?.uri) {
+    return <img className="dh-rcard-thumb" src={preview.uri} alt="" loading="lazy" />;
+  }
+  return preview?.kind === 'doc' ? <DocPlaceholder /> : <CanvasPlaceholder />;
+}
+
+export default DocumentPreview;

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -499,8 +499,12 @@
   color: var(--rail-danger);
 }
 
-/* The secondary store — a rule and one quiet line under the ring. */
+/* The secondary store — a rule and one quiet line under the ring.
+   `display: block` is load-bearing: the card is a <button>, whose content model
+   is phrasing content, so these are spans — and an inline box would drop the
+   margin, padding and border below. */
 .dh-storage-foot {
+  display: block;
   margin-top: 9px;
   padding-top: 8px;
   border-top: 1px solid var(--rail-edge);

--- a/src/ui/home/DocumentsHome.css
+++ b/src/ui/home/DocumentsHome.css
@@ -32,6 +32,17 @@
   --rail-hover: rgba(214, 224, 240, 0.05);
   --rail-gold-wash: rgba(201, 162, 98, 0.12);
   --rail-gold-edge: rgba(201, 162, 98, 0.34);
+  /* Steel-blue accent for rail data viz (the capacity ring's document share).
+     Named here rather than inlined: the JP-301 split bar referenced
+     `--rail-accent` with a hex fallback that always fired, which is exactly the
+     stray hardcoded colour this block exists to prevent. */
+  --rail-accent: #6ea8fe;
+  /* Danger ON NAVY. `--danger` is #7a2238 in BOTH themes — a deep maroon tuned
+     for paper — so the rail's at-cap states (the storage ring, the full-cloud
+     callout) were rendering near-black on near-black. The rail is constant
+     navy and needs the lightened red that dark surfaces use, which is exactly
+     what `--danger-text` resolves to in the dark theme. */
+  --rail-danger: #e89b9b;
 
   flex: 0 0 272px;
   display: flex;
@@ -435,105 +446,160 @@
   border-color: var(--rail-gold-edge);
   background: var(--rail-gold-wash);
 }
-.dh-storage-top {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--rail-text-bright);
-}
 .dh-storage-manage {
-  margin-left: auto;
+  flex: 0 0 auto;
   font-size: 10px;
   font-weight: var(--font-weight-normal);
   letter-spacing: 0.02em;
   color: var(--brand-gold-soft);
 }
-.dh-storage-row {
-  margin-top: 8px;
+/* JP-477: ring + readout. The ring is the fixed element and the readout takes
+   the rest, so a long byte pair truncates rather than pushing the ring. */
+.dh-storage-main {
+  display: flex;
+  align-items: center;
+  gap: 11px;
 }
-.dh-storage-rowtop {
+.dh-storage-readout {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+/* The scope is the card's eyebrow — it carries the rail's mono/uppercase
+   micro-label rhythm (COLLECTIONS, CONTINUE WORKING) so folding the old
+   "Storage" header into it loses no structure. */
+.dh-storage-scope-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 8px;
 }
-.dh-storage-rowlabel {
-  font-size: var(--font-size-xs);
-  color: var(--rail-text-dim);
-}
-.dh-storage-rowval {
+.dh-storage-scope {
+  min-width: 0;
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--rail-text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dh-storage-value {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--rail-text-bright);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
-.dh-storage-bar {
-  height: 5px;
-  margin: 5px 0 0;
+.dh-storage-value--over {
+  color: var(--rail-danger);
+}
+
+/* The secondary store — a rule and one quiet line under the ring. */
+.dh-storage-foot {
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px solid var(--rail-edge);
+}
+.dh-storage-foot-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--rail-text-dim);
+  font-size: var(--font-size-xs);
+}
+.dh-storage-foot-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dh-storage-foot-val {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+.dh-storage-foot-bar {
+  display: block;
+  height: 3px;
+  margin-top: 6px;
   border-radius: var(--radius-pill);
   background: rgba(214, 224, 240, 0.12);
   overflow: hidden;
 }
-.dh-storage-fill {
+.dh-storage-foot-fill {
+  display: block;
   height: 100%;
   border-radius: var(--radius-pill);
-  background: var(--brand-gold);
+  background: var(--rail-text-dim);
   transition: width 0.3s ease;
-}
-.dh-storage-fill--over {
-  background: var(--danger);
 }
 
-/* JP-301: three-share stacked meter — documents, files, configuration. The
-   bar is a flex row so the shares sit end to end and the remaining track shows
-   through; each share keeps a hairline min-width so a tiny-but-nonzero
-   category (configuration is usually kilobytes against megabytes) is still
-   visible rather than rounding away to nothing. */
-.dh-storage-bar--split {
+/* ── CapacityRing (JP-477) ───────────────────────────────────────────────
+   A donut carrying the metered shares as arcs, with the fill percentage at
+   its centre. Replaces the pair of 5px bars plus a three-item text legend
+   that had grown to a third of the rail's foot. Arc colours match the shares
+   the old split bar used, so the vocabulary carries over. */
+.dh-ring {
+  position: relative;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: var(--dh-ring-size);
+  height: var(--dh-ring-size);
+}
+.dh-ring svg {
+  display: block;
+}
+.dh-ring-track {
+  stroke: rgba(214, 224, 240, 0.13);
+}
+.dh-ring-arc {
+  stroke-linecap: butt;
+  transition: stroke-dasharray 0.35s ease, stroke-dashoffset 0.35s ease;
+}
+.dh-ring-arc--docs,
+.dh-ring-arc--all {
+  stroke: var(--rail-accent);
+}
+.dh-ring-arc--files {
+  stroke: var(--brand-gold);
+}
+.dh-ring-arc--config {
+  stroke: var(--rail-text-dim);
+}
+.dh-ring--over .dh-ring-arc {
+  stroke: var(--rail-danger);
+}
+.dh-ring-centre {
+  position: absolute;
   display: flex;
+  align-items: baseline;
+  gap: 0.5px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--rail-text-bright);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
-.dh-storage-seg {
-  height: 100%;
-  min-width: 2px;
-  transition: width 0.3s ease;
-}
-.dh-storage-seg--docs {
-  background: var(--rail-accent, #6ea8fe);
-}
-.dh-storage-seg--files {
-  background: var(--brand-gold);
-}
-.dh-storage-seg--config {
-  background: var(--rail-text-dim, #8d9bb1);
-}
-.dh-storage-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 10px;
-  margin-top: 6px;
-}
-.dh-storage-legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 10.5px;
+/* The unit is a footnote to the number, not a peer of it. */
+.dh-ring-pct {
+  font-size: 8px;
+  font-weight: var(--font-weight-normal);
   color: var(--rail-text-dim);
 }
-.dh-storage-sw {
-  width: 7px;
-  height: 7px;
-  border-radius: 2px;
-  flex-shrink: 0;
+.dh-ring--over .dh-ring-centre {
+  color: var(--rail-danger);
 }
-.dh-storage-legend-val {
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
+.dh-ring--pending .dh-ring-centre {
+  color: var(--rail-text-dim);
 }
 
 /* JP-443: at-cap callout under the storage meters — the ways out of a full
@@ -545,9 +611,9 @@
   margin-top: 6px;
   padding: 8px 9px;
   border: 1px solid
-    color-mix(in srgb, var(--danger) 35%, transparent);
+    color-mix(in srgb, var(--rail-danger) 35%, transparent);
   border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--danger) 8%, transparent);
+  background: color-mix(in srgb, var(--rail-danger) 14%, transparent);
 }
 .dh-cap-note-text {
   font-size: var(--font-size-xs);
@@ -568,8 +634,8 @@
   cursor: pointer;
 }
 .dh-cap-note-btn:hover {
-  border-color: var(--danger);
-  color: var(--danger);
+  border-color: var(--rail-danger);
+  color: var(--rail-danger);
 }
 
 .dh-user {
@@ -689,24 +755,43 @@
   background: var(--bg-hover);
 }
 .dh-crumb {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
   font-size: var(--font-size-lg);
 }
 .dh-crumb strong {
   font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* The count lives with the title, not in a second heading over the list. */
+.dh-crumb-count {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 .dh-search {
-  flex: 1 1 auto;
+  /* Basis at the FLOOR, not `auto`. Flexbox breaks lines using each item's
+     hypothetical size before it flexes anything, so a content-or-max basis had
+     the search claiming its full 420px while deciding the row didn't fit — the
+     actions wrapped to a second line with 200px of slack the search was never
+     asked to give back. Growing from 180 lets it take the leftovers instead. */
+  flex: 1 1 180px;
   display: flex;
   align-items: center;
   gap: 8px;
-  /* A floor (rather than the default content-based min-width) so the search is
-     the elastic element: it shrinks toward this width, then the row wraps the
-     actions to a second line rather than overflowing. 180px clears a 320px
-     viewport. */
+  /* 180px clears a 320px viewport. */
   min-width: 180px;
-  max-width: 520px;
-  padding: 9px 12px;
+  max-width: 420px;
+  height: 34px;
+  padding: 0 10px 0 12px;
   border: 1px solid var(--border-color-input);
   border-radius: var(--radius-lg);
   background: var(--bg-primary);
@@ -740,26 +825,54 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 10px;
+  /* Tight inside the row; the two clusters are separated by the rule, not by a
+     wider gap, so the hierarchy survives a narrow header. */
+  gap: 8px;
 }
-.dh-sort {
+/* Display controls: how the library is shown. */
+.dh-top-utils {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: var(--font-size-sm);
-  color: var(--text-muted);
 }
-.dh-sort select {
+.dh-top-rule {
+  width: 1px;
+  height: 22px;
+  margin: 0 2px;
+  background: var(--border-color);
+}
+
+/* Sort + Group, in one designed trigger instead of two native selects. */
+.dh-viewmenu {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 9px 0 10px;
   border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
   background: var(--bg-primary);
-  color: var(--text-primary);
+  color: var(--text-secondary);
   font-size: var(--font-size-md);
-  padding: 6px 8px;
   cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.dh-viewmenu:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+/* Grouping is the one setting here that restructures the list, so the trigger
+   reports it rather than letting it be a hidden mode. */
+.dh-viewmenu--active {
+  border-color: var(--color-primary);
+  color: var(--text-primary);
+}
+.dh-viewmenu-label {
+  white-space: nowrap;
 }
 .dh-view-toggle {
   display: flex;
+  height: 34px;
   border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
   overflow: hidden;
@@ -768,24 +881,28 @@
   display: grid;
   place-items: center;
   width: 32px;
-  height: 32px;
   border: none;
   background: var(--bg-primary);
   color: var(--text-muted);
   cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.dh-view-toggle button:hover:not(.on) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 .dh-view-toggle button.on {
   background: var(--color-primary-light);
   color: var(--text-primary);
 }
 .dh-refresh {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
   border: 1px solid var(--border-color-input);
   border-radius: var(--radius-md);
-  background: var(--bg-secondary);
+  background: var(--bg-primary);
   color: var(--text-secondary);
   cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease;
@@ -803,29 +920,35 @@
   }
 }
 
+/* Import is the secondary action — a ghost button, so the gold CTA beside it
+   is unambiguously the primary one. They read as equals before JP-477. */
 .dh-import {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
-  border: 1px solid var(--border-color-input);
+  height: 34px;
+  padding: 0 12px;
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
+  background: transparent;
+  color: var(--text-secondary);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: background 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 .dh-import:hover {
+  border-color: var(--border-color-input);
   background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .dh-new {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
+  height: 34px;
+  padding: 0 14px;
   border: none;
   border-radius: var(--radius-md);
   background: var(--color-cta);
@@ -1020,78 +1143,6 @@ button.dh-colhead-col:hover {
   background-image: radial-gradient(color-mix(in srgb, var(--text-faint) 42%, transparent) 1px, transparent 1px);
   background-size: 14px 14px;
 }
-.dh-rcard-thumb {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  padding: 8px;
-}
-
-/* Canvas placeholder: node chips + connector paths on the dot grid. */
-.dh-rcard-ph {
-  position: absolute;
-  inset: 0;
-  display: block;
-}
-.dh-rcard-ph-edges {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-}
-.dh-rcard-ph-edges path {
-  fill: none;
-  stroke: color-mix(in srgb, var(--text-faint) 60%, transparent);
-  stroke-width: 1;
-  stroke-dasharray: 3 3;
-  vector-effect: non-scaling-stroke;
-}
-.dh-rcard-ph-node {
-  position: absolute;
-  width: 26%;
-  height: 20%;
-  border-radius: 5px;
-  border: 1px solid color-mix(in srgb, var(--rcard-accent, var(--brand-gold)) 55%, transparent);
-  background: color-mix(in srgb, var(--rcard-accent, var(--brand-gold)) 16%, transparent);
-}
-.dh-rcard-ph-node--a {
-  left: 10%;
-  top: 18%;
-}
-.dh-rcard-ph-node--b {
-  left: 60%;
-  top: 48%;
-}
-.dh-rcard-ph-node--c {
-  left: 16%;
-  top: 62%;
-  width: 18%;
-  height: 16%;
-}
-
-/* Doc placeholder: skeleton text lines on a paper gradient. */
-.dh-rcard-ph--doc {
-  padding: 14px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  background: linear-gradient(180deg, #fffefa, #f6f4ec);
-}
-.dh-rcard-ph-line {
-  height: 6px;
-  border-radius: 3px;
-  background: color-mix(in srgb, var(--navy-900) 14%, transparent);
-}
-.dh-rcard-ph-line--title {
-  width: 55%;
-  height: 8px;
-  background: color-mix(in srgb, var(--rcard-accent, var(--navy-900)) 34%, transparent);
-}
-.dh-rcard-ph-line--short {
-  width: 40%;
-}
-
 .dh-rcard-meta {
   display: flex;
   flex-direction: column;
@@ -1112,18 +1163,6 @@ button.dh-colhead-col:hover {
   color: var(--text-muted);
 }
 
-/* Dark theme: the doc placeholder's paper gradient flips to the kit's navy
-   card surfaces (the dot grid + accent chips already follow the tokens). */
-.documents-home[data-theme='dark'] .dh-rcard-ph--doc {
-  background: linear-gradient(180deg, #13233a, #0e1c30);
-}
-.documents-home[data-theme='dark'] .dh-rcard-ph-line {
-  background: rgba(214, 224, 240, 0.14);
-}
-.documents-home[data-theme='dark'] .dh-rcard-ph-line--title {
-  background: color-mix(in srgb, var(--rcard-accent, var(--brand-gold-soft)) 45%, transparent);
-}
-
 /* The shared DocumentList renders the editor's existing `.document-browser__*`
    list markup; it inherits global styling. Nothing to override here in Slice 1. */
 
@@ -1133,8 +1172,8 @@ button.dh-colhead-col:hover {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .dh-storage-seg,
-  .dh-storage-fill,
+  .dh-ring-arc,
+  .dh-storage-foot-fill,
   .dh-rcard,
   .dh-switch,
   .dh-swmenu-item,
@@ -1155,6 +1194,22 @@ button.dh-colhead-col:hover {
    horizontal overflow at any width >= 320px", not a full mobile redesign. The
    literals mirror the --bp-regular (1024px) / --bp-compact (640px) tokens in
    index.css (CSS @media can't read custom properties). */
+/* Shed the header's least-load-bearing pixels before letting it wrap. Import's
+   icon is unambiguous next to the labelled New button, and the `/` hint is a
+   nicety — dropping both buys roughly 90px, which is the difference between one
+   row and two on a laptop-width window. */
+@media (max-width: 1200px) {
+  .dh-import-label {
+    display: none;
+  }
+  .dh-import {
+    padding: 0 9px;
+  }
+  .dh-search-kbd {
+    display: none;
+  }
+}
+
 @media (max-width: 1024px) {
   .dh-side {
     /* Reclaim width for the content area; the fixed 272px crowds it on a
@@ -1216,6 +1271,11 @@ button.dh-colhead-col:hover {
   .dh-top-actions {
     flex: 1 1 100%;
     flex-wrap: wrap;
+  }
+  /* The rule separates two clusters on one line; once they wrap it's just an
+     orphaned tick, and the 5px it costs is what pushes New onto a third row. */
+  .dh-top-rule {
+    display: none;
   }
   .dh-recents {
     /* A single full-width column instead of the 240px-floor track, which could

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -41,7 +41,8 @@ import {
   Upload,
   Users,
 } from 'lucide-react';
-import { useDocumentBrowserModel, SORT_LABELS } from '../settings/useDocumentBrowserModel';
+import { useDocumentBrowserModel } from '../settings/useDocumentBrowserModel';
+import { BrowserViewMenu } from './BrowserViewMenu';
 import { DocumentList, SelectionBar } from '../settings/DocumentList';
 import { CollectionActionsMenu } from '../settings/CollectionActionsMenu';
 import { isWorkspaceCollection } from '../../store/collectionStore';
@@ -59,10 +60,14 @@ import { RailWorkspaceSwitcher } from './RailWorkspaceSwitcher';
 import { opener } from '../../platform/opener';
 import { blobStorage } from '../../storage/BlobStorage';
 import type { StorageStats } from '../../storage/BlobTypes';
-import { formatFileSize } from '../../utils/imageUtils';
+import {
+  formatStorageSize,
+  formatStoragePair,
+  storagePercent,
+} from '../../utils/formatStorageSize';
+import { CapacityRing, type CapacitySegment } from './CapacityRing';
 import { openCloudSignIn } from '../cloud/cloudSignInStore';
 import type {
-  DocumentBrowserGroupBy,
   DocumentBrowserSort,
   DocumentBrowserView,
 } from '../../store/uiPreferencesStore';
@@ -331,8 +336,16 @@ export function DocumentsHome({
   // query. Skipped for tiny libraries (≤4 docs) where it would just duplicate
   // the table below (JP-444).
   const recents = useMemo(() => documentList.slice(0, 6), [documentList]);
+  // Grid view is excluded (JP-477): once the grid cards carry the same
+  // thumbnails, the strip is the first six of the list rendered twice, one row
+  // above itself. It still earns its place over the list view, where it's the
+  // only visual representation on screen.
   const showRecents =
-    nav === 'all' && collectionFilter === null && !searchQuery && documentList.length > 4;
+    view === 'list' &&
+    nav === 'all' &&
+    collectionFilter === null &&
+    !searchQuery &&
+    documentList.length > 4;
 
   const activeLabel = collectionFilter
     ? (collections.find((c) => c.id === collectionFilter)?.name ?? 'Collection')
@@ -485,25 +498,35 @@ export function DocumentsHome({
             onClick={() => goMainView('storage')}
             title="Manage storage"
           >
-            <div className="dh-storage-top">
-              <Database size={14} aria-hidden="true" />
-              <span>Storage</span>
-              <span className="dh-storage-manage">Manage</span>
-            </div>
-            <StorageMeter
-              label="Local · this device"
-              used={storage ? storage.used : null}
-              quota={storage && storage.available > 0 ? storage.available : null}
-              pending={storage === null}
-            />
-            {signedIn && (
-              <StorageMeter
-                label="Cloud workspace"
-                used={relayUsage ? relayUsage.storageBytes : null}
-                quota={relayUsage ? relayUsage.storageQuota : null}
-                pending={relayUsage === null}
-                over={atCloudCap}
-                shares={resolveShares(relayUsage)}
+            {/* The ring reports whichever store is the one that can actually
+                run out: the cloud workspace when signed in, otherwise the
+                device. The other becomes a one-line footnote — two full meters
+                is one more than the rail has room for. The scope doubles as the
+                card's eyebrow, so there's no separate "Storage" header row for
+                it to contradict. */}
+            {signedIn ? (
+              <>
+                <StorageHeadline
+                  scope="Cloud workspace"
+                  used={relayUsage ? relayUsage.storageBytes : null}
+                  quota={relayUsage ? relayUsage.storageQuota : null}
+                  pending={relayUsage === null}
+                  over={atCloudCap}
+                  shares={resolveShares(relayUsage)}
+                />
+                <StorageFootnote
+                  label="This device"
+                  used={storage ? storage.used : null}
+                  quota={storage && storage.available > 0 ? storage.available : null}
+                  pending={storage === null}
+                />
+              </>
+            ) : (
+              <StorageHeadline
+                scope="This device"
+                used={storage ? storage.used : null}
+                quota={storage && storage.available > 0 ? storage.available : null}
+                pending={storage === null}
               />
             )}
           </button>
@@ -607,8 +630,13 @@ export function DocumentsHome({
               <span>Editor</span>
             </button>
           )}
+          {/* Title carries the count, so the list below doesn't repeat it in a
+              heading of its own. */}
           <div className="dh-crumb">
             <strong>{activeLabel}</strong>
+            <span className="dh-crumb-count">
+              {documentList.length} {documentList.length === 1 ? 'item' : 'items'}
+            </span>
           </div>
           <div className="dh-search">
             <Search size={16} aria-hidden="true" />
@@ -622,75 +650,63 @@ export function DocumentsHome({
             />
             <kbd className="dh-search-kbd" aria-hidden="true">/</kbd>
           </div>
+          {/* Two clusters, not one undifferentiated row: how the library is
+              displayed (view · sort/group · refresh), then what you do to it
+              (import · new). The rule between them is the hierarchy. */}
           <div className="dh-top-actions">
-            {/* In list view the sortable column headers own sorting (JP-444);
-                the dropdown remains for grid view, which has no headers. */}
-            {view === 'grid' && (
-              <label className="dh-sort">
-                <span className="dh-sort-label">Sort</span>
-                <select value={sort} onChange={(e) => setSort(e.target.value as DocumentBrowserSort)}>
-                  {Object.entries(SORT_LABELS).map(([value, label]) => (
-                    <option key={value} value={value}>
-                      {label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-            <label className="dh-sort">
-              <span className="dh-sort-label">Group</span>
-              <select
-                value={groupBy}
-                onChange={(e) => setGroupBy(e.target.value as DocumentBrowserGroupBy)}
-                title="Group documents by collection"
-              >
-                <option value="none">None</option>
-                <option value="collection">Collection</option>
-              </select>
-            </label>
-            <div className="dh-view-toggle" role="group" aria-label="View mode">
+            <div className="dh-top-utils">
+              <div className="dh-view-toggle" role="group" aria-label="View mode">
+                <button
+                  className={view === 'list' ? 'on' : ''}
+                  onClick={() => setView('list' as DocumentBrowserView)}
+                  title="List view"
+                  aria-label="List view"
+                  aria-pressed={view === 'list'}
+                >
+                  <List size={16} aria-hidden="true" />
+                </button>
+                <button
+                  className={view === 'grid' ? 'on' : ''}
+                  onClick={() => setView('grid' as DocumentBrowserView)}
+                  title="Grid view"
+                  aria-label="Grid view"
+                  aria-pressed={view === 'grid'}
+                >
+                  <LayoutGrid size={16} aria-hidden="true" />
+                </button>
+              </div>
+              <BrowserViewMenu
+                view={view}
+                sort={sort}
+                setSort={setSort}
+                groupBy={groupBy}
+                setGroupBy={setGroupBy}
+              />
               <button
-                className={view === 'list' ? 'on' : ''}
-                onClick={() => setView('list' as DocumentBrowserView)}
-                title="List view"
-                aria-label="List view"
-                aria-pressed={view === 'list'}
+                className="dh-refresh"
+                onClick={() => {
+                  setRefreshSpin(true);
+                  handleRefresh();
+                  window.setTimeout(() => setRefreshSpin(false), 600);
+                }}
+                title="Refresh document list"
+                aria-label="Refresh document list"
               >
-                <List size={16} aria-hidden="true" />
-              </button>
-              <button
-                className={view === 'grid' ? 'on' : ''}
-                onClick={() => setView('grid' as DocumentBrowserView)}
-                title="Grid view"
-                aria-label="Grid view"
-                aria-pressed={view === 'grid'}
-              >
-                <LayoutGrid size={16} aria-hidden="true" />
+                <RefreshCw
+                  size={16}
+                  aria-hidden="true"
+                  className={isFetchingRemote || refreshSpin ? 'dh-refresh-spin' : undefined}
+                />
               </button>
             </div>
-            <button
-              className="dh-refresh"
-              onClick={() => {
-                setRefreshSpin(true);
-                handleRefresh();
-                window.setTimeout(() => setRefreshSpin(false), 600);
-              }}
-              title="Refresh document list"
-              aria-label="Refresh document list"
-            >
-              <RefreshCw
-                size={16}
-                aria-hidden="true"
-                className={isFetchingRemote || refreshSpin ? 'dh-refresh-spin' : undefined}
-              />
-            </button>
+            <span className="dh-top-rule" aria-hidden="true" />
             <button
               className="dh-import"
               onClick={handleImport}
               title="Import a .docushark document (with its assets)"
             >
               <Upload size={16} aria-hidden="true" />
-              <span>Import</span>
+              <span className="dh-import-label">Import</span>
             </button>
             <button className="dh-new" onClick={onNew} title="New document">
               <FilePlus2 size={16} aria-hidden="true" />
@@ -736,12 +752,10 @@ export function DocumentsHome({
             </section>
           ) : (
             <section className="dh-section dh-section--list">
-              <h2 className="dh-section-title">
-                {searchQuery ? 'Results' : activeLabel}
-                <span className="dh-section-count">
-                  {documentList.length} {documentList.length === 1 ? 'item' : 'items'}
-                </span>
-              </h2>
+              {/* No heading here — the header's title + count already name this
+                  list. A search gets one, because "Results" is the only case
+                  where the list is no longer what the header says it is. */}
+              {searchQuery && <h2 className="dh-section-title">Results</h2>}
               {view === 'list' && documentList.length > 0 && (
                 <ColumnHeader sort={sort} setSort={setSort} />
               )}
@@ -857,80 +871,106 @@ export function resolveShares(usage: RelayUsage | null): StorageShares | null {
   return { docBytes, blobBytes, configBytes: config };
 }
 
-function StorageMeter({
-  label,
+/**
+ * The rail's primary storage readout: a `CapacityRing` beside the scope and the
+ * used/allowance pair.
+ *
+ * The JP-301 share breakdown is still here — it's drawn as the ring's arcs, and
+ * the named byte counts moved to this element's tooltip (and the full Storage
+ * view, one click away). That was the trade for a card that no longer wraps its
+ * legend onto a second line.
+ */
+function StorageHeadline({
+  scope,
   used,
   quota,
   pending,
   over = false,
   shares = null,
 }: {
+  scope: string;
+  used: number | null;
+  quota: number | null;
+  pending: boolean;
+  /** At/over quota (JP-443) — renders the ring in the danger color. */
+  over?: boolean;
+  /** Per-category breakdown (JP-301), when the relay reports one that sums. */
+  shares?: StorageShares | null;
+}) {
+  const segments: CapacitySegment[] | null = shares
+    ? [
+        { key: 'docs', label: 'Documents', bytes: shares.docBytes },
+        { key: 'files', label: 'Files', bytes: shares.blobBytes },
+        { key: 'config', label: 'Configuration', bytes: shares.configBytes },
+      ]
+    : null;
+
+  const value = pending ? 'Calculating…' : used === null ? '—' : formatStoragePair(used, quota);
+
+  // Named shares live here rather than in a permanent legend. Configuration
+  // gets its plain-language gloss appended — it's the one share whose name
+  // doesn't explain itself.
+  const tooltip = segments
+    ? segments
+        .map((s) => `${s.label}: ${formatStorageSize(s.bytes)}`)
+        .concat('Configuration is your synced style profiles.')
+        .join('\n')
+    : undefined;
+
+  return (
+    <div className="dh-storage-main" title={tooltip}>
+      <CapacityRing
+        used={used}
+        quota={quota}
+        segments={segments}
+        over={over}
+        pending={pending}
+        size={46}
+      />
+      <span className="dh-storage-readout">
+        <span className="dh-storage-scope-row">
+          <span className="dh-storage-scope">{scope}</span>
+          <span className="dh-storage-manage">Manage</span>
+        </span>
+        <span className={`dh-storage-value${over ? ' dh-storage-value--over' : ''}`}>{value}</span>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The secondary store, as one quiet line.
+ *
+ * It carries a bar only once it's half full — below that the bar is a sliver of
+ * noise reporting a non-problem, and `navigator.storage.estimate()` reports no
+ * quota at all on WebKitGTK, where a drawn track would be a fabrication.
+ */
+function StorageFootnote({
+  label,
+  used,
+  quota,
+  pending,
+}: {
   label: string;
   used: number | null;
   quota: number | null;
   pending: boolean;
-  /** At/over quota (JP-443) — renders the fill in the danger color. */
-  over?: boolean;
-  /**
-   * Per-category breakdown (JP-301). When present and not at cap, the bar is
-   * drawn as stacked shares with a legend. Suppressed at cap so the danger
-   * state reads as one unambiguous "full" signal.
-   */
-  shares?: StorageShares | null;
 }) {
-  const pct = used !== null && quota !== null && quota > 0 ? Math.min(100, (used / quota) * 100) : null;
-  const value = pending
-    ? 'Calculating…'
-    : used === null
-      ? '—'
-      : quota !== null && quota > 0
-        ? `${formatFileSize(used)} / ${formatFileSize(quota)}`
-        : `${formatFileSize(used)} used`;
-
-  const split = !over && !pending && shares && quota !== null && quota > 0 ? shares : null;
-  const widthOf = (bytes: number) =>
-    `${Math.min(100, (bytes / (quota as number)) * 100)}%`;
+  const pct = storagePercent(used ?? 0, quota);
+  const value = pending ? 'Calculating…' : used === null ? '—' : formatStorageSize(used);
+  const showBar = !pending && pct !== null && pct >= 50;
 
   return (
-    <div className="dh-storage-row">
-      <div className="dh-storage-rowtop">
-        <span className="dh-storage-rowlabel">{label}</span>
-        <span className="dh-storage-rowval">{value}</span>
-      </div>
-      {split ? (
-        <>
-          <div className="dh-storage-bar dh-storage-bar--split">
-            <div className="dh-storage-seg dh-storage-seg--docs" style={{ width: widthOf(split.docBytes) }} />
-            <div className="dh-storage-seg dh-storage-seg--files" style={{ width: widthOf(split.blobBytes) }} />
-            <div className="dh-storage-seg dh-storage-seg--config" style={{ width: widthOf(split.configBytes) }} />
-          </div>
-          <div className="dh-storage-legend">
-            <span className="dh-storage-legend-item">
-              <span className="dh-storage-sw dh-storage-seg--docs" /> Documents{' '}
-              <span className="dh-storage-legend-val">{formatFileSize(split.docBytes)}</span>
-            </span>
-            <span className="dh-storage-legend-item">
-              <span className="dh-storage-sw dh-storage-seg--files" /> Files{' '}
-              <span className="dh-storage-legend-val">{formatFileSize(split.blobBytes)}</span>
-            </span>
-            <span
-              className="dh-storage-legend-item"
-              title="Style profiles synced across your devices."
-            >
-              <span className="dh-storage-sw dh-storage-seg--config" /> Configuration{' '}
-              <span className="dh-storage-legend-val">{formatFileSize(split.configBytes)}</span>
-            </span>
-          </div>
-        </>
-      ) : (
-        pct !== null && (
-          <div className="dh-storage-bar">
-            <div
-              className={`dh-storage-fill${over ? ' dh-storage-fill--over' : ''}`}
-              style={{ width: `${pct}%` }}
-            />
-          </div>
-        )
+    <div className="dh-storage-foot">
+      <span className="dh-storage-foot-row">
+        <HardDrive size={12} aria-hidden="true" />
+        <span className="dh-storage-foot-label">{label}</span>
+        <span className="dh-storage-foot-val">{value}</span>
+      </span>
+      {showBar && (
+        <span className="dh-storage-foot-bar">
+          <span className="dh-storage-foot-fill" style={{ width: `${pct}%` }} />
+        </span>
       )}
     </div>
   );

--- a/src/ui/home/DocumentsHome.tsx
+++ b/src/ui/home/DocumentsHome.tsx
@@ -918,7 +918,7 @@ function StorageHeadline({
     : undefined;
 
   return (
-    <div className="dh-storage-main" title={tooltip}>
+    <span className="dh-storage-main" title={tooltip}>
       <CapacityRing
         used={used}
         quota={quota}
@@ -934,7 +934,7 @@ function StorageHeadline({
         </span>
         <span className={`dh-storage-value${over ? ' dh-storage-value--over' : ''}`}>{value}</span>
       </span>
-    </div>
+    </span>
   );
 }
 
@@ -961,7 +961,7 @@ function StorageFootnote({
   const showBar = !pending && pct !== null && pct >= 50;
 
   return (
-    <div className="dh-storage-foot">
+    <span className="dh-storage-foot">
       <span className="dh-storage-foot-row">
         <HardDrive size={12} aria-hidden="true" />
         <span className="dh-storage-foot-label">{label}</span>
@@ -972,7 +972,7 @@ function StorageFootnote({
           <span className="dh-storage-foot-fill" style={{ width: `${pct}%` }} />
         </span>
       )}
-    </div>
+    </span>
   );
 }
 

--- a/src/ui/home/RecentCard.tsx
+++ b/src/ui/home/RecentCard.tsx
@@ -4,12 +4,10 @@
  * stylized placeholder) over a title + mono meta strip. The card's accent
  * (placeholder chips, hover edge) picks up the doc's collection color.
  */
-import { useEffect, useState } from 'react';
 import type { CSSProperties } from 'react';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
-import { useThemeStore } from '../../store/themeStore';
 import { formatDate } from '../DocumentCard';
-import { getRecentPreview, type RecentPreview } from './recentThumbnails';
+import { DocumentPreview, useDocumentPreview } from './DocumentPreview';
 
 function sourceLabel(record: DocumentRecord): string {
   switch (record.type) {
@@ -24,33 +22,6 @@ function sourceLabel(record: DocumentRecord): string {
   }
 }
 
-/** Dotted-canvas placeholder with a few node chips — reads as "a diagram". */
-function CanvasPlaceholder() {
-  return (
-    <span className="dh-rcard-ph dh-rcard-ph--canvas" aria-hidden="true">
-      <svg className="dh-rcard-ph-edges" viewBox="0 0 100 60" preserveAspectRatio="none">
-        <path d="M28 20 C 44 20, 48 34, 62 36" />
-        <path d="M30 44 C 44 44, 52 40, 62 38" />
-      </svg>
-      <span className="dh-rcard-ph-node dh-rcard-ph-node--a" />
-      <span className="dh-rcard-ph-node dh-rcard-ph-node--b" />
-      <span className="dh-rcard-ph-node dh-rcard-ph-node--c" />
-    </span>
-  );
-}
-
-/** Skeleton text lines — reads as "a written document". */
-function DocPlaceholder() {
-  return (
-    <span className="dh-rcard-ph dh-rcard-ph--doc" aria-hidden="true">
-      <span className="dh-rcard-ph-line dh-rcard-ph-line--title" />
-      <span className="dh-rcard-ph-line" />
-      <span className="dh-rcard-ph-line" />
-      <span className="dh-rcard-ph-line dh-rcard-ph-line--short" />
-    </span>
-  );
-}
-
 export interface RecentCardProps {
   record: DocumentRecord;
   /** Collection accent for the preview (name for tooltip, color for tint). */
@@ -59,23 +30,7 @@ export interface RecentCardProps {
 }
 
 export function RecentCard({ record, accent, onOpen }: RecentCardProps) {
-  const [preview, setPreview] = useState<RecentPreview | null>(null);
-  // AUTO-coloured shapes resolve against the theme (white ink on dark) — a
-  // theme flip re-renders the thumbnail with the matching ink.
-  const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
-
-  useEffect(() => {
-    let cancelled = false;
-    void getRecentPreview(record, resolvedTheme).then((p) => {
-      if (!cancelled) setPreview(p);
-    });
-    return () => {
-      cancelled = true;
-    };
-    // Re-render only when the doc actually changed (id or edit time) or the
-    // surface theme flipped.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [record.id, record.modifiedAt, resolvedTheme]);
+  const preview = useDocumentPreview(record);
 
   const style = accent?.color
     ? ({ '--rcard-accent': accent.color } as CSSProperties)
@@ -89,13 +44,7 @@ export function RecentCard({ record, accent, onOpen }: RecentCardProps) {
       title={accent ? `${record.name} — ${accent.name}` : record.name}
     >
       <span className="dh-rcard-preview">
-        {preview?.uri ? (
-          <img className="dh-rcard-thumb" src={preview.uri} alt="" loading="lazy" />
-        ) : preview?.kind === 'doc' ? (
-          <DocPlaceholder />
-        ) : (
-          <CanvasPlaceholder />
-        )}
+        <DocumentPreview preview={preview} />
       </span>
       <span className="dh-rcard-meta">
         <span className="dh-rcard-title">{record.name}</span>

--- a/src/ui/settings/DocumentBrowser.css
+++ b/src/ui/settings/DocumentBrowser.css
@@ -467,9 +467,13 @@
 }
 
 /* Grid layout for the doc list */
+/* JP-477: 206px floor, up from 180px. At 180 the name truncated on roughly
+   half the cards. 206 clears the longest names in practice and still lands
+   five columns on a 1440px window, where a 220px floor fell one short of the
+   available 1109px and jumped to four very wide cards. */
 .document-browser__list--grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(206px, 1fr));
   gap: var(--space-2);
 }
 
@@ -740,7 +744,7 @@
 
 .document-browser__section-body--grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(206px, 1fr));
   gap: var(--space-2);
 }
 

--- a/src/ui/settings/DocumentList.tsx
+++ b/src/ui/settings/DocumentList.tsx
@@ -168,7 +168,15 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
 
   return (
     <>
-    <div className={`document-browser__list ${view === 'grid' ? 'document-browser__list--grid' : ''}`}>
+    {/* The grid track lives on whichever element actually holds the cards. When
+        grouping is on that's each section's body, and putting it here as well
+        made the *sections* grid items — collections laid out side by side as
+        columns instead of stacking (JP-477). */}
+    <div
+      className={`document-browser__list ${
+        view === 'grid' && !groupedSections ? 'document-browser__list--grid' : ''
+      }`}
+    >
       {documentList.length === 0 ? (
         <div className="document-browser__empty">
           {searchQuery ? (
@@ -233,8 +241,9 @@ export function DocumentList({ model, compact = false, onOpened }: DocumentListP
           )}
         </div>
       ) : groupedSections ? (
+        // The model only emits sections that hold documents, so there's no
+        // empty-section case to filter out here.
         groupedSections.map(({ key, collection, docs }) => {
-          if (docs.length === 0 && collection === null) return null;
           const collapsed = collapsedMap[key] === true;
           return (
             <CollectionSection
@@ -494,11 +503,7 @@ function CollectionSection({
         <div
           className={`document-browser__section-body ${view === 'grid' ? 'document-browser__section-body--grid' : ''}`}
         >
-          {docs.length === 0 ? (
-            <div className="document-browser__section-empty">No documents in this collection.</div>
-          ) : (
-            docs.map((d) => renderCard(d))
-          )}
+          {docs.map((d) => renderCard(d))}
         </div>
       )}
     </div>

--- a/src/ui/settings/useDocumentBrowserModel.test.ts
+++ b/src/ui/settings/useDocumentBrowserModel.test.ts
@@ -17,8 +17,11 @@ import {
   canManagePermissions,
   canPublishToRelay,
   canMoveToPersonal,
+  buildGroupedSections,
+  UNASSIGNED_KEY,
 } from './useDocumentBrowserModel';
 import type { DocumentRecord } from '../../types/DocumentRegistry';
+import type { Collection } from '../../store/collectionStore';
 
 /** Minimal record shape — the helpers only read these fields. */
 function rec(partial: Partial<DocumentRecord>): DocumentRecord {
@@ -149,5 +152,62 @@ describe('permission gates', () => {
     expect(canMoveToPersonal(rec({ type: 'remote', permission: 'editor', ownerId: 'u' }), true, 'u')).toBe(true);
     expect(canMoveToPersonal(rec({ type: 'remote', permission: 'editor', ownerId: 'x' }), true, 'u')).toBe(false);
     expect(canMoveToPersonal(rec({ type: 'local' }), true)).toBe(false);
+  });
+});
+
+describe('buildGroupedSections', () => {
+  const coll = (id: string, name: string): Collection =>
+    ({ id, name, createdAt: 0 }) as Collection;
+
+  const specs = coll('c1', 'Specs');
+  const research = coll('c2', 'Research');
+  const archive = coll('c3', 'Archive');
+  const collections = [specs, research, archive];
+  const map = { c1: specs, c2: research, c3: archive };
+
+  const a = rec({ id: 'a', name: 'Alpha' });
+  const b = rec({ id: 'b', name: 'Bravo' });
+  const loose = rec({ id: 'z', name: 'Zulu' });
+
+  it('emits a section per collection that actually holds documents', () => {
+    const sections = buildGroupedSections([a, b], { a: 'c1', b: 'c2' }, map, collections);
+    expect(sections.map((s) => s.key)).toEqual(['c1', 'c2']);
+  });
+
+  it('omits collections with nothing in the list', () => {
+    // The JP-477 defect: filtering the list down to one collection still
+    // rendered every other collection as an empty section, contradicting the
+    // filter the user had just applied.
+    const sections = buildGroupedSections([a], { a: 'c1' }, map, collections);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.collection).toBe(specs);
+    expect(sections[0]!.docs).toEqual([a]);
+  });
+
+  it('returns no sections at all for an empty list', () => {
+    expect(buildGroupedSections([], {}, map, collections)).toEqual([]);
+  });
+
+  it('collects unfiled documents into a trailing unassigned section', () => {
+    const sections = buildGroupedSections([a, loose], { a: 'c1' }, map, collections);
+    expect(sections.map((s) => s.key)).toEqual(['c1', UNASSIGNED_KEY]);
+    expect(sections[1]!.collection).toBeNull();
+    expect(sections[1]!.docs).toEqual([loose]);
+  });
+
+  it('follows the rail order, not the order documents appear in', () => {
+    // b is filed under Research (2nd in the rail) but comes first in the list.
+    const sections = buildGroupedSections([b, a], { a: 'c1', b: 'c2' }, map, collections);
+    expect(sections.map((s) => s.key)).toEqual(['c1', 'c2']);
+  });
+
+  it('treats an assignment to a deleted collection as unassigned', () => {
+    const sections = buildGroupedSections([a], { a: 'gone' }, map, collections);
+    expect(sections.map((s) => s.key)).toEqual([UNASSIGNED_KEY]);
+  });
+
+  it('preserves document order within a section', () => {
+    const sections = buildGroupedSections([b, a], { a: 'c1', b: 'c1' }, map, collections);
+    expect(sections[0]!.docs.map((d) => d.id)).toEqual(['b', 'a']);
   });
 });

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -70,6 +70,49 @@ export function isSharedWithMe(record: DocumentRecord, userId: string | undefine
 /** Section key for documents that belong to no collection. */
 export const UNASSIGNED_KEY = '__unassigned__';
 
+/**
+ * Bucket an already-filtered document list into collection sections.
+ *
+ * Sections describe what's IN the list, so a collection contributing nothing
+ * gets no section (JP-477). Emitting one per collection regardless meant that
+ * narrowing to a single collection still rendered every *other* collection as a
+ * header over "No documents in this collection." — the list contradicting the
+ * filter the user had just applied. An empty section has no job to do here
+ * anyway: there's no drag-and-drop for it to be a drop target of, and the rail
+ * already lists every collection with its count.
+ *
+ * Order follows `collections` (the user's own order in the rail) rather than
+ * the order documents happen to appear in, with unassigned always last.
+ */
+export function buildGroupedSections(
+  documentList: DocumentRecord[],
+  assignments: Record<string, string | undefined>,
+  collectionsMap: Record<string, Collection | undefined>,
+  collections: Collection[],
+): GroupedSection[] {
+  const buckets = new Map<string, DocumentRecord[]>();
+  for (const doc of documentList) {
+    const cid = assignments[doc.id];
+    // An assignment pointing at a collection that no longer exists falls back
+    // to unassigned rather than minting a phantom section.
+    const key = cid && collectionsMap[cid] ? cid : UNASSIGNED_KEY;
+    const arr = buckets.get(key);
+    if (arr) arr.push(doc);
+    else buckets.set(key, [doc]);
+  }
+
+  const sections: GroupedSection[] = [];
+  for (const c of collections) {
+    const docs = buckets.get(c.id);
+    if (docs && docs.length > 0) sections.push({ key: c.id, collection: c, docs });
+  }
+  const unassigned = buckets.get(UNASSIGNED_KEY);
+  if (unassigned && unassigned.length > 0) {
+    sections.push({ key: UNASSIGNED_KEY, collection: null, docs: unassigned });
+  }
+  return sections;
+}
+
 export function compareRecords(a: DocumentRecord, b: DocumentRecord, sort: DocumentBrowserSort): number {
   switch (sort) {
     case 'modified-desc':
@@ -447,27 +490,13 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
   }, []);
 
   // Bucket documents by collection when grouping is enabled.
-  const groupedSections = useMemo<GroupedSection[] | null>(() => {
-    if (groupBy !== 'collection') return null;
-    const buckets = new Map<string, DocumentRecord[]>();
-    for (const doc of documentList) {
-      const cid = assignments[doc.id];
-      const key = cid && collectionsMap[cid] ? cid : UNASSIGNED_KEY;
-      const arr = buckets.get(key);
-      if (arr) arr.push(doc);
-      else buckets.set(key, [doc]);
-    }
-    const sections: GroupedSection[] = [];
-    for (const c of collections) {
-      sections.push({ key: c.id, collection: c, docs: buckets.get(c.id) ?? [] });
-    }
-    sections.push({
-      key: UNASSIGNED_KEY,
-      collection: null,
-      docs: buckets.get(UNASSIGNED_KEY) ?? [],
-    });
-    return sections;
-  }, [groupBy, documentList, assignments, collectionsMap, collections]);
+  const groupedSections = useMemo<GroupedSection[] | null>(
+    () =>
+      groupBy === 'collection'
+        ? buildGroupedSections(documentList, assignments, collectionsMap, collections)
+        : null,
+    [groupBy, documentList, assignments, collectionsMap, collections],
+  );
 
   // Count documents by type. JP-370: relay-backed docs (remote/cached) are
   // scoped to the ACTIVE workspace — same as the list (getFilteredDocuments) —

--- a/src/utils/formatStorageSize.test.ts
+++ b/src/utils/formatStorageSize.test.ts
@@ -1,0 +1,71 @@
+import { formatStorageSize, formatStoragePair, storagePercent } from './formatStorageSize';
+
+const KB = 1024;
+const MB = 1024 * 1024;
+const GB = 1024 * 1024 * 1024;
+
+describe('formatStorageSize', () => {
+  it('renders sub-kilobyte values as whole bytes', () => {
+    expect(formatStorageSize(285)).toBe('285 B');
+    expect(formatStorageSize(1023)).toBe('1023 B');
+  });
+
+  it('renders KB and MB with one decimal', () => {
+    expect(formatStorageSize(1536)).toBe('1.5 KB');
+    expect(formatStorageSize(8_074_035)).toBe('7.7 MB');
+  });
+
+  it('renders GB with two decimals', () => {
+    // The exact numbers the sidebar meter was cramping before JP-477.
+    expect(formatStorageSize(20 * GB)).toBe('20.00 GB');
+    expect(formatStorageSize(141_838_925_824)).toBe('132.10 GB');
+  });
+
+  it('switches unit exactly at each boundary', () => {
+    expect(formatStorageSize(KB - 1)).toBe('1023 B');
+    expect(formatStorageSize(KB)).toBe('1.0 KB');
+    expect(formatStorageSize(MB - 1)).toBe('1024.0 KB');
+    expect(formatStorageSize(MB)).toBe('1.0 MB');
+    expect(formatStorageSize(GB - 1)).toBe('1024.0 MB');
+    expect(formatStorageSize(GB)).toBe('1.00 GB');
+  });
+
+  it('carries on into TB rather than printing five-digit GB', () => {
+    expect(formatStorageSize(2048 * GB)).toBe('2.00 TB');
+  });
+
+  it('treats zero, negative and non-finite input as empty', () => {
+    expect(formatStorageSize(0)).toBe('0 B');
+    expect(formatStorageSize(-5)).toBe('0 B');
+    expect(formatStorageSize(Number.NaN)).toBe('0 B');
+  });
+});
+
+describe('formatStoragePair', () => {
+  it('keeps each side in its own natural unit', () => {
+    // The used side stays in MB so its moving digits survive; only the
+    // allowance gets the GB treatment.
+    expect(formatStoragePair(8_074_035, 20 * GB)).toBe('7.7 MB / 20.00 GB');
+  });
+
+  it('states "used" when there is no allowance to divide by', () => {
+    expect(formatStoragePair(8_074_035, null)).toBe('7.7 MB used');
+    expect(formatStoragePair(8_074_035, 0)).toBe('7.7 MB used');
+  });
+});
+
+describe('storagePercent', () => {
+  it('rounds to a whole percent', () => {
+    expect(storagePercent(GB / 2, GB)).toBe(50);
+    expect(storagePercent(1, GB)).toBe(0);
+  });
+
+  it('clamps an over-quota workspace to 100', () => {
+    expect(storagePercent(3 * GB, GB)).toBe(100);
+  });
+
+  it('returns null without a quota, so callers can hide the readout', () => {
+    expect(storagePercent(GB, null)).toBeNull();
+    expect(storagePercent(GB, 0)).toBeNull();
+  });
+});

--- a/src/utils/formatStorageSize.ts
+++ b/src/utils/formatStorageSize.ts
@@ -1,0 +1,60 @@
+/**
+ * Storage-meter number formatting (JP-477).
+ *
+ * `formatFileSize` (imageUtils) tops out at MB, so a workspace quota renders as
+ * `20480.0 MB` and a device quota as `135266.5 MB` — technically correct, and
+ * unreadable at the width of a sidebar meter. This helper is for *capacity*
+ * numbers (quotas, workspace totals), where the useful unit is GB.
+ *
+ * Precision is deliberately unit-dependent: GB carries two decimals so a
+ * workspace at 7.7 GB of 20 GB still moves the number visibly as it fills,
+ * while smaller units keep one. The GB cutover is driven by **magnitude, not
+ * plan** — the editor is the OSS side and has no tier claim to read (tier names
+ * exist only in the Cloud control plane), so "is this a large allowance?" can
+ * only be answered by the byte count itself. That happens to line up: a paid
+ * workspace's quota clears 1 GB, a free one doesn't.
+ */
+
+const KB = 1024;
+const MB = 1024 * 1024;
+const GB = 1024 * 1024 * 1024;
+const TB = 1024 * 1024 * 1024 * 1024;
+
+/**
+ * Format a byte count for a capacity readout.
+ *
+ * ```
+ *          512  → "512 B"
+ *      1_536    → "1.5 KB"
+ *  8_074_035    → "7.7 MB"
+ * 21_474_836_480 → "20.00 GB"
+ * ```
+ */
+export function formatStorageSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  if (bytes < KB) return `${Math.round(bytes)} B`;
+  if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+  if (bytes < GB) return `${(bytes / MB).toFixed(1)} MB`;
+  if (bytes < TB) return `${(bytes / GB).toFixed(2)} GB`;
+  return `${(bytes / TB).toFixed(2)} TB`;
+}
+
+/**
+ * Format a used/total pair for a meter.
+ *
+ * Each side keeps its own natural unit, so a nearly-empty workspace reads
+ * `7.7 MB / 20.00 GB` rather than collapsing the used side to `0.01 GB` and
+ * throwing away the only digits that are moving. A null/zero total means the
+ * allowance is unknown or unmetered — say so instead of drawing a ratio
+ * against a number we don't have.
+ */
+export function formatStoragePair(used: number, quota: number | null): string {
+  if (quota === null || quota <= 0) return `${formatStorageSize(used)} used`;
+  return `${formatStorageSize(used)} / ${formatStorageSize(quota)}`;
+}
+
+/** Whole-percent fill, clamped to 0–100. `null` when there's no quota to divide by. */
+export function storagePercent(used: number, quota: number | null): number | null {
+  if (quota === null || quota <= 0) return null;
+  return Math.max(0, Math.min(100, Math.round((used / quota) * 100)));
+}


### PR DESCRIPTION
Closes JP-477.

A UX pass over the document browser, driven by four observed defects. Everything below was measured against the live local stack signed into a workspace, not eyeballed.

## What was wrong

| | Measured |
|---|---|
| **Top controls** | Header **57px in list, 115px in grid** — grid adds a Sort `<select>` and the row wraps. The two native selects ate **337px of 657px** of action width. Six controls at identical gaps, no hierarchy. |
| **Grid cards** | Text-only at a 180px track floor, while the recents strip *directly above* showed real thumbnails of the same documents. Names truncated on ~half the cards. |
| **Grouped grid** | `.document-browser__list--grid` is `display: grid`, so section wrappers became grid items — collections laid out **side by side as columns**. |
| **Collection filter** | `groupedSections` emitted a section per collection regardless of `collectionFilter`; filtering to one still rendered the others as "No documents in this collection." |
| **Storage card** | **134px** inside a 211px foot (24% of the rail): header, two labelled meters, split bar, three legend items wrapping to two lines. |
| **Units** | `formatFileSize` stops at MB → `135266.5 MB` and `20480.0 MB`. |

## What changed

**Top bar.** Sort + Group collapse into one **View** popover on the shared `DropdownMenu` (which already supported `checked`; this adds a `heading` entry kind). Header holds **one row down to 1180px in both views**. Title carries the item count, so the duplicate heading over the list is gone. Controls share a 34px baseline; Import demotes to a ghost so the gold CTA reads as primary.

One subtle fix worth naming: the search box now flex-bases at its **180px floor**. Flexbox breaks lines using hypothetical sizes *before* it flexes anything, so a content basis had the search claiming its full 420px while deciding the row didn't fit — the actions wrapped with ~200px of slack the search was never asked to give back.

**Grid.** Cards gain a 16:10 preview from the existing `recentThumbnails` engine (cached, local-only, no network). The placeholder renderers are **extracted to a shared `DocumentPreview`** rather than copied — a parallel renderer is exactly how the canvas/prose placeholders would drift into disagreeing about one document on one screen. Track floor 206px (five columns at 1440px, no truncation). Hover actions move onto the preview plate instead of reserving ~38px of permanent blank row per card. The recents strip is suppressed in grid view, where it was the first six of the list rendered twice.

**Grouping.** The grid track now goes on whichever element actually holds the cards. `buildGroupedSections` is extracted and pinned: sections describe what is *in* the list, so a collection contributing nothing gets no section.

**Storage.** A new `CapacityRing` — arcs carry the JP-301 documents/files/configuration split, named amounts in the tooltip, over one quiet line for the device. **134px → 100px**, five elements instead of ten, breakdown preserved rather than dropped. The arc math floors a tiny share to a visible sliver but repays it from the largest, so the ring's outer edge still lands on the true fill.

`formatStorageSize` renders GB at two decimals: `7.7 MB / 20.00 GB`, `132.10 GB`. Driven by **magnitude, not plan** — the editor is the OSS side and has no tier claim to read.

## Found while verifying (pre-existing)

The rail's at-cap states consumed `var(--danger)`, which is `#7a2238` in **both** themes — a maroon tuned for paper, rendering near-black on the constant-navy rail. Added `--rail-danger` to the sanctioned rail token block and repointed the five rail consumers; the trash view's uses are main-area and stay semantic. Separately, `--rail-accent` was referenced with a hex fallback that always fired — the stray hardcoded colour that block exists to prevent. Now defined.

## Verification

- `bun run typecheck`, **3353 tests across 285 files**, production build — all green.
- By hand on the local stack signed into a workspace: both themes, list and grid, grouped and filtered, 1440px down to 380px with no horizontal overflow.
- Docs updated in the same change — `collections.md` (View menu + empty-section behaviour), `settings.md` and `styling.md` (ring + tooltip).

## Not done

`formatFileSize` is duplicated in `utils/imageUtils.ts` and `utils/fileUtils.ts` with different ceilings. Consolidating touches ~15 call sites across unrelated surfaces — noted on the issue, deliberately not folded in here.

Assisted-by: Opus 5