### PR TITLE
JP-486: a status bar that fits the screen it's on

### DIFF
--- a/docs-site/getting-started/interface-tour.md
+++ b/docs-site/getting-started/interface-tour.md
@@ -95,6 +95,13 @@ The bottom bar shows you:
 - **Active tool** name
 - **Connection status** when collaborating (🟢 Connected, 🟡 Reconnecting, 🔴 Offline)
 
+On a small screen or a touch device the bar reduces to what still applies there:
+the zoom controls whenever a canvas is on screen, plus connection status. Mouse
+coordinates, shape count and the tool name are left out — the first has no
+meaning without a hovering pointer, and the others cost more width than they
+earn. When you're writing with no canvas in view and there's nothing to report,
+the bar steps aside entirely and returns the space to the page.
+
 ## Keyboard Quick Reference
 
 These are the shortcuts you'll use most often:

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,7 +6,12 @@ import { PropertyPanel } from './PropertyPanel';
 import { LayerPanel } from './LayerPanel';
 import { NavigatorPanel } from './NavigatorPanel';
 import { useActivePanelState, useActiveLayoutMode, useLayoutActions } from './layout/useLayout';
-import { isFlyoutLayout, propertiesDockedVisible, resolveRegions } from './layout/modes';
+import {
+  isCanvasHidden,
+  isFlyoutLayout,
+  propertiesDockedVisible,
+  resolveRegions,
+} from './layout/modes';
 import { useBreakpoint } from './layout/useBreakpoint';
 import { useMobileAdaptation } from './layout/useMobileAdaptation';
 import { MobilePreviewGate } from './mobile/MobilePreviewGate';
