### PR TITLE
JP-481: restore provenance as a badge, version history on ModalShell, PWA metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="DocuShark" />
-    <title>DocuShark — Diagramming &amp; Whiteboard</title>
+    <title>DocuShark — Documents, diagrams, and files in one place</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/migrations/documentMigrations.test.ts
+++ b/src/migrations/documentMigrations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { migrateDocument, DocumentVersionError } from './documentMigrations';
+import { migrateDocument, DocumentVersionError, liftRestoredProvenance } from './documentMigrations';
 import { createDocument, DOCUMENT_VERSION, type DiagramDocument } from '../types/Document';
 import type { GroupShape, RectangleShape } from '../shapes/Shape';
 
@@ -240,5 +240,90 @@ describe('migrateDocument — v2 invariants (JP-347)', () => {
     expect((out.pages['page-1']!.shapes['g1'] as GroupShape).ownerId).toBeNull();
     // idempotent
     expect(migrateDocument(out)).toEqual(out);
+  });
+});
+
+describe('liftRestoredProvenance (JP-481)', () => {
+  const doc = (name: string, extra: Partial<DiagramDocument> = {}): DiagramDocument =>
+    ({
+      id: 'd',
+      name,
+      pages: {},
+      pageOrder: [],
+      activePageId: '',
+      createdAt: 1,
+      modifiedAt: 1,
+      version: 2,
+      ...extra,
+    }) as unknown as DiagramDocument;
+
+  /** A locale string this machine will definitely round-trip. */
+  const stamp = Date.UTC(2026, 6, 29, 15, 4, 11);
+  const stampText = new Date(stamp).toLocaleString();
+
+  it('lifts a machine-generated suffix into restoredFrom', () => {
+    const out = liftRestoredProvenance(doc(`vcs testing (Restored ${stampText})`));
+    expect(out.name).toBe('vcs testing');
+    // toLocaleString drops sub-minute precision in some locales; compare loosely.
+    expect(Math.abs((out.restoredFrom ?? 0) - stamp)).toBeLessThan(60_000);
+  });
+
+  it('leaves a hand-written suffix completely alone', () => {
+    const original = doc('Notes (Restored from backup)');
+    const out = liftRestoredProvenance(original);
+    expect(out).toBe(original);
+    expect(out.name).toBe('Notes (Restored from backup)');
+  });
+
+  it('leaves a bare "(Restored)" alone — nothing to parse', () => {
+    const original = doc('ABC (Restored)');
+    expect(liftRestoredProvenance(original)).toBe(original);
+  });
+
+  it('unwinds a name that compounded across several restores', () => {
+    // The bug this replaces: each restore appended another suffix.
+    const older = new Date(Date.UTC(2026, 5, 1, 9, 0, 0)).toLocaleString();
+    const newer = new Date(Date.UTC(2026, 6, 29, 15, 4, 11)).toLocaleString();
+    const out = liftRestoredProvenance(doc(`Plan (Restored ${older}) (Restored ${newer})`));
+    expect(out.name).toBe('Plan');
+    // The outermost suffix is the most recent restore — that's the one kept.
+    expect(out.restoredFrom).toBeGreaterThan(Date.UTC(2026, 6, 1));
+  });
+
+  it('is idempotent — a second pass changes nothing', () => {
+    const once = liftRestoredProvenance(doc(`Plan (Restored ${stampText})`));
+    const twice = liftRestoredProvenance(once);
+    expect(twice).toBe(once);
+  });
+
+  it('returns the same reference for an ordinary name', () => {
+    const original = doc('Quarterly Plan');
+    expect(liftRestoredProvenance(original)).toBe(original);
+  });
+
+  it('never overwrites a restoredFrom that is already set', () => {
+    const out = liftRestoredProvenance(
+      doc(`Plan (Restored ${stampText})`, { restoredFrom: 12345 } as Partial<DiagramDocument>),
+    );
+    expect(out.restoredFrom).toBe(12345);
+    expect(out.name).toBe('Plan');
+  });
+
+  it('rejects a timestamp outside the plausible window', () => {
+    // "(Restored 1995)" parses as a date but predates the product — almost
+    // certainly part of the title, not provenance.
+    const original = doc('Archive (Restored 1995)');
+    expect(liftRestoredProvenance(original)).toBe(original);
+  });
+
+  it('keeps the original when the name is nothing but a suffix', () => {
+    const original = doc(`(Restored ${stampText})`);
+    expect(liftRestoredProvenance(original)).toBe(original);
+  });
+
+  it('runs as part of the migrateDocument funnel', () => {
+    const out = migrateDocument(doc(`Funnelled (Restored ${stampText})`));
+    expect(out.name).toBe('Funnelled');
+    expect(out.restoredFrom).toBeDefined();
   });
 });

