### PR TITLE
JP-483: property panel spacing, form grid, and a quick bar

### DIFF
--- a/src/ui/CompactColorInput.css
+++ b/src/ui/CompactColorInput.css
@@ -2,13 +2,13 @@
 .compact-color-input {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   position: relative;
 }
 
 /* Label */
 .compact-color-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 40px;
 }
@@ -17,17 +17,17 @@
 .compact-color-controls {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex: 1;
 }
 
 /* Native Color Picker */
 .compact-color-picker {
-  width: 26px;
-  height: 26px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   background: transparent;
   flex-shrink: 0;
@@ -54,11 +54,11 @@
 
 /* Swatch button — opens our palette instead of the OS picker */
 .compact-color-swatch {
-  width: 26px;
-  height: 26px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   flex-shrink: 0;
   display: flex;
@@ -120,14 +120,14 @@
 .compact-color-hex-input {
   flex: 1;
   min-width: 0;
-  height: 26px;
-  padding: 0 6px;
-  font-size: 0.75rem;
+  height: var(--control-height-md);
+  padding: 0 var(--space-1-5);
+  font-size: var(--font-size-sm);
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
   color: var(--text-primary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease;
@@ -151,15 +151,15 @@
 
 /* Edit Button */
 .compact-color-edit {
-  width: 26px;
-  height: 26px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   padding: 0;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-secondary);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   flex-shrink: 0;
   transition: background-color 0.15s ease, color 0.15s ease;

--- a/src/ui/CompactColorInput.tsx
+++ b/src/ui/CompactColorInput.tsx
@@ -20,6 +20,13 @@ interface CompactColorInputProps {
   showNoFill?: boolean;
   /** Whether to show the "Automatic" (contrast-aware) option */
   showAuto?: boolean;
+  /**
+   * Render the swatch alone — no label, hex readout or `#` button. For dense
+   * strips (the property panel's quick bar) where the colour itself is the
+   * control and `label` becomes its accessible name. The palette dropdown is
+   * unaffected.
+   */
+  swatchOnly?: boolean;
 }
 
 /**
@@ -49,6 +56,7 @@ export function CompactColorInput({
   showPalette = true,
   showNoFill = false,
   showAuto = false,
+  swatchOnly = false,
 }: CompactColorInputProps) {
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -242,8 +250,11 @@ export function CompactColorInput({
     : `Pick ${label.toLowerCase()} color`;
 
   return (
-    <div className="compact-color-input" ref={containerRef}>
-      <label className="compact-color-label">{label}</label>
+    <div
+      className={`compact-color-input${swatchOnly ? ' compact-color-input--swatch-only' : ''}`}
+      ref={containerRef}
+    >
+      {!swatchOnly && <label className="compact-color-label">{label}</label>}
       <div className="compact-color-controls" ref={triggerRef}>
         {showPalette ? (
           <button
@@ -268,7 +279,7 @@ export function CompactColorInput({
             title={swatchTitle}
           />
         )}
-        {isEditing ? (
+        {swatchOnly ? null : isEditing ? (
           <input
             ref={inputRef}
             type="text"
@@ -288,7 +299,7 @@ export function CompactColorInput({
             {isAuto ? <span className="compact-color-auto-label">Auto</span> : hasValue ? displayValue : 'none'}
           </button>
         )}
-        {(hasValue || isAuto) && showPalette && !isEditing && (
+        {!swatchOnly && (hasValue || isAuto) && showPalette && !isEditing && (
           <button
             className="compact-color-edit"
             onClick={handleStartEdit}

--- a/src/ui/NumberInput.css
+++ b/src/ui/NumberInput.css
@@ -2,24 +2,24 @@
 .number-input-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 2px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-0-5);
 }
 
 .number-input-label {
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   min-width: 55px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 /* Input Container */
 .number-input-container {
   display: flex;
   align-items: stretch;
-  height: 28px;
+  height: var(--control-height-md);
   border: 1px solid var(--border-color-input);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   overflow: hidden;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -45,9 +45,9 @@
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 0.75rem;
+  font-size: var(--font-size-sm);
   text-align: center;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   outline: none;
   -moz-appearance: textfield;
 }
@@ -58,12 +58,13 @@
   display: none;
 }
 
-/* Buttons */
+/* Buttons — width tracks the control scale so the stepper stays a comfortable
+ * target at every density (it is full-height, so this is the narrow axis). */
 .number-input-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
+  width: var(--control-height-sm);
   padding: 0;
   border: none;
   background: var(--bg-tertiary);
@@ -96,13 +97,13 @@
 }
 
 .number-input-btn svg {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
 }
 
 /* Suffix */
 .number-input-suffix {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-xs);
   color: var(--text-muted, var(--text-secondary));
   opacity: 0.8;
 }

--- a/src/ui/PropertyPanel.css
+++ b/src/ui/PropertyPanel.css
@@ -79,8 +79,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: var(--control-height-md);
+  height: var(--control-height-md);
   flex-shrink: 0;
   padding: 0;
   border: none;
@@ -237,7 +237,7 @@
 
 .compact-number-input {
   width: 64px;
-  height: 28px;
+  height: var(--control-height-md);
   padding: 0 var(--space-2);
   padding-right: var(--space-1);
   font-size: var(--font-size-sm);
@@ -379,7 +379,7 @@
 /* Text Input */
 .property-text-input {
   width: 100%;
-  height: 30px;
+  height: var(--control-height-md);
   padding: 0 10px;
   font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input);
@@ -452,7 +452,7 @@
 
 .align-button {
   width: 28px;
-  height: 28px;
+  height: var(--control-height-md);
   padding: 0;
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
@@ -506,7 +506,7 @@
 
 .compact-select {
   flex: 1;
-  height: 28px;
+  height: var(--control-height-md);
   padding: 0 var(--space-2);
   font-size: var(--font-size-sm);
   border: 1px solid var(--border-color-input);
@@ -637,8 +637,8 @@
 }
 
 .compact-checkbox-row input[type="checkbox"]:not(.compact-checkbox) {
-  width: 15px;
-  height: 15px;
+  width: 16px;
+  height: 16px;
   margin: 0;
   flex-shrink: 0;
   accent-color: var(--color-primary);
@@ -659,7 +659,7 @@
 .rotation-input {
   flex: 1;
   min-width: 0;
-  height: 28px;
+  height: var(--control-height-md);
   padding: 0 var(--space-2);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
@@ -691,7 +691,7 @@
 }
 
 .rotation-unit-toggle button {
-  height: 28px;
+  height: var(--control-height-md);
   min-width: 30px;
   padding: 0 var(--space-2);
   border: none;
@@ -1601,7 +1601,7 @@
 .uml-member-name,
 .uml-member-type,
 .swimlane-lane-name {
-  height: 28px;
+  height: var(--control-height-md);
   padding: 0 var(--space-2);
   min-width: 64px;
 }
@@ -1612,7 +1612,7 @@
 }
 
 .uml-member-visibility {
-  height: 28px;
+  height: var(--control-height-md);
 }
 
 .erd-members-list,
@@ -1759,4 +1759,145 @@
   font-size: 11px;
   opacity: 0.7;
   font-style: italic;
+}
+
+/* --- Quick bar -----------------------------------------------------------
+ * The always-visible strip of shared properties under the panel header. Reads
+ * as a toolbar, not a form: no labels, no group card, controls sized to their
+ * content. That is what keeps it from looking like a second copy of the
+ * Appearance section rather than a shortcut to it. */
+.property-quick-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) 14px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+/* The swatch-only colour inputs collapse to just their button. */
+.property-quick-bar .compact-color-input--swatch-only,
+.property-quick-bar .compact-color-input--swatch-only .compact-color-controls {
+  flex: 0 0 auto;
+  gap: 0;
+}
+
+.property-quick-bar-slot {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+/* Punch the centre out of the stroke swatch so the colour reads as a ring —
+ * the same way a stroke reads on the canvas — which is what tells the two
+ * otherwise-identical swatches apart without labelling them. */
+.property-quick-bar-slot--stroke .compact-color-swatch::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 2px;
+  background: var(--bg-secondary);
+}
+
+/* Keep the "A" (auto) and "/" (none) badges above that cut-out. */
+.property-quick-bar-slot--stroke .compact-color-swatch > span {
+  position: relative;
+  z-index: 1;
+}
+
+.property-quick-bar-opacity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+  color: var(--text-muted, var(--text-secondary));
+}
+
+.property-quick-bar-opacity .compact-slider {
+  flex: 1;
+  min-width: 0;
+}
+
+.property-quick-bar-value {
+  flex-shrink: 0;
+  min-width: 34px;
+  text-align: right;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- One form grid per section -------------------------------------------
+ * Each row type used to size its own label column — 40px (colour), 55px
+ * (number / slider / info), 65px (a long colour label), 70px (rotation) — so
+ * controls began at four different x positions and ended at three different
+ * right edges. Nothing was misaligned by intent; the columns simply never
+ * agreed. Pin one label column and let every fluid control run to a single
+ * right edge, and the section reads as one form instead of a stack of
+ * independently-built rows.
+ *
+ * Scoped under `.property-section-body` (0,2,0) so these outrank each
+ * component's own bare-class rule (0,1,0) regardless of CSS import order —
+ * the label widths live in three separate files. */
+.property-section-body .number-input-label,
+.property-section-body .compact-number-label,
+.property-section-body .compact-slider-label,
+.property-section-body .compact-color-label,
+.property-section-body .compact-select-label,
+.property-section-body .compact-string-label,
+.property-section-body .info-label {
+  flex: 0 0 72px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Editable controls fill the column. This is also the "larger targets" win:
+ * a full-width stepper turns a 22px increment button into a comfortable one
+ * without changing its height. Read-only `.info-value` stays a natural-width
+ * chip — stretching a value you cannot edit only adds noise. */
+.property-section-body .number-input-container,
+.property-section-body .compact-number-input {
+  flex: 1 1 auto;
+  width: auto;
+}
+
+/* The stepper's own field is fixed at 44px; without this it stays 44px inside
+ * a stretched container and the whole control bunches against the left border. */
+.property-section-body .number-input-field {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+}
+
+/* A suffix ("px") is the flex sibling that gets squeezed once the control
+ * grows — pin it so a long value can never eat its label. */
+.property-section-body .number-input-suffix {
+  flex-shrink: 0;
+}
+
+/* `.compact-number-row` pushed its input to the far edge with space-between,
+ * which was the one row type that right-aligned. Now that the input flexes,
+ * the gap after the label is all the separation it needs. */
+.property-section-body .compact-number-row {
+  justify-content: flex-start;
+}
+
+/* Narrow panel: give the controls the room instead. The query targets the
+ * labels, not `.property-section-body` — the body IS the container, and a
+ * container query can only style a container's descendants, never itself.
+ * Must also sit BELOW the rules it overrides: a container query carries no
+ * specificity bonus, so source order is what decides. */
+@container (max-width: 280px) {
+  .property-section-body .number-input-label,
+  .property-section-body .compact-number-label,
+  .property-section-body .compact-slider-label,
+  .property-section-body .compact-color-label,
+  .property-section-body .compact-select-label,
+  .property-section-body .compact-string-label,
+  .property-section-body .info-label {
+    flex-basis: 56px;
+  }
 }

--- a/src/ui/PropertyPanel.tsx
+++ b/src/ui/PropertyPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import { ChevronsDownUp, ChevronsUpDown, MousePointerClick, ArrowRight, GitFork, Square } from 'lucide-react';
+import { ChevronsDownUp, ChevronsUpDown, MousePointerClick, ArrowRight, GitFork, Square, Blend } from 'lucide-react';
 import { useSessionStore } from '../store/sessionStore';
 import { useDocumentStore } from '../store/documentStore';
 import { useActiveDocReadOnly } from '../store/documentRegistry';
@@ -183,6 +183,92 @@ function InfoRow({ label, value }: { label: string; value: string | number }) {
     <div className="info-row">
       <span className="info-label">{label}</span>
       <span className="info-value">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Quick bar — the handful of properties worth reaching without hunting for the
+ * right group, pinned above the scrolling section list so they stay reachable
+ * however far you have scrolled and whichever sections are collapsed.
+ *
+ * Driven off `BaseShape` (fill / stroke / opacity) rather than a per-type list
+ * of "primary" properties, because the panel has two rendering paths: core
+ * shapes (rectangle, ellipse, text, connector…) render from hand-written JSX
+ * below, while library shapes render from `ShapeMetadata.properties`. A
+ * `primary` flag on the metadata would therefore only ever surface on library
+ * shapes — half the panel. These three fields are the intersection that always
+ * exists, so the bar cannot drift out of step with either path or rot when a
+ * shape type is added.
+ *
+ * The fill/stroke visibility conditions are copied from the Appearance section
+ * below rather than tightened: the bar is a shortcut to those controls, so it
+ * must show exactly what the section shows. (A line keeps a non-null `fill`
+ * it never paints, and both surfaces offer it — consistently.)
+ */
+function PropertyQuickBar({
+  shape,
+  selectedShapes,
+  onBulkUpdate,
+}: {
+  shape: Shape;
+  selectedShapes: Shape[];
+  onBulkUpdate: (updates: Partial<Shape>) => void;
+}) {
+  // Text uses `fill` as its glyph colour, so it shows even when null.
+  const isTextShape = isText(shape);
+  const showFill = shape.fill !== null || isTextShape;
+  const showStroke = shape.stroke !== null;
+
+  const mixed = (getter: (s: Shape) => unknown) =>
+    getSharedValue(selectedShapes, getter) === MIXED;
+
+  const fillLabel = `${isTextShape ? 'Color' : 'Fill'}${mixed((s) => s.fill) ? ' (Mixed)' : ''}`;
+  const strokeLabel = `Stroke${mixed((s) => s.stroke) ? ' (Mixed)' : ''}`;
+  const opacityLabel = `Opacity${mixed((s) => s.opacity) ? ' (Mixed)' : ''}`;
+
+  return (
+    <div className="property-quick-bar" role="group" aria-label="Quick properties">
+      {/* Slot classes carry the fill-vs-stroke distinction: unlabelled, two
+          identical swatches are indistinguishable, so the stroke one is drawn
+          as a ring the way a stroke reads on the canvas. */}
+      {showFill && (
+        <span className="property-quick-bar-slot property-quick-bar-slot--fill">
+          <CompactColorInput
+            label={fillLabel}
+            value={shape.fill || ''}
+            onChange={(color) => onBulkUpdate({ fill: color })}
+            showNoFill={!isTextShape}
+            showAuto
+            swatchOnly
+          />
+        </span>
+      )}
+      {showStroke && (
+        <span className="property-quick-bar-slot property-quick-bar-slot--stroke">
+          <CompactColorInput
+            label={strokeLabel}
+            value={shape.stroke || ''}
+            onChange={(color) => onBulkUpdate({ stroke: color })}
+            showAuto
+            swatchOnly
+          />
+        </span>
+      )}
+      <span className="property-quick-bar-opacity" title={opacityLabel}>
+        <Blend size={14} strokeWidth={2} aria-hidden="true" />
+        <input
+          type="range"
+          className="compact-slider"
+          value={shape.opacity}
+          onChange={(e) => onBulkUpdate({ opacity: parseFloat(e.target.value) })}
+          min={0}
+          max={1}
+          step={0.05}
+          aria-label={opacityLabel}
+        />
+        <span className="property-quick-bar-value">{Math.round(shape.opacity * 100)}%</span>
+      </span>
     </div>
   );
 }
@@ -1684,6 +1770,18 @@ export function PropertyPanel({ className }: PropertyPanelProps = {}) {
 
       {/* Alignment Panel for multi-selection */}
       <AlignmentPanel />
+
+      {/* Sits OUTSIDE `.property-panel-content` on purpose: pinning it inside
+          the scroll container would need `position: sticky`, which then
+          competes with the section headers' own sticky offset. Out here it is
+          simply always visible, and the headers keep their behaviour. */}
+      {!isGroupSelected && (
+        <PropertyQuickBar
+          shape={shape}
+          selectedShapes={selectedShapes}
+          onBulkUpdate={handleBulkUpdate}
+        />
+      )}
 
       <div className="property-panel-content" ref={contentRef}>
         {/* Shape Type Badge */}

--- a/src/ui/PropertySection.css
+++ b/src/ui/PropertySection.css
@@ -157,19 +157,28 @@
   transition: grid-template-rows 0.25s ease;
 }
 
+/* The grid item the 0fr row collapses. It must carry NO padding: a grid item's
+ * padding is part of its min-content contribution, which floors the flexible
+ * track — so padding here survives the collapse and leaves a collapsed section
+ * 16px tall. `min-height: 0` only zeroes the *content* contribution, not the
+ * padding, which is why the spacing lives on `.property-section-body` below. */
 .property-section-content-inner {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-3) var(--space-3) var(--space-3);
   min-height: 0;
   overflow: hidden;
   opacity: 1;
   transition: opacity 0.2s ease;
+}
+
+.property-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3) var(--space-3) var(--space-3);
   /* Become a size container so controls inside (e.g. `.property-grid-2`) can
    * respond to the panel's own resizable width via @container queries —
    * independent of the viewport. Inline-axis only, so the grid-rows height
-   * animation on the parent is unaffected. */
+   * animation on the ancestor is unaffected. Sits on the padded element so the
+   * query resolves against the content box the controls actually occupy. */
   container-type: inline-size;
 }
 

--- a/src/ui/PropertySection.test.tsx
+++ b/src/ui/PropertySection.test.tsx
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PropertySection } from './PropertySection';
+
+afterEach(cleanup);
+
+/**
+ * JP-483. A collapsed section used to keep 16px of dead height. The cause is
+ * subtle enough to be reintroduced by anyone tidying the CSS: the section
+ * collapses via `grid-template-rows: 1fr → 0fr`, and a grid item's *padding*
+ * is part of its min-content contribution, so it floors the flexible track.
+ * `min-height: 0` zeroes only the content contribution, not the padding.
+ *
+ * jsdom performs no layout, so the height itself is not observable here.
+ * These pin the two things that produce it instead: the wrapper element that
+ * keeps the animating grid item padding-free, and the absence of padding on
+ * that item in the stylesheet.
+ */
+describe('PropertySection collapse geometry', () => {
+  const css = readFileSync(resolve(process.cwd(), 'src/ui/PropertySection.css'), 'utf8');
+
+  /** The declaration block for a top-level selector, without nested at-rules. */
+  function ruleBody(selector: string): string {
+    const start = css.indexOf(`\n${selector} {`);
+    expect(start, `selector ${selector} not found`).toBeGreaterThan(-1);
+    const open = css.indexOf('{', start);
+    return css.slice(open + 1, css.indexOf('}', open));
+  }
+
+  it('renders children inside a padded wrapper, not the collapsing grid item', () => {
+    const { container } = render(
+      <PropertySection id="test-geometry" title="Geometry">
+        <span>child control</span>
+      </PropertySection>
+    );
+
+    const inner = container.querySelector('.property-section-content-inner');
+    const body = container.querySelector('.property-section-body');
+    expect(inner).not.toBeNull();
+    expect(body).not.toBeNull();
+
+    // The grid item must be the parent of the padded body, and the children
+    // must sit inside the body — that nesting is what allows the 0fr row to
+    // actually reach zero.
+    expect(body!.parentElement).toBe(inner);
+    expect(body!.contains(screen.getByText('child control'))).toBe(true);
+  });
+
+  it('keeps the collapsing grid item free of padding', () => {
+    expect(ruleBody('.property-section-content-inner')).not.toMatch(/(^|[\s;])padding/);
+  });
+
+  it('puts the section padding on the wrapper instead', () => {
+    expect(ruleBody('.property-section-body')).toMatch(/(^|[\s;])padding:/);
+  });
+
+  it('leaves the container unclipped so the sticky header keeps working', () => {
+    // An overflow-clipping ancestor between a `position: sticky` header and its
+    // scroll container disables sticky. The card rounds its corners on the
+    // header/content instead of clipping the container.
+    expect(ruleBody('.property-section-container')).not.toMatch(/overflow/);
+  });
+});

