### PR TITLE
JP-484: prose content flow — table overflow + reading measure as a layout knob

### DIFF
--- a/docs-site/guide/layout-modes.md
+++ b/docs-site/guide/layout-modes.md
@@ -59,6 +59,21 @@ control so you can shift emphasis without leaving the layout:
 Switch focus from the control in the toolbar or with
 <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>\\</kbd>.
 
+## Reading Width
+
+Wherever the document is the main region — Write and Split both — the writing
+column stops at a comfortable measure rather than stretching the full width of
+the window, and sits centered with a margin either side.
+
+Choose how far it grows from **Settings → Layout → Reading width**:
+
+- **Normal** — a comfortable measure for reading. Best on laptop screens.
+- **Wide** — longer lines with less empty space. Best on large or ultrawide
+  displays.
+
+The margins shrink automatically as the space narrows, so a document sharing the
+window with the canvas still gets breathing room without wasting it.
+
 ## Custom Window Chrome
 
 If you prefer a more app-like window, you can opt into DocuShark's own title bar

--- a/src/store/uiPreferencesStore.ts
+++ b/src/store/uiPreferencesStore.ts
@@ -12,6 +12,7 @@ import type {
   LayoutState,
   PanelId,
   PanelState,
+  ReadingWidth,
 } from '../ui/layout/types';
 import { LAYOUT_MODES } from '../ui/layout/types';
 import { LAYOUT_PRESETS } from '../ui/layout/modes';
@@ -231,6 +232,8 @@ export interface UIPreferencesActions {
   togglePinFor: (mode: LayoutMode, panel: PanelId) => void;
   /** Set the custom-chrome opt-in flag. */
   setCustomChrome: (enabled: boolean) => void;
+  /** Set how wide the prose reading column may grow (app-level). */
+  setReadingWidth: (width: ReadingWidth) => void;
   /** Drop all per-layout customization, preserving defaultMode + customChrome. */
   resetLayoutCustomization: () => void;
 
@@ -292,6 +295,7 @@ const initialLayoutState: LayoutState = {
   defaultMode: 'relaxed',
   modeOverrides: EMPTY_MODE_OVERRIDES,
   customChrome: false,
+  readingWidth: 'normal',
 };
 
 /**
@@ -560,6 +564,10 @@ export const useUIPreferencesStore = create<UIPreferencesState & UIPreferencesAc
 
       setCustomChrome: (enabled) => {
         set({ layout: { ...get().layout, customChrome: enabled } });
+      },
+
+      setReadingWidth: (width) => {
+        set({ layout: { ...get().layout, readingWidth: width } });
       },
 
       resetLayoutCustomization: () => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -501,10 +501,14 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
                       isFullscreen={isEditorFullscreen}
                       onToggleFullscreen={handleToggleFullscreen}
                       onCustomizeLayout={handleOpenLayoutSettings}
-                      // Centered reading column when prose owns the full width
-                      // (write); fill the pane edge-to-edge when sharing with
-                      // the canvas (split).
-                      presentation={regions.split ? 'docked' : 'reading'}
+                      // Centered reading column whenever prose is the primary
+                      // region — write AND split. Keyed on the region's role,
+                      // not on `regions.split` (a pane-count boolean): the
+                      // measure is now `min(100%, …)`, so in a split pane it
+                      // simply resolves to the pane width and contributes
+                      // gutters rather than a cap. Gating on the pane count
+                      // instead left split prose flush against both edges.
+                      presentation={regions.primary === 'document' ? 'reading' : 'docked'}
                     />
                   </Suspense>
                 </ErrorBoundary>

--- a/src/ui/DocumentEditorPanel.css
+++ b/src/ui/DocumentEditorPanel.css
@@ -95,15 +95,39 @@
   background: var(--bg-hover);
 }
 
+/* The reading measure — the one knob. `[data-reading-width]` is set from the
+ * app-level `layout.readingWidth` preference (see `ReadingWidth` in
+ * layout/types.ts). A new named width is a block here plus an entry there; a
+ * future page-oriented mode would additionally override `--reading-gutter` and
+ * add page dimensions, without changing the structure. */
+.document-editor-panel {
+  --reading-measure: 52rem;
+  /* Fluid gutter. The percentage resolves against the *containing block* — the
+   * pane — so it is container-relative without `container-type`, which would
+   * apply layout containment and make this element a containing block for the
+   * prose toolbar's absolutely-positioned popovers. */
+  --reading-gutter: clamp(var(--space-4), 4%, var(--space-8));
+}
+
+.document-editor-panel[data-reading-width='wide'] {
+  --reading-measure: 64rem;
+}
+
 /* Centered reading column — shared by full-screen mode and the `reading`
- * presentation (Relaxed write/split). Fluid so it adapts to viewport size and
- * the future mobile layout; capped at a comfortable measure on wide screens. */
+ * presentation (Relaxed write *and* split).
+ *
+ * `min(100%, …)` rather than a `clamp()` with a lower bound: the previous
+ * `clamp(36rem, 60vw, 52rem)` put a 576px *floor* on a max-width, so in any
+ * pane narrower than that the content box exceeded its container and was
+ * clipped by the panel's `overflow: hidden`. It also measured `60vw` — the
+ * viewport, not the pane — so the same declaration meant different things in
+ * a full-width region and a split one. */
 .document-editor-panel.fullscreen .document-editor-panel-content,
 .document-editor-panel.reading .document-editor-panel-content {
-  max-width: clamp(36rem, 60vw, 52rem);
+  max-width: min(100%, var(--reading-measure));
   margin: 0 auto;
   width: 100%;
-  padding: 0 var(--space-8);
+  padding: 0 var(--reading-gutter);
 }
 
 /* Full-screen mode */
@@ -115,14 +139,12 @@
   animation: editor-fullscreen-in 0.25s ease-out;
 }
 