--- a/src/migrations/documentMigrations.ts
+++ b/src/migrations/documentMigrations.ts
@@ -90,7 +90,96 @@ interface Migration {
  *   id form in the same pass. See `mintHeadingIdsAndRewriteLinks`.
  */
 function normalizeInvariants(doc: DiagramDocument): DiagramDocument {
-  return mintHeadingIdsAndRewriteLinks(healActivePageIds(backfillGroupOwnership(doc)));
+  return liftRestoredProvenance(
+    mintHeadingIdsAndRewriteLinks(healActivePageIds(backfillGroupOwnership(doc))),
+  );
+}
+
+/**
+ * Matches a trailing `(Restored <something>)`, where `<something>` holds no
+ * parentheses of its own. Anchored to the END and non-nesting on purpose: a
+ * name that compounded (`X (Restored A) (Restored B)`) is peeled one suffix at
+ * a time, newest first.
+ */
+const RESTORED_SUFFIX = /^(.*?)\s*\(Restored\s+([^()]+)\)\s*$/;
+
+/** Earliest plausible restore stamp — the product did not exist before this. */
+const PLAUSIBLE_FROM = Date.UTC(2020, 0, 1);
+
+/**
+ * Parse a legacy suffix's timestamp, or null when it isn't one.
+ *
+ * The suffix was written with `toLocaleString()`, so its exact shape depends on
+ * the locale of the machine that produced it. Rather than try to reverse every
+ * locale, this accepts only what `Date.parse` understands AND what lands in a
+ * plausible window — so a deliberately-titled `Notes (Restored from backup)`
+ * fails the test and keeps its name, which is the point.
+ */
+function parseRestoredStamp(raw: string): number | null {
+  const ms = Date.parse(raw.trim());
+  if (!Number.isFinite(ms)) return null;
+  // A day of slack ahead of now absorbs clock skew between devices.
+  if (ms < PLAUSIBLE_FROM || ms > Date.now() + 86_400_000) return null;
+  return ms;
+}
+
+/**
+ * Peel every machine-generated `(Restored <timestamp>)` off a document name.
+ *
+ * Returns the cleaned name plus the newest timestamp found (`null` when there
+ * was nothing to lift). Exported because the restore path needs the same
+ * parsing on a name it's handed directly, not just on a stored document —
+ * otherwise restoring a legacy-named document would nest the suffix again.
+ *
+ * Peeling repeatedly cleans names that already compounded; the FIRST match (the
+ * outermost, newest suffix) is the one reported.
+ */
+export function stripRestoredSuffix(rawName: string): {
+  name: string;
+  restoredFrom: number | null;
+} {
+  let name = rawName;
+  let newest: number | null = null;
+
+  // Bounded: every pass removes one suffix, and a name is finite.
+  for (;;) {
+    const match = RESTORED_SUFFIX.exec(name);
+    if (!match) break;
+    const stamp = parseRestoredStamp(match[2]!);
+    // Unparseable means it probably wasn't machine-generated — stop here and
+    // leave this suffix (and anything left of it) alone.
+    if (stamp === null) break;
+    if (newest === null) newest = stamp;
+    name = match[1]!;
+  }
+
+  const trimmed = name.trim();
+  // A name that was ONLY a suffix would end up empty; keep the original rather
+  // than leave the document nameless.
+  if (trimmed.length === 0) return { name: rawName, restoredFrom: null };
+  return { name: trimmed, restoredFrom: newest };
+}
+
+/**
+ * Lift `Name (Restored <timestamp>)` out of the title and into `restoredFrom`
+ * (JP-481). Pure and idempotent — a document with no such suffix, or with an
+ * unparseable one, is returned by reference. An existing `restoredFrom` is
+ * never overwritten.
+ */
+export function liftRestoredProvenance(doc: DiagramDocument): DiagramDocument {
+  const { name, restoredFrom: newest } = stripRestoredSuffix(doc.name);
+
+  if (name === doc.name) return doc;
+
+  // Conditional spread, not `restoredFrom: … ?? undefined` — the project runs
+  // `exactOptionalPropertyTypes`, where an explicit `undefined` is not the same
+  // as an absent key.
+  const stamp = doc.restoredFrom ?? newest;
+  return {
+    ...doc,
+    name: name.trim(),
+    ...(stamp !== null && stamp !== undefined ? { restoredFrom: stamp } : {}),
+  };
 }
 
 /** Stamp `ownerId: null` on any group shape missing it. Pure; returns the same

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -107,6 +107,22 @@ export interface DiagramDocument {
    */
   tags?: string[];
 
+  // Restore provenance (JP-481)
+  /**
+   * When this document was restored from a recovery point, the timestamp of the
+   * **recovery point** — i.e. what moment in time this content is from.
+   *
+   * Restoring used to encode this in the document's own name
+   * (`My Doc (Restored 7/29/2026, 3:04:11 PM)`), which put a machine-generated
+   * locale string into a user-facing title and compounded on every subsequent
+   * restore. It's provenance, so it lives here and renders as a badge.
+   *
+   * Optional/additive: an older document simply has no key (no `version` bump).
+   * `normalizeInvariants` lifts the legacy suffix into this field wherever the
+   * trailing timestamp parses.
+   */
+  restoredFrom?: number;
+
   // Relay document fields (Phase 14.1)
   /** Whether this is a relay document (stored on host, synced via CRDT) */
   isRelayDocument?: boolean;
@@ -205,6 +221,12 @@ export interface DocumentMetadata {
    *  Absent on local docs and on relay entries written before size
    *  recording. */
   sizeBytes?: number;
+  /** Recovery-point timestamp this document was restored from (JP-481); absent
+   *  = not a restored copy. Derived locally from the document body. NOT lifted
+   *  by the relay yet, so a restored copy published to a workspace loses the
+   *  badge on the round-trip — restores are created local-only, so this covers
+   *  the case that occurs in practice. */
+  restoredFrom?: number;
 }
 
 /**
@@ -286,6 +308,10 @@ export function getDocumentMetadata(doc: DiagramDocument): DocumentMetadata {
     modifiedAt: doc.modifiedAt,
     createdAt: doc.createdAt,
   };
+
+  if (doc.restoredFrom !== undefined) {
+    metadata.restoredFrom = doc.restoredFrom;
+  }
 
   // Only include relay document fields if they are defined
   if (doc.isRelayDocument !== undefined) {

--- a/src/types/DocumentRegistry.ts
+++ b/src/types/DocumentRegistry.ts
@@ -63,6 +63,10 @@ export interface DocumentEntryBase {
    *  counts toward the workspace storage meter. Absent on local docs and on
    *  entries from relays that predate size recording. */
   sizeBytes?: number;
+  /** Recovery-point timestamp this document was restored from (JP-481); absent
+   *  = not a restored copy. Drives the card's Restored badge. Local-only for
+   *  now — the relay listing doesn't derive it. */
+  restoredFrom?: number;
 }
 
 /**
@@ -251,6 +255,7 @@ export function toLocalDocument(metadata: DocumentMetadata): LocalDocument {
     modifiedAt: metadata.modifiedAt,
     ...(metadata.tags !== undefined ? { tags: metadata.tags } : {}),
     ...(metadata.sizeBytes !== undefined ? { sizeBytes: metadata.sizeBytes } : {}),
+    ...(metadata.restoredFrom !== undefined ? { restoredFrom: metadata.restoredFrom } : {}),
   };
 }
 

--- a/src/ui/DocumentCard.css
+++ b/src/ui/DocumentCard.css
@@ -143,12 +143,36 @@
   border-radius: 4px;
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  color: #64748b;
-  background: rgba(100, 116, 139, 0.12);
+  /* Was a hardcoded Tailwind slate (#64748b / rgba(100,116,139,.12)) — the same
+     off-brand stray this file's Restored chip below is written to avoid. */
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 12%, transparent);
   white-space: nowrap;
 }
 
 .document-card__foreign-relay svg {
+  flex-shrink: 0;
+}
+
+/* Restored copy (JP-481) — provenance that used to live in the document's own
+   name. Quiet by design: it labels the document, it isn't a status to act on. */
+.document-card__restored {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 12%, transparent);
+  white-space: nowrap;
+  cursor: help;
+}
+
+.document-card__restored svg {
   flex-shrink: 0;
 }
 

