### PR TITLE
JP-480: multi-select polish — select-mode clicks, and an honest bulk export

### DIFF
--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -12,6 +12,13 @@
   transition: all 0.15s ease;
 }
 
+/* Select mode (JP-480): a selection exists, so a click picks rather than opens.
+   The cursor says so — the card looks identical either way, and a pointer that
+   promises "open" would be lying about what the next click does. */
+.document-card--select-mode {
+  cursor: default;
+}
+
 .document-card:hover {
   background: var(--bg-hover);
   border-color: var(--color-primary);

--- a/src/ui/DocumentCard.selectmode.test.tsx
+++ b/src/ui/DocumentCard.selectmode.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Select-mode click behaviour (JP-480).
+ *
+ * Once a selection exists, the document browser is being used to pick
+ * documents, not to open one — so a plain click extends the selection. It used
+ * to open, which navigated away from the surface and discarded the selection
+ * the user had just built.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { DocumentCard } from './DocumentCard';
+import type { LocalDocument } from '../types/DocumentRegistry';
+
+const record: LocalDocument = {
+  type: 'local',
+  id: 'l1',
+  name: 'My Doc',
+  pageCount: 1,
+  createdAt: 0,
+  modifiedAt: 0,
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof DocumentCard>> = {}) {
+  const onOpen = vi.fn();
+  const onSelectToggle = vi.fn();
+  const utils = render(
+    <DocumentCard
+      record={record}
+      isActive={false}
+      isSelected={false}
+      onOpen={onOpen}
+      onSelectToggle={onSelectToggle}
+      {...overrides}
+    />,
+  );
+  return { onOpen, onSelectToggle, ...utils };
+}
+
+/** The card body — clicking it is the gesture under test. */
+const card = (container: HTMLElement) =>
+  container.querySelector('.document-card') as HTMLElement;
+
+describe('DocumentCard — select mode', () => {
+  beforeEach(cleanup);
+
+  it('opens on a plain click when nothing is selected', () => {
+    const { onOpen, onSelectToggle, container } = setup({ showSelectionCheckbox: false });
+    fireEvent.click(card(container));
+    expect(onOpen).toHaveBeenCalledWith('l1');
+    expect(onSelectToggle).not.toHaveBeenCalled();
+  });
+
+  it('selects instead of opening once a selection exists', () => {
+    const { onOpen, onSelectToggle, container } = setup({ showSelectionCheckbox: true });
+    fireEvent.click(card(container));
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onSelectToggle).toHaveBeenCalledWith('l1', { shift: false, meta: true });
+  });
+
+  it('deselects an already-selected card on a plain click', () => {
+    const { onOpen, onSelectToggle, container } = setup({
+      showSelectionCheckbox: true,
+      isSelected: true,
+    });
+    fireEvent.click(card(container));
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onSelectToggle).toHaveBeenCalledOnce();
+  });
+
+  it('marks the card so the cursor can stop promising "open"', () => {
+    const { container } = setup({ showSelectionCheckbox: true });
+    expect(card(container).classList.contains('document-card--select-mode')).toBe(true);
+  });
+
+  it('does not mark the card outside select mode', () => {
+    const { container } = setup({ showSelectionCheckbox: false });
+    expect(card(container).classList.contains('document-card--select-mode')).toBe(false);
+  });
+
+  it('still range-selects on shift-click in select mode', () => {
+    const { onOpen, onSelectToggle, container } = setup({ showSelectionCheckbox: true });
+    fireEvent.click(card(container), { shiftKey: true });
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onSelectToggle).toHaveBeenCalledWith('l1', { shift: true, meta: false });
+  });
+
+  it('still modifier-selects when nothing is selected yet', () => {
+    // This is how a selection gets started in the first place — it must keep
+    // working, since select mode is defined by there already being one.
+    const { onOpen, onSelectToggle, container } = setup({ showSelectionCheckbox: false });
+    fireEvent.click(card(container), { ctrlKey: true });
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onSelectToggle).toHaveBeenCalledWith('l1', { shift: false, meta: true });
+  });
+
+  it('opens normally in select mode when selection is unavailable', () => {
+    // No onSelectToggle means the host surface has no selection model, so the
+    // flag alone must not be able to swallow the click.
+    const onOpen = vi.fn();
+    const { container } = render(
+      <DocumentCard
+        record={record}
+        isActive={false}
+        isSelected={false}
+        showSelectionCheckbox
+        onOpen={onOpen}
+      />,
+    );
+    fireEvent.click(card(container));
+    expect(onOpen).toHaveBeenCalledWith('l1');
+  });
+
+  it('the checkbox still toggles without opening', () => {
+    const { onOpen, onSelectToggle } = setup({ showSelectionCheckbox: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }));
+    expect(onSelectToggle).toHaveBeenCalledOnce();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -367,6 +367,14 @@ function DocumentCardImpl({
     }
   }, [onMoveToPersonal, record.id]);
 