-/* On a narrow viewport the reading column uses the full width (no room for
- * generous side gutters). */
-@media (max-width: 640px) {
-  .document-editor-panel.reading .document-editor-panel-content {
-    max-width: 100%;
-    padding: 0 var(--space-4);
-  }
-}
+/* (A `@media (max-width: 640px)` override used to relax the column on narrow
+ * screens. It is gone because both halves are now inherent: `min(100%, …)`
+ * never exceeds the pane, and `--reading-gutter` shrinks on its own. It was
+ * also keyed to the *viewport* while listing only `.reading` — so it missed
+ * `.fullscreen` entirely, and never fired for a narrow *pane* inside a wide
+ * window, which is exactly the split case.) */
 
 @keyframes editor-fullscreen-in {
   from {

--- a/src/ui/DocumentEditorPanel.tsx
+++ b/src/ui/DocumentEditorPanel.tsx
@@ -16,6 +16,7 @@ import { history } from 'prosemirror-history';
 import { DocumentEditorToolbar } from './DocumentEditorToolbar';
 import { MobileProseToolbar } from './mobile/MobileProseToolbar';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
 import { useKeyboardInset } from './mobile/useKeyboardInset';
 import { TiptapEditor } from './TiptapEditor';
 import { resolveBlobImagesIn } from './proseBlobImages';
@@ -103,6 +104,7 @@ export function DocumentEditorPanel({
   presentation = 'docked',
 }: DocumentEditorPanelProps) {
   const { mobileActive } = useMobileAdaptation();
+  const readingWidth = useUIPreferencesStore((s) => s.layout.readingWidth);
   // Reserve the on-screen keyboard's height as panel padding so the mobile
   // bottom toolbar (last flex child) rides above the keyboard (JP-332).
   const keyboardInset = useKeyboardInset();
@@ -599,6 +601,10 @@ export function DocumentEditorPanel({
         className={`document-editor-panel ${isFullscreen ? 'fullscreen' : ''} ${
           presentation === 'reading' ? 'reading' : ''
         }`}
+        // Scoped to this subtree rather than stamped on <html>: the measure only
+        // affects the reading column, so it needs no global side effect and stays
+        // trivially testable.
+        data-reading-width={readingWidth}
         style={mobileActive && keyboardInset > 0 ? { paddingBottom: keyboardInset } : undefined}
       >
         <RichTextTabBar trailing={trailing} />

--- a/src/ui/TiptapEditor.css
+++ b/src/ui/TiptapEditor.css
@@ -339,8 +339,8 @@
    `width: 100%` + `table-layout: fixed` is the known-good geometry — columns get
    real, equal widths so posAtCoords can tell laterally-adjacent cells apart (a
    `max-content` width collapsed columns and broke lateral multi-cell selection).
-   The `.tableWrapper`'s `overflow-x: auto` still lets a resized-wider table
-   scroll. Fuller anti-cramping is JP-416 item 6 follow-up. */
+   Both are load-bearing; the anti-cramping fix below deliberately leaves them
+   alone. */
 .tiptap-editor .ProseMirror table {
   border-collapse: separate;
   border-spacing: 0;
@@ -349,6 +349,38 @@
   width: 100%;
   table-layout: fixed;
   overflow: hidden;
+}
+
+/* Anti-cramping (JP-484, the JP-416 item 6 follow-up).
+ *
+ * The floor goes on the COLUMN, not the cell and not the table. Under
+ * `table-layout: fixed` the browser sizes the table from the column definitions
+ * alone — it ignores cell `min-width` and cell content — so a floor on `td`/`th`
+ * lets the columns shrink anyway, and a floor on the table redistributes badly
+ * (a sized column keeps its width while the extra lands on the wrong columns).
+ * Flooring `<col>` raises the table's own width instead, which is what finally
+ * gives `.tableWrapper`'s `overflow-x: auto` something to scroll.
+ *
+ * This preserves the geometry above, and it preserves stored column widths: an
+ * explicit `colwidth` is written as an inline `width`, which the floor leaves
+ * alone whenever it is the larger of the two — so a resized column is untouched.
+ *
+ * `!important` is load-bearing, not a shortcut. Tiptap writes its own
+ * `min-width: 25px` as an INLINE style on every unsized `<col>`, and an inline
+ * declaration outranks any selector specificity — those are exactly the columns
+ * that crush, so without `!important` this rule is silently inert (it applies
+ * only to the sized columns, which never needed it). Verified in the DOM:
+ * unsized cols carry `style="min-width: 25px"`.
+ *
+ * Consequence worth knowing: this is a floor for ALL columns, so dragging a
+ * column narrower than `--table-min-col` snaps back. That is the intended
+ * trade — a sub-120px column is the cramping this fixes. */
+.tiptap-editor {
+  --table-min-col: 7.5rem;
+}
+
+.tiptap-editor .ProseMirror table colgroup col {
+  min-width: var(--table-min-col) !important;
 }
 
 /* The wrapper owns the vertical margin now. */

--- a/src/ui/layout/types.ts
+++ b/src/ui/layout/types.ts
@@ -69,7 +69,41 @@ export interface LayoutState {
    * because native decorations are the safest cross-platform path.
    */
   customChrome: boolean;
+  /**
+   * How wide the prose reading column may grow. App-level like `defaultMode`.
+   *
+   * Additive: the store's `merge` spreads `initialLayoutState` first, so state
+   * persisted before this field existed hydrates with the default and needs no
+   * migration.
+   */
+  readingWidth: ReadingWidth;
 }
+
+/**
+ * Named widths for the prose reading column.
+ *
+ * Each value maps to a `--reading-measure` override keyed off
+ * `[data-reading-width]` in `DocumentEditorPanel.css` — the measure is the only
+ * thing a value has to supply, so adding one is a CSS block plus an entry here.
+ * That is the extension point for a future page-oriented mode (per-page feel,
+ * print/PDF-exact content flow), which would additionally override the gutter
+ * and page dimensions rather than change any of this structure.
+ */
+export type ReadingWidth = 'normal' | 'wide';
+
+/** Ordered tuple of the reading widths, for settings UI and tests. */
+export const READING_WIDTHS: readonly ReadingWidth[] = ['normal', 'wide'] as const;
+
+/** Human-readable labels + one-line rationale for the settings UI. */
+export const READING_WIDTH_LABELS: Record<ReadingWidth, string> = {
+  normal: 'Normal',
+  wide: 'Wide',
+};
+
+export const READING_WIDTH_DESCRIPTIONS: Record<ReadingWidth, string> = {
+  normal: 'A comfortable measure for reading. Best on laptop screens.',
+  wide: 'Longer lines with less empty space. Best on large or ultrawide displays.',
+};
 
 /** Ordered tuple of all known layouts, useful for selectors and tests. */
 export const LAYOUT_MODES: readonly LayoutMode[] = [

--- a/src/ui/proseContentFlow.test.ts
+++ b/src/ui/proseContentFlow.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { useUIPreferencesStore } from '../store/uiPreferencesStore';
+import { READING_WIDTHS } from './layout/types';
+
+/**
+ * JP-484. Two content-flow contracts that are invisible in code review and
+ * silently regress if someone tidies the CSS.
+ *
+ * jsdom performs no layout, so these assert the declarations rather than the
+ * resulting geometry (which was measured live in the browser instead).
+ */
+
+function ruleBody(css: string, selector: string): string {
+  const start = css.indexOf(`\n${selector} {`);
+  expect(start, `selector ${selector} not found`).toBeGreaterThan(-1);
+  const open = css.indexOf('{', start);
+  return css.slice(open + 1, css.indexOf('}', open));
+}
+
+describe('prose table anti-cramping', () => {
+  const css = readFileSync(resolve(process.cwd(), 'src/ui/TiptapEditor.css'), 'utf8');
+  const colRule = ruleBody(css, '.tiptap-editor .ProseMirror table colgroup col');
+
+  it('floors the column, which is the only lever `table-layout: fixed` reads', () => {
+    // Under fixed layout the browser sizes the table from the column
+    // definitions alone — a floor on `td`/`th` lets columns shrink anyway.
+    expect(colRule).toMatch(/min-width:\s*var\(--table-min-col\)/);
+    expect(css).toMatch(/--table-min-col:\s*[\d.]+rem/);
+  });
+
+  it('keeps `!important`, without which the rule is inert', () => {
+    // Tiptap writes `min-width: 25px` as an INLINE style on every unsized
+    // <col>, and inline beats any selector specificity. Those are exactly the
+    // columns that crush, so dropping `!important` silently restores the bug
+    // while the rule still appears to be doing something.
+    expect(colRule).toMatch(/min-width:[^;]*!important/);
+  });
+
+  it('leaves the load-bearing table geometry alone', () => {
+    // `width: 100%` + `table-layout: fixed` is required for posAtCoords to tell
+    // laterally-adjacent cells apart; a `max-content` width broke lateral
+    // multi-cell selection.
+    const tableRule = ruleBody(css, '.tiptap-editor .ProseMirror table');
+    expect(tableRule).toMatch(/table-layout:\s*fixed/);
+    expect(tableRule).toMatch(/width:\s*100%/);
+  });
+
+  it('keeps the wrapper as the scroll container', () => {
+    expect(ruleBody(css, '.tiptap-editor .ProseMirror .tableWrapper')).toMatch(/overflow-x:\s*auto/);
+  });
+});
+
+describe('reading measure', () => {
+  const css = readFileSync(resolve(process.cwd(), 'src/ui/DocumentEditorPanel.css'), 'utf8');
+  const readingRule = ruleBody(
+    css,
+    '.document-editor-panel.fullscreen .document-editor-panel-content,\n.document-editor-panel.reading .document-editor-panel-content'
+  );
+
+  it('never lets the column exceed its pane', () => {
+    // The previous `clamp(36rem, 60vw, 52rem)` put a 576px *floor* on a
+    // max-width, so any pane narrower than that overflowed and was clipped.
+    expect(readingRule).toMatch(/max-width:\s*min\(100%,\s*var\(--reading-measure\)\)/);
+  });
+
+  it('measures the pane, not the viewport', () => {
+    // `vw` resolves against the window, so the same declaration meant different
+    // things in a full-width region and a split one.
+    expect(readingRule).not.toMatch(/\dvw/);
+  });
+
+  it('declares a measure for every named reading width', () => {
+    expect(css).toMatch(/\.document-editor-panel\s*\{[^}]*--reading-measure:/);
+    for (const width of READING_WIDTHS) {
+      if (width === 'normal') continue; // the base declaration is the default
+      expect(css).toMatch(
+        new RegExp(`\\[data-reading-width=['"]${width}['"]\\][^{]*\\{[^}]*--reading-measure:`)
+      );
+    }
+  });
+});
+
+describe('readingWidth preference', () => {
+  beforeEach(() => {
+    useUIPreferencesStore.setState((s) => ({ layout: { ...s.layout, readingWidth: 'normal' } }));
+  });
+
+  it('defaults to normal', () => {
+    expect(useUIPreferencesStore.getState().layout.readingWidth).toBe('normal');
+  });
+
+  it('round-trips every named width without disturbing the rest of the slice', () => {
+    const before = useUIPreferencesStore.getState().layout;
+    for (const width of READING_WIDTHS) {
+      useUIPreferencesStore.getState().setReadingWidth(width);
+      const after = useUIPreferencesStore.getState().layout;
+      expect(after.readingWidth).toBe(width);
+      expect(after.defaultMode).toBe(before.defaultMode);
+      expect(after.customChrome).toBe(before.customChrome);
+      expect(after.modeOverrides).toEqual(before.modeOverrides);
+    }
+  });
+});

--- a/src/ui/settings/LayoutSettings.css
+++ b/src/ui/settings/LayoutSettings.css
@@ -143,3 +143,46 @@
 .layout-settings-reset:hover {
   background: var(--bg-tertiary, var(--bg-secondary));
 }
+
+/* Reading width — same option-card affordance as the default-layout picker,
+   minus the thumbnail (there is nothing structural to preview; the difference
+   is a measure). Left-aligned rather than centered because these read as two
+   text choices, not two diagrams. */
+.layout-settings-section-hint {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.layout-settings-reading-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.layout-settings-reading-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  cursor: pointer;
+}
+
+.layout-settings-reading-option input[type='radio'] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.layout-settings-reading-option.active {
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
+}
+
+.layout-settings-reading-option .layout-settings-default-text {
+  text-align: left;
+}

--- a/src/ui/settings/LayoutSettings.tsx
+++ b/src/ui/settings/LayoutSettings.tsx
@@ -12,7 +12,17 @@ import {
   LAYOUT_PRESETS,
   resolvePanelState,
 } from '../layout/modes';
-import { LAYOUT_MODES, PANEL_IDS, type DockSide, type LayoutMode, type PanelId, type PanelState } from '../layout/types';
+import {
+  LAYOUT_MODES,
+  PANEL_IDS,
+  READING_WIDTHS,
+  READING_WIDTH_DESCRIPTIONS,
+  READING_WIDTH_LABELS,
+  type DockSide,
+  type LayoutMode,
+  type PanelId,
+  type PanelState,
+} from '../layout/types';
 import { LayoutThumbnail } from '../layout/LayoutThumbnail';
 import './LayoutSettings.css';
 
@@ -44,6 +54,7 @@ export function LayoutSettings({ embedded = false }: LayoutSettingsProps = {}) {
   const setPanelVisibleFor = useUIPreferencesStore((s) => s.setPanelVisibleFor);
   const togglePinFor = useUIPreferencesStore((s) => s.togglePinFor);
   const resetLayoutCustomization = useUIPreferencesStore((s) => s.resetLayoutCustomization);
+  const setReadingWidth = useUIPreferencesStore((s) => s.setReadingWidth);
 
   const handleReset = () => {
     const ok = window.confirm(
@@ -79,6 +90,36 @@ export function LayoutSettings({ embedded = false }: LayoutSettingsProps = {}) {
               <div className="layout-settings-default-text">
                 <div className="layout-settings-default-name">{LAYOUT_LABELS[mode]}</div>
                 <div className="layout-settings-default-desc">{LAYOUT_DESCRIPTIONS[mode]}</div>
+              </div>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      <section className="layout-settings-section">
+        <h4>Reading width</h4>
+        <p className="layout-settings-section-hint">
+          How wide the writing column grows before it stops. Applies wherever
+          prose is the main region, including alongside the canvas.
+        </p>
+        <div className="layout-settings-reading-row">
+          {READING_WIDTHS.map((width) => (
+            <label
+              key={width}
+              className={`layout-settings-reading-option ${layout.readingWidth === width ? 'active' : ''}`}
+            >
+              <input
+                type="radio"
+                name="reading-width"
+                value={width}
+                checked={layout.readingWidth === width}
+                onChange={() => setReadingWidth(width)}
+              />
+              <div className="layout-settings-default-text">
+                <div className="layout-settings-default-name">{READING_WIDTH_LABELS[width]}</div>
+                <div className="layout-settings-default-desc">
+                  {READING_WIDTH_DESCRIPTIONS[width]}
+                </div>
               </div>
             </label>
           ))}


### PR DESCRIPTION
Two content-flow defects in the prose editor, both diagnosed by measuring the
live DOM rather than reading the CSS.

Closes JP-484

## 1. Tables squeezed instead of scrolling

Two faults, not one:

- `.tiptap-editor .ProseMirror table` set `width: 100%`, so a table with no
  stored column widths could never exceed its container — `.tableWrapper`'s
  `overflow-x: auto` was **dead code**, with nothing to scroll.
- `table-layout: fixed` sizes the table from the **column definitions alone** —
  it ignores cell `min-width` and cell content — so the columns absorbed the
  squeeze instead of the table growing. Unsized columns fell back to Tiptap's
  `min-width: 25px`, which wraps text one character per line.

### The floor goes on the column

Not the cell (ignored outright under fixed layout) and not the table (slack
lands on the wrong columns — a sized column keeps its width). Flooring `<col>`
raises the table's own width, which is what finally gives the wrapper something
to scroll.

Measured at a 509px pane on a real 4-column table with stored widths
`343 / 25 / 131 / 25`:

| | table | scrolls | cells |
|---|---|---|---|
| before | 526px | yes, but | `[343, `**`25`**`, 131, `**`25`**`]` |
| after | 716px | yes | `[343, 120, 131, 120]` |

Stored widths survive exactly; only unsized columns move. The roomy case is
unchanged — a table that already fits still fills the column with no scrollbar.

`table-layout: fixed` and `width: 100%` are **untouched**. Both are load-bearing
for `posAtCoords` lateral multi-cell selection, per the comment already sitting
above them; a `max-content` width previously broke that.

### `!important` is load-bearing here

Tiptap writes its `min-width: 25px` as an **inline style** on unsized `<col>`
elements, and inline outranks any selector specificity. Without `!important` the
rule applies only to the *sized* columns — which never needed it — and is
silently inert on exactly the ones that crush.

I shipped it without `!important` first and the DOM proved it did nothing:

```
{ inlineStyle: "width: 343px;",    computedMinW: "120px" }   <- rule applied, irrelevant
{ inlineStyle: "min-width: 25px;", computedMinW: "25px"  }   <- rule lost, this is the bug
```

There is a test pinning it, because "remove the stray `!important`" is exactly
what a future tidy-up does.

**Trade-off:** this is a floor for *all* columns, so dragging one narrower than
`--table-min-col` (7.5rem) snaps back. That is intended — a sub-120px column is
the cramping being fixed — and the token makes it a one-line change.

## 2. The reading column was all-or-nothing

Measured in Relaxed at a 1208px viewport:

| | Write | Split |
|---|---|---|
| panel | 1208 (full) | 604 (half) |
| content `max-width` | 724.8px | **none** |
| gutters | 32px | **0** |
| text width | ~614px | ~557px |

`App.tsx` gated presentation on `regions.split` — a **pane-count boolean** —
so Write got clamp + gutters and Split got neither. It is keyed on the region's
role now, which is what `DocumentEditorPanel.css:98` already documented
("Relaxed write/split"), contradicting the `App.tsx` comment. The intent was
never settled; this settles it.

### The value had to change with the condition

`clamp(36rem, 60vw, 52rem)` carried two latent bugs that would have bitten the
moment Split got the treatment:

- a **576px floor on a `max-width`** — in any pane narrower than that the
  content box exceeds its container and is clipped by the panel's
  `overflow: hidden`. A 604px split pane sails close; a 320px one fails hard.
- **`60vw` measures the viewport, not the pane**, so one declaration meant two
  different things depending on the region.

Now `min(100%, var(--reading-measure))` with a percentage-based gutter —
container-relative **without** `container-type`, which would apply layout
containment and make the panel a containing block for the prose toolbar's
absolutely-positioned popovers.

That also retires the `@media (max-width: 640px)` override: both halves are now
inherent, and it was keyed to the viewport while listing only `.reading`, so it
missed `.fullscreen` entirely and never fired for a narrow pane in a wide window.

## 3. The measure is a knob, not a new magic number

`normal` / `wide`, app-level on the `layout` slice, surfaced in
**Settings → Layout → Reading width**, applied via `[data-reading-width]`
scoped to the panel subtree rather than stamped on `<html>` (no global side
effect, trivially testable).

Adding a width is a CSS block plus an entry in `ReadingWidth`. A future
page-oriented mode — per-page feel, print/PDF-exact content flow — slots in as
another value that additionally overrides the gutter and adds page dimensions,
with no structural change.

Additive field: the store's hand-rolled `merge` spreads `initialLayoutState`
first, so state persisted before this field existed hydrates with the default.
No migration, no store version bump.

## Verification

Measured live, before and after:

| | content | text | gutter |
|---|---|---|---|
| Write / normal | 725 → **832px** | 614 → **721px** | 32px |
| Write / wide | **1024px** | **913px** | 32px |
| Split | flush → **604px** | 509px | 0 → **24.2px** (fluid) |
| 320px pane | **fits** (overflowed at the old 576px floor) | — | **16px** |

Plus: `data-reading-width` round-trips; tables scroll in Split and stay
unchanged when they fit; persisted state without the new field hydrates cleanly.

`typecheck` clean, `build` clean, **3426 tests pass** (291 files). New
`proseContentFlow.test.ts` pins the CSS contracts that regress invisibly — the
`!important`, the column-not-cell floor, `min(100%, …)`, no `vw`, and the
load-bearing table geometry. Each guard was verified to actually fail when the
rule is reverted.

`docs-site/guide/layout-modes.md` updated in the same PR per the
user-facing-settings rule.

## Notes

- `pdfExportUtils.ts` computes its own table column widths from `colwidth` and
  is unaffected by CSS — since stored widths are preserved, editor and PDF stay
  consistent rather than drifting.
- All three prose surfaces (editor, collaborative editor, read-only preview)
  share `TiptapEditor.css`, so the table fix reaches all of them.

Assisted-by: Opus 5