--- a/src/ui/DocumentCard.selectmode.test.tsx
+++ b/src/ui/DocumentCard.selectmode.test.tsx
@@ -118,3 +118,43 @@ describe('DocumentCard — select mode', () => {
     expect(onOpen).not.toHaveBeenCalled();
   });
 });
+
+describe('DocumentCard — restored badge (JP-481)', () => {
+  beforeEach(cleanup);
+
+  it('shows a Restored badge when the document carries provenance', () => {
+    const restoredFrom = Date.UTC(2026, 6, 29, 15, 4, 11);
+    const { container } = render(
+      <DocumentCard
+        record={{ ...record, restoredFrom }}
+        isActive={false}
+        isSelected={false}
+        onOpen={() => {}}
+      />,
+    );
+    const badge = container.querySelector('.document-card__restored');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('Restored');
+    // The date the title used to carry is now in the tooltip, not the name.
+    expect(badge?.getAttribute('title')).toMatch(/Restored from a version saved/);
+  });
+
+  it('shows no badge on an ordinary document', () => {
+    const { container } = render(
+      <DocumentCard record={record} isActive={false} isSelected={false} onOpen={() => {}} />,
+    );
+    expect(container.querySelector('.document-card__restored')).toBeNull();
+  });
+
+  it('leaves the name untouched — the badge is the whole signal', () => {
+    const { container } = render(
+      <DocumentCard
+        record={{ ...record, restoredFrom: Date.UTC(2026, 6, 29) }}
+        isActive={false}
+        isSelected={false}
+        onOpen={() => {}}
+      />,
+    );
+    expect(container.querySelector('.document-card__name')?.textContent).toBe('My Doc');
+  });
+});

