### PR TITLE
JP-479: the drafting-card toast

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,12 @@
   --color-on-primary: #f6f4ec;    /* text/icons on a solid primary fill (paper on navy) */
 
   /* Semantic status (fills + readable text) */
+  /* `info` completes the set (JP-479). Its absence is why NotificationToast
+     invented a `--color-info` that resolved to a stray Tailwind blue. Drawn
+     from the sanctioned navy tag hue so it stays on the brand's hue. */
+  --info: #1f3354;
+  --info-text: #1f3354;
+  --info-bg: rgba(31, 51, 84, 0.10);
   --success: #2d8f63;
   --success-text: #2d8f63;
   --danger: #7a2238;
@@ -228,6 +234,9 @@
   --color-on-primary: #0a1525;    /* ink on the gold primary fill */
 
   /* Semantic status — fills stay solid; text is lightened for navy */
+  --info: #1f3354;
+  --info-text: #a9c0e4;
+  --info-bg: rgba(169, 192, 228, 0.12);
   --success: #2d8f63;
   --success-text: #8edcb1;
   --danger: #7a2238;

--- a/src/store/notificationStore.test.ts
+++ b/src/store/notificationStore.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, afterEach, vi } from 'vitest';
+import { useNotificationStore } from './notificationStore';
+
+/**
+ * The auto-dismiss countdown (JP-479). It used to be a bare `setTimeout` that
+ * ran whether or not anyone was reading the toast; these pin the pausable
+ * version, including the leak cases that only show up under eviction.
+ */
+describe('notification auto-dismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().dismissAll();
+  });
+
+  afterEach(() => {
+    useNotificationStore.getState().dismissAll();
+    vi.useRealTimers();
+  });
+
+  const ids = () => useNotificationStore.getState().notifications.map((n) => n.id);
+
+  it('dismisses itself once the duration elapses', () => {
+    const id = useNotificationStore.getState().info('hello', { duration: 1000 });
+    expect(ids()).toContain(id);
+    vi.advanceTimersByTime(1001);
+    expect(ids()).not.toContain(id);
+  });
+
+  it('never auto-dismisses a duration-0 toast', () => {
+    const id = useNotificationStore.getState().info('sticky', { duration: 0 });
+    vi.advanceTimersByTime(120_000);
+    expect(ids()).toContain(id);
+  });
+
+  it('holds the countdown while paused', () => {
+    const store = useNotificationStore.getState();
+    const id = store.info('hello', { duration: 1000 });
+    vi.advanceTimersByTime(600);
+    store.pauseDismiss(id);
+    // Well past the original deadline — a paused toast must not expire.
+    vi.advanceTimersByTime(10_000);
+    expect(ids()).toContain(id);
+  });
+
+  it('resumes with only the remaining time, not a fresh full duration', () => {
+    const store = useNotificationStore.getState();
+    const id = store.info('hello', { duration: 1000 });
+    vi.advanceTimersByTime(600);
+    store.pauseDismiss(id);
+    vi.advanceTimersByTime(5000);
+    store.resumeDismiss(id);
+    // 400ms were owed. Just short of it, still here.
+    vi.advanceTimersByTime(350);
+    expect(ids()).toContain(id);
+    vi.advanceTimersByTime(100);
+    expect(ids()).not.toContain(id);
+  });
+
+  it('grants a minimum grace period to a toast paused past its deadline', () => {
+    const store = useNotificationStore.getState();
+    const id = store.info('hello', { duration: 1000 });
+    // Pausing at 999ms leaves ~1ms owed; resuming shouldn't vanish it instantly
+    // the moment the pointer leaves.
+    vi.advanceTimersByTime(999);
+    store.pauseDismiss(id);
+    store.resumeDismiss(id);
+    vi.advanceTimersByTime(200);
+    expect(ids()).toContain(id);
+    vi.advanceTimersByTime(300);
+    expect(ids()).not.toContain(id);
+  });
+
+  it('is idempotent — a second pause does not lose the remaining time', () => {
+    const store = useNotificationStore.getState();
+    const id = store.info('hello', { duration: 1000 });
+    vi.advanceTimersByTime(400);
+    store.pauseDismiss(id);
+    store.pauseDismiss(id);
+    store.resumeDismiss(id);
+    vi.advanceTimersByTime(550);
+    expect(ids()).toContain(id);
+    vi.advanceTimersByTime(100);
+    expect(ids()).not.toContain(id);
+  });
+
+  it('ignores pause/resume for an unknown id', () => {
+    const store = useNotificationStore.getState();
+    expect(() => store.pauseDismiss('nope')).not.toThrow();
+    expect(() => store.resumeDismiss('nope')).not.toThrow();
+  });
+
+  it('does not resurrect a toast dismissed while paused', () => {
+    const store = useNotificationStore.getState();
+    const id = store.info('hello', { duration: 1000 });
+    store.pauseDismiss(id);
+    store.dismiss(id);
+    store.resumeDismiss(id);
+    vi.advanceTimersByTime(10_000);
+    expect(ids()).not.toContain(id);
+  });
+
+  it('drops the countdown of a toast evicted by the max-notifications cap', () => {
+    const store = useNotificationStore.getState();
+    const max = store.maxNotifications;
+    const first = store.info('oldest', { duration: 1000 });
+    for (let i = 0; i < max; i += 1) store.info(`filler ${i}`, { duration: 60_000 });
+
+    // `first` was pushed out by the cap, not dismissed.
+    expect(ids()).not.toContain(first);
+    const before = ids().length;
+    // Its orphaned timer would fire here; it must not disturb the survivors.
+    vi.advanceTimersByTime(2000);
+    expect(ids().length).toBe(before);
+  });
+
+  it('clears every countdown on dismissAll', () => {
+    const store = useNotificationStore.getState();
+    store.info('a', { duration: 1000 });
+    store.info('b', { duration: 1000 });
+    store.dismissAll();
+    const late = store.info('c', { duration: 5000 });
+    // The cleared timers must not fire and take the new toast's place.
+    vi.advanceTimersByTime(2000);
+    expect(ids()).toEqual([late]);
+  });
+});
+
+describe('notification title (JP-479)', () => {
+  beforeEach(() => useNotificationStore.getState().dismissAll());
+
+  it('is omitted entirely when not supplied, so existing callers are unchanged', () => {
+    const id = useNotificationStore.getState().success('Saved');
+    const n = useNotificationStore.getState().notifications.find((x) => x.id === id);
+    expect(n).toBeDefined();
+    expect('title' in n!).toBe(false);
+  });
+
+  it('is carried through notify()', () => {
+    const id = useNotificationStore.getState().notify({
+      title: 'Import finished',
+      message: '12 pages added.',
+      severity: 'success',
+    });
+    const n = useNotificationStore.getState().notifications.find((x) => x.id === id);
+    expect(n?.title).toBe('Import finished');
+  });
+
+  it('can be set on an existing toast via update()', () => {
+    const store = useNotificationStore.getState();
+    const id = store.info('Importing…', { duration: 0 });
+    store.update(id, { title: 'Import finished', message: 'Done.' });
+    const n = useNotificationStore.getState().notifications.find((x) => x.id === id);
+    expect(n?.title).toBe('Import finished');
+    expect(n?.message).toBe('Done.');
+  });
+});

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -21,6 +21,16 @@ export type NotificationCategory = 'transient' | 'permanent' | 'info';
 export interface Notification {
   /** Unique ID */
   id: string;
+  /**
+   * Optional short headline above the message (JP-479).
+   *
+   * Deliberately optional: every existing caller passes a message only, and a
+   * titled toast is a different shape — a headline you can scan plus a sentence
+   * you can read. Adding one where the message is already a single short
+   * sentence would just say the same thing twice, so most toasts shouldn't
+   * have one.
+   */
+  title?: string;
   /** Message to display */
   message: string;
   /** Severity level */
@@ -41,6 +51,8 @@ export interface Notification {
 
 /** Notification creation options */
 export interface NotificationOptions {
+  /** Optional short headline above the message (JP-479). */
+  title?: string;
   /** Message to display */
   message: string;
   /** Severity level (default: 'info') */
@@ -82,8 +94,22 @@ interface NotificationState {
    */
   update: (
     id: string,
-    changes: Partial<Pick<Notification, 'message' | 'severity' | 'progress'>>,
+    changes: Partial<Pick<Notification, 'title' | 'message' | 'severity' | 'progress'>>,
   ) => void;
+
+  /**
+   * Hold a toast's auto-dismiss countdown where it is (JP-479).
+   *
+   * Called while the pointer is over the toast stack: a timer that keeps
+   * running while you're reading is a timer that deletes the thing you're
+   * reading, and on a toast carrying an action button it can retract the button
+   * out from under the cursor. Idempotent, and a no-op for a toast with no
+   * countdown (`duration: 0`) or one already paused.
+   */
+  pauseDismiss: (id: string) => void;
+
+  /** Resume a paused countdown from wherever it stopped. */
+  resumeDismiss: (id: string) => void;
 
   /** Dismiss a notification by ID */
   dismiss: (id: string) => void;
@@ -96,6 +122,45 @@ interface NotificationState {
 const generateId = (): string => {
   return `notif-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 };
+
+/**
+ * Live auto-dismiss countdowns, keyed by notification id (JP-479).
+ *
+ * Held outside the store: they're host timers, not rendered state, and putting
+ * them in the store would re-render every toast each time one is paused. A
+ * timer is removed the moment its notification leaves, so an evicted or
+ * hand-dismissed toast can't fire a stale dismissal later.
+ */
+interface DismissTimer {
+  handle: ReturnType<typeof setTimeout>;
+  /** Wall-clock ms when the current run began. */
+  startedAt: number;
+  /** Ms left to run when this run began. */
+  remaining: number;
+}
+
+const timers = new Map<string, DismissTimer>();
+
+function armTimer(id: string, ms: number, onFire: (id: string) => void): void {
+  timers.set(id, {
+    handle: setTimeout(() => {
+      timers.delete(id);
+      onFire(id);
+    }, ms),
+    startedAt: Date.now(),
+    remaining: ms,
+  });
+}
+
+function clearTimer(id: string): void {
+  const timer = timers.get(id);
+  if (!timer) return;
+  clearTimeout(timer.handle);
+  timers.delete(id);
+}
+
+/** Paused countdowns, keyed by id → ms still owed. */
+const paused = new Map<string, number>();
 
 /**
  * Default durations by severity. Bumped (JP-237) so toasts linger long enough to
@@ -123,6 +188,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
       category: options.category ?? 'info',
       duration: options.duration ?? DEFAULT_DURATIONS[severity],
       createdAt: Date.now(),
+      ...(options.title !== undefined ? { title: options.title } : {}),
       ...(options.actionLabel !== undefined ? { actionLabel: options.actionLabel } : {}),
       ...(options.onAction !== undefined ? { onAction: options.onAction } : {}),
       ...(options.progress !== undefined ? { progress: options.progress } : {}),
@@ -133,6 +199,13 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
 
       // Enforce max notifications limit
       if (notifications.length > state.maxNotifications) {
+        const evicted = notifications.slice(0, notifications.length - state.maxNotifications);
+        // Drop the evicted toasts' countdowns with them — otherwise a timer
+        // outlives the toast it belonged to and fires into an empty id.
+        for (const gone of evicted) {
+          clearTimer(gone.id);
+          paused.delete(gone.id);
+        }
         notifications = notifications.slice(-state.maxNotifications);
       }
 
@@ -141,9 +214,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
 
     // Auto-dismiss if duration > 0
     if (notification.duration > 0) {
-      setTimeout(() => {
-        get().dismiss(id);
-      }, notification.duration);
+      armTimer(id, notification.duration, (expired) => get().dismiss(expired));
     }
 
     return id;
@@ -181,13 +252,40 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
     }));
   },
 
+  pauseDismiss: (id) => {
+    const timer = timers.get(id);
+    // No timer means either no countdown (duration 0) or already paused.
+    if (!timer) return;
+    clearTimeout(timer.handle);
+    timers.delete(id);
+    const elapsed = Date.now() - timer.startedAt;
+    // Floor at a beat rather than 0: a toast whose countdown expired under the
+    // cursor should still get a moment on screen after the pointer leaves,
+    // instead of vanishing the instant it moves away.
+    paused.set(id, Math.max(400, timer.remaining - elapsed));
+  },
+
+  resumeDismiss: (id) => {
+    const remaining = paused.get(id);
+    if (remaining === undefined) return;
+    paused.delete(id);
+    // The toast may have been dismissed while paused; don't resurrect a timer
+    // for something that's gone.
+    if (!get().notifications.some((n) => n.id === id)) return;
+    armTimer(id, remaining, (expired) => get().dismiss(expired));
+  },
+
   dismiss: (id) => {
+    clearTimer(id);
+    paused.delete(id);
     set((state) => ({
       notifications: state.notifications.filter((n) => n.id !== id),
     }));
   },
 
   dismissAll: () => {
+    for (const id of [...timers.keys()]) clearTimer(id);
+    paused.clear();
     set({ notifications: [] });
   },
 }));

--- a/src/ui/NotificationToast.css
+++ b/src/ui/NotificationToast.css
@@ -2,18 +2,22 @@
  * Notification Toast Styles
  *
  * Phase 14.9.2 — Error Handling & Resilience.
- * JP-237 polish: rounded toasts, rich per-severity coloring + haloed icons, and
- * a rotating glow ring on appearance that pauses on hover/focus.
+ * JP-237 polish: rounded toasts, per-severity coloring, rotating glow ring.
+ * JP-479 — the drafting-card treatment:
+ *
+ *   - The card is the app's own surface, translucent, ruled with the same grid
+ *     the canvas is ruled with (`--grid-minor`). Severity moved to a spine on
+ *     the leading edge, which is what frees the body to match the surface
+ *     behind it instead of being tinted a different colour per severity.
+ *   - One settle-pulse on arrival, then rest. JP-237's ring rotated forever;
+ *     perpetual motion in a persistent element is a distraction that carries no
+ *     information, and it kept a compositor layer alive for the toast's life.
+ *   - Every colour now comes from a token that EXISTS. This file previously
+ *     referenced `--color-surface`, `--color-text`, `--color-surface-hover` and
+ *     `--color-info`, none of which are defined — so every fallback fired and
+ *     the toast rendered on stale Tailwind greys (#fff/#1f2937, #f9fafb) while
+ *     the rest of the app wore warm paper and navy.
  */
-
-/* Animatable angle for the rotating glow ring. Registered so the custom prop
-   actually interpolates; where @property is unsupported the ring stays static
-   (graceful degradation). */
-@property --toast-angle {
-  syntax: '<angle>';
-  initial-value: 0deg;
-  inherits: false;
-}
 
 .notification-container {
   position: fixed;
@@ -28,83 +32,335 @@
 }
 
 .notification-toast {
+  --toast-accent: var(--info-text);
+
   position: relative;
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 13px 16px;
-  /* Round, not square. */
-  border-radius: 16px;
-  /* Drop shadow + a soft severity-tinted glow. */
-  box-shadow: var(--shadow-lg), 0 0 18px -6px var(--toast-glow, transparent);
+  /* Extra leading padding clears the severity spine. */
+  padding: 13px 14px 13px 20px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-lg);
   pointer-events: auto;
-  animation: toast-enter 0.22s ease-out;
-  /* Subtle severity tint over the surface (falls back to plain surface where
-     color-mix is unsupported — the preceding declaration wins there). */
-  background: var(--color-surface, #fff);
-  background: color-mix(in srgb, var(--toast-glow, transparent) 7%, var(--color-surface, #fff));
-  border: 1px solid color-mix(in srgb, var(--toast-glow, transparent) 22%, transparent);
+  /* Pinned to the right edge so the hover magnify grows inward, away from the
+     viewport edge the stack is anchored to. */
+  transform-origin: 100% 50%;
+  transition:
+    transform 0.18s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.18s ease,
+    border-color 0.18s ease;
+  /* No fill-mode on the settle. A filling animation keeps holding the property
+     it animated after it finishes, and an animated value outranks a normal
+     declaration — with `both` here, the pulse's final frame pinned `box-shadow`
+     for the toast's whole life and the hover lift below simply never rendered.
+     The 100% keyframe is the resting value anyway, so letting it release is
+     seamless. */
+  animation:
+    toast-enter 0.26s cubic-bezier(0.22, 1, 0.36, 1),
+    toast-settle 1.15s ease-out 0.1s 1;
 }
 
-/* Rotating glow ring drawn just outside the toast, masked to a thin border. */
-.notification-toast::before {
-  content: '';
-  position: absolute;
-  inset: -1.5px;
-  border-radius: inherit;
-  padding: 1.5px;
-  background: conic-gradient(
-    from var(--toast-angle, 0deg),
-    transparent 0deg,
-    var(--toast-glow, transparent) 70deg,
-    transparent 150deg,
-    transparent 210deg,
-    var(--toast-glow, transparent) 290deg,
-    transparent 360deg
-  );
-  /* Show only the 1.5px ring (exclude the filled centre). */
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  mask-composite: exclude;
-  animation: toast-glow-rotate 3.2s linear infinite;
-  pointer-events: none;
-  opacity: 0.9;
-}
-
-/* The user reads/interacts — settle the rotation. */
-.notification-toast:hover::before,
-.notification-toast:focus-within::before {
-  animation-play-state: paused;
-}
-
-@keyframes toast-glow-rotate {
-  to {
-    --toast-angle: 360deg;
+/* Translucency only where the engine can actually blur behind it. Without the
+   blur a semi-transparent card just shows whatever it happens to be sitting
+   over — legible one moment, not the next — so opaque is the correct fallback,
+   not a degraded one. WebKitGTK (the Tauri shell) is the reason this is
+   guarded rather than assumed. */
+@supports ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .notification-toast {
+    background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
+    -webkit-backdrop-filter: blur(14px) saturate(1.4);
+    backdrop-filter: blur(14px) saturate(1.4);
   }
 }
 
+/* Blueprint etching — the canvas's own rule colour, at the canvas's own
+   rhythm, fading out toward the trailing edge so it reads as texture under the
+   text rather than a table the text is sitting in. */
+.notification-toast::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      var(--grid-minor) 0 1px,
+      transparent 1px 12px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      var(--grid-minor) 0 1px,
+      transparent 1px 12px
+    );
+  -webkit-mask-image: linear-gradient(105deg, #000 0%, rgba(0, 0, 0, 0.35) 55%, transparent 92%);
+  mask-image: linear-gradient(105deg, #000 0%, rgba(0, 0, 0, 0.35) 55%, transparent 92%);
+}
+
+/* Severity spine. */
+.notification-toast__spine {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--toast-accent);
+}
+
+/* Gentle magnify. The lift is small on purpose — the toast is telling you it's
+   interactive, not presenting itself. */
+.notification-toast:hover,
+.notification-toast:focus-within {
+  transform: scale(1.02);
+  box-shadow: var(--shadow-xl);
+  border-color: color-mix(in srgb, var(--toast-accent) 32%, var(--border-color));
+}
+
+/* Arrival: rise and settle. */
 @keyframes toast-enter {
   from {
     opacity: 0;
-    transform: translateX(16px) scale(0.98);
+    transform: translateY(8px) scale(0.985);
   }
   to {
     opacity: 1;
-    transform: translateX(0) scale(1);
+    transform: translateY(0) scale(1);
   }
 }
 
-/* Reduced motion: no rotation, no slide — just a gentle fade and a static glow. */
+/* One pulse of the severity colour, then gone — the card announcing itself
+   once. `both` holds the resting frame so nothing snaps at the end. */
+@keyframes toast-settle {
+  0% {
+    box-shadow: var(--shadow-lg), 0 0 0 0 transparent;
+  }
+  35% {
+    box-shadow:
+      var(--shadow-lg),
+      0 0 22px 3px color-mix(in srgb, var(--toast-accent) 42%, transparent);
+  }
+  100% {
+    box-shadow: var(--shadow-lg), 0 0 0 0 transparent;
+  }
+}
+
+/* Severity → accent. These read the `-text` variants, not the raw fills:
+   `--success` and `--danger` are IDENTICAL in both themes (only the `-text`
+   pair flips), so driving the accent from the fill put a deep maroon error
+   spine on a navy surface. Same defect class as the rail's in JP-477. */
+.notification-toast--info {
+  --toast-accent: var(--info-text);
+}
+.notification-toast--success {
+  --toast-accent: var(--success-text);
+}
+.notification-toast--warning {
+  --toast-accent: var(--warning);
+}
+.notification-toast--error {
+  --toast-accent: var(--danger-text);
+}
+
+/* Icon — severity-coloured, sitting above the etching. */
+.notification-toast__icon {
+  position: relative;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--toast-accent);
+}
+
+/* Content */
+.notification-toast__content {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Title — a slow gradient across two adjacent brand tones. Wide background,
+   slid slowly: the movement should register at the edge of attention and never
+   pull the eye off the message underneath. */
+.notification-toast__title {
+  margin: 0 0 2px;
+  font-size: 13.5px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+/* Gated: without background-clip support, `color: transparent` would render an
+   invisible title. The solid colour above stays as-is where that's the case. */
+@supports ((background-clip: text) or (-webkit-background-clip: text)) {
+  .notification-toast__title {
+    /* The bright stop is the accent pulled toward the text colour, not the raw
+       accent. Raw, it fails contrast at the moment it sweeps a glyph — ochre on
+       warm paper is ~3.4:1, and a 13.5px title doesn't qualify as large text.
+       Mixing toward `--text-primary` works in both themes by construction,
+       since that token is always the highest-contrast ink for the surface. */
+    --toast-title-lift: color-mix(in srgb, var(--toast-accent) 55%, var(--text-primary));
+
+    background-image: linear-gradient(
+      100deg,
+      var(--text-primary) 0%,
+      var(--toast-title-lift) 38%,
+      var(--text-primary) 74%,
+      var(--toast-title-lift) 100%
+    );
+    background-size: 260% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: toast-title-drift 9s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes toast-title-drift {
+  from {
+    background-position: 0% 50%;
+  }
+  to {
+    background-position: 100% 50%;
+  }
+}
+
+.notification-toast__message {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  word-wrap: break-word;
+}
+
+/* With a title above it, the message steps back so the headline leads. */
+.notification-toast__message--secondary {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.notification-toast__hint {
+  display: block;
+  margin-top: 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+/* Actions */
+/* The gap has to clear the dismiss button's expanded hit area (below), or the
+   two targets overlap and the edge of Retry dismisses the toast instead. */
+.notification-toast__actions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.notification-toast__action-btn {
+  position: relative;
+  height: 30px;
+  padding: 0 14px;
+  font-size: 12.5px;
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--toast-accent) 45%, transparent);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.notification-toast__action-btn:hover {
+  background: var(--color-cta);
+  border-color: var(--color-cta);
+  color: var(--color-cta-text);
+}
+
+.notification-toast__dismiss-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-full);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+/* The visible controls stay 30px so they don't shout, but their hit areas
+   extend past them to ~44px. Sized in the negative so a target grows without
+   moving anything — the old dismiss button was 24×24, well under any touch
+   guidance.
+
+   Growth is deliberately asymmetric. A symmetric `inset: -7px` on the dismiss
+   button reached back across the 4px gap and covered the last few pixels of
+   the Retry button, so clicking the edge of Retry dismissed the toast instead
+   of retrying — the one mis-click on this component that actually costs the
+   user something. Vertical growth is free; horizontal growth stops short of
+   whatever sits alongside. */
+.notification-toast__action-btn::after,
+.notification-toast__dismiss-btn::after {
+  content: '';
+  position: absolute;
+  inset: -7px 0;
+}
+
+.notification-toast__dismiss-btn::after {
+  /* Right expands toward the card edge (nothing there); left stays inside the
+     10px gap so it can never reach the action button. */
+  inset: -7px -7px -7px -4px;
+}
+
+.notification-toast__dismiss-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* Determinate progress bar (blob sync + long-running operations) */
+.notification-toast__progress {
+  position: relative;
+  margin-top: 7px;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-hover);
+  overflow: hidden;
+}
+
+.notification-toast__progress-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--toast-accent);
+  transition: width 0.2s ease-out;
+}
+
+/* Reduced motion: keep the arrival legible, drop everything that moves for its
+   own sake — no rise, no pulse, no drifting title. */
 @media (prefers-reduced-motion: reduce) {
   .notification-toast {
     animation: toast-fade 0.2s ease-out;
+    transition: box-shadow 0.18s ease, border-color 0.18s ease;
   }
-  .notification-toast::before {
+  .notification-toast:hover,
+  .notification-toast:focus-within {
+    transform: none;
+  }
+  .notification-toast__title {
     animation: none;
-    /* Even, static halo. */
-    background: var(--toast-glow, transparent);
-    opacity: 0.5;
+    /* Park the gradient somewhere legible rather than mid-sweep. */
+    background-position: 0% 50%;
   }
   @keyframes toast-fade {
     from {
@@ -114,131 +370,4 @@
       opacity: 1;
     }
   }
-}
-
-/* Severity → glow color (drives the ring, the box-shadow halo, the tint, and the
-   icon). One variable per severity keeps the treatment consistent. */
-.notification-toast--info {
-  --toast-glow: var(--color-info, #3b82f6);
-}
-.notification-toast--success {
-  --toast-glow: var(--success);
-}
-.notification-toast--warning {
-  --toast-glow: var(--warning);
-}
-.notification-toast--error {
-  --toast-glow: var(--danger);
-}
-
-/* Icon — colored to the severity with a soft halo so it reads rich, not flat. */
-.notification-toast__icon {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--toast-glow, var(--color-info, #3b82f6));
-  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--toast-glow, transparent) 55%, transparent));
-}
-
-/* Content */
-.notification-toast__content {
-  flex: 1;
-  min-width: 0;
-}
-
-.notification-toast__message {
-  margin: 0;
-  font-size: 14px;
-  line-height: 1.4;
-  color: var(--color-text, #1f2937);
-  word-wrap: break-word;
-}
-
-.notification-toast__hint {
-  display: block;
-  margin-top: 4px;
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-/* Actions */
-.notification-toast__actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-.notification-toast__action-btn {
-  padding: 4px 12px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-primary);
-  background: transparent;
-  border: 1px solid var(--color-primary);
-  border-radius: 999px; /* pill, matching the rounded toast */
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.notification-toast__action-btn:hover {
-  background: var(--color-cta);
-  color: var(--color-cta-text);
-}
-
-.notification-toast__dismiss-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  background: transparent;
-  border: none;
-  border-radius: 999px;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.notification-toast__dismiss-btn:hover {
-  background: var(--color-surface-hover, #f3f4f6);
-  color: var(--color-text, #1f2937);
-}
-
-/* Dark theme support */
-[data-theme='dark'] .notification-toast {
-  background: var(--color-surface, #1f2937);
-  background: color-mix(in srgb, var(--toast-glow, transparent) 12%, var(--color-surface, #1f2937));
-  box-shadow: var(--shadow-lg), 0 0 20px -6px var(--toast-glow, transparent);
-}
-
-[data-theme='dark'] .notification-toast__message {
-  color: var(--color-text, #f9fafb);
-}
-
-[data-theme='dark'] .notification-toast__dismiss-btn:hover {
-  background: var(--color-surface-hover, #374151);
-  color: var(--color-text, #f9fafb);
-}
-
-/* Determinate progress bar (blob sync + long-running operations) */
-.notification-toast__progress {
-  margin-top: 6px;
-  height: 4px;
-  border-radius: 2px;
-  background: var(--color-surface-hover, #e5e7eb);
-  overflow: hidden;
-}
-
-.notification-toast__progress-fill {
-  height: 100%;
-  border-radius: 2px;
-  background: var(--color-primary, #1f3354);
-  transition: width 0.2s ease-out;
-}
-
-[data-theme='dark'] .notification-toast__progress {
-  background: var(--color-surface-hover, #374151);
 }

--- a/src/ui/NotificationToast.test.tsx
+++ b/src/ui/NotificationToast.test.tsx
@@ -66,6 +66,45 @@ describe('NotificationToast', () => {
     expect(screen.getByText('Saved')).toBeTruthy();
   });
 
+  it('renders exactly the hooks the stylesheet targets', () => {
+    // The CSS was verified against hand-built markup in a real browser (the MCP
+    // console evaluates in an isolated world, so the live store can't be driven
+    // from it, and every real toast trigger in the app mutates a document).
+    // This pins the other half of that: if a class name here drifts, the
+    // treatment silently stops applying and nothing else would catch it.
+    act(() => {
+      useNotificationStore.getState().notify({
+        title: 'Titled',
+        message: 'Body',
+        severity: 'warning',
+        category: 'transient',
+        duration: 0,
+        actionLabel: 'Retry',
+        onAction: () => {},
+        progress: { current: 1, total: 4 },
+      });
+    });
+    const { container } = render(<NotificationToast />);
+    for (const selector of [
+      '.notification-container',
+      '.notification-toast',
+      '.notification-toast--warning',
+      '.notification-toast__spine',
+      '.notification-toast__icon',
+      '.notification-toast__content',
+      '.notification-toast__title',
+      '.notification-toast__message--secondary',
+      '.notification-toast__hint',
+      '.notification-toast__actions',
+      '.notification-toast__action-btn',
+      '.notification-toast__dismiss-btn',
+      '.notification-toast__progress',
+      '.notification-toast__progress-fill',
+    ]) {
+      expect(container.querySelector(selector), selector).not.toBeNull();
+    }
+  });
+
   it('escalates aria-live for errors only', () => {
     act(() => {
       useNotificationStore.getState().error('broke', { duration: 0 });

--- a/src/ui/NotificationToast.test.tsx
+++ b/src/ui/NotificationToast.test.tsx
@@ -1,0 +1,156 @@
+import { beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { NotificationToast } from './NotificationToast';
+import { useNotificationStore } from '../store/notificationStore';
+
+describe('NotificationToast', () => {
+  beforeEach(() => {
+    act(() => useNotificationStore.getState().dismissAll());
+  });
+
+  afterEach(() => {
+    // Unmount before clearing the store: draining notifications while a toast
+    // is still mounted is a state update outside act(), which React reports as
+    // a warning on every test in the file.
+    cleanup();
+    act(() => useNotificationStore.getState().dismissAll());
+  });
+
+  it('renders nothing when there are no notifications', () => {
+    const { container } = render(<NotificationToast />);
+    expect(container.querySelector('.notification-container')).toBeNull();
+  });
+
+  it('renders one toast per notification, tagged with its severity', () => {
+    act(() => {
+      useNotificationStore.getState().info('one', { duration: 0 });
+      useNotificationStore.getState().error('two', { duration: 0 });
+    });
+    const { container } = render(<NotificationToast />);
+    expect(container.querySelectorAll('.notification-toast')).toHaveLength(2);
+    expect(container.querySelector('.notification-toast--info')).not.toBeNull();
+    expect(container.querySelector('.notification-toast--error')).not.toBeNull();
+  });
+
+  it('gives every toast a severity spine', () => {
+    act(() => {
+      useNotificationStore.getState().warning('careful', { duration: 0 });
+    });
+    const { container } = render(<NotificationToast />);
+    expect(container.querySelector('.notification-toast__spine')).not.toBeNull();
+  });
+
+  it('renders a title when one is supplied, and steps the message back', () => {
+    act(() => {
+      useNotificationStore.getState().notify({
+        title: 'Import finished',
+        message: '12 pages added.',
+        severity: 'success',
+        duration: 0,
+      });
+    });
+    const { container } = render(<NotificationToast />);
+    expect(screen.getByText('Import finished')).toBeTruthy();
+    expect(container.querySelector('.notification-toast__message--secondary')).not.toBeNull();
+  });
+
+  it('renders no title element when none is supplied', () => {
+    // The path every existing caller takes — the toast must look like it always
+    // did, not sprout an empty headline.
+    act(() => {
+      useNotificationStore.getState().success('Saved', { duration: 0 });
+    });
+    const { container } = render(<NotificationToast />);
+    expect(container.querySelector('.notification-toast__title')).toBeNull();
+    expect(container.querySelector('.notification-toast__message--secondary')).toBeNull();
+    expect(screen.getByText('Saved')).toBeTruthy();
+  });
+
+  it('escalates aria-live for errors only', () => {
+    act(() => {
+      useNotificationStore.getState().error('broke', { duration: 0 });
+      useNotificationStore.getState().info('fyi', { duration: 0 });
+    });
+    const { container } = render(<NotificationToast />);
+    expect(
+      container.querySelector('.notification-toast--error')?.getAttribute('aria-live'),
+    ).toBe('assertive');
+    expect(
+      container.querySelector('.notification-toast--info')?.getAttribute('aria-live'),
+    ).toBe('polite');
+  });
+
+  it('dismisses when the dismiss button is pressed', () => {
+    act(() => {
+      useNotificationStore.getState().info('bye', { duration: 0 });
+    });
+    render(<NotificationToast />);
+    fireEvent.click(screen.getByLabelText('Dismiss notification'));
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it('runs the action and dismisses in one press', () => {
+    const onAction = vi.fn();
+    act(() => {
+      useNotificationStore
+        .getState()
+        .error('failed', { duration: 0, actionLabel: 'Retry', onAction });
+    });
+    render(<NotificationToast />);
+    fireEvent.click(screen.getByText('Retry'));
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  describe('hover holds the countdown', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('pauses every toast in the stack, not just the hovered one', () => {
+      // Pausing only the hovered toast would let its neighbours expire
+      // underneath it, sliding the one being read out from under the cursor.
+      act(() => {
+        useNotificationStore.getState().info('first', { duration: 1000 });
+        useNotificationStore.getState().info('second', { duration: 1000 });
+      });
+      const { container } = render(<NotificationToast />);
+      const stack = container.querySelector('.notification-container')!;
+
+      fireEvent.mouseEnter(stack);
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(2);
+
+      fireEvent.mouseLeave(stack);
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it('also holds while focus is inside the stack, for keyboard users', () => {
+      act(() => {
+        useNotificationStore.getState().info('focus me', { duration: 1000 });
+      });
+      const { container } = render(<NotificationToast />);
+      const stack = container.querySelector('.notification-container')!;
+
+      fireEvent.focus(screen.getByLabelText('Dismiss notification'));
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+
+      fireEvent.blur(stack);
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+  });
+});

--- a/src/ui/NotificationToast.tsx
+++ b/src/ui/NotificationToast.tsx
@@ -3,13 +3,26 @@
  *
  * Displays toast notifications from the notification store.
  *
- * Phase 14.9.2 - Error Handling & Resilience
+ * Phase 14.9.2 — Error Handling & Resilience.
+ * JP-479: the drafting-card treatment. A toast arrives like a plate set on a
+ * table — one settle-pulse of its severity colour, then it rests: translucent
+ * over the app surface, ruled with the same grid the canvas is ruled with.
+ * Severity lives on a spine at the leading edge rather than tinting the whole
+ * card, which is what lets the surface actually match the surface behind it.
  */
 
+import { useCallback } from 'react';
 import { Info, CircleCheck, TriangleAlert, CircleX, X } from 'lucide-react';
 import { useNotificationStore, type Notification } from '../store/notificationStore';
 import { Icon } from './icons';
 import './NotificationToast.css';
+
+const SEVERITY_ICON = {
+  info: Info,
+  success: CircleCheck,
+  warning: TriangleAlert,
+  error: CircleX,
+} as const;
 
 /** Single toast notification */
 function Toast({ notification }: { notification: Notification }) {
@@ -26,21 +39,34 @@ function Toast({ notification }: { notification: Notification }) {
     dismiss(notification.id);
   };
 
+  const SeverityIcon = SEVERITY_ICON[notification.severity];
+
   return (
     <div
       className={`notification-toast notification-toast--${notification.severity}`}
       role="alert"
       aria-live={notification.severity === 'error' ? 'assertive' : 'polite'}
     >
+      {/* Severity spine — the whole colour signal, so the card body can stay
+          the app's own surface. Decorative: the icon and role="alert" already
+          carry the meaning for assistive tech. */}
+      <span className="notification-toast__spine" aria-hidden="true" />
+
       <div className="notification-toast__icon">
-        {notification.severity === 'info' && <Icon icon={Info} size={20} />}
-        {notification.severity === 'success' && <Icon icon={CircleCheck} size={20} />}
-        {notification.severity === 'warning' && <Icon icon={TriangleAlert} size={20} />}
-        {notification.severity === 'error' && <Icon icon={CircleX} size={20} />}
+        <Icon icon={SeverityIcon} size={20} />
       </div>
 
       <div className="notification-toast__content">
-        <p className="notification-toast__message">{notification.message}</p>
+        {notification.title && (
+          <p className="notification-toast__title">{notification.title}</p>
+        )}
+        <p
+          className={`notification-toast__message${
+            notification.title ? ' notification-toast__message--secondary' : ''
+          }`}
+        >
+          {notification.message}
+        </p>
         {notification.progress && notification.progress.total > 0 && (
           <div
             className="notification-toast__progress"
@@ -91,13 +117,34 @@ function Toast({ notification }: { notification: Notification }) {
 /** Notification container - renders all active toasts */
 export function NotificationToast() {
   const notifications = useNotificationStore((state) => state.notifications);
+  const pauseDismiss = useNotificationStore((state) => state.pauseDismiss);
+  const resumeDismiss = useNotificationStore((state) => state.resumeDismiss);
+
+  // Hovering (or tabbing into) the stack holds EVERY countdown, not just the
+  // one under the pointer (JP-479). Pausing only the hovered toast would let
+  // its neighbours expire underneath it, collapsing the stack and sliding the
+  // toast you were reading — or its action button — out from under the cursor.
+  const pauseAll = useCallback(() => {
+    for (const n of notifications) pauseDismiss(n.id);
+  }, [notifications, pauseDismiss]);
+
+  const resumeAll = useCallback(() => {
+    for (const n of notifications) resumeDismiss(n.id);
+  }, [notifications, resumeDismiss]);
 
   if (notifications.length === 0) {
     return null;
   }
 
   return (
-    <div className="notification-container" aria-label="Notifications">
+    <div
+      className="notification-container"
+      aria-label="Notifications"
+      onMouseEnter={pauseAll}
+      onMouseLeave={resumeAll}
+      onFocusCapture={pauseAll}
+      onBlurCapture={resumeAll}
+    >
       {notifications.map((notification) => (
         <Toast key={notification.id} notification={notification} />
       ))}


### PR DESCRIPTION
Closes JP-479.

A toast now arrives like a plate set on a table — **one settle-pulse** of its severity colour, then it rests: translucent over the app's own surface, ruled with the same grid the canvas is ruled with.

## Why it never looked like the rest of the app

This CSS referenced four tokens that **do not exist**, so every fallback fired:

| Referenced | Fell back to | Now reads |
|---|---|---|
| `--color-surface` | `#fff` / `#1f2937` | `--bg-primary` |
| `--color-text` | `#1f2937` / `#f9fafb` | `--text-primary` |
| `--color-surface-hover` | `#f3f4f6` / `#374151` | `--bg-hover` |
| `--color-info` | `#3b82f6` | **new `--info-text`** |

Those are stale Tailwind greys. Measured on the dark theme before the change: the card computed to a tint over `#1f2937` against a brand surface of `#0e1c30`, and the message to `#f9fafb` — against a brand rule that the dark theme uses paper/steel text and **never white**. JP-158 swept these project-wide; this file was missed.

`--info` / `--info-text` / `--info-bg` are added to `index.css` to complete a status set that had success, warning and danger but no info — which is precisely why the toast had invented one.

Severity accents now read the **`-text`** variants, not the raw fills: `--success` and `--danger` are *identical in both themes* and only the `-text` pair flips, so driving the accent from the fill put a deep maroon error signal on a navy surface. Same defect class as the rail's in #438.

## The five asks

1. **Magnify + targets** — `scale(1.02)` with the origin pinned to the right edge so it grows inward, away from the edge the stack is anchored to. Dismiss and action go from 24×24 / 57×25 to **44px** effective targets.
2. **Translucent surface + etching** — `--bg-primary` at 86% behind an `@supports` guard for `backdrop-filter` (WebKitGTK ships in Tauri, and an unblurred translucent card is just unpredictable, so opaque is the correct fallback). Etching is two repeating gradients in `--grid-minor` — the canvas's own rule colour at its own rhythm — masked to fade out.
3. **Single pulse** — JP-237's conic ring rotated forever; replaced by one pulse that resolves and stops.
4. **Gradient title** — new optional `title`, 9s drift. The bright stop is the accent **mixed toward `--text-primary`**: raw, it fails contrast the instant it sweeps a glyph (ochre on warm paper is ~3.4:1, and 13.5px semibold isn't large text).
5. **Backend + extras** — severity moved to a 3px **spine**, which is what frees the body to be the app surface rather than an approximation; pausable auto-dismiss; mono hint styling.

## Backend

Auto-dismiss was a bare `setTimeout` that ran whether or not anyone was reading it. It's now a pausable countdown (`pauseDismiss` / `resumeDismiss`) held outside the store — timers are host state, not rendered state, and storing them would re-render every toast on each pause.

The stack pauses **as a whole** on hover or focus. Pausing only the hovered toast would let its neighbours expire underneath it and slide the one being read — or its action button — out from under the cursor. Timers are also dropped on eviction, so a capped-out toast can't fire a stale dismissal later.

`title` is optional and omitted from the object entirely when unset, so all **48 existing call sites across 40 files** are untouched.

## Two defects caught while verifying — both mine

- A symmetric expanded hit area on **dismiss** reached back across the 4px gap and covered the last pixels of **Retry**, so clicking the edge of Retry dismissed the toast instead of retrying — the one mis-click here that actually costs something. Growth is now asymmetric, gap widened; measured via `elementFromPoint` before and after.
- `toast-settle` carried `animation-fill-mode: both`, so its final frame held `box-shadow` **permanently** — and an animated value outranks a normal declaration, meaning the hover lift never rendered at all. Caught by reading the cascade, confirmed with `getAnimations()`, fixed by letting the fill release.

## Verification

- typecheck, **3379 tests across 287 files** (23 new — pausable timer incl. eviction/grace/idempotence, and component rendering incl. title/no-title and focus-pause), production build.
- Against the **live stylesheet** in both themes for all four severities: surface resolves to `#0e1c30`/86% dark and `#f9f6ee`/86% light, spines to the per-theme `-text` values, targets to 44px, hover to `matrix(1.02, …)` with the shadow stepping `lg` → `xl`.

Note on method: a Vite dev module-instance split made it impossible to drive the real store from the console after editing it, and I was not willing to trash the user's live cloud documents to raise a toast — so the visual pass was done by rendering the real markup against the real stylesheet, and behaviour was pinned in tests instead.

Assisted-by: Opus 5