--- a/src/ui/PropertySection.tsx
+++ b/src/ui/PropertySection.tsx
@@ -107,7 +107,13 @@ export function PropertySection({
         aria-label={title}
         aria-hidden={!isExpanded}
       >
-        <div className="property-section-content-inner">{children}</div>
+        {/* Two nested elements on purpose: `-inner` is the grid item that the
+            0fr row collapses, so it must stay padding-free (padding survives
+            the collapse as a min-content floor and leaves the section 16px
+            tall). All the spacing lives on `-body` instead. */}
+        <div className="property-section-content-inner">
+          <div className="property-section-body">{children}</div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Polish pass on the property panel: the collapsed-group padding bug, a real form
grid, larger targets, and a common-settings strip.

## Collapsed sections kept 16px of dead height

The collapse animates `grid-template-rows: 1fr → 0fr`, but a grid item's
**padding is part of its min-content contribution** and floors the flexible
track — `min-height: 0` zeroes only the *content* contribution. Since
`.property-section-content-inner` carried `4px / 12px`, every collapsed section
stayed 16px tall; five collapsed groups wasted 80px.

The padding moves onto a new `.property-section-body` child so the animating
grid item is padding-free. `container-type` moves with it, so the existing
`@container` threshold still resolves against the same content box.

| Section | Before | After |
|---|---|---|
| Position (collapsed) | container 48, content **16** | container 32, content **0** |
| Size (collapsed) | container 48, content **16** | container 32, content **0** |
| Appearance / Label / Icons (expanded) | 205 / 222 / 91 | 205 / 222 / 91 (unchanged) |

## Control heights disagreed

The panel ran 26 / 28 / 30px depending on which component drew the control, so
nothing lined up. All now read `--control-height-md` — the size an earlier pass
had already chosen for the member editors ("matching the rest of the panel's
controls") without finishing the sweep.

`NumberInput.css` and `CompactColorInput.css` predate the token system: raw
`26px`, `0.75rem`, `500`, `4px` radii. Tokenized here, so they finally respond
to **Appearance → Density** (which scales `--control-height-*` / `--space-*`).

## There was no form grid

Each row type sized its own label column — 40px (colour), 55px
(number/slider/info), 65px, 70px (rotation) — so controls began at **four**
different x positions and ended at **three** different right edges.

One 72px label column now (56px when the panel is dragged narrow), with
editable controls filling to a single right edge. That doubles as the larger
targets ask: the stepper spans the column instead of sitting at a fixed 92px,
and its buttons go 22px → 24px.

## Quick bar

A compact always-visible strip under the panel header carrying the properties
every shape shares — fill, stroke, opacity.

It is driven off `BaseShape` rather than a per-type list of "primary"
properties, because the panel has **two rendering paths**: core shapes
(rectangle, ellipse, text, connector) render from hand-written JSX, library
shapes render from `ShapeMetadata.properties`. A `primary` flag on the metadata
would therefore only ever appear on library shapes — never on the shapes users
select most. The three `BaseShape` fields are the intersection that always
exists, so the bar cannot rot when a shape type is added.

It sits **outside** `.property-panel-content`, so it needs no `position:
sticky` and cannot compete with the section headers' own sticky offset. The
stroke swatch renders as a ring — two unlabelled swatches are otherwise
indistinguishable. Visibility conditions are copied from the Appearance section
rather than tightened, so the shortcut always shows exactly what it shortcuts.

## Verification

Measured live in the editor, not assumed:

- Collapsed content height `0`; expanded sections byte-identical (205/222/91).
- Label column and **both** container-query breakpoints measured at wide and
  narrow panel widths, and confirmed to restore cleanly.
- Quick bar ↔ Appearance section confirmed in sync through the store for both
  colour (`#ef4444` on both surfaces) and opacity (60% on both).
- Light and dark themes; multi-select mixed state; `file` and `line` shapes.
- No console errors.
- `typecheck` clean, `build` clean, **3417 tests pass** (290 files).

New `PropertySection.test.tsx` pins the collapse geometry as a source guard —
the padding regression is silent and easy to reintroduce while tidying CSS. The
guard was verified to actually fail when the padding is put back.

## Out of scope

- UML/ERD member rows keep their denser 20/22px inline buttons — a repeating
  list is a different context from the main property groups.
- The Style Profiles panel below is a separate component and was left alone.
- Numeric rows are still one-per-row; pairing them two-up needs per-shape-type
  JSX restructuring for little gain now that the columns align.

Closes JP-483

Assisted-by: Opus 5