--- a/src/ui/DocumentCard.tsx
+++ b/src/ui/DocumentCard.tsx
@@ -757,6 +757,20 @@ function DocumentCardImpl({
             )
           )}
 
+          {/* Restored copy (JP-481) — provenance, not part of the name. The
+              chip says WHAT it is; the tooltip says which point in time the
+              content came from, which is the detail that used to be jammed
+              into the document's title. */}
+          {record.restoredFrom !== undefined && (
+            <span
+              className="document-card__restored"
+              title={`Restored from a version saved ${formatDate(record.restoredFrom)}`}
+            >
+              <History size={11} aria-hidden="true" />
+              Restored
+            </span>
+          )}
+
           {/* Tags (JP-388) — deterministic-color chips; clicking one filters
               the browser (`#tag` search). */}
           {record.tags && record.tags.length > 0 && (

--- a/src/ui/VersionHistoryPanel.css
+++ b/src/ui/VersionHistoryPanel.css
@@ -1,71 +1,30 @@
 /**
  * VersionHistoryPanel styles (JP-185; grown out of the JP-183 backups drawer).
- * Hand-rolled modal shell + brand tokens. Should adopt `components/ModalShell`
- * (JP-456) — it was left on its own copy to keep that PR scoped.
+ *
+ * JP-481: the hand-rolled modal shell is gone — overlay, card, header, close
+ * button and entrance keyframes now come from `components/ModalShell`, which
+ * this file's header had flagged as the intended follow-up since JP-456. What
+ * remains here is only what's specific to version history: the list, the
+ * per-version summary, and the actions.
+ *
+ * The old shell also carried a cluster of stale colour references, all removed
+ * with it:
+ *   - `var(--error-color, #dc2626)` — `--error-color` was retired in JP-151, so
+ *     the fallback always fired and errors rendered in a Tailwind red.
+ *   - four `color: white` declarations, against the brand's paper/steel rule.
+ *   - raw `--navy-700` / `--navy-900` ramps rather than semantic tokens, which
+ *     is why the header gradient barely separated from the card on the dark
+ *     theme — `--bg-primary` there IS navy-900.
+ *   - dead `var(--token, fallback)` pairs on tokens that are defined.
  */
 
-.version-history__overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(2px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  animation: fadeIn 0.15s ease;
-}
-
+/* Sizing only — the shell owns the rest of the card. */
 .version-history {
-  background: var(--bg-primary);
-  border-radius: 12px;
-  width: 90%;
-  max-width: 520px;
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-  box-shadow: var(--shadow-xl);
-  animation: slideIn 0.2s ease;
-}
-
-.version-history__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px;
-  border-bottom: 1px solid var(--border-color);
-  background: linear-gradient(135deg, var(--navy-900) 0%, var(--navy-700) 100%);
-  border-radius: 12px 12px 0 0;
-}
-
-.version-history__header h3 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: white;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.version-history__close {
-  background: rgba(255, 255, 255, 0.2);
-  border: none;
-  font-size: 20px;
-  line-height: 1;
-  color: white;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: background 0.15s;
-}
-
-.version-history__close:hover {
-  background: rgba(255, 255, 255, 0.3);
+  max-width: 34rem;
 }
 
 .version-history__content {
-  padding: 20px;
+  padding: var(--space-5);
   overflow-y: auto;
   flex: 1;
 }
@@ -73,36 +32,37 @@
 .version-history__current {
   display: flex;
   flex-direction: column;
-  padding: 10px 12px;
-  margin-bottom: 12px;
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-3);
   border: 1px solid var(--border-color);
-  border-left: 3px solid var(--navy-700);
-  border-radius: 8px;
-  background: var(--bg-secondary, transparent);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
 }
 
 .version-history__error {
-  margin: 0 0 12px;
-  font-size: 13px;
-  color: var(--error-color, #dc2626);
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-md);
+  color: var(--danger-text);
 }
 
 .version-history__empty {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--text-secondary);
 }
 
 .version-history__group {
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-3);
 }
 
 .version-history__day {
-  margin: 0 0 6px;
-  font-size: 12px;
-  font-weight: 600;
+  margin: 0 0 var(--space-1-5);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-secondary);
+  letter-spacing: 0.09em;
+  color: var(--text-faint);
 }
 
 .version-history__list {
@@ -111,93 +71,100 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .version-history__row {
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
+  transition: border-color 0.15s ease;
+}
+
+.version-history__row:hover {
+  border-color: var(--border-color-input);
 }
 
 .version-history__row--selected {
-  border-color: var(--navy-700);
+  border-color: var(--color-primary);
 }
 
 .version-history__row-main {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   width: 100%;
-  padding: 10px 12px;
+  padding: var(--space-2) var(--space-3);
   border: none;
   background: transparent;
   color: inherit;
   cursor: pointer;
   text-align: left;
-  transition: background 0.15s;
+  transition: background 0.15s ease;
 }
 
 .version-history__row-main:hover {
-  background: var(--bg-hover, rgba(0, 0, 0, 0.05));
+  background: var(--bg-hover);
 }
 
 .version-history__time {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
 }
 
 .version-history__sub {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
+/* "Latest" marker on the newest recovery point. */
 .version-history__latest {
-  margin-left: 8px;
+  margin-left: var(--space-2);
   padding: 1px 6px;
-  border-radius: 8px;
-  font-size: 10px;
-  font-weight: 600;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  background: var(--navy-700);
-  color: white;
+  letter-spacing: 0.06em;
+  background: var(--color-primary-light);
+  color: var(--text-primary);
   vertical-align: middle;
 }
 
 .version-history__summary {
-  padding: 0 12px 12px;
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 .version-history__summary-note {
   margin: 0;
-  padding: 0 12px 12px;
-  font-size: 12px;
+  padding: 0 var(--space-3) var(--space-3);
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
 .version-history__summary-pages {
   list-style: none;
-  margin: 0 0 8px;
-  padding: 8px 10px;
+  margin: 0 0 var(--space-2);
+  padding: var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  border-radius: 6px;
-  background: var(--bg-secondary, rgba(0, 0, 0, 0.03));
+  gap: var(--space-1);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
 }
 
 .version-history__summary-pages li {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .version-history__page-name {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -205,46 +172,51 @@
 }
 
 .version-history__page-count {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
 
 .version-history__delta {
-  margin: 0 0 10px;
-  font-size: 12px;
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
 }
 
 .version-history__actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   justify-content: flex-end;
 }
 
 .version-history__btn {
-  padding: 6px 12px;
-  font-size: 13px;
-  border-radius: 6px;
-  border: 1px solid var(--border-color);
-  background: var(--bg-secondary, transparent);
+  height: 30px;
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color-input);
+  background: var(--bg-primary);
   color: var(--text-primary);
   cursor: pointer;
-  transition: background 0.15s, opacity 0.15s;
+  transition: background 0.15s ease, opacity 0.15s ease;
 }
 
 .version-history__btn:hover:not(:disabled) {
-  background: var(--bg-hover, rgba(0, 0, 0, 0.05));
+  background: var(--bg-hover);
 }
 
+/* Restore is the consequential action here, so it takes the gold CTA. */
 .version-history__btn--primary {
-  background: var(--navy-700);
-  border-color: var(--navy-700);
-  color: white;
+  background: var(--color-cta);
+  border-color: var(--color-cta);
+  color: var(--color-cta-text);
+  font-weight: var(--font-weight-semibold);
 }
 
 .version-history__btn--primary:hover:not(:disabled) {
-  background: var(--navy-900);
+  background: var(--color-cta-hover);
+  border-color: var(--color-cta-hover);
 }
 
 .version-history__btn:disabled {

--- a/src/ui/VersionHistoryPanel.test.ts
+++ b/src/ui/VersionHistoryPanel.test.ts
@@ -41,18 +41,46 @@ describe('buildLocalCopyFromVersion', () => {
     expect(copy.version).toBe(DOCUMENT_VERSION);
   });
 
-  it('mints a fresh id, names the copy with the version time, and strips relay ownership', () => {
+  it('mints a fresh id, keeps the name, and strips relay ownership', () => {
     const createdAt = 1_700_000_000_000;
     const copy = buildLocalCopyFromVersion(versionContent(), 'Cloud Doc', createdAt);
     expect(copy.id).not.toBe('doc-cloud');
-    expect(copy.name).toContain('Cloud Doc (Restored ');
-    // Same-day copies must stay distinguishable, so the name carries the full
-    // timestamp (date AND time), not just the date.
-    expect(copy.name).toContain(new Date(createdAt).toLocaleString());
+    // JP-481: the copy keeps the document's name. It used to become
+    // `Cloud Doc (Restored 11/14/2023, 10:13:20 PM)` — a machine-generated
+    // locale string in a user-facing title, which also compounded on every
+    // subsequent restore.
+    expect(copy.name).toBe('Cloud Doc');
+    expect(copy.name).not.toContain('Restored');
     expect(copy.isRelayDocument).toBe(false);
     expect('ownerId' in copy).toBe(false);
     expect('ownerName' in copy).toBe(false);
     expect('serverVersion' in copy).toBe(false);
+  });
+
+  it('records which recovery point the content came from', () => {
+    const createdAt = 1_700_000_000_000;
+    const copy = buildLocalCopyFromVersion(versionContent(), 'Cloud Doc', createdAt);
+    // The detail the name used to carry, now addressable: the badge renders it
+    // and the tooltip formats it.
+    expect(copy.restoredFrom).toBe(createdAt);
+  });
+
+  it('does not compound when restoring a document that was itself restored', () => {
+    // The reported bug: `X (Restored A) (Restored B) (Restored C)`. Names no
+    // longer accumulate, and the newest restore point wins.
+    const first = buildLocalCopyFromVersion(versionContent(), 'Cloud Doc', 1_700_000_000_000);
+    const second = buildLocalCopyFromVersion(first, first.name, 1_800_000_000_000);
+    expect(second.name).toBe('Cloud Doc');
+    expect(second.restoredFrom).toBe(1_800_000_000_000);
+  });
+
+  it('lifts a legacy suffix off the source name instead of nesting it', () => {
+    // A document restored under the OLD scheme still carries the suffix in its
+    // name; restoring it again must clean it up rather than wrap it again.
+    const legacyName = `Cloud Doc (Restored ${new Date(1_700_000_000_000).toLocaleString()})`;
+    const copy = buildLocalCopyFromVersion(versionContent(), legacyName, 1_800_000_000_000);
+    expect(copy.name).toBe('Cloud Doc');
+    expect(copy.restoredFrom).toBe(1_800_000_000_000);
   });
 
   it('drops a fossilized legacy richTextContent when richTextPages exists', () => {

--- a/src/ui/VersionHistoryPanel.tsx
+++ b/src/ui/VersionHistoryPanel.tsx
@@ -28,7 +28,7 @@ import { collectBlobReferences } from '../storage/AssetBundler';
 import { useDocumentRegistry } from '../store/documentRegistry';
 import { getDocumentMetadata } from '../types/Document';
 import type { DiagramDocument } from '../types/Document';
-import { migrateDocument } from '../migrations/documentMigrations';
+import { migrateDocument, stripRestoredSuffix } from '../migrations/documentMigrations';
 import { confirmDialog } from './confirm/confirmStore';
 import {
   summarizeDocument,
@@ -39,6 +39,7 @@ import {
 import type { RelayRecoveryPoint } from '../api/relayClient';
 import { repointShareLink, stashPendingRepoint } from '../share/publishFlow';
 import { webClient } from '../api/webClient';
+import { ModalShell } from './components/ModalShell';
 import './VersionHistoryPanel.css';
 
 interface VersionHistoryPanelProps {
@@ -65,7 +66,18 @@ export function buildLocalCopyFromVersion(
   const copy = {
     ...migrateDocument(content),
     id: crypto.randomUUID(),
-    name: `${docName} (Restored ${formatTimestamp(createdAt)})`,
+    // The copy keeps the document's name (JP-481). It used to become
+    // `${docName} (Restored ${localeTimestamp})`, which put a machine-generated
+    // string in a user-facing title and compounded on every subsequent restore
+    // — `X (Restored A) (Restored B)`. The restore point is provenance, so it
+    // rides in `restoredFrom` and renders as a badge. `migrateDocument` above
+    // has already lifted any legacy suffix off the source CONTENT's name, but
+    // `docName` arrives as a prop and needs the same treatment — otherwise
+    // restoring a document that was named under the old scheme would carry its
+    // suffix straight into the new copy. This stamp supersedes whatever the
+    // name yielded, since this restore is the newer one.
+    name: stripRestoredSuffix(docName).name,
+    restoredFrom: createdAt,
     isRelayDocument: false,
   };
   delete copy.ownerId;
@@ -375,20 +387,18 @@ export function VersionHistoryPanel({
   };
 
   return (
-    <div className="version-history__overlay" onClick={onClose}>
-      <div
-        className="version-history"
-        role="dialog"
-        aria-label={`Version history for ${docName}`}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="version-history__header">
-          <h3>Version history — {docName}</h3>
-          <button className="version-history__close" onClick={onClose} aria-label="Close">
-            ×
-          </button>
-        </div>
-        <div className="version-history__content">
+    // ModalShell (JP-481) — the shared overlay + card chrome this panel was
+    // always meant to adopt (JP-456 deferred it to stay scoped). It brings the
+    // portal, the focus trap, Escape handling and `aria-modal`, none of which
+    // the hand-rolled shell had, and puts the panel on the same z-index as
+    // every other dialog instead of its own 1000.
+    <ModalShell
+      title="Version history"
+      subtitle={docName}
+      onClose={onClose}
+      className="version-history"
+    >
+      <div className="version-history__content">
           <div className="version-history__current">
             <span className="version-history__time">Current version</span>
             <span className="version-history__sub">
@@ -443,8 +453,7 @@ export function VersionHistoryPanel({
               </section>
             ))
           )}
-        </div>
       </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,12 +45,22 @@ export default defineConfig({
       manifest: {
         name: 'DocuShark',
         short_name: 'DocuShark',
-        description: 'High-performance diagramming and whiteboard editor.',
+        // Positioning, not feature list: DocuShark is a document hub — prose, a
+        // real drawing canvas and files in one place — not the "diagramming and
+        // whiteboard editor" this said when the product was only the canvas.
+        description:
+          'Prose, a real drawing canvas, and your files — in one document.',
         start_url: '/',
         scope: '/',
         display: 'standalone',
-        background_color: '#ffffff',
-        theme_color: '#2196f3',
+        // Brand surfaces (JP-481). These were '#ffffff' and Material blue
+        // '#2196f3' — predating the palette entirely, so an installed PWA
+        // opened on a blue splash and a pure-white background while the app
+        // itself is warm paper. Matches the light `--bg-primary` and the
+        // `theme-color` meta in index.html, which themeStore then tracks at
+        // runtime.
+        background_color: '#f9f6ee',
+        theme_color: '#f9f6ee',
         icons: [
           { src: '/icon-192x192.png', sizes: '192x192', type: 'image/png' },
           { src: '/icon-512x512.png', sizes: '512x512', type: 'image/png' },


### PR DESCRIPTION
Closes JP-481.

## 1. Restoring stopped mangling the title

A restored copy was named `${docName} (Restored ${localeTimestamp})` — a machine-generated string in a user-facing name. It also **compounded**: restore a restored document and you got `X (Restored A) (Restored B)`, which is the buggy behaviour reported.

The restore point is provenance, so it moves to an optional `restoredFrom` on the document and renders as a quiet chip whose tooltip carries the date the name used to.

**Existing names** are cleaned by `liftRestoredProvenance`, composed into `normalizeInvariants` — version-independent and idempotent, so **no `DOCUMENT_VERSION` bump**, and lazy on load exactly like the other invariants there (group ownership, active page ids). Nothing rewrites stored names in bulk.

The lift is **parseable-only**, by your call:

| Name | Result |
|---|---|
| `vcs testing (Restored 7/29/2026, 3:04:11 PM)` | → `vcs testing` + badge |
| `ABC (Restored)` | untouched — nothing to parse |
| `Notes (Restored from backup)` | untouched — not a date |
| `Archive (Restored 1995)` | untouched — outside the plausible window |

Peeling loops, so names that already compounded unwind and the newest stamp wins.

`stripRestoredSuffix` is exported and shared — which a test caught the need for. `migrateDocument` cleans the source *content's* name, but `docName` arrives as a prop, so restoring a legacy-named document nested the suffix again until both paths used the same parser.

## 2. Version history adopted `ModalShell`

The follow-up its own CSS header had flagged since JP-456, and which `ModalShell`'s docstring lists it under. **Not a repaint** — the panel had no focus trap, no `aria-modal`, and sat at `z-index: 1000` while every other dialog is at 10050.

The hand-rolled shell took a cluster of stale colour with it:

- `var(--error-color, #dc2626)` — that token was **retired in JP-151**, so the Tailwind red always won.
- four `color: white`, against the brand's paper/steel rule.
- raw `--navy-*` ramps where semantic tokens are required — which is why the header barely separated from the card in dark mode, since `--bg-primary` there *is* navy-900. Now `--bg-tertiary`, measured at `#16273f` on `#0e1c30`.
- dead `var(--token, fallback)` pairs.

Restore takes the gold CTA, being the consequential action. The `foreign-relay` chip beside it was on a hardcoded Tailwind slate; moved onto tokens in passing.

## 3. PWA metadata (the bonus, slightly bigger than billed)

Stale past the title: the manifest still carried `theme_color: '#2196f3'` — **Material blue** — and `background_color: '#ffffff'`, both predating the palette, so an installed app opened on a blue splash against a warm-paper product. Both now track the light `--bg-primary`; title and description moved off "Diagramming & Whiteboard" onto the document-hub positioning.

## Known limit

Restored copies are created local-only (`isRelayDocument: false`), so the badge covers what happens in practice. A restored copy *published* to a workspace loses it on the round-trip until the relay derives `restoredFrom` into its listing — deliberately not widened into the Rust crate here.

## Verification

- typecheck, **3410 tests across 289 files** (16 new), production build.
- Live: the new title is in the tab; `ABC (Restored)` in the real library is correctly untouched by the parseable-only rule; the modal renders on the brand surface with the header on `--bg-tertiary`, the gold CTA at `#c9a262` with navy ink, and the overlay at 10050.

One trade-off worth naming: two restores of the same document now produce two documents with the **same name**, distinguished by the badge date and modified time rather than by the title. That follows directly from wanting the name clean — flagging it rather than burying it.

Assisted-by: Opus 5