@@ -175,7 +180,9 @@ function App({ authCallbackConsumed = false }: { authCallbackConsumed?: boolean 
   // remounts on a layout switch). In Relaxed it becomes a resizable secondary
   // pane in split focus, or hides in write focus; elsewhere it stays dominant.
   const canvasIsSecondary = isRelaxed && regions.primary === 'document' && regions.split;
-  const canvasIsHidden = isRelaxed && regions.primary === 'document' && !regions.split;
+  // Shared with StatusBar, which drops its canvas-only readouts when the canvas
+  // is hidden — the two must agree on what "no canvas" means.
+  const canvasIsHidden = isCanvasHidden(activeMode, relaxedFocus, band);
   const relaxedSplitCanvasWidth = useUIPreferencesStore((s) => s.relaxedSplitCanvasWidth);
   const canvasWrapperClass = [
     'canvas-area-wrapper',

--- a/src/ui/StatusBar.compact.test.tsx
+++ b/src/ui/StatusBar.compact.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * StatusBar responsive + focus-aware behaviour (JP-486).
+ *
+ * The bar used to render every readout unconditionally at a fixed 24px, which
+ * on a 375px viewport overflowed its own width by ~57px — the active tool name
+ * ended up off-screen entirely. These tests pin the two decisions that fixed it:
+ * *what* renders at each viewport, and that a bar with nothing left to say
+ * removes itself instead of holding an empty strip.
+ *
+ * `useBreakpoint` and `useActiveLayoutMode` are mocked because jsdom reports no
+ * meaningful viewport band or pointer type; the layout mode is mocked to keep
+ * this isolated from the persisted uiPreferences store.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { LayoutMode } from './layout/types';
+import type { BreakpointState } from './layout/useBreakpoint';
+
+let breakpoint: BreakpointState = { band: 'wide', isTouch: false, standalone: false };
+let layoutMode: LayoutMode = 'relaxed';
+let offline = false;
+
+vi.mock('./layout/useBreakpoint', () => ({
+  useBreakpoint: () => breakpoint,
+}));
+vi.mock('./layout/useLayout', () => ({
+  useActiveLayoutMode: () => layoutMode,
+}));
+vi.mock('../collaboration/sharedDocOffline', () => ({
+  useSharedDocOffline: () => offline,
+}));
+
+import { StatusBar } from './StatusBar';
+import { useSessionStore } from '../store/sessionStore';
+import { useConnectionStore } from '../store/connectionStore';
+
+/** The zoom cluster's presence tell — `Fit` is unambiguous, unlike "100%". */
+const zoomCluster = () => screen.queryByTitle('Fit to center');
+const coordinates = () => screen.queryByText('X:');
+const shapeCount = () => screen.queryByText('Shapes:');
+
+describe('StatusBar responsive behaviour (JP-486)', () => {
+  beforeEach(() => {
+    cleanup();
+    useConnectionStore.getState().reset();
+    useSessionStore.getState().setRelaxedFocus('write');
+    useSessionStore.getState().setEditingGroupId(null);
+    breakpoint = { band: 'wide', isTouch: false, standalone: false };
+    layoutMode = 'relaxed';
+    offline = false;
+  });
+
+  describe('regular viewport — unchanged', () => {
+    it('renders every readout, including in write focus', () => {
+      render(<StatusBar />);
+      expect(coordinates()).toBeTruthy();
+      expect(shapeCount()).toBeTruthy();
+      expect(zoomCluster()).toBeTruthy();
+    });
+  });
+
+  describe('compact viewport', () => {
+    it('drops coordinates and shape count when a canvas IS visible', () => {
+      breakpoint = { band: 'narrow', isTouch: false, standalone: false };
+      useSessionStore.getState().setRelaxedFocus('diagram');
+      render(<StatusBar />);
+
+      // The zoom cluster steers a canvas that is on screen, so it stays.
+      expect(zoomCluster()).toBeTruthy();
+      // These are what the old fixed layout pushed off the right edge.
+      expect(coordinates()).toBeNull();
+      expect(shapeCount()).toBeNull();
+    });
+
+    it('drops the zoom cluster in write focus — there is no canvas to steer', () => {
+      breakpoint = { band: 'narrow', isTouch: false, standalone: false };
+      offline = true;
+      useConnectionStore.getState().setStatus('disconnected');
+      render(<StatusBar />);
+
+      expect(zoomCluster()).toBeNull();
+      // The connection chip is the one readout that matters *more* on mobile.
+      expect(screen.getByText('Offline')).toBeTruthy();
+    });
+
+    it('removes itself entirely when nothing is left to report', () => {
+      breakpoint = { band: 'narrow', isTouch: false, standalone: false };
+      // write focus (no canvas) + online + no drill-down + no blob sync
+      const { container } = render(<StatusBar />);
+      expect(container.querySelector('.status-bar')).toBeNull();
+    });
+
+    it('reappears for ambient state even with no canvas', () => {
+      breakpoint = { band: 'narrow', isTouch: false, standalone: false };
+      useSessionStore.getState().setEditingGroupId('group-1');
+      const { container } = render(<StatusBar />);
+
+      expect(container.querySelector('.status-bar')).toBeTruthy();
+      expect(screen.getByText('In group')).toBeTruthy();
+      expect(zoomCluster()).toBeNull();
+    });
+
+    it('treats a touch device as compact even at a medium band', () => {
+      // A tablet in landscape clears 640px but still has no hover and needs
+      // finger-sized targets, so it must not fall back to the desktop bar.
+      breakpoint = { band: 'medium', isTouch: true, standalone: false };
+      useSessionStore.getState().setRelaxedFocus('diagram');
+      render(<StatusBar />);
+
+      expect(coordinates()).toBeNull();
+      expect(zoomCluster()).toBeTruthy();
+    });
+  });
+
+  describe('non-Relaxed layouts', () => {
+    it('keeps the zoom cluster on a compact viewport — the canvas is always present', () => {
+      breakpoint = { band: 'narrow', isTouch: true, standalone: false };
+      layoutMode = 'designer';
+      // Focus is a Relaxed-only concept; a stale value must not hide the canvas.
+      useSessionStore.getState().setRelaxedFocus('write');
+      render(<StatusBar />);
+
+      expect(zoomCluster()).toBeTruthy();
+      expect(coordinates()).toBeNull();
+    });
+  });
+});

--- a/src/ui/StatusBar.css
+++ b/src/ui/StatusBar.css
@@ -9,6 +9,14 @@
   border-top: 1px solid var(--border-color);
   font-size: var(--font-size-xs);
   color: var(--text-secondary);
+  /* Backstop (JP-486): this bar shipped for a long time overflowing its own
+     width on a narrow viewport, silently pushing the active tool name and part
+     of the Fit button past the right edge where nothing could reach them.
+     Clipping is not a fix for that — the responsive rules at the bottom of this
+     file are — but it guarantees a future addition fails visibly, inside the
+     bar, instead of escaping the viewport unnoticed. */
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Sections */
@@ -222,4 +230,72 @@
 
 [data-theme="dark"] .status-bar-btn:hover {
   background: var(--bg-hover);
+}
+
+/* ---------------------------------------------------------------------------
+   Responsive + touch (JP-486)
+
+   Two independent axes, kept separate on purpose:
+
+   - WIDTH (`max-width: 640px`, the `--bp-compact` value) — stop overflowing.
+     The structural cause was the fixed `min-width: 120px` floors on the outer
+     sections: 120 + zoom cluster + 120 exceeded a 375px viewport before any
+     content was measured. A narrow *mouse* window needs this and nothing else;
+     it must not become chunky.
+   - INPUT (`pointer: coarse`) — size the targets for a finger. The bar's own
+     24px height is the binding constraint, so it grows too.
+
+   Which readouts render at all is decided in StatusBar.tsx, not here; these
+   rules only handle the geometry. Placed last so they win on source order.
+   ------------------------------------------------------------------------ */
+
+@media (max-width: 640px) {
+  .status-bar-left,
+  .status-bar-right {
+    min-width: 0;
+  }
+
+  /* The connection chip is the one thing that may still need to give ground;
+     it carries a `title`, so a truncated label stays recoverable. */
+  .status-bar-right {
+    overflow: hidden;
+  }
+
+  .status-bar-conn {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+/* The compact bar drops its outer sections, so `space-between` can leave a lone
+   cluster hugging one edge. A gap keeps whatever remains from touching. */
+.status-bar--compact {
+  gap: var(--space-2);
+}
+
+@media (pointer: coarse) {
+  .status-bar {
+    height: 44px;
+  }
+
+  /* 44px is the touch-target size already adopted for the Relaxed focus
+     segments; matching it keeps one answer in the codebase rather than two. */
+  .status-bar-zoom-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .status-bar-btn {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0 var(--space-3);
+  }
+
+  /* Text scaled for a 24px strip is too small to read at arm's length. */
+  .status-bar-zoom-value,
+  .status-bar-value {
+    font-size: var(--font-size-sm);
+  }
 }

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -5,6 +5,27 @@
  * - Zoom level with quick controls
  * - Shape count
  * - Current active tool
+ *
+ * Responsive behaviour (JP-486). Almost everything here is *canvas* status, and
+ * the bar used to render all of it unconditionally at a fixed 24px — which on a
+ * 375px viewport overflowed its own width by ~57px, pushing the active tool name
+ * off-screen entirely, with controls far below any touch-target minimum.
+ *
+ * Two independent signals fix that, deliberately governing different things so
+ * they cannot drift:
+ *
+ * - **Content** is decided here, from `useBreakpoint` — a narrow viewport or a
+ *   touch device drops the readouts that are dead (cursor coordinates never
+ *   populate without a hover) or unaffordable (shape count, tool name).
+ * - **Sizing** is decided in StatusBar.css under `@media (pointer: coarse)`,
+ *   the same convention RelaxedFocusControl/resizeHandle/ColorPicker already use.
+ *
+ * On top of that the bar is *focus-aware*: Relaxed's `write` focus renders no
+ * canvas at all, so a zoom cluster there would steer a viewport that isn't on
+ * screen. With nothing left worth showing, the bar removes itself rather than
+ * hold 24px for an empty strip — the same self-hiding contract as
+ * FloatingCollabIndicator. It reappears the moment something ambient and
+ * consequential happens (offline, group drill-down, blob sync).
  */
 
 import { useCallback, useMemo } from 'react';
@@ -14,6 +35,9 @@ import { useDocumentStore } from '../store/documentStore';
 import { useConnectionStore } from '../store/connectionStore';
 import { useSharedDocOffline } from '../collaboration/sharedDocOffline';
 import { calculateCombinedBounds } from '../shapes/utils/bounds';
+import { useBreakpoint } from './layout/useBreakpoint';
+import { useActiveLayoutMode } from './layout/useLayout';
+import { isCanvasHidden } from './layout/modes';
 import { Icon } from './icons';
 import './StatusBar.css';
 
@@ -40,10 +64,31 @@ const ZOOM_PRESETS = [0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4];
  * StatusBar component.
  */
 export function StatusBar() {
+  // Narrow viewport or coarse pointer → the reduced bar. `isTouch` is included
+  // so a tablet in landscape (a `medium` band) still gets finger-sized targets.
+  const { band, isTouch } = useBreakpoint();
+  const compact = band === 'narrow' || isTouch;
+
+  // Is there a canvas on screen to report on? Shared with App via the same pure
+  // helper so the two cannot disagree about what "no canvas" means.
+  const activeMode = useActiveLayoutMode();
+  const relaxedFocus = useSessionStore((state) => state.relaxedFocus);
+  const canvasHidden = isCanvasHidden(activeMode, relaxedFocus, band);
+
+  const showCoords = !compact;
+  const showCounts = !compact;
+  const showZoom = !compact || !canvasHidden;
+
   const camera = useSessionStore((state) => state.camera);
   const setCamera = useSessionStore((state) => state.setCamera);
   const activeTool = useSessionStore((state) => state.activeTool);
-  const cursorWorldPosition = useSessionStore((state) => state.cursorWorldPosition);
+  // The coordinate readout is the *only* consumer of `cursorWorldPosition`,
+  // which Engine.handlePointerEvent writes on every normalized pointer event.
+  // Selecting a constant when it isn't rendered means the subscription can no
+  // longer re-render this bar on every pointer move.
+  const cursorWorldPosition = useSessionStore((state) =>
+    showCoords ? state.cursorWorldPosition : null
+  );
   const blobSyncProgress = useSessionStore((state) => state.blobSyncProgress);
   const editingGroupId = useSessionStore((state) => state.editingGroupId);
   const setEditingGroupId = useSessionStore((state) => state.setEditingGroupId);
@@ -97,10 +142,24 @@ export function StatusBar() {
       return;
     }
 
-    // Get viewport size (approximate from document body or use defaults)
-    // StatusBar doesn't have direct access to viewport, so we use window
-    const viewportWidth = window.innerWidth * 0.7; // Approximate canvas width
-    const viewportHeight = window.innerHeight - 100; // Approximate canvas height
+    // Measure the real canvas area. The previous constants (70% of the window
+    // width, height minus 100) hard-coded a desktop shell with side panels
+    // taking the other 30%; wherever the panels are hidden — every mobile
+    // layout, and Designer with the document panel closed — that under-zoomed
+    // by a wide margin. Fall back to the old approximation if the wrapper isn't
+    // mounted (e.g. Relaxed `write` focus, where Fit isn't reachable anyway).
+    //
+    // NOTE: `Camera.zoomToFit(bounds, padding)` already does this correctly from
+    // the camera's own `setViewport` dimensions, but the Camera instance lives
+    // in CanvasContainer's local state and isn't reachable from here without new
+    // plumbing. Worth collapsing onto that once the engine is addressable.
+    const canvasRect = document
+      .querySelector('.canvas-area-wrapper')
+      ?.getBoundingClientRect();
+    const viewportWidth =
+      canvasRect && canvasRect.width > 0 ? canvasRect.width : window.innerWidth * 0.7;
+    const viewportHeight =
+      canvasRect && canvasRect.height > 0 ? canvasRect.height : window.innerHeight - 100;
 
     // Add padding (10% on each side)
     const padding = 0.1;
@@ -129,33 +188,44 @@ export function StatusBar() {
   // Format tool name
   const toolDisplayName = activeTool.charAt(0).toUpperCase() + activeTool.slice(1);
 
-  return (
-    <div className="status-bar">
-      {/* Left Section: Cursor Position */}
-      <div className="status-bar-section status-bar-left">
-        <span className="status-bar-label">X:</span>
-        <span className="status-bar-value">{cursorWorldPosition ? Math.round(cursorWorldPosition.x) : '—'}</span>
-        <span className="status-bar-label">Y:</span>
-        <span className="status-bar-value">{cursorWorldPosition ? Math.round(cursorWorldPosition.y) : '—'}</span>
-      </div>
+  // Everything the reduced bar could still carry is ambient and conditional. If
+  // none of it applies there is nothing to say, so don't hold a strip to say it.
+  const hasAmbient = sharedOffline || editingGroupId !== null || syncStatusText !== null;
+  if (compact && !showZoom && !hasAmbient) return null;
 
-      {/* Center Section: Zoom Controls */}
-      <div className="status-bar-section status-bar-center">
-        <button className="status-bar-zoom-btn" onClick={handleZoomOut} title="Zoom out">
-          -
-        </button>
-        <span className="status-bar-zoom-value">{zoomPercent}%</span>
-        <button className="status-bar-zoom-btn" onClick={handleZoomIn} title="Zoom in">
-          +
-        </button>
-        <div className="status-bar-divider" />
-        <button className="status-bar-btn" onClick={handleZoomFit} title="Fit to center">
-          Fit
-        </button>
-        <button className="status-bar-btn" onClick={handleZoom100} title="Reset to 100%">
-          100%
-        </button>
-      </div>
+  return (
+    <div className={`status-bar${compact ? ' status-bar--compact' : ''}`}>
+      {/* Left Section: Cursor Position. Dropped when compact — a coarse pointer
+          has no hover, so this reads "—" except mid-drag, for a fixed 120px. */}
+      {showCoords && (
+        <div className="status-bar-section status-bar-left">
+          <span className="status-bar-label">X:</span>
+          <span className="status-bar-value">{cursorWorldPosition ? Math.round(cursorWorldPosition.x) : '—'}</span>
+          <span className="status-bar-label">Y:</span>
+          <span className="status-bar-value">{cursorWorldPosition ? Math.round(cursorWorldPosition.y) : '—'}</span>
+        </div>
+      )}
+
+      {/* Center Section: Zoom Controls. Steers the canvas, so it goes wherever
+          the canvas does. */}
+      {showZoom && (
+        <div className="status-bar-section status-bar-center">
+          <button className="status-bar-zoom-btn" onClick={handleZoomOut} title="Zoom out" aria-label="Zoom out">
+            -
+          </button>
+          <span className="status-bar-zoom-value">{zoomPercent}%</span>
+          <button className="status-bar-zoom-btn" onClick={handleZoomIn} title="Zoom in" aria-label="Zoom in">
+            +
+          </button>
+          <div className="status-bar-divider" />
+          <button className="status-bar-btn" onClick={handleZoomFit} title="Fit to center">
+            Fit
+          </button>
+          <button className="status-bar-btn" onClick={handleZoom100} title="Reset to 100%">
+            100%
+          </button>
+        </div>
+      )}
 
       {/* Right Section: Info */}
       <div className="status-bar-section status-bar-right">
@@ -202,12 +272,19 @@ export function StatusBar() {
             <div className="status-bar-divider" />
           </>
         )}
-        <span className="status-bar-info">
-          <span className="status-bar-label">Shapes:</span>
-          <span className="status-bar-value">{shapeCount.toLocaleString()}</span>
-        </span>
-        <div className="status-bar-divider" />
-        <span className="status-bar-tool">{toolDisplayName}</span>
+        {/* Shape count + active tool: reference readouts, not controls. They
+            are the first thing to go when width is scarce — and they were the
+            content the old fixed layout pushed off-screen. */}
+        {showCounts && (
+          <>
+            <span className="status-bar-info">
+              <span className="status-bar-label">Shapes:</span>
+              <span className="status-bar-value">{shapeCount.toLocaleString()}</span>
+            </span>
+            <div className="status-bar-divider" />
+            <span className="status-bar-tool">{toolDisplayName}</span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/ui/layout/modes.test.ts
+++ b/src/ui/layout/modes.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { LAYOUT_PRESETS, primaryRegion, propertiesDockedVisible, resolveRegions } from './modes';
+import {
+  LAYOUT_PRESETS,
+  isCanvasHidden,
+  primaryRegion,
+  propertiesDockedVisible,
+  resolveRegions,
+} from './modes';
 import { LAYOUT_MODES } from './types';
 import type { PanelState } from './types';
 
@@ -33,6 +39,50 @@ describe('resolveRegions', () => {
   it('Relaxed diagram promotes the canvas to primary', () => {
     expect(resolveRegions('relaxed', 'diagram', 'wide')).toEqual({ primary: 'canvas', split: false });
     expect(resolveRegions('relaxed', 'diagram', 'narrow')).toEqual({ primary: 'canvas', split: false });
+  });
+});
+
+describe('isCanvasHidden (JP-486)', () => {
+  it('is false for every non-Relaxed layout — they always render the canvas', () => {
+    for (const mode of LAYOUT_MODES) {
+      if (mode === 'relaxed') continue;
+      // Focus and band are Relaxed-only inputs; no combination may hide it.
+      expect(isCanvasHidden(mode, 'write', 'narrow')).toBe(false);
+      expect(isCanvasHidden(mode, 'split', 'wide')).toBe(false);
+      expect(isCanvasHidden(mode, 'diagram', 'medium')).toBe(false);
+    }
+  });
+
+  it('is true in Relaxed write focus at every band — prose only, no canvas', () => {
+    expect(isCanvasHidden('relaxed', 'write', 'wide')).toBe(true);
+    expect(isCanvasHidden('relaxed', 'write', 'medium')).toBe(true);
+    expect(isCanvasHidden('relaxed', 'write', 'narrow')).toBe(true);
+  });
+
+  it('is false in Relaxed diagram focus — the canvas is the primary region', () => {
+    expect(isCanvasHidden('relaxed', 'diagram', 'wide')).toBe(false);
+    expect(isCanvasHidden('relaxed', 'diagram', 'narrow')).toBe(false);
+  });
+
+  it('tracks split collapsing on narrow: canvas is present only while the split survives', () => {
+    expect(isCanvasHidden('relaxed', 'split', 'wide')).toBe(false);
+    expect(isCanvasHidden('relaxed', 'split', 'medium')).toBe(false);
+    // A narrow viewport forbids the side-by-side split, so the canvas is gone.
+    expect(isCanvasHidden('relaxed', 'split', 'narrow')).toBe(true);
+  });
+
+  it('agrees with resolveRegions across the whole input space', () => {
+    // The helper exists so App and StatusBar cannot drift; pin it to the source
+    // of truth rather than to a second hand-written table.
+    for (const mode of LAYOUT_MODES) {
+      for (const focus of ['write', 'split', 'diagram'] as const) {
+        for (const band of ['narrow', 'medium', 'wide'] as const) {
+          const regions = resolveRegions(mode, focus, band);
+          const expected = regions.primary === 'document' && !regions.split;
+          expect(isCanvasHidden(mode, focus, band)).toBe(expected);
+        }
+      }
+    }
   });
 });
 

--- a/src/ui/layout/modes.ts
+++ b/src/ui/layout/modes.ts
@@ -137,6 +137,24 @@ export function resolveRegions(
   }
 }
 
+/**
+ * Is the canvas absent from the resolved region layout?
+ *
+ * Only Relaxed can hide the canvas outright (`write` focus, or `split` collapsed
+ * to single-pane on a narrow viewport); every other mode always renders it. Kept
+ * here rather than inline at the call sites so `App` (which sizes the editor
+ * regions) and `StatusBar` (which drops canvas-only readouts when there is no
+ * canvas to read out) cannot drift apart.
+ */
+export function isCanvasHidden(
+  mode: LayoutMode,
+  focus: RelaxedFocus,
+  band: ViewportBand
+): boolean {
+  const regions = resolveRegions(mode, focus, band);
+  return regions.primary === 'document' && !regions.split;
+}
+
 /** Human-readable label for a layout mode (UI display). */
 export const LAYOUT_LABELS: Record<LayoutMode, string> = {
   relaxed: 'Relaxed',


### PR DESCRIPTION
Closes JP-486.

The status bar was the only major chrome component with **no responsive or touch treatment at all**. `StatusBar.css` carried no `@media` rule except `prefers-reduced-motion`, and the file appeared in neither the `data-mobile` nor the `pointer: coarse` grep. Everything else adapted around it and it was left behind.

## What was measured

At 375x812 — identical on the plain desktop path and with the mobile shell active:

| Symptom | Before | After |
| -- | -- | -- |
| Bar vs. its own width | `scrollWidth` **432** vs `clientWidth` **375** | **375 = 375**, both focuses |
| Content off-screen | right section ran to x=432; active tool unreachable, `Fit` clipped | nothing clipped |
| Touch targets (WCAG 2.2 AA is 24x24) | 20x18, 20x18, 25x17, 40x17 | **44x44** on coarse pointers |
| Width spent on `X: — Y: —` | fixed **120px (32% of viewport)** | dropped when compact |

The coordinates were dead weight — no hover means they read `—` except mid-drag — and were the structural cause of the overflow.

## Approach

Two independent signals govern two different things, so they cannot drift:

- **Content** — decided in the component from the `useBreakpoint` seam (`band === 'narrow' || isTouch`, so a tablet in landscape still counts).
- **Sizing** — decided in CSS under `@media (pointer: coarse)`, the convention `RelaxedFocusControl` / `resizeHandle` / `ColorPicker` already use.

A narrow *mouse* window therefore gets the width fix without becoming chunky, and **desktop at regular width is untouched**.

The bar is also **focus-aware**. Relaxed's `write` focus renders no canvas, so a zoom cluster there would steer a viewport that isn't on screen. With nothing left worth showing the bar removes itself rather than hold 24px for an empty strip — the same self-hiding contract as `FloatingCollabIndicator` — and returns for ambient state (offline, group drill-down, blob sync). The predicate `App` already computed inline is now the shared pure `isCanvasHidden`, so the two agree by construction rather than by convention.

| Viewport | Renders |
| -- | -- |
| regular | unchanged |
| compact, canvas visible | zoom cluster + `Fit` + connection chip |
| compact, write focus | connection chip only — or nothing, and no bar |

The connection chip is never dropped: it is the one readout that matters *more* on a phone.

## Also here

- **Per-pointer-move re-render.** The coordinate readout was the only consumer of `cursorWorldPosition`, which `Engine.handlePointerEvent` writes on *every* normalized pointer event. The selector now returns a constant when coordinates aren't rendered, so the subscription can no longer re-render the bar on every pointer move to display two em-dashes.
- **`handleZoomFit` geometry.** It hard-coded a desktop shell — 70% of the window width (assuming side panels took the rest) and height minus 100 — and so under-zoomed systematically wherever the panels are hidden. It now measures the canvas area, falling back to the old approximation. `Camera.zoomToFit` already does this correctly from its own `setViewport` dimensions; the Camera instance isn't reachable from here without new plumbing, so that's noted in place rather than done.

## Verification

`bun run typecheck` clean; **295 test files / 3509 tests pass**. New coverage: an `isCanvasHidden` truth table pinned against `resolveRegions` across the whole input space, and seven StatusBar cases covering each viewport/focus combination including the self-removal. The existing `StatusBar.connchip.test.tsx` passes unmodified.

Verified live at 375x812 in both Write and Diagram focus — no overflow, no console errors.

**One caveat worth stating plainly:** the browser pane reports a fine pointer, so `@media (pointer: coarse)` cannot *match* there and the 44px sizing could not be observed the normal way. It was measured instead by reading the parsed rules out of the CSSOM and applying them directly: bar 44px, all four controls 44x44, still no overflow, **12.8px headroom at 375px with the offline chip present** (the busiest realistic case). That is strong evidence, not a substitute for a real device — worth a look on a phone before this is called done.

## Docs

`interface-tour.md` described the bar's contents unconditionally; it now notes the reduction on small and touch screens. Left the Mermaid layout node as the desktop depiction rather than clutter it with responsive hedging.

Assisted-by: Opus 5