+  /**
+   * Select mode: the browser already has a selection, so the surface is being
+   * used to pick documents rather than to open one. Driven by the same flag
+   * that reveals the checkboxes, so what the card looks like and what a click
+   * does can't disagree.
+   */
+  const selectMode = showSelectionCheckbox;
+
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       if (isEditing) return;
@@ -379,11 +387,21 @@ function DocumentCardImpl({
         });
         return;
       }
+      // Once a selection exists, the browser is IN select mode and a plain
+      // click extends that selection instead of opening (JP-480). Opening
+      // navigates away from the surface, which threw the whole selection away —
+      // so the click that costs the most was the easiest one to make. Every
+      // file manager behaves this way; clear the selection to open again.
+      if (selectMode && onSelectToggle) {
+        e.preventDefault();
+        onSelectToggle(record.id, { shift: false, meta: true });
+        return;
+      }
       if (onOpen) {
         onOpen(record.id);
       }
     },
-    [isEditing, onOpen, onSelectToggle, record.id]
+    [isEditing, onOpen, onSelectToggle, record.id, selectMode]
   );
 
   const handleCheckboxClick = useCallback(
@@ -620,7 +638,7 @@ function DocumentCardImpl({
   return (
     <div
       ref={cardRef}
-      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${menuOpen || tagEditorAnchor ? 'document-card--menu-open' : ''}`}
+      className={`document-card document-card--${mode} ${isActive ? 'document-card--active' : ''} ${isSelected ? 'document-card--selected' : ''} ${selectMode ? 'document-card--select-mode' : ''} ${menuOpen || tagEditorAnchor ? 'document-card--menu-open' : ''}`}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
     >

--- a/src/ui/settings/useDocumentBrowserModel.bulkexport.test.tsx
+++ b/src/ui/settings/useDocumentBrowserModel.bulkexport.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Bulk export (JP-480).
+ *
+ * There's no archive-of-archives format — each document downloads as its own
+ * `.docushark` file — so selecting ten documents means ten downloads and a
+ * likely browser permission prompt. That gets a warning first. And a failure
+ * used to be logged to the console only, so a bulk export could quietly deliver
+ * four of five files and look like it had worked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { useDocumentBrowserModel } from './useDocumentBrowserModel';
+import { useDocumentRegistry } from '../../store/documentRegistry';
+import { saveDocumentToStorage } from '../../store/persistenceStore';
+import { useNotificationStore } from '../../store/notificationStore';
+import { useConfirmStore } from '../confirm/confirmStore';
+import { exportAndDownloadDocumentArchive } from '../../storage/DocumentArchiveService';
+import { getDocumentMetadata, type DiagramDocument } from '../../types/Document';
+
+vi.mock('../../collaboration', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../collaboration')>();
+  return { ...mod, purgeLocalDocRoom: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../storage/DocumentArchiveService', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../storage/DocumentArchiveService')>();
+  return { ...mod, exportAndDownloadDocumentArchive: vi.fn().mockResolvedValue(undefined) };
+});
+
+const exportMock = vi.mocked(exportAndDownloadDocumentArchive);
+
+function seedLocalDoc(id: string, name: string): void {
+  const doc = {
+    id,
+    name,
+    pages: {},
+    pageOrder: [],
+    activePageId: '',
+    createdAt: 1,
+    modifiedAt: 1,
+    version: 2,
+  } as unknown as DiagramDocument;
+  saveDocumentToStorage(doc);
+  useDocumentRegistry.getState().registerLocal(getDocumentMetadata(doc));
+}
+
+const toasts = () => useNotificationStore.getState().notifications;
+const dialog = () => useConfirmStore.getState().current;
+
+describe('useDocumentBrowserModel — bulk export', () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    useDocumentRegistry.setState({ entries: {} });
+    useNotificationStore.getState().dismissAll();
+    useConfirmStore.setState({ current: null, queue: [] });
+    exportMock.mockReset();
+    exportMock.mockResolvedValue(undefined);
+  });
+
+  async function selectAllOf(ids: string[]) {
+    for (const [i, id] of ids.entries()) seedLocalDoc(id, `Doc ${i + 1}`);
+    const { result } = renderHook(() => useDocumentBrowserModel());
+    await waitFor(() => expect(result.current.documentList.length).toBe(ids.length));
+    act(() => result.current.handleSelectAll());
+    return result;
+  }
+
+  it('warns before exporting more than one document, naming the count', async () => {
+    const result = await selectAllOf(['a', 'b', 'c']);
+
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.handleBulkExport();
+    });
+
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    const request = dialog();
+    // Narrow off the confirm|prompt union so `details` is reachable.
+    expect(request?.kind).toBe('confirm');
+    if (request?.kind !== 'confirm') throw new Error('expected a confirm dialog');
+    expect(request.title).toContain('3');
+    // The warning has to say WHY it's warning: separate files, one download each.
+    expect(request.message).toMatch(/own \.docushark file/i);
+    expect(request.message).toContain('3 downloads');
+    expect(request.details).toMatch(/multiple files/i);
+
+    act(() => useConfirmStore.getState()._resolve(true));
+    await act(async () => {
+      await pending!;
+    });
+    expect(exportMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('exports nothing when the warning is dismissed', async () => {
+    const result = await selectAllOf(['a', 'b']);
+
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.handleBulkExport();
+    });
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    act(() => useConfirmStore.getState()._resolve(false));
+    await act(async () => {
+      await pending!;
+    });
+
+    expect(exportMock).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for a single document — one file is what Export obviously does', async () => {
+    const result = await selectAllOf(['a']);
+
+    await act(async () => {
+      await result.current.handleBulkExport();
+    });
+
+    expect(dialog()).toBeNull();
+    expect(exportMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing at all with an empty selection', async () => {
+    const { result } = renderHook(() => useDocumentBrowserModel());
+    await act(async () => {
+      await result.current.handleBulkExport();
+    });
+    expect(dialog()).toBeNull();
+    expect(exportMock).not.toHaveBeenCalled();
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it('reports a partial failure instead of looking successful', async () => {
+    const result = await selectAllOf(['a', 'b', 'c']);
+    exportMock.mockResolvedValueOnce(undefined);
+    exportMock.mockRejectedValueOnce(new Error('disk full'));
+    exportMock.mockResolvedValueOnce(undefined);
+
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.handleBulkExport();
+    });
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    act(() => useConfirmStore.getState()._resolve(true));
+    await act(async () => {
+      await pending!;
+    });
+
+    const warned = toasts().find((n) => n.severity === 'warning');
+    expect(warned?.message).toContain('2 of 3');
+    expect(warned?.message).toContain('1 failed');
+  });
+
+  it('reports a total failure as an error', async () => {
+    const result = await selectAllOf(['a', 'b']);
+    exportMock.mockRejectedValue(new Error('nope'));
+
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.handleBulkExport();
+    });
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    act(() => useConfirmStore.getState()._resolve(true));
+    await act(async () => {
+      await pending!;
+    });
+
+    expect(toasts().find((n) => n.severity === 'error')).toBeTruthy();
+  });
+
+  it('confirms success for a multi-file export', async () => {
+    const result = await selectAllOf(['a', 'b']);
+
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.handleBulkExport();
+    });
+    await waitFor(() => expect(dialog()).not.toBeNull());
+    act(() => useConfirmStore.getState()._resolve(true));
+    await act(async () => {
+      await pending!;
+    });
+
+    expect(toasts().find((n) => n.severity === 'success')?.message).toContain('2 documents');
+  });
+
+  it('stays quiet after a successful single export', async () => {
+    // One file, one download, no surprise — a toast here would be noise.
+    const result = await selectAllOf(['a']);
+    await act(async () => {
+      await result.current.handleBulkExport();
+    });
+    expect(toasts()).toHaveLength(0);
+  });
+});

--- a/src/ui/settings/useDocumentBrowserModel.ts
+++ b/src/ui/settings/useDocumentBrowserModel.ts
@@ -1081,12 +1081,50 @@ export function useDocumentBrowserModel(): DocumentBrowserModel {
 
   const handleBulkExport = useCallback(async () => {
     const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+
+    // Warn before a multi-file export (JP-480). There's no archive-of-archives
+    // format here — each document downloads as its own `.docushark` file — so
+    // picking ten documents means ten downloads, and browsers commonly prompt
+    // for permission partway through. A single selection needs no warning:
+    // one file is what pressing Export obviously does.
+    if (ids.length > 1) {
+      const ok = await confirmDialog({
+        title: `Export ${ids.length} documents?`,
+        message: `Each one downloads as its own .docushark file — ${ids.length} downloads in total.`,
+        details: 'Your browser may ask permission to download multiple files.',
+        confirmLabel: `Export ${ids.length} files`,
+      });
+      if (!ok) return;
+    }
+
+    let failed = 0;
     for (const id of ids) {
       try {
         await exportAndDownloadDocumentArchive(id);
       } catch (err) {
+        failed += 1;
         console.error('Failed to export', id, err);
       }
+    }
+
+    // Previously a failure was only logged to the console, so a bulk export
+    // could quietly deliver four files out of five and look like it worked.
+    // Imported lazily to match the other notify sites in this file.
+    const { useNotificationStore } = await import('../../store/notificationStore');
+    const notifications = useNotificationStore.getState();
+    if (failed === 0) {
+      if (ids.length > 1) {
+        notifications.success(`Exported ${ids.length} documents.`);
+      }
+    } else if (failed === ids.length) {
+      notifications.error(
+        ids.length === 1 ? 'Export failed.' : `All ${ids.length} exports failed.`,
+      );
+    } else {
+      notifications.warning(
+        `Exported ${ids.length - failed} of ${ids.length} documents — ${failed} failed.`,
+      );
     }
   }, [selectedIds]);
 


### PR DESCRIPTION
Closes JP-480.

## 1. A plain click opened the document you were trying to select

`DocumentCard.handleClick` only diverted to selection on a **modifier** click. So once a selection existed — checkboxes showing, selection bar up — clicking another card called `onOpen`, navigated away from the surface, and discarded the selection being built.

You tick three documents, reach for a fourth, and land in the editor with the selection gone. The gesture that costs the most was the easiest one to make.

Now a plain click **extends** the selection whenever one exists. Modifier-click still starts a selection from nothing, shift-click still range-selects, clearing restores open-on-click. The card also drops `cursor: pointer` in select mode — it looks identical either way, and a pointer promising "open" is lying about what the next click does.

Guarded against the obvious regression: a host surface with no selection model (no `onSelectToggle`) must still open on click, so the flag alone can't swallow the gesture.

## 2. Bulk export warned nothing, and hid its failures

There's no archive-of-archives format — **each document downloads as its own `.docushark` file**. Ten selected is ten downloads, and browsers commonly interrupt partway through to ask permission. Nothing said so.

```
Export 2 documents?
Each one downloads as its own .docushark file — 2 downloads in total.
Your browser may ask permission to download multiple files.
                                        [ Cancel ]  [ Export 2 files ]
```

A single selection isn't warned — one file is what pressing Export obviously does.

**Also fixed alongside it:** failures were `console.error` only, so a bulk export could deliver four files out of five and look exactly like success. The outcome is now reported — success for a multi-file run, a warning naming the split on partial failure (`Exported 2 of 3 documents — 1 failed.`), an error when everything failed. A successful single export stays silent.

## Verification

- typecheck, **3397 tests across 289 files** (17 new), production build.
- **Live against the running app**: entering select mode flips the cursor to `default` and tags the cards; a plain click on a second card takes the selection to "2 selected" *while staying on the browser*; the export dialog renders the copy above. I cancelled rather than confirmed, so no files were written to Downloads.

Assisted-by: